### PR TITLE
fix(membership-ops): hide Merge Participants from nav until merge bug fixed

### DIFF
--- a/checkin-app/src/lib/membershipOpsNav.ts
+++ b/checkin-app/src/lib/membershipOpsNav.ts
@@ -12,7 +12,23 @@ export interface MembershipOpsNavLink {
 
 export const MEMBERSHIP_OPS_NAV_LINKS: MembershipOpsNavLink[] = [
   { name: "Participants", href: "/membership-ops/participants", icon: "👥", description: "Browse and manage participant profiles." },
-  { name: "Merge Participants", href: "/membership-ops/participants/merge", icon: "🔗", description: "Combine duplicate participant records." },
+  // HIDDEN: "Merge Participants" is unlinked until the merge API reconciles join-table
+  // collisions instead of blind-deleting the merge-side row.
+  // The merge route (src/app/api/admin/participants/merge/route.ts, lines 82-145) resolves
+  // unique-key collisions on join tables by blind-deleting the merge-side row, ignoring which
+  // row holds better data. When both participants have a row on the same key this silently
+  // downgrades data:
+  //   - toolStatus: keep=BASIC + merge=MAY_CERTIFY_OTHERS -> higher cert destroyed, survivor
+  //     left at BASIC (safety/tool-access regression).
+  //   - programParticipant: keep=PENDING + merge=ACTIVE -> active enrollment reverted to PENDING.
+  //   - feePayment / rsvp: merge-side payment metadata (customNote, shopifyLink,
+  //     quickBooksInvoice, paidOn) and RSVP status dropped.
+  // Correct fix reconciles the two rows (higher cert level, ACTIVE over PENDING, the row with
+  // payment metadata) instead of deleting the merge-side row. Until that lands the feature is
+  // hidden so admins cannot silently corrupt certification/enrollment data via a merge. Page and
+  // API route are kept intact. See it.failing cases ("should keep the HIGHER" / "should keep the
+  // ACTIVE") in src/app/api/admin/participants/merge/__tests__/route.integration.test.ts.
+  // { name: "Merge Participants", href: "/membership-ops/participants/merge", icon: "🔗", description: "Combine duplicate participant records." },
   { name: "Manage Memberships", href: "/membership-ops/households", icon: "🏠", description: "Grant or revoke household facility membership." },
   { name: "Membership Applications", href: "/membership-ops/applications", icon: "📋", description: "Review and approve membership applications." },
   { name: "Unclaimed Accounts", href: "/membership-ops/unclaimed", icon: "📨", description: "Households with an email but no Google sign-in yet." },


### PR DESCRIPTION
## What

Comment out the **Merge Participants** entry in `checkin-app/src/lib/membershipOpsNav.ts` so the page at `/membership-ops/participants/merge` is no longer reachable from the Membership Ops UI. Page and API route are left intact.

## Why

The merge API route (`checkin-app/src/app/api/admin/participants/merge/route.ts`, lines 82-145) resolves unique-key collisions on join tables by **blind-deleting the merge-side row**, ignoring which row holds better data. When both participants have a row on the same key, this silently downgrades data:

- **toolStatus**: keep=`BASIC` + merge=`MAY_CERTIFY_OTHERS` destroys the higher cert, leaving the survivor at `BASIC` (safety/tool-access regression).
- **programParticipant**: keep=`PENDING` + merge=`ACTIVE` reverts the active enrollment to `PENDING`.
- **feePayment / rsvp**: merge-side payment metadata (`customNote`, `shopifyLink`, `quickBooksInvoice`, `paidOn`) and RSVP status are dropped.

The correct fix reconciles the two rows (higher cert level, `ACTIVE` over `PENDING`, the row with payment metadata) instead of deleting the merge-side row. Until that lands, the feature is hidden so admins cannot silently corrupt certification/enrollment data via a merge.

## Notes for reviewer

- The full rationale is left as a code comment above the disabled nav entry.
- Failing `it.failing` cases already document the bug: search `"should keep the HIGHER"` / `"should keep the ACTIVE"` in `checkin-app/src/app/api/admin/participants/merge/__tests__/route.integration.test.ts`.
- Grep confirmed `membershipOpsNav.ts` was the only user-facing link to the route.
- ESLint clean on the changed file. (Pre-commit test hook reports 0 tests — known worktree `testPathIgnorePatterns` artifact, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)