### PR TITLE
fix(nav): readable sidebar hover instead of white-on-white (#284)

### DIFF
--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -263,7 +263,19 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
       </AppShell.Header>
 
       {showNav && (
-        <AppShell.Navbar p="md" bg={brand.nav.sidebar}>
+        <AppShell.Navbar
+          p="md"
+          bg={brand.nav.sidebar}
+          // On the dark sidebar, Mantine's hover fill for non-active items is the near-white
+          // `default-hover` token, which left white labels invisible (white-on-white, #284).
+          // Scope that token to a translucent white so hovering just lightens the purple and the
+          // white label stays readable — and it works in dark mode too, unlike a fixed color.
+          style={
+            onColoredSidebar
+              ? ({ '--mantine-color-default-hover': 'rgba(255, 255, 255, 0.12)' } as React.CSSProperties)
+              : undefined
+          }
+        >
           {visibleItems.map((item) => {
             const active = isActive(pathname, item.href);
             // On the colored sidebar all text is white; the 'light' variant gives a soft


### PR DESCRIPTION
Fixes #284.

## Problem
On the dark purple sidebar (`treehousePurple.9`), the nav labels are forced white. Mantine's `NavLink` fills a **non-active** item on hover with its `--mantine-color-default-hover` token, which is near-white (`#f1f3f5`) in light mode. White label + near-white hover fill = the label vanishes — the reported "white-on-white when you hover."

## Fix
Scope `--mantine-color-default-hover` to a translucent white (`rgba(255, 255, 255, 0.12)`) on the colored Navbar only. Hovering now just lightens the purple and the white label stays readable.

A translucent white (rather than a fixed color) is deliberate:
- It stays consistent with the rest of the sidebar's white-on-purple language and the active item's subtle overlay.
- It's correct in **dark mode** too, where the default token is already dark — a literal "purple text on white pill" would become purple-on-dark there, its own low-contrast bug.

Scoped to `onColoredSidebar`, so the unbranded `base` brand (white sidebar) is untouched.

## Testing
Visual/CSS-only change. Could not run the test suite locally (dependencies not installed in this environment). One file changed, +13/−1.