### PR TITLE
fix(admin/membership): stop tab bar jumping between membership pages

### DIFF
--- a/checkin-app/src/app/admin/membership/page.tsx
+++ b/checkin-app/src/app/admin/membership/page.tsx
@@ -160,16 +160,15 @@ export default function AdminMembershipPage() {
 
   return (
     <Stack>
-      <div>
-        <Title order={1}>Membership Applications</Title>
-        <Text c="dimmed">
-          In-flight applications. Use the manual controls below to confirm the contract was signed
-          or that background-check consent was received. (The contract is also confirmed
-          automatically once the Zoho webhook is configured.)
-        </Text>
-      </div>
+      <Title order={1}>Membership Applications</Title>
 
       <MembershipTabs active="applications" />
+
+      <Text c="dimmed">
+        In-flight applications. Use the manual controls below to confirm the contract was signed
+        or that background-check consent was received. (The contract is also confirmed
+        automatically once the Zoho webhook is configured.)
+      </Text>
 
       <AlertBanner message={message} tone={isError ? 'error' : 'success'} />
 


### PR DESCRIPTION
## What

On the membership admin pages, the **Applications** page rendered its dimmed description *between* the title and the membership tab bar, while **Households** renders its description *below* the tabs. That offset difference put the tab bar at a different vertical position on each page, so the tab bar visibly **jumped** when switching tabs.

Fix: move the Applications page description below the `<MembershipTabs>` bar so the title → tabs sequence is identical across pages and the tab bar stays put.

## Why

Reported on https://ops-dev.innovationtreehouse.org/admin/membership — descriptions were shifting the tabs. Now title → tabs → description on every page.

## Notes for reviewer

- Single-file change: [checkin-app/src/app/admin/membership/page.tsx](checkin-app/src/app/admin/membership/page.tsx).
- Households/Settings pages already render the description below the tabs (via `AdminPageHeader`); this only aligns Applications to that.
- Minor residual: Applications still uses a raw `<Title>` while the others use `AdminPageHeader` (with a back link). Heights are close; left as-is since the reported jump is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)