### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data exposure in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Used `dangerouslySetInnerHTML` to inject CSS dynamically in React components (`src/components/ContentWrapper.tsx`).
 **Learning:** `dangerouslySetInnerHTML` can open up possibilities for XSS, even if it's currently injecting a static or semi-static string. It bypasses React's built-in escaping mechanisms. The project explicitly avoids using `dangerouslySetInnerHTML` for CSS injection in React components, favoring global CSS rules and class toggling on root elements like `body` (from memory).
 **Prevention:** Avoid `dangerouslySetInnerHTML` unless absolutely necessary. Use CSS classes or inline styles with React's `style` prop instead. For global styles, toggle a class on a root element (like `body`) using a `useEffect` hook.
+
+## 2024-05-24 - [Sensitive Data Exposure in Email Fallback Logging]
+**Vulnerability:** The `sendEmail` utility function in `src/lib/email.ts` logged the full HTML body of emails when `RESEND_API_KEY` was not configured.
+**Learning:** Logging entire email payloads in fallback or local development modes can inadvertently expose highly sensitive data such as magic links, password reset tokens, and Personally Identifiable Information (PII) to server logs or terminal output.
+**Prevention:** Email utility functions must never log the full email body to the console. Log only high-level metadata like recipient (`to`) and `subject` for troubleshooting purposes.

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -13,7 +13,6 @@ const FROM_ADDRESS = config.emailFrom();
 export async function sendEmail(to: string, subject: string, html: string): Promise<boolean> {
     if (!resend) {
         console.log(`[Email (no RESEND_API_KEY)] To: ${to} | Subject: ${subject}`);
-        console.log(`[Email Body]: ${html}`);
         return false;
     }
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `sendEmail` utility function in `src/lib/email.ts` logged the full HTML body of emails to the console when `RESEND_API_KEY` was not configured (fallback/dev mode).
🎯 **Impact:** Highly sensitive information, such as password reset tokens, magic links, or Personally Identifiable Information (PII) contained within the email body, could be inadvertently exposed in server logs or developer terminal output, potentially allowing unauthorized access.
🔧 **Fix:** Removed `console.log(\`[Email Body]: \${html}\`);` from the fallback block in `src/lib/email.ts`. High-level metadata like the recipient and subject continue to be logged for troubleshooting. Also added a journal entry documenting the vulnerability and prevention strategy to `.jules/sentinel.md`.
✅ **Verification:** Verified that email metadata (recipient, subject) is logged but the body is not by reviewing the `sendEmail` function's logic. Tests and linters were run (though limited by sandbox environment) to confirm no syntax regressions.

---
*PR created automatically by Jules for task [12720386457788519036](https://jules.google.com/task/12720386457788519036) started by @dkaygithub*