### PR TITLE
fix(s-read): validate Shopify bulk-export URL before fetch (SSRF guard)

### DIFF
--- a/s-read-function/src/shopify/bulk.ts
+++ b/s-read-function/src/shopify/bulk.ts
@@ -28,6 +28,36 @@ export const BULK_DOWNLOAD_TIMEOUT_MS = 60_000;
 /** Bounded retries for a transient download failure (matches the GraphQL client's spirit). */
 export const BULK_DOWNLOAD_MAX_ATTEMPTS = 4;
 
+/**
+ * Hosts a Shopify bulk-operation result URL is allowed to point at. Shopify serves the
+ * JSONL as a Google Cloud Storage signed URL on storage.googleapis.com. The URL comes
+ * from the GraphQL `currentBulkOperation.url` response, so it is attacker-influenced if
+ * that response is ever spoofed/compromised — restricting the host stops the download
+ * from being turned into SSRF against internal endpoints or the cloud metadata service.
+ */
+export const ALLOWED_BULK_HOSTS = ["storage.googleapis.com"];
+
+/** Parse + validate a bulk result URL: https only, host on the allowlist. Throws otherwise. */
+export function assertAllowedBulkUrl(url: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("bulk result URL rejected: not a valid URL");
+  }
+  if (parsed.protocol !== "https:") {
+    logger.warn("rejected bulk download URL (scheme)", { protocol: parsed.protocol, host: parsed.hostname });
+    throw new Error(`bulk result URL rejected: scheme ${parsed.protocol} (https required)`);
+  }
+  const host = parsed.hostname.toLowerCase();
+  const allowed = ALLOWED_BULK_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
+  if (!allowed) {
+    logger.warn("rejected bulk download URL (host)", { host });
+    throw new Error(`bulk result URL rejected: host ${host} not on allowlist`);
+  }
+  return parsed;
+}
+
 export { reassembleOrders, parseBulkJsonl } from "@inventory/s-ingest-core";
 
 export interface BulkOperation {
@@ -75,6 +105,9 @@ export async function downloadBulkJsonl(
   const maxAttempts = opts.maxAttempts ?? BULK_DOWNLOAD_MAX_ATTEMPTS;
   const backoffMs = opts.backoffMs ?? jitteredBackoffMs;
 
+  // Validate before any fetch: SSRF guard on the attacker-influenceable GraphQL-supplied URL.
+  const safeUrl = assertAllowedBulkUrl(url);
+
   let attempt = 0;
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -82,7 +115,13 @@ export async function downloadBulkJsonl(
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const res = await fetch(url, { signal: controller.signal });
+      // redirect: "manual" so a 3xx can't bounce us off the allowlist to an internal host.
+      const res = await fetch(safeUrl, { signal: controller.signal, redirect: "manual" });
+      if (res.type === "opaqueredirect" || (res.status >= 300 && res.status < 400)) {
+        logger.warn("bulk download blocked redirect", { status: res.status });
+        // Non-retryable (recognized prefix): a redirect off the signed URL is not transient.
+        throw new Error(`Failed to download bulk result: HTTP ${res.status} (redirect blocked)`);
+      }
       if (!res.ok) {
         const transient = res.status === 429 || res.status >= 500;
         if (transient && attempt < maxAttempts) {

--- a/s-read-function/test/unit/backfill.test.ts
+++ b/s-read-function/test/unit/backfill.test.ts
@@ -85,13 +85,13 @@ it("polls a tracked op still running and returns RUNNING with objectCount", asyn
 it("downloads + ingests a COMPLETED op, advances the watermark, clears state, returns INGESTED", async () => {
   const maxOccurredAt = new Date("2026-03-15T00:00:00Z");
   vi.mocked(getBulkState).mockResolvedValue({ bulkOperationId: "gid://op/1", bulkStatus: "RUNNING" });
-  vi.mocked(getCurrentBulkOperation).mockResolvedValue({ id: "gid://op/1", status: "COMPLETED", url: "https://bulk/result.jsonl" });
+  vi.mocked(getCurrentBulkOperation).mockResolvedValue({ id: "gid://op/1", status: "COMPLETED", url: "https://storage.googleapis.com/shopify-bulk/result.jsonl" });
   vi.mocked(downloadBulkJsonl).mockResolvedValue('{"id":"gid://shopify/Order/1"}\n');
   vi.mocked(ingestBulkOrders).mockResolvedValue({ exportId: 7n, recordCount: 1, ingested: 1, maxOccurredAt });
 
   const res = await run();
 
-  expect(downloadBulkJsonl).toHaveBeenCalledWith("https://bulk/result.jsonl");
+  expect(downloadBulkJsonl).toHaveBeenCalledWith("https://storage.googleapis.com/shopify-bulk/result.jsonl");
   expect(vi.mocked(ingestBulkOrders).mock.calls[0][1]).toMatchObject({
     storeId: "store-1",
     jsonl: '{"id":"gid://shopify/Order/1"}\n',

--- a/s-read-function/test/unit/bulk-lifecycle.test.ts
+++ b/s-read-function/test/unit/bulk-lifecycle.test.ts
@@ -45,13 +45,44 @@ describe("getCurrentBulkOperation", () => {
 describe("downloadBulkJsonl", () => {
   it("returns the body text on success", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "line1\nline2\n" }));
-    expect(await downloadBulkJsonl("https://bulk/result.jsonl")).toBe("line1\nline2\n");
+    expect(await downloadBulkJsonl("https://storage.googleapis.com/shopify-bulk/result.jsonl")).toBe("line1\nline2\n");
+  });
+
+  it("accepts an allowlisted https GCS host without rejecting", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "ok\n" });
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await downloadBulkJsonl("https://storage.googleapis.com/shopify-bulk/r.jsonl")).toBe("ok\n");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects SSRF targets (http, metadata IP, arbitrary host, suffix-spoof) before any fetch", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    for (const url of [
+      "http://storage.googleapis.com/shopify-bulk/r.jsonl", // not https
+      "https://169.254.169.254/latest/meta-data/", // cloud metadata service
+      "https://evil.example.com/r.jsonl", // off-allowlist host
+      "https://storage.googleapis.com.evil.com/r.jsonl", // suffix-spoof
+    ]) {
+      await expect(downloadBulkJsonl(url, { backoffMs: () => 0 })).rejects.toThrow(/rejected/);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks a redirect off the signed URL (redirect: manual), no retry", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ type: "opaqueredirect", ok: false, status: 0, text: async () => "" });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(
+      downloadBulkJsonl("https://storage.googleapis.com/shopify-bulk/r.jsonl", { backoffMs: () => 0 }),
+    ).rejects.toThrow("redirect blocked");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "manual" });
   });
 
   it("throws immediately on a non-retryable status (403 expired signed URL), no retry", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 403, text: async () => "" });
     vi.stubGlobal("fetch", fetchMock);
-    await expect(downloadBulkJsonl("https://bulk/result.jsonl", { backoffMs: () => 0 })).rejects.toThrow("HTTP 403");
+    await expect(downloadBulkJsonl("https://storage.googleapis.com/shopify-bulk/result.jsonl", { backoffMs: () => 0 })).rejects.toThrow("HTTP 403");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -62,7 +93,7 @@ describe("downloadBulkJsonl", () => {
       .mockResolvedValueOnce({ ok: true, status: 200, text: async () => "ok\n" });
     vi.stubGlobal("fetch", fetchMock);
 
-    expect(await downloadBulkJsonl("https://bulk/r.jsonl", { backoffMs: () => 0 })).toBe("ok\n");
+    expect(await downloadBulkJsonl("https://storage.googleapis.com/shopify-bulk/r.jsonl", { backoffMs: () => 0 })).toBe("ok\n");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -74,7 +105,7 @@ describe("downloadBulkJsonl", () => {
       .mockResolvedValueOnce({ ok: true, status: 200, text: async () => "late\n" });
     vi.stubGlobal("fetch", fetchMock);
 
-    expect(await downloadBulkJsonl("https://bulk/r.jsonl", { backoffMs: () => 0 })).toBe("late\n");
+    expect(await downloadBulkJsonl("https://storage.googleapis.com/shopify-bulk/r.jsonl", { backoffMs: () => 0 })).toBe("late\n");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -83,7 +114,7 @@ describe("downloadBulkJsonl", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      downloadBulkJsonl("https://bulk/r.jsonl", { maxAttempts: 3, backoffMs: () => 0 }),
+      downloadBulkJsonl("https://storage.googleapis.com/shopify-bulk/r.jsonl", { maxAttempts: 3, backoffMs: () => 0 }),
     ).rejects.toThrow("HTTP 500");
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
@@ -101,7 +132,7 @@ describe("downloadBulkJsonl", () => {
       });
       vi.stubGlobal("fetch", fetchMock);
 
-      const p = downloadBulkJsonl("https://bulk/r.jsonl", { timeoutMs: 1_000, maxAttempts: 1, backoffMs: () => 0 });
+      const p = downloadBulkJsonl("https://storage.googleapis.com/shopify-bulk/r.jsonl", { timeoutMs: 1_000, maxAttempts: 1, backoffMs: () => 0 });
       const rejects = expect(p).rejects.toThrow(/abort/i);
       await vi.advanceTimersByTimeAsync(1_000);
       await rejects;


### PR DESCRIPTION
## What

Validate the Shopify bulk-export result URL before downloading it in `downloadBulkJsonl` ([s-read-function/src/shopify/bulk.ts](../blob/claude/eager-euler-6a1cdb/s-read-function/src/shopify/bulk.ts)).

## Why

`downloadBulkJsonl(op.url)` fetched `currentBulkOperation.url` straight from the Shopify GraphQL response — no scheme or host validation — then read the whole body with `res.text()`. If that response is ever spoofed/compromised or returns an attacker-influenced URL, the Lambda makes an unvalidated outbound GET: **SSRF** to internal endpoints or the cloud metadata service (`169.254.169.254`), with the response pulled back into the function.

## Change

- New `assertAllowedBulkUrl(url)`, run **before any fetch**:
  - require `https:` scheme (rejects http/file/gopher/etc.)
  - require host on an allowlist — `storage.googleapis.com` (Shopify serves bulk results as GCS signed URLs; confirmed against shopify.dev, e.g. `https://storage.googleapis.com/shopify/...`). Subdomain `.storage.googleapis.com` allowed; suffix-spoof like `storage.googleapis.com.evil.com` rejected.
  - reject with a clear error + log the rejected host/scheme.
- `fetch(..., { redirect: "manual" })` so a 3xx can't bounce off-allowlist to an internal host; a redirect is treated as non-retryable.
- Existing AbortController timeout + bounded retry/backoff behavior unchanged.

## Tests

`s-read-function/test/unit/bulk-lifecycle.test.ts`:
- allowlisted https GCS URL passes
- `http://`, metadata IP `169.254.169.254`, arbitrary host, and suffix-spoof all reject **before** any fetch
- redirect off the signed URL blocked (asserts `redirect: "manual"`)

All 22 tests in the package pass; `tsc --noEmit` clean.

## Reviewer notes

- If Shopify ever changes the signed-URL domain, broaden `ALLOWED_BULK_HOSTS`.
- `package-lock.json` intentionally not included (only churned by a local `npm install` in the worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)