### PR TITLE
fix(build): satisfy JWT return type in jwt callback; type-check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
           DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"
         run: npx prisma generate
 
+      # The deploy image runs `npm run build`, which type-checks. Catch type
+      # errors here at PR time instead of after merge in the dev deploy.
+      - name: Type check
+        run: npx tsc --noEmit
+
       - name: Push Prisma Schema
         env:
           DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -1,4 +1,5 @@
 import { NextAuthOptions } from "next-auth";
+import type { JWT } from "next-auth/jwt";
 import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { PrismaAdapter } from "@auth/prisma-adapter";
@@ -194,8 +195,9 @@ export const authOptions: NextAuthOptions = {
 
                 if (!dbParticipant) {
                     // Account no longer exists — return an empty token so every
-                    // downstream authorization check fails closed.
-                    return {};
+                    // downstream authorization check fails closed. The cast is
+                    // deliberate: JWT requires `id`, and omitting it is the point.
+                    return {} as JWT;
                 }
 
                 token.sysadmin = dbParticipant.sysadmin;


### PR DESCRIPTION
## Why

Every **Deploy dev** run since CICD was set up has failed at the *Build and push image* step. The Docker build runs `npm run build`, which type-checks, and fails on:

```
src/lib/auth-options.ts:132 — Type 'Promise<{}>' is not assignable to type 'Awaitable<JWT>'.
Property 'id' is missing in type 'Promise<{}>' but required in type 'JWT'.
```

The fail-closed `return {}` (deleted-account path) in the `jwt` callback widens the inferred return type to `Promise<{}>`, which doesn't satisfy the augmented `JWT` interface (required `id`). CI stayed green because it only runs Jest — no type checking.

## What

- Cast the empty token `as JWT` with a comment explaining the deliberate omission of `id` (runtime behavior unchanged: downstream auth checks still fail closed).
- Add a `tsc --noEmit` step to CI so type errors surface at PR time instead of breaking the deploy after merge.

Verified locally: `npx tsc --noEmit` and full `npm run build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)