### PR TITLE
feat(shop): tools list, by-person drilldowns, and all-assignments view (#159)

### DIFF
--- a/src/app/api/shop/certifications/route.ts
+++ b/src/app/api/shop/certifications/route.ts
@@ -16,6 +16,23 @@ export async function GET(req: Request) {
         const { searchParams } = new URL(req.url);
         const participantIdParam = searchParams.get('participantId');
         const toolIdParam = searchParams.get('toolId');
+        const allParam = searchParams.get('all');
+
+        // ?all=true returns every assignment — admin/shop steward only
+        if (allParam === 'true') {
+            const isAuthorized = session.user?.sysadmin || session.user?.boardMember || session.user?.shopSteward;
+            if (!isAuthorized) {
+                return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+            }
+            const certifications = await prisma.toolStatus.findMany({
+                orderBy: [{ tool: { name: 'asc' } }, { user: { name: 'asc' } }],
+                include: {
+                    tool: true,
+                    user: { select: { id: true, name: true, email: true } },
+                },
+            });
+            return NextResponse.json(certifications);
+        }
 
         let targetUserId = session.user.id;
 

--- a/src/app/api/shop/tools/[id]/route.ts
+++ b/src/app/api/shop/tools/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth-options";
+import prisma from "@/lib/prisma";
+import { logBackendError } from "@/lib/logger";
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+    const session = await getServerSession(authOptions);
+
+    if (!session) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const isAuthorized = session.user?.sysadmin || session.user?.boardMember || session.user?.shopSteward;
+    if (!isAuthorized) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    const toolId = parseInt(id, 10);
+    if (isNaN(toolId)) {
+        return NextResponse.json({ error: "Invalid tool ID" }, { status: 400 });
+    }
+
+    try {
+        const body = await req.json();
+        const { name, safetyGuide } = body;
+
+        const data: { name?: string; safetyGuide?: string | null } = {};
+        if (name !== undefined) data.name = name;
+        if (safetyGuide !== undefined) data.safetyGuide = safetyGuide || null;
+
+        const tool = await prisma.tool.update({
+            where: { id: toolId },
+            data,
+        });
+
+        await prisma.auditLog.create({
+            data: {
+                actorId: session.user.id,
+                action: 'EDIT',
+                tableName: 'Tool',
+                affectedEntityId: toolId,
+                newData: JSON.stringify(tool),
+            },
+        });
+
+        return NextResponse.json({ success: true, tool });
+    } catch (error) {
+        await logBackendError(error, "PATCH /api/shop/tools/[id]");
+        return NextResponse.json({ error: "Failed to update tool" }, { status: 500 });
+    }
+}

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -82,8 +82,8 @@ export default function ShopStewardPage() {
                             style={{ background: 'rgba(234, 179, 8, 0.2)', borderColor: 'rgba(234, 179, 8, 0.4)', padding: '2.5rem', fontSize: '1.25rem', flexDirection: 'column', gridColumn: isAdmin ? 'span 1' : '1 / -1' }}
                         >
                             <span style={{ fontSize: '2rem', marginBottom: '0.5rem' }}>&#128203;</span>
-                            <strong>Manage Certifications</strong>
-                            <p style={{ margin: '0.5rem 0 0 0', fontSize: '1rem', color: 'var(--color-text)' }}>Review master tool lists and grant safety clearance levels to fellow members.</p>
+                            <strong>Manage Tools &amp; Certifications</strong>
+                            <p style={{ margin: '0.5rem 0 0 0', fontSize: '1rem', color: 'var(--color-text)' }}>Browse all tools and safety guides, drill into certifications by tool or person, and grant clearance levels.</p>
                         </button>
                     )}
 

--- a/src/app/shop/tools/page.tsx
+++ b/src/app/shop/tools/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { useState, useEffect, useRef } from 'react';
 import { useSession } from 'next-auth/react';
@@ -11,482 +10,593 @@ type Tool = {
     id: number;
     name: string;
     safetyGuide: string | null;
+    _count?: { toolStatuses: number };
 };
 
 type Certification = {
     userId: number;
     toolId: number;
     level: "BASIC" | "DOF" | "CERTIFIED" | "MAY_CERTIFY_OTHERS";
-    user?: {
-        id: number;
-        name: string | null;
-        email: string;
-    };
-    tool?: {
-        id: number;
-        name: string;
-    };
+    user?: { id: number; name: string | null; email: string };
+    tool?: { id: number; name: string };
 };
 
-type ParticipantOption = {
-    id: number;
-    name: string | null;
-    email: string;
+type Member = { id: number; name: string | null; email: string };
+
+type Tab = 'tools' | 'person' | 'all';
+
+const LEVEL_RANKS: Record<string, number> = {
+    NONE: 0, BASIC: 1, CERTIFIED: 2, DOF: 3, MAY_CERTIFY_OTHERS: 4,
 };
 
-export default function ToolManagementPage() {
-    const { status } = useSession();
-    const router = useRouter();
-    const hasFetched = useRef(false);
+const LEVEL_LABELS: Record<string, string> = {
+    BASIC: 'Basic', CERTIFIED: 'Certified', DOF: 'DoF', MAY_CERTIFY_OTHERS: 'Certifier',
+};
 
-    const [filterMode, setFilterMode] = useState<'MEMBER' | 'TOOL'>('MEMBER');
-
-    const [tools, setTools] = useState<Tool[]>([]);
-    const [selectedToolId, setSelectedToolId] = useState<number | null>(null);
-    const [allParticipants, setAllParticipants] = useState<ParticipantOption[]>([]);
-    const [selectedMemberId, setSelectedMemberId] = useState<number | null>(null);
-    const [certifications, setCertifications] = useState<Certification[]>([]);
-
-    const [confirmDialog, setConfirmDialog] = useState<{
-        type: 'PROMOTION' | 'DEMOTION' | 'NEW';
-        userName: string;
-        toolName: string;
-        oldLevel: string;
-        newLevel: string;
-        payload: { toolId: number, participantId: number, level: string }
-    } | null>(null);
-
-    const LEVEL_RANKS: Record<string, number> = {
-        "NONE": 0,
-        "BASIC": 1,
-        "CERTIFIED": 2,
-        "DOF": 3,
-        "MAY_CERTIFY_OTHERS": 4
+function levelBadge(level: string) {
+    const colors: Record<string, { bg: string; color: string }> = {
+        BASIC: { bg: '#ef4444', color: '#fff' },
+        CERTIFIED: { bg: '#22c55e', color: '#000' },
+        DOF: { bg: '#eab308', color: '#000' },
+        MAY_CERTIFY_OTHERS: { bg: '#3b82f6', color: '#fff' },
     };
+    const c = colors[level] || { bg: 'transparent', color: 'gray' };
+    return (
+        <span style={{
+            background: c.bg, color: c.color,
+            padding: '0.25rem 0.55rem', borderRadius: '10px',
+            fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.04em',
+            whiteSpace: 'nowrap',
+        }}>
+            {LEVEL_LABELS[level] ?? level}
+        </span>
+    );
+}
 
-    const [newCertUserId, setNewCertUserId] = useState("");
-    const [newCertToolId, setNewCertToolId] = useState("");
-    const [newCertLevel, setNewCertLevel] = useState("CERTIFIED");
+function GrantForm({
+    tools, members, prefillToolId, prefillMemberId, onGranted, saving, setSaving,
+}: {
+    tools: Tool[];
+    members: Member[];
+    prefillToolId?: number;
+    prefillMemberId?: number;
+    onGranted: (msg: string) => void;
+    saving: boolean;
+    setSaving: (v: boolean) => void;
+}) {
+    const [toolId, setToolId] = useState(prefillToolId?.toString() ?? "");
+    const [memberId, setMemberId] = useState(prefillMemberId?.toString() ?? "");
+    const [level, setLevel] = useState("CERTIFIED");
+    const [confirm, setConfirm] = useState<null | { toolName: string; userName: string; oldLevel: string; newLevel: string; payload: object }>(null);
 
-    const [loading, setLoading] = useState(true);
-    const [saving, setSaving] = useState(false);
-    const [message, setMessage] = useState("");
+    const selectedTool = tools.find(t => t.id === parseInt(toolId));
+    const selectedMember = members.find(m => m.id === parseInt(memberId));
 
-    const [searchQuery, setSearchQuery] = useState("");
-
-    useEffect(() => {
-        if (status === "unauthenticated") {
-            router.push('/');
-        } else if (status === "authenticated" && !hasFetched.current) {
-            hasFetched.current = true;
-            fetchTools();
-            fetchAllParticipants();
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [status]);
-
-    useEffect(() => {
-        if (filterMode === 'TOOL' && selectedToolId) {
-            fetchCertifications('TOOL', selectedToolId);
-        } else if (filterMode === 'MEMBER' && selectedMemberId) {
-            fetchCertifications('MEMBER', selectedMemberId);
-        } else {
-            setCertifications([]);
-        }
-    }, [filterMode, selectedToolId, selectedMemberId]);
-
-    const fetchTools = async () => {
-        try {
-            const res = await fetch('/api/shop/tools');
-            if (res.ok) setTools(await res.json());
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    const fetchAllParticipants = async () => {
-        try {
-            const res = await fetch('/api/shop/members');
-            if (res.ok) {
-                const data = await res.json();
-                setAllParticipants(data.members || []);
-            }
-        } catch { /* silent fail */ }
-    };
-
-    const fetchCertifications = async (type: 'TOOL' | 'MEMBER', id: number) => {
-        try {
-            const url = type === 'TOOL'
-                ? `/api/shop/certifications?toolId=${id}`
-                : `/api/shop/certifications?participantId=${id}`;
-            const res = await fetch(url);
-            if (res.ok) setCertifications(await res.json());
-        } catch { }
-    };
-
-    const initiateGrantCertification = (e: React.FormEvent) => {
+    const initiate = (e: React.FormEvent) => {
         e.preventDefault();
-        setMessage("");
-
-        let participantId: number;
-        let toolId: number;
-        let userName = "Unknown User";
-        let toolName = "Unknown Tool";
-
-        if (filterMode === 'TOOL') {
-            if (!selectedToolId || !newCertUserId || !newCertLevel) return;
-            participantId = parseInt(newCertUserId);
-            toolId = selectedToolId;
-            const participant = allParticipants.find(p => p.id === participantId);
-            userName = participant?.name || participant?.email || "Unknown User";
-            toolName = tools.find(t => t.id === toolId)?.name || "Unknown Tool";
-        } else {
-            if (!selectedMemberId || !newCertToolId || !newCertLevel) return;
-            participantId = selectedMemberId;
-            toolId = parseInt(newCertToolId);
-            const participant = allParticipants.find(p => p.id === participantId);
-            userName = participant?.name || participant?.email || "Unknown User";
-            toolName = tools.find(t => t.id === toolId)?.name || "Unknown Tool";
-        }
-
-        const existingCert = certifications.find(c =>
-            filterMode === 'TOOL' ? c.userId === participantId : c.toolId === toolId
-        );
-        const oldLevel = existingCert ? existingCert.level : "NONE";
-
-        if (oldLevel === newCertLevel) {
-            setMessage(`User already has the ${newCertLevel} certification level on this tool.`);
-            return;
-        }
-
-        const oldRank = LEVEL_RANKS[oldLevel];
-        const newRank = LEVEL_RANKS[newCertLevel];
-        const type = oldRank === 0 ? 'NEW' : newRank > oldRank ? 'PROMOTION' : 'DEMOTION';
-
-        setConfirmDialog({
-            type,
-            userName,
-            toolName,
-            oldLevel,
-            newLevel: newCertLevel,
-            payload: {
-                toolId,
-                participantId,
-                level: newCertLevel
-            }
+        if (!toolId || !memberId || !level) return;
+        setConfirm({
+            toolName: selectedTool?.name ?? '?',
+            userName: selectedMember?.name ?? selectedMember?.email ?? '?',
+            oldLevel: 'NONE',
+            newLevel: level,
+            payload: { toolId: parseInt(toolId), participantId: parseInt(memberId), level },
         });
     };
 
-    const confirmGrantCertification = async () => {
-        if (!confirmDialog) return;
+    const confirm_ = async () => {
+        if (!confirm) return;
         setSaving(true);
-        setMessage("");
-
         try {
             const res = await fetch('/api/shop/certifications', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(confirmDialog.payload)
+                body: JSON.stringify(confirm.payload),
             });
-
+            const data = await res.json();
             if (res.ok) {
-                setMessage(`Certification successfully updated for ${confirmDialog.userName} on ${confirmDialog.toolName}.`);
-                if (filterMode === 'TOOL') setNewCertUserId("");
-                if (filterMode === 'MEMBER') setNewCertToolId("");
-
-                fetchCertifications(
-                    filterMode,
-                    filterMode === 'TOOL' ? selectedToolId! : selectedMemberId!
-                );
+                onGranted(`Certification updated for ${confirm.userName} on ${confirm.toolName}.`);
+                setMemberId(prefillMemberId?.toString() ?? "");
+                setToolId(prefillToolId?.toString() ?? "");
             } else {
-                const data = await res.json();
-                setMessage(data.error || "Failed to grant certification.");
+                onGranted(data.error ?? 'Failed.');
             }
-        } catch (_error) {
-            setMessage("Network error.");
         } finally {
             setSaving(false);
-            setConfirmDialog(null);
+            setConfirm(null);
         }
     };
-
-    const filteredTools = tools.filter(tool =>
-        (tool.name || "").toLowerCase().includes((searchQuery || "").toLowerCase())
-    );
-
-    const filteredParticipants = allParticipants.filter(p =>
-        (p.name || "").toLowerCase().includes((searchQuery || "").toLowerCase()) ||
-        (p.email || "").toLowerCase().includes((searchQuery || "").toLowerCase())
-    );
-
-    const getBadgeStyle = (level: string) => {
-        switch (level) {
-            case 'BASIC': return { bg: '#ef4444', color: '#fff', label: 'Basic' }; // Red
-            case 'CERTIFIED': return { bg: '#22c55e', color: '#000', label: 'Certified' }; // Green
-            case 'DOF': return { bg: '#eab308', color: '#000', label: 'DoF' }; // Yellow
-            case 'MAY_CERTIFY_OTHERS': return { bg: '#3b82f6', color: '#fff', label: 'Certifier' }; // Blue
-            default: return { bg: 'transparent', color: 'gray', label: '-' };
-        }
-    };
-
-    if (loading || status === "loading") {
-        return <main className={styles.main}><div className="glass-container animate-float"><h2>Loading...</h2></div></main>;
-    }
 
     return (
-        <main className={styles.main}>
-            <div className={`glass-container ${styles.heroContainer}`} style={{ maxWidth: '1000px', width: '100%' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
-                    <h1 className="text-gradient" style={{ margin: 0, fontSize: '2.5rem' }}>Tool Certifications</h1>
-                    <Link href="/shop" className="glass-button" style={{ textDecoration: 'none' }}>
-                        &larr; Shop Dashboard
-                    </Link>
-                </div>
-
-                {message && (
-                    <div style={{ marginBottom: '1.5rem', padding: '1rem', background: 'rgba(56, 189, 248, 0.1)', border: '1px solid rgba(56, 189, 248, 0.3)', borderRadius: '8px', color: '#38bdf8' }}>
-                        {message}
+        <>
+            <form onSubmit={initiate} style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'flex-end' }}>
+                {!prefillToolId && (
+                    <div style={{ flex: '1 1 180px' }}>
+                        <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.8rem', color: 'gray' }}>Tool</label>
+                        <select className="glass-input" value={toolId} onChange={e => setToolId(e.target.value)} required style={{ width: '100%', padding: '0.6rem' }}>
+                            <option value="">-- Tool --</option>
+                            {tools.map(t => <option key={t.id} value={t.id}>{t.name}</option>)}
+                        </select>
                     </div>
                 )}
-
-                <div style={{ display: 'grid', gridTemplateColumns: 'minmax(250px, 1fr) 2fr', gap: '2rem' }}>
-
-                    {/* Left Sidebar */}
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-                        <div>
-                            {/* Filter Mode Toggle */}
-                            <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem', background: 'rgba(255,255,255,0.05)', padding: '0.25rem', borderRadius: '12px' }}>
-                                <button
-                                    onClick={() => { setFilterMode('MEMBER'); setSearchQuery(""); }}
-                                    style={{
-                                        flex: 1, padding: '0.5rem', borderRadius: '8px', border: 'none', cursor: 'pointer', transition: 'all 0.2s',
-                                        background: filterMode === 'MEMBER' ? 'rgba(56, 189, 248, 0.2)' : 'transparent',
-                                        color: filterMode === 'MEMBER' ? '#38bdf8' : 'gray',
-                                        fontWeight: filterMode === 'MEMBER' ? 600 : 400
-                                    }}>
-                                    By Member
-                                </button>
-                                <button
-                                    onClick={() => { setFilterMode('TOOL'); setSearchQuery(""); }}
-                                    style={{
-                                        flex: 1, padding: '0.5rem', borderRadius: '8px', border: 'none', cursor: 'pointer', transition: 'all 0.2s',
-                                        background: filterMode === 'TOOL' ? 'rgba(56, 189, 248, 0.2)' : 'transparent',
-                                        color: filterMode === 'TOOL' ? '#38bdf8' : 'gray',
-                                        fontWeight: filterMode === 'TOOL' ? 600 : 400
-                                    }}>
-                                    By Tool
-                                </button>
-                            </div>
-
-                            <div style={{ marginBottom: '1rem' }}>
-                                <input
-                                    type="text"
-                                    className="glass-input"
-                                    placeholder={filterMode === 'TOOL' ? "Search tools..." : "Search members..."}
-                                    value={searchQuery}
-                                    onChange={e => setSearchQuery(e.target.value)}
-                                    style={{ width: '100%', padding: '0.75rem' }}
-                                />
-                            </div>
-
-                            <div style={{ maxHeight: '530px', overflowY: 'auto', paddingRight: '0.5rem' }}>
-                                {filterMode === 'TOOL' ? (
-                                    <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-                                        {filteredTools.map(tool => (
-                                            <li key={tool.id}>
-                                                <button
-                                                    onClick={() => setSelectedToolId(tool.id)}
-                                                    style={{
-                                                        width: '100%',
-                                                        textAlign: 'left',
-                                                        padding: '0.75rem 1rem',
-                                                        borderRadius: '8px',
-                                                        border: '1px solid',
-                                                        borderColor: selectedToolId === tool.id ? '#38bdf8' : 'rgba(255,255,255,0.1)',
-                                                        background: selectedToolId === tool.id ? 'rgba(56, 189, 248, 0.1)' : 'rgba(255,255,255,0.05)',
-                                                        color: selectedToolId === tool.id ? '#fff' : 'var(--color-text-muted)',
-                                                        cursor: 'pointer',
-                                                        fontWeight: selectedToolId === tool.id ? 600 : 400,
-                                                        transition: 'all 0.2s'
-                                                    }}
-                                                >
-                                                    {tool.name}
-                                                </button>
-                                            </li>
-                                        ))}
-                                        {filteredTools.length === 0 && <p style={{ color: 'gray' }}>No tools match your search.</p>}
-                                    </ul>
-                                ) : (
-                                    <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-                                        {filteredParticipants.map(participant => (
-                                            <li key={participant.id}>
-                                                <button
-                                                    onClick={() => setSelectedMemberId(participant.id)}
-                                                    style={{
-                                                        width: '100%',
-                                                        textAlign: 'left',
-                                                        padding: '0.75rem 1rem',
-                                                        borderRadius: '8px',
-                                                        border: '1px solid',
-                                                        borderColor: selectedMemberId === participant.id ? '#38bdf8' : 'rgba(255,255,255,0.1)',
-                                                        background: selectedMemberId === participant.id ? 'rgba(56, 189, 248, 0.1)' : 'rgba(255,255,255,0.05)',
-                                                        color: selectedMemberId === participant.id ? '#fff' : 'var(--color-text-muted)',
-                                                        cursor: 'pointer',
-                                                        fontWeight: selectedMemberId === participant.id ? 600 : 400,
-                                                        transition: 'all 0.2s'
-                                                    }}
-                                                >
-                                                    <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                                        {participant.name || 'Unnamed'}
-                                                    </div>
-                                                    <div style={{ fontSize: '0.75rem', color: selectedMemberId === participant.id ? 'rgba(255,255,255,0.7)' : 'gray', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                                        {participant.email}
-                                                    </div>
-                                                </button>
-                                            </li>
-                                        ))}
-                                        {filteredParticipants.length === 0 && <p style={{ color: 'gray' }}>No members match your search.</p>}
-                                    </ul>
-                                )}
-                            </div>
-                        </div>
+                {!prefillMemberId && (
+                    <div style={{ flex: '1 1 180px' }}>
+                        <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.8rem', color: 'gray' }}>Member</label>
+                        <select className="glass-input" value={memberId} onChange={e => setMemberId(e.target.value)} required style={{ width: '100%', padding: '0.6rem' }}>
+                            <option value="">-- Member --</option>
+                            {members.map(m => <option key={m.id} value={m.id}>{m.name ?? m.email}</option>)}
+                        </select>
                     </div>
-
-                    {/* Right Content Area */}
-                    <div style={{ background: 'rgba(0,0,0,0.2)', borderRadius: '12px', padding: '1.5rem', border: '1px solid rgba(255,255,255,0.1)', minHeight: '400px' }}>
-                        {(filterMode === 'TOOL' && !selectedToolId) || (filterMode === 'MEMBER' && !selectedMemberId) ? (
-                            <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'gray' }}>
-                                Select a {filterMode === 'TOOL' ? 'tool' : 'member'} from the list to view or grant certifications.
-                            </div>
-                        ) : (
-                            <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-                                <div>
-                                    <h3 style={{ margin: '0 0 1rem 0', borderBottom: '1px solid rgba(255,255,255,0.1)', paddingBottom: '0.5rem' }}>
-                                        Grant Certification Level
-                                    </h3>
-                                    <form onSubmit={initiateGrantCertification} style={{ display: 'flex', gap: '1rem', alignItems: 'flex-end', flexWrap: 'wrap' }}>
-
-                                        {filterMode === 'TOOL' ? (
-                                            <div style={{ flex: 1, minWidth: '200px' }}>
-                                                <label style={{ display: 'block', marginBottom: '0.5rem', fontSize: '0.85rem', color: 'gray' }}>Member</label>
-                                                <select className="glass-input" value={newCertUserId} onChange={e => setNewCertUserId(e.target.value)} required style={{ width: '100%', padding: '0.75rem' }}>
-                                                    <option value="">-- Select Member --</option>
-                                                    {allParticipants.map(p => (
-                                                        <option key={p.id} value={p.id}>{p.name} ({p.email})</option>
-                                                    ))}
-                                                </select>
-                                            </div>
-                                        ) : (
-                                            <div style={{ flex: 1, minWidth: '200px' }}>
-                                                <label style={{ display: 'block', marginBottom: '0.5rem', fontSize: '0.85rem', color: 'gray' }}>Tool</label>
-                                                <select className="glass-input" value={newCertToolId} onChange={e => setNewCertToolId(e.target.value)} required style={{ width: '100%', padding: '0.75rem' }}>
-                                                    <option value="">-- Select Tool --</option>
-                                                    {tools.map(t => (
-                                                        <option key={t.id} value={t.id}>{t.name}</option>
-                                                    ))}
-                                                </select>
-                                            </div>
-                                        )}
-
-                                        <div style={{ width: '150px' }}>
-                                            <label style={{ display: 'block', marginBottom: '0.5rem', fontSize: '0.85rem', color: 'gray' }}>Level</label>
-                                            <select className="glass-input" value={newCertLevel} onChange={e => setNewCertLevel(e.target.value)} required style={{ width: '100%', padding: '0.75rem' }}>
-                                                <option value="BASIC">Basic</option>
-                                                <option value="CERTIFIED">Certified</option>
-                                                <option value="DOF">DoF</option>
-                                                <option value="MAY_CERTIFY_OTHERS">Certifier</option>
-                                            </select>
-                                        </div>
-                                        <button type="submit" className="glass-button" disabled={saving || (filterMode === 'TOOL' ? !newCertUserId : !newCertToolId)} style={{ padding: '0.75rem 1.5rem', background: 'rgba(34, 197, 94, 0.2)', borderColor: 'rgba(34, 197, 94, 0.4)' }}>
-                                            Grant
-                                        </button>
-                                    </form>
-                                    <p style={{ margin: '0.5rem 0 0 0', fontSize: '0.85rem', color: '#fbbf24' }}>* You must have the &apos;Certifier&apos; level on this tool, or be an Admin, to successfully grant levels to others.</p>
-                                </div>
-
-                                <div>
-                                    <h3 style={{ margin: '0 0 1rem 0' }}>
-                                        {filterMode === 'TOOL'
-                                            ? `Certified Members on ${tools.find(t => t.id === selectedToolId)?.name || 'Tool'}`
-                                            : `Certifications for ${allParticipants.find(p => p.id === selectedMemberId)?.name || 'Member'}`}
-                                    </h3>
-                                    {certifications.length === 0 ? <p style={{ color: 'gray' }}>No certifications found.</p> : (
-                                        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-                                            {certifications.map(cert => {
-                                                const style = getBadgeStyle(cert.level);
-                                                return (
-                                                    <li key={`${cert.userId}-${cert.toolId}`} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'rgba(255,255,255,0.05)', padding: '0.75rem 1rem', borderRadius: '8px' }}>
-                                                        {filterMode === 'TOOL' ? (
-                                                            <span>{cert.user?.name || 'Unnamed'} <span style={{ color: 'gray', fontSize: '0.85rem' }}>({cert.user?.email})</span></span>
-                                                        ) : (
-                                                            <span>{cert.tool?.name || 'Unknown Tool'}</span>
-                                                        )}
-                                                        <span style={{
-                                                            background: style.bg,
-                                                            color: style.color,
-                                                            padding: '0.3rem 0.6rem',
-                                                            borderRadius: '12px',
-                                                            fontSize: '0.75rem',
-                                                            fontWeight: 600,
-                                                            letterSpacing: '0.05em'
-                                                        }}>
-                                                            {style.label}
-                                                        </span>
-                                                    </li>
-                                                );
-                                            })}
-                                        </ul>
-                                    )}
-                                </div>
-                            </div>
-                        )}
-                    </div>
-
+                )}
+                <div style={{ width: '130px' }}>
+                    <label style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.8rem', color: 'gray' }}>Level</label>
+                    <select className="glass-input" value={level} onChange={e => setLevel(e.target.value)} style={{ width: '100%', padding: '0.6rem' }}>
+                        <option value="BASIC">Basic</option>
+                        <option value="CERTIFIED">Certified</option>
+                        <option value="DOF">DoF</option>
+                        <option value="MAY_CERTIFY_OTHERS">Certifier</option>
+                    </select>
                 </div>
-            </div>
+                <button type="submit" className="glass-button" disabled={saving} style={{ padding: '0.6rem 1.2rem', background: 'rgba(34,197,94,0.2)', borderColor: 'rgba(34,197,94,0.4)' }}>
+                    Grant
+                </button>
+            </form>
 
-            {confirmDialog && (
-                <div style={{
-                    position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
-                    background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(4px)',
-                    display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000
-                }}>
-                    <div className="glass-container" style={{ maxWidth: '400px', width: '90%', padding: '2rem', textAlign: 'center' }}>
-                        <h2 style={{ margin: '0 0 1rem 0' }}>Confirm {confirmDialog.type === 'PROMOTION' ? 'Promotion' : confirmDialog.type === 'DEMOTION' ? 'Demotion' : 'Certification'}</h2>
-
-                        <div style={{ marginBottom: '1.5rem' }}>
-                            {confirmDialog.type === 'PROMOTION' && <div style={{ fontSize: '3rem', color: '#4ade80', lineHeight: 1 }}>&#8593;</div>}
-                            {confirmDialog.type === 'DEMOTION' && <div style={{ fontSize: '3rem', color: '#ef4444', lineHeight: 1 }}>&#8595;</div>}
-                            {confirmDialog.type === 'NEW' && <div style={{ fontSize: '3rem', color: '#38bdf8', lineHeight: 1 }}>&#10024;</div>}
-                        </div>
-
-                        <p style={{ marginBottom: '1.5rem', fontSize: '1.1rem' }}>
-                            You are about to change the certification level for <strong>{confirmDialog.userName}</strong> on <strong>{confirmDialog.toolName}</strong>.
+            {confirm && (
+                <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(4px)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}>
+                    <div className="glass-container" style={{ maxWidth: '380px', width: '90%', padding: '2rem', textAlign: 'center' }}>
+                        <h3 style={{ margin: '0 0 1rem 0' }}>Confirm Certification</h3>
+                        <p style={{ marginBottom: '1.5rem' }}>
+                            Grant <strong>{confirm.newLevel}</strong> on <strong>{confirm.toolName}</strong> to <strong>{confirm.userName}</strong>?
                         </p>
-
-                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '1rem', marginBottom: '2rem', fontWeight: 'bold' }}>
-                            {confirmDialog.oldLevel !== 'NONE' && (
-                                <>
-                                    <span style={{ color: 'gray' }}>{confirmDialog.oldLevel}</span>
-                                    <span>&rarr;</span>
-                                </>
-                            )}
-                            <span style={{ color: confirmDialog.type === 'DEMOTION' ? '#ef4444' : '#4ade80' }}>
-                                {confirmDialog.newLevel}
-                            </span>
-                        </div>
-
                         <div style={{ display: 'flex', gap: '1rem' }}>
-                            <button className="glass-button" onClick={() => setConfirmDialog(null)} style={{ flex: 1 }}>
-                                Cancel
-                            </button>
-                            <button className="glass-button" onClick={confirmGrantCertification} disabled={saving} style={{ flex: 1, background: confirmDialog.type === 'DEMOTION' ? 'rgba(239, 68, 68, 0.2)' : 'rgba(34, 197, 94, 0.2)', borderColor: confirmDialog.type === 'DEMOTION' ? 'rgba(239, 68, 68, 0.4)' : 'rgba(34, 197, 94, 0.4)' }}>
-                                {saving ? "Saving..." : "Confirm"}
+                            <button className="glass-button" style={{ flex: 1 }} onClick={() => setConfirm(null)}>Cancel</button>
+                            <button className="glass-button" style={{ flex: 1, background: 'rgba(34,197,94,0.2)', borderColor: 'rgba(34,197,94,0.4)' }} onClick={confirm_} disabled={saving}>
+                                {saving ? 'Saving...' : 'Confirm'}
                             </button>
                         </div>
                     </div>
                 </div>
             )}
+        </>
+    );
+}
+
+// ---- Tools tab ----
+
+function ToolsTab({ tools, members, isAdmin, isCertifier, onToolsChange }: {
+    tools: Tool[];
+    members: Member[];
+    isAdmin: boolean;
+    isCertifier: boolean;
+    onToolsChange: () => void;
+}) {
+    const [expanded, setExpanded] = useState<number | null>(null);
+    const [certs, setCerts] = useState<Certification[]>([]);
+    const [loadingCerts, setLoadingCerts] = useState(false);
+    const [editingGuide, setEditingGuide] = useState<{ id: number; value: string } | null>(null);
+    const [savingGuide, setSavingGuide] = useState(false);
+    const [msg, setMsg] = useState("");
+    const [grantMsg, setGrantMsg] = useState("");
+    const [grantSaving, setGrantSaving] = useState(false);
+    const [search, setSearch] = useState("");
+
+    const toggle = async (toolId: number) => {
+        if (expanded === toolId) { setExpanded(null); setCerts([]); return; }
+        setExpanded(toolId);
+        setLoadingCerts(true);
+        try {
+            const res = await fetch(`/api/shop/certifications?toolId=${toolId}`);
+            if (res.ok) setCerts(await res.json());
+        } finally {
+            setLoadingCerts(false);
+        }
+    };
+
+    const saveGuide = async () => {
+        if (!editingGuide) return;
+        setSavingGuide(true);
+        try {
+            const res = await fetch(`/api/shop/tools/${editingGuide.id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ safetyGuide: editingGuide.value }),
+            });
+            if (res.ok) {
+                setMsg("Safety guide updated.");
+                setEditingGuide(null);
+                onToolsChange();
+                if (expanded === editingGuide.id) {
+                    const toolRes = await fetch(`/api/shop/certifications?toolId=${editingGuide.id}`);
+                    if (toolRes.ok) setCerts(await toolRes.json());
+                }
+            } else {
+                setMsg("Failed to update.");
+            }
+        } finally {
+            setSavingGuide(false);
+        }
+    };
+
+    const filtered = tools.filter(t => t.name.toLowerCase().includes(search.toLowerCase()));
+
+    return (
+        <div>
+            {msg && <div style={{ marginBottom: '1rem', padding: '0.75rem 1rem', background: 'rgba(56,189,248,0.1)', border: '1px solid rgba(56,189,248,0.3)', borderRadius: '8px', color: '#38bdf8' }}>{msg}</div>}
+
+            <div style={{ display: 'flex', gap: '1rem', marginBottom: '1.25rem', alignItems: 'center', flexWrap: 'wrap' }}>
+                <input
+                    type="text"
+                    className="glass-input"
+                    placeholder="Search tools..."
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    style={{ flex: '1 1 220px', padding: '0.6rem 0.9rem' }}
+                />
+                {isAdmin && (
+                    <Link href="/shop/tools/new" className="glass-button" style={{ textDecoration: 'none', padding: '0.6rem 1.2rem', background: 'rgba(56,189,248,0.2)', borderColor: 'rgba(56,189,248,0.4)', whiteSpace: 'nowrap' }}>
+                        + New Tool
+                    </Link>
+                )}
+            </div>
+
+            {filtered.length === 0 && <p style={{ color: 'gray' }}>No tools match.</p>}
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                {filtered.map(tool => {
+                    const isOpen = expanded === tool.id;
+                    return (
+                        <div key={tool.id} style={{ borderRadius: '10px', border: '1px solid', borderColor: isOpen ? 'rgba(56,189,248,0.4)' : 'rgba(255,255,255,0.1)', overflow: 'hidden' }}>
+                            {/* Row */}
+                            <div
+                                style={{ display: 'flex', alignItems: 'center', gap: '1rem', padding: '0.85rem 1rem', background: isOpen ? 'rgba(56,189,248,0.07)' : 'rgba(255,255,255,0.03)', cursor: 'pointer' }}
+                                onClick={() => toggle(tool.id)}
+                            >
+                                <span style={{ flex: 1, fontWeight: 600, color: isOpen ? '#38bdf8' : 'var(--color-text)' }}>{tool.name}</span>
+
+                                <span style={{ fontSize: '0.8rem', color: 'gray', whiteSpace: 'nowrap' }}>
+                                    {tool._count?.toolStatuses ?? '?'} certified
+                                </span>
+
+                                {tool.safetyGuide ? (
+                                    <a href={tool.safetyGuide} target="_blank" rel="noopener noreferrer"
+                                        onClick={e => e.stopPropagation()}
+                                        style={{ fontSize: '0.8rem', color: '#38bdf8', whiteSpace: 'nowrap', textDecoration: 'none' }}>
+                                        Safety Guide ↗
+                                    </a>
+                                ) : (
+                                    <span style={{ fontSize: '0.8rem', color: 'rgba(255,255,255,0.25)', whiteSpace: 'nowrap' }}>No guide</span>
+                                )}
+
+                                {isAdmin && (
+                                    <button
+                                        className="glass-button"
+                                        style={{ padding: '0.25rem 0.6rem', fontSize: '0.75rem', background: 'transparent', borderColor: 'rgba(255,255,255,0.2)' }}
+                                        onClick={e => { e.stopPropagation(); setEditingGuide({ id: tool.id, value: tool.safetyGuide ?? '' }); setMsg(""); }}
+                                    >
+                                        Edit guide
+                                    </button>
+                                )}
+
+                                <span style={{ color: 'gray', fontSize: '0.9rem' }}>{isOpen ? '▲' : '▼'}</span>
+                            </div>
+
+                            {/* Drilldown */}
+                            {isOpen && (
+                                <div style={{ padding: '1rem 1.25rem', borderTop: '1px solid rgba(255,255,255,0.07)', background: 'rgba(0,0,0,0.15)' }}>
+                                    {loadingCerts ? <p style={{ color: 'gray' }}>Loading...</p> : (
+                                        <>
+                                            <h4 style={{ margin: '0 0 0.75rem 0', fontSize: '0.9rem', color: 'var(--color-text-muted)' }}>Certified members</h4>
+                                            {certs.length === 0 ? (
+                                                <p style={{ color: 'gray', fontSize: '0.9rem' }}>No certifications yet.</p>
+                                            ) : (
+                                                <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 1.25rem 0', display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+                                                    {certs.map(c => (
+                                                        <li key={`${c.userId}-${c.toolId}`} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0.5rem 0.75rem', background: 'rgba(255,255,255,0.04)', borderRadius: '6px' }}>
+                                                            <span style={{ fontSize: '0.9rem' }}>
+                                                                {c.user?.name ?? 'Unnamed'}{' '}
+                                                                <span style={{ color: 'gray', fontSize: '0.8rem' }}>({c.user?.email})</span>
+                                                            </span>
+                                                            {levelBadge(c.level)}
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            )}
+
+                                            {isCertifier && (
+                                                <>
+                                                    {grantMsg && <p style={{ fontSize: '0.85rem', color: '#38bdf8', marginBottom: '0.75rem' }}>{grantMsg}</p>}
+                                                    <GrantForm
+                                                        tools={tools} members={members}
+                                                        prefillToolId={tool.id}
+                                                        onGranted={m => { setGrantMsg(m); toggle(tool.id).then(() => toggle(tool.id)); }}
+                                                        saving={grantSaving} setSaving={setGrantSaving}
+                                                    />
+                                                </>
+                                            )}
+                                        </>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+
+            {/* Edit guide modal */}
+            {editingGuide && (
+                <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(4px)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}>
+                    <div className="glass-container" style={{ maxWidth: '480px', width: '90%', padding: '2rem' }}>
+                        <h3 style={{ margin: '0 0 1rem 0' }}>Edit Safety Guide URL</h3>
+                        <input
+                            type="url"
+                            className="glass-input"
+                            placeholder="https://..."
+                            value={editingGuide.value}
+                            onChange={e => setEditingGuide({ ...editingGuide, value: e.target.value })}
+                            style={{ width: '100%', padding: '0.75rem', marginBottom: '1rem' }}
+                        />
+                        <div style={{ display: 'flex', gap: '1rem' }}>
+                            <button className="glass-button" style={{ flex: 1 }} onClick={() => setEditingGuide(null)}>Cancel</button>
+                            <button className="glass-button" style={{ flex: 1, background: 'rgba(34,197,94,0.2)', borderColor: 'rgba(34,197,94,0.4)' }} onClick={saveGuide} disabled={savingGuide}>
+                                {savingGuide ? 'Saving...' : 'Save'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+// ---- By Person tab ----
+
+function PersonTab({ members, tools, isCertifier }: { members: Member[]; tools: Tool[]; isCertifier: boolean }) {
+    const [expanded, setExpanded] = useState<number | null>(null);
+    const [certs, setCerts] = useState<Certification[]>([]);
+    const [loadingCerts, setLoadingCerts] = useState(false);
+    const [search, setSearch] = useState("");
+    const [grantMsg, setGrantMsg] = useState("");
+    const [grantSaving, setGrantSaving] = useState(false);
+
+    const toggle = async (memberId: number) => {
+        if (expanded === memberId) { setExpanded(null); setCerts([]); return; }
+        setExpanded(memberId);
+        setLoadingCerts(true);
+        try {
+            const res = await fetch(`/api/shop/certifications?participantId=${memberId}`);
+            if (res.ok) setCerts(await res.json());
+        } finally {
+            setLoadingCerts(false);
+        }
+    };
+
+    const filtered = members.filter(m =>
+        (m.name ?? '').toLowerCase().includes(search.toLowerCase()) ||
+        m.email.toLowerCase().includes(search.toLowerCase())
+    );
+
+    return (
+        <div>
+            <input
+                type="text"
+                className="glass-input"
+                placeholder="Search members..."
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                style={{ width: '100%', padding: '0.6rem 0.9rem', marginBottom: '1.25rem' }}
+            />
+
+            {filtered.length === 0 && <p style={{ color: 'gray' }}>No members match.</p>}
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                {filtered.map(member => {
+                    const isOpen = expanded === member.id;
+                    return (
+                        <div key={member.id} style={{ borderRadius: '10px', border: '1px solid', borderColor: isOpen ? 'rgba(56,189,248,0.4)' : 'rgba(255,255,255,0.1)', overflow: 'hidden' }}>
+                            <div
+                                style={{ display: 'flex', alignItems: 'center', gap: '1rem', padding: '0.85rem 1rem', background: isOpen ? 'rgba(56,189,248,0.07)' : 'rgba(255,255,255,0.03)', cursor: 'pointer' }}
+                                onClick={() => toggle(member.id)}
+                            >
+                                <div style={{ flex: 1, overflow: 'hidden' }}>
+                                    <div style={{ fontWeight: 600, color: isOpen ? '#38bdf8' : 'var(--color-text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                        {member.name ?? 'Unnamed'}
+                                    </div>
+                                    <div style={{ fontSize: '0.8rem', color: 'gray', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{member.email}</div>
+                                </div>
+                                <span style={{ color: 'gray', fontSize: '0.9rem' }}>{isOpen ? '▲' : '▼'}</span>
+                            </div>
+
+                            {isOpen && (
+                                <div style={{ padding: '1rem 1.25rem', borderTop: '1px solid rgba(255,255,255,0.07)', background: 'rgba(0,0,0,0.15)' }}>
+                                    {loadingCerts ? <p style={{ color: 'gray' }}>Loading...</p> : (
+                                        <>
+                                            <h4 style={{ margin: '0 0 0.75rem 0', fontSize: '0.9rem', color: 'var(--color-text-muted)' }}>Tool certifications</h4>
+                                            {certs.length === 0 ? (
+                                                <p style={{ color: 'gray', fontSize: '0.9rem' }}>No certifications.</p>
+                                            ) : (
+                                                <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 1.25rem 0', display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+                                                    {certs.map(c => (
+                                                        <li key={`${c.userId}-${c.toolId}`} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0.5rem 0.75rem', background: 'rgba(255,255,255,0.04)', borderRadius: '6px' }}>
+                                                            <span style={{ fontSize: '0.9rem' }}>{c.tool?.name ?? 'Unknown Tool'}</span>
+                                                            {levelBadge(c.level)}
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            )}
+
+                                            {isCertifier && (
+                                                <>
+                                                    {grantMsg && <p style={{ fontSize: '0.85rem', color: '#38bdf8', marginBottom: '0.75rem' }}>{grantMsg}</p>}
+                                                    <GrantForm
+                                                        tools={tools} members={members}
+                                                        prefillMemberId={member.id}
+                                                        onGranted={m => { setGrantMsg(m); toggle(member.id).then(() => toggle(member.id)); }}
+                                                        saving={grantSaving} setSaving={setGrantSaving}
+                                                    />
+                                                </>
+                                            )}
+                                        </>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+// ---- All Assignments tab ----
+
+function AllTab() {
+    const [certs, setCerts] = useState<Certification[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [search, setSearch] = useState("");
+
+    useEffect(() => {
+        fetch('/api/shop/certifications?all=true')
+            .then(r => r.ok ? r.json() : [])
+            .then(setCerts)
+            .finally(() => setLoading(false));
+    }, []);
+
+    if (loading) return <p style={{ color: 'gray' }}>Loading...</p>;
+
+    const filtered = certs.filter(c =>
+        (c.tool?.name ?? '').toLowerCase().includes(search.toLowerCase()) ||
+        (c.user?.name ?? '').toLowerCase().includes(search.toLowerCase()) ||
+        (c.user?.email ?? '').toLowerCase().includes(search.toLowerCase())
+    );
+
+    return (
+        <div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem', gap: '1rem', flexWrap: 'wrap' }}>
+                <input
+                    type="text"
+                    className="glass-input"
+                    placeholder="Filter by tool or member..."
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    style={{ flex: '1 1 220px', padding: '0.6rem 0.9rem' }}
+                />
+                <span style={{ fontSize: '0.85rem', color: 'gray', whiteSpace: 'nowrap' }}>{filtered.length} assignment{filtered.length !== 1 ? 's' : ''}</span>
+            </div>
+
+            {filtered.length === 0 ? (
+                <p style={{ color: 'gray' }}>No assignments found.</p>
+            ) : (
+                <div style={{ overflowX: 'auto' }}>
+                    <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+                        <thead>
+                            <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.15)' }}>
+                                <th style={{ textAlign: 'left', padding: '0.5rem 0.75rem', color: 'var(--color-text-muted)', fontWeight: 600 }}>Tool</th>
+                                <th style={{ textAlign: 'left', padding: '0.5rem 0.75rem', color: 'var(--color-text-muted)', fontWeight: 600 }}>Member</th>
+                                <th style={{ textAlign: 'left', padding: '0.5rem 0.75rem', color: 'var(--color-text-muted)', fontWeight: 600 }}>Email</th>
+                                <th style={{ textAlign: 'center', padding: '0.5rem 0.75rem', color: 'var(--color-text-muted)', fontWeight: 600 }}>Level</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {filtered.map((c, i) => (
+                                <tr key={`${c.userId}-${c.toolId}`} style={{ borderBottom: '1px solid rgba(255,255,255,0.06)', background: i % 2 === 0 ? 'transparent' : 'rgba(255,255,255,0.025)' }}>
+                                    <td style={{ padding: '0.5rem 0.75rem', fontWeight: 500 }}>{c.tool?.name ?? '?'}</td>
+                                    <td style={{ padding: '0.5rem 0.75rem' }}>{c.user?.name ?? 'Unnamed'}</td>
+                                    <td style={{ padding: '0.5rem 0.75rem', color: 'gray', fontSize: '0.8rem' }}>{c.user?.email}</td>
+                                    <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center' }}>{levelBadge(c.level)}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}
+
+// ---- Main page ----
+
+export default function ToolManagementPage() {
+    const { data: session, status } = useSession();
+    const router = useRouter();
+    const hasFetched = useRef(false);
+
+    const [tab, setTab] = useState<Tab>('tools');
+    const [tools, setTools] = useState<Tool[]>([]);
+    const [members, setMembers] = useState<Member[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (status === "unauthenticated") router.push('/');
+        else if (status === "authenticated" && !hasFetched.current) {
+            hasFetched.current = true;
+            Promise.all([
+                fetch('/api/shop/tools').then(r => r.ok ? r.json() : []),
+                fetch('/api/shop/members').then(r => r.ok ? r.json() : { members: [] }),
+            ]).then(([toolData, memberData]) => {
+                setTools(toolData);
+                setMembers(memberData.members ?? []);
+            }).finally(() => setLoading(false));
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [status]);
+
+    if (loading || status === "loading") {
+        return <main className={styles.main}><div className="glass-container animate-float"><h2>Loading...</h2></div></main>;
+    }
+
+    const isSysadmin = session?.user?.sysadmin;
+    const isBoardMember = session?.user?.boardMember;
+    const isAdmin = isSysadmin || isBoardMember || session?.user?.shopSteward;
+
+    const hasCertifierAuth = (session?.user?.toolStatuses ?? []).some(
+        (ts: { level?: string }) => ts.level === 'MAY_CERTIFY_OTHERS'
+    );
+    const isCertifier = isSysadmin || isBoardMember || session?.user?.shopSteward || hasCertifierAuth;
+
+    if (!isCertifier && !isAdmin) {
+        return (
+            <main className={styles.main}>
+                <div className="glass-container animate-float">
+                    <h2>Access Denied</h2>
+                    <p style={{ color: '#ef4444' }}>Forbidden: You require the Shop Steward, Admin, Board Member, or Certifier role.</p>
+                    <button className="glass-button" onClick={() => router.push('/shop')}>Back to Shop Ops</button>
+                </div>
+            </main>
+        );
+    }
+
+    const reloadTools = () => {
+        fetch('/api/shop/tools').then(r => r.ok ? r.json() : []).then(setTools);
+    };
+
+    const tabStyle = (t: Tab) => ({
+        flex: 1, padding: '0.5rem', borderRadius: '8px', border: 'none', cursor: 'pointer' as const, transition: 'all 0.2s',
+        background: tab === t ? 'rgba(56,189,248,0.2)' : 'transparent',
+        color: tab === t ? '#38bdf8' : 'gray',
+        fontWeight: tab === t ? 600 : 400,
+        fontSize: '0.9rem',
+    });
+
+    return (
+        <main className={styles.main}>
+            <div className={`glass-container ${styles.heroContainer}`} style={{ maxWidth: '1060px', width: '100%' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
+                    <h1 className="text-gradient" style={{ margin: 0, fontSize: '2.5rem' }}>Tools & Certifications</h1>
+                    <Link href="/shop" className="glass-button" style={{ textDecoration: 'none' }}>&larr; Shop Dashboard</Link>
+                </div>
+
+                {/* Tab bar */}
+                <div style={{ display: 'flex', gap: '0.25rem', marginBottom: '1.75rem', background: 'rgba(255,255,255,0.05)', padding: '0.25rem', borderRadius: '12px' }}>
+                    <button style={tabStyle('tools')} onClick={() => setTab('tools')}>All Tools</button>
+                    <button style={tabStyle('person')} onClick={() => setTab('person')}>By Person</button>
+                    {isAdmin && <button style={tabStyle('all')} onClick={() => setTab('all')}>All Assignments</button>}
+                </div>
+
+                {tab === 'tools' && <ToolsTab tools={tools} members={members} isAdmin={!!isAdmin} isCertifier={!!isCertifier} onToolsChange={reloadTools} />}
+                {tab === 'person' && <PersonTab members={members} tools={tools} isCertifier={!!isCertifier} />}
+                {tab === 'all' && <AllTab />}
+            </div>
         </main>
     );
 }


### PR DESCRIPTION
## Summary
Closes #159. Replaces the old "select-to-see" certifications page with a proper three-tab view at `/shop/tools`:

**All Tools tab** (default)
- Every tool listed with cert count and safety guide link (clickable ↗)
- Click any row to expand — shows all certified members with level badges
- Admin users get an inline "Edit guide" button → modal to set/update the safety guide URL
- "+ New Tool" shortcut at the top for admins

**By Person tab**
- Every member listed; click to expand their full cert list
- Grant form pre-filled with the selected person — certifiers can assign any tool from the dropdown

**All Assignments tab** (admin/shop steward only)
- Dense table: tool | member | email | level
- Filterable by tool name or member name/email
- Shows total count

## API additions
- `PATCH /api/shop/tools/[id]` — update `name` / `safetyGuide`, admin-only, audit-logged
- `GET /api/shop/certifications?all=true` — returns all tool-person assignments ordered by tool name then member name; restricted to admin/shop steward

## Test plan
- [ ] All Tools tab: verify tools list loads, cert count shown, safety guide link clickable, expand shows members
- [ ] Admin: "Edit guide" button appears, modal saves and reflects immediately
- [ ] Non-admin: no "Edit guide" button, no "+ New Tool", no "All Assignments" tab
- [ ] By Person tab: member list loads, expand shows correct certs
- [ ] Certifier: grant form appears in drilldowns, confirm dialog shown, cert updates
- [ ] All Assignments tab: full table loads, filter works
- [ ] Non-admin/non-shop-steward: All Assignments tab hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)