### PR TITLE
feat(roles): add Hide Youth filter to role assignment page

### DIFF
--- a/checkin-app/src/app/api/admin/roles/route.ts
+++ b/checkin-app/src/app/api/admin/roles/route.ts
@@ -9,17 +9,12 @@ export const GET = withAuth(
             const eighteenYearsAgo = new Date();
             eighteenYearsAgo.setFullYear(eighteenYearsAgo.getFullYear() - 18);
 
-            const participants = await prisma.participant.findMany({
-                where: {
-                    OR: [
-                        { dob: { lte: eighteenYearsAgo } },
-                        { dob: null }
-                    ]
-                },
+            const rows = await prisma.participant.findMany({
                 select: {
                     id: true,
                     email: true,
                     name: true,
+                    dob: true,
                     sysadmin: true,
                     boardMember: true,
                     keyholder: true,
@@ -27,6 +22,11 @@ export const GET = withAuth(
                 },
                 orderBy: { name: "asc" },
             });
+            // Don't leak dob (PII); expose only a youth flag for filtering.
+            const participants = rows.map(({ dob, ...p }: (typeof rows)[number]) => ({
+                ...p,
+                isYouth: dob != null && dob > eighteenYearsAgo,
+            }));
             return NextResponse.json({ participants });
         } catch (error) {
             console.error("Error fetching roles:", error);

--- a/checkin-app/src/app/settings/roles/page.tsx
+++ b/checkin-app/src/app/settings/roles/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { Center, Checkbox, Loader, Stack, Table, Text, TextInput } from '@mantine/core';
+import { Center, Checkbox, Group, Loader, Stack, Table, Text, TextInput } from '@mantine/core';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { SettingsTabs } from '@/components/admin/SettingsTabs';
 import { AlertBanner } from '@/components/admin/AlertBanner';
@@ -14,6 +14,7 @@ type UserRole = {
   boardMember: boolean;
   keyholder: boolean;
   backgroundCheckReviewer: boolean;
+  isYouth: boolean;
 };
 
 const ROLE_COLUMNS: { field: keyof UserRole; label: string }[] = [
@@ -31,6 +32,7 @@ export default function RoleAssignmentPage() {
   const [message, setMessage] = useState("");
   const [savingId, setSavingId] = useState<number | null>(null);
   const [userSearchText, setUserSearchText] = useState("");
+  const [hideYouth, setHideYouth] = useState(true);
 
   const currentUserIsSysadmin = !!user?.sysadmin;
 
@@ -92,8 +94,9 @@ export default function RoleAssignmentPage() {
   if (!ready) return null;
 
   const filteredUsers = users.filter(u =>
-    (u.name || "").toLowerCase().includes((userSearchText || "").toLowerCase()) ||
-    (u.email || "").toLowerCase().includes((userSearchText || "").toLowerCase())
+    (!hideYouth || !u.isYouth) &&
+    ((u.name || "").toLowerCase().includes((userSearchText || "").toLowerCase()) ||
+     (u.email || "").toLowerCase().includes((userSearchText || "").toLowerCase()))
   );
 
   return (
@@ -107,12 +110,20 @@ export default function RoleAssignmentPage() {
 
       <AlertBanner message={message} tone="error" />
 
-      <TextInput
-        placeholder="Search users by name or email..."
-        value={userSearchText}
-        onChange={(e) => setUserSearchText(e.currentTarget.value)}
-        maw={400}
-      />
+      <Group justify="space-between">
+        <TextInput
+          placeholder="Search users by name or email..."
+          value={userSearchText}
+          onChange={(e) => setUserSearchText(e.currentTarget.value)}
+          maw={400}
+          style={{ flex: 1 }}
+        />
+        <Checkbox
+          label="Hide Youth"
+          checked={hideYouth}
+          onChange={(e) => setHideYouth(e.currentTarget.checked)}
+        />
+      </Group>
 
       <Table.ScrollContainer minWidth={700}>
         <Table verticalSpacing="sm" highlightOnHover>


### PR DESCRIPTION
## What

Adds a **Hide Youth** checkbox to the role assignment page (`/settings/roles`) that filters youth (under 18) out of the user list. Default **on**, so the page looks unchanged on load.

## Why

The role assignment API previously hard-excluded youth at the query layer (`dob <= 18yo OR dob null`), so youth could never be viewed or assigned roles at all. This replaces that hard exclusion with a UI toggle, letting admins opt to reveal youth when needed while keeping them hidden by default.

## Changes

- **`api/admin/roles/route.ts`** — drop the WHERE clause that excluded youth; return all participants with a computed `isYouth` boolean. Raw `dob` (PII) stays server-side; only the flag is sent to the client.
- **`settings/roles/page.tsx`** — "Hide Youth" checkbox beside the search box, `hideYouth` state defaulting to `true`, list filtered accordingly.

## Reviewer notes

- Youth = `dob` under 18. Null `dob` is treated as adult (matches prior logic, which included null-dob participants).
- Toggle state is not persisted across reloads — resets to hidden. Add persistence later if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)