### PR TITLE
feat(membership-ops): add Unclaimed Accounts tab

### DIFF
--- a/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration Tests for Admin Unclaimed Households API
+ * Tests GET /api/admin/unclaimed-households for identifying households with an
+ * email-but-no-googleId member (registered but never claimed via Google).
+ */
+
+import { GET } from '@/app/api/admin/unclaimed-households/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+// Mock NextAuth
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+describe('Admin Unclaimed Households API Integration Tests', () => {
+    let testAdminId: number;
+    let testUserId: number;
+    let testUnclaimedHouseholdId: number;
+    let testClaimedHouseholdId: number;
+
+    beforeAll(async () => {
+        await prisma.membership.deleteMany({});
+        await prisma.participant.deleteMany({
+            where: { email: { contains: 'unclaimed-api-test' } }
+        });
+        await prisma.household.deleteMany({
+            where: { name: { contains: 'Unclaimed API Test' } }
+        });
+
+        const admin = await prisma.participant.create({
+            data: { email: 'admin-unclaimed-api-test@example.com', name: 'Admin Unclaimed Test', sysadmin: true, household: { create: {} } }
+        });
+        testAdminId = admin.id;
+
+        const user = await prisma.participant.create({
+            data: { email: 'user-unclaimed-api-test@example.com', name: 'User Unclaimed Test', sysadmin: false, household: { create: {} } }
+        });
+        testUserId = user.id;
+
+        // 1. Household with a member that has an email but NO googleId -> unclaimed
+        const unclaimed = await prisma.household.create({ data: { name: 'Unclaimed API Test HH Unclaimed' } });
+        testUnclaimedHouseholdId = unclaimed.id;
+        await prisma.participant.create({
+            data: { email: 'member1-unclaimed-api-test@example.com', name: 'Unclaimed Member', householdId: testUnclaimedHouseholdId, googleId: null }
+        });
+
+        // 2. Household where every member with an email HAS a googleId -> not unclaimed
+        const claimed = await prisma.household.create({ data: { name: 'Unclaimed API Test HH Claimed' } });
+        testClaimedHouseholdId = claimed.id;
+        await prisma.participant.create({
+            data: { email: 'member2-unclaimed-api-test@example.com', name: 'Claimed Member', householdId: testClaimedHouseholdId, googleId: 'unclaimed-test-google-id' }
+        });
+    });
+
+    afterAll(async () => {
+        await prisma.membership.deleteMany({});
+        await prisma.participant.deleteMany({
+            where: { email: { contains: 'unclaimed-api-test' } }
+        });
+        await prisma.household.deleteMany({
+            where: { id: { in: [testUnclaimedHouseholdId, testClaimedHouseholdId] } }
+        });
+    });
+
+    describe('GET /api/admin/unclaimed-households', () => {
+        it('should return 403 Forbidden without admin', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testUserId, sysadmin: false, boardMember: false }
+            });
+
+            const req = new Request('http://localhost:4000/api/admin/unclaimed-households', { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(403);
+        });
+
+        it('should list households with an unclaimed member but not fully-claimed ones', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, sysadmin: true }
+            });
+
+            const req = new Request('http://localhost:4000/api/admin/unclaimed-households', { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(Array.isArray(data.households)).toBe(true);
+
+            const ids = data.households.map((h: { id: number }) => h.id);
+            expect(ids).toContain(testUnclaimedHouseholdId);
+            expect(ids).not.toContain(testClaimedHouseholdId);
+
+            // Unclaimed household exposes the unclaimed member
+            const hh = data.households.find((h: { id: number }) => h.id === testUnclaimedHouseholdId);
+            expect(hh.members.some((m: { email: string }) => m.email === 'member1-unclaimed-api-test@example.com')).toBe(true);
+        });
+    });
+});

--- a/checkin-app/src/app/api/admin/unclaimed-households/route.ts
+++ b/checkin-app/src/app/api/admin/unclaimed-households/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+
+export const dynamic = 'force-dynamic';
+
+export const GET = withAuth(
+    { roles: ['sysadmin', 'boardMember'] },
+    async () => {
+        try {
+            // Households with at least one participant that has an email but no
+            // Google sign-in yet (account created at registration, never claimed).
+            const households = await prisma.household.findMany({
+                where: {
+                    participants: { some: { email: { not: null }, googleId: null } }
+                },
+                include: { participants: true }
+            });
+
+            const result = households.map(h => ({
+                id: h.id,
+                name: h.name
+                    || h.participants.find(p => p.name)?.name
+                    || `Household #${h.id}`,
+                hasClaimedMember: h.participants.some(p => p.googleId !== null),
+                members: h.participants
+                    .filter(p => p.email !== null && p.googleId === null)
+                    .map(p => ({ id: p.id, name: p.name, email: p.email }))
+            }));
+
+            return NextResponse.json({ households: result });
+        } catch (error) {
+            console.error("Failed to fetch unclaimed households:", error);
+            return NextResponse.json({ error: "Failed to fetch unclaimed households" }, { status: 500 });
+        }
+    }
+);

--- a/checkin-app/src/app/membership-ops/unclaimed/page.tsx
+++ b/checkin-app/src/app/membership-ops/unclaimed/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Badge, Box, Card, Group, Stack, Text, Title } from "@mantine/core";
+
+type UnclaimedHousehold = {
+  id: number;
+  name: string;
+  hasClaimedMember: boolean;
+  members: { id: number; name: string | null; email: string | null }[];
+};
+
+export default function UnclaimedHouseholdsIndex() {
+  const [households, setHouseholds] = useState<UnclaimedHousehold[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/admin/unclaimed-households');
+        const data = await res.json();
+        if (data.households) setHouseholds(data.households);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  return (
+    <Stack maw={1000} mx="auto">
+      <div>
+        <Title order={1}>Unclaimed Accounts</Title>
+        <Text c="dimmed">Households with at least one member who has an email but has never signed in with Google.</Text>
+      </div>
+
+      <Box>
+        {households.length > 0 ? (
+          <Stack gap="sm">
+            {households.map((h) => (
+              <Card key={h.id} withBorder radius="md" padding="md">
+                <Group justify="space-between" wrap="wrap" mb="xs">
+                  <Text fw={600}>{h.name}</Text>
+                  {h.hasClaimedMember && <Badge color="green" variant="light">Has a claimed member</Badge>}
+                </Group>
+                <Stack gap={4}>
+                  {h.members.map((m) => (
+                    <Text key={m.id} size="sm" c="dimmed">{m.name || 'Unnamed'} • {m.email}</Text>
+                  ))}
+                </Stack>
+              </Card>
+            ))}
+          </Stack>
+        ) : !loading ? (
+          <Text ta="center" c="dimmed">No unclaimed accounts.</Text>
+        ) : null}
+      </Box>
+    </Stack>
+  );
+}

--- a/checkin-app/src/lib/membershipOpsNav.ts
+++ b/checkin-app/src/lib/membershipOpsNav.ts
@@ -15,4 +15,5 @@ export const MEMBERSHIP_OPS_NAV_LINKS: MembershipOpsNavLink[] = [
   { name: "Merge Participants", href: "/membership-ops/participants/merge", icon: "🔗", description: "Combine duplicate participant records." },
   { name: "Manage Memberships", href: "/membership-ops/households", icon: "🏠", description: "Grant or revoke household facility membership." },
   { name: "Membership Applications", href: "/membership-ops/applications", icon: "📋", description: "Review and approve membership applications." },
+  { name: "Unclaimed Accounts", href: "/membership-ops/unclaimed", icon: "📨", description: "Households with an email but no Google sign-in yet." },
 ];


### PR DESCRIPTION
## What

Adds a 5th tab to the Membership Ops top tab bar — **📨 Unclaimed Accounts** — listing households (families) with at least one participant that has an `email` set but `googleId IS NULL`: accounts created at registration but never claimed via Google sign-in.

## Why

Surface families who registered but never finished claiming their account, so staff can follow up. Existing `/api/admin/orphans` answers a related but different question (minor students lacking a signed-up adult); this is grouped by family and covers any email-but-no-googleId member.

## Changes

- **`api/admin/unclaimed-households/route.ts`** — `GET`, `withAuth({ roles: ['sysadmin','boardMember'] })`, `force-dynamic`. Queries households where `participants.some({ email: { not: null }, googleId: null })`. Returns `{ households: [{ id, name, hasClaimedMember, members: [{ id, name, email }] }] }`; name falls back to a member name, then `Household #<id>`.
- **`lib/membershipOpsNav.ts`** — 5th nav entry (single source of truth; layout renders the tab automatically).
- **`membership-ops/unclaimed/page.tsx`** — client page, one Card per family showing the household and its unclaimed members. Matches the participants page Mantine style.
- **`adminUnclaimedHouseholdsAPI.integration.test.ts`** — 403 for non-admin; an unclaimed household appears with its member email; a fully-claimed household is excluded.

## Reviewer notes

- `googleId != null` is the de-facto "account claimed" flag (set to `profile.sub` in `auth-options.ts`); there is no `claimed` column.
- Filter is family-grouped: a partly-claimed household still shows, surfacing only its unclaimed members. The optional `hasClaimedMember` flag is returned so the UI can badge those.

## Verify

Integration test passes 2/2 against a throwaway Postgres; `tsc --noEmit` clean on new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)