### PR TITLE
fix(dev-instance): persona-mint always denied on dev — authorize() never saw the caller's session

### DIFF
--- a/checkin-app/src/app/signin/page.tsx
+++ b/checkin-app/src/app/signin/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { ORG_DOMAIN } from "@/lib/config";
-import { useIsDevInstance } from "@/components/EnvProvider";
+import { useCheckinEnv, useIsDevInstance } from "@/components/EnvProvider";
 
 // Layout for the glass hero (this page still uses the legacy glass-* utilities, not Mantine).
 // Inlined from the former page.module.css, which the Mantine migration removed.
@@ -35,10 +35,18 @@ function SignInInner() {
     const params = useSearchParams();
     const { data: session, status } = useSession();
     const isDevInstance = useIsDevInstance();
+    const checkinEnv = useCheckinEnv();
     const callbackUrl = params.get("callbackUrl") || "/";
+    const error = params.get("error");
 
-    // Signed in but routed here = a valid Google login that isn't an org member (failed the hd gate).
-    const wrongAccount = status === "authenticated" && !!session?.user;
+    const signedIn = status === "authenticated" && !!session?.user;
+    // The same org gate the dev middleware enforces (hd + verified email). Only a session that
+    // actually FAILS it gets the "wrong account" treatment — a verified org member can also land
+    // here (e.g. a persona-mint that was refused redirects back with ?error=), and telling them
+    // their account isn't in the Workspace would be wrong on both counts. The gate only exists on
+    // the cloud dev instance; local sessions never carry the hd claim.
+    const orgVerified = session?.user?.hd === ORG_DOMAIN && session?.user?.emailVerified === true;
+    const wrongAccount = signedIn && checkinEnv === "dev" && !orgVerified;
 
     return (
         <main style={mainStyle}>
@@ -90,6 +98,45 @@ function SignInInner() {
                         >
                             Sign out &amp; use another account
                         </button>
+                    </div>
+                ) : signedIn ? (
+                    <div
+                        style={{
+                            width: "100%",
+                            maxWidth: 360,
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "center",
+                            gap: "1rem",
+                        }}
+                    >
+                        {error && (
+                            <div
+                                style={{
+                                    width: "100%",
+                                    padding: "1rem",
+                                    background: "rgba(245, 158, 11, 0.12)",
+                                    border: "1px solid rgba(245, 158, 11, 0.4)",
+                                    borderRadius: 12,
+                                    color: "#fcd34d",
+                                    fontSize: "0.95rem",
+                                }}
+                            >
+                                That sign-in attempt didn&apos;t complete (code: <code>{error}</code>).
+                                You are still signed in as <strong>{session.user?.email}</strong>.
+                            </div>
+                        )}
+                        <a
+                            className="glass-button"
+                            href={callbackUrl}
+                            style={{
+                                width: "100%",
+                                background: "rgba(59, 130, 246, 0.2)",
+                                borderColor: "rgba(59, 130, 246, 0.4)",
+                            }}
+                        >
+                            Continue as {session.user?.name || session.user?.email}
+                        </a>
                     </div>
                 ) : (
                     <div

--- a/checkin-app/src/components/DevDashboard.tsx
+++ b/checkin-app/src/components/DevDashboard.tsx
@@ -102,7 +102,12 @@ export default function DevDashboard() {
     const impersonate = (personaId: string) => {
         if (!personaId) return;
         setSwitching(true);
-        signIn("persona-mint", { personaId, mode: "impersonate", callbackUrl: "/" });
+        // Land back on the page being viewed, re-rendered as the new persona.
+        signIn("persona-mint", {
+            personaId,
+            mode: "impersonate",
+            callbackUrl: window.location.pathname + window.location.search,
+        });
     };
 
     const runMacro = (fn: () => Promise<ActionResult>) => {

--- a/checkin-app/src/components/DevImpersonationBar.tsx
+++ b/checkin-app/src/components/DevImpersonationBar.tsx
@@ -26,7 +26,11 @@ export default function DevImpersonationBar() {
 
     const returnToMe = () => {
         setBusy(true);
-        signIn("persona-mint", { mode: "return", callbackUrl: "/" });
+        // Land back on the page being viewed, re-rendered as the real identity.
+        signIn("persona-mint", {
+            mode: "return",
+            callbackUrl: window.location.pathname + window.location.search,
+        });
     };
 
     return (

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -3,6 +3,7 @@ import type { JWT } from "next-auth/jwt";
 import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { getToken } from "next-auth/jwt";
+import { cookies as requestCookies } from "next/headers";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import prisma from "@/lib/prisma";
 import { config, ORG_DOMAIN } from "@/lib/config";
@@ -112,8 +113,15 @@ export const authOptions: NextAuthOptions = {
 
                     // The caller's *current* session — the security boundary. getToken decrypts the
                     // session cookie carried on this request; null when not signed in.
+                    // The `req` NextAuth hands to a credentials authorize() has NO `cookies` field
+                    // (only query/body/headers/method), and getToken reads req.cookies exclusively —
+                    // it never parses the cookie header. Without the next/headers cookie store the
+                    // caller always looks anonymous and every dev-instance mint is denied.
                     const callerToken = await getToken({
-                        req: req as Parameters<typeof getToken>[0]["req"],
+                        req: {
+                            headers: req.headers,
+                            cookies: await requestCookies(),
+                        } as unknown as Parameters<typeof getToken>[0]["req"],
                         secret: config.nextAuthSecret(),
                     });
 


### PR DESCRIPTION
## Bug

Clicking **Change mock account → a persona** on the cloud dev instance bounced to `/signin` with the "this Google account is not managed by the Workspace" error, even for a verified org member.

## Root cause

In next-auth 4.24.x, the `req` handed to a credentials provider's `authorize()` contains only `{query, body, headers, method}` — **no `cookies`** — and `getToken()` reads `req.cookies` exclusively (its `SessionStore` never parses the `cookie` header; the only fallback is an `Authorization: Bearer` header).

So inside the persona-mint `authorize()`, `callerToken` was always `null`. `evaluateMint` then (correctly) refused the anonymous mint on `dev` — anonymous mints are legal on `local`, which is why the feature passed local testing. NextAuth redirected to `/signin?error=CredentialsSignin`, where the page showed the Workspace-gate error for *any* authenticated session, misattributing the failure.

## Fix

- **`auth-options.ts`** — hand `getToken()` the `next/headers` cookie store (the same source NextAuth's own app-router wrapper uses), so the caller's real session claims reach `evaluateMint`. The security boundary is unchanged: dev mints still require a verified org caller.
- **`signin/page.tsx`** — only show the "not managed by the Workspace" message when the session actually fails the hd gate *on the cloud dev env* (`hd`/`emailVerified` are already surfaced on the session). A signed-in org member landing here now sees the real error code plus a "Continue as …" link.
- **`DevDashboard.tsx` / `DevImpersonationBar.tsx`** — persona switches and return-to-me use the current `pathname + search` as `callbackUrl`, so switching while on `/household` re-renders `/household` as the new persona instead of jumping to `/`.

## Validation

- `tsc --noEmit` clean
- `npm run test:ci` — 26 suites / 137 tests pass (mocked; integration runs in CI per repo policy)
- Needs a quick manual check on the dev instance after deploy: impersonate from `/household`, confirm you stay on `/household` as the persona, then "Return to me".

🤖 Generated with [Claude Code](https://claude.com/claude-code)