### PR TITLE
refactor(admin): fold System Health panels into dashboard, drop standalone page

### DIFF
--- a/checkin-app/src/app/admin/page.tsx
+++ b/checkin-app/src/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { Alert, Card, Group, List, SimpleGrid, Stack, Text, Title } from "@manti
 import { IconAlertTriangle } from "@tabler/icons-react";
 import Link from "next/link";
 import { ADMIN_NAV_SECTIONS } from "@/lib/adminNav";
+import { BadgeScanChart, SystemVersionBox } from "@/components/admin/SystemHealthPanels";
 
 type Orphan = { id: number; name?: string | null; email?: string | null };
 
@@ -120,6 +121,10 @@ export default function AdminDashboardIndex() {
           </List>
         </Card>
       </SimpleGrid>
+
+      <SystemVersionBox />
+
+      <BadgeScanChart />
     </Stack>
   );
 }

--- a/checkin-app/src/components/admin/SystemHealthPanels.tsx
+++ b/checkin-app/src/components/admin/SystemHealthPanels.tsx
@@ -89,7 +89,7 @@ type GithubCommit = {
   commit: { message: string };
 };
 
-function SystemVersionBox() {
+export function SystemVersionBox() {
   const [currentVersion, setCurrentVersion] = useState<string | null>(null);
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [commits, setCommits] = useState<GithubCommit[]>([]);
@@ -193,7 +193,7 @@ function SystemVersionBox() {
   );
 }
 
-export default function SystemHealthPage() {
+export function BadgeScanChart() {
   const [stats, setStats] = useState<DailyStat[] | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -210,31 +210,20 @@ export default function SystemHealthPage() {
   }, []);
 
   return (
-    <Stack>
-      <div>
-        <Title order={1}>System Health</Title>
-        <Text c="dimmed">
-          Monitor the backend performance and round-trip response times for Kiosk functionality.
-        </Text>
-      </div>
+    <Card withBorder radius="md" padding="lg">
+      <Title order={4}>Badge Scan Response Times (Last 30 Days)</Title>
+      <Text c="dimmed" size="sm" mb="lg">
+        This graph displays the operational latency of the badge scanning system. Lower values
+        indicate faster responses.
+      </Text>
 
-      <SystemVersionBox />
-
-      <Card withBorder radius="md" padding="lg">
-        <Title order={4}>Badge Scan Response Times (Last 30 Days)</Title>
-        <Text c="dimmed" size="sm" mb="lg">
-          This graph displays the operational latency of the badge scanning system. Lower values
-          indicate faster responses.
-        </Text>
-
-        {loading ? (
-          <Center py="xl"><Loader /></Center>
-        ) : stats ? (
-          <SvgLineChart data={stats} />
-        ) : (
-          <Center py="xl"><Text c="red">Failed to load metrics.</Text></Center>
-        )}
-      </Card>
-    </Stack>
+      {loading ? (
+        <Center py="xl"><Loader /></Center>
+      ) : stats ? (
+        <SvgLineChart data={stats} />
+      ) : (
+        <Center py="xl"><Text c="red">Failed to load metrics.</Text></Center>
+      )}
+    </Card>
   );
 }

--- a/checkin-app/src/lib/adminNav.ts
+++ b/checkin-app/src/lib/adminNav.ts
@@ -22,12 +22,6 @@ export const ADMIN_NAV_SECTIONS: AdminNavSection[] = [
     links: [{ name: "Dashboard", href: "/admin", icon: "📊" }],
   },
   {
-    title: "Operations",
-    links: [
-      { name: "System Health", href: "/admin/systemhealth", icon: "🫀", description: "Service and integration status." },
-    ],
-  },
-  {
     title: "People",
     links: [
       { name: "Membership Settings", href: "/admin/membership/settings", icon: "⚙️", description: "Configure dues and membership-year settings." },


### PR DESCRIPTION
## What

Moves the two panels from `/admin/systemhealth` — **System Version** (current vs. latest GitHub `main`) and the **Badge Scan Response Times** latency chart — onto the main admin dashboard, rendered at the bottom below Quick Stats and System Health.

Removes the standalone `/admin/systemhealth` page and its now-empty "Operations" nav section.

## Why

Cleanup/consolidation — surface the system-health info directly on the dashboard instead of a separate page.

## How

- New `components/admin/SystemHealthPanels.tsx` exports `SystemVersionBox` + `BadgeScanChart` (each self-contained, fetches its own data).
- `admin/page.tsx` renders both at the bottom.
- Deleted `app/admin/systemhealth/page.tsx`; removed the "Operations" section from `lib/adminNav.ts`.

## Notes for reviewer

- API route `/api/admin/system-health` is unchanged — `BadgeScanChart` still hits it.
- No behavior change to the panels themselves; pure move + extract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)