### PR TITLE
refactor(admin): shared <AdminPageHeader> (audit #4, part 2)

### DIFF
--- a/src/app/admin/events/badges/page.tsx
+++ b/src/app/admin/events/badges/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
-import { Button, Center, Group, Loader, Stack, Table, Title } from '@mantine/core';
+import { Center, Loader, Stack, Table } from '@mantine/core';
 import { useRequireRole } from '@/hooks/useRequireRole';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { formatDateTime } from '@/lib/time';
 
@@ -16,7 +16,6 @@ type BadgeEvent = {
 
 export default function AdminBadgesPage() {
   const { ready, loading: authLoading } = useRequireRole(['sysadmin']);
-  const router = useRouter();
 
   const [loading, setLoading] = useState(true);
   const [badges, setBadges] = useState<BadgeEvent[]>([]);
@@ -50,10 +49,7 @@ export default function AdminBadgesPage() {
 
   return (
     <Stack>
-      <Group justify="space-between" align="center" wrap="wrap">
-        <Title order={1}>Raw Badge Events</Title>
-        <Button variant="default" onClick={() => router.push('/admin')}>← Admin Ops</Button>
-      </Group>
+      <AdminPageHeader title="Raw Badge Events" back={{ href: '/admin', label: '← Admin Ops' }} />
 
       <AlertBanner message={message} tone={message.includes('success') ? 'success' : 'error'} />
 

--- a/src/app/admin/events/new/page.tsx
+++ b/src/app/admin/events/new/page.tsx
@@ -3,8 +3,8 @@
 import { useState, useEffect, useCallback, Suspense } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import Link from 'next/link';
-import { Button, Card, Center, Checkbox, Container, Group, Loader, Select, SimpleGrid, Stack, Text, TextInput, Title } from '@mantine/core';
+import { Button, Card, Center, Checkbox, Container, Group, Loader, Select, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 
 const DAYS_MAP = [
@@ -127,10 +127,7 @@ function NewEventForm() {
 
   return (
     <Card withBorder radius="md" padding="lg">
-      <Group justify="space-between" align="center" wrap="wrap" mb="lg">
-        <Title order={1}>Schedule Event</Title>
-        <Button component={Link} href={cancelHref} variant="default">Cancel</Button>
-      </Group>
+      <AdminPageHeader title="Schedule Event" back={{ href: cancelHref, label: 'Cancel' }} mb="lg" />
 
       <AlertBanner message={message} tone="error" mb="md" />
 

--- a/src/app/admin/events/visits/page.tsx
+++ b/src/app/admin/events/visits/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
-import { Button, Center, Group, Loader, Stack, Table, Text, TextInput, Title } from '@mantine/core';
+import { Button, Center, Group, Loader, Stack, Table, Text, TextInput } from '@mantine/core';
 import { useRequireRole } from '@/hooks/useRequireRole';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
 
@@ -17,7 +17,6 @@ type Visit = {
 
 export default function AdminVisitsPage() {
   const { ready, loading: authLoading } = useRequireRole(['sysadmin']);
-  const router = useRouter();
 
   const [loading, setLoading] = useState(true);
   const [visits, setVisits] = useState<Visit[]>([]);
@@ -88,10 +87,7 @@ export default function AdminVisitsPage() {
 
   return (
     <Stack>
-      <Group justify="space-between" align="center" wrap="wrap">
-        <Title order={1}>Visit History</Title>
-        <Button variant="default" onClick={() => router.push('/admin')}>← Admin Ops</Button>
-      </Group>
+      <AdminPageHeader title="Visit History" back={{ href: '/admin', label: '← Admin Ops' }} />
 
       <AlertBanner message={message} tone={message.includes('success') ? 'success' : 'error'} />
 

--- a/src/app/admin/households/page.tsx
+++ b/src/app/admin/households/page.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { Alert, Button, Center, Group, List, Loader, Stack, Table, Text, Title } from '@mantine/core';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
+import { Alert, Button, Center, Group, List, Loader, Stack, Table, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 
 type Household = {
@@ -70,10 +70,7 @@ export default function AdminHouseholdsPage() {
 
   return (
     <Stack>
-      <Group justify="space-between" align="center" wrap="wrap">
-        <Title order={1}>Manage Memberships</Title>
-        <Button component={Link} href="/admin" variant="default">← Admin Hub</Button>
-      </Group>
+      <AdminPageHeader title="Manage Memberships" back={{ href: '/admin', label: '← Admin Hub' }} />
 
       <Text c="dimmed">
         View all households and toggle their official facility Membership status. Memberships grant

--- a/src/app/admin/membership/settings/page.tsx
+++ b/src/app/admin/membership/settings/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import Link from "next/link";
 import { Alert, Button, Card, Center, Checkbox, Group, Loader, Stack, Text, TextInput, Title } from "@mantine/core";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 
 interface Settings {
   normalDuesCents: number;
@@ -122,10 +122,7 @@ export default function MembershipSettingsPage() {
 
   return (
     <Stack maw={820} mx="auto">
-      <Group justify="space-between" align="center" wrap="wrap">
-        <Title order={1}>Membership Settings</Title>
-        <Button component={Link} href="/admin/membership" variant="default">← Applications</Button>
-      </Group>
+      <AdminPageHeader title="Membership Settings" back={{ href: '/admin/membership', label: '← Applications' }} />
 
       {message && <Alert color={isError ? "yellow" : "green"}>{message}</Alert>}
 

--- a/src/app/admin/participants/import/page.tsx
+++ b/src/app/admin/participants/import/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { Alert, Badge, Box, Button, Card, FileInput, Group, List, Stack, Table, Text, Title } from "@mantine/core";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 
 type RowStatus = "ready" | "update" | "warning" | "error";
 
@@ -40,7 +40,6 @@ const STATUS_META: Record<RowStatus | "all", { label: string; icon: string; colo
 };
 
 export default function BulkImportParticipants() {
-  const router = useRouter();
   const [file, setFile] = useState<File | null>(null);
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
@@ -121,10 +120,7 @@ export default function BulkImportParticipants() {
 
   return (
     <Stack maw={900} mx="auto">
-      <Group justify="space-between" align="center" wrap="wrap">
-        <Title order={1}>Bulk Import Participants</Title>
-        <Button variant="default" onClick={() => router.push('/admin')}>← Back to Admin</Button>
-      </Group>
+      <AdminPageHeader title="Bulk Import Participants" back={{ href: '/admin', label: '← Back to Admin' }} />
 
       {/* Step 1: Upload */}
       {!preview && !importResult && (

--- a/src/app/admin/participants/new/page.tsx
+++ b/src/app/admin/participants/new/page.tsx
@@ -2,11 +2,11 @@
 
 import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
-import Link from 'next/link';
 import { useRequireRole } from '@/hooks/useRequireRole';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { EntityPicker } from '@/components/admin/EntityPicker';
 import { isMinor } from '@/lib/time';
-import { Alert, Button, Card, Center, Checkbox, Container, Group, Loader, Paper, Stack, Text, TextInput, Title } from '@mantine/core';
+import { Alert, Button, Card, Center, Checkbox, Container, Loader, Paper, Stack, Text, TextInput } from '@mantine/core';
 
 type HouseholdOption = {
   id: number;
@@ -120,10 +120,7 @@ function NewParticipantForm() {
   return (
     <Container size="md" py="md">
       <Card withBorder radius="md" padding="lg">
-        <Group justify="space-between" align="center" wrap="wrap" mb="md">
-          <Title order={1}>Register New User</Title>
-          <Button component={Link} href="/admin" variant="default">← Admin Hub</Button>
-        </Group>
+        <AdminPageHeader title="Register New User" back={{ href: '/admin', label: '← Admin Hub' }} mb="md" />
 
         <Text c="dimmed" mb="lg">
           System Administrators can manually register a new participant into the database. When they

--- a/src/app/admin/print-badges/page.tsx
+++ b/src/app/admin/print-badges/page.tsx
@@ -5,8 +5,9 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import QRCode from "qrcode";
 import { pdf } from "@react-pdf/renderer";
-import { Badge, Button, Center, Checkbox, Group, Loader, Stack, Table, Text, TextInput, Title } from "@mantine/core";
+import { Badge, Button, Center, Checkbox, Group, Loader, Stack, Table, Text, TextInput } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import BadgeDocument from "@/components/admin/BadgeDocument";
 import StickerDocument from "@/components/admin/StickerDocument";
 
@@ -128,10 +129,7 @@ export default function PrintBadgesPage() {
 
   return (
     <Stack>
-      <Group justify="space-between" align="center" wrap="wrap">
-        <Title order={1}>Print ID Badges</Title>
-        <Button variant="default" onClick={() => router.push('/admin')}>← Back to Admin Hub</Button>
-      </Group>
+      <AdminPageHeader title="Print ID Badges" back={{ href: '/admin', label: '← Back to Admin Hub' }} />
 
       <Text c="dimmed">
         Select participants to generate double-sided standard Avery 5390 ID badges.

--- a/src/app/admin/programs/new/page.tsx
+++ b/src/app/admin/programs/new/page.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Alert, Button, Card, Center, Checkbox, Container, Group, Loader, NumberInput, SimpleGrid, Stack, Text, TextInput, Title } from '@mantine/core';
+import { Alert, Button, Card, Center, Checkbox, Container, Group, Loader, NumberInput, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
 import { useRequireRole } from '@/hooks/useRequireRole';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { EntityPicker } from '@/components/admin/EntityPicker';
 
 type ParticipantOption = {
@@ -84,10 +85,7 @@ export default function CreateProgramPage() {
   return (
     <Container size="md" py="md">
       <Card withBorder radius="md" padding="lg">
-        <Group justify="space-between" align="center" wrap="wrap" mb="md">
-          <Title order={1}>Create Program</Title>
-          <Button variant="default" onClick={() => router.push('/programs')}>← Back to Programs</Button>
-        </Group>
+        <AdminPageHeader title="Create Program" back={{ href: '/programs', label: '← Back to Programs' }} mb="md" />
 
         <Text c="dimmed" mb="lg">
           Create a new program. You can configure the roster and schedule events later.

--- a/src/app/admin/programs/pending/page.tsx
+++ b/src/app/admin/programs/pending/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { Button, Center, Group, Loader, Stack, Table, Text, Title } from '@mantine/core';
+import { Button, Center, Loader, Stack, Table, Text, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { formatDateTime } from '@/lib/time';
 
@@ -97,10 +98,7 @@ export default function PaymentPlansPage() {
 
   return (
     <Stack>
-      <Group justify="space-between" align="center" wrap="wrap">
-        <Title order={1}>Payment Plan Requests</Title>
-        <Button variant="default" onClick={() => router.push('/admin')}>← Back to Admin</Button>
-      </Group>
+      <AdminPageHeader title="Payment Plan Requests" back={{ href: '/admin', label: '← Back to Admin' }} />
 
       <Text c="dimmed">
         Review pending participants who have clicked the &quot;Request Payment Plan&quot; button.

--- a/src/app/admin/roles/page.tsx
+++ b/src/app/admin/roles/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
-import { Button, Center, Checkbox, Group, Loader, Stack, Table, Text, TextInput, Title } from '@mantine/core';
+import { Center, Checkbox, Loader, Stack, Table, Text, TextInput } from '@mantine/core';
 import { useRequireRole } from '@/hooks/useRequireRole';
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 
 type UserRole = {
@@ -27,7 +27,6 @@ const ROLE_COLUMNS: { field: keyof UserRole; label: string }[] = [
 
 export default function RoleAssignmentPage() {
   const { user, ready, loading: authLoading } = useRequireRole(['sysadmin', 'boardMember']);
-  const router = useRouter();
 
   const [users, setUsers] = useState<UserRole[]>([]);
   const [loading, setLoading] = useState(true);
@@ -101,10 +100,7 @@ export default function RoleAssignmentPage() {
 
   return (
     <Stack>
-      <Group justify="space-between" align="center" wrap="wrap">
-        <Title order={1}>Role Assignment</Title>
-        <Button variant="default" onClick={() => router.push('/admin')}>← Back to Admin Hub</Button>
-      </Group>
+      <AdminPageHeader title="Role Assignment" back={{ href: '/admin', label: '← Back to Admin Hub' }} />
 
       <Text c="dimmed">
         Manage administrative privileges and access levels for community members. Checkboxes save

--- a/src/components/admin/AdminPageHeader.tsx
+++ b/src/components/admin/AdminPageHeader.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { Button, Group, Title } from "@mantine/core";
+
+export interface AdminPageBackLink {
+  href: string;
+  label: string;
+}
+
+export interface AdminPageHeaderProps {
+  /** Page heading, rendered as <Title order={1}>. */
+  title: React.ReactNode;
+  /** Optional back/cancel link rendered on the right of the header row. */
+  back?: AdminPageBackLink;
+  /** Optional extra right-aligned actions, shown to the left of the back link. */
+  actions?: React.ReactNode;
+  /** Bottom margin for the header row (Mantine spacing token or number). */
+  mb?: string | number;
+}
+
+/**
+ * Shared admin page header: a left-aligned title with an optional right-aligned
+ * back link (and/or action buttons). Consolidates the
+ * `<Group justify="space-between"><Title/><Button>back</Button></Group>` block
+ * that was duplicated across the admin pages.
+ */
+export function AdminPageHeader({ title, back, actions, mb }: AdminPageHeaderProps) {
+  return (
+    <Group justify="space-between" align="center" wrap="wrap" mb={mb}>
+      <Title order={1}>{title}</Title>
+      {(actions || back) && (
+        <Group gap="xs">
+          {actions}
+          {back && (
+            <Button component={Link} href={back.href} variant="default">
+              {back.label}
+            </Button>
+          )}
+        </Group>
+      )}
+    </Group>
+  );
+}

--- a/src/components/admin/__tests__/AdminPageHeader.test.tsx
+++ b/src/components/admin/__tests__/AdminPageHeader.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import { AdminPageHeader } from "../AdminPageHeader";
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+});
+
+const renderHeader = (props: React.ComponentProps<typeof AdminPageHeader>) =>
+  render(
+    <MantineProvider>
+      <AdminPageHeader {...props} />
+    </MantineProvider>,
+  );
+
+describe("AdminPageHeader", () => {
+  it("renders the title", () => {
+    renderHeader({ title: "Visit History" });
+    expect(screen.getByRole("heading", { name: "Visit History" })).toBeTruthy();
+  });
+
+  it("renders no back link when back is omitted", () => {
+    const { container } = renderHeader({ title: "Programs" });
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  it("renders a back link to the given href", () => {
+    renderHeader({ title: "Role Assignment", back: { href: "/admin", label: "← Back to Admin" } });
+    const link = screen.getByRole("link", { name: "← Back to Admin" });
+    expect(link.getAttribute("href")).toBe("/admin");
+  });
+
+  it("renders extra actions alongside the back link", () => {
+    renderHeader({
+      title: "Participants",
+      actions: <button type="button">Add</button>,
+      back: { href: "/admin", label: "Back" },
+    });
+    expect(screen.getByRole("button", { name: "Add" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Back" })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Part 2 of the admin-pages simplification audit (part 1 was the shared `<AlertBanner>`, #238).

Eleven admin pages each hand-rolled the same header row — a `space-between` `<Group>` wrapping a `<Title order={1}>` and a "back"/Cancel `<Button>`. The implementations had drifted:

- Half navigated with `router.push(...)`, half with `next/link`.
- Back-link labels and styling varied for the same destination (e.g. `← Admin Ops`, `← Back to Admin`, `← Back to Admin Hub`, `← Admin Hub` all pointing at `/admin`).

This extracts a single `<AdminPageHeader title back actions mb />` and adopts it across:

`events/visits`, `events/badges`, `events/new`, `roles`, `programs/pending`, `programs/new`, `households`, `membership/settings`, `print-badges`, `participants/new`, `participants/import`.

## Notes

- Back links now consistently render via `next/link` (prefetch + plain anchor). Now-dead `Title`/`Group`/`Button` imports and `useRouter` handles that *only* served the header were removed.
- **Existing per-page back-link labels are preserved** — this is a pure markup consolidation, no visible copy/behavior change. Normalizing the inconsistent labels is an easy follow-up if wanted.
- The audit referred to this as "AdminPageShell"; it's implemented as a header component (not a full page wrapper) because the page wrappers vary between `Stack`/`Card`/`Container`.

## Tests

- New `AdminPageHeader.test.tsx` (4 cases: title, no-back, back href, actions+back).
- Full suite green: **130 passed**. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)