### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix sensitive data exposure in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Used `dangerouslySetInnerHTML` to inject CSS dynamically in React components (`src/components/ContentWrapper.tsx`).
 **Learning:** `dangerouslySetInnerHTML` can open up possibilities for XSS, even if it's currently injecting a static or semi-static string. It bypasses React's built-in escaping mechanisms. The project explicitly avoids using `dangerouslySetInnerHTML` for CSS injection in React components, favoring global CSS rules and class toggling on root elements like `body` (from memory).
 **Prevention:** Avoid `dangerouslySetInnerHTML` unless absolutely necessary. Use CSS classes or inline styles with React's `style` prop instead. For global styles, toggle a class on a root element (like `body`) using a `useEffect` hook.
+## 2025-02-28 - Information Exposure in Email Module
+**Vulnerability:** The email utility (`src/lib/email.ts`) was logging the entire HTML payload of emails directly to the server's stdout (`console.log`) whenever the `RESEND_API_KEY` was missing (e.g., in development or fallback scenarios).
+**Learning:** Developers frequently log complete payloads during development or in "dry-run" modes to verify contents without realizing that production or shared-environment logs will permanently capture sensitive user information like password resets, OTP codes, or PII contained within those email bodies.
+**Prevention:** Never log the complete payload or body of communications (emails, SMS, etc.). Log only necessary metadata such as the recipient and subject for auditing/debugging purposes.

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -13,7 +13,6 @@ const FROM_ADDRESS = config.emailFrom();
 export async function sendEmail(to: string, subject: string, html: string): Promise<boolean> {
     if (!resend) {
         console.log(`[Email (no RESEND_API_KEY)] To: ${to} | Subject: ${subject}`);
-        console.log(`[Email Body]: ${html}`);
         return false;
     }
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL / HIGH
💡 **Vulnerability:** Information Exposure / Sensitive Data Leakage. The `sendEmail` function in `src/lib/email.ts` was logging the entire HTML body of outbound emails to stdout when running without a Resend API key configured.
🎯 **Impact:** If this code runs in production (due to a missing env var) or in a shared development/staging environment, highly sensitive information like Password Reset Links, One-Time Passwords (OTPs), or user PII would be permanently written to system logs or aggregators (e.g., Datadog, CloudWatch), accessible to anyone with log access.
🔧 **Fix:** Removed the `console.log(\`[Email Body]: \${html}\`)` statement from the fallback branch of `sendEmail`. Retained the logging of non-sensitive metadata (recipient and subject) for debugging purposes.
✅ **Verification:** Verified by code inspection that the `html` payload is no longer emitted to the console in `src/lib/email.ts`.

---
*PR created automatically by Jules for task [3858980760817705096](https://jules.google.com/task/3858980760817705096) started by @dkaygithub*