### PR TITLE
test(trusted-adult): cover all 6 mutating paths in atomicity rollback suite

### DIFF
--- a/checkin-app/src/app/__tests__/trustedAdultAtomicity.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultAtomicity.integration.test.ts
@@ -16,6 +16,9 @@
 import {
     createTrustedAdult,
     decideReview,
+    overrideReview,
+    renewTrustedAdult,
+    runExpirySweep,
     withdrawTrustedAdult,
 } from '@/lib/trusted-adult/service';
 import prisma from '@/lib/prisma';
@@ -121,5 +124,67 @@ describe('Trusted Adults — mutation + audit are atomic', () => {
 
         const after = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } });
         expect(after!.status).toBe('PENDING_BOARD_REVIEW'); // NOT REVOKED
+    });
+
+    it('createTrustedAdult: a failing audit rolls back the whole create — no TA, review, or audit row', async () => {
+        const taBefore = await prisma.trustedAdult.count({ where: { householdId } });
+        const auditBefore = await prisma.auditLog.count();
+
+        const spy = breakAuditInTransaction();
+        await expect(discloseOne()).rejects.toThrow('forced audit failure');
+        spy.mockRestore();
+
+        // TA + its INITIAL review are created inside the same tx as the audit — all roll back.
+        expect(await prisma.trustedAdult.count({ where: { householdId } })).toBe(taBefore);
+        expect(await prisma.auditLog.count()).toBe(auditBefore);
+    });
+
+    it('renewTrustedAdult: a failing audit rolls back the RENEWAL — no new review, no audit row', async () => {
+        const ta = await discloseOne();
+        // Renew is allowed only when the latest review is terminal; withdraw to REVOKED first.
+        await withdrawTrustedAdult(ta.id, leadId);
+
+        const reviewsBefore = await prisma.trustedAdultReview.count({ where: { trustedAdultId: ta.id } });
+        const auditBefore = await prisma.auditLog.count();
+
+        const spy = breakAuditInTransaction();
+        await expect(renewTrustedAdult(ta.id, leadId)).rejects.toThrow('forced audit failure');
+        spy.mockRestore();
+
+        expect(await prisma.trustedAdultReview.count({ where: { trustedAdultId: ta.id } })).toBe(reviewsBefore);
+        expect(await prisma.auditLog.count()).toBe(auditBefore);
+    });
+
+    it('overrideReview: a failing audit rolls back the force-DENY — status stays PENDING_BOARD_REVIEW', async () => {
+        const ta = await discloseOne();
+        const reviewId = ta.reviews[0].id;
+        const auditBefore = await prisma.auditLog.count();
+
+        const spy = breakAuditInTransaction();
+        await expect(overrideReview(reviewId, boardId, 'deny')).rejects.toThrow('forced audit failure');
+        spy.mockRestore();
+
+        const after = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } });
+        expect(after!.status).toBe('PENDING_BOARD_REVIEW'); // NOT DENIED
+        expect(after!.decision).toBeNull();
+        expect(await prisma.auditLog.count()).toBe(auditBefore);
+    });
+
+    it('runExpirySweep: a failing audit rolls back the EXPIRED transition — status stays APPROVED', async () => {
+        const ta = await discloseOne();
+        const reviewId = ta.reviews[0].id;
+        await decideReview(reviewId, boardId, { decision: 'APPROVE', sharedNote: 'Grandma may pick up the kids.' });
+        // Push reviewBy into the past so the sweep treats this approval as lapsed.
+        await prisma.trustedAdultReview.update({ where: { id: reviewId }, data: { reviewBy: new Date('2000-01-01T00:00:00Z') } });
+
+        const auditBefore = await prisma.auditLog.count();
+
+        const spy = breakAuditInTransaction();
+        await expect(runExpirySweep(new Date())).rejects.toThrow('forced audit failure');
+        spy.mockRestore();
+
+        const after = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } });
+        expect(after!.status).toBe('APPROVED'); // NOT EXPIRED
+        expect(await prisma.auditLog.count()).toBe(auditBefore);
     });
 });


### PR DESCRIPTION
## What

Extend the trusted-adult atomicity rollback suite ([trustedAdultAtomicity.integration.test.ts](checkin-app/src/app/__tests__/trustedAdultAtomicity.integration.test.ts)) from 2 paths to all 6.

PR #368 made every trusted-adult state mutation atomic with its audit write (mutation + audit wrapped in one `prisma.$transaction`). The rollback test that *proves* that atomicity — force the audit write to throw, assert state unchanged — only covered `decideReview` and `withdrawTrustedAdult`. The other 4 paths could silently regress to non-atomic (audit-after-commit) with green CI.

Adds rollback tests for the remaining 4, using the same `breakAuditInTransaction` harness:

| Path | Setup | Asserts after forced audit throw |
|------|-------|--------|
| `createTrustedAdult` | none | no TA/review created, no audit row |
| `renewTrustedAdult` | withdraw → REVOKED (terminal, so renew allowed) | review count unchanged, no audit row |
| `overrideReview` | PENDING review, force `deny` | status still PENDING_BOARD_REVIEW, decision null, no audit row |
| `runExpirySweep` EXPIRED | APPROVE then backdate `reviewBy` to 2000 | status still APPROVED, no audit row |

## Why

Locks in atomicity so a future refactor to audit-after-commit fails CI loudly instead of shipping a trusted-adult record with no audit trail.

## Notes for reviewer

- **Test-only.** Source unchanged. All 6 paths pass against current code — they're already transactional. No atomicity bug found.
- `renew` needs a terminal latest review or it throws `already_open` before reaching the audit write — so the test withdraws first.
- `runExpirySweep`: backdated `reviewBy` fires the lapsed/EXPIRED branch, not the 30-day warn branch (which needs `reviewBy > now`).
- "No audit row left behind" is checked via an `auditLog.count()` delta of 0 around each broken call.
- Verified locally: 6/6 pass against a throwaway Postgres. (Pre-commit `test:ci` finds 0 tests in a worktree due to existing `testPathIgnorePatterns` matching the worktree path + `.integration.test` — pre-existing, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)