### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix length leak vulnerability in cron authorization

### DIFF
--- a/src/app/api/cron/nightly/route.ts
+++ b/src/app/api/cron/nightly/route.ts
@@ -1,22 +1,11 @@
 import { NextResponse } from "next/server";
-import crypto from "crypto";
 import prisma from "@/lib/prisma";
 import { processPostEventEmails } from "@/lib/postEventEmails";
 import { processVisitCheckout } from "@/lib/attendanceTransitions";
+import { isAuthorizedCron } from "@/lib/cron-auth";
 
 export async function GET(req: Request) {
-    const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
-
-    if (!cronSecret || !authHeader) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const expectedHeader = `Bearer ${cronSecret}`;
-    const providedBuffer = Buffer.from(authHeader);
-    const expectedBuffer = Buffer.from(expectedHeader);
-
-    if (providedBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
+    if (!isAuthorizedCron(req)) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/src/app/api/cron/pending-participants/route.ts
+++ b/src/app/api/cron/pending-participants/route.ts
@@ -1,20 +1,9 @@
 import { NextResponse } from "next/server";
-import crypto from "crypto";
 import prisma from "@/lib/prisma";
+import { isAuthorizedCron } from "@/lib/cron-auth";
 
 export async function GET(req: Request) {
-    const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
-
-    if (!cronSecret || !authHeader) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const expectedHeader = `Bearer ${cronSecret}`;
-    const providedBuffer = Buffer.from(authHeader);
-    const expectedBuffer = Buffer.from(expectedHeader);
-
-    if (providedBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
+    if (!isAuthorizedCron(req)) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/src/app/api/cron/post-event/route.ts
+++ b/src/app/api/cron/post-event/route.ts
@@ -1,24 +1,13 @@
 import { NextResponse } from "next/server";
-import crypto from "crypto";
 import { processPostEventEmails } from "@/lib/postEventEmails";
+import { isAuthorizedCron } from "@/lib/cron-auth";
 
 /**
  * Expected to be called by an external CRON trigger (e.g. Vercel Cron or CloudWatch Events)
  * GET /api/cron/post-event
  */
 export async function GET(req: Request) {
-    const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
-
-    if (!cronSecret || !authHeader) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const expectedHeader = `Bearer ${cronSecret}`;
-    const providedBuffer = Buffer.from(authHeader);
-    const expectedBuffer = Buffer.from(expectedHeader);
-
-    if (providedBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
+    if (!isAuthorizedCron(req)) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -1,25 +1,14 @@
 import { NextResponse } from "next/server";
-import crypto from "crypto";
 import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
+import { isAuthorizedCron } from "@/lib/cron-auth";
 
 /**
  * Expected to be called by an external CRON trigger (e.g. Vercel Cron or CloudWatch Events)
  * GET /api/cron/reminders
  */
 export async function GET(req: Request) {
-    const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
-
-    if (!cronSecret || !authHeader) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const expectedHeader = `Bearer ${cronSecret}`;
-    const providedBuffer = Buffer.from(authHeader);
-    const expectedBuffer = Buffer.from(expectedHeader);
-
-    if (providedBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
+    if (!isAuthorizedCron(req)) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/src/lib/__tests__/cron-auth.test.ts
+++ b/src/lib/__tests__/cron-auth.test.ts
@@ -1,0 +1,63 @@
+import { isAuthorizedCron } from '../cron-auth';
+
+// Mock logger to avoid console spew during tests
+jest.mock('@/lib/logger', () => ({
+    logger: {
+        error: jest.fn(),
+    },
+}));
+
+describe('isAuthorizedCron', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env = { ...originalEnv };
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('returns true for a valid authorization header', () => {
+        process.env.CRON_SECRET = 'valid-secret';
+        const req = {
+            headers: new Headers({
+                authorization: 'Bearer valid-secret',
+            }),
+        } as unknown as Request;
+
+        expect(isAuthorizedCron(req)).toBe(true);
+    });
+
+    it('returns false for an invalid authorization header', () => {
+        process.env.CRON_SECRET = 'valid-secret';
+        const req = {
+            headers: new Headers({
+                authorization: 'Bearer invalid-secret',
+            }),
+        } as unknown as Request;
+
+        expect(isAuthorizedCron(req)).toBe(false);
+    });
+
+    it('returns false if the authorization header is missing', () => {
+        process.env.CRON_SECRET = 'valid-secret';
+        const req = {
+            headers: new Headers(),
+        } as unknown as Request;
+
+        expect(isAuthorizedCron(req)).toBe(false);
+    });
+
+    it('returns false if CRON_SECRET is missing', () => {
+        delete process.env.CRON_SECRET;
+        const req = {
+            headers: new Headers({
+                authorization: 'Bearer any-secret',
+            }),
+        } as unknown as Request;
+
+        expect(isAuthorizedCron(req)).toBe(false);
+    });
+});

--- a/src/lib/cron-auth.ts
+++ b/src/lib/cron-auth.ts
@@ -1,0 +1,32 @@
+import crypto from "crypto";
+import { logger } from "@/lib/logger";
+
+/**
+ * Validates the authorization header for cron endpoints against process.env.CRON_SECRET.
+ * Uses SHA-256 hashing to prevent timing attacks and length leakage.
+ *
+ * @param req The incoming Request object
+ * @returns boolean indicating if the request is authorized
+ */
+export function isAuthorizedCron(req: Request): boolean {
+    const authHeader = req.headers.get("authorization");
+    const cronSecret = process.env.CRON_SECRET;
+
+    if (!cronSecret) {
+        logger.error("Cron secret is not configured in environment variables.");
+        return false;
+    }
+
+    if (!authHeader) {
+        return false;
+    }
+
+    const expectedHeader = `Bearer ${cronSecret}`;
+
+    // Hash both headers before comparing to prevent length leakage
+    // since timingSafeEqual fails fast if lengths don't match
+    const providedHash = crypto.createHash('sha256').update(authHeader).digest();
+    const expectedHash = crypto.createHash('sha256').update(expectedHeader).digest();
+
+    return crypto.timingSafeEqual(providedHash, expectedHash);
+}


### PR DESCRIPTION
## 🚨 Severity
MEDIUM

## 💡 Vulnerability
The cron job endpoints in `src/app/api/cron/` authenticated requests via an `authorization` header containing `Bearer ${process.env.CRON_SECRET}`. While they properly used `crypto.timingSafeEqual()` for comparison, they first checked if `providedBuffer.length !== expectedBuffer.length`, failing early if they did not match. This allowed a theoretical attacker to infer the exact length of `CRON_SECRET` through timing analysis, slightly weakening the secret's protection.

## 🎯 Impact
An attacker with network access could theoretically iterate through header lengths, measuring server response times to discover the exact length of the expected secret. 

## 🛠️ Fix
- Created a centralized `isAuthorizedCron` utility in `src/lib/cron-auth.ts`.
- The new utility hashes both the provided header and the expected secret using `crypto.createHash('sha256')` before comparing them with `crypto.timingSafeEqual`. This guarantees that both buffers being compared are always exactly 32 bytes long, eliminating any length-based early-exit leaks.
- Refactored `nightly`, `pending-participants`, `post-event`, and `reminders` cron endpoints to use the shared, secure utility.
- Added comprehensive unit tests in `src/lib/__tests__/cron-auth.test.ts`.

## ✅ Verification
- All endpoints correctly authorize with the valid secret.
- Full unit tests for the utility pass: `npm test src/lib/__tests__/cron-auth.test.ts`.
- `crypto.timingSafeEqual()` now correctly protects both timing AND length.

---
*PR created automatically by Jules for task [12244290823947968059](https://jules.google.com/task/12244290823947968059) started by @dkaygithub*