### PR TITLE
🧹 code health: refactor DevLoginPicker to avoid react-hooks/purity violations

### DIFF
--- a/src/components/DevLoginPicker.tsx
+++ b/src/components/DevLoginPicker.tsx
@@ -1,5 +1,4 @@
 "use client";
-/* eslint-disable react-hooks/purity */
 
 import { useState, useEffect } from "react";
 import { signIn } from "next-auth/react";
@@ -25,15 +24,20 @@ export default function DevLoginPicker() {
     const [personas, setPersonas] = useState<Persona[]>([]);
     const [loading, setLoading] = useState(true);
     const [signingIn, setSigningIn] = useState<string | null>(null);
+    const [now, setNow] = useState<number | null>(null);
 
     useEffect(() => {
         fetch("/api/auth/dev-personas", { cache: "no-store" })
             .then((res) => res.json())
             .then((data) => {
                 setPersonas(data.personas || []);
+                setNow(Date.now());
                 setLoading(false);
             })
-            .catch(() => setLoading(false));
+            .catch(() => {
+                setNow(Date.now());
+                setLoading(false);
+            });
     }, []);
 
     const handleLogin = (email: string) => {
@@ -49,9 +53,9 @@ export default function DevLoginPicker() {
         if (p.shopSteward) badges.push({ label: "Shop Steward", color: "#f59e0b" });
         if (p.toolStatuses?.length > 0) badges.push({ label: "Certified", color: "#10b981" });
         if (p.householdId) badges.push({ label: "Household", color: "#6366f1" });
-        if (p.dob) {
+        if (p.dob && now !== null) {
             const age = Math.floor(
-                (Date.now() - new Date(p.dob).getTime()) / (365.25 * 24 * 60 * 60 * 1000)
+                (now - new Date(p.dob).getTime()) / (365.25 * 24 * 60 * 60 * 1000)
             );
             if (age < 18) badges.push({ label: `Student (${age})`, color: "#ec4899" });
         }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed `eslint-disable react-hooks/purity` from `src/components/DevLoginPicker.tsx` and refactored the component to cleanly calculate `Date.now()`.

💡 **Why:** How this improves maintainability
Calling `Date.now()` during the render phase causes side-effects during component rendering, potentially leading to hydration mismatches between SSR and client, as well as violating React's pure render rule. Setting `now` to a stable state value calculated when the data is loaded preserves purity and makes the logic explicit.

✅ **Verification:** How you confirmed the change is safe
Ran `npm run lint` which successfully passes with the eslint disable rule removed. Also ran Playwright verification testing, successfully loading the page with mocked personas and verifying that the time-based "Student" badge renders as expected for a minor. Running tests passes all UI-related tests (database tests are failing due to Docker pull rate limit but the UI code is isolated).

✨ **Result:** The improvement achieved
A cleaner component without lint warnings, correctly following React state management best practices.

---
*PR created automatically by Jules for task [16735120953250892785](https://jules.google.com/task/16735120953250892785) started by @dkaygithub*