### PR TITLE
ci: don't cancel dev deploys + smoke-test the app before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,8 @@ jobs:
   # but never push or deploy it. The deploy flow's build was previously only exercised on
   # push to main, so build-only failures (e.g. a Turbopack "module not found" that tsc can't
   # see) slipped through CI and broke the post-merge deploy. Building here gates the MR.
+  # It ALSO boots the built image and probes `/` (smoke test) — `docker build` alone can't
+  # catch a runtime crash on startup, which only surfaced post-merge as a hung ECS rollout.
   deploy-build:
     name: Deploy build (no deploy)
     needs: changes
@@ -184,3 +186,35 @@ jobs:
             --build-arg NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN="$NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN" \
             -f checkin-app/Dockerfile \
             -t checkin-deploy-build:${{ github.sha }} .
+
+      # Actually RUN the image: it must boot and serve `/` (mirrors the ALB health
+      # check, which accepts 200-399 for the app's auth redirect). Placeholder env,
+      # no DB — `/` is reachable without one. This catches a startup crash that the
+      # build can't, before the change can merge and hang the post-merge rollout.
+      - name: Smoke test — boot the app and probe /
+        if: needs.changes.outputs.app == 'true'
+        run: |
+          set -uo pipefail
+          docker run -d --name checkin-smoke -p 4000:4000 \
+            -e NODE_ENV=production -e PORT=4000 -e HOSTNAME=0.0.0.0 \
+            -e DATABASE_URL='postgresql://u:p@127.0.0.1:5432/db?sslmode=disable' \
+            -e NEXTAUTH_URL='http://127.0.0.1:4000' -e AUTH_TRUST_HOST=true -e NEXTAUTH_SECRET=smoke \
+            -e CHECKIN_ENV=dev -e AWS_REGION=us-east-2 \
+            checkin-deploy-build:${{ github.sha }}
+
+          ok=
+          for i in $(seq 1 30); do
+            if [ -z "$(docker ps -q -f name=checkin-smoke -f status=running)" ]; then
+              echo "container is no longer running"; break
+            fi
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4000/ || echo 000)
+            case "$code" in
+              2??|3??) echo "app booted — GET / -> $code"; ok=1; break ;;
+            esac
+            sleep 2
+          done
+
+          echo "----- container logs (tail) -----"
+          docker logs checkin-smoke 2>&1 | tail -50 || true
+          docker rm -f checkin-smoke >/dev/null 2>&1 || true
+          [ -n "$ok" ] || { echo "::error::checkin app failed to boot / serve \"/\" within ~60s"; exit 1; }

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,8 +26,15 @@ permissions:
   pull-requests: write  # comment on the originating PR
 
 concurrency:
-  group: checkin-deploy-dev
-  cancel-in-progress: false  # serialize deploys; never abandon one mid-rollout
+  # Group PER COMMIT (not a single shared group): with one shared group, GitHub
+  # collapses queued runs to the latest when merges land back-to-back, so an
+  # intermediate commit's deploy gets cancelled before it runs — losing the signal
+  # for which change broke things. Per-commit, every merge's deploy runs to
+  # completion and its result is pinned to that commit (re-runs of the SAME commit
+  # still dedup). Trade-off: two near-simultaneous merges can deploy in parallel
+  # (last update-service wins); acceptable for dev, and worth it for the visibility.
+  group: checkin-deploy-dev-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false # never abandon a deploy mid-rollout
 
 env:
   AWS_REGION: us-east-2


### PR DESCRIPTION
Two CI hardening changes prompted by the dev rollout hanging undiagnosed.

## 1. Deploy dev is no longer cancelled when merges stack up

`cancel-in-progress: false` already protected a *running* deploy — but with a single shared concurrency group, GitHub **collapses queued runs to the latest** when merges land back-to-back, so an intermediate commit's deploy gets cancelled before it ever runs. That's the trail of `cancelled` Deploy dev runs, and it hides which commit broke things.

Fix: group **per commit** (`checkin-deploy-dev-${{ github.event.workflow_run.head_sha }}`). Now every merge's deploy runs to completion and its result is pinned to that commit; re-runs of the same commit still dedup.

> Trade-off: two near-simultaneous merges can now deploy in parallel (last `update-service` wins). Acceptable for dev, and worth it for the per-commit visibility you asked for.

## 2. CI now actually runs the app before a PR can merge

`Deploy build (no deploy)` built the image but never started it — so a runtime **startup crash** sails through CI and only surfaces post-merge as a hung ECS rollout. Added a smoke step to that (already-required) job:

- `docker run` the freshly built image with placeholder env, **no DB**
- poll `GET /` for up to ~60s, pass on **200-399** (mirrors the ALB health matcher / the app's auth redirect)
- on failure: dump the container logs and fail the check

Because it lives in the existing required `Deploy build (no deploy)` check, it **gates PRs with no branch-protection change**. (Locally I verified the current image boots in ~34ms and `/`→307 with this exact env, so it passes for a healthy build and fails on a boot crash.)

### Notes
- The smoke test is deliberately DB-less to mirror the ALB health check (which probes `/`, reachable without the DB). If `/` ever grows a hard DB dependency, we'd add a `postgres` service + migrations like the `Run Tests` job.
- Skips correctly on client-only changes (same `needs.changes.outputs.app` gate as the rest of the job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)