### PR TITLE
fix(db): catch-up migration for membership-era schema drift + CI drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,19 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      # Tests run on `db push` (full schema), deploys run on `migrate deploy`
+      # (only committed migrations) — so a schema change without a migration
+      # passes CI and then breaks the deployed app (P2022 at runtime). Replay
+      # the migrations onto a clean DB and require zero diff vs schema.prisma.
+      - name: Check migrations match schema (no drift)
+        env:
+          DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/drift_check"
+          PGPASSWORD: testpassword
+        run: |
+          psql -h localhost -U testuser -d checkmein_test -c 'CREATE DATABASE drift_check'
+          npx prisma migrate deploy
+          npx prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code
+
       - name: Push Prisma Schema
         env:
           DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"

--- a/prisma/migrations/20260610180000_reconcile_membership_schema_drift/migration.sql
+++ b/prisma/migrations/20260610180000_reconcile_membership_schema_drift/migration.sql
@@ -1,0 +1,161 @@
+-- CreateEnum
+CREATE TYPE "ProgramParticipantStatus" AS ENUM ('PENDING', 'ACTIVE');
+
+-- CreateEnum
+CREATE TYPE "MembershipStatus" AS ENUM ('NONE', 'ACTIVE', 'REVOKED');
+
+-- CreateEnum
+CREATE TYPE "MembershipProcessKind" AS ENUM ('INITIAL', 'RENEWAL');
+
+-- CreateEnum
+CREATE TYPE "MembershipProcessStatus" AS ENUM ('INTAKE', 'PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW', 'PENDING_PAYMENT', 'ACTIVE', 'BLOCKED', 'PENDING_RENEWAL', 'RENEWAL_PENDING_BG');
+
+-- CreateEnum
+CREATE TYPE "AttestationResult" AS ENUM ('APPROVE', 'REJECT');
+
+-- DropForeignKey
+ALTER TABLE "Membership" DROP CONSTRAINT "Membership_corporateId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Membership" DROP CONSTRAINT "Membership_householdId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Membership" DROP CONSTRAINT "Membership_volunteerId_fkey";
+
+-- AlterTable
+ALTER TABLE "Membership" DROP COLUMN "active",
+DROP COLUMN "corporateId",
+DROP COLUMN "latestDocusign",
+DROP COLUMN "latestShopifyReceipt",
+DROP COLUMN "type",
+DROP COLUMN "volunteerId",
+ADD COLUMN     "isVolunteer" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "status" "MembershipStatus" NOT NULL DEFAULT 'NONE',
+ALTER COLUMN "householdId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Participant" ADD COLUMN     "allergies" TEXT,
+ADD COLUMN     "backgroundCheckReviewer" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "Program" ADD COLUMN     "memberPrice" INTEGER,
+ADD COLUMN     "nonMemberPrice" INTEGER,
+ADD COLUMN     "shopifyMemberVariantId" TEXT,
+ADD COLUMN     "shopifyNonMemberVariantId" TEXT,
+ADD COLUMN     "shopifyProductId" TEXT;
+
+-- AlterTable
+ALTER TABLE "ProgramParticipant" ADD COLUMN     "paymentPlanRequested" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "pendingSince" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "status" "ProgramParticipantStatus" NOT NULL DEFAULT 'PENDING';
+
+-- DropEnum
+DROP TYPE "MembershipType";
+
+-- CreateTable
+CREATE TABLE "MembershipProcess" (
+    "id" SERIAL NOT NULL,
+    "membershipId" INTEGER NOT NULL,
+    "kind" "MembershipProcessKind" NOT NULL,
+    "status" "MembershipProcessStatus" NOT NULL,
+    "stageEnteredAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "zohoEnvelopeId" TEXT,
+    "contractSignedAt" TIMESTAMP(3),
+    "bgConsentAt" TIMESTAMP(3),
+    "shopifyDraftOrderId" TEXT,
+    "shopifyInvoiceUrl" TEXT,
+    "shopifyOrderId" TEXT,
+    "paidAt" TIMESTAMP(3),
+    "certifiedById" INTEGER,
+    "renewalReminderSentAt" TIMESTAMP(3),
+
+    CONSTRAINT "MembershipProcess_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BackgroundCheckAttestation" (
+    "id" SERIAL NOT NULL,
+    "processId" INTEGER NOT NULL,
+    "reviewerId" INTEGER NOT NULL,
+    "result" "AttestationResult" NOT NULL,
+    "markedVolunteer" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BackgroundCheckAttestation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "VolunteerDesignation" (
+    "id" SERIAL NOT NULL,
+    "email" TEXT NOT NULL,
+    "createdById" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "VolunteerDesignation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BoardSettings" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "normalDuesCents" INTEGER NOT NULL DEFAULT 0,
+    "volunteerDuesCents" INTEGER NOT NULL DEFAULT 0,
+    "membershipYearBoundary" TIMESTAMP(3),
+    "shopifyMembershipProductId" TEXT,
+    "shopifyNormalVariantId" TEXT,
+    "shopifyVolunteerVariantId" TEXT,
+    "shopifyPriceSyncedAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BoardSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SystemMetric" (
+    "id" SERIAL NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "metric" TEXT NOT NULL,
+    "value" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "SystemMetric_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MembershipProcess_membershipId_idx" ON "MembershipProcess"("membershipId");
+
+-- CreateIndex
+CREATE INDEX "MembershipProcess_status_idx" ON "MembershipProcess"("status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BackgroundCheckAttestation_processId_reviewerId_key" ON "BackgroundCheckAttestation"("processId", "reviewerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VolunteerDesignation_email_key" ON "VolunteerDesignation"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Membership_householdId_key" ON "Membership"("householdId");
+
+-- CreateIndex
+CREATE INDEX "Membership_status_idx" ON "Membership"("status");
+
+-- CreateIndex
+CREATE INDEX "RawBadgeEvent_participantId_time_idx" ON "RawBadgeEvent"("participantId", "time");
+
+-- CreateIndex
+CREATE INDEX "Visit_participantId_departed_idx" ON "Visit"("participantId", "departed");
+
+-- AddForeignKey
+ALTER TABLE "Membership" ADD CONSTRAINT "Membership_householdId_fkey" FOREIGN KEY ("householdId") REFERENCES "Household"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MembershipProcess" ADD CONSTRAINT "MembershipProcess_membershipId_fkey" FOREIGN KEY ("membershipId") REFERENCES "Membership"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BackgroundCheckAttestation" ADD CONSTRAINT "BackgroundCheckAttestation_processId_fkey" FOREIGN KEY ("processId") REFERENCES "MembershipProcess"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BackgroundCheckAttestation" ADD CONSTRAINT "BackgroundCheckAttestation_reviewerId_fkey" FOREIGN KEY ("reviewerId") REFERENCES "Participant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Program" ADD CONSTRAINT "Program_leadMentorId_fkey" FOREIGN KEY ("leadMentorId") REFERENCES "Participant"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+


### PR DESCRIPTION
Daniel's first authenticated request on dev failed in the NextAuth callback with:

```
The column Participant.allergies does not exist in the current database. (P2022)
```

TLS is fixed (#220) — this is the next layer: **schema drift**. The membership feature era changed `schema.prisma` without adding migrations. CI never noticed because tests run `prisma db push` (full schema), while deploys run `prisma migrate deploy` (committed migrations only). The dev DB is at migrations-state, so it's missing every drifted change: `Participant.allergies`/`backgroundCheckReviewer`, `Program` pricing/Shopify columns, the `Membership` status model + enums, `MembershipProcess`, `BackgroundCheckAttestation`, `VolunteerDesignation`, `BoardSettings`, and more (161 lines of diff).

**Fix**
- One reconciling migration generated with `prisma migrate diff` from a clean DB with all migrations replayed → current `schema.prisma`. Verified: fresh DB + `migrate deploy` (incl. this migration) → `migrate diff --exit-code` reports **no difference**.
- New CI step replays migrations onto a clean DB and fails on any diff vs `schema.prisma` — drift now fails at PR time, not at first sign-in.

Note: the migration includes `DROP COLUMN`s on `Membership` (the pre-cutover columns that only exist in migrations-state DBs, never in any db-push DB). Dev's DB is fresh/empty so nothing is lost; prod hasn't had its first deploy yet and replays the same sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)