### PR TITLE
🛡️ Sentinel: [HIGH] Fix development authentication exposure risk

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Used `dangerouslySetInnerHTML` to inject CSS dynamically in React components (`src/components/ContentWrapper.tsx`).
 **Learning:** `dangerouslySetInnerHTML` can open up possibilities for XSS, even if it's currently injecting a static or semi-static string. It bypasses React's built-in escaping mechanisms. The project explicitly avoids using `dangerouslySetInnerHTML` for CSS injection in React components, favoring global CSS rules and class toggling on root elements like `body` (from memory).
 **Prevention:** Avoid `dangerouslySetInnerHTML` unless absolutely necessary. Use CSS classes or inline styles with React's `style` prop instead. For global styles, toggle a class on a root element (like `body`) using a `useEffect` hook.
+
+## 2024-05-24 - Development Backdoor Exposure via NEXT_PUBLIC_
+**Vulnerability:** The `DevLoginPicker` component and its associated mock authentication endpoint (`/api/auth/dev-personas`) relied solely on the `NEXT_PUBLIC_DEV_AUTH` environment variable to determine if they should be enabled.
+**Learning:** `NEXT_PUBLIC_` environment variables are embedded directly into the frontend bundle at build time. Relying purely on this variable to hide development authentication backdoors exposes the system to a critical risk if this variable is mistakenly set or leaked in production.
+**Prevention:** Development-only mock authentication features must include a strict server-side `process.env.NODE_ENV !== 'production'` check to guarantee they are entirely disabled in a production environment, regardless of other configuration settings.

--- a/src/app/api/auth/dev-personas/route.ts
+++ b/src/app/api/auth/dev-personas/route.ts
@@ -10,8 +10,8 @@ export const dynamic = 'force-dynamic';
  * with their role flags for the dev login picker.
  */
 export async function GET() {
-    // Block if dev auth is not explicitly enabled
-    if (!process.env.NEXT_PUBLIC_DEV_AUTH) {
+    // Block if dev auth is not explicitly enabled or if in production
+    if (!process.env.NEXT_PUBLIC_DEV_AUTH || process.env.NODE_ENV === 'production') {
         return NextResponse.json({ error: "Not available" }, { status: 404 });
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,7 +143,7 @@ export default function Home() {
 
               {/* Check-in Toggle Button — in production, only privileged users can self-check-in from the web */}
               {isCheckedIn !== null && (
-                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || process.env.NEXT_PUBLIC_DEV_AUTH) ? (
+                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || (process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production')) ? (
                   <button
                     className="glass-button"
                     onClick={handleToggleCheckin}
@@ -258,7 +258,7 @@ export default function Home() {
               >
                 Sign In To Dashboard
               </button>
-              {process.env.NEXT_PUBLIC_DEV_AUTH && <DevLoginPicker />}
+              {(process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production') && <DevLoginPicker />}
             </div>
           )}
         </div>

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -58,7 +58,7 @@ export const authOptions: NextAuthOptions = {
                 }
             }
         }),
-        ...(process.env.NEXT_PUBLIC_DEV_AUTH ? [
+        ...((process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production') ? [
             CredentialsProvider({
                 name: "Development Mock Auth",
                 credentials: {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Development mock authentication components and endpoints rely solely on the `NEXT_PUBLIC_DEV_AUTH` environment variable.
🎯 Impact: If the `NEXT_PUBLIC_DEV_AUTH` environment variable is mistakenly set or leaked in production, attackers could bypass authentication entirely using the dev mock personas.
🔧 Fix: Added an explicit `process.env.NODE_ENV !== 'production'` check to the dev authentication API endpoint (`src/app/api/auth/dev-personas/route.ts`), the NextAuth configuration (`src/lib/auth-options.ts`), and the front-end page rendering (`src/app/page.tsx`) to ensure they are strictly disabled in production builds. Documented this finding in `.jules/sentinel.md`.
✅ Verification: Ensure the project builds successfully and the mock login feature is completely absent when `NODE_ENV` is set to `production`. Tests and linters were skipped due to environment limitations in the sandbox.

---
*PR created automatically by Jules for task [1117756674771519298](https://jules.google.com/task/1117756674771519298) started by @dkaygithub*