### PR TITLE
feat(nav): move My Household above Attendance in sidebar

### DIFF
--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -55,8 +55,8 @@ type NavItem = {
 };
 
 const NAV_ITEMS: NavItem[] = [
-  { href: '/kioskdisplay', label: 'Attendance', icon: <IconClipboardList size={18} />, visible: (_u, signedIn) => signedIn },
   { href: '/household', label: 'My Household', icon: <IconHome size={18} />, visible: (_u, signedIn) => signedIn },
+  { href: '/kioskdisplay', label: 'Attendance', icon: <IconClipboardList size={18} />, visible: (_u, signedIn) => signedIn },
   { href: '/programs', label: 'Programs', icon: <IconCalendarEvent size={18} />, visible: () => true },
   {
     href: '/shop',


### PR DESCRIPTION
## What
Swap sidebar nav order so **My Household** sits above **Attendance**.

## Why
Requested reorder — household is the more common landing for signed-in members.

## Notes
Single-line change in `checkin-app/src/components/AppFrame.tsx` (`NAV_ITEMS` order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)