### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent sensitive info leakage in 500 API errors

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Used `dangerouslySetInnerHTML` to inject CSS dynamically in React components (`src/components/ContentWrapper.tsx`).
 **Learning:** `dangerouslySetInnerHTML` can open up possibilities for XSS, even if it's currently injecting a static or semi-static string. It bypasses React's built-in escaping mechanisms. The project explicitly avoids using `dangerouslySetInnerHTML` for CSS injection in React components, favoring global CSS rules and class toggling on root elements like `body` (from memory).
 **Prevention:** Avoid `dangerouslySetInnerHTML` unless absolutely necessary. Use CSS classes or inline styles with React's `style` prop instead. For global styles, toggle a class on a root element (like `body`) using a `useEffect` hook.
+## 2024-05-24 - Info Leakage in API 500 Errors
+**Vulnerability:** Found multiple API routes returning `error.message` or `String(error)` directly to the client in their 500 error handlers via `NextResponse.json({ error: error.message })`.
+**Learning:** Returning verbose backend errors can leak sensitive internal details, database structures, or infrastructure information to potential attackers, providing a map for further exploits.
+**Prevention:** Catch blocks should log the detailed error internally (`console.error`), but the JSON response sent to the client should use a generic, sanitized string (e.g., "Internal Server Error" or "Failed to update record").

--- a/src/app/api/admin/participants/[id]/household/route.ts
+++ b/src/app/api/admin/participants/[id]/household/route.ts
@@ -82,7 +82,6 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
         return NextResponse.json({ success: true, participant: updatedParticipant });
     } catch (error) {
         console.error("Error updating participant household:", error);
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        return NextResponse.json({ error: `Internal server error: ${errorMessage}` }, { status: 500 });
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }

--- a/src/app/api/admin/participants/import/route.ts
+++ b/src/app/api/admin/participants/import/route.ts
@@ -447,7 +447,6 @@ export async function POST(req: NextRequest) {
 
     } catch (error: unknown) {
         console.error("Error in participant bulk import:", error);
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-        return NextResponse.json({ error: `Internal server error: ${errorMessage}` }, { status: 500 });
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }

--- a/src/app/api/admin/participants/merge/route.ts
+++ b/src/app/api/admin/participants/merge/route.ts
@@ -162,7 +162,7 @@ export const POST = withAuth(
             return NextResponse.json({ success: true });
         } catch (error: unknown) {
             console.error("Merge error:", error);
-            return NextResponse.json({ error: error instanceof Error ? error.message : "Failed to merge participants" }, { status: 500 });
+            return NextResponse.json({ error: "Failed to merge participants" }, { status: 500 });
         }
     }
 );

--- a/src/app/api/admin/participants/route.ts
+++ b/src/app/api/admin/participants/route.ts
@@ -125,7 +125,6 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ success: true, participant: newParticipant });
     } catch (error: unknown) {
         console.error("Failed to create participant:", error);
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        return NextResponse.json({ error: `Failed to create participant: ${errorMessage}` }, { status: 500 });
+        return NextResponse.json({ error: "Failed to create participant" }, { status: 500 });
     }
 }

--- a/src/app/api/admin/system-health/route.ts
+++ b/src/app/api/admin/system-health/route.ts
@@ -80,7 +80,7 @@ export const GET = withAuth(
             });
         } catch (error) {
             console.error("Failed to fetch system health metrics:", error);
-            return NextResponse.json({ error: "Internal Server Error", details: String(error) }, { status: 500 });
+            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
         }
     }
 );

--- a/src/app/api/programs/[id]/public-register/route.ts
+++ b/src/app/api/programs/[id]/public-register/route.ts
@@ -199,6 +199,6 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
     } catch (error: any) {
         console.error("Public registration error:", error);
-        return NextResponse.json({ error: error.message || "An error occurred during registration." }, { status: 500 });
+        return NextResponse.json({ error: "An error occurred during registration." }, { status: 500 });
     }
 }

--- a/src/app/api/programs/route.ts
+++ b/src/app/api/programs/route.ts
@@ -165,6 +165,6 @@ export async function POST(req: Request) {
         return NextResponse.json(responseObj);
     } catch (error: unknown) {
         console.error("Program creation error:", error);
-        return NextResponse.json({ error: error instanceof Error ? error.message : "Failed to create program" }, { status: 500 });
+        return NextResponse.json({ error: "Failed to create program" }, { status: 500 });
     }
 }

--- a/src/app/api/shop/certifications/route.ts
+++ b/src/app/api/shop/certifications/route.ts
@@ -131,6 +131,6 @@ export async function POST(req: Request) {
         return NextResponse.json({ success: true, certification: upsertedCert });
     } catch (error: unknown) {
         console.error("Certification error:", error);
-        return NextResponse.json({ error: error instanceof Error ? error.message : "Failed to upsert certification" }, { status: 500 });
+        return NextResponse.json({ error: "Failed to upsert certification" }, { status: 500 });
     }
 }

--- a/src/app/api/shop/tools/route.ts
+++ b/src/app/api/shop/tools/route.ts
@@ -68,6 +68,6 @@ export async function POST(req: Request) {
         return NextResponse.json({ success: true, tool: newTool });
     } catch (error: unknown) {
         console.error("Tool creation error:", error);
-        return NextResponse.json({ error: error instanceof Error ? error.message : "Failed to create tool" }, { status: 500 });
+        return NextResponse.json({ error: "Failed to create tool" }, { status: 500 });
     }
 }


### PR DESCRIPTION
### 🚨 Severity
MEDIUM

### 💡 Vulnerability
Multiple API routes (`src/app/api`) were catching unhandled exceptions and returning the raw `error.message` or `String(error)` directly to the client via `NextResponse.json()` on a 500 status code. This can inadvertently expose sensitive internal details, database queries, file paths, or infrastructure structure.

### 🎯 Impact
If exploited, attackers could deliberately trigger edge-case errors (e.g., malformed payloads) to read stack traces or database schema details in the response, mapping out the system for more targeted attacks.

### 🔧 Fix
Replaced the dynamic `error.message` responses with static, generic strings (e.g., `"Internal server error"`, `"Failed to upsert certification"`) across 9 files in `src/app/api`. The detailed errors are still securely logged on the server using `console.error` for observability.

### ✅ Verification
1. Run `npm run lint` and `npm test` to ensure changes are syntactically valid and don't break existing types.
2. Manually trigger a 500 error on an affected endpoint (e.g., by sending an invalid payload to `/api/admin/participants`) and verify the response JSON only contains the sanitized string.

---
*PR created automatically by Jules for task [1745623596759452596](https://jules.google.com/task/1745623596759452596) started by @dkaygithub*