### PR TITLE
fix(membership): return the embedded signer to checkin after signing (redirect_pages)

### DIFF
--- a/checkin-app/src/lib/membership/contract/__tests__/zohoClient.test.ts
+++ b/checkin-app/src/lib/membership/contract/__tests__/zohoClient.test.ts
@@ -66,8 +66,20 @@ describe("zohoClient", () => {
             recipientName: "X",
             requestName: "Agreement",
             expirationDays: 15,
+            redirectPages: {
+                sign_completed: "https://app.example.com/membership?signed=1",
+                sign_success: "https://app.example.com/membership?signed=1",
+                sign_declined: "https://app.example.com/membership?declined=1",
+                sign_later: "https://app.example.com/membership",
+            },
         });
         expect(result).toEqual({ requestId: "req-1", actionId: "act-1", documentId: "doc-1" });
+        // redirect_pages must ride in the create payload so the embedded signer is
+        // returned to checkin after signing (not stranded on Zoho's page).
+        const sentData = JSON.parse(
+            ((global.fetch as jest.Mock).mock.calls[0][1].body as FormData).get("data") as string,
+        );
+        expect(sentData.requests.redirect_pages.sign_completed).toContain("/membership?signed=1");
     });
 
     it("createRequest throws when Zoho reports a non-success status", async () => {
@@ -81,6 +93,12 @@ describe("zohoClient", () => {
                 recipientName: "X",
                 requestName: "Agreement",
                 expirationDays: 15,
+                redirectPages: {
+                    sign_completed: "https://app.example.com/membership?signed=1",
+                    sign_success: "https://app.example.com/membership?signed=1",
+                    sign_declined: "https://app.example.com/membership?declined=1",
+                    sign_later: "https://app.example.com/membership",
+                },
             }),
         ).rejects.toBeInstanceOf(ZohoError);
     });

--- a/checkin-app/src/lib/membership/contract/zohoClient.ts
+++ b/checkin-app/src/lib/membership/contract/zohoClient.ts
@@ -83,6 +83,13 @@ export interface CreateRequestResult {
  * Upload the agreement PDF and register the single SIGN recipient. Mirrors the
  * script's create_request: is_sequential, one SIGN action, verify_recipient false.
  */
+export interface RedirectPages {
+    sign_completed: string;
+    sign_success: string;
+    sign_declined: string;
+    sign_later: string;
+}
+
 export async function createRequest(params: {
     token: string;
     pdf: Buffer;
@@ -91,12 +98,18 @@ export async function createRequest(params: {
     recipientName: string;
     requestName: string;
     expirationDays: number;
+    redirectPages: RedirectPages;
 }): Promise<CreateRequestResult> {
     const payload = {
         requests: {
             request_name: params.requestName,
             expiration_days: params.expirationDays,
             is_sequential: true,
+            // Where Zoho sends the (embedded) signer when they finish. Without this
+            // the embedded session ends on Zoho's own page and the applicant is
+            // stranded — never returned to checkin. Set at creation, inside
+            // `requests` (Zoho has no redirect param on the embedtoken call).
+            redirect_pages: params.redirectPages,
             actions: [
                 {
                     action_type: "SIGN",

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -196,6 +196,9 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
         const pdf = isProd ? agreement.pdf : await stampWatermark(agreement.pdf, "DEV TEST — NOT A LEGAL AGREEMENT");
         const requestName = `${isProd ? "" : "[DEV TEST — NOT BINDING] "}Membership Agreement — ${recipientName}`;
 
+        // Return the embedded signer to checkin when they finish (Zoho navigates
+        // the window to these). signed=1 lets the membership page confirm + refresh.
+        const membershipUrl = `${config.baseUrl()}/membership`;
         const created = await createRequest({
             token,
             pdf,
@@ -204,6 +207,12 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
             recipientName,
             requestName,
             expirationDays: CONTRACT_EXPIRATION_DAYS,
+            redirectPages: {
+                sign_completed: `${membershipUrl}?signed=1`,
+                sign_success: `${membershipUrl}?signed=1`,
+                sign_declined: `${membershipUrl}?declined=1`,
+                sign_later: membershipUrl,
+            },
         });
         await submitRequest({
             token,


### PR DESCRIPTION
## Symptom

After completing signing (Zoho shows it complete), the applicant (1) **wasn't returned to checkin** and (2) checkin **didn't show it complete**. These are two separate problems — this PR fixes #1.

## #1 — No return (fixed here)

`startSigning()` navigates the **whole window** to the embedded sign URL (`window.location.href = data.url`), but the create-request never set Zoho's **`redirect_pages`**, so Zoho had nowhere to send the signer afterward — they end on Zoho's own page.

Per the Zoho Sign docs, the post-sign redirect is configured with a `redirect_pages` object **inside `requests` at document creation** (there's no redirect param on the `embedtoken` call; `host` is only the iframe allow-list). Added it:

| Zoho event | Redirect |
|---|---|
| `sign_completed` / `sign_success` | `/membership?signed=1` |
| `sign_declined` | `/membership?declined=1` |
| `sign_later` | `/membership` |

`tsc` clean · zoho client tests 5/5 (added an assertion that `redirect_pages` rides in the create payload).

## #2 — Status not updating (NOT fixed here — needs the webhook)

"Complete" in checkin is driven solely by the Zoho **webhook** → `POST /api/webhooks/zoho` → `markContractSigned`. The handler/parser are correct, so Zoho simply isn't calling it. **Configure the webhook in the Zoho Sign console:**

- URL: `https://ops-dev.innovationtreehouse.org/api/webhooks/zoho` (POST)
- Custom header: `x-zoho-webhook-token: <the checkin-dev/zoho-webhook-secret value>`
- Trigger: request **completed**

⚠️ **Reliability caveat:** once ops-dev is scale-to-zero (infra #107), it's usually **down**, so a Zoho webhook would hit a cold start / the "warming" page and Zoho's delivery could fail → status still wouldn't update. The robust fix is to **sync status on return**: when the signer lands back on `/membership?signed=1`, have checkin poll Zoho for the request status and mark it signed — no dependence on an inbound webhook to a sleeping service. I can build that as a follow-up (adds `getRequestStatus` + a sync endpoint the page calls on return). **Recommended** given the scale-to-zero direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)