### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent development authentication exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Used `dangerouslySetInnerHTML` to inject CSS dynamically in React components (`src/components/ContentWrapper.tsx`).
 **Learning:** `dangerouslySetInnerHTML` can open up possibilities for XSS, even if it's currently injecting a static or semi-static string. It bypasses React's built-in escaping mechanisms. The project explicitly avoids using `dangerouslySetInnerHTML` for CSS injection in React components, favoring global CSS rules and class toggling on root elements like `body` (from memory).
 **Prevention:** Avoid `dangerouslySetInnerHTML` unless absolutely necessary. Use CSS classes or inline styles with React's `style` prop instead. For global styles, toggle a class on a root element (like `body`) using a `useEffect` hook.
+
+## 2025-02-14 - Enforce environment check for dev auth feature flags
+**Vulnerability:** Development authentication endpoints and UI (DevLoginPicker) could be exposed in production if the `NEXT_PUBLIC_DEV_AUTH` feature flag was mistakenly set.
+**Learning:** Feature flags alone are not sufficient protection for development/debug features, especially those that mock authentication.
+**Prevention:** Always pair development feature flags with a strict `process.env.NODE_ENV !== 'production'` check to create an unbreakable safety net.

--- a/src/app/api/auth/dev-personas/route.ts
+++ b/src/app/api/auth/dev-personas/route.ts
@@ -10,8 +10,8 @@ export const dynamic = 'force-dynamic';
  * with their role flags for the dev login picker.
  */
 export async function GET() {
-    // Block if dev auth is not explicitly enabled
-    if (!process.env.NEXT_PUBLIC_DEV_AUTH) {
+    // Block if dev auth is not explicitly enabled or if in production
+    if (!process.env.NEXT_PUBLIC_DEV_AUTH || process.env.NODE_ENV === 'production') {
         return NextResponse.json({ error: "Not available" }, { status: 404 });
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,7 +143,7 @@ export default function Home() {
 
               {/* Check-in Toggle Button — in production, only privileged users can self-check-in from the web */}
               {isCheckedIn !== null && (
-                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || process.env.NEXT_PUBLIC_DEV_AUTH) ? (
+                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || (process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production')) ? (
                   <button
                     className="glass-button"
                     onClick={handleToggleCheckin}
@@ -258,7 +258,7 @@ export default function Home() {
               >
                 Sign In To Dashboard
               </button>
-              {process.env.NEXT_PUBLIC_DEV_AUTH && <DevLoginPicker />}
+              {process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production' && <DevLoginPicker />}
             </div>
           )}
         </div>

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -58,7 +58,7 @@ export const authOptions: NextAuthOptions = {
                 }
             }
         }),
-        ...(process.env.NEXT_PUBLIC_DEV_AUTH ? [
+        ...(process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production' ? [
             CredentialsProvider({
                 name: "Development Mock Auth",
                 credentials: {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The development mock authentication features (DevLoginPicker, dev-personas API, and CredentialsProvider) were protected only by the `NEXT_PUBLIC_DEV_AUTH` environment variable. If this variable was accidentally set in production, anyone could bypass authentication using mock personas.
🎯 **Impact:** If exposed, an attacker could assume any mock role, including `sysadmin` or `boardMember`, gaining full unauthorized access to the application and its data.
🔧 **Fix:** Hardcoded `process.env.NODE_ENV !== 'production'` alongside the `NEXT_PUBLIC_DEV_AUTH` checks across `src/app/page.tsx`, `src/app/api/auth/dev-personas/route.ts`, and `src/lib/auth-options.ts`.
✅ **Verification:** Verified by code inspection that mock providers and endpoints are unreachabe when `NODE_ENV === 'production'`.

---
*PR created automatically by Jules for task [10328182522577787072](https://jules.google.com/task/10328182522577787072) started by @dkaygithub*