### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix sensitive information disclosure in email logs

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -13,7 +13,6 @@ const FROM_ADDRESS = config.emailFrom();
 export async function sendEmail(to: string, subject: string, html: string): Promise<boolean> {
     if (!resend) {
         console.log(`[Email (no RESEND_API_KEY)] To: ${to} | Subject: ${subject}`);
-        console.log(`[Email Body]: ${html}`);
         return false;
     }
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix sensitive information disclosure in email logs

🚨 Severity: MEDIUM
💡 Vulnerability: The `sendEmail` utility in `src/lib/email.ts` exposed the raw HTML contents of all sent emails to `console.log` whenever the `RESEND_API_KEY` was missing or unconfigured. This exposes sensitive information such as password reset links, OTPs, or PII in standard application logs.
🎯 Impact: Attackers who gain access to the application logs (or logging systems like Datadog/CloudWatch) could harvest sensitive PII or authentication mechanisms.
🔧 Fix: Removed the `console.log` line that printed the `html` content. The utility still logs the `To` address and `Subject`, which is sufficient for basic troubleshooting without leaking the email payload.
✅ Verification: Tested via unit tests and manually inspected to ensure only metadata is logged, in line with Sentinel guidelines.

---
*PR created automatically by Jules for task [7668799609209899594](https://jules.google.com/task/7668799609209899594) started by @dkaygithub*