### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack in Shopify webhook signature verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Timing Attack in Webhook Verification]
+**Vulnerability:** Found a timing attack vulnerability in `src/app/api/webhooks/shopify/route.ts` where the HMAC signature from Shopify (`headerSignature`) was being compared to the expected signature (`generatedSignature`) using a standard string equality operator (`!==`).
+**Learning:** Standard string comparisons fail early as soon as a mismatching character is found. This "fail-fast" behavior leaks timing information to an attacker, theoretically allowing them to guess the correct HMAC character by character and forge a valid Shopify webhook signature to bypass payment verification.
+**Prevention:** Always use `crypto.timingSafeEqual()` when comparing security-sensitive signatures, hashes, or tokens. Both values must be converted to `Buffer` objects of the exact same length before comparison to ensure constant-time execution regardless of where the mismatch occurs.

--- a/src/app/api/webhooks/shopify/route.ts
+++ b/src/app/api/webhooks/shopify/route.ts
@@ -25,7 +25,13 @@ export async function POST(req: Request) {
             .update(rawBody, "utf8")
             .digest("base64");
 
-        if (generatedSignature !== headerSignature) {
+        // Convert both signatures to Buffers to prevent timing attacks using crypto.timingSafeEqual.
+        // Since HMAC-SHA256 in base64 is a known fixed length, an early length check does not leak
+        // any secret information about the signature itself.
+        const generatedBuffer = Buffer.from(generatedSignature);
+        const headerBuffer = Buffer.from(headerSignature);
+
+        if (generatedBuffer.length !== headerBuffer.length || !crypto.timingSafeEqual(generatedBuffer, headerBuffer)) {
             console.error("Shopify webhook signature mismatch.");
             return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
         }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability in webhook verification

🚨 Severity: HIGH
💡 Vulnerability: The Shopify webhook signature verification (`src/app/api/webhooks/shopify/route.ts`) was using a standard string equality operator (`!==`). This is vulnerable to timing attacks, as string comparison stops evaluating upon the first mismatching character. An attacker could potentially use the response time differences to guess the correct signature byte-by-byte and forge a valid webhook payload to maliciously alter application state.
🎯 Impact: A forged payload could mark unpaid enrollments as "ACTIVE", bypassing payment enforcement for programs.
🔧 Fix: Replaced string comparison with `crypto.timingSafeEqual`. Both signatures are converted to `Buffer` objects, checked for equal length, and then compared in constant time to prevent leaking timing data. 
✅ Verification: Ran `npm run lint` and `npm test` locally. Confirmed `npx tsc --noEmit` passes. The code safely handles invalid lengths before invoking the strict equal check. I have also documented this learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2944947128356089615](https://jules.google.com/task/2944947128356089615) started by @dkaygithub*