### PR TITLE
fix(kiosk): stop over-returning PII from certifications endpoint

### DIFF
--- a/checkin-app/src/app/api/kiosk/certifications/route.ts
+++ b/checkin-app/src/app/api/kiosk/certifications/route.ts
@@ -47,7 +47,6 @@ export async function GET(req: NextRequest) {
                             id: true,
                             email: true,
                             name: true,
-                            dob: true,
                             toolStatuses: {
                                 select: { toolId: true, level: true }
                             }
@@ -63,7 +62,6 @@ export async function GET(req: NextRequest) {
                     id: true,
                     email: true,
                     name: true,
-                    dob: true,
                     toolStatuses: {
                         select: { toolId: true, level: true }
                     }
@@ -71,29 +69,12 @@ export async function GET(req: NextRequest) {
             });
         }
 
-        const participantsWithAgeCategory = participantsData.map((participant) => {
-            const dob = participant.dob;
-            let ageCategory = "ADULT";
-
-            if (dob) {
-                const birthDate = new Date(dob);
-                const today = new Date();
-                let age = today.getFullYear() - birthDate.getFullYear();
-                const m = today.getMonth() - birthDate.getMonth();
-                if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) age--;
-                if (age < 18) {
-                    ageCategory = "STUDENT";
-                }
-            }
-
-            return {
-                id: participant.id,
-                email: participant.email,
-                name: participant.name,
-                toolStatuses: participant.toolStatuses,
-                ageCategory,
-            };
-        });
+        const participants = participantsData.map((participant) => ({
+            id: participant.id,
+            email: participant.email,
+            name: participant.name,
+            toolStatuses: participant.toolStatuses,
+        }));
 
         const tools = await prisma.tool.findMany({
             orderBy: {
@@ -105,7 +86,7 @@ export async function GET(req: NextRequest) {
             }
         });
 
-        return NextResponse.json({ participants: participantsWithAgeCategory, tools });
+        return NextResponse.json({ participants, tools });
     } catch (error) {
         console.error("Certifications fetch error:", error);
         return NextResponse.json(

--- a/checkin-app/src/app/kioskdisplay/certifications/page.tsx
+++ b/checkin-app/src/app/kioskdisplay/certifications/page.tsx
@@ -13,7 +13,6 @@ type Participant = {
   id: number;
   email: string;
   name: string | null;
-  ageCategory?: "ADULT" | "STUDENT";
   toolStatuses: {
     toolId: number;
     level: ToolStatusLevel;


### PR DESCRIPTION
## What

`GET /api/kiosk/certifications` returned an `ageCategory` field computed from each participant's `dob`. The only consumer — `src/app/kioskdisplay/certifications/page.tsx` — never uses it (no render/sort/logic, only a type field). Since the age category was the sole reason `dob` was fetched, the endpoint was pulling minor-PII (date of birth / minor flag) for no purpose.

## Changes

- `checkin-app/src/app/api/kiosk/certifications/route.ts`
  - Dropped `dob: true` from both Prisma selects (`limitToPresent` branch + `findMany` branch).
  - Removed the `ageCategory` computation; response now maps each participant to `{ id, email, name, toolStatuses }`.
- `checkin-app/src/app/kioskdisplay/certifications/page.tsx`
  - Removed the unused `ageCategory?: "ADULT" | "STUDENT"` field from the `Participant` type.

`dob` is no longer fetched anywhere in this route.

## Why

PII minimization — stop sending date-of-birth-derived data that nothing consumes.

## Reviewer notes

- Auth is unchanged. Route stays wrapped in `withAuth` (sysadmin/boardMember/keyholder or kiosk signature).
- `email`, `name`, `id`, `toolStatuses` kept — still used by the consumer.

## Verify

- `tsc --noEmit`: no errors in changed files.
- authz integration test (`authzRoutes.integration.test.ts`): 10/10 pass.