### PR TITLE
fix(membership): send Zoho OAuth secrets in body, not URL query (S1)

### DIFF
--- a/checkin-app/src/lib/membership/contract/zohoClient.ts
+++ b/checkin-app/src/lib/membership/contract/zohoClient.ts
@@ -39,13 +39,22 @@ export async function getAccessToken(): Promise<string> {
     if (cachedToken && cachedToken.expiresAt > Date.now()) return cachedToken.token;
 
     const { clientId, clientSecret, refreshToken } = requireSecrets();
-    const url = new URL(`${config.zohoAccountsUrl()}/oauth/v2/token`);
-    url.searchParams.set("grant_type", "refresh_token");
-    url.searchParams.set("client_id", clientId);
-    url.searchParams.set("client_secret", clientSecret);
-    url.searchParams.set("refresh_token", refreshToken);
+    // Secrets (client_secret, refresh_token) go in the form-urlencoded body, not the
+    // URL query string: query strings are routinely written to access logs / APM at
+    // every TLS-terminating hop, request bodies are not. This is the OAuth2 (RFC 6749)
+    // form; Zoho's token endpoint accepts it.
+    const body = new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+    });
 
-    const resp = await fetch(url, { method: "POST" });
+    const resp = await fetch(`${config.zohoAccountsUrl()}/oauth/v2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body,
+    });
     if (!resp.ok) throw new ZohoError(`Token exchange failed (${resp.status}): ${await resp.text()}`);
     const data = (await resp.json()) as { access_token?: string; expires_in?: number };
     if (!data.access_token) throw new ZohoError(`Token exchange returned no access_token: ${JSON.stringify(data)}`);


### PR DESCRIPTION
## S1: Zoho OAuth secrets leak into plaintext logs

### Problem
`getAccessToken()` in `checkin-app/src/lib/membership/contract/zohoClient.ts` passed `client_secret` and `refresh_token` as **URL query-string params**. TLS encrypts them in transit, but URLs (including query strings) are routinely written to access logs / APM at every TLS-terminating hop, while request bodies are not. So the long-lived refresh token leaks into plaintext logs.

### Fix
Move the params into a `application/x-www-form-urlencoded` request body — the OAuth2 (RFC 6749) form. Only `getAccessToken` changes; the token-cache logic and error handling around the fetch are untouched. The other Zoho calls already use FormData bodies / non-secret URL params and are left as-is.

### Notes
- Zoho accepts form-urlencoded token requests per OAuth2, but this should be confirmed against the live Zoho config once real secrets are populated (consistent with the existing "confirm against live Zoho" notes in the codebase).
- The "caches the access token" unit test mocks fetch and asserts on token value + call count only — it does not assert on URL shape, so no test change was needed.

### Stacking
Stacked on `feat/membership-agreement-signing` (this code does not exist on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
