### PR TITLE
🧹 Remove deprecated isStudentByDob alias

### DIFF
--- a/src/lib/getFullAttendance.ts
+++ b/src/lib/getFullAttendance.ts
@@ -1,11 +1,6 @@
 import prisma from "@/lib/prisma";
 import { isMinor } from "@/lib/time";
 
-/**
- * @deprecated Use isMinor() from @/lib/time instead.
- */
-export const isStudentByDob = isMinor;
-
 export async function getFullAttendance() {
     const activeVisits = await prisma.visit.findMany({
         where: { departed: null },


### PR DESCRIPTION
This change removes the deprecated `isStudentByDob` function, which was a simple alias for `isMinor`. I've also removed an unused import of this function in `src/app/api/attendance/route.ts`. Grep confirmed there are no other usages of this function in the codebase.

---
*PR created automatically by Jules for task [17355830849094938361](https://jules.google.com/task/17355830849094938361) started by @dkaygithub*