### PR TITLE
feat(membership): sync contract status on return from signing

### DIFF
--- a/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
@@ -23,6 +23,7 @@ jest.mock('@/lib/membership/contract/zohoClient', () => ({
     createRequest: jest.fn().mockResolvedValue({ requestId: 'REQ-1', actionId: 'ACT-1', documentId: 'DOC-1' }),
     submitRequest: jest.fn().mockResolvedValue(undefined),
     getEmbeddedSignUrl: jest.fn().mockResolvedValue('https://sign.zoho.com/embed/xyz'),
+    getRequestStatus: jest.fn().mockResolvedValue(false),
 }));
 
 // Imported AFTER the mocks so the route picks up the mocked client.

--- a/checkin-app/src/app/api/membership/contract/sync/route.ts
+++ b/checkin-app/src/app/api/membership/contract/sync/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { logger } from "@/lib/logger";
+import { syncContractStatus } from "@/lib/membership/external";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/membership/contract/sync — applicant-facing "did my signature land?"
+ * check, called when the signer returns from embedded signing (?signed=1). Pulls
+ * the request status from Zoho and records it signed if complete, so the UI
+ * reflects completion immediately instead of waiting on the (scale-to-zero-fragile)
+ * Zoho webhook. Returns the current external status.
+ */
+export const POST = withAuth({}, async (_req, auth) => {
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    try {
+        const status = await syncContractStatus(auth.user.id);
+        return NextResponse.json({ status });
+    } catch (error) {
+        logger.error(`Contract status sync error: ${error instanceof Error ? error.message : String(error)}`);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+});

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import type { MembershipProcessStatus, MembershipStatus } from "@/generated/prisma/client";
@@ -139,6 +139,43 @@ export default function MembershipPage() {
   useEffect(() => {
     if (sessionStatus === "authenticated") load();
     else if (sessionStatus === "unauthenticated") setLoading(false);
+  }, [sessionStatus, load]);
+
+  // Return from embedded signing: Zoho redirects back with ?signed=1 (or
+  // ?declined=1). Sync the contract status straight from Zoho rather than waiting
+  // on the inbound webhook (ops-dev is scale-to-zero and may be asleep when Zoho
+  // fires it), refresh, then strip the query so a manual reload doesn't re-run.
+  const signReturnHandled = useRef(false);
+  useEffect(() => {
+    if (sessionStatus !== "authenticated" || signReturnHandled.current) return;
+    const params = new URLSearchParams(window.location.search);
+    const signed = params.get("signed") === "1";
+    const declined = params.get("declined") === "1";
+    if (!signed && !declined) return;
+    signReturnHandled.current = true;
+    window.history.replaceState(null, "", window.location.pathname);
+    if (declined) {
+      setMessage("You declined the agreement. You can restart signing when you're ready.");
+      setIsError(true);
+      return;
+    }
+    (async () => {
+      let signedNow = false;
+      try {
+        const res = await fetch("/api/membership/contract/sync", { method: "POST" });
+        const data = await res.json().catch(() => null);
+        signedNow = !!data?.status?.contractSigned;
+      } catch {
+        /* best-effort — the Zoho webhook is still a backstop */
+      }
+      await load();
+      setMessage(
+        signedNow
+          ? "Thanks — your signature was received."
+          : "Signature received — finalizing. If it doesn't update shortly, use “Refresh status”.",
+      );
+      setIsError(false);
+    })();
   }, [sessionStatus, load]);
 
   // When awaiting payment, fetch the dues amount and Shopify checkout link.

--- a/checkin-app/src/lib/membership/contract/__tests__/zohoClient.test.ts
+++ b/checkin-app/src/lib/membership/contract/__tests__/zohoClient.test.ts
@@ -5,6 +5,7 @@ import {
     getAccessToken,
     createRequest,
     getEmbeddedSignUrl,
+    getRequestStatus,
     ZohoError,
     _resetTokenCache,
 } from "@/lib/membership/contract/zohoClient";
@@ -110,5 +111,13 @@ describe("zohoClient", () => {
         const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as URL;
         expect(calledUrl.toString()).toContain("/requests/req-1/actions/act-1/embedtoken");
         expect(calledUrl.searchParams.get("host")).toBe("https://app.example.com");
+    });
+
+    it("getRequestStatus is true only when the request is completed", async () => {
+        mockFetchOnce({ requests: { request_status: "completed" } });
+        await expect(getRequestStatus("t", "req-1")).resolves.toBe(true);
+
+        mockFetchOnce({ requests: { request_status: "inprogress" } });
+        await expect(getRequestStatus("t", "req-1")).resolves.toBe(false);
     });
 });

--- a/checkin-app/src/lib/membership/contract/zohoClient.ts
+++ b/checkin-app/src/lib/membership/contract/zohoClient.ts
@@ -228,3 +228,19 @@ export async function getEmbeddedSignUrl(params: {
     if (!signUrl) throw new ZohoError(`Embed token response missing sign_url: ${JSON.stringify(result)}`);
     return signUrl;
 }
+
+/**
+ * Read a signing request's current status. Returns true once the request is fully
+ * completed. Used to sync state on the applicant's return from embedded signing,
+ * so completion doesn't depend on the inbound webhook (which is unreliable against
+ * a scale-to-zero dev instance).
+ */
+export async function getRequestStatus(token: string, requestId: string): Promise<boolean> {
+    const resp = await fetch(`${config.zohoSignApi()}/requests/${requestId}`, {
+        method: "GET",
+        headers: authHeader(token),
+    });
+    if (!resp.ok) throw new ZohoError(`Failed to get request status (${resp.status}): ${await resp.text()}`);
+    const result = (await resp.json()) as { requests?: { request_status?: string } };
+    return result.requests?.request_status?.toLowerCase() === "completed";
+}

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -8,6 +8,7 @@ import {
     submitRequest,
     getAccessToken,
     getEmbeddedSignUrl,
+    getRequestStatus,
 } from "@/lib/membership/contract/zohoClient";
 import { loadAgreementPdf, stampWatermark, AGREEMENT_FILENAME, AgreementUnavailableError } from "@/lib/membership/contract/agreementDocument";
 
@@ -126,6 +127,42 @@ export async function setZohoEnvelope(processId: number, requestId: string, acto
 /** Find the in-flight process tied to a Zoho request id (for webhook matching). */
 export async function findProcessByEnvelope(requestId: string) {
     return prisma.membershipProcess.findFirst({ where: { zohoEnvelopeId: requestId } });
+}
+
+/**
+ * Pull the contract status from Zoho for the applicant's in-flight process and
+ * record it signed if Zoho says so. Called when the signer returns from embedded
+ * signing (?signed=1) so completion doesn't hinge on the inbound webhook — which
+ * is unreliable against a scale-to-zero dev instance that may be asleep when Zoho
+ * fires it. Best-effort: a Zoho hiccup is swallowed (the webhook is the backstop)
+ * and the current status is returned regardless. Returns null when the user has no
+ * in-flight signing process.
+ */
+export async function syncContractStatus(userId: number): Promise<ExternalStatus | null> {
+    const user = await prisma.participant.findUnique({
+        where: { id: userId },
+        include: { household: { include: { membership: { include: { processes: true } } } } },
+    });
+    // Same selection as the signing action: the latest process awaiting external action.
+    const process = (user?.household?.membership?.processes ?? [])
+        .filter((p) => p.status === "PENDING_EXTERNAL_ACTION")
+        .sort((a, b) => b.id - a.id)[0];
+    if (!process) return null;
+
+    if (!process.contractSignedAt && process.zohoEnvelopeId && config.zohoConfigured()) {
+        try {
+            const token = await getAccessToken();
+            if (await getRequestStatus(token, process.zohoEnvelopeId)) {
+                await markContractSigned(process.id, userId);
+            }
+        } catch (e) {
+            logger.error(`Zoho status sync failed for process ${process.id}: ${e instanceof Error ? e.message : String(e)}`);
+        }
+    }
+
+    // Re-read: markContractSigned may have flipped contractSignedAt (and advanced the phase).
+    const fresh = await prisma.membershipProcess.findUnique({ where: { id: process.id } });
+    return fresh ? getExternalStatus(fresh) : null;
 }
 
 /** Days an applicant has to sign before the Zoho request expires (mirrors the script's default). */


### PR DESCRIPTION
**Stacked on #319** (base = `fix/zoho-embedded-redirect`). Merge #319 first; GitHub retargets this to `main`.

## Why

Completion in checkin updates **only** via the Zoho webhook (`POST /api/webhooks/zoho`). That's fragile once ops-dev is scale-to-zero (infra #107): the service is normally **asleep**, so Zoho's callback hits a cold start / the "warming" page and may never land — leaving checkin stuck on "not signed" even though Zoho shows complete. That's exactly what you hit.

## Fix — sync on the user's return (no dependency on an inbound webhook)

When the signer comes back from embedded signing (the `?signed=1` redirect added in #319), checkin pulls the status straight from Zoho. The user's own return wakes the service through the normal path, so it always works — and it reflects completion immediately instead of waiting on an async callback.

- **`zohoClient.getRequestStatus(token, requestId)`** — `GET /requests/{id}`, true when `request_status === "completed"`.
- **`external.syncContractStatus(userId)`** — for the applicant's in-flight process, pull Zoho status and `markContractSigned` (idempotent) if complete. Best-effort: a Zoho hiccup is swallowed (webhook stays a backstop); returns current status.
- **`POST /api/membership/contract/sync`** — applicant-facing trigger (`withAuth`, session).
- **membership page** — on `?signed=1`: call sync → refresh → confirm ("your signature was received"); `?declined=1` shows a restart message. The query is stripped so a manual reload doesn't re-run it.

The **webhook path is unchanged** and still works for email signing / prod.

## Validation
- `tsc` clean · eslint clean (incl. the new effect's hook deps).
- Zoho client tests 6/6 (added a `getRequestStatus` completed/in-progress test).
- `check-route-coverage`: 0 errors (new route is an advisory `unmigrated` warning, same as the sibling `sign` route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)