### PR TITLE
fix(auth): populate householdLead JWT claim so leads can check in/out family

### DIFF
--- a/checkin-app/src/lib/__tests__/authClaims.test.ts
+++ b/checkin-app/src/lib/__tests__/authClaims.test.ts
@@ -53,3 +53,26 @@ describe('assignParticipantClaims — household login gate', () => {
         },
     );
 });
+
+describe('assignParticipantClaims — householdLead claim', () => {
+    it('stamps householdLead=true when a HouseholdLead row exists', () => {
+        const token = {} as JWT;
+        assignParticipantClaims(token, participant({ householdLeads: [{ participantId: 7 }] }));
+        expect(token.householdLead).toBe(true);
+    });
+
+    it('stamps householdLead=false when no HouseholdLead row exists', () => {
+        const token = {} as JWT;
+        assignParticipantClaims(token, participant({ householdLeads: [] }));
+        expect(token.householdLead).toBe(false);
+    });
+
+    it('forces householdLead=false for a DENIED household even with a lead row', () => {
+        const token = {} as JWT;
+        assignParticipantClaims(token, participant({
+            householdLeads: [{ participantId: 7 }],
+            household: { membership: { status: 'DENIED' } },
+        }));
+        expect(token.householdLead).toBe(false);
+    });
+});

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -244,6 +244,8 @@ export const authOptions: NextAuthOptions = {
                                 level: true
                             }
                         },
+                        // One row is enough to mark this participant a household lead.
+                        householdLeads: { take: 1, select: { participantId: true } },
                         household: { include: { membership: true } }
                     }
                 }));
@@ -281,6 +283,8 @@ export const authOptions: NextAuthOptions = {
                                 level: true
                             }
                         },
+                        // One row is enough to mark this participant a household lead.
+                        householdLeads: { take: 1, select: { participantId: true } },
                         household: { include: { membership: true } }
                     }
                 }));
@@ -308,6 +312,7 @@ export const authOptions: NextAuthOptions = {
                 session.user.boardMember = token.boardMember;
                 session.user.backgroundCheckReviewer = token.backgroundCheckReviewer;
                 session.user.householdId = token.householdId;
+                session.user.householdLead = token.householdLead ?? false;
                 session.user.toolStatuses = token.toolStatuses || [];
                 session.user.impersonatedBy = token.impersonatedBy ?? null;
                 // Surface the org-gate claims so dev-only server actions (assertDevActor) can

--- a/checkin-app/src/lib/authClaims.ts
+++ b/checkin-app/src/lib/authClaims.ts
@@ -11,6 +11,9 @@ export type ClaimSourceParticipant = {
     backgroundCheckReviewer: boolean;
     householdId: number;
     toolStatuses: { toolId: number; level: string }[];
+    // Any row here means this participant leads a household (the relation is already
+    // filtered to their own leads). Empty/absent → not a lead.
+    householdLeads?: { participantId: number }[];
     household?: { membership?: { status: MembershipStatus } | null } | null;
 };
 
@@ -32,5 +35,6 @@ export function assignParticipantClaims(token: JWT, p: ClaimSourceParticipant): 
     token.boardMember = denied ? false : p.boardMember;
     token.backgroundCheckReviewer = denied ? false : p.backgroundCheckReviewer;
     token.householdId = p.householdId;
+    token.householdLead = denied ? false : (p.householdLeads?.length ?? 0) > 0;
     token.toolStatuses = denied ? [] : p.toolStatuses;
 }


### PR DESCRIPTION
## What

`assignParticipantClaims` (checkin-app/src/lib/authClaims.ts) stamped every authority flag onto the JWT **except** `householdLead`, so `token.householdLead` / `session.user.householdLead` was always `undefined`.

Three live hot-path reads evaluated false permanently as a result:
- `scan/route.ts:49` — `user.householdId && user.householdLead` (a lead scanning a family member at kiosk/web) → never ran.
- `attendance/route.ts:119` — `isHouseholdCheckOut` → never true.
- `attendance/route.ts:167` — `isHouseholdCheckIn` → never true.

Net effect: household leads were silently unable to check their own family members in or out via the web.

## Why it's a correctness/UX bug, not a security hole

Fail-closed. The missing claim only ever **denied** a real privilege — it never wrongly granted one.

## Fix (root cause — stamp the claim once at JWT time)

No per-request DB lookup added to the scan/attendance hot paths.

- `ClaimSourceParticipant` gains optional `householdLeads` rows. A participant is a household lead iff a `HouseholdLead` row with their `participantId` exists; the Prisma relation `participant.householdLeads` is already filtered to their own leads, so no `where` is needed.
- Both jwt-callback query sites (fresh sign-in + per-request refresh) `include` `householdLeads: { take: 1, select: { participantId: true } }`.
- `assignParticipantClaims` derives the boolean and forces it `false` when the household membership is DENIED, consistent with the other flags.
- Session callback copies `token.householdLead` → `session.user.householdLead`. Types in `next-auth.d.ts` already existed.

Left the nav `todo-counts` route's `?? DB-findFirst` fallback alone — it already worked and is now simply redundant.

## Tests

Added 3 focused `authClaims` unit tests: lead row → `true`, no row → `false`, DENIED forces `false`. Existing scan/attendance route tests mock the session claim directly, so they cover the route logic *given* the claim; these new tests cover the claim being stamped from the DB.

- `npx tsc --noEmit`: clean (no new errors in touched files).
- `authClaims.test.ts`: 8/8 pass.

Note: the pre-commit hook found 0 tests because Jest's `testPathIgnorePatterns` matches the worktree rootDir — a known worktree quirk, not a real failure. Ran the unit suite manually instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)