### PR TITLE
fix(household): remove redundant Back button

### DIFF
--- a/checkin-app/src/app/household/page.tsx
+++ b/checkin-app/src/app/household/page.tsx
@@ -303,10 +303,7 @@ export default function HouseholdPage() {
       <Stack>
         <TodoCard />
         <Card withBorder radius="md" padding="lg">
-          <Group justify="space-between" align="center" wrap="wrap" mb="md">
-            <Title order={1}>{household?.name || 'My Household'}</Title>
-            <Button variant="default" onClick={() => router.push('/')}>← Back</Button>
-          </Group>
+          <Title order={1} mb="md">{household?.name || 'My Household'}</Title>
 
           {household && (
             household.membership?.status === 'ACTIVE' ? (


### PR DESCRIPTION
## What

Removes the "← Back" button from the household page header. Collapses the now-single-child `Group` into a bare `Title`.

## Why

Navigation controls now live on the left side of the screen, making the per-page Back button redundant.

## Notes

- `router` and `Group` are still used elsewhere in the file; imports untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)