### PR TITLE
fix(membership): recover sign flow when only an envelope id is stored

### DIFF
--- a/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
@@ -155,6 +155,20 @@ describe('POST /api/membership/contract/sign', () => {
         await prisma.membershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: 'REQ-1', zohoActionId: 'ACT-1' } });
     });
 
+    it('recovers when an envelope id was stored without an action id (legacy admin/email flow)', async () => {
+        // setZohoEnvelope stores zohoEnvelopeId WITHOUT an action id — that pair
+        // can't be embedded, so the in-app flow must re-create and overwrite it
+        // rather than 409 forever on the incomplete pair.
+        await prisma.membershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: 'LEGACY-ENV', zohoActionId: null } });
+        asUser(leadId);
+        const res = await SIGN(signReq());
+        expect(res.status).toBe(200);
+        expect(zoho.createRequest).toHaveBeenCalledTimes(1);
+        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        expect(p?.zohoEnvelopeId).toBe('REQ-1'); // overwritten with the embeddable request
+        expect(p?.zohoActionId).toBe('ACT-1');
+    });
+
     it('409s when the application is not in the EXTERNAL phase', async () => {
         await prisma.membershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
         asUser(leadId);

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -220,12 +220,20 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
 
         // Atomically claim the process for THIS request's ids. Two concurrent
         // POSTs can both pass the null check above and both create a Zoho request;
-        // the conditional update (zohoEnvelopeId still null) lets only the first
-        // writer win. If we lost the race (count 0), discard our just-created
-        // request and reuse the winner's stored ids so the process keeps a single
-        // canonical signing request — our orphaned Zoho request simply expires.
+        // this conditional update lets only the first writer win. If we lost the
+        // race (count 0), discard our just-created request and reuse the winner's
+        // stored ids so the process keeps a single canonical signing request — our
+        // orphaned Zoho request simply expires.
+        //
+        // The claim matches an INCOMPLETE pair (either id null), not just a null
+        // envelope: setZohoEnvelope (the legacy admin/email flow) stores
+        // zohoEnvelopeId WITHOUT an action id, which can't be embedded. That state
+        // must be claimable here or the create-trigger above (needs both ids) would
+        // re-create on every click and a `zohoEnvelopeId: null`-only claim would
+        // always lose — a permanent 409. Overwriting it points the process (and its
+        // webhook match) at the embeddable in-app request.
         const claim = await prisma.membershipProcess.updateMany({
-            where: { id: process.id, zohoEnvelopeId: null },
+            where: { id: process.id, OR: [{ zohoEnvelopeId: null }, { zohoActionId: null }] },
             data: { zohoEnvelopeId: created.requestId, zohoActionId: created.actionId },
         });
         if (claim.count === 0) {


### PR DESCRIPTION
## What
Stacked on #290. Fixes a deadlock between the legacy admin envelope-setter and the new embedded-signing create guard.

## The bug
`getOrCreateContractSigningUrl` enters the create block whenever **either** `zohoEnvelopeId` or `zohoActionId` is missing (both are needed to embed). But the atomic race guard only claimed the process when `zohoEnvelopeId` was **null**:

```ts
where: { id: process.id, zohoEnvelopeId: null }
```

`setZohoEnvelope` (the legacy admin/email flow, `POST /api/admin/membership/external`) stores `zohoEnvelopeId` **without** an action id. For a process in that state:

1. create-trigger fires (actionId null) → a fresh Zoho request is created + submitted;
2. claim `where zohoEnvelopeId: null` → **count 0** (envelope already set) → loser branch;
3. winner re-read still has `zohoActionId === null` → throws `wrong_phase` 409.

Result: a permanent 409 on the in-app **Sign** button, plus a leaked (orphaned) Zoho request on **every** click.

## The fix
Match an **incomplete pair** (either id null), not just a null envelope:

```ts
where: { id: process.id, OR: [{ zohoEnvelopeId: null }, { zohoActionId: null }] }
```

The envelope-only state is now claimable and gets overwritten with the embeddable in-app request (repointing the webhook match too). The orphaned legacy request simply expires — same as the existing race-loser path. One-line behavior change; the rest is comment + a regression test (`recovers when an envelope id was stored without an action id`).

## Test
Added to `membershipContractSignAPI.integration.test.ts`: seed `zohoEnvelopeId` set / `zohoActionId` null → expect 200, one `createRequest`, both ids stored, envelope overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)