### PR TITLE
Fixes #83: Archive Jules conversation when issue is closed

### DIFF
--- a/.github/workflows/jules.yml
+++ b/.github/workflows/jules.yml
@@ -33,26 +33,27 @@ jobs:
           prompt: |
             You are an AI agent for the CheckMeIn project. Before starting, read and follow CONSTITUTION.md. 
 
-            Please diagnose and fix the following GitHub issue:
+            ${{ github.event.action == 'closed' && 'This issue has been closed. Please wrap up your work and close/archive this conversation.' || '' }}
+            ${{ github.event.action != 'closed' && 'Please diagnose and fix the following GitHub issue:' || '' }}
 
-            Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}
+            ${{ github.event.action != 'closed' && format('Issue #{0}: {1}', github.event.issue.number, github.event.issue.title) || '' }}
 
-            ${{ github.event.issue.body }}
+            ${{ github.event.action != 'closed' && github.event.issue.body || '' }}
 
-            ${{ github.event.comment.body && format('Additional context from comment:\n{0}', github.event.comment.body) || '' }}
+            ${{ github.event.action != 'closed' && github.event.comment.body && format('Additional context from comment:\n{0}', github.event.comment.body) || '' }}
 
-            Process:
-            1. **Analysis** - Review the issue and identify the root cause
-            2. **Diagnosis** - Trace the issue through the codebase
-            3. **Fix** - Implement a minimal, targeted fix
-            4. **Testing** - Add tests if appropriate
-            5. **Documentation** - Add comments explaining the fix
+            ${{ github.event.action != 'closed' && 'Process:' || '' }}
+            ${{ github.event.action != 'closed' && '1. **Analysis** - Review the issue and identify the root cause' || '' }}
+            ${{ github.event.action != 'closed' && '2. **Diagnosis** - Trace the issue through the codebase' || '' }}
+            ${{ github.event.action != 'closed' && '3. **Fix** - Implement a minimal, targeted fix' || '' }}
+            ${{ github.event.action != 'closed' && '4. **Testing** - Add tests if appropriate' || '' }}
+            ${{ github.event.action != 'closed' && '5. **Documentation** - Add comments explaining the fix' || '' }}
 
-            Constraints:
-            - Follow the CONSTITUTION.md guidelines
-            - Keep changes minimal and targeted
-            - All existing tests must pass
-            - In the PR title, include "Fixes #${{ github.event.issue.number }}"
-            - In the PR description, include "Fixes #${{ github.event.issue.number }}" so the issue is automatically linked and closed when the PR is merged
+            ${{ github.event.action != 'closed' && 'Constraints:' || '' }}
+            ${{ github.event.action != 'closed' && '- Follow the CONSTITUTION.md guidelines' || '' }}
+            ${{ github.event.action != 'closed' && '- Keep changes minimal and targeted' || '' }}
+            ${{ github.event.action != 'closed' && '- All existing tests must pass' || '' }}
+            ${{ github.event.action != 'closed' && format('- In the PR title, include "Fixes #{0}"', github.event.issue.number) || '' }}
+            ${{ github.event.action != 'closed' && format('- In the PR description, include "Fixes #{0}" so the issue is automatically linked and closed when the PR is merged', github.event.issue.number) || '' }}
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           starting_branch: 'main'


### PR DESCRIPTION
Fixes #83

When a GitHub issue is closed, Jules is currently triggering with the default prompt, which tells it to diagnose and fix the issue from the beginning. Instead, when `github.event.action == 'closed'`, the prompt is conditionally set to tell Jules to "wrap up your work and close/archive this conversation" so that the ongoing agent conversation does not continue inappropriately.

---
*PR created automatically by Jules for task [14450965119655414609](https://jules.google.com/task/14450965119655414609) started by @dkaygithub*