### PR TITLE
fix(membership): clarify "volunteer-only family" wording

### DIFF
--- a/checkin-app/src/app/admin/membership/settings/page.tsx
+++ b/checkin-app/src/app/admin/membership/settings/page.tsx
@@ -215,10 +215,10 @@ export default function MembershipSettingsPage() {
           </Card>
 
           <Card withBorder radius="md" padding="lg">
-            <Title order={3} mb="xs">Volunteer-designated emails</Title>
+            <Title order={3} mb="xs">Volunteer-only designated emails</Title>
             <Text c="dimmed" mb="md">
               If one of these emails applies for membership, that whole household is treated as a
-              volunteer family (lower dues).
+              volunteer only family (lower dues).
             </Text>
             <Group gap="sm" wrap="wrap" mb="md" align="flex-end">
               <TextInput

--- a/checkin-app/src/app/household/page.tsx
+++ b/checkin-app/src/app/household/page.tsx
@@ -305,7 +305,7 @@ export default function HouseholdPage() {
               <Alert color="green" mb="lg">
                 <Group gap="xs" wrap="wrap">
                   <Text fw={600}>✓ Member{household.membership.since ? ` since ${formatDate(household.membership.since)}` : ''}</Text>
-                  {household.membership.isVolunteer && <Badge color="green" variant="light">Volunteer family</Badge>}
+                  {household.membership.isVolunteer && <Badge color="green" variant="light">Volunteer-only family</Badge>}
                 </Group>
               </Alert>
             ) : (

--- a/checkin-app/src/app/membership/review/page.tsx
+++ b/checkin-app/src/app/membership/review/page.tsx
@@ -133,7 +133,7 @@ export default function MembershipReviewPage() {
                 my="md"
                 checked={!!volunteer[item.id]}
                 onChange={(e) => setVolunteer((v) => ({ ...v, [item.id]: e.currentTarget.checked }))}
-                label="This is a volunteer family"
+                label="This is a volunteer only family (no students)"
               />
 
               <Group gap="sm" wrap="wrap">

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -169,7 +169,7 @@ async function advanceToPayment(processId: number, actorId: number) {
 
 /**
  * Sticky/additive volunteer status: set Membership.isVolunteer = true if ANY
- * reviewer marked the family volunteer OR a household parent's email is pre-
+ * reviewer marked the family volunteer-only OR a household parent's email is pre-
  * designated. Never clears it here.
  */
 export async function applyVolunteerStatus(membershipId: number, householdId: number, markedByReviewer: boolean) {


### PR DESCRIPTION
## What

Rename user-facing strings and one code comment from "volunteer family" to **"volunteer-only family"**.

| Spot | Before | After |
|------|--------|-------|
| Review checkbox label | This is a volunteer family | This is a volunteer only family (no students) |
| Household membership badge | Volunteer family | Volunteer-only family |
| Membership settings body copy | ...treated as a volunteer family (lower dues) | ...treated as a volunteer only family (lower dues) |
| Membership settings card title | Volunteer-designated emails | Volunteer-only designated emails |
| `isVolunteer` doc comment | marked the family volunteer | marked the family volunteer-only |

## Why

The "volunteer family" designation means the household has **no students** (volunteer-only, lower dues) — not merely a family that happens to volunteer. The old wording was ambiguous. No logic changes.

## Reviewer notes

- Text-only. The program-volunteer concept (assigned volunteers, Core Volunteer, dues label) is unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)