### PR TITLE
🛡️ Sentinel: Fix sensitive data exposure in email logging

### DIFF
--- a/src/lib/__tests__/email.test.ts
+++ b/src/lib/__tests__/email.test.ts
@@ -1,0 +1,44 @@
+import { sendEmail } from '../email.ts';
+jest.mock('resend');
+jest.mock('../config.ts', () => ({
+    config: {
+        resendApiKey: () => null,
+        emailFrom: () => 'test@test.com'
+    }
+}));
+
+describe('Email Logging Security', () => {
+    let originalConsoleLog: (...data: unknown[]) => void;
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+        originalConsoleLog = console.log;
+        console.log = jest.fn();
+        originalEnv = process.env.NODE_ENV;
+    });
+
+    afterEach(() => {
+        console.log = originalConsoleLog;
+        process.env.NODE_ENV = originalEnv;
+    });
+
+    it('should not log email body in production', async () => {
+        process.env.NODE_ENV = 'production';
+        const html = 'Sensitive Information <a href="reset">Link</a>';
+
+        await sendEmail('test@test.com', 'Test Subject', html);
+
+        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[Email (no RESEND_API_KEY)]'));
+        expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining(html));
+    });
+
+    it('should log email body in development', async () => {
+        process.env.NODE_ENV = 'development';
+        const html = 'Development Body';
+
+        await sendEmail('test@test.com', 'Test Subject', html);
+
+        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[Email (no RESEND_API_KEY)]'));
+        expect(console.log).toHaveBeenCalledWith(expect.stringContaining(html));
+    });
+});

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -13,7 +13,9 @@ const FROM_ADDRESS = config.emailFrom();
 export async function sendEmail(to: string, subject: string, html: string): Promise<boolean> {
     if (!resend) {
         console.log(`[Email (no RESEND_API_KEY)] To: ${to} | Subject: ${subject}`);
-        console.log(`[Email Body]: ${html}`);
+        if (process.env.NODE_ENV === 'development') {
+            console.log(`[Email Body]: ${html}`);
+        }
         return false;
     }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `sendEmail` utility logs the raw `html` email body to the console in production environments when no `RESEND_API_KEY` is configured.
🎯 Impact: Sensitive user data (e.g., password reset links, PII) sent via email could be exposed in server logs.
🔧 Fix: Conditionally log the `html` email body only when `process.env.NODE_ENV === 'development'`.
✅ Verification: Verified that the email body is no longer logged in production when `RESEND_API_KEY` is missing by using unit tests.

---
*PR created automatically by Jules for task [9625786291562558808](https://jules.google.com/task/9625786291562558808) started by @dkaygithub*