### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data exposure in email logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The application was using the feature flag `NEXT_PUBLIC_DEV_AUTH` to enable development-only personas and login mechanisms. If this flag were accidentally set to `true` in a production environment (e.g. through misconfiguration in Vercel), it would expose mock administrative users and allow unauthorized login without a password.
 **Learning:** Development feature flags that bypass authentication or authorization are dangerous. They must never be trusted solely by their value in environment variables.
 **Prevention:** Always pair development-only feature flags (like `NEXT_PUBLIC_DEV_AUTH`) with a strict environment assertion: `process.env.NODE_ENV !== 'production'`. This provides defense-in-depth, guaranteeing that even if a flag is misconfigured, the potentially dangerous feature cannot be enabled in the production build.
+
+## 2024-05-24 - Sensitive Data Exposure in Email Logging
+**Vulnerability:** The application logged the entire raw HTML body of emails to the console when running without a Resend API key.
+**Learning:** Email bodies often contain highly sensitive data, such as Personally Identifiable Information (PII), password reset links, or magic login URLs. Logging this data to the console exposes it to server logs and any third-party logging services, creating a severe data leak risk.
+**Prevention:** To prevent sensitive information leakage, the `sendEmail` utility in `src/lib/email.ts` must never log the `html` email body to the console; log only high-level metadata like recipient (`to`) and `subject` for troubleshooting purposes in the absence of a configured `RESEND_API_KEY`.

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -13,7 +13,12 @@ const FROM_ADDRESS = config.emailFrom();
 export async function sendEmail(to: string, subject: string, html: string): Promise<boolean> {
     if (!resend) {
         console.log(`[Email (no RESEND_API_KEY)] To: ${to} | Subject: ${subject}`);
-        console.log(`[Email Body]: ${html}`);
+        // SECURITY: Do not log the raw `html` body to the console in production to prevent
+        // sensitive data (e.g., magic links, PII) from leaking into server logs.
+        // We only allow this logging in development mode for debugging.
+        if (process.env.NODE_ENV === 'development') {
+            console.log(`[Email Body]: ${html}`);
+        }
         return false;
     }
 


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** The `sendEmail` utility logged the full `html` email body to the console when `RESEND_API_KEY` was missing.
**🎯 Impact:** Exposed sensitive information, such as PII or authentication links, in plaintext server logs in a production environment.
**🔧 Fix:** Restricts the `html` logging to development environments only (`process.env.NODE_ENV === 'development'`), retaining only the recipient and subject metadata in production.
**✅ Verification:** Verified code no longer logs `html` payload in production via inspection.

---
*PR created automatically by Jules for task [14496135976876292161](https://jules.google.com/task/14496135976876292161) started by @dkaygithub*