### PR TITLE
test(attendance): cover manual visit-create advisory lock against concurrent submits

### DIFF
--- a/checkin-app/jest.setup.js
+++ b/checkin-app/jest.setup.js
@@ -22,7 +22,7 @@ process.env.CHECKIN_ENV = 'dev';
   // pool of >= 2 so their two enroll transactions run on separate connections,
   // making the program-row FOR UPDATE lock (not pool-1 serialization) the thing
   // that serializes them — matching production.
-  if (testPath && /(scanConcurrency|programsParticipantsConcurrency|programsPublicRegisterConcurrency|trustedAdultConcurrency)\.integration\.test\.[jt]sx?$/.test(testPath)) {
+  if (testPath && /(scanConcurrency|attendanceManualConcurrency|programsParticipantsConcurrency|programsPublicRegisterConcurrency|trustedAdultConcurrency)\.integration\.test\.[jt]sx?$/.test(testPath)) {
     process.env.TEST_DB_POOL_MAX = '2';
   }
 }

--- a/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Concurrency regression test for POST /api/attendance/manual.
+ *
+ * Creating an open visit (arrived, no departure) is a read-modify-write on a
+ * participant's visit state, same as /api/scan. Before the per-participant
+ * advisory lock (route.ts ~line 40), two near-simultaneous manual check-ins for
+ * one participant could both pass the open-visit re-check and both create a
+ * visit, leaving two open visits — checkout closes only one, the other lingers
+ * and corrupts attendance/keyholder counts.
+ *
+ * The fix wraps the open-visit check + create in a $transaction that takes
+ * `pg_advisory_xact_lock(participantId)` first, then returns the existing open
+ * visit if one is found (loser no-ops, status 201, same visit id). This test
+ * fires two concurrent create-open-visit POSTs and asserts exactly one open
+ * visit survives and both responses reference the same visit.
+ *
+ * (Note: jest.setup.js gives this suite a connection pool of 2 — via
+ * TEST_DB_POOL_MAX — instead of the default 1. With a pool of 1 the
+ * $transaction wrapping serializes the two requests on its own and the
+ * assertions pass even without the lock; with a pool of 2 the two transactions
+ * run on separate connections, so the advisory lock is the *only* thing that
+ * serializes them, exactly as in production. Deleting the
+ * `pg_advisory_xact_lock` line in route.ts makes this suite fail.)
+ */
+import { POST } from '@/app/api/attendance/manual/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+const EMAIL_TAG = 'manual-attendance-concurrency-test';
+
+function manualRequest(arrived: string) {
+    return new Request('http://localhost:4000/api/attendance/manual', {
+        method: 'POST',
+        body: JSON.stringify({ arrived }),
+    }) as unknown as import('next/server').NextRequest;
+}
+
+async function openVisitCount(participantId: number) {
+    return prisma.visit.count({ where: { participantId, departed: null } });
+}
+
+describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
+    let subjectId: number;
+    let householdId: number;
+
+    beforeAll(async () => {
+        // Clean any leaked state from a prior run.
+        const leaked = await prisma.participant.findMany({
+            where: { email: { contains: EMAIL_TAG } },
+            select: { id: true, householdId: true },
+        });
+        const leakedIds = leaked.map(p => p.id);
+        const leakedHouseholdIds = leaked.map(p => p.householdId);
+        await prisma.visit.deleteMany({ where: { participantId: { in: leakedIds } } });
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: leakedIds } } });
+        await prisma.participant.deleteMany({ where: { id: { in: leakedIds } } });
+        await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
+
+        const subject = await prisma.participant.create({
+            data: { email: `subject-${EMAIL_TAG}@example.com`, name: 'Manual Concurrency Subject', household: { create: {} } },
+        });
+        subjectId = subject.id;
+        householdId = subject.householdId;
+    });
+
+    afterAll(async () => {
+        await prisma.visit.deleteMany({ where: { participantId: subjectId } });
+        await prisma.auditLog.deleteMany({ where: { actorId: subjectId } });
+        await prisma.participant.deleteMany({ where: { id: subjectId } });
+        await prisma.household.deleteMany({ where: { id: householdId } });
+    });
+
+    it('two concurrent manual check-ins → exactly one open visit, both responses share it', async () => {
+        // Fresh state: no open visit before the race.
+        await prisma.visit.deleteMany({ where: { participantId: subjectId } });
+        expect(await openVisitCount(subjectId)).toBe(0);
+
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: subjectId } });
+
+        const arrived = new Date(Date.now() - 1800000).toISOString(); // 30 min ago
+
+        const [resA, resB] = await Promise.all([
+            POST(manualRequest(arrived)) as Promise<Response>,
+            POST(manualRequest(arrived)) as Promise<Response>,
+        ]);
+
+        // Neither request errors (loser no-ops by returning the existing visit).
+        expect(resA.status).toBe(201);
+        expect(resB.status).toBe(201);
+
+        const [bodyA, bodyB] = await Promise.all([resA.json(), resB.json()]);
+        expect(bodyA.visit).toBeDefined();
+        expect(bodyB.visit).toBeDefined();
+        // Both responses reference the same open visit — the loser returned the
+        // winner's row instead of creating a second one.
+        expect(bodyA.visit.id).toBe(bodyB.visit.id);
+
+        // The core invariant: the race did not open two visits.
+        expect(await openVisitCount(subjectId)).toBe(1);
+    });
+});


### PR DESCRIPTION
## What

Adds a concurrency integration test for the per-participant advisory lock in `POST /api/attendance/manual`, plus the jest config wiring it needs.

- `checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts` — fires two concurrent create-open-visit POSTs for one participant via `Promise.all` and asserts exactly one open visit survives, with both responses referencing the same visit id.
- `checkin-app/jest.setup.js` — registers the new suite for `TEST_DB_POOL_MAX=2`.

## Why

[#372](https://github.com/innovationtreehouse/checkin/pull/372) guarded the manual visit-create with `pg_advisory_xact_lock(participantId)` inside a transaction, re-checking for an existing open visit before creating, so two concurrent submissions (or a manual submit racing a kiosk scan) can't leave two open visits for one participant — duplicate open visits corrupt attendance/keyholder counts (checkout closes only one; the other lingers forever).

The lock had no test and could silently regress. This mirrors the existing `scanConcurrency.integration.test.ts` coverage for the scan route's equivalent lock.

## Reviewer notes

- **Contract asserted:** loser no-ops by returning the winner's existing visit row (status 201), so both responses share the same `visit.id` and the DB ends with exactly one open visit.
- **Pool of 2 is load-bearing:** with the default pool of 1, the `$transaction` wrapping serializes the two requests on its own and the test would pass even without the lock. Pool of 2 runs the two transactions on separate connections, so the advisory lock is the *only* thing serializing them — matching production (pool 10).
- **Genuinely contends:** verified that removing the `pg_advisory_xact_lock` line makes the test fail (two distinct visits created). Test passes with the lock restored.
- Test-only — no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)