### PR TITLE
Fixes #47

### DIFF
--- a/.github/workflows/jules.yml
+++ b/.github/workflows/jules.yml
@@ -1,14 +1,14 @@
 name: Jules AI Agent
 
+# Trigger only when an issue is labeled
 on:
   issues:
-    types: [opened, reopened, labeled]
-  issue_comment:
-    types: [created]
+    types: [labeled]
 
 jobs:
   jules:
-    if: ${{ !github.event.issue.pull_request }}
+    # Restrict execution to issues labeled 'jules' and ignore pull requests
+    if: ${{ github.event.label.name == 'jules' && !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fixes #47

Updates the `jules.yml` GitHub Actions workflow to only trigger when an issue is labeled with the 'jules' label. This restricts the workflow execution and avoids unnecessary runs on issue creation or comments. 

The `on` trigger was modified to only listen to the `labeled` event type for issues, and a job-level `if` condition was added to check that the applied label is exactly 'jules'. The condition to ignore pull requests was retained.

---
*PR created automatically by Jules for task [16888843782513337552](https://jules.google.com/task/16888843782513337552) started by @dkaygithub*