### PR TITLE
fix(ui): unify sort-header icons across facility/membership tables

### DIFF
--- a/checkin-app/src/app/facility/visits/page.tsx
+++ b/checkin-app/src/app/facility/visits/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button, Center, Group, Loader, Stack, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
+import { IconChevronDown, IconChevronUp, IconSelector } from '@tabler/icons-react';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
@@ -50,18 +51,20 @@ export default function AdminVisitsPage() {
   const toggleSort = (key: SortKey) =>
     setSort((s) => s.key === key ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'asc' });
 
-  const SortableTh = ({ k, label }: { k: SortKey; label: string }) => (
-    <Table.Th>
-      <UnstyledButton onClick={() => toggleSort(k)} style={{ font: 'inherit' }}>
-        <Group gap={4} wrap="nowrap">
-          <span>{label}</span>
-          <Text component="span" c={sort.key === k ? undefined : 'dimmed'} size="xs">
-            {sort.key === k ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}
-          </Text>
-        </Group>
-      </UnstyledButton>
-    </Table.Th>
-  );
+  const SortableTh = ({ k, label }: { k: SortKey; label: string }) => {
+    const active = sort.key === k;
+    const Icon = !active ? IconSelector : sort.dir === 'asc' ? IconChevronUp : IconChevronDown;
+    return (
+      <Table.Th>
+        <UnstyledButton onClick={() => toggleSort(k)} style={{ font: 'inherit' }}>
+          <Group gap={4} wrap="nowrap">
+            <span>{label}</span>
+            <Icon size={14} stroke={1.5} />
+          </Group>
+        </UnstyledButton>
+      </Table.Th>
+    );
+  };
 
   const fetchVisits = useCallback(async () => {
     try {

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Alert, Box, Button, Card, Group, Modal, Paper, Stack, Table, Text, TextInput, Title, UnstyledButton } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
+import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons-react";
 import { EntityPicker } from "@/components/admin/EntityPicker";
 import { AdminEditHouseholdModal } from "@/components/admin/AdminEditHouseholdModal";
 
@@ -212,13 +213,20 @@ export default function AdminParticipantsIndex() {
                       { key: "name", label: "Name" },
                       { key: "email", label: "Email" },
                       { key: "household", label: "Household" },
-                    ] as const).map((c) => (
-                      <Table.Th key={c.key}>
-                        <UnstyledButton onClick={() => toggleSort(c.key)} style={{ fontWeight: 600, fontSize: "inherit" }}>
-                          {c.label}{sortBy === c.key ? (sortDir === "asc" ? " ▲" : " ▼") : ""}
-                        </UnstyledButton>
-                      </Table.Th>
-                    ))}
+                    ] as const).map((c) => {
+                      const active = sortBy === c.key;
+                      const Icon = !active ? IconSelector : sortDir === "asc" ? IconChevronUp : IconChevronDown;
+                      return (
+                        <Table.Th key={c.key}>
+                          <UnstyledButton onClick={() => toggleSort(c.key)} style={{ fontWeight: 600, fontSize: "inherit" }}>
+                            <Group gap={4} wrap="nowrap">
+                              {c.label}
+                              <Icon size={14} stroke={1.5} />
+                            </Group>
+                          </UnstyledButton>
+                        </Table.Th>
+                      );
+                    })}
                     <Table.Th>Actions</Table.Th>
                   </Table.Tr>
                 </Table.Thead>


### PR DESCRIPTION
## What

Make the sort indicators on **Facility → Visits** and **Membership Ops → Participants** match the master pattern on **Facility → Badges**.

- Badges (via the shared `DataTable`) uses `@tabler/icons-react`: `IconSelector` on inactive sortable columns, `IconChevronUp`/`IconChevronDown` on the active one.
- **Visits** used Unicode text glyphs (`↕`/`▲`/`▼`).
- **Participants** showed **nothing** on inactive sortable columns — clickable but no affordance until you sorted by them.

## Why

Inconsistent sort UI across three tables. Badges is the reference. Participants in particular gave no hint its columns were sortable.

## Changes

- `facility/visits/page.tsx` — `SortableTh` now renders the tabler icons instead of glyphs.
- `membership-ops/participants/page.tsx` — header map now renders `IconSelector` on inactive columns and the active chevron, wrapped in a `Group` to match Badges.

Result: all three tables now render an identical affordance — `IconSelector` on every inactive sortable column, up/down chevron on the active one. Non-sortable columns (Actions) stay plain.

## Reviewer notes

UI-only, no logic/data changes. Did not migrate Visits/Participants onto the shared `DataTable` (bigger diff — each has its own sort state + fetch/filter/edit logic); just aligned the icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)