### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix dev authentication bypass vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Used `dangerouslySetInnerHTML` to inject CSS dynamically in React components (`src/components/ContentWrapper.tsx`).
 **Learning:** `dangerouslySetInnerHTML` can open up possibilities for XSS, even if it's currently injecting a static or semi-static string. It bypasses React's built-in escaping mechanisms. The project explicitly avoids using `dangerouslySetInnerHTML` for CSS injection in React components, favoring global CSS rules and class toggling on root elements like `body` (from memory).
 **Prevention:** Avoid `dangerouslySetInnerHTML` unless absolutely necessary. Use CSS classes or inline styles with React's `style` prop instead. For global styles, toggle a class on a root element (like `body`) using a `useEffect` hook.
+
+## 2024-05-24 - Dev Authentication Exposure in Production
+**Vulnerability:** Developer authentication endpoints (`/api/auth/dev-personas`) and mock login providers were only protected by a feature flag (`NEXT_PUBLIC_DEV_AUTH`), which could theoretically leak or be enabled accidentally in production.
+**Learning:** Checking only a feature flag can be dangerous for powerful development tools (like bypassing Google SSO to log in as an arbitrary SysAdmin). Feature flags can be misconfigured in CI/CD or intentionally toggled, whereas the `NODE_ENV` provides a hard guarantee of the runtime environment.
+**Prevention:** Always pair development-only feature flags (like `NEXT_PUBLIC_DEV_AUTH`) with an explicit `process.env.NODE_ENV !== 'production'` check, especially when these features allow authentication bypass or privilege escalation.

--- a/src/app/api/auth/dev-personas/route.ts
+++ b/src/app/api/auth/dev-personas/route.ts
@@ -10,8 +10,8 @@ export const dynamic = 'force-dynamic';
  * with their role flags for the dev login picker.
  */
 export async function GET() {
-    // Block if dev auth is not explicitly enabled
-    if (!process.env.NEXT_PUBLIC_DEV_AUTH) {
+    // Block if dev auth is not explicitly enabled or if in production
+    if (!process.env.NEXT_PUBLIC_DEV_AUTH || process.env.NODE_ENV === 'production') {
         return NextResponse.json({ error: "Not available" }, { status: 404 });
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,7 +143,7 @@ export default function Home() {
 
               {/* Check-in Toggle Button — in production, only privileged users can self-check-in from the web */}
               {isCheckedIn !== null && (
-                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || process.env.NEXT_PUBLIC_DEV_AUTH) ? (
+                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || (process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production')) ? (
                   <button
                     className="glass-button"
                     onClick={handleToggleCheckin}
@@ -258,7 +258,7 @@ export default function Home() {
               >
                 Sign In To Dashboard
               </button>
-              {process.env.NEXT_PUBLIC_DEV_AUTH && <DevLoginPicker />}
+              {(process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production') && <DevLoginPicker />}
             </div>
           )}
         </div>

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -58,7 +58,7 @@ export const authOptions: NextAuthOptions = {
                 }
             }
         }),
-        ...(process.env.NEXT_PUBLIC_DEV_AUTH ? [
+        ...(process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production' ? [
             CredentialsProvider({
                 name: "Development Mock Auth",
                 credentials: {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Developer authentication mechanisms (`NEXT_PUBLIC_DEV_AUTH`) and mock personas were only gated by a feature flag, allowing potential exposure in production if the flag was accidentally enabled or leaked.
🎯 Impact: An attacker could bypass Google authentication and log in as any user (including sysadmins) if the dev auth flag was active in production.
🔧 Fix: Added explicit `process.env.NODE_ENV !== 'production'` checks alongside all `NEXT_PUBLIC_DEV_AUTH` feature flags in API routes, NextAuth options, and UI components to completely disable dev tools in production environments regardless of env var configuration.
✅ Verification: Run `npm test` and `npm run lint`. Verify that dev UI and `/api/auth/dev-personas` return 404/null when `NODE_ENV=production`.

---
*PR created automatically by Jules for task [1621948166425331785](https://jules.google.com/task/1621948166425331785) started by @dkaygithub*