### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Dev Auth Exposure in Production

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Used `dangerouslySetInnerHTML` to inject CSS dynamically in React components (`src/components/ContentWrapper.tsx`).
 **Learning:** `dangerouslySetInnerHTML` can open up possibilities for XSS, even if it's currently injecting a static or semi-static string. It bypasses React's built-in escaping mechanisms. The project explicitly avoids using `dangerouslySetInnerHTML` for CSS injection in React components, favoring global CSS rules and class toggling on root elements like `body` (from memory).
 **Prevention:** Avoid `dangerouslySetInnerHTML` unless absolutely necessary. Use CSS classes or inline styles with React's `style` prop instead. For global styles, toggle a class on a root element (like `body`) using a `useEffect` hook.
+
+## 2024-05-24 - Dev Auth Exposure in Production
+**Vulnerability:** The application was using the feature flag `NEXT_PUBLIC_DEV_AUTH` to enable development-only personas and login mechanisms. If this flag were accidentally set to `true` in a production environment (e.g. through misconfiguration in Vercel), it would expose mock administrative users and allow unauthorized login without a password.
+**Learning:** Development feature flags that bypass authentication or authorization are dangerous. They must never be trusted solely by their value in environment variables.
+**Prevention:** Always pair development-only feature flags (like `NEXT_PUBLIC_DEV_AUTH`) with a strict environment assertion: `process.env.NODE_ENV !== 'production'`. This provides defense-in-depth, guaranteeing that even if a flag is misconfigured, the potentially dangerous feature cannot be enabled in the production build.

--- a/src/app/api/auth/dev-personas/route.ts
+++ b/src/app/api/auth/dev-personas/route.ts
@@ -10,8 +10,8 @@ export const dynamic = 'force-dynamic';
  * with their role flags for the dev login picker.
  */
 export async function GET() {
-    // Block if dev auth is not explicitly enabled
-    if (!process.env.NEXT_PUBLIC_DEV_AUTH) {
+    // Block if dev auth is not explicitly enabled or if in production
+    if (!process.env.NEXT_PUBLIC_DEV_AUTH || process.env.NODE_ENV === 'production') {
         return NextResponse.json({ error: "Not available" }, { status: 404 });
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,7 +143,7 @@ export default function Home() {
 
               {/* Check-in Toggle Button — in production, only privileged users can self-check-in from the web */}
               {isCheckedIn !== null && (
-                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || process.env.NEXT_PUBLIC_DEV_AUTH) ? (
+                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || (process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production')) ? (
                   <button
                     className="glass-button"
                     onClick={handleToggleCheckin}
@@ -258,7 +258,7 @@ export default function Home() {
               >
                 Sign In To Dashboard
               </button>
-              {process.env.NEXT_PUBLIC_DEV_AUTH && <DevLoginPicker />}
+              {(process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production') && <DevLoginPicker />}
             </div>
           )}
         </div>

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -58,7 +58,7 @@ export const authOptions: NextAuthOptions = {
                 }
             }
         }),
-        ...(process.env.NEXT_PUBLIC_DEV_AUTH ? [
+        ...(process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production' ? [
             CredentialsProvider({
                 name: "Development Mock Auth",
                 credentials: {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The application was using a single feature flag (`NEXT_PUBLIC_DEV_AUTH`) to enable development-only personas and unauthenticated login routes (mock auth). If this environment variable were accidentally enabled in production, an attacker could use the DevLoginPicker or credentials provider to log in as any user, including sysadmins, without a password.
🎯 **Impact**: Total authentication bypass and administrative takeover if misconfigured in production.
🔧 **Fix**: Paired the `NEXT_PUBLIC_DEV_AUTH` feature flag checks with a strict `process.env.NODE_ENV !== 'production'` assertion across `src/app/api/auth/dev-personas/route.ts`, `src/lib/auth-options.ts`, and `src/app/page.tsx` to provide defense-in-depth against environmental misconfigurations. Also added a `.jules/sentinel.md` entry.
✅ **Verification**: Verified that the dev auth features are only rendered or executed when `NODE_ENV` is not `production`. The Next.js build process will now correctly dead-code eliminate the `DevLoginPicker` entirely from production builds.

---
*PR created automatically by Jules for task [14747536644230582919](https://jules.google.com/task/14747536644230582919) started by @dkaygithub*