### PR TITLE
fix(layout): make admin sidebar scroll independently (#163)

### DIFF
--- a/src/app/admin/admin.module.css
+++ b/src/app/admin/admin.module.css
@@ -1,6 +1,7 @@
 .layout {
   display: flex;
-  min-height: 100vh;
+  height: calc(100vh - 70px);
+  overflow: hidden;
   background: var(--color-background);
 }
 
@@ -12,15 +13,16 @@
   display: flex;
   flex-direction: column;
   padding: 2rem 1rem;
-  position: sticky;
-  top: 0;
-  height: 100vh;
+  height: 100%;
+  overflow-y: auto;
+  flex-shrink: 0;
   z-index: 100;
 }
 
 .content {
   flex: 1;
   padding: 2rem;
+  height: 100%;
   overflow-y: auto;
 }
 
@@ -100,18 +102,27 @@
 @media (max-width: 768px) {
   .layout {
     flex-direction: column;
+    height: auto;
+    min-height: calc(100vh - 70px);
+    overflow: visible;
   }
-  
+
   .sidebar {
     width: 100%;
     height: auto;
     flex-direction: row;
     padding: 0.5rem;
     overflow-x: auto;
+    overflow-y: visible;
     position: sticky;
     top: 0;
     border-right: none;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .content {
+    height: auto;
+    overflow-y: visible;
   }
   
   .logo, .sectionTitle {


### PR DESCRIPTION
Closes #163. The admin nav sidebar was sharing scroll with the page content, pushing nav items off screen on long pages. This gives sidebar and content independent `overflow-y` scroll contexts so the nav is always reachable.

## What changed

`src/app/admin/admin.module.css`:

- `.layout`: changed from `min-height: 100vh` to `height: calc(100vh - 70px)` with `overflow: hidden` — creates a fixed-height scroll container that accounts for the top NavBar
- `.sidebar`: removed `position: sticky` / `top: 0` (no longer needed), changed `height: 100vh` → `height: 100%`, added `overflow-y: auto` and `flex-shrink: 0` — sidebar now scrolls independently
- `.content`: added `height: 100%` to match the container constraint (already had `overflow-y: auto`)
- Mobile breakpoint (`≤768px`): restored `height: auto` / `min-height: calc(100vh - 70px)` / `overflow: visible` so the stacked mobile layout still scrolls naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)