### PR TITLE
fix(trusted-adult): lock parent row on mutations to close TOCTOU race

### DIFF
--- a/checkin-app/jest.setup.js
+++ b/checkin-app/jest.setup.js
@@ -22,7 +22,7 @@ process.env.CHECKIN_ENV = 'dev';
   // pool of >= 2 so their two enroll transactions run on separate connections,
   // making the program-row FOR UPDATE lock (not pool-1 serialization) the thing
   // that serializes them — matching production.
-  if (testPath && /(scanConcurrency|programsParticipantsConcurrency|programsPublicRegisterConcurrency)\.integration\.test\.[jt]sx?$/.test(testPath)) {
+  if (testPath && /(scanConcurrency|programsParticipantsConcurrency|programsPublicRegisterConcurrency|trustedAdultConcurrency)\.integration\.test\.[jt]sx?$/.test(testPath)) {
     process.env.TEST_DB_POOL_MAX = '2';
   }
 }

--- a/checkin-app/src/app/__tests__/trustedAdultConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultConcurrency.integration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Concurrency tests for trusted-adult mutating operations. Unlike the membership
+ * BG-review flow (lib/membership/review.ts FOR UPDATE), the trusted-adult service
+ * was check-then-act with NO row lock — a TOCTOU race:
+ *   - renewTrustedAdult: two concurrent renews both read a terminal latest review,
+ *     both pass the "already open" guard, both create a PENDING review → TWO open
+ *     reviews for one trusted adult.
+ *   - decideReview: two board members both read PENDING_BOARD_REVIEW, both update
+ *     and both write an audit row → the loser leaves an ORPHAN audit row that
+ *     contradicts the final state.
+ *
+ * These serialize on a SELECT ... FOR UPDATE of the parent TrustedAdult row inside
+ * a $transaction (mirrors review.ts). jest.setup.js gives this suite
+ * TEST_DB_POOL_MAX=2 so the two writes run on separate connections — the row lock,
+ * not pool-1 serialization, is what makes them safe.
+ */
+
+import { createTrustedAdult, decideReview, renewTrustedAdult, TrustedAdultError } from '@/lib/trusted-adult/service';
+import prisma from '@/lib/prisma';
+
+const sendEmail = jest.fn().mockResolvedValue(true);
+jest.mock('@/lib/email', () => ({ sendEmail: (...a: unknown[]) => sendEmail(...a) }));
+
+const TAG = 'trustedadult-concurrency-test';
+const SHARED = 'Grandma may pick up the kids.';
+
+async function wipe() {
+    const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+    const ids = hhs.map((h) => h.id);
+    if (ids.length) {
+        await prisma.trustedAdultReview.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.trustedAdult.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: ids } } });
+    }
+}
+
+function code(r: PromiseSettledResult<unknown>): string {
+    return r.status === 'fulfilled' ? 'fulfilled' : (r.reason as TrustedAdultError).code;
+}
+
+describe('trusted-adult mutation concurrency', () => {
+    let householdId = 0;
+    let leadId = 0;
+    let boardId = 0;
+
+    beforeAll(async () => {
+        await wipe();
+        const hh = await prisma.household.create({ data: { name: `Family HH ${TAG}` } });
+        householdId = hh.id;
+        const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
+        leadId = lead.id;
+        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        const boardHh = await prisma.household.create({ data: { name: `Board HH ${TAG}` } });
+        boardId = (await prisma.participant.create({ data: { name: 'Boardie', boardMember: true, householdId: boardHh.id } })).id;
+    });
+
+    afterAll(async () => {
+        await wipe();
+        await prisma.$disconnect();
+    });
+
+    async function disclose() {
+        return createTrustedAdult({
+            householdId,
+            counterpartyName: 'Jane External',
+            counterpartyContact: 'jane@example.com',
+            familyContext: 'Our nanny; may collect the kids on weekdays.',
+            disclosedById: leadId,
+        });
+    }
+
+    it('two concurrent renewals open exactly ONE pending review (not two)', async () => {
+        // Latest review terminal (APPROVED) so a renewal is allowed.
+        const ta = await disclose();
+        await decideReview(ta.reviews[0].id, boardId, { decision: 'APPROVE', sharedNote: SHARED });
+
+        const [a, b] = await Promise.allSettled([
+            renewTrustedAdult(ta.id, leadId),
+            renewTrustedAdult(ta.id, leadId),
+        ]);
+        const codes = [code(a), code(b)];
+
+        // Exactly one renewal wins; the other re-reads the now-open review under the
+        // lock and bails with already_open. Pre-fix BOTH win and two PENDING reviews open.
+        expect(codes.filter((c) => c === 'fulfilled')).toHaveLength(1);
+        expect(codes.filter((c) => c === 'already_open')).toHaveLength(1);
+
+        const pending = await prisma.trustedAdultReview.count({
+            where: { trustedAdultId: ta.id, status: 'PENDING_BOARD_REVIEW' },
+        });
+        expect(pending).toBe(1);
+    });
+
+    it('two concurrent decisions on one review — one wins, no orphan audit', async () => {
+        const ta = await disclose();
+        const reviewId = ta.reviews[0].id;
+
+        const [a, b] = await Promise.allSettled([
+            decideReview(reviewId, boardId, { decision: 'APPROVE', sharedNote: SHARED }),
+            decideReview(reviewId, boardId, { decision: 'DENY' }),
+        ]);
+        const codes = [code(a), code(b)];
+
+        // One decision lands; the loser re-reads a non-PENDING review and bails.
+        expect(codes.filter((c) => c === 'fulfilled')).toHaveLength(1);
+        expect(codes.filter((c) => c === 'wrong_phase')).toHaveLength(1);
+
+        const review = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } });
+        expect(['APPROVED', 'DENIED']).toContain(review!.status);
+
+        // Exactly ONE decision audit row, and it matches the final state — pre-fix the
+        // loser also writes an audit row whose decision contradicts the persisted one.
+        const audits = await prisma.auditLog.findMany({
+            where: { tableName: 'TrustedAdult', affectedEntityId: ta.id },
+            select: { newData: true },
+        });
+        const decisions = audits.filter((x) => String(x.newData).includes('"decision":'));
+        expect(decisions).toHaveLength(1);
+        expect(String(decisions[0].newData)).toContain(`"status":"${review!.status}"`);
+    });
+});

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -4,6 +4,17 @@ import { sendEmail } from "@/lib/email";
 import { escapeHtml } from "@/lib/email-templates/base";
 import { logger } from "@/lib/logger";
 
+type TxClient = Prisma.TransactionClient;
+
+/**
+ * Serialize all mutations of one TrustedAdult by taking a row lock on the parent.
+ * renew/withdraw/decide each read-check-write; without this lock two concurrent
+ * calls both pass the check and both write (TOCTOU). Mirrors lib/membership/review.ts.
+ */
+function lockTrustedAdult(tx: TxClient, taId: number) {
+    return tx.$queryRaw`SELECT id FROM "TrustedAdult" WHERE id = ${taId} FOR UPDATE`;
+}
+
 /**
  * Trusted Adult management.
  *
@@ -113,19 +124,18 @@ export async function createTrustedAdult(input: CreateInput) {
  * by a lead of the household.
  */
 export async function renewTrustedAdult(id: number, actorId: number) {
-    const ta = await prisma.trustedAdult.findUnique({
-        where: { id },
-        include: { reviews: { orderBy: { id: "desc" }, take: 1 } },
-    });
+    const ta = await prisma.trustedAdult.findUnique({ where: { id }, select: { id: true, householdId: true } });
     if (!ta) throw new TrustedAdultError("not_found", "Trusted adult not found.");
     await assertHouseholdLead(ta.householdId, actorId);
 
-    const latest = ta.reviews[0];
-    if (latest && (latest.status === "PENDING_BOARD_REVIEW" || latest.status === "PENDING_SUBJECT_ACTION")) {
-        throw new TrustedAdultError("already_open", "A review for this trusted adult is already in progress.");
-    }
-
+    // Lock the parent, re-read the latest review under the lock, then create. Without
+    // the lock two concurrent renews both see a terminal latest and both open a review.
     const review = await prisma.$transaction(async (tx) => {
+        await lockTrustedAdult(tx, ta.id);
+        const latest = await tx.trustedAdultReview.findFirst({ where: { trustedAdultId: ta.id }, orderBy: { id: "desc" } });
+        if (latest && (latest.status === "PENDING_BOARD_REVIEW" || latest.status === "PENDING_SUBJECT_ACTION")) {
+            throw new TrustedAdultError("already_open", "A review for this trusted adult is already in progress.");
+        }
         const created = await tx.trustedAdultReview.create({
             data: { trustedAdultId: ta.id, householdId: ta.householdId, kind: "RENEWAL", status: "PENDING_BOARD_REVIEW" },
         });
@@ -138,22 +148,19 @@ export async function renewTrustedAdult(id: number, actorId: number) {
 
 /** A household lead withdraws a Trusted Adult — sets the latest review REVOKED. */
 export async function withdrawTrustedAdult(id: number, actorId: number) {
-    const ta = await prisma.trustedAdult.findUnique({
-        where: { id },
-        include: { reviews: { orderBy: { id: "desc" }, take: 1 } },
-    });
+    const ta = await prisma.trustedAdult.findUnique({ where: { id }, select: { id: true, householdId: true } });
     if (!ta) throw new TrustedAdultError("not_found", "Trusted adult not found.");
     await assertHouseholdLead(ta.householdId, actorId);
 
-    const latest = ta.reviews[0];
-    if (!latest || latest.status === "REVOKED") throw new TrustedAdultError("wrong_phase", "Nothing to withdraw.");
-
-    const updated = await prisma.$transaction(async (tx) => {
-        const u = await tx.trustedAdultReview.update({ where: { id: latest.id }, data: { status: "REVOKED" } });
+    // Lock the parent so withdraw serializes against renew and decide on the same TA.
+    return prisma.$transaction(async (tx) => {
+        await lockTrustedAdult(tx, ta.id);
+        const latest = await tx.trustedAdultReview.findFirst({ where: { trustedAdultId: ta.id }, orderBy: { id: "desc" } });
+        if (!latest || latest.status === "REVOKED") throw new TrustedAdultError("wrong_phase", "Nothing to withdraw.");
+        const updated = await tx.trustedAdultReview.update({ where: { id: latest.id }, data: { status: "REVOKED" } });
         await audit(tx, actorId, ta.id, { status: latest.status }, { status: "REVOKED" });
-        return u;
+        return updated;
     });
-    return updated;
 }
 
 export interface DecideInput {
@@ -172,53 +179,63 @@ export interface DecideInput {
  *   REQUEST_INFO  -> PENDING_SUBJECT_ACTION (notify household)
  */
 export async function decideReview(reviewId: number, boardMemberId: number, input: DecideInput) {
-    const review = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } });
-    if (!review) throw new TrustedAdultError("not_found", "Review not found.");
-    if (review.status !== "PENDING_BOARD_REVIEW") {
-        throw new TrustedAdultError("wrong_phase", "This review is not awaiting board review.");
-    }
+    // Pure input validation — independent of locked state, so do it before the tx.
     if (input.decision === "APPROVE" && !input.sharedNote?.trim()) {
         throw new TrustedAdultError(
             "bad_input",
             "A shared note (what keyholders & program leads should know, e.g. who can pick up whom) is required to approve.",
         );
     }
-
-    const now = new Date();
-    const data: Record<string, unknown> = {
-        decidedById: boardMemberId,
-        decision: input.decision,
-        decisionNote: input.note?.trim() || null,
-    };
-    let status: string;
-    switch (input.decision) {
-        case "APPROVE":
-            status = "APPROVED";
-            data.effectiveFrom = now;
-            data.reviewBy = daysFromNow(now, APPROVAL_VALID_DAYS);
-            data.sharedNote = input.sharedNote!.trim();
-            break;
-        case "DENY":
-            status = "DENIED";
-            break;
-        case "REQUEST_INFO":
-            status = "PENDING_SUBJECT_ACTION";
-            break;
-        default:
-            throw new TrustedAdultError("bad_input", "Unknown decision.");
+    if (!["APPROVE", "DENY", "REQUEST_INFO"].includes(input.decision)) {
+        throw new TrustedAdultError("bad_input", "Unknown decision.");
     }
-    data.status = status;
 
-    const updated = await prisma.$transaction(async (tx) => {
-        const u = await tx.trustedAdultReview.update({ where: { id: reviewId }, data });
+    const head = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId }, select: { trustedAdultId: true } });
+    if (!head) throw new TrustedAdultError("not_found", "Review not found.");
+
+    // Lock the parent TA, then re-read the review under the lock and check its phase.
+    // Without this two board members both read PENDING_BOARD_REVIEW, both update, and
+    // both write an audit row — the loser leaving an orphan audit that contradicts state.
+    const result = await prisma.$transaction(async (tx) => {
+        await lockTrustedAdult(tx, head.trustedAdultId);
+        const review = await tx.trustedAdultReview.findUnique({ where: { id: reviewId } });
+        if (!review) throw new TrustedAdultError("not_found", "Review not found.");
+        if (review.status !== "PENDING_BOARD_REVIEW") {
+            throw new TrustedAdultError("wrong_phase", "This review is not awaiting board review.");
+        }
+
+        const now = new Date();
+        const data: Record<string, unknown> = {
+            decidedById: boardMemberId,
+            decision: input.decision,
+            decisionNote: input.note?.trim() || null,
+        };
+        let status: string;
+        switch (input.decision) {
+            case "APPROVE":
+                status = "APPROVED";
+                data.effectiveFrom = now;
+                data.reviewBy = daysFromNow(now, APPROVAL_VALID_DAYS);
+                data.sharedNote = input.sharedNote!.trim();
+                break;
+            case "DENY":
+                status = "DENIED";
+                break;
+            default:
+                status = "PENDING_SUBJECT_ACTION";
+                break;
+        }
+        data.status = status;
+
+        const updated = await tx.trustedAdultReview.update({ where: { id: reviewId }, data });
         await audit(tx, boardMemberId, review.trustedAdultId, { status: review.status }, { status, decision: input.decision });
-        return u;
+        return { updated, householdId: review.householdId };
     });
 
     if (input.decision === "REQUEST_INFO") {
-        await notifyHouseholdFamily(review.householdId, "The board needs more information about a trusted adult", input.note?.trim());
+        await notifyHouseholdFamily(result.householdId, "The board needs more information about a trusted adult", input.note?.trim());
     }
-    return updated;
+    return result.updated;
 }
 
 /** Board / sysadmin override: force a review to a terminal state regardless of phase. */
@@ -346,7 +363,7 @@ async function notifyHouseholdFamily(householdId: number, subject: string, body?
 }
 
 function audit(
-    db: Prisma.TransactionClient | typeof prisma,
+    db: TxClient | typeof prisma,
     actorId: number,
     taId: number,
     oldData: object,


### PR DESCRIPTION
## What

Trusted-adult mutating operations (`renewTrustedAdult`, `withdrawTrustedAdult`, `decideReview`) were **check-then-act with no row lock**, unlike the membership BG-review flow which serializes on `SELECT ... FOR UPDATE` ([review.ts:130](https://github.com/innovationtreehouse/checkin/blob/main/checkin-app/src/lib/membership/review.ts#L130)). Same TOCTOU shape the membership side explicitly defends against — here undefended and, until now, untested.

Concrete races:
- **renew:** two concurrent renews both read a terminal latest review, both pass the "already open" guard, both create a `PENDING_BOARD_REVIEW` → **two open reviews** for one trusted adult.
- **decide:** two board members both read `PENDING_BOARD_REVIEW`, both update, both write an audit row → the loser leaves an **orphan audit** contradicting the persisted state.
- **renew vs withdraw:** could open a review while another revokes.

## Fix

Serialize all mutations of one `TrustedAdult` on a `SELECT ... FOR UPDATE` of the **parent row** inside a `$transaction` (new `lockTrustedAdult` helper), mirroring `review.ts`. All three functions lock the same row, so they serialize against each other. The audit write moves **inside** the transaction so the row always reflects the actual final state.

The lock + transaction compose with the separate audit-atomicity work: the `FOR UPDATE` lives in that same transaction. `audit()` now takes a db client as its first arg; create/override/expiry-sweep pass `prisma` (unchanged behavior), the locked paths pass `tx`.

## Test

Adds `trustedAdultConcurrency.integration.test.ts` (registered for `TEST_DB_POOL_MAX=2` so the two writes run on separate connections — the row lock, not pool-1 serialization, is what makes it safe):
1. Two concurrent `renewTrustedAdult` → exactly ONE pending review, the other rejects `already_open`.
2. Two concurrent `decideReview` (APPROVE vs DENY) → one wins, the other `wrong_phase`; exactly ONE decision audit row, matching the final state (no orphan).

Both tests **fail against the pre-lock code** (verified: both calls won, 2 reviews / 2 audit rows) and **pass with the lock**. Full trusted-adult integration suite: 17/17 green.

> Note: skipped the optional renew-vs-withdraw race test — withdraw-then-renew opens a pending review *by design* even when serialized (renew only blocks on PENDING states, not REVOKED), so an assertion there would test policy, not the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)