### PR TITLE
feat(dev-instance): logged-out and admin quick sessions in the dev dashboard

### DIFF
--- a/checkin-app/src/components/DevDashboard.tsx
+++ b/checkin-app/src/components/DevDashboard.tsx
@@ -34,6 +34,7 @@ interface PersonaOption {
     id: number;
     email: string;
     name: string | null;
+    sysadmin?: boolean;
 }
 
 function relTime(when: string | Date): string {
@@ -110,6 +111,16 @@ export default function DevDashboard() {
         });
     };
 
+    // Mint a synthetic logged-out (guest) session: preview the signed-out UX while staying past the
+    // dev org gate, with one-click "Return to me" via the DevImpersonationBar.
+    const viewLoggedOut = () => {
+        setSwitching(true);
+        signIn("persona-mint", {
+            mode: "logout",
+            callbackUrl: window.location.pathname + window.location.search,
+        });
+    };
+
     const runMacro = (fn: () => Promise<ActionResult>) => {
         startTransition(async () => {
             try {
@@ -140,6 +151,8 @@ export default function DevDashboard() {
 
     const lastActivity = activity[0];
     const currentName = session.user.name || session.user.email;
+    // Quick "View as admin" reuses the seeded sysadmin persona (e.g. boardmember@example.com).
+    const adminPersona = personas.find((p) => p.sysadmin);
 
     return (
         <div
@@ -234,6 +247,27 @@ export default function DevDashboard() {
                         <div style={{ fontSize: "0.75rem", color: "#9ca3af", marginBottom: "0.5rem" }}>
                             Currently <strong style={{ color: "#d1d5db" }}>{currentName}</strong>
                             {session.user.impersonatedBy ? <> (you are {session.user.impersonatedBy})</> : null}
+                        </div>
+                        {/* Quick sessions: one-click admin + logged-out, alongside the persona list. */}
+                        <div style={{ display: "flex", gap: "0.35rem", marginBottom: "0.5rem" }}>
+                            {adminPersona && (
+                                <button
+                                    onClick={() => impersonate(String(adminPersona.id))}
+                                    disabled={switching}
+                                    style={{ ...macroBtn(switching), flex: 1 }}
+                                    title={`Sysadmin — ${adminPersona.email}`}
+                                >
+                                    🛡 Admin
+                                </button>
+                            )}
+                            <button
+                                onClick={viewLoggedOut}
+                                disabled={switching}
+                                style={{ ...macroBtn(switching), flex: 1 }}
+                                title="Preview the signed-out experience (you can return to yourself)"
+                            >
+                                🔓 Logged out
+                            </button>
                         </div>
                         <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", maxHeight: "9.5rem", overflowY: "auto" }}>
                             {personas.length === 0 && (

--- a/checkin-app/src/lib/__tests__/impersonation.test.ts
+++ b/checkin-app/src/lib/__tests__/impersonation.test.ts
@@ -15,6 +15,8 @@ describe('evaluateMint', () => {
                 .toEqual({ allowed: false });
             expect(evaluateMint({ checkinEnv: 'prod', mode: 'return', caller: { ...orgCaller, impersonatedBy: 'x@y.org' } }))
                 .toEqual({ allowed: false });
+            expect(evaluateMint({ checkinEnv: 'prod', mode: 'logout', caller: orgCaller }))
+                .toEqual({ allowed: false });
         });
     });
 
@@ -25,6 +27,7 @@ describe('evaluateMint', () => {
                 targetEmail: null,
                 impersonatedBy: 'daniel@innovationtreehouse.org',
                 carryGateClaims: true,
+                guest: false,
             });
         });
 
@@ -58,6 +61,7 @@ describe('evaluateMint', () => {
                 targetEmail: 'daniel@innovationtreehouse.org',
                 impersonatedBy: null,
                 carryGateClaims: true,
+                guest: false,
             });
         });
 
@@ -69,6 +73,39 @@ describe('evaluateMint', () => {
         });
     });
 
+    describe('dev — logout (synthetic guest session)', () => {
+        it('allows a verified org member and mints a guest crediting their email', () => {
+            expect(evaluateMint({ checkinEnv: 'dev', mode: 'logout', caller: orgCaller })).toEqual({
+                allowed: true,
+                targetEmail: null,
+                impersonatedBy: 'daniel@innovationtreehouse.org',
+                carryGateClaims: true,
+                guest: true,
+            });
+        });
+
+        it('refuses an unverified / non-org caller', () => {
+            expect(evaluateMint({ checkinEnv: 'dev', mode: 'logout', caller: { email: 'x@gmail.com', hd: null, emailVerified: true } }))
+                .toEqual({ allowed: false });
+            expect(evaluateMint({ checkinEnv: 'dev', mode: 'logout', caller: { email: 'x@innovationtreehouse.org', hd: ORG_DOMAIN, emailVerified: false } }))
+                .toEqual({ allowed: false });
+        });
+
+        it('refuses an anonymous caller (dev requires Google first)', () => {
+            expect(evaluateMint({ checkinEnv: 'dev', mode: 'logout', caller: null }))
+                .toEqual({ allowed: false });
+        });
+
+        it('credits the real human when viewing logged-out mid-impersonation', () => {
+            const nested = { email: 'jane@example.com', hd: ORG_DOMAIN, emailVerified: true, impersonatedBy: 'daniel@innovationtreehouse.org' };
+            expect(evaluateMint({ checkinEnv: 'dev', mode: 'logout', caller: nested })).toMatchObject({
+                allowed: true,
+                guest: true,
+                impersonatedBy: 'daniel@innovationtreehouse.org',
+            });
+        });
+    });
+
     describe('local', () => {
         it('first login (no caller) is a plain login, not an impersonation', () => {
             expect(evaluateMint({ checkinEnv: 'local', mode: 'impersonate', caller: null })).toEqual({
@@ -76,6 +113,7 @@ describe('evaluateMint', () => {
                 targetEmail: null,
                 impersonatedBy: null,
                 carryGateClaims: false,
+                guest: false,
             });
         });
 
@@ -86,6 +124,7 @@ describe('evaluateMint', () => {
                 targetEmail: null,
                 impersonatedBy: 'me@example.com',
                 carryGateClaims: false,
+                guest: false,
             });
         });
 
@@ -96,6 +135,27 @@ describe('evaluateMint', () => {
                 targetEmail: 'me@example.com',
                 impersonatedBy: null,
                 carryGateClaims: false,
+                guest: false,
+            });
+        });
+
+        it('logout is allowed for any caller and carries no gate claims', () => {
+            // No caller (laptop first action) → a plain guest with no real human to credit.
+            expect(evaluateMint({ checkinEnv: 'local', mode: 'logout', caller: null })).toEqual({
+                allowed: true,
+                targetEmail: null,
+                impersonatedBy: null,
+                carryGateClaims: false,
+                guest: true,
+            });
+            // From an existing local session → credits that identity so "Return to me" lands back.
+            const local = { email: 'me@example.com', hd: null, emailVerified: false, impersonatedBy: null };
+            expect(evaluateMint({ checkinEnv: 'local', mode: 'logout', caller: local })).toEqual({
+                allowed: true,
+                targetEmail: null,
+                impersonatedBy: 'me@example.com',
+                carryGateClaims: false,
+                guest: true,
             });
         });
     });

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -109,7 +109,10 @@ export const authOptions: NextAuthOptions = {
                     mode: { label: "Mode", type: "text" },
                 },
                 async authorize(credentials, req) {
-                    const mode: MintMode = credentials?.mode === "return" ? "return" : "impersonate";
+                    const mode: MintMode =
+                        credentials?.mode === "return" ? "return"
+                        : credentials?.mode === "logout" ? "logout"
+                        : "impersonate";
 
                     // The caller's *current* session — the security boundary. getToken decrypts the
                     // session cookie carried on this request; null when not signed in.
@@ -138,6 +141,23 @@ export const authOptions: NextAuthOptions = {
                             : null,
                     });
                     if (!decision.allowed) return null;
+
+                    // Logged-out preview: mint a synthetic guest session with NO participant. authz
+                    // sees a logged-out visitor (no id/roles via the jwt callback's email guard); the
+                    // inert impersonatedBy still credits the real human so "Return to me" works.
+                    if (decision.guest) {
+                        await recordLedger(
+                            "impersonate",
+                            decision.impersonatedBy ?? "unknown",
+                            "logged out",
+                        );
+                        return {
+                            id: "guest",
+                            email: null,
+                            name: "Logged out",
+                            impersonatedBy: decision.impersonatedBy,
+                        };
+                    }
 
                     // Resolve the target participant (fake data only — must already exist).
                     let dbParticipant;
@@ -208,9 +228,13 @@ export const authOptions: NextAuthOptions = {
                     token.emailVerified = true;
                 }
             }
-            if (user) {
+            // Guard on `user.email`: a synthetic guest mint (logged-out preview) returns a user with
+            // no email, so it resolves no participant and the token carries no id/roles — authz sees
+            // a logged-out visitor, while the persona-mint block above still stamped the gate claims
+            // + impersonatedBy so the dev gate passes and "Return to me" works.
+            if (user?.email) {
                 const dbParticipant = await prisma.participant.findUnique({
-                    where: { email: user.email! },
+                    where: { email: user.email },
                     include: {
                         toolStatuses: {
                             select: {

--- a/checkin-app/src/lib/impersonation.ts
+++ b/checkin-app/src/lib/impersonation.ts
@@ -11,8 +11,16 @@ import { ORG_DOMAIN, type CheckinEnv } from './config';
  * only — no authorization path (including the middleware gate) ever reads it. So that the dev
  * middleware still passes for an impersonating org member, minted dev sessions instead carry the
  * normal org gate claims (`hd` / `email_verified`), which is what `carryGateClaims` signals.
+ *
+ * Three modes:
+ *  - `impersonate` — become an existing @example.com persona.
+ *  - `return`      — go back to the real human in `impersonatedBy`.
+ *  - `logout`      — mint a synthetic *guest* session (no participant): authz sees a logged-out
+ *                    visitor (no id/roles), but the session still carries the gate claims +
+ *                    `impersonatedBy`, so an org member can preview the signed-out UX on the gated
+ *                    dev instance and click "Return to me" — without dropping their Google session.
  */
-export type MintMode = 'impersonate' | 'return';
+export type MintMode = 'impersonate' | 'return' | 'logout';
 
 /** The caller's *current* session claims (decoded JWT), or null if not signed in. */
 export interface CallerClaims {
@@ -35,6 +43,11 @@ export type MintDecision =
           impersonatedBy: string | null;
           /** Stamp org gate claims (hd/email_verified) so the dev middleware still passes. */
           carryGateClaims: boolean;
+          /**
+           * `logout` mode → mint a guest session with NO target participant; the provider returns a
+           * synthetic logged-out user instead of resolving `targetEmail`/`personaId`.
+           */
+          guest: boolean;
       };
 
 export function evaluateMint(params: {
@@ -59,23 +72,39 @@ export function evaluateMint(params: {
             targetEmail: realEmail,
             impersonatedBy: null,
             carryGateClaims: checkinEnv === 'dev',
+            guest: false,
+        };
+    }
+
+    // `impersonate` and `logout` share one caller gate: on the publicly-reachable cloud dev
+    // instance, only a verified org member may mint. (On local there is no Google identity, so this
+    // is relaxed — any session, or none, may mint.)
+    if (checkinEnv === 'dev' && !callerIsVerifiedOrg) return { allowed: false };
+
+    // The real identity behind the session: preserve the original if the caller is already
+    // impersonating (so nested "become X then become Y", or "become X then view logged out", still
+    // credits the real human), else the caller's own email, else null (local first-login = a plain
+    // login, not an impersonation).
+    const realIdentity = caller ? caller.impersonatedBy ?? caller.email ?? null : null;
+
+    if (mode === 'logout') {
+        // Guest session: no target participant. authz sees a logged-out visitor; the gate claims +
+        // inert impersonatedBy keep the dev instance reachable and "Return to me" working.
+        return {
+            allowed: true,
+            targetEmail: null,
+            impersonatedBy: realIdentity,
+            carryGateClaims: checkinEnv === 'dev',
+            guest: true,
         };
     }
 
     // mode === 'impersonate'
-    // On the publicly-reachable cloud dev instance, only a verified org member may mint.
-    // (On local there is no Google identity, so this is relaxed — any session, or none, may mint.)
-    if (checkinEnv === 'dev' && !callerIsVerifiedOrg) return { allowed: false };
-
-    // The real identity behind the impersonation: preserve the original if the caller is already
-    // impersonating (so nested "become X then become Y" still credits the real human), else the
-    // caller's own email, else null (local first-login = a plain login, not an impersonation).
-    const realIdentity = caller ? caller.impersonatedBy ?? caller.email ?? null : null;
-
     return {
         allowed: true,
         targetEmail: null,
         impersonatedBy: realIdentity,
         carryGateClaims: checkinEnv === 'dev',
+        guest: false,
     };
 }


### PR DESCRIPTION
## What

Adds two new session shortcuts to the **dev dashboard** "Change mock account" drawer, for an already-signed-in org member on the dev/local instance:

- **🔓 Logged out** — preview the *signed-out* experience on the gated dev instance **without dropping your real Google session**.
- **🛡 Admin** — one-click impersonate of the seeded sysadmin persona (`boardmember@example.com`).

Both go through the existing `persona-mint` flow and are gated by the same verified-org-member check — **dead in prod by construction**.

## How "logged out" works (the only non-trivial bit)

The dev instance gates every page behind org login, so literally signing out just bounces you to `/signin` and drops your Google session. Instead, a new **`logout` mint mode** produces a *synthetic guest* session:

| Claim | Value | Effect |
|---|---|---|
| participant id / roles | _none_ | authz sees a **logged-out visitor** |
| `hd` / `emailVerified` | org gate claims | **middleware still lets you browse** |
| `impersonatedBy` | the real human | **"Return to me"** works in one click |

The provider returns a user with no email; the `jwt` callback now skips the participant lookup when the minted user has no email (`if (user?.email)`), so the token carries no id/roles. The policy lives in the pure, exhaustively-unit-tested `evaluateMint()`: `logout` shares `impersonate`'s caller gate and credits the **real** human across nested "impersonate → view logged out". **No authorization path reads `impersonatedBy`** — the cardinal rule from `DEV_INSTANCE_DESIGN.md §5` is preserved.

`admin` adds no new persona — it reuses the seeded sysadmin (the design doc's §11 open question, "becoming a sysadmin persona is desired", answered yes).

## Files

- `src/lib/impersonation.ts` — `MintMode` gains `logout`; `MintDecision` gains `guest`; `impersonate`/`logout` share one caller gate.
- `src/lib/auth-options.ts` — `authorize()` handles `mode: "logout"` (synthetic guest user); `jwt` callback guards the participant lookup on `user?.email`.
- `src/components/DevDashboard.tsx` — 🛡 Admin + 🔓 Logged out quick-session buttons.
- `src/lib/__tests__/impersonation.test.ts` — `logout` coverage on dev/local/prod (verified-org gate, anonymous refusal, nested-impersonation credit, no-gate-claims on local) + `guest` field on existing cases.

## Testing

- `npx tsc --noEmit` clean.
- Full unit suite green (28 suites / 159 tests), incl. pre-commit `test:ci` + eslint + tsc.
- Integration suite not run locally (shared dev DB) — runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)