### PR TITLE
fix: improve Board Directory readability and close on click outside (Fixes #23)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -251,11 +251,18 @@ export default function Home() {
       </div>
 
       {showBoardDirectory && (
-        <div style={{
-          position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
-          background: 'rgba(0,0,0,0.8)', zIndex: 999, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem'
-        }}>
-          <div className="glass-container animate-float" style={{ maxWidth: '500px', width: '100%', padding: '2rem', position: 'relative' }}>
+        <div
+          onClick={() => setShowBoardDirectory(false)}
+          style={{
+            position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+            background: 'rgba(0,0,0,0.8)', zIndex: 999, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem'
+          }}
+        >
+          <div
+            className="glass-container animate-float"
+            onClick={(e) => e.stopPropagation()}
+            style={{ maxWidth: '500px', width: '100%', padding: '2rem', position: 'relative', background: 'var(--color-bg-base)' }}
+          >
             <button 
               onClick={() => setShowBoardDirectory(false)}
               style={{ position: 'absolute', top: '1rem', right: '1rem', background: 'none', border: 'none', color: 'white', fontSize: '1.5rem', cursor: 'pointer' }}


### PR DESCRIPTION
Fixes #23

This PR improves the usability of the Board Directory popup on the main page.

- Added a solid background color (`var(--color-bg-base)`) to the modal to improve readability and fix the low opacity issue.
- Added an `onClick` handler to the outer modal overlay that closes the popup, allowing users to close the directory by clicking outside of it.
- Added `e.stopPropagation()` to the inner modal container to prevent clicks inside the directory from closing the modal.

---
*PR created automatically by Jules for task [9605412311421054011](https://jules.google.com/task/9605412311421054011) started by @dkaygithub*