### PR TITLE
🔒 fix: Handle malformed JSON safely and validate participantId in /api/scan

### DIFF
--- a/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from '../route';
+import { authenticateRequest } from '@/lib/auth';
+
+jest.mock('@/lib/auth', () => ({
+    authenticateRequest: jest.fn(),
+}));
+
+jest.mock('@/lib/prisma', () => ({
+    participant: {
+        findUnique: jest.fn(),
+    },
+    rawBadgeEvent: {
+        create: jest.fn(),
+    },
+    visit: {
+        findFirst: jest.fn(),
+    },
+    systemMetric: {
+        create: jest.fn().mockResolvedValue({}),
+    },
+}));
+
+jest.mock('@/lib/logger', () => ({
+    logBackendError: jest.fn(),
+}));
+
+jest.mock('@/lib/scan-service', () => ({
+    processCheckin: jest.fn(),
+    processCheckout: jest.fn(),
+}));
+
+describe('POST /api/scan', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return 400 if the payload is not valid JSON', async () => {
+        (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'session', user: { id: '1' } });
+        const req = new Request('http://localhost/api/scan', {
+            method: 'POST',
+            body: 'not-json'
+        }) as any;
+
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+
+        const json = await res.json();
+        expect(json.error).toBe('Invalid JSON payload.');
+    });
+
+    it('should return 400 if participantId is missing', async () => {
+        (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'session', user: { id: '1' } });
+        const req = new Request('http://localhost/api/scan', {
+            method: 'POST',
+            body: JSON.stringify({ other: 'data' })
+        }) as any;
+
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+
+        const json = await res.json();
+        expect(json.error).toBe('A valid numeric participantId is required.');
+    });
+
+    it('should return 400 if participantId is not a number', async () => {
+        (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'session', user: { id: '1' } });
+        const req = new Request('http://localhost/api/scan', {
+            method: 'POST',
+            body: JSON.stringify({ participantId: '123' })
+        }) as any;
+
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+
+        const json = await res.json();
+        expect(json.error).toBe('A valid numeric participantId is required.');
+    });
+});

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -13,11 +13,17 @@ export async function POST(req: NextRequest) {
         // 1. Authenticate
         const auth = await authenticateRequest(req, rawBody);
 
-        const body = JSON.parse(rawBody);
+        let body;
+        try {
+            body = JSON.parse(rawBody);
+        } catch (e) {
+            return apiError("Invalid JSON payload.", 400);
+        }
+
         const participantId = body.participantId;
 
-        if (!participantId) {
-            return apiError("participantId is required.", 400);
+        if (!participantId || typeof participantId !== 'number') {
+            return apiError("A valid numeric participantId is required.", 400);
         }
 
         // 2. Authorization


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR addresses an issue where the `rawBody` payload in `src/app/api/scan/route.ts` was passed to `JSON.parse` without any error handling. It also strengthens input validation for `participantId`.

⚠️ **Risk:** The potential impact if left unfixed
If a client sent malformed JSON to this endpoint, `JSON.parse` would throw a synchronous `SyntaxError`, bubbling up and potentially causing an unexpected internal server error (`500`). Additionally, loosely validating `participantId` could allow non-numeric types to be passed, which could lead to type mismatch errors later when querying the Prisma database.

🛡️ **Solution:** How the fix addresses the vulnerability
1. Wrapped `JSON.parse(rawBody)` in a `try...catch` block. If a parsing error occurs, the endpoint now gracefully returns a `400 Bad Request` with an appropriate error message (`"Invalid JSON payload."`).
2. Updated the `participantId` validation to ensure it is strictly a `number` type, rejecting invalid inputs with a `400 Bad Request` before database queries are made.
3. Added unit test coverage specifically for the `/api/scan` route to verify these validation and error-handling paths.

---
*PR created automatically by Jules for task [216999290011243447](https://jules.google.com/task/216999290011243447) started by @dkaygithub*