### PR TITLE
fix(ui): signin font, dev-env error message, softer nav highlights

### DIFF
--- a/checkin-app/src/app/signin/page.tsx
+++ b/checkin-app/src/app/signin/page.tsx
@@ -43,7 +43,7 @@ function SignInInner() {
     return (
         <main style={mainStyle}>
             <div className="glass-container animate-float" style={heroStyle}>
-                <h1 className="text-gradient" style={{ fontSize: "3rem", margin: "0 0 0.5rem 0" }}>
+                <h1 className="text-gradient" style={{ fontSize: "3rem", margin: "0 0 0.5rem 0", fontFamily: "var(--mantine-font-family-headings)" }}>
                     {isDevInstance ? "Welcome to Innovation Treehouse Dev" : "CheckMeIn"}
                 </h1>
                 <p style={{ color: "var(--color-text-muted)", fontSize: "1.1rem", marginBottom: "2rem" }}>
@@ -74,8 +74,10 @@ function SignInInner() {
                                 fontSize: "0.95rem",
                             }}
                         >
-                            <strong>{session.user?.email}</strong> isn&apos;t an <code>@{ORG_DOMAIN}</code>{" "}
-                            account, so it can&apos;t access the dev environment.
+                            Signed in as <strong>{session.user?.email}</strong>, but this Google account is not
+                            managed by the <code>@{ORG_DOMAIN}</code> Google Workspace — it may be a personal
+                            account or a forwarding alias. Sign out and use an actual{" "}
+                            <code>@{ORG_DOMAIN}</code> Workspace account to access the dev environment.
                         </div>
                         <button
                             className="glass-button"

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -192,7 +192,9 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
         <AppShell.Navbar p="md" bg={brand.nav.sidebar}>
           {visibleItems.map((item) => {
             const active = isActive(pathname, item.href);
-            const onSidebarText = onColoredSidebar && !active ? 'var(--mantine-color-white)' : undefined;
+            // On the colored sidebar all text is white; the 'light' variant gives a soft
+            // translucent overlay on the active item rather than a harsh solid fill.
+            const sidebarText = onColoredSidebar ? 'var(--mantine-color-white)' : undefined;
             return (
               <NavLink
                 key={item.href}
@@ -201,14 +203,14 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                 label={item.label}
                 leftSection={item.icon}
                 active={active}
-                variant={onColoredSidebar ? 'filled' : 'light'}
+                variant="light"
                 color={brand.nav.accent}
                 onClick={closeMobile}
                 mb={4}
                 styles={{
                   root: { borderRadius: 'var(--mantine-radius-md)' },
-                  label: { color: onSidebarText, fontWeight: 600 },
-                  section: { color: onSidebarText },
+                  label: { color: sidebarText, fontWeight: 600 },
+                  section: { color: sidebarText },
                 }}
               />
             );


### PR DESCRIPTION
Three visual/UX fixes from the dev deployment screenshot.

### 1 — Signin heading uses wrong font (serif browser default)
The `<h1>` on the signin page uses a CSS class (`text-gradient`) rather than a Mantine `<Title>`, so it didn't pick up the brand heading font from the Mantine theme. Added `fontFamily: 'var(--mantine-font-family-headings)'` inline — the CSS variable is always on `:root` from Mantine, so it resolves to the HNKani/Nunito heading stack.

### 2 — Error message is self-contradictory
The real situation: it's a forwarding alias, not a Google **Workspace** account, so Google doesn't issue an `hd` (hosted-domain) claim for it and the dev gate rejects it. Reworded:

> *Signed in as <email>, but this Google account is not managed by the <org domain> Google Workspace — it may be a personal account or a forwarding alias. Sign out and use an actual <org domain> Workspace account to access the dev environment.*

### 3 — Soften active nav highlights on the colored sidebar
The `filled` variant rendered a solid bright-green active pill against the dark purple (`#3a2651`) sidebar, making the white label text hard to read against the jarring contrast. Switching to `variant="light"` everywhere gives a translucent green overlay that sits softer on the dark background while still clearly indicating the active page. Non-active items keep their white text unchanged.

`tsc` + `eslint` + tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)