### PR TITLE
refactor(shop): remove Shop Steward role; gate Certifier promotion to board/admin

### DIFF
--- a/checkin-app/prisma/migrations/20260613000000_remove_shop_steward_role/migration.sql
+++ b/checkin-app/prisma/migrations/20260613000000_remove_shop_steward_role/migration.sql
@@ -1,0 +1,7 @@
+-- The Shop Steward role is removed. No role grants carte-blanche
+-- "may certify others" authority anymore: only sysadmin/board may promote a
+-- user to MAY_CERTIFY_OTHERS, and such users can change certification status up
+-- to (but not including) MAY_CERTIFY_OTHERS.
+
+-- DropColumn
+ALTER TABLE "Participant" DROP COLUMN "shopSteward";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -94,8 +94,6 @@ model Participant {
   /// @sensitivity:internal
   keyholder               Boolean @default(false)
   /// @sensitivity:internal
-  shopSteward             Boolean @default(false)
-  /// @sensitivity:internal
   backgroundCheckReviewer Boolean @default(false)
 
   toolStatuses        ToolStatus[]

--- a/checkin-app/scripts/full_reset_and_dev_init.sh
+++ b/checkin-app/scripts/full_reset_and_dev_init.sh
@@ -46,22 +46,25 @@ async function seed() {
     );
 
     // ── Participants ──
+    // The Shop Steward role was removed (only sysadmin/board grant the per-tool Certifier level).
+    // Carol and Frank stay keyholders; certifier authority is now a per-tool MAY_CERTIFY_OTHERS
+    // grant seeded elsewhere, not a participant flag.
     const personas = [
-        { name: 'Alice Admin',     email: 'alice.admin@example.com',      sysadmin: true,  boardMember: true,  keyholder: true,  shopSteward: false, householdId: householdId, dob: '1985-03-15' },
-        { name: 'Bob Board',       email: 'bob.board@example.com',        sysadmin: false, boardMember: true,  keyholder: false, shopSteward: false, householdId: null,        dob: '1990-06-22' },
-        { name: 'Carol Keyholder', email: 'carol.keyholder@example.com',  sysadmin: false, boardMember: false, keyholder: true,  shopSteward: true,  householdId: household2Id, dob: '1988-11-05' },
-        { name: 'Dave Member',     email: 'dave.member@example.com',      sysadmin: false, boardMember: false, keyholder: false, shopSteward: false, householdId: householdId, dob: '1992-01-30' },
-        { name: 'Eve Guest',       email: 'eve.guest@example.com',        sysadmin: false, boardMember: false, keyholder: false, shopSteward: false, householdId: null,        dob: '1995-09-12' },
-        { name: 'Frank Steward',   email: 'frank.steward@example.com',    sysadmin: false, boardMember: false, keyholder: true,  shopSteward: true,  householdId: household2Id, dob: '1987-04-18' },
-        { name: 'Grace Minor',     email: null,                           sysadmin: false, boardMember: false, keyholder: false, shopSteward: false, householdId: householdId, dob: '2015-07-25' },
-        { name: 'Henry Teen',      email: 'henry.teen@example.com',       sysadmin: false, boardMember: false, keyholder: false, shopSteward: false, householdId: householdId, dob: '2010-12-03' },
+        { name: 'Alice Admin',     email: 'alice.admin@example.com',      sysadmin: true,  boardMember: true,  keyholder: true,  householdId: householdId, dob: '1985-03-15' },
+        { name: 'Bob Board',       email: 'bob.board@example.com',        sysadmin: false, boardMember: true,  keyholder: false, householdId: null,        dob: '1990-06-22' },
+        { name: 'Carol Keyholder', email: 'carol.keyholder@example.com',  sysadmin: false, boardMember: false, keyholder: true,  householdId: household2Id, dob: '1988-11-05' },
+        { name: 'Dave Member',     email: 'dave.member@example.com',      sysadmin: false, boardMember: false, keyholder: false, householdId: householdId, dob: '1992-01-30' },
+        { name: 'Eve Guest',       email: 'eve.guest@example.com',        sysadmin: false, boardMember: false, keyholder: false, householdId: null,        dob: '1995-09-12' },
+        { name: 'Frank Member',    email: 'frank.member@example.com',     sysadmin: false, boardMember: false, keyholder: true,  householdId: household2Id, dob: '1987-04-18' },
+        { name: 'Grace Minor',     email: null,                           sysadmin: false, boardMember: false, keyholder: false, householdId: householdId, dob: '2015-07-25' },
+        { name: 'Henry Teen',      email: 'henry.teen@example.com',       sysadmin: false, boardMember: false, keyholder: false, householdId: householdId, dob: '2010-12-03' },
     ];
 
     for (const p of personas) {
         const result = await pool.query(
-            \`INSERT INTO \"Participant\" (name, email, sysadmin, \"boardMember\", keyholder, \"shopSteward\", \"householdId\", dob)
-             VALUES (\\\$1, \\\$2, \\\$3, \\\$4, \\\$5, \\\$6, \\\$7, \\\$8) RETURNING id\`,
-            [p.name, p.email, p.sysadmin, p.boardMember, p.keyholder, p.shopSteward, p.householdId, p.dob ? new Date(p.dob) : null]
+            \`INSERT INTO \"Participant\" (name, email, sysadmin, \"boardMember\", keyholder, \"householdId\", dob)
+             VALUES (\\\$1, \\\$2, \\\$3, \\\$4, \\\$5, \\\$6, \\\$7) RETURNING id\`,
+            [p.name, p.email, p.sysadmin, p.boardMember, p.keyholder, p.householdId, p.dob ? new Date(p.dob) : null]
         );
         console.log('  ✓ ' + p.name + (p.email ? ' (' + p.email + ')' : ' (no email — minor)'));
 

--- a/checkin-app/src/app/__tests__/safetyLinkAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/safetyLinkAPI.integration.test.ts
@@ -20,7 +20,7 @@ const TAG = 'safetylink-api-test';
 
 function as(id: number, householdId: number, roles: { boardMember?: boolean; sysadmin?: boolean } = {}) {
     (getServerSession as jest.Mock).mockResolvedValue({
-        user: { id, householdId, sysadmin: false, boardMember: false, keyholder: false, shopSteward: false, backgroundCheckReviewer: false, ...roles },
+        user: { id, householdId, sysadmin: false, boardMember: false, keyholder: false, backgroundCheckReviewer: false, ...roles },
     });
 }
 function post(url: string, body: unknown) {

--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -18,7 +18,7 @@ jest.mock('next-auth/next', () => ({
 }));
 describe('Shop API Integration Tests', () => {
     let adminId: number;
-    let stewardId: number;
+    let boardId: number;
     let certifierId: number;
     let commonId: number;
     
@@ -67,11 +67,11 @@ describe('Shop API Integration Tests', () => {
         });
         adminId = admin.id;
 
-        // Create Steward
-        const steward = await prisma.participant.create({
-            data: { email: 'steward-shop-api-test@example.com', name: 'Steward', shopSteward: true, household: { create: {} } }
+        // Create Board Member
+        const board = await prisma.participant.create({
+            data: { email: 'board-shop-api-test@example.com', name: 'Board', boardMember: true, household: { create: {} } }
         });
-        stewardId = steward.id;
+        boardId = board.id;
 
         // Create Common User
         const commonUser = await prisma.participant.create({
@@ -109,7 +109,7 @@ describe('Shop API Integration Tests', () => {
     });
 
     afterAll(async () => {
-        const existingUserIds = [adminId, stewardId, certifierId, commonId].filter(id => id !== undefined);
+        const existingUserIds = [adminId, boardId, certifierId, commonId].filter(id => id !== undefined);
 
         if (existingUserIds.length > 0) {
             const participants = await prisma.participant.findMany({
@@ -168,8 +168,8 @@ describe('Shop API Integration Tests', () => {
              expect(res.status).toBe(403);
         });
 
-        it('should return 200 and active occupants for standard shop steward', async () => {
-             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: stewardId, shopSteward: true } });
+        it('should return 200 and active occupants for board member', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, boardMember: true } });
 
              const res = await getActive() as Response;
              expect(res.status).toBe(200);
@@ -243,16 +243,16 @@ describe('Shop API Integration Tests', () => {
              expect(data.tool.name).toBe('Shop Test Tool Admin');
         });
 
-        it('should allow shop stewards to create a new tool', async () => {
-             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: stewardId, shopSteward: true } });
+        it('should allow board members to create a new tool', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, boardMember: true } });
 
-             const req = createReq('POST', { body: { name: 'Shop Test Tool Steward' } });
+             const req = createReq('POST', { body: { name: 'Shop Test Tool Board' } });
              const res = await postTools(req) as Response;
              expect(res.status).toBe(200);
-             
+
              const data = await res.json();
              expect(data.success).toBe(true);
-             expect(data.tool.name).toBe('Shop Test Tool Steward');
+             expect(data.tool.name).toBe('Shop Test Tool Board');
         });
     });
 
@@ -290,6 +290,27 @@ describe('Shop API Integration Tests', () => {
              expect(data.success).toBe(true);
              expect(data.certification.level).toBe('BASIC');
              expect(data.certification.userId).toBe(commonId);
+        });
+
+        it('should forbid a Certifier from promoting someone to MAY_CERTIFY_OTHERS', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: certifierId } });
+
+             const req = createReq('POST', { body: { participantId: commonId, toolId: mockToolId, level: 'MAY_CERTIFY_OTHERS' } });
+             const res = await postCerts(req) as Response;
+             // Only admins/board may grant the Certifier level.
+             expect(res.status).toBe(403);
+        });
+
+        it('should allow an admin to grant MAY_CERTIFY_OTHERS', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, sysadmin: true } });
+
+             const req = createReq('POST', { body: { participantId: commonId, toolId: mockToolId, level: 'MAY_CERTIFY_OTHERS' } });
+             const res = await postCerts(req) as Response;
+             expect(res.status).toBe(200);
+
+             const data = await res.json();
+             expect(data.success).toBe(true);
+             expect(data.certification.level).toBe('MAY_CERTIFY_OTHERS');
         });
     });
 });

--- a/checkin-app/src/app/admin/print-badges/page.tsx
+++ b/checkin-app/src/app/admin/print-badges/page.tsx
@@ -18,7 +18,6 @@ type ParticipantRow = {
   email: string | null;
   isMember?: boolean;
   boardMember?: boolean;
-  shopSteward?: boolean;
   keyholder?: boolean;
 };
 
@@ -97,7 +96,6 @@ export default function PrintBadgesPage() {
             name: p.name ?? '',
             isMember: !!p.isMember,
             boardMember: !!p.boardMember,
-            shopSteward: !!p.shopSteward,
             keyholder: !!p.keyholder,
             qrDataUri,
           };
@@ -164,9 +162,8 @@ export default function PrintBadgesPage() {
       render: (p) => (
         <Group gap={4}>
           {p.boardMember && <Badge size="xs" color="blue">BOARD</Badge>}
-          {p.shopSteward && <Badge size="xs" color="grape">STEWARD</Badge>}
           {p.keyholder && <Badge size="xs" color="orange">KEYHOLDER</Badge>}
-          {!p.boardMember && !p.shopSteward && !p.keyholder && p.isMember && (
+          {!p.boardMember && !p.keyholder && p.isMember && (
             <Badge size="xs" color="green">MEMBER</Badge>
           )}
         </Group>

--- a/checkin-app/src/app/admin/roles/page.tsx
+++ b/checkin-app/src/app/admin/roles/page.tsx
@@ -13,7 +13,6 @@ type UserRole = {
   sysadmin: boolean;
   boardMember: boolean;
   keyholder: boolean;
-  shopSteward: boolean;
   backgroundCheckReviewer: boolean;
 };
 
@@ -21,7 +20,6 @@ const ROLE_COLUMNS: { field: keyof UserRole; label: string }[] = [
   { field: 'sysadmin', label: 'Sysadmin' },
   { field: 'boardMember', label: 'Board Member' },
   { field: 'keyholder', label: 'Keyholder' },
-  { field: 'shopSteward', label: 'Shop Steward' },
   { field: 'backgroundCheckReviewer', label: 'BG Reviewer' },
 ];
 

--- a/checkin-app/src/app/api/admin/participants/[id]/route.ts
+++ b/checkin-app/src/app/api/admin/participants/[id]/route.ts
@@ -46,7 +46,6 @@ export async function PUT(
             email: updatedParticipant.email,
             phone: updatedParticipant.phone,
             boardMember: updatedParticipant.boardMember,
-            shopSteward: updatedParticipant.shopSteward,
             keyholder: updatedParticipant.keyholder,
             household: updatedParticipant.household,
         };

--- a/checkin-app/src/app/api/admin/participants/search/route.ts
+++ b/checkin-app/src/app/api/admin/participants/search/route.ts
@@ -41,7 +41,6 @@ export const GET = withAuth(
                 phone: p.phone,
                 isMember: participantRecordIsActiveMember(p),
                 boardMember: p.boardMember,
-                shopSteward: p.shopSteward,
                 keyholder: p.keyholder,
                 household: p.household,
             }));

--- a/checkin-app/src/app/api/admin/roles/route.ts
+++ b/checkin-app/src/app/api/admin/roles/route.ts
@@ -23,7 +23,6 @@ export const GET = withAuth(
                     sysadmin: true,
                     boardMember: true,
                     keyholder: true,
-                    shopSteward: true,
                     backgroundCheckReviewer: true,
                 },
                 orderBy: { name: "asc" },
@@ -55,7 +54,7 @@ export const PATCH = withAuth(
                 );
             }
 
-            const allowedFields = ["sysadmin", "boardMember", "keyholder", "shopSteward", "backgroundCheckReviewer"];
+            const allowedFields = ["sysadmin", "boardMember", "keyholder", "backgroundCheckReviewer"];
             const updateData: Record<string, NonNullable<unknown> | null | string | number | boolean | Date> = {};
             for (const field of allowedFields) {
                 if (roleUpdates[field] !== undefined) {
@@ -77,7 +76,6 @@ export const PATCH = withAuth(
                     sysadmin: true,
                     boardMember: true,
                     keyholder: true,
-                    shopSteward: true,
                     backgroundCheckReviewer: true,
                 },
             });

--- a/checkin-app/src/app/api/auth/dev-personas/route.ts
+++ b/checkin-app/src/app/api/auth/dev-personas/route.ts
@@ -37,7 +37,6 @@ export async function GET() {
             sysadmin: true,
             boardMember: true,
             keyholder: true,
-            shopSteward: true,
             backgroundCheckReviewer: true,
             dob: true,
             householdId: true,

--- a/checkin-app/src/app/api/kiosk/certifications/route.ts
+++ b/checkin-app/src/app/api/kiosk/certifications/route.ts
@@ -48,7 +48,6 @@ export async function GET(req: NextRequest) {
                             email: true,
                             name: true,
                             dob: true,
-                            shopSteward: true,
                             toolStatuses: {
                                 select: { toolId: true, level: true }
                             }
@@ -65,7 +64,6 @@ export async function GET(req: NextRequest) {
                     email: true,
                     name: true,
                     dob: true,
-                    shopSteward: true,
                     toolStatuses: {
                         select: { toolId: true, level: true }
                     }
@@ -92,7 +90,6 @@ export async function GET(req: NextRequest) {
                 id: participant.id,
                 email: participant.email,
                 name: participant.name,
-                shopSteward: participant.shopSteward,
                 toolStatuses: participant.toolStatuses,
                 ageCategory,
             };

--- a/checkin-app/src/app/api/shop/active/route.ts
+++ b/checkin-app/src/app/api/shop/active/route.ts
@@ -17,11 +17,10 @@ export async function GET() {
 
     const isAuthorized = session.user?.sysadmin ||
         session.user?.boardMember ||
-        session.user?.shopSteward ||
         hasCertifierAuth;
 
     if (!isAuthorized) {
-        return NextResponse.json({ error: "Forbidden: Requires Shop Steward, Admin, or Certifier role" }, { status: 403 });
+        return NextResponse.json({ error: "Forbidden: Requires Admin, Board, or Certifier role" }, { status: 403 });
     }
 
     try {

--- a/checkin-app/src/app/api/shop/certifications/route.ts
+++ b/checkin-app/src/app/api/shop/certifications/route.ts
@@ -18,9 +18,9 @@ export async function GET(req: Request) {
         const toolIdParam = searchParams.get('toolId');
         const allParam = searchParams.get('all');
 
-        // ?all=true returns every assignment — admin/shop steward only
+        // ?all=true returns every assignment — admin/board only
         if (allParam === 'true') {
-            const isAuthorized = session.user?.sysadmin || session.user?.boardMember || session.user?.shopSteward;
+            const isAuthorized = session.user?.sysadmin || session.user?.boardMember;
             if (!isAuthorized) {
                 return NextResponse.json({ error: "Forbidden" }, { status: 403 });
             }
@@ -108,6 +108,13 @@ export async function POST(req: Request) {
 
         if (!hasCertifierPermission) {
             return NextResponse.json({ error: "Forbidden: You are not authorized to certify users on this tool" }, { status: 403 });
+        }
+
+        // Only sysadmins/board may promote a user to MAY_CERTIFY_OTHERS. A tool
+        // certifier can change certification status up to (but not including)
+        // MAY_CERTIFY_OTHERS — they cannot mint new certifiers.
+        if (level === "MAY_CERTIFY_OTHERS" && !isSysAdminOrBoard) {
+            return NextResponse.json({ error: "Forbidden: Only admins and board members can grant the Certifier level" }, { status: 403 });
         }
 
         const tId = parseInt(toolId, 10);

--- a/checkin-app/src/app/api/shop/members/route.ts
+++ b/checkin-app/src/app/api/shop/members/route.ts
@@ -18,11 +18,10 @@ export async function GET() {
 
     const isAuthorized = session.user?.sysadmin ||
         session.user?.boardMember ||
-        session.user?.shopSteward ||
         hasCertifierAuth;
 
     if (!isAuthorized) {
-        return NextResponse.json({ error: "Forbidden: Requires Shop Steward, Admin, or Certifier role" }, { status: 403 });
+        return NextResponse.json({ error: "Forbidden: Requires Admin, Board, or Certifier role" }, { status: 403 });
     }
 
     try {

--- a/checkin-app/src/app/api/shop/tools/[id]/route.ts
+++ b/checkin-app/src/app/api/shop/tools/[id]/route.ts
@@ -11,7 +11,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const isAuthorized = session.user?.sysadmin || session.user?.boardMember || session.user?.shopSteward;
+    const isAuthorized = session.user?.sysadmin || session.user?.boardMember;
     if (!isAuthorized) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/checkin-app/src/app/api/shop/tools/route.ts
+++ b/checkin-app/src/app/api/shop/tools/route.ts
@@ -35,10 +35,10 @@ export async function POST(req: Request) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const isAuthorized = session.user?.sysadmin || session.user?.boardMember || session.user?.shopSteward;
+    const isAuthorized = session.user?.sysadmin || session.user?.boardMember;
 
     if (!isAuthorized) {
-        return NextResponse.json({ error: "Forbidden: Only admins, board members, and shop stewards can create tools" }, { status: 403 });
+        return NextResponse.json({ error: "Forbidden: Only admins and board members can create tools" }, { status: 403 });
     }
 
     try {

--- a/checkin-app/src/app/kioskdisplay/certifications/page.tsx
+++ b/checkin-app/src/app/kioskdisplay/certifications/page.tsx
@@ -14,7 +14,6 @@ type Participant = {
   email: string;
   name: string | null;
   ageCategory?: "ADULT" | "STUDENT";
-  shopSteward?: boolean;
   toolStatuses: {
     toolId: number;
     level: ToolStatusLevel;
@@ -138,13 +137,8 @@ function KioskCertificationsInner() {
       </td>
       {tools.map((tool) => {
         const status = participant.toolStatuses.find(ts => ts.toolId === tool.id);
-        let bgColor = getColorForLevel(status?.level);
-        let opacity = status ? 0.8 : 1;
-
-        if (participant.shopSteward) {
-          bgColor = getColorForLevel("MAY_CERTIFY_OTHERS");
-          opacity = 0.8;
-        }
+        const bgColor = getColorForLevel(status?.level);
+        const opacity = status ? 0.8 : 1;
 
         return (
           <td key={tool.id} style={{ padding: 0, textAlign: 'center', borderRight: cellBorder, height: '100%' }}>

--- a/checkin-app/src/app/shop/page.tsx
+++ b/checkin-app/src/app/shop/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Alert, Button, Card, Center, Container, Group, Loader, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 
-export default function ShopStewardPage() {
+export default function ShopOpsPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
 
@@ -30,13 +30,12 @@ export default function ShopStewardPage() {
 
   const isSysadmin = session?.user?.sysadmin;
   const isBoardMember = session?.user?.boardMember;
-  const isShopSteward = session?.user?.shopSteward;
-  const isAdmin = isSysadmin || isBoardMember || isShopSteward;
+  const isAdmin = isSysadmin || isBoardMember;
 
-  // Certifier check: either Shop Steward, Board Member, Admin, or explicitly has MAY_CERTIFY_OTHERS
+  // Certifier check: Board Member, Admin, or explicitly has MAY_CERTIFY_OTHERS
   const certs = session?.user?.toolStatuses || [];
   const hasCertifierAuth = certs.some((ts: { level?: string }) => ts.level === 'MAY_CERTIFY_OTHERS');
-  const isCertifier = isSysadmin || isBoardMember || session?.user?.shopSteward || hasCertifierAuth;
+  const isCertifier = isSysadmin || isBoardMember || hasCertifierAuth;
 
   if (!isCertifier && !isAdmin) {
     return (
@@ -44,7 +43,7 @@ export default function ShopStewardPage() {
         <Card withBorder radius="md" padding="xl">
           <Title order={2} mb="sm">Access Denied</Title>
           <Alert color="red" mb="md">
-            Forbidden: You require the Shop Steward, Admin, Board Member, or Certifier role to view
+            Forbidden: You require the Admin, Board Member, or Certifier role to view
             this page.
           </Alert>
           <Button onClick={() => router.push('/dashboard')}>Back to Dashboard</Button>

--- a/checkin-app/src/app/shop/tools/new/page.tsx
+++ b/checkin-app/src/app/shop/tools/new/page.tsx
@@ -50,7 +50,7 @@ export default function CreateToolPage() {
     return <Center mih="60vh"><Loader /></Center>;
   }
 
-  const isAdmin = session?.user?.boardMember || session?.user?.sysadmin || session?.user?.shopSteward;
+  const isAdmin = session?.user?.boardMember || session?.user?.sysadmin;
 
   if (!isAdmin) {
     return (
@@ -58,7 +58,7 @@ export default function CreateToolPage() {
         <Card withBorder radius="md" padding="xl">
           <Title order={2} mb="sm">Access Denied</Title>
           <Alert color="red" mb="md">
-            Forbidden: Only Admins, Board Members, and Shop Stewards can define new tools.
+            Forbidden: Only Admins and Board Members can define new tools.
           </Alert>
           <Button onClick={() => router.push('/shop')}>Back to Shop Ops</Button>
         </Card>

--- a/checkin-app/src/app/shop/tools/page.tsx
+++ b/checkin-app/src/app/shop/tools/page.tsx
@@ -38,7 +38,7 @@ const LEVEL_OPTIONS = [
 ];
 
 function GrantForm({
-  tools, members, prefillToolId, prefillMemberId, onGranted, saving, setSaving,
+  tools, members, prefillToolId, prefillMemberId, onGranted, saving, setSaving, canGrantCertifier,
 }: {
   tools: Tool[];
   members: Member[];
@@ -47,7 +47,14 @@ function GrantForm({
   onGranted: (msg: string) => void;
   saving: boolean;
   setSaving: (v: boolean) => void;
+  // Only admins/board may grant the Certifier (MAY_CERTIFY_OTHERS) level.
+  canGrantCertifier: boolean;
 }) {
+  // Tool certifiers can grant up to (but not including) Certifier; the backend
+  // enforces this too — this just keeps the option out of their dropdown.
+  const levelOptions = canGrantCertifier
+    ? LEVEL_OPTIONS
+    : LEVEL_OPTIONS.filter(o => o.value !== 'MAY_CERTIFY_OTHERS');
   const [toolId, setToolId] = useState(prefillToolId?.toString() ?? "");
   const [memberId, setMemberId] = useState(prefillMemberId?.toString() ?? "");
   const [level, setLevel] = useState("CERTIFIED");
@@ -110,7 +117,7 @@ function GrantForm({
               data={members.map(m => ({ value: String(m.id), label: m.name ?? m.email }))}
             />
           )}
-          <Select label="Level" w={140} value={level} onChange={(v) => setLevel(v ?? "CERTIFIED")} allowDeselect={false} data={LEVEL_OPTIONS} />
+          <Select label="Level" w={140} value={level} onChange={(v) => setLevel(v ?? "CERTIFIED")} allowDeselect={false} data={levelOptions} />
           <Button type="submit" color="green" disabled={saving}>Grant</Button>
         </Group>
       </form>
@@ -239,6 +246,7 @@ function ToolsTab({ tools, members, isAdmin, isCertifier, onToolsChange }: {
                         <>
                           {grantMsg && <Text size="sm" c="cyan" mb="sm">{grantMsg}</Text>}
                           <GrantForm tools={tools} members={members} prefillToolId={tool.id}
+                            canGrantCertifier={isAdmin}
                             onGranted={m => { setGrantMsg(m); toggle(tool.id).then(() => toggle(tool.id)); }}
                             saving={grantSaving} setSaving={setGrantSaving} />
                         </>
@@ -265,7 +273,7 @@ function ToolsTab({ tools, members, isAdmin, isCertifier, onToolsChange }: {
 
 // ---- By Person tab ----
 
-function PersonTab({ members, tools, isCertifier }: { members: Member[]; tools: Tool[]; isCertifier: boolean }) {
+function PersonTab({ members, tools, isCertifier, isAdmin }: { members: Member[]; tools: Tool[]; isCertifier: boolean; isAdmin: boolean }) {
   const [expanded, setExpanded] = useState<number | null>(null);
   const [certs, setCerts] = useState<Certification[]>([]);
   const [loadingCerts, setLoadingCerts] = useState(false);
@@ -330,6 +338,7 @@ function PersonTab({ members, tools, isCertifier }: { members: Member[]; tools: 
                         <>
                           {grantMsg && <Text size="sm" c="cyan" mb="sm">{grantMsg}</Text>}
                           <GrantForm tools={tools} members={members} prefillMemberId={member.id}
+                            canGrantCertifier={isAdmin}
                             onGranted={m => { setGrantMsg(m); toggle(member.id).then(() => toggle(member.id)); }}
                             saving={grantSaving} setSaving={setGrantSaving} />
                         </>
@@ -437,17 +446,17 @@ export default function ToolManagementPage() {
 
   const isSysadmin = session?.user?.sysadmin;
   const isBoardMember = session?.user?.boardMember;
-  const isAdmin = isSysadmin || isBoardMember || session?.user?.shopSteward;
+  const isAdmin = isSysadmin || isBoardMember;
 
   const hasCertifierAuth = (session?.user?.toolStatuses ?? []).some((ts: { level?: string }) => ts.level === 'MAY_CERTIFY_OTHERS');
-  const isCertifier = isSysadmin || isBoardMember || session?.user?.shopSteward || hasCertifierAuth;
+  const isCertifier = isSysadmin || isBoardMember || hasCertifierAuth;
 
   if (!isCertifier && !isAdmin) {
     return (
       <Container size="sm" py="xl">
         <Card withBorder radius="md" padding="xl">
           <Title order={2} mb="sm">Access Denied</Title>
-          <Alert color="red" mb="md">Forbidden: You require the Shop Steward, Admin, Board Member, or Certifier role.</Alert>
+          <Alert color="red" mb="md">Forbidden: You require the Admin, Board Member, or Certifier role.</Alert>
           <Button onClick={() => router.push('/shop')}>Back to Shop Ops</Button>
         </Card>
       </Container>
@@ -476,7 +485,7 @@ export default function ToolManagementPage() {
           <ToolsTab tools={tools} members={members} isAdmin={!!isAdmin} isCertifier={!!isCertifier} onToolsChange={reloadTools} />
         </Tabs.Panel>
         <Tabs.Panel value="person">
-          <PersonTab members={members} tools={tools} isCertifier={!!isCertifier} />
+          <PersonTab members={members} tools={tools} isCertifier={!!isCertifier} isAdmin={!!isAdmin} />
         </Tabs.Panel>
         {isAdmin && (
           <Tabs.Panel value="all">

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -39,7 +39,6 @@ import type { TodoCounts } from '@/app/api/nav/todo-counts/route';
 type SessionUser = {
   sysadmin?: boolean;
   boardMember?: boolean;
-  shopSteward?: boolean;
   toolStatuses?: Array<{ level: string }>;
 };
 
@@ -61,7 +60,6 @@ const NAV_ITEMS: NavItem[] = [
     visible: (u) =>
       !!u?.sysadmin ||
       !!u?.boardMember ||
-      !!u?.shopSteward ||
       !!u?.toolStatuses?.some((ts) => ts.level === 'MAY_CERTIFY_OTHERS'),
   },
   {

--- a/checkin-app/src/components/DevLoginPicker.tsx
+++ b/checkin-app/src/components/DevLoginPicker.tsx
@@ -11,7 +11,6 @@ interface Persona {
   sysadmin: boolean;
   boardMember: boolean;
   keyholder: boolean;
-  shopSteward: boolean;
   backgroundCheckReviewer: boolean;
   dob: string | null;
   householdId: number | null;
@@ -54,7 +53,6 @@ export default function DevLoginPicker() {
     if (p.sysadmin) badges.push({ label: "Sysadmin", color: "red" });
     if (p.boardMember) badges.push({ label: "Board", color: "grape" });
     if (p.keyholder) badges.push({ label: "Keyholder", color: "blue" });
-    if (p.shopSteward) badges.push({ label: "Shop Steward", color: "orange" });
     if (p.backgroundCheckReviewer) badges.push({ label: "BG Reviewer", color: "teal" });
     if (p.toolStatuses?.length > 0) badges.push({ label: "Certified", color: "green" });
     if (p.householdId) badges.push({ label: "Household", color: "indigo" });

--- a/checkin-app/src/components/admin/BadgeDocument.tsx
+++ b/checkin-app/src/components/admin/BadgeDocument.tsx
@@ -107,7 +107,6 @@ interface ParticipantBadge {
     name: string;
     isMember: boolean;
     boardMember: boolean;
-    shopSteward: boolean;
     keyholder: boolean;
     qrDataUri: string;
 }
@@ -174,17 +173,12 @@ export default function BadgeDocument({ badges }: { badges: ParticipantBadge[] }
                                                 <Text style={styles.roleText}>BOARD</Text>
                                             </View>
                                         )}
-                                        {badge.shopSteward && (
-                                            <View style={{ ...styles.rolePill, backgroundColor: '#8b5cf6' }}>
-                                                <Text style={styles.roleText}>STEWARD</Text>
-                                            </View>
-                                        )}
                                         {badge.keyholder && (
                                             <View style={{ ...styles.rolePill, backgroundColor: '#f59e0b' }}>
                                                 <Text style={styles.roleText}>KEYHOLDER</Text>
                                             </View>
                                         )}
-                                        {(!badge.boardMember && !badge.shopSteward && !badge.keyholder && badge.isMember) && (
+                                        {(!badge.boardMember && !badge.keyholder && badge.isMember) && (
                                             <View style={{ ...styles.rolePill, backgroundColor: '#10b981' }}>
                                                 <Text style={styles.roleText}>MEMBER</Text>
                                             </View>

--- a/checkin-app/src/components/ui/RoleBadge.tsx
+++ b/checkin-app/src/components/ui/RoleBadge.tsx
@@ -13,7 +13,6 @@ const ROLE_META: Record<string, RoleMeta> = {
   sysadmin: { label: 'Sysadmin', color: 'red' },
   boardMember: { label: 'Board', color: 'grape' },
   keyholder: { label: 'Keyholder', color: 'blue' },
-  shopSteward: { label: 'Shop Steward', color: 'teal' },
   backgroundCheckReviewer: { label: 'BG Reviewer', color: 'indigo' },
   coreVolunteer: { label: 'Core Volunteer', color: 'pink' },
   // Tool certification levels

--- a/checkin-app/src/lib/__tests__/authClaims.test.ts
+++ b/checkin-app/src/lib/__tests__/authClaims.test.ts
@@ -7,7 +7,6 @@ function participant(overrides: Partial<ClaimSourceParticipant> = {}): ClaimSour
         sysadmin: true,
         keyholder: true,
         boardMember: true,
-        shopSteward: true,
         backgroundCheckReviewer: true,
         householdId: 99,
         toolStatuses: [{ toolId: 1, level: 'CERTIFIED' }],
@@ -25,7 +24,6 @@ describe('assignParticipantClaims — household login gate', () => {
         expect(token.sysadmin).toBe(false);
         expect(token.keyholder).toBe(false);
         expect(token.boardMember).toBe(false);
-        expect(token.shopSteward).toBe(false);
         expect(token.backgroundCheckReviewer).toBe(false);
         expect(token.toolStatuses).toEqual([]);
         // Identity is preserved so the session still resolves and the gate can act.

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -305,7 +305,6 @@ export const authOptions: NextAuthOptions = {
                 session.user.sysadmin = token.sysadmin;
                 session.user.keyholder = token.keyholder;
                 session.user.boardMember = token.boardMember;
-                session.user.shopSteward = token.shopSteward;
                 session.user.backgroundCheckReviewer = token.backgroundCheckReviewer;
                 session.user.householdId = token.householdId;
                 session.user.toolStatuses = token.toolStatuses || [];

--- a/checkin-app/src/lib/authClaims.ts
+++ b/checkin-app/src/lib/authClaims.ts
@@ -8,7 +8,6 @@ export type ClaimSourceParticipant = {
     sysadmin: boolean;
     keyholder: boolean;
     boardMember: boolean;
-    shopSteward: boolean;
     backgroundCheckReviewer: boolean;
     householdId: number;
     toolStatuses: { toolId: number; level: string }[];
@@ -31,7 +30,6 @@ export function assignParticipantClaims(token: JWT, p: ClaimSourceParticipant): 
     token.sysadmin = denied ? false : p.sysadmin;
     token.keyholder = denied ? false : p.keyholder;
     token.boardMember = denied ? false : p.boardMember;
-    token.shopSteward = denied ? false : p.shopSteward;
     token.backgroundCheckReviewer = denied ? false : p.backgroundCheckReviewer;
     token.householdId = p.householdId;
     token.toolStatuses = denied ? [] : p.toolStatuses;

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -141,15 +141,17 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         },
     });
 
-    await prisma.participant.upsert({
-        where: { email: "shop.steward@example.com" },
-        update: { name: "Shop Steward", phone: "555-555-0008", shopSteward: true },
+    // No carte-blanche "may certify others" role exists. This persona is a plain
+    // member who holds the MAY_CERTIFY_OTHERS certification on a single tool (granted
+    // below), exercising the per-tool certifier path.
+    const toolCertifier = await prisma.participant.upsert({
+        where: { email: "tool.certifier@example.com" },
+        update: { name: "Tool Certifier", phone: "555-555-0008" },
         create: {
-            email: "shop.steward@example.com",
-            name: "Shop Steward",
+            email: "tool.certifier@example.com",
+            name: "Tool Certifier",
             phone: "555-555-0008",
-            shopSteward: true,
-            household: { create: { name: "Shop Steward Household" } },
+            household: { create: { name: "Tool Certifier Household" } },
         },
     });
 
@@ -203,6 +205,11 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         where: { userId_toolId: { userId: certifiedAdult.id, toolId: drillPress.id } },
         update: { level: "CERTIFIED" },
         create: { userId: certifiedAdult.id, toolId: drillPress.id, level: "CERTIFIED" },
+    });
+    await prisma.toolStatus.upsert({
+        where: { userId_toolId: { userId: toolCertifier.id, toolId: tableSaw.id } },
+        update: { level: "MAY_CERTIFY_OTHERS" },
+        create: { userId: toolCertifier.id, toolId: tableSaw.id, level: "MAY_CERTIFY_OTHERS" },
     });
 
     // 5. Sample program

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -228,8 +228,6 @@ export function callerHoldsRole(
             return auth.type === 'session' && auth.user.boardMember;
         case 'keyholder':
             return auth.type === 'session' && auth.user.keyholder;
-        case 'shopSteward':
-            return auth.type === 'session' && auth.user.shopSteward;
         case 'backgroundCheckReviewer':
             return auth.type === 'session' && auth.user.backgroundCheckReviewer;
         case 'householdLead':

--- a/checkin-app/src/security/core.ts
+++ b/checkin-app/src/security/core.ts
@@ -53,7 +53,6 @@ export type Role =
     | 'sysadmin'
     | 'boardMember'
     | 'keyholder'
-    | 'shopSteward'
     | 'backgroundCheckReviewer'
     | 'householdLead'
     | 'programLeadMentor'
@@ -75,7 +74,6 @@ const VALID_ROLES = new Set<Role>([
     'sysadmin',
     'boardMember',
     'keyholder',
-    'shopSteward',
     'backgroundCheckReviewer',
     'householdLead',
     'programLeadMentor',

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -20,7 +20,6 @@ export const classifications = {
         sysadmin: 'internal',
         boardMember: 'public',
         keyholder: 'internal',
-        shopSteward: 'internal',
         backgroundCheckReviewer: 'internal',
     },
     Tool: {

--- a/checkin-app/src/types/auth.ts
+++ b/checkin-app/src/types/auth.ts
@@ -4,7 +4,7 @@ import type { SessionUser } from './participant';
  * Business role field names from the Participant model.
  * Used by withAuth() to check roles directly via user[role] === true.
  */
-export type BusinessRole = 'sysadmin' | 'boardMember' | 'keyholder' | 'shopSteward' | 'backgroundCheckReviewer';
+export type BusinessRole = 'sysadmin' | 'boardMember' | 'keyholder' | 'backgroundCheckReviewer';
 
 /**
  * Result of authenticating a request — either kiosk, session, or unauthenticated.

--- a/checkin-app/src/types/next-auth.d.ts
+++ b/checkin-app/src/types/next-auth.d.ts
@@ -13,7 +13,6 @@ declare module "next-auth" {
       sysadmin?: boolean;
       keyholder?: boolean;
       boardMember?: boolean;
-      shopSteward?: boolean;
       backgroundCheckReviewer?: boolean;
       householdId?: number | null;
       householdLead?: boolean;
@@ -32,7 +31,6 @@ declare module "next-auth" {
     sysadmin?: boolean;
     keyholder?: boolean;
     boardMember?: boolean;
-    shopSteward?: boolean;
     backgroundCheckReviewer?: boolean;
     householdId?: number | null;
     householdLead?: boolean;
@@ -55,7 +53,6 @@ declare module "next-auth/jwt" {
     sysadmin?: boolean;
     keyholder?: boolean;
     boardMember?: boolean;
-    shopSteward?: boolean;
     backgroundCheckReviewer?: boolean;
     householdId?: number | null;
     householdLead?: boolean;

--- a/checkin-app/src/types/participant.ts
+++ b/checkin-app/src/types/participant.ts
@@ -11,7 +11,6 @@ export interface SessionUser {
     sysadmin: boolean;
     boardMember: boolean;
     keyholder: boolean;
-    shopSteward: boolean;
     backgroundCheckReviewer: boolean;
     householdId?: number;
     householdLead?: boolean;

--- a/checkin-app/tests/security/personas.ts
+++ b/checkin-app/tests/security/personas.ts
@@ -17,7 +17,6 @@ async function ensure(
         sysadmin: boolean;
         boardMember: boolean;
         keyholder: boolean;
-        shopSteward: boolean;
         backgroundCheckReviewer: boolean;
     }>,
 ) {
@@ -45,7 +44,6 @@ export async function loadPersonas(): Promise<Record<string, Persona>> {
     const sysadmin = await ensure('sysadmin', { name: 'Sys Admin', sysadmin: true });
     const boardMember = await ensure('board-member', { name: 'Board Member', boardMember: true });
     const keyholder = await ensure('keyholder', { name: 'Key Holder', keyholder: true });
-    const shopSteward = await ensure('shop-steward', { name: 'Shop Steward', shopSteward: true });
     const bgReviewer = await ensure('bg-reviewer', { name: 'BG Reviewer', backgroundCheckReviewer: true });
 
     const mkUser = (p: {
@@ -55,7 +53,6 @@ export async function loadPersonas(): Promise<Record<string, Persona>> {
         sysadmin: boolean;
         boardMember: boolean;
         keyholder: boolean;
-        shopSteward: boolean;
         backgroundCheckReviewer: boolean;
     }): SessionUser => ({
         id: p.id,
@@ -64,7 +61,6 @@ export async function loadPersonas(): Promise<Record<string, Persona>> {
         sysadmin: p.sysadmin,
         boardMember: p.boardMember,
         keyholder: p.keyholder,
-        shopSteward: p.shopSteward,
         backgroundCheckReviewer: p.backgroundCheckReviewer,
     });
 
@@ -90,11 +86,6 @@ export async function loadPersonas(): Promise<Record<string, Persona>> {
             role: 'keyholder',
             sessionUser: mkUser(keyholder),
             description: 'keyholder=true',
-        },
-        shopSteward: {
-            role: 'shopSteward',
-            sessionUser: mkUser(shopSteward),
-            description: 'shopSteward=true',
         },
         backgroundCheckReviewer: {
             role: 'backgroundCheckReviewer',


### PR DESCRIPTION
## What

Removes the **Shop Steward** role entirely. No role grants carte-blanche "may certify others" authority anymore:

- Only **sysadmin/board** may promote a user to `MAY_CERTIFY_OTHERS` (the per-tool Certifier level).
- A per-tool **certifier** can change certification status **up to (but not including)** `MAY_CERTIFY_OTHERS` — they cannot mint new certifiers.

## How

- **Schema/migration:** drop `Participant.shopSteward` (`20260613000000_remove_shop_steward_role`).
- **Vocabulary:** remove `shopSteward` from the security `Role` union + `VALID_ROLES`, `callerHoldsRole`, `BusinessRole`, generated classifications, all next-auth type augmentations, and the auth-claims builder.
- **Authorization:** every `sysadmin || boardMember || shopSteward` surface falls back to `sysadmin || boardMember` (+ per-tool certifier where the view warrants it — shop active/members). New gate in `POST /api/shop/certifications` blocks a per-tool certifier from granting `MAY_CERTIFY_OTHERS` (backend), and the tools-page dropdown hides that level for non-admins (defense in depth).
- **UI/badges/kiosk:** drop the STEWARD badge and the kiosk "steward = certifier-on-all-tools" special-case.
- **Dev seed:** the `shop.steward@example.com` persona becomes a per-tool **Tool Certifier** (`MAY_CERTIFY_OTHERS` on one tool), exercising the certifier path. The standalone `full_reset_and_dev_init.sh` reset script is updated to drop the column too.

## Tests

- New: a per-tool Certifier is **forbidden** (403) from granting `MAY_CERTIFY_OTHERS`; an admin **can** (200).
- Updated steward→board/certifier cases across shop API, auth-claims, and security personas.
- Full `test:ci` suite green (31 suites / 169 tests).

## Notes for reviewers

- **No data backfill.** The column is dropped outright, so any *current* shop steward who isn't also board/admin loses certify-others authority — an admin must re-grant it per tool. This is intended (the old role was global; there's no clean per-tool target to backfill to), but worth confirming for any real stewards in prod.
- Optional follow-up: add a positive-path test that a per-tool certifier can still grant a *lower* level (the "up to but not including" side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)