### PR TITLE
fix: remove navbar from kiosk display routes (Fixes #7)

### DIFF
--- a/src/components/ContentWrapper.tsx
+++ b/src/components/ContentWrapper.tsx
@@ -6,7 +6,7 @@ import { Suspense } from "react";
 function ContentWrapperInner({ children }: { children: React.ReactNode }) {
     const pathname = usePathname();
     const searchParams = useSearchParams();
-    const isKioskMode = searchParams.get('mode') === 'kiosk' || searchParams.get('sig');
+    const isKioskMode = searchParams.get('mode') === 'kiosk' || searchParams.get('sig') || pathname?.startsWith('/kioskdisplay');
 
     return (
         <div style={{ paddingTop: isKioskMode ? '0px' : '70px', minHeight: '100vh', cursor: isKioskMode ? 'none' : 'auto' }}>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -24,8 +24,8 @@ function NavBarInner() {
     const toggleMobileMenu = () => setIsMobileMenuOpen(!isMobileMenuOpen);
     const closeMobileMenu = () => setIsMobileMenuOpen(false);
 
-    // Hide navbar entirely in kiosk mode (mode=kiosk param or valid cert signature present)
-    const isKioskMode = searchParams.get('mode') === 'kiosk' || searchParams.get('sig');
+    // Hide navbar entirely in kiosk mode (mode=kiosk param, valid cert signature present, or kioskdisplay route)
+    const isKioskMode = searchParams.get('mode') === 'kiosk' || searchParams.get('sig') || pathname?.startsWith('/kioskdisplay');
     if (isKioskMode) return null;
 
     // Don't show navigation on the homepage if they aren't signed in


### PR DESCRIPTION
Fixes #7

This updates the `NavBar.tsx` and `ContentWrapper.tsx` components to explicitly check if the current `pathname` starts with `/kioskdisplay`. Previously, the kiosk mode would only activate if `?mode=kiosk` or a valid signature was present in the URL query string. This PR completely removes the top navigation bar and its associated padding from all kiosk display pages, as requested.

Testing done: Verified via automated local headless Playwright script that the navbar is no longer present on `/kioskdisplay`. Types successfully passed.

---
*PR created automatically by Jules for task [1693258174091371741](https://jules.google.com/task/1693258174091371741) started by @dkaygithub*