### PR TITLE
feat(shop): embed live certifications center inline

### DIFF
--- a/checkin-app/src/app/shop/page.tsx
+++ b/checkin-app/src/app/shop/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { Alert, Button, Card, Center, Container, Group, Loader, Stack, Tabs, Text, TextInput, Title } from '@mantine/core';
+import { Alert, Box, Button, Card, Center, Container, Group, Loader, Stack, Tabs, Text, TextInput, Title } from '@mantine/core';
 
 export default function ShopOpsPage() {
   const { data: session, status } = useSession();
@@ -148,14 +148,29 @@ export default function ShopOpsPage() {
         )}
 
         <Tabs.Panel value="live" pt="lg">
-          <Stack gap="md" align="flex-start">
+          <Stack gap="md">
             <Text c="dimmed">
               View a live matrix of participants currently at the facility and their tool
               certifications.
             </Text>
-            <Button onClick={() => window.open('/kioskdisplay/certifications', '_blank')}>
-              Open Live Certifications Center
-            </Button>
+            {/* ponytail: iframe reuses the kiosk route as-is; embedding the component
+                inline fights its position:absolute inset:0 kiosk layout. */}
+            <Box
+              style={{
+                position: 'relative',
+                width: '100%',
+                height: '70vh',
+                border: '1px solid var(--mantine-color-default-border)',
+                borderRadius: 8,
+                overflow: 'hidden',
+              }}
+            >
+              <iframe
+                src="/kioskdisplay/certifications"
+                title="Live Certifications Center"
+                style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 0 }}
+              />
+            </Box>
           </Stack>
         </Tabs.Panel>
       </Tabs>


### PR DESCRIPTION
## What

On the `/shop` Live Certifications Center tab, replaced the **Open Live Certifications Center** button (which opened `/kioskdisplay/certifications` in a new tab) with an inline iframe that renders the live matrix in place.

## Why

User wanted the live certifications content embedded where the button was, instead of navigating away.

## Notes for reviewer

- Used an **iframe** rather than rendering `KioskCertificationsInner` directly. The certifications component uses `position: absolute; inset: 0` for its kiosk fullscreen layout, which would break the tab panel if mounted inline. The iframe isolates that layout and preserves the component's existing 10s auto-refresh.
- iframe sits in a `70vh` bordered `Box`. Added `Box` to the Mantine import.
- Follow-up if a non-iframe embed is ever wanted: extract/refactor `KioskCertificationsInner` to decouple absolute positioning + kiosk-mode params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)