### PR TITLE
feat(membership): show membership status on the household page

### DIFF
--- a/src/app/household/page.tsx
+++ b/src/app/household/page.tsx
@@ -17,7 +17,7 @@ export default function HouseholdPage() {
         name?: string;
         leads?: Array<{ participantId: number }>;
         participants?: Array<{ id: number; name?: string; email?: string; dob?: string; phone?: string; programVolunteers?: Array<{ id: number; program: { name: string; end?: string }; events?: Array<{ start: string }> }>; programParticipants?: Array<{ id: number; program: { name: string; end?: string }; events?: Array<{ start: string }> }> }>;
-        membership?: unknown;
+        membership?: { status?: string; since?: string; isVolunteer?: boolean } | null;
         emergencyContactName?: string;
         emergencyContactPhone?: string;
         address?: string;
@@ -267,6 +267,24 @@ export default function HouseholdPage() {
                         &larr; Back
                     </button>
                 </div>
+
+                {household && (
+                    household.membership?.status === 'ACTIVE' ? (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', marginBottom: '1.5rem', padding: '0.85rem 1rem', background: 'rgba(34, 197, 94, 0.1)', border: '1px solid rgba(34, 197, 94, 0.3)', borderRadius: '8px', color: '#4ade80', flexWrap: 'wrap' }}>
+                            <span style={{ fontWeight: 600 }}>✓ Member{household.membership.since ? ` since ${formatDate(household.membership.since)}` : ''}</span>
+                            {household.membership.isVolunteer && (
+                                <span style={{ background: 'rgba(34, 197, 94, 0.25)', padding: '1px 8px', borderRadius: '999px', fontSize: '0.75rem' }}>Volunteer family</span>
+                            )}
+                        </div>
+                    ) : (
+                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', marginBottom: '1.5rem', padding: '1rem 1.25rem', background: 'rgba(59, 130, 246, 0.12)', border: '1px solid rgba(59, 130, 246, 0.4)', borderRadius: '8px', flexWrap: 'wrap' }}>
+                            <span style={{ color: 'var(--color-text-muted)' }}>Your household isn&apos;t a member yet.</span>
+                            <button className="glass-button" onClick={() => router.push('/membership')} style={{ background: 'rgba(59, 130, 246, 0.3)', borderColor: 'rgba(59, 130, 246, 0.5)', whiteSpace: 'nowrap' }}>
+                                Join the Treehouse!
+                            </button>
+                        </div>
+                    )
+                )}
 
                 {message && (
                     <div style={{


### PR DESCRIPTION
## Household page — membership status (feedback follow-up)

Stacked on #197.

Per feedback: the `/household` page didn't surface membership state. It now shows, under the header:
- **Active member** → green **"✓ Member since &lt;date&gt;"** badge (+ a "Volunteer family" tag when applicable)
- **Non-member** → a **"Join the Treehouse!"** button linking to `/membership`

Uses the `membership` already returned by `GET /api/household` (1:1 since PR4) — no API change. One-file UI change.

### Why a separate PR (not folded into PR5)
Thematically this belongs with PR5 (the Join-banner / membership-UI PR), but that's 8 branches deep and this box's git is 2.34 (no `git rebase --update-refs`), so folding it in would mean manually rebasing + force-pushing 8 stacked branches for a one-file cosmetic tweak. A focused follow-up on top of the stack is safer; it only depends on PR4 (the `membership` relation) + PR5 (`/membership`), both already below.

tsc + lint clean; no test impact (client display; the household API is covered elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)