### PR TITLE
fix(docker): trust the RDS CA so pg can verify Aurora's TLS certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,13 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
+# RDS TLS: the pg driver verifies the server certificate (sslmode=require is
+# strict in the Prisma 7 / pg stack), and Amazon's RDS CA is not in the OS
+# trust store — without this, every query dies with "unable to get local
+# issuer certificate". NODE_EXTRA_CA_CERTS appends to Node's default roots.
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /app/rds-global-bundle.pem
+ENV NODE_EXTRA_CA_CERTS=/app/rds-global-bundle.pem
+
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
First real sign-in on dev got past Google (after the console redirect-URI fix) and then failed in the NextAuth callback. App logs:

```
[next-auth][error][adapter_error_getUserByAccount]
Invalid `prisma.account.findUnique()` invocation:
Error opening a TLS connection: unable to get local issuer certificate  (P1011)
```

The Prisma 7 / `pg` stack verifies the server certificate under `sslmode=require` (the old non-verifying behavior is gone), and Amazon's RDS CA isn't in the image trust store. Migrations were unaffected because the migrate engine ships its own CA handling.

Fix: bake the [AWS RDS global trust bundle](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) into the runner stage and set `NODE_EXTRA_CA_CERTS` (appends to Node's default roots — no secret/URL changes, and connections are now actually verified rather than falling back to no-verify).

Verified in the built image: bundle present (108 CAs), env var set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)