### PR TITLE
feat: containerize for AWS ECS with RDS and automated CD

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -1,0 +1,58 @@
+{
+  "comment": "Template used by the CD workflow. Tokens like <ACCOUNT_ID> are replaced by the workflow before registration.",
+  "family": "checkin-app",
+  "cpu": "512",
+  "memory": "1024",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "executionRoleArn": "arn:aws:iam::<ACCOUNT_ID>:role/checkin-ecs-execution-role",
+  "taskRoleArn": "arn:aws:iam::<ACCOUNT_ID>:role/checkin-ecs-task-role",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "<IMAGE_URI>",
+      "portMappings": [
+        {
+          "containerPort": 4000,
+          "protocol": "tcp"
+        }
+      ],
+      "environment": [
+        { "name": "NODE_ENV", "value": "production" },
+        { "name": "PORT",     "value": "4000" },
+        { "name": "NEXTAUTH_URL", "value": "<NEXTAUTH_URL>" }
+      ],
+      "secrets": [
+        {
+          "name": "DATABASE_URL",
+          "valueFrom": "arn:aws:secretsmanager:<REGION>:<ACCOUNT_ID>:secret:checkin/database-url"
+        },
+        {
+          "name": "NEXTAUTH_SECRET",
+          "valueFrom": "arn:aws:secretsmanager:<REGION>:<ACCOUNT_ID>:secret:checkin/nextauth-secret"
+        },
+        {
+          "name": "GOOGLE_CLIENT_ID",
+          "valueFrom": "arn:aws:secretsmanager:<REGION>:<ACCOUNT_ID>:secret:checkin/google-client-id"
+        },
+        {
+          "name": "GOOGLE_CLIENT_SECRET",
+          "valueFrom": "arn:aws:secretsmanager:<REGION>:<ACCOUNT_ID>:secret:checkin/google-client-secret"
+        },
+        {
+          "name": "RESEND_API_KEY",
+          "valueFrom": "arn:aws:secretsmanager:<REGION>:<ACCOUNT_ID>:secret:checkin/resend-api-key"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/checkin",
+          "awslogs-region": "<REGION>",
+          "awslogs-stream-prefix": "app"
+        }
+      },
+      "essential": true
+    }
+  ]
+}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,209 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:  # allow manual deploys
+
+# Prevent two deploys running in parallel; the second queues behind the first.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  id-token: write  # required for OIDC
+  contents: read
+
+jobs:
+  # ── 1. Tests must pass before any deploy ─────────────────────────────────
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpassword
+          POSTGRES_DB: checkmein_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma Client
+        env:
+          DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"
+        run: npx prisma generate
+
+      - name: Push Prisma Schema
+        env:
+          DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"
+        run: npx prisma db push --accept-data-loss
+
+      - name: Run tests
+        env:
+          DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"
+        run: npm run test:ci
+
+  # ── 2. Build & push Docker image to ECR ───────────────────────────────────
+  build:
+    name: Build & Push to ECR
+    runs-on: ubuntu-latest
+    needs: test
+    outputs:
+      image-uri: ${{ steps.build-push.outputs.image-uri }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push image
+        id: build-push
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: sha-${{ github.sha }}
+        run: |
+          IMAGE_URI="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker build -t "$IMAGE_URI" .
+          docker push "$IMAGE_URI"
+          echo "image-uri=$IMAGE_URI" >> "$GITHUB_OUTPUT"
+
+  # ── 3. Run database migrations (one-off Fargate task) ─────────────────────
+  migrate:
+    name: Run DB Migrations
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # Register a fresh migration task definition with the new image
+      - name: Register migration task definition
+        id: register-migrate-td
+        env:
+          IMAGE_URI: ${{ needs.build.outputs.image-uri }}
+          ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          TD=$(aws ecs describe-task-definition \
+            --task-definition checkin-migrate \
+            --query "taskDefinition" \
+            --output json)
+
+          NEW_TD=$(echo "$TD" | \
+            jq --arg img "$IMAGE_URI" \
+               '.containerDefinitions[0].image = $img
+                | del(.taskDefinitionArn, .revision, .status,
+                       .requiresAttributes, .compatibilities,
+                       .registeredAt, .registeredBy)')
+
+          ARN=$(aws ecs register-task-definition \
+            --cli-input-json "$NEW_TD" \
+            --query "taskDefinition.taskDefinitionArn" \
+            --output text)
+
+          echo "task-def-arn=$ARN" >> "$GITHUB_OUTPUT"
+
+      - name: Run migration task
+        id: run-migrate
+        env:
+          CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          SUBNETS: ${{ secrets.ECS_PRIVATE_SUBNETS }}
+          SG: ${{ secrets.ECS_SECURITY_GROUP }}
+          TASK_DEF: ${{ steps.register-migrate-td.outputs.task-def-arn }}
+        run: |
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "$CLUSTER" \
+            --task-definition "$TASK_DEF" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG],assignPublicIp=DISABLED}" \
+            --query "tasks[0].taskArn" \
+            --output text)
+
+          echo "Waiting for migration task $TASK_ARN ..."
+          aws ecs wait tasks-stopped \
+            --cluster "$CLUSTER" \
+            --tasks "$TASK_ARN"
+
+          EXIT_CODE=$(aws ecs describe-tasks \
+            --cluster "$CLUSTER" \
+            --tasks "$TASK_ARN" \
+            --query "tasks[0].containers[0].exitCode" \
+            --output text)
+
+          echo "Migration container exited with code: $EXIT_CODE"
+          [ "$EXIT_CODE" = "0" ] || exit 1
+
+  # ── 4. Deploy updated app task definition to ECS ──────────────────────────
+  deploy:
+    name: Deploy to ECS
+    runs-on: ubuntu-latest
+    needs: [build, migrate]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Render task definition with new image
+        id: render-td
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: .aws/task-definition.json
+          container-name: app
+          image: ${{ needs.build.outputs.image-uri }}
+          environment-variables: |
+            NEXTAUTH_URL=${{ secrets.NEXTAUTH_URL }}
+
+      - name: Substitute account/region tokens in task definition
+        env:
+          ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          sed -i \
+            -e "s|<ACCOUNT_ID>|$ACCOUNT_ID|g" \
+            -e "s|<REGION>|$REGION|g" \
+            "${{ steps.render-td.outputs.task-definition }}"
+
+      - name: Deploy to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-td.outputs.task-definition }}
+          service: ${{ secrets.ECS_SERVICE }}
+          cluster: ${{ secrets.ECS_CLUSTER }}
+          wait-for-service-stability: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Stage 1: Install dependencies
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci
 
 # Stage 2: Build the app
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -13,7 +13,7 @@ RUN npx prisma generate
 RUN npm run build
 
 # Stage 3: Production image
-FROM node:20-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
@@ -22,6 +22,13 @@ COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/prisma ./prisma
+
+# Include prisma CLI so migrations can be run as a separate ECS task
+# using the same image with command override:
+#   ["node_modules/.bin/prisma", "migrate", "deploy"]
+COPY --from=builder /app/node_modules/.bin/prisma ./node_modules/.bin/prisma
+COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
+COPY --from=builder /app/node_modules/@prisma/engines ./node_modules/@prisma/engines
 
 EXPOSE 4000
 ENV PORT=4000

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,167 @@
+# AWS ECS Deployment
+
+This directory contains CloudFormation templates to provision the AWS infrastructure
+for the checkin app on ECS Fargate + RDS PostgreSQL.
+
+## Architecture
+
+```
+Internet
+   │
+   ▼
+[ALB]  ←─ public subnets (2 AZs)
+   │
+   ▼
+[ECS Fargate service]  ←─ private subnets
+   │                        (Node 24 container, port 4000)
+   ▼
+[RDS PostgreSQL 15]  ←─ private subnets
+```
+
+Secrets (database URL, OAuth credentials, etc.) are stored in **AWS Secrets Manager**
+and injected into the container as environment variables at launch time.
+
+The CD pipeline uses **GitHub Actions OIDC** — no static AWS credentials are stored
+in GitHub; the workflow exchanges a short-lived GitHub token for an AWS role.
+
+---
+
+## One-time setup
+
+### 1. Deploy the VPC stack
+
+```bash
+aws cloudformation deploy \
+  --stack-name checkin-vpc \
+  --template-file cloudformation/vpc.yml \
+  --capabilities CAPABILITY_IAM \
+  --region us-east-1
+```
+
+### 2. Deploy the app stack
+
+Collect the values you need first:
+
+| Parameter | How to get it |
+|-----------|--------------|
+| `DBPassword` | Generate: `openssl rand -base64 24` |
+| `NextAuthSecret` | Generate: `openssl rand -base64 32` |
+| `GoogleClientId` | Google Cloud Console → OAuth 2.0 credentials |
+| `GoogleClientSecret` | Google Cloud Console → OAuth 2.0 credentials |
+| `ResendApiKey` | resend.com dashboard |
+| `GitHubOrg` | Your GitHub username or org (e.g. `myorg`) |
+| `NextAuthUrl` | Leave blank for now; update after step 3 |
+
+```bash
+aws cloudformation deploy \
+  --stack-name checkin-app \
+  --template-file cloudformation/app.yml \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+  --region us-east-1 \
+  --parameter-overrides \
+      DBPassword=<db-password> \
+      NextAuthSecret=<nextauth-secret> \
+      GoogleClientId=<google-client-id> \
+      GoogleClientSecret=<google-client-secret> \
+      ResendApiKey=<resend-api-key> \
+      GitHubOrg=<your-github-org> \
+      GitHubRepo=checkin
+```
+
+> The initial deploy uses a placeholder image for the ECS task definition.
+> The first CD pipeline run (after step 4) will replace it with the real image.
+
+### 3. Note the stack outputs
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name checkin-app \
+  --query "Stacks[0].Outputs" \
+  --output table
+```
+
+Key outputs:
+
+| Output | Use |
+|--------|-----|
+| `ALBDnsName` | Point your DNS CNAME here |
+| `GitHubActionsRoleArn` | Set as `AWS_ROLE_ARN` in GitHub secrets |
+| `ECRRepositoryUri` | Set as `ECR_REPOSITORY` in GitHub secrets |
+| `ECSClusterName` | Set as `ECS_CLUSTER` in GitHub secrets |
+| `ECSServiceName` | Set as `ECS_SERVICE` in GitHub secrets |
+| `RDSEndpoint` | Already embedded in the `checkin/database-url` secret |
+
+### 4. Set GitHub Actions secrets
+
+In your GitHub repo → Settings → Secrets and variables → Actions, add:
+
+| Secret | Value |
+|--------|-------|
+| `AWS_ROLE_ARN` | From `GitHubActionsRoleArn` output |
+| `AWS_REGION` | e.g. `us-east-1` |
+| `AWS_ACCOUNT_ID` | Your 12-digit AWS account ID |
+| `ECR_REPOSITORY` | Repository name portion of `ECRRepositoryUri` (e.g. `checkin`) |
+| `ECS_CLUSTER` | From `ECSClusterName` output |
+| `ECS_SERVICE` | From `ECSServiceName` output |
+| `ECS_PRIVATE_SUBNETS` | Comma-separated private subnet IDs (from vpc stack outputs) |
+| `ECS_SECURITY_GROUP` | ECS security group ID (from vpc stack outputs) |
+| `NEXTAUTH_URL` | `http://<ALBDnsName>` or your custom domain |
+
+### 5. Push to `main` to trigger the first deployment
+
+```bash
+git push origin main
+```
+
+The CD pipeline will:
+1. Run all tests against a ephemeral PostgreSQL container
+2. Build the Node 24 Docker image and push to ECR
+3. Run `prisma migrate deploy` as a one-off Fargate task
+4. Deploy the updated task definition to the ECS service
+
+---
+
+## Updating secrets after initial deploy
+
+To update any secret (e.g. rotate credentials):
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id checkin/google-client-secret \
+  --secret-string "new-value"
+```
+
+Then redeploy the ECS service to pick up the new value:
+
+```bash
+aws ecs update-service \
+  --cluster checkin-cluster \
+  --service checkin-service \
+  --force-new-deployment
+```
+
+---
+
+## HTTPS / custom domain
+
+The ALB listener is HTTP-only by default. To enable HTTPS:
+
+1. Request a certificate in **AWS Certificate Manager** for your domain.
+2. Add an HTTPS listener in the `app.yml` template (port 443, your ACM ARN).
+3. Redirect HTTP → HTTPS on the port 80 listener.
+4. Update `NextAuthUrl` and the `checkin/database-url` secret if needed.
+
+---
+
+## Costs (approximate, us-east-1, as of 2025)
+
+| Resource | Approx. monthly |
+|----------|----------------|
+| Fargate (0.5 vCPU / 1 GB, 1 task) | ~$15 |
+| RDS db.t3.micro (PostgreSQL) | ~$15 |
+| NAT Gateway | ~$35 |
+| ALB | ~$18 |
+| ECR storage | ~$1 |
+
+Smallest useful monthly cost is around **$85**. Swap to `db.t3.micro` Multi-AZ
+or increase Fargate count for production hardening.

--- a/infra/cloudformation/app.yml
+++ b/infra/cloudformation/app.yml
@@ -1,0 +1,522 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  checkin – ECR, RDS PostgreSQL, ECS Fargate cluster + service, ALB, IAM roles,
+  Secrets Manager, and GitHub Actions OIDC trust.
+  Requires the vpc.yml stack to be deployed first.
+
+Parameters:
+  AppName:
+    Type: String
+    Default: checkin
+  AppPort:
+    Type: Number
+    Default: 4000
+  Environment:
+    Type: String
+    Default: production
+    AllowedValues: [production, staging]
+
+  # ECS sizing
+  TaskCpu:
+    Type: Number
+    Default: 512
+    Description: Fargate task CPU units (512 = 0.5 vCPU)
+  TaskMemory:
+    Type: Number
+    Default: 1024
+    Description: Fargate task memory in MB
+  DesiredCount:
+    Type: Number
+    Default: 1
+
+  # RDS
+  DBName:
+    Type: String
+    Default: checkmein
+  DBUsername:
+    Type: String
+    Default: checkinapp
+  DBPassword:
+    Type: String
+    NoEcho: true
+    MinLength: 16
+    Description: Master password for the RDS instance (store this securely)
+  DBInstanceClass:
+    Type: String
+    Default: db.t3.micro
+
+  # App config — must be supplied at deploy time
+  NextAuthUrl:
+    Type: String
+    Description: >
+      Public URL of the app, e.g. https://checkin.example.com or the ALB DNS name.
+      Can be updated after first deploy once you know the ALB URL.
+    Default: ""
+
+  # Secrets that must be set manually in the AWS console after stack creation.
+  # The stack creates the Secrets Manager entries; you fill in the real values.
+  NextAuthSecret:
+    Type: String
+    NoEcho: true
+    Default: "REPLACE_ME"
+    Description: Random secret for NextAuth session encryption (openssl rand -base64 32)
+  GoogleClientId:
+    Type: String
+    Default: "REPLACE_ME"
+    Description: Google OAuth2 client ID
+  GoogleClientSecret:
+    Type: String
+    NoEcho: true
+    Default: "REPLACE_ME"
+    Description: Google OAuth2 client secret
+  ResendApiKey:
+    Type: String
+    NoEcho: true
+    Default: "REPLACE_ME"
+    Description: Resend transactional email API key
+
+  # GitHub OIDC — for the CD workflow to assume the deploy role
+  GitHubOrg:
+    Type: String
+    Description: GitHub organisation or username that owns the repo
+  GitHubRepo:
+    Type: String
+    Default: checkin
+    Description: GitHub repository name
+
+Resources:
+  # ── ECR ─────────────────────────────────────────────────────────────────────
+  ECRRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Ref AppName
+      ImageScanningConfiguration:
+        ScanOnPush: true
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Keep last 10 sha- tagged images",
+                "selection": {
+                  "tagStatus": "tagged",
+                  "tagPrefixList": ["sha-"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 10
+                },
+                "action": { "type": "expire" }
+              },
+              {
+                "rulePriority": 2,
+                "description": "Expire untagged images after 7 days",
+                "selection": {
+                  "tagStatus": "untagged",
+                  "countType": "sinceImagePushed",
+                  "countUnit": "days",
+                  "countNumber": 7
+                },
+                "action": { "type": "expire" }
+              }
+            ]
+          }
+
+  # ── RDS PostgreSQL ──────────────────────────────────────────────────────────
+  DBSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Private subnets for RDS
+      SubnetIds:
+        - Fn::ImportValue: !Sub "${AppName}-PrivateSubnet1Id"
+        - Fn::ImportValue: !Sub "${AppName}-PrivateSubnet2Id"
+
+  DBInstance:
+    Type: AWS::RDS::DBInstance
+    DeletionPolicy: Snapshot
+    UpdateReplacePolicy: Snapshot
+    Properties:
+      DBName: !Ref DBName
+      MasterUsername: !Ref DBUsername
+      MasterUserPassword: !Ref DBPassword
+      DBInstanceClass: !Ref DBInstanceClass
+      Engine: postgres
+      EngineVersion: "15"
+      AllocatedStorage: "20"
+      StorageType: gp3
+      StorageEncrypted: true
+      MultiAZ: false
+      PubliclyAccessible: false
+      DBSubnetGroupName: !Ref DBSubnetGroup
+      VPCSecurityGroups:
+        - Fn::ImportValue: !Sub "${AppName}-RDSSecurityGroupId"
+      BackupRetentionPeriod: 7
+      DeletionProtection: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-db"
+
+  # ── Secrets Manager ─────────────────────────────────────────────────────────
+  SecretDatabaseUrl:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "${AppName}/database-url"
+      Description: Full PostgreSQL connection string for the app
+      # Constructed automatically from RDS endpoint after stack creation.
+      # The CD workflow injects DATABASE_URL using this secret.
+      SecretString: !Sub
+        - "postgresql://${DBUsername}:${DBPassword}@${Endpoint}/${DBName}?schema=public"
+        - Endpoint: !GetAtt DBInstance.Endpoint.Address
+
+  SecretNextAuthSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "${AppName}/nextauth-secret"
+      Description: NextAuth.js session encryption secret
+      SecretString: !Ref NextAuthSecret
+
+  SecretGoogleClientId:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "${AppName}/google-client-id"
+      Description: Google OAuth2 client ID
+      SecretString: !Ref GoogleClientId
+
+  SecretGoogleClientSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "${AppName}/google-client-secret"
+      Description: Google OAuth2 client secret
+      SecretString: !Ref GoogleClientSecret
+
+  SecretResendApiKey:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: !Sub "${AppName}/resend-api-key"
+      Description: Resend transactional email API key
+      SecretString: !Ref ResendApiKey
+
+  # ── IAM ─────────────────────────────────────────────────────────────────────
+  ECSTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AppName}-ecs-execution-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: SecretsAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref SecretDatabaseUrl
+                  - !Ref SecretNextAuthSecret
+                  - !Ref SecretGoogleClientId
+                  - !Ref SecretGoogleClientSecret
+                  - !Ref SecretResendApiKey
+
+  ECSTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AppName}-ecs-task-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      # Add bucket/queue/etc. permissions here if the app needs them
+
+  # GitHub Actions OIDC provider + deploy role
+  GitHubOIDCProvider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        - 6938fd4d98bab03faadb97b34396831e3780aea
+
+  GitHubActionsDeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AppName}-github-deploy-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Ref GitHubOIDCProvider
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                "token.actions.githubusercontent.com:aud": sts.amazonaws.com
+              StringLike:
+                "token.actions.githubusercontent.com:sub":
+                  !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/main"
+      Policies:
+        - PolicyName: ECSDeployPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                  - ecr:InitiateLayerUpload
+                  - ecr:UploadLayerPart
+                  - ecr:CompleteLayerUpload
+                  - ecr:PutImage
+                Resource: !GetAtt ECRRepository.Arn
+              - Effect: Allow
+                Action:
+                  - ecs:RegisterTaskDefinition
+                  - ecs:DescribeTaskDefinition
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ecs:UpdateService
+                  - ecs:DescribeServices
+                  - ecs:RunTask
+                  - ecs:DescribeTasks
+                  - ecs:StopTask
+                Resource: "*"
+                Condition:
+                  ArnLike:
+                    "ecs:cluster": !GetAtt ECSCluster.Arn
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  - !GetAtt ECSTaskExecutionRole.Arn
+                  - !GetAtt ECSTaskRole.Arn
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !GetAtt AppLogGroup.Arn
+
+  # ── CloudWatch Logs ──────────────────────────────────────────────────────────
+  AppLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/ecs/${AppName}"
+      RetentionInDays: 30
+
+  # ── ALB ─────────────────────────────────────────────────────────────────────
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub "${AppName}-alb"
+      Scheme: internet-facing
+      Type: application
+      Subnets:
+        - Fn::ImportValue: !Sub "${AppName}-PublicSubnet1Id"
+        - Fn::ImportValue: !Sub "${AppName}-PublicSubnet2Id"
+      SecurityGroups:
+        - Fn::ImportValue: !Sub "${AppName}-ALBSecurityGroupId"
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "${AppName}-tg"
+      Port: !Ref AppPort
+      Protocol: HTTP
+      TargetType: ip
+      VpcId:
+        Fn::ImportValue: !Sub "${AppName}-VpcId"
+      HealthCheckPath: /api/health
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+
+  HTTPListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+      # To enable HTTPS: add an AWS::ElasticLoadBalancingV2::Listener on port 443
+      # with your ACM certificate ARN, then redirect HTTP → HTTPS here.
+
+  # ── ECS ─────────────────────────────────────────────────────────────────────
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub "${AppName}-cluster"
+      CapacityProviders:
+        - FARGATE
+        - FARGATE_SPOT
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+
+  AppTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub "${AppName}-app"
+      Cpu: !Ref TaskCpu
+      Memory: !Ref TaskMemory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt ECSTaskRole.Arn
+      ContainerDefinitions:
+        - Name: app
+          # Image is updated on every deployment by the CD workflow.
+          # The initial placeholder lets the stack deploy before the first push.
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${AppName}:latest"
+          PortMappings:
+            - ContainerPort: !Ref AppPort
+              Protocol: tcp
+          Environment:
+            - Name: NODE_ENV
+              Value: production
+            - Name: PORT
+              Value: !Sub "${AppPort}"
+            - Name: NEXTAUTH_URL
+              Value: !Ref NextAuthUrl
+          Secrets:
+            - Name: DATABASE_URL
+              ValueFrom: !Ref SecretDatabaseUrl
+            - Name: NEXTAUTH_SECRET
+              ValueFrom: !Ref SecretNextAuthSecret
+            - Name: GOOGLE_CLIENT_ID
+              ValueFrom: !Ref SecretGoogleClientId
+            - Name: GOOGLE_CLIENT_SECRET
+              ValueFrom: !Ref SecretGoogleClientSecret
+            - Name: RESEND_API_KEY
+              ValueFrom: !Ref SecretResendApiKey
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref AppLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: app
+          Essential: true
+
+  # Separate task definition used only for running migrations (one-off ECS task)
+  MigrateTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub "${AppName}-migrate"
+      Cpu: !Ref TaskCpu
+      Memory: !Ref TaskMemory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt ECSTaskRole.Arn
+      ContainerDefinitions:
+        - Name: migrate
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${AppName}:latest"
+          Command:
+            - node_modules/.bin/prisma
+            - migrate
+            - deploy
+          Environment:
+            - Name: NODE_ENV
+              Value: production
+          Secrets:
+            - Name: DATABASE_URL
+              ValueFrom: !Ref SecretDatabaseUrl
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref AppLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: migrate
+          Essential: true
+
+  ECSService:
+    Type: AWS::ECS::Service
+    DependsOn: HTTPListener
+    Properties:
+      ServiceName: !Sub "${AppName}-service"
+      Cluster: !Ref ECSCluster
+      TaskDefinition: !Ref AppTaskDefinition
+      DesiredCount: !Ref DesiredCount
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets:
+            - Fn::ImportValue: !Sub "${AppName}-PrivateSubnet1Id"
+            - Fn::ImportValue: !Sub "${AppName}-PrivateSubnet2Id"
+          SecurityGroups:
+            - Fn::ImportValue: !Sub "${AppName}-ECSSecurityGroupId"
+      LoadBalancers:
+        - ContainerName: app
+          ContainerPort: !Ref AppPort
+          TargetGroupArn: !Ref TargetGroup
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      DeploymentController:
+        Type: ECS
+
+Outputs:
+  ECRRepositoryUri:
+    Value: !GetAtt ECRRepository.RepositoryUri
+    Export:
+      Name: !Sub "${AppName}-ECRRepositoryUri"
+
+  ECSClusterName:
+    Value: !Ref ECSCluster
+    Export:
+      Name: !Sub "${AppName}-ECSClusterName"
+
+  ECSServiceName:
+    Value: !GetAtt ECSService.Name
+    Export:
+      Name: !Sub "${AppName}-ECSServiceName"
+
+  AppTaskDefinitionFamily:
+    Value: !Sub "${AppName}-app"
+    Export:
+      Name: !Sub "${AppName}-AppTaskFamily"
+
+  MigrateTaskDefinitionFamily:
+    Value: !Sub "${AppName}-migrate"
+    Export:
+      Name: !Sub "${AppName}-MigrateTaskFamily"
+
+  GitHubActionsRoleArn:
+    Value: !GetAtt GitHubActionsDeployRole.Arn
+    Description: ARN to set as AWS_ROLE_ARN in GitHub Actions secrets
+    Export:
+      Name: !Sub "${AppName}-GitHubActionsRoleArn"
+
+  ALBDnsName:
+    Value: !GetAtt LoadBalancer.DNSName
+    Description: >
+      Set this as your DNS CNAME target and update NextAuthUrl / NEXTAUTH_URL
+      in the Secrets Manager secret once the stack is up.
+
+  RDSEndpoint:
+    Value: !GetAtt DBInstance.Endpoint.Address
+    Description: RDS hostname (already embedded in the database-url secret)
+
+  AppLogGroupName:
+    Value: !Ref AppLogGroup

--- a/infra/cloudformation/vpc.yml
+++ b/infra/cloudformation/vpc.yml
@@ -1,0 +1,254 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  checkin – VPC, subnets, internet gateway, NAT gateway, and security groups.
+  Deploy this stack first; the app stack imports its outputs.
+
+Parameters:
+  AppName:
+    Type: String
+    Default: checkin
+  VpcCidr:
+    Type: String
+    Default: "10.0.0.0/16"
+  PublicSubnet1Cidr:
+    Type: String
+    Default: "10.0.0.0/24"
+  PublicSubnet2Cidr:
+    Type: String
+    Default: "10.0.1.0/24"
+  PrivateSubnet1Cidr:
+    Type: String
+    Default: "10.0.10.0/24"
+  PrivateSubnet2Cidr:
+    Type: String
+    Default: "10.0.11.0/24"
+  AppPort:
+    Type: Number
+    Default: 4000
+
+Resources:
+  # ── VPC ────────────────────────────────────────────────────────────────────
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-vpc"
+
+  # ── Public subnets (ALB) ────────────────────────────────────────────────────
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Ref PublicSubnet1Cidr
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-public-1"
+
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Ref PublicSubnet2Cidr
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-public-2"
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-igw"
+
+  IGWAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-public-rt"
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: IGWAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnet1RTAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet1
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnet2RTAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref PublicRouteTable
+
+  # ── Private subnets (ECS tasks, RDS) ───────────────────────────────────────
+  PrivateSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Ref PrivateSubnet1Cidr
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-private-1"
+
+  PrivateSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Ref PrivateSubnet2Cidr
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-private-2"
+
+  NatEIP:
+    Type: AWS::EC2::EIP
+    DependsOn: IGWAttachment
+    Properties:
+      Domain: vpc
+
+  NatGateway:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatEIP.AllocationId
+      SubnetId: !Ref PublicSubnet1
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-nat"
+
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-private-rt"
+
+  PrivateRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId: !Ref NatGateway
+
+  PrivateSubnet1RTAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet1
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnet2RTAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet2
+      RouteTableId: !Ref PrivateRouteTable
+
+  # ── Security groups ─────────────────────────────────────────────────────────
+  ALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow HTTP/HTTPS inbound to the load balancer
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: "0.0.0.0/0"
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: "0.0.0.0/0"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-alb-sg"
+
+  ECSSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow traffic from ALB to ECS tasks
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref AppPort
+          ToPort: !Ref AppPort
+          SourceSecurityGroupId: !Ref ALBSecurityGroup
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-ecs-sg"
+
+  RDSSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow PostgreSQL from ECS tasks only
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+      Tags:
+        - Key: Name
+          Value: !Sub "${AppName}-rds-sg"
+
+Outputs:
+  VPCId:
+    Value: !Ref VPC
+    Export:
+      Name: !Sub "${AppName}-VpcId"
+
+  PublicSubnet1Id:
+    Value: !Ref PublicSubnet1
+    Export:
+      Name: !Sub "${AppName}-PublicSubnet1Id"
+
+  PublicSubnet2Id:
+    Value: !Ref PublicSubnet2
+    Export:
+      Name: !Sub "${AppName}-PublicSubnet2Id"
+
+  PrivateSubnet1Id:
+    Value: !Ref PrivateSubnet1
+    Export:
+      Name: !Sub "${AppName}-PrivateSubnet1Id"
+
+  PrivateSubnet2Id:
+    Value: !Ref PrivateSubnet2
+    Export:
+      Name: !Sub "${AppName}-PrivateSubnet2Id"
+
+  ALBSecurityGroupId:
+    Value: !Ref ALBSecurityGroup
+    Export:
+      Name: !Sub "${AppName}-ALBSecurityGroupId"
+
+  ECSSecurityGroupId:
+    Value: !Ref ECSSecurityGroup
+    Export:
+      Name: !Sub "${AppName}-ECSSecurityGroupId"
+
+  RDSSecurityGroupId:
+    Value: !Ref RDSSecurityGroup
+    Export:
+      Name: !Sub "${AppName}-RDSSecurityGroupId"


### PR DESCRIPTION
- Dockerfile: upgrade to Node 24; copy Prisma CLI into the runner stage so the same image can run migrations as a separate ECS task
- infra/cloudformation/vpc.yml: VPC, public/private subnets across 2 AZs, IGW, NAT gateway, and security groups for ALB / ECS / RDS
- infra/cloudformation/app.yml: ECR repository, RDS PostgreSQL 15, ECS Fargate cluster + app service, ALB, IAM roles (ECS execution, task, and GitHub Actions OIDC deploy role), Secrets Manager entries for all runtime secrets, and a separate migrate task definition
- .aws/task-definition.json: task definition template consumed by the CD workflow on every deploy
- .github/workflows/cd.yml: four-stage CD pipeline — test → build & push to ECR → run prisma migrate deploy as one-off Fargate task → deploy updated task definition to ECS service; uses GitHub OIDC (no static AWS credentials stored in GitHub)
- .github/workflows/ci.yml: bump Node to 24 to match runtime