### PR TITLE
fix(security): close fail-open scope leak on nested row-scoped relations

### DIFF
--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -96,18 +96,44 @@ export async function buildCallerContext(auth: AuthResult): Promise<CallerContex
 }
 
 /**
+ * Models whose sensitive fields MUST be gated per-row by a scope key the row
+ * carries. If that key isn't present on the (possibly nested) row — e.g. a
+ * query selected the row but not its `householdId` — we cannot prove the
+ * caller's relationship to it, so `scopesHeld` returns NO scopes (not even
+ * `'everyones'`) and the stripper drops every sensitive field. This fails
+ * CLOSED: a missing selected column must never let an `everyones:*` (admin/
+ * board) view leak a whole row. Each entry also needs a `case` below that
+ * derives the row-scoped grant from the same key.
+ */
+const ROW_SCOPE_KEY: Record<string, string> = {
+    EmergencyContact: 'householdId',
+};
+
+/**
  * Per-row scope resolver. Returns the set of Scopes the caller holds on the
- * given row. `'everyones'` is always included (unconditional scope).
+ * given row. `'everyones'` is included for non-row-scoped models (unconditional
+ * scope); for models in `ROW_SCOPE_KEY` it is granted only once the row's scope
+ * key is present, so a key-less row fails closed.
  */
 export function scopesHeld(
     modelName: string,
     row: Record<string, unknown> | null | undefined,
     ctx: CallerContext,
 ): Set<Scope> {
-    const scopes = new Set<Scope>(['everyones']);
-    if (!row || typeof row !== 'object') return scopes;
+    if (!row || typeof row !== 'object') {
+        // No row to gate on. Row-scoped models fail closed; others get the broad scope.
+        return modelName in ROW_SCOPE_KEY ? new Set<Scope>() : new Set<Scope>(['everyones']);
+    }
 
     const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : undefined);
+
+    // Defense-in-depth: row-scoped model missing its scope key → fail closed.
+    const scopeKey = ROW_SCOPE_KEY[modelName];
+    if (scopeKey !== undefined && num(row[scopeKey]) === undefined) {
+        return new Set<Scope>();
+    }
+
+    const scopes = new Set<Scope>(['everyones']);
 
     switch (modelName) {
         case 'Participant': {
@@ -126,6 +152,16 @@ export function scopesHeld(
         case 'Household': {
             const id = num(row.id);
             if (id !== undefined && id === ctx.householdId) scopes.add('their_households');
+            break;
+        }
+        case 'EmergencyContact': {
+            // Row-scoped (see ROW_SCOPE_KEY): householdId is guaranteed present
+            // by the fail-closed guard above. Belongs to one household, so the
+            // household's own members/leads see its personal fields.
+            const householdId = num(row.householdId);
+            if (householdId !== undefined && householdId === ctx.householdId) {
+                scopes.add('their_households');
+            }
             break;
         }
         case 'HouseholdLead': {
@@ -223,10 +259,16 @@ export function scopesHeld(
             if (ctx.isKeyholder) scopes.add('keyholders');
             break;
         }
-        // Corporation, CorporationLead, CorporationMember, AuditLog,
-        // VerificationToken, ErrorLog, SystemMetric, Tool — no per-row
-        // scopes beyond 'everyones' in this version. Admin (sysadmin/
-        // boardMember) views grant 'everyones:*' so they still get through.
+        // MembershipProcess, BackgroundCheckAttestation, Corporation,
+        // CorporationLead, CorporationMember, AuditLog, VerificationToken,
+        // ErrorLog, SystemMetric, Tool — no per-row scopes beyond 'everyones'
+        // yet. Admin (sysadmin/boardMember) views grant 'everyones:*' so they
+        // still get through. These SHOULD be row-scoped too (they carry
+        // membershipId / processId / corporationId); until each has a case +
+        // ROW_SCOPE_KEY entry, a non-admin view cannot see them and an admin
+        // view sees them ungated. Add them to ROW_SCOPE_KEY as cases land.
+        // ponytail: EmergencyContact done first (carries householdId);
+        // extend to the rest when a route needs non-admin access to them.
     }
     return scopes;
 }

--- a/checkin-app/src/security/core.ts
+++ b/checkin-app/src/security/core.ts
@@ -5,7 +5,9 @@
  *   'public'                — public-tier fields, always visible (no row gate)
  *   '<scope>:<tier>'        — tier ∈ {pii, personal, internal}; the grant
  *                             applies on rows where the caller holds <scope>
- *   scope = 'everyones'     — unconditional (broad grant, no row check)
+ *   scope = 'everyones'     — broad grant; held on every row by default, but a
+ *                             row-scoped model missing its scope key fails
+ *                             closed and does NOT hold it (see scopesHeld)
  *   scope = 'their_own' | 'their_households' | 'their_program_participants'
  *           | 'all_current_visitors' — per-row predicates evaluated by the
  *                             handler against a prefetched CallerContext.
@@ -216,7 +218,10 @@ export function fieldVisible(
         const parsed = parseToken(tok);
         if (parsed === null || parsed === 'public') continue;
         if (parsed.tier !== tier) continue;
-        if (parsed.scope === 'everyones') return true;
+        // 'everyones' is a normal scope here: scopesHeld() seeds it for every
+        // row EXCEPT a row-scoped model whose scope key is absent, which fails
+        // closed by omitting it. So even an everyones:* grant is gated on the
+        // caller actually holding the everyones scope on this row.
         if (scopesHeld.has(parsed.scope)) return true;
     }
     return false;

--- a/checkin-app/tests/security/stripper.test.ts
+++ b/checkin-app/tests/security/stripper.test.ts
@@ -252,6 +252,84 @@ describe('stripValue — nested relations', () => {
     });
 });
 
+describe('scopesHeld — row-scoped fail-closed', () => {
+    it('EmergencyContact.their_households when row.householdId === caller.householdId', () => {
+        const s = scopesHeld('EmergencyContact', { id: 1, householdId: 2 }, ctx({ householdId: 2 }));
+        expect(s.has('their_households')).toBe(true);
+        const s2 = scopesHeld('EmergencyContact', { id: 1, householdId: 99 }, ctx({ householdId: 2 }));
+        expect(s2.has('their_households')).toBe(false);
+        expect(s2.has('everyones')).toBe(true); // key present, just not the caller's household
+    });
+
+    it('EmergencyContact missing its scope key yields NO scopes (not even everyones)', () => {
+        // Nested row where householdId was not selected → cannot prove relationship.
+        const s = scopesHeld('EmergencyContact', { id: 1, name: 'X' }, ctx({ householdId: 2 }));
+        expect(s).toEqual(new Set());
+    });
+});
+
+describe('stripValue — nested EmergencyContact (the leak)', () => {
+    const ec = (householdId: number | undefined) => ({
+        id: 1,
+        householdId,
+        name: 'Aunt May',
+        phone: '555-1234',
+        priority: 1,
+        createdAt: '2026-01-01',
+    });
+
+    it('(a) non-admin their_households view shows only allowed fields on own household EC', () => {
+        const homeCtx = ctx({ selfId: 5, householdId: 2 });
+        const tokens = ['their_households:personal', 'public'] as const;
+        const household = { id: 2, name: 'Home', emergencyContacts: [ec(2)] };
+        const out = stripValue('Household', household, tokens, homeCtx) as Record<string, unknown>;
+        const got = (out.emergencyContacts as Record<string, unknown>[])[0];
+        expect(got.name).toBe('Aunt May'); // personal, granted via their_households
+        expect(got.phone).toBe('555-1234');
+        expect(got.priority).toBe(1); // public
+        expect(got.createdAt).toBeUndefined(); // internal — not granted
+    });
+
+    it('(a) same view strips personal on another household’s EC', () => {
+        const homeCtx = ctx({ selfId: 5, householdId: 2 });
+        const tokens = ['their_households:personal', 'public'] as const;
+        const household = { id: 99, name: 'Other', emergencyContacts: [ec(99)] };
+        const out = stripValue('Household', household, tokens, homeCtx) as Record<string, unknown>;
+        const got = (out.emergencyContacts as Record<string, unknown>[])[0];
+        expect(got.name).toBeUndefined();
+        expect(got.phone).toBeUndefined();
+        expect(got.priority).toBe(1); // public still shows
+    });
+
+    it('(b) everyones:* view does NOT leak personal/internal on a key-less nested EC', () => {
+        // Admin/board view; the nested EC row omitted householdId. Must fail closed.
+        const adminCtx = ctx({ selfId: 1 });
+        const tokens = ['everyones:pii', 'everyones:personal', 'everyones:internal', 'public'] as const;
+        const household = {
+            id: 2,
+            name: 'Home',
+            emergencyContacts: [{ id: 1, name: 'Aunt May', phone: '555-1234', priority: 1, createdAt: '2026-01-01' }],
+        };
+        const out = stripValue('Household', household, tokens, adminCtx) as Record<string, unknown>;
+        const got = (out.emergencyContacts as Record<string, unknown>[])[0];
+        expect(got.name).toBeUndefined(); // personal — stripped despite everyones:personal
+        expect(got.phone).toBeUndefined();
+        expect(got.createdAt).toBeUndefined(); // internal — stripped despite everyones:internal
+        expect(got.priority).toBe(1); // public — unaffected
+        expect(got.id).toBe(1);
+    });
+
+    it('everyones:* view DOES show fields when the key is present (admin intent preserved)', () => {
+        const adminCtx = ctx({ selfId: 1 });
+        const tokens = ['everyones:personal', 'everyones:internal', 'public'] as const;
+        const household = { id: 2, name: 'Home', emergencyContacts: [ec(2)] };
+        const out = stripValue('Household', household, tokens, adminCtx) as Record<string, unknown>;
+        const got = (out.emergencyContacts as Record<string, unknown>[])[0];
+        expect(got.name).toBe('Aunt May');
+        expect(got.createdAt).toBe('2026-01-01');
+    });
+});
+
 describe('stripValue — _count preservation', () => {
     it('preserves Prisma _count aggregate', () => {
         const row = { id: 5, name: 'Me', _count: { visits: 3 } };


### PR DESCRIPTION
## What

Nested relations under admin/board (`everyones:*`) views could leak personal/internal fields with no per-row gate.

`scopesHeld()` seeded `{everyones}` for every model, and `fieldVisible()` treated an `everyones:*` token as unconditionally visible. So any row-scoped model with **no `scopesHeld` case** — or whose scope key was **not selected onto a nested row** — collapsed to `{everyones}` and returned all personal/internal fields under an admin view. Affected nested models: `EmergencyContact` (via `Household.emergencyContacts`), `MembershipProcess`, `BackgroundCheckAttestation`, `Corporation*`, etc.

This was fail-CLOSED for `their_*` tokens but fail-OPEN for `everyones:*` — a missing selected column silently granted an admin the whole row.

## Changes

- **`access-resolvers.ts`** — add a `ROW_SCOPE_KEY` registry + an explicit `EmergencyContact` case (`their_households` via `householdId`). A row-scoped model whose scope key is absent from the (nested) row now returns an **empty scope set — fail CLOSED** — instead of defaulting to `{everyones}`.
- **`core.ts`** — `fieldVisible()` now treats `'everyones'` as a scope the caller must actually hold (`scopesHeld.has(scope)`) rather than a hard `return true`. `scopesHeld()` still seeds `everyones` for every row *except* the fail-closed path, so the empty-set strip becomes real even under an `everyones:*` grant.
- **tests** — (a) nested `EmergencyContact` under a non-admin `their_households` view shows only allowed fields; (b) a key-less nested row under an `everyones:*` view no longer leaks personal/internal.

## Reviewer notes

- Both `core.ts` and `access-resolvers.ts` are CODEOWNERS-gated. The `core.ts` change shifts `everyones` token semantics globally — it is safe for all current callers (the stripper sources scopes from `scopesHeld`, which seeds `everyones` everywhere but the fail-closed path; all `fieldVisible` tests pass `everyones` in the set when testing `everyones` tokens), but it is the load-bearing part of the fix and deserves a close look.
- `MembershipProcess` / `BackgroundCheckAttestation` / `Corporation*` remain admin-only (no case yet) — they carry `membershipId` / `processId` / `corporationId`, not `householdId`, so they need their own scope logic. Tracked in a code comment; no behavior change for them in this PR.

## Verification

`tests/security/stripper.test.ts` (38 pass) and `tests/security/policy.contract.integration.test.ts` (20 pass, against a throwaway Postgres). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)