### PR TITLE
refactor(security): route membership PII reads through the security handler

### DIFF
--- a/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -179,9 +179,30 @@ describe('Membership BG review API', () => {
         const res = await REVIEW_QUEUE(req({}) as never);
         const data = await res.json();
         expect(Array.isArray(data.queue)).toBe(true);
-        // rev2 shares no household with applicants; every queued item is PENDING_BG_REVIEW and not yet attested by rev2.
+        // Model-shaped rows now: id + _count.attestations + household leads (parents).
         for (const item of data.queue) {
-            expect(typeof item.processId).toBe('number');
+            expect(typeof item.id).toBe('number');
+            expect(item._count).toBeDefined();
         }
+    });
+
+    it('queue returns only parents (leads) and never exposes children', async () => {
+        // Self-contained applicant household: one parent (lead) + one child (non-lead).
+        const hh = await prisma.household.create({ data: { name: `ChildExcl ${TAG}` } });
+        const parent = await prisma.participant.create({ data: { name: 'Excl Parent', email: `exclparent-${TAG}@example.com`, householdId: hh.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: parent.id } });
+        await prisma.participant.create({ data: { name: 'Excl Child', email: `exclchild-${TAG}@example.com`, householdId: hh.id } });
+        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
+
+        as(rev2, { backgroundCheckReviewer: true }); // different household → eligible
+        const data = await (await REVIEW_QUEUE(req({}) as never)).json();
+        const blob = JSON.stringify(data);
+
+        // Parent (lead) is present; the child's PII never leaves the server.
+        expect(blob).toContain('Excl Parent');
+        expect(blob).toContain('exclparent');
+        expect(blob).not.toContain('Excl Child');
+        expect(blob).not.toContain('exclchild');
     });
 });

--- a/src/app/api/admin/membership/route.ts
+++ b/src/app/api/admin/membership/route.ts
@@ -1,15 +1,18 @@
-import { NextResponse } from "next/server";
-import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+import { handler } from "@/security/handler";
 
 export const dynamic = "force-dynamic";
 
 /**
  * GET /api/admin/membership — in-flight membership applications for the board.
- * Returns every process not yet ACTIVE, with its household and external-phase
- * flags, so the board can drive the manual steps (contract / BG consent).
+ * Every process not yet ACTIVE, with its household + external-phase flags.
+ *
+ * Field visibility is governed by the security registry (sysadmin/board get the
+ * full applicant PII; anyone else admitted would be stripped to public). The bag
+ * is keyed by the model name so the stripper can classify it; the 'processes'
+ * envelope preserves the response shape consumers expect.
  */
-export const GET = withAuth({ roles: ["sysadmin", "boardMember"] }, async () => {
+export const GET = handler("GET /api/admin/membership", async () => {
     const processes = await prisma.membershipProcess.findMany({
         where: { status: { not: "ACTIVE" } },
         orderBy: { createdAt: "desc" },
@@ -38,5 +41,5 @@ export const GET = withAuth({ roles: ["sysadmin", "boardMember"] }, async () => 
         },
     });
 
-    return NextResponse.json({ processes });
+    return { MembershipProcess: processes };
 });

--- a/src/app/api/membership/reviews/route.ts
+++ b/src/app/api/membership/reviews/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
-import { listReviewQueue, attest, ReviewError } from "@/lib/membership/review";
+import prisma from "@/lib/prisma";
+import { handler, unauthorized } from "@/security/handler";
+import { eligibleReviewProcessIds, attest, ReviewError } from "@/lib/membership/review";
 
 export const dynamic = "force-dynamic";
 
@@ -13,10 +15,40 @@ const STATUS_FOR: Record<ReviewError["code"], number> = {
     already_attested: 409,
 };
 
-// GET /api/membership/reviews — applications this reviewer may attest.
-export const GET = withAuth({ roles: ["backgroundCheckReviewer"] }, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    return NextResponse.json({ queue: await listReviewQueue(auth.user.id) });
+/**
+ * GET /api/membership/reviews — applications this reviewer may attest.
+ *
+ * Eligibility is computed in the service; the result is returned as model rows
+ * so the security stripper governs field visibility (registry grants reviewers
+ * pii + public only — applicant parents' names/emails, nothing internal). The
+ * attestation _count doubles as the approval count for queue rows.
+ *
+ * The query selects ONLY the household leads' (parents') participant rows — the
+ * reviewer never needs the children, so their PII never leaves the DB. The
+ * stripper is defense-in-depth on top of this narrowing, not the primary filter.
+ */
+export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
+    if (auth.type !== "session") throw unauthorized();
+    const ids = await eligibleReviewProcessIds(auth.user.id);
+    const queue = await prisma.membershipProcess.findMany({
+        where: { id: { in: ids } },
+        orderBy: { stageEnteredAt: "asc" },
+        select: {
+            id: true,
+            membership: {
+                select: {
+                    household: {
+                        select: {
+                            name: true,
+                            leads: { select: { participant: { select: { id: true, name: true, email: true } } } },
+                        },
+                    },
+                },
+            },
+            _count: { select: { attestations: true } },
+        },
+    });
+    return { MembershipProcess: queue };
 });
 
 // POST /api/membership/reviews — submit an attestation { processId, result, markedVolunteer }.

--- a/src/app/membership/review/page.tsx
+++ b/src/app/membership/review/page.tsx
@@ -4,11 +4,17 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 
+interface Participant {
+    id: number;
+    name: string | null;
+    email: string | null;
+}
+// Shape returned by GET /api/membership/reviews (security-stripped model rows).
+// Only the household leads (parents) are returned — children are never sent.
 interface QueueItem {
-    processId: number;
-    householdName: string | null;
-    parents: { name: string | null; email: string | null }[];
-    approvals: number;
+    id: number;
+    membership: { household: { name: string | null; leads: { participant: Participant }[] } | null } | null;
+    _count: { attestations: number };
 }
 
 export default function MembershipReviewPage() {
@@ -109,37 +115,40 @@ export default function MembershipReviewPage() {
                 </div>
             ) : (
                 <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-                    {queue.map((item) => (
-                        <div key={item.processId} className="glass-container" style={{ padding: "1.25rem 1.5rem" }}>
-                            <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>{item.householdName || `Household (application #${item.processId})`}</div>
+                    {queue.map((item) => {
+                        const parents = (item.membership?.household?.leads ?? []).map((l) => l.participant);
+                        return (
+                        <div key={item.id} className="glass-container" style={{ padding: "1.25rem 1.5rem" }}>
+                            <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>{item.membership?.household?.name || `Household (application #${item.id})`}</div>
                             <div style={{ fontSize: "0.85rem", color: "var(--color-text-muted)", marginTop: "0.25rem" }}>
-                                {item.parents.length > 0
-                                    ? item.parents.map((p) => `${p.name || "—"}${p.email ? ` <${p.email}>` : ""}`).join(", ")
+                                {parents.length > 0
+                                    ? parents.map((p) => `${p.name || "—"}${p.email ? ` <${p.email}>` : ""}`).join(", ")
                                     : "No parent contact on file."}
                             </div>
                             <div style={{ fontSize: "0.8rem", color: "var(--color-text-muted)", marginTop: "0.25rem" }}>
-                                {item.approvals}/2 approvals so far.
+                                {item._count.attestations}/2 approvals so far.
                             </div>
 
                             <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", margin: "0.9rem 0", cursor: "pointer" }}>
                                 <input
                                     type="checkbox"
-                                    checked={!!volunteer[item.processId]}
-                                    onChange={(e) => setVolunteer((v) => ({ ...v, [item.processId]: e.target.checked }))}
+                                    checked={!!volunteer[item.id]}
+                                    onChange={(e) => setVolunteer((v) => ({ ...v, [item.id]: e.target.checked }))}
                                 />
                                 <span>This is a volunteer family</span>
                             </label>
 
                             <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
-                                <button className="glass-button" disabled={busyId === item.processId} onClick={() => submit(item.processId, "APPROVE")} style={{ padding: "0.55rem 1.1rem", background: "rgba(34,197,94,0.2)", borderColor: "rgba(34,197,94,0.4)" }}>
-                                    {busyId === item.processId ? "…" : "Attest — check is clean"}
+                                <button className="glass-button" disabled={busyId === item.id} onClick={() => submit(item.id, "APPROVE")} style={{ padding: "0.55rem 1.1rem", background: "rgba(34,197,94,0.2)", borderColor: "rgba(34,197,94,0.4)" }}>
+                                    {busyId === item.id ? "…" : "Attest — check is clean"}
                                 </button>
-                                <button className="glass-button" disabled={busyId === item.processId} onClick={() => submit(item.processId, "REJECT")} style={{ padding: "0.55rem 1.1rem", background: "rgba(239,68,68,0.18)", borderColor: "rgba(239,68,68,0.45)" }}>
-                                    {busyId === item.processId ? "…" : "Reject"}
+                                <button className="glass-button" disabled={busyId === item.id} onClick={() => submit(item.id, "REJECT")} style={{ padding: "0.55rem 1.1rem", background: "rgba(239,68,68,0.18)", borderColor: "rgba(239,68,68,0.45)" }}>
+                                    {busyId === item.id ? "…" : "Reject"}
                                 </button>
                             </div>
                         </div>
-                    ))}
+                        );
+                    })}
                 </div>
             )}
         </main>

--- a/src/lib/membership/notifications.ts
+++ b/src/lib/membership/notifications.ts
@@ -1,5 +1,5 @@
 import prisma from "@/lib/prisma";
-import { listReviewQueue } from "@/lib/membership/review";
+import { eligibleReviewProcessIds } from "@/lib/membership/review";
 
 export interface MembershipNotifications {
     /** Applications this background-check reviewer may currently attest. */
@@ -19,7 +19,7 @@ export async function getMembershipNotifications(user: {
     sysadmin?: boolean;
     boardMember?: boolean;
 }): Promise<MembershipNotifications> {
-    const pendingReviews = user.backgroundCheckReviewer ? (await listReviewQueue(user.id)).length : 0;
+    const pendingReviews = user.backgroundCheckReviewer ? (await eligibleReviewProcessIds(user.id)).length : 0;
     const blocked =
         user.sysadmin || user.boardMember
             ? await prisma.membershipProcess.count({ where: { status: "BLOCKED" } })

--- a/src/lib/membership/review.ts
+++ b/src/lib/membership/review.ts
@@ -73,8 +73,15 @@ async function loadReviewer(reviewerId: number) {
     return prisma.participant.findUnique({ where: { id: reviewerId }, select: { id: true, householdId: true, backgroundCheckReviewer: true } });
 }
 
-/** Applications this reviewer may currently attest (eligibility filtered). */
-export async function listReviewQueue(reviewerId: number) {
+/**
+ * IDs of the applications this reviewer may currently attest (eligibility
+ * filtered: not their own household, not already attested, no household-mate
+ * already on it). The route turns these into model rows for the stripper; the
+ * notifications endpoint just counts them. In PENDING_BG_REVIEW a process only
+ * ever holds APPROVE attestations (any REJECT moves it to BLOCKED), so a row's
+ * attestation _count equals its approval count.
+ */
+export async function eligibleReviewProcessIds(reviewerId: number): Promise<number[]> {
     const reviewer = await loadReviewer(reviewerId);
     if (!reviewer?.backgroundCheckReviewer) return [];
 
@@ -83,14 +90,8 @@ export async function listReviewQueue(reviewerId: number) {
         orderBy: { stageEnteredAt: "asc" },
         select: {
             id: true,
-            createdAt: true,
-            membership: {
-                select: {
-                    householdId: true,
-                    household: { select: { name: true, participants: { select: { id: true, name: true, email: true } }, leads: { select: { participantId: true } } } },
-                },
-            },
-            attestations: { select: { reviewerId: true, result: true, reviewer: { select: { householdId: true } } } },
+            membership: { select: { householdId: true } },
+            attestations: { select: { reviewerId: true, reviewer: { select: { householdId: true } } } },
         },
     });
 
@@ -101,18 +102,7 @@ export async function listReviewQueue(reviewerId: number) {
             if (p.attestations.some((a) => a.reviewer.householdId === reviewer.householdId)) return false; // shares household with other reviewer
             return true;
         })
-        .map((p) => {
-            // Parents are the household leads.
-            const leadIds = new Set((p.membership.household?.leads ?? []).map((l) => l.participantId));
-            return {
-                processId: p.id,
-                householdName: p.membership.household?.name ?? null,
-                parents: (p.membership.household?.participants ?? [])
-                    .filter((x) => leadIds.has(x.id))
-                    .map((x) => ({ name: x.name, email: x.email })),
-                approvals: p.attestations.filter((a) => a.result === "APPROVE").length,
-            };
-        });
+        .map((p) => p.id);
 }
 
 /**

--- a/src/security/registry.ts
+++ b/src/security/registry.ts
@@ -52,6 +52,31 @@ defineRoute({
     ],
 });
 
+// Board's in-flight membership applications. Exposes every applicant household's
+// PII (parents + children names/emails), so only sysadmin/board may see it, and
+// the field grant is explicit per role.
+defineRoute({
+    endpoint: 'GET /api/admin/membership',
+    authorize: { anyRole: ['sysadmin', 'boardMember'] },
+    envelope: 'processes',
+    orderedView: [
+        ['sysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'public']],
+        ['boardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'public']],
+    ],
+});
+
+// Background-check reviewers' queue. Reviewers must see applicant parents' names
+// + emails (to look them up on Averity) but NOT internal/personal fields — so the
+// grant is deliberately limited to pii + public.
+defineRoute({
+    endpoint: 'GET /api/membership/reviews',
+    authorize: { anyRole: ['backgroundCheckReviewer'] },
+    envelope: 'queue',
+    orderedView: [
+        ['backgroundCheckReviewer', ['everyones:pii', 'public']],
+    ],
+});
+
 // ─── Outbound surfaces ─────────────────────────────────────────────────────
 
 defineOutbound({


### PR DESCRIPTION
## PR13 — security hardening (your decision 5)

Stacked on #195 (`feat/membership-notifications`).

The two membership reads that expose **other people's PII** now flow through the `/security` policy layer (registry + `handler()` + stripper) instead of `withAuth`. Field visibility is an explicit, sensitivity-tiered decision per role.

### Registry decisions (`src/security/registry.ts`)
| Endpoint | Role | Grant |
|---|---|---|
| `GET /api/admin/membership` | sysadmin, boardMember | `everyones:pii/personal/internal/public` (full applicant data) |
| `GET /api/membership/reviews` | backgroundCheckReviewer | **`pii + public` only** — applicant parents' names/emails to look up on Averity; **no** internal/personal fields |

### Changes
- `GET /api/admin/membership` → `handler()`, returns `{ MembershipProcess }` under the `processes` envelope. Board's view is unchanged, so the admin page is untouched.
- `GET /api/membership/reviews` → `handler()` returning model rows. Eligibility stays in the service (`eligibleReviewProcessIds`, replacing `listReviewQueue`); a queue row's attestation `_count` is its approval count (a reject removes it from the queue). Reviewer page + notifications endpoint updated to the model shape.
- **POST/attest, certify, override, settings, intake/payment/renew** stay on `withAuth` — they're actions or the caller's-own/board-config data (their_own scope), not cross-household PII reads. (That was the "all routes" option you declined; easy to extend later.)

### Why these two only
The stripper classifies **model-shaped** data; my other routes return derived shapes (intake state, etc.). These two return model rows and are exactly where "who sees whose PII" matters.

### Validation
The security **contract test** now auto-covers both routes (+3 cases). tsc clean · 82 unit · **319 integration**.

> Note: regenerated the Prisma client mid-work — a concurrent branch had run `prisma generate` from a different schema, leaving a stale client in `node_modules`. DB + my `schema.prisma` were unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)