### PR TITLE
fix(signin): show pointer cursor on glass buttons (#266)

### DIFF
--- a/checkin-app/src/app/globals.css
+++ b/checkin-app/src/app/globals.css
@@ -10,6 +10,11 @@ body {
   margin: 0;
 }
 
+/* Glass buttons are real <button>s; show a pointer on hover like a link. */
+.glass-button {
+  cursor: pointer;
+}
+
 /* Kiosk display runs unattended on a Raspberry Pi — never show a pointer there. */
 .kiosk-mode,
 .kiosk-mode * {


### PR DESCRIPTION
## What

The "Sign in with Google" button (and other `.glass-button`s) showed the default arrow cursor on hover instead of a pointer, since native `<button>`s don't use a pointer cursor by default and `.glass-button` had no `cursor` rule.

Adds `.glass-button { cursor: pointer; }` to `globals.css`.

## Notes

- Placed before the kiosk rule, so `.kiosk-mode * { cursor: none !important; }` still wins on the Raspberry Pi display.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)