### PR TITLE
feat(membership): annual renewal — cron sweep + 3-yr BG rule + renewal review

### DIFF
--- a/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for renewal: the cron sweep, beginRenewal (3-yr BG rule),
+ * and the renewal background-review path reusing the 2-of-N flow.
+ */
+
+import { GET as CRON } from '@/app/api/cron/membership-renewals/route';
+import { runRenewalSweep, beginRenewal, nextBoundary } from '@/lib/membership/renewal';
+import { attest } from '@/lib/membership/review';
+import prisma from '@/lib/prisma';
+
+jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+
+const TAG = 'renewal-test';
+const CRON_SECRET = 'cron-test-secret';
+
+function cronReq(token: string | null) {
+    return new Request('http://localhost:4000/api/cron/membership-renewals', {
+        headers: token ? { authorization: `Bearer ${token}` } : {},
+    });
+}
+
+describe('Membership renewal', () => {
+    const prevSecret = process.env.CRON_SECRET;
+    let prevBoundary: Date | null = null;
+    let rev1: number, rev2: number;
+    // The sweep is global; track where we started so afterAll can remove every
+    // process this test opened (including renewals on other suites' memberships).
+    let preMaxProcessId = 0;
+
+    async function makeActiveMembership(label: string, parentBg: Date | null) {
+        const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
+        // The guardian is a household lead (drives the 3-yr BG-freshness check).
+        const parent = await prisma.participant.create({ data: { name: `${label} Parent`, householdId: hh.id, lastBackgroundCheck: parentBg ?? undefined } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: parent.id } });
+        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
+        return { householdId: hh.id, membershipId: m.id };
+    }
+
+    async function wipe() {
+        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
+        const ids = hhs.map((h) => h.id);
+        if (ids.length) {
+            await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: ids } } } } });
+            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
+            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.household.deleteMany({ where: { id: { in: ids } } });
+        }
+        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+    }
+
+    async function setBoundary(date: Date | null) {
+        await prisma.boardSettings.upsert({
+            where: { id: 1 },
+            create: { id: 1, normalDuesCents: 0, volunteerDuesCents: 0, membershipYearBoundary: date },
+            update: { membershipYearBoundary: date },
+        });
+    }
+
+    beforeAll(async () => {
+        process.env.CRON_SECRET = CRON_SECRET;
+        const maxRow = await prisma.membershipProcess.findFirst({ orderBy: { id: 'desc' }, select: { id: true } });
+        preMaxProcessId = maxRow?.id ?? 0;
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevBoundary = existing?.membershipYearBoundary ?? null;
+        await wipe();
+        const r1 = await prisma.participant.create({ data: { email: `rev1-${TAG}@example.com`, name: 'Rev1', backgroundCheckReviewer: true, household: { create: { name: `Rev1 HH ${TAG}` } } } });
+        rev1 = r1.id;
+        rev2 = (await prisma.participant.create({ data: { email: `rev2-${TAG}@example.com`, name: 'Rev2', backgroundCheckReviewer: true, household: { create: { name: `Rev2 HH ${TAG}` } } } })).id;
+    });
+
+    afterAll(async () => {
+        // Remove every process (and its attestations) this test's global sweeps opened.
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { processId: { gt: preMaxProcessId } } });
+        await prisma.membershipProcess.deleteMany({ where: { id: { gt: preMaxProcessId } } });
+        await wipe();
+        await setBoundary(prevBoundary);
+        if (prevSecret === undefined) delete process.env.CRON_SECRET;
+        else process.env.CRON_SECRET = prevSecret;
+        await prisma.$disconnect();
+    });
+
+    it('cron rejects missing/invalid bearer', async () => {
+        expect((await CRON(cronReq(null))).status).toBe(401);
+        expect((await CRON(cronReq('wrong'))).status).toBe(401);
+    });
+
+    it('nextBoundary rolls to next year when the date has passed', () => {
+        const boundary = new Date(Date.UTC(2020, 7, 1)); // Aug 1
+        const now = new Date(Date.UTC(2026, 8, 15)); // Sep 15 2026 (past Aug 1)
+        expect(nextBoundary(boundary, now).getUTCFullYear()).toBe(2027);
+    });
+
+    it('does nothing outside the renewal window', async () => {
+        await setBoundary(new Date(Date.UTC(2000, 7, 1))); // Aug 1
+        const res = await runRenewalSweep(new Date(Date.UTC(2026, 0, 1))); // Jan — far from Aug
+        expect(res.opened).toBe(0);
+    });
+
+    it('opens a PENDING_RENEWAL process within the window, once', async () => {
+        await setBoundary(new Date(Date.UTC(2000, 7, 1))); // Aug 1
+        const m = await makeActiveMembership('Due', null);
+        const now = new Date(Date.UTC(2026, 6, 1)); // Jul 1 — within 2 months before Aug 1
+
+        const first = await runRenewalSweep(now);
+        expect(first.opened).toBeGreaterThanOrEqual(1);
+        const proc = await prisma.membershipProcess.findFirst({ where: { membershipId: m.membershipId } });
+        expect(proc?.status).toBe('PENDING_RENEWAL');
+        expect(proc?.kind).toBe('RENEWAL');
+
+        const second = await runRenewalSweep(now);
+        const count = await prisma.membershipProcess.count({ where: { membershipId: m.membershipId } });
+        expect(count).toBe(1); // not duplicated
+        expect(second).toBeDefined();
+    });
+
+    it('beginRenewal goes straight to payment when a parent BG is fresh', async () => {
+        await setBoundary(new Date(Date.UTC(2000, 7, 1)));
+        const m = await makeActiveMembership('Fresh', new Date()); // recent BG
+        const proc = await prisma.membershipProcess.create({ data: { membershipId: m.membershipId, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
+        const out = await beginRenewal(proc.id);
+        expect(out.status).toBe('PENDING_PAYMENT');
+    });
+
+    it('beginRenewal requires re-review when BG is stale', async () => {
+        await setBoundary(new Date(Date.UTC(2000, 7, 1)));
+        const m = await makeActiveMembership('Stale', null); // no BG on record
+        const proc = await prisma.membershipProcess.create({ data: { membershipId: m.membershipId, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
+        const out = await beginRenewal(proc.id);
+        expect(out.status).toBe('RENEWAL_PENDING_BG');
+
+        // The 2-of-N review flow handles renewal BG too: 2 approvals -> PENDING_PAYMENT.
+        await attest(rev1, proc.id, { result: 'APPROVE' });
+        const final = await attest(rev2, proc.id, { result: 'APPROVE' });
+        expect(final.status).toBe('PENDING_PAYMENT');
+    });
+
+    it('cron runs with a valid bearer', async () => {
+        // Far-future boundary so the real-time sweep is a no-op (no global pollution).
+        await setBoundary(new Date(Date.now() + 150 * 24 * 3600 * 1000));
+        const res = await CRON(cronReq(CRON_SECRET));
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.success).toBe(true);
+    });
+});

--- a/src/app/api/cron/membership-renewals/route.ts
+++ b/src/app/api/cron/membership-renewals/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+import { logger } from "@/lib/logger";
+import { runRenewalSweep } from "@/lib/membership/renewal";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/cron/membership-renewals — open renewal processes for memberships due
+ * within the lead window. Authorized by `Authorization: Bearer $CRON_SECRET`.
+ */
+export async function GET(req: Request) {
+    const authHeader = req.headers.get("authorization");
+    const cronSecret = process.env.CRON_SECRET;
+    if (!cronSecret || !authHeader) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const expected = `Bearer ${cronSecret}`;
+    const a = Buffer.from(authHeader);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    try {
+        const result = await runRenewalSweep(new Date());
+        logger.info("[CRON] membership renewal sweep:", result);
+        return NextResponse.json({ success: true, ...result });
+    } catch (error) {
+        logger.error("Membership renewal sweep error:", error);
+        return NextResponse.json({ error: "Sweep failed" }, { status: 500 });
+    }
+}

--- a/src/app/api/membership/renew/route.ts
+++ b/src/app/api/membership/renew/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { beginRenewalForUser, RenewalError } from "@/lib/membership/renewal";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/membership/renew — member confirms renewal; advances PENDING_RENEWAL.
+export const POST = withAuth({}, async (_req, auth) => {
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    try {
+        const process = await beginRenewalForUser(auth.user.id);
+        return NextResponse.json({ process });
+    } catch (error) {
+        if (error instanceof RenewalError) {
+            return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 409 });
+        }
+        console.error("Renewal begin error:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+});

--- a/src/app/membership/page.tsx
+++ b/src/app/membership/page.tsx
@@ -218,6 +218,21 @@ export default function MembershipPage() {
         }
     };
 
+    const renew = async () => {
+        setSaving(true);
+        flash("");
+        try {
+            const res = await fetch("/api/membership/renew", { method: "POST" });
+            const data = await res.json();
+            if (res.ok) { await load(); flash("Renewal started."); }
+            else flash(data.error || "Could not start renewal.", true);
+        } catch {
+            flash("Network error.", true);
+        } finally {
+            setSaving(false);
+        }
+    };
+
     const addChild = () => setChildren((c) => [...c, { name: "", email: "", dob: "", allergies: "" }]);
     const updateChild = (i: number, field: keyof ChildForm, value: string) =>
         setChildren((c) => c.map((child, idx) => (idx === i ? { ...child, [field]: value } : child)));
@@ -242,6 +257,7 @@ export default function MembershipPage() {
     const inStatus = state?.process?.status ?? null;
     const isIntake = inStatus === "INTAKE";
     const isActive = state?.membershipStatus === "ACTIVE";
+    const isRenewal = state?.process?.kind === "RENEWAL";
     const labelStyle: React.CSSProperties = { display: "block", marginBottom: "0.35rem", fontWeight: 500 };
     const fieldStyle: React.CSSProperties = { width: "100%", padding: "0.6rem" };
 
@@ -258,27 +274,50 @@ export default function MembershipPage() {
                 </div>
             )}
 
-            {isActive ? (
-                <div className="glass-container" style={{ padding: "2rem" }}>
-                    <h2 style={{ marginTop: 0 }}>You&apos;re a member 🎉</h2>
-                    <p style={{ color: "var(--color-text-muted)" }}>Your household membership is active. Thank you for being part of the Treehouse!</p>
-                </div>
-            ) : !state?.process ? (
+            {!state?.process ? (
+                isActive ? (
+                    <div className="glass-container" style={{ padding: "2rem" }}>
+                        <h2 style={{ marginTop: 0 }}>You&apos;re a member 🎉</h2>
+                        <p style={{ color: "var(--color-text-muted)" }}>Your household membership is active. Thank you for being part of the Treehouse!</p>
+                    </div>
+                ) : (
+                    <div className="glass-container" style={{ padding: "2rem", maxWidth: "640px" }}>
+                        <h2 style={{ marginTop: 0 }}>Become a member</h2>
+                        <p style={{ color: "var(--color-text-muted)" }}>
+                            Membership is for your whole household. We&apos;ll collect some information about your family, then walk you through signing a
+                            contract, a background check, and payment. You can stop and resume anytime.
+                        </p>
+                        <button className="glass-button" disabled={saving} onClick={startApplication} style={{ background: "rgba(59,130,246,0.3)", borderColor: "rgba(59,130,246,0.5)", padding: "0.9rem 1.4rem", marginTop: "0.5rem" }}>
+                            {saving ? "Starting…" : "Start application"}
+                        </button>
+                    </div>
+                )
+            ) : isRenewal && inStatus === "PENDING_RENEWAL" ? (
                 <div className="glass-container" style={{ padding: "2rem", maxWidth: "640px" }}>
-                    <h2 style={{ marginTop: 0 }}>Become a member</h2>
+                    <h2 style={{ marginTop: 0 }}>Time to renew</h2>
                     <p style={{ color: "var(--color-text-muted)" }}>
-                        Membership is for your whole household. We&apos;ll collect some information about your family, then walk you through signing a
-                        contract, a background check, and payment. You can stop and resume anytime.
+                        Your household membership is up for renewal. You&apos;re still an active member — confirm below to continue for another year.
+                        No contract to re-sign; we&apos;ll only re-check a background if it&apos;s been more than three years.
                     </p>
-                    <button className="glass-button" disabled={saving} onClick={startApplication} style={{ background: "rgba(59,130,246,0.3)", borderColor: "rgba(59,130,246,0.5)", padding: "0.9rem 1.4rem", marginTop: "0.5rem" }}>
-                        {saving ? "Starting…" : "Start application"}
+                    <button className="glass-button" disabled={saving} onClick={renew} style={{ background: "rgba(34,197,94,0.25)", borderColor: "rgba(34,197,94,0.5)", padding: "0.9rem 1.4rem", marginTop: "0.5rem" }}>
+                        {saving ? "Starting…" : "Renew now"}
                     </button>
+                </div>
+            ) : isRenewal && inStatus === "RENEWAL_PENDING_BG" ? (
+                <div className="glass-container" style={{ padding: "2rem", maxWidth: "640px" }}>
+                    <h2 style={{ marginTop: 0 }}>Renewal in progress</h2>
+                    <p style={{ color: "var(--color-text-muted)" }}>
+                        We&apos;re re-confirming your household&apos;s background check (it&apos;s been over three years). You&apos;ll be able to pay once that&apos;s done.
+                        Your membership stays active in the meantime.
+                    </p>
                 </div>
             ) : (
                 <div style={{ display: "flex", gap: "2rem", alignItems: "flex-start", flexWrap: "wrap" }}>
-                    <div style={{ flex: "0 0 auto" }}>
-                        <MembershipFlowStepper currentStatus={inStatus} />
-                    </div>
+                    {!isRenewal && (
+                        <div style={{ flex: "0 0 auto" }}>
+                            <MembershipFlowStepper currentStatus={inStatus} />
+                        </div>
+                    )}
 
                     <div style={{ flex: "1 1 420px", minWidth: "320px" }}>
                         {isIntake ? (

--- a/src/lib/membership/intake.ts
+++ b/src/lib/membership/intake.ts
@@ -59,8 +59,11 @@ export async function getIntakeState(userId: number) {
 
     const household = user.household;
     const membership = household?.membership ?? null;
+    // The current in-flight process of any kind (INITIAL or RENEWAL) — anything
+    // not yet ACTIVE. During renewal the membership stays ACTIVE while its RENEWAL
+    // process cycles, so we surface that here rather than the "you're a member" card.
     const process = membership?.processes
-        .filter((p) => p.kind === "INITIAL" && IN_FLIGHT_INITIAL_STATUSES.includes(p.status))
+        .filter((p) => p.status !== "ACTIVE")
         .sort((a, b) => b.id - a.id)[0] ?? null;
 
     // Parents/guardians are the household leads; children are non-lead members.

--- a/src/lib/membership/renewal.ts
+++ b/src/lib/membership/renewal.ts
@@ -1,0 +1,149 @@
+import prisma from "@/lib/prisma";
+import { sendEmail } from "@/lib/email";
+import { logger } from "@/lib/logger";
+import { notifyReviewers } from "@/lib/membership/review";
+
+/**
+ * Annual renewal. A common membership-year boundary (BoardSettings) drives every
+ * household. Two months out, the cron opens a RENEWAL process at PENDING_RENEWAL
+ * and reminds the household — the membership stays ACTIVE throughout.
+ *
+ * When the member begins renewal, the 3-year background-check rule decides the
+ * path: if EITHER parent's lastBackgroundCheck is within 3 years of the boundary,
+ * skip straight to PENDING_PAYMENT; otherwise re-run review (RENEWAL_PENDING_BG).
+ * The Zoho contract is NOT re-signed at renewal. No auto-revoke — that's a manual
+ * admin action.
+ */
+
+const SYSTEM_ACTOR = 0;
+const RENEWAL_LEAD_MONTHS = 2;
+const BG_VALID_YEARS = 3;
+
+export class RenewalError extends Error {
+    constructor(public readonly code: "not_found" | "wrong_phase", message: string) {
+        super(message);
+        this.name = "RenewalError";
+    }
+}
+
+/** The next occurrence (>= now) of the boundary's month/day. */
+export function nextBoundary(boundary: Date, now: Date): Date {
+    const b = new Date(Date.UTC(now.getUTCFullYear(), boundary.getUTCMonth(), boundary.getUTCDate()));
+    if (b.getTime() < now.getTime()) b.setUTCFullYear(b.getUTCFullYear() + 1);
+    return b;
+}
+
+function monthsBefore(date: Date, months: number): Date {
+    const d = new Date(date);
+    d.setUTCMonth(d.getUTCMonth() - months);
+    return d;
+}
+
+/**
+ * Open renewal processes for every ACTIVE membership due within the lead window,
+ * unless one was already opened this cycle. Returns a summary.
+ */
+export async function runRenewalSweep(now: Date) {
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    if (!settings?.membershipYearBoundary) {
+        return { opened: 0, skipped: 0, reason: "no membership-year boundary configured" };
+    }
+
+    const boundary = nextBoundary(settings.membershipYearBoundary, now);
+    const windowStart = monthsBefore(boundary, RENEWAL_LEAD_MONTHS);
+    if (now.getTime() < windowStart.getTime()) {
+        return { opened: 0, skipped: 0, reason: "not yet within renewal window" };
+    }
+
+    const memberships = await prisma.membership.findMany({
+        where: { status: "ACTIVE" },
+        select: { id: true, householdId: true, processes: { where: { kind: "RENEWAL", createdAt: { gte: windowStart } }, select: { id: true } } },
+    });
+
+    let opened = 0;
+    let skipped = 0;
+    for (const m of memberships) {
+        if (m.processes.length > 0) { skipped++; continue; } // already opened this cycle
+        const process = await prisma.membershipProcess.create({
+            data: { membershipId: m.id, kind: "RENEWAL", status: "PENDING_RENEWAL" },
+        });
+        await prisma.membershipProcess.update({ where: { id: process.id }, data: { renewalReminderSentAt: now } });
+        await prisma.auditLog.create({
+            data: { actorId: SYSTEM_ACTOR, action: "CREATE", tableName: "MembershipProcess", affectedEntityId: process.id, newData: JSON.stringify({ kind: "RENEWAL", status: "PENDING_RENEWAL" }) },
+        });
+        await remindHousehold(m.householdId, boundary);
+        opened++;
+    }
+
+    return { opened, skipped, boundary: boundary.toISOString() };
+}
+
+/**
+ * Member begins renewal: PENDING_RENEWAL -> RENEWAL_PENDING_BG (re-review needed)
+ * or PENDING_PAYMENT (background check still valid). Idempotent-ish: only acts
+ * from PENDING_RENEWAL.
+ */
+export async function beginRenewal(processId: number) {
+    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    if (!process) throw new RenewalError("not_found", "Renewal not found.");
+    if (process.status !== "PENDING_RENEWAL") throw new RenewalError("wrong_phase", "This renewal is not awaiting your confirmation.");
+
+    const membership = await prisma.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
+    if (!membership) throw new RenewalError("not_found", "Membership not found.");
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const boundary = settings?.membershipYearBoundary ? nextBoundary(settings.membershipYearBoundary, new Date()) : new Date();
+    const bgFresh = await householdBgIsFresh(membership.householdId, boundary);
+
+    const nextStatus = bgFresh ? "PENDING_PAYMENT" : "RENEWAL_PENDING_BG";
+    const updated = await prisma.membershipProcess.update({ where: { id: processId }, data: { status: nextStatus, stageEnteredAt: new Date() } });
+    await prisma.auditLog.create({
+        data: { actorId: SYSTEM_ACTOR, action: "EDIT", tableName: "MembershipProcess", affectedEntityId: processId, oldData: JSON.stringify({ status: "PENDING_RENEWAL" }), newData: JSON.stringify({ status: nextStatus }) },
+    });
+    if (nextStatus === "RENEWAL_PENDING_BG") await notifyReviewers();
+    return updated;
+}
+
+/** Resolve and begin the caller's household renewal. */
+export async function beginRenewalForUser(userId: number) {
+    const user = await prisma.participant.findUnique({ where: { id: userId }, select: { householdId: true } });
+    if (!user?.householdId) throw new RenewalError("not_found", "You are not in a household.");
+    const process = await prisma.membershipProcess.findFirst({
+        where: { membership: { householdId: user.householdId }, status: "PENDING_RENEWAL" },
+        orderBy: { id: "desc" },
+    });
+    if (!process) throw new RenewalError("wrong_phase", "No renewal is awaiting your confirmation.");
+    return beginRenewal(process.id);
+}
+
+/** True if EITHER guardian (household lead) has a lastBackgroundCheck within BG_VALID_YEARS of the boundary. */
+export async function householdBgIsFresh(householdId: number, boundary: Date): Promise<boolean> {
+    const threshold = new Date(boundary);
+    threshold.setUTCFullYear(threshold.getUTCFullYear() - BG_VALID_YEARS);
+    const fresh = await prisma.participant.findFirst({
+        where: { householdId, householdLeads: { some: { householdId } }, lastBackgroundCheck: { gte: threshold } },
+        select: { id: true },
+    });
+    return fresh !== null;
+}
+
+async function remindHousehold(householdId: number, boundary: Date) {
+    try {
+        const leads = await prisma.householdLead.findMany({ where: { householdId }, select: { participant: { select: { email: true } } } });
+        const base = process.env.NEXTAUTH_URL ?? "";
+        const due = boundary.toISOString().slice(0, 10);
+        await Promise.all(
+            leads
+                .map((l) => l.participant?.email)
+                .filter((e): e is string => !!e)
+                .map((email) =>
+                    sendEmail(
+                        email,
+                        "Time to renew your Treehouse membership",
+                        `<p>Your household membership is up for renewal by ${due}. Please sign in to renew: <a href="${base}/membership">${base}/membership</a></p>`,
+                    ).catch((e) => logger.error("Renewal reminder failed:", e)),
+                ),
+        );
+    } catch (e) {
+        logger.error("remindHousehold failed:", e);
+    }
+}

--- a/src/lib/membership/review.ts
+++ b/src/lib/membership/review.ts
@@ -79,7 +79,7 @@ export async function listReviewQueue(reviewerId: number) {
     if (!reviewer?.backgroundCheckReviewer) return [];
 
     const processes = await prisma.membershipProcess.findMany({
-        where: { status: "PENDING_BG_REVIEW" },
+        where: { status: { in: ["PENDING_BG_REVIEW", "RENEWAL_PENDING_BG"] } },
         orderBy: { stageEnteredAt: "asc" },
         select: {
             id: true,
@@ -132,7 +132,7 @@ export async function attest(
         include: { attestations: { include: { reviewer: { select: { householdId: true } } } } },
     });
     if (!process) throw new ReviewError("not_found", "Application not found.");
-    if (process.status !== "PENDING_BG_REVIEW") throw new ReviewError("wrong_phase", "This application is not awaiting background-check review.");
+    if (process.status !== "PENDING_BG_REVIEW" && process.status !== "RENEWAL_PENDING_BG") throw new ReviewError("wrong_phase", "This application is not awaiting background-check review.");
     const membership = await prisma.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
     if (membership?.householdId === reviewer.householdId) throw new ReviewError("same_household_applicant", "You cannot review an applicant in your own household.");
     if (process.attestations.some((a) => a.reviewerId === reviewerId)) throw new ReviewError("already_attested", "You have already reviewed this application.");
@@ -144,7 +144,7 @@ export async function attest(
 
     if (input.result === "REJECT") {
         await prisma.membershipProcess.update({ where: { id: processId }, data: { status: "BLOCKED", stageEnteredAt: new Date() } });
-        await audit(reviewerId, processId, { status: "PENDING_BG_REVIEW" }, { status: "BLOCKED", reason: "reviewer reject" });
+        await audit(reviewerId, processId, { status: process.status }, { status: "BLOCKED", reason: "reviewer reject" });
         return { status: "BLOCKED" as const };
     }
 
@@ -174,7 +174,7 @@ async function advanceToPayment(processId: number, actorId: number) {
 
     await applyVolunteerStatus(process.membershipId, householdId, process.attestations.some((a) => a.markedVolunteer));
 
-    await audit(actorId, processId, { status: "PENDING_BG_REVIEW" }, { status: "PENDING_PAYMENT" });
+    await audit(actorId, processId, { status: process.status }, { status: "PENDING_PAYMENT" });
 }
 
 /**
@@ -204,11 +204,13 @@ export async function overrideBlocked(processId: number, actorId: number, action
     if (process.status !== "BLOCKED") throw new ReviewError("wrong_phase", "This application is not blocked.");
 
     if (action === "reset") {
+        // Restore the review state that matches the cycle (initial vs renewal).
+        const reviewStatus = process.kind === "RENEWAL" ? "RENEWAL_PENDING_BG" : "PENDING_BG_REVIEW";
         await prisma.backgroundCheckAttestation.deleteMany({ where: { processId } });
-        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: "PENDING_BG_REVIEW", stageEnteredAt: new Date() } });
-        await audit(actorId, processId, { status: "BLOCKED" }, { status: "PENDING_BG_REVIEW", action: "board reset" });
+        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: reviewStatus, stageEnteredAt: new Date() } });
+        await audit(actorId, processId, { status: "BLOCKED" }, { status: reviewStatus, action: "board reset" });
         await notifyReviewers();
-        return { status: "PENDING_BG_REVIEW" as const };
+        return { status: reviewStatus as "PENDING_BG_REVIEW" | "RENEWAL_PENDING_BG" };
     }
     await advanceToPayment(processId, actorId);
     return { status: "PENDING_PAYMENT" as const };


### PR DESCRIPTION
## PR10 of the membership stack — annual renewal

Stacked on #192 (`feat/membership-board-settings`). Closes the lifecycle loop.

A common membership-year boundary (`BoardSettings`) drives every household.

### Flow
- **Cron sweep** (`runRenewalSweep`): for each ACTIVE membership within **2 months** of the boundary, opens a `RENEWAL` process at `PENDING_RENEWAL` (once per cycle) and emails the household a reminder. The membership stays **ACTIVE** throughout.
- **`beginRenewal`** (member clicks "Renew now"): applies the **3-year background-check rule** — if *either* parent's `lastBackgroundCheck` is within 3 years of the boundary → straight to `PENDING_PAYMENT`; otherwise `RENEWAL_PENDING_BG`. **No Zoho re-sign.**
- The **2-of-N review flow now handles `RENEWAL_PENDING_BG`** too (same queue/attest; block→reset restores the right review state by cycle).
- Payment reuses PR8 (`PENDING_PAYMENT` → `ACTIVE`).
- **No auto-revoke** — that stays a manual admin action.

### Surfaces
- Cron route `GET /api/cron/membership-renewals` — `Authorization: Bearer $CRON_SECRET` (timing-safe), mirroring the existing crons.
- Member `POST /api/membership/renew` + `/membership` renewal UI (renew prompt, BG-waiting, shared payment view). `getIntakeState` now surfaces the current non-ACTIVE process of **any kind**, so renewals appear while the membership is still ACTIVE.

### Decision logged
The member confirms renewal ("Renew now") to leave `PENDING_RENEWAL` — avoids surprise charges and keeps `PENDING_RENEWAL` a real state. Easy to make auto-advancing later if you'd prefer.

### 🔑 Go-live (you flagged this)
- **`CRON_SECRET`** + a scheduler (systemd `.timer` or platform cron) hitting `/api/cron/membership-renewals` daily. The existing crons are dead/401 until this is set up.

### Validation
tsc clean · 82 unit · **310 integration** (7 new: cron auth, boundary rollover, out-of-window no-op, open-once sweep, beginRenewal fresh/stale BG, renewal 2-of-N → payment, valid cron run). The global sweep is fully cleaned up in tests — full suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)