### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data exposure in email logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The application was using the feature flag `NEXT_PUBLIC_DEV_AUTH` to enable development-only personas and login mechanisms. If this flag were accidentally set to `true` in a production environment (e.g. through misconfiguration in Vercel), it would expose mock administrative users and allow unauthorized login without a password.
 **Learning:** Development feature flags that bypass authentication or authorization are dangerous. They must never be trusted solely by their value in environment variables.
 **Prevention:** Always pair development-only feature flags (like `NEXT_PUBLIC_DEV_AUTH`) with a strict environment assertion: `process.env.NODE_ENV !== 'production'`. This provides defense-in-depth, guaranteeing that even if a flag is misconfigured, the potentially dangerous feature cannot be enabled in the production build.
+
+## 2026-05-18 - Sensitive Data Exposure in Email Logs
+**Vulnerability:** The application was logging the raw `html` body of emails to the console when `RESEND_API_KEY` was missing in production (e.g., in `src/lib/email.ts`).
+**Learning:** Logging entire email bodies can inadvertently expose sensitive information, such as authentication links or personal user details, to server logs where they can be accessed by unauthorized personnel or aggregated inappropriately.
+**Prevention:** Avoid logging raw email content in production. Ensure that fallback logging mechanisms only record the full body when `process.env.NODE_ENV === 'development'`. In production, log only metadata like the recipient and subject.

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -13,7 +13,9 @@ const FROM_ADDRESS = config.emailFrom();
 export async function sendEmail(to: string, subject: string, html: string): Promise<boolean> {
     if (!resend) {
         console.log(`[Email (no RESEND_API_KEY)] To: ${to} | Subject: ${subject}`);
-        console.log(`[Email Body]: ${html}`);
+        if (process.env.NODE_ENV === 'development') {
+            console.log(`[Email Body]: ${html}`);
+        }
         return false;
     }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application was logging the entire raw `html` body of emails to the console in `src/lib/email.ts` whenever the `RESEND_API_KEY` was missing. In a production environment, this could expose sensitive information (like authentication links, PII, etc.) to the server logs.
🎯 Impact: Unauthorized personnel with access to logs could potentially intercept sensitive email content, leading to account takeover or data breaches.
🔧 Fix: Updated the fallback logging mechanism in `sendEmail` to conditionally log the raw `html` body only when `process.env.NODE_ENV === 'development'`.
✅ Verification: Ensure that in a production environment without a configured Resend API key, the server logs only contain the recipient and subject, not the body of the email. In development mode, the full body should still be printed.

---
*PR created automatically by Jules for task [16937090546166517587](https://jules.google.com/task/16937090546166517587) started by @dkaygithub*