### PR TITLE
Revert "Fixes #47" - this PR stopped jules from getting any pings when issues were raised

### DIFF
--- a/.github/workflows/jules.yml
+++ b/.github/workflows/jules.yml
@@ -1,14 +1,14 @@
 name: Jules AI Agent
 
-# Trigger only when an issue is labeled
 on:
   issues:
-    types: [labeled]
+    types: [opened, reopened, labeled]
+  issue_comment:
+    types: [created]
 
 jobs:
   jules:
-    # Restrict execution to issues labeled 'jules' and ignore pull requests
-    if: ${{ github.event.label.name == 'jules' && !github.event.issue.pull_request }}
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Reverts innovationtreehouse/checkin#49

Even when issues were labeled like https://github.com/innovationtreehouse/checkin/issues/57, jules was not triggered. 

Let's revert while we work on some way to limit access 