### PR TITLE
fix(shop): show only live view in embedded certifications iframe

### DIFF
--- a/checkin-app/src/app/shop/page.tsx
+++ b/checkin-app/src/app/shop/page.tsx
@@ -166,7 +166,7 @@ export default function ShopOpsPage() {
               }}
             >
               <iframe
-                src="/kioskdisplay/certifications"
+                src="/kioskdisplay/certifications?mode=kiosk"
                 title="Live Certifications Center"
                 style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 0 }}
               />


### PR DESCRIPTION
## What

The shop **Live** tab embeds the certifications center via an `<iframe>` pointing at `/kioskdisplay/certifications`. It was loading the route without `mode=kiosk`, so `AppFrame` rendered the full app chrome — nav sidebar, header, footer — *inside* the iframe, alongside the live matrix.

Fix: add `?mode=kiosk` to the iframe `src`.

## Why it works

- `AppFrame` already strips all chrome when `mode=kiosk` (or a `sig` param) is present — renders a bare full-screen container.
- The certifications page keys off the same flag to use its fullscreen kiosk layout.

Result: the embed shows only the live view, as intended.

## Reviewer notes

- One-line change in `checkin-app/src/app/shop/page.tsx`.
- Minor cosmetic: kiosk mode hides the cursor inside the iframe. If undesired, a separate `?embedded` flag would be needed — but `mode=kiosk` is the existing no-chrome mechanism and fits here.
- Verify at `/shop` → Live tab on the dev instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)