### PR TITLE
fix(programs): show Planning badge on unpublished programs (#158)

### DIFF
--- a/src/app/admin/programs/page.tsx
+++ b/src/app/admin/programs/page.tsx
@@ -70,11 +70,24 @@ export default function AdminProgramsIndex() {
                                         {program._count?.participants || 0} Participants • {program._count?.events || 0} Events
                                     </div>
                                 </div>
-                                <div style={{ display: 'flex', gap: '8px' }}>
-                                    <span style={{ 
-                                        padding: '4px 8px', 
-                                        borderRadius: '4px', 
-                                        fontSize: '0.75rem', 
+                                <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                                    {program.phase === 'PLANNING' && (
+                                        <span style={{
+                                            padding: '4px 8px',
+                                            borderRadius: '4px',
+                                            fontSize: '0.75rem',
+                                            background: 'rgba(234, 179, 8, 0.2)',
+                                            color: '#fde047',
+                                            border: '1px solid rgba(234, 179, 8, 0.4)',
+                                            fontWeight: 600,
+                                        }}>
+                                            Planning / Not Published
+                                        </span>
+                                    )}
+                                    <span style={{
+                                        padding: '4px 8px',
+                                        borderRadius: '4px',
+                                        fontSize: '0.75rem',
                                         background: program.memberOnly ? 'rgba(168, 85, 247, 0.2)' : 'rgba(59, 130, 246, 0.2)',
                                         color: program.memberOnly ? '#d8b4fe' : '#93c5fd'
                                     }}>

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -111,6 +111,11 @@ export default function PublicProgramsDirectory() {
                                         Member Only
                                     </span>
                                 )}
+                                {program.phase === 'PLANNING' && (
+                                    <span style={{ background: 'rgba(234, 179, 8, 0.2)', color: '#fde047', padding: '0.2rem 0.6rem', borderRadius: '12px', fontSize: '0.75rem', fontWeight: 600, border: '1px solid rgba(234, 179, 8, 0.4)', marginLeft: '0.5rem' }}>
+                                        Planning / Not Published
+                                    </span>
+                                )}
                                 {program.enrollmentStatus === 'CLOSED' && (
                                     <span style={{ background: 'rgba(239, 68, 68, 0.2)', color: '#fca5a5', padding: '0.2rem 0.6rem', borderRadius: '12px', fontSize: '0.75rem', fontWeight: 600, border: '1px solid rgba(239, 68, 68, 0.4)', marginLeft: '0.5rem' }}>
                                         Enrollment Closed


### PR DESCRIPTION
Closes #158. Programs in the Planning state showed no visual indicator, making it easy to assume they were published. Adds a visible 'Planning / Not Published' badge so admins can clearly distinguish draft programs from live ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)