### PR TITLE
refactor(admin): adopt <AlertBanner> for remaining admin status banners

### DIFF
--- a/src/app/admin/events/[id]/page.tsx
+++ b/src/app/admin/events/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, use, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Badge, Button, Card, Center, Checkbox, Container, Group, Loader, Modal, Select, SimpleGrid, Stack, Table, Text, TextInput, Title } from '@mantine/core';
+import { AlertBanner } from '@/components/admin/AlertBanner';
 import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
 
 type ParticipantDetail = {
@@ -310,7 +311,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
           </Button>
         </Group>
 
-        {message && <Alert color="cyan" mb="lg">{message}</Alert>}
+        <AlertBanner message={message} tone="info" mb="lg" />
 
         {/* PAST EVENT: ATTENDANCE CONFIRMATION */}
         {isPastEvent && canManageAttendance && (

--- a/src/app/admin/households/page.tsx
+++ b/src/app/admin/households/page.tsx
@@ -4,8 +4,9 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
-import { Alert, Button, Center, Group, List, Loader, Stack, Table, Text } from '@mantine/core';
+import { Button, Center, Group, List, Loader, Stack, Table, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
+import { AlertBanner } from '@/components/admin/AlertBanner';
 
 type Household = {
   id: number;
@@ -77,7 +78,7 @@ export default function AdminHouseholdsPage() {
         shop access and other organizational privileges.
       </Text>
 
-      {error && <Alert color="red">{error}</Alert>}
+      <AlertBanner message={error} tone="error" />
 
       <Table.ScrollContainer minWidth={600}>
         <Table verticalSpacing="sm" highlightOnHover>

--- a/src/app/admin/membership/page.tsx
+++ b/src/app/admin/membership/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { Alert, Badge, Button, Card, Center, Group, Loader, Stack, Text, Title } from "@mantine/core";
+import { AlertBanner } from "@/components/admin/AlertBanner";
 
 interface Participant {
   id: number;
@@ -163,7 +164,7 @@ export default function AdminMembershipPage() {
         </Text>
       </div>
 
-      {message && <Alert color={isError ? "red" : "green"}>{message}</Alert>}
+      <AlertBanner message={message} tone={isError ? 'error' : 'success'} />
 
       {!loading && rows.length > 0 && (
         <>

--- a/src/app/admin/membership/settings/page.tsx
+++ b/src/app/admin/membership/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Alert, Button, Card, Center, Checkbox, Group, Loader, Stack, Text, TextInput, Title } from "@mantine/core";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { AlertBanner } from "@/components/admin/AlertBanner";
 
 interface Settings {
   normalDuesCents: number;
@@ -124,7 +125,7 @@ export default function MembershipSettingsPage() {
     <Stack maw={820} mx="auto">
       <AdminPageHeader title="Membership Settings" back={{ href: '/admin/membership', label: '← Applications' }} />
 
-      {message && <Alert color={isError ? "yellow" : "green"}>{message}</Alert>}
+      <AlertBanner message={message} tone={isError ? 'warning' : 'success'} />
 
       {loading ? (
         <Center py="xl"><Loader /></Center>

--- a/src/app/admin/participants/merge/page.tsx
+++ b/src/app/admin/participants/merge/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Alert, Box, Button, Card, Group, List, Paper, SimpleGrid, Stack, Text, TextInput, Title } from "@mantine/core";
+import { AlertBanner } from "@/components/admin/AlertBanner";
 
 interface ParticipantMergeView {
   id: number;
@@ -242,7 +243,7 @@ export default function MergeParticipants() {
         </Text>
       </div>
 
-      {error && <Alert color="red">{error}</Alert>}
+      <AlertBanner message={error} tone="error" />
 
       {!previewMode ? (
         <>

--- a/src/app/admin/participants/new/page.tsx
+++ b/src/app/admin/participants/new/page.tsx
@@ -6,7 +6,8 @@ import { useRequireRole } from '@/hooks/useRequireRole';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { EntityPicker } from '@/components/admin/EntityPicker';
 import { isMinor } from '@/lib/time';
-import { Alert, Button, Card, Center, Checkbox, Container, Loader, Paper, Stack, Text, TextInput } from '@mantine/core';
+import { Button, Card, Center, Checkbox, Container, Loader, Paper, Stack, Text, TextInput } from '@mantine/core';
+import { AlertBanner } from '@/components/admin/AlertBanner';
 
 type HouseholdOption = {
   id: number;
@@ -128,7 +129,7 @@ function NewParticipantForm() {
           this profile.
         </Text>
 
-        {message && <Alert color={isError ? 'red' : 'green'} mb="md">{message}</Alert>}
+        <AlertBanner message={message} tone={isError ? 'error' : 'success'} mb="md" />
 
         <form onSubmit={handleSubmit}>
           <Stack>

--- a/src/app/admin/programs/[id]/page.tsx
+++ b/src/app/admin/programs/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   Alert, Anchor, Badge, Box, Button, Card, Center, Checkbox, Container, Divider, Group,
   Loader, NumberInput, Paper, Select, SimpleGrid, Stack, Table, Tabs, Text, TextInput, Title,
 } from '@mantine/core';
+import { AlertBanner } from '@/components/admin/AlertBanner';
 import { formatDateTime } from '@/lib/time';
 
 type ProgramDetail = {
@@ -366,7 +367,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
           <Button variant="default" onClick={() => router.push('/admin/programs')}>← Back to Programs</Button>
         </Group>
 
-        {message && <Alert color="cyan" mb="lg">{message}</Alert>}
+        <AlertBanner message={message} tone="info" mb="lg" />
 
         <Tabs value={activeTab} onChange={(v) => setActiveTab((v as typeof activeTab) ?? 'general')}>
           <Tabs.List mb="lg">

--- a/src/app/admin/programs/new/page.tsx
+++ b/src/app/admin/programs/new/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Alert, Button, Card, Center, Checkbox, Container, Group, Loader, NumberInput, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
+import { AlertBanner } from '@/components/admin/AlertBanner';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { EntityPicker } from '@/components/admin/EntityPicker';
@@ -91,7 +92,7 @@ export default function CreateProgramPage() {
           Create a new program. You can configure the roster and schedule events later.
         </Text>
 
-        {message && <Alert color={messageType === 'success' ? 'green' : 'red'} mb="md">{message}</Alert>}
+        <AlertBanner message={message} tone={messageType === 'success' ? 'success' : 'error'} mb="md" />
 
         <form onSubmit={handleCreate}>
           <Stack>


### PR DESCRIPTION
## What

Finishes the `<AlertBanner>` rollout (from #238) across the remaining **admin** status banners — the inline `{msg && <Alert color={…}>{msg}</Alert>}` pattern in 8 pages becomes `<AlertBanner message tone … />`, centralizing the empty-check and tone→color mapping.

| Page | Before | tone |
|---|---|---|
| programs/new | `messageType==='success' ? green : red` | `success`/`error` |
| participants/new | `isError ? red : green` | `error`/`success` |
| membership | `isError ? red : green` | `error`/`success` |
| membership/settings | `isError ? **yellow** : green` | `warning`/`success` |
| households, participants/merge | `red` | `error` |
| programs/[id], events/[id] (message) | `cyan` | `info` |

**Colors are preserved exactly** — including membership/settings' deliberate *yellow* error state (→ `tone="warning"`).

## Scope

- Only the simple single-line status banners are migrated. The **rich** Alerts on these pages (icons, titles, variants, inline warnings) are intentionally left as raw `<Alert>` — `<AlertBanner>` is for the message/tone banner, not those.
- `Alert` dropped from the import only where nothing else used it (`participants/new`, `households`).
- Non-admin pages (profile, membership, kiosk, etc.) are out of scope — this matches the admin-pages audit.

`tsc` + `eslint` clean; full suite (133) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)