### PR TITLE
fix(docker): placeholder auth envs for Next.js page-data collection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,13 @@ RUN npx prisma generate
 # be present here. Passed via --build-arg by the deploy workflow; harmless if empty.
 ARG NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN
 ENV NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN=${NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN}
+# auth-options.ts builds its NextAuth providers at module import, which "collecting
+# page data" triggers — so these must EXIST during build, though their values are
+# never used (every route is dynamic; real values come from ECS at runtime). Builder
+# stage only; nothing here reaches the runner image.
+ENV GOOGLE_CLIENT_ID=build-placeholder \
+    GOOGLE_CLIENT_SECRET=build-placeholder \
+    NEXTAUTH_SECRET=build-placeholder
 RUN npm run build
 
 # Stage 3: Production image


### PR DESCRIPTION
Second blocker for **Deploy dev** (after #211): with type errors fixed, the image build now dies at *collecting page data* —

```
Error: Missing required env var: GOOGLE_CLIENT_ID
Error: Failed to collect page data for /api/admin/participants/[id]
```

`next build` imports every route module, and `auth-options.ts` constructs its Google provider at import time via `requireEnv()`. Local builds pass only because `.env` exists; the Docker builder has nothing.

Fix: give the **builder stage** placeholder `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `NEXTAUTH_SECRET`. The values are never used — every route is dynamic (verified: `npm run build` with no `.env` + only these three placeholders succeeds, all routes ƒ), and the runner stage gets real values from ECS Secrets Manager injection at launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)