### PR TITLE
refactor(membership): centralize active-member read model

### DIFF
--- a/src/app/api/admin/participants/search/route.ts
+++ b/src/app/api/admin/participants/search/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { participantRecordIsActiveMember } from "@/lib/membership";
 
 export const dynamic = 'force-dynamic';
 
@@ -29,7 +30,8 @@ export const GET = withAuth(
                     },
                     household: {
                         include: {
-                            participants: true
+                            participants: true,
+                            memberships: { where: { active: true } },
                         }
                     }
                 }
@@ -40,7 +42,7 @@ export const GET = withAuth(
                 name: p.name,
                 email: p.email,
                 phone: p.phone,
-                isMember: p.memberships.length > 0,
+                isMember: participantRecordIsActiveMember(p),
                 boardMember: p.boardMember,
                 shopSteward: p.shopSteward,
                 keyholder: p.keyholder,

--- a/src/app/api/programs/[id]/eligible-participants/route.ts
+++ b/src/app/api/programs/[id]/eligible-participants/route.ts
@@ -2,6 +2,8 @@ import { NextResponse, NextRequest } from "next/server";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth-options";
 import prisma from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { ACTIVE_MEMBER_PARTICIPANT_WHERE } from "@/lib/membership";
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
@@ -32,7 +34,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 
         const q = req.nextUrl.searchParams.get("q") || "";
 
-        const andClauses: Record<string, unknown>[] = [
+        const andClauses: Prisma.ParticipantWhereInput[] = [
             {
                 NOT: {
                     OR: [
@@ -53,12 +55,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         }
 
         if (currentProgram.memberOnly) {
-            andClauses.push({
-                OR: [
-                    { memberships: { some: { active: true } } },
-                    { household: { memberships: { some: { active: true } } } }
-                ]
-            });
+            andClauses.push(ACTIVE_MEMBER_PARTICIPANT_WHERE);
         }
 
         const members = await prisma.participant.findMany({

--- a/src/app/api/programs/[id]/route.ts
+++ b/src/app/api/programs/[id]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth-options";
 import prisma from "@/lib/prisma";
 import { handler, notFound, forbidden, badRequest } from "@/security/handler";
+import { isActiveMember } from "@/lib/membership";
 
 export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ auth, params }) => {
     const programId = parseInt(params.id, 10);
@@ -30,11 +31,7 @@ export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
 
     if (program.memberOnly && !isPrivileged) {
         if (!sessionUser) throw notFound('Program not found');
-        const participant = await prisma.participant.findUnique({
-            where: { id: sessionUser.id },
-            include: { memberships: { where: { active: true } } },
-        });
-        const hasActiveMembership = !!(participant && participant.memberships.length > 0);
+        const hasActiveMembership = await isActiveMember(sessionUser.id);
         if (!hasActiveMembership) throw forbidden('Forbidden: Member-Only Program');
     }
 

--- a/src/app/api/programs/route.ts
+++ b/src/app/api/programs/route.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
 import { createShopifyProgramVariants } from "@/lib/shopify";
 import { logBackendError } from "@/lib/logger";
+import { isActiveMember } from "@/lib/membership";
 
 export async function GET(req: Request) {
     const session = await getServerSession(authOptions);
@@ -21,18 +22,7 @@ export async function GET(req: Request) {
             if (user.sysadmin || user.boardMember) {
                 canSeeMemberOnly = true;
             } else {
-                // Check if user has an active membership
-                const participant = await prisma.participant.findUnique({
-                    where: { id: user.id },
-                    include: {
-                        memberships: {
-                            where: { active: true }
-                        }
-                    }
-                });
-                if (participant && participant.memberships.length > 0) {
-                    canSeeMemberOnly = true;
-                }
+                canSeeMemberOnly = await isActiveMember(user.id);
             }
         }
 

--- a/src/app/api/shop/members/route.ts
+++ b/src/app/api/shop/members/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth-options";
 import prisma from "@/lib/prisma";
+import { ACTIVE_MEMBER_PARTICIPANT_WHERE } from "@/lib/membership";
 
 export const dynamic = 'force-dynamic';
 
@@ -26,12 +27,7 @@ export async function GET() {
 
     try {
         const members = await prisma.participant.findMany({
-            where: {
-                OR: [
-                    { household: { memberships: { some: { active: true } } } },
-                    { memberships: { some: { active: true } } }
-                ]
-            },
+            where: ACTIVE_MEMBER_PARTICIPANT_WHERE,
             select: {
                 id: true,
                 name: true,

--- a/src/lib/membership.ts
+++ b/src/lib/membership.ts
@@ -1,0 +1,65 @@
+import type { Prisma } from "@prisma/client";
+import prisma from "@/lib/prisma";
+
+/**
+ * Canonical "is this person an active member?" read model.
+ *
+ * A Participant counts as an active member when EITHER:
+ *   - their household holds an active Membership, OR
+ *   - they personally hold an active Membership (legacy individual/volunteer link).
+ *
+ * This is the single source of truth for member gating. Several call sites
+ * historically checked only `participant.memberships` (own-only), which wrongly
+ * excluded a child or second parent whose membership lives on the household.
+ * Route those through here instead.
+ *
+ * NOTE: the individual-membership leg is legacy. When the schema cutover (PR4)
+ * drops per-participant memberships, collapse this to household-only in ONE
+ * place — here — and every consumer follows automatically.
+ */
+export const ACTIVE_MEMBER_PARTICIPANT_WHERE: Prisma.ParticipantWhereInput = {
+    OR: [
+        { household: { memberships: { some: { active: true } } } },
+        { memberships: { some: { active: true } } },
+    ],
+};
+
+/**
+ * Prisma `include` fragment that loads exactly the membership data
+ * `participantRecordIsActiveMember` needs (household + own active memberships).
+ * Spread into a findMany/findUnique `include` to compute membership in-query
+ * without an extra round-trip.
+ */
+export const ACTIVE_MEMBER_INCLUDE = {
+    memberships: { where: { active: true } },
+    household: { include: { memberships: { where: { active: true } } } },
+} satisfies Prisma.ParticipantInclude;
+
+/**
+ * Does the Participant with this id currently count as an active member?
+ * One indexed existence check; returns false for unknown ids.
+ */
+export async function isActiveMember(participantId: number): Promise<boolean> {
+    if (!Number.isInteger(participantId)) return false;
+    const match = await prisma.participant.findFirst({
+        where: { AND: [{ id: participantId }, ACTIVE_MEMBER_PARTICIPANT_WHERE] },
+        select: { id: true },
+    });
+    return match !== null;
+}
+
+/**
+ * Pure predicate over an already-loaded Participant record. Use when a query has
+ * already pulled membership data (e.g. via {@link ACTIVE_MEMBER_INCLUDE}) and an
+ * extra query would be wasteful. Accepts any record shaped with the relevant
+ * relations; missing relations read as "not a member".
+ */
+export function participantRecordIsActiveMember(p: {
+    memberships?: { active: boolean }[] | null;
+    household?: { memberships?: { active: boolean }[] | null } | null;
+}): boolean {
+    return (
+        (p.memberships?.some((m) => m.active) ?? false) ||
+        (p.household?.memberships?.some((m) => m.active) ?? false)
+    );
+}


### PR DESCRIPTION
## PR3 of the membership stack — read-model centralization

Stacked on #185 (`feat/membership-schema-models`). Pure refactor on the **current** schema; no schema change, no behavior change for already-correct sites.

### What
Adds `src/lib/membership.ts` as the single source of truth for *"is this participant an active member?"*:
- `ACTIVE_MEMBER_PARTICIPANT_WHERE` — Prisma `where` fragment (household active OR own active)
- `isActiveMember(id)` — async existence check
- `participantRecordIsActiveMember(record)` — pure predicate over a loaded record
- `ACTIVE_MEMBER_INCLUDE` — include fragment for the pure predicate

Repoints 5 call sites to it.

### Bug fixed
Three sites checked only `participant.memberships` and ignored the household, so a **child or second parent** whose membership lives on the household read as a non-member:
- `GET /api/programs` (member-only visibility)
- `GET /api/programs/[id]` (member-only gate)
- `GET /api/admin/participants/search` (`isMember` flag)

`shop/members` and `eligible-participants` already used the correct OR-household form — repointed for consistency only.

### Why first
Centralizing now means the **PR4 schema cutover** (drop individual/volunteer memberships) collapses the member definition to household-only in *one place* — every consumer follows automatically, keeping each commit green under the full-suite pre-commit gate.

### Gate
tsc clean · route-coverage 0 errors · 82/82 tests · eslint clean. Each edit independently adversarially verified (routes-through-helper, types-sound, bug-fixed/behavior-preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)