### PR TITLE
Hide email in Tools & Certifications By Person view

### DIFF
--- a/checkin-app/src/app/shop/tools/page.tsx
+++ b/checkin-app/src/app/shop/tools/page.tsx
@@ -310,7 +310,6 @@ function PersonTab({ members, tools, isCertifier, isAdmin }: { members: Member[]
               <Group gap="md" p="md" wrap="nowrap" style={{ cursor: 'pointer' }} onClick={() => toggle(member.id)}>
                 <div style={{ flex: 1, overflow: 'hidden' }}>
                   <Text fw={600} c={isOpen ? 'cyan' : undefined} truncate>{member.name ?? 'Unnamed'}</Text>
-                  <Text size="sm" c="dimmed" truncate>{member.email}</Text>
                 </div>
                 <Text c="dimmed" size="sm">{isOpen ? '▲' : '▼'}</Text>
               </Group>


### PR DESCRIPTION
## What
Remove the dimmed email line under each person's name in the **By Person** tab of Manage Tools & Certifications (`checkin-app/src/app/shop/tools/page.tsx`).

## Why
Email no longer needed in this card view.

## Notes
- `member.email` still powers the search filter — typing an email still finds the person. Only the visible line was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)