### PR TITLE
fix(kioskdisplay): skip force-checkout confirm for self-checkout

### DIFF
--- a/checkin-app/src/app/kioskdisplay/page.tsx
+++ b/checkin-app/src/app/kioskdisplay/page.tsx
@@ -200,8 +200,8 @@ function KioskDisplayInner() {
     }
   };
 
-  const handleForceCheckout = async (visitId: number) => {
-    if (!confirm("Are you sure you want to force checkout this user?")) return;
+  const handleForceCheckout = async (visitId: number, isSelf: boolean = false) => {
+    if (!isSelf && !confirm("Are you sure you want to force checkout this user?")) return;
     setCheckingOut(visitId);
     try {
       const res = await fetch("/api/attendance", {
@@ -210,7 +210,7 @@ function KioskDisplayInner() {
         body: JSON.stringify({ visitId }),
       });
       if (res.ok) refreshAttendance();
-      else alert("Failed to force checkout.");
+      else alert(isSelf ? "Failed to check out." : "Failed to force checkout.");
     } catch (e) {
       console.error(e);
       alert("Network error.");
@@ -284,7 +284,7 @@ function KioskDisplayInner() {
             )}
           </Box>
           {showCheckout && (
-            <Button size="compact-xs" color="red" variant="light" onClick={() => handleForceCheckout(visit.id)} disabled={checkingOut === visit.id}>
+            <Button size="compact-xs" color="red" variant="light" onClick={() => handleForceCheckout(visit.id, visit.participant.id === (session?.user as SessionUser)?.id)} disabled={checkingOut === visit.id}>
               {checkingOut === visit.id ? "..." : "Out"}
             </Button>
           )}


### PR DESCRIPTION
## What

Self-checkout on the kioskdisplay page now goes through without the "Are you sure you want to force checkout this user?" confirm dialog, and a failed self-checkout shows "Failed to check out." instead of "Failed to force checkout."

## Why

Self-checkout and forcing another user out shared one handler (`handleForceCheckout`). The backend (`DELETE /api/attendance`) already accepts self-checkout via the `isSelf` permission path — there is no `force` flag. So checking yourself out always worked, but the UI wrapped it in a "force checkout" confirm and error wording aimed at admins forcing others out.

## Change

`handleForceCheckout` takes an `isSelf` arg: when true, skip the confirm and use neutral error copy. The call site passes `visit.participant.id === current user id`. Forcing another user out (household lead / admin) is unchanged — still confirms.

## Reviewer notes

- No backend change; permission model untouched.
- One UI branch, no test added.