### PR TITLE
fix(system-status): remove stale unclaimed-students warning

### DIFF
--- a/checkin-app/src/app/system-status/page.tsx
+++ b/checkin-app/src/app/system-status/page.tsx
@@ -1,28 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Alert, Card, Center, Group, List, Loader, SimpleGrid, Stack, Text, Title } from "@mantine/core";
-import { IconAlertTriangle } from "@tabler/icons-react";
+import { Card, Center, Group, List, Loader, SimpleGrid, Stack, Text, Title } from "@mantine/core";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { BadgeScanChart, SystemVersionBox } from "@/components/admin/SystemHealthPanels";
 
-type Orphan = { id: number; name?: string | null; email?: string | null };
-
 export default function SystemStatusIndex() {
   const { user, loading, ready } = useRequireRole(["sysadmin", "boardMember"]);
-  const [orphans, setOrphans] = useState<Orphan[]>([]);
-
-  useEffect(() => {
-    if (!ready) return;
-    fetch('/api/admin/orphans')
-      .then(res => res.json())
-      .then(data => {
-        if (data.orphans) {
-          setOrphans(data.orphans);
-        }
-      })
-      .catch(console.error);
-  }, [ready]);
 
   if (loading) {
     return (
@@ -42,23 +25,6 @@ export default function SystemStatusIndex() {
           status and pending tasks.
         </Text>
       </div>
-
-      {orphans.length > 0 && (
-        <Alert color="red" icon={<IconAlertTriangle size={18} />} title="Attention Required">
-          <Text mb="sm">
-            There are {orphans.length} student(s) registered whose parents have not yet claimed
-            their accounts. These students cannot be tracked correctly until their households are
-            linked.
-          </Text>
-          <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing="xs">
-            {orphans.map((o) => (
-              <Text key={o.id} fw={500} size="sm">
-                {o.name || o.email || `Student ID ${o.id}`}
-              </Text>
-            ))}
-          </SimpleGrid>
-        </Alert>
-      )}
 
       <SimpleGrid cols={{ base: 1, sm: 2 }}>
         <Card withBorder radius="md" padding="lg">


### PR DESCRIPTION
## What

Removes the red **"Attention Required"** alert on `/system-status` that listed students whose parents had not yet claimed their accounts.

## Why

- The warning was inaccurate.
- Its function now lives at `/membership-ops/unclaimed`.

## Changes

- Drop the `Alert` block from `system-status/page.tsx`.
- Remove now-dead supporting code: `orphans` state, the `useEffect` fetch to `/api/admin/orphans`, the `Orphan` type, and the unused `Alert` / `IconAlertTriangle` imports.

## Notes for reviewer

- `/api/admin/orphans` route left intact — still covered by tests and likely backs the new `/membership-ops/unclaimed` page. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)