### PR TITLE
Publish + pull checkin image from ghcr.io

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,6 +22,7 @@ on:
 permissions:
   id-token: write       # assume the deploy role via OIDC
   contents: read        # checkout
+  packages: write       # push the image to ghcr.io
   pull-requests: write  # comment on the originating PR
 
 concurrency:
@@ -30,8 +31,7 @@ concurrency:
 
 env:
   AWS_REGION: us-east-2
-  ECR_REGISTRY: 639595353568.dkr.ecr.us-east-2.amazonaws.com
-  ECR_REPOSITORY: checkin-dev
+  IMAGE_REPO: ghcr.io/innovationtreehouse/checkin-dev
   ECS_CLUSTER: checkin-dev
   ECS_SERVICE: checkin-dev
   APP_TASK_FAMILY: checkin-dev
@@ -68,13 +68,17 @@ jobs:
           role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Log in to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
         id: build
         env:
-          IMAGE: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.vars.outputs.sha }}
+          IMAGE: ${{ env.IMAGE_REPO }}:${{ steps.vars.outputs.sha }}
           # Public store domain baked into the client bundle (NEXT_PUBLIC_*, build-time).
           # Set as a repo variable (Settings > Variables); empty is harmless.
           NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN: ${{ vars.SHOPIFY_STORE_DOMAIN }}
@@ -202,7 +206,7 @@ jobs:
           if [ "$STATUS" = "success" ]; then
             BODY="### ✅ Deployed to dev
           Commit \`$SHORT_SHA\` is live on [$APP_URL]($APP_URL).
-          - Image: \`$ECR_REPOSITORY:$SHORT_SHA\`
+          - Image: \`$IMAGE_REPO:$SHORT_SHA\`
           - Migrations: applied · Service: stable
           - [Deploy run]($RUN_URL)"
           else


### PR DESCRIPTION
## What
Moves the checkin app image from **ECR → private ghcr.io** (`ghcr.io/innovationtreehouse/checkin-dev`). Final piece of the egress/ghcr migration; companion to **infra PR #72** (drops the ECR VPC endpoints, adds `repositoryCredentials` to the checkin task defs) — apply that first.

## Changes (`deploy-dev.yml`)
- `permissions: packages: write`.
- env: drop `ECR_REGISTRY`/`ECR_REPOSITORY`; add `IMAGE_REPO: ghcr.io/innovationtreehouse/checkin-dev`.
- Replace `amazon-ecr-login` with a ghcr.io `docker/login-action` (`GITHUB_TOKEN`).
- Build/push and the PR-comment image line use `IMAGE_REPO`.

## Why minimal elsewhere
- **No `assignPublicIp` change**: the migrate run-task reuses the service's own `networkConfiguration` (already public-IP, no NAT), so it can pull the private ghcr image and reach the DB unchanged.
- **`repositoryCredentials` preserved**: both task-def re-registers take `containerDefinitions` whole and only swap `.image`, so the creds added in infra #72 survive.
- **`ci.yml` untouched**: its `docker build` is a local build-check with no push.
- AWS OIDC creds stay — still needed for ECS rollout + migrations.

## ⚠️ Required out-of-band
- The `ghcr.io/innovationtreehouse/checkin-dev` package must exist and be writable by the repo's `GITHUB_TOKEN` (or a PAT), and readable by the infra `ghcr-pull-credentials` secret used by ECS.
- (Prod, when it exists) mirror this for `checkin-prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)