### PR TITLE
feat(rbac): add backgroundCheckReviewer role

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,6 +97,8 @@ model Participant {
   keyholder   Boolean @default(false)
   /// @sensitivity:internal
   shopSteward Boolean @default(false)
+  /// @sensitivity:internal
+  backgroundCheckReviewer Boolean @default(false)
 
   toolStatuses        ToolStatus[]
   householdLeads      HouseholdLead[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -156,6 +156,19 @@ async function main() {
     })
     console.log(`✅ shop.steward@example.com (id: ${shopSteward.id}) — Shop Steward`)
 
+    const bgReviewer = await prisma.participant.upsert({
+        where: { email: 'bg.reviewer@example.com' },
+        update: { name: 'BG Reviewer', phone: '555-555-0009', backgroundCheckReviewer: true },
+        create: {
+            email: 'bg.reviewer@example.com',
+            name: 'BG Reviewer',
+            phone: '555-555-0009',
+            backgroundCheckReviewer: true,
+            household: { create: { name: 'BG Reviewer Household' } },
+        },
+    })
+    console.log(`✅ bg.reviewer@example.com (id: ${bgReviewer.id}) — Background Check Reviewer`)
+
     // ──────────────────────────────────────────────
     // 3. Household assignments & leads
     // ──────────────────────────────────────────────

--- a/src/app/admin/roles/page.tsx
+++ b/src/app/admin/roles/page.tsx
@@ -13,6 +13,7 @@ type UserRole = {
     boardMember: boolean;
     keyholder: boolean;
     shopSteward: boolean;
+    backgroundCheckReviewer: boolean;
 };
 
 type SessionUser = {
@@ -159,6 +160,7 @@ export default function RoleAssignmentPage() {
                                 <th style={{ padding: '1rem 0.5rem', textAlign: 'center' }}>Board Member</th>
                                 <th style={{ padding: '1rem 0.5rem', textAlign: 'center' }}>Keyholder</th>
                                 <th style={{ padding: '1rem 0.5rem', textAlign: 'center' }}>Shop Steward</th>
+                                <th style={{ padding: '1rem 0.5rem', textAlign: 'center' }}>BG Reviewer</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -201,6 +203,15 @@ export default function RoleAssignmentPage() {
                                             checked={user.shopSteward}
                                             disabled={savingId === user.id}
                                             onChange={(e) => handleRoleChange(user.id, 'shopSteward', e.target.checked)}
+                                            style={{ width: '1.2rem', height: '1.2rem', cursor: 'pointer' }}
+                                        />
+                                    </td>
+                                    <td style={{ padding: '1rem 0.5rem', textAlign: 'center' }}>
+                                        <input
+                                            type="checkbox"
+                                            checked={user.backgroundCheckReviewer}
+                                            disabled={savingId === user.id}
+                                            onChange={(e) => handleRoleChange(user.id, 'backgroundCheckReviewer', e.target.checked)}
                                             style={{ width: '1.2rem', height: '1.2rem', cursor: 'pointer' }}
                                         />
                                     </td>

--- a/src/app/api/admin/roles/route.ts
+++ b/src/app/api/admin/roles/route.ts
@@ -24,6 +24,7 @@ export const GET = withAuth(
                     boardMember: true,
                     keyholder: true,
                     shopSteward: true,
+                    backgroundCheckReviewer: true,
                 },
                 orderBy: { name: "asc" },
             });
@@ -54,7 +55,7 @@ export const PATCH = withAuth(
                 );
             }
 
-            const allowedFields = ["sysadmin", "boardMember", "keyholder", "shopSteward"];
+            const allowedFields = ["sysadmin", "boardMember", "keyholder", "shopSteward", "backgroundCheckReviewer"];
             const updateData: Record<string, NonNullable<unknown> | null | string | number | boolean | Date> = {};
             for (const field of allowedFields) {
                 if (roleUpdates[field] !== undefined) {
@@ -77,6 +78,7 @@ export const PATCH = withAuth(
                     boardMember: true,
                     keyholder: true,
                     shopSteward: true,
+                    backgroundCheckReviewer: true,
                 },
             });
 

--- a/src/app/api/auth/dev-personas/route.ts
+++ b/src/app/api/auth/dev-personas/route.ts
@@ -27,6 +27,7 @@ export async function GET() {
             boardMember: true,
             keyholder: true,
             shopSteward: true,
+            backgroundCheckReviewer: true,
             dob: true,
             householdId: true,
             toolStatuses: {

--- a/src/components/DevLoginPicker.tsx
+++ b/src/components/DevLoginPicker.tsx
@@ -11,6 +11,7 @@ interface Persona {
     boardMember: boolean;
     keyholder: boolean;
     shopSteward: boolean;
+    backgroundCheckReviewer: boolean;
     dob: string | null;
     householdId: number | null;
     toolStatuses: { toolId: number; level: string }[];
@@ -51,6 +52,7 @@ export default function DevLoginPicker() {
         if (p.boardMember) badges.push({ label: "Board", color: "#8b5cf6" });
         if (p.keyholder) badges.push({ label: "Keyholder", color: "#3b82f6" });
         if (p.shopSteward) badges.push({ label: "Shop Steward", color: "#f59e0b" });
+        if (p.backgroundCheckReviewer) badges.push({ label: "BG Reviewer", color: "#14b8a6" });
         if (p.toolStatuses?.length > 0) badges.push({ label: "Certified", color: "#10b981" });
         if (p.householdId) badges.push({ label: "Household", color: "#6366f1" });
         if (p.dob && now !== null) {

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -152,6 +152,7 @@ export const authOptions: NextAuthOptions = {
                     token.keyholder = dbParticipant.keyholder;
                     token.boardMember = dbParticipant.boardMember;
                     token.shopSteward = dbParticipant.shopSteward;
+                    token.backgroundCheckReviewer = dbParticipant.backgroundCheckReviewer;
                     token.householdId = dbParticipant.householdId;
                     token.toolStatuses = dbParticipant.toolStatuses;
                 }
@@ -165,6 +166,7 @@ export const authOptions: NextAuthOptions = {
                 session.user.keyholder = token.keyholder;
                 session.user.boardMember = token.boardMember;
                 session.user.shopSteward = token.shopSteward;
+                session.user.backgroundCheckReviewer = token.backgroundCheckReviewer;
                 session.user.householdId = token.householdId;
                 session.user.toolStatuses = token.toolStatuses || [];
             }

--- a/src/security/access-resolvers.ts
+++ b/src/security/access-resolvers.ts
@@ -222,6 +222,8 @@ export function callerHoldsRole(
             return auth.type === 'session' && auth.user.keyholder;
         case 'shopSteward':
             return auth.type === 'session' && auth.user.shopSteward;
+        case 'backgroundCheckReviewer':
+            return auth.type === 'session' && auth.user.backgroundCheckReviewer;
         case 'householdLead':
             return auth.type === 'session' && !!auth.user.householdLead;
         case 'programLeadMentor': {

--- a/src/security/core.ts
+++ b/src/security/core.ts
@@ -54,6 +54,7 @@ export type Role =
     | 'boardMember'
     | 'keyholder'
     | 'shopSteward'
+    | 'backgroundCheckReviewer'
     | 'householdLead'
     | 'programLeadMentor'
     | 'programCoreVolunteer';
@@ -75,6 +76,7 @@ const VALID_ROLES = new Set<Role>([
     'boardMember',
     'keyholder',
     'shopSteward',
+    'backgroundCheckReviewer',
     'householdLead',
     'programLeadMentor',
     'programCoreVolunteer',

--- a/src/security/generated/classifications.ts
+++ b/src/security/generated/classifications.ts
@@ -20,6 +20,7 @@ export const classifications = {
         boardMember: 'public',
         keyholder: 'internal',
         shopSteward: 'internal',
+        backgroundCheckReviewer: 'internal',
     },
     Tool: {
         id: 'public',

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -4,7 +4,7 @@ import type { SessionUser } from './participant';
  * Business role field names from the Participant model.
  * Used by withAuth() to check roles directly via user[role] === true.
  */
-export type BusinessRole = 'sysadmin' | 'boardMember' | 'keyholder' | 'shopSteward';
+export type BusinessRole = 'sysadmin' | 'boardMember' | 'keyholder' | 'shopSteward' | 'backgroundCheckReviewer';
 
 /**
  * Result of authenticating a request — either kiosk, session, or unauthenticated.

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -12,6 +12,7 @@ declare module "next-auth" {
       keyholder?: boolean;
       boardMember?: boolean;
       shopSteward?: boolean;
+      backgroundCheckReviewer?: boolean;
       householdId?: number | null;
       householdLead?: boolean;
       toolStatuses?: { toolId: number; level: string }[];
@@ -24,6 +25,7 @@ declare module "next-auth" {
     keyholder?: boolean;
     boardMember?: boolean;
     shopSteward?: boolean;
+    backgroundCheckReviewer?: boolean;
     householdId?: number | null;
     householdLead?: boolean;
     toolStatuses?: { toolId: number; level: string }[];
@@ -37,6 +39,7 @@ declare module "next-auth/jwt" {
     keyholder?: boolean;
     boardMember?: boolean;
     shopSteward?: boolean;
+    backgroundCheckReviewer?: boolean;
     householdId?: number | null;
     householdLead?: boolean;
     toolStatuses?: { toolId: number; level: string }[];

--- a/src/types/participant.ts
+++ b/src/types/participant.ts
@@ -10,6 +10,7 @@ export interface SessionUser {
     boardMember: boolean;
     keyholder: boolean;
     shopSteward: boolean;
+    backgroundCheckReviewer: boolean;
     householdId?: number;
     householdLead?: boolean;
 }

--- a/tests/security/personas.ts
+++ b/tests/security/personas.ts
@@ -18,6 +18,7 @@ async function ensure(
         boardMember: boolean;
         keyholder: boolean;
         shopSteward: boolean;
+        backgroundCheckReviewer: boolean;
     }>,
 ) {
     const email = `policy-persona-${emailSuffix}@example.test`;
@@ -45,6 +46,7 @@ export async function loadPersonas(): Promise<Record<string, Persona>> {
     const boardMember = await ensure('board-member', { name: 'Board Member', boardMember: true });
     const keyholder = await ensure('keyholder', { name: 'Key Holder', keyholder: true });
     const shopSteward = await ensure('shop-steward', { name: 'Shop Steward', shopSteward: true });
+    const bgReviewer = await ensure('bg-reviewer', { name: 'BG Reviewer', backgroundCheckReviewer: true });
 
     const mkUser = (p: {
         id: number;
@@ -54,6 +56,7 @@ export async function loadPersonas(): Promise<Record<string, Persona>> {
         boardMember: boolean;
         keyholder: boolean;
         shopSteward: boolean;
+        backgroundCheckReviewer: boolean;
     }): SessionUser => ({
         id: p.id,
         email: p.email ?? '',
@@ -62,6 +65,7 @@ export async function loadPersonas(): Promise<Record<string, Persona>> {
         boardMember: p.boardMember,
         keyholder: p.keyholder,
         shopSteward: p.shopSteward,
+        backgroundCheckReviewer: p.backgroundCheckReviewer,
     });
 
     cached = {
@@ -91,6 +95,11 @@ export async function loadPersonas(): Promise<Record<string, Persona>> {
             role: 'shopSteward',
             sessionUser: mkUser(shopSteward),
             description: 'shopSteward=true',
+        },
+        backgroundCheckReviewer: {
+            role: 'backgroundCheckReviewer',
+            sessionUser: mkUser(bgReviewer),
+            description: 'backgroundCheckReviewer=true',
         },
         kiosk: { role: 'kiosk', description: 'Kiosk signature (no user)' },
         // programLeadMentor, programCoreVolunteer, householdLead are data-scoped roles


### PR DESCRIPTION
## PR 1/12 — Household membership application & review stack

Adds a `backgroundCheckReviewer` RBAC role — the foundation for the dual-control background-check review step later in the stack.

### What changed
- **Schema**: `Participant.backgroundCheckReviewer Boolean @default(false)` (`@sensitivity:internal`).
- **Auth**: propagated through NextAuth JWT + session callbacks and TS types.
- **Security policy**: added to the `Role` union + `VALID_ROLES`, and a `callerHoldsRole` case in `access-resolvers`.
- **Admin**: assignable via the Roles page checkbox + roles API `allowedFields`/selects.
- **Generated**: regenerated `src/security/generated/classifications.ts`.
- **Dev/test**: seed persona, dev-login persona+badge, and a `bg-reviewer` security-contract persona exercising the new resolver case.

### Deliberately out of scope
- Not added to shop/badge/kiosk authorization (unrelated to BG review).
- Does not gate any route yet — reviewer access to the BG-review queue lands in PR 7.

### Verification
`tsc --noEmit` clean · `eslint` 0 errors · `npm run test:ci` 82/82 · pre-commit hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
