### PR TITLE
fix(memberships): remove back link from households header

### DIFF
--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -99,7 +99,7 @@ export default function AdminHouseholdsPage() {
 
   return (
     <Stack>
-      <AdminPageHeader title="Manage Memberships" back={{ href: '/membership-ops', label: '← Membership Ops' }} />
+      <AdminPageHeader title="Manage Memberships" />
 
       <Text c="dimmed">
         View all households and toggle their official facility Membership status. Memberships grant


### PR DESCRIPTION
## What

Remove the "← Membership Ops" back link from the Manage Memberships (households) page header.

## Why

Requested cleanup — the back link is no longer wanted on this page.

## Notes

`AdminPageHeader`'s `back` prop is optional, so the header renders cleanly with the prop dropped. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)