### PR TITLE
feat(ui): prominent DEV environment indicator in the header

### DIFF
--- a/src/components/AppFrame.tsx
+++ b/src/components/AppFrame.tsx
@@ -4,11 +4,11 @@ import { Suspense } from 'react';
 import {
   ActionIcon,
   AppShell,
+  Badge,
   Burger,
   Button,
   Group,
   NavLink,
-  Text,
   Title,
   Tooltip,
   useMantineColorScheme,
@@ -123,10 +123,14 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
         <Image src={brand.logo.src} alt={brand.logo.alt} width={brand.logo.width} height={brand.logo.height} priority />
       ) : (
         <Title order={3} c={`${brand.nav.accent}.7`}>
-          {isDevInstance ? `${brand.appName}-dev` : brand.appName}
+          {brand.appName}
         </Title>
       )}
-      {brand.logo && isDevInstance && <Text size="xs" c="dimmed" fw={700}>dev</Text>}
+      {isDevInstance && (
+        <Badge color="orange" variant="filled" size="sm" radius="sm" aria-label="Development environment">
+          DEV
+        </Badge>
+      )}
     </Link>
   );
 
@@ -164,7 +168,9 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
       }
       padding="md"
     >
-      <AppShell.Header>
+      <AppShell.Header
+        style={isDevInstance ? { borderBottom: '3px solid var(--mantine-color-orange-6)' } : undefined}
+      >
         <Group h="100%" px="md" justify="space-between" wrap="nowrap">
           <Group gap="sm" wrap="nowrap">
             {showNav && (


### PR DESCRIPTION
## What

Makes the dev-instance distinction obvious instead of a small dimmed "dev" at the upper-left.

- Replaces the dimmed `dev` text (and the `appname-dev` title fallback) with a **filled orange `DEV` Badge**, shown whenever `useIsDevInstance()` is true — consistently whether or not a brand logo is present.
- Adds a **3px orange accent border** under the `AppShell.Header` on dev, so the whole top bar reads as non-prod at a glance.

Gated entirely on the existing `isDevInstance` (CHECKIN_ENV=dev) — prod is visually unchanged.

## Notes

- Orange chosen to stand out from the green brand and the red Sign-Out button without implying "error".
- `tsc` + `eslint` clean; full suite (133) passes. It's a small presentational change; it'll be visible on the next dev deploy. Happy to dial it up further (e.g. a full-width ribbon) if you want it louder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)