### PR TITLE
feat(admin): admin/board editor for household info (closes #168)

### DIFF
--- a/checkin-app/src/app/admin/households/page.tsx
+++ b/checkin-app/src/app/admin/households/page.tsx
@@ -8,6 +8,7 @@ import { MembershipTabs } from '@/components/admin/MembershipTabs';
 import { Button, Center, Group, List, Loader, Stack, Table, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
+import { AdminEditHouseholdModal } from '@/components/admin/AdminEditHouseholdModal';
 
 type Household = {
   id: number;
@@ -23,6 +24,7 @@ export default function AdminHouseholdsPage() {
   const [households, setHouseholds] = useState<Household[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [editHouseholdId, setEditHouseholdId] = useState<number | null>(null);
 
   const fetchHouseholds = useCallback(async () => {
     try {
@@ -125,6 +127,13 @@ export default function AdminHouseholdsPage() {
                       <Button
                         size="xs"
                         variant="light"
+                        onClick={() => setEditHouseholdId(household.id)}
+                      >
+                        Edit Info
+                      </Button>
+                      <Button
+                        size="xs"
+                        variant="light"
                         onClick={() => router.push(`/admin/participants/new?householdId=${household.id}`)}
                       >
                         + Add Participant
@@ -153,6 +162,13 @@ export default function AdminHouseholdsPage() {
           </Table.Tbody>
         </Table>
       </Table.ScrollContainer>
+
+      <AdminEditHouseholdModal
+        householdId={editHouseholdId}
+        opened={editHouseholdId !== null}
+        onClose={() => setEditHouseholdId(null)}
+        onSaved={() => fetchHouseholds()}
+      />
     </Stack>
   );
 }

--- a/checkin-app/src/app/admin/participants/page.tsx
+++ b/checkin-app/src/app/admin/participants/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Alert, Box, Button, Card, Group, Modal, Paper, Stack, Text, TextInput, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { EntityPicker } from "@/components/admin/EntityPicker";
+import { AdminEditHouseholdModal } from "@/components/admin/AdminEditHouseholdModal";
 
 type HouseholdRef = {
   id: number;
@@ -57,6 +58,9 @@ export default function AdminParticipantsIndex() {
   const [editingParticipant, setEditingParticipant] = useState<ParticipantRow | null>(null);
   const [editForm, setEditForm] = useState({ name: "", email: "", phone: "" });
   const [savingDetails, setSavingDetails] = useState(false);
+
+  // Admin edit of household's own info (name, address, emergency contact)
+  const [editHouseholdId, setEditHouseholdId] = useState<number | null>(null);
 
   const showNotification = (message: string, type: 'success' | 'error' = 'success') => {
     notifications.show({ message, color: type === 'error' ? 'red' : 'green' });
@@ -181,7 +185,11 @@ export default function AdminParticipantsIndex() {
                     </div>
                     <Group gap="md" wrap="wrap" align="center">
                       <Text size="sm" c="dimmed">{p.household?.name || 'No household'}</Text>
-                      {!p.household && (
+                      {p.household ? (
+                        <Button size="xs" variant="light" onClick={() => setEditHouseholdId(p.household!.id)}>
+                          Edit Household
+                        </Button>
+                      ) : (
                         <Button size="xs" variant="light" onClick={() => { setSelectedParticipant(p); setAssignModalOpen(true); }}>
                           Assign Household
                         </Button>
@@ -274,14 +282,22 @@ export default function AdminParticipantsIndex() {
               <div>
                 <Text fw={500} size="sm" mb={4}>Household</Text>
                 <Paper withBorder radius="md" p="sm">
-                  <Group justify="space-between">
+                  <Group justify="space-between" wrap="wrap">
                     <Text size="sm">{editingParticipant.household.name}</Text>
-                    <Button size="xs" variant="default" onClick={() => {
-                      setEditModalOpen(false);
-                      setSelectedParticipant(editingParticipant);
-                      setEditingParticipant(null);
-                      setAssignModalOpen(true);
-                    }}>Edit Household</Button>
+                    <Group gap="xs">
+                      <Button size="xs" variant="light" onClick={() => {
+                        const hid = editingParticipant.household!.id;
+                        setEditModalOpen(false);
+                        setEditingParticipant(null);
+                        setEditHouseholdId(hid);
+                      }}>Edit Household Info</Button>
+                      <Button size="xs" variant="default" onClick={() => {
+                        setEditModalOpen(false);
+                        setSelectedParticipant(editingParticipant);
+                        setEditingParticipant(null);
+                        setAssignModalOpen(true);
+                      }}>Move to Another Household</Button>
+                    </Group>
                   </Group>
                 </Paper>
               </div>
@@ -293,6 +309,18 @@ export default function AdminParticipantsIndex() {
           </Group>
         </form>
       </Modal>
+
+      {/* Admin edit of household's own info */}
+      <AdminEditHouseholdModal
+        householdId={editHouseholdId}
+        opened={editHouseholdId !== null}
+        onClose={() => setEditHouseholdId(null)}
+        onSaved={(h) => {
+          setResults(results.map(p =>
+            p.household?.id === h.id ? { ...p, household: { ...p.household, name: h.name } } : p
+          ));
+        }}
+      />
     </Stack>
   );
 }

--- a/checkin-app/src/app/api/admin/households/[id]/route.ts
+++ b/checkin-app/src/app/api/admin/households/[id]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { authenticateRequest } from "@/lib/auth";
+
+/**
+ * Admin edit of a household's own info (name, address, emergency contact).
+ *
+ * Distinct from the participant-level "assign household" flow — this edits the
+ * household record itself, on behalf of a member, using admin privileges. Gated
+ * to sysadmin + board, and every edit is written to the audit log with before/
+ * after snapshots since the actor is not a member of the household they touch.
+ */
+export async function PATCH(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const auth = await authenticateRequest(request);
+    if (auth.type !== 'session') {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!auth.user.sysadmin && !auth.user.boardMember) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    try {
+        const { id: idParam } = await params;
+        const id = parseInt(idParam, 10);
+        if (isNaN(id)) {
+            return NextResponse.json({ error: "Invalid household ID" }, { status: 400 });
+        }
+
+        const existing = await prisma.household.findUnique({ where: { id } });
+        if (!existing) {
+            return NextResponse.json({ error: "Household not found" }, { status: 404 });
+        }
+
+        const body = await request.json();
+        const data: {
+            name?: string | null;
+            address?: string | null;
+            emergencyContactName?: string | null;
+            emergencyContactPhone?: string | null;
+        } = {};
+        if (body.name !== undefined) data.name = body.name;
+        if (body.address !== undefined) data.address = body.address;
+        if (body.emergencyContactName !== undefined) data.emergencyContactName = body.emergencyContactName;
+        if (body.emergencyContactPhone !== undefined) data.emergencyContactPhone = body.emergencyContactPhone;
+
+        if (Object.keys(data).length === 0) {
+            return NextResponse.json({ error: "No fields to update provided" }, { status: 400 });
+        }
+
+        const updated = await prisma.household.update({ where: { id }, data });
+
+        await prisma.auditLog.create({
+            data: {
+                actorId: auth.user.id,
+                action: "EDIT",
+                tableName: "Household",
+                affectedEntityId: id,
+                oldData: JSON.stringify({
+                    name: existing.name,
+                    address: existing.address,
+                    emergencyContactName: existing.emergencyContactName,
+                    emergencyContactPhone: existing.emergencyContactPhone,
+                }),
+                newData: JSON.stringify(data),
+            }
+        });
+
+        return NextResponse.json({ household: updated });
+    } catch (error) {
+        console.error("Failed to update household:", error);
+        return NextResponse.json({ error: "Failed to update household" }, { status: 500 });
+    }
+}

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Alert, Button, Group, Loader, Modal, SimpleGrid, Stack, Text, TextInput, Title } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+
+export type AdminHousehold = {
+  id: number;
+  name: string | null;
+  address: string | null;
+  emergencyContactName: string | null;
+  emergencyContactPhone: string | null;
+};
+
+type FormState = {
+  name: string;
+  address: string;
+  emergencyContactName: string;
+  emergencyContactPhone: string;
+};
+
+const EMPTY: FormState = { name: "", address: "", emergencyContactName: "", emergencyContactPhone: "" };
+
+/**
+ * Admin/board editor for a household's own info. Denser than the member-facing
+ * `/household` editor and reachable from any admin surface that has a household id.
+ *
+ * Saving is intentionally two-step: the form gates behind an "are you using admin
+ * powers" confirmation dialog — not a data-confirmation, but an acknowledgement
+ * that you're editing a household you don't belong to (the edit is also audited).
+ */
+export function AdminEditHouseholdModal({
+  householdId,
+  opened,
+  onClose,
+  onSaved,
+}: {
+  householdId: number | null;
+  opened: boolean;
+  onClose: () => void;
+  onSaved?: (household: AdminHousehold) => void;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [displayName, setDisplayName] = useState("");
+
+  useEffect(() => {
+    if (!opened || householdId == null) return;
+    let cancelled = false;
+    setLoading(true);
+    setConfirming(false);
+    (async () => {
+      try {
+        const res = await fetch(`/api/admin/households?id=${householdId}`);
+        const data = await res.json();
+        const h: AdminHousehold | null = data.household;
+        if (cancelled) return;
+        if (h) {
+          setForm({
+            name: h.name || "",
+            address: h.address || "",
+            emergencyContactName: h.emergencyContactName || "",
+            emergencyContactPhone: h.emergencyContactPhone || "",
+          });
+          setDisplayName(h.name || `Household #${h.id}`);
+        }
+      } catch {
+        notifications.show({ color: "red", message: "Failed to load household." });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [opened, householdId]);
+
+  const update = (patch: Partial<FormState>) => setForm((f) => ({ ...f, ...patch }));
+
+  const handleSave = async () => {
+    if (householdId == null) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/households/${householdId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        notifications.show({ color: "green", message: "Household updated." });
+        onSaved?.(data.household);
+        setConfirming(false);
+        onClose();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        notifications.show({ color: "red", message: data.error || "Failed to update household." });
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error." });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <Modal
+        opened={opened}
+        onClose={onClose}
+        size="lg"
+        title={<Title order={4}>Edit Household Info{displayName ? ` — ${displayName}` : ""}</Title>}
+      >
+        {loading ? (
+          <Group justify="center" py="xl">
+            <Loader />
+          </Group>
+        ) : (
+          <Stack>
+            <Text size="sm" c="dimmed">
+              Admin view — edits apply to the whole household and are recorded in the audit log.
+            </Text>
+            <TextInput
+              label="Household Name"
+              value={form.name}
+              onChange={(e) => update({ name: e.currentTarget.value })}
+              placeholder="The Smith Family"
+            />
+            <TextInput
+              label="Primary Address"
+              value={form.address}
+              onChange={(e) => update({ address: e.currentTarget.value })}
+              placeholder="123 Main St, City, ST 12345"
+            />
+            <SimpleGrid cols={{ base: 1, sm: 2 }}>
+              <TextInput
+                label="Emergency Contact Name"
+                value={form.emergencyContactName}
+                onChange={(e) => update({ emergencyContactName: e.currentTarget.value })}
+                placeholder="Full Name"
+              />
+              <TextInput
+                type="tel"
+                label="Emergency Contact Phone"
+                value={form.emergencyContactPhone}
+                onChange={(e) => update({ emergencyContactPhone: e.currentTarget.value })}
+                placeholder="(555) 555-5555"
+              />
+            </SimpleGrid>
+            <Group justify="flex-end" mt="md">
+              <Button variant="default" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button color="green" onClick={() => setConfirming(true)}>
+                Save Changes
+              </Button>
+            </Group>
+          </Stack>
+        )}
+      </Modal>
+
+      <Modal
+        opened={confirming}
+        onClose={() => setConfirming(false)}
+        size="sm"
+        zIndex={1100}
+        title={<Title order={5}>Use admin powers?</Title>}
+      >
+        <Alert color="orange" mb="md">
+          You&apos;re editing <strong>{displayName}</strong>, a household you&apos;re not a member of. This
+          uses your administrative privileges and is recorded in the audit log.
+        </Alert>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={() => setConfirming(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button color="orange" onClick={handleSave} loading={saving}>
+            Yes, save changes
+          </Button>
+        </Group>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
## Problem

Issue #168: the admin **"Edit Household"** flow reachable from `/admin/participants` only let you *move people* between households — there was no way to edit a household's own info (name, address, emergency contact).

## What this does

Builds out a denser admin/board editor for the household's own fields, gated behind an explicit "I'm using admin powers" confirmation.

- **`PATCH /api/admin/households/[id]`** — edits `name` / `address` / `emergencyContactName` / `emergencyContactPhone`. Gated to `sysadmin` + `boardMember` (in-handler role check kept as defense-in-depth, matching `admin/participants/[id]`). Writes an `AuditLog` EDIT row capturing **before + after**, since the actor is editing a household they don't belong to.
- **`AdminEditHouseholdModal`** — reusable, denser-than-member editor. Fetches the household by id, and gates **Save** behind a second confirmation dialog whose sole purpose is acknowledging use of admin privileges (*not* a data confirmation): *"You're editing {household}, a household you're not a member of. This uses your administrative privileges and is recorded in the audit log."*
- **Wiring** — `/admin/households` gets a per-row **"Edit Info"** button; `/admin/participants` gets a row **"Edit Household"** button, and the participant modal now splits **"Edit Household Info"** from **"Move to Another Household"** so the two distinct actions are unambiguous.

## Scope note

The issue author was unsure whether the add/remove-people flow is still needed. This PR **keeps** it (relabeled "Move to Another Household") rather than removing it — that's a separate product decision.

## Testing

- `tsc --noEmit`: clean
- `test:ci` (mocked, DB-free): 154/154 pass (ran via pre-commit hook)
- `eslint`: clean
- `check-route-coverage`: 0 errors (new route is an advisory "unmigrated" warning, same as every other admin mutation route)

Follow-up (not included): a PATCH case in `adminHouseholdsAPI.integration.test.ts` — that suite needs a live DB and runs in CI only; happy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)