### PR TITLE
Fixes #77: Require lead mentor when creating a program

### DIFF
--- a/src/app/__tests__/auditLog.test.ts
+++ b/src/app/__tests__/auditLog.test.ts
@@ -88,7 +88,7 @@ describe('AuditLog Integration Tests', () => {
     it('should generate an AuditLog when a Program is created', async () => {
         const req = new Request('http://localhost:4000/api/programs', {
             method: 'POST',
-            body: JSON.stringify({ name: 'Audit Test Program', enrollmentStatus: 'OPEN', begin: new Date() })
+            body: JSON.stringify({ name: 'Audit Test Program', enrollmentStatus: 'OPEN', begin: new Date(), leadMentorId: testAdminId })
         });
 
         const res = await createProgram(req);

--- a/src/app/__tests__/programsAPI.test.ts
+++ b/src/app/__tests__/programsAPI.test.ts
@@ -150,12 +150,23 @@ describe('Programs API Integration Tests', () => {
              expect(data.error).toMatch(/Forbidden/);
         });
 
-        it('should missing required program name', async () => {
+        it('should reject when missing required program name', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, sysadmin: true } });
 
              const req = new Request('http://localhost:4000/api/programs', {
                  method: 'POST',
                  body: JSON.stringify({ leadMentorId: leadId })
+             });
+             const res = await POST(req as any);
+             expect(res.status).toBe(400);
+        });
+
+        it('should reject when missing required leadMentorId', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, sysadmin: true } });
+
+             const req = new Request('http://localhost:4000/api/programs', {
+                 method: 'POST',
+                 body: JSON.stringify({ name: 'Created API Test Program Missing Mentor', minAge: 12, maxAge: 17 })
              });
              const res = await POST(req as any);
              expect(res.status).toBe(400);

--- a/src/app/admin/programs/new/page.tsx
+++ b/src/app/admin/programs/new/page.tsx
@@ -74,6 +74,13 @@ export default function CreateProgramPage() {
         e.preventDefault();
         if (!name) return;
 
+        // Require a lead mentor per issue #77
+        if (!leadMentorId) {
+            setMessage("Lead mentor is required.");
+            setMessageType("error");
+            return;
+        }
+
         setSaving(true);
         setMessage("");
 
@@ -168,7 +175,7 @@ export default function CreateProgramPage() {
 
                             {/* Lead Mentor Selector */}
                             <div style={{ position: 'relative' }}>
-                                <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 500 }}>Lead Mentor / Program Coordinator (Optional)</label>
+                                <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 500 }}>Lead Mentor / Program Coordinator</label>
                                 <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
                                     <input
                                         type="text"

--- a/src/app/api/programs/route.ts
+++ b/src/app/api/programs/route.ts
@@ -110,6 +110,11 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Program name is required" }, { status: 400 });
         }
 
+        // Require a lead mentor per issue #77
+        if (!leadMentorId) {
+            return NextResponse.json({ error: "Lead mentor is required" }, { status: 400 });
+        }
+
         const mPrice = memberPrice ? parseInt(memberPrice, 10) : null;
         const nmPrice = nonMemberPrice ? parseInt(nonMemberPrice, 10) : null;
         const maxPart = maxParticipants ? parseInt(maxParticipants, 10) : null;


### PR DESCRIPTION
Fixes #77

This PR updates the program creation flow to require a lead mentor, as requested in issue #77. 

Changes include:
- Removing the "(Optional)" text from the Lead Mentor label on the frontend program creation form.
- Adding a validation check on the frontend to require a `leadMentorId` before allowing form submission.
- Adding a corresponding validation check on the backend (`POST /api/programs`) to enforce that `leadMentorId` is provided, returning a 400 Bad Request otherwise.
- The Prisma schema (`leadMentorId Int?`) remains unchanged to ensure backwards compatibility with any existing programs that might currently lack a lead mentor.

---
*PR created automatically by Jules for task [5986059975739599473](https://jules.google.com/task/5986059975739599473) started by @dkaygithub*