### PR TITLE
fix(settings): left-align membership Settings title

### DIFF
--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -146,7 +146,7 @@ export default function MembershipSettingsPage() {
   };
 
   return (
-    <Stack maw={820} mx="auto">
+    <Stack>
       <AdminPageHeader title="Settings" />
 
       <SettingsTabs active="membership" />


### PR DESCRIPTION
## What

Drop `maw={820} mx="auto"` from the outer `<Stack>` on the membership settings page (`/settings/membership`).

## Why

The wrapper centered an 820px column, which pushed the **Settings** title inward to the right and made the whole page feel inset/offset — instead of the top-left, full-width alignment used by its sibling `/settings/roles` page and the shop pages (which was the visual reference).

## Result

Title and cards now sit full-width, left-aligned, consistent with the rest of the app. One-line change; cards span the main content width (no per-card `maw`), same as the roles page. Inputs keep their fixed widths, so no odd stretching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)