### PR TITLE
feat(membership): 2-of-N background-check review + volunteer status + board override

### DIFF
--- a/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -13,6 +13,8 @@ import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+// Advancing to PENDING_BG_REVIEW pings reviewers; don't hit Resend in tests.
+jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
 
 const TAG = 'membership-external-test';
 const SECRET = 'zoho-test-secret';

--- a/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the PENDING_BG_REVIEW phase: 2-of-N attestation,
+ * eligibility rules, sticky volunteer status, reject -> BLOCKED, board override.
+ */
+
+import { GET as REVIEW_QUEUE, POST as ATTEST } from '@/app/api/membership/reviews/route';
+import { POST as OVERRIDE } from '@/app/api/admin/membership/review-override/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+// Don't hit Resend during tests — the reviewer ping is exercised, not actually sent.
+jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+
+const TAG = 'review-test';
+
+function as(id: number, roles: { backgroundCheckReviewer?: boolean; boardMember?: boolean; sysadmin?: boolean } = {}) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, sysadmin: false, boardMember: false, backgroundCheckReviewer: false, ...roles } });
+}
+function req(body: unknown) {
+    return new Request('http://localhost:4000/x', { method: 'POST', body: JSON.stringify(body) }) as unknown as Parameters<typeof ATTEST>[0];
+}
+
+describe('Membership BG review API', () => {
+    let rev1: number, rev2: number, rev1b: number, revInApplicant: number, nonReviewer: number, board: number;
+    let applicantHh: number;
+
+    async function makeApplicantProcess(label: string, parentEmail?: string) {
+        const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
+        // A parent/guardian is a household lead.
+        const parent = await prisma.participant.create({ data: { name: `${label} Parent`, householdId: hh.id, ...(parentEmail ? { email: parentEmail } : {}) } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: parent.id } });
+        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
+        return { householdId: hh.id, membershipId: m.id, processId: p.id };
+    }
+
+    async function wipe() {
+        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
+        const ids = hhs.map((h) => h.id);
+        if (ids.length) {
+            await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: ids } } } } });
+            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
+            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.household.deleteMany({ where: { id: { in: ids } } });
+        }
+        await prisma.volunteerDesignation.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+    }
+
+    beforeAll(async () => {
+        await wipe();
+        const mk = async (slug: string, role: object, householdId?: number) => {
+            const data = householdId
+                ? { email: `${slug}-${TAG}@example.com`, name: slug, householdId, ...role }
+                : { email: `${slug}-${TAG}@example.com`, name: slug, household: { create: { name: `${slug} HH ${TAG}` } }, ...role };
+            return prisma.participant.create({ data });
+        };
+        const r1 = await mk('rev1', { backgroundCheckReviewer: true });
+        rev1 = r1.id;
+        rev1b = (await mk('rev1b', { backgroundCheckReviewer: true }, r1.householdId!)).id; // shares rev1's household
+        rev2 = (await mk('rev2', { backgroundCheckReviewer: true })).id;
+        board = (await mk('board', { boardMember: true })).id;
+        nonReviewer = (await mk('plain', {})).id;
+
+        const app = await makeApplicantProcess('Applicant');
+        applicantHh = app.householdId;
+        revInApplicant = (await mk('revapp', { backgroundCheckReviewer: true }, applicantHh)).id; // in applicant household
+    });
+
+    afterAll(async () => {
+        await wipe();
+        await prisma.$disconnect();
+    });
+
+    it('rejects a non-reviewer (403)', async () => {
+        as(nonReviewer);
+        const proc = await makeApplicantProcess('NR');
+        const res = await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
+        expect(res.status).toBe(403);
+    });
+
+    it('blocks a reviewer in the applicant household', async () => {
+        as(revInApplicant, { backgroundCheckReviewer: true });
+        const proc = await prisma.membershipProcess.findFirst({ where: { membership: { householdId: applicantHh } } });
+        const res = await ATTEST(req({ processId: proc!.id, result: 'APPROVE' }) as never);
+        const data = await res.json();
+        expect(res.status).toBe(403);
+        expect(data.code).toBe('same_household_applicant');
+    });
+
+    it('2 distinct reviewers approving advances to PENDING_PAYMENT, stamps BG date, applies marked volunteer', async () => {
+        const proc = await makeApplicantProcess('Approve');
+        as(rev1, { backgroundCheckReviewer: true });
+        const r1 = await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
+        expect((await r1.json()).outcome.status).toBe('PENDING_BG_REVIEW');
+
+        // same reviewer again -> already_attested
+        const dup = await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
+        expect(dup.status).toBe(409);
+
+        // reviewer sharing rev1's household -> blocked
+        as(rev1b, { backgroundCheckReviewer: true });
+        const shared = await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
+        expect((await shared.json()).code).toBe('same_household_reviewer');
+
+        // rev2 approves with volunteer checkbox -> advances
+        as(rev2, { backgroundCheckReviewer: true });
+        const r2 = await ATTEST(req({ processId: proc.processId, result: 'APPROVE', markedVolunteer: true }) as never);
+        expect((await r2.json()).outcome.status).toBe('PENDING_PAYMENT');
+
+        const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
+        expect(updated?.status).toBe('PENDING_PAYMENT');
+        const membership = await prisma.membership.findUnique({ where: { id: proc.membershipId } });
+        expect(membership?.isVolunteer).toBe(true);
+        const parent = await prisma.participant.findFirst({ where: { householdId: proc.householdId, householdLeads: { some: { householdId: proc.householdId } } } });
+        expect(parent?.lastBackgroundCheck).not.toBeNull();
+    });
+
+    it('applies volunteer status from a pre-designation (dot-insensitive), without a checkbox', async () => {
+        const proc = await makeApplicantProcess('Predesig', `vol.parent-${TAG}@example.com`);
+        await prisma.volunteerDesignation.create({ data: { email: `volparent-${TAG}@example.com` } }); // no dot
+        as(rev1, { backgroundCheckReviewer: true });
+        await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
+        as(rev2, { backgroundCheckReviewer: true });
+        await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
+        const membership = await prisma.membership.findUnique({ where: { id: proc.membershipId } });
+        expect(membership?.isVolunteer).toBe(true);
+    });
+
+    it('a single REJECT blocks the application', async () => {
+        const proc = await makeApplicantProcess('Reject');
+        as(rev1, { backgroundCheckReviewer: true });
+        const res = await ATTEST(req({ processId: proc.processId, result: 'REJECT' }) as never);
+        expect((await res.json()).outcome.status).toBe('BLOCKED');
+        const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
+        expect(updated?.status).toBe('BLOCKED');
+    });
+
+    it('board reset on a BLOCKED app clears attestations and returns it to review', async () => {
+        const proc = await makeApplicantProcess('ResetMe');
+        as(rev1, { backgroundCheckReviewer: true });
+        await ATTEST(req({ processId: proc.processId, result: 'REJECT' }) as never);
+
+        as(board, { boardMember: true });
+        const res = await OVERRIDE(req({ processId: proc.processId, action: 'reset' }) as never);
+        expect(res.status).toBe(200);
+        const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
+        expect(updated?.status).toBe('PENDING_BG_REVIEW');
+        const count = await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } });
+        expect(count).toBe(0);
+    });
+
+    it('board override-approve on a BLOCKED app forces it to PENDING_PAYMENT', async () => {
+        const proc = await makeApplicantProcess('ForceApprove');
+        as(rev1, { backgroundCheckReviewer: true });
+        await ATTEST(req({ processId: proc.processId, result: 'REJECT' }) as never);
+
+        as(board, { boardMember: true });
+        const res = await OVERRIDE(req({ processId: proc.processId, action: 'approve' }) as never);
+        expect(res.status).toBe(200);
+        const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
+        expect(updated?.status).toBe('PENDING_PAYMENT');
+    });
+
+    it('non-board cannot override', async () => {
+        as(nonReviewer);
+        const res = await OVERRIDE(req({ processId: 1, action: 'reset' }) as never);
+        expect(res.status).toBe(403);
+    });
+
+    it('queue lists eligible apps for a reviewer and excludes their own-household applicants', async () => {
+        as(rev2, { backgroundCheckReviewer: true });
+        const res = await REVIEW_QUEUE(req({}) as never);
+        const data = await res.json();
+        expect(Array.isArray(data.queue)).toBe(true);
+        // rev2 shares no household with applicants; every queued item is PENDING_BG_REVIEW and not yet attested by rev2.
+        for (const item of data.queue) {
+            expect(typeof item.processId).toBe('number');
+        }
+    });
+});

--- a/src/app/admin/membership/page.tsx
+++ b/src/app/admin/membership/page.tsx
@@ -7,6 +7,11 @@ interface Participant {
     name: string | null;
     email: string | null;
 }
+interface Attestation {
+    id: number;
+    result: string;
+    markedVolunteer: boolean;
+}
 interface ProcessRow {
     id: number;
     kind: string;
@@ -15,6 +20,7 @@ interface ProcessRow {
     zohoEnvelopeId: string | null;
     contractSignedAt: string | null;
     bgConsentAt: string | null;
+    attestations: Attestation[];
     membership: {
         householdId: number;
         isVolunteer: boolean;
@@ -71,6 +77,32 @@ export default function AdminMembershipPage() {
             } else {
                 setIsError(true);
                 setMessage(data.error || "Action failed.");
+            }
+        } catch {
+            setIsError(true);
+            setMessage("Network error.");
+        } finally {
+            setBusyId(null);
+        }
+    };
+
+    const override = async (processId: number, action: "reset" | "approve") => {
+        setBusyId(processId);
+        setMessage("");
+        try {
+            const res = await fetch("/api/admin/membership/review-override", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ processId, action }),
+            });
+            const data = await res.json();
+            if (res.ok) {
+                setIsError(false);
+                setMessage(action === "reset" ? "Sent back for re-review." : "Overridden to payment.");
+                await load();
+            } else {
+                setIsError(true);
+                setMessage(data.error || "Override failed.");
             }
         } catch {
             setIsError(true);
@@ -150,6 +182,26 @@ export default function AdminMembershipPage() {
                                                 {busyId === r.id ? "…" : "Confirm BG consent"}
                                             </button>
                                         )}
+                                    </div>
+                                </div>
+                            )}
+
+                            {r.status === "PENDING_BG_REVIEW" && (
+                                <div style={{ marginTop: "1rem", fontSize: "0.9rem", color: "var(--color-text-muted)" }}>
+                                    Awaiting reviewers — <strong style={{ color: "var(--color-text-main, #f8fafc)" }}>{r.attestations.filter((a) => a.result === "APPROVE").length}/2</strong> approvals recorded.
+                                </div>
+                            )}
+
+                            {r.status === "BLOCKED" && (
+                                <div style={{ marginTop: "1rem", padding: "1rem", background: "rgba(239,68,68,0.12)", border: "1px solid rgba(239,68,68,0.4)", borderRadius: "10px" }}>
+                                    <div style={{ color: "#fca5a5", fontWeight: 600, marginBottom: "0.75rem" }}>🚨 Blocked at background review — needs board attention.</div>
+                                    <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+                                        <button className="glass-button" disabled={busyId === r.id} onClick={() => override(r.id, "reset")} style={{ padding: "0.45rem 0.9rem" }}>
+                                            {busyId === r.id ? "…" : "Reset for re-review"}
+                                        </button>
+                                        <button className="glass-button" disabled={busyId === r.id} onClick={() => override(r.id, "approve")} style={{ padding: "0.45rem 0.9rem", background: "rgba(34,197,94,0.2)", borderColor: "rgba(34,197,94,0.4)" }}>
+                                            {busyId === r.id ? "…" : "Override → payment"}
+                                        </button>
                                     </div>
                                 </div>
                             )}

--- a/src/app/api/admin/membership/review-override/route.ts
+++ b/src/app/api/admin/membership/review-override/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { overrideBlocked, ReviewError } from "@/lib/membership/review";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/admin/membership/review-override — board action on a BLOCKED application.
+ * Body: { processId, action: 'reset' | 'approve' }
+ *   reset   — clear attestations, send back to PENDING_BG_REVIEW (re-ping reviewers)
+ *   approve — board override straight to PENDING_PAYMENT
+ */
+export const POST = withAuth({ roles: ["sysadmin", "boardMember"] }, async (req, auth) => {
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    let body: { processId?: number; action?: "reset" | "approve" };
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+    if (!body.processId || (body.action !== "reset" && body.action !== "approve")) {
+        return NextResponse.json({ error: "processId and action (reset|approve) are required" }, { status: 400 });
+    }
+    try {
+        const outcome = await overrideBlocked(body.processId, auth.user.id, body.action);
+        return NextResponse.json({ outcome });
+    } catch (error) {
+        if (error instanceof ReviewError) {
+            return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 409 });
+        }
+        console.error("Review override error:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+});

--- a/src/app/api/admin/membership/route.ts
+++ b/src/app/api/admin/membership/route.ts
@@ -21,6 +21,7 @@ export const GET = withAuth({ roles: ["sysadmin", "boardMember"] }, async () => 
             zohoEnvelopeId: true,
             contractSignedAt: true,
             bgConsentAt: true,
+            attestations: { select: { id: true, result: true, markedVolunteer: true } },
             membership: {
                 select: {
                     householdId: true,

--- a/src/app/api/membership/reviews/route.ts
+++ b/src/app/api/membership/reviews/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { listReviewQueue, attest, ReviewError } from "@/lib/membership/review";
+
+export const dynamic = "force-dynamic";
+
+const STATUS_FOR: Record<ReviewError["code"], number> = {
+    not_reviewer: 403,
+    not_found: 404,
+    wrong_phase: 409,
+    same_household_applicant: 403,
+    same_household_reviewer: 403,
+    already_attested: 409,
+};
+
+// GET /api/membership/reviews — applications this reviewer may attest.
+export const GET = withAuth({ roles: ["backgroundCheckReviewer"] }, async (_req, auth) => {
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ queue: await listReviewQueue(auth.user.id) });
+});
+
+// POST /api/membership/reviews — submit an attestation { processId, result, markedVolunteer }.
+export const POST = withAuth({ roles: ["backgroundCheckReviewer"] }, async (req, auth) => {
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    let body: { processId?: number; result?: "APPROVE" | "REJECT"; markedVolunteer?: boolean };
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+    if (!body.processId || (body.result !== "APPROVE" && body.result !== "REJECT")) {
+        return NextResponse.json({ error: "processId and result (APPROVE|REJECT) are required" }, { status: 400 });
+    }
+    try {
+        const outcome = await attest(auth.user.id, body.processId, { result: body.result, markedVolunteer: body.markedVolunteer });
+        return NextResponse.json({ outcome });
+    } catch (error) {
+        if (error instanceof ReviewError) {
+            return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
+        }
+        console.error("Attestation error:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+});

--- a/src/app/membership/review/page.tsx
+++ b/src/app/membership/review/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+
+interface QueueItem {
+    processId: number;
+    householdName: string | null;
+    parents: { name: string | null; email: string | null }[];
+    approvals: number;
+}
+
+export default function MembershipReviewPage() {
+    const { status: sessionStatus } = useSession();
+    const [queue, setQueue] = useState<QueueItem[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [forbidden, setForbidden] = useState(false);
+    const [busyId, setBusyId] = useState<number | null>(null);
+    const [volunteer, setVolunteer] = useState<Record<number, boolean>>({});
+    const [message, setMessage] = useState("");
+    const [isError, setIsError] = useState(false);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        try {
+            const res = await fetch("/api/membership/reviews");
+            if (res.status === 403) {
+                setForbidden(true);
+                return;
+            }
+            if (res.ok) {
+                const data = await res.json();
+                setQueue(data.queue || []);
+            }
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (sessionStatus === "authenticated") load();
+        else if (sessionStatus === "unauthenticated") setLoading(false);
+    }, [sessionStatus, load]);
+
+    const submit = async (processId: number, result: "APPROVE" | "REJECT") => {
+        setBusyId(processId);
+        setMessage("");
+        try {
+            const res = await fetch("/api/membership/reviews", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ processId, result, markedVolunteer: !!volunteer[processId] }),
+            });
+            const data = await res.json();
+            if (res.ok) {
+                setIsError(false);
+                setMessage(result === "APPROVE" ? "Attestation recorded — thank you." : "Recorded. The board has been notified.");
+                await load();
+            } else {
+                setIsError(true);
+                setMessage(data.error || "Could not record your attestation.");
+            }
+        } catch {
+            setIsError(true);
+            setMessage("Network error.");
+        } finally {
+            setBusyId(null);
+        }
+    };
+
+    if (sessionStatus === "loading" || loading) {
+        return <main style={{ padding: "2rem", textAlign: "center", color: "var(--color-text-muted)" }}>Loading…</main>;
+    }
+
+    if (forbidden || sessionStatus === "unauthenticated") {
+        return (
+            <main style={{ padding: "2rem", textAlign: "center" }}>
+                <div className="glass-container" style={{ maxWidth: "480px", margin: "0 auto", padding: "2rem" }}>
+                    <h1>Background-check review</h1>
+                    <p style={{ color: "var(--color-text-muted)" }}>This area is for background-check reviewers only.</p>
+                    <Link href="/" className="glass-button">Home</Link>
+                </div>
+            </main>
+        );
+    }
+
+    return (
+        <main style={{ maxWidth: "820px", margin: "0 auto", padding: "2rem 1.5rem" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: "1rem", marginBottom: "1.5rem" }}>
+                <h1 className="text-gradient" style={{ margin: 0 }}>Background-check review</h1>
+                <Link href="/" className="glass-button" style={{ textDecoration: "none", color: "white" }}>&larr; Home</Link>
+            </div>
+
+            <p style={{ color: "var(--color-text-muted)", marginTop: 0 }}>
+                Review each applicant&apos;s background check on Averity, then attest below. Two independent reviewers are required.
+                If anything is concerning, choose <strong>Reject</strong> — the board is notified and the applicant is not told the reason.
+            </p>
+
+            {message && (
+                <div style={{ margin: "1rem 0", padding: "0.85rem 1rem", borderRadius: "8px", background: isError ? "rgba(239,68,68,0.1)" : "rgba(34,197,94,0.1)", border: `1px solid ${isError ? "rgba(239,68,68,0.3)" : "rgba(34,197,94,0.3)"}`, color: isError ? "#f87171" : "#4ade80" }}>
+                    {message}
+                </div>
+            )}
+
+            {queue.length === 0 ? (
+                <div className="glass-container" style={{ padding: "2rem", textAlign: "center", color: "var(--color-text-muted)" }}>
+                    Nothing awaiting your review right now.
+                </div>
+            ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+                    {queue.map((item) => (
+                        <div key={item.processId} className="glass-container" style={{ padding: "1.25rem 1.5rem" }}>
+                            <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>{item.householdName || `Household (application #${item.processId})`}</div>
+                            <div style={{ fontSize: "0.85rem", color: "var(--color-text-muted)", marginTop: "0.25rem" }}>
+                                {item.parents.length > 0
+                                    ? item.parents.map((p) => `${p.name || "—"}${p.email ? ` <${p.email}>` : ""}`).join(", ")
+                                    : "No parent contact on file."}
+                            </div>
+                            <div style={{ fontSize: "0.8rem", color: "var(--color-text-muted)", marginTop: "0.25rem" }}>
+                                {item.approvals}/2 approvals so far.
+                            </div>
+
+                            <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", margin: "0.9rem 0", cursor: "pointer" }}>
+                                <input
+                                    type="checkbox"
+                                    checked={!!volunteer[item.processId]}
+                                    onChange={(e) => setVolunteer((v) => ({ ...v, [item.processId]: e.target.checked }))}
+                                />
+                                <span>This is a volunteer family</span>
+                            </label>
+
+                            <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+                                <button className="glass-button" disabled={busyId === item.processId} onClick={() => submit(item.processId, "APPROVE")} style={{ padding: "0.55rem 1.1rem", background: "rgba(34,197,94,0.2)", borderColor: "rgba(34,197,94,0.4)" }}>
+                                    {busyId === item.processId ? "…" : "Attest — check is clean"}
+                                </button>
+                                <button className="glass-button" disabled={busyId === item.processId} onClick={() => submit(item.processId, "REJECT")} style={{ padding: "0.55rem 1.1rem", background: "rgba(239,68,68,0.18)", borderColor: "rgba(239,68,68,0.45)" }}>
+                                    {busyId === item.processId ? "…" : "Reject"}
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </main>
+    );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,6 +154,15 @@ export default function Home() {
                 </div>
               )}
 
+              {/* Background-check reviewers: entry point to their review queue */}
+              {(session.user as SessionUser)?.backgroundCheckReviewer && (
+                <div style={{ width: '100%', gridColumn: '1 / -1' }}>
+                  <a href="/membership/review" className="glass-button" style={{ display: 'inline-block', textDecoration: 'none', color: 'white', padding: '0.75rem 1.25rem', background: 'rgba(168,85,247,0.25)', borderColor: 'rgba(168,85,247,0.5)' }}>
+                    🔍 Background-check reviews
+                  </a>
+                </div>
+              )}
+
               {/* Operational Warnings */}
               {isTwoDeepViolation && (
                 <div style={{ background: 'rgba(239, 68, 68, 0.2)', border: '1px solid rgba(239, 68, 68, 0.5)', color: '#fca5a5', padding: '1rem', borderRadius: '8px', width: '100%', gridColumn: '1 / -1', display: 'flex', gap: '12px', alignItems: 'center' }}>

--- a/src/lib/membership/external.ts
+++ b/src/lib/membership/external.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { backgroundCheckProvider } from "@/lib/membership/background-check/manual-adapter";
+import { notifyReviewers } from "@/lib/membership/review";
 
 /**
  * EXTERNAL-phase service — the two parallel actions an applicant completes after
@@ -56,6 +57,8 @@ export async function advanceExternalIfComplete(processId: number) {
             newData: JSON.stringify({ status: "PENDING_BG_REVIEW" }),
         },
     });
+    // Ping background-check reviewers that an application is ready (log-only until email is configured).
+    await notifyReviewers();
     return advanced;
 }
 

--- a/src/lib/membership/review.ts
+++ b/src/lib/membership/review.ts
@@ -1,0 +1,228 @@
+import prisma from "@/lib/prisma";
+import { sendEmail } from "@/lib/email";
+import { logger } from "@/lib/logger";
+
+/**
+ * Background-check review (PENDING_BG_REVIEW phase).
+ *
+ * Two DISTINCT eligible reviewers (role backgroundCheckReviewer) must each
+ * attest the check independently. A reviewer may not share a household with the
+ * applicant or with the other reviewer, and may not attest twice.
+ *   - 2 APPROVE  -> advance to PENDING_PAYMENT; stamp parents' lastBackgroundCheck;
+ *                   apply (sticky) volunteer status.
+ *   - any REJECT -> BLOCKED (board override/reset; applicant is NOT told why).
+ *
+ * The system never sees the check itself — only the attestations.
+ */
+
+const SYSTEM_ACTOR = 0;
+const REQUIRED_APPROVALS = 2;
+
+export class ReviewError extends Error {
+    constructor(
+        public readonly code:
+            | "not_reviewer"
+            | "not_found"
+            | "wrong_phase"
+            | "same_household_applicant"
+            | "same_household_reviewer"
+            | "already_attested",
+        message: string,
+    ) {
+        super(message);
+        this.name = "ReviewError";
+    }
+}
+
+/**
+ * Normalize an email for volunteer-designation matching: lowercase, and strip
+ * dots from the local part (Gmail-style). "Foo.Bar@Gmail.com" -> "foobar@gmail.com".
+ */
+export function normalizeEmail(email: string): string {
+    const lower = email.trim().toLowerCase();
+    const at = lower.indexOf("@");
+    if (at < 0) return lower;
+    return lower.slice(0, at).replace(/\./g, "") + lower.slice(at);
+}
+
+/** Email every background-check reviewer that an application awaits review. */
+export async function notifyReviewers(): Promise<void> {
+    try {
+        const reviewers = await prisma.participant.findMany({
+            where: { backgroundCheckReviewer: true, email: { not: null } },
+            select: { email: true },
+        });
+        const base = process.env.NEXTAUTH_URL ?? "";
+        await Promise.all(
+            reviewers.map((r) =>
+                r.email
+                    ? sendEmail(
+                          r.email,
+                          "Membership: a background-check review is needed",
+                          `<p>An application is ready for your background-check review. Please sign in to review it: <a href="${base}/membership/review">${base}/membership/review</a></p>`,
+                      ).catch((e) => logger.error("Reviewer ping failed:", e))
+                    : Promise.resolve(),
+            ),
+        );
+    } catch (e) {
+        logger.error("notifyReviewers failed:", e);
+    }
+}
+
+async function loadReviewer(reviewerId: number) {
+    return prisma.participant.findUnique({ where: { id: reviewerId }, select: { id: true, householdId: true, backgroundCheckReviewer: true } });
+}
+
+/** Applications this reviewer may currently attest (eligibility filtered). */
+export async function listReviewQueue(reviewerId: number) {
+    const reviewer = await loadReviewer(reviewerId);
+    if (!reviewer?.backgroundCheckReviewer) return [];
+
+    const processes = await prisma.membershipProcess.findMany({
+        where: { status: "PENDING_BG_REVIEW" },
+        orderBy: { stageEnteredAt: "asc" },
+        select: {
+            id: true,
+            createdAt: true,
+            membership: {
+                select: {
+                    householdId: true,
+                    household: { select: { name: true, participants: { select: { id: true, name: true, email: true } }, leads: { select: { participantId: true } } } },
+                },
+            },
+            attestations: { select: { reviewerId: true, result: true, reviewer: { select: { householdId: true } } } },
+        },
+    });
+
+    return processes
+        .filter((p) => {
+            if (p.membership.householdId === reviewer.householdId) return false; // own household
+            if (p.attestations.some((a) => a.reviewerId === reviewer.id)) return false; // already attested
+            if (p.attestations.some((a) => a.reviewer.householdId === reviewer.householdId)) return false; // shares household with other reviewer
+            return true;
+        })
+        .map((p) => {
+            // Parents are the household leads.
+            const leadIds = new Set((p.membership.household?.leads ?? []).map((l) => l.participantId));
+            return {
+                processId: p.id,
+                householdName: p.membership.household?.name ?? null,
+                parents: (p.membership.household?.participants ?? [])
+                    .filter((x) => leadIds.has(x.id))
+                    .map((x) => ({ name: x.name, email: x.email })),
+                approvals: p.attestations.filter((a) => a.result === "APPROVE").length,
+            };
+        });
+}
+
+/**
+ * Record a reviewer's attestation. Validates eligibility, then on REJECT blocks
+ * the application and on the 2nd APPROVE advances it to PENDING_PAYMENT.
+ */
+export async function attest(
+    reviewerId: number,
+    processId: number,
+    input: { result: "APPROVE" | "REJECT"; markedVolunteer?: boolean },
+) {
+    const reviewer = await loadReviewer(reviewerId);
+    if (!reviewer?.backgroundCheckReviewer) throw new ReviewError("not_reviewer", "You are not a background-check reviewer.");
+
+    const process = await prisma.membershipProcess.findUnique({
+        where: { id: processId },
+        include: { attestations: { include: { reviewer: { select: { householdId: true } } } } },
+    });
+    if (!process) throw new ReviewError("not_found", "Application not found.");
+    if (process.status !== "PENDING_BG_REVIEW") throw new ReviewError("wrong_phase", "This application is not awaiting background-check review.");
+    const membership = await prisma.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
+    if (membership?.householdId === reviewer.householdId) throw new ReviewError("same_household_applicant", "You cannot review an applicant in your own household.");
+    if (process.attestations.some((a) => a.reviewerId === reviewerId)) throw new ReviewError("already_attested", "You have already reviewed this application.");
+    if (process.attestations.some((a) => a.reviewer.householdId === reviewer.householdId)) throw new ReviewError("same_household_reviewer", "Another reviewer from your household has already reviewed this application.");
+
+    await prisma.backgroundCheckAttestation.create({
+        data: { processId, reviewerId, result: input.result, markedVolunteer: !!input.markedVolunteer },
+    });
+
+    if (input.result === "REJECT") {
+        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: "BLOCKED", stageEnteredAt: new Date() } });
+        await audit(reviewerId, processId, { status: "PENDING_BG_REVIEW" }, { status: "BLOCKED", reason: "reviewer reject" });
+        return { status: "BLOCKED" as const };
+    }
+
+    const approvals = process.attestations.filter((a) => a.result === "APPROVE").length + 1;
+    if (approvals >= REQUIRED_APPROVALS) {
+        await advanceToPayment(processId, reviewerId);
+        return { status: "PENDING_PAYMENT" as const };
+    }
+    return { status: "PENDING_BG_REVIEW" as const, approvals };
+}
+
+/** Advance a reviewed/overridden application to payment: stamp BG dates + volunteer status. */
+async function advanceToPayment(processId: number, actorId: number) {
+    const process = await prisma.membershipProcess.findUnique({
+        where: { id: processId },
+        include: { attestations: true },
+    });
+    if (!process) throw new ReviewError("not_found", "Application not found.");
+    const membership = await prisma.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
+    if (!membership) throw new ReviewError("not_found", "Membership not found.");
+    const householdId = membership.householdId;
+
+    await prisma.membershipProcess.update({ where: { id: processId }, data: { status: "PENDING_PAYMENT", stageEnteredAt: new Date() } });
+
+    // Stamp the guardians' (household leads') lastBackgroundCheck (drives the 3-year renewal rule).
+    await prisma.participant.updateMany({ where: { householdId, householdLeads: { some: { householdId } } }, data: { lastBackgroundCheck: new Date() } });
+
+    await applyVolunteerStatus(process.membershipId, householdId, process.attestations.some((a) => a.markedVolunteer));
+
+    await audit(actorId, processId, { status: "PENDING_BG_REVIEW" }, { status: "PENDING_PAYMENT" });
+}
+
+/**
+ * Sticky/additive volunteer status: set Membership.isVolunteer = true if ANY
+ * reviewer marked the family volunteer OR a household parent's email is pre-
+ * designated. Never clears it here.
+ */
+export async function applyVolunteerStatus(membershipId: number, householdId: number, markedByReviewer: boolean) {
+    let isVolunteer = markedByReviewer;
+    if (!isVolunteer) {
+        const parents = await prisma.participant.findMany({ where: { householdId, householdLeads: { some: { householdId } }, email: { not: null } }, select: { email: true } });
+        const parentEmails = new Set(parents.map((p) => normalizeEmail(p.email!)));
+        if (parentEmails.size) {
+            const designations = await prisma.volunteerDesignation.findMany({ select: { email: true } });
+            isVolunteer = designations.some((d) => parentEmails.has(normalizeEmail(d.email)));
+        }
+    }
+    if (isVolunteer) {
+        await prisma.membership.update({ where: { id: membershipId }, data: { isVolunteer: true } });
+    }
+}
+
+/** Board override on a BLOCKED application: reset for re-review, or force-approve to payment. */
+export async function overrideBlocked(processId: number, actorId: number, action: "reset" | "approve") {
+    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    if (!process) throw new ReviewError("not_found", "Application not found.");
+    if (process.status !== "BLOCKED") throw new ReviewError("wrong_phase", "This application is not blocked.");
+
+    if (action === "reset") {
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { processId } });
+        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: "PENDING_BG_REVIEW", stageEnteredAt: new Date() } });
+        await audit(actorId, processId, { status: "BLOCKED" }, { status: "PENDING_BG_REVIEW", action: "board reset" });
+        await notifyReviewers();
+        return { status: "PENDING_BG_REVIEW" as const };
+    }
+    await advanceToPayment(processId, actorId);
+    return { status: "PENDING_PAYMENT" as const };
+}
+
+function audit(actorId: number, processId: number, oldData: object, newData: object) {
+    return prisma.auditLog.create({
+        data: {
+            actorId: actorId || SYSTEM_ACTOR,
+            action: "EDIT",
+            tableName: "MembershipProcess",
+            affectedEntityId: processId,
+            oldData: JSON.stringify(oldData),
+            newData: JSON.stringify(newData),
+        },
+    });
+}


### PR DESCRIPTION
## PR7 of the membership stack — the PENDING_BG_REVIEW phase

Stacked on #189 (`feat/membership-external-zoho-bg`).

Two independent `backgroundCheckReviewer`s must each attest a clean check before an application proceeds. The system never sees the check itself — only the attestations.

### Rules (in `src/lib/membership/review.ts`)
- **Eligibility:** a reviewer can't share a household with the applicant or with the other reviewer, and can't attest twice.
- **2 × APPROVE →** `PENDING_PAYMENT`: stamps the household parents' `lastBackgroundCheck` (drives the 3-yr renewal rule) and applies volunteer status.
- **Any REJECT →** `BLOCKED`: the applicant is *not* told why; the board gets a red alert.
- **Sticky volunteer:** `isVolunteer = OR(any reviewer's checkbox, any parent's email pre-designated)` — case- **and** dot-insensitive matching (Gmail-style). Only ever set true, never cleared.

### Surfaces
- Reviewer routes (role `backgroundCheckReviewer`): `GET/POST /api/membership/reviews`.
- Board override: `POST /api/admin/membership/review-override` — `reset` (clear attestations, back to review, re-ping) or `approve` (force to payment).
- **Reviewer UI** at `/membership/review` (outside `/admin`, which reviewers can't enter) + a home-page entry point.
- Admin **Membership Applications** view gains approval progress (`n/2`) and the BLOCKED override buttons.
- **Email pings** to all reviewers on entering `PENDING_BG_REVIEW` (via the EXTERNAL advance and on board reset). Degrades to log-only without `RESEND_API_KEY`.

### 🔑 Credential for go-live (not blocking)
- **`RESEND_API_KEY`** + a verified sender domain — until then reviewer pings log to the console instead of sending. (Reviewers can still work from the in-app queue / home-page link.)

### Validation
tsc clean · 82 unit · **287 integration** (9 new: eligibility guards, double-attest, 2-approve advance + BG stamp + volunteer, pre-designation dot-insensitive match, reject→BLOCKED, board reset/approve). Email mocked in tests (no external calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)