### PR TITLE
Add BSD 4-clause license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+Copyright (c) 2026, Innovation Treehouse Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. All advertising materials mentioning features or use of this software must
+   display the following acknowledgement:
+     This product includes software developed by Innovation Treehouse Inc.
+
+4. Neither the name of Innovation Treehouse Inc. nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL INNOVATION TREEHOUSE INC. OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "checkin-monorepo",
   "private": true,
+  "license": "BSD-4-Clause",
   "workspaces": [
     "packages/*",
     "*-app"


### PR DESCRIPTION
## What
Adds a `LICENSE` file with the **BSD 4-Clause** license (the original BSD license, including the advertising-acknowledgement clause), copyright **Innovation Treehouse Inc.** (2026), and sets the matching `"license": "BSD-4-Clause"` SPDX field in the root `package.json`.

## Notes
- This licenses the **source code only**. Per [TRADEMARKS.md](TRADEMARKS.md), it does **not** grant any rights to the Innovation Treehouse trademarks, logos, wordmark, brand colors, or other brand collateral — those remain reserved.
- BSD 4-Clause includes the clause 3 "advertising acknowledgement" requirement; confirm that's intended (vs. the more common 3-Clause, which drops it) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)