### PR TITLE
fix(onboarding): don't nudge minors for a phone number (#169)

### DIFF
--- a/src/app/__tests__/onboardingStatusAPI.integration.test.ts
+++ b/src/app/__tests__/onboardingStatusAPI.integration.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration Tests for Onboarding Status API
+ * Tests GET /api/profile/onboarding-status — in particular that minors
+ * are never asked for a phone number (issue #169)
+ */
+
+import { GET } from '@/app/api/profile/onboarding-status/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+// Mock NextAuth
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn()
+}));
+
+describe('Onboarding Status API Integration Tests', () => {
+    let adultId: number;
+    let minorId: number;
+    let noDobId: number;
+    const householdIds: number[] = [];
+
+    const minorDob = () => {
+        const d = new Date();
+        d.setFullYear(d.getFullYear() - 12);
+        return d;
+    };
+
+    beforeAll(async () => {
+        // Clean up any leaked state
+        const existingUsers = await prisma.participant.findMany({
+            where: { email: { contains: 'onboarding-status-test' } },
+            select: { id: true, householdId: true }
+        });
+        const existingUserIds = existingUsers.map(u => u.id);
+        const existingHouseholdIds = existingUsers.map(u => u.householdId).filter((id): id is number => id !== null);
+
+        // RESTRICT: delete participants before their households
+        await prisma.participant.deleteMany({ where: { id: { in: existingUserIds } } });
+        await prisma.household.deleteMany({ where: { id: { in: existingHouseholdIds } } });
+
+        const adult = await prisma.participant.create({
+            data: {
+                email: 'adult-onboarding-status-test@example.com',
+                name: 'Adult No Phone',
+                dob: new Date('1990-01-01'),
+                household: { create: {} }
+            }
+        });
+        adultId = adult.id;
+        householdIds.push(adult.householdId);
+
+        const minor = await prisma.participant.create({
+            data: {
+                email: 'minor-onboarding-status-test@example.com',
+                name: 'Minor No Phone',
+                dob: minorDob(),
+                household: { create: {} }
+            }
+        });
+        minorId = minor.id;
+        householdIds.push(minor.householdId);
+
+        const noDob = await prisma.participant.create({
+            data: {
+                email: 'nodob-onboarding-status-test@example.com',
+                name: 'No DOB No Phone',
+                household: { create: {} }
+            }
+        });
+        noDobId = noDob.id;
+        householdIds.push(noDob.householdId);
+    });
+
+    afterAll(async () => {
+        // RESTRICT: delete participants before their households
+        await prisma.participant.deleteMany({
+            where: { id: { in: [adultId, minorId, noDobId] } }
+        });
+        await prisma.household.deleteMany({
+            where: { id: { in: householdIds } }
+        });
+    });
+
+    const callRoute = async (userId: number | null) => {
+        (getServerSession as jest.Mock).mockResolvedValue(userId === null ? null : { user: { id: userId } });
+        const req = new Request('http://localhost:4000/api/profile/onboarding-status', { method: 'GET' });
+        return GET(req as unknown as import("next/server").NextRequest);
+    };
+
+    describe('GET /api/profile/onboarding-status', () => {
+        it('should return 401 Unauthorized without session', async () => {
+            const res = await callRoute(null);
+            expect(res.status).toBe(401);
+        });
+
+        it('should require a phone for an adult without one', async () => {
+            const res = await callRoute(adultId);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.needsPhone).toBe(true);
+        });
+
+        it('should NOT require a phone for a minor (issue #169)', async () => {
+            const res = await callRoute(minorId);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.needsPhone).toBe(false);
+        });
+
+        it('should require a phone when DOB is unknown', async () => {
+            const res = await callRoute(noDobId);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.needsPhone).toBe(true);
+        });
+
+        it('should not require a phone once one is set', async () => {
+            await prisma.participant.update({
+                where: { id: adultId },
+                data: { phone: '555-123-4567' }
+            });
+
+            const res = await callRoute(adultId);
+            const data = await res.json();
+            expect(data.needsPhone).toBe(false);
+            expect(data.phone).toBe('555-123-4567');
+        });
+    });
+});

--- a/src/app/api/profile/onboarding-status/route.ts
+++ b/src/app/api/profile/onboarding-status/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { withAuth } from "@/lib/auth";
+import { isMinor } from "@/lib/time";
 
 export const GET = withAuth(
     {},
@@ -21,7 +22,8 @@ export const GET = withAuth(
                 return NextResponse.json({ error: "Participant not found" }, { status: 404 });
             }
 
-            const needsPhone = !user.phone;
+            // Minors are never required to provide a phone number (issue #169)
+            const needsPhone = !user.phone && !isMinor(user.dob);
             const isLead = user.householdId && user.householdLeads.some((lead: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => lead.householdId === user.householdId);
             
             const needsEmergencyContact = isLead && (!user.household?.emergencyContactName || !user.household?.emergencyContactPhone);


### PR DESCRIPTION
## Problem
Closes #169. The onboarding gate asked **every** participant without a phone number to provide one — including youth accounts. A minor given an email login by a parent doesn't necessarily have a phone and shouldn't be required to enter one.

## Fix
In `GET /api/profile/onboarding-status`, compute `needsPhone` using the canonical `isMinor()` helper (`src/lib/time.ts`):

```diff
-const needsPhone = !user.phone;
+const needsPhone = !user.phone && !isMinor(user.dob);
```

No frontend change needed — `OnboardingGate.tsx` renders whatever `needsPhone` reports, and its copy already says "Required for all adult participants."

## Behavior notes
- Minors (DOB < 18 years ago) are never prompted for a phone.
- Participants with **no DOB on file** are still prompted (`isMinor` returns `false` for a null DOB) — failing closed on unknown age. Happy to flip this if you'd prefer to fail open.
- The `POST /api/profile/onboarding` route never enforced phone server-side, so no change there.

## Tests
Adds `src/app/__tests__/onboardingStatusAPI.integration.test.ts` covering adult-needs-phone, minor-exempt, unknown-DOB-needs-phone, has-phone, and unauthenticated cases. Full suite green (82 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)