### PR TITLE
fix(security): fail closed when no kiosk key is configured

### DIFF
--- a/src/app/api/attendance/route.ts
+++ b/src/app/api/attendance/route.ts
@@ -6,6 +6,7 @@ import { getKioskPublicKeys, verifyKioskSignature } from "@/lib/verify-kiosk";
 import { getFullAttendance } from "@/lib/getFullAttendance";
 import { findAssociatedEventAt, processVisitCheckout } from "@/lib/attendanceTransitions";
 import { logBackendError } from "@/lib/logger";
+import { config } from "@/lib/config";
 
 export async function GET(req: NextRequest) {
     try {
@@ -34,9 +35,14 @@ export async function GET(req: NextRequest) {
         } else if (!session && pubKeys.length > 0) {
             // No session and no kiosk headers — reject
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        } else if (!session && pubKeys.length === 0) {
-            // Dev mode: no pubKey configured, treat as kiosk (allow all)
+        } else if (!session && pubKeys.length === 0 && config.isLocal()) {
+            // Local dev only (CHECKIN_ENV=local): no pubKey configured, treat as kiosk.
+            // Deliberately gated on isLocal() — on the cloud dev instance or prod an
+            // unset KIOSK_PUBLIC_KEY must NOT grant full attendance/safety access to
+            // anonymous callers. Mirrors the keyless-kiosk gating in src/lib/auth.ts.
             isKiosk = true;
+        } else if (!session) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
         const { attendance, counts, safety } = await getFullAttendance();

--- a/src/app/api/kiosk/certifications/route.ts
+++ b/src/app/api/kiosk/certifications/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth-options";
 import prisma from "@/lib/prisma";
 import { getKioskPublicKeys, verifyKioskSignature } from "@/lib/verify-kiosk";
+import { config } from "@/lib/config";
 
 export async function GET(req: NextRequest) {
     try {
@@ -23,6 +24,12 @@ export async function GET(req: NextRequest) {
                 return NextResponse.json({ error: result.error }, { status: result.status });
             }
         } else if (!session && pubKeys.length > 0) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        } else if (!session && !config.isLocal()) {
+            // No session and no kiosk key configured (pubKeys empty). Outside local dev
+            // this must fail closed — otherwise an unset KIOSK_PUBLIC_KEY would serve all
+            // participants' PII (email, name, age, certifications) to anonymous callers.
+            // Mirrors the keyless-kiosk gating in src/lib/auth.ts.
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 


### PR DESCRIPTION
## Summary
`GET /api/kiosk/certifications` and `GET /api/attendance` both **fail open** when `KIOSK_PUBLIC_KEY` is unset (`pubKeys` empty):

- **certifications** had no `pubKeys.length === 0` branch, so control fell through and returned all participants' PII (email, name, derived age, tool certification levels) to any anonymous caller.
- **attendance** had an explicit `pubKeys.length === 0 → treat as kiosk (allow all)` branch returning full attendance + safety data.

Neither was gated on `config.isLocal()`. `KIOSK_PUBLIC_KEY` is sourced as `process.env.KIOSK_PUBLIC_KEY || null` (not `requireEnv`), so a deployment that simply forgot to set it boots normally and serves this data publicly — and `middleware.ts` exempts `/api/*`, so there is no backstop.

## Fix
Gate the keyless path on `config.isLocal()`, mirroring the deliberate gating in `src/lib/auth.ts`: keyless access is allowed only on local laptops (`CHECKIN_ENV=local`); the cloud dev instance and prod now reject with `401` when no key is configured.

## Notes
- `node_modules` was not installed in the working checkout, so `tsc`/`eslint` were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)