### PR TITLE
fix(age): correct calendar-age math; gate program age at start date

### DIFF
--- a/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
@@ -20,11 +20,12 @@ describe('Public Program Registration API Integration Tests', () => {
     let fullProgramId: number;
     let exactAgeProgramId: number;
     let maxAgeBoundaryProgramId: number;
+    let startBasisProgramId: number;
     let existingParticipantId: number;
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const testEmails = ['test-primary-parent@example.com', 'existing-user-test@example.com', 'max-age-boundary-parent@example.com'];
+        const testEmails = ['test-primary-parent@example.com', 'existing-user-test@example.com', 'max-age-boundary-parent@example.com', 'start-basis-parent@example.com'];
         const existingUsers = await prisma.participant.findMany({
             where: { email: { in: testEmails } },
             select: { id: true }
@@ -99,10 +100,17 @@ describe('Public Program Registration API Integration Tests', () => {
             data: { name: 'Max Age Boundary Public Reg Test', phase: 'RUNNING', enrollmentStatus: 'OPEN', maxAge: 17 }
         });
         maxAgeBoundaryProgramId = maxAgeBoundaryProgram.id;
+
+        // Free, minAge 18, starts 2026-09-01. Used to prove the age gate judges
+        // age as of the program START date, not registration time.
+        const startBasisProgram = await prisma.program.create({
+            data: { name: 'Start Basis Public Reg Test', phase: 'RUNNING', enrollmentStatus: 'OPEN', minAge: 18, begin: new Date('2026-09-01T00:00:00.000Z') }
+        });
+        startBasisProgramId = startBasisProgram.id;
     });
 
     afterAll(async () => {
-        const testEmails = ['test-primary-parent@example.com', 'existing-user-test@example.com', 'max-age-boundary-parent@example.com'];
+        const testEmails = ['test-primary-parent@example.com', 'existing-user-test@example.com', 'max-age-boundary-parent@example.com', 'start-basis-parent@example.com'];
         const existingUsers = await prisma.participant.findMany({
             where: { email: { in: testEmails } },
             select: { id: true, householdId: true }
@@ -110,7 +118,7 @@ describe('Public Program Registration API Integration Tests', () => {
         const existingUserIds = existingUsers.map(u => u.id);
         const householdIds = existingUsers.map(u => u.householdId).filter(id => id !== null) as number[];
 
-        const validProgramIds = [standardProgramId, freeProgramId, fullProgramId, exactAgeProgramId, maxAgeBoundaryProgramId].filter(id => id !== undefined);
+        const validProgramIds = [standardProgramId, freeProgramId, fullProgramId, exactAgeProgramId, maxAgeBoundaryProgramId, startBasisProgramId].filter(id => id !== undefined);
 
         if (existingUserIds.length > 0) {
             await prisma.programParticipant.deleteMany({
@@ -300,6 +308,30 @@ describe('Public Program Registration API Integration Tests', () => {
                 expect(res.status).toBe(400);
                 const data = await res.json();
                 expect(data.error).toMatch(/at least 18/i);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it('should judge age as of the program START date, not registration time', async () => {
+            // startBasisProgram: minAge 18, begins 2026-09-01. Clock frozen at
+            // 2026-01-01, applicant born 2008-06-15 => age 17 NOW but 18 by the
+            // start date. Registration-time math would reject; start-date math admits.
+            jest.useFakeTimers(FAKE_TIMER_OPTS);
+            try {
+                const req = new Request(`http://localhost:4000/api/programs/${startBasisProgramId}/public-register`, {
+                    method: 'POST',
+                    headers: { 'x-forwarded-for': '203.0.113.12' },
+                    body: JSON.stringify({
+                        parents: [{ name: 'Boundary Parent', email: 'start-basis-parent@example.com', phone: '555-123-9999' }],
+                        emergencyContact: { name: 'Aunt Sue', phone: '555-999-9988' },
+                        participants: [{ name: 'Turns Eighteen', dob: '2008-06-15T12:00:00.000Z' }]
+                    })
+                });
+                const res = await POST(req as unknown as import("next/server").NextRequest, createParams(startBasisProgramId) as unknown as never);
+                expect(res.status).toBe(200);
+                const data = await res.json();
+                expect(data.success).toBe(true);
             } finally {
                 jest.useRealTimers();
             }

--- a/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
@@ -19,11 +19,12 @@ describe('Public Program Registration API Integration Tests', () => {
     let freeProgramId: number;
     let fullProgramId: number;
     let exactAgeProgramId: number;
+    let maxAgeBoundaryProgramId: number;
     let existingParticipantId: number;
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const testEmails = ['test-primary-parent@example.com', 'existing-user-test@example.com'];
+        const testEmails = ['test-primary-parent@example.com', 'existing-user-test@example.com', 'max-age-boundary-parent@example.com'];
         const existingUsers = await prisma.participant.findMany({
             where: { email: { in: testEmails } },
             select: { id: true }
@@ -91,10 +92,17 @@ describe('Public Program Registration API Integration Tests', () => {
             data: { name: 'Age Restricted Public Reg Test', phase: 'RUNNING', enrollmentStatus: 'OPEN', minAge: 18, maxAge: 21 }
         });
         exactAgeProgramId = exactAgeProgram.id;
+
+        // Free (price-less => ACTIVE) program with a tight upper age bound, used
+        // by the age-boundary regression tests below.
+        const maxAgeBoundaryProgram = await prisma.program.create({
+            data: { name: 'Max Age Boundary Public Reg Test', phase: 'RUNNING', enrollmentStatus: 'OPEN', maxAge: 17 }
+        });
+        maxAgeBoundaryProgramId = maxAgeBoundaryProgram.id;
     });
 
     afterAll(async () => {
-        const testEmails = ['test-primary-parent@example.com', 'existing-user-test@example.com'];
+        const testEmails = ['test-primary-parent@example.com', 'existing-user-test@example.com', 'max-age-boundary-parent@example.com'];
         const existingUsers = await prisma.participant.findMany({
             where: { email: { in: testEmails } },
             select: { id: true, householdId: true }
@@ -102,7 +110,7 @@ describe('Public Program Registration API Integration Tests', () => {
         const existingUserIds = existingUsers.map(u => u.id);
         const householdIds = existingUsers.map(u => u.householdId).filter(id => id !== null) as number[];
 
-        const validProgramIds = [standardProgramId, freeProgramId, fullProgramId, exactAgeProgramId].filter(id => id !== undefined);
+        const validProgramIds = [standardProgramId, freeProgramId, fullProgramId, exactAgeProgramId, maxAgeBoundaryProgramId].filter(id => id !== undefined);
 
         if (existingUserIds.length > 0) {
             await prisma.programParticipant.deleteMany({
@@ -230,6 +238,71 @@ describe('Public Program Registration API Integration Tests', () => {
             expect(res.status).toBe(400);
             const data = await res.json();
             expect(data.error).toMatch(/at least 18/i);
+        });
+
+        // Regression: the old inline epoch-delta age math
+        // (`new Date(Date.now()-dob).getUTCFullYear()-1970`) ignores month/day and
+        // counts someone whose birthday hasn't happened yet this year as ONE YEAR
+        // TOO OLD. We freeze the clock so a participant who is calendar-age 17
+        // (turns 18 *tomorrow*) is read as 18 by the buggy code. The leap-day
+        // drift that triggers the off-by-one only surfaces in Jan/Feb, so the
+        // frozen instant is required for these to be deterministic year-round.
+        // Date faked only (timers left real) so Prisma's pg pool keeps working.
+        const FAKE_TIMER_OPTS = {
+            doNotFake: [
+                'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval',
+                'setImmediate', 'clearImmediate', 'nextTick', 'queueMicrotask',
+                'requestAnimationFrame', 'cancelAnimationFrame', 'hrtime', 'performance',
+            ] as const,
+            now: new Date('2026-01-01T12:00:00.000Z'),
+        };
+        const BOUNDARY_DOB = '2008-01-02T12:00:00.000Z'; // calendar-age 17 at the frozen now; buggy math -> 18
+
+        it('should NOT reject an at-maximum-age participant whose birthday is later this year', async () => {
+            jest.useFakeTimers(FAKE_TIMER_OPTS);
+            try {
+                const req = new Request(`http://localhost:4000/api/programs/${maxAgeBoundaryProgramId}/public-register`, {
+                    method: 'POST',
+                    // Own IP bucket so the shared per-IP rate limit (other tests use the
+                    // default "unknown" IP) can't pre-exhaust this request.
+                    headers: { 'x-forwarded-for': '203.0.113.10' },
+                    body: JSON.stringify({
+                        parents: [{ name: 'Boundary Parent', email: 'max-age-boundary-parent@example.com', phone: '555-123-7777' }],
+                        emergencyContact: { name: 'Aunt Sue', phone: '555-999-7788' },
+                        participants: [{ name: 'Birthday Kid', dob: BOUNDARY_DOB }] // 17 now (max is 17); buggy math says 18
+                    })
+                });
+                const res = await POST(req as unknown as import("next/server").NextRequest, createParams(maxAgeBoundaryProgramId) as unknown as never);
+                // Buggy code rejected this with "maximum age is 17"; correct code admits the 17-year-old.
+                expect(res.status).toBe(200);
+                const data = await res.json();
+                expect(data.success).toBe(true);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it('should reject an under-minimum-age participant the buggy math counted as old enough', async () => {
+            jest.useFakeTimers(FAKE_TIMER_OPTS);
+            try {
+                // exactAgeProgram has minAge 18; the participant is calendar-age 17.
+                const req = new Request(`http://localhost:4000/api/programs/${exactAgeProgramId}/public-register`, {
+                    method: 'POST',
+                    headers: { 'x-forwarded-for': '203.0.113.11' },
+                    body: JSON.stringify({
+                        parents: [{ name: 'Boundary Parent', email: 'min-age-boundary-parent@example.com', phone: '555-123-8888' }],
+                        emergencyContact: { name: 'Aunt Sue', phone: '555-999-8877' },
+                        participants: [{ name: 'Birthday Kid', dob: BOUNDARY_DOB }] // 17 now (min is 18); buggy math says 18
+                    })
+                });
+                const res = await POST(req as unknown as import("next/server").NextRequest, createParams(exactAgeProgramId) as unknown as never);
+                // Buggy code admitted this 17-year-old (counted as 18); correct code rejects.
+                expect(res.status).toBe(400);
+                const data = await res.json();
+                expect(data.error).toMatch(/at least 18/i);
+            } finally {
+                jest.useRealTimers();
+            }
         });
 
         it('should successfully register a family with correct PENDING status and return Shopify URL', async () => {

--- a/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
@@ -256,12 +256,12 @@ describe('Public Program Registration API Integration Tests', () => {
         // drift that triggers the off-by-one only surfaces in Jan/Feb, so the
         // frozen instant is required for these to be deterministic year-round.
         // Date faked only (timers left real) so Prisma's pg pool keeps working.
-        const FAKE_TIMER_OPTS = {
+        const FAKE_TIMER_OPTS: Parameters<typeof jest.useFakeTimers>[0] = {
             doNotFake: [
                 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval',
                 'setImmediate', 'clearImmediate', 'nextTick', 'queueMicrotask',
                 'requestAnimationFrame', 'cancelAnimationFrame', 'hrtime', 'performance',
-            ] as const,
+            ],
             now: new Date('2026-01-01T12:00:00.000Z'),
         };
         const BOUNDARY_DOB = '2008-01-02T12:00:00.000Z'; // calendar-age 17 at the frozen now; buggy math -> 18

--- a/checkin-app/src/app/admin/programs/[id]/page.tsx
+++ b/checkin-app/src/app/admin/programs/[id]/page.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mantine/core';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { ScrollableTabsList } from '@/components/ui/ScrollableTabsList';
-import { formatDateTime } from '@/lib/time';
+import { formatDateTime, calculateAge } from '@/lib/time';
 
 type ProgramDetail = {
   id: number;
@@ -524,7 +524,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                         (p) => { setNewPartId(p.id.toString()); setPartSearch(`${p.name || 'Unnamed'} (${p.email})`); setPartResults([]); },
                         (p) => {
                           if (!p.dob) return null;
-                          const age = Math.abs(new Date(Date.now() - new Date(p.dob).getTime()).getUTCFullYear() - 1970);
+                          const age = calculateAge(p.dob);
                           let warning: string | null = null;
                           if (program.minAge !== null && age < program.minAge) warning = `⚠️ Too Young (${age})`;
                           if (program.maxAge !== null && age > program.maxAge) warning = `⚠️ Too Old (${age})`;

--- a/checkin-app/src/app/admin/programs/[id]/page.tsx
+++ b/checkin-app/src/app/admin/programs/[id]/page.tsx
@@ -524,7 +524,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                         (p) => { setNewPartId(p.id.toString()); setPartSearch(`${p.name || 'Unnamed'} (${p.email})`); setPartResults([]); },
                         (p) => {
                           if (!p.dob) return null;
-                          const age = calculateAge(p.dob);
+                          const age = calculateAge(p.dob, program.begin ?? undefined);
                           let warning: string | null = null;
                           if (program.minAge !== null && age < program.minAge) warning = `⚠️ Too Young (${age})`;
                           if (program.maxAge !== null && age > program.maxAge) warning = `⚠️ Too Old (${age})`;

--- a/checkin-app/src/app/api/admin/participants/import/route.ts
+++ b/checkin-app/src/app/api/admin/participants/import/route.ts
@@ -6,6 +6,7 @@ import * as xlsx from "xlsx";
 import { logBackendError } from "@/lib/logger";
 import { addHouseholdLead, HouseholdLeadLimitError, MAX_HOUSEHOLD_LEADS } from "@/lib/household/leads";
 import { parseImportDob } from "@/lib/importDob";
+import { calculateAge } from "@/lib/time";
 
 export async function POST(req: NextRequest) {
     try {
@@ -70,7 +71,7 @@ export async function POST(req: NextRequest) {
             dob?: Date;
             address?: string;
         }, db: Prisma.TransactionClient = prisma) => {
-            const isAdult = !data.dob || (new Date().getFullYear() - data.dob.getFullYear()) >= 18;
+            const isAdult = !data.dob || calculateAge(data.dob) >= 18;
             const participant = await db.participant.create({
                 data: {
                     ...(data.email && { email: data.email }),

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -91,7 +91,8 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                 if (!participantData?.dob) {
                     return NextResponse.json({ error: "Participant Date of Birth is missing.", requiresOverride: true }, { status: 400 });
                 }
-                const age = calculateAge(participantData.dob);
+                // Age as of program start; now for dateless programs.
+                const age = calculateAge(participantData.dob, currentProgram.begin ?? undefined);
                 if (currentProgram.minAge !== null && age < currentProgram.minAge) {
                     return NextResponse.json({ error: `Participant must be at least ${currentProgram.minAge} years old.`, requiresOverride: true }, { status: 400 });
                 }

--- a/checkin-app/src/app/api/programs/[id]/public-register/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/public-register/route.ts
@@ -102,7 +102,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                     if (!p.dob) {
                         return NextResponse.json({ error: `Date of Birth is required for participant ${p.name} to verify age constraints.` }, { status: 400 });
                     }
-                    const age = calculateAge(p.dob);
+                    // Judge age as of the program's start date; fall back to now
+                    // for dateless ("TBD") programs.
+                    const age = calculateAge(p.dob, currentProgram.begin ?? undefined);
                     if (currentProgram.minAge !== null && age < currentProgram.minAge) {
                         return NextResponse.json({ error: `Participant ${p.name} must be at least ${currentProgram.minAge} years old.` }, { status: 400 });
                     }

--- a/checkin-app/src/app/api/programs/[id]/public-register/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/public-register/route.ts
@@ -6,6 +6,7 @@ import { addHouseholdLead, HouseholdLeadLimitError } from "@/lib/household/leads
 import { lockProgramAndCheckCapacity, ProgramCapacityError } from "@/lib/program/capacity";
 import { createContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
 import { rateLimit, rateLimitEmail } from "@/lib/rate-limit";
+import { calculateAge } from "@/lib/time";
 
 interface ParentInput {
     name: string;
@@ -101,9 +102,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                     if (!p.dob) {
                         return NextResponse.json({ error: `Date of Birth is required for participant ${p.name} to verify age constraints.` }, { status: 400 });
                     }
-                    const ageDifMs = Date.now() - new Date(p.dob).getTime();
-                    const ageDate = new Date(ageDifMs);
-                    const age = Math.abs(ageDate.getUTCFullYear() - 1970);
+                    const age = calculateAge(p.dob);
                     if (currentProgram.minAge !== null && age < currentProgram.minAge) {
                         return NextResponse.json({ error: `Participant ${p.name} must be at least ${currentProgram.minAge} years old.` }, { status: 400 });
                     }

--- a/checkin-app/src/app/household/page.tsx
+++ b/checkin-app/src/app/household/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Badge, Button, Card, Center, Checkbox, Container, Group, Loader, Paper, SimpleGrid, Stack, Text, TextInput, Title } from '@mantine/core';
-import { formatDate, formatTime, formatDateTime } from '@/lib/time';
+import { formatDate, formatTime, formatDateTime, calculateAge } from '@/lib/time';
 import TrustedAdultPanel from '@/components/TrustedAdultPanel';
 import TodoCard from '@/components/TodoCard';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
@@ -319,7 +319,7 @@ export default function HouseholdPage() {
               <SimpleGrid cols={{ base: 1, sm: 2 }} mb="lg">
                 {sortedMembers.map((p) => {
                   const memberIsLead = isLead(p.id);
-                  const isAdult = p.dob && (new Date().getFullYear() - new Date(p.dob).getFullYear() >= 18);
+                  const isAdult = p.dob && calculateAge(p.dob) >= 18;
                   return (
                     <Card key={p.id} withBorder radius="md" padding="md">
                       {editingMemberId === p.id ? (
@@ -329,7 +329,7 @@ export default function HouseholdPage() {
                             <TextInput size="xs" type="email" label="Email" value={editForm.email} onChange={(e) => setEditForm({ ...editForm, email: e.currentTarget.value })} />
                             <TextInput size="xs" type="date" label="Date of Birth" value={editForm.dob} onChange={(e) => setEditForm({ ...editForm, dob: e.currentTarget.value })} />
                             <TextInput size="xs" type="tel" label="Phone" value={editForm.phone} onChange={(e) => setEditForm({ ...editForm, phone: e.currentTarget.value })} />
-                            {p.id !== userId && editForm.dob && (new Date().getFullYear() - new Date(editForm.dob).getFullYear() >= 18) && (
+                            {p.id !== userId && editForm.dob && calculateAge(editForm.dob) >= 18 && (
                               <Checkbox label="Household Lead" checked={editForm.isLead} onChange={(e) => setEditForm({ ...editForm, isLead: e.currentTarget.checked })} />
                             )}
                             <Group gap="xs">

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -4,7 +4,7 @@ import { use, useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Anchor, Button, Card, Center, Container, Divider, Group, Loader, Radio, Stack, Text, Title } from '@mantine/core';
-import { formatDate } from '@/lib/time';
+import { formatDate, calculateAge } from '@/lib/time';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { formatCents } from '@inventory/money';
 
@@ -304,9 +304,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                         if (!member.dob) {
                           ageError = "DOB missing";
                         } else {
-                          const ageDifMs = Date.now() - new Date(member.dob).getTime();
-                          const ageDate = new Date(ageDifMs);
-                          const age = Math.abs(ageDate.getUTCFullYear() - 1970);
+                          const age = calculateAge(member.dob);
                           if (program.minAge !== null && age < program.minAge) ageError = "Too young";
                           if (program.maxAge !== null && age > program.maxAge) ageError = "Too old";
                         }

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -304,7 +304,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                         if (!member.dob) {
                           ageError = "DOB missing";
                         } else {
-                          const age = calculateAge(member.dob);
+                          const age = calculateAge(member.dob, program.begin ?? undefined);
                           if (program.minAge !== null && age < program.minAge) ageError = "Too young";
                           if (program.maxAge !== null && age > program.maxAge) ageError = "Too old";
                         }

--- a/checkin-app/src/lib/time.ts
+++ b/checkin-app/src/lib/time.ts
@@ -51,12 +51,16 @@ export function fromDatetimeLocal(value: string | null | undefined): string {
 
 /**
  * Returns the calendar age in whole years for the given DOB, decremented if
- * this year's birthday hasn't happened yet. Canonical implementation — use
+ * the birthday hasn't happened yet as of `asOf`. Canonical implementation — use
  * this everywhere instead of inline epoch-diff age math.
+ *
+ * `asOf` defaults to now (the common case). Program age gates pass the program's
+ * start date so the bound is judged as-of when the program begins, not when the
+ * person happens to register.
  */
-export function calculateAge(dob: Date | string): number {
+export function calculateAge(dob: Date | string, asOf: Date | string = new Date()): number {
     const birthDate = new Date(dob);
-    const today = new Date();
+    const today = new Date(asOf);
     let age = today.getFullYear() - birthDate.getFullYear();
     const m = today.getMonth() - birthDate.getMonth();
     if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) age--;


### PR DESCRIPTION
## What

Two related changes to how participant age is computed.

### 1. Fix broken calendar-age math (commit 1)
The public program-registration age gate used the epoch-delta hack
`new Date(Date.now()-dob).getUTCFullYear()-1970`, which ignores month/day and
counts someone whose birthday hasn't occurred yet this year as a year too old —
wrong exactly at a `minAge`/`maxAge` boundary. Routed through the calendar-aware
`calculateAge` (`lib/time`). Swept the same class of bug everywhere age is
computed, all kept on request-time ("now") basis:

- import participant-adult flag: year-only → `calculateAge` (this flag drives
  household-lead creation, which is what background-check freshness keys off)
- household editor adult checks: year-only → `calculateAge`
- public program page + admin roster age warnings: epoch-delta → `calculateAge`

### 2. Gate program age at the program START date (commit 2)
Age gates measured age at registration time. Registration that opens months
before a program begins would reject a kid who is under the minimum today but
reaches it by the start date. Now judged as of `Program.begin`, falling back to
now for dateless ("TBD") programs.

- `calculateAge(dob, asOf = new Date())` — optional reference date, default now;
  existing now-callers unaffected.
- public-register + admin enroll gates, plus the two age-warning displays, pass
  `program.begin ?? undefined`.

**Resolved policy defaults:** null `begin` → now; past `begin` → judged at start
(late registrants). Easy to switch the latter to `max(begin, now)` if wanted.

## Tests

Clock-frozen regression tests in `programsPublicRegistrationAPI.integration`:
- at-maximum-age applicant whose birthday is later this year → admitted (the
  original bug)
- under-minimum applicant the buggy math counted old enough → rejected
- applicant 17 now but 18 by program start → admitted (proves START basis)

`programAgeBounds` + `programsParticipantsAPI` green (23/23). tsc clean.

## Note
Pre-existing: 2 tests in the public-register suite return 429 when the file runs
alone (shared per-IP rate-limit bucket, limit 5, exhausted by earlier
block-tests). Reproduces on `main`, not introduced here; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)