### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Dev Auth Exposure in Production

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The application was logging the raw `html` body of emails to the console when `RESEND_API_KEY` was missing in production (e.g., in `src/lib/email.ts`).
 **Learning:** Logging entire email bodies can inadvertently expose sensitive information, such as authentication links or personal user details, to server logs where they can be accessed by unauthorized personnel or aggregated inappropriately.
 **Prevention:** Avoid logging raw email content in production. Ensure that fallback logging mechanisms only record the full body when `process.env.NODE_ENV === 'development'`. In production, log only metadata like the recipient and subject.
+
+## 2026-06-14 - Dev Auth Exposure via Rules of Hooks Violation
+**Vulnerability:** When fixing the dev auth exposure in `DevLoginPicker.tsx`, placing the early environment return (`if (process.env.NODE_ENV === 'production') return null;`) before hook declarations (`useState`, `useEffect`) violated the React Rules of Hooks. While it doesn't crash at runtime since the environment variable is static, it breaks the CI/CD pipeline via `eslint-plugin-react-hooks`.
+**Learning:** Security fixes in React components must respect the fundamental Rules of Hooks. Early returns for security/environment checks must be placed after all hook declarations.
+**Prevention:** When adding conditional early returns to React components (e.g., environment checks), ensure they are placed after all hook declarations.

--- a/checkin-app/src/app/api/auth/dev-personas/route.ts
+++ b/checkin-app/src/app/api/auth/dev-personas/route.ts
@@ -16,6 +16,9 @@ export const dynamic = 'force-dynamic';
  * logged-out picker is the initial login path).
  */
 export async function GET() {
+    if (process.env.NODE_ENV === 'production') {
+        return NextResponse.json({ error: "Not available" }, { status: 404 });
+    }
     if (!config.isDevInstance()) {
         return NextResponse.json({ error: "Not available" }, { status: 404 });
     }

--- a/checkin-app/src/components/DevLoginPicker.tsx
+++ b/checkin-app/src/components/DevLoginPicker.tsx
@@ -63,6 +63,8 @@ export default function DevLoginPicker() {
     return badges;
   };
 
+  if (process.env.NODE_ENV === 'production') return null;
+
   if (loading) {
     return (
       <Center mt="md">

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -101,7 +101,7 @@ export const authOptions: NextAuthOptions = {
         // lives in evaluateMint(); this provider just supplies the caller's claims and the target.
         // (Replaces the old local-only "Offline Login" provider — local mints are the
         // unauthenticated-caller case in evaluateMint.)
-        ...(config.isDevInstance() ? [
+        ...(config.isDevInstance() && process.env.NODE_ENV !== 'production' ? [
             CredentialsProvider({
                 id: PERSONA_MINT_PROVIDER_ID,
                 name: "Persona",


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application relied solely on a custom feature flag (`isDevInstance`) to gate the development persona login mechanisms (`DevLoginPicker`, `persona-mint` credentials provider, and `/api/auth/dev-personas`).
🎯 Impact: If the development feature flag was misconfigured in a production environment, it would expose mock administrative users and allow unauthorized login without a password.
🔧 Fix: Added explicit `process.env.NODE_ENV !== 'production'` checks alongside the custom feature flag to strictly prevent dev authentication features from being enabled in production builds.
✅ Verification: Verified that the dev auth features are disabled when `NODE_ENV` is set to `production`.

---
*PR created automatically by Jules for task [14192075725826188391](https://jules.google.com/task/14192075725826188391) started by @dkaygithub*