### PR TITLE
feat(app): show deployed build's commit SHA in a footer

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -84,6 +84,7 @@ jobs:
           # ECS task defs require (runtime_platform.cpu_architecture = ARM64).
           docker build \
             --build-arg NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN="$NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN" \
+            --build-arg NEXT_PUBLIC_GIT_SHA="${{ steps.vars.outputs.sha }}" \
             -t "$IMAGE" .
           docker push "$IMAGE"
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ RUN npx prisma generate
 # be present here. Passed via --build-arg by the deploy workflow; harmless if empty.
 ARG NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN
 ENV NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN=${NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN}
+# Build stamp surfaced in the app footer: the deployed commit SHA, passed via
+# --build-arg by the deploy workflow and inlined into the bundle (NEXT_PUBLIC_*,
+# build-time). Empty in local/ad-hoc builds -> the footer shows "dev".
+ARG NEXT_PUBLIC_GIT_SHA
+ENV NEXT_PUBLIC_GIT_SHA=${NEXT_PUBLIC_GIT_SHA}
 # Needed for GitHub to build the image, overwritten by secrets in AWS at run time.
 # (next build imports auth-options.ts, which requires these to exist; the values
 # are never used — every route is dynamic — and never reach the runner stage.)

--- a/src/components/AppFrame.tsx
+++ b/src/components/AppFrame.tsx
@@ -32,6 +32,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { brand } from '@/brand';
 import { useIsDevInstance } from '@/components/EnvProvider';
+import { BuildInfoFooter } from '@/components/BuildInfoFooter';
 
 type SessionUser = {
   sysadmin?: boolean;
@@ -155,6 +156,7 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
   return (
     <AppShell
       header={{ height: 60 }}
+      footer={{ height: 28 }}
       navbar={
         showNav
           ? { width: 260, breakpoint: 'sm', collapsed: { mobile: !mobileOpened } }
@@ -212,6 +214,10 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
       )}
 
       <AppShell.Main>{children}</AppShell.Main>
+
+      <AppShell.Footer>
+        <BuildInfoFooter />
+      </AppShell.Footer>
     </AppShell>
   );
 }

--- a/src/components/BuildInfoFooter.tsx
+++ b/src/components/BuildInfoFooter.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Text } from "@mantine/core";
+
+// The deployed commit SHA. NEXT_PUBLIC_* vars are inlined into the bundle at
+// build time (Dockerfile ARG -> ENV, passed via --build-arg by the deploy
+// workflow), so this is the SHA of the image that's actually running.
+// VERCEL_GIT_COMMIT_SHA is kept as a fallback for Vercel-style builds; unset in
+// local dev -> "dev".
+const FULL_SHA =
+  process.env.NEXT_PUBLIC_GIT_SHA || process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA;
+
+/** Short, human-facing build label: the 7-char SHA, or "dev" when unbuilt. */
+export function buildLabel(sha: string | undefined | null): string {
+  if (!sha) return "dev";
+  return sha.slice(0, 7);
+}
+
+export function BuildInfoFooter() {
+  const label = buildLabel(FULL_SHA);
+  return (
+    <Text
+      component="div"
+      size="xs"
+      c="dimmed"
+      ta="right"
+      px="md"
+      title={FULL_SHA ? `commit ${FULL_SHA}` : "local development build"}
+      style={{ lineHeight: "28px", fontFamily: "var(--mantine-font-family-monospace)" }}
+    >
+      build {label}
+    </Text>
+  );
+}

--- a/src/components/__tests__/BuildInfoFooter.test.tsx
+++ b/src/components/__tests__/BuildInfoFooter.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import { BuildInfoFooter, buildLabel } from "../BuildInfoFooter";
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+});
+
+describe("buildLabel", () => {
+  it("truncates a full SHA to 7 chars", () => {
+    expect(buildLabel("0123456789abcdef0123456789abcdef01234567")).toBe("0123456");
+  });
+
+  it("returns 'dev' for an unset SHA", () => {
+    expect(buildLabel(undefined)).toBe("dev");
+    expect(buildLabel(null)).toBe("dev");
+    expect(buildLabel("")).toBe("dev");
+  });
+});
+
+describe("BuildInfoFooter", () => {
+  it("renders a build label (dev when NEXT_PUBLIC_GIT_SHA is unset)", () => {
+    render(
+      <MantineProvider>
+        <BuildInfoFooter />
+      </MantineProvider>,
+    );
+    // No SHA is inlined under jest, so it falls back to "dev".
+    expect(screen.getByText("build dev")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Adds a small, dimmed footer (`AppShell.Footer`) that shows the **7-char commit SHA of the running build**, so it's immediately obvious which image is live — especially handy on the dev deployment.

## How

- `<BuildInfoFooter>` reads `process.env.NEXT_PUBLIC_GIT_SHA` (full SHA in the `title` tooltip, 7 chars shown). Falls back to `"dev"` for local/ad-hoc builds. `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` kept as a secondary fallback (matching the existing convention in `api/kiosk/version`).
- **Dockerfile**: `ARG`/`ENV NEXT_PUBLIC_GIT_SHA`, mirroring the existing `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN` build-arg (inlined into the bundle at build time).
- **deploy-dev.yml**: passes `--build-arg NEXT_PUBLIC_GIT_SHA=<deployed sha>` (the workflow already resolves the deployed commit SHA).

## Verification

- Built locally with a sentinel SHA: `docker build --build-arg NEXT_PUBLIC_GIT_SHA=<sentinel> .` — confirmed the value is inlined into **both** the SSR chunk and the client chunk, so the footer renders the real SHA server-side and after hydration.
- `tsc` + `eslint` clean; full suite green (**129 passed**), incl. new `BuildInfoFooter.test.tsx`.
- The PR's `deploy-build` CI gate rebuilds the image (with an empty SHA → footer shows `dev`), exercising the Dockerfile change end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)