### PR TITLE
feat(dev-instance): foundation — CHECKIN_ENV flag, org-login gate, env cleanup

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,14 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import '@testing-library/jest-dom'
 
+// Tests run as a non-production environment. Previously this was implicit via
+// NODE_ENV=test; under the single CHECKIN_ENV flag we declare it explicitly so
+// prod-only gates (e.g. the scan self-check-in block) stay off during tests.
+// 'dev' (not 'local') reproduces the old behavior exactly: it disables the
+// prod-only gates while leaving the keyless-kiosk fallback and offline
+// credential login (both local-only) off, just as NODE_ENV=test did.
+process.env.CHECKIN_ENV = 'dev';
+
 // Polyfill text encoding
 const { TextEncoder, TextDecoder } = require('util');
 global.TextEncoder = TextEncoder;

--- a/src/app/api/auth/dev-personas/route.ts
+++ b/src/app/api/auth/dev-personas/route.ts
@@ -1,17 +1,18 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import { config } from "@/lib/config";
 
 export const dynamic = 'force-dynamic';
 
 /**
  * GET /api/auth/dev-personas
  *
- * Dev-only endpoint that returns all @example.com participants
- * with their role flags for the dev login picker.
+ * Local-only endpoint that returns all @example.com participants with their role flags
+ * for the offline login picker. Gated to CHECKIN_ENV=local (developer laptops); the cloud
+ * dev instance uses the separate gated mint flow, not this open picker.
  */
 export async function GET() {
-    // Block if dev auth is not explicitly enabled or if in production
-    if (!process.env.NEXT_PUBLIC_DEV_AUTH || process.env.NODE_ENV === 'production') {
+    if (!config.isLocal()) {
         return NextResponse.json({ error: "Not available" }, { status: 404 });
     }
 

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -4,6 +4,7 @@ import { authenticateRequest } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { processCheckin, processCheckout } from "@/lib/scan-service";
 import { logBackendError } from "@/lib/logger";
+import { config } from "@/lib/config";
 
 export async function POST(req: NextRequest) {
     const startTime = Date.now();
@@ -40,7 +41,7 @@ export async function POST(req: NextRequest) {
 
             // In production, only privileged users may self-check-in via web.
             // Everyone else must use the kiosk badge scanner.
-            if (isSelf && !isAdmin && process.env.NODE_ENV === 'production') {
+            if (isSelf && !isAdmin && config.isProd()) {
                 return apiError("Please use the kiosk badge scanner to check in.", 403);
             }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,11 +2,17 @@ import './globals.css';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import AuthProvider from '@/components/AuthProvider';
+import { EnvProvider } from '@/components/EnvProvider';
 import NavBar from '@/components/NavBar';
 import OnboardingGate from '@/components/OnboardingGate';
 import ContentWrapper from '@/components/ContentWrapper';
+import { config } from '@/lib/config';
 
 const inter = Inter({ subsets: ['latin'] });
+
+// CHECKIN_ENV is read at runtime (the same image runs in prod/dev/local), so the root
+// layout must render dynamically rather than baking a build-time value into static HTML.
+export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   title: 'CheckMeIn Next',
@@ -21,14 +27,16 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <AuthProvider>
-          <OnboardingGate>
-            <NavBar />
-            <ContentWrapper>
-              {children}
-            </ContentWrapper>
-          </OnboardingGate>
-        </AuthProvider>
+        <EnvProvider value={config.checkinEnv()}>
+          <AuthProvider>
+            <OnboardingGate>
+              <NavBar />
+              <ContentWrapper>
+                {children}
+              </ContentWrapper>
+            </OnboardingGate>
+          </AuthProvider>
+        </EnvProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,12 +5,14 @@ import { useRouter } from 'next/navigation';
 import { useSession, signIn } from "next-auth/react";
 import styles from './page.module.css';
 import DevLoginPicker from '@/components/DevLoginPicker';
-import { config } from '@/lib/config';
+import { useIsDevInstance, useIsLocalInstance } from '@/components/EnvProvider';
 import type { SessionUser, BoardMember } from '@/types/participant';
 
 export default function Home() {
   const router = useRouter();
   const { data: session } = useSession();
+  const isDevInstance = useIsDevInstance();
+  const isLocalInstance = useIsLocalInstance();
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
   const [isCheckedIn, setIsCheckedIn] = useState<boolean | null>(null);
@@ -105,7 +107,7 @@ export default function Home() {
     <main className={styles.main}>
       <div className={`glass-container animate-float ${styles.heroContainer}`}>
         <h1 className="text-gradient" style={{ fontSize: '3rem', margin: '0 0 1rem 0' }}>
-          {config.isDev ? 'CMI-dev' : 'CheckMeIn'}
+          {isDevInstance ? 'CMI-dev' : 'CheckMeIn'}
         </h1>
         <p style={{ color: 'var(--color-text-muted)', fontSize: '1.25rem', marginBottom: '2rem' }}>
           The elegant next-generation facility check-in system.
@@ -143,7 +145,7 @@ export default function Home() {
 
               {/* Check-in Toggle Button — in production, only privileged users can self-check-in from the web */}
               {isCheckedIn !== null && (
-                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || (process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production')) ? (
+                ((session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember || (session.user as SessionUser)?.keyholder || isDevInstance) ? (
                   <button
                     className="glass-button"
                     onClick={handleToggleCheckin}
@@ -258,7 +260,7 @@ export default function Home() {
               >
                 Sign In To Dashboard
               </button>
-              {(process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production') && <DevLoginPicker />}
+              {isLocalInstance && <DevLoginPicker />}
             </div>
           )}
         </div>

--- a/src/components/EnvProvider.tsx
+++ b/src/components/EnvProvider.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { createContext, useContext } from 'react';
+import type { CheckinEnv } from '@/lib/config';
+
+/**
+ * Carries the server's CHECKIN_ENV into client components.
+ *
+ * CHECKIN_ENV is server-only (not NEXT_PUBLIC_), so client code cannot read it from
+ * process.env. The root layout (a server component) reads it at request time and feeds
+ * it in here; client components consume it via the hooks below instead of config.isDev.
+ */
+const CheckinEnvContext = createContext<CheckinEnv>('prod');
+
+export function EnvProvider({
+    value,
+    children,
+}: {
+    value: CheckinEnv;
+    children: React.ReactNode;
+}) {
+    return <CheckinEnvContext.Provider value={value}>{children}</CheckinEnvContext.Provider>;
+}
+
+export function useCheckinEnv(): CheckinEnv {
+    return useContext(CheckinEnvContext);
+}
+
+/** True on the cloud dev instance OR a local laptop (i.e. not prod). */
+export function useIsDevInstance(): boolean {
+    return useContext(CheckinEnvContext) !== 'prod';
+}
+
+/** True only on a developer laptop — gates offline credential login UI. */
+export function useIsLocalInstance(): boolean {
+    return useContext(CheckinEnvContext) === 'local';
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -5,7 +5,7 @@ import { useSession, signIn, signOut } from "next-auth/react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import Link from 'next/link';
 import styles from './NavBar.module.css';
-import { config } from '@/lib/config';
+import { useIsDevInstance } from '@/components/EnvProvider';
 
 type SessionUser = {
     sysadmin?: boolean;
@@ -19,6 +19,7 @@ function NavBarInner() {
     const router = useRouter();
     const pathname = usePathname();
     const searchParams = useSearchParams();
+    const isDevInstance = useIsDevInstance();
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
     const toggleMobileMenu = () => setIsMobileMenuOpen(!isMobileMenuOpen);
@@ -99,7 +100,7 @@ function NavBarInner() {
                 <div className={styles.leftSection}>
                     <Link href="/" onClick={closeMobileMenu} style={{ textDecoration: 'none' }}>
                         <h2 className="text-gradient" style={{ margin: 0, fontSize: '1.5rem', cursor: 'pointer' }}>
-                            {config.isDev ? 'CMI-dev' : 'CheckMeIn'}
+                            {isDevInstance ? 'CMI-dev' : 'CheckMeIn'}
                         </h2>
                     </Link>
                     <div className={styles.navLinks}>

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -86,11 +86,15 @@ export const authOptions: NextAuthOptions = {
                 }
             }
         }),
-        ...(process.env.NEXT_PUBLIC_DEV_AUTH && process.env.NODE_ENV !== 'production' ? [
+        // Offline credential login — local laptops only (CHECKIN_ENV=local). Lets a developer
+        // sign in without Google. This is NOT enabled on the cloud dev instance (CHECKIN_ENV=dev),
+        // which is publicly reachable and must use real Google org login; impersonation there is
+        // handled by the separate gated mint flow (see DEV_INSTANCE_DESIGN.md §5).
+        ...(config.isLocal() ? [
             CredentialsProvider({
-                name: "Development Mock Auth",
+                name: "Local Offline Login",
                 credentials: {
-                    email: { label: "Enter any email to mock login", type: "email", placeholder: "test@example.com" }
+                    email: { label: "Enter any email to log in locally", type: "email", placeholder: "test@example.com" }
                 },
                 async authorize(credentials) {
                     if (!credentials?.email) return null; console.log("Dev Login Email:", credentials.email);
@@ -120,7 +124,15 @@ export const authOptions: NextAuthOptions = {
         strategy: "jwt",
     },
     callbacks: {
-        async jwt({ token, user, account }) {
+        async jwt({ token, user, account, profile }) {
+            // Capture Google's hosted-domain + email_verified claims on sign-in so the dev-instance
+            // middleware can gate on verified org membership (see DEV_INSTANCE_DESIGN.md §4).
+            // Prefer the `hd` claim over string-matching the email suffix.
+            if (account?.provider === "google" && profile) {
+                const googleProfile = profile as { hd?: string; email_verified?: boolean };
+                token.hd = googleProfile.hd ?? null;
+                token.emailVerified = googleProfile.email_verified ?? false;
+            }
             if (user) {
                 const dbParticipant = await prisma.participant.findUnique({
                     where: { email: user.email! },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -28,8 +28,12 @@ export async function authenticateRequest(
             pubKeys
         );
         if (result.ok) return { type: 'kiosk' };
-    } else if (pubKeys.length === 0 && config.isDev && process.env.NODE_ENV !== 'test') {
-        // Dev mode: treat as kiosk if no key configured
+    } else if (pubKeys.length === 0 && config.isLocal()) {
+        // Local laptops only (CHECKIN_ENV=local): treat as kiosk when no signing key is
+        // configured, so the kiosk/check-in flows can be exercised without provisioning keys.
+        // Deliberately NOT enabled on the cloud dev instance (CHECKIN_ENV=dev) — that box is
+        // publicly reachable and must require a real kiosk key, exactly like prod. CHECKIN_ENV
+        // is unset under tests, so this stays off there too.
         if (hasKioskHeaders || !req.headers.get('cookie')) {
             return { type: 'kiosk' };
         }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,6 +9,24 @@ function requireEnv(name: string): string {
     return value;
 }
 
+/**
+ * The single environment-personality switch (see docs/designs/DEV_INSTANCE_DESIGN.md).
+ *   prod  — production (default when unset). Real data, public landing, no impersonation.
+ *   dev   — cloud dev instance. Entire site behind org login.
+ *   local — a developer laptop. Permits offline credential login + keyless kiosk.
+ *
+ * IMPORTANT: this is server-only. CHECKIN_ENV is intentionally NOT NEXT_PUBLIC_, so it is
+ * never inlined into the client bundle (which keeps the same image safe in every environment).
+ * Client components must read it via useCheckinEnv() (see components/EnvProvider), never here.
+ */
+export type CheckinEnv = 'prod' | 'dev' | 'local';
+
+function readCheckinEnv(): CheckinEnv {
+    const value = process.env.CHECKIN_ENV;
+    // Anything unrecognized — including unset — fails safe to prod.
+    return value === 'dev' || value === 'local' ? value : 'prod';
+}
+
 export const config = {
     // Database
     databaseUrl: () => requireEnv('DATABASE_URL'),
@@ -27,7 +45,14 @@ export const config = {
     emailFrom: () => process.env.EMAIL_FROM || 'CheckMeIn <onboarding@resend.dev>',
 
     // App
-    isDev: process.env.NODE_ENV === 'development',
+    checkinEnv: (): CheckinEnv => readCheckinEnv(),
+    // Production (default when unset). Consumers should call this rather than
+    // string-comparing checkinEnv() so the env predicates live in one place.
+    isProd: (): boolean => readCheckinEnv() === 'prod',
+    // True on the cloud dev instance OR a local laptop (i.e. not prod). Server-only.
+    isDevInstance: (): boolean => readCheckinEnv() !== 'prod',
+    // True only on a developer laptop. Gates offline credential login + keyless kiosk.
+    isLocal: (): boolean => readCheckinEnv() === 'local',
     baseUrl: (): string => {
         if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
         return process.env.NEXTAUTH_URL || 'http://localhost:4000';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { config as appConfig } from '@/lib/config';
+
+// Verified Google Workspace hosted-domain that may access the dev instance.
+const ORG_DOMAIN = 'innovationtreehouse.org';
+
+/**
+ * Site-wide org-login gate for the cloud dev instance (see DEV_INSTANCE_DESIGN.md §4).
+ *
+ * When CHECKIN_ENV=dev, every page route requires a session whose Google hosted-domain (`hd`)
+ * claim is the org domain and whose email is verified. Anonymous visitors and bots are bounced
+ * to Google login and can read nothing else — delivering both "reachable by org members" and
+ * "not world-readable".
+ *
+ * In `prod` and `local` the gate is inert (public surfaces stay public; local work needs no Google).
+ */
+export async function middleware(req: NextRequest) {
+    if (appConfig.checkinEnv() !== 'dev') {
+        return NextResponse.next();
+    }
+
+    const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+    const isVerifiedOrgMember = token?.hd === ORG_DOMAIN && token?.emailVerified === true;
+    if (isVerifiedOrgMember) {
+        return NextResponse.next();
+    }
+
+    const signInUrl = new URL('/api/auth/signin', req.url);
+    signInUrl.searchParams.set('callbackUrl', req.nextUrl.pathname + req.nextUrl.search);
+    return NextResponse.redirect(signInUrl);
+}
+
+export const config = {
+    // Gate page navigation only. Exempt:
+    //  - api/*       — routes self-enforce auth (withAuth / kiosk signature). Skipping them also
+    //                  lets a keyed kiosk reach /api/scan on dev, keeps NextAuth's own sign-in +
+    //                  Google callback reachable, and avoids redirecting JSON clients to HTML.
+    //  - _next/*, favicon — framework internals + static assets.
+    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+};

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -35,6 +35,9 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT {
     id: number;
+    // Google hosted-domain + email_verified claims, used by the dev-instance org-login gate.
+    hd?: string | null;
+    emailVerified?: boolean;
     sysadmin?: boolean;
     keyholder?: boolean;
     boardMember?: boolean;


### PR DESCRIPTION
Implements the **foundation slice** of `docs/designs/DEV_INSTANCE_DESIGN.md` (#196). Collapses all environment personality onto a single server-side `CHECKIN_ENV` (`prod|dev|local`; unset = `prod`) and removes the `NODE_ENV` / `NEXT_PUBLIC_DEV_AUTH` auth shortcuts.

## What's in this PR
- **`config.ts`** — `checkinEnv()`, `isProd()`, `isDevInstance()`, `isLocal()`. `isDev` semantics are `dev||local` (fixes the design's latent `!== 'prod'` bug, which would have treated unset prod as dev).
- **`EnvProvider.tsx` (new) + root `layout.tsx` (`force-dynamic`)** — server→client channel so client components read `CHECKIN_ENV` at runtime. It is intentionally **not** `NEXT_PUBLIC_`, so the same image is safe in every environment. `page.tsx` / `NavBar` move off `config.isDev` onto `useIsDevInstance()` / `useIsLocalInstance()`.
- **`middleware.ts` (new)** — site-wide org-login gate, active **only** on `CHECKIN_ENV=dev`, requiring Google `hd=innovationtreehouse.org` + `email_verified`. Gates page routes; exempts `/api` (self-enforcing auth), `/_next`, static.
- **`auth-options.ts`** — captures `hd`/`email_verified` into the JWT; replaces the open mock provider with an offline credential login gated to `CHECKIN_ENV=local`.
- **`auth.ts`** — keyless kiosk fallback re-gated to **local only** (off on the publicly-reachable cloud dev box and in prod).
- **`scan/route.ts`** — self-checkin block keys on `config.isProd()`.
- **`dev-personas` route** — gated to local.
- **`jest.setup.js`** — declares `CHECKIN_ENV=dev` so tests keep their prior "non-prod" semantics.

## Deliberate deviations from the design doc (flagged for review)
1. **`isDev` = `dev||local`**, not the doc's `!== 'prod'` (latent bug fix).
2. **Middleware gates page routes only**, exempting `/api/*` — so a keyed kiosk can reach `/api/scan` on dev and JSON clients aren't redirected to HTML; API routes already self-enforce auth.
3. **Keyless kiosk = `local` only** — the cloud dev instance requires a real kiosk key, like prod.

## Not in this PR (follow-ups)
Mint-as-persona impersonation + `impersonatedBy` claim + banner, the dev dashboard, seed macros, the activity ledger, and the reset button.

## Testing
- `tsc --noEmit` clean on all touched files; `eslint` clean.
- Full non-integration suite green via the pre-commit hook (16 suites / 84 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)