### PR TITLE
fix(membership): make activate() idempotent under concurrent webhooks

### DIFF
--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -13,6 +13,7 @@ import { POST as CERTIFY } from '@/app/api/admin/membership/certify-payment/rout
 import { computeDuesCents, ensurePaymentLink, ensurePaymentLinkForUser, activate } from '@/lib/membership/payment';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
+import { sendEmail } from '@/lib/email';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
 jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
@@ -166,6 +167,30 @@ describe('Membership payment API', () => {
         asUser(leadId);
         const res = await CERTIFY(new Request('http://localhost:4000/x', { method: 'POST', body: JSON.stringify({ processId: 1 }) }) as never);
         expect(res.status).toBe(403);
+    });
+
+    it('concurrent activate() of the same process sends one email and writes one audit row', async () => {
+        // Fresh proc with a lead so a congrats email would fire.
+        const hh = await prisma.household.create({ data: { name: `Concurrent ${TAG}` } });
+        const lead = await prisma.participant.create({ data: { email: `concurrent-${TAG}@example.com`, name: 'C Lead', householdId: hh.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer: false } });
+        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT' } });
+
+        (sendEmail as jest.Mock).mockClear();
+
+        // Two near-simultaneous deliveries (Shopify retry) hit the same sink.
+        await Promise.all([
+            activate(p.id, { via: 'payment', shopifyOrderId: 'race-1' }),
+            activate(p.id, { via: 'payment', shopifyOrderId: 'race-2' }),
+        ]);
+
+        const auditRows = await prisma.auditLog.count({ where: { tableName: 'MembershipProcess', affectedEntityId: p.id } });
+        expect(auditRows).toBe(1);
+        expect(sendEmail as jest.Mock).toHaveBeenCalledTimes(1);
+
+        const proc = await prisma.membershipProcess.findUnique({ where: { id: p.id } });
+        expect(proc?.status).toBe('ACTIVE');
     });
 
     it('activate() is a no-op once already ACTIVE', async () => {

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -104,36 +104,47 @@ export async function activate(
 ) {
     const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new PaymentError("not_found", "Application not found.");
-    const membership = await prisma.membership.findUnique({ where: { id: process.membershipId }, select: { status: true, householdId: true } });
+    const membership = await prisma.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
     if (!membership) throw new PaymentError("not_found", "Membership not found.");
-    if (process.status === "ACTIVE" && membership.status === "ACTIVE") return process;
 
     const now = new Date();
-    const updated = await prisma.membershipProcess.update({
-        where: { id: processId },
-        data: {
-            status: "ACTIVE",
-            stageEnteredAt: now,
-            paidAt: now,
-            ...(opts.shopifyOrderId ? { shopifyOrderId: opts.shopifyOrderId } : {}),
-            ...(opts.via === "certified" && opts.actorId ? { certifiedById: opts.actorId } : {}),
-        },
-    });
-    await prisma.membership.update({ where: { id: process.membershipId }, data: { status: "ACTIVE" } });
+    // The flip + membership update + audit row are one transaction, and the flip
+    // is CONDITIONAL on status != ACTIVE. Under Read Committed, two concurrent
+    // updateMany re-check the WHERE against the just-committed row, so exactly one
+    // sees count === 1 and the rest see 0 — no row lock needed. Shopify retries
+    // an orders/paid webhook routinely; this makes activate() truly idempotent
+    // (no duplicate audit rows, no duplicate congrats emails).
+    const flipped = await prisma.$transaction(async (tx) => {
+        const { count } = await tx.membershipProcess.updateMany({
+            where: { id: processId, status: { not: "ACTIVE" } },
+            data: {
+                status: "ACTIVE",
+                stageEnteredAt: now,
+                paidAt: now,
+                ...(opts.shopifyOrderId ? { shopifyOrderId: opts.shopifyOrderId } : {}),
+                ...(opts.via === "certified" && opts.actorId ? { certifiedById: opts.actorId } : {}),
+            },
+        });
+        if (count === 0) return false; // already ACTIVE — a retry; skip audit + email
 
-    await prisma.auditLog.create({
-        data: {
-            actorId: opts.actorId ?? SYSTEM_ACTOR,
-            action: "EDIT",
-            tableName: "MembershipProcess",
-            affectedEntityId: processId,
-            oldData: JSON.stringify({ status: process.status }),
-            newData: JSON.stringify({ status: "ACTIVE", via: opts.via }),
-        },
+        await tx.membership.update({ where: { id: process.membershipId }, data: { status: "ACTIVE" } });
+        await tx.auditLog.create({
+            data: {
+                actorId: opts.actorId ?? SYSTEM_ACTOR,
+                action: "EDIT",
+                tableName: "MembershipProcess",
+                affectedEntityId: processId,
+                oldData: JSON.stringify({ status: process.status }),
+                newData: JSON.stringify({ status: "ACTIVE", via: opts.via }),
+            },
+        });
+        return true;
     });
 
-    await sendCongrats(membership.householdId);
-    return updated;
+    // Email outside the transaction: a slow/failed send must not roll back the
+    // activation, and we only send when this call is the one that flipped it.
+    if (flipped) await sendCongrats(membership.householdId);
+    return prisma.membershipProcess.findUnique({ where: { id: processId } });
 }
 
 /** Board override: certify a payment plan and activate without a Shopify payment. */


### PR DESCRIPTION
## What

`activate()` in `checkin-app/src/lib/membership/payment.ts` is now idempotent under concurrent/retried calls.

The old guard was a read-then-write: read whether the process/membership was already `ACTIVE`, then run the body (flip status, write audit log, send congrats email). Shopify retries `orders/paid` webhooks routinely — two near-simultaneous deliveries both read a non-`ACTIVE` state, both passed the guard, and both ran the full body → **duplicate congrats emails to the household and duplicate audit log rows**.

## Fix

- Flip + membership update + audit row now run in a single `prisma.$transaction`.
- The flip is **conditional**: `updateMany({ where: { id, status: { not: 'ACTIVE' } }, ... })`. Under Postgres Read Committed, concurrent updates re-check the `WHERE` against the just-committed row, so exactly one sees `count === 1` and the rest see `0`. The audit row + congrats email only run when this call did the flip.
- Congrats email is sent **outside** the transaction so a slow/failed send can't roll back the activation (matches prior behavior — email errors were already swallowed).

## Notes for reviewers

- **No row lock needed.** The conditional `updateMany` is the atomic gate — the dedup lives in the `WHERE` itself. This achieves the same serialization intent as the `SELECT ... FOR UPDATE` pattern in `checkin-app/src/lib/household/leads.ts` without an explicit lock.
- **No schema migration.** `shopifyOrderId` has no unique constraint; the conditional flip dedups without one. A unique constraint can be added later if a caller needs cross-process dedup.
- **Out of scope:** the Shopify webhook payment-validation gap (TODO #278, validate order amount/discount before activating) is a separate fix and intentionally untouched. `activate()` is the shared sink both the webhook and the board certify override hit.

## Test

Adds an integration test that calls `activate()` twice concurrently for the same process and asserts exactly one audit row and one congrats email. Full `membershipPaymentAPI.integration.test.ts` suite: 10/10 pass against a throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)