### PR TITLE
fix(deploy): retry migrations while Aurora resumes from auto-pause

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -116,11 +116,26 @@ jobs:
             --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
             --query 'services[0].networkConfiguration' --output json)
 
+          # The shared Aurora cluster is Serverless v2 with min capacity 0 and
+          # auto-pause: when idle (dev DB: always), the first connection races
+          # the ~30s resume and Prisma fails fast with P1001. Override the
+          # container command with a retry loop so the task survives the wake-up.
+          cat > "$RUNNER_TEMP/migrate-overrides.json" <<'EOF'
+          {
+            "containerOverrides": [{
+              "name": "checkin-migrate",
+              "command": ["sh", "-c",
+                "for i in 1 2 3 4 5; do npx prisma migrate deploy && exit 0; echo \"attempt $i failed — DB may be resuming from auto-pause; retrying in 20s\"; sleep 20; done; exit 1"]
+            }]
+          }
+          EOF
+
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \
             --task-definition "$MIGRATE_ARN" \
             --launch-type FARGATE \
             --network-configuration "$NETWORK_CONFIG" \
+            --overrides "file://$RUNNER_TEMP/migrate-overrides.json" \
             --query 'tasks[0].taskArn' --output text)
           echo "Migration task: $TASK_ARN"
 


### PR DESCRIPTION
Fifth (and hopefully last) dev-deploy blocker. With #217 the migrate task loads its config and resolves the DB — and now fails with:

```
Error: P1001: Can't reach database server at treehouse-production.cluster-...:5432
```

Root cause (from AWS, read-only): the shared Aurora cluster is **Serverless v2 with MinCapacity 0 / SecondsUntilAutoPause 480**. The dev DB is idle at every deploy, so the cluster is paused; the first connection triggers a ~30s resume, and `prisma migrate deploy` gives up in ~5s with P1001. SGs/VPC/routing are all correct (`rds-ec2-1` allows 5432 from `checkin-service`).

Fix: `run-task --overrides` wraps the migrate command in a 5×20s retry loop, plenty for the wake-up. No task-def or infra change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)