### PR TITLE
chore: bump checkin-app to Node 24 (app container + CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         if: needs.changes.outputs.app == 'true'
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - name: Install dependencies

--- a/checkin-app/Dockerfile
+++ b/checkin-app/Dockerfile
@@ -3,7 +3,7 @@
 # Build with:  docker build -f checkin-app/Dockerfile .
 
 # Stage 1: Install dependencies (whole workspace, hoisted to /app/node_modules)
-FROM node:22-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 # Copy only the manifests + lockfile first for a cache-friendly `npm ci` layer.
 # Add packages/*/package.json here when @checkin/* packages land (item 4).
@@ -12,7 +12,7 @@ COPY checkin-app/package.json ./checkin-app/package.json
 RUN npm ci
 
 # Stage 2: Build the app
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -39,7 +39,7 @@ ENV GOOGLE_CLIENT_ID=build-placeholder \
 RUN npm -w checkin-app run build
 
 # Stage 3: Production image
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 

--- a/checkin-app/package.json
+++ b/checkin-app/package.json
@@ -14,7 +14,7 @@
     "import:zoho": "tsx scripts/import-zoho.ts"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
Moves the long-running **checkin-app** (Next.js) to **Node 24** (current LTS).

**Changed → Node 24**
- `checkin-app/Dockerfile`: `node:22-alpine` → `node:24-alpine` (deps / builder / runner)
- `checkin-app/package.json` `engines.node`: `>=22` → `>=24`
- `.github/workflows/ci.yml`: `setup-node` `22` → `24`

**Deliberately left on `nodejs22.x` (Lambda toolchain — would break)**
- root `package.json` `engines` stays `>=22` — the workspace still ships the Node-22 Lambda layer, so the repo as a whole still supports 22
- `scripts/bundle-function.mjs` esbuild `target: node22`, `layers/prisma-runtime/`, `monitoring-watchdog-function/` — `prisma-runtime`'s README marks `nodejs22.x` **"not negotiable"** (nodejs20 throws `ERR_REQUIRE_ESM` at cold start), and AWS may not offer a `nodejs24.x` managed runtime yet. Migrating the Lambda to 24 is a separate, validated effort.

⚠️ **The CI run on this PR is the compatibility gate** — it exercises Next.js + Prisma on Node 24. If Prisma/Next don't support 24 on this version, the `Run Tests` / `Deploy build` checks will fail and we hold/adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)