### PR TITLE
Improve sign-out and account switching security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@
 *.pem
 
 # debug
+dev_server.log
+dev_server.pid
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -69,7 +69,7 @@ function NavBarInner() {
                 My Profile
             </button>
             <button
-                onClick={() => { signOut(); closeMobileMenu(); }}
+                onClick={() => { signOut({ callbackUrl: '/' }); closeMobileMenu(); }}
                 style={{
                     background: 'rgba(239, 68, 68, 0.2)',
                     border: '1px solid rgba(239, 68, 68, 0.4)',

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -4,6 +4,7 @@ import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import prisma from "@/lib/prisma";
+import { config } from "@/lib/config";
 
 // NextAuth PrismaAdapter hardcodes `prisma.user` for its user operations.
 // We map `.user` to `.participant` so the adapter can find our custom model.
@@ -38,8 +39,15 @@ export const authOptions: NextAuthOptions = {
     adapter: patchedAdapter,
     providers: [
         GoogleProvider({
-            clientId: process.env.GOOGLE_CLIENT_ID || "",
-            clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
+            clientId: config.googleClientId(),
+            clientSecret: config.googleClientSecret(),
+            authorization: {
+                params: {
+                    prompt: "select_account",
+                    access_type: "offline",
+                    response_type: "code"
+                }
+            },
             profile(profile) {
                 return {
                     id: profile.sub,
@@ -81,7 +89,7 @@ export const authOptions: NextAuthOptions = {
             })
         ] : [])
     ],
-    secret: process.env.NEXTAUTH_SECRET,
+    secret: config.nextAuthSecret(),
     session: {
         strategy: "jwt",
     },


### PR DESCRIPTION
This PR addresses the sign-out functionality by ensuring that session state is correctly reset and that users are prompted to select an account when signing back in.

Key changes:
- In `NavBar.tsx`, the `signOut` call now explicitly redirects to the home page.
- In `auth-options.ts`, the Google provider is updated with the `prompt: 'select_account'` parameter. This is crucial for environments where multiple users might use the same machine, as it forces Google to show the account selection screen instead of automatically logging in with the previous session.
- Authentication options now pull from the centralized `config` utility, which provides better error reporting if required environment variables like `NEXTAUTH_SECRET` are missing.
- Added `/dev_server.log` and `/dev_server.pid` to `.gitignore` to keep the repository clean.

Fixes #73

---
*PR created automatically by Jules for task [5615154079093058843](https://jules.google.com/task/5615154079093058843) started by @dkaygithub*