### PR TITLE
feat: Shopify Client Credentials Grant auth, inventory management, and member variant selection

### DIFF
--- a/src/app/admin/programs/new/page.tsx
+++ b/src/app/admin/programs/new/page.tsx
@@ -23,6 +23,7 @@ export default function CreateProgramPage() {
     const [maxAge, setMaxAge] = useState("");
     const [memberPrice, setMemberPrice] = useState("");
     const [nonMemberPrice, setNonMemberPrice] = useState("");
+    const [maxParticipants, setMaxParticipants] = useState("");
     const [memberOnly, setMemberOnly] = useState(false);
     const [saving, setSaving] = useState(false);
     const [message, setMessage] = useState("");
@@ -89,6 +90,7 @@ export default function CreateProgramPage() {
                     maxAge: maxAge ? parseInt(maxAge) : null,
                     memberPrice: memberPrice ? parseInt(memberPrice) : null,
                     nonMemberPrice: nonMemberPrice ? parseInt(nonMemberPrice) : null,
+                    maxParticipants: maxParticipants ? parseInt(maxParticipants) : null,
                     leadMentorId: leadMentorId ? parseInt(leadMentorId) : null
                 })
             });
@@ -277,6 +279,24 @@ export default function CreateProgramPage() {
                                 </div>
                             </div>
                             <p style={{ margin: 0, fontSize: '0.8rem', color: 'var(--color-text-muted)' }}>Leave prices blank or 0 for a free program. Setting a price automatically creates a checkout flow on Shopify.</p>
+                            <div style={{ marginTop: '1rem' }}>
+                                <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 500 }}>Max Participants (Optional)</label>
+                                <input
+                                    type="number"
+                                    className="glass-input"
+                                    value={maxParticipants}
+                                    onChange={e => setMaxParticipants(e.target.value)}
+                                    placeholder="Leave blank for unlimited"
+                                    min="1"
+                                    style={{ width: '100%', padding: '0.75rem', background: 'rgba(0,0,0,0.2)', color: 'white' }}
+                                />
+                                <p style={{ margin: '0.5rem 0 0 0', fontSize: '0.8rem', color: 'var(--color-text-muted)' }}>Sets the inventory limit on Shopify. Leave blank for unlimited enrollment.</p>
+                                {(memberPrice || nonMemberPrice) && !maxParticipants && (
+                                    <div style={{ marginTop: '0.5rem', padding: '0.75rem', background: 'rgba(234, 179, 8, 0.1)', border: '1px solid rgba(234, 179, 8, 0.3)', borderRadius: '6px', fontSize: '0.85rem', color: '#eab308' }}>
+                                        ⚠️ No max participants set — Shopify will allow unlimited purchases for this program.
+                                    </div>
+                                )}
+                            </div>
                         </div>
                         <div style={{ marginTop: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                             <input

--- a/src/app/api/household/route.ts
+++ b/src/app/api/household/route.ts
@@ -11,7 +11,7 @@ export const GET = withAuth(
 
             const user = await prisma.participant.findUnique({
                 where: { id: userId },
-                include: { household: { include: { participants: true, leads: true } } }
+                include: { household: { include: { participants: true, leads: true, memberships: { where: { active: true } } } } }
             });
 
             if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });

--- a/src/app/api/programs/route.ts
+++ b/src/app/api/programs/route.ts
@@ -104,7 +104,7 @@ export async function POST(req: Request) {
 
     try {
         const body = await req.json();
-        const { name, leadMentorId, begin, end, memberOnly, minAge, maxAge, memberPrice, nonMemberPrice } = body;
+        const { name, leadMentorId, begin, end, memberOnly, minAge, maxAge, memberPrice, nonMemberPrice, maxParticipants } = body;
 
         if (!name) {
             return NextResponse.json({ error: "Program name is required" }, { status: 400 });
@@ -112,13 +112,14 @@ export async function POST(req: Request) {
 
         const mPrice = memberPrice ? parseInt(memberPrice, 10) : null;
         const nmPrice = nonMemberPrice ? parseInt(nonMemberPrice, 10) : null;
+        const maxPart = maxParticipants ? parseInt(maxParticipants, 10) : null;
 
         // Try to create Shopify entities
         let shopifyData: { shopifyProductId: string, shopifyMemberVariantId: string | null, shopifyNonMemberVariantId: string | null } | null = null;
         
         // Only try to create if at least one price is provided. Otherwise it's a free program.
         if ((mPrice && mPrice > 0) || (nmPrice && nmPrice > 0)) {
-            shopifyData = await createShopifyProgramVariants(name, mPrice, nmPrice);
+            shopifyData = await createShopifyProgramVariants(name, mPrice, nmPrice, maxPart);
         }
 
         const newProgram = await prisma.program.create({
@@ -132,6 +133,7 @@ export async function POST(req: Request) {
                 maxAge: maxAge || null,
                 memberPrice: mPrice,
                 nonMemberPrice: nmPrice,
+                maxParticipants: maxPart,
                 shopifyProductId: shopifyData?.shopifyProductId || null,
                 shopifyMemberVariantId: shopifyData?.shopifyMemberVariantId || null,
                 shopifyNonMemberVariantId: shopifyData?.shopifyNonMemberVariantId || null,

--- a/src/app/programs/[id]/page.tsx
+++ b/src/app/programs/[id]/page.tsx
@@ -164,17 +164,18 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                 if (isPayingOnShopify) {
                     setSuccessMessage("Redirecting to Shopify for secure payment...");
                     
-                    const userRes = await fetch(`/api/admin/participants/${selectedParticipantId}`);
+                    // Check membership via household data (already fetched)
+                    const householdRes = await fetch('/api/household');
                     let isMember = false;
-                    if (userRes.ok) {
-                        const userData = await userRes.json();
-                        isMember = userData.participant?.memberships?.some((m: any) => m.active) || false;
+                    if (householdRes.ok) {
+                        const householdData = await householdRes.json();
+                        isMember = householdData.household?.memberships?.some((m: any) => m.active) || false;
                     }
 
                     const variantId = isMember ? program.shopifyMemberVariantId : program.shopifyNonMemberVariantId;
                     
                     if (variantId) {
-                        const storeDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN || 'innovationtreehouse.myshopify.com';
+                        const storeDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
                         const checkoutUrl = `https://${storeDomain}/cart/${variantId}:1?attributes[CheckMeIn_Account_ID]=${selectedParticipantId}&attributes[Program_ID]=${id}`;
                         window.location.href = checkoutUrl;
                     } else {

--- a/src/lib/__tests__/shopify.test.ts
+++ b/src/lib/__tests__/shopify.test.ts
@@ -1,4 +1,4 @@
-import { createShopifyProgramVariants } from '../shopify';
+import { createShopifyProgramVariants, resetTokenCache } from '../shopify';
 import { sendEmail } from '../email';
 import prisma from '../prisma';
 
@@ -15,6 +15,14 @@ jest.mock('../prisma', () => ({
     }
 }));
 
+// Helper: mock a successful token response
+function mockTokenResponse(fetchMock: jest.Mock) {
+    fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'test_token', scope: 'write_products,write_inventory,read_locations,read_orders', expires_in: 86400 })
+    });
+}
+
 describe('createShopifyProgramVariants', () => {
     let originalEnv: NodeJS.ProcessEnv;
     let fetchMock: jest.Mock;
@@ -22,12 +30,14 @@ describe('createShopifyProgramVariants', () => {
     beforeEach(() => {
         originalEnv = { ...process.env };
         process.env.SHOPIFY_STORE_DOMAIN = 'test.myshopify.com';
-        process.env.SHOPIFY_ADMIN_ACCESS_TOKEN = 'test_token';
+        process.env.SHOPIFY_CLIENT_ID = 'test_client_id';
+        process.env.SHOPIFY_CLIENT_SECRET = 'test_client_secret';
 
         fetchMock = jest.fn();
         global.fetch = fetchMock;
 
         jest.clearAllMocks();
+        resetTokenCache();
     });
 
     afterEach(() => {
@@ -43,16 +53,22 @@ describe('createShopifyProgramVariants', () => {
     });
 
     it('should successfully create product and variants', async () => {
+        // Token request
+        mockTokenResponse(fetchMock);
+
+        // Product creation
         fetchMock.mockResolvedValueOnce({
             ok: true,
             json: async () => ({ product: { id: 12345 } })
         });
 
+        // Member variant
         fetchMock.mockResolvedValueOnce({
             ok: true,
             json: async () => ({ variant: { id: 67890 } })
         });
 
+        // Non-member variant
         fetchMock.mockResolvedValueOnce({
             ok: true,
             json: async () => ({ variant: { id: 11111 } })
@@ -66,11 +82,15 @@ describe('createShopifyProgramVariants', () => {
             shopifyNonMemberVariantId: '11111'
         });
 
-        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(fetchMock).toHaveBeenCalledTimes(4); // token + product + 2 variants
         expect(sendEmail).not.toHaveBeenCalled();
     });
 
     it('should send email to admins and board members when product creation fails', async () => {
+        // Token request
+        mockTokenResponse(fetchMock);
+
+        // Product creation fails
         fetchMock.mockResolvedValueOnce({
             ok: false,
             status: 400,
@@ -107,6 +127,10 @@ describe('createShopifyProgramVariants', () => {
     });
 
     it('should send email to admins and board members when fetch throws an error', async () => {
+        // Token request succeeds
+        mockTokenResponse(fetchMock);
+
+        // Product creation throws
         fetchMock.mockRejectedValueOnce(new Error('Network error'));
 
         const mockAdmins = [
@@ -125,5 +149,18 @@ describe('createShopifyProgramVariants', () => {
             'Shopify Integration Error',
             expect.stringContaining('Network error')
         );
+    });
+
+    it('should return null when token request fails', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: false,
+            status: 401,
+            text: async () => '{"error":"invalid_client"}'
+        });
+
+        const result = await createShopifyProgramVariants('Test Program', 10, 20);
+
+        expect(result).toBeNull();
+        expect(fetchMock).toHaveBeenCalledTimes(1); // only token request
     });
 });

--- a/src/lib/shopify.ts
+++ b/src/lib/shopify.ts
@@ -7,6 +7,12 @@ import { sendEmail } from "@/lib/email";
 let cachedToken: string | null = null;
 let tokenExpiresAt: number = 0;
 
+/** @internal - Exported only for test isolation */
+export function resetTokenCache() {
+  cachedToken = null;
+  tokenExpiresAt = 0;
+}
+
 /**
  * Fetches a fresh Admin API access token using the client credentials grant.
  * Caches the token and refreshes ~5 minutes before expiry.
@@ -61,7 +67,7 @@ async function getAccessToken(): Promise<string | null> {
   }
 }
 
-export async function createShopifyProgramVariants(name: string, memberPrice: number | null, nonMemberPrice: number | null) {
+export async function createShopifyProgramVariants(name: string, memberPrice: number | null, nonMemberPrice: number | null, maxParticipants: number | null = null) {
   const storeDomain = process.env.SHOPIFY_STORE_DOMAIN;
   const accessToken = await getAccessToken();
 
@@ -75,7 +81,7 @@ export async function createShopifyProgramVariants(name: string, memberPrice: nu
     const productTitle = `Program Enrollment: ${name}`;
 
     // 1. Create Product
-    const productRes = await fetch(`https://${storeDomain}/admin/api/2024-01/products.json`, {
+    const productRes = await fetch(`https://${storeDomain}/admin/api/2026-01/products.json`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -108,6 +114,8 @@ export async function createShopifyProgramVariants(name: string, memberPrice: nu
             option1: "Member",
             price: (memberPrice).toFixed(2),
             requires_shipping: false,
+            inventory_management: maxParticipants ? 'shopify' : null,
+            inventory_policy: maxParticipants ? 'deny' : 'continue',
         });
     }
 
@@ -117,6 +125,8 @@ export async function createShopifyProgramVariants(name: string, memberPrice: nu
             option1: "Non-Member",
             price: (nonMemberPrice).toFixed(2),
             requires_shipping: false,
+            inventory_management: maxParticipants ? 'shopify' : null,
+            inventory_policy: maxParticipants ? 'deny' : 'continue',
         });
     }
 
@@ -125,7 +135,7 @@ export async function createShopifyProgramVariants(name: string, memberPrice: nu
 
     if (variants.length > 0) {
         for (const variant of variants) {
-            const variantRes = await fetch(`https://${storeDomain}/admin/api/2024-01/products/${productId}/variants.json`, {
+            const variantRes = await fetch(`https://${storeDomain}/admin/api/2026-01/products/${productId}/variants.json`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -140,6 +150,41 @@ export async function createShopifyProgramVariants(name: string, memberPrice: nu
                     memberVariantId = variantData.variant.id.toString();
                 } else {
                     nonMemberVariantId = variantData.variant.id.toString();
+                }
+
+                // Set inventory level if maxParticipants is configured
+                if (maxParticipants && variantData.variant.inventory_item_id) {
+                    try {
+                        // Get the store's primary location
+                        const locRes = await fetch(`https://${storeDomain}/admin/api/2026-01/locations.json`, {
+                            headers: { 'X-Shopify-Access-Token': accessToken },
+                        });
+                        if (locRes.ok) {
+                            const locData = await locRes.json();
+                            const locationId = locData.locations?.[0]?.id;
+                            if (locationId) {
+                                const invRes = await fetch(`https://${storeDomain}/admin/api/2026-01/inventory_levels/set.json`, {
+                                    method: 'POST',
+                                    headers: {
+                                        'Content-Type': 'application/json',
+                                        'X-Shopify-Access-Token': accessToken,
+                                    },
+                                    body: JSON.stringify({
+                                        location_id: locationId,
+                                        inventory_item_id: variantData.variant.inventory_item_id,
+                                        available: maxParticipants,
+                                    })
+                                });
+                                if (invRes.ok) {
+                                    console.log(`[SHOPIFY] Set inventory for variant ${variant.option1} to ${maxParticipants} at location ${locationId}`);
+                                } else {
+                                    console.error(`[SHOPIFY] Failed to set inventory: ${invRes.status}`, await invRes.text());
+                                }
+                            }
+                        }
+                    } catch (invErr) {
+                        console.error("Failed to set Shopify inventory level:", invErr);
+                    }
                 }
             } else {
                 console.error("Failed to create Shopify variant:", await variantRes.text());


### PR DESCRIPTION
## Summary

Upgrades the Shopify integration with the new Client Credentials Grant authentication flow (replacing the static admin access token) and adds inventory management tied to program max participants.

## Changes

### Authentication
- Migrate from `SHOPIFY_ADMIN_ACCESS_TOKEN` to Client Credentials Grant using `SHOPIFY_CLIENT_ID` and `SHOPIFY_CLIENT_SECRET`
- In-memory token caching with 23h55m TTL (tokens expire after 24h)

### Inventory Management
- When `maxParticipants` is set on a program, Shopify variant inventory is set to that value (blocking purchases when sold out)
- When `maxParticipants` is not set, Shopify allows unlimited purchases
- The admin Create Program form now includes a `Max Participants` field with an inline warning when prices are set without a max

### Bug Fixes
- **Member variant selection**: Fixed broken `GET /api/admin/participants/` call (405) by using household membership data instead
- **Hardcoded domain**: Removed `innovationtreehouse.myshopify.com` fallback, now strictly uses `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN`
- **API version**: Upgraded from `2024-01` to `2026-01`
- **Household API**: Now includes active memberships in response

### Required Shopify App Scopes
The Shopify custom app must have these scopes:
- `write_products`
- `write_inventory`
- `read_locations`
- `read_orders`

### Required Environment Variables
```
SHOPIFY_CLIENT_ID=...
SHOPIFY_CLIENT_SECRET=...
SHOPIFY_STORE_DOMAIN=...
NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN=...
SHOPIFY_WEBHOOK_SECRET=...
```

### Tests
- Updated Shopify tests for new auth flow with token cache isolation
- All Shopify tests passing (5/5)
- Pre-existing `cronPostEventAPI.test.ts` failure is unrelated