### PR TITLE
🛡️ Sentinel: [HIGH] Fix development authentication exposure in production

### DIFF
--- a/src/app/api/auth/dev-personas/route.ts
+++ b/src/app/api/auth/dev-personas/route.ts
@@ -10,8 +10,8 @@ export const dynamic = 'force-dynamic';
  * with their role flags for the dev login picker.
  */
 export async function GET() {
-    // Block if dev auth is not explicitly enabled
-    if (!process.env.NEXT_PUBLIC_DEV_AUTH) {
+    // Block if dev auth is not explicitly enabled or if in production
+    if (!process.env.NEXT_PUBLIC_DEV_AUTH || process.env.NODE_ENV === 'production') {
         return NextResponse.json({ error: "Not available" }, { status: 404 });
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,7 +143,7 @@ export default function Home() {
 
               {/* Check-in Toggle Button — in production, only privileged users can self-check-in from the web */}
               {isCheckedIn !== null && (
-                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || process.env.NEXT_PUBLIC_DEV_AUTH) ? (
+                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || (process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production')) ? (
                   <button
                     className="glass-button"
                     onClick={handleToggleCheckin}
@@ -258,7 +258,7 @@ export default function Home() {
               >
                 Sign In To Dashboard
               </button>
-              {process.env.NEXT_PUBLIC_DEV_AUTH && <DevLoginPicker />}
+              {(process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production') && <DevLoginPicker />}
             </div>
           )}
         </div>

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -58,7 +58,7 @@ export const authOptions: NextAuthOptions = {
                 }
             }
         }),
-        ...(process.env.NEXT_PUBLIC_DEV_AUTH ? [
+        ...(process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production' ? [
             CredentialsProvider({
                 name: "Development Mock Auth",
                 credentials: {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The dev mock authentication provider and dev login UI elements rely solely on `process.env.NEXT_PUBLIC_DEV_AUTH`. If this flag is accidentally enabled in the production environment variables, it allows anyone to mock-login as an admin or other roles, completely bypassing production authentication.
🎯 **Impact:** Unauthorized access to admin endpoints and user data in a production system. Complete system compromise if an attacker logs in as a sysadmin.
🔧 **Fix:** Added a strict `process.env.NODE_ENV !== 'production'` check alongside the existing flag check in the route, the provider configuration, and the frontend component logic. Next.js enforces `NODE_ENV` as `'production'` in deployed builds.
✅ **Verification:** Attempting to view dev personas, mock authenticate, or use the dev login picker will fail or not render when the app is built and running in a production environment.

---
*PR created automatically by Jules for task [4477685849324489397](https://jules.google.com/task/4477685849324489397) started by @dkaygithub*