### PR TITLE
Static Program Fees After Creation

### DIFF
--- a/src/app/admin/programs/[id]/page.tsx
+++ b/src/app/admin/programs/[id]/page.tsx
@@ -589,14 +589,14 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                                         Member Price ($)
                                         {program.memberPrice !== null && <span style={{ marginLeft: '0.5rem', fontSize: '0.85rem', color: 'var(--color-primary)' }}>(Current: ${program.memberPrice})</span>}
                                     </label>
-                                    <input type="number" className="glass-input" value={memberPrice} onChange={e => setMemberPrice(e.target.value)} disabled={!isSysAdminOrBoard} style={{ width: '100%', padding: '0.75rem', boxSizing: 'border-box', opacity: !isSysAdminOrBoard ? 0.5 : 1 }} title={!isSysAdminOrBoard ? "Only Board Members can alter program pricing." : ""} />
+                                    <input type="number" className="glass-input" value={memberPrice} onChange={e => setMemberPrice(e.target.value)} disabled={true} style={{ width: '100%', padding: '0.75rem', boxSizing: 'border-box', opacity: 0.5 }} title="Program fees cannot be changed after creation." />
                                 </div>
                                 <div style={{ flex: '1 1 200px', minWidth: '200px' }}>
                                     <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 500 }}>
                                         Non-Member Price ($)
                                         {program.nonMemberPrice !== null && <span style={{ marginLeft: '0.5rem', fontSize: '0.85rem', color: 'var(--color-primary)' }}>(Current: ${program.nonMemberPrice})</span>}
                                     </label>
-                                    <input type="number" className="glass-input" value={nonMemberPrice} onChange={e => setNonMemberPrice(e.target.value)} disabled={!isSysAdminOrBoard} style={{ width: '100%', padding: '0.75rem', boxSizing: 'border-box', opacity: !isSysAdminOrBoard ? 0.5 : 1 }} title={!isSysAdminOrBoard ? "Only Board Members can alter program pricing." : ""} />
+                                    <input type="number" className="glass-input" value={nonMemberPrice} onChange={e => setNonMemberPrice(e.target.value)} disabled={true} style={{ width: '100%', padding: '0.75rem', boxSizing: 'border-box', opacity: 0.5 }} title="Program fees cannot be changed after creation." />
                                 </div>
                             </div>
 

--- a/src/app/api/programs/[id]/route.ts
+++ b/src/app/api/programs/[id]/route.ts
@@ -137,15 +137,6 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
             ...(leadMentorNotificationSettings !== undefined && { leadMentorNotificationSettings }),
         };
 
-        // Only allow sysadmin or board to update prices
-        if (isSysAdminOrBoard) {
-            if (memberPrice !== undefined) {
-                updateData.memberPrice = memberPrice ? parseInt(memberPrice, 10) : null;
-            }
-            if (nonMemberPrice !== undefined) {
-                updateData.nonMemberPrice = nonMemberPrice ? parseInt(nonMemberPrice, 10) : null;
-            }
-        }
 
         const updatedProgram = await prisma.program.update({
             where: { id: programId },


### PR DESCRIPTION
This change ensures that program fees cannot be modified by anyone (including admins and board members) once a program has been created. It includes both frontend UI restrictions (disabled inputs with tooltips) and backend enforcement (ignoring price fields in the PATCH request).

Fixes #59

---
*PR created automatically by Jules for task [15600231990430161102](https://jules.google.com/task/15600231990430161102) started by @dkaygithub*