### PR TITLE
fix(facility): remove email from print-badges list

### DIFF
--- a/checkin-app/src/app/facility/print-badges/page.tsx
+++ b/checkin-app/src/app/facility/print-badges/page.tsx
@@ -146,12 +146,7 @@ export default function PrintBadgesPage() {
     { header: 'ID', render: (p) => <Text span c="dimmed">#{p.id}</Text> },
     {
       header: 'Name',
-      render: (p) => (
-        <>
-          <Text fw={600}>{p.name || 'N/A'}</Text>
-          <Text size="sm" c="dimmed">{p.email}</Text>
-        </>
-      ),
+      render: (p) => <Text fw={600}>{p.name || 'N/A'}</Text>,
     },
     {
       header: 'Membership',


### PR DESCRIPTION
## What

Remove the email address shown under each participant's name in the **Facility → Print ID Badges** list.

## Why

The badge-printing view surfaced every participant's email as PII with no need — only name/membership/roles matter for printing badges.

## Notes

- Search still matches email server-side (placeholder text unchanged, `email` field still fetched).
- Single-file change: `checkin-app/src/app/facility/print-badges/page.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)