### PR TITLE
chore(husky): drop deprecated v8 shim lines from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 echo "Regenerating security classifications from schema..."
 npx prisma generate || {
   echo "Prisma generate failed (likely missing /// @sensitivity annotation). Commit blocked."


### PR DESCRIPTION
## Summary
- The pre-commit hook had two lines left over from husky v8's generated format (`#!/bin/sh` + `. "$(dirname "$0")/_/husky.sh"`).
- Husky v9 (currently installed at 9.1.7) prints a deprecation warning on every commit about these; they **will hard-fail in v10**.
- Three-line deletion, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)