### PR TITLE
test(zoho-webhook): cover missing-secret + replay/idempotency

### DIFF
--- a/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -134,6 +134,45 @@ describe('Membership EXTERNAL phase API', () => {
         expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
     });
 
+    it('rejects (500) a completed Zoho webhook when the secret is unset, with no mutation', async () => {
+        const { processId } = await makeProcess(`C ${TAG}`, 'zoho-C');
+        delete process.env.ZOHO_WEBHOOK_SECRET;
+        try {
+            const res = await ZOHO_WEBHOOK(zohoReq({ requests: { request_id: 'zoho-C', request_status: 'completed' } }, SECRET));
+            // Route bails before token verify when the secret is unconfigured.
+            expect(res.status).toBe(500);
+        } finally {
+            process.env.ZOHO_WEBHOOK_SECRET = SECRET;
+        }
+        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        expect(p?.contractSignedAt).toBeNull();
+        expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
+    });
+
+    it('replaying the same completed Zoho webhook is a safe no-op (no double-advance, single audit row)', async () => {
+        const { processId } = await makeProcess(`D ${TAG}`, 'zoho-D');
+        const req = () => ZOHO_WEBHOOK(zohoReq({ requests: { request_id: 'zoho-D', request_status: 'completed' } }, SECRET));
+        // Fresh process: the contract-signed webhook is the only thing that audits it.
+        const auditCount = () =>
+            prisma.auditLog.count({ where: { tableName: 'MembershipProcess', affectedEntityId: processId } });
+
+        const first = await req();
+        expect(first.status).toBe(200);
+        const afterFirst = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        expect(afterFirst?.contractSignedAt).not.toBeNull();
+        expect(afterFirst?.status).toBe('PENDING_EXTERNAL_ACTION'); // no BG consent → stays EXTERNAL
+        expect(await auditCount()).toBe(1);
+
+        // Zoho retries at-least-once: replay the identical signed payload.
+        const second = await req();
+        expect(second.status).toBe(200);
+        const afterSecond = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        // State identical: same signed timestamp, same phase, no second audit row.
+        expect(afterSecond?.contractSignedAt?.getTime()).toBe(afterFirst?.contractSignedAt?.getTime());
+        expect(afterSecond?.status).toBe(afterFirst?.status);
+        expect(await auditCount()).toBe(1);
+    });
+
     it('ignores a non-completed Zoho event without changing state', async () => {
         const res = await ZOHO_WEBHOOK(zohoReq({ requests: { request_id: 'zoho-B', request_status: 'inprogress' } }, SECRET));
         expect(res.status).toBe(200);


### PR DESCRIPTION
## What

Add two integration tests for `POST /api/webhooks/zoho`, mirroring the coverage the Shopify webhook already has:

1. **Missing secret** — unset `ZOHO_WEBHOOK_SECRET`, POST a valid-looking completed-envelope payload → asserts the route's **500** reject (it bails at `route.ts:17-20` before token verify) **and** that no membership state mutated (`contractSignedAt` null, status unchanged).
2. **Replay / idempotency** — POST the same completed-envelope payload twice with a valid token → first signs the contract, second is a safe no-op. Asserts identical `contractSignedAt` timestamp, same process phase, and a single audit row (no double-advance, no duplicate audit).

## Why

The Zoho contract webhook had asymmetric test coverage vs the Shopify webhook — it was missing the unconfigured-secret and replay/idempotency cases. Both are forgery-surface gaps (Zoho retries deliveries at-least-once, and a misconfigured secret must fail closed).

## Notes for reviewers

- **Test-only. No source change.** Idempotency is already correct by design: `markContractSigned` uses `updateMany where contractSignedAt: null`, so a replayed delivery flips nothing and the audit row is written exactly once. The new test documents and locks in that behavior.
- Missing-secret returns **500**, not 401 — the route rejects on unconfigured secret before reaching token verification. The test matches the route's actual behavior.
- Both tests create their own TAG-scoped processes (`zoho-C`, `zoho-D`) and are cleaned up by the existing `wipe()`.
- Verified green locally via `test:integration` against a throwaway Postgres (12/12 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)