### PR TITLE
ci: fix required-check deadlock for client-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,18 +4,58 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'client/**'
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'client/**'
   merge_group:
 
 jobs:
+  # "Run Tests" and "Deploy build (no deploy)" are REQUIRED status checks on main.
+  # The Python kiosk client (client/**) has no Node CI, so a client-only change has
+  # nothing to test — but skipping the workflow via `paths-ignore` left those required
+  # checks permanently "pending" and blocked client-only PRs from ever merging.
+  #
+  # Fix: this job decides whether anything OUTSIDE client/** changed. The required jobs
+  # below ALWAYS run (so the required contexts always report a result) but skip their
+  # actual work when only client/** changed. A skipped *workflow* deadlocks a required
+  # check; a job that runs and reports success does not.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.detect.outputs.app }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Only a pull_request whose every changed file is under client/ may skip the
+          # Node CI. push-to-main and merge_group always run the full pipeline.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Non-PR event ($EVENT_NAME) — running full CI."
+            echo "app=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$PR_BASE_SHA...$PR_HEAD_SHA")"
+          echo "Changed files:"; printf '%s\n' "$changed"
+          # grep -v exits 0 if ANY line is NOT under client/ → there's app work to do.
+          if printf '%s\n' "$changed" | grep -qvE '^client/'; then
+            echo "Non-client files changed — running full CI."
+            echo "app=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Client-only change — skipping Node CI work (required checks still pass)."
+            echo "app=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Run Tests
+    needs: changes
     runs-on: ubuntu-latest
 
     services:
@@ -34,22 +74,31 @@ jobs:
           --health-retries 5
 
     steps:
+      - name: Skip notice (client-only change)
+        if: needs.changes.outputs.app != 'true'
+        run: echo "Only client/** changed — no Node CI to run; reporting success."
+
       - name: Checkout code
+        if: needs.changes.outputs.app == 'true'
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: needs.changes.outputs.app == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'npm'
 
       - name: Install dependencies
+        if: needs.changes.outputs.app == 'true'
         run: npm ci
 
       - name: Lint
+        if: needs.changes.outputs.app == 'true'
         run: npm run lint
 
       - name: Generate Prisma Client
+        if: needs.changes.outputs.app == 'true'
         env:
           DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"
         run: npx prisma generate
@@ -59,6 +108,7 @@ jobs:
       # CSS module type-checks fine yet breaks the build). The full production
       # build runs in the `deploy-build` job below.
       - name: Type check
+        if: needs.changes.outputs.app == 'true'
         run: npx tsc --noEmit
 
       # Tests run on `db push` (full schema), deploys run on `migrate deploy`
@@ -66,6 +116,7 @@ jobs:
       # passes CI and then breaks the deployed app (P2022 at runtime). Replay
       # the migrations onto a clean DB and require zero diff vs schema.prisma.
       - name: Check migrations match schema (no drift)
+        if: needs.changes.outputs.app == 'true'
         env:
           DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/drift_check"
           PGPASSWORD: testpassword
@@ -75,11 +126,13 @@ jobs:
           npx prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code
 
       - name: Push Prisma Schema
+        if: needs.changes.outputs.app == 'true'
         env:
           DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"
         run: npx prisma db push --accept-data-loss
 
       - name: Verify security classifications are up to date
+        if: needs.changes.outputs.app == 'true'
         env:
           DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"
         run: |
@@ -87,14 +140,17 @@ jobs:
           git diff --exit-code src/security/generated/ || (echo 'src/security/generated/ is stale; run prisma generate locally and commit' && exit 1)
 
       - name: Check route coverage (security policy lint)
+        if: needs.changes.outputs.app == 'true'
         run: npm run check-route-coverage
 
       - name: Run Jest Tests
+        if: needs.changes.outputs.app == 'true'
         env:
           DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"
         run: npm run test:ci
 
       - name: Run security policy contract tests
+        if: needs.changes.outputs.app == 'true'
         env:
           DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/checkmein_test"
         run: npx jest tests/security/policy.contract.integration.test.ts --runInBand --forceExit --testPathIgnorePatterns=/node_modules/
@@ -105,15 +161,22 @@ jobs:
   # see) slipped through CI and broke the post-merge deploy. Building here gates the MR.
   deploy-build:
     name: Deploy build (no deploy)
+    needs: changes
     runs-on: ubuntu-latest
     steps:
+      - name: Skip notice (client-only change)
+        if: needs.changes.outputs.app != 'true'
+        run: echo "Only client/** changed — no deploy build to run; reporting success."
+
       - name: Checkout code
+        if: needs.changes.outputs.app == 'true'
         uses: actions/checkout@v4
 
       # Mirrors deploy-dev.yml's build step minus `docker push`. Architecture is irrelevant
       # (the image is discarded), so the default x64 runner is fine — the deploy builds arm64
       # on its own runner for ECS.
       - name: Build deploy image (no push)
+        if: needs.changes.outputs.app == 'true'
         env:
           NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN: ${{ vars.SHOPIFY_STORE_DOMAIN }}
         run: |


### PR DESCRIPTION
## Problem

Branch protection on `main` **requires** two status checks — `Run Tests` and `Deploy build (no deploy)` — both produced by `ci.yml`. But `ci.yml` triggered with `paths-ignore: ['client/**']`. When a PR changes **only** the Python kiosk client (`client/**`), GitHub skips the whole workflow, so those required checks **never report** and sit permanently "pending" → the PR is `BLOCKED` and can never merge.

This is GitHub's well-known "required check + `paths-ignore`" trap, and it affects **any** client-only PR — e.g. #203 (the kiosk XSS fix), which has no workflow runs and `mergeStateStatus: BLOCKED` despite being `MERGEABLE`.

## Fix

Move the path filtering from the **workflow level** to **inside the jobs**, so the required jobs always run (and therefore always report a result) but do no real work for client-only changes:

- Removed `paths-ignore` from the `push`/`pull_request` triggers.
- Added a small `changes` job that sets `app=true` unless a `pull_request`'s changed files are *all* under `client/**` (push-to-main and `merge_group` always run the full pipeline).
- `test` and `deploy-build` keep their exact names (the required contexts) and now `needs: changes`; every real step is guarded with `if: needs.changes.outputs.app == 'true'`, plus a "skip notice" step for the client-only case.

Result:
- **Client-only PR** → jobs run as fast no-ops, report ✅ → no longer deadlocked.
- **Normal PR** → full pipeline runs exactly as before.

## Notes

- The two required contexts (`Run Tests`, `Deploy build (no deploy)`) are unchanged, so no branch-protection edit is needed.
- After this merges, **#203 can be re-run/merged normally**. (Until then, #203 still needs an admin merge.)
- The monorepo PR #231 also rewrites `ci.yml`; whichever lands second should carry this same job-level-guard structure forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)