### PR TITLE
fix(membership): give the intake form real error feedback

### DIFF
--- a/checkin-app/src/app/api/membership/intake/route.ts
+++ b/checkin-app/src/app/api/membership/intake/route.ts
@@ -1,16 +1,9 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
-import { saveIntake, IntakeError } from "@/lib/membership/intake";
+import { saveIntake } from "@/lib/membership/intake";
+import { intakeErrorResponse } from "@/lib/membership/intakeResponse";
 
 export const dynamic = "force-dynamic";
-
-const STATUS_FOR: Record<IntakeError["code"], number> = {
-    no_household: 400,
-    not_lead: 403,
-    already_member: 409,
-    no_process: 400,
-    incomplete: 400,
-};
 
 // PATCH /api/membership/intake — save (partial) intake form data. Resumable.
 export const PATCH = withAuth({}, async (req, auth) => {
@@ -20,10 +13,6 @@ export const PATCH = withAuth({}, async (req, auth) => {
         const state = await saveIntake(auth.user.id, body);
         return NextResponse.json({ state });
     } catch (error) {
-        if (error instanceof IntakeError) {
-            return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
-        }
-        console.error("Membership intake save error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return intakeErrorResponse(error, "Membership intake save error");
     }
 });

--- a/checkin-app/src/app/api/membership/intake/submit/route.ts
+++ b/checkin-app/src/app/api/membership/intake/submit/route.ts
@@ -1,16 +1,9 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
-import { submitIntake, getIntakeState, IntakeError } from "@/lib/membership/intake";
+import { submitIntake, getIntakeState } from "@/lib/membership/intake";
+import { intakeErrorResponse } from "@/lib/membership/intakeResponse";
 
 export const dynamic = "force-dynamic";
-
-const STATUS_FOR: Record<IntakeError["code"], number> = {
-    no_household: 400,
-    not_lead: 403,
-    already_member: 409,
-    no_process: 400,
-    incomplete: 400,
-};
 
 // POST /api/membership/intake/submit — validate + advance INTAKE -> EXTERNAL.
 export const POST = withAuth({}, async (_req, auth) => {
@@ -20,10 +13,6 @@ export const POST = withAuth({}, async (_req, auth) => {
         const state = await getIntakeState(auth.user.id);
         return NextResponse.json({ state });
     } catch (error) {
-        if (error instanceof IntakeError) {
-            return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
-        }
-        console.error("Membership intake submit error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return intakeErrorResponse(error, "Membership intake submit error");
     }
 });

--- a/checkin-app/src/app/api/membership/route.ts
+++ b/checkin-app/src/app/api/membership/route.ts
@@ -1,24 +1,11 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
-import { getIntakeState, startIntake, IntakeError } from "@/lib/membership/intake";
+import { getIntakeState, startIntake } from "@/lib/membership/intake";
+import { intakeErrorResponse } from "@/lib/membership/intakeResponse";
 
 export const dynamic = "force-dynamic";
 
-const STATUS_FOR: Record<IntakeError["code"], number> = {
-    no_household: 400,
-    not_lead: 403,
-    already_member: 409,
-    no_process: 400,
-    incomplete: 400,
-};
-
-function handleError(error: unknown) {
-    if (error instanceof IntakeError) {
-        return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
-    }
-    console.error("Membership route error:", error);
-    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
-}
+const handleError = (error: unknown) => intakeErrorResponse(error, "Membership route error");
 
 // GET /api/membership — the caller's current application state, prefilled.
 export const GET = withAuth({}, async (_req, auth) => {

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -70,6 +70,9 @@ export default function MembershipPage() {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
   const [isError, setIsError] = useState(false);
+  // Per-field validation errors, keyed by form field ("address", "emName",
+  // "emPhone", "primaryName"). Drives the red-highlighted inputs.
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   // Intake form fields
   const [address, setAddress] = useState("");
@@ -150,6 +153,43 @@ export default function MembershipPage() {
     setIsError(error);
   };
 
+  // Build an error message from an API response, appending the dev-only `detail`
+  // (the real server failure) when present so an "Internal Server Error" isn't a
+  // dead end. Falls back to a friendly default when the body carries nothing.
+  const apiError = (data: { error?: string; detail?: string } | null | undefined, fallback: string) =>
+    [data?.error, data?.detail].filter(Boolean).join(" — ") || fallback;
+
+  // Clear a single field's error (called as the user edits it).
+  const clearErr = (key: string) =>
+    setFieldErrors((fe) => (fe[key] ? Object.fromEntries(Object.entries(fe).filter(([k]) => k !== key)) : fe));
+
+  // Required-field check for submit, mirroring the server's rules so the user
+  // gets instant red-box feedback on every environment (no round-trip needed).
+  const validateIntake = (): Record<string, string> => {
+    const errs: Record<string, string> = {};
+    if (!address.trim()) errs.address = "Home address is required.";
+    if (!emName.trim()) errs.emName = "Emergency contact name is required.";
+    if (!emPhone.trim()) errs.emPhone = "Emergency contact phone is required.";
+    if (!primaryName.trim()) errs.primaryName = "Your name is required.";
+    return errs;
+  };
+
+  // Map the server's field keys (from an `incomplete` submit) onto form inputs —
+  // covers cases the client can't detect locally (e.g. an emergency contact that
+  // is itself a household member).
+  const mapServerFields = (fields?: string[]): Record<string, string> => {
+    const errs: Record<string, string> = {};
+    for (const f of fields ?? []) {
+      if (f === "address") errs.address = "Home address is required.";
+      else if (f === "primaryName") errs.primaryName = "Your name is required.";
+      else if (f === "emergencyContact") {
+        errs.emName = "Add an emergency contact who isn't in your household.";
+        errs.emPhone = "Add an emergency contact who isn't in your household.";
+      }
+    }
+    return errs;
+  };
+
   const startApplication = async () => {
     setSaving(true);
     flash("");
@@ -157,7 +197,7 @@ export default function MembershipPage() {
       const res = await fetch("/api/membership", { method: "POST" });
       const data = await res.json();
       if (res.ok) { hydrate(data.state); notifyNavRefresh(); }
-      else flash(data.error || "Could not start your application.", true);
+      else flash(apiError(data, "Could not start your application."), true);
     } catch {
       flash("Network error.", true);
     } finally {
@@ -189,7 +229,7 @@ export default function MembershipPage() {
       if (res.ok) {
         hydrate(data.state);
         flash("Progress saved.");
-      } else flash(data.error || "Could not save.", true);
+      } else flash(apiError(data, "Could not save."), true);
     } catch {
       flash("Network error.", true);
     } finally {
@@ -198,6 +238,14 @@ export default function MembershipPage() {
   };
 
   const submit = async () => {
+    // Highlight missing required fields up front — instant feedback, no round-trip.
+    const errs = validateIntake();
+    setFieldErrors(errs);
+    if (Object.keys(errs).length) {
+      flash("Please complete the highlighted fields.", true);
+      return;
+    }
+
     setSaving(true);
     flash("");
     try {
@@ -209,16 +257,22 @@ export default function MembershipPage() {
       });
       if (!saveRes.ok) {
         const d = await saveRes.json();
-        flash(d.error || "Could not save.", true);
+        flash(apiError(d, "Could not save."), true);
         return;
       }
       const res = await fetch("/api/membership/intake/submit", { method: "POST" });
       const data = await res.json();
       if (res.ok) {
+        setFieldErrors({});
         hydrate(data.state);
         notifyNavRefresh();
         flash("Submitted! Next: sign your contract and consent to a background check.");
-      } else flash(data.error || "Could not submit.", true);
+      } else {
+        // The server may flag fields the client can't check locally (e.g. an
+        // emergency contact who is a household member) — highlight those too.
+        if (data.fields) setFieldErrors(mapServerFields(data.fields));
+        flash(apiError(data, "Could not submit."), true);
+      }
     } catch {
       flash("Network error.", true);
     } finally {
@@ -233,7 +287,7 @@ export default function MembershipPage() {
       const res = await fetch("/api/membership/renew", { method: "POST" });
       const data = await res.json();
       if (res.ok) { await load(); notifyNavRefresh(); flash("Renewal started."); }
-      else flash(data.error || "Could not start renewal.", true);
+      else flash(apiError(data, "Could not start renewal."), true);
     } catch {
       flash("Network error.", true);
     } finally {
@@ -326,16 +380,16 @@ export default function MembershipPage() {
                 <Stack gap="lg">
                   <section>
                     <Title order={2} mb="sm">Your household</Title>
-                    <TextInput label="Home address" value={address} onChange={(e) => setAddress(e.currentTarget.value)} placeholder="123 Main St, City, State ZIP" />
+                    <TextInput label="Home address" value={address} error={fieldErrors.address} onChange={(e) => { setAddress(e.currentTarget.value); clearErr("address"); }} placeholder="123 Main St, City, State ZIP" />
                     <SimpleGrid cols={{ base: 1, sm: 2 }} mt="md">
-                      <TextInput label="Emergency contact name" value={emName} onChange={(e) => setEmName(e.currentTarget.value)} />
-                      <TextInput label="Emergency contact phone" value={emPhone} onChange={(e) => setEmPhone(e.currentTarget.value)} />
+                      <TextInput label="Emergency contact name" value={emName} error={fieldErrors.emName} onChange={(e) => { setEmName(e.currentTarget.value); clearErr("emName"); }} />
+                      <TextInput label="Emergency contact phone" value={emPhone} error={fieldErrors.emPhone} onChange={(e) => { setEmPhone(e.currentTarget.value); clearErr("emPhone"); }} />
                     </SimpleGrid>
                   </section>
 
                   <section>
                     <Title order={2} mb="sm">Primary parent / guardian</Title>
-                    <TextInput label="Full name" value={primaryName} onChange={(e) => setPrimaryName(e.currentTarget.value)} />
+                    <TextInput label="Full name" value={primaryName} error={fieldErrors.primaryName} onChange={(e) => { setPrimaryName(e.currentTarget.value); clearErr("primaryName"); }} />
                     <SimpleGrid cols={{ base: 1, sm: 2 }} mt="md">
                       <TextInput type="date" label="Date of birth" value={primaryDob} onChange={(e) => setPrimaryDob(e.currentTarget.value)} />
                       <TextInput label="Allergies (optional)" value={primaryAllergies} onChange={(e) => setPrimaryAllergies(e.currentTarget.value)} />

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -15,7 +15,17 @@ import { upsertPrimaryContact, reconcileHouseholdConflicts } from "@/lib/emergen
  */
 
 export class IntakeError extends Error {
-    constructor(public readonly code: "no_household" | "not_lead" | "already_member" | "no_process" | "incomplete", message: string) {
+    /**
+     * @param fields  form field keys this error applies to, so the client can
+     *                highlight the offending inputs (e.g. an `incomplete` submit).
+     *                Keys match the intake form: "address", "emergencyContact",
+     *                "primaryName".
+     */
+    constructor(
+        public readonly code: "no_household" | "not_lead" | "already_member" | "no_process" | "incomplete",
+        message: string,
+        public readonly fields?: string[],
+    ) {
         super(message);
         this.name = "IntakeError";
     }
@@ -283,17 +293,23 @@ export async function submitIntake(userId: number) {
         .sort((a, b) => b.id - a.id)[0];
     if (!process) throw new IntakeError("no_process", "No application is awaiting your information.");
 
-    const missing: string[] = [];
-    if (!household.address?.trim()) missing.push("home address");
+    // Each missing requirement carries the form field key to highlight + a label
+    // for the summary message.
+    const missing: { field: string; label: string }[] = [];
+    if (!household.address?.trim()) missing.push({ field: "address", label: "home address" });
     // A household must keep >= 1 valid (non-member, complete) emergency contact.
     const hasValidContact = household.emergencyContacts.some(
         (c) => c.conflictParticipantId === null && c.name.trim() && c.phone.trim(),
     );
-    if (!hasValidContact) missing.push("a valid emergency contact (someone outside the household)");
+    if (!hasValidContact) missing.push({ field: "emergencyContact", label: "a valid emergency contact (someone outside the household)" });
     const primary = household.participants.find((p) => p.id === userId);
-    if (!primary?.name?.trim()) missing.push("primary parent name");
+    if (!primary?.name?.trim()) missing.push({ field: "primaryName", label: "primary parent name" });
     if (missing.length) {
-        throw new IntakeError("incomplete", `Please complete: ${missing.join(", ")}.`);
+        throw new IntakeError(
+            "incomplete",
+            `Please complete: ${missing.map((m) => m.label).join(", ")}.`,
+            missing.map((m) => m.field),
+        );
     }
 
     const advanced = await prisma.membershipProcess.update({

--- a/checkin-app/src/lib/membership/intakeResponse.ts
+++ b/checkin-app/src/lib/membership/intakeResponse.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { config } from "@/lib/config";
+import { IntakeError } from "@/lib/membership/intake";
+
+const STATUS_FOR: Record<IntakeError["code"], number> = {
+    no_household: 400,
+    not_lead: 403,
+    already_member: 409,
+    no_process: 400,
+    incomplete: 400,
+};
+
+/**
+ * Map an intake-service error to its HTTP response, shared by the membership
+ * routes. A known IntakeError becomes a 4xx carrying its `code` and any `fields`
+ * (so the form can highlight the offending inputs — on every environment).
+ *
+ * Anything else is an unexpected 500: the full error is logged, and its message
+ * is echoed back as `detail` ONLY on dev/local instances so an internal tester
+ * isn't stuck on a blank "Internal Server Error". Prod stays generic — we never
+ * leak DB/stack detail to applicants.
+ */
+export function intakeErrorResponse(error: unknown, logContext: string) {
+    if (error instanceof IntakeError) {
+        return NextResponse.json(
+            { error: error.message, code: error.code, ...(error.fields ? { fields: error.fields } : {}) },
+            { status: STATUS_FOR[error.code] },
+        );
+    }
+    console.error(`${logContext}:`, error);
+    const detail = config.isDevInstance() ? (error instanceof Error ? error.message : String(error)) : undefined;
+    return NextResponse.json({ error: "Internal Server Error", ...(detail ? { detail } : {}) }, { status: 500 });
+}


### PR DESCRIPTION
## Problem

Starting or submitting a membership application could fail with a bare **"Internal Server Error"** (or a top-of-page flash) and **no indication of which field was wrong** — a dead end for the applicant.

## Changes

**Field-level red highlighting (every environment, prod included)**
- `submit()` runs a client-side `validateIntake()` *before* any network call: missing **home address**, **emergency contact name/phone**, or **primary name** turn those inputs red (Mantine `error` prop) with inline messages + a summary banner. Instant, no round-trip.
- Errors clear per-field as you type, and clear on a successful submit.

**Server-driven highlighting for what the client can't see**
- `IntakeError` now carries `fields?: string[]`; `submitIntake` tags each missing requirement (`address` / `emergencyContact` / `primaryName`). The submit route returns those keys and the client maps them back to inputs — so a case the browser can't detect locally (e.g. an emergency contact who is itself a household member) still lights up the right boxes.

**Unexpected 500s: shared, transparent mapping**
- Error→response logic is centralized in `lib/membership/intakeResponse.ts` and shared by all three membership routes (removes duplicated `STATUS_FOR`/try-catch). The real error message is echoed back as `detail` **only on dev/local instances** (`config.isDevInstance()`); prod stays generic — no DB/stack leak. The full error is always logged.

## Why this matters

Beyond the UX win, the dev-only `detail` makes the current "Start application" 500 on `ops-dev` self-diagnosing — the next click will name the real cause (suspected `EmergencyContact`/migration drift) instead of a blank error.

## Validation
- `tsc --noEmit` ✅, `eslint --max-warnings 0` ✅
- Pre-commit hook: full mocked suite **177/177 passing** ✅
- Existing intake integration test preserved — still asserts `400` + `code: 'incomplete'`; `fields` is purely additive (CI runs the integration suite).

## Files
- `lib/membership/intake.ts` — `IntakeError.fields` + structured `missing`
- `lib/membership/intakeResponse.ts` *(new)* — shared error→response (status + `fields` + dev `detail`)
- `api/membership/route.ts`, `api/membership/intake/route.ts`, `api/membership/intake/submit/route.ts` — use the shared helper
- `app/membership/page.tsx` — `fieldErrors` state, validation/mapping helpers, `error=` on the four required inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)