### PR TITLE
feat: dynamic dev environment visual indicator

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useSession, signIn, signOut } from "next-auth/react";
 import styles from './page.module.css';
 import DevLoginPicker from '@/components/DevLoginPicker';
+import { config } from '@/lib/config';
 
 export default function Home() {
   const router = useRouter();
@@ -104,7 +105,7 @@ export default function Home() {
     <main className={styles.main}>
       <div className={`glass-container animate-float ${styles.heroContainer}`}>
         <h1 className="text-gradient" style={{ fontSize: '3rem', margin: '0 0 1rem 0' }}>
-          CheckMeIn
+          {config.isDev ? 'CMI-dev' : 'CheckMeIn'}
         </h1>
         <p style={{ color: 'var(--color-text-muted)', fontSize: '1.25rem', marginBottom: '2rem' }}>
           The elegant next-generation facility check-in system.

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -5,6 +5,7 @@ import { useSession, signIn, signOut } from "next-auth/react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import Link from 'next/link';
 import styles from './NavBar.module.css';
+import { config } from '@/lib/config';
 
 type SessionUser = {
     sysadmin?: boolean;
@@ -98,7 +99,7 @@ function NavBarInner() {
                 <div className={styles.leftSection}>
                     <Link href="/" onClick={closeMobileMenu} style={{ textDecoration: 'none' }}>
                         <h2 className="text-gradient" style={{ margin: 0, fontSize: '1.5rem', cursor: 'pointer' }}>
-                            CheckMeIn
+                            {config.isDev ? 'CMI-dev' : 'CheckMeIn'}
                         </h2>
                     </Link>
                     <div className={styles.navLinks}>


### PR DESCRIPTION
Updated the main navigation bar and landing page hero text to dynamically switch to "CMI-dev" when running locally in development mode, making it easier for developers to instantly recognize which environment they are using.

---
*PR created automatically by Jules for task [1937728192928787153](https://jules.google.com/task/1937728192928787153) started by @dkaygithub*