### PR TITLE
feat(membership): show current membership-year boundary in settings

### DIFF
--- a/checkin-app/src/app/admin/membership/settings/page.tsx
+++ b/checkin-app/src/app/admin/membership/settings/page.tsx
@@ -22,6 +22,17 @@ interface Designation {
 
 const dollars = (cents: number) => (cents / 100).toFixed(2);
 
+// Next occurrence (>= now) of the stored boundary's month/day, as a label.
+// ponytail: mirrors nextBoundary() in lib/membership/renewal.ts — can't import, it pulls in prisma.
+const currentBoundaryLabel = (iso: string) => {
+  const [, m, d] = iso.split("-").map(Number);
+  if (!m || !d) return null;
+  const now = new Date();
+  let b = Date.UTC(now.getUTCFullYear(), m - 1, d);
+  if (b < now.getTime()) b = Date.UTC(now.getUTCFullYear() + 1, m - 1, d);
+  return new Date(b).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" });
+};
+
 export default function MembershipSettingsPage() {
   const [normalDues, setNormalDues] = useState("0");
   const [volunteerDues, setVolunteerDues] = useState("0");
@@ -215,6 +226,10 @@ export default function MembershipSettingsPage() {
               <Text size="sm" mb="sm">
                 ⚠️ Changing this date shifts the renewal cycle for <strong>every household</strong>.
                 Only change it if you are sure.
+              </Text>
+              <Text size="sm" mb="sm">
+                Current boundary:{" "}
+                <strong>{boundary ? (currentBoundaryLabel(boundary) ?? "—") : "not set"}</strong>
               </Text>
               <Checkbox
                 mb="sm"


### PR DESCRIPTION
## What

Adds a **Current boundary** line to the "Membership-year boundary" section of `/admin/membership/settings`. It shows the next occurrence (≥ today) of the stored boundary's month/day, e.g. "September 1, 2026" — or "not set" when no boundary is configured.

## Why

The section let admins *edit* the boundary date but never displayed what it currently resolves to. There was no way to see the active renewal cycle without unlocking and inspecting the date input.

## Notes for reviewers

- `currentBoundaryLabel()` is a small inline helper that mirrors `nextBoundary()` in `lib/membership/renewal.ts`. It's duplicated rather than imported because `renewal.ts` pulls in `prisma` and can't be imported into a client component. Marked with a `ponytail:` comment.
- Computation uses UTC to match the server-side `nextBoundary` logic.
- Display-only change; no API or schema changes.

## Testing

Unit suite passes 177/177 (run via the worktree path override — the repo's pre-commit `test:ci` reports a false 0-tests inside `.claude/worktrees/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)