### PR TITLE
fix(dev): hide DevImpersonationBar in kiosk mode

### DIFF
--- a/checkin-app/src/components/DevImpersonationBar.tsx
+++ b/checkin-app/src/components/DevImpersonationBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useSession, signIn } from "next-auth/react";
 import { useIsDevInstance } from "@/components/EnvProvider";
 
@@ -13,11 +14,26 @@ import { useIsDevInstance } from "@/components/EnvProvider";
  * through the single persona-mint flow.
  */
 export default function DevImpersonationBar() {
+    // useSearchParams needs a Suspense boundary (mirrors AppFrame's AppFrameInner wrap).
+    return (
+        <Suspense fallback={null}>
+            <DevImpersonationBarInner />
+        </Suspense>
+    );
+}
+
+function DevImpersonationBarInner() {
     const { data: session } = useSession();
     const isDevInstance = useIsDevInstance();
+    const searchParams = useSearchParams();
     const [busy, setBusy] = useState(false);
 
     const signedIn = !!session?.user;
+
+    // Kiosk mode strips all chrome (see AppFrame); the dev bar must vanish too, else it
+    // overlaps the full-screen kiosk view (e.g. Live Certifications). Same condition as AppFrame.
+    const isKioskMode = searchParams.get("mode") === "kiosk" || !!searchParams.get("sig");
+    if (isKioskMode) return null;
 
     if (!isDevInstance || !signedIn) return null;
 


### PR DESCRIPTION
## Problem
The "🛠 Dev instance — signed in as …" bar (`DevImpersonationBar`) overlaps the Live Certifications kiosk view — visible in `/shop` → Live Certifications Center tab (which embeds `/kioskdisplay/certifications?mode=kiosk` via iframe) and on the real Raspberry-Pi kiosk display.

## Root cause
`DevImpersonationBar` is rendered in the root `layout.tsx` **outside** `AppFrame`. In kiosk mode `AppFrame` strips all chrome and returns a bare full-screen div, but the dev bar still renders above it. The certifications page uses `position: absolute; inset: 0`, anchoring to the viewport top and overlaying the bar.

## Fix
Suppress the dev bar in kiosk mode too — kiosk = no chrome, universally. Added a `useSearchParams()` check in `DevImpersonationBar` returning `null` when `mode=kiosk` or a cert `sig` is present, mirroring the exact condition `AppFrame` uses. Inner component wrapped in `<Suspense>` since `useSearchParams` needs a boundary (same pattern as `AppFrameInner`).

This covers both the iframe embed and the real Pi kiosk.

## Verification
- App boots on the dev instance (`CHECKIN_ENV=local`), `/shop` and `/kioskdisplay/certifications?mode=kiosk` both return 200, no compile errors.
- Signed-in visual confirmation of the overlap gone was not automated (no connected browser session available in this environment); the change short-circuits before any session-dependent render and reuses AppFrame's already-proven kiosk condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)