### PR TITLE
Adjust Jules workflow triggers to include @jules mentions

### DIFF
--- a/.github/workflows/jules.yml
+++ b/.github/workflows/jules.yml
@@ -1,14 +1,25 @@
 name: Jules AI Agent
 
-# Trigger only when an issue is labeled
+# Trigger when an issue is labeled, opened, or edited, or when a comment is created or edited
 on:
   issues:
-    types: [labeled]
+    types: [labeled, opened, edited]
+  issue_comment:
+    types: [created, edited]
 
 jobs:
   jules:
-    # Restrict execution to issues labeled 'jules' and ignore pull requests
-    if: ${{ github.event.label.name == 'jules' && !github.event.issue.pull_request }}
+    # Restrict execution to:
+    # 1. Issues (not pull requests)
+    # 2. EITHER:
+    #    - Labeled 'jules'
+    #    - OR Issue/Comment body contains '@jules' AND author is an organization MEMBER or OWNER
+    if: >
+      !github.event.issue.pull_request && (
+        github.event.label.name == 'jules' ||
+        (github.event_name == 'issues' && contains(github.event.issue.body, '@jules') && (github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'OWNER')) ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@jules') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,6 +37,8 @@ jobs:
             Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}
 
             ${{ github.event.issue.body }}
+
+            ${{ github.event.comment.body && format('Additional context from comment:\n{0}', github.event.comment.body) || '' }}
 
             Process:
             1. **Analysis** - Review the issue and identify the root cause


### PR DESCRIPTION
This PR updates the `.github/workflows/jules.yml` workflow to be more flexible in how Jules is invoked. It now supports:
1. The existing behavior of triggering when the 'jules' label is added to an issue.
2. Triggering when an issue is opened or edited and contains '@jules' in the body, provided the author is an organization MEMBER or OWNER.
3. Triggering when a comment is created or edited on an issue and contains '@jules' in the body, provided the author is an organization MEMBER or OWNER.

Additionally, when triggered by a comment, the comment text is now explicitly passed to the Jules AI agent to provide full context for the request. Pull requests continue to be excluded from these triggers.

Fixes #60

---
*PR created automatically by Jules for task [6918550615219351974](https://jules.google.com/task/6918550615219351974) started by @dkaygithub*