### PR TITLE
test(audit): assert actorId on membership + trusted-adult audit rows

### DIFF
--- a/checkin-app/src/app/__tests__/membershipExternalConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalConcurrency.integration.test.ts
@@ -68,6 +68,12 @@ describe('EXTERNAL advance concurrency', () => {
         // Exactly one advance audit row + exactly one reviewer ping.
         expect(await advanceAudits(processId)).toBe(1);
         expect(notifyReviewers as jest.Mock).toHaveBeenCalledTimes(1);
+
+        // Each mutation's audit row carries its own actor: SYSTEM_ACTOR for the contract sign
+        // (default), the board member's id (1) for the bg-consent mark.
+        const all = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true, actorId: true } });
+        expect(all.find((a) => String(a.newData).includes('"contractSignedAt":true'))?.actorId).toBe(0);
+        expect(all.find((a) => String(a.newData).includes('"bgConsentAt":true'))?.actorId).toBe(1);
     });
 
     it('second markContractSigned is a no-op (one contractSignedAt audit, idempotent)', async () => {
@@ -75,9 +81,10 @@ describe('EXTERNAL advance concurrency', () => {
 
         await Promise.all([markContractSigned(processId), markContractSigned(processId)]);
 
-        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true } });
-        const signedRows = audits.filter((a) => String(a.newData).includes('"contractSignedAt":true')).length;
-        expect(signedRows).toBe(1);
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true, actorId: true } });
+        const signed = audits.filter((a) => String(a.newData).includes('"contractSignedAt":true'));
+        expect(signed).toHaveLength(1);
+        expect(signed[0].actorId).toBe(0); // markContractSigned default actor = SYSTEM_ACTOR
     });
 
     it('does not regress a process already past PENDING_EXTERNAL_ACTION', async () => {

--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -161,6 +161,11 @@ describe('Membership payment API', () => {
         const proc = await prisma.membershipProcess.findUnique({ where: { id: certProc } });
         expect(proc?.status).toBe('ACTIVE');
         expect(proc?.certifiedById).toBe(leadId);
+
+        // The audit row records WHO certified — the acting board member, not SYSTEM_ACTOR.
+        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'MembershipProcess', affectedEntityId: certProc }, orderBy: { id: 'desc' } });
+        expect(audit?.actorId).toBe(leadId);
+        expect(JSON.parse(String(audit?.newData))).toMatchObject({ status: 'ACTIVE' });
     });
 
     it('non-board cannot certify', async () => {

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -120,6 +120,11 @@ describe('Membership BG review API', () => {
         expect(membership?.isVolunteer).toBe(true);
         const parent = await prisma.participant.findFirst({ where: { householdId: proc.householdId, householdLeads: { some: { householdId: proc.householdId } } } });
         expect(parent?.lastBackgroundCheck).not.toBeNull();
+
+        // The advance audit records the reviewer whose attestation triggered it (rev2), not rev1/SYSTEM.
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
+        const advance = audits.find((a) => String(a.newData).includes('"status":"PENDING_PAYMENT"'));
+        expect(advance?.actorId).toBe(rev2);
     });
 
     it('applies volunteer status from a pre-designation (dot-insensitive), without a checkbox', async () => {
@@ -140,6 +145,11 @@ describe('Membership BG review API', () => {
         expect((await res.json()).outcome.status).toBe('BLOCKED');
         const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
         expect(updated?.status).toBe('BLOCKED');
+
+        // The BLOCKED audit records the rejecting reviewer.
+        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
+        expect(audit?.actorId).toBe(rev1);
+        expect(JSON.parse(String(audit?.newData))).toMatchObject({ status: 'BLOCKED' });
     });
 
     it('board reset on a BLOCKED app clears attestations and returns it to review', async () => {
@@ -154,6 +164,11 @@ describe('Membership BG review API', () => {
         expect(updated?.status).toBe('PENDING_BG_REVIEW');
         const count = await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } });
         expect(count).toBe(0);
+
+        // The reset audit records the acting board member and the action.
+        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
+        expect(audit?.actorId).toBe(board);
+        expect(JSON.parse(String(audit?.newData))).toMatchObject({ action: 'board reset' });
     });
 
     it('board override-approve on a BLOCKED app forces it to PENDING_PAYMENT', async () => {
@@ -166,6 +181,11 @@ describe('Membership BG review API', () => {
         expect(res.status).toBe(200);
         const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
         expect(updated?.status).toBe('PENDING_PAYMENT');
+
+        // The advance audit records the acting board member.
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
+        const advance = audits.find((a) => String(a.newData).includes('"status":"PENDING_PAYMENT"'));
+        expect(advance?.actorId).toBe(board);
     });
 
     it('non-board cannot override', async () => {

--- a/checkin-app/src/app/__tests__/membershipReviewConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewConcurrency.integration.test.ts
@@ -92,6 +92,9 @@ describe('attest() concurrency', () => {
         expect(statuses.filter((s) => s === 'PENDING_PAYMENT')).toHaveLength(1);
         expect(statuses.filter((s) => s === 'wrong_phase')).toHaveLength(1);
 
+        // The winner is whichever attest returned PENDING_PAYMENT — its id is what the advance audit must carry.
+        const winner = b.status === 'fulfilled' && (b.value as { status: string }).status === 'PENDING_PAYMENT' ? revB : revC;
+
         const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe('PENDING_PAYMENT');
 
@@ -99,9 +102,21 @@ describe('attest() concurrency', () => {
         const attestations = await prisma.backgroundCheckAttestation.count({ where: { processId } });
         expect(attestations).toBe(2);
 
-        // advanceToPayment ran exactly once → exactly one PENDING_PAYMENT audit row.
-        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true } });
-        const advances = audits.filter((a) => String(a.newData).includes('"status":"PENDING_PAYMENT"')).length;
-        expect(advances).toBe(1);
+        // advanceToPayment ran exactly once → exactly one PENDING_PAYMENT audit row, stamped with the winner's id.
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true, actorId: true } });
+        const advances = audits.filter((a) => String(a.newData).includes('"status":"PENDING_PAYMENT"'));
+        expect(advances).toHaveLength(1);
+        expect(advances[0].actorId).toBe(winner); // not revA (prior approver) nor the loser
+    });
+
+    it('a REJECT audit carries the rejecting reviewer\'s id, not another reviewer\'s', async () => {
+        const processId = await makePendingProcess();
+        // revB rejects; revA never touches this process.
+        await attest(revB, processId, { result: 'REJECT' });
+
+        const blocked = await prisma.auditLog.findFirst({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, orderBy: { id: 'desc' } });
+        expect(String(blocked?.newData)).toContain('"status":"BLOCKED"');
+        expect(blocked?.actorId).toBe(revB);
+        expect(blocked?.actorId).not.toBe(revA);
     });
 });

--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -63,6 +63,12 @@ describe('Trusted Adults service', () => {
 
     beforeEach(() => sendEmail.mockClear());
 
+    // Newest audit row for a trusted adult. Each action appends one row keyed by the
+    // TrustedAdult id, so "newest" is the row the just-run action wrote. Queries
+    // prisma.auditLog directly so it survives the audit() write becoming transactional.
+    const latestAudit = (taId: number) =>
+        prisma.auditLog.findFirst({ where: { tableName: 'TrustedAdult', affectedEntityId: taId }, orderBy: { id: 'desc' } });
+
     async function discloseOne() {
         return createTrustedAdult({
             householdId,
@@ -80,6 +86,11 @@ describe('Trusted Adults service', () => {
         expect(ta.reviews[0].kind).toBe('INITIAL');
         expect(ta.reviews[0].status).toBe('PENDING_BOARD_REVIEW');
         expect(sendEmail).toHaveBeenCalled(); // board notified
+
+        const audit = await latestAudit(ta.id);
+        expect(audit?.actorId).toBe(leadId); // the disclosing lead, not SYSTEM_ACTOR
+        expect(audit?.action).toBe('CREATE');
+        expect(JSON.parse(String(audit?.newData))).toMatchObject({ created: true, status: 'PENDING_BOARD_REVIEW' });
     });
 
     it('rejects a disclosure missing name, contact, or family context', async () => {
@@ -105,6 +116,10 @@ describe('Trusted Adults service', () => {
         const days = (out.reviewBy!.getTime() - before) / 86400000;
         expect(days).toBeGreaterThan(360);
         expect(days).toBeLessThan(370);
+
+        const audit = await latestAudit(ta.id);
+        expect(audit?.actorId).toBe(boardId); // the deciding board member
+        expect(JSON.parse(String(audit?.newData))).toMatchObject({ status: 'APPROVED', decision: 'APPROVE' });
     });
 
     it('REQUEST_INFO moves to PENDING_SUBJECT_ACTION and emails the family', async () => {
@@ -112,6 +127,24 @@ describe('Trusted Adults service', () => {
         const out = await decideReview(ta.reviews[0].id, boardId, { decision: 'REQUEST_INFO', note: 'Please clarify dates.' });
         expect(out.status).toBe('PENDING_SUBJECT_ACTION');
         expect(sendEmail).toHaveBeenCalledWith(`lead-${TAG}@ex.com`, expect.stringContaining('more information'), expect.any(String));
+
+        const audit = await latestAudit(ta.id);
+        expect(audit?.actorId).toBe(boardId);
+        expect(JSON.parse(String(audit?.newData))).toMatchObject({ status: 'PENDING_SUBJECT_ACTION', decision: 'REQUEST_INFO' });
+    });
+
+    it('audit records the deciding/overriding board member on DENY and override-deny', async () => {
+        const ta = await discloseOne();
+        await decideReview(ta.reviews[0].id, boardId, { decision: 'DENY' });
+        const denyAudit = await latestAudit(ta.id);
+        expect(denyAudit?.actorId).toBe(boardId);
+        expect(JSON.parse(String(denyAudit?.newData))).toMatchObject({ status: 'DENIED', decision: 'DENY' });
+
+        const ta2 = await discloseOne();
+        await overrideReview(ta2.reviews[0].id, boardId, 'deny');
+        const overrideAudit = await latestAudit(ta2.id);
+        expect(overrideAudit?.actorId).toBe(boardId);
+        expect(JSON.parse(String(overrideAudit?.newData))).toMatchObject({ status: 'DENIED', override: 'deny' });
     });
 
     it('renewal opens a fresh review reusing the same trusted adult, and refuses while one is open', async () => {
@@ -121,6 +154,12 @@ describe('Trusted Adults service', () => {
         expect(review.kind).toBe('RENEWAL');
         expect(review.status).toBe('PENDING_BOARD_REVIEW');
         expect(review.trustedAdultId).toBe(ta.id);
+
+        const audit = await latestAudit(ta.id);
+        expect(audit?.actorId).toBe(leadId); // the renewing lead
+        expect(audit?.action).toBe('CREATE');
+        expect(JSON.parse(String(audit?.newData))).toMatchObject({ renewal: review.id, status: 'PENDING_BOARD_REVIEW' });
+
         await expect(renewTrustedAdult(ta.id, leadId)).rejects.toMatchObject({ code: 'already_open' });
     });
 
@@ -150,6 +189,11 @@ describe('Trusted Adults service', () => {
         expect(expireRun.expired).toBeGreaterThanOrEqual(1);
         const expired = await prisma.trustedAdultReview.findUnique({ where: { id: r.id } });
         expect(expired!.status).toBe('EXPIRED');
+
+        // The system, not a person, drives the nightly expiry transition.
+        const audit = await latestAudit(ta.id);
+        expect(audit?.actorId).toBe(0); // SYSTEM_ACTOR
+        expect(JSON.parse(String(audit?.newData))).toMatchObject({ status: 'EXPIRED' });
     });
 
     it('a lead can withdraw; board override can force-revoke; force-approve needs a note', async () => {
@@ -158,12 +202,23 @@ describe('Trusted Adults service', () => {
         const latest = await prisma.trustedAdultReview.findFirst({ where: { trustedAdultId: ta.id }, orderBy: { id: 'desc' } });
         expect(latest!.status).toBe('REVOKED');
 
+        const withdrawAudit = await latestAudit(ta.id);
+        expect(withdrawAudit?.actorId).toBe(leadId); // the withdrawing lead
+        expect(JSON.parse(String(withdrawAudit?.newData))).toMatchObject({ status: 'REVOKED' });
+
         const ta2 = await discloseOne();
         const reviewId = ta2.reviews[0].id;
         await expect(overrideReview(reviewId, boardId, 'approve')).rejects.toMatchObject({ code: 'bad_input' });
         const approved = await overrideReview(reviewId, boardId, 'approve', SHARED);
         expect(approved.status).toBe('APPROVED');
+        const approveAudit = await latestAudit(ta2.id);
+        expect(approveAudit?.actorId).toBe(boardId); // the overriding board member
+        expect(JSON.parse(String(approveAudit?.newData))).toMatchObject({ status: 'APPROVED', override: 'approve' });
+
         const revoked = await overrideReview(reviewId, boardId, 'revoke');
         expect(revoked.status).toBe('REVOKED');
+        const revokeAudit = await latestAudit(ta2.id);
+        expect(revokeAudit?.actorId).toBe(boardId);
+        expect(JSON.parse(String(revokeAudit?.newData))).toMatchObject({ status: 'REVOKED', override: 'revoke' });
     });
 });


### PR DESCRIPTION
## What & why

Audit-log integration tests verified that an `AuditLog` row **existed** (by count and status string) but almost never asserted **`actorId`** — the field recording *who* performed an auditable safety/membership action. A refactor passing the wrong actor (`SYSTEM_ACTOR`, or reviewer A's id on reviewer B's action) would have passed every test. This closes that gap systematically.

**Test-only. No source changed.** All assertions pass against current source, so no actor bug was found — this is regression armor.

Scope excludes membership grant/revoke and participant merge (handled by a separate chip).

## Changes (5 suites)

**Membership** (`checkin-app/src/app/__tests__/`):
- `membershipPaymentAPI` — certify: newest audit `actorId === ` certifying board member (was: only `proc.certifiedById` checked).
- `membershipReviewAPI` — attest advance → `rev2`; REJECT → `rev1`; board reset → `board` + `newData.action === 'board reset'`; override-approve advance → `board`.
- `membershipReviewConcurrency` — advance row `actorId === ` the winning reviewer (computed from which `attest` returned `PENDING_PAYMENT`), not the prior approver or the loser. **New negative test**: a REJECT audit carries the rejecting reviewer's id, not another reviewer's.
- `membershipExternalConcurrency` — `contractSigned` row `actorId === 0` (SYSTEM default), `bgConsent` row `actorId === ` the marking board member.

**Trusted-adult** — `trustedAdultService` (suite previously read `AuditLog` **zero** times):
- create / renew / withdraw / `decideReview` APPROVE+DENY+REQUEST_INFO / `overrideReview` approve+deny+revoke / expiry sweep EXPIRED. Each asserts the row exists, `actorId` is the acting participant (`SYSTEM_ACTOR` for expiry), and `newData` matches. **Adds DENY + override-deny coverage**, which had no test at all.

## Reviewer notes

- Assertions query `prisma.auditLog` directly (newest row per entity via a `latestAudit` helper) — robust to the **parallel chip** making trusted-adult audit writes transactional; they don't couple to the `audit()` signature.
- `newData` is a `Json?` column holding a stringified blob; matched in JS (`String(a.newData).includes(...)` / `JSON.parse`) like the existing tests, not DB JSON filters.
- `SYSTEM_ACTOR` is `0` in all modules; asserted as literal `0`.
- Verified locally against a throwaway Postgres + `prisma/seed.ts`: **6 suites, 41 tests pass.**
- `trustedAdultService` "pings the board" assertion depends on seeded board members having emails (its own Boardie has none) — pre-existing, passes once the seed is loaded. Not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
