### PR TITLE
fix(programs): close enroll-capacity TOCTOU races with a row lock

### DIFF
--- a/checkin-app/__tests__/programSignupIntegration.test.ts
+++ b/checkin-app/__tests__/programSignupIntegration.test.ts
@@ -25,9 +25,8 @@ jest.mock('@/lib/shopify', () => ({
 }));
 
 // Mock Prisma
-jest.mock('@/lib/prisma', () => ({
-  __esModule: true,
-  default: {
+jest.mock('@/lib/prisma', () => {
+  const mock = {
     participant: {
       create: jest.fn(),
       findUnique: jest.fn(),
@@ -65,12 +64,19 @@ jest.mock('@/lib/prisma', () => ({
       findUnique: jest.fn(),
       update: jest.fn(),
       deleteMany: jest.fn(),
+      count: jest.fn(),
     },
     auditLog: {
       create: jest.fn(),
     },
-  },
-}));
+    // Enroll route now wraps the insert in $transaction + a FOR UPDATE
+    // capacity check; run the callback against this same mock as the tx client.
+    $queryRaw: jest.fn(),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (mock as any).$transaction = jest.fn((cb: (tx: typeof mock) => unknown) => cb(mock));
+  return { __esModule: true, default: mock };
+});
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockGetSession = require('next-auth/next').getServerSession;

--- a/checkin-app/jest.setup.js
+++ b/checkin-app/jest.setup.js
@@ -18,7 +18,11 @@ process.env.CHECKIN_ENV = 'dev';
 // on it too); @/lib/prisma reads TEST_DB_POOL_MAX when it first loads.
 {
   const { testPath } = expect.getState();
-  if (testPath && /scanConcurrency\.integration\.test\.[jt]sx?$/.test(testPath)) {
+  // Same reasoning for the program-capacity concurrency suites: they need a
+  // pool of >= 2 so their two enroll transactions run on separate connections,
+  // making the program-row FOR UPDATE lock (not pool-1 serialization) the thing
+  // that serializes them — matching production.
+  if (testPath && /(scanConcurrency|programsParticipantsConcurrency|programsPublicRegisterConcurrency)\.integration\.test\.[jt]sx?$/.test(testPath)) {
     process.env.TEST_DB_POOL_MAX = '2';
   }
 }

--- a/checkin-app/src/app/__tests__/programsParticipantsConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsConcurrency.integration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Concurrency regression test for POST /api/programs/[id]/participants.
+ *
+ * Capacity used to be checked against a `_count` read when the program was
+ * loaded, then the enrollment was created with no lock between. N concurrent
+ * enrolls for the last seat all read count==max-1, all passed, all inserted —
+ * overfilling the program past maxParticipants.
+ *
+ * The fix re-checks capacity under a Program-row FOR UPDATE lock INSIDE a
+ * transaction immediately before the create. This test has one household lead
+ * enroll two household members concurrently into a 1-seat program and asserts
+ * exactly one succeeds and the program is not overfilled.
+ *
+ * (jest.setup.js gives this suite TEST_DB_POOL_MAX=2 so the two transactions
+ * run on separate connections; the FOR UPDATE lock is then the only thing
+ * serializing them, as in production.)
+ */
+import { POST } from '@/app/api/programs/[id]/participants/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+jest.mock('@/lib/notifications', () => ({
+    sendNotification: jest.fn().mockResolvedValue(true),
+}));
+
+const TAG = 'partic-conc-test';
+
+describe('POST /api/programs/[id]/participants concurrency (capacity lock)', () => {
+    let leadId: number;
+    let member1Id: number;
+    let member2Id: number;
+    let householdId: number;
+    let programId: number;
+
+    async function cleanup() {
+        const users = await prisma.participant.findMany({
+            where: { email: { contains: TAG } },
+            select: { id: true, householdId: true },
+        });
+        const ids = users.map(u => u.id);
+        const householdIds = [...new Set(users.map(u => u.householdId))];
+        await prisma.programParticipant.deleteMany({ where: { participantId: { in: ids } } });
+        await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: ids } } });
+        await prisma.householdLead.deleteMany({ where: { participantId: { in: ids } } });
+        await prisma.participant.deleteMany({ where: { id: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
+    }
+
+    beforeAll(async () => {
+        await cleanup();
+
+        const household = await prisma.household.create({ data: { name: `${TAG} household` } });
+        householdId = household.id;
+
+        const lead = await prisma.participant.create({
+            data: { email: `lead-${TAG}@example.com`, name: 'Lead', householdId },
+        });
+        leadId = lead.id;
+        await prisma.householdLead.create({ data: { householdId, participantId: leadId } });
+
+        const m1 = await prisma.participant.create({
+            data: { email: `m1-${TAG}@example.com`, name: 'Member One', householdId },
+        });
+        member1Id = m1.id;
+        const m2 = await prisma.participant.create({
+            data: { email: `m2-${TAG}@example.com`, name: 'Member Two', householdId },
+        });
+        member2Id = m2.id;
+
+        const program = await prisma.program.create({
+            data: {
+                name: `${TAG} program`,
+                phase: 'RUNNING',
+                enrollmentStatus: 'OPEN',
+                maxParticipants: 1, // one seat
+                memberPrice: null,
+                nonMemberPrice: null, // free → no override needed, capacity still enforced
+            },
+        });
+        programId = program.id;
+
+        // Lead is the actor for both enrollments (household-lead authorization).
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: leadId } });
+    });
+
+    afterAll(cleanup);
+
+    const params = (id: number) => ({ params: Promise.resolve({ id: id.toString() }) });
+
+    function enroll(participantId: number) {
+        return new Request(`http://localhost:4000/api/programs/${programId}/participants`, {
+            method: 'POST',
+            body: JSON.stringify({ participantId }),
+        });
+    }
+
+    it('two concurrent enrolls for the last seat → exactly one succeeds, no overfill', async () => {
+        const [resA, resB] = await Promise.all([
+            POST(enroll(member1Id) as unknown as import('next/server').NextRequest, params(programId) as unknown as never),
+            POST(enroll(member2Id) as unknown as import('next/server').NextRequest, params(programId) as unknown as never),
+        ]);
+
+        const statuses = [resA.status, resB.status].sort();
+        // Exactly one 200, one 400 — never two 200s.
+        expect(statuses).toEqual([200, 400]);
+
+        const loser = resA.status === 400 ? resA : resB;
+        expect((await loser.json()).error).toMatch(/maximum capacity/i);
+
+        // The core invariant: at most one enrollment exists.
+        const enrolled = await prisma.programParticipant.count({ where: { programId } });
+        expect(enrolled).toBe(1);
+    });
+});

--- a/checkin-app/src/app/__tests__/programsPublicRegisterConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublicRegisterConcurrency.integration.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Concurrency regression test for POST /api/programs/[id]/public-register.
+ *
+ * Capacity used to be checked against a `_count` read BEFORE the create
+ * transaction. Two near-simultaneous public registrations for the last seat
+ * both read count==max-1, both passed, and both inserted — overfilling the
+ * program. This endpoint is public/unauthenticated, so it is trivially raced.
+ *
+ * The fix locks the Program row (SELECT ... FOR UPDATE) and re-counts INSIDE
+ * the existing transaction before creating enrollments. This test fires two
+ * concurrent registrations for a 1-seat program and asserts exactly one
+ * succeeds and the program is not overfilled.
+ *
+ * (jest.setup.js gives this suite TEST_DB_POOL_MAX=2 so the two transactions
+ * run on separate connections; the FOR UPDATE lock is then the only thing
+ * serializing them, exactly as in production. With pool 1 the assertions pass
+ * even without the lock.)
+ */
+import { POST } from '@/app/api/programs/[id]/public-register/route';
+import prisma from '@/lib/prisma';
+
+jest.mock('@/lib/notifications', () => ({
+    sendNotification: jest.fn().mockResolvedValue(true),
+}));
+
+const NAME_TAG = 'PublicRegConcurrency Test';
+
+describe('POST /api/programs/[id]/public-register concurrency (capacity lock)', () => {
+    let programId: number;
+
+    async function cleanup() {
+        const progs = await prisma.program.findMany({
+            where: { name: { contains: NAME_TAG } },
+            select: { id: true },
+        });
+        const progIds = progs.map(p => p.id);
+        // Households created by registrations: reached via their enrolled members.
+        const members = await prisma.participant.findMany({
+            where: { programParticipants: { some: { programId: { in: progIds } } } },
+            select: { id: true, householdId: true },
+        });
+        const householdIds = [...new Set(members.map(m => m.householdId))];
+        await prisma.programParticipant.deleteMany({ where: { programId: { in: progIds } } });
+        await prisma.emergencyContact.deleteMany({ where: { householdId: { in: householdIds } } });
+        await prisma.householdLead.deleteMany({ where: { householdId: { in: householdIds } } });
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: members.map(m => m.id) } } });
+        await prisma.participant.deleteMany({ where: { householdId: { in: householdIds } } });
+        await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
+        await prisma.program.deleteMany({ where: { id: { in: progIds } } });
+    }
+
+    beforeAll(async () => {
+        await cleanup();
+        const program = await prisma.program.create({
+            data: {
+                name: NAME_TAG,
+                phase: 'RUNNING',
+                enrollmentStatus: 'OPEN',
+                maxParticipants: 1, // exactly one seat
+                memberPrice: null,
+                nonMemberPrice: null, // free → no payment/checkout path
+            },
+        });
+        programId = program.id;
+    });
+
+    afterAll(cleanup);
+
+    const params = (id: number) => ({ params: Promise.resolve({ id: id.toString() }) });
+
+    function registration(idx: number) {
+        return new Request(`http://localhost:4000/api/programs/${programId}/public-register`, {
+            method: 'POST',
+            body: JSON.stringify({
+                parents: [{ name: `Parent ${idx}`, email: `pubreg-conc-${idx}@example.com`, phone: `555-000-000${idx}` }],
+                emergencyContact: { name: `Aunt ${idx}`, phone: `555-111-222${idx}` },
+                participants: [{ name: `Kid ${idx}`, dob: '2015-01-01' }],
+            }),
+        });
+    }
+
+    it('two concurrent registrations for the last seat → exactly one succeeds, no overfill', async () => {
+        const [resA, resB] = await Promise.all([
+            POST(registration(1) as unknown as import('next/server').NextRequest, params(programId) as unknown as never),
+            POST(registration(2) as unknown as import('next/server').NextRequest, params(programId) as unknown as never),
+        ]);
+
+        const statuses = [resA.status, resB.status].sort();
+        // Exactly one 200, one 400 (capacity rejected) — never two 200s.
+        expect(statuses).toEqual([200, 400]);
+
+        const loser = resA.status === 400 ? resA : resB;
+        expect((await loser.json()).error).toMatch(/Not enough open spots/i);
+
+        // The core invariant: the program holds at most its capacity.
+        const enrolled = await prisma.programParticipant.count({ where: { programId } });
+        expect(enrolled).toBe(1);
+    });
+});

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth-options";
 import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
+import { lockProgramAndCheckCapacity, ProgramCapacityError } from "@/lib/program/capacity";
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
@@ -25,11 +26,10 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
             return NextResponse.json({ error: "participantId is required" }, { status: 400 });
         }
 
+        // Capacity is counted under a row lock inside the enroll transaction
+        // below, so no _count is fetched here.
         const currentProgram = await prisma.program.findUnique({
-            where: { id: programId },
-            include: {
-                _count: { select: { participants: true } }
-            }
+            where: { id: programId }
         });
         if (!currentProgram) {
             return NextResponse.json({ error: "Program not found" }, { status: 404 });
@@ -67,13 +67,13 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
              return NextResponse.json({ error: "This bypasses all payment. Are you sure?", requiresOverride: true }, { status: 400 });
         }
 
-        // Validation Checks
-        if (!override || (!isSysAdminOrBoard)) {
-            // Check Capacity
-            if (currentProgram.maxParticipants !== null && currentProgram._count.participants >= currentProgram.maxParticipants) {
-                return NextResponse.json({ error: "Program has reached maximum capacity.", requiresOverride: true }, { status: 400 });
-            }
+        // When true, capacity/enrollment-status/age limits apply (a board
+        // override skips them). Capacity itself is re-checked under a row lock
+        // inside the transaction below — the _count read above is racy.
+        const enforceLimits = !override || (!isSysAdminOrBoard);
 
+        // Validation Checks
+        if (enforceLimits) {
             // Check Enrollment Status
             if (currentProgram.enrollmentStatus === 'CLOSED') {
                 return NextResponse.json({ error: "Program enrollment is currently closed.", requiresOverride: true }, { status: 400 });
@@ -101,12 +101,19 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         // Default status is PENDING, unless board is bypassing or the program is free
         const initialStatus = ((isSysAdminOrBoard && override) || isFree) ? 'ACTIVE' : 'PENDING';
 
-        const enrollment = await prisma.programParticipant.create({
-            data: {
-                programId,
-                participantId,
-                status: initialStatus
+        const enrollment = await prisma.$transaction(async (tx) => {
+            // Re-check capacity under a row lock right before insert, so
+            // concurrent enrollers can't both pass a stale count and overfill.
+            if (enforceLimits) {
+                await lockProgramAndCheckCapacity(tx, programId, 1, currentProgram.maxParticipants);
             }
+            return tx.programParticipant.create({
+                data: {
+                    programId,
+                    participantId,
+                    status: initialStatus
+                }
+            });
         });
 
         await prisma.auditLog.create({
@@ -125,6 +132,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
         return NextResponse.json({ success: true, enrollment });
     } catch (error) {
+        if (error instanceof ProgramCapacityError) {
+            return NextResponse.json({ error: "Program has reached maximum capacity.", requiresOverride: true }, { status: 400 });
+        }
         console.error("Enrollment creation error:", error);
         return NextResponse.json({ error: "Failed to enroll participant" }, { status: 500 });
     }

--- a/checkin-app/src/app/api/programs/[id]/public-register/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/public-register/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
 import { logBackendError } from "@/lib/logger";
 import { addHouseholdLead, HouseholdLeadLimitError } from "@/lib/household/leads";
+import { lockProgramAndCheckCapacity, ProgramCapacityError } from "@/lib/program/capacity";
 import { createContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
 
 interface ParentInput {
@@ -25,11 +26,10 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
             return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
         }
 
+        // Capacity is counted under a row lock inside the registration
+        // transaction below, so no _count is fetched here.
         const currentProgram = await prisma.program.findUnique({
-            where: { id: programId },
-            include: {
-                _count: { select: { participants: true } }
-            }
+            where: { id: programId }
         });
 
         if (!currentProgram) {
@@ -64,10 +64,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
             }
         }
 
-        // Check Capacity
-        if (currentProgram.maxParticipants !== null && currentProgram._count.participants + participants.length > currentProgram.maxParticipants) {
-            return NextResponse.json({ error: `Not enough open spots. Only ${currentProgram.maxParticipants - currentProgram._count.participants} spots left.` }, { status: 400 });
-        }
+        // Capacity is re-checked under a row lock INSIDE the transaction below
+        // (this endpoint is public/unauthenticated, so it is trivially raced).
+        // The _count read above is stale by the time we write.
 
         // Check Enrollment Status
         if (currentProgram.enrollmentStatus === 'CLOSED') {
@@ -109,6 +108,10 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
         // Transactionally create everything
         const result = await prisma.$transaction(async (tx) => {
+            // 0. Lock the program and re-check capacity against the committed
+            //    enrollment count, serializing concurrent registrations.
+            await lockProgramAndCheckCapacity(tx, programId, participants.length, currentProgram.maxParticipants);
+
             // 1. Create Household
             const household = await tx.household.create({
                 data: {
@@ -210,6 +213,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         });
 
     } catch (error) {
+        if (error instanceof ProgramCapacityError) {
+            return NextResponse.json({ error: `Not enough open spots. Only ${error.spotsLeft} spots left.` }, { status: 400 });
+        }
         if (error instanceof HouseholdLeadLimitError || error instanceof EmergencyContactError) {
             return NextResponse.json({ error: error.message }, { status: 400 });
         }

--- a/checkin-app/src/lib/program/capacity.ts
+++ b/checkin-app/src/lib/program/capacity.ts
@@ -1,0 +1,40 @@
+import { Prisma } from "@/generated/prisma/client";
+
+/** Thrown by {@link lockProgramAndCheckCapacity} when a program is full. */
+export class ProgramCapacityError extends Error {
+    constructor(public readonly spotsLeft: number) {
+        super("Program has reached maximum capacity.");
+        this.name = "ProgramCapacityError";
+    }
+}
+
+/**
+ * Lock the Program row and verify it has room for `seats` more enrollments,
+ * run inside a transaction. Mirrors the lead-cap fix in
+ * {@link file://./../household/leads.ts}: the bare count-then-create that
+ * callers used to do is a TOCTOU race — under Postgres' default Read Committed
+ * isolation two concurrent enrollers both count N and both insert, overfilling
+ * the program. The `FOR UPDATE` lock serializes enrollers for this program: the
+ * second blocks until the first commits, then re-counts and is rejected.
+ *
+ * No-op when `maxParticipants` is null (uncapped program). Throws
+ * {@link ProgramCapacityError} (carrying remaining spots) when full. The lock
+ * auto-releases on commit/rollback.
+ */
+export async function lockProgramAndCheckCapacity(
+    tx: Prisma.TransactionClient,
+    programId: number,
+    seats: number,
+    maxParticipants: number | null,
+): Promise<void> {
+    // FOR UPDATE serializes enrollments for this program. The lock — not the
+    // count — is what closes the race; Read Committed alone does not.
+    await tx.$queryRaw`SELECT id FROM "Program" WHERE id = ${programId} FOR UPDATE`;
+
+    if (maxParticipants === null) return;
+
+    const count = await tx.programParticipant.count({ where: { programId } });
+    if (count + seats > maxParticipants) {
+        throw new ProgramCapacityError(Math.max(0, maxParticipants - count));
+    }
+}


### PR DESCRIPTION
## What

Both program-enroll paths checked capacity against a participant count read *before* the create, with no lock in between. Concurrent enrolls on the last seat (double-click, retry, two tabs, webhook) all read `count == max-1`, all passed the gate, and all inserted — overfilling the program past `maxParticipants`. There is no DB constraint backing capacity, so nothing caught it.

Two endpoints affected:
- **`POST /api/programs/[id]/public-register`** — capacity checked *before* the existing transaction. This endpoint is **public / unauthenticated**, so it is trivially raced. (Prioritized.)
- **`POST /api/programs/[id]/participants`** — capacity checked against a count loaded with the program, create had no transaction at all.

## Fix

New helper `lockProgramAndCheckCapacity(tx, programId, seats, max)` in `src/lib/program/capacity.ts`: takes a `SELECT ... FOR UPDATE` lock on the `Program` row, re-counts enrollments, throws `ProgramCapacityError` if full. Mirrors the existing closed-race patterns in `src/lib/household/leads.ts` (FOR UPDATE + count + create) and `/api/scan` (advisory lock).

Both routes now call it **inside** the create transaction, immediately before insert:
- `public-register`: capacity re-check moved into the existing `$transaction`.
- `participants`: create wrapped in a `$transaction`; the board-override path still skips the check, as before.
- Dropped the now-unused `_count` include from both program reads.

## Why a row lock

Postgres' default Read Committed isolation does **not** stop two transactions from both counting N and both inserting. The explicit `FOR UPDATE` lock serializes enrollers: the second blocks until the first commits, then re-counts and is rejected.

## Tests

Two new integration suites fire two concurrent requests at the last seat and assert exactly one succeeds (`[200, 400]`) and the program is not overfilled:
- `programsParticipantsConcurrency.integration.test.ts`
- `programsPublicRegisterConcurrency.integration.test.ts`

Both are wired into the `TEST_DB_POOL_MAX=2` list in `jest.setup.js` (same trick as the scan suite) so the two transactions run on separate connections — making the `FOR UPDATE` lock, not pool-1 serialization, the thing that serializes them, matching production. Verified meaningful: removing the lock makes both suites fail with two 200s and an overfilled program.

All green: tsc clean on changed files, 20 tests pass (2 new concurrency suites + the existing `programsParticipantsAPI` / `programsPublicRegistrationAPI` suites).

## Note for reviewers

The original scope also named a household-create TOCTOU (`POST /api/household`). That handler was **unreachable dead code** — `Participant.householdId` is a required (NOT NULL) FK, so the `if (user?.householdId) return 400` guard always fires. It has since been removed from `main` in #302, so no fix is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)