### PR TITLE
feat(membership): EXTERNAL phase — Zoho contract webhook + background-check adapter

### DIFF
--- a/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -3,7 +3,7 @@
  */
 /**
  * Integration tests for the EXTERNAL phase: the Zoho contract webhook,
- * the board external controls, and the advance-to-BG_REVIEW logic.
+ * the board external controls, and the advance-to-PENDING_BG_REVIEW logic.
  */
 
 import { POST as ZOHO_WEBHOOK } from '@/app/api/webhooks/zoho/route';
@@ -51,7 +51,7 @@ describe('Membership EXTERNAL phase API', () => {
         const hh = await prisma.household.create({ data: { name } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         const p = await prisma.membershipProcess.create({
-            data: { membershipId: m.id, kind: 'INITIAL', status: 'EXTERNAL', zohoEnvelopeId: envelopeId },
+            data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION', zohoEnvelopeId: envelopeId },
         });
         return { householdId: hh.id, processId: p.id };
     }
@@ -106,16 +106,16 @@ describe('Membership EXTERNAL phase API', () => {
         expect(res.status).toBe(200);
         const p = await prisma.membershipProcess.findUnique({ where: { id: procA } });
         expect(p?.contractSignedAt).not.toBeNull();
-        expect(p?.status).toBe('EXTERNAL');
+        expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
     });
 
-    it('marking BG consent after the contract advances to BG_REVIEW', async () => {
+    it('marking BG consent after the contract advances to PENDING_BG_REVIEW', async () => {
         asBoard(boardId);
         const res = await BOARD_EXTERNAL(boardReq({ processId: procA, action: 'mark-bg-consent' }) as never);
         expect(res.status).toBe(200);
         const p = await prisma.membershipProcess.findUnique({ where: { id: procA } });
         expect(p?.bgConsentAt).not.toBeNull();
-        expect(p?.status).toBe('BG_REVIEW');
+        expect(p?.status).toBe('PENDING_BG_REVIEW');
     });
 
     it('rejects a Zoho webhook with a bad token', async () => {
@@ -129,7 +129,7 @@ describe('Membership EXTERNAL phase API', () => {
         const p = await prisma.membershipProcess.findUnique({ where: { id: procB } });
         expect(p?.contractSignedAt).not.toBeNull();
         // BG consent not yet given → still EXTERNAL.
-        expect(p?.status).toBe('EXTERNAL');
+        expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
     });
 
     it('ignores a non-completed Zoho event without changing state', async () => {
@@ -166,6 +166,6 @@ describe('Membership EXTERNAL phase API', () => {
         expect(ids).toEqual(expect.arrayContaining([procA, procB]));
         const a = data.processes.find((p: { id: number }) => p.id === procA);
         expect(a.membership.householdId).toBe(hhA);
-        expect(a.status).toBe('BG_REVIEW');
+        expect(a.status).toBe('PENDING_BG_REVIEW');
     });
 });

--- a/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the EXTERNAL phase: the Zoho contract webhook,
+ * the board external controls, and the advance-to-BG_REVIEW logic.
+ */
+
+import { POST as ZOHO_WEBHOOK } from '@/app/api/webhooks/zoho/route';
+import { POST as BOARD_EXTERNAL } from '@/app/api/admin/membership/external/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+const TAG = 'membership-external-test';
+const SECRET = 'zoho-test-secret';
+
+function asBoard(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, sysadmin: false, boardMember: true } });
+}
+function asUser(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, sysadmin: false, boardMember: false } });
+}
+
+function boardReq(body: unknown) {
+    return new Request('http://localhost:4000/api/admin/membership/external', {
+        method: 'POST',
+        body: JSON.stringify(body),
+    }) as unknown as Parameters<typeof BOARD_EXTERNAL>[0];
+}
+function zohoReq(body: unknown, token: string | null) {
+    return new Request('http://localhost:4000/api/webhooks/zoho', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...(token ? { 'x-zoho-webhook-token': token } : {}) },
+        body: JSON.stringify(body),
+    });
+}
+
+describe('Membership EXTERNAL phase API', () => {
+    let boardId: number;
+    let plainUserId: number;
+    let hhA: number;
+    let hhB: number;
+    let procA: number;
+    let procB: number;
+    const prevSecret = process.env.ZOHO_WEBHOOK_SECRET;
+
+    async function makeProcess(name: string, envelopeId: string) {
+        const hh = await prisma.household.create({ data: { name } });
+        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        const p = await prisma.membershipProcess.create({
+            data: { membershipId: m.id, kind: 'INITIAL', status: 'EXTERNAL', zohoEnvelopeId: envelopeId },
+        });
+        return { householdId: hh.id, processId: p.id };
+    }
+
+    async function wipe() {
+        const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+        const ids = hhs.map((h) => h.id);
+        if (ids.length) {
+            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
+            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.household.deleteMany({ where: { id: { in: ids } } });
+        }
+        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+    }
+
+    beforeAll(async () => {
+        process.env.ZOHO_WEBHOOK_SECRET = SECRET;
+        await wipe();
+
+        const board = await prisma.participant.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', boardMember: true, household: { create: {} } } });
+        boardId = board.id;
+        const user = await prisma.participant.create({ data: { email: `user-${TAG}@example.com`, name: 'User', household: { create: {} } } });
+        plainUserId = user.id;
+
+        const a = await makeProcess(`A ${TAG}`, 'zoho-A');
+        hhA = a.householdId;
+        procA = a.processId;
+        const b = await makeProcess(`B ${TAG}`, 'zoho-B');
+        hhB = b.householdId;
+        procB = b.processId;
+    });
+
+    afterAll(async () => {
+        await wipe();
+        // boardId/userId households
+        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        if (prevSecret === undefined) delete process.env.ZOHO_WEBHOOK_SECRET;
+        else process.env.ZOHO_WEBHOOK_SECRET = prevSecret;
+        await prisma.$disconnect();
+    });
+
+    it('rejects a non-board user from the external controls', async () => {
+        asUser(plainUserId);
+        const res = await BOARD_EXTERNAL(boardReq({ processId: procA, action: 'mark-contract' }) as never);
+        expect(res.status).toBe(403);
+    });
+
+    it('marking the contract alone keeps the process in EXTERNAL', async () => {
+        asBoard(boardId);
+        const res = await BOARD_EXTERNAL(boardReq({ processId: procA, action: 'mark-contract' }) as never);
+        expect(res.status).toBe(200);
+        const p = await prisma.membershipProcess.findUnique({ where: { id: procA } });
+        expect(p?.contractSignedAt).not.toBeNull();
+        expect(p?.status).toBe('EXTERNAL');
+    });
+
+    it('marking BG consent after the contract advances to BG_REVIEW', async () => {
+        asBoard(boardId);
+        const res = await BOARD_EXTERNAL(boardReq({ processId: procA, action: 'mark-bg-consent' }) as never);
+        expect(res.status).toBe(200);
+        const p = await prisma.membershipProcess.findUnique({ where: { id: procA } });
+        expect(p?.bgConsentAt).not.toBeNull();
+        expect(p?.status).toBe('BG_REVIEW');
+    });
+
+    it('rejects a Zoho webhook with a bad token', async () => {
+        const res = await ZOHO_WEBHOOK(zohoReq({ requests: { request_id: 'zoho-B', request_status: 'completed' } }, 'wrong'));
+        expect(res.status).toBe(401);
+    });
+
+    it('a valid completed Zoho webhook records the contract as signed', async () => {
+        const res = await ZOHO_WEBHOOK(zohoReq({ requests: { request_id: 'zoho-B', request_status: 'completed' } }, SECRET));
+        expect(res.status).toBe(200);
+        const p = await prisma.membershipProcess.findUnique({ where: { id: procB } });
+        expect(p?.contractSignedAt).not.toBeNull();
+        // BG consent not yet given → still EXTERNAL.
+        expect(p?.status).toBe('EXTERNAL');
+    });
+
+    it('ignores a non-completed Zoho event without changing state', async () => {
+        const res = await ZOHO_WEBHOOK(zohoReq({ requests: { request_id: 'zoho-B', request_status: 'inprogress' } }, SECRET));
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.ignored).toBeDefined();
+    });
+
+    it('set-envelope associates a Zoho request id', async () => {
+        asBoard(boardId);
+        const res = await BOARD_EXTERNAL(boardReq({ processId: procB, action: 'set-envelope', envelopeId: 'zoho-B2' }) as never);
+        expect(res.status).toBe(200);
+        const p = await prisma.membershipProcess.findUnique({ where: { id: procB } });
+        expect(p?.zohoEnvelopeId).toBe('zoho-B2');
+    });
+
+    it('keeps hhA/hhB distinct (sanity)', () => {
+        expect(hhA).not.toBe(hhB);
+    });
+});

--- a/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -8,6 +8,7 @@
 
 import { POST as ZOHO_WEBHOOK } from '@/app/api/webhooks/zoho/route';
 import { POST as BOARD_EXTERNAL } from '@/app/api/admin/membership/external/route';
+import { GET as ADMIN_LIST } from '@/app/api/admin/membership/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 
@@ -148,5 +149,23 @@ describe('Membership EXTERNAL phase API', () => {
 
     it('keeps hhA/hhB distinct (sanity)', () => {
         expect(hhA).not.toBe(hhB);
+    });
+
+    it('admin listing rejects a non-board user', async () => {
+        asUser(plainUserId);
+        const res = await ADMIN_LIST(boardReq({}) as never);
+        expect(res.status).toBe(403);
+    });
+
+    it('admin listing returns in-flight processes with household + flags for the board', async () => {
+        asBoard(boardId);
+        const res = await ADMIN_LIST(boardReq({}) as never);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        const ids = data.processes.map((p: { id: number }) => p.id);
+        expect(ids).toEqual(expect.arrayContaining([procA, procB]));
+        const a = data.processes.find((p: { id: number }) => p.id === procA);
+        expect(a.membership.householdId).toBe(hhA);
+        expect(a.status).toBe('BG_REVIEW');
     });
 });

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -72,6 +72,7 @@ export default function AdminLayout({
         { name: "Participants", href: "/admin/participants", icon: "👥" },
         { name: "Merge Participants", href: "/admin/participants/merge", icon: "🔗" },
         { name: "Manage Memberships", href: "/admin/households", icon: "🏠" },
+        { name: "Membership Applications", href: "/admin/membership", icon: "📋" },
         { name: "Pending Participants", href: "/admin/programs/pending", icon: "⏳" },
         { name: "Emergency Contacts", href: "/admin/emergency-contacts", icon: "🚑" },
         { name: "Role Assignment", href: "/admin/roles", icon: "🔐" },

--- a/src/app/admin/membership/page.tsx
+++ b/src/app/admin/membership/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Participant {
+    id: number;
+    name: string | null;
+    email: string | null;
+    role: string;
+}
+interface ProcessRow {
+    id: number;
+    kind: string;
+    status: string;
+    createdAt: string;
+    zohoEnvelopeId: string | null;
+    contractSignedAt: string | null;
+    bgConsentAt: string | null;
+    membership: {
+        householdId: number;
+        isVolunteer: boolean;
+        household: { name: string | null; participants: Participant[] } | null;
+    } | null;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+    INTAKE: "#94a3b8",
+    EXTERNAL: "#3b82f6",
+    BG_REVIEW: "#a855f7",
+    PENDING_PAYMENT: "#f59e0b",
+    BLOCKED: "#ef4444",
+    PENDING_RENEWAL: "#14b8a6",
+    RENEWAL_PENDING_BG: "#a855f7",
+};
+
+export default function AdminMembershipPage() {
+    const [rows, setRows] = useState<ProcessRow[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [busyId, setBusyId] = useState<number | null>(null);
+    const [message, setMessage] = useState("");
+    const [isError, setIsError] = useState(false);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        try {
+            const res = await fetch("/api/admin/membership");
+            if (res.ok) {
+                const data = await res.json();
+                setRows(data.processes || []);
+            }
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => { load(); }, [load]);
+
+    const act = async (processId: number, action: string, extra?: Record<string, unknown>) => {
+        setBusyId(processId);
+        setMessage("");
+        try {
+            const res = await fetch("/api/admin/membership/external", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ processId, action, ...extra }),
+            });
+            const data = await res.json();
+            if (res.ok) {
+                setIsError(false);
+                setMessage("Updated.");
+                await load();
+            } else {
+                setIsError(true);
+                setMessage(data.error || "Action failed.");
+            }
+        } catch {
+            setIsError(true);
+            setMessage("Network error.");
+        } finally {
+            setBusyId(null);
+        }
+    };
+
+    const householdLabel = (r: ProcessRow) => {
+        const hh = r.membership?.household;
+        if (!hh) return `Household #${r.membership?.householdId ?? "?"}`;
+        const parents = (hh.participants || []).filter((p) => p.role === "PARENT").map((p) => p.name || p.email).filter(Boolean);
+        return hh.name || parents.join(" & ") || `Household #${r.membership?.householdId}`;
+    };
+
+    return (
+        <div style={{ maxWidth: "1000px", margin: "0 auto" }}>
+            <div className="glass-container animate-float" style={{ padding: "2rem", marginBottom: "1.5rem" }}>
+                <h1 className="text-gradient" style={{ marginTop: 0 }}>Membership Applications</h1>
+                <p style={{ color: "var(--color-text-muted)", margin: 0 }}>
+                    In-flight applications. Use the manual controls below to confirm the contract was signed or that
+                    background-check consent was received. (The contract is also confirmed automatically once the Zoho
+                    webhook is configured.)
+                </p>
+            </div>
+
+            {message && (
+                <div style={{ marginBottom: "1rem", padding: "0.85rem 1rem", borderRadius: "8px", background: isError ? "rgba(239,68,68,0.1)" : "rgba(34,197,94,0.1)", border: `1px solid ${isError ? "rgba(239,68,68,0.3)" : "rgba(34,197,94,0.3)"}`, color: isError ? "#f87171" : "#4ade80" }}>
+                    {message}
+                </div>
+            )}
+
+            {loading ? (
+                <p style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+            ) : rows.length === 0 ? (
+                <div className="glass-container" style={{ padding: "2rem", textAlign: "center", color: "var(--color-text-muted)" }}>
+                    No in-flight membership applications.
+                </div>
+            ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+                    {rows.map((r) => (
+                        <div key={r.id} className="glass-container" style={{ padding: "1.25rem 1.5rem" }}>
+                            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: "0.75rem" }}>
+                                <div>
+                                    <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>{householdLabel(r)}</div>
+                                    <div style={{ fontSize: "0.8rem", color: "var(--color-text-muted)" }}>
+                                        {r.kind} · application #{r.id}
+                                        {r.membership?.isVolunteer && <span style={{ marginLeft: 8, color: "#4ade80" }}>· volunteer</span>}
+                                    </div>
+                                </div>
+                                <span style={{ background: STATUS_COLORS[r.status] || "#64748b", color: "#0f172a", padding: "3px 10px", borderRadius: "999px", fontSize: "0.75rem", fontWeight: 700 }}>
+                                    {r.status.replace(/_/g, " ")}
+                                </span>
+                            </div>
+
+                            {r.status === "EXTERNAL" && (
+                                <div style={{ display: "flex", gap: "1.5rem", flexWrap: "wrap", marginTop: "1rem" }}>
+                                    <div>
+                                        <div style={{ fontSize: "0.8rem", color: "var(--color-text-muted)", marginBottom: "0.35rem" }}>Contract</div>
+                                        {r.contractSignedAt ? (
+                                            <span style={{ color: "#4ade80", fontWeight: 600 }}>✓ Signed</span>
+                                        ) : (
+                                            <button className="glass-button" disabled={busyId === r.id} onClick={() => act(r.id, "mark-contract")} style={{ padding: "0.45rem 0.9rem", background: "rgba(59,130,246,0.25)", borderColor: "rgba(59,130,246,0.5)" }}>
+                                                {busyId === r.id ? "…" : "Confirm contract signed"}
+                                            </button>
+                                        )}
+                                    </div>
+                                    <div>
+                                        <div style={{ fontSize: "0.8rem", color: "var(--color-text-muted)", marginBottom: "0.35rem" }}>Background-check consent</div>
+                                        {r.bgConsentAt ? (
+                                            <span style={{ color: "#4ade80", fontWeight: 600 }}>✓ Received</span>
+                                        ) : (
+                                            <button className="glass-button" disabled={busyId === r.id} onClick={() => act(r.id, "mark-bg-consent")} style={{ padding: "0.45rem 0.9rem" }}>
+                                                {busyId === r.id ? "…" : "Confirm BG consent"}
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/admin/membership/page.tsx
+++ b/src/app/admin/membership/page.tsx
@@ -6,7 +6,6 @@ interface Participant {
     id: number;
     name: string | null;
     email: string | null;
-    role: string;
 }
 interface ProcessRow {
     id: number;
@@ -19,14 +18,14 @@ interface ProcessRow {
     membership: {
         householdId: number;
         isVolunteer: boolean;
-        household: { name: string | null; participants: Participant[] } | null;
+        household: { name: string | null; participants: Participant[]; leads: { participantId: number }[] } | null;
     } | null;
 }
 
 const STATUS_COLORS: Record<string, string> = {
     INTAKE: "#94a3b8",
-    EXTERNAL: "#3b82f6",
-    BG_REVIEW: "#a855f7",
+    PENDING_EXTERNAL_ACTION: "#3b82f6",
+    PENDING_BG_REVIEW: "#a855f7",
     PENDING_PAYMENT: "#f59e0b",
     BLOCKED: "#ef4444",
     PENDING_RENEWAL: "#14b8a6",
@@ -84,7 +83,9 @@ export default function AdminMembershipPage() {
     const householdLabel = (r: ProcessRow) => {
         const hh = r.membership?.household;
         if (!hh) return `Household #${r.membership?.householdId ?? "?"}`;
-        const parents = (hh.participants || []).filter((p) => p.role === "PARENT").map((p) => p.name || p.email).filter(Boolean);
+        // Parents are the household leads.
+        const leadIds = new Set((hh.leads || []).map((l) => l.participantId));
+        const parents = (hh.participants || []).filter((p) => leadIds.has(p.id)).map((p) => p.name || p.email).filter(Boolean);
         return hh.name || parents.join(" & ") || `Household #${r.membership?.householdId}`;
     };
 
@@ -128,7 +129,7 @@ export default function AdminMembershipPage() {
                                 </span>
                             </div>
 
-                            {r.status === "EXTERNAL" && (
+                            {r.status === "PENDING_EXTERNAL_ACTION" && (
                                 <div style={{ display: "flex", gap: "1.5rem", flexWrap: "wrap", marginTop: "1rem" }}>
                                     <div>
                                         <div style={{ fontSize: "0.8rem", color: "var(--color-text-muted)", marginBottom: "0.35rem" }}>Contract</div>

--- a/src/app/api/admin/membership/external/route.ts
+++ b/src/app/api/admin/membership/external/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { markContractSigned, markBgConsent, setZohoEnvelope, ExternalError } from "@/lib/membership/external";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/admin/membership/external — board controls for the EXTERNAL phase.
+ *
+ * Body: { processId, action, envelopeId? }
+ *   action 'mark-contract'    — manually record the contract as signed (fallback to the Zoho webhook)
+ *   action 'mark-bg-consent'  — human-mark that Averity consent was submitted
+ *   action 'set-envelope'     — associate a Zoho signing request id (needs envelopeId)
+ *
+ * Any action that completes both external steps advances the application to BG_REVIEW.
+ */
+export const POST = withAuth({ roles: ["sysadmin", "boardMember"] }, async (req, auth) => {
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const actorId = auth.user.id;
+
+    let body: { processId?: number; action?: string; envelopeId?: string };
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const { processId, action, envelopeId } = body;
+    if (!processId || !action) {
+        return NextResponse.json({ error: "processId and action are required" }, { status: 400 });
+    }
+
+    try {
+        switch (action) {
+            case "mark-contract":
+                return NextResponse.json({ process: await markContractSigned(processId, actorId) });
+            case "mark-bg-consent":
+                return NextResponse.json({ process: await markBgConsent(processId, actorId) });
+            case "set-envelope":
+                if (!envelopeId) return NextResponse.json({ error: "envelopeId is required" }, { status: 400 });
+                return NextResponse.json({ process: await setZohoEnvelope(processId, envelopeId, actorId) });
+            default:
+                return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });
+        }
+    } catch (error) {
+        if (error instanceof ExternalError) {
+            return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 400 });
+        }
+        console.error("Membership external action error:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+});

--- a/src/app/api/admin/membership/external/route.ts
+++ b/src/app/api/admin/membership/external/route.ts
@@ -12,7 +12,7 @@ export const dynamic = "force-dynamic";
  *   action 'mark-bg-consent'  — human-mark that Averity consent was submitted
  *   action 'set-envelope'     — associate a Zoho signing request id (needs envelopeId)
  *
- * Any action that completes both external steps advances the application to BG_REVIEW.
+ * Any action that completes both external steps advances the application to PENDING_BG_REVIEW.
  */
 export const POST = withAuth({ roles: ["sysadmin", "boardMember"] }, async (req, auth) => {
     if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/admin/membership/route.ts
+++ b/src/app/api/admin/membership/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/membership — in-flight membership applications for the board.
+ * Returns every process not yet ACTIVE, with its household and external-phase
+ * flags, so the board can drive the manual steps (contract / BG consent).
+ */
+export const GET = withAuth({ roles: ["sysadmin", "boardMember"] }, async () => {
+    const processes = await prisma.membershipProcess.findMany({
+        where: { status: { not: "ACTIVE" } },
+        orderBy: { createdAt: "desc" },
+        select: {
+            id: true,
+            kind: true,
+            status: true,
+            createdAt: true,
+            zohoEnvelopeId: true,
+            contractSignedAt: true,
+            bgConsentAt: true,
+            membership: {
+                select: {
+                    householdId: true,
+                    isVolunteer: true,
+                    household: {
+                        select: {
+                            name: true,
+                            participants: { select: { id: true, name: true, email: true, role: true } },
+                        },
+                    },
+                },
+            },
+        },
+    });
+
+    return NextResponse.json({ processes });
+});

--- a/src/app/api/admin/membership/route.ts
+++ b/src/app/api/admin/membership/route.ts
@@ -28,7 +28,8 @@ export const GET = withAuth({ roles: ["sysadmin", "boardMember"] }, async () => 
                     household: {
                         select: {
                             name: true,
-                            participants: { select: { id: true, name: true, email: true, role: true } },
+                            participants: { select: { id: true, name: true, email: true } },
+                            leads: { select: { participantId: true } },
                         },
                     },
                 },

--- a/src/app/api/webhooks/zoho/route.ts
+++ b/src/app/api/webhooks/zoho/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { verifyZohoToken, parseZohoWebhook, ZOHO_WEBHOOK_HEADER } from "@/lib/membership/contract/zoho";
+import { findProcessByEnvelope, markContractSigned } from "@/lib/membership/external";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/webhooks/zoho — Zoho Sign contract completion callback.
+ *
+ * Verifies the shared-secret header, finds the membership process by its stored
+ * Zoho request id, and (on a completed signing) records the contract as signed —
+ * which may advance the application to BG_REVIEW. We never read contract content.
+ */
+export async function POST(req: Request) {
+    if (!process.env.ZOHO_WEBHOOK_SECRET) {
+        logger.error("Zoho webhook received but ZOHO_WEBHOOK_SECRET is not configured.");
+        return NextResponse.json({ error: "Configuration Error" }, { status: 500 });
+    }
+
+    if (!verifyZohoToken(req.headers.get(ZOHO_WEBHOOK_HEADER))) {
+        return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
+
+    let body: unknown;
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+    }
+
+    const { requestId, completed } = parseZohoWebhook(body);
+    if (!requestId) {
+        logger.error("Zoho webhook missing request id.");
+        return NextResponse.json({ error: "Missing request id" }, { status: 400 });
+    }
+
+    // Only act on completed signings; acknowledge other events so Zoho stops retrying.
+    if (!completed) return NextResponse.json({ ok: true, ignored: "not completed" });
+
+    const mp = await findProcessByEnvelope(requestId);
+    if (!mp) {
+        logger.error(`Zoho webhook: no membership process for request ${requestId}.`);
+        // Acknowledge to avoid endless retries for an unknown request.
+        return NextResponse.json({ ok: true, ignored: "unknown request" });
+    }
+
+    await markContractSigned(mp.id);
+    return NextResponse.json({ ok: true });
+}

--- a/src/app/api/webhooks/zoho/route.ts
+++ b/src/app/api/webhooks/zoho/route.ts
@@ -10,7 +10,7 @@ export const dynamic = "force-dynamic";
  *
  * Verifies the shared-secret header, finds the membership process by its stored
  * Zoho request id, and (on a completed signing) records the contract as signed —
- * which may advance the application to BG_REVIEW. We never read contract content.
+ * which may advance the application to PENDING_BG_REVIEW. We never read contract content.
  */
 export async function POST(req: Request) {
     if (!process.env.ZOHO_WEBHOOK_SECRET) {

--- a/src/app/membership/page.tsx
+++ b/src/app/membership/page.tsx
@@ -14,10 +14,17 @@ interface PersonPrefill {
     allergies: string | null;
 }
 
+interface ExternalStatus {
+    contractSigned: boolean;
+    bgConsented: boolean;
+    deepLinkUrl: string | null;
+}
+
 interface IntakeState {
     hasHousehold: boolean;
     membershipStatus: MembershipStatus | null;
     process: { id: number; kind: string; status: MembershipProcessStatus } | null;
+    external: ExternalStatus | null;
     prefill: {
         household: { name: string | null; address: string | null; emergencyContactName: string | null; emergencyContactPhone: string | null } | null;
         primaryParent: PersonPrefill | null;
@@ -32,6 +39,20 @@ interface ChildForm {
     email: string;
     dob: string;
     allergies: string;
+}
+
+function ExternalTask({ done, title, doneText, children }: { done: boolean; title: string; doneText: string; children: React.ReactNode }) {
+    return (
+        <div style={{ border: "1px solid rgba(255,255,255,0.12)", borderRadius: "12px", padding: "1.25rem", display: "flex", gap: "0.9rem", alignItems: "flex-start", background: done ? "rgba(34,197,94,0.08)" : "transparent" }}>
+            <span aria-hidden style={{ width: "26px", height: "26px", borderRadius: "50%", background: done ? "#4ade80" : "rgba(255,255,255,0.15)", color: "#0f172a", display: "flex", alignItems: "center", justifyContent: "center", fontWeight: 700, flexShrink: 0 }}>
+                {done ? "✓" : "•"}
+            </span>
+            <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 600, marginBottom: "0.4rem" }}>{title}</div>
+                {done ? <p style={{ margin: 0, color: "#86efac" }}>{doneText}</p> : children}
+            </div>
+        </div>
+    );
 }
 
 export default function MembershipPage() {
@@ -346,11 +367,49 @@ export default function MembershipPage() {
                                     </button>
                                 </div>
                             </div>
+                        ) : inStatus === "EXTERNAL" ? (
+                            <div className="glass-container" style={{ padding: "1.75rem", display: "flex", flexDirection: "column", gap: "1.25rem" }}>
+                                <div>
+                                    <h2 style={{ marginTop: 0, marginBottom: "0.25rem" }}>Two quick steps</h2>
+                                    <p style={{ color: "var(--color-text-muted)", margin: 0 }}>
+                                        These can be done in any order. We&apos;ll move you forward automatically once both are complete.
+                                    </p>
+                                </div>
+
+                                <ExternalTask
+                                    done={!!state.external?.contractSigned}
+                                    title="Sign your membership contract"
+                                    doneText="Contract signed — thank you!"
+                                >
+                                    <p style={{ margin: 0, color: "var(--color-text-muted)" }}>
+                                        We&apos;ve sent your membership contract via Zoho Sign. Please check your email and sign it. This page updates
+                                        automatically once it&apos;s signed.
+                                    </p>
+                                </ExternalTask>
+
+                                <ExternalTask
+                                    done={!!state.external?.bgConsented}
+                                    title="Consent to a background check"
+                                    doneText="Background-check consent received."
+                                >
+                                    {state.external?.deepLinkUrl ? (
+                                        <a href={state.external.deepLinkUrl} target="_blank" rel="noopener noreferrer" className="glass-button" style={{ display: "inline-block", textDecoration: "none", color: "white", padding: "0.6rem 1.1rem", background: "rgba(59,130,246,0.3)", borderColor: "rgba(59,130,246,0.5)" }}>
+                                            Consent on Averity →
+                                        </a>
+                                    ) : (
+                                        <p style={{ margin: 0, color: "var(--color-text-muted)" }}>The background-check link isn&apos;t available yet. Please check back shortly.</p>
+                                    )}
+                                </ExternalTask>
+
+                                <button className="glass-button" disabled={saving} onClick={load} style={{ alignSelf: "flex-start", padding: "0.6rem 1.1rem" }}>
+                                    Refresh status
+                                </button>
+                            </div>
                         ) : (
                             <div className="glass-container" style={{ padding: "2rem" }}>
                                 <h2 style={{ marginTop: 0 }}>Application in progress</h2>
                                 <p style={{ color: "var(--color-text-muted)" }}>
-                                    Your information is in. Follow the steps on the left — the next stages (contract, background check, and payment)
+                                    Your information is in. Follow the steps on the left — the next stages (background check and payment)
                                     will appear here as they open.
                                 </p>
                             </div>

--- a/src/app/membership/page.tsx
+++ b/src/app/membership/page.tsx
@@ -367,7 +367,7 @@ export default function MembershipPage() {
                                     </button>
                                 </div>
                             </div>
-                        ) : inStatus === "EXTERNAL" ? (
+                        ) : inStatus === "PENDING_EXTERNAL_ACTION" ? (
                             <div className="glass-container" style={{ padding: "1.75rem", display: "flex", flexDirection: "column", gap: "1.25rem" }}>
                                 <div>
                                     <h2 style={{ marginTop: 0, marginBottom: "0.25rem" }}>Two quick steps</h2>

--- a/src/lib/membership/background-check/manual-adapter.ts
+++ b/src/lib/membership/background-check/manual-adapter.ts
@@ -1,0 +1,19 @@
+import prisma from "@/lib/prisma";
+import type { BackgroundCheckProvider } from "./provider";
+
+/**
+ * Manual (human-marked) background-check provider for Averity/VERITY.
+ *
+ * Consent link comes from BoardSettings.averityDeepLinkUrl (set on the board
+ * settings page). There is no API: a board member receives Averity's email when
+ * an applicant submits consent and marks it in our system.
+ */
+export class ManualBackgroundCheckProvider implements BackgroundCheckProvider {
+    async getConsentDeepLink(): Promise<string | null> {
+        const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        return settings?.averityDeepLinkUrl ?? null;
+    }
+}
+
+/** The active provider. Swap here if a real-API provider is ever introduced. */
+export const backgroundCheckProvider: BackgroundCheckProvider = new ManualBackgroundCheckProvider();

--- a/src/lib/membership/background-check/provider.ts
+++ b/src/lib/membership/background-check/provider.ts
@@ -1,0 +1,17 @@
+/**
+ * Background-check provider abstraction.
+ *
+ * Averity (VERITY / Verity Secure) exposes NO public API — only a hosted
+ * consent page (a deep link) and email notifications to a human. So the
+ * provider's job is narrow: hand applicants the right consent link. Consent
+ * and completion are recorded by a human marking them in our system (see
+ * markBgConsent / the BG review in PR7). The system never sees background-check
+ * results — only whether a board member has attested to them.
+ *
+ * Keeping this behind an interface means a future provider with a real API can
+ * drop in without touching the flow.
+ */
+export interface BackgroundCheckProvider {
+    /** The hosted consent deep link to show an applicant, or null if unconfigured. */
+    getConsentDeepLink(): Promise<string | null>;
+}

--- a/src/lib/membership/contract/zoho.ts
+++ b/src/lib/membership/contract/zoho.ts
@@ -1,0 +1,58 @@
+import crypto from "crypto";
+
+/**
+ * Zoho Sign contract webhook helpers.
+ *
+ * Zoho Sign has no strong native HMAC; instead we configure the webhook in Zoho
+ * with a custom header carrying a shared secret (ZOHO_WEBHOOK_SECRET) and verify
+ * it here with a timing-safe compare. The header name is configurable so it can
+ * match whatever the Zoho webhook config uses.
+ *
+ * NOTE: confirm the exact Zoho Sign webhook payload shape + header against the
+ * live Zoho config when credentials are available; the parser below is tolerant
+ * of the documented variants (request_id / request_status).
+ */
+export const ZOHO_WEBHOOK_HEADER = "x-zoho-webhook-token";
+
+/** Timing-safe shared-secret check. Returns false if the secret is unset. */
+export function verifyZohoToken(headerToken: string | null | undefined): boolean {
+    const secret = process.env.ZOHO_WEBHOOK_SECRET;
+    if (!secret || !headerToken) return false;
+    const a = Buffer.from(headerToken);
+    const b = Buffer.from(secret);
+    return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+export interface ZohoWebhookResult {
+    requestId: string | null;
+    /** True when the signing request reached a fully-signed/completed state. */
+    completed: boolean;
+}
+
+/**
+ * Pull the request id + completion out of a Zoho Sign webhook body, tolerant of
+ * the documented shapes:
+ *   { requests: { request_id, request_status } }
+ *   { request_id, request_status }
+ *   { notifications: { ... } } wrappers
+ * "completed" maps from request_status === "completed".
+ */
+export function parseZohoWebhook(body: unknown): ZohoWebhookResult {
+    const root = (body ?? {}) as Record<string, unknown>;
+    const candidates: Record<string, unknown>[] = [root];
+    for (const key of ["requests", "request", "notifications", "data"]) {
+        const nested = root[key];
+        if (nested && typeof nested === "object") candidates.push(nested as Record<string, unknown>);
+    }
+
+    let requestId: string | null = null;
+    let status: string | null = null;
+    for (const c of candidates) {
+        const id = c["request_id"] ?? c["requestId"] ?? c["request_id_str"];
+        if (id != null && requestId == null) requestId = String(id);
+        const s = c["request_status"] ?? c["requestStatus"] ?? c["status"];
+        if (typeof s === "string" && status == null) status = s;
+    }
+
+    return { requestId, completed: status?.toLowerCase() === "completed" };
+}

--- a/src/lib/membership/external.ts
+++ b/src/lib/membership/external.ts
@@ -4,7 +4,7 @@ import { backgroundCheckProvider } from "@/lib/membership/background-check/manua
 /**
  * EXTERNAL-phase service — the two parallel actions an applicant completes after
  * intake: signing the Zoho contract and consenting to a background check on
- * Averity. When BOTH are recorded, the application advances to BG_REVIEW.
+ * Averity. When BOTH are recorded, the application advances to PENDING_BG_REVIEW.
  *
  * The contract is recorded automatically (Zoho webhook) or manually by the
  * board; BG consent is always human-marked by the board (no Averity API). The
@@ -36,15 +36,15 @@ export async function getExternalStatus(process: { contractSignedAt: Date | null
     };
 }
 
-/** If both external actions are done and we're still in EXTERNAL, advance to BG_REVIEW. */
+/** If both external actions are done and we're still in EXTERNAL, advance to PENDING_BG_REVIEW. */
 export async function advanceExternalIfComplete(processId: number) {
     const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
-    if (!process || process.status !== "EXTERNAL") return process;
+    if (!process || process.status !== "PENDING_EXTERNAL_ACTION") return process;
     if (!process.contractSignedAt || !process.bgConsentAt) return process;
 
     const advanced = await prisma.membershipProcess.update({
         where: { id: processId },
-        data: { status: "BG_REVIEW", stageEnteredAt: new Date() },
+        data: { status: "PENDING_BG_REVIEW", stageEnteredAt: new Date() },
     });
     await prisma.auditLog.create({
         data: {
@@ -52,8 +52,8 @@ export async function advanceExternalIfComplete(processId: number) {
             action: "EDIT",
             tableName: "MembershipProcess",
             affectedEntityId: processId,
-            oldData: JSON.stringify({ status: "EXTERNAL" }),
-            newData: JSON.stringify({ status: "BG_REVIEW" }),
+            oldData: JSON.stringify({ status: "PENDING_EXTERNAL_ACTION" }),
+            newData: JSON.stringify({ status: "PENDING_BG_REVIEW" }),
         },
     });
     return advanced;

--- a/src/lib/membership/external.ts
+++ b/src/lib/membership/external.ts
@@ -1,0 +1,102 @@
+import prisma from "@/lib/prisma";
+import { backgroundCheckProvider } from "@/lib/membership/background-check/manual-adapter";
+
+/**
+ * EXTERNAL-phase service — the two parallel actions an applicant completes after
+ * intake: signing the Zoho contract and consenting to a background check on
+ * Averity. When BOTH are recorded, the application advances to BG_REVIEW.
+ *
+ * The contract is recorded automatically (Zoho webhook) or manually by the
+ * board; BG consent is always human-marked by the board (no Averity API). The
+ * system never sees contract content or check results.
+ *
+ * actorId 0 denotes a system actor (e.g. the Zoho webhook) in the audit log.
+ */
+const SYSTEM_ACTOR = 0;
+
+export class ExternalError extends Error {
+    constructor(public readonly code: "not_found" | "wrong_phase", message: string) {
+        super(message);
+        this.name = "ExternalError";
+    }
+}
+
+export interface ExternalStatus {
+    contractSigned: boolean;
+    bgConsented: boolean;
+    deepLinkUrl: string | null;
+}
+
+/** Applicant-facing status of the two external actions (+ the consent deep link). */
+export async function getExternalStatus(process: { contractSignedAt: Date | null; bgConsentAt: Date | null }): Promise<ExternalStatus> {
+    return {
+        contractSigned: !!process.contractSignedAt,
+        bgConsented: !!process.bgConsentAt,
+        deepLinkUrl: await backgroundCheckProvider.getConsentDeepLink(),
+    };
+}
+
+/** If both external actions are done and we're still in EXTERNAL, advance to BG_REVIEW. */
+export async function advanceExternalIfComplete(processId: number) {
+    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    if (!process || process.status !== "EXTERNAL") return process;
+    if (!process.contractSignedAt || !process.bgConsentAt) return process;
+
+    const advanced = await prisma.membershipProcess.update({
+        where: { id: processId },
+        data: { status: "BG_REVIEW", stageEnteredAt: new Date() },
+    });
+    await prisma.auditLog.create({
+        data: {
+            actorId: SYSTEM_ACTOR,
+            action: "EDIT",
+            tableName: "MembershipProcess",
+            affectedEntityId: processId,
+            oldData: JSON.stringify({ status: "EXTERNAL" }),
+            newData: JSON.stringify({ status: "BG_REVIEW" }),
+        },
+    });
+    return advanced;
+}
+
+/** Record that the membership contract was signed (idempotent), then maybe advance. */
+export async function markContractSigned(processId: number, actorId: number = SYSTEM_ACTOR) {
+    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    if (!process) throw new ExternalError("not_found", "Application not found.");
+    if (!process.contractSignedAt) {
+        await prisma.membershipProcess.update({ where: { id: processId }, data: { contractSignedAt: new Date() } });
+        await prisma.auditLog.create({
+            data: { actorId, action: "EDIT", tableName: "MembershipProcess", affectedEntityId: processId, newData: JSON.stringify({ contractSignedAt: true }) },
+        });
+    }
+    return advanceExternalIfComplete(processId);
+}
+
+/** Board human-marks that the applicant submitted background-check consent, then maybe advance. */
+export async function markBgConsent(processId: number, actorId: number) {
+    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    if (!process) throw new ExternalError("not_found", "Application not found.");
+    if (!process.bgConsentAt) {
+        await prisma.membershipProcess.update({ where: { id: processId }, data: { bgConsentAt: new Date() } });
+        await prisma.auditLog.create({
+            data: { actorId, action: "EDIT", tableName: "MembershipProcess", affectedEntityId: processId, newData: JSON.stringify({ bgConsentAt: true }) },
+        });
+    }
+    return advanceExternalIfComplete(processId);
+}
+
+/** Associate a Zoho signing request id with a process so its webhook can match. */
+export async function setZohoEnvelope(processId: number, requestId: string, actorId: number) {
+    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    if (!process) throw new ExternalError("not_found", "Application not found.");
+    const updated = await prisma.membershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: requestId } });
+    await prisma.auditLog.create({
+        data: { actorId, action: "EDIT", tableName: "MembershipProcess", affectedEntityId: processId, newData: JSON.stringify({ zohoEnvelopeId: requestId }) },
+    });
+    return updated;
+}
+
+/** Find the in-flight process tied to a Zoho request id (for webhook matching). */
+export async function findProcessByEnvelope(requestId: string) {
+    return prisma.membershipProcess.findFirst({ where: { zohoEnvelopeId: requestId } });
+}

--- a/src/lib/membership/intake.ts
+++ b/src/lib/membership/intake.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { IN_FLIGHT_INITIAL_STATUSES } from "@/lib/membership/phases";
+import { getExternalStatus } from "@/lib/membership/external";
 
 /**
  * Membership intake service — the write/read model behind the "Join the
@@ -77,10 +78,13 @@ export async function getIntakeState(userId: number) {
         allergies: p.allergies,
     });
 
+    const external = process ? await getExternalStatus(process) : null;
+
     return {
         hasHousehold: !!household,
         membershipStatus: membership?.status ?? null,
         process: process ? { id: process.id, kind: process.kind, status: process.status } : null,
+        external,
         prefill: {
             household: household
                 ? {


### PR DESCRIPTION
## PR6 of the membership stack — the EXTERNAL phase

Stacked on #188 (`feat/membership-intake-flow`).

After intake, an applicant completes two **parallel** external actions; when both are recorded, the application advances `EXTERNAL → BG_REVIEW`. The system never sees contract content or check results.

### Background check (Averity / VERITY — no API)
- `BackgroundCheckProvider` interface + `ManualBackgroundCheckProvider`: serves the hosted consent deep link from `BoardSettings.averityDeepLinkUrl`. Consent submission is **human-marked** by the board (after Averity's email notification).

### Contract (Zoho Sign — real webhook)
- `POST /api/webhooks/zoho`: shared-secret header verification (timing-safe) + a tolerant payload parser; on a completed signing it records the contract signed (and may advance). Acknowledges unknown/non-completed events so Zoho stops retrying.

### Service + board controls
- `external.ts`: `markContractSigned` (idempotent), `markBgConsent`, `setZohoEnvelope`, `advanceExternalIfComplete`. System actor (id 0) for webhook audit rows.
- `POST /api/admin/membership/external` (board): `mark-contract` / `mark-bg-consent` / `set-envelope`.
- Applicant `/membership` EXTERNAL view: two task cards with live status + the Averity consent link.

### No schema change
Uses existing `MembershipProcess` fields (`zohoEnvelopeId`, `contractSignedAt`, `bgConsentAt`). Graceful when unconfigured: webhook 500s without `ZOHO_WEBHOOK_SECRET`; consent link hides until `averityDeepLinkUrl` is set.

### 🔑 Credentials I'll need to take this live (not blocking the PR)
- **`ZOHO_WEBHOOK_SECRET`** — shared secret to set as a custom header (`x-zoho-webhook-token`) in the Zoho Sign webhook config. Also need the **webhook URL** registered in Zoho → `https://<host>/api/webhooks/zoho`, and confirmation of Zoho's actual payload shape/header (the parser is tolerant but should be verified).
- **Averity consent deep link** → stored in `BoardSettings.averityDeepLinkUrl` (set via the board settings page in PR9), plus the **email address** that receives Averity's consent notifications.
- *(Deferred)* if we later auto-send contracts via the Zoho API: Zoho client id/secret/refresh token + the membership contract template id.

### Validation
tsc clean · 82 unit · **276 integration** (8 new: advance-on-both, contract-only stays EXTERNAL, webhook valid/invalid/non-completed, board controls + auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)