### PR TITLE
ci: bump GitHub Actions to node24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       app: ${{ steps.detect.outputs.app }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - id: detect
@@ -80,11 +80,11 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.app == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         if: needs.changes.outputs.app == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'
@@ -170,7 +170,7 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.app == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Mirrors deploy-dev.yml's build step minus `docker push`. Architecture is irrelevant
       # (the image is discarded), so the default x64 runner is fine — the deploy builds arm64

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -58,12 +58,12 @@ jobs:
           echo "short_sha=${SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout deployed commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.vars.outputs.sha }}
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## What

Bumps the JS-based GitHub Actions off the **node20** runtime to **node24** (GitHub's JS-action runtimes go `node20` → `node24` — there's no `node22` action runtime, so node24 is the ≥22 target):

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | node24 |
| `actions/setup-node` | v4 | **v5** | node24 |
| `aws-actions/configure-aws-credentials` | v4 | **v6** | node24 (v5 is still node20) |
| `aws-actions/amazon-ecr-login` | v2 | _unchanged_ | already node24 ✓ |

Files: `.github/workflows/ci.yml` (checkout ×3, setup-node), `.github/workflows/deploy-dev.yml` (checkout, configure-aws-credentials).

## Breaking-change review (all safe for our usage)

- **checkout v5** — only the runtime bump + a minimum-runner requirement (GitHub-hosted runners satisfy it). Drop-in.
- **setup-node v5** — the breaking change is automatic package-manager caching when `package.json` has a `packageManager` field. We set `cache: 'npm'` explicitly and have no `packageManager` field, so behavior is unchanged.
- **configure-aws-credentials v4→v6** — v5's only breaking change is stricter *invalid boolean input* handling; we pass only `role-to-assume` + `aws-region` (no booleans). v6 is the node24 bump. The OIDC `id-token: write` flow is unchanged.

## Notes

- I pinned the **node24-transition major** for each (minimal change to clear the bar) rather than the absolute latest; `actions/checkout`/`setup-node` also have v6 if you'd prefer to track latest.
- The monorepo PR #231 rewrites these workflows with the old `@v4` pins — whichever lands second should carry these node24 pins forward.
- CI runs on this PR (it touches `ci.yml`, not `client/`), exercising checkout v5 + setup-node v5 directly. The `deploy-dev.yml` change (configure-aws-credentials v6) only runs post-merge on the next dev deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)