### PR TITLE
feat(membership): in-app notifications via general /api/notifications (PR12)

### DIFF
--- a/src/app/__tests__/notificationsAPI.integration.test.ts
+++ b/src/app/__tests__/notificationsAPI.integration.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for GET /api/notifications — role-relevant in-app counts,
+ * namespaced by domain (membership today).
+ */
+
+import { GET as NOTIFS } from '@/app/api/notifications/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+const TAG = 'notif-test';
+
+function as(id: number, roles: { backgroundCheckReviewer?: boolean; boardMember?: boolean; sysadmin?: boolean } = {}) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, sysadmin: false, boardMember: false, backgroundCheckReviewer: false, ...roles } });
+}
+const req = () => new Request('http://localhost:4000/x') as never;
+
+describe('Membership notifications API', () => {
+    let reviewerId: number, boardId: number, plainId: number;
+
+    async function wipe() {
+        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
+        const ids = hhs.map((h) => h.id);
+        if (ids.length) {
+            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
+            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.household.deleteMany({ where: { id: { in: ids } } });
+        }
+        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+    }
+
+    beforeAll(async () => {
+        await wipe();
+        reviewerId = (await prisma.participant.create({ data: { email: `rev-${TAG}@example.com`, name: 'Rev', backgroundCheckReviewer: true, household: { create: { name: `Rev HH ${TAG}` } } } })).id;
+        boardId = (await prisma.participant.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', boardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
+        plainId = (await prisma.participant.create({ data: { email: `plain-${TAG}@example.com`, name: 'Plain', household: { create: { name: `Plain HH ${TAG}` } } } })).id;
+
+        // An application awaiting review (eligible for the reviewer — different household).
+        const appHh = await prisma.household.create({ data: { name: `App HH ${TAG}` } });
+        const m1 = await prisma.membership.create({ data: { householdId: appHh.id, status: 'NONE' } });
+        await prisma.membershipProcess.create({ data: { membershipId: m1.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
+
+        // A blocked application (for the board).
+        const blkHh = await prisma.household.create({ data: { name: `Blk HH ${TAG}` } });
+        const m2 = await prisma.membership.create({ data: { householdId: blkHh.id, status: 'NONE' } });
+        await prisma.membershipProcess.create({ data: { membershipId: m2.id, kind: 'INITIAL', status: 'BLOCKED' } });
+    });
+
+    afterAll(async () => {
+        await wipe();
+        await prisma.$disconnect();
+    });
+
+    it('a reviewer sees their pending review count', async () => {
+        as(reviewerId, { backgroundCheckReviewer: true });
+        const data = await (await NOTIFS(req())).json();
+        expect(data.membership.pendingReviews).toBeGreaterThanOrEqual(1);
+        expect(data.membership.blocked).toBe(0); // not board
+    });
+
+    it('a board member sees the blocked count', async () => {
+        as(boardId, { boardMember: true });
+        const data = await (await NOTIFS(req())).json();
+        expect(data.membership.blocked).toBeGreaterThanOrEqual(1);
+        expect(data.membership.pendingReviews).toBe(0); // not a reviewer
+    });
+
+    it('a plain user sees nothing', async () => {
+        as(plainId);
+        const data = await (await NOTIFS(req())).json();
+        expect(data).toEqual({ membership: { pendingReviews: 0, blocked: 0 } });
+    });
+});

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { getMembershipNotifications } from "@/lib/membership/notifications";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/notifications — aggregated, role-relevant in-app notification counts for
+ * the current user, namespaced by domain so new sources (events, shop, …) can be
+ * added as sibling keys without changing the response shape or the client contract.
+ *   { membership: { pendingReviews, blocked } }
+ */
+export const GET = withAuth({}, async (_req, auth) => {
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const membership = await getMembershipNotifications(auth.user);
+
+    return NextResponse.json({ membership });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import styles from './page.module.css';
 import DevLoginPicker from '@/components/DevLoginPicker';
 import { useIsDevInstance, useIsLocalInstance } from '@/components/EnvProvider';
 import JoinTreehouseBanner from '@/components/JoinTreehouseBanner';
+import Notifications from '@/components/Notifications';
 import { config } from '@/lib/config';
 import type { SessionUser, BoardMember } from '@/types/participant';
 
@@ -154,14 +155,10 @@ export default function Home() {
                 </div>
               )}
 
-              {/* Background-check reviewers: entry point to their review queue */}
-              {(session.user as SessionUser)?.backgroundCheckReviewer && (
-                <div style={{ width: '100%', gridColumn: '1 / -1' }}>
-                  <a href="/membership/review" className="glass-button" style={{ display: 'inline-block', textDecoration: 'none', color: 'white', padding: '0.75rem 1.25rem', background: 'rgba(168,85,247,0.25)', borderColor: 'rgba(168,85,247,0.5)' }}>
-                    🔍 Background-check reviews
-                  </a>
-                </div>
-              )}
+              {/* In-app red-dot indicators (membership reviewer queue / blocked apps, …) */}
+              <div style={{ width: '100%', gridColumn: '1 / -1' }}>
+                <Notifications />
+              </div>
 
               {/* Operational Warnings */}
               {isTwoDeepViolation && (

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+
+interface NotificationData {
+    membership: { pendingReviews: number; blocked: number };
+}
+
+/**
+ * In-app red-dot indicators, fed by GET /api/notifications. Today it surfaces the
+ * membership domain (a reviewer's pending queue, the board's blocked applications);
+ * other domains can be added as new sections as the API grows. Renders nothing when
+ * there's nothing to show. Polls lightly so the dots stay current without a refresh.
+ */
+export default function Notifications() {
+    const [data, setData] = useState<NotificationData | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        const fetchCounts = () =>
+            fetch("/api/notifications")
+                .then((res) => (res.ok ? res.json() : null))
+                .then((d) => { if (!cancelled && d) setData(d); })
+                .catch(() => { /* silent — indicators are best-effort */ });
+        fetchCounts();
+        const t = setInterval(fetchCounts, 60000);
+        return () => { cancelled = true; clearInterval(t); };
+    }, []);
+
+    const m = data?.membership;
+    if (!m || (m.pendingReviews === 0 && m.blocked === 0)) return null;
+
+    const badge = (color: string, label: string) => (
+        <span style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", minWidth: "20px", height: "20px", padding: "0 6px", borderRadius: "999px", background: color, color: "white", fontSize: "0.72rem", fontWeight: 700 }}>
+            {label}
+        </span>
+    );
+
+    const linkStyle: React.CSSProperties = { display: "inline-flex", alignItems: "center", gap: "0.5rem", textDecoration: "none", color: "white", padding: "0.75rem 1.25rem", borderRadius: "var(--glass-radius, 16px)" };
+
+    return (
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+            {m.pendingReviews > 0 && (
+                <Link href="/membership/review" className="glass-button" style={{ ...linkStyle, background: "rgba(168,85,247,0.25)", borderColor: "rgba(168,85,247,0.5)" }}>
+                    🔍 Background-check reviews {badge("#a855f7", String(m.pendingReviews))}
+                </Link>
+            )}
+            {m.blocked > 0 && (
+                <Link href="/admin/membership" className="glass-button" style={{ ...linkStyle, background: "rgba(239,68,68,0.2)", borderColor: "rgba(239,68,68,0.5)" }}>
+                    🚨 Blocked applications {badge("#ef4444", String(m.blocked))}
+                </Link>
+            )}
+        </div>
+    );
+}

--- a/src/lib/membership/notifications.ts
+++ b/src/lib/membership/notifications.ts
@@ -1,0 +1,28 @@
+import prisma from "@/lib/prisma";
+import { listReviewQueue } from "@/lib/membership/review";
+
+export interface MembershipNotifications {
+    /** Applications this background-check reviewer may currently attest. */
+    pendingReviews: number;
+    /** Applications stuck at BLOCKED (board/sysadmin). */
+    blocked: number;
+}
+
+/**
+ * Role-relevant membership counts for the in-app red-dot indicators. One domain's
+ * contribution to GET /api/notifications — kept here so the membership rules live
+ * with the rest of the membership code, not in the shared notifications route.
+ */
+export async function getMembershipNotifications(user: {
+    id: number;
+    backgroundCheckReviewer?: boolean;
+    sysadmin?: boolean;
+    boardMember?: boolean;
+}): Promise<MembershipNotifications> {
+    const pendingReviews = user.backgroundCheckReviewer ? (await listReviewQueue(user.id)).length : 0;
+    const blocked =
+        user.sysadmin || user.boardMember
+            ? await prisma.membershipProcess.count({ where: { status: "BLOCKED" } })
+            : 0;
+    return { pendingReviews, blocked };
+}


### PR DESCRIPTION
## What this adds

In-app **red-dot notification indicators** on the homepage, fed by a new **general** endpoint so future non-membership notifications slot in without a new API or client contract.

### Endpoint — `GET /api/notifications`
Aggregated, role-relevant counts for the current user, **namespaced by domain**:

```json
{ "membership": { "pendingReviews": 3, "blocked": 1 } }
```

Future sources (events, shop, …) become sibling keys — the shape and the client contract don't change. Membership's contribution lives in `src/lib/membership/notifications.ts` (`getMembershipNotifications`), so domain rules stay with their domain; the route just composes them.

### UI
- `components/Notifications.tsx` — generic indicator component; polls `/api/notifications`, renders the membership badges today (reviewer queue → `/membership/review`, blocked apps → `/admin/membership`), renders nothing when empty.
- Mounted on the homepage (replaces the old static "Background-check reviews" link).

### Membership counts
- `pendingReviews` — applications this background-check reviewer may attest (reviewers only)
- `blocked` — applications stuck at `BLOCKED` (board/sysadmin only)

## Tests
`notificationsAPI.integration.test.ts`: reviewer sees their pending count; board sees blocked; a plain user sees `{ membership: { pendingReviews: 0, blocked: 0 } }`. Validated locally with tsc + the mocked unit suite; integration runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
