### PR TITLE
fix(membership-ops): drop redundant h1 on review tab

### DIFF
--- a/checkin-app/src/app/membership/review/page.tsx
+++ b/checkin-app/src/app/membership/review/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { Alert, Button, Card, Center, Checkbox, Container, Group, Loader, Stack, Text, Title } from "@mantine/core";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
@@ -21,6 +22,9 @@ interface QueueItem {
 
 export default function MembershipReviewPage() {
   const { status: sessionStatus } = useSession();
+  // Inside the Membership Ops section the tab bar already labels this page, so the
+  // h1 is redundant there; keep it on the standalone /membership/review route.
+  const inOps = usePathname().startsWith("/membership-ops");
   const [queue, setQueue] = useState<QueueItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [forbidden, setForbidden] = useState(false);
@@ -97,7 +101,7 @@ export default function MembershipReviewPage() {
   return (
     <Container size="md" pb="md">
       <Group justify="space-between" align="center" wrap="wrap" mb="md">
-        <Title order={1}>Background-check review</Title>
+        {!inOps && <Title order={1}>Background-check review</Title>}
         <Button component={Link} href="/" variant="default">← Home</Button>
       </Group>
 


### PR DESCRIPTION
## What
Hide the per-page `<Title order={1}>Background-check review</Title>` h1 when the page renders inside the Membership Ops section (`/membership-ops/review`), where the tab bar already shows the "Background-check Review" label.

## Why
The Background-check Review tab (#413) landed after the ops-header cleanup (#410), which dropped redundant per-page h1s across the other ops tabs. This tab missed that pass, so its h1 duplicated the tab label.

## Note for reviewers
The component is shared: it also serves the standalone `/membership/review` route (linked from the home Notifications card and reviewer emails), where there is **no** tab bar. The fix gates the h1 on `usePathname().startsWith("/membership-ops")` so the standalone route keeps its title. `Title` is still used by the not-authorized branch, so no import was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)