### PR TITLE
feat(my-programs): remove "Browse More Programs" button

### DIFF
--- a/checkin-app/src/app/my-activities/programs/page.tsx
+++ b/checkin-app/src/app/my-activities/programs/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Alert, Badge, Button, Card, Center, Container, Group, Loader, SimpleGrid, Text, Title } from '@mantine/core';
+import { Alert, Badge, Button, Card, Center, Container, Loader, SimpleGrid, Text, Title } from '@mantine/core';
 import { formatDate } from '@/lib/time';
 
 type UserProgram = {
@@ -61,12 +61,7 @@ export default function MyProgramsDashboard() {
 
   return (
     <Container size="lg" pb="md">
-      <Group justify="space-between" align="center" mb="md" wrap="wrap">
-        <Title order={1}>My Programs</Title>
-        <Button variant="default" onClick={() => router.push('/programs')}>
-          Browse More Programs
-        </Button>
-      </Group>
+      <Title order={1} mb="md">My Programs</Title>
 
       <Text c="dimmed" mb="lg">
         Manage the programs you are currently enrolled in.


### PR DESCRIPTION
## What

Remove the **Browse More Programs** button from the My Programs page header (`/my-activities/programs`).

## Why

Requested removal. With the button gone, the `Group` wrapper held a single `Title`, so it was collapsed to a plain `Title` and the now-unused `Group` import dropped.

## Notes

- `Button` import retained (still used by per-card program links).
- `router` retained (still used for the unauthenticated redirect).