### PR TITLE
feat(membership): go-live button to open renewals for all active members (PR11)

### DIFF
--- a/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
+++ b/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the go-live "open renewals for all active members" action.
+ */
+
+import { POST as BULK } from '@/app/api/admin/membership/bulk-open-renewals/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import { sendEmail } from '@/lib/email';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+
+const TAG = 'bulk-renewal-test';
+
+function asSysadmin(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, sysadmin: true, boardMember: false } });
+}
+function asBoard(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, sysadmin: false, boardMember: true } });
+}
+function asPlain(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, sysadmin: false, boardMember: false } });
+}
+function jsonReq(body?: unknown) {
+    return new Request('http://localhost:4000/x', { method: 'POST', ...(body ? { body: JSON.stringify(body) } : {}) }) as never;
+}
+
+describe('Bulk renewal migration', () => {
+    let sysId: number, boardId: number, plainId: number;
+    let mA: number, mB: number;
+    let preMaxProcessId = 0;
+
+    async function makeActive(label: string) {
+        const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
+        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
+        return m.id;
+    }
+
+    async function wipe() {
+        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
+        const ids = hhs.map((h) => h.id);
+        if (ids.length) {
+            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
+            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.household.deleteMany({ where: { id: { in: ids } } });
+        }
+        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+    }
+
+    beforeAll(async () => {
+        const maxRow = await prisma.membershipProcess.findFirst({ orderBy: { id: 'desc' }, select: { id: true } });
+        preMaxProcessId = maxRow?.id ?? 0;
+        await wipe();
+        sysId = (await prisma.participant.create({ data: { email: `sys-${TAG}@example.com`, name: 'Sys', sysadmin: true, household: { create: { name: `Sys HH ${TAG}` } } } })).id;
+        boardId = (await prisma.participant.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', boardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
+        plainId = (await prisma.participant.create({ data: { email: `plain-${TAG}@example.com`, name: 'Plain', household: { create: { name: `Plain HH ${TAG}` } } } })).id;
+        mA = await makeActive('A');
+        mB = await makeActive('B');
+    });
+
+    afterAll(async () => {
+        await prisma.membershipProcess.deleteMany({ where: { id: { gt: preMaxProcessId } } });
+        await wipe();
+        await prisma.$disconnect();
+    });
+
+    it('an unprivileged user is forbidden', async () => {
+        asPlain(plainId);
+        const res = await BULK(jsonReq({}));
+        expect(res.status).toBe(403);
+    });
+
+    it('a board member opens PENDING_RENEWAL for all active members, idempotently, no email by default', async () => {
+        (sendEmail as jest.Mock).mockClear();
+        asBoard(boardId);
+
+        const res = await BULK(jsonReq({ sendReminders: false }));
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.success).toBe(true);
+        expect(data.opened).toBeGreaterThanOrEqual(2);
+
+        const a = await prisma.membershipProcess.findFirst({ where: { membershipId: mA } });
+        const b = await prisma.membershipProcess.findFirst({ where: { membershipId: mB } });
+        expect(a?.status).toBe('PENDING_RENEWAL');
+        expect(b?.status).toBe('PENDING_RENEWAL');
+        expect(sendEmail as jest.Mock).not.toHaveBeenCalled();
+
+        // Idempotent: a second press opens nothing new.
+        const second = await BULK(jsonReq({ sendReminders: false }));
+        expect((await second.json()).opened).toBe(0);
+        const count = await prisma.membershipProcess.count({ where: { membershipId: mA } });
+        expect(count).toBe(1);
+    });
+
+    it('a sysadmin may also trigger it', async () => {
+        asSysadmin(sysId);
+        const res = await BULK(jsonReq({ sendReminders: false }));
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.success).toBe(true);
+        expect(typeof data.opened).toBe('number');
+        expect(typeof data.skipped).toBe('number');
+    });
+});

--- a/src/app/admin/membership/settings/page.tsx
+++ b/src/app/admin/membership/settings/page.tsx
@@ -25,6 +25,8 @@ export default function MembershipSettingsPage() {
     const [designations, setDesignations] = useState<Designation[]>([]);
     const [newEmail, setNewEmail] = useState("");
 
+    const [bulkReminders, setBulkReminders] = useState(false);
+
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [message, setMessage] = useState("");
@@ -98,6 +100,23 @@ export default function MembershipSettingsPage() {
             await fetch(`/api/admin/membership/volunteer-designations?id=${id}`, { method: "DELETE" });
             await load();
         } finally { setSaving(false); }
+    };
+
+    const bulkOpenRenewals = async () => {
+        if (!confirm("Open a renewal cycle for ALL active members now? This is a one-time go-live action.")) return;
+        setSaving(true);
+        flash("");
+        try {
+            const res = await fetch("/api/admin/membership/bulk-open-renewals", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ sendReminders: bulkReminders }),
+            });
+            const data = await res.json();
+            if (res.ok) flash(`Opened ${data.opened} renewal(s); ${data.skipped} already in progress.`);
+            else flash(data.error || "Failed.", true);
+        } catch { flash("Network error.", true); }
+        finally { setSaving(false); }
     };
 
     const labelStyle: React.CSSProperties = { display: "block", marginBottom: "0.35rem", fontWeight: 500 };
@@ -181,6 +200,21 @@ export default function MembershipSettingsPage() {
                                 ))}
                             </ul>
                         )}
+                    </div>
+
+                    <div className="glass-container" style={{ padding: "1.75rem", marginTop: "1.5rem", border: "1px solid rgba(245,158,11,0.35)" }}>
+                        <h2 style={{ marginTop: 0 }}>Go-live: open renewals</h2>
+                        <p style={{ color: "#fcd34d", fontSize: "0.9rem" }}>
+                            ⚠️ One-time go-live action. Opens a renewal cycle for <strong>every active member</strong> so they renew for the upcoming year.
+                            Press this once, after your existing members are imported (board or sysadmin).
+                        </p>
+                        <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", margin: "0.75rem 0", cursor: "pointer" }}>
+                            <input type="checkbox" checked={bulkReminders} onChange={(e) => setBulkReminders(e.target.checked)} />
+                            <span>Also email each household a renewal reminder</span>
+                        </label>
+                        <button className="glass-button" disabled={saving} onClick={bulkOpenRenewals} style={{ padding: "0.7rem 1.3rem", background: "rgba(245,158,11,0.2)", borderColor: "rgba(245,158,11,0.45)" }}>
+                            {saving ? "Working…" : "Open renewals for all active members"}
+                        </button>
                     </div>
                 </>
             )}

--- a/src/app/api/admin/membership/bulk-open-renewals/route.ts
+++ b/src/app/api/admin/membership/bulk-open-renewals/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { openRenewalsForAllActive } from "@/lib/membership/renewal";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/admin/membership/bulk-open-renewals — go-live action.
+ * Opens a renewal cycle (PENDING_RENEWAL) for every active membership not already
+ * mid-renewal. Board members or sysadmins may trigger it; it is a deliberate,
+ * manual one-time action (nothing opens automatically).
+ * Body: { sendReminders?: boolean } (default false — avoids a mass email blast).
+ */
+export const POST = withAuth({ roles: ["sysadmin", "boardMember"] }, async (req, auth) => {
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    let body: { sendReminders?: boolean } = {};
+    try {
+        body = await req.json();
+    } catch {
+        /* empty body is fine */
+    }
+    const result = await openRenewalsForAllActive(new Date(), { sendReminders: !!body.sendReminders });
+    return NextResponse.json({ success: true, ...result });
+});

--- a/src/lib/membership/renewal.ts
+++ b/src/lib/membership/renewal.ts
@@ -64,14 +64,7 @@ export async function runRenewalSweep(now: Date) {
     let skipped = 0;
     for (const m of memberships) {
         if (m.processes.length > 0) { skipped++; continue; } // already opened this cycle
-        const process = await prisma.membershipProcess.create({
-            data: { membershipId: m.id, kind: "RENEWAL", status: "PENDING_RENEWAL" },
-        });
-        await prisma.membershipProcess.update({ where: { id: process.id }, data: { renewalReminderSentAt: now } });
-        await prisma.auditLog.create({
-            data: { actorId: SYSTEM_ACTOR, action: "CREATE", tableName: "MembershipProcess", affectedEntityId: process.id, newData: JSON.stringify({ kind: "RENEWAL", status: "PENDING_RENEWAL" }) },
-        });
-        await remindHousehold(m.householdId, boundary);
+        await createRenewalProcess(m.id, m.householdId, now, { remind: true, boundary });
         opened++;
     }
 
@@ -101,6 +94,47 @@ export async function beginRenewal(processId: number) {
     });
     if (nextStatus === "RENEWAL_PENDING_BG") await notifyReviewers();
     return updated;
+}
+
+/** Create one PENDING_RENEWAL process (+ audit, optional reminder). */
+async function createRenewalProcess(membershipId: number, householdId: number, now: Date, opts: { remind: boolean; boundary: Date }) {
+    const process = await prisma.membershipProcess.create({
+        data: { membershipId, kind: "RENEWAL", status: "PENDING_RENEWAL", renewalReminderSentAt: opts.remind ? now : null },
+    });
+    await prisma.auditLog.create({
+        data: { actorId: SYSTEM_ACTOR, action: "CREATE", tableName: "MembershipProcess", affectedEntityId: process.id, newData: JSON.stringify({ kind: "RENEWAL", status: "PENDING_RENEWAL" }) },
+    });
+    if (opts.remind) await remindHousehold(householdId, opts.boundary);
+    return process;
+}
+
+/**
+ * Go-live migration: open a renewal cycle for EVERY active membership that isn't
+ * already mid-renewal, ignoring the date window. Reminders are opt-in (default
+ * off) to avoid an unexpected mass email blast on the button press — the board
+ * can send them deliberately or let the normal cron remind on schedule.
+ */
+export async function openRenewalsForAllActive(now: Date, opts: { sendReminders?: boolean } = {}) {
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const boundary = settings?.membershipYearBoundary ? nextBoundary(settings.membershipYearBoundary, now) : now;
+
+    const memberships = await prisma.membership.findMany({
+        where: { status: "ACTIVE" },
+        select: {
+            id: true,
+            householdId: true,
+            processes: { where: { kind: "RENEWAL", status: { in: ["PENDING_RENEWAL", "RENEWAL_PENDING_BG", "PENDING_PAYMENT"] } }, select: { id: true } },
+        },
+    });
+
+    let opened = 0;
+    let skipped = 0;
+    for (const m of memberships) {
+        if (m.processes.length > 0) { skipped++; continue; }
+        await createRenewalProcess(m.id, m.householdId, now, { remind: !!opts.sendReminders, boundary });
+        opened++;
+    }
+    return { opened, skipped };
 }
 
 /** Resolve and begin the caller's household renewal. */


### PR DESCRIPTION
## What this adds

A **board/sysadmin button** to open the first renewal cycle at go-live. Nothing happens automatically — a board member or sysadmin presses it once, deliberately.

- **Button** in Membership Settings → *"Open renewals for all active members"*, behind a confirm dialog (`settings/page.tsx`).
- → `POST /api/admin/membership/bulk-open-renewals` (roles: **boardMember or sysadmin**) → `openRenewalsForAllActive()`.
- Opens a `PENDING_RENEWAL` process for every **active** membership not already mid-renewal.
- **Reminders are opt-in** (a checkbox, default **off**) so pressing the button does not blast emails. The board can send them deliberately, or let the normal renewal cron remind on schedule.
- **Idempotent** — pressing it again opens nothing new for anyone already in a renewal cycle.

## What it does NOT do
- It does **not** run on deploy, import, or any automatic trigger.
- It does **not** import a member list — it operates over memberships that are already `ACTIVE` (seeded/imported separately).

## Auth
`boardMember` or `sysadmin` may trigger it (an unprivileged user gets 403).

## Tests
`membershipBulkRenewalAPI.integration.test.ts`: unprivileged → 403; board member opens all active (idempotent, no email by default); sysadmin may also trigger. Validated locally with tsc + the mocked unit suite; the integration test runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
