### PR TITLE
refactor(admin): datetime-local helpers + isMinor reuse (audit #3 of 5)

### DIFF
--- a/src/app/admin/events/[id]/page.tsx
+++ b/src/app/admin/events/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, use, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Badge, Button, Card, Center, Checkbox, Container, Group, Loader, Modal, Select, SimpleGrid, Stack, Table, Text, TextInput, Title } from '@mantine/core';
-import { formatDateTime } from '@/lib/time';
+import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
 
 type ParticipantDetail = {
   participantId: number;
@@ -69,8 +69,8 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
         const data = await res.json();
         setEventData(data);
 
-        const startStr = new Date(new Date(data.start).getTime() - new Date(data.start).getTimezoneOffset() * 60000).toISOString().slice(0, 16);
-        const endStr = new Date(new Date(data.end).getTime() - new Date(data.end).getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+        const startStr = toDatetimeLocal(data.start);
+        const endStr = toDatetimeLocal(data.end);
         setNewStart(startStr);
         setNewEnd(endStr);
       } else {
@@ -116,8 +116,8 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
   const handleEditTime = async () => {
     setActionLoading(true);
     try {
-      const startIso = new Date(newStart).toISOString();
-      const endIso = new Date(newEnd).toISOString();
+      const startIso = fromDatetimeLocal(newStart);
+      const endIso = fromDatetimeLocal(newEnd);
 
       const res = await fetch(`/api/events/${id}`, {
         method: 'PATCH',
@@ -150,8 +150,8 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
           action: 'manualEditAttendance',
           participantId: editingAttendance.participantId,
           status: manualStatus,
-          arrived: manualStatus === 'Present' ? (new Date(manualArrived).toISOString()) : null,
-          departed: manualStatus === 'Present' && manualDeparted ? (new Date(manualDeparted).toISOString()) : null
+          arrived: manualStatus === 'Present' ? fromDatetimeLocal(manualArrived) : null,
+          departed: manualStatus === 'Present' && manualDeparted ? fromDatetimeLocal(manualDeparted) : null
         })
       });
       if (res.ok) {
@@ -272,12 +272,12 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
                           setEditingAttendance(member);
                           if (visit) {
                             setManualStatus("Present");
-                            setManualArrived(new Date(new Date(visit.arrived).getTime() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 16));
-                            setManualDeparted(visit.departed ? new Date(new Date(visit.departed).getTime() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 16) : "");
+                            setManualArrived(toDatetimeLocal(visit.arrived));
+                            setManualDeparted(visit.departed ? toDatetimeLocal(visit.departed) : "");
                           } else {
                             setManualStatus("Absent");
-                            setManualArrived(new Date(new Date(eventData.start).getTime() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 16));
-                            setManualDeparted(new Date(new Date(eventData.end).getTime() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 16));
+                            setManualArrived(toDatetimeLocal(eventData.start));
+                            setManualDeparted(toDatetimeLocal(eventData.end));
                           }
                         }}>
                           Manual Edit

--- a/src/app/admin/events/visits/page.tsx
+++ b/src/app/admin/events/visits/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Alert, Button, Center, Group, Loader, Stack, Table, Text, TextInput, Title } from '@mantine/core';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { formatDateTime } from '@/lib/time';
+import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
 
 type Visit = {
   id: number;
@@ -50,14 +50,9 @@ export default function AdminVisitsPage() {
     if (!confirmEdit) return;
 
     setEditingVisitId(visit.id);
-    const formatForInput = (dateString: string | null) => {
-      if (!dateString) return "";
-      const d = new Date(dateString);
-      return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
-    };
     setEditForm({
-      arrived: formatForInput(visit.arrived),
-      departed: formatForInput(visit.departed ?? null)
+      arrived: toDatetimeLocal(visit.arrived),
+      departed: toDatetimeLocal(visit.departed ?? null)
     });
   };
 
@@ -68,8 +63,8 @@ export default function AdminVisitsPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           visitId: id,
-          arrived: editForm.arrived ? new Date(editForm.arrived).toISOString() : undefined,
-          departed: editForm.departed ? new Date(editForm.departed).toISOString() : undefined
+          arrived: editForm.arrived ? fromDatetimeLocal(editForm.arrived) : undefined,
+          departed: editForm.departed ? fromDatetimeLocal(editForm.departed) : undefined
         })
       });
       if (res.ok) {

--- a/src/app/admin/participants/new/page.tsx
+++ b/src/app/admin/participants/new/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { EntityPicker } from '@/components/admin/EntityPicker';
+import { isMinor } from '@/lib/time';
 import { Alert, Button, Card, Center, Checkbox, Container, Group, Loader, Paper, Stack, Text, TextInput, Title } from '@mantine/core';
 
 type HouseholdOption = {
@@ -35,19 +36,7 @@ function NewParticipantForm() {
   const [householdId, setHouseholdId] = useState("");
   const [householdSearch, setHouseholdSearch] = useState("");
 
-  const isStudent = () => {
-    if (!dob) return false;
-    const birthDate = new Date(dob);
-    const today = new Date();
-    let age = today.getFullYear() - birthDate.getFullYear();
-    const m = today.getMonth() - birthDate.getMonth();
-    if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
-      age--;
-    }
-    return age < 18;
-  };
-
-  const studentSelected = isStudent();
+  const studentSelected = isMinor(dob);
 
   const [alreadyMember, setAlreadyMember] = useState(false);
   const [saving, setSaving] = useState(false);

--- a/src/lib/__tests__/time.test.ts
+++ b/src/lib/__tests__/time.test.ts
@@ -1,4 +1,23 @@
-import { formatDate, formatTime, formatDateTime, APP_TIMEZONE } from '../time';
+import { formatDate, formatTime, formatDateTime, APP_TIMEZONE, toDatetimeLocal, fromDatetimeLocal } from '../time';
+
+describe('datetime-local helpers', () => {
+  it('round-trips a datetime-local value', () => {
+    const local = '2024-03-07T12:30';
+    expect(toDatetimeLocal(fromDatetimeLocal(local))).toBe(local);
+  });
+
+  it('returns empty string for empty/invalid input', () => {
+    expect(toDatetimeLocal(null)).toBe('');
+    expect(toDatetimeLocal('')).toBe('');
+    expect(toDatetimeLocal('not-a-date')).toBe('');
+    expect(fromDatetimeLocal('')).toBe('');
+    expect(fromDatetimeLocal(undefined)).toBe('');
+  });
+
+  it('fromDatetimeLocal yields a UTC ISO string', () => {
+    expect(fromDatetimeLocal('2024-03-07T12:30')).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+});
 
 describe('time.ts formatting utilities', () => {
   const testDate = new Date('2024-03-07T12:00:00Z'); // UTC NOON

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -25,6 +25,31 @@ export function formatDateTime(date: Date | string | number | null | undefined, 
 }
 
 /**
+ * Format a date as a value for an <input type="datetime-local"> (yyyy-MM-ddTHH:mm).
+ *
+ * NOTE: datetime-local is inherently local, so this uses the BROWSER's timezone — matching the
+ * inline `getTime() - getTimezoneOffset()*60000` conversions it replaces. It deliberately does
+ * NOT use APP_TIMEZONE; switching to that would change the displayed value.
+ */
+export function toDatetimeLocal(date: Date | string | number | null | undefined): string {
+    if (!date) return '';
+    const d = new Date(date);
+    if (Number.isNaN(d.getTime())) return '';
+    return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+}
+
+/**
+ * Parse an <input type="datetime-local"> value into a UTC ISO string. Inverse of toDatetimeLocal.
+ * Returns '' for empty/invalid input.
+ */
+export function fromDatetimeLocal(value: string | null | undefined): string {
+    if (!value) return '';
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toISOString();
+}
+
+/**
  * Returns true if the person with the given DOB is under 18 years old.
  * Canonical implementation — use this everywhere instead of inline age checks.
  */


### PR DESCRIPTION
**Third of 5 stacked cleanup PRs** from the admin-pages audit. Stacked on #223 (base `refactor/admin-entity-picker`).

## What
- Adds `toDatetimeLocal` / `fromDatetimeLocal` to `src/lib/time.ts`, replacing the fragile inline `getTime() - getTimezoneOffset()*60000 …toISOString().slice(0,16)` idiom duplicated across `events/[id]` (4×) and `events/visits`.
- Replaces the inline DOB→age check in `participants/new` with the canonical `isMinor()` (which `lib/time` already documents as "use everywhere").

## Behavior
The helpers keep the **browser-local** timezone the inline code used (datetime-local is inherently local; they deliberately do not switch to `APP_TIMEZONE`). One minor alignment: the visit-edit prefill in `events/[id]` previously used `new Date().getTimezoneOffset()` (now's offset) for a past date and now uses the target date's own offset via the shared helper — only observable across a DST boundary.

## Scope note
This PR is the **helpers portion of audit item #3**. The other two parts each deserve their own PR and are intentionally not bundled here:
- `<RoleBadge>` — the role-pill label/color mapping shared between `print-badges` and the react-pdf `BadgeDocument`.
- `<ProgramForm>` — the create/edit form extraction from the 887-line `programs/[id]` (the largest single refactor in the audit).

## Checks
3 helper unit tests; `tsc` + `eslint` + full non-integration jest suite green (95 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)