### PR TITLE
test(audit): cover audit-row writes for attendance + cert-grant routes

### DIFF
--- a/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
@@ -121,6 +121,11 @@ describe('Event Attendance API Integration Tests', () => {
         await prisma.visit.deleteMany({
             where: { participantId: { in: [testParticipant1Id, testParticipant2Id] } }
         });
+        // Clear audit rows so each test asserts exactly its own write.
+        // testEventId is fresh per run, so this is leak-proof.
+        await prisma.auditLog.deleteMany({
+            where: { tableName: 'Visit', affectedEntityId: testEventId }
+        });
     });
 
     describe('POST /api/events/[id]/attendance', () => {
@@ -187,6 +192,17 @@ describe('Event Attendance API Integration Tests', () => {
             expect(visits.length).toBe(1);
             expect(visits[0].arrived).not.toBeNull();
             expect(visits[0].departed).not.toBeNull();
+
+            // Audit: exactly one row crediting the acting lead mentor.
+            const auditRows = await prisma.auditLog.findMany({
+                where: { tableName: 'Visit', affectedEntityId: testEventId }
+            });
+            expect(auditRows.length).toBe(1);
+            expect(auditRows[0].actorId).toBe(testLeadMentorId);
+            expect(auditRows[0].action).toBe('EDIT');
+            expect(JSON.parse(auditRows[0].newData as string)).toEqual({
+                validatedParticipants: [testParticipant1Id]
+            });
         });
 
         it('should link an existing unassociated visit that overlaps with the event', async () => {
@@ -224,6 +240,17 @@ describe('Event Attendance API Integration Tests', () => {
             expect(visits.length).toBe(1); // Should only be the one we created
             expect(visits[0].associatedEventId).toBe(testEventId); // It was successfully linked
             expect(visits[0].arrived.getTime()).toBe(earlyArrival.getTime()); // Validates it used the existing visit
+
+            // Audit: exactly one row crediting the acting admin.
+            const auditRows = await prisma.auditLog.findMany({
+                where: { tableName: 'Visit', affectedEntityId: testEventId }
+            });
+            expect(auditRows.length).toBe(1);
+            expect(auditRows[0].actorId).toBe(testAdminId);
+            expect(auditRows[0].action).toBe('EDIT');
+            expect(JSON.parse(auditRows[0].newData as string)).toEqual({
+                validatedParticipants: [testParticipant2Id]
+            });
         });
     });
 });

--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -290,6 +290,14 @@ describe('Shop API Integration Tests', () => {
              expect(data.success).toBe(true);
              expect(data.certification.level).toBe('BASIC');
              expect(data.certification.userId).toBe(commonId);
+
+             // Audit: first grant on this participant+tool → CREATE, no prior data.
+             const auditRows = await prisma.auditLog.findMany({
+                 where: { tableName: 'ToolStatus', actorId: certifierId, affectedEntityId: commonId, secondaryAffectedEntity: mockToolId }
+             });
+             expect(auditRows.length).toBe(1);
+             expect(auditRows[0].action).toBe('CREATE');
+             expect(auditRows[0].oldData).toBeNull();
         });
 
         it('should forbid a Certifier from promoting someone to MAY_CERTIFY_OTHERS', async () => {
@@ -311,6 +319,15 @@ describe('Shop API Integration Tests', () => {
              const data = await res.json();
              expect(data.success).toBe(true);
              expect(data.certification.level).toBe('MAY_CERTIFY_OTHERS');
+
+             // Audit: a prior status (BASIC) now exists → EDIT, with old data captured.
+             const auditRows = await prisma.auditLog.findMany({
+                 where: { tableName: 'ToolStatus', actorId: adminId, affectedEntityId: commonId, secondaryAffectedEntity: mockToolId }
+             });
+             expect(auditRows.length).toBe(1);
+             expect(auditRows[0].action).toBe('EDIT');
+             expect(auditRows[0].oldData).not.toBeNull();
+             expect(JSON.parse(auditRows[0].oldData as string).level).toBe('BASIC');
         });
     });
 });


### PR DESCRIPTION
## What

Add audit-row assertions to two integration suites whose accountability-sensitive audit writes were previously untested.

**Event attendance validation** ([eventAttendanceAPI.integration.test.ts](checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts))
- Synthetic-visit and link-existing-visit cases now assert exactly one `Visit` audit row.
- Checks `actorId` == acting lead mentor / admin, `action` `EDIT`, `affectedEntityId` == eventId, `newData.validatedParticipants`.
- `afterEach` clears the event's audit rows so each case asserts exactly its own write (fresh `testEventId` per run = leak-proof).

**Shop tool certification grant** ([shopAPI.integration.test.ts](checkin-app/src/app/__tests__/shopAPI.integration.test.ts))
- First grant on a participant+tool → `action` `CREATE`, `oldData` null.
- Subsequent grant on the same participant+tool → `action` `EDIT`, `oldData` non-null with prior `level` (`BASIC`) captured.
- Both rows assert `affectedEntityId` == participantId, `secondaryAffectedEntity` == toolId, `actorId` == certifier. Rows isolated by `actorId` filter.

## Why

These routes write the "who did what to whom" audit trail (who marked participants present, who certified whom on which tool). The trail had no test coverage, so a regression in the audit write would pass silently. These assertions lock the actor, action, and affected-entity fields.

## Reviewer notes

- Field names verified against the routes: attendance `action` is hardcoded `EDIT` (not branched), so the test asserts `EDIT`. Shop `action` branches `CREATE`/`EDIT` on prior status.
- Both integration suites verified green against a real Postgres (`npm run test:integration`), 19 tests passing.
- TAG-scoped data + cleanup, consistent with the existing suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)