### PR TITLE
fix(program-ops): remove Back to Programs button on Create Program page

### DIFF
--- a/checkin-app/src/app/program-ops/new/page.tsx
+++ b/checkin-app/src/app/program-ops/new/page.tsx
@@ -86,7 +86,7 @@ export default function CreateProgramPage() {
   return (
     <Container size="md" pb="md">
       <Card withBorder radius="md" padding="lg">
-        <AdminPageHeader title="Create Program" back={{ href: '/programs', label: '← Back to Programs' }} mb="md" />
+        <AdminPageHeader title="Create Program" mb="md" />
 
         <Text c="dimmed" mb="lg">
           Create a new program. You can configure the roster and schedule events later.


### PR DESCRIPTION
## What
Remove the **← Back to Programs** button from the Create Program page (`/program-ops/new`).

## Why
Button not wanted on this page.

## How
Drop the `back` prop from `AdminPageHeader`. Prop is optional, so the header renders without it.

## Notes
Single-line change. No behavior change beyond the removed link.