### PR TITLE
fix(security): gate GET /api/events/[id] to event staff (IDOR + PII)

### DIFF
--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -36,6 +36,20 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
 
         if (!event) return NextResponse.json({ error: "Event not found" }, { status: 404 });
 
+        // Authorization: this response embeds full participant records (email, phone,
+        // dob, googleId — including minors) for everyone enrolled in / RSVP'd to the
+        // program. Restrict it to event staff, matching the PATCH handler below.
+        // Without this gate any authenticated user could harvest roster PII by
+        // enumerating sequential event IDs.
+        const user = session.user as unknown as { id: number; sysadmin?: boolean; boardMember?: boolean };
+        const userId = user.id;
+        const isSysAdminOrBoard = user?.sysadmin || user?.boardMember;
+        const isLeadMentor = event.program?.leadMentorId === userId;
+        const isCoreVolunteer = event.program?.volunteers?.some(v => v.participantId === userId && v.isCore) || false;
+        if (!isSysAdminOrBoard && !isLeadMentor && !isCoreVolunteer) {
+            return NextResponse.json({ error: "Forbidden: Not authorized to view this event" }, { status: 403 });
+        }
+
         return NextResponse.json(event);
     } catch (error: unknown) {
         console.error("Failed to fetch event:", error);


### PR DESCRIPTION
## Summary
`GET /api/events/[id]` only checked for an authenticated session, then returned the event with full nested participant records (program participants, volunteers, and RSVPs) via `NextResponse.json(event)`. `Participant` carries PII — `email`, `phone`, `dob`, `googleId` — so any authenticated user could harvest the entire roster's PII (including minors' dates of birth) by enumerating sequential integer event IDs. This route was never migrated to the `handler()`/stripper policy layer (it is not in `scripts/migrated-routes.txt`).

## Fix
Add an authorization gate mirroring the **PATCH** handler already in this same file: allow only sysadmin/board members, the program's lead mentor, or a core volunteer. The sole consumer is the admin event-detail page (`src/app/admin/events/[id]/page.tsx`), so legitimate use is unaffected.

## Notes
- A deeper fix would migrate this route to `handler()` + field stripping; this PR is the targeted authz gate.
- `node_modules` was not installed in the working checkout, so `tsc`/`eslint` were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)