### PR TITLE
fix(tests): resolve tsc errors in email.test.ts blocking pre-commit hook

### DIFF
--- a/src/lib/__tests__/email.test.ts
+++ b/src/lib/__tests__/email.test.ts
@@ -1,4 +1,4 @@
-import { sendEmail } from '../email.ts';
+import { sendEmail } from '../email';
 jest.mock('resend');
 jest.mock('../config.ts', () => ({
     config: {
@@ -6,6 +6,11 @@ jest.mock('../config.ts', () => ({
         emailFrom: () => 'test@test.com'
     }
 }));
+
+// process.env.NODE_ENV is typed read-only; tests need to vary it at runtime
+const setNodeEnv = (value: string | undefined) => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value, configurable: true });
+};
 
 describe('Email Logging Security', () => {
     let originalConsoleLog: (...data: unknown[]) => void;
@@ -19,11 +24,11 @@ describe('Email Logging Security', () => {
 
     afterEach(() => {
         console.log = originalConsoleLog;
-        process.env.NODE_ENV = originalEnv;
+        setNodeEnv(originalEnv);
     });
 
     it('should not log email body in production', async () => {
-        process.env.NODE_ENV = 'production';
+        setNodeEnv('production');
         const html = 'Sensitive Information <a href="reset">Link</a>';
 
         await sendEmail('test@test.com', 'Test Subject', html);
@@ -33,7 +38,7 @@ describe('Email Logging Security', () => {
     });
 
     it('should log email body in development', async () => {
-        process.env.NODE_ENV = 'development';
+        setNodeEnv('development');
         const html = 'Development Body';
 
         await sendEmail('test@test.com', 'Test Subject', html);


### PR DESCRIPTION
## Problem
The sentinel-authored `src/lib/__tests__/email.test.ts` fails `tsc --noEmit`, which the husky pre-commit hook runs. This blocks *every* commit on `main`:

- `import { sendEmail } from '../email.ts'` — TS5097 (extension not allowed unless `allowImportingTsExtensions`)
- `process.env.NODE_ENV = ...` — TS2540 (assigning to a read-only property)

## Fix
- Drop the `.ts` extension from the import.
- Set `NODE_ENV` via `Object.defineProperty` (a small `setNodeEnv` helper) instead of direct assignment.

No behavior change to the test assertions. `tsc --noEmit` is clean and the email tests pass (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)