### PR TITLE
fix(dev-gate): exempt /public static assets so the brand logo loads on dev

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,6 +34,10 @@ export const config = {
     //                  lets a keyed kiosk reach /api/scan on dev, keeps NextAuth's own sign-in +
     //                  Google callback reachable, and avoids redirecting JSON clients to HTML.
     //  - signin      — the custom sign-in screen itself, or anonymous visitors would loop forever.
-    //  - _next/*, favicon — framework internals + static assets.
-    matcher: ['/((?!api|signin|_next/static|_next/image|favicon.ico).*)'],
+    //  - _next/*, favicon — framework internals.
+    //  - any path with a file extension (`.*\..*`) — public static assets under /public (the brand
+    //    logo/mark, svgs, the import template). They must stay reachable on the dev instance, and
+    //    next/image optimizes via an origin fetch of its source — so a gated /brand/*.webp source
+    //    makes /_next/image return 400 (the broken dev-instance logo).
+    matcher: ['/((?!api|signin|_next/static|_next/image|favicon.ico|.*\\..*).*)'],
 };


### PR DESCRIPTION
## Symptom
On the dev instance the Innovation Treehouse **logo is broken** (top-left). It is **not** a packaging problem — the file ships in the image (verified: a local standalone build serves `/brand/treehouse-logo-full.webp` `200` and `/_next/image` `200`).

## Root cause
The `CHECKIN_ENV=dev` org-login middleware ([src/middleware.ts](../blob/main/src/middleware.ts)) gates everything except `api | signin | _next/static | _next/image | favicon.ico`. It does **not** exempt `/public` assets, so:
- `GET /brand/treehouse-logo-full.webp` → **307 → /signin** (gated).
- `next/image` is exempt and reachable, but it optimizes by fetching its **source** (`/brand/…webp`) from the origin — that fetch is gated, so **`GET /_next/image?...` → 400**, and the `<img>` breaks.

Confirmed against the live dev URL: raw asset `307`, optimizer `400`. It's invisible locally because the gate is inert unless `CHECKIN_ENV=dev`.

## Fix
Exempt any path with a file extension (`.*\..*`) from the gate — i.e. `/public` static assets (brand logo/mark, the svgs, the import template). Page routes have no extension, so they stay gated.

```
matcher: ['/((?!api|signin|_next/static|_next/image|favicon.ico|.*\\..*).*)']
```

## Verification
- Regex unit check: `/admin`, `/household`, `/` → gated; `/brand/*.webp`, `*.png`, `*.svg`, `*.xlsx` → exempt; `/signin`, `/api/*` → exempt.
- Ran the app with `CHECKIN_ENV=dev`: `/admin` still **307 → /signin**; `/brand/treehouse-logo-full.webp` now **200**; `/_next/image` now **200** (were 307/400).
- `tsc` + `eslint` clean.

No sensitive exposure: only static assets under `/public` (all intended to be public) become reachable; every page route stays gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)