### PR TITLE
🛡️ Sentinel: [HIGH] Remove insecure dangerouslySetInnerHTML usage

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,3 +120,8 @@ body {
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
+
+/* Kiosk mode cursor hiding */
+.kiosk-mode, .kiosk-mode * {
+  cursor: none !important;
+}

--- a/src/components/ContentWrapper.tsx
+++ b/src/components/ContentWrapper.tsx
@@ -1,20 +1,28 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 
 function ContentWrapperInner({ children }: { children: React.ReactNode }) {
 
     const searchParams = useSearchParams();
     const isKioskMode = searchParams.get('mode') === 'kiosk' || searchParams.get('sig');
 
+    useEffect(() => {
+        if (isKioskMode) {
+            document.body.classList.add('kiosk-mode');
+        } else {
+            document.body.classList.remove('kiosk-mode');
+        }
+
+        // Cleanup on unmount or when isKioskMode changes
+        return () => {
+            document.body.classList.remove('kiosk-mode');
+        };
+    }, [isKioskMode]);
+
     return (
         <div style={{ paddingTop: isKioskMode ? '0px' : '70px', minHeight: '100vh', cursor: isKioskMode ? 'none' : 'auto' }}>
-            {isKioskMode && (
-                <style dangerouslySetInnerHTML={{ __html: `
-                    body, * { cursor: none !important; }
-                `}} />
-            )}
             {children}
         </div>
     );


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `src/components/ContentWrapper.tsx` component used `dangerouslySetInnerHTML` to inject an inline `<style>` tag that applied `cursor: none !important;` to the `body` and all children. While not an immediate XSS vulnerability because the string was hardcoded, using `dangerouslySetInnerHTML` is an insecure React pattern. Furthermore, injecting inline `<style>` tags violates strict Content Security Policies (CSP) that forbid `unsafe-inline`, creating a broader security configuration issue.
🎯 Impact: This pattern prevents the application from enforcing a robust CSP without exceptions, and creates a bad precedent for DOM manipulation in React.
🔧 Fix: Removed `dangerouslySetInnerHTML`. The component now safely uses a `useEffect` hook to toggle a `.kiosk-mode` CSS class on `document.body`. The corresponding CSS rule was added to `src/app/globals.css`. This is inherently safer, CSP-compliant, and leverages standard React paradigms.
✅ Verification: Ran `npm run lint` and visually verified the application in kiosk mode using a Playwright test. The cursor hides successfully via the stylesheet class with no console errors or warnings.

---
*PR created automatically by Jules for task [10814296587771271125](https://jules.google.com/task/10814296587771271125) started by @dkaygithub*