### PR TITLE
refactor(ui): drop redundant section/page headers above ops tabs

### DIFF
--- a/checkin-app/src/app/finance-ops/pending/page.tsx
+++ b/checkin-app/src/app/finance-ops/pending/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { Button, Center, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import { Button, Center, Loader, Stack, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
@@ -123,13 +123,6 @@ export default function PendingParticipantsPage() {
 
   return (
     <Stack>
-      <Group justify="space-between" align="flex-start" wrap="wrap">
-        <div>
-          <Title order={1}>Finance Operations</Title>
-          <Text c="dimmed">Payments and billing review.</Text>
-        </div>
-      </Group>
-
       <Text c="dimmed">
         Review pending participants who have clicked the &quot;Request Payment Plan&quot; button.
         Approving a request marks the user as ACTIVE and exempts them from the 7-day automated

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Alert, Badge, Button, Card, Center, Group, Loader, Stack, Text, Title } from "@mantine/core";
+import { Alert, Badge, Button, Card, Center, Group, Loader, Stack, Text } from "@mantine/core";
 import { AlertBanner } from "@/components/admin/AlertBanner";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 
@@ -159,8 +159,6 @@ export default function AdminMembershipPage() {
 
   return (
     <Stack>
-      <Title order={1}>Membership Applications</Title>
-
       <Text c="dimmed">
         In-flight applications. Use the manual controls below to confirm the contract was signed
         or that background-check consent was received. (The contract is also confirmed

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { Button, Center, Group, List, Loader, Stack, Table, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
@@ -99,8 +98,6 @@ export default function AdminHouseholdsPage() {
 
   return (
     <Stack>
-      <AdminPageHeader title="Manage Memberships" back={{ href: '/membership-ops', label: '← Membership Ops' }} />
-
       <Text c="dimmed">
         View all households and toggle their official facility Membership status. Memberships grant
         shop access and other organizational privileges. Denying membership blocks login for every

--- a/checkin-app/src/app/membership-ops/layout.tsx
+++ b/checkin-app/src/app/membership-ops/layout.tsx
@@ -44,9 +44,6 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
 
   return (
     <Stack>
-      <Text fw={800} size="lg" c="blue">
-        Membership Ops
-      </Text>
       <Tabs value={activeTab} onChange={(value) => value && router.push(value)}>
         <ScrollableTabsList>
           {MEMBERSHIP_OPS_NAV_LINKS.map((link) => {

--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -236,7 +236,6 @@ export default function MergeParticipants() {
   return (
     <Stack maw={1000} mx="auto">
       <div>
-        <Title order={1}>Merge Participants</Title>
         <Text c="dimmed">
           Combine two participant records. The data from the merged record (visits, programs, etc)
           will be moved to the kept record. The merged record will be tombstoned.

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -180,7 +180,6 @@ export default function AdminParticipantsIndex() {
     <Stack maw={1000} mx="auto">
       <Group justify="space-between" align="flex-start" wrap="wrap">
         <div>
-          <Title order={1}>Participants</Title>
           <Text c="dimmed">Search and manage system participants and households.</Text>
         </div>
         <Group>

--- a/checkin-app/src/app/membership-ops/unclaimed/page.tsx
+++ b/checkin-app/src/app/membership-ops/unclaimed/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Badge, Box, Card, Group, Stack, Text, Title } from "@mantine/core";
+import { Badge, Box, Card, Group, Stack, Text } from "@mantine/core";
 
 type UnclaimedHousehold = {
   id: number;
@@ -31,7 +31,6 @@ export default function UnclaimedHouseholdsIndex() {
   return (
     <Stack maw={1000} mx="auto">
       <div>
-        <Title order={1}>Unclaimed Accounts</Title>
         <Text c="dimmed">Households with at least one member who has an email but has never signed in with Google.</Text>
       </div>
 

--- a/checkin-app/src/app/shop/layout.tsx
+++ b/checkin-app/src/app/shop/layout.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { Alert, Button, Card, Center, Container, Group, Loader, Tabs, Text, Title } from "@mantine/core";
+import { Alert, Button, Card, Center, Container, Loader, Tabs, Title } from "@mantine/core";
 import { ScrollableTabsList } from "@/components/ui/ScrollableTabsList";
 import { SHOP_NAV_LINKS, shopRoles } from "@/lib/shopNav";
 
@@ -64,13 +64,6 @@ export default function ShopLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <Container size="lg" pb="md">
-      <Group justify="space-between" align="flex-start" mb="lg" wrap="wrap">
-        <div>
-          <Title order={1}>Shop Operations</Title>
-          <Text c="dimmed">Centralized hub for tool management and safety certifications.</Text>
-        </div>
-      </Group>
-
       <Tabs
         value={active}
         onChange={(value) => {


### PR DESCRIPTION
## What

Remove redundant section labels and per-page `<Title order={1}>` headings that sat above the ops tab bars. Each duplicated either the active tab label or the visible URL/breadcrumb, adding vertical noise.

- **finance-ops/pending** — removed the "Finance Operations / Payments and billing review." header block
- **membership-ops layout** — removed the "Membership Ops" label above the tabs
- **membership-ops tab pages** — dropped the h1 that repeated the tab name on Participants, Merge Participants, Manage Memberships (households), Membership Applications, Unclaimed Accounts. Households also drops the now-redundant "← Membership Ops" back link (tabs cover that nav).
- **shop layout** — removed the "Shop Operations" header block above the tabs

## Why

The tab bar already names the current tool, and the URL shows the section. The extra heading was pure duplication.

## Notes

- Descriptive subtitles under each removed title are kept.
- Unused imports left by the removals (`Group`, `Title`, `Text`, `AdminPageHeader`) were pruned; `Title` retained where still used (modals, Access Denied states).
- UI-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)