### PR TITLE
fix(security): re-sync JWT role flags from DB to honor revocations

### DIFF
--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -122,6 +122,11 @@ export const authOptions: NextAuthOptions = {
     secret: config.nextAuthSecret(),
     session: {
         strategy: "jwt",
+        // Bound token lifetime so a stale or forgotten session cannot live for the
+        // 30-day NextAuth default. The jwt callback below also re-syncs role flags
+        // from the DB on every request so revocations take effect promptly.
+        maxAge: 60 * 60 * 8,   // 8 hours
+        updateAge: 60 * 15,    // 15 minutes
     },
     callbacks: {
         async jwt({ token, user, account, profile }) {
@@ -168,6 +173,38 @@ export const authOptions: NextAuthOptions = {
                     token.householdId = dbParticipant.householdId;
                     token.toolStatuses = dbParticipant.toolStatuses;
                 }
+            } else if (token.id) {
+                // On every subsequent request (no `user` present), re-sync authority
+                // flags from the DB so role grants/revocations take effect without
+                // waiting for the token to expire. Previously these flags were only
+                // read at sign-in, which let a revoked sysadmin/keyholder keep their
+                // privileges (including the /api/admin/roles endpoint) until the JWT
+                // aged out — up to 30 days.
+                const dbParticipant = await prisma.participant.findUnique({
+                    where: { id: token.id as number },
+                    include: {
+                        toolStatuses: {
+                            select: {
+                                toolId: true,
+                                level: true
+                            }
+                        }
+                    }
+                });
+
+                if (!dbParticipant) {
+                    // Account no longer exists — return an empty token so every
+                    // downstream authorization check fails closed.
+                    return {};
+                }
+
+                token.sysadmin = dbParticipant.sysadmin;
+                token.keyholder = dbParticipant.keyholder;
+                token.boardMember = dbParticipant.boardMember;
+                token.shopSteward = dbParticipant.shopSteward;
+                token.backgroundCheckReviewer = dbParticipant.backgroundCheckReviewer;
+                token.householdId = dbParticipant.householdId;
+                token.toolStatuses = dbParticipant.toolStatuses;
             }
             return token;
         },


### PR DESCRIPTION
## Summary
Sessions use the JWT strategy, but the `jwt` callback only read role flags (`sysadmin`/`keyholder`/`boardMember`/`shopSteward`/`backgroundCheckReviewer`) from the DB **at sign-in**. On every later request the flags were served from the signed token unchanged, and no session `maxAge` was set (30-day NextAuth default).

Because roles are mutable at runtime via `PATCH /api/admin/roles`, a revoked admin kept their privileges — including access to the roles endpoint itself — for up to 30 days, with no server-side revocation path.

## Fix
- Re-fetch authority flags from the DB on **every** `jwt` callback invocation (the `else if (token.id)` branch), so grants/revocations take effect on the next request. A deleted account yields an empty token (fail closed).
- Add session `maxAge` (8h) and `updateAge` (15m) as defense-in-depth bounds.

## Notes / caveats
- One indexed PK lookup per authenticated request — acceptable at this app's scale.
- `node_modules` was not installed in the working checkout, so `tsc`/`eslint` were **not** run locally; the change mirrors the existing sign-in assignment block.
- ⚠️ Will conflict in `auth-options.ts` with the `feat/security-policy-sprint-*` branches — whichever lands second needs a trivial rebase. Those sprint branches are currently behind main and revert the dev-auth gate; rebase them before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)