### PR TITLE
feat(membership-ops): top tabs in place of sidebar + landing cards

### DIFF
--- a/checkin-app/src/app/membership-ops/layout.tsx
+++ b/checkin-app/src/app/membership-ops/layout.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { Badge, Box, Center, Flex, Loader, NavLink, Paper, Stack, Text } from "@mantine/core";
+import { Badge, Box, Center, Loader, Stack, Tabs, Text } from "@mantine/core";
 import { MEMBERSHIP_OPS_NAV_LINKS } from "@/lib/membershipOpsNav";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { useTodoCounts } from "@/hooks/useTodoCounts";
@@ -17,6 +16,7 @@ function membershipTodoCountFor(href: string, counts: TodoCounts | null): number
 
 export default function MembershipOpsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const router = useRouter();
   const { data: session } = useSession();
   const sessionUser = session?.user as { sysadmin?: boolean; boardMember?: boolean } | undefined;
   const { loading, ready } = useRequireRole(["sysadmin", "boardMember"]);
@@ -35,39 +35,46 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
 
   if (!ready) return null;
 
+  // Longest-prefix match so sub-routes (e.g. /participants/123) keep their parent tab active.
+  const activeTab =
+    [...MEMBERSHIP_OPS_NAV_LINKS]
+      .sort((a, b) => b.href.length - a.href.length)
+      .find((l) => pathname === l.href || pathname.startsWith(l.href + "/"))?.href ?? null;
+
   return (
-    <Flex gap="md" align="flex-start" wrap="wrap">
-      <Paper withBorder p="xs" style={{ width: 240, flexShrink: 0 }}>
-        <Text fw={800} size="lg" c="blue" px="sm" py="xs">
-          Membership Ops
-        </Text>
-        {MEMBERSHIP_OPS_NAV_LINKS.map((link) => {
-          const todoCount = membershipTodoCountFor(link.href, todoCounts);
-          return (
-            <NavLink
-              key={link.href}
-              component={Link}
-              href={link.href}
-              label={link.name}
-              leftSection={<span>{link.icon}</span>}
-              rightSection={
-                todoCount > 0 ? (
-                  <Badge
-                    size="xs"
-                    color="treehouseGreen"
-                    variant="filled"
-                    aria-label={`${todoCount} item${todoCount === 1 ? "" : "s"} need attention`}
-                  >
-                    {todoCount}
-                  </Badge>
-                ) : undefined
-              }
-              active={pathname === link.href}
-            />
-          );
-        })}
-      </Paper>
-      <Box style={{ flex: 1, minWidth: 0 }}>{children}</Box>
-    </Flex>
+    <Stack>
+      <Text fw={800} size="lg" c="blue">
+        Membership Ops
+      </Text>
+      <Tabs value={activeTab} onChange={(value) => value && router.push(value)}>
+        <Tabs.List>
+          {MEMBERSHIP_OPS_NAV_LINKS.map((link) => {
+            const todoCount = membershipTodoCountFor(link.href, todoCounts);
+            return (
+              <Tabs.Tab
+                key={link.href}
+                value={link.href}
+                leftSection={<span>{link.icon}</span>}
+                rightSection={
+                  todoCount > 0 ? (
+                    <Badge
+                      size="xs"
+                      color="treehouseGreen"
+                      variant="filled"
+                      aria-label={`${todoCount} item${todoCount === 1 ? "" : "s"} need attention`}
+                    >
+                      {todoCount}
+                    </Badge>
+                  ) : undefined
+                }
+              >
+                {link.name}
+              </Tabs.Tab>
+            );
+          })}
+        </Tabs.List>
+      </Tabs>
+      <Box style={{ minWidth: 0 }}>{children}</Box>
+    </Stack>
   );
 }

--- a/checkin-app/src/app/membership-ops/page.tsx
+++ b/checkin-app/src/app/membership-ops/page.tsx
@@ -1,39 +1,7 @@
-"use client";
-
-import { Card, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core";
-import Link from "next/link";
+import { redirect } from "next/navigation";
 import { MEMBERSHIP_OPS_NAV_LINKS } from "@/lib/membershipOpsNav";
 
 export default function MembershipOpsIndex() {
-  const links = MEMBERSHIP_OPS_NAV_LINKS;
-  return (
-    <Stack>
-      <div>
-        <Title order={1}>Membership Ops</Title>
-        <Text c="dimmed">Participant and membership management.</Text>
-      </div>
-
-      <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }}>
-        {links.map((link) => (
-          <Card
-            key={link.href}
-            component={Link}
-            href={link.href}
-            withBorder
-            radius="md"
-            padding="md"
-            style={{ textDecoration: "none" }}
-          >
-            <Group gap="sm" wrap="nowrap" align="flex-start">
-              <Text fz={22} component="span">{link.icon}</Text>
-              <div>
-                <Text fw={600} c="var(--mantine-color-text)">{link.name}</Text>
-                {link.description && <Text size="xs" c="dimmed">{link.description}</Text>}
-              </div>
-            </Group>
-          </Card>
-        ))}
-      </SimpleGrid>
-    </Stack>
-  );
+  // Tabs live in the layout now; the hub has no landing content of its own.
+  redirect(MEMBERSHIP_OPS_NAV_LINKS[0].href);
 }

--- a/checkin-app/src/lib/membershipOpsNav.ts
+++ b/checkin-app/src/lib/membershipOpsNav.ts
@@ -1,14 +1,12 @@
 /**
- * Single source of truth for the Membership Ops tools. Rendered both as the
- * persistent sidebar (membership-ops/layout.tsx) and as the landing card grid
- * on the Membership Ops hub (/membership-ops). Add a tool once here and it
- * shows up in both.
+ * Single source of truth for the Membership Ops tools. Rendered as the top tab
+ * bar in membership-ops/layout.tsx; the hub (/membership-ops) redirects to the
+ * first entry. Add a tool once here and it shows up as a tab.
  */
 export interface MembershipOpsNavLink {
   name: string;
   href: string;
   icon: string;
-  /** One-line description shown on the hub landing grid (not in the sidebar). */
   description?: string;
 }
 


### PR DESCRIPTION
## What

Convert Membership Ops navigation to a **top tab bar** (matching `/shop`), replacing the left sidebar and the 4-card landing grid.

- `layout.tsx` — left sidebar (`NavLink`/`Paper`/`Flex`) → Mantine `Tabs` at top. Tabs navigate via `router.push`; active tab uses longest-prefix match so sub-routes (e.g. `/participants/123`) keep their parent tab active. Todo badges preserved on tabs.
- `page.tsx` (hub index) — deleted the 4 card buttons; now `redirect`s to the first tab.
- `membershipOpsNav.ts` — updated stale doc comment.

## Why

Requested: drop the 4 buttons on `/membership-ops` and convert the items to top tabs like `/shop`.

## Reviewer notes

- Unlike `/shop` (content embedded inline per tab), these 4 items are separate routes — tabs navigate to them rather than embedding inline.
- `description` field in `membershipOpsNav.ts` is now unused (was only on the deleted cards) but kept as optional.
- Not typechecked locally: worktree has no `node_modules`. Change is standard Mantine `Tabs` usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)