### PR TITLE
🔒 Fix unsafe JSON parsing in Shopify webhook

### DIFF
--- a/src/app/api/webhooks/shopify/route.ts
+++ b/src/app/api/webhooks/shopify/route.ts
@@ -37,7 +37,13 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
         }
 
-        const order = JSON.parse(rawBody);
+        let order;
+        try {
+            order = JSON.parse(rawBody);
+        } catch (parseError) {
+            logger.error("Failed to parse Shopify webhook payload:", parseError);
+            return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+        }
 
         // Iterate through line items to find CheckMeIn_Account_ID and Program_ID
         // We set these custom attributes in the permalink URL:


### PR DESCRIPTION
🎯 **What:** The `JSON.parse(rawBody)` call in the Shopify webhook endpoint (`src/app/api/webhooks/shopify/route.ts`) was executed directly without error handling.
⚠️ **Risk:** If a malicious user or an unexpected error sends a malformed JSON payload (or non-JSON body), `JSON.parse` will throw an unhandled exception. This causes the API route to crash and return a generic 500 error instead of failing gracefully, potentially leading to instability or denial of service on that endpoint.
🛡️ **Solution:** Wrapped the `JSON.parse` call in a `try...catch` block. If parsing fails, the error is logged and a `400 Bad Request` response is safely returned to the caller.

---
*PR created automatically by Jules for task [13335633108425863331](https://jules.google.com/task/13335633108425863331) started by @dkaygithub*