### PR TITLE
feat(membership): payment phase — Shopify draft order + paid webhook + activate

### DIFF
--- a/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the payment phase: dues, the Shopify invoice link,
+ * the orders/paid webhook -> activate(), and the board certify override.
+ */
+
+import crypto from 'crypto';
+import { POST as SHOPIFY_WEBHOOK } from '@/app/api/webhooks/shopify/route';
+import { POST as CERTIFY } from '@/app/api/admin/membership/certify-payment/route';
+import { computeDuesCents, ensurePaymentLink, ensurePaymentLinkForUser, activate } from '@/lib/membership/payment';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/shopify', () => ({
+    createMembershipDraftOrder: jest.fn().mockResolvedValue({ draftOrderId: 'draft-1', invoiceUrl: 'https://shop.example/invoice/abc' }),
+}));
+
+import { createMembershipDraftOrder } from '@/lib/shopify';
+
+const TAG = 'payment-test';
+const WEBHOOK_SECRET = 'shopify-test-secret';
+
+function asBoard(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, sysadmin: false, boardMember: true } });
+}
+function asUser(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, sysadmin: false, boardMember: false } });
+}
+function shopifyReq(payload: unknown, secret: string) {
+    const raw = JSON.stringify(payload);
+    const sig = crypto.createHmac('sha256', secret).update(raw, 'utf8').digest('base64');
+    return new Request('http://localhost:4000/api/webhooks/shopify', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-shopify-hmac-sha256': sig },
+        body: raw,
+    });
+}
+
+describe('Membership payment API', () => {
+    let leadId: number;
+    let normalProc: number, normalMembership: number, normalHh: number;
+    let volProc: number;
+    let certProc: number;
+    const prevWebhookSecret = process.env.SHOPIFY_WEBHOOK_SECRET;
+    let prevSettings: { normalDuesCents: number; volunteerDuesCents: number } | null = null;
+
+    async function makeProc(label: string, isVolunteer: boolean, withLead = false) {
+        const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
+        if (withLead) {
+            const lead = await prisma.participant.create({ data: { email: `lead-${TAG}@example.com`, name: 'Lead', householdId: hh.id } });
+            await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+            leadId = lead.id;
+        }
+        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer } });
+        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT' } });
+        return { householdId: hh.id, membershipId: m.id, processId: p.id };
+    }
+
+    async function wipe() {
+        const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+        const ids = hhs.map((h) => h.id);
+        if (ids.length) {
+            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
+            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.household.deleteMany({ where: { id: { in: ids } } });
+        }
+        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+    }
+
+    beforeAll(async () => {
+        process.env.SHOPIFY_WEBHOOK_SECRET = WEBHOOK_SECRET;
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevSettings = existing ? { normalDuesCents: existing.normalDuesCents, volunteerDuesCents: existing.volunteerDuesCents } : null;
+        await prisma.boardSettings.upsert({
+            where: { id: 1 },
+            create: { id: 1, normalDuesCents: 10000, volunteerDuesCents: 2500 },
+            update: { normalDuesCents: 10000, volunteerDuesCents: 2500 },
+        });
+        await wipe();
+
+        const normal = await makeProc('Normal', false, true);
+        normalProc = normal.processId;
+        normalMembership = normal.membershipId;
+        normalHh = normal.householdId;
+        volProc = (await makeProc('Vol', true)).processId;
+        certProc = (await makeProc('Cert', false)).processId;
+    });
+
+    afterAll(async () => {
+        await wipe();
+        if (prevSettings) await prisma.boardSettings.update({ where: { id: 1 }, data: prevSettings });
+        if (prevWebhookSecret === undefined) delete process.env.SHOPIFY_WEBHOOK_SECRET;
+        else process.env.SHOPIFY_WEBHOOK_SECRET = prevWebhookSecret;
+        await prisma.$disconnect();
+    });
+
+    it('computes dues by tier from BoardSettings', async () => {
+        expect(await computeDuesCents(false)).toBe(10000);
+        expect(await computeDuesCents(true)).toBe(2500);
+    });
+
+    it('creates + stores the Shopify invoice link, and is idempotent', async () => {
+        (createMembershipDraftOrder as jest.Mock).mockClear();
+        const first = await ensurePaymentLink(normalProc);
+        expect(first).toEqual({ amountCents: 10000, invoiceUrl: 'https://shop.example/invoice/abc' });
+        const stored = await prisma.membershipProcess.findUnique({ where: { id: normalProc } });
+        expect(stored?.shopifyInvoiceUrl).toBe('https://shop.example/invoice/abc');
+
+        const second = await ensurePaymentLink(normalProc);
+        expect(second.invoiceUrl).toBe('https://shop.example/invoice/abc');
+        expect(createMembershipDraftOrder as jest.Mock).toHaveBeenCalledTimes(1); // not re-created
+    });
+
+    it('uses the volunteer rate for a volunteer household', async () => {
+        const res = await ensurePaymentLink(volProc);
+        expect(res.amountCents).toBe(2500);
+    });
+
+    it('resolves the payment link for the calling user', async () => {
+        const res = await ensurePaymentLinkForUser(leadId);
+        expect(res.amountCents).toBe(10000);
+    });
+
+    it('orders/paid webhook activates the membership (and is idempotent)', async () => {
+        const payload = { id: 555, note_attributes: [{ name: 'Membership_Process_ID', value: String(normalProc) }] };
+        const res = await SHOPIFY_WEBHOOK(shopifyReq(payload, WEBHOOK_SECRET) as never);
+        expect(res.status).toBe(200);
+
+        const proc = await prisma.membershipProcess.findUnique({ where: { id: normalProc } });
+        expect(proc?.status).toBe('ACTIVE');
+        expect(proc?.paidAt).not.toBeNull();
+        expect(proc?.shopifyOrderId).toBe('555');
+        const m = await prisma.membership.findUnique({ where: { id: normalMembership } });
+        expect(m?.status).toBe('ACTIVE');
+
+        // Idempotent: a second identical webhook does not throw or change state.
+        const again = await SHOPIFY_WEBHOOK(shopifyReq(payload, WEBHOOK_SECRET) as never);
+        expect(again.status).toBe(200);
+    });
+
+    it('rejects a webhook with a bad HMAC', async () => {
+        const res = await SHOPIFY_WEBHOOK(shopifyReq({ id: 1, note_attributes: [] }, 'wrong-secret') as never);
+        expect(res.status).toBe(401);
+    });
+
+    it('board certify-payment activates without a Shopify payment', async () => {
+        asBoard(leadId); // leadId is fine as an actor id; role mocked as board
+        const res = await CERTIFY(new Request('http://localhost:4000/x', { method: 'POST', body: JSON.stringify({ processId: certProc }) }) as never);
+        expect(res.status).toBe(200);
+        const proc = await prisma.membershipProcess.findUnique({ where: { id: certProc } });
+        expect(proc?.status).toBe('ACTIVE');
+        expect(proc?.certifiedById).toBe(leadId);
+    });
+
+    it('non-board cannot certify', async () => {
+        asUser(leadId);
+        const res = await CERTIFY(new Request('http://localhost:4000/x', { method: 'POST', body: JSON.stringify({ processId: 1 }) }) as never);
+        expect(res.status).toBe(403);
+    });
+
+    it('activate() is a no-op once already ACTIVE', async () => {
+        const before = await prisma.membershipProcess.findUnique({ where: { id: normalProc } });
+        await activate(normalProc, { via: 'payment', shopifyOrderId: 'ignored' });
+        const after = await prisma.membershipProcess.findUnique({ where: { id: normalProc } });
+        expect(after?.shopifyOrderId).toBe(before?.shopifyOrderId); // unchanged
+    });
+});

--- a/src/app/admin/membership/page.tsx
+++ b/src/app/admin/membership/page.tsx
@@ -112,6 +112,32 @@ export default function AdminMembershipPage() {
         }
     };
 
+    const certify = async (processId: number) => {
+        setBusyId(processId);
+        setMessage("");
+        try {
+            const res = await fetch("/api/admin/membership/certify-payment", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ processId }),
+            });
+            const data = await res.json();
+            if (res.ok) {
+                setIsError(false);
+                setMessage("Certified — membership activated.");
+                await load();
+            } else {
+                setIsError(true);
+                setMessage(data.error || "Certification failed.");
+            }
+        } catch {
+            setIsError(true);
+            setMessage("Network error.");
+        } finally {
+            setBusyId(null);
+        }
+    };
+
     const householdLabel = (r: ProcessRow) => {
         const hh = r.membership?.household;
         if (!hh) return `Household #${r.membership?.householdId ?? "?"}`;
@@ -189,6 +215,15 @@ export default function AdminMembershipPage() {
                             {r.status === "PENDING_BG_REVIEW" && (
                                 <div style={{ marginTop: "1rem", fontSize: "0.9rem", color: "var(--color-text-muted)" }}>
                                     Awaiting reviewers — <strong style={{ color: "var(--color-text-main, #f8fafc)" }}>{r.attestations.filter((a) => a.result === "APPROVE").length}/2</strong> approvals recorded.
+                                </div>
+                            )}
+
+                            {r.status === "PENDING_PAYMENT" && (
+                                <div style={{ marginTop: "1rem", display: "flex", alignItems: "center", gap: "1rem", flexWrap: "wrap" }}>
+                                    <span style={{ fontSize: "0.85rem", color: "var(--color-text-muted)" }}>Awaiting payment.</span>
+                                    <button className="glass-button" disabled={busyId === r.id} onClick={() => certify(r.id)} style={{ padding: "0.45rem 0.9rem", background: "rgba(34,197,94,0.2)", borderColor: "rgba(34,197,94,0.4)" }}>
+                                        {busyId === r.id ? "…" : "Certify payment plan → activate"}
+                                    </button>
                                 </div>
                             )}
 

--- a/src/app/api/admin/membership/certify-payment/route.ts
+++ b/src/app/api/admin/membership/certify-payment/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { certifyPaymentPlan, PaymentError } from "@/lib/membership/payment";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/admin/membership/certify-payment — board override.
+ * Certifies a payment plan and activates the membership without a Shopify payment.
+ * Body: { processId }
+ */
+export const POST = withAuth({ roles: ["sysadmin", "boardMember"] }, async (req, auth) => {
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    let body: { processId?: number };
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+    if (!body.processId) return NextResponse.json({ error: "processId is required" }, { status: 400 });
+    try {
+        const process = await certifyPaymentPlan(body.processId, auth.user.id);
+        return NextResponse.json({ process });
+    } catch (error) {
+        if (error instanceof PaymentError) {
+            return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 409 });
+        }
+        console.error("Certify payment error:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+});

--- a/src/app/api/membership/payment/route.ts
+++ b/src/app/api/membership/payment/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { ensurePaymentLinkForUser, PaymentError } from "@/lib/membership/payment";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/membership/payment — the caller's dues amount + Shopify invoice link.
+export const GET = withAuth({}, async (_req, auth) => {
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    try {
+        return NextResponse.json(await ensurePaymentLinkForUser(auth.user.id));
+    } catch (error) {
+        if (error instanceof PaymentError) {
+            return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 409 });
+        }
+        console.error("Payment link error:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+});

--- a/src/app/api/webhooks/shopify/route.ts
+++ b/src/app/api/webhooks/shopify/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import crypto from "crypto";
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
+import { activateByProcessId } from "@/lib/membership/payment";
 
 // Shopify Webhook for `orders/paid` or `orders/create`
 // Verifies HMAC signature, extracts custom attributes, and marks user as ACTIVE
@@ -51,13 +52,25 @@ export async function POST(req: Request) {
         
         let accountIdStr = null;
         let programIdStr = null;
+        let membershipProcessIdStr = null;
 
         // Custom attributes in Cart Permalinks are usually mapped to `note_attributes` on the Order
         if (order.note_attributes && Array.isArray(order.note_attributes)) {
             for (const attr of order.note_attributes) {
                 if (attr.name === "CheckMeIn_Account_ID") accountIdStr = attr.value;
                 if (attr.name === "Program_ID") programIdStr = attr.value;
+                if (attr.name === "Membership_Process_ID") membershipProcessIdStr = attr.value;
             }
+        }
+
+        // Membership draft-order payment → activate the household membership.
+        if (membershipProcessIdStr) {
+            const processId = parseInt(membershipProcessIdStr, 10);
+            if (!isNaN(processId)) {
+                await activateByProcessId(processId, order.id ? String(order.id) : "");
+                logger.info(`[SHOPIFY WEBHOOK] Activated membership for process ${processId}`);
+            }
+            return NextResponse.json({ success: true });
         }
 
         if (accountIdStr && programIdStr) {

--- a/src/app/membership/page.tsx
+++ b/src/app/membership/page.tsx
@@ -78,6 +78,7 @@ export default function MembershipPage() {
     const [secondaryDob, setSecondaryDob] = useState("");
     const [secondaryAllergies, setSecondaryAllergies] = useState("");
     const [children, setChildren] = useState<ChildForm[]>([]);
+    const [payment, setPayment] = useState<{ amountCents: number; invoiceUrl: string | null } | null>(null);
 
     const hydrate = useCallback((s: IntakeState) => {
         setState(s);
@@ -125,6 +126,17 @@ export default function MembershipPage() {
         if (sessionStatus === "authenticated") load();
         else if (sessionStatus === "unauthenticated") setLoading(false);
     }, [sessionStatus, load]);
+
+    // When awaiting payment, fetch (and lazily create) the Shopify invoice link.
+    useEffect(() => {
+        if (state?.process?.status !== "PENDING_PAYMENT") return;
+        let cancelled = false;
+        fetch("/api/membership/payment")
+            .then((res) => (res.ok ? res.json() : null))
+            .then((data) => { if (!cancelled && data) setPayment(data); })
+            .catch(() => { /* shown as link-unavailable */ });
+        return () => { cancelled = true; };
+    }, [state?.process?.status]);
 
     const flash = (msg: string, error = false) => {
         setMessage(msg);
@@ -404,6 +416,33 @@ export default function MembershipPage() {
                                 <button className="glass-button" disabled={saving} onClick={load} style={{ alignSelf: "flex-start", padding: "0.6rem 1.1rem" }}>
                                     Refresh status
                                 </button>
+                            </div>
+                        ) : inStatus === "PENDING_PAYMENT" ? (
+                            <div className="glass-container" style={{ padding: "1.75rem" }}>
+                                <h2 style={{ marginTop: 0 }}>Membership dues</h2>
+                                {payment ? (
+                                    <>
+                                        <p style={{ color: "var(--color-text-muted)" }}>
+                                            Your annual household dues are{" "}
+                                            <strong style={{ color: "var(--color-text-main, #f8fafc)" }}>
+                                                ${(payment.amountCents / 100).toFixed(2)}
+                                            </strong>.
+                                        </p>
+                                        {payment.invoiceUrl ? (
+                                            <a href={payment.invoiceUrl} target="_blank" rel="noopener noreferrer" className="glass-button" style={{ display: "inline-block", textDecoration: "none", color: "white", padding: "0.85rem 1.4rem", background: "rgba(34,197,94,0.25)", borderColor: "rgba(34,197,94,0.5)" }}>
+                                                Pay here with Shopify →
+                                            </a>
+                                        ) : (
+                                            <p style={{ color: "#fcd34d" }}>The payment link isn&apos;t available yet. Please check back shortly.</p>
+                                        )}
+                                        <p style={{ fontSize: "0.85rem", color: "var(--color-text-muted)", marginTop: "1.25rem" }}>
+                                            To discuss alternative arrangements, please email{" "}
+                                            <a href="mailto:finance@innovationtreehouse.org" style={{ color: "var(--color-primary, #3b82f6)" }}>finance@innovationtreehouse.org</a>.
+                                        </p>
+                                    </>
+                                ) : (
+                                    <p style={{ color: "var(--color-text-muted)" }}>Preparing your invoice…</p>
+                                )}
                             </div>
                         ) : (
                             <div className="glass-container" style={{ padding: "2rem" }}>

--- a/src/lib/membership/payment.ts
+++ b/src/lib/membership/payment.ts
@@ -1,0 +1,143 @@
+import prisma from "@/lib/prisma";
+import { sendEmail } from "@/lib/email";
+import { logger } from "@/lib/logger";
+import { createMembershipDraftOrder } from "@/lib/shopify";
+
+/**
+ * Payment phase (PENDING_PAYMENT -> ACTIVE).
+ *
+ * Our system is the source of truth for dues (volunteer vs normal, from
+ * BoardSettings). We create a per-household Shopify draft order at that price and
+ * hand back its unique invoice URL. Payment (orders/paid webhook) OR a board
+ * "payment-plan certified" override both converge on activate(): one place that
+ * flips the membership ACTIVE, records how, and sends one congrats email.
+ */
+
+const SYSTEM_ACTOR = 0;
+
+export class PaymentError extends Error {
+    constructor(public readonly code: "not_found" | "wrong_phase", message: string) {
+        super(message);
+        this.name = "PaymentError";
+    }
+}
+
+/** Annual dues in cents for this membership tier (volunteer families pay the lower rate). */
+export async function computeDuesCents(isVolunteer: boolean): Promise<number> {
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    return isVolunteer ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
+}
+
+/**
+ * Ensure a payment link exists for a process in PENDING_PAYMENT, creating the
+ * Shopify draft order on first call. Idempotent: returns the stored link after.
+ * If Shopify isn't configured, returns the amount with a null link.
+ */
+export async function ensurePaymentLink(processId: number): Promise<{ amountCents: number; invoiceUrl: string | null }> {
+    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    if (!process) throw new PaymentError("not_found", "Application not found.");
+    if (process.status !== "PENDING_PAYMENT") throw new PaymentError("wrong_phase", "This application is not awaiting payment.");
+
+    const membership = await prisma.membership.findUnique({ where: { id: process.membershipId }, select: { isVolunteer: true } });
+    if (!membership) throw new PaymentError("not_found", "Membership not found.");
+    const amountCents = await computeDuesCents(membership.isVolunteer);
+    if (process.shopifyInvoiceUrl) return { amountCents, invoiceUrl: process.shopifyInvoiceUrl };
+
+    const draft = await createMembershipDraftOrder({ processId, amountCents, isVolunteer: membership.isVolunteer });
+    if (!draft) return { amountCents, invoiceUrl: null };
+
+    await prisma.membershipProcess.update({
+        where: { id: processId },
+        data: { shopifyDraftOrderId: draft.draftOrderId, shopifyInvoiceUrl: draft.invoiceUrl },
+    });
+    return { amountCents, invoiceUrl: draft.invoiceUrl };
+}
+
+/** Resolve the caller's household PENDING_PAYMENT process and ensure its payment link. */
+export async function ensurePaymentLinkForUser(userId: number) {
+    const user = await prisma.participant.findUnique({ where: { id: userId }, select: { householdId: true } });
+    if (!user?.householdId) throw new PaymentError("not_found", "You are not in a household.");
+    const process = await prisma.membershipProcess.findFirst({
+        where: { membership: { householdId: user.householdId }, status: "PENDING_PAYMENT" },
+        orderBy: { id: "desc" },
+    });
+    if (!process) throw new PaymentError("wrong_phase", "No application is awaiting payment.");
+    return ensurePaymentLink(process.id);
+}
+
+/**
+ * The single activation path. Flips the membership ACTIVE, marks the process
+ * ACTIVE + paid, records how (Shopify order id or certifying board member), and
+ * sends one congratulations email. Idempotent: a no-op if already ACTIVE.
+ */
+export async function activate(
+    processId: number,
+    opts: { via: "payment" | "certified"; actorId?: number; shopifyOrderId?: string },
+) {
+    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    if (!process) throw new PaymentError("not_found", "Application not found.");
+    const membership = await prisma.membership.findUnique({ where: { id: process.membershipId }, select: { status: true, householdId: true } });
+    if (!membership) throw new PaymentError("not_found", "Membership not found.");
+    if (process.status === "ACTIVE" && membership.status === "ACTIVE") return process;
+
+    const now = new Date();
+    const updated = await prisma.membershipProcess.update({
+        where: { id: processId },
+        data: {
+            status: "ACTIVE",
+            stageEnteredAt: now,
+            paidAt: now,
+            ...(opts.shopifyOrderId ? { shopifyOrderId: opts.shopifyOrderId } : {}),
+            ...(opts.via === "certified" && opts.actorId ? { certifiedById: opts.actorId } : {}),
+        },
+    });
+    await prisma.membership.update({ where: { id: process.membershipId }, data: { status: "ACTIVE" } });
+
+    await prisma.auditLog.create({
+        data: {
+            actorId: opts.actorId ?? SYSTEM_ACTOR,
+            action: "EDIT",
+            tableName: "MembershipProcess",
+            affectedEntityId: processId,
+            oldData: JSON.stringify({ status: process.status }),
+            newData: JSON.stringify({ status: "ACTIVE", via: opts.via }),
+        },
+    });
+
+    await sendCongrats(membership.householdId);
+    return updated;
+}
+
+/** Board override: certify a payment plan and activate without a Shopify payment. */
+export async function certifyPaymentPlan(processId: number, actorId: number) {
+    return activate(processId, { via: "certified", actorId });
+}
+
+/** Webhook path: activate the process tied to a paid Shopify draft order. */
+export async function activateByProcessId(processId: number, shopifyOrderId: string) {
+    return activate(processId, { via: "payment", shopifyOrderId });
+}
+
+async function sendCongrats(householdId: number) {
+    try {
+        const leads = await prisma.householdLead.findMany({
+            where: { householdId },
+            select: { participant: { select: { email: true, name: true } } },
+        });
+        const base = process.env.NEXTAUTH_URL ?? "";
+        await Promise.all(
+            leads
+                .map((l) => l.participant?.email)
+                .filter((e): e is string => !!e)
+                .map((email) =>
+                    sendEmail(
+                        email,
+                        "Welcome to the Treehouse — your membership is active!",
+                        `<p>Congratulations! Your household membership is now active. Welcome to the Innovation Treehouse community.</p><p><a href="${base}">Visit your dashboard</a></p>`,
+                    ).catch((e) => logger.error("Congrats email failed:", e)),
+                ),
+        );
+    } catch (e) {
+        logger.error("sendCongrats failed:", e);
+    }
+}

--- a/src/lib/shopify.ts
+++ b/src/lib/shopify.ts
@@ -233,3 +233,63 @@ export async function createShopifyProgramVariants(name: string, memberPrice: nu
     return null;
   }
 }
+
+/**
+ * Create a per-household membership Draft Order at OUR computed price (our system
+ * is the source of truth for dues). The draft carries the membership process id
+ * in note_attributes so the orders/paid webhook can match it, and returns the
+ * unique invoice URL the household uses to pay.
+ *
+ * Requires the `write_draft_orders` scope. Returns null if Shopify is not
+ * configured or the API call fails (caller degrades gracefully).
+ */
+export async function createMembershipDraftOrder(params: {
+  processId: number;
+  amountCents: number;
+  isVolunteer: boolean;
+}): Promise<{ draftOrderId: string; invoiceUrl: string } | null> {
+  const storeDomain = process.env.SHOPIFY_STORE_DOMAIN;
+  const accessToken = await getAccessToken();
+  if (!storeDomain || !accessToken) {
+    console.warn("[SHOPIFY] Draft order skipped — integration not configured.");
+    return null;
+  }
+
+  const price = (params.amountCents / 100).toFixed(2);
+  const title = params.isVolunteer
+    ? "Treehouse Household Membership (Volunteer)"
+    : "Treehouse Household Membership";
+
+  try {
+    const res = await fetch(`https://${storeDomain}/admin/api/2026-01/draft_orders.json`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Shopify-Access-Token": accessToken,
+      },
+      body: JSON.stringify({
+        draft_order: {
+          line_items: [{ title, price, quantity: 1 }],
+          note_attributes: [{ name: "Membership_Process_ID", value: String(params.processId) }],
+          tags: "membership",
+        },
+      }),
+    });
+
+    if (!res.ok) {
+      console.error(`[SHOPIFY] Draft order create failed: ${res.status}`, await res.text());
+      return null;
+    }
+
+    const data = await res.json();
+    const draft = data.draft_order;
+    if (!draft?.id || !draft?.invoice_url) {
+      console.error("[SHOPIFY] Draft order response missing id/invoice_url.");
+      return null;
+    }
+    return { draftOrderId: String(draft.id), invoiceUrl: String(draft.invoice_url) };
+  } catch (error) {
+    console.error("[SHOPIFY] Draft order create error:", error);
+    return null;
+  }
+}


### PR DESCRIPTION
## PR8 of the membership stack — the payment phase

Stacked on #190 (`feat/membership-bg-review`). `PENDING_PAYMENT → ACTIVE`.

Our system is the source of truth for dues; Shopify just collects the money.

### Flow
- **Dues** (`computeDuesCents`): volunteer vs normal rate from `BoardSettings`.
- **Invoice** (`ensurePaymentLink`): lazily creates a per-household Shopify **draft order** at our price with `Membership_Process_ID` in `note_attributes`, stores the unique `invoice_url` (idempotent — created once).
- **`activate()`** — the single convergence point for both the Shopify payment and the board override: flips Membership + process to `ACTIVE`, records *how* (Shopify order id / certifying board member), sends **one** congrats email. Idempotent.
- **Webhook**: the existing `orders/paid` handler now detects `Membership_Process_ID` and calls `activateByProcessId`.
- **Board override**: `POST /api/admin/membership/certify-payment` — "payment-plan certified" → activate without a Shopify payment.

### Surfaces
- Applicant `/membership` `PENDING_PAYMENT` view: dues amount + **"Pay here with Shopify"** + the *"to discuss alternative arrangements, email finance@innovationtreehouse.org"* note.
- Admin Membership view: **"Certify payment plan → activate"** button.

### No schema change
Uses existing `shopifyDraftOrderId` / `shopifyInvoiceUrl` / `shopifyOrderId` / `paidAt` / `certifiedById`. The common renewal boundary (`BoardSettings.membershipYearBoundary`) makes a per-membership expiry field unnecessary.

### 🔑 Go-live blocker (you flagged this earlier)
- **Shopify `write_draft_orders` scope** — the app currently lacks it, so `createMembershipDraftOrder` returns null and the applicant sees "payment link not available yet" (board can still certify, and pay-by-other-means via finance@). Everything else (webhook, activate, dues, certify) works today.
- `SHOPIFY_WEBHOOK_SECRET` is already used by the existing orders webhook.

### Validation
tsc clean · 82 unit · **296 integration** (9 new: dues by tier, link create/store/idempotent, volunteer rate, paid-webhook activate + idempotent, bad-HMAC 401, board certify + auth, activate no-op). Shopify + email mocked → no external calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)