### PR TITLE
fix(import): fail fast when DATABASE_URL is unset or unreachable

### DIFF
--- a/checkin-app/scripts/import-zoho.ts
+++ b/checkin-app/scripts/import-zoho.ts
@@ -48,7 +48,11 @@ async function main() {
         return;
     }
 
-    const pool = new Pool({ connectionString: `${process.env.DATABASE_URL}` });
+    if (!process.env.DATABASE_URL) {
+        throw new Error("DATABASE_URL is not set — point it at the target database before --commit.");
+    }
+    // connectionTimeoutMillis: pg defaults to infinite, so an unreachable DB hangs forever. Fail fast.
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL, connectionTimeoutMillis: 10_000 });
     const adapter = new PrismaPg(pool);
     const prisma = new PrismaClient({ adapter });
     try {


### PR DESCRIPTION
## What

The Zoho importer (`scripts/import-zoho.ts`, merged in #291) hung indefinitely when run with `--commit` against an unset or unreachable `DATABASE_URL`. `pg`'s default `connectionTimeoutMillis` is `0` (infinite), so a missing env var or a blocked network path (e.g. RDS not reachable from the shell) produced a silent hang instead of an error.

## Change

- Guard: throw a clear error if `DATABASE_URL` is unset before opening the pool.
- Set `connectionTimeoutMillis: 10_000` so an unreachable DB fails in 10s with a connection error.

6-line change, `scripts/import-zoho.ts` only.

## Why

Surfaced in real use: running the importer from a shell where the RDS endpoint wasn't reachable just hung with no output. Fail-fast makes the cause obvious (bad/missing URL vs. network) instead of looking like the script is stuck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)