### PR TITLE
fix(ui): remove top padding above page titles

### DIFF
--- a/checkin-app/src/app/admin/events/[id]/page.tsx
+++ b/checkin-app/src/app/admin/events/[id]/page.tsx
@@ -299,7 +299,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
   };
 
   return (
-    <Container size="lg" py="md">
+    <Container size="lg" pb="md">
       <Card withBorder radius="md" padding="lg">
         <Group justify="space-between" align="flex-start" wrap="wrap" mb="lg">
           <div>

--- a/checkin-app/src/app/admin/events/new/page.tsx
+++ b/checkin-app/src/app/admin/events/new/page.tsx
@@ -205,7 +205,7 @@ function NewEventForm() {
 
 export default function NewEventPage() {
   return (
-    <Container size="md" py="md">
+    <Container size="md" pb="md">
       <Suspense fallback={<Center mih="60vh"><Loader /></Center>}>
         <NewEventForm />
       </Suspense>

--- a/checkin-app/src/app/admin/programs/[id]/page.tsx
+++ b/checkin-app/src/app/admin/programs/[id]/page.tsx
@@ -357,7 +357,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
   );
 
   return (
-    <Container size="lg" py="md">
+    <Container size="lg" pb="md">
       <Card withBorder radius="md" padding="lg">
         <Group justify="space-between" align="center" wrap="wrap" mb="lg">
           <Group align="center" gap="sm">

--- a/checkin-app/src/app/admin/programs/new/page.tsx
+++ b/checkin-app/src/app/admin/programs/new/page.tsx
@@ -84,7 +84,7 @@ export default function CreateProgramPage() {
   if (!ready) return null;
 
   return (
-    <Container size="md" py="md">
+    <Container size="md" pb="md">
       <Card withBorder radius="md" padding="lg">
         <AdminPageHeader title="Create Program" back={{ href: '/programs', label: '← Back to Programs' }} mb="md" />
 

--- a/checkin-app/src/app/dashboard/programs/page.tsx
+++ b/checkin-app/src/app/dashboard/programs/page.tsx
@@ -45,7 +45,7 @@ export default function MyProgramsDashboard() {
   if (!session) return null;
 
   return (
-    <Container size="lg" py="md">
+    <Container size="lg" pb="md">
       <Group justify="space-between" align="center" mb="md" wrap="wrap">
         <Title order={1}>My Programs</Title>
         <Button variant="default" onClick={() => router.push('/programs')}>

--- a/checkin-app/src/app/household/page.tsx
+++ b/checkin-app/src/app/household/page.tsx
@@ -281,7 +281,7 @@ export default function HouseholdPage() {
   });
 
   return (
-    <Container size="md" py="md">
+    <Container size="md" pb="md">
       <Stack>
         <TodoCard />
         <Card withBorder radius="md" padding="lg">

--- a/checkin-app/src/app/kioskdisplay/manual/page.tsx
+++ b/checkin-app/src/app/kioskdisplay/manual/page.tsx
@@ -41,7 +41,7 @@ export default function ManualAttendance() {
   };
 
   return (
-    <Container size="sm" py="md">
+    <Container size="sm" pb="md">
       <Card withBorder radius="md" padding="lg">
         <Group justify="space-between" align="center" wrap="wrap" mb="md">
           <Title order={1}>Manual Time Entry</Title>

--- a/checkin-app/src/app/membership-ops/participants/new/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/page.tsx
@@ -119,7 +119,7 @@ function NewParticipantForm() {
   const submitDisabled = saving || (!studentSelected && !email && !householdId) || (studentSelected && !parentEmail && !householdId);
 
   return (
-    <Container size="md" py="md">
+    <Container size="md" pb="md">
       <Card withBorder radius="md" padding="lg">
         <AdminPageHeader title="Register New User" back={{ href: '/membership-ops', label: '← Membership Ops' }} mb="md" />
 

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -391,7 +391,7 @@ export default function MembershipPage() {
   const isRenewal = state?.process?.kind === "RENEWAL";
 
   return (
-    <Container size="lg" py="md">
+    <Container size="lg" pb="md">
       <Group justify="space-between" align="center" wrap="wrap" mb="lg">
         <Title order={1}>Treehouse Membership</Title>
         <Button component={Link} href="/" variant="default">← Home</Button>

--- a/checkin-app/src/app/membership/review/page.tsx
+++ b/checkin-app/src/app/membership/review/page.tsx
@@ -95,7 +95,7 @@ export default function MembershipReviewPage() {
   }
 
   return (
-    <Container size="md" py="md">
+    <Container size="md" pb="md">
       <Group justify="space-between" align="center" wrap="wrap" mb="md">
         <Title order={1}>Background-check review</Title>
         <Button component={Link} href="/" variant="default">← Home</Button>

--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -122,7 +122,7 @@ export default function ProfilePage() {
   if (!session) return null; // Fallback while router redirects
 
   return (
-    <Container size="sm" py="md">
+    <Container size="sm" pb="md">
       <Stack>
         <Card withBorder radius="md" padding="lg">
           <Title order={1}>My Profile</Title>

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -224,7 +224,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   const alreadySelected = selectedParticipantId !== null && program.participants.some(p => p.participantId === selectedParticipantId);
 
   return (
-    <Container size="md" py="md">
+    <Container size="md" pb="md">
       <Card withBorder radius="md" padding="lg">
         <Group justify="space-between" align="center" wrap="wrap" mb="lg">
           <Title order={1}>{program.name}</Title>

--- a/checkin-app/src/app/programs/[id]/register/page.tsx
+++ b/checkin-app/src/app/programs/[id]/register/page.tsx
@@ -165,7 +165,7 @@ export default function PublicRegistrationPage({ params }: { params: Promise<{ i
   }
 
   return (
-    <Container size="md" py="md">
+    <Container size="md" pb="md">
       <Card withBorder radius="md" padding="lg">
         <Stack align="center" gap={4} mb="lg">
           <Title order={1}>Register for Program</Title>

--- a/checkin-app/src/app/shop/page.tsx
+++ b/checkin-app/src/app/shop/page.tsx
@@ -83,7 +83,7 @@ export default function ShopOpsPage() {
   }
 
   return (
-    <Container size="lg" py="md">
+    <Container size="lg" pb="md">
       <Group justify="space-between" align="flex-start" mb="lg" wrap="wrap">
         <div>
           <Title order={1}>Shop Operations</Title>

--- a/checkin-app/src/app/shop/tools/page.tsx
+++ b/checkin-app/src/app/shop/tools/page.tsx
@@ -486,7 +486,7 @@ export function ToolManagementPanel() {
 
 export default function ToolManagementPage() {
   return (
-    <Container size="lg" py="md">
+    <Container size="lg" pb="md">
       <Title order={1} mb="lg">Tools &amp; Certifications</Title>
       <ToolManagementPanel />
     </Container>


### PR DESCRIPTION
## What
Page content `Container`s used `py="md"`, adding vertical space above the page title. Switched to `pb="md"` across all titled pages — titles now sit flush at the top, bottom padding preserved.

Triggered by extra space above the **Shop Operations** title; applied to every page sharing the pattern.

## Pages changed (15)
shop, shop/tools, profile, household, dashboard/programs, membership, membership/review, membership-ops/participants/new, programs/[id], programs/[id]/register, admin/programs/new, admin/programs/[id], admin/events/new, admin/events/[id], kioskdisplay/manual

## Notes
- Left `py="xl"` containers untouched — those are centered loading/error states, not titled content.
- Pure padding tweak, no logic change.