### PR TITLE
ci: bump docker/login-action v3 → v4 (Node 24 runtime)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -76,7 +76,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
The dev deploy logs a Node 20 deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `docker/login-action@v3`.

`docker/login-action` v3.x (incl. the latest v3.7.0) declares `using: node20`. **v4.0.0** switched the default runtime to **node24** ("Node 24 as default runtime"). Bumping `@v3 → @v4` clears the warning and matches the repo's floating-major convention.

- Only change: `docker/login-action@v3` → `@v4` in `deploy-dev.yml`.
- GitHub-hosted runners satisfy v4's requirement (Actions runner ≥ 2.327.1).

Sibling PRs do the same in arbor and wiki (login-action is used there too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)