### PR TITLE
refactor(admin): shared useRequireRole hook (audit #1 of 5)

### DIFF
--- a/src/app/admin/emergency-contacts/page.tsx
+++ b/src/app/admin/emergency-contacts/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { Badge, Button, Card, Center, Group, List, Loader, Paper, SimpleGrid, Stack, Text, TextInput, Title } from "@mantine/core";
+import { useRequireRole } from "@/hooks/useRequireRole";
 
 type ParticipantInfo = {
   id: number;
@@ -29,7 +29,7 @@ type Household = {
 };
 
 export default function EmergencyContactsPage() {
-  const { data: session, status } = useSession();
+  const { ready, loading: authLoading } = useRequireRole(['sysadmin', 'boardMember', 'keyholder']);
   const router = useRouter();
 
   const [households, setHouseholds] = useState<Household[]>([]);
@@ -63,18 +63,8 @@ export default function EmergencyContactsPage() {
   }, []);
 
   useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    } else if (status === "authenticated") {
-      const user = session?.user as { sysadmin?: boolean; boardMember?: boolean; keyholder?: boolean };
-      const isAuthorized = user?.sysadmin || user?.boardMember || user?.keyholder;
-      if (!isAuthorized) {
-        router.push('/');
-      } else {
-        fetchContacts();
-      }
-    }
-  }, [status, session, router, fetchContacts]);
+    if (ready) fetchContacts();
+  }, [ready, fetchContacts]);
 
   // Derived state for searching
   const filteredHouseholds = households.filter((h) => {
@@ -85,9 +75,11 @@ export default function EmergencyContactsPage() {
     return false;
   });
 
-  if (loading || status === "loading") {
+  if (authLoading || loading) {
     return <Center mih="60vh"><Loader /></Center>;
   }
+
+  if (!ready) return null;
 
   if (error) {
     return (

--- a/src/app/admin/events/badges/page.tsx
+++ b/src/app/admin/events/badges/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Button, Center, Group, Loader, Stack, Table, Title } from '@mantine/core';
+import { useRequireRole } from '@/hooks/useRequireRole';
 import { formatDateTime } from '@/lib/time';
 
 type BadgeEvent = {
@@ -14,7 +14,7 @@ type BadgeEvent = {
 };
 
 export default function AdminBadgesPage() {
-  const { data: session, status } = useSession();
+  const { ready, loading: authLoading } = useRequireRole(['sysadmin']);
   const router = useRouter();
 
   const [loading, setLoading] = useState(true);
@@ -38,22 +38,14 @@ export default function AdminBadgesPage() {
   }, []);
 
   useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    } else if (status === "authenticated") {
-      if (!session.user?.sysadmin) {
-        router.push('/');
-      } else {
-        fetchBadges();
-      }
-    }
-  }, [status, session, router, fetchBadges]);
+    if (ready) fetchBadges();
+  }, [ready, fetchBadges]);
 
-  if (loading || status === "loading") {
+  if (authLoading || loading) {
     return <Center mih="60vh"><Loader /></Center>;
   }
 
-  if (!session || !session.user?.sysadmin) return null;
+  if (!ready) return null;
 
   return (
     <Stack>

--- a/src/app/admin/events/visits/page.tsx
+++ b/src/app/admin/events/visits/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Button, Center, Group, Loader, Stack, Table, Text, TextInput, Title } from '@mantine/core';
+import { useRequireRole } from '@/hooks/useRequireRole';
 import { formatDateTime } from '@/lib/time';
 
 type Visit = {
@@ -15,7 +15,7 @@ type Visit = {
 };
 
 export default function AdminVisitsPage() {
-  const { data: session, status } = useSession();
+  const { ready, loading: authLoading } = useRequireRole(['sysadmin']);
   const router = useRouter();
 
   const [loading, setLoading] = useState(true);
@@ -42,16 +42,8 @@ export default function AdminVisitsPage() {
   }, []);
 
   useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    } else if (status === "authenticated") {
-      if (!session.user?.sysadmin) {
-        router.push('/');
-      } else {
-        fetchVisits();
-      }
-    }
-  }, [status, session, router, fetchVisits]);
+    if (ready) fetchVisits();
+  }, [ready, fetchVisits]);
 
   const handleEditClick = (visit: Visit) => {
     const confirmEdit = window.confirm("Warning: You are editing a past visit record using Admin overrides. This will be permanently logged.");
@@ -92,11 +84,11 @@ export default function AdminVisitsPage() {
     }
   };
 
-  if (loading || status === "loading") {
+  if (authLoading || loading) {
     return <Center mih="60vh"><Loader /></Center>;
   }
 
-  if (!session || !session.user?.sysadmin) return null;
+  if (!ready) return null;
 
   return (
     <Stack>

--- a/src/app/admin/households/page.tsx
+++ b/src/app/admin/households/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { useRequireRole } from '@/hooks/useRequireRole';
 import { Alert, Button, Center, Group, List, Loader, Stack, Table, Text, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 
@@ -15,7 +15,7 @@ type Household = {
 };
 
 export default function AdminHouseholdsPage() {
-  const { data: session, status } = useSession();
+  const { ready, loading: authLoading } = useRequireRole(['sysadmin', 'boardMember']);
   const router = useRouter();
 
   const [households, setHouseholds] = useState<Household[]>([]);
@@ -39,17 +39,8 @@ export default function AdminHouseholdsPage() {
   }, []);
 
   useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    } else if (status === "authenticated") {
-      const isAuthorized = session?.user?.sysadmin || session?.user?.boardMember;
-      if (!isAuthorized) {
-        router.push('/');
-      } else {
-        fetchHouseholds();
-      }
-    }
-  }, [status, session, router, fetchHouseholds]);
+    if (ready) fetchHouseholds();
+  }, [ready, fetchHouseholds]);
 
   const toggleMembership = async (householdId: number, currentActive: boolean) => {
     try {
@@ -69,11 +60,11 @@ export default function AdminHouseholdsPage() {
     }
   };
 
-  if (loading || status === "loading") {
+  if (authLoading || loading) {
     return <Center mih="60vh"><Loader /></Center>;
   }
 
-  if (!session || (!session.user?.sysadmin && !session.user?.boardMember)) {
+  if (!ready) {
     return null;
   }
 

--- a/src/app/admin/participants/new/page.tsx
+++ b/src/app/admin/participants/new/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, Suspense } from 'react';
-import { useSession } from 'next-auth/react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { useRequireRole } from '@/hooks/useRequireRole';
 import { Alert, Box, Button, Card, Center, Checkbox, Container, Group, Loader, Paper, Stack, Text, TextInput, Title } from '@mantine/core';
 
 type HouseholdOption = {
@@ -21,8 +21,7 @@ export default function NewParticipantPage() {
 }
 
 function NewParticipantForm() {
-  const { data: session, status } = useSession();
-  const router = useRouter();
+  const { ready, loading: authLoading } = useRequireRole(['sysadmin', 'boardMember']);
   const searchParams = useSearchParams();
   const queryHouseholdId = searchParams.get('householdId');
 
@@ -55,17 +54,6 @@ function NewParticipantForm() {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
   const [isError, setIsError] = useState(false);
-
-  useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    } else if (status === "authenticated") {
-      const isAuthorized = session?.user?.sysadmin || session?.user?.boardMember;
-      if (!isAuthorized) {
-        router.push('/');
-      }
-    }
-  }, [status, session, router]);
 
   // Handle deep linked household
   useEffect(() => {
@@ -112,11 +100,11 @@ function NewParticipantForm() {
     return () => clearTimeout(timeoutId);
   }, [householdSearch, householdId]);
 
-  if (status === "loading") {
+  if (authLoading) {
     return <Center mih="60vh"><Loader /></Center>;
   }
 
-  if (!session || (!session.user?.sysadmin && !session.user?.boardMember)) {
+  if (!ready) {
     return null;
   }
 

--- a/src/app/admin/programs/new/page.tsx
+++ b/src/app/admin/programs/new/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect } from 'react';
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Box, Button, Card, Center, Checkbox, Container, Group, Loader, NumberInput, Paper, SimpleGrid, Stack, Text, TextInput, Title } from '@mantine/core';
+import { useRequireRole } from '@/hooks/useRequireRole';
 
 type ParticipantOption = {
   id: number;
@@ -12,7 +12,7 @@ type ParticipantOption = {
 };
 
 export default function CreateProgramPage() {
-  const { data: session, status } = useSession();
+  const { ready, loading: authLoading } = useRequireRole(['sysadmin', 'boardMember'], { redirectTo: '/admin' });
   const router = useRouter();
 
   const [name, setName] = useState("");
@@ -34,17 +34,6 @@ export default function CreateProgramPage() {
   const [mentorSearch, setMentorSearch] = useState("");
   const [mentorResults, setMentorResults] = useState<ParticipantOption[]>([]);
   const [mentorSearching, setMentorSearching] = useState(false);
-
-  useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    } else if (status === "authenticated") {
-      const isAuthorized = session.user?.sysadmin || session.user?.boardMember;
-      if (!isAuthorized) {
-        router.push('/admin');
-      }
-    }
-  }, [status, router, session]);
 
   // Debounced mentor search
   useEffect(() => {
@@ -111,11 +100,11 @@ export default function CreateProgramPage() {
     }
   };
 
-  if (status === "loading") {
+  if (authLoading) {
     return <Center mih="60vh"><Loader /></Center>;
   }
 
-  if (!session) return null;
+  if (!ready) return null;
 
   return (
     <Container size="md" py="md">

--- a/src/app/admin/roles/page.tsx
+++ b/src/app/admin/roles/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Button, Center, Checkbox, Group, Loader, Stack, Table, Text, TextInput, Title } from '@mantine/core';
+import { useRequireRole } from '@/hooks/useRequireRole';
 
 type UserRole = {
   id: number;
@@ -16,14 +16,6 @@ type UserRole = {
   backgroundCheckReviewer: boolean;
 };
 
-type SessionUser = {
-  id: number;
-  sysadmin?: boolean;
-  keyholder?: boolean;
-  boardMember?: boolean;
-  householdId?: number | null;
-};
-
 const ROLE_COLUMNS: { field: keyof UserRole; label: string }[] = [
   { field: 'sysadmin', label: 'Sysadmin' },
   { field: 'boardMember', label: 'Board Member' },
@@ -33,7 +25,7 @@ const ROLE_COLUMNS: { field: keyof UserRole; label: string }[] = [
 ];
 
 export default function RoleAssignmentPage() {
-  const { data: session, status } = useSession();
+  const { user, ready, loading: authLoading } = useRequireRole(['sysadmin', 'boardMember']);
   const router = useRouter();
 
   const [users, setUsers] = useState<UserRole[]>([]);
@@ -42,7 +34,7 @@ export default function RoleAssignmentPage() {
   const [savingId, setSavingId] = useState<number | null>(null);
   const [userSearchText, setUserSearchText] = useState("");
 
-  const currentUserIsSysadmin = (session?.user as SessionUser)?.sysadmin || false;
+  const currentUserIsSysadmin = !!user?.sysadmin;
 
   const fetchUsers = useCallback(async () => {
     try {
@@ -61,17 +53,8 @@ export default function RoleAssignmentPage() {
   }, []);
 
   useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    } else if (status === "authenticated") {
-      const isAuthorized = (session.user as SessionUser)?.sysadmin || (session.user as SessionUser)?.boardMember;
-      if (!isAuthorized) {
-        router.push('/');
-      } else {
-        fetchUsers();
-      }
-    }
-  }, [status, router, session, fetchUsers]);
+    if (ready) fetchUsers();
+  }, [ready, fetchUsers]);
 
   const handleRoleChange = async (userId: number, field: keyof UserRole, value: boolean) => {
     setSavingId(userId);
@@ -104,11 +87,11 @@ export default function RoleAssignmentPage() {
     }
   };
 
-  if (loading || status === "loading") {
+  if (authLoading || loading) {
     return <Center mih="60vh"><Loader /></Center>;
   }
 
-  if (!session) return null;
+  if (!ready) return null;
 
   const filteredUsers = users.filter(u =>
     (u.name || "").toLowerCase().includes((userSearchText || "").toLowerCase()) ||

--- a/src/app/admin/trends/page.tsx
+++ b/src/app/admin/trends/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
 import { Card, Center, Group, Loader, SegmentedControl, Select, SimpleGrid, Stack, Table, Text, Title } from "@mantine/core";
+import { useRequireRole } from "@/hooks/useRequireRole";
 
 type PeriodType = "week" | "month" | "quarter" | "year";
 
@@ -24,8 +23,7 @@ interface ProgramOption {
 }
 
 export default function ParticipationTrendsPage() {
-  const { data: session, status } = useSession();
-  const router = useRouter();
+  const { ready, loading: authLoading } = useRequireRole(['sysadmin', 'boardMember']);
 
   const [period, setPeriod] = useState<PeriodType>("month");
   const [programId, setProgramId] = useState<string>("");
@@ -33,18 +31,6 @@ export default function ParticipationTrendsPage() {
   const [buckets, setBuckets] = useState<TrendBucket[]>([]);
   const [totals, setTotals] = useState<TrendBucket | null>(null);
   const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push("/");
-    } else if (status === "authenticated") {
-      const user = session?.user as { sysadmin?: boolean; boardMember?: boolean } | undefined;
-      const isAuthorized = user?.sysadmin || user?.boardMember;
-      if (!isAuthorized) {
-        router.push("/");
-      }
-    }
-  }, [status, session, router]);
 
   // Fetch programs for the dropdown
   useEffect(() => {
@@ -60,7 +46,7 @@ export default function ParticipationTrendsPage() {
 
   // Fetch trends data
   useEffect(() => {
-    if (status !== "authenticated") return;
+    if (!ready) return;
 
     const params = new URLSearchParams({ period });
     if (programId) params.set("programId", programId);
@@ -73,9 +59,15 @@ export default function ParticipationTrendsPage() {
       })
       .catch(console.error)
       .finally(() => setLoading(false));
-  }, [period, programId, status]);
+  }, [period, programId, ready]);
 
-  if (status === "loading" || (status === "authenticated" && loading && buckets.length === 0)) {
+  if (authLoading) {
+    return <Center mih="60vh"><Loader /></Center>;
+  }
+
+  if (!ready) return null;
+
+  if (loading && buckets.length === 0) {
     return <Center mih="60vh"><Loader /></Center>;
   }
 

--- a/src/hooks/__tests__/useRequireRole.test.tsx
+++ b/src/hooks/__tests__/useRequireRole.test.tsx
@@ -1,0 +1,56 @@
+import { renderHook } from "@testing-library/react";
+import { useRequireRole } from "../useRequireRole";
+
+const push = jest.fn();
+let mockSession: { data: unknown; status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("useRequireRole", () => {
+  it("is ready and does not redirect when the user holds an allowed role", () => {
+    mockSession = { data: { user: { id: 1, sysadmin: true } }, status: "authenticated" };
+    const { result } = renderHook(() => useRequireRole(["sysadmin", "boardMember"]));
+    expect(result.current.ready).toBe(true);
+    expect(result.current.authorized).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("redirects to / when authenticated but missing every allowed role", () => {
+    mockSession = { data: { user: { id: 2, keyholder: true } }, status: "authenticated" };
+    const { result } = renderHook(() => useRequireRole(["sysadmin", "boardMember"]));
+    expect(result.current.ready).toBe(false);
+    expect(result.current.authorized).toBe(false);
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects to / when unauthenticated", () => {
+    mockSession = { data: null, status: "unauthenticated" };
+    const { result } = renderHook(() => useRequireRole(["sysadmin"]));
+    expect(result.current.ready).toBe(false);
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("sends unauthorized users to options.redirectTo when provided", () => {
+    mockSession = { data: { user: { id: 3, keyholder: true } }, status: "authenticated" };
+    renderHook(() => useRequireRole(["sysadmin", "boardMember"], { redirectTo: "/admin" }));
+    expect(push).toHaveBeenCalledWith("/admin");
+  });
+
+  it("reports loading and does not redirect while the session resolves", () => {
+    mockSession = { data: null, status: "loading" };
+    const { result } = renderHook(() => useRequireRole(["sysadmin"]));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.ready).toBe(false);
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useRequireRole.ts
+++ b/src/hooks/useRequireRole.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import type { BusinessRole } from "@/types/auth";
+
+type AdminSessionUser = NonNullable<ReturnType<typeof useSession>["data"]>["user"];
+
+export interface RequireRoleResult {
+  /** The typed session user (the role flags come from the next-auth.d.ts augmentation). */
+  user: AdminSessionUser | undefined;
+  /** True once the user is authenticated AND holds one of the allowed roles. */
+  authorized: boolean;
+  /** Session is still resolving — render a loader. */
+  loading: boolean;
+  /** Safe to render the page (authenticated + authorized). */
+  ready: boolean;
+}
+
+/**
+ * Client-side admin role gate. Redirects unauthenticated or unauthorized users to `/`
+ * and returns the typed session user plus loading/ready flags.
+ *
+ * Replaces the copy-pasted `useSession` + `useEffect(redirect)` + `session.user as {...}`
+ * block that each admin page hand-rolled. The `/admin` layout still enforces the global
+ * gate; this enforces the page's own (often stricter) role requirement and removes the
+ * unnecessary casts — `Session['user']` is already typed via `src/types/next-auth.d.ts`.
+ *
+ * Unauthenticated users are always sent to `/` (they must sign in); authenticated users who
+ * lack every allowed role are sent to `options.redirectTo` (default `/`).
+ *
+ * Usage:
+ *   const { user, loading, ready } = useRequireRole(['sysadmin', 'boardMember']);
+ *   if (loading) return <Center mih="60vh"><Loader /></Center>;
+ *   if (!ready) return null; // a redirect is in flight
+ */
+export function useRequireRole(
+  allowed: BusinessRole[],
+  options?: { redirectTo?: string },
+): RequireRoleResult {
+  const redirectTo = options?.redirectTo ?? "/";
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const user = session?.user;
+  const authorized = !!user && allowed.some((role) => user[role] === true);
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/");
+    } else if (status === "authenticated" && !authorized) {
+      router.push(redirectTo);
+    }
+  }, [status, authorized, router, redirectTo]);
+
+  return {
+    user,
+    authorized,
+    loading: status === "loading",
+    ready: status === "authenticated" && authorized,
+  };
+}


### PR DESCRIPTION
**First of 5 stacked cleanup PRs** from the admin-pages audit. Based on the open Mantine migration (#207) rather than `main`, per the audit's recommendation, so it doesn't conflict with #207.

## What
Adds `src/hooks/useRequireRole(allowed, { redirectTo })` — a typed client auth gate — and adopts it across the 8 admin pages that hand-rolled the identical gate.

Each page previously had: `useSession` + a `useEffect` redirect + a render-time guard + an inline `session.user as {…}` cast. The role flags are already typed via `src/types/next-auth.d.ts`, so the casts were dead weight, and the role logic had drifted across pages.

## Pages converted (role requirement preserved exactly)
`households`, `roles`, `events/visits`, `events/badges`, `emergency-contacts`, `participants/new`, `trends`, `programs/new` (keeps its `→/admin` unauthorized redirect via `redirectTo`).

## Out of scope (left for a follow-up — special access logic)
`programs/pending` (forbidden-UI variant), `programs/[id]` + `events/[id]` + `events/new` (program-lead / program-flow access), `print-badges` (minimal gate).

## Behavior
Preserving — same role per page, same redirect targets. The `/admin` layout still enforces the global gate; this enforces each page's (often stricter) requirement.

## Tests / checks
5 unit tests for the hook (authorized / unauthorized / unauthenticated / loading / `redirectTo`). `tsc`, `eslint`, and the full non-integration jest suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)