### PR TITLE
test(jest): classify failures, surface thrown (schema/mock rot) loudly

### DIFF
--- a/checkin-app/jest.config.js
+++ b/checkin-app/jest.config.js
@@ -11,6 +11,9 @@ const createJestConfig = nextJest({
 // excluded from the default run so `npm run test:ci` works without a DB.
 // Run them with `npm run test:integration` against a live database.
 const customJestConfig = {
+    // 'default' keeps jest's built-in output; ours appends a loud summary of
+    // tests that failed by THROWING (schema/mock rot) vs honest assertions.
+    reporters: ['default', '<rootDir>/test/failureClassifierReporter.js'],
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     testEnvironment: 'jest-environment-jsdom',
     moduleNameMapper: {

--- a/checkin-app/test/failureClassifierReporter.js
+++ b/checkin-app/test/failureClassifierReporter.js
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// Custom jest reporter: splits failures into "assertion" (a real expect()
+// mismatch — the code under test misbehaved) vs "thrown" (the test crashed in
+// setup/route before its assertions ran — renamed Prisma fields, incomplete
+// mocks, FK violations). Thrown failures mean the invariant the test guards is
+// now UNPROTECTED, so we reprint just those, loudly, at the end of the run.
+// Does not change exit code — jest already fails on any failure.
+
+// A message is an assertion failure if it carries jest's matcher fingerprint.
+function isAssertion(msg) {
+    if (!msg) return false
+    return (
+        msg.includes('expect(') ||
+        (msg.includes('Expected') && msg.includes('Received'))
+    )
+}
+
+function firstErrorLine(msg) {
+    if (!msg) return '(no message)'
+    const line = msg.split('\n').find((l) => l.trim().length > 0)
+    return (line || '(no message)').trim()
+}
+
+class FailureClassifierReporter {
+    onRunComplete(_contexts, results) {
+        const thrown = []
+
+        for (const suite of results.testResults || []) {
+            const suitePath = suite.testFilePath
+
+            // Suite-level crash (beforeAll/beforeEach/import error, no individual
+            // test ran) — almost always the rot class.
+            if (suite.testExecError) {
+                thrown.push({
+                    suitePath,
+                    testName: '(suite setup / load)',
+                    line: firstErrorLine(
+                        suite.testExecError.message || String(suite.testExecError),
+                    ),
+                })
+            }
+
+            for (const t of suite.testResults || []) {
+                if (t.status !== 'failed') continue
+                const msgs = t.failureMessages || []
+                // matcherResult present on any detail => jest matcher failure.
+                const hasMatcher = (t.failureDetails || []).some(
+                    (d) => d && d.matcherResult,
+                )
+                const looksAssertion =
+                    hasMatcher || msgs.some(isAssertion)
+                if (looksAssertion) continue // jest reports these well already
+
+                thrown.push({
+                    suitePath,
+                    testName: [...(t.ancestorTitles || []), t.title]
+                        .filter(Boolean)
+                        .join(' › '),
+                    line: firstErrorLine(msgs[0]),
+                })
+            }
+        }
+
+        if (thrown.length === 0) return
+
+        const bar = '─'.repeat(72)
+        const out = ['', bar]
+        out.push(
+            '⚠ Tests that FAILED BY THROWING (possible schema/mock rot, not an assertion):',
+        )
+        out.push(bar)
+        for (const f of thrown) {
+            out.push(`  ${f.suitePath}`)
+            out.push(`    ${f.testName}`)
+            out.push(`      ${f.line}`)
+        }
+        out.push(bar)
+        out.push(
+            `  ${thrown.length} thrown failure(s). These crashed before their assertions — the invariant they guard may be unprotected.`,
+        )
+        out.push(bar, '')
+        // eslint-disable-next-line no-console
+        console.log(out.join('\n'))
+    }
+}
+
+module.exports = FailureClassifierReporter

--- a/checkin-app/test/failureClassifierReporter.js
+++ b/checkin-app/test/failureClassifierReporter.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
 // Custom jest reporter: splits failures into "assertion" (a real expect()
 // mismatch — the code under test misbehaved) vs "thrown" (the test crashed in
 // setup/route before its assertions ran — renamed Prisma fields, incomplete
@@ -79,7 +78,6 @@ class FailureClassifierReporter {
             `  ${thrown.length} thrown failure(s). These crashed before their assertions — the invariant they guard may be unprotected.`,
         )
         out.push(bar, '')
-        // eslint-disable-next-line no-console
         console.log(out.join('\n'))
     }
 }


### PR DESCRIPTION
## What

Custom jest reporter ([checkin-app/test/failureClassifierReporter.js](checkin-app/test/failureClassifierReporter.js)) that splits failures into two buckets and reprints the dangerous one at the end of the run:

- **assertion** — a real `expect()` mismatch (`expect(`, Expected/Received, or `matcherResult` present). The code under test genuinely misbehaved. Left alone; jest reports these well.
- **thrown** — the test crashed in setup/route *before* its assertions ran: `PrismaClientValidationError`, `Unknown argument`, `Cannot read properties of undefined`, `TypeError`, FK violations like `*_householdId_fkey`. Suite-level `testExecError` (beforeAll/import crashes) also bucket here.

Thrown failures get a delimited summary block:

```
⚠ Tests that FAILED BY THROWING (possible schema/mock rot, not an assertion):
```

## Why

A thrown failure means the invariant a test was written to guard is now **unprotected** — but in CI it reads as the same generic red X as an honest assertion miss. We just fixed several of these (stale `memberPrice`→`memberPriceCents`, an FK delete-order bug, an incomplete PDF mock). Separating the shapes turns a future regression of this rot class into an obvious signal.

## Notes for reviewer

- Pure Node, no new deps. Does **not** change exit code — jest already fails on any failure; this is purely an extra summary.
- Wired via the `reporters` array in [checkin-app/jest.config.js](checkin-app/jest.config.js) (`['default', ...]` so built-in output is preserved). There was no prior `reporters` key. Applies to `test`/`test:ci`/`test:integration` and both CI jest invocations (ci.yml:164, ci.yml:170) automatically — no script changes.
- Verified with a throwaway 2-test run (one `throw new TypeError`, one `expect(1).toBe(2)`): the TypeError landed in the summary block, the assertion did not. Throwaway removed; only the reporter + wiring ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)