### PR TITLE
fix(membership): mark the Zoho signer action embedded (is_embedded)

### DIFF
--- a/checkin-app/src/lib/membership/contract/zohoClient.ts
+++ b/checkin-app/src/lib/membership/contract/zohoClient.ts
@@ -104,6 +104,11 @@ export async function createRequest(params: {
                     recipient_name: params.recipientName,
                     signing_order: 0,
                     verify_recipient: false,
+                    // Required for the in-app embedded signing flow: the recipient must be
+                    // created as embedded, or the embedtoken call later fails with Zoho
+                    // code 2009 "Action is not embedded" (the recipient defaults to
+                    // email-based signing otherwise).
+                    is_embedded: true,
                 },
             ],
         },
@@ -165,6 +170,9 @@ export async function submitRequest(params: {
                     recipient_name: params.recipientName,
                     recipient_email: params.recipientEmail,
                     action_type: "SIGN",
+                    // Re-assert embedded on submit so the field-attach step can't reset the
+                    // recipient back to email signing (keeps the embedtoken call valid).
+                    is_embedded: true,
                     fields,
                 },
             ],


### PR DESCRIPTION
## Symptom

Membership signing fails at the embed-token step:

```
Created Zoho signing request 423660000000251001 for membership process 34.
Membership contract sign error: Failed to get embed token (400):
  {"code":2009,"message":"Action is not embedded","status":"failure"}
```

OAuth, request creation, and submit all succeed (Zoho is fully wired now) — only `getEmbeddedSignUrl` fails.

## Cause

`createRequest` registers the SIGN recipient **without** `is_embedded`, so Zoho creates a normal **email** signer. The `embedtoken` endpoint then rejects it with **code 2009 "Action is not embedded."** Embedded (in-app) signing requires the recipient action to be created as embedded.

## Fix

Set `is_embedded: true` on the recipient action in `createRequest`, and re-assert it in `submitRequest` so the field-attach step can't reset the recipient back to email signing. One-line-class change; the rest of the flow was already working.

- `zohoClient` tests: 5/5 pass · `tsc --noEmit`: clean.

## ⚠️ Possible second step (Zoho console, not code)

`getEmbeddedSignUrl` passes `host = config.baseUrl()` (dev: `https://ops-dev.innovationtreehouse.org`), and **that host must be allow-listed for embedded signing in the Zoho Sign console**. If after this fix the embedtoken call returns a *host/domain not allowed* error (rather than 2009), add `ops-dev.innovationtreehouse.org` (and the prod host) to the allowed domains in Zoho Sign → Settings → Embedded/Integrations. No code change for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)