### PR TITLE
fix(deploy): give the migrate task a Prisma config (Prisma 7 reads DB URL only from config)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,9 @@ RUN npx prisma generate
 # be present here. Passed via --build-arg by the deploy workflow; harmless if empty.
 ARG NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN
 ENV NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN=${NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN}
-# auth-options.ts builds its NextAuth providers at module import, which "collecting
-# page data" triggers — so these must EXIST during build, though their values are
-# never used (every route is dynamic; real values come from ECS at runtime). Builder
-# stage only; nothing here reaches the runner image.
+# Needed for GitHub to build the image, overwritten by secrets in AWS at run time.
+# (next build imports auth-options.ts, which requires these to exist; the values
+# are never used — every route is dynamic — and never reach the runner stage.)
 ENV GOOGLE_CLIENT_ID=build-placeholder \
     GOOGLE_CLIENT_SECRET=build-placeholder \
     NEXTAUTH_SECRET=build-placeholder
@@ -36,6 +35,11 @@ COPY --from=builder /app/public ./public
 # which Next's standalone output tracing bundles automatically — there is no
 # node_modules/.prisma engine directory to copy as there was with prisma-client-js.
 COPY --from=builder /app/prisma ./prisma
+# Prisma 7 only reads the datasource URL from a config file (schema-level `url`
+# was removed), so the migrate ECS task — `npx prisma migrate deploy` in this
+# image — needs one. The repo's prisma.config.ts can't be shipped: its dotenv /
+# prisma/config imports don't resolve here. The deploy variant has no imports.
+COPY --from=builder /app/prisma.config.deploy.ts ./prisma.config.ts
 
 EXPOSE 4000
 ENV PORT=4000

--- a/prisma.config.deploy.ts
+++ b/prisma.config.deploy.ts
@@ -1,0 +1,16 @@
+// Prisma config for the DEPLOY IMAGE only — the Dockerfile copies this into the
+// runner stage as prisma.config.ts (the real prisma.config.ts is not shipped).
+// `prisma migrate deploy` runs in the migrate ECS task via an npx-installed CLI,
+// so this file must have ZERO imports: `dotenv` and `prisma/config` are not
+// resolvable there. A plain default export is fine — the config loader passes it
+// through defineConfig itself. DATABASE_URL comes from ECS Secrets Manager
+// injection, no dotenv needed.
+export default {
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: process.env["DATABASE_URL"],
+  },
+};


### PR DESCRIPTION
Fourth blocker for **Deploy dev**: the migrate ECS task now launches (#215) but `prisma migrate deploy` exits 1:

```
Error: The datasource.url property is required in your Prisma config file when using prisma migrate deploy.
```

Prisma 7 removed schema-level `url = env(...)` (validated — it's a hard P1012 error now), so the URL **must** come from a config file, and the runner image has never shipped one. The repo's `prisma.config.ts` can't just be copied in: it imports `dotenv/config` and `prisma/config`, neither of which resolves next to the npx-installed CLI inside the image.

Fix: `prisma.config.deploy.ts` — a zero-import plain-object config (the loader feeds plain default exports through `defineConfig` itself) — copied into the runner stage as `prisma.config.ts`. `DATABASE_URL` comes from ECS Secrets Manager injection.

Also rewords the build-placeholder comment per Daniel's review.

**Verified locally in the actual image**:
- `docker run <image> npx prisma migrate deploy` against a clean postgres:15 → all migrations applied, exit 0
- app smoke test from the same image: `/` → 307, `/api/auth/providers` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)