### PR TITLE
fix(reminders): stamp reminderSentAt only when the email actually sent

### DIFF
--- a/checkin-app/src/app/api/cron/reminders/route.ts
+++ b/checkin-app/src/app/api/cron/reminders/route.ts
@@ -63,9 +63,10 @@ export async function GET(req: Request) {
                 const promise = Promise.resolve(sendNotification(rsvp.participantId, 'EVENT_STARTING_SOON', {
                     eventName: event.name,
                     hours: 2
-                })).then(async () => {
-                    // Mark sent only after the notification resolves, so a send failure
-                    // leaves it eligible for the next run rather than silently dropped.
+                })).then(async (ok) => {
+                    // Mark sent only when the notification actually delivered, so a send
+                    // failure leaves it eligible for the next run rather than silently dropped.
+                    if (!ok) return;
                     await prisma.rSVP.update({
                         where: {
                             eventId_participantId: {

--- a/checkin-app/src/lib/__tests__/notifications.test.ts
+++ b/checkin-app/src/lib/__tests__/notifications.test.ts
@@ -1,0 +1,44 @@
+import { sendNotification } from '../notifications';
+import { sendEmail } from '../email';
+import prisma from '../prisma';
+
+jest.mock('../email', () => ({ sendEmail: jest.fn() }));
+jest.mock('../prisma', () => ({
+    __esModule: true,
+    default: { participant: { findUnique: jest.fn() } },
+}));
+
+const mockSendEmail = sendEmail as jest.Mock;
+const mockFindUnique = (prisma as unknown as { participant: { findUnique: jest.Mock } }).participant.findUnique;
+
+describe('sendNotification return contract', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('returns true and sends nothing when email is disabled (no forever-retry)', async () => {
+        mockFindUnique.mockResolvedValue({ email: 'a@b.com', name: 'A', notificationSettings: { email: false } });
+        await expect(sendNotification(1, 'EVENT_STARTING_SOON', {})).resolves.toBe(true);
+        expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it('returns sendEmail boolean when enabled', async () => {
+        mockFindUnique.mockResolvedValue({ email: 'a@b.com', name: 'A', notificationSettings: {} });
+        mockSendEmail.mockResolvedValue(true);
+        await expect(sendNotification(1, 'EVENT_STARTING_SOON', {})).resolves.toBe(true);
+
+        mockSendEmail.mockResolvedValue(false);
+        await expect(sendNotification(1, 'EVENT_STARTING_SOON', {})).resolves.toBe(false);
+    });
+
+    it('returns false when sendEmail throws (retryable)', async () => {
+        mockFindUnique.mockResolvedValue({ email: 'a@b.com', name: 'A', notificationSettings: {} });
+        mockSendEmail.mockRejectedValue(new Error('boom'));
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        await expect(sendNotification(1, 'EVENT_STARTING_SOON', {})).resolves.toBe(false);
+    });
+
+    it('returns true when user not found (nothing to ever send)', async () => {
+        mockFindUnique.mockResolvedValue(null);
+        await expect(sendNotification(1, 'EVENT_STARTING_SOON', {})).resolves.toBe(true);
+        expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+});

--- a/checkin-app/src/lib/notifications.ts
+++ b/checkin-app/src/lib/notifications.ts
@@ -19,14 +19,19 @@ export type NotificationEvent =
     | 'CHECKIN'
     | 'CHECKOUT';
 
-export async function sendNotification(userId: number, eventType: NotificationEvent, payload: Record<string, unknown>) {
+/**
+ * @returns true if delivery succeeded or there was nothing to send (don't retry),
+ *          false if the send failed (caller should retry).
+ */
+export async function sendNotification(userId: number, eventType: NotificationEvent, payload: Record<string, unknown>): Promise<boolean> {
     try {
         const user = await prisma.participant.findUnique({
             where: { id: userId },
             select: { email: true, notificationSettings: true, name: true }
         });
 
-        if (!user || !user.email) return;
+        // No user / no address: nothing can ever be sent here — treat as done, not retryable.
+        if (!user || !user.email) return true;
 
         // Construct message based on type
         let message = "";
@@ -61,12 +66,15 @@ export async function sendNotification(userId: number, eventType: NotificationEv
         const settings = user.notificationSettings as unknown as Record<string, boolean>;
         const wantsEmail = settings?.email !== false; // Active by default
 
-        if (wantsEmail) {
-            await sendEmail(user.email, subject, `<p>${escapeHtml(message)}</p>`);
-        }
+        // Email disabled: return true so a user who opted out isn't retried forever.
+        if (!wantsEmail) return true;
+
+        const ok = await sendEmail(user.email, subject, `<p>${escapeHtml(message)}</p>`);
+        return ok;
 
     } catch (error) {
         console.error("Failed to sequence notification:", error);
+        return false;
     }
 }
 


### PR DESCRIPTION
## What

The reminders cron stamped `reminderSentAt` even when the email failed to send, silently dropping the reminder and contradicting the route's own documented **at-least-once** guarantee.

Root cause: `sendNotification` called `sendEmail(...)` but never captured its return value, and its try/catch swallowed errors and resolved `undefined`. `sendEmail` returns `false` on soft failure (no Resend key / Resend error) and never throws — so the cron's `.then()` always ran and stamped `reminderSentAt`, even when no email left.

## Fix

Root-caused in `sendNotification` so every caller benefits:

- `sendNotification` now returns `Promise<boolean>`:
  - `true` on send-success, **email-disabled**, or **user-missing** — nothing to ever retry.
  - `false` when `sendEmail` returns `false` or throws — retryable.
- Email-disabled and user-missing deliberately return `true`, not `false`, so an opted-out or absent user isn't retried forever every cron run.
- `cron/reminders/route.ts` captures the result: `if (!ok) return;` before the `reminderSentAt` update. A failed send leaves `reminderSentAt: null` → retried next run, matching the docstring. `notificationsSent` now counts real deliveries.

## Reviewer notes

- Other `sendNotification` callers (`programs`, `participants`, `public-register`) `await`-and-ignore the result — `void`→`boolean` is backward compatible, `tsc --noEmit` clean on touched files.
- Added `src/lib/__tests__/notifications.test.ts` asserting the return contract (true when disabled, `sendEmail`'s boolean when enabled, false when it throws, true when user missing). Mocks prisma + email, no DB needed; 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)