### PR TITLE
refactor(config): route ZOHO_WEBHOOK_SECRET through config module

### DIFF
--- a/checkin-app/src/app/api/webhooks/zoho/route.ts
+++ b/checkin-app/src/app/api/webhooks/zoho/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+import { config } from "@/lib/config";
 import { verifyZohoToken, parseZohoWebhook, ZOHO_WEBHOOK_HEADER } from "@/lib/membership/contract/zoho";
 import { findProcessByEnvelope, markContractSigned } from "@/lib/membership/external";
 
@@ -13,7 +14,7 @@ export const dynamic = "force-dynamic";
  * which may advance the application to PENDING_BG_REVIEW. We never read contract content.
  */
 export async function POST(req: Request) {
-    if (!process.env.ZOHO_WEBHOOK_SECRET) {
+    if (!config.zohoWebhookSecret()) {
         logger.error("Zoho webhook received but ZOHO_WEBHOOK_SECRET is not configured.");
         return NextResponse.json({ error: "Configuration Error" }, { status: 500 });
     }

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -51,6 +51,9 @@ export const config = {
     // static hosted URL provided out-of-band, so it lives in config, not BoardSettings.
     averityConsentUrl: (): string | null => process.env.AVERITY_CONSENT_URL || null,
 
+    // Zoho Sign webhook shared secret (timing-safe compared in verifyZohoToken).
+    zohoWebhookSecret: (): string | null => process.env.ZOHO_WEBHOOK_SECRET || null,
+
     // App
     checkinEnv: (): CheckinEnv => readCheckinEnv(),
     // Production (default when unset). Consumers should call this rather than

--- a/checkin-app/src/lib/membership/contract/zoho.ts
+++ b/checkin-app/src/lib/membership/contract/zoho.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import { config } from "@/lib/config";
 
 /**
  * Zoho Sign contract webhook helpers.
@@ -16,7 +17,7 @@ export const ZOHO_WEBHOOK_HEADER = "x-zoho-webhook-token";
 
 /** Timing-safe shared-secret check. Returns false if the secret is unset. */
 export function verifyZohoToken(headerToken: string | null | undefined): boolean {
-    const secret = process.env.ZOHO_WEBHOOK_SECRET;
+    const secret = config.zohoWebhookSecret();
     if (!secret || !headerToken) return false;
     const a = Buffer.from(headerToken);
     const b = Buffer.from(secret);


### PR DESCRIPTION
## What

The Zoho webhook shared secret was read directly from `process.env.ZOHO_WEBHOOK_SECRET` in two places, bypassing the central config module — even though `checkin-app/src/lib/config.ts` states "All process.env access should go through this module."

- Added `config.zohoWebhookSecret()` accessor in `config.ts`.
- `verifyZohoToken` (`src/lib/membership/contract/zoho.ts`) now uses it.
- Webhook route (`src/app/api/webhooks/zoho/route.ts`) null-check now uses it.

## Why

Centralize env access per the config module's stated contract.

## Notes for reviewer

- Behavior identical: timing-safe compare and the 500-on-missing-secret guard work exactly as before.
- Accessor added standalone (no `zohoClientId`/etc. accessors on this branch; those land separately in #290). Placed next to other secret accessors.
- `npx tsc --noEmit` introduces no new errors in touched files (pre-existing baseline errors only: missing generated prisma client, implicit-any in tests).
- No zoho webhook tests exist (`grep -rl verifyZohoToken` hits only source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)