### PR TITLE
feat: admin tool to merge participant records

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -70,6 +70,7 @@ export default function AdminLayout({
       title: "People",
       links: [
         { name: "Participants", href: "/admin/participants", icon: "👥" },
+        { name: "Merge Participants", href: "/admin/participants/merge", icon: "🔗" },
         { name: "Manage Memberships", href: "/admin/households", icon: "🏠" },
         { name: "Pending Participants", href: "/admin/programs/pending", icon: "⏳" },
         { name: "Emergency Contacts", href: "/admin/emergency-contacts", icon: "🚑" },

--- a/src/app/admin/participants/merge/page.tsx
+++ b/src/app/admin/participants/merge/page.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import styles from "../../../page.module.css";
+
+export default function MergeParticipants() {
+    const router = useRouter();
+    const [searchA, setSearchA] = useState("");
+    const [searchB, setSearchB] = useState("");
+    const [resultsA, setResultsA] = useState<any[]>([]);
+    const [resultsB, setResultsB] = useState<any[]>([]);
+
+    const [pA, setPA] = useState<any>(null);
+    const [pB, setPB] = useState<any>(null);
+
+    const [analyzedA, setAnalyzedA] = useState<any>(null);
+    const [analyzedB, setAnalyzedB] = useState<any>(null);
+
+    const [keepId, setKeepId] = useState<number | null>(null);
+
+    const [loading, setLoading] = useState(false);
+    const [merging, setMerging] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [success, setSuccess] = useState(false);
+
+    const [previewMode, setPreviewMode] = useState(false);
+
+    useEffect(() => {
+        if (searchA.length > 2 && !pA) {
+            fetch(`/api/admin/participants/search?q=${encodeURIComponent(searchA)}`)
+                .then(r => r.json())
+                .then(d => setResultsA(d.participants || []));
+        } else {
+            setResultsA([]);
+        }
+    }, [searchA, pA]);
+
+    useEffect(() => {
+        if (searchB.length > 2 && !pB) {
+            fetch(`/api/admin/participants/search?q=${encodeURIComponent(searchB)}`)
+                .then(r => r.json())
+                .then(d => setResultsB(d.participants || []));
+        } else {
+            setResultsB([]);
+        }
+    }, [searchB, pB]);
+
+    useEffect(() => {
+        if (pA && pB) {
+            setLoading(true);
+            fetch(`/api/admin/participants/merge/analyze?a=${pA.id}&b=${pB.id}`)
+                .then(r => r.json())
+                .then(d => {
+                    if (d.participants) {
+                        setAnalyzedA(d.participants[0]);
+                        setAnalyzedB(d.participants[1]);
+
+                        // Recommend keeping the one with more activity or better data
+                        const score = (p: any) => {
+                            let s = 0;
+                            s += p._count.visits * 2;
+                            s += p._count.rawBadgeEvents;
+                            s += p._count.programParticipants * 5;
+                            s += p._count.programVolunteers * 5;
+                            if (p.email) s += 10;
+                            if (p.phone) s += 10;
+                            if (p.googleId) s += 20; // real account
+                            return s;
+                        };
+                        const sA = score(d.participants[0]);
+                        const sB = score(d.participants[1]);
+
+                        setKeepId(sA >= sB ? pA.id : pB.id);
+                    }
+                })
+                .catch(e => setError("Failed to analyze participants"))
+                .finally(() => setLoading(false));
+        } else {
+            setAnalyzedA(null);
+            setAnalyzedB(null);
+            setKeepId(null);
+            setPreviewMode(false);
+        }
+    }, [pA, pB]);
+
+    const handleMerge = async () => {
+        setMerging(true);
+        setError(null);
+        try {
+            const res = await fetch("/api/admin/participants/merge", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    keepId,
+                    mergeId: keepId === pA?.id ? pB?.id : pA?.id
+                })
+            });
+            const data = await res.json();
+            if (res.ok) {
+                setSuccess(true);
+            } else {
+                setError(data.error || "Failed to merge");
+            }
+        } catch (e: any) {
+            setError(e.message || "Network error");
+        } finally {
+            setMerging(false);
+        }
+    };
+
+    const renderSearch = (label: string, value: string, setValue: (v: string) => void, results: any[], selected: any, setSelected: (p: any) => void) => (
+        <div style={{ flex: 1, position: "relative" }}>
+            <label style={{ display: "block", marginBottom: "0.5rem" }}>{label}</label>
+            {selected ? (
+                <div className="glass-container" style={{ padding: "1rem", display: "flex", justifyContent: "space-between", alignItems: "center", background: "rgba(59, 130, 246, 0.1)" }}>
+                    <div>
+                        <strong>{selected.name || "Unnamed"}</strong>
+                        <div style={{ fontSize: "0.85rem", color: "var(--color-text-muted)" }}>{selected.email || "No email"} | ID: {selected.id}</div>
+                    </div>
+                    <button onClick={() => setSelected(null)} className="glass-button" style={{ padding: "0.25rem 0.5rem", fontSize: "0.8rem" }}>Change</button>
+                </div>
+            ) : (
+                <>
+                    <input
+                        className="glass-input"
+                        value={value}
+                        onChange={e => setValue(e.target.value)}
+                        placeholder="Search by name or email..."
+                        style={{ width: "100%", padding: "0.75rem" }}
+                    />
+                    {results.length > 0 && (
+                        <div style={{ position: "absolute", top: "100%", left: 0, right: 0, zIndex: 10, background: "#1e293b", border: "1px solid rgba(255,255,255,0.1)", borderRadius: "4px", maxHeight: "250px", overflowY: "auto" }}>
+                            {results.map(r => (
+                                <div key={r.id} onClick={() => setSelected(r)} style={{ padding: "0.75rem", cursor: "pointer", borderBottom: "1px solid rgba(255,255,255,0.05)" }}>
+                                    <div>{r.name || "Unnamed"} <span style={{ color: "gray", fontSize: "0.8rem" }}>(ID: {r.id})</span></div>
+                                    <div style={{ fontSize: "0.8rem", color: "gray" }}>{r.email}</div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </>
+            )}
+        </div>
+    );
+
+    const renderStats = (p: any, isKept: boolean, isLeadWithOthers: boolean) => (
+        <div className="glass-container" style={{ padding: "1.5rem", border: isKept ? "2px solid #22c55e" : "2px solid #ef4444", background: isKept ? "rgba(34, 197, 94, 0.05)" : "rgba(239, 68, 68, 0.05)" }}>
+            <h3 style={{ marginTop: 0, color: isKept ? "#4ade80" : "#f87171" }}>
+                {isKept ? "Keep and augment" : "Merge and delete"}
+            </h3>
+
+            <div style={{ marginBottom: "1rem" }}>
+                <strong>{p.name || "Unnamed"}</strong> (ID: {p.id})
+                <div>Email: {p.email || "—"}</div>
+                <div>Phone: {p.phone || "—"}</div>
+                <div>Google Auth: {p.googleId ? "Yes" : "No"}</div>
+            </div>
+
+            <div style={{ fontSize: "0.9rem", color: "var(--color-text-muted)" }}>
+                <div>Visits: {p._count.visits}</div>
+                <div>Raw Badge Events: {p._count.rawBadgeEvents}</div>
+                <div>Program Participation: {p._count.programParticipants}</div>
+                <div>Program Volunteering: {p._count.programVolunteers}</div>
+
+                <div style={{ marginTop: "1rem" }}>
+                    Household: {p.household ? p.household.name || `Household #${p.household.id}` : "None"}
+                    {p.household && (
+                        <ul style={{ margin: "0.25rem 0", paddingLeft: "1.2rem" }}>
+                            {p.household.participants.map((hp: any) => (
+                                <li key={hp.id}>{hp.name} {hp.id === p.id && "(This)"} {p.household.leads.find((l:any) => l.participantId === hp.id) && "[Lead]"}</li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            </div>
+
+            {!isKept && isLeadWithOthers && (
+                <div style={{ marginTop: "1rem", color: "#f87171", fontWeight: "bold", background: "rgba(239, 68, 68, 0.2)", padding: "0.5rem", borderRadius: "4px" }}>
+                    Error: This participant is the lead of a household with other members. You cannot delete them. Change the household lead first.
+                </div>
+            )}
+
+            {!isKept && p.household && !isLeadWithOthers && p.household.participants.length > 1 && (
+                <div style={{ marginTop: "1rem", color: "#eab308", fontWeight: "bold", background: "rgba(234, 179, 8, 0.2)", padding: "0.5rem", borderRadius: "4px" }}>
+                    Warning: This participant is in a household with others. They will be removed from that household during deletion.
+                </div>
+            )}
+        </div>
+    );
+
+    if (success) {
+        return (
+            <div style={{ maxWidth: "1000px", margin: "0 auto", padding: "2rem" }}>
+                <div className="glass-container" style={{ padding: "2rem", textAlign: "center", borderColor: "#22c55e" }}>
+                    <h2 style={{ color: "#4ade80", margin: "0 0 1rem 0" }}>Merge Successful!</h2>
+                    <p>The participants have been successfully merged.</p>
+                    <button className="glass-button" onClick={() => {
+                        setSuccess(false);
+                        setPA(null); setPB(null);
+                        setSearchA(""); setSearchB("");
+                    }}>Merge More</button>
+                    <button className="glass-button" style={{ marginLeft: "1rem" }} onClick={() => router.push('/admin/participants')}>Back to Participants</button>
+                </div>
+            </div>
+        );
+    }
+
+    const mergeParticipant = keepId === analyzedA?.id ? analyzedB : analyzedA;
+    const keepParticipant = keepId === analyzedA?.id ? analyzedA : analyzedB;
+
+    let isLeadWithOthers = false;
+    if (mergeParticipant && !previewMode) {
+        const isLead = mergeParticipant.household?.leads.find((l:any) => l.participantId === mergeParticipant.id);
+        const othersCount = mergeParticipant.household?.participants.filter((p:any) => p.id !== mergeParticipant.id).length || 0;
+        isLeadWithOthers = isLead && othersCount > 0;
+    }
+
+    return (
+        <div style={{ maxWidth: "1000px", margin: "0 auto" }}>
+            <div className="glass-container animate-float" style={{ padding: '2rem', marginBottom: '2rem' }}>
+                <h1 className="text-gradient" style={{ marginTop: 0 }}>Merge Participants</h1>
+                <p style={{ color: 'var(--color-text-muted)' }}>
+                    Combine two participant records. The data from the merged record (visits, programs, etc) will be moved to the kept record. The merged record will be tombstoned.
+                </p>
+            </div>
+
+            {error && (
+                <div style={{ padding: "1rem", background: "rgba(239, 68, 68, 0.2)", color: "#fca5a5", border: "1px solid #ef4444", borderRadius: "8px", marginBottom: "1rem" }}>
+                    {error}
+                </div>
+            )}
+
+            {!previewMode ? (
+                <>
+                    <div className="glass-container" style={{ padding: "1.5rem", marginBottom: "2rem", display: "flex", gap: "2rem" }}>
+                        {renderSearch("Participant 1", searchA, setSearchA, resultsA, pA, setPA)}
+                        {renderSearch("Participant 2", searchB, setSearchB, resultsB, pB, setPB)}
+                    </div>
+
+                    {loading && <p>Analyzing participants...</p>}
+
+                    {analyzedA && analyzedB && (
+                        <div>
+                            <div style={{ display: "flex", justifyContent: "center", marginBottom: "1rem" }}>
+                                <button className="glass-button" onClick={() => setKeepId(keepId === analyzedA.id ? analyzedB.id : analyzedA.id)}>
+                                    Swap Kept / Merged
+                                </button>
+                            </div>
+
+                            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "2rem" }}>
+                                {renderStats(analyzedA, keepId === analyzedA.id, analyzedA.id !== keepId ? isLeadWithOthers : false)}
+                                {renderStats(analyzedB, keepId === analyzedB.id, analyzedB.id !== keepId ? isLeadWithOthers : false)}
+                            </div>
+
+                            <div style={{ marginTop: "2rem", textAlign: "right" }}>
+                                <button
+                                    className="glass-button"
+                                    style={{ background: "rgba(59, 130, 246, 0.2)", borderColor: "rgba(59, 130, 246, 0.5)", padding: "0.75rem 2rem", fontSize: "1.1rem" }}
+                                    disabled={isLeadWithOthers}
+                                    onClick={() => setPreviewMode(true)}
+                                >
+                                    Proceed to Preview
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                </>
+            ) : (
+                <div className="glass-container" style={{ padding: "2rem", border: "1px solid #eab308" }}>
+                    <h2 style={{ marginTop: 0, color: "#facc15" }}>Preview & Confirm Merge</h2>
+                    <p><strong>This action is extremely difficult to undo.</strong> Please review the changes below.</p>
+
+                    <ul style={{ fontSize: "1.1rem", lineHeight: "1.8", margin: "2rem 0" }}>
+                        <li><strong>{mergeParticipant.name || mergeParticipant.email || `ID ${mergeParticipant.id}`}</strong> will be tombstoned.</li>
+                        <li>All visits, program enrollments, RSVPs, and fee payments will be transferred to <strong>{keepParticipant.name || keepParticipant.email || `ID ${keepParticipant.id}`}</strong>.</li>
+                        <li>Missing personal info on the kept participant will be filled in from the merged participant.</li>
+                        <li>Raw badge scans will remain on the tombstoned record for audit purposes.</li>
+                    </ul>
+
+                    <div style={{ display: "flex", gap: "1rem", justifyContent: "flex-end" }}>
+                        <button className="glass-button" onClick={() => setPreviewMode(false)} disabled={merging}>Cancel</button>
+                        <button className="glass-button" style={{ background: "rgba(239, 68, 68, 0.2)", borderColor: "rgba(239, 68, 68, 0.5)" }} onClick={handleMerge} disabled={merging}>
+                            {merging ? "Merging..." : "Confirm Merge & Delete"}
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/api/admin/participants/merge/__tests__/route.test.ts
+++ b/src/app/api/admin/participants/merge/__tests__/route.test.ts
@@ -1,0 +1,110 @@
+import { POST } from "../route";
+import prisma from "@/lib/prisma";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+
+jest.mock("next-auth/next");
+const mockGetServerSession = getServerSession as jest.Mock;
+
+describe("Merge Participants API", () => {
+    let pKeepId: number;
+    let pMergeId: number;
+    let householdId: number;
+
+    beforeEach(async () => {
+        // Setup mock session as a sysadmin
+        mockGetServerSession.mockResolvedValue({
+            user: { email: "admin@checkme.in", sysadmin: true }
+        });
+
+        // Create two participants
+        const pKeep = await prisma.participant.create({
+            data: {
+                name: "Keep User",
+                email: "keep@example.com",
+            }
+        });
+        pKeepId = pKeep.id;
+
+        const pMerge = await prisma.participant.create({
+            data: {
+                name: "Merge User",
+                email: "merge@example.com",
+                phone: "123-456-7890"
+            }
+        });
+        pMergeId = pMerge.id;
+    });
+
+    afterEach(async () => {
+        // Cleanup
+        await prisma.visit.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
+        await prisma.programParticipant.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
+        await prisma.householdLead.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
+        await prisma.participant.deleteMany({ where: { id: { in: [pKeepId, pMergeId] } } });
+        if (householdId) {
+            await prisma.household.deleteMany({ where: { id: householdId } });
+        }
+    });
+
+    it("should successfully merge two participants", async () => {
+        // Add some data to pMerge
+        await prisma.visit.create({
+            data: {
+                participantId: pMergeId,
+                arrived: new Date()
+            }
+        });
+
+        const req = new Request("http://localhost/api/admin/participants/merge", {
+            method: "POST",
+            body: JSON.stringify({ keepId: pKeepId, mergeId: pMergeId })
+        }) as any;
+
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+
+        const data = await res.json();
+        expect(data.success).toBe(true);
+
+        // Verify data was moved
+        const visits = await prisma.visit.findMany({ where: { participantId: pKeepId } });
+        expect(visits.length).toBe(1);
+
+        // Verify kept user got merged user's phone
+        const kept = await prisma.participant.findUnique({ where: { id: pKeepId } });
+        expect(kept?.phone).toBe("123-456-7890");
+
+        // Verify merged user was tombstoned
+        const merged = await prisma.participant.findUnique({ where: { id: pMergeId } });
+        expect(merged?.email).toContain("merged-");
+        expect(merged?.email).toContain("@deleted.checkme.in");
+        expect(merged?.phone).toBeNull();
+    });
+
+    it("should fail to merge if merged user is the lead of a household with other members", async () => {
+        // Create household
+        const hh = await prisma.household.create({
+            data: { name: "Test Household" }
+        });
+        householdId = hh.id;
+
+        // Assign both users to it, make merge user the lead
+        await prisma.participant.update({ where: { id: pMergeId }, data: { householdId: hh.id } });
+        await prisma.participant.update({ where: { id: pKeepId }, data: { householdId: hh.id } });
+        await prisma.householdLead.create({
+            data: { householdId: hh.id, participantId: pMergeId }
+        });
+
+        const req = new Request("http://localhost/api/admin/participants/merge", {
+            method: "POST",
+            body: JSON.stringify({ keepId: pKeepId, mergeId: pMergeId })
+        }) as any;
+
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+
+        const data = await res.json();
+        expect(data.error).toContain("lead of a household with other members");
+    });
+});

--- a/src/app/api/admin/participants/merge/analyze/route.ts
+++ b/src/app/api/admin/participants/merge/analyze/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+
+export const dynamic = 'force-dynamic';
+
+export const GET = withAuth(
+    { roles: ['sysadmin', 'boardMember'] },
+    async (req) => {
+        try {
+            const url = new URL(req.url);
+            const aId = parseInt(url.searchParams.get('a') || '0');
+            const bId = parseInt(url.searchParams.get('b') || '0');
+
+            if (!aId || !bId) {
+                return NextResponse.json({ error: "Missing IDs" }, { status: 400 });
+            }
+
+            const getParticipant = async (id: number) => {
+                const p = await prisma.participant.findUnique({
+                    where: { id },
+                    include: {
+                        household: {
+                            include: {
+                                participants: true,
+                                leads: true
+                            }
+                        },
+                        _count: {
+                            select: {
+                                rawBadgeEvents: true,
+                                visits: true,
+                                programParticipants: true,
+                                programVolunteers: true
+                            }
+                        }
+                    }
+                });
+                return p;
+            };
+
+            const [pA, pB] = await Promise.all([getParticipant(aId), getParticipant(bId)]);
+
+            if (!pA || !pB) {
+                return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+            }
+
+            return NextResponse.json({ participants: [pA, pB] });
+        } catch (error) {
+            console.error("Failed to analyze participants:", error);
+            return NextResponse.json({ error: "Server error" }, { status: 500 });
+        }
+    }
+);

--- a/src/app/api/admin/participants/merge/route.ts
+++ b/src/app/api/admin/participants/merge/route.ts
@@ -1,0 +1,168 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+
+export const dynamic = 'force-dynamic';
+
+export const POST = withAuth(
+    { roles: ['sysadmin', 'boardMember'] },
+    async (req) => {
+        try {
+            const body = await req.json();
+            const { keepId, mergeId } = body;
+
+            if (!keepId || !mergeId || keepId === mergeId) {
+                return NextResponse.json({ error: "Invalid participant IDs provided." }, { status: 400 });
+            }
+
+            const keepParticipant = await prisma.participant.findUnique({
+                where: { id: keepId },
+                include: {
+                    programParticipants: true,
+                    programVolunteers: true,
+                    rsvps: true,
+                    toolStatuses: true,
+                    feePayments: true
+                }
+            });
+
+            const mergeParticipant = await prisma.participant.findUnique({
+                where: { id: mergeId },
+                include: {
+                    programParticipants: true,
+                    programVolunteers: true,
+                    rsvps: true,
+                    toolStatuses: true,
+                    feePayments: true,
+                    householdLeads: true,
+                    household: {
+                        include: {
+                            participants: true
+                        }
+                    }
+                }
+            });
+
+            if (!keepParticipant || !mergeParticipant) {
+                return NextResponse.json({ error: "Participant(s) not found." }, { status: 404 });
+            }
+
+            const isLead = mergeParticipant.householdLeads.length > 0;
+            const householdOthersCount = mergeParticipant.household?.participants.filter(p => p.id !== mergeId).length || 0;
+
+            if (isLead && householdOthersCount > 0) {
+                return NextResponse.json({ error: "Cannot merge: the to-be-deleted participant is the lead of a household with other members." }, { status: 400 });
+            }
+
+            await prisma.$transaction(async (tx) => {
+                const updates: any = {};
+                const fields = ['googleId', 'email', 'phone', 'name', 'dob', 'homeAddress', 'image', 'lastWaiverSign', 'lastBackgroundCheck'];
+                for (const field of fields) {
+                    const keepVal = keepParticipant[field as keyof typeof keepParticipant];
+                    const mergeVal = mergeParticipant[field as keyof typeof mergeParticipant];
+                    if (!keepVal && mergeVal) {
+                        updates[field] = mergeVal;
+                    }
+                }
+
+                if (Object.keys(updates).length > 0) {
+                    await tx.participant.update({
+                        where: { id: keepId },
+                        data: updates
+                    });
+                }
+
+                await tx.visit.updateMany({
+                    where: { participantId: mergeId },
+                    data: { participantId: keepId }
+                });
+
+                // Instead of failing on unique constraints, we migrate manually:
+                for (const pp of mergeParticipant.programParticipants) {
+                    if (!keepParticipant.programParticipants.find(k => k.programId === pp.programId)) {
+                        await tx.programParticipant.update({
+                            where: { programId_participantId: { programId: pp.programId, participantId: mergeId } },
+                            data: { participantId: keepId }
+                        });
+                    } else {
+                        await tx.programParticipant.delete({
+                            where: { programId_participantId: { programId: pp.programId, participantId: mergeId } }
+                        });
+                    }
+                }
+
+                for (const pv of mergeParticipant.programVolunteers) {
+                    if (!keepParticipant.programVolunteers.find(k => k.programId === pv.programId)) {
+                        await tx.programVolunteer.update({
+                            where: { programId_participantId: { programId: pv.programId, participantId: mergeId } },
+                            data: { participantId: keepId }
+                        });
+                    } else {
+                        await tx.programVolunteer.delete({
+                            where: { programId_participantId: { programId: pv.programId, participantId: mergeId } }
+                        });
+                    }
+                }
+
+                for (const rsvp of mergeParticipant.rsvps) {
+                    if (!keepParticipant.rsvps.find(k => k.eventId === rsvp.eventId)) {
+                        await tx.rSVP.update({
+                            where: { eventId_participantId: { eventId: rsvp.eventId, participantId: mergeId } },
+                            data: { participantId: keepId }
+                        });
+                    } else {
+                        await tx.rSVP.delete({
+                            where: { eventId_participantId: { eventId: rsvp.eventId, participantId: mergeId } }
+                        });
+                    }
+                }
+
+                for (const fee of mergeParticipant.feePayments) {
+                    if (!keepParticipant.feePayments.find(k => k.feeId === fee.feeId)) {
+                        await tx.feePayment.update({
+                            where: { feeId_participantId: { feeId: fee.feeId, participantId: mergeId } },
+                            data: { participantId: keepId }
+                        });
+                    } else {
+                        await tx.feePayment.delete({
+                            where: { feeId_participantId: { feeId: fee.feeId, participantId: mergeId } }
+                        });
+                    }
+                }
+
+                for (const tool of mergeParticipant.toolStatuses) {
+                    if (!keepParticipant.toolStatuses.find(k => k.toolId === tool.toolId)) {
+                        await tx.toolStatus.update({
+                            where: { userId_toolId: { toolId: tool.toolId, userId: mergeId } },
+                            data: { userId: keepId }
+                        });
+                    } else {
+                        await tx.toolStatus.delete({
+                            where: { userId_toolId: { toolId: tool.toolId, userId: mergeId } }
+                        });
+                    }
+                }
+
+                await tx.householdLead.deleteMany({
+                    where: { participantId: mergeId }
+                });
+
+                await tx.participant.update({
+                    where: { id: mergeId },
+                    data: {
+                        googleId: null,
+                        email: `merged-${mergeId}@deleted.checkme.in`,
+                        phone: null,
+                        name: `${mergeParticipant.name || 'Unknown'} (Merged into ${keepId})`,
+                        householdId: null,
+                    }
+                });
+            });
+
+            return NextResponse.json({ success: true });
+        } catch (error: any) {
+            console.error("Merge error:", error);
+            return NextResponse.json({ error: error.message || "Failed to merge participants" }, { status: 500 });
+        }
+    }
+);


### PR DESCRIPTION
Implements an admin interface and API to safely merge duplicate participant records.
- Analyzes engagement across programs, visits, and profile completeness to recommend the "keep and augment" target.
- Enforces household lead constraints, blocking merges if the deleted participant is a household lead with other members.
- Combines all visits, program participations, and RSVPs while retaining raw badge events on the tombstoned record for auditing.
- Provides a detailed preview screen before confirming the destructive merge action.

Fixes #27

---
*PR created automatically by Jules for task [7718415770596701335](https://jules.google.com/task/7718415770596701335) started by @dkaygithub*