### PR TITLE
feat(membership): make the background check non-blocking in the application flow

### DIFF
--- a/checkin-app/prisma/migrations/20260628120000_bg_check_nonblocking/migration.sql
+++ b/checkin-app/prisma/migrations/20260628120000_bg_check_nonblocking/migration.sql
@@ -1,0 +1,26 @@
+-- Background check becomes a parallel (non-blocking) track in the membership
+-- application flow. Adds the PENDING_BG_CLEARANCE status (paid, awaiting check)
+-- and a bgClearedAt marker, then backfills existing rows so nothing regresses.
+
+-- AlterEnum: new "paid, awaiting background check" holding status.
+-- (Not used in this migration's data statements, so it is safe inside the
+-- migration transaction on PostgreSQL 12+.)
+ALTER TYPE "MembershipProcessStatus" ADD VALUE 'PENDING_BG_CLEARANCE';
+
+-- AlterTable: single source of truth for "BG cleared this cycle".
+ALTER TABLE "MembershipProcess" ADD COLUMN "bgClearedAt" TIMESTAMP(3);
+
+-- Backfill 1: any process already at or past payment cleared its background
+-- check under the old (sequential) ordering, so mark it cleared. Use the most
+-- meaningful timestamp available.
+UPDATE "MembershipProcess"
+   SET "bgClearedAt" = COALESCE("paidAt", "stageEnteredAt", CURRENT_TIMESTAMP)
+ WHERE "status" IN ('PENDING_PAYMENT', 'ACTIVE');
+
+-- Backfill 2: in-flight INITIAL applications still in background review move to
+-- PENDING_PAYMENT so they are unblocked immediately; their review continues in
+-- parallel (bgClearedAt stays NULL until two reviewers approve). Renewal review
+-- (RENEWAL_PENDING_BG) is intentionally left as-is.
+UPDATE "MembershipProcess"
+   SET "status" = 'PENDING_PAYMENT', "stageEnteredAt" = CURRENT_TIMESTAMP
+ WHERE "status" = 'PENDING_BG_REVIEW';

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -233,6 +233,11 @@ enum MembershipProcessStatus {
   PENDING_EXTERNAL_ACTION
   PENDING_BG_REVIEW
   PENDING_PAYMENT
+  // Paid, but the background check has not yet cleared. The membership stays
+  // INACTIVE here — it activates automatically once two reviewers approve (or a
+  // prior valid check is detected). The BG review runs in parallel with payment,
+  // so an applicant is never forced to wait on the long-tail check before paying.
+  PENDING_BG_CLEARANCE
   ACTIVE
   BLOCKED
   PENDING_RENEWAL
@@ -310,6 +315,12 @@ model MembershipProcess {
   contractSignedAt      DateTime?
   /// @sensitivity:internal
   bgConsentAt           DateTime?
+  /// When the background-check requirement was satisfied for this cycle — either
+  /// two reviewers approved, or a still-valid prior check was detected at intake.
+  /// The single source of truth for "BG cleared", independent of the payment
+  /// track; the membership only goes ACTIVE once this is set AND dues are paid.
+  /// @sensitivity:internal
+  bgClearedAt           DateTime?
   /// @sensitivity:internal
   shopifyDraftOrderId   String?
   /// @sensitivity:personal

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -15,6 +15,7 @@ import { markContractSigned, markBgConsent } from '@/lib/membership/external';
 import { attest } from '@/lib/membership/review';
 import { certifyPaymentPlan, activate } from '@/lib/membership/payment';
 import { submitIntake } from '@/lib/membership/intake';
+import { beginRenewal } from '@/lib/membership/renewal';
 import prisma from '@/lib/prisma';
 import { sendEmail } from '@/lib/email';
 
@@ -40,6 +41,18 @@ async function makeBoardMember(): Promise<number> {
         data: { email: `board-${TAG}@example.com`, name: 'Board', boardMember: true, household: { create: { name: `Board HH ${TAG}` } } },
     });
     return r.id;
+}
+
+/** ACTIVE membership + lead with a valid prior check + a PENDING_RENEWAL process. */
+async function makeFreshRenewal() {
+    const hh = await prisma.household.create({ data: { name: `Renewal ${TAG} ${Math.random()}` } });
+    const lead = await prisma.participant.create({
+        data: { email: `rlead-${Math.random()}-${TAG}@example.com`, name: 'R Lead', householdId: hh.id, lastBackgroundCheck: new Date() },
+    });
+    await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+    const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
+    const proc = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
+    return { membershipId: m.id, processId: proc.id };
 }
 
 /** Applicant household + a lead + membership + a process at the given status. */
@@ -191,6 +204,18 @@ describe('background check is non-blocking', () => {
         await markContractSigned(processId);
         expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
         await certifyPaymentPlan(processId, lead!.id);
+        expect(await statusOf(processId)).toBe('ACTIVE');
+        expect(await membershipStatusOf(membershipId)).toBe('ACTIVE');
+    });
+
+    it('renewal with a still-valid check → PENDING_PAYMENT + bgClearedAt, then paying activates (not stuck)', async () => {
+        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
+        const { membershipId, processId } = await makeFreshRenewal();
+        await beginRenewal(processId);
+        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe('PENDING_PAYMENT');
+        expect(proc?.bgClearedAt).not.toBeNull(); // the bug: was null → paid renewal stuck forever
+        await activate(processId, { via: 'payment', shopifyOrderId: 'renew-pay' });
         expect(await statusOf(processId)).toBe('ACTIVE');
         expect(await membershipStatusOf(membershipId)).toBe('ACTIVE');
     });

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -235,4 +235,12 @@ describe('background check is non-blocking', () => {
         const activations = audits.filter((a) => String(a.newData).includes('"status":"ACTIVE"')).length;
         expect(activations).toBe(1);
     });
+
+    it('a stray payment for a process not awaiting payment is ignored (no state corruption)', async () => {
+        const { processId } = await makeApplicant('PENDING_EXTERNAL_ACTION'); // no checkout link exists for this phase
+        await activate(processId, { via: 'payment', shopifyOrderId: 'stray' });
+        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe('PENDING_EXTERNAL_ACTION');
+        expect(proc?.paidAt).toBeNull();
+    });
 });

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration coverage for the non-blocking background-check flow.
+ *
+ * The check is now a PARALLEL track: after the contract is signed + consent is
+ * given (or a valid prior check exists), the application advances straight to
+ * PENDING_PAYMENT. The membership only goes ACTIVE once BOTH payment and the
+ * check are done — whichever finishes last. A valid prior check auto-clears the
+ * requirement; a reject after payment blocks (and would need a manual refund).
+ */
+
+import { markContractSigned, markBgConsent } from '@/lib/membership/external';
+import { attest } from '@/lib/membership/review';
+import { certifyPaymentPlan, activate } from '@/lib/membership/payment';
+import { submitIntake } from '@/lib/membership/intake';
+import prisma from '@/lib/prisma';
+
+jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+
+const TAG = 'bg-nonblocking-test';
+
+async function makeReviewer(label: string): Promise<number> {
+    const r = await prisma.participant.create({
+        data: {
+            email: `${label}-${TAG}@example.com`,
+            name: label,
+            backgroundCheckReviewer: true,
+            household: { create: { name: `${label} HH ${TAG}` } },
+        },
+    });
+    return r.id;
+}
+
+/** Applicant household + a lead + membership + a process at the given status. */
+async function makeApplicant(status: 'PENDING_EXTERNAL_ACTION', extra: { lastBackgroundCheck?: Date } = {}) {
+    const hh = await prisma.household.create({ data: { name: `Applicant ${TAG} ${Math.random()}` } });
+    const lead = await prisma.participant.create({
+        data: { email: `lead-${Math.random()}-${TAG}@example.com`, name: 'Lead Parent', householdId: hh.id, lastBackgroundCheck: extra.lastBackgroundCheck ?? null },
+    });
+    await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+    const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
+    const proc = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status } });
+    return { householdId: hh.id, membershipId: m.id, processId: proc.id, leadId: lead.id };
+}
+
+const statusOf = async (id: number) => (await prisma.membershipProcess.findUnique({ where: { id } }))?.status;
+const membershipStatusOf = async (id: number) => (await prisma.membership.findUnique({ where: { id } }))?.status;
+
+async function wipe() {
+    const hhs = await prisma.household.findMany({
+        where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] },
+        select: { id: true },
+    });
+    const ids = hhs.map((h) => h.id);
+    if (ids.length) {
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: ids } } } } });
+        await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
+        await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.emergencyContact.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: ids } } });
+    }
+    await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+}
+
+describe('background check is non-blocking', () => {
+    let revA: number, revB: number;
+    let prevBgRecheckMonths = 0;
+
+    beforeAll(async () => {
+        await wipe();
+        // BoardSettings (id=1) is a global singleton; remember what we change so the
+        // auto-clear scenario doesn't pollute other suites' BoardSettings reads.
+        prevBgRecheckMonths = (await prisma.boardSettings.findUnique({ where: { id: 1 } }))?.bgRecheckMonths ?? 0;
+        revA = await makeReviewer('RevA');
+        revB = await makeReviewer('RevB');
+    });
+    afterAll(async () => {
+        await wipe();
+        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: prevBgRecheckMonths }, update: { bgRecheckMonths: prevBgRecheckMonths } });
+        await prisma.$disconnect();
+    });
+
+    it('contract + consent advance to PENDING_PAYMENT (not BG review) — payment unblocked', async () => {
+        const { processId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        await markContractSigned(processId);
+        expect(await statusOf(processId)).toBe('PENDING_EXTERNAL_ACTION'); // consent still missing
+        await markBgConsent(processId, revA);
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT'); // payment available; review runs in parallel
+    });
+
+    it('pay before the check clears → holds at PENDING_BG_CLEARANCE, then 2 approvals activate', async () => {
+        const { processId, membershipId, householdId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        await markContractSigned(processId);
+        await markBgConsent(processId, revA);
+        // Pay first.
+        await certifyPaymentPlan(processId, revA);
+        expect(await statusOf(processId)).toBe('PENDING_BG_CLEARANCE');
+        expect(await membershipStatusOf(membershipId)).toBe('NONE'); // NOT active without a valid check
+
+        // Review clears in parallel; the 2nd approval converges to ACTIVE.
+        await attest(revA, processId, { result: 'APPROVE' });
+        expect(await statusOf(processId)).toBe('PENDING_BG_CLEARANCE');
+        await attest(revB, processId, { result: 'APPROVE' });
+        expect(await statusOf(processId)).toBe('ACTIVE');
+        expect(await membershipStatusOf(membershipId)).toBe('ACTIVE');
+        // Guardians' lastBackgroundCheck stamped.
+        const lead = await prisma.participant.findUnique({ where: { id: leadId } });
+        expect(lead?.lastBackgroundCheck).not.toBeNull();
+        expect(householdId).toBeGreaterThan(0);
+    });
+
+    it('check clears before payment → stays PENDING_PAYMENT, then paying activates', async () => {
+        const { processId, membershipId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        await markContractSigned(processId);
+        await markBgConsent(processId, revA);
+        await attest(revA, processId, { result: 'APPROVE' });
+        await attest(revB, processId, { result: 'APPROVE' });
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT'); // cleared, but unpaid → not active
+        expect(await membershipStatusOf(membershipId)).toBe('NONE');
+        await certifyPaymentPlan(processId, revA);
+        expect(await statusOf(processId)).toBe('ACTIVE');
+        expect(await membershipStatusOf(membershipId)).toBe('ACTIVE');
+    });
+
+    it('reject after payment → BLOCKED, membership stays inactive', async () => {
+        const { processId, membershipId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        await markContractSigned(processId);
+        await markBgConsent(processId, revA);
+        await certifyPaymentPlan(processId, revA); // paid → PENDING_BG_CLEARANCE
+        await attest(revA, processId, { result: 'REJECT' });
+        expect(await statusOf(processId)).toBe('BLOCKED');
+        expect(await membershipStatusOf(membershipId)).toBe('NONE');
+    });
+
+    it('a still-valid prior check auto-clears at submit — no consent needed, pay activates directly', async () => {
+        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
+        const { processId, membershipId, householdId } = await makeApplicant('PENDING_EXTERNAL_ACTION', { lastBackgroundCheck: new Date() });
+        // Reset the process to INTAKE with the household fully filled so submitIntake passes validation.
+        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
+        await prisma.household.update({ where: { id: householdId }, data: { address: '123 Test St' } });
+        await prisma.emergencyContact.create({ data: { householdId, name: 'Out Of House', phone: '555-555-1212', phoneDigits: '5555551212', priority: 0 } });
+        const lead = await prisma.participant.findFirst({ where: { householdId, householdLeads: { some: { householdId } } } });
+
+        await submitIntake(lead!.id);
+        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe('PENDING_EXTERNAL_ACTION');
+        expect(proc?.bgClearedAt).not.toBeNull(); // auto-validated
+
+        // Contract alone advances (no BG consent needed), and paying activates immediately.
+        await markContractSigned(processId);
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
+        await certifyPaymentPlan(processId, lead!.id);
+        expect(await statusOf(processId)).toBe('ACTIVE');
+        expect(await membershipStatusOf(membershipId)).toBe('ACTIVE');
+    });
+
+    it('paying twice is idempotent (one activation)', async () => {
+        const { processId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        await markContractSigned(processId);
+        await markBgConsent(processId, revA);
+        await attest(revA, processId, { result: 'APPROVE' });
+        await attest(revB, processId, { result: 'APPROVE' }); // cleared, PENDING_PAYMENT
+        // The idempotent payment path is the Shopify webhook (activate), which a
+        // retry hits twice; the deliberate board certify rejects a non-payment phase.
+        await activate(processId, { via: 'payment', shopifyOrderId: 'pay-1' }); // ACTIVE
+        await activate(processId, { via: 'payment', shopifyOrderId: 'pay-2' }); // retry — no-op
+        expect(await statusOf(processId)).toBe('ACTIVE');
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true } });
+        const activations = audits.filter((a) => String(a.newData).includes('"status":"ACTIVE"')).length;
+        expect(activations).toBe(1);
+    });
+});

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -16,6 +16,7 @@ import { attest } from '@/lib/membership/review';
 import { certifyPaymentPlan, activate } from '@/lib/membership/payment';
 import { submitIntake } from '@/lib/membership/intake';
 import prisma from '@/lib/prisma';
+import { sendEmail } from '@/lib/email';
 
 jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
 
@@ -29,6 +30,14 @@ async function makeReviewer(label: string): Promise<number> {
             backgroundCheckReviewer: true,
             household: { create: { name: `${label} HH ${TAG}` } },
         },
+    });
+    return r.id;
+}
+
+/** A board member (notifyBoardPaidReject's recipient) in their own household. */
+async function makeBoardMember(): Promise<number> {
+    const r = await prisma.participant.create({
+        data: { email: `board-${TAG}@example.com`, name: 'Board', boardMember: true, household: { create: { name: `Board HH ${TAG}` } } },
     });
     return r.id;
 }
@@ -77,6 +86,7 @@ describe('background check is non-blocking', () => {
         prevBgRecheckMonths = (await prisma.boardSettings.findUnique({ where: { id: 1 } }))?.bgRecheckMonths ?? 0;
         revA = await makeReviewer('RevA');
         revB = await makeReviewer('RevB');
+        await makeBoardMember(); // recipient for the paid-reject refund alert
     });
     afterAll(async () => {
         await wipe();
@@ -134,6 +144,33 @@ describe('background check is non-blocking', () => {
         await attest(revA, processId, { result: 'REJECT' });
         expect(await statusOf(processId)).toBe('BLOCKED');
         expect(await membershipStatusOf(membershipId)).toBe('NONE');
+    });
+
+    it('reject BEFORE the payment webhook → payment still recorded + board notified (no dropped money)', async () => {
+        const { processId, membershipId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        await markContractSigned(processId);
+        await markBgConsent(processId, revA);            // → PENDING_PAYMENT
+        await attest(revA, processId, { result: 'APPROVE' });
+        await attest(revB, processId, { result: 'REJECT' }); // → BLOCKED, not yet paid
+        expect(await statusOf(processId)).toBe('BLOCKED');
+
+        (sendEmail as jest.Mock).mockClear();
+        await activate(processId, { via: 'payment', shopifyOrderId: 'late-pay' }); // webhook lands after the reject
+
+        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe('BLOCKED');                 // not resurrected
+        expect(proc?.paidAt).not.toBeNull();                  // payment recorded, not dropped
+        expect(proc?.shopifyOrderId).toBe('late-pay');
+        expect(await membershipStatusOf(membershipId)).toBe('NONE');
+        expect(sendEmail as jest.Mock).toHaveBeenCalled();    // board alerted for refund
+
+        // Webhook retry is idempotent: paidAt unchanged, no second alert.
+        const firstPaidAt = proc?.paidAt?.getTime();
+        (sendEmail as jest.Mock).mockClear();
+        await activate(processId, { via: 'payment', shopifyOrderId: 'late-pay' });
+        const proc2 = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        expect(proc2?.paidAt?.getTime()).toBe(firstPaidAt);
+        expect(sendEmail as jest.Mock).not.toHaveBeenCalled();
     });
 
     it('a still-valid prior check auto-clears at submit — no consent needed, pay activates directly', async () => {

--- a/checkin-app/src/app/__tests__/membershipContractSync.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSync.integration.test.ts
@@ -5,7 +5,7 @@
  * Integration tests for syncContractStatus — the PRIMARY contract-completion path
  * in dev (the Zoho webhook is unreliable against a scale-to-zero instance). Pulls
  * the signing status from Zoho on the signing-return (?signed=1), records the
- * contract signed, and advances the process to PENDING_BG_REVIEW when BG consent
+ * contract signed, and advances the process to PENDING_PAYMENT when BG consent
  * is already present. Best-effort: a Zoho hiccup is swallowed.
  *
  * Zoho is mocked (getAccessToken / getRequestStatus) like the other external tests.
@@ -18,7 +18,7 @@ import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
-// Advancing to PENDING_BG_REVIEW pings reviewers; don't hit Resend in tests.
+// Advancing to PENDING_PAYMENT pings reviewers; don't hit Resend in tests.
 jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
 // Mock the whole Zoho client so no real OAuth/HTTP happens. Only getAccessToken +
 // getRequestStatus are exercised by syncContractStatus; the rest are stubs.
@@ -65,7 +65,7 @@ async function audits(processId: number) {
     });
     return {
         signed: rows.filter((r) => String(r.newData).includes('"contractSignedAt":true')),
-        advanced: rows.filter((r) => String(r.newData).includes('"status":"PENDING_BG_REVIEW"')),
+        advanced: rows.filter((r) => String(r.newData).includes('"status":"PENDING_PAYMENT"')),
     };
 }
 
@@ -105,7 +105,7 @@ describe('syncContractStatus', () => {
         await prisma.$disconnect();
     });
 
-    it('HAPPY: Zoho signed=true records contractSignedAt and (with bgConsent present) advances to PENDING_BG_REVIEW', async () => {
+    it('HAPPY: Zoho signed=true records contractSignedAt and (with bgConsent present) advances to PENDING_PAYMENT', async () => {
         const { userId, processId } = await makeApplicant({ bgConsentAt: new Date() });
         mockGetRequestStatus.mockResolvedValue(true);
 
@@ -114,7 +114,7 @@ describe('syncContractStatus', () => {
         expect(status?.contractSigned).toBe(true);
         const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
         expect(p?.contractSignedAt).not.toBeNull();
-        expect(p?.status).toBe('PENDING_BG_REVIEW');
+        expect(p?.status).toBe('PENDING_PAYMENT');
 
         // Contract-signed audit is attributed to the signing applicant (actorId = userId).
         const a = await audits(processId);
@@ -157,7 +157,7 @@ describe('syncContractStatus', () => {
         await syncContractStatus(userId);
 
         const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
-        expect(p?.status).toBe('PENDING_BG_REVIEW');
+        expect(p?.status).toBe('PENDING_PAYMENT');
         const a = await audits(processId);
         expect(a.signed).toHaveLength(1);
         expect(a.advanced).toHaveLength(1);

--- a/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -111,13 +111,13 @@ describe('Membership EXTERNAL phase API', () => {
         expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
     });
 
-    it('marking BG consent after the contract advances to PENDING_BG_REVIEW', async () => {
+    it('marking BG consent after the contract advances to PENDING_PAYMENT', async () => {
         asBoard(boardId);
         const res = await BOARD_EXTERNAL(boardReq({ processId: procA, action: 'mark-bg-consent' }) as never);
         expect(res.status).toBe(200);
         const p = await prisma.membershipProcess.findUnique({ where: { id: procA } });
         expect(p?.bgConsentAt).not.toBeNull();
-        expect(p?.status).toBe('PENDING_BG_REVIEW');
+        expect(p?.status).toBe('PENDING_PAYMENT');
     });
 
     it('rejects a Zoho webhook with a bad token', async () => {
@@ -207,6 +207,6 @@ describe('Membership EXTERNAL phase API', () => {
         expect(ids).toEqual(expect.arrayContaining([procA, procB]));
         const a = data.processes.find((p: { id: number }) => p.id === procA);
         expect(a.membership.householdId).toBe(hhA);
-        expect(a.status).toBe('PENDING_BG_REVIEW');
+        expect(a.status).toBe('PENDING_PAYMENT');
     });
 });

--- a/checkin-app/src/app/__tests__/membershipExternalConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalConcurrency.integration.test.ts
@@ -32,7 +32,7 @@ async function makeExternalProcess(data: Record<string, unknown> = {}): Promise<
 
 async function advanceAudits(processId: number): Promise<number> {
     const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true } });
-    return audits.filter((a) => String(a.newData).includes('"status":"PENDING_BG_REVIEW"')).length;
+    return audits.filter((a) => String(a.newData).includes('"status":"PENDING_PAYMENT"')).length;
 }
 
 async function wipe() {
@@ -63,7 +63,7 @@ describe('EXTERNAL advance concurrency', () => {
         ]);
 
         const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
-        expect(proc?.status).toBe('PENDING_BG_REVIEW');
+        expect(proc?.status).toBe('PENDING_PAYMENT');
 
         // Exactly one advance audit row + exactly one reviewer ping.
         expect(await advanceAudits(processId)).toBe(1);

--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -57,7 +57,10 @@ describe('Membership payment API', () => {
             leadId = lead.id;
         }
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer } });
-        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT' } });
+        // bgClearedAt set: the background check has already cleared, so paying
+        // activates the membership (the BG-not-cleared path is covered by the
+        // non-blocking flow test).
+        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() } });
         return { householdId: hh.id, membershipId: m.id, processId: p.id };
     }
 
@@ -204,7 +207,8 @@ describe('Membership payment API', () => {
         const lead = await prisma.participant.create({ data: { email: `concurrent-${TAG}@example.com`, name: 'C Lead', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer: false } });
-        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT' } });
+        // bgClearedAt set so paying activates (and the one congrats email fires).
+        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() } });
 
         (sendEmail as jest.Mock).mockClear();
 

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -171,7 +171,7 @@ describe('Membership BG review API', () => {
         const res = await OVERRIDE(req({ processId: proc.processId, action: 'reset' }) as never);
         expect(res.status).toBe(200);
         const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
-        expect(updated?.status).toBe('PENDING_BG_REVIEW');
+        expect(updated?.status).toBe('PENDING_PAYMENT');
         const count = await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } });
         expect(count).toBe(0);
 

--- a/checkin-app/src/app/api/admin/membership/external/route.ts
+++ b/checkin-app/src/app/api/admin/membership/external/route.ts
@@ -12,7 +12,8 @@ export const dynamic = "force-dynamic";
  *   action 'mark-bg-consent'  — human-mark that Averity consent was submitted
  *   action 'set-envelope'     — associate a Zoho signing request id (needs envelopeId)
  *
- * Any action that completes both external steps advances the application to PENDING_BG_REVIEW.
+ * Completing the contract + background-check consent advances the application to
+ * PENDING_PAYMENT; the background check then reviews in parallel with payment.
  */
 export const POST = withAuth({ roles: ["sysadmin", "boardMember"] }, async (req, auth) => {
     if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/checkin-app/src/app/api/admin/membership/review-override/route.ts
+++ b/checkin-app/src/app/api/admin/membership/review-override/route.ts
@@ -7,8 +7,9 @@ export const dynamic = "force-dynamic";
 /**
  * POST /api/admin/membership/review-override — board action on a BLOCKED application.
  * Body: { processId, action: 'reset' | 'approve' }
- *   reset   — clear attestations, send back to PENDING_BG_REVIEW (re-ping reviewers)
- *   approve — board override straight to PENDING_PAYMENT
+ *   reset   — clear attestations, send back for re-review (re-ping reviewers)
+ *   approve — board override: clear the check, activating if already paid else
+ *             leaving it at PENDING_PAYMENT
  */
 export const POST = withAuth({ roles: ["sysadmin", "boardMember"] }, async (req, auth) => {
     if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/checkin-app/src/app/api/admin/membership/route.ts
+++ b/checkin-app/src/app/api/admin/membership/route.ts
@@ -24,6 +24,8 @@ export const GET = handler("GET /api/admin/membership", async () => {
             zohoEnvelopeId: true,
             contractSignedAt: true,
             bgConsentAt: true,
+            bgClearedAt: true,
+            paidAt: true,
             attestations: { select: { id: true, result: true, markedVolunteer: true } },
             membership: {
                 select: {

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -86,8 +86,16 @@ export async function POST(req: Request) {
         if (membershipProcessIdStr) {
             const processId = parseInt(membershipProcessIdStr, 10);
             if (!isNaN(processId)) {
-                await activateByProcessId(processId, order.id ? String(order.id) : "");
-                logger.info(`[SHOPIFY WEBHOOK] Activated membership for process ${processId}`);
+                const proc = await activateByProcessId(processId, order.id ? String(order.id) : "");
+                if (proc?.status === "ACTIVE") {
+                    logger.info(`[SHOPIFY WEBHOOK] Activated membership for process ${processId}`);
+                } else if (proc?.status === "BLOCKED") {
+                    logger.warn(`[SHOPIFY WEBHOOK] Payment recorded for BLOCKED process ${processId} — membership NOT activated; board notified for refund`);
+                } else if (proc?.status === "PENDING_BG_CLEARANCE") {
+                    logger.info(`[SHOPIFY WEBHOOK] Payment recorded for process ${processId}; awaiting background-check clearance`);
+                } else {
+                    logger.info(`[SHOPIFY WEBHOOK] Payment webhook for process ${processId} — no state change (already processed)`);
+                }
             }
             return NextResponse.json({ success: true });
         }

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -23,6 +23,8 @@ interface ProcessRow {
   zohoEnvelopeId: string | null;
   contractSignedAt: string | null;
   bgConsentAt: string | null;
+  bgClearedAt: string | null;
+  paidAt: string | null;
   attestations: Attestation[];
   membership: {
     householdId: number;
@@ -36,6 +38,7 @@ const STATUS_COLORS: Record<string, string> = {
   PENDING_EXTERNAL_ACTION: "blue",
   PENDING_BG_REVIEW: "grape",
   PENDING_PAYMENT: "orange",
+  PENDING_BG_CLEARANCE: "grape",
   BLOCKED: "red",
   PENDING_RENEWAL: "teal",
   RENEWAL_PENDING_BG: "grape",
@@ -43,6 +46,14 @@ const STATUS_COLORS: Record<string, string> = {
 
 const statusColor = (status: string) => STATUS_COLORS[status] || "gray";
 const statusLabel = (status: string) => status.replace(/_/g, " ");
+
+// The background check is a parallel track: an application still needs review
+// when it hasn't cleared and is past consent (mirrors review.ts isAwaitingBgReview).
+const awaitingBg = (r: ProcessRow) =>
+  !r.bgClearedAt &&
+  (r.status === "PENDING_BG_REVIEW" ||
+    r.status === "RENEWAL_PENDING_BG" ||
+    ((r.status === "PENDING_PAYMENT" || r.status === "PENDING_BG_CLEARANCE") && !!r.bgConsentAt));
 
 export default function AdminMembershipPage() {
   const [rows, setRows] = useState<ProcessRow[]>([]);
@@ -231,9 +242,9 @@ export default function AdminMembershipPage() {
                 </Group>
               )}
 
-              {r.status === "PENDING_BG_REVIEW" && (
+              {awaitingBg(r) && (
                 <Text size="sm" c="dimmed" mt="md">
-                  Awaiting reviewers — <Text component="span" fw={600}>{r.attestations.filter((a) => a.result === "APPROVE").length}/2</Text> approvals recorded.
+                  Background check (in parallel) — <Text component="span" fw={600}>{r.attestations.filter((a) => a.result === "APPROVE").length}/2</Text> approvals recorded.
                 </Text>
               )}
 
@@ -241,9 +252,15 @@ export default function AdminMembershipPage() {
                 <Group mt="md" gap="md" wrap="wrap" align="center">
                   <Text size="sm" c="dimmed">Awaiting payment.</Text>
                   <Button size="xs" fz={15} color="green" disabled={busyId === r.id} onClick={() => certify(r.id)}>
-                    Certify payment plan → activate
+                    Certify payment plan → {r.bgClearedAt ? "activate" : "(holds for background check)"}
                   </Button>
                 </Group>
+              )}
+
+              {r.status === "PENDING_BG_CLEARANCE" && (
+                <Text size="sm" c="dimmed" mt="md">
+                  Paid — membership activates automatically once the background check clears.
+                </Text>
               )}
 
               {r.status === "BLOCKED" && (

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -265,12 +265,17 @@ export default function AdminMembershipPage() {
 
               {r.status === "BLOCKED" && (
                 <Alert color="red" variant="light" mt="md" title="🚨 Blocked at background review — needs board attention.">
+                  {r.paidAt && (
+                    <Text size="sm" c="red" fw={700} mb="sm">
+                      💸 This household already paid — a refund is likely needed (membership was not activated).
+                    </Text>
+                  )}
                   <Group gap="sm" wrap="wrap">
                     <Button size="xs" fz={15} variant="default" disabled={busyId === r.id} onClick={() => override(r.id, "reset")}>
                       Reset for re-review
                     </Button>
                     <Button size="xs" fz={15} color="green" disabled={busyId === r.id} onClick={() => override(r.id, "approve")}>
-                      Override → payment
+                      Override → {r.paidAt ? "activate" : "payment"}
                     </Button>
                   </Group>
                 </Alert>

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -23,6 +23,7 @@ interface ExternalStatus {
   contractSigned: boolean;
   contractStarted: boolean;
   bgConsented: boolean;
+  bgCleared: boolean;
   deepLinkUrl: string | null;
 }
 
@@ -312,7 +313,7 @@ export default function MembershipPage() {
         setFieldErrors({});
         hydrate(data.state);
         notifyNavRefresh();
-        flash("Submitted! Next: sign your contract and consent to a background check.");
+        flash("Submitted! Next: sign your contract and start your background check — then you can pay right away.");
         setWarnings(saveWarnings);
       } else {
         // The server may flag fields the client can't check locally (e.g. an
@@ -529,10 +530,11 @@ export default function MembershipPage() {
               <Card withBorder radius="md" padding="lg">
                 <Stack gap="md">
                   <div>
-                    <Title order={2}>Two quick steps</Title>
+                    <Title order={2}>Sign &amp; start your background check</Title>
                     <Text c="dimmed">
-                      These can be done in any order. We&apos;ll move you forward automatically once
-                      both are complete.
+                      Once your agreement is signed and your background check is underway, we&apos;ll
+                      move you straight to payment — you won&apos;t have to wait for the check to come
+                      back.
                     </Text>
                   </div>
 
@@ -548,15 +550,27 @@ export default function MembershipPage() {
                     </Stack>
                   </ExternalTask>
 
-                  <ExternalTask done={!!state.external?.bgConsented} title="Consent to a background check" doneText="Background-check consent received.">
-                    {state.external?.deepLinkUrl ? (
-                      <Button component="a" href={state.external.deepLinkUrl} target="_blank" rel="noopener noreferrer">
-                        Consent on Averity →
-                      </Button>
-                    ) : (
-                      <Text c="dimmed">The background-check link isn&apos;t available yet. Please check back shortly.</Text>
-                    )}
-                  </ExternalTask>
+                  {state.external?.bgCleared ? (
+                    <ExternalTask done title="Background check" doneText="Your household&apos;s background check is still valid — no new check needed.">
+                      <Text c="dimmed" />
+                    </ExternalTask>
+                  ) : (
+                    <ExternalTask done={!!state.external?.bgConsented} title="Start your background check" doneText="Background check started — we&apos;ll finish it in the background.">
+                      <Stack gap="xs" align="flex-start">
+                        <Text c="dimmed">
+                          Consent to your background check on Averity. It runs in the background — you
+                          can keep going and pay while it completes.
+                        </Text>
+                        {state.external?.deepLinkUrl ? (
+                          <Button component="a" href={state.external.deepLinkUrl} target="_blank" rel="noopener noreferrer">
+                            Consent on Averity →
+                          </Button>
+                        ) : (
+                          <Text c="dimmed">The background-check link isn&apos;t available yet. Please check back shortly.</Text>
+                        )}
+                      </Stack>
+                    </ExternalTask>
+                  )}
 
                   <Button variant="default" disabled={saving} onClick={load} style={{ alignSelf: "flex-start" }}>
                     Refresh status
@@ -578,6 +592,12 @@ export default function MembershipPage() {
                     ) : (
                       <Text c="yellow" mt="md">The payment link isn&apos;t available yet. Please check back shortly.</Text>
                     )}
+                    {!state.external?.bgCleared && (
+                      <Alert color="blue" variant="light" mt="md">
+                        Your background check is being reviewed in the background — you can pay now.
+                        Your membership activates as soon as both the payment and the check are done.
+                      </Alert>
+                    )}
                     <Text size="sm" c="dimmed" mt="lg">
                       To discuss alternative arrangements, please email{" "}
                       <Anchor href="mailto:finance@innovationtreehouse.org">finance@innovationtreehouse.org</Anchor>.
@@ -586,6 +606,15 @@ export default function MembershipPage() {
                 ) : (
                   <Text c="dimmed">Preparing your invoice…</Text>
                 )}
+              </Card>
+            ) : inStatus === "PENDING_BG_CLEARANCE" ? (
+              <Card withBorder radius="md" padding="lg">
+                <Title order={2} mb="sm">Payment received 🎉</Title>
+                <Text c="dimmed">
+                  Thanks — your dues are paid. We&apos;re just finishing your background check. Your
+                  membership activates automatically the moment it clears, and we&apos;ll email you
+                  then. Nothing else to do.
+                </Text>
               </Card>
             ) : (
               <Card withBorder radius="md" padding="xl">

--- a/checkin-app/src/components/MembershipFlowStepper.tsx
+++ b/checkin-app/src/components/MembershipFlowStepper.tsx
@@ -1,5 +1,5 @@
 import { Alert, Card, Stepper, Text } from "@mantine/core";
-import { INITIAL_PHASES, phaseIndex } from "@/lib/membership/phases";
+import { INITIAL_PHASES, stepperActiveIndex } from "@/lib/membership/phases";
 import type { MembershipProcessStatus } from "@/generated/prisma/client";
 
 /**
@@ -13,8 +13,9 @@ export default function MembershipFlowStepper({
   currentStatus: MembershipProcessStatus | null;
 }) {
   const blocked = currentStatus === "BLOCKED";
-  // Before starting (null), nothing is complete; treat position as -1.
-  const activeIdx = currentStatus ? phaseIndex(currentStatus) : -1;
+  // Position in the 4-step payment track. PENDING_BG_CLEARANCE (paid, awaiting
+  // the parallel check) counts payment as done with Member still pending.
+  const activeIdx = stepperActiveIndex(currentStatus);
 
   return (
     <Card withBorder radius="md" padding="lg" miw={240}>

--- a/checkin-app/src/lib/membership/boardAlerts.ts
+++ b/checkin-app/src/lib/membership/boardAlerts.ts
@@ -1,0 +1,39 @@
+import prisma from "@/lib/prisma";
+import { sendEmail } from "@/lib/email";
+import { logger } from "@/lib/logger";
+
+/**
+ * Board-facing membership email alerts. Kept dependency-free (prisma + email +
+ * logger only) so both the review path (review.ts) and the payment path
+ * (payment.ts) can fire them without an import cycle.
+ */
+
+/**
+ * Email board members that a household which ALREADY PAID did not pass
+ * background-check review, so a refund can be arranged out-of-band. Fires in
+ * BOTH orderings — a reject after the payment landed (review.ts) and a payment
+ * webhook that lands after the reject (payment.ts). (We never move money
+ * automatically.)
+ */
+export async function notifyBoardPaidReject(processId: number): Promise<void> {
+    try {
+        const board = await prisma.participant.findMany({
+            where: { boardMember: true, email: { not: null } },
+            select: { email: true },
+        });
+        const base = process.env.NEXTAUTH_URL ?? "";
+        await Promise.all(
+            board.map((b) =>
+                b.email
+                    ? sendEmail(
+                          b.email,
+                          "Membership: a paid application was blocked at background check",
+                          `<p>A household that already paid did not pass background-check review (application #${processId}). The membership has <strong>not</strong> been activated and a refund may be needed — please review and contact the household. <a href="${base}/membership-ops/applications">Open applications</a></p>`,
+                      ).catch((e) => logger.error("Paid-reject board ping failed:", e))
+                    : Promise.resolve(),
+            ),
+        );
+    } catch (e) {
+        logger.error("notifyBoardPaidReject failed:", e);
+    }
+}

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -13,9 +13,12 @@ import {
 import { loadAgreementPdf, stampWatermark, AGREEMENT_FILENAME, AgreementUnavailableError } from "@/lib/membership/contract/agreementDocument";
 
 /**
- * EXTERNAL-phase service — the two parallel actions an applicant completes after
- * intake: signing the Zoho contract and consenting to a background check on
- * Averity. When BOTH are recorded, the application advances to PENDING_BG_REVIEW.
+ * EXTERNAL-phase service — the actions an applicant completes after intake:
+ * signing the Zoho contract and consenting to a background check on Averity.
+ * Once the contract is signed AND the check is handled (consent recorded, or a
+ * still-valid prior check detected), the application advances to PENDING_PAYMENT.
+ * The background check is NOT a gate on payment — it reviews in parallel and only
+ * the final ACTIVE transition waits on it.
  *
  * The contract is recorded automatically (Zoho webhook) or manually by the
  * board; BG consent is always human-marked by the board (no Averity API). The
@@ -45,6 +48,8 @@ export interface ExternalStatus {
     /** True once a Zoho signing request exists — lets the UI say "Resume signing". */
     contractStarted: boolean;
     bgConsented: boolean;
+    /** True when a still-valid prior check was detected — no new check is needed. */
+    bgCleared: boolean;
     deepLinkUrl: string | null;
 }
 
@@ -52,34 +57,47 @@ export interface ExternalStatus {
 export async function getExternalStatus(process: {
     contractSignedAt: Date | null;
     bgConsentAt: Date | null;
+    bgClearedAt: Date | null;
     zohoEnvelopeId: string | null;
 }): Promise<ExternalStatus> {
     return {
         contractSigned: !!process.contractSignedAt,
         contractStarted: !!process.zohoEnvelopeId,
         bgConsented: !!process.bgConsentAt,
+        bgCleared: !!process.bgClearedAt,
         deepLinkUrl: await backgroundCheckProvider.getConsentDeepLink(),
     };
 }
 
 /**
- * If both external actions are done and we're still in EXTERNAL, advance to
- * PENDING_BG_REVIEW. The conditional updateMany (status guard) is the atomic gate:
- * two concurrent callers (Zoho webhook + board "mark bg consent") both reach here,
- * but only the one whose updateMany flips PENDING_EXTERNAL_ACTION sees count === 1
- * — so the audit row and reviewer ping fire exactly once, and a later status
- * (BLOCKED/PENDING_PAYMENT) is never regressed. Mirrors review.ts `attest`.
+ * Once the contract is signed AND the background check is handled — either a
+ * still-valid prior check (bgClearedAt) or fresh consent recorded (bgConsentAt)
+ * — advance from EXTERNAL straight to PENDING_PAYMENT. The check no longer gates
+ * payment: when it still needs a human review (no prior valid check), it runs in
+ * PARALLEL while the applicant pays, and only the final ACTIVE flip waits on it.
+ *
+ * The conditional updateMany (status guard) is the atomic gate: two concurrent
+ * callers (Zoho webhook + board "mark bg consent") both reach here, but only the
+ * one whose updateMany flips PENDING_EXTERNAL_ACTION sees count === 1 — so the
+ * audit row and reviewer ping fire exactly once, and a later status is never
+ * regressed. Mirrors review.ts `attest`.
  */
 export async function advanceExternalIfComplete(processId: number) {
     const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
     if (!process) return process;
     if (process.status !== "PENDING_EXTERNAL_ACTION") return process;
-    if (!process.contractSignedAt || !process.bgConsentAt) return process;
+    if (!process.contractSignedAt) return process;
+    if (!process.bgClearedAt && !process.bgConsentAt) return process;
 
     const advanced = await prisma.$transaction(async (tx) => {
         const { count } = await tx.membershipProcess.updateMany({
-            where: { id: processId, status: "PENDING_EXTERNAL_ACTION", contractSignedAt: { not: null }, bgConsentAt: { not: null } },
-            data: { status: "PENDING_BG_REVIEW", stageEnteredAt: new Date() },
+            where: {
+                id: processId,
+                status: "PENDING_EXTERNAL_ACTION",
+                contractSignedAt: { not: null },
+                OR: [{ bgClearedAt: { not: null } }, { bgConsentAt: { not: null } }],
+            },
+            data: { status: "PENDING_PAYMENT", stageEnteredAt: new Date() },
         });
         if (count !== 1) return null; // lost the race or no longer eligible — no audit, no notify
         await tx.auditLog.create({
@@ -89,15 +107,16 @@ export async function advanceExternalIfComplete(processId: number) {
                 tableName: "MembershipProcess",
                 affectedEntityId: processId,
                 oldData: JSON.stringify({ status: "PENDING_EXTERNAL_ACTION" }),
-                newData: JSON.stringify({ status: "PENDING_BG_REVIEW" }),
+                newData: JSON.stringify({ status: "PENDING_PAYMENT" }),
             },
         });
         return tx.membershipProcess.findUnique({ where: { id: processId } });
     });
     if (!advanced) return prisma.membershipProcess.findUnique({ where: { id: processId } });
 
-    // Ping background-check reviewers that an application is ready (log-only until email is configured).
-    await notifyReviewers();
+    // No valid prior check ⇒ a human review is still needed. Ping the reviewers;
+    // the review now proceeds in parallel with payment (log-only until email is configured).
+    if (!advanced.bgClearedAt) await notifyReviewers();
     return advanced;
 }
 

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -1,6 +1,7 @@
 import prisma from "@/lib/prisma";
 import { IN_FLIGHT_INITIAL_STATUSES } from "@/lib/membership/phases";
 import { getExternalStatus } from "@/lib/membership/external";
+import { householdBgIsFresh, nextBoundary } from "@/lib/membership/renewal";
 import { addHouseholdLead, HouseholdLeadLimitError, MAX_HOUSEHOLD_LEADS } from "@/lib/household/leads";
 import { upsertPrimaryContact, reconcileHouseholdConflicts } from "@/lib/emergencyContacts/service";
 
@@ -327,9 +328,20 @@ export async function submitIntake(userId: number) {
         );
     }
 
+    // If a household guardian already holds a still-valid background check (same
+    // rule as renewals), auto-clear the BG requirement now — the applicant won't
+    // need to consent to or wait on a new check, just sign + pay.
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const boundary = settings?.membershipYearBoundary ? nextBoundary(settings.membershipYearBoundary, new Date()) : new Date();
+    const bgFresh = await householdBgIsFresh(household.id, boundary, settings?.bgRecheckMonths ?? 0);
+
     const advanced = await prisma.membershipProcess.update({
         where: { id: process.id },
-        data: { status: "PENDING_EXTERNAL_ACTION", stageEnteredAt: new Date() },
+        data: {
+            status: "PENDING_EXTERNAL_ACTION",
+            stageEnteredAt: new Date(),
+            ...(bgFresh ? { bgClearedAt: new Date() } : {}),
+        },
     });
 
     await prisma.auditLog.create({
@@ -339,7 +351,7 @@ export async function submitIntake(userId: number) {
             tableName: "MembershipProcess",
             affectedEntityId: process.id,
             oldData: JSON.stringify({ status: "INTAKE" }),
-            newData: JSON.stringify({ status: "PENDING_EXTERNAL_ACTION" }),
+            newData: JSON.stringify({ status: "PENDING_EXTERNAL_ACTION", ...(bgFresh ? { bgClearedAt: true } : {}) }),
         },
     });
 

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -94,40 +94,48 @@ export async function ensurePaymentLinkForUser(userId: number) {
 }
 
 /**
- * The single activation path. Flips the membership ACTIVE, marks the process
- * ACTIVE + paid, records how (Shopify order id or certifying board member), and
- * sends one congratulations email. Idempotent: a no-op if already ACTIVE.
+ * The single payment path. Records the payment (paidAt + how), then gates on the
+ * background check: if it has already cleared (bgClearedAt set), flip the
+ * membership ACTIVE and send one congrats email; otherwise hold the process at
+ * PENDING_BG_CLEARANCE — paid, but membership stays INACTIVE until two reviewers
+ * approve (review.ts › clearBackgroundCheck then flips ACTIVE).
+ *
+ * FOR UPDATE serializes against the review path's attest() transaction, which
+ * takes the same row lock — so the payment/clearance race can't lose an update.
+ * Idempotent: a no-op if already paid (Shopify retries an orders/paid webhook
+ * routinely), already active, or blocked (a late webhook must not resurrect a
+ * failed application).
  */
 export async function activate(
     processId: number,
     opts: { via: "payment" | "certified"; actorId?: number; shopifyOrderId?: string },
 ) {
-    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
-    if (!process) throw new PaymentError("not_found", "Application not found.");
-    const membership = await prisma.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
-    if (!membership) throw new PaymentError("not_found", "Membership not found.");
+    const result = await prisma.$transaction(async (tx) => {
+        await tx.$queryRaw`SELECT id FROM "MembershipProcess" WHERE id = ${processId} FOR UPDATE`;
+        const process = await tx.membershipProcess.findUnique({ where: { id: processId } });
+        if (!process) throw new PaymentError("not_found", "Application not found.");
+        if (process.paidAt || process.status === "ACTIVE" || process.status === "BLOCKED") {
+            return { kind: "noop" as const }; // retry / already done / failed — skip audit + email
+        }
+        const membership = await tx.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
+        if (!membership) throw new PaymentError("not_found", "Membership not found.");
 
-    const now = new Date();
-    // The flip + membership update + audit row are one transaction, and the flip
-    // is CONDITIONAL on status != ACTIVE. Under Read Committed, two concurrent
-    // updateMany re-check the WHERE against the just-committed row, so exactly one
-    // sees count === 1 and the rest see 0 — no row lock needed. Shopify retries
-    // an orders/paid webhook routinely; this makes activate() truly idempotent
-    // (no duplicate audit rows, no duplicate congrats emails).
-    const flipped = await prisma.$transaction(async (tx) => {
-        const { count } = await tx.membershipProcess.updateMany({
-            where: { id: processId, status: { not: "ACTIVE" } },
-            data: {
-                status: "ACTIVE",
-                stageEnteredAt: now,
-                paidAt: now,
-                ...(opts.shopifyOrderId ? { shopifyOrderId: opts.shopifyOrderId } : {}),
-                ...(opts.via === "certified" && opts.actorId ? { certifiedById: opts.actorId } : {}),
-            },
+        const now = new Date();
+        const paidData = {
+            paidAt: now,
+            stageEnteredAt: now,
+            ...(opts.shopifyOrderId ? { shopifyOrderId: opts.shopifyOrderId } : {}),
+            ...(opts.via === "certified" && opts.actorId ? { certifiedById: opts.actorId } : {}),
+        };
+        const activating = !!process.bgClearedAt;
+
+        await tx.membershipProcess.update({
+            where: { id: processId },
+            data: { ...paidData, status: activating ? "ACTIVE" : "PENDING_BG_CLEARANCE" },
         });
-        if (count === 0) return false; // already ACTIVE — a retry; skip audit + email
-
-        await tx.membership.update({ where: { id: process.membershipId }, data: { status: "ACTIVE" } });
+        if (activating) {
+            await tx.membership.update({ where: { id: process.membershipId }, data: { status: "ACTIVE" } });
+        }
         await tx.auditLog.create({
             data: {
                 actorId: opts.actorId ?? SYSTEM_ACTOR,
@@ -135,15 +143,15 @@ export async function activate(
                 tableName: "MembershipProcess",
                 affectedEntityId: processId,
                 oldData: JSON.stringify({ status: process.status }),
-                newData: JSON.stringify({ status: "ACTIVE", via: opts.via }),
+                newData: JSON.stringify(activating ? { status: "ACTIVE", via: opts.via } : { status: "PENDING_BG_CLEARANCE", via: opts.via, paid: true }),
             },
         });
-        return true;
+        return activating ? { kind: "active" as const, householdId: membership.householdId } : { kind: "held" as const };
     });
 
     // Email outside the transaction: a slow/failed send must not roll back the
     // activation, and we only send when this call is the one that flipped it.
-    if (flipped) await sendCongrats(membership.householdId);
+    if (result.kind === "active") await sendCongrats(result.householdId);
     return prisma.membershipProcess.findUnique({ where: { id: processId } });
 }
 
@@ -165,7 +173,8 @@ export async function activateByProcessId(processId: number, shopifyOrderId: str
     return activate(processId, { via: "payment", shopifyOrderId });
 }
 
-async function sendCongrats(householdId: number) {
+/** Send the one "welcome — your membership is active" email to a household's leads. */
+export async function sendCongrats(householdId: number) {
     try {
         const leads = await prisma.householdLead.findMany({
             where: { householdId },

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -1,6 +1,7 @@
 import prisma from "@/lib/prisma";
 import { sendEmail } from "@/lib/email";
 import { logger } from "@/lib/logger";
+import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
 
 /**
  * Payment phase (PENDING_PAYMENT -> ACTIVE).
@@ -102,9 +103,13 @@ export async function ensurePaymentLinkForUser(userId: number) {
  *
  * FOR UPDATE serializes against the review path's attest() transaction, which
  * takes the same row lock — so the payment/clearance race can't lose an update.
- * Idempotent: a no-op if already paid (Shopify retries an orders/paid webhook
- * routinely), already active, or blocked (a late webhook must not resurrect a
- * failed application).
+ * Idempotent: a no-op only once the payment is already recorded (Shopify retries
+ * an orders/paid webhook routinely) or the membership is already active.
+ *
+ * BLOCKED is NOT a silent no-op: if the check was rejected before the payment
+ * webhook landed, the money is already at Shopify. We record the payment (keeping
+ * the application BLOCKED — never activate without a valid check) and alert the
+ * board to refund, rather than dropping the payment on the floor.
  */
 export async function activate(
     processId: number,
@@ -114,24 +119,40 @@ export async function activate(
         await tx.$queryRaw`SELECT id FROM "MembershipProcess" WHERE id = ${processId} FOR UPDATE`;
         const process = await tx.membershipProcess.findUnique({ where: { id: processId } });
         if (!process) throw new PaymentError("not_found", "Application not found.");
-        if (process.paidAt || process.status === "ACTIVE" || process.status === "BLOCKED") {
-            return { kind: "noop" as const }; // retry / already done / failed — skip audit + email
+        // Already recorded this payment (webhook retry) or already active → nothing to do.
+        if (process.paidAt || process.status === "ACTIVE") {
+            return { kind: "noop" as const };
         }
         const membership = await tx.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
         if (!membership) throw new PaymentError("not_found", "Membership not found.");
 
         const now = new Date();
-        const paidData = {
-            paidAt: now,
-            stageEnteredAt: now,
+        const payMeta = {
             ...(opts.shopifyOrderId ? { shopifyOrderId: opts.shopifyOrderId } : {}),
             ...(opts.via === "certified" && opts.actorId ? { certifiedById: opts.actorId } : {}),
         };
-        const activating = !!process.bgClearedAt;
 
+        // Reject landed before the payment: record the payment but stay BLOCKED
+        // (don't resurrect / don't bump stageEnteredAt) and flag for refund.
+        if (process.status === "BLOCKED") {
+            await tx.membershipProcess.update({ where: { id: processId }, data: { paidAt: now, ...payMeta } });
+            await tx.auditLog.create({
+                data: {
+                    actorId: opts.actorId ?? SYSTEM_ACTOR,
+                    action: "EDIT",
+                    tableName: "MembershipProcess",
+                    affectedEntityId: processId,
+                    oldData: JSON.stringify({ status: "BLOCKED" }),
+                    newData: JSON.stringify({ status: "BLOCKED", via: opts.via, paid: true, refundNeeded: true }),
+                },
+            });
+            return { kind: "paid_while_blocked" as const };
+        }
+
+        const activating = !!process.bgClearedAt;
         await tx.membershipProcess.update({
             where: { id: processId },
-            data: { ...paidData, status: activating ? "ACTIVE" : "PENDING_BG_CLEARANCE" },
+            data: { paidAt: now, stageEnteredAt: now, ...payMeta, status: activating ? "ACTIVE" : "PENDING_BG_CLEARANCE" },
         });
         if (activating) {
             await tx.membership.update({ where: { id: process.membershipId }, data: { status: "ACTIVE" } });
@@ -149,9 +170,10 @@ export async function activate(
         return activating ? { kind: "active" as const, householdId: membership.householdId } : { kind: "held" as const };
     });
 
-    // Email outside the transaction: a slow/failed send must not roll back the
-    // activation, and we only send when this call is the one that flipped it.
+    // Side effects outside the transaction: a slow/failed send must not roll back
+    // the write, and only the call that actually recorded the change emits one.
     if (result.kind === "active") await sendCongrats(result.householdId);
+    if (result.kind === "paid_while_blocked") await notifyBoardPaidReject(processId);
     return prisma.membershipProcess.findUnique({ where: { id: processId } });
 }
 

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -149,6 +149,16 @@ export async function activate(
             return { kind: "paid_while_blocked" as const };
         }
 
+        // Only a process actually awaiting payment advances. A checkout link is
+        // minted only at PENDING_PAYMENT, so a payment for any other status
+        // (INTAKE/EXTERNAL/renewal-review) is anomalous — a forged/replayed
+        // webhook (TODO #278) or a process that moved unexpectedly. Don't advance
+        // it; surface it instead of corrupting state.
+        if (process.status !== "PENDING_PAYMENT") {
+            logger.warn(`[membership] activate() ignored payment for process ${processId} in status ${process.status} — no payment was due`);
+            return { kind: "noop" as const };
+        }
+
         const activating = !!process.bgClearedAt;
         await tx.membershipProcess.update({
             where: { id: processId },

--- a/checkin-app/src/lib/membership/phases.ts
+++ b/checkin-app/src/lib/membership/phases.ts
@@ -3,8 +3,13 @@ import type { MembershipProcessStatus } from "@/generated/prisma/client";
 /**
  * Applicant-facing phases of an INITIAL membership application, in order.
  * Drives the left-rail flow diagram (MembershipFlowStepper) and lets the API
- * report "where am I?" without leaking internal mechanics. BLOCKED is an
- * off-track error state handled separately (never shown as a step).
+ * report "where am I?" without leaking internal mechanics.
+ *
+ * The background check is NOT a sequential phase here — it runs as a parallel
+ * track (consent in the Contract & Background Check step, then review in the
+ * background) and only gates the final ACTIVE transition. PENDING_BG_CLEARANCE
+ * (paid, awaiting the check) and BLOCKED are off-track states handled separately
+ * (never shown as their own step).
  */
 export interface IntakePhase {
     status: MembershipProcessStatus;
@@ -14,8 +19,7 @@ export interface IntakePhase {
 
 export const INITIAL_PHASES: IntakePhase[] = [
     { status: "INTAKE", label: "Your Family", description: "Tell us about your household." },
-    { status: "PENDING_EXTERNAL_ACTION", label: "Contract & Consent", description: "Sign the membership contract and consent to a background check." },
-    { status: "PENDING_BG_REVIEW", label: "Background Review", description: "Our team confirms the background check." },
+    { status: "PENDING_EXTERNAL_ACTION", label: "Contract & Background Check", description: "Sign the contract and start your background check." },
     { status: "PENDING_PAYMENT", label: "Payment", description: "Pay your annual membership dues." },
     { status: "ACTIVE", label: "Member", description: "Welcome to the Treehouse!" },
 ];
@@ -26,13 +30,32 @@ export function phaseIndex(status: MembershipProcessStatus): number {
 }
 
 /**
+ * Stepper position for a status: how many INITIAL_PHASES steps are complete.
+ * PENDING_BG_CLEARANCE (paid, awaiting the check) sits between Payment and
+ * Member — payment shows complete, Member is the pending current step. BLOCKED
+ * and other off-track statuses return -1 (handled with an inline alert).
+ */
+export function stepperActiveIndex(status: MembershipProcessStatus | null): number {
+    switch (status) {
+        case "INTAKE": return 0;
+        case "PENDING_EXTERNAL_ACTION": return 1;
+        case "PENDING_PAYMENT": return 2;
+        case "PENDING_BG_CLEARANCE": return 3;
+        case "ACTIVE": return 4;
+        default: return -1;
+    }
+}
+
+/**
  * Statuses where an application is still open (work remains). Excludes the
  * terminal ACTIVE and the off-track BLOCKED. Renewal-specific statuses are not
- * part of the INITIAL flow.
+ * part of the INITIAL flow. PENDING_BG_REVIEW is retained for any legacy rows;
+ * the live flow uses PENDING_BG_CLEARANCE for the paid-awaiting-check state.
  */
 export const IN_FLIGHT_INITIAL_STATUSES: MembershipProcessStatus[] = [
     "INTAKE",
     "PENDING_EXTERNAL_ACTION",
     "PENDING_BG_REVIEW",
     "PENDING_PAYMENT",
+    "PENDING_BG_CLEARANCE",
 ];

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -93,13 +93,17 @@ export async function beginRenewal(processId: number) {
     // Conditional on status PENDING_RENEWAL: a double-submit has both callers reach
     // here, but only the winner's updateMany flips it (count === 1) — so the audit
     // row and reviewer ping fire exactly once. Mirrors external.ts markContractSigned.
+    // Fresh check ⇒ no re-review, so clear the BG requirement here (there's no
+    // consent step / reviewer queue for a fresh renewal). Without this the renewal
+    // pays and parks at PENDING_BG_CLEARANCE forever. Re-review renewals
+    // (RENEWAL_PENDING_BG) get bgClearedAt from clearBackgroundCheck instead.
     const { count } = await prisma.membershipProcess.updateMany({
         where: { id: processId, status: "PENDING_RENEWAL" },
-        data: { status: nextStatus, stageEnteredAt: new Date() },
+        data: { status: nextStatus, stageEnteredAt: new Date(), ...(bgFresh ? { bgClearedAt: new Date() } : {}) },
     });
     if (count === 1) {
         await prisma.auditLog.create({
-            data: { actorId: SYSTEM_ACTOR, action: "EDIT", tableName: "MembershipProcess", affectedEntityId: processId, oldData: JSON.stringify({ status: "PENDING_RENEWAL" }), newData: JSON.stringify({ status: nextStatus }) },
+            data: { actorId: SYSTEM_ACTOR, action: "EDIT", tableName: "MembershipProcess", affectedEntityId: processId, oldData: JSON.stringify({ status: "PENDING_RENEWAL" }), newData: JSON.stringify({ status: nextStatus, ...(bgFresh ? { bgClearedAt: true } : {}) }) },
         });
         if (nextStatus === "RENEWAL_PENDING_BG") await notifyReviewers();
     }

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -276,7 +276,13 @@ export async function overrideBlocked(processId: number, actorId: number, action
         return { status: reviewStatus };
     }
 
-    const { activated, householdId } = await prisma.$transaction((tx) => clearBackgroundCheck(tx, processId, actorId));
+    // FOR UPDATE per clearBackgroundCheck's contract: serializes a board approve
+    // against a late payment webhook (activate also locks), so the override reads
+    // a fresh paidAt and converges to ACTIVE rather than parking it at PENDING_PAYMENT.
+    const { activated, householdId } = await prisma.$transaction(async (tx) => {
+        await tx.$queryRaw`SELECT id FROM "MembershipProcess" WHERE id = ${processId} FOR UPDATE`;
+        return clearBackgroundCheck(tx, processId, actorId);
+    });
     if (activated) await sendCongrats(householdId);
     const status: MembershipProcessStatus = activated ? "ACTIVE" : "PENDING_PAYMENT";
     return { status };

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { sendEmail } from "@/lib/email";
 import { logger } from "@/lib/logger";
 import { sendCongrats } from "@/lib/membership/payment";
+import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
 
 type TxClient = Prisma.TransactionClient;
 
@@ -99,34 +100,6 @@ export async function notifyReviewers(): Promise<void> {
         );
     } catch (e) {
         logger.error("notifyReviewers failed:", e);
-    }
-}
-
-/**
- * Email board members that a household which ALREADY PAID was blocked at
- * background-check review, so a refund can be arranged out-of-band. (We never
- * move money automatically.)
- */
-export async function notifyBoardPaidReject(processId: number): Promise<void> {
-    try {
-        const board = await prisma.participant.findMany({
-            where: { boardMember: true, email: { not: null } },
-            select: { email: true },
-        });
-        const base = process.env.NEXTAUTH_URL ?? "";
-        await Promise.all(
-            board.map((b) =>
-                b.email
-                    ? sendEmail(
-                          b.email,
-                          "Membership: a paid application was blocked at background check",
-                          `<p>A household that already paid did not pass background-check review (application #${processId}). The membership has <strong>not</strong> been activated and a refund may be needed — please review and contact the household. <a href="${base}/membership-ops/applications">Open applications</a></p>`,
-                      ).catch((e) => logger.error("Paid-reject board ping failed:", e))
-                    : Promise.resolve(),
-            ),
-        );
-    } catch (e) {
-        logger.error("notifyBoardPaidReject failed:", e);
     }
 }
 

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -1,19 +1,25 @@
-import { Prisma } from "@/generated/prisma/client";
+import { Prisma, type MembershipProcessStatus } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { sendEmail } from "@/lib/email";
 import { logger } from "@/lib/logger";
+import { sendCongrats } from "@/lib/membership/payment";
 
 type TxClient = Prisma.TransactionClient;
 
 /**
- * Background-check review (PENDING_BG_REVIEW phase).
+ * Background-check review — now a PARALLEL track, not a blocking phase.
  *
- * Two DISTINCT eligible reviewers (role backgroundCheckReviewer) must each
- * attest the check independently. A reviewer may not share a household with the
- * applicant or with the other reviewer, and may not attest twice.
- *   - 2 APPROVE  -> advance to PENDING_PAYMENT; stamp parents' lastBackgroundCheck;
- *                   apply (sticky) volunteer status.
- *   - any REJECT -> BLOCKED (board override/reset; applicant is NOT told why).
+ * After intake the application advances to PENDING_PAYMENT regardless of the
+ * check; the review happens while the applicant pays. Two DISTINCT eligible
+ * reviewers (role backgroundCheckReviewer) must each attest independently. A
+ * reviewer may not share a household with the applicant or the other reviewer,
+ * and may not attest twice.
+ *   - 2 APPROVE  -> clear the check (stamp parents' lastBackgroundCheck + sticky
+ *                  volunteer status), then ACTIVATE if already paid, else leave
+ *                  at PENDING_PAYMENT for the applicant to pay.
+ *   - any REJECT -> BLOCKED (membership never activates without a valid check).
+ *                  If the household already paid, the board is notified so a
+ *                  refund can be handled manually.
  *
  * The system never sees the check itself — only the attestations.
  */
@@ -36,6 +42,30 @@ export class ReviewError extends Error {
         this.name = "ReviewError";
     }
 }
+
+/**
+ * Whether a process is currently awaiting background-check review. The check is
+ * a parallel track keyed off bgClearedAt (not status): a process needs review
+ * when it hasn't cleared and is past consent —
+ *   - PENDING_BG_REVIEW / RENEWAL_PENDING_BG: the (legacy/renewal) review states.
+ *   - PENDING_PAYMENT / PENDING_BG_CLEARANCE: the INITIAL parallel states, once
+ *     consent has been recorded (bgConsentAt set).
+ */
+function isAwaitingBgReview(p: { status: MembershipProcessStatus; bgConsentAt: Date | null; bgClearedAt: Date | null }): boolean {
+    if (p.bgClearedAt) return false;
+    if (p.status === "PENDING_BG_REVIEW" || p.status === "RENEWAL_PENDING_BG") return true;
+    if ((p.status === "PENDING_PAYMENT" || p.status === "PENDING_BG_CLEARANCE") && p.bgConsentAt) return true;
+    return false;
+}
+
+/** Prisma `where` matching the same predicate as isAwaitingBgReview, for queue queries. */
+export const AWAITING_BG_WHERE: Prisma.MembershipProcessWhereInput = {
+    bgClearedAt: null,
+    OR: [
+        { status: { in: ["PENDING_BG_REVIEW", "RENEWAL_PENDING_BG"] } },
+        { status: { in: ["PENDING_PAYMENT", "PENDING_BG_CLEARANCE"] }, bgConsentAt: { not: null } },
+    ],
+};
 
 /**
  * Normalize an email for volunteer-designation matching: lowercase, and strip
@@ -72,6 +102,34 @@ export async function notifyReviewers(): Promise<void> {
     }
 }
 
+/**
+ * Email board members that a household which ALREADY PAID was blocked at
+ * background-check review, so a refund can be arranged out-of-band. (We never
+ * move money automatically.)
+ */
+export async function notifyBoardPaidReject(processId: number): Promise<void> {
+    try {
+        const board = await prisma.participant.findMany({
+            where: { boardMember: true, email: { not: null } },
+            select: { email: true },
+        });
+        const base = process.env.NEXTAUTH_URL ?? "";
+        await Promise.all(
+            board.map((b) =>
+                b.email
+                    ? sendEmail(
+                          b.email,
+                          "Membership: a paid application was blocked at background check",
+                          `<p>A household that already paid did not pass background-check review (application #${processId}). The membership has <strong>not</strong> been activated and a refund may be needed — please review and contact the household. <a href="${base}/membership-ops/applications">Open applications</a></p>`,
+                      ).catch((e) => logger.error("Paid-reject board ping failed:", e))
+                    : Promise.resolve(),
+            ),
+        );
+    } catch (e) {
+        logger.error("notifyBoardPaidReject failed:", e);
+    }
+}
+
 async function loadReviewer(reviewerId: number) {
     return prisma.participant.findUnique({ where: { id: reviewerId }, select: { id: true, householdId: true, backgroundCheckReviewer: true } });
 }
@@ -80,8 +138,8 @@ async function loadReviewer(reviewerId: number) {
  * IDs of the applications this reviewer may currently attest (eligibility
  * filtered: not their own household, not already attested, no household-mate
  * already on it). The route turns these into model rows for the stripper; the
- * notifications endpoint just counts them. In PENDING_BG_REVIEW a process only
- * ever holds APPROVE attestations (any REJECT moves it to BLOCKED), so a row's
+ * notifications endpoint just counts them. A process awaiting review only ever
+ * holds APPROVE attestations (any REJECT moves it to BLOCKED), so a row's
  * attestation _count equals its approval count.
  */
 export async function eligibleReviewProcessIds(reviewerId: number): Promise<number[]> {
@@ -89,7 +147,7 @@ export async function eligibleReviewProcessIds(reviewerId: number): Promise<numb
     if (!reviewer?.backgroundCheckReviewer) return [];
 
     const processes = await prisma.membershipProcess.findMany({
-        where: { status: { in: ["PENDING_BG_REVIEW", "RENEWAL_PENDING_BG"] } },
+        where: AWAITING_BG_WHERE,
         orderBy: { stageEnteredAt: "asc" },
         select: {
             id: true,
@@ -110,7 +168,8 @@ export async function eligibleReviewProcessIds(reviewerId: number): Promise<numb
 
 /**
  * Record a reviewer's attestation. Validates eligibility, then on REJECT blocks
- * the application and on the 2nd APPROVE advances it to PENDING_PAYMENT.
+ * the application and on the 2nd APPROVE clears the check — activating the
+ * membership if dues are already paid, else leaving it at PENDING_PAYMENT.
  */
 export async function attest(
     reviewerId: number,
@@ -120,13 +179,12 @@ export async function attest(
     const reviewer = await loadReviewer(reviewerId);
     if (!reviewer?.backgroundCheckReviewer) throw new ReviewError("not_reviewer", "You are not a background-check reviewer.");
 
-    // Re-check eligibility, create the attestation, recompute approvals, and advance
+    // Re-check eligibility, create the attestation, recompute approvals, and converge
     // all inside one transaction. FOR UPDATE on the MembershipProcess row serializes
-    // concurrent attestations on the same process — without it, two reviewers can both
-    // read 1 prior APPROVE, both compute approvals === 2, and both advanceToPayment
-    // (double advance / double background-date stamp). The same_household_reviewer and
-    // already_attested checks are TOCTOU for the same reason. Mirrors leads.ts.
-    return prisma.$transaction(async (tx) => {
+    // concurrent attestations AND the payment path (payment.ts › activate takes the
+    // same lock) — so the payment/clearance race can't lose an update: whoever commits
+    // second sees the other's field set and flips ACTIVE. Mirrors leads.ts.
+    const result = await prisma.$transaction(async (tx) => {
         await tx.$queryRaw`SELECT id FROM "MembershipProcess" WHERE id = ${processId} FOR UPDATE`;
 
         const process = await tx.membershipProcess.findUnique({
@@ -134,7 +192,7 @@ export async function attest(
             include: { attestations: { include: { reviewer: { select: { householdId: true } } } } },
         });
         if (!process) throw new ReviewError("not_found", "Application not found.");
-        if (process.status !== "PENDING_BG_REVIEW" && process.status !== "RENEWAL_PENDING_BG") throw new ReviewError("wrong_phase", "This application is not awaiting background-check review.");
+        if (!isAwaitingBgReview(process)) throw new ReviewError("wrong_phase", "This application is not awaiting background-check review.");
         const membership = await tx.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
         if (membership?.householdId === reviewer.householdId) throw new ReviewError("same_household_applicant", "You cannot review an applicant in your own household.");
         if (process.attestations.some((a) => a.reviewerId === reviewerId)) throw new ReviewError("already_attested", "You have already reviewed this application.");
@@ -147,20 +205,37 @@ export async function attest(
         if (input.result === "REJECT") {
             await tx.membershipProcess.update({ where: { id: processId }, data: { status: "BLOCKED", stageEnteredAt: new Date() } });
             await audit(tx, reviewerId, processId, { status: process.status }, { status: "BLOCKED", reason: "reviewer reject" });
-            return { status: "BLOCKED" as const };
+            // A paid household that fails review needs a manual refund — flag the board (post-tx).
+            return { status: "BLOCKED" as const, notifyPaidReject: !!process.paidAt };
         }
 
         const approvals = process.attestations.filter((a) => a.result === "APPROVE").length + 1;
         if (approvals >= REQUIRED_APPROVALS) {
-            await advanceToPayment(tx, processId, reviewerId);
-            return { status: "PENDING_PAYMENT" as const };
+            const { activated, householdId } = await clearBackgroundCheck(tx, processId, reviewerId);
+            const status: MembershipProcessStatus = activated ? "ACTIVE" : "PENDING_PAYMENT";
+            return { status, activated, householdId };
         }
-        return { status: "PENDING_BG_REVIEW" as const, approvals };
+        return { status: process.status, approvals };
     });
+
+    // Side effects outside the transaction (a slow/failed send must not roll it back).
+    if ("activated" in result && result.activated) await sendCongrats(result.householdId);
+    if ("notifyPaidReject" in result && result.notifyPaidReject) await notifyBoardPaidReject(processId);
+
+    if ("approvals" in result) return { status: result.status, approvals: result.approvals };
+    return { status: result.status };
 }
 
-/** Advance a reviewed/overridden application to payment: stamp BG dates + volunteer status. */
-async function advanceToPayment(tx: TxClient, processId: number, actorId: number) {
+/**
+ * The background check is satisfied (2 approvals or a board override). Stamp the
+ * guardians' lastBackgroundCheck + sticky volunteer status + bgClearedAt, then
+ * converge on the two-track gate:
+ *   - already paid -> ACTIVE (payment finished first)
+ *   - not yet paid -> PENDING_PAYMENT (applicant still needs to pay)
+ * Returns whether it activated + householdId so the caller can send congrats.
+ * Must run inside a tx holding a FOR UPDATE lock on the process row.
+ */
+async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: number): Promise<{ activated: boolean; householdId: number }> {
     const process = await tx.membershipProcess.findUnique({
         where: { id: processId },
         include: { attestations: true },
@@ -169,16 +244,24 @@ async function advanceToPayment(tx: TxClient, processId: number, actorId: number
     const membership = await tx.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
     if (!membership) throw new ReviewError("not_found", "Membership not found.");
     const householdId = membership.householdId;
-
-    await tx.membershipProcess.update({ where: { id: processId }, data: { status: "PENDING_PAYMENT", stageEnteredAt: new Date() } });
+    const now = new Date();
+    const paid = !!process.paidAt;
 
     // Stamp the guardians' (household leads') lastBackgroundCheck. Expiry is derived from this
     // plus BoardSettings.bgRecheckMonths at read time (see householdBgIsFresh) — not stored.
-    await tx.participant.updateMany({ where: { householdId, householdLeads: { some: { householdId } } }, data: { lastBackgroundCheck: new Date() } });
-
+    await tx.participant.updateMany({ where: { householdId, householdLeads: { some: { householdId } } }, data: { lastBackgroundCheck: now } });
     await applyVolunteerStatus(tx, process.membershipId, householdId, process.attestations.some((a) => a.markedVolunteer));
 
-    await audit(tx, actorId, processId, { status: process.status }, { status: "PENDING_PAYMENT" });
+    await tx.membershipProcess.update({
+        where: { id: processId },
+        data: { bgClearedAt: now, status: paid ? "ACTIVE" : "PENDING_PAYMENT", stageEnteredAt: now },
+    });
+    if (paid) {
+        await tx.membership.update({ where: { id: process.membershipId }, data: { status: "ACTIVE" } });
+    }
+
+    await audit(tx, actorId, processId, { status: process.status }, { status: paid ? "ACTIVE" : "PENDING_PAYMENT", bgCleared: true });
+    return { activated: paid, householdId };
 }
 
 /**
@@ -201,23 +284,29 @@ export async function applyVolunteerStatus(db: TxClient | typeof prisma, members
     }
 }
 
-/** Board override on a BLOCKED application: reset for re-review, or force-approve to payment. */
+/** Board override on a BLOCKED application: reset for re-review, or force-clear the check. */
 export async function overrideBlocked(processId: number, actorId: number, action: "reset" | "approve") {
     const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new ReviewError("not_found", "Application not found.");
     if (process.status !== "BLOCKED") throw new ReviewError("wrong_phase", "This application is not blocked.");
 
     if (action === "reset") {
-        // Restore the review state that matches the cycle (initial vs renewal).
-        const reviewStatus = process.kind === "RENEWAL" ? "RENEWAL_PENDING_BG" : "PENDING_BG_REVIEW";
+        // Restore the review state that matches the cycle. The check runs in parallel,
+        // so an initial application returns to PENDING_BG_CLEARANCE if it had already
+        // paid, else PENDING_PAYMENT; renewals go back to RENEWAL_PENDING_BG.
+        const reviewStatus: MembershipProcessStatus =
+            process.kind === "RENEWAL" ? "RENEWAL_PENDING_BG" : process.paidAt ? "PENDING_BG_CLEARANCE" : "PENDING_PAYMENT";
         await prisma.backgroundCheckAttestation.deleteMany({ where: { processId } });
-        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: reviewStatus, stageEnteredAt: new Date() } });
+        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: reviewStatus, bgClearedAt: null, stageEnteredAt: new Date() } });
         await audit(prisma, actorId, processId, { status: "BLOCKED" }, { status: reviewStatus, action: "board reset" });
         await notifyReviewers();
-        return { status: reviewStatus as "PENDING_BG_REVIEW" | "RENEWAL_PENDING_BG" };
+        return { status: reviewStatus };
     }
-    await prisma.$transaction((tx) => advanceToPayment(tx, processId, actorId));
-    return { status: "PENDING_PAYMENT" as const };
+
+    const { activated, householdId } = await prisma.$transaction((tx) => clearBackgroundCheck(tx, processId, actorId));
+    if (activated) await sendCongrats(householdId);
+    const status: MembershipProcessStatus = activated ? "ACTIVE" : "PENDING_PAYMENT";
+    return { status };
 }
 
 function audit(db: TxClient | typeof prisma, actorId: number, processId: number, oldData: object, newData: object) {

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -74,6 +74,7 @@ export const classifications = {
         zohoActionId: 'internal',
         contractSignedAt: 'internal',
         bgConsentAt: 'internal',
+        bgClearedAt: 'internal',
         shopifyDraftOrderId: 'internal',
         shopifyInvoiceUrl: 'personal',
         shopifyOrderId: 'internal',


### PR DESCRIPTION
## Problem

The background check was a **hard gate between contract/consent and payment**. The flow was strictly linear:

```
INTAKE → PENDING_EXTERNAL_ACTION → PENDING_BG_REVIEW → PENDING_PAYMENT → ACTIVE
         (sign + consent)          (2 reviewers,        (pay)
                                    long-tail/human)
```

Averity has no API, so the check is human-marked and slow. Applicants sat in `PENDING_BG_REVIEW` and **could not pay** until the board cleared it — a long-tail step blocking everything behind it.

## What changed

The background check becomes a **parallel track**. After the contract is signed **and** the check is handled (consent recorded, or a still-valid prior check), the application advances **straight to `PENDING_PAYMENT`**. The membership only goes **ACTIVE once BOTH payment and a valid check are done — whichever finishes last.**

```
INTAKE → CONTRACT & BACKGROUND CHECK → PAYMENT ──┐
                                                 ├─► ACTIVE  (needs: paid AND bg-cleared)
         (BG review runs in parallel) ───────────┘
              └─ paid first → PENDING_BG_CLEARANCE (paid, membership still inactive)
```

Behavior (decisions confirmed with the requester):
- **Payment gate** — unlocks once the contract is signed and the check is *handled* (consent clicked, or a valid existing check). The applicant pays while the review runs.
- **Never active without a valid check** — if paid first, the process holds at the new `PENDING_BG_CLEARANCE` status (membership stays inactive); the 2nd reviewer approval then flips it ACTIVE.
- **Auto-validate a still-valid prior check** — at intake, if any guardian's `lastBackgroundCheck` is within `BoardSettings.bgRecheckMonths`, the requirement auto-clears (mirrors renewals) with a "no new check needed" message — no consent, no wait.
- **Reject after payment → BLOCKED** + the board is emailed (manual refund); no automated money movement.

## Model

- New `MembershipProcess.bgClearedAt` — single source of truth for "BG cleared this cycle" (set by 2 approvals, a board override, or a detected valid prior check).
- New status `PENDING_BG_CLEARANCE` — paid, awaiting the check.
- `review.ts` and `payment.ts` converge on a **`FOR UPDATE`-locked gate** so the payment/clearance race can't lose an update (whoever commits second sees the other's field set and activates).
- Background-review eligibility is now keyed off the BG fields (`AWAITING_BG_WHERE`), not status — so review works in parallel across `PENDING_PAYMENT` / `PENDING_BG_CLEARANCE`, and the board todo-count follows.

### Migration
`20260628120000_bg_check_nonblocking`: adds the enum value + `bgClearedAt`, then **backfills** — existing `PENDING_PAYMENT`/`ACTIVE` marked cleared; in-flight `PENDING_BG_REVIEW` moved to `PENDING_PAYMENT` (unblocked, review continues in parallel). Verified: applies cleanly and `migrate diff` reports no drift from the schema.

## UI

- `MembershipFlowStepper`: 4 steps (Family → Contract & Check → Payment → Member); BG is parallel, `PENDING_BG_CLEARANCE` shows Payment done / Member pending.
- Member page: auto-validated message, "pay now — check in progress" note on Payment, and a "Paid — activating when your check clears" holding card.
- Board applications view: shows BG progress (`N/2`) in parallel and the new holding state.

## Validation (against a live Postgres + dev server)

- New integration suite `membershipBgNonBlocking` (6 cases): advance-to-payment, pay-before-check → holding → activate, check-before-pay, reject-after-pay → blocked, fresh-check auto-clear, webhook idempotency. **All membership integration tests pass (52).**
- Updated the existing tests that encoded the old sequential order (external/review/payment/contract-sync) to the new behavior.
- Full integration run matches the clean-`main` baseline exactly — **this change adds zero new failures** (pre-existing environmental failures: cron/kiosk/renewal-concurrency).
- Rendered and screenshotted the new member states (parallel-payment note, paid-awaiting-check, auto-validated check).
- Rebased on latest `main`; reconciled with #397 (certify guard — kept), #409/#399 (intake/renewal refactors), #413 (BG-review tab — works via the updated queue). ESLint + `tsc` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)