### PR TITLE
refactor(facility): drop redundant headers on facility subpages

### DIFF
--- a/checkin-app/src/app/facility/badges/page.tsx
+++ b/checkin-app/src/app/facility/badges/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Center, Loader, Stack } from '@mantine/core';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
 import { formatDateTime } from '@/lib/time';
@@ -58,8 +57,6 @@ export default function AdminBadgesPage() {
 
   return (
     <Stack>
-      <AdminPageHeader title="Raw Badge Events" back={{ href: '/facility', label: '← Facility Ops' }} />
-
       <AlertBanner message={message} tone={message.includes('success') ? 'success' : 'error'} />
 
       <DataTable columns={COLUMNS} rows={badges} getRowKey={(b) => b.id} emptyMessage="No badge events." />

--- a/checkin-app/src/app/facility/print-badges/page.tsx
+++ b/checkin-app/src/app/facility/print-badges/page.tsx
@@ -7,7 +7,6 @@ import QRCode from "qrcode";
 import { pdf } from "@react-pdf/renderer";
 import { Badge, Button, Checkbox, Group, Stack, Text, TextInput } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
-import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import { DataTable, type DataTableColumn } from "@/components/admin/DataTable";
 import BadgeDocument from "@/components/admin/BadgeDocument";
 import StickerDocument from "@/components/admin/StickerDocument";
@@ -173,8 +172,6 @@ export default function PrintBadgesPage() {
 
   return (
     <Stack>
-      <AdminPageHeader title="Print ID Badges" back={{ href: '/facility', label: '← Back to Facility Ops' }} />
-
       <Text c="dimmed">
         Select participants to generate double-sided standard Avery 5390 ID badges.
       </Text>

--- a/checkin-app/src/app/facility/trends/page.tsx
+++ b/checkin-app/src/app/facility/trends/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Card, Center, Group, Loader, SegmentedControl, Select, SimpleGrid, Stack, Table, Text, Title } from "@mantine/core";
+import { Card, Center, Group, Loader, SegmentedControl, Select, SimpleGrid, Stack, Table, Text } from "@mantine/core";
 import { useRequireRole } from "@/hooks/useRequireRole";
 
 type PeriodType = "week" | "month" | "quarter" | "year";
@@ -88,10 +88,7 @@ export default function ParticipationTrendsPage() {
 
   return (
     <Stack>
-      <div>
-        <Title order={1}>📈 Participation Trends</Title>
-        <Text c="dimmed">Facility usage metrics across time periods and programs.</Text>
-      </div>
+      <Text c="dimmed">Facility usage metrics across time periods and programs.</Text>
 
       <Group justify="space-between" wrap="wrap">
         <SegmentedControl

--- a/checkin-app/src/app/facility/visits/page.tsx
+++ b/checkin-app/src/app/facility/visits/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Button, Center, Group, Loader, Stack, Table, Text, TextInput } from '@mantine/core';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
 
@@ -87,8 +86,6 @@ export default function AdminVisitsPage() {
 
   return (
     <Stack>
-      <AdminPageHeader title="Visit History" back={{ href: '/facility', label: '← Facility Ops' }} />
-
       <AlertBanner message={message} tone={message.includes('success') ? 'success' : 'error'} />
 
       <Table.ScrollContainer minWidth={800}>


### PR DESCRIPTION
## What

Remove the per-page header (`AdminPageHeader` title + "← Facility Ops" back button) from four facility subpages:

- **Visit History** (`/facility/visits`)
- **Raw Badge Events** (`/facility/badges`)
- **Print ID Badges** (`/facility/print-badges`)
- **Participation Trends** (`/facility/trends`) — dropped the redundant `Title`, kept the descriptive subtext

Pruned now-unused imports.

## Why

The facility hub already provides navigation context; the duplicate titles and back buttons were redundant clutter.

## Notes

- Pre-commit hook reports "No tests found" in worktrees (testPathIgnorePatterns matches the worktree rootDir) — unrelated to this change; CI runs from the main path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)