### PR TITLE
🧹 [Code Health] Remove deprecated getKioskPublicKey function

### DIFF
--- a/src/lib/verify-kiosk.ts
+++ b/src/lib/verify-kiosk.ts
@@ -33,12 +33,6 @@ export function getKioskPublicKeys(): Buffer[] {
         .map(k => Buffer.from(k, "hex"));
 }
 
-/** @deprecated Use getKioskPublicKeys() instead */
-export function getKioskPublicKey(): Buffer | null {
-    const keys = getKioskPublicKeys();
-    return keys.length > 0 ? keys[0] : null;
-}
-
 export type VerifyResult =
     | { ok: true }
     | { ok: false; status: number; error: string };


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `getKioskPublicKey()` function from `src/lib/verify-kiosk.ts`.
💡 **Why:** The function was deprecated in favor of `getKioskPublicKeys()`. Removing dead/deprecated code reduces clutter and prevents accidental usage in the future, improving code maintainability.
✅ **Verification:** 
- Used `grep` to confirm there are absolutely zero references to `getKioskPublicKey()` remaining in the codebase.
- Ran specific unit tests (`npx jest src/lib/__tests__/verify-kiosk.test.ts`), which all passed. 
- Executed `npx tsc --noEmit` to verify there are no TypeScript build failures caused by missing imports.
✨ **Result:** A cleaner `verify-kiosk.ts` file without deprecated logic, with no impact to existing functionality.

---
*PR created automatically by Jules for task [2349896087269072971](https://jules.google.com/task/2349896087269072971) started by @dkaygithub*