### PR TITLE
fix(kiosk): stop sending raw participant email from certifications API (#329)

### DIFF
--- a/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
@@ -159,6 +159,9 @@ describe('Kiosk Certifications API Integration Tests', () => {
              const visitMatches = data.participants.filter((v: {id: number}) => v.id === testUserId);
              expect(visitMatches.length).toBe(1);
              expect(visitMatches[0].toolStatuses.some((t: {toolId: number, level: string}) => t.toolId === toolId && t.level === 'CERTIFIED')).toBe(true);
+             // Returns a display name and never the raw email — data minimization (#329).
+             expect(visitMatches[0].name).toBe('User Kiosk Test');
+             expect('email' in visitMatches[0]).toBe(false);
              
              const toolMatches = data.tools.filter((t: {id: number}) => t.id === toolId);
              expect(toolMatches.length).toBe(1);

--- a/checkin-app/src/app/api/kiosk/certifications/route.ts
+++ b/checkin-app/src/app/api/kiosk/certifications/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 
-// Serves the full participant roster + PII (email, name, minor flag, tool certs).
-// Same data class as /api/attendance, so the same gate: a valid kiosk signature, or
+// Serves the participant roster for the tool-certification grid: id, a display name, and
+// tool certs. The raw email is read only to resolve the name fallback and never leaves the
+// DB (#329). Same data class as /api/attendance, so the same gate: a valid kiosk signature, or
 // a privileged session (sysadmin/boardMember/keyholder). A plain member session gets
 // 403 — withAuth handles the kiosk path, role check, denied-household, and local dev.
 export const GET = withAuth(
@@ -48,8 +49,9 @@ export const GET = withAuth(
 
         const participants = participantsData.map((participant) => ({
             id: participant.id,
-            email: participant.email,
-            name: participant.name,
+            // The grid only ever shows a display name, so resolve the name-or-email-prefix
+            // fallback here and drop the raw address from the response (#329).
+            name: participant.name?.trim() || participant.email?.split("@")[0] || "",
             toolStatuses: participant.toolStatuses,
         }));
 

--- a/checkin-app/src/app/kioskdisplay/certifications/page.tsx
+++ b/checkin-app/src/app/kioskdisplay/certifications/page.tsx
@@ -11,8 +11,8 @@ type ToolStatusLevel = "BASIC" | "DOF" | "CERTIFIED" | "INSTRUCTOR" | "MAY_CERTI
 
 type Participant = {
   id: number;
-  email: string;
-  name: string | null;
+  // Display name resolved server-side (real name, else email-prefix); never the raw email (#329).
+  name: string;
   toolStatuses: {
     toolId: number;
     level: ToolStatusLevel;
@@ -100,10 +100,10 @@ function KioskCertificationsInner() {
     return name.split(/\s+/).map(word => (word.length > MAX_WORD_LEN ? word.slice(0, MAX_WORD_LEN - 1) + '.' : word));
   };
 
-  // Sort users alphabetically by first name (fallback to email prefix)
+  // Sort users alphabetically by first name (name is server-resolved, email-prefix included)
   const sortAlphabetically = (a: Participant, b: Participant) => {
-    const nameA = a.name || a.email.split('@')[0];
-    const nameB = b.name || b.email.split('@')[0];
+    const nameA = a.name;
+    const nameB = b.name;
     const getFirstName = (name: string) => {
       if (name.includes(',')) return name.split(',')[1].trim().toLowerCase();
       return name.split(' ')[0].toLowerCase();
@@ -131,7 +131,7 @@ function KioskCertificationsInner() {
     <tr key={participant.id} style={{ borderBottom: index % 2 === 1 ? '3px solid var(--mantine-color-default-border)' : cellBorder }}>
       <td style={{ padding: isKioskMode ? '0.5rem 0.75rem' : '0.75rem 1rem', position: 'sticky', left: 0, background: 'var(--mantine-color-body)', zIndex: 5, borderRight: cellBorder }}>
         <Text fw={isKioskMode ? 700 : 500} fz={isKioskMode ? '1.1rem' : undefined} truncate>
-          {displayNames.get(participant.id) || participant.name || participant.email.split('@')[0]}
+          {displayNames.get(participant.id) || participant.name}
         </Text>
       </td>
       {tools.map((tool) => {

--- a/checkin-app/src/lib/kiosk-names.ts
+++ b/checkin-app/src/lib/kiosk-names.ts
@@ -1,7 +1,9 @@
 type NamedEntity = {
     id: number;
     name: string | null;
-    email: string;
+    // Optional: some feeds (e.g. the certifications grid) resolve the email-prefix
+    // fallback server-side and omit the raw address entirely.
+    email?: string;
 };
 
 /**
@@ -11,8 +13,8 @@ type NamedEntity = {
 function parseName(entity: NamedEntity): { first: string; last: string } {
     const raw = entity.name?.trim();
     if (!raw) {
-        // Fallback to email prefix
-        return { first: entity.email.split("@")[0], last: "" };
+        // Fallback to email prefix when present (may be omitted — see NamedEntity).
+        return { first: entity.email?.split("@")[0] ?? "", last: "" };
     }
 
     // Handle "Last, First" format


### PR DESCRIPTION
Fixes #329.

## Problem
`GET /api/kiosk/certifications` returned each participant's full `email`, but the only consumer (`kioskdisplay/certifications/page.tsx`) used just the local-part (`email.split('@')[0]`) as a display-name fallback. The full address — domain included — was sent over the wire and never rendered.

## Fix (issue's preferred Option 1 — data minimization)
Resolve the `name || email-prefix` fallback **server-side** and return it as `name`, dropping `email` from the response entirely. The raw address is still read from the DB only to compute the fallback and never leaves it.

- **route**: response is now `{ id, name, toolStatuses }`; `email` is no longer emitted. (`email` stays in the Prisma `select` solely to compute the fallback.)
- **`lib/kiosk-names.ts`**: `NamedEntity.email` is now optional — the certs feed omits it — and the email-prefix fallback guards against a missing address. The other caller (`kioskdisplay/page.tsx`) still passes `email`, unaffected.
- **certifications page**: `Participant` type drops `email`; sort/render use the server-resolved `name`.
- **test**: assert the response carries a display name and has no `email` field.

## Notes
- Not an access-control change — the route's `withAuth` gate (sysadmin / boardMember / keyholder, or valid kiosk signature) is untouched. This is the PII-minimization follow-up the issue describes.
- Behavior is identical to before for display/disambiguation: when `name` was null, the client already fell back to the email-prefix; that resolution now just happens on the server.

## Testing
Dependencies aren't installed in this environment (offline monorepo), so I couldn't run the Jest suite locally. Change is type-safe by inspection; added a regression assertion to the existing integration test. 4 files, +20/−13.