### PR TITLE
fix(events): wrap cancel-event writes in a transaction

### DIFF
--- a/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the cancel-event transaction rollback.
+ *
+ * PATCH /api/events/[id] action 'cancel' deletes RSVPs, nulls the
+ * associatedEventId on visits, then deletes the event. These three writes run
+ * inside one `prisma.$transaction([...])`, so a failure mid-way must leave all
+ * three untouched — no orphaned visits, no RSVPs deleted under a live event.
+ *
+ * To force a mid-transaction failure we stub the final delete op to a query
+ * that errors at the DB (`SELECT 1/0`), which aborts the whole transaction.
+ *
+ * Covered:
+ *   - single-event cancel: failure rolls back RSVP delete + visit unlink
+ *   - applyToFuture series cancel: same rollback across the series
+ */
+import { PATCH } from '@/app/api/events/[id]/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+const TAG = 'cancel-rollback-test';
+const HOUR = 60 * 60 * 1000;
+
+function patch(eventId: number, body: Record<string, unknown>) {
+    const req = new Request('http://localhost/api/events/x', {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+    });
+    return PATCH(req, { params: Promise.resolve({ id: String(eventId) }) });
+}
+
+describe('PATCH /api/events/[id] cancel — transaction rollback on partial failure', () => {
+    let participantId: number;
+    let householdId: number;
+    let adminId: number;
+    let adminHouseholdId: number;
+
+    beforeAll(async () => {
+        const p = await prisma.participant.create({
+            data: { name: 'Cancel Attendee', email: `attendee-${TAG}@example.com`, household: { create: {} } },
+        });
+        participantId = p.id;
+        householdId = p.householdId;
+
+        const admin = await prisma.participant.create({
+            data: { name: 'Cancel Admin', email: `admin-${TAG}@example.com`, household: { create: {} } },
+        });
+        adminId = admin.id;
+        adminHouseholdId = admin.householdId;
+    });
+
+    beforeEach(() => {
+        jest.restoreAllMocks();
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, sysadmin: true } });
+    });
+
+    afterEach(async () => {
+        jest.restoreAllMocks();
+        await prisma.visit.deleteMany({ where: { participantId } });
+        await prisma.rSVP.deleteMany({ where: { participantId } });
+        await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
+    });
+
+    afterAll(async () => {
+        await prisma.visit.deleteMany({ where: { participantId } });
+        await prisma.rSVP.deleteMany({ where: { participantId } });
+        await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
+        await prisma.participant.deleteMany({ where: { id: { in: [participantId, adminId] } } });
+        await prisma.household.deleteMany({ where: { id: { in: [householdId, adminHouseholdId] } } });
+    });
+
+    async function makeEvent(label: string, recurringGroupId?: string) {
+        const start = new Date(Date.now() + 24 * HOUR);
+        const event = await prisma.event.create({
+            data: {
+                name: `${TAG} ${label}`,
+                start,
+                end: new Date(start.getTime() + HOUR),
+                description: 'cancel',
+                ...(recurringGroupId ? { recurringGroupId } : {}),
+            },
+        });
+        await prisma.rSVP.create({
+            data: { eventId: event.id, participantId, status: 'ATTENDING' },
+        });
+        await prisma.visit.create({
+            data: { participantId, arrived: start, associatedEventId: event.id },
+        });
+        return event.id;
+    }
+
+    function counts(eventId: number) {
+        return Promise.all([
+            prisma.event.count({ where: { id: eventId } }),
+            prisma.rSVP.count({ where: { eventId } }),
+            prisma.visit.count({ where: { associatedEventId: eventId } }),
+        ]);
+    }
+
+    it('rolls back the single-event cancel when a write fails mid-transaction', async () => {
+        const eventId = await makeEvent('single');
+        expect(await counts(eventId)).toEqual([1, 1, 1]);
+
+        // Force the final delete op to fail at the DB, aborting the transaction.
+        jest.spyOn(prisma.event, 'delete').mockImplementationOnce(
+            () => prisma.$queryRaw`SELECT 1/0` as never
+        );
+
+        const res = await patch(eventId, { action: 'cancel' });
+        expect(res.status).toBe(500);
+
+        // Nothing committed: event, RSVP, and visit link all intact.
+        expect(await counts(eventId)).toEqual([1, 1, 1]);
+    });
+
+    it('rolls back the applyToFuture series cancel when a write fails mid-transaction', async () => {
+        const group = `${TAG}-group`;
+        const first = await makeEvent('series-1', group);
+        const second = await makeEvent('series-2', group);
+        expect(await counts(first)).toEqual([1, 1, 1]);
+        expect(await counts(second)).toEqual([1, 1, 1]);
+
+        jest.spyOn(prisma.event, 'deleteMany').mockImplementationOnce(
+            () => prisma.$queryRaw`SELECT 1/0` as never
+        );
+
+        const res = await patch(first, { action: 'cancel', applyToFuture: true });
+        expect(res.status).toBe(500);
+
+        expect(await counts(first)).toEqual([1, 1, 1]);
+        expect(await counts(second)).toEqual([1, 1, 1]);
+    });
+});

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -119,12 +119,14 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 
                 if (body.action === 'cancel') {
                     const eventIds = futureEvents.map(e => e.id);
-                    // Cleanup RSVPs and Visits first to avoid foreign key constraints
-                    await prisma.rSVP.deleteMany({ where: { eventId: { in: eventIds } } });
-                    await prisma.visit.updateMany({ where: { associatedEventId: { in: eventIds } }, data: { associatedEventId: null } });
-                    // Delete all future events in series
-                    await prisma.event.deleteMany({ where: { id: { in: eventIds } } });
-                    
+                    // Cleanup RSVPs and Visits first to avoid foreign key constraints.
+                    // All three writes in one transaction so a mid-way failure rolls back.
+                    await prisma.$transaction([
+                        prisma.rSVP.deleteMany({ where: { eventId: { in: eventIds } } }),
+                        prisma.visit.updateMany({ where: { associatedEventId: { in: eventIds } }, data: { associatedEventId: null } }),
+                        prisma.event.deleteMany({ where: { id: { in: eventIds } } }),
+                    ]);
+
                     return NextResponse.json({ success: true, count: futureEvents.length });
                 } else if (body.action === 'editTime') {
                     const ops: Prisma.PrismaPromise<unknown>[] = futureEvents.map(fe => {
@@ -153,9 +155,12 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
             } else {
                 // Apply ONLY to this single event
                 if (body.action === 'cancel') {
-                    await prisma.rSVP.deleteMany({ where: { eventId: event.id } });
-                    await prisma.visit.updateMany({ where: { associatedEventId: event.id }, data: { associatedEventId: null } });
-                    await prisma.event.delete({ where: { id: event.id } });
+                    // All three writes in one transaction so a mid-way failure rolls back.
+                    await prisma.$transaction([
+                        prisma.rSVP.deleteMany({ where: { eventId: event.id } }),
+                        prisma.visit.updateMany({ where: { associatedEventId: event.id }, data: { associatedEventId: null } }),
+                        prisma.event.delete({ where: { id: event.id } }),
+                    ]);
                     return NextResponse.json({ success: true });
                 } else if (body.action === 'editTime') {
                     const startChanged = timeShiftStartMs !== 0;


### PR DESCRIPTION
## What

Both cancel paths in `checkin-app/src/app/api/events/[id]/route.ts` now wrap their three writes in `prisma.$transaction([...])`:

- **single-event cancel** (~line 155)
- **applyToFuture series cancel** (~line 120)

## Why

Both paths ran three writes with **no transaction**: delete RSVPs → null visits' `associatedEventId` → delete the event. A failure between writes corrupted data — visits left orphaned (already nulled) or RSVPs deleted with the event still alive.

The existing `editTime` series path already used `prisma.$transaction([...])`; this makes cancel consistent with it (array form, same pattern).

## Test

New integration test `eventCancelRollback.integration.test.ts` (2 cases, single + series). Forces a mid-transaction failure by stubbing the final delete op to a DB-erroring query (`SELECT 1/0`), then asserts the event, RSVPs, and visits are all left intact — proving rollback.

Verified against a real Postgres (throwaway docker PG, `prisma db push` + `generate`):

```
Tests: 2 passed, 2 total
```

## Reviewer notes

- The `console.error("Failed to update event", ...)` division-by-zero output in test logs is the route logging the **expected** injected failure (500 path), not a test failure.
- Pre-commit `test:ci` is skipped in this worktree — the worktree path sits in jest's `testPathIgnorePatterns`, so it finds 0 unit tests and exits 1 (known worktree quirk). The integration test was run directly against real PG instead.
- A bad-id failure trick wouldn't work uniformly: `deleteMany` on a non-existent id returns count 0 without throwing, so the series path needs a DB-level error like `SELECT 1/0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)