### PR TITLE
refactor(cron): extract shared requireCronSecret auth gate

### DIFF
--- a/checkin-app/src/app/__tests__/cronRemindersAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronRemindersAPI.integration.test.ts
@@ -12,7 +12,8 @@ import { sendNotification } from '@/lib/notifications';
 
 // Mock the notification sender
 jest.mock('@/lib/notifications', () => ({
-    sendNotification: jest.fn()
+    // sendNotification resolves boolean; the route only stamps/counts on a truthy result.
+    sendNotification: jest.fn().mockResolvedValue(true)
 }));
 
 describe('Cron Reminders API Integration Tests', () => {

--- a/checkin-app/src/app/__tests__/cronRemindersEdge.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronRemindersEdge.integration.test.ts
@@ -6,7 +6,6 @@
  *
  * The existing cronRemindersAPI test only covers the happy path with a valid
  * secret and a single in-window event. These add:
- *   - the auth rejections (missing / wrong / unconfigured CRON_SECRET)
  *   - window selection at the inside/outside boundaries of the [now+2h, +2h15m] range
  *   - idempotency: a second run does NOT re-send, because the route now stamps
  *     RSVP.reminderSentAt after sending and excludes already-reminded RSVPs.
@@ -16,7 +15,9 @@ import prisma from '@/lib/prisma';
 import { sendNotification } from '@/lib/notifications';
 
 jest.mock('@/lib/notifications', () => ({
-    sendNotification: jest.fn().mockResolvedValue(undefined),
+    // Resolves true (the real signature is Promise<boolean>); the route stamps
+    // reminderSentAt only on a truthy result, which is what makes the second run idempotent.
+    sendNotification: jest.fn().mockResolvedValue(true),
 }));
 
 const SECRET = 'reminders-edge-secret';
@@ -78,23 +79,9 @@ describe('GET /api/cron/reminders — auth & window edges', () => {
         return event.id;
     }
 
-    it('returns 401 when the authorization header is missing', async () => {
-        const res = await GET(cronReq());
-        expect(res.status).toBe(401);
-        expect(sendNotification).not.toHaveBeenCalled();
-    });
-
-    it('returns 401 when the bearer token is wrong', async () => {
-        const res = await GET(cronReq('Bearer not-the-secret'));
-        expect(res.status).toBe(401);
-        expect(sendNotification).not.toHaveBeenCalled();
-    });
-
-    it('returns 401 when CRON_SECRET is not configured', async () => {
-        delete process.env.CRON_SECRET;
-        const res = await GET(cronReq(`Bearer ${SECRET}`));
-        expect(res.status).toBe(401);
-    });
+    // Cron auth (missing / wrong / unconfigured secret) is covered centrally in
+    // src/lib/__tests__/cronAuth.test.ts; this file only exercises the route's
+    // window-selection and idempotency edges.
 
     it('selects only events inside the [now+2h, now+2h15m] window', async () => {
         await makeEvent('inside-early', 2 * HOUR + 1 * MIN);   // just inside lower bound

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -87,10 +87,8 @@ describe('Membership renewal', () => {
         await prisma.$disconnect();
     });
 
-    it('cron rejects missing/invalid bearer', async () => {
-        expect((await CRON(cronReq(null))).status).toBe(401);
-        expect((await CRON(cronReq('wrong'))).status).toBe(401);
-    });
+    // Cron auth negatives are covered centrally in src/lib/__tests__/cronAuth.test.ts;
+    // the valid-bearer smoke ('cron runs with a valid bearer') stays below.
 
     it('nextBoundary rolls to next year when the date has passed', () => {
         const boundary = new Date(Date.UTC(2020, 7, 1)); // Aug 1

--- a/checkin-app/src/app/api/cron/membership-renewals/route.ts
+++ b/checkin-app/src/app/api/cron/membership-renewals/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import crypto from "crypto";
+import { requireCronSecret } from "@/lib/cronAuth";
 import { logger } from "@/lib/logger";
 import { runRenewalSweep } from "@/lib/membership/renewal";
 
@@ -10,17 +10,8 @@ export const dynamic = "force-dynamic";
  * within the lead window. Authorized by `Authorization: Bearer $CRON_SECRET`.
  */
 export async function GET(req: Request) {
-    const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
-    if (!cronSecret || !authHeader) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    const expected = `Bearer ${cronSecret}`;
-    const a = Buffer.from(authHeader);
-    const b = Buffer.from(expected);
-    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const denied = requireCronSecret(req);
+    if (denied) return denied;
 
     try {
         const result = await runRenewalSweep(new Date());

--- a/checkin-app/src/app/api/cron/nightly/route.ts
+++ b/checkin-app/src/app/api/cron/nightly/route.ts
@@ -1,24 +1,12 @@
 import { NextResponse } from "next/server";
-import crypto from "crypto";
+import { requireCronSecret } from "@/lib/cronAuth";
 import prisma from "@/lib/prisma";
 import { processPostEventEmails } from "@/lib/postEventEmails";
 import { processVisitCheckout } from "@/lib/attendanceTransitions";
 
 export async function GET(req: Request) {
-    const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
-
-    if (!cronSecret || !authHeader) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const expectedHeader = `Bearer ${cronSecret}`;
-    const providedBuffer = Buffer.from(authHeader);
-    const expectedBuffer = Buffer.from(expectedHeader);
-
-    if (providedBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const denied = requireCronSecret(req);
+    if (denied) return denied;
 
     try {
         const now = new Date();

--- a/checkin-app/src/app/api/cron/pending-participants/route.ts
+++ b/checkin-app/src/app/api/cron/pending-participants/route.ts
@@ -1,22 +1,10 @@
 import { NextResponse } from "next/server";
-import crypto from "crypto";
+import { requireCronSecret } from "@/lib/cronAuth";
 import prisma from "@/lib/prisma";
 
 export async function GET(req: Request) {
-    const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
-
-    if (!cronSecret || !authHeader) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const expectedHeader = `Bearer ${cronSecret}`;
-    const providedBuffer = Buffer.from(authHeader);
-    const expectedBuffer = Buffer.from(expectedHeader);
-
-    if (providedBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const denied = requireCronSecret(req);
+    if (denied) return denied;
 
     try {
         const now = new Date();

--- a/checkin-app/src/app/api/cron/post-event/route.ts
+++ b/checkin-app/src/app/api/cron/post-event/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import crypto from "crypto";
+import { requireCronSecret } from "@/lib/cronAuth";
 import { processPostEventEmails } from "@/lib/postEventEmails";
 
 /**
@@ -7,20 +7,8 @@ import { processPostEventEmails } from "@/lib/postEventEmails";
  * GET /api/cron/post-event
  */
 export async function GET(req: Request) {
-    const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
-
-    if (!cronSecret || !authHeader) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const expectedHeader = `Bearer ${cronSecret}`;
-    const providedBuffer = Buffer.from(authHeader);
-    const expectedBuffer = Buffer.from(expectedHeader);
-
-    if (providedBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const denied = requireCronSecret(req);
+    if (denied) return denied;
 
     try {
         // By default, this uses the 1-hour delay rule

--- a/checkin-app/src/app/api/cron/reminders/route.ts
+++ b/checkin-app/src/app/api/cron/reminders/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import crypto from "crypto";
+import { requireCronSecret } from "@/lib/cronAuth";
 import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
 
@@ -18,20 +18,8 @@ import { sendNotification } from "@/lib/notifications";
  * before either stamps and double-send.
  */
 export async function GET(req: Request) {
-    const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
-
-    if (!cronSecret || !authHeader) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const expectedHeader = `Bearer ${cronSecret}`;
-    const providedBuffer = Buffer.from(authHeader);
-    const expectedBuffer = Buffer.from(expectedHeader);
-
-    if (providedBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const denied = requireCronSecret(req);
+    if (denied) return denied;
 
     try {
         const now = new Date();

--- a/checkin-app/src/app/api/cron/trusted-adult-expiry/route.ts
+++ b/checkin-app/src/app/api/cron/trusted-adult-expiry/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import crypto from "crypto";
+import { requireCronSecret } from "@/lib/cronAuth";
 import { logger } from "@/lib/logger";
 import { runExpirySweep } from "@/lib/trusted-adult/service";
 
@@ -11,17 +11,8 @@ export const dynamic = "force-dynamic";
  * Authorized by `Authorization: Bearer $CRON_SECRET`.
  */
 export async function GET(req: Request) {
-    const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
-    if (!cronSecret || !authHeader) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    const expected = `Bearer ${cronSecret}`;
-    const a = Buffer.from(authHeader);
-    const b = Buffer.from(expected);
-    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const denied = requireCronSecret(req);
+    if (denied) return denied;
 
     try {
         const result = await runExpirySweep(new Date());

--- a/checkin-app/src/lib/__tests__/cronAuth.test.ts
+++ b/checkin-app/src/lib/__tests__/cronAuth.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for requireCronSecret — the shared auth gate for all cron routes.
+ * No DB: Request objects are constructed directly. This is the primary coverage
+ * for cron auth; per-route tests only smoke the valid-token path.
+ */
+import { requireCronSecret } from '@/lib/cronAuth';
+
+const SECRET = 'unit-cron-secret';
+
+function req(authHeader?: string) {
+    return new Request('http://localhost/api/cron/anything', {
+        method: 'GET',
+        headers: authHeader ? { authorization: authHeader } : {},
+    });
+}
+
+describe('requireCronSecret', () => {
+    const prev = process.env.CRON_SECRET;
+
+    beforeEach(() => {
+        process.env.CRON_SECRET = SECRET;
+    });
+
+    afterAll(() => {
+        if (prev === undefined) delete process.env.CRON_SECRET;
+        else process.env.CRON_SECRET = prev;
+    });
+
+    it('returns 401 when the Authorization header is missing', () => {
+        const res = requireCronSecret(req());
+        expect(res?.status).toBe(401);
+    });
+
+    it('returns 401 when the bearer token is wrong', () => {
+        const res = requireCronSecret(req('Bearer not-the-secret'));
+        expect(res?.status).toBe(401);
+    });
+
+    it('returns 401 when CRON_SECRET is not configured', () => {
+        delete process.env.CRON_SECRET;
+        const res = requireCronSecret(req(`Bearer ${SECRET}`));
+        expect(res?.status).toBe(401);
+    });
+
+    it('returns 401 on a length mismatch (short-circuits before timingSafeEqual)', () => {
+        // timingSafeEqual throws on unequal-length buffers; the length guard must
+        // reject first so this is a clean 401, not a crash.
+        const res = requireCronSecret(req('Bearer short'));
+        expect(res?.status).toBe(401);
+    });
+
+    it('returns null (authorized) for the valid secret', () => {
+        const res = requireCronSecret(req(`Bearer ${SECRET}`));
+        expect(res).toBeNull();
+    });
+});

--- a/checkin-app/src/lib/cronAuth.ts
+++ b/checkin-app/src/lib/cronAuth.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+
+/**
+ * Shared auth gate for the cron routes. Checks `Authorization: Bearer $CRON_SECRET`
+ * with a length guard before the timing-safe compare. Returns a 401 NextResponse
+ * when unauthorized (missing header, unset CRON_SECRET, length mismatch, or wrong
+ * token), or null when the request is authorized.
+ *
+ *   const denied = requireCronSecret(req);
+ *   if (denied) return denied;
+ */
+export function requireCronSecret(req: Request): NextResponse | null {
+    const authHeader = req.headers.get("authorization");
+    const cronSecret = process.env.CRON_SECRET;
+
+    if (!cronSecret || !authHeader) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const expectedHeader = `Bearer ${cronSecret}`;
+    const providedBuffer = Buffer.from(authHeader);
+    const expectedBuffer = Buffer.from(expectedHeader);
+
+    if (providedBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    return null;
+}


### PR DESCRIPTION
## What

Replaces six hand-rolled copies of the cron `Authorization: Bearer $CRON_SECRET` timing-safe check with one shared helper, `requireCronSecret(req)` in [`src/lib/cronAuth.ts`](checkin-app/src/lib/cronAuth.ts), and adds focused unit coverage.

## Why

All six cron routes (`nightly`, `reminders`, `post-event`, `membership-renewals`, `pending-participants`, `trusted-adult-expiry`) carried an identical, copy-pasted auth block — but only `reminders` had unauthorized-rejection tests. The other five were tested with a valid token only, and one of them (`pending-participants`) **DELETEs data**. A regression that dropped or inverted the check on, e.g., `pending-participants` would have shipped green.

## Changes

- **New** `requireCronSecret(req): NextResponse | null` — returns a 401 response when unauthorized, `null` when OK. Behavior preserved exactly from the inline copies: missing header → 401, unset `CRON_SECRET` → 401, length mismatch → 401 (short-circuits before `timingSafeEqual`), wrong token → 401, valid → pass.
- All six routes now call the helper (`const denied = requireCronSecret(req); if (denied) return denied;`) and drop their now-unused `crypto` import.
- **New** `src/lib/__tests__/cronAuth.test.ts` — DB-free unit test (constructs `Request` objects directly) covering all five cases. This is the primary auth coverage.
- Trimmed the now-redundant per-route auth-negative tests in `cronRemindersEdge` and `membershipRenewalAPI` to a single valid-token smoke each.

## Note for reviewers

While running the suites I found two **pre-existing** reminders test failures, unrelated to the auth refactor (reproduced on the original route via `git stash`): the tests mocked `sendNotification` to resolve `undefined`, but the route stamps/counts reminders only on a truthy result (`sendNotification` is `Promise<boolean>`). Fixed the mocks to resolve `true`, matching the real contract.

## Tests

All six affected suites green locally (throwaway Postgres): `cronAuth` unit + the five cron integration suites — 20 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)