### PR TITLE
feat(participants): audit-log destructive participant merges

### DIFF
--- a/checkin-app/src/app/api/admin/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/admin/participants/merge/__tests__/route.integration.test.ts
@@ -9,18 +9,30 @@ describe("Merge Participants API", () => {
     let pKeepId: number;
     let pMergeId: number;
     let householdId: number;
+    let actorId: number;
 
     beforeEach(async () => {
-        // Setup mock session as a sysadmin
-        mockGetServerSession.mockResolvedValue({
-            user: { email: "admin@checkme.in", sysadmin: true }
-        });
-
         // Create a household for the participants (every participant must belong to one)
         const hh = await prisma.household.create({
             data: { name: "Merge Test Household" }
         });
         householdId = hh.id;
+
+        // The acting board member — audit rows record actorId from the session.
+        const actor = await prisma.participant.create({
+            data: {
+                name: "Board Actor",
+                email: "actor@checkme.in",
+                householdId: hh.id,
+                boardMember: true,
+            }
+        });
+        actorId = actor.id;
+
+        // Setup mock session as the board member
+        mockGetServerSession.mockResolvedValue({
+            user: { id: actorId, email: "actor@checkme.in", boardMember: true }
+        });
 
         // Create two participants
         const pKeep = await prisma.participant.create({
@@ -48,7 +60,8 @@ describe("Merge Participants API", () => {
         await prisma.visit.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
         await prisma.programParticipant.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
         await prisma.householdLead.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
-        await prisma.participant.deleteMany({ where: { id: { in: [pKeepId, pMergeId] } } });
+        await prisma.auditLog.deleteMany({ where: { actorId } });
+        await prisma.participant.deleteMany({ where: { id: { in: [pKeepId, pMergeId, actorId] } } });
         if (householdId) {
             await prisma.household.deleteMany({ where: { id: householdId } });
         }
@@ -87,6 +100,29 @@ describe("Merge Participants API", () => {
         expect(merged?.email).toContain("merged-");
         expect(merged?.email).toContain("@deleted.checkme.in");
         expect(merged?.phone).toBeNull();
+    });
+
+    it("should write an AuditLog row capturing the merge", async () => {
+        await prisma.visit.create({
+            data: { participantId: pMergeId, arrived: new Date() }
+        });
+
+        const req = new Request("http://localhost/api/admin/participants/merge", {
+            method: "POST",
+            body: JSON.stringify({ keepId: pKeepId, mergeId: pMergeId })
+        }) as unknown as import('next/server').NextRequest;
+
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+
+        const log = await prisma.auditLog.findFirst({
+            where: { tableName: "Participant", affectedEntityId: pKeepId, secondaryAffectedEntity: pMergeId }
+        });
+        expect(log).not.toBeNull();
+        expect(log?.actorId).toBe(actorId);
+        const newData = log?.newData as { keepId: number; moved: { visits: number } };
+        expect(newData.keepId).toBe(pKeepId);
+        expect(newData.moved.visits).toBe(1);
     });
 
     it("should fail to merge if merged user is the lead of a household with other members", async () => {

--- a/checkin-app/src/app/api/admin/participants/merge/route.ts
+++ b/checkin-app/src/app/api/admin/participants/merge/route.ts
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic';
 
 export const POST = withAuth(
     { roles: ['sysadmin', 'boardMember'] },
-    async (req) => {
+    async (req, auth) => {
         try {
             const body = await req.json();
             const { keepId, mergeId } = body;
@@ -73,10 +73,19 @@ export const POST = withAuth(
                     });
                 }
 
-                await tx.visit.updateMany({
+                const moved = {
+                    visits: 0,
+                    programParticipants: { migrated: 0, deleted: 0 },
+                    programVolunteers: { migrated: 0, deleted: 0 },
+                    rsvps: { migrated: 0, deleted: 0 },
+                    feePayments: { migrated: 0, deleted: 0 },
+                    toolStatuses: { migrated: 0, deleted: 0 },
+                };
+
+                moved.visits = (await tx.visit.updateMany({
                     where: { participantId: mergeId },
                     data: { participantId: keepId }
-                });
+                })).count;
 
                 // Instead of failing on unique constraints, we migrate manually:
                 for (const pp of mergeParticipant.programParticipants) {
@@ -85,10 +94,12 @@ export const POST = withAuth(
                             where: { programId_participantId: { programId: pp.programId, participantId: mergeId } },
                             data: { participantId: keepId }
                         });
+                        moved.programParticipants.migrated++;
                     } else {
                         await tx.programParticipant.delete({
                             where: { programId_participantId: { programId: pp.programId, participantId: mergeId } }
                         });
+                        moved.programParticipants.deleted++;
                     }
                 }
 
@@ -98,10 +109,12 @@ export const POST = withAuth(
                             where: { programId_participantId: { programId: pv.programId, participantId: mergeId } },
                             data: { participantId: keepId }
                         });
+                        moved.programVolunteers.migrated++;
                     } else {
                         await tx.programVolunteer.delete({
                             where: { programId_participantId: { programId: pv.programId, participantId: mergeId } }
                         });
+                        moved.programVolunteers.deleted++;
                     }
                 }
 
@@ -111,10 +124,12 @@ export const POST = withAuth(
                             where: { eventId_participantId: { eventId: rsvp.eventId, participantId: mergeId } },
                             data: { participantId: keepId }
                         });
+                        moved.rsvps.migrated++;
                     } else {
                         await tx.rSVP.delete({
                             where: { eventId_participantId: { eventId: rsvp.eventId, participantId: mergeId } }
                         });
+                        moved.rsvps.deleted++;
                     }
                 }
 
@@ -124,10 +139,12 @@ export const POST = withAuth(
                             where: { feeId_participantId: { feeId: fee.feeId, participantId: mergeId } },
                             data: { participantId: keepId }
                         });
+                        moved.feePayments.migrated++;
                     } else {
                         await tx.feePayment.delete({
                             where: { feeId_participantId: { feeId: fee.feeId, participantId: mergeId } }
                         });
+                        moved.feePayments.deleted++;
                     }
                 }
 
@@ -137,10 +154,12 @@ export const POST = withAuth(
                             where: { userId_toolId: { toolId: tool.toolId, userId: mergeId } },
                             data: { userId: keepId }
                         });
+                        moved.toolStatuses.migrated++;
                     } else {
                         await tx.toolStatus.delete({
                             where: { userId_toolId: { toolId: tool.toolId, userId: mergeId } }
                         });
+                        moved.toolStatuses.deleted++;
                     }
                 }
 
@@ -160,6 +179,25 @@ export const POST = withAuth(
                         name: `${mergeParticipant.name || 'Unknown'} (Merged into ${keepId})`,
                     }
                 });
+
+                // ponytail: audit only — undo is unimplemented; merge is still irreversible.
+                if (auth.type === 'session') {
+                    await tx.auditLog.create({
+                        data: {
+                            actorId: auth.user.id,
+                            action: "DELETE",
+                            tableName: "Participant",
+                            affectedEntityId: keepId,
+                            secondaryAffectedEntity: mergeId,
+                            oldData: {
+                                id: mergeParticipant.id,
+                                name: mergeParticipant.name,
+                                email: mergeParticipant.email,
+                            },
+                            newData: { keepId, moved },
+                        }
+                    });
+                }
             });
 
             return NextResponse.json({ success: true });


### PR DESCRIPTION
## What

The participant-merge route (`checkin-app/src/app/api/admin/participants/merge/route.ts`) performs a destructive merge — tombstones the merge-side participant and repoints `visits`/`programParticipants`/`programVolunteers`/`rsvps`/`feePayments`/`toolStatuses` to the keep-side, deleting conflicting rows — but wrote **no** AuditLog row. Merges were destructive, unrecoverable **and** untraceable: no record of who merged whom or what moved.

This adds an audit trail.

## Changes

- Handler signature now `(req, auth)` to read the acting user id (mirrors `households/route.ts`).
- Inside the existing `$transaction`, after the tombstone update, write `tx.auditLog.create`:
  - `action: "DELETE"` (enum has `EDIT`/`DELETE`; `DELETE` fits a destructive merge)
  - `tableName: "Participant"`, `affectedEntityId: keepId`, `secondaryAffectedEntity: mergeId`
  - `actorId` from the session, guarded on `auth.type === 'session'`
  - `oldData`: merge-side `{id, name, email}` captured pre-merge
  - `newData`: `keepId` + per-relation migrated/deleted counts (tracked during the repoint loops)
- Audit row is inside the `$transaction` → atomic with the merge; rolls back together.

## Tests

`route.integration.test.ts`: new case merges two participants and asserts the AuditLog row — `actorId` === acting board member, `affectedEntityId` === keepId, `secondaryAffectedEntity` === mergeId, `newData.moved.visits` reflects migrated count. Existing session mock updated to carry a real `user.id` (the audit write needs `actorId`). All 3 tests pass against a local Postgres.

## Notes for reviewer

- Undo/unmerge is **not** implemented — out of scope. Merge remains irreversible, but is now traceable. Flagged with a `// ponytail:` comment in the route.
- `package-lock.json` had a pre-existing unrelated node-engine bump at session start; left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)