### PR TITLE
fix(programs): log orphaned Shopify product id on creation failure

### DIFF
--- a/checkin-app/src/app/api/programs/route.ts
+++ b/checkin-app/src/app/api/programs/route.ts
@@ -93,6 +93,9 @@ export async function POST(req: Request) {
         return NextResponse.json({ error: "Forbidden: Only Admin or Board Members can create programs" }, { status: 403 });
     }
 
+    // Hoisted so the catch can name an orphaned Shopify product (created, but DB write failed) for manual cleanup.
+    let shopifyData: { shopifyProductId: string, shopifyMemberVariantId: string | null, shopifyNonMemberVariantId: string | null } | null = null;
+
     try {
         const body = await req.json();
         const { name, leadMentorId, begin, end, memberOnly, minAge, maxAge, memberPrice, nonMemberPrice, maxParticipants } = body;
@@ -111,8 +114,6 @@ export async function POST(req: Request) {
         const maxPart = maxParticipants ? parseInt(maxParticipants, 10) : null;
 
         // Try to create Shopify entities
-        let shopifyData: { shopifyProductId: string, shopifyMemberVariantId: string | null, shopifyNonMemberVariantId: string | null } | null = null;
-        
         // Only try to create if at least one price is provided. Otherwise it's a free program.
         if ((mPrice && mPrice > 0) || (nmPrice && nmPrice > 0)) {
             shopifyData = await createShopifyProgramVariants(name, mPrice, nmPrice, maxPart);
@@ -157,6 +158,9 @@ export async function POST(req: Request) {
 
         return NextResponse.json(responseObj);
     } catch (error: unknown) {
+        if (shopifyData?.shopifyProductId) {
+            console.error("[Shopify] Orphaned product after program DB write failed, manual cleanup needed:", shopifyData.shopifyProductId);
+        }
         await logBackendError(error, "POST /api/programs");
         return NextResponse.json({ error: "Failed to create program" }, { status: 500 });
     }

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -77,6 +77,9 @@ export async function createShopifyProgramVariants(name: string, memberPriceCent
     return null;
   }
 
+  // Hoisted so the catch can name an orphaned product (created, but variants/DB failed) for manual cleanup.
+  let productId: string | number | null = null;
+
   try {
     // Determine product title
     const productTitle = `Program Enrollment: ${name}`;
@@ -105,7 +108,7 @@ export async function createShopifyProgramVariants(name: string, memberPriceCent
     }
 
     const productData = await productRes.json();
-    const productId = productData.product.id;
+    productId = productData.product.id;
 
     // 2. Create Variants
     const variants = [];
@@ -195,13 +198,16 @@ export async function createShopifyProgramVariants(name: string, memberPriceCent
     }
 
     return {
-        shopifyProductId: productId.toString(),
+        shopifyProductId: productId!.toString(),
         shopifyMemberVariantId: memberVariantId,
         shopifyNonMemberVariantId: nonMemberVariantId
     };
 
   } catch (error) {
     console.error("[Shopify Error] Failed to create product/variants:", error);
+    if (productId) {
+        console.error("[Shopify] Orphaned product after variant failure, manual cleanup needed:", productId);
+    }
 
     try {
         const admins = await prisma.participant.findMany({


### PR DESCRIPTION
## What

When program creation fails after a Shopify product is already created, log the orphaned product id so an admin can clean it up manually.

Two failure paths previously lost the id:

1. **Intra-helper variant failure** — `createShopifyProgramVariants` in `checkin-app/src/lib/shopify.ts`. `productId` was `const`-scoped inside the `try`, invisible to the `catch`. Hoisted to a `let` so the catch can `console.error` the orphaned product id.
2. **DB write failure after Shopify success** — `POST /api/programs` in `checkin-app/src/app/api/programs/route.ts`. `shopifyData` was declared inside the `try`, out of scope in the `catch`. Hoisted so the catch logs the orphaned product id when a Shopify product was created but the DB write threw.

## Why

A failed program creation can leave a Shopify product with no matching DB `Program` row (an orphan). The product id was never logged in a way an admin could act on. Now it always lands in the logs.

## Notes for reviewer

- **Log-only by design.** No automated cleanup, delete helper, or reconciliation job — manual admin cleanup is the chosen approach.
- No success-path behavior change. Tiny diff (2 files).
- The task brief described the variant-failure path as a `throw`; the actual code `console.error`s and continues at that branch, so the real orphan path is a fetch/`.json()` throw landing in the outer catch — that's where the new log sits, where `productId` is in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)