### PR TITLE
feat(system-status): add Errors tab for backend error log

### DIFF
--- a/checkin-app/src/app/api/admin/error-log/route.ts
+++ b/checkin-app/src/app/api/admin/error-log/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+
+export const GET = withAuth(
+    { roles: ['sysadmin', 'boardMember'] },
+    async () => {
+        try {
+            const errors = await prisma.errorLog.findMany({
+                orderBy: { createdAt: "desc" },
+                take: 100,
+            });
+            return NextResponse.json({ errors });
+        } catch (error) {
+            console.error("Failed to fetch error logs:", error);
+            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        }
+    }
+);

--- a/checkin-app/src/app/system-status/page.tsx
+++ b/checkin-app/src/app/system-status/page.tsx
@@ -4,6 +4,7 @@ import { Card, Center, Group, List, Loader, SimpleGrid, Stack, Tabs, Text, Title
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { BadgeScanChart, SystemVersionBox } from "@/components/admin/SystemHealthPanels";
 import { LinkStatusPanel } from "@/components/admin/LinkStatusPanel";
+import { ErrorLogPanel } from "@/components/admin/ErrorLogPanel";
 
 export default function SystemStatusIndex() {
   const { loading, ready } = useRequireRole(["sysadmin", "boardMember"]);
@@ -22,6 +23,7 @@ export default function SystemStatusIndex() {
       <Tabs.List mb="md">
         <Tabs.Tab value="system-status">System Status</Tabs.Tab>
         <Tabs.Tab value="link-status">Link Status</Tabs.Tab>
+        <Tabs.Tab value="errors">Errors</Tabs.Tab>
       </Tabs.List>
 
       <Tabs.Panel value="system-status">
@@ -77,6 +79,10 @@ export default function SystemStatusIndex() {
 
       <Tabs.Panel value="link-status">
         <LinkStatusPanel />
+      </Tabs.Panel>
+
+      <Tabs.Panel value="errors">
+        <ErrorLogPanel />
       </Tabs.Panel>
     </Tabs>
   );

--- a/checkin-app/src/components/admin/ErrorLogPanel.tsx
+++ b/checkin-app/src/components/admin/ErrorLogPanel.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Fragment, useEffect, useState } from "react";
+import { Card, Center, Code, Loader, Stack, Table, Text, Title } from "@mantine/core";
+
+type ErrorLogRow = {
+  id: number;
+  createdAt: string;
+  route: string | null;
+  message: string;
+  stack: string | null;
+  context: unknown;
+};
+
+export function ErrorLogPanel() {
+  const [errors, setErrors] = useState<ErrorLogRow[] | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  useEffect(() => {
+    fetch("/api/admin/error-log")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => setErrors(data.errors ?? []))
+      .catch(() => setFailed(true));
+  }, []);
+
+  if (failed) return <Text c="red">Failed to load error log.</Text>;
+  if (!errors) {
+    return (
+      <Center mih="30vh">
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (errors.length === 0) {
+    return (
+      <Card withBorder radius="md" padding="lg">
+        <Text c="green">● No backend errors logged.</Text>
+        <Text size="sm" c="dimmed" mt="xs">
+          Backend errors captured by logBackendError appear here. Rolling 30-day log.
+        </Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card withBorder radius="md" padding="lg">
+      <Title order={4} mb="md">Recent Backend Errors</Title>
+      <Text c="dimmed" size="sm" mb="md">
+        Up to 100 most recent entries (auto-purged after 30 days). Click a row to expand stack/context.
+      </Text>
+      <Table.ScrollContainer minWidth={600}>
+        <Table striped highlightOnHover verticalSpacing="sm">
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Time</Table.Th>
+              <Table.Th>Route</Table.Th>
+              <Table.Th>Message</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {errors.map((e) => (
+              <Fragment key={e.id}>
+                <Table.Tr
+                  onClick={() => setExpanded(expanded === e.id ? null : e.id)}
+                  style={{ cursor: "pointer" }}
+                >
+                  <Table.Td style={{ whiteSpace: "nowrap" }}>
+                    {new Date(e.createdAt).toLocaleString()}
+                  </Table.Td>
+                  <Table.Td>{e.route ? <Code>{e.route}</Code> : <Text c="dimmed">—</Text>}</Table.Td>
+                  <Table.Td>{e.message}</Table.Td>
+                </Table.Tr>
+                {expanded === e.id && (
+                  <Table.Tr>
+                    <Table.Td colSpan={3}>
+                      <Stack gap="xs">
+                        {e.stack && (
+                          <div>
+                            <Text size="xs" fw={700} tt="uppercase" c="dimmed">Stack</Text>
+                            <Code block fz="xs">{e.stack}</Code>
+                          </div>
+                        )}
+                        {e.context != null && (
+                          <div>
+                            <Text size="xs" fw={700} tt="uppercase" c="dimmed">Context</Text>
+                            <Code block fz="xs">{JSON.stringify(e.context, null, 2)}</Code>
+                          </div>
+                        )}
+                        {!e.stack && e.context == null && (
+                          <Text c="dimmed" size="sm">No additional detail.</Text>
+                        )}
+                      </Stack>
+                    </Table.Td>
+                  </Table.Tr>
+                )}
+              </Fragment>
+            ))}
+          </Table.Tbody>
+        </Table>
+      </Table.ScrollContainer>
+    </Card>
+  );
+}


### PR DESCRIPTION
## What

Adds a third **Errors** tab to the System Status page that surfaces recent backend error-log entries.

The `ErrorLog` table was write-only — `logBackendError()` records route/message/stack/context (with a 30-day TTL) but nothing read it back. There was no UI, API route, or nav link. This builds the read/view side.

## Changes

- **`GET /api/admin/error-log`** — gated `sysadmin`/`boardMember` via `withAuth` (same pattern as other `/api/admin/*` routes), returns the 100 newest `ErrorLog` rows, newest first.
- **`ErrorLogPanel`** component — mirrors the existing `LinkStatusPanel` style: a Mantine table of time / route / message; click a row to expand stack + context. Handles loading, failed, and empty states.
- **`system-status/page.tsx`** — adds the "Errors" tab alongside the existing **System Status** and **Link Status** (#434) tabs.

No new nav link (System Status already in the sidebar) and no schema change (reads the existing table).

## Reviewer notes

- Builds on top of #434's Link Status tab — this branch was rebased onto current `main`, so it slots in as a third tab rather than re-doing the Tabs conversion.
- Read-only: no mutation route, unlike Link Status' resolve action.
- Verified earlier against a local Postgres: route returns 403 unauthenticated, and the query returns rows with all rendered fields (createdAt/route/message/stack/context). tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)