### PR TITLE
fix: mobile views on admin participants page (Fixes #5)

### DIFF
--- a/src/app/admin/participants/page.tsx
+++ b/src/app/admin/participants/page.tsx
@@ -205,7 +205,7 @@ export default function AdminParticipantsIndex() {
             </div>
 
             <div className="glass-container" style={{ padding: '2rem', marginBottom: '2rem' }}>
-                <form onSubmit={handleSearch} style={{ display: 'flex', gap: '1rem' }}>
+                <form onSubmit={handleSearch} style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
                     <input 
                         type="text" 
                         placeholder="Search by name or email..." 
@@ -230,14 +230,14 @@ export default function AdminParticipantsIndex() {
                     {results.length > 0 ? (
                         <div style={{ display: 'grid', gap: '1rem' }}>
                             {results.map(p => (
-                                <div key={p.id} className="glass-container" style={{ padding: '1rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'rgba(255,255,255,0.02)' }}>
+                                <div key={p.id} className="glass-container" style={{ padding: '1rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem', background: 'rgba(255,255,255,0.02)' }}>
                                     <div>
                                         <div style={{ fontWeight: 600 }}>{p.name}</div>
                                         <div style={{ fontSize: '0.85rem', color: 'var(--color-text-muted)' }}>
                                             {p.email || 'No email'}{p.phone ? ` • ${p.phone}` : ''}
                                         </div>
                                     </div>
-                                    <div style={{ fontSize: '0.85rem', color: 'var(--color-text-muted)', display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                                    <div style={{ fontSize: '0.85rem', color: 'var(--color-text-muted)', display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>
                                         {p.household?.name || 'No household'}
                                         {!p.household && (
                                             <button 


### PR DESCRIPTION
Fixes #5

This PR addresses the issue where the "chips" on the `/admin/participants` page were too wide and didn't wrap correctly on mobile devices.

Changes:
- Added `flexWrap: 'wrap'` to the search form to ensure the input and search button wrap on small screens.
- Added `flexWrap: 'wrap'` and `gap: '1rem'` to the inner action buttons container of the participant list items to allow buttons to break onto the next line gracefully when space is limited.
- Added `flexWrap: 'wrap'` and `gap: '1rem'` to the outer container of the participant list items so the left and right side content can stack properly on very narrow viewports.

---
*PR created automatically by Jules for task [16436746190508468511](https://jules.google.com/task/16436746190508468511) started by @dkaygithub*