### PR TITLE
feat(program-ops): one-time events list tab + inline create form

### DIFF
--- a/checkin-app/src/app/api/events/route.ts
+++ b/checkin-app/src/app/api/events/route.ts
@@ -5,6 +5,25 @@ import prisma from "@/lib/prisma";
 import { addDays, parseISO, isBefore, isEqual, getDay, setHours, setMinutes } from 'date-fns';
 import { fromZonedTime } from 'date-fns-tz';
 
+// List standalone (one-time) events — those with no associated program.
+export async function GET() {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const user = session.user as unknown as { sysadmin?: boolean; boardMember?: boolean };
+    if (!user?.sysadmin && !user?.boardMember) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const events = await prisma.event.findMany({
+        where: { programId: null },
+        orderBy: { start: "desc" },
+        select: { id: true, name: true, start: true, end: true, description: true },
+    });
+    return NextResponse.json(events);
+}
+
 export async function POST(req: Request) {
     const session = await getServerSession(authOptions);
 

--- a/checkin-app/src/app/program-ops/events/page.tsx
+++ b/checkin-app/src/app/program-ops/events/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { Card, Center, Checkbox, Group, Loader, Stack, Table, Text, TextInput, Title } from "@mantine/core";
+
+type OneTimeEvent = {
+  id: number;
+  name: string;
+  start: string;
+  end: string;
+  description: string | null;
+};
+
+const fmt = (iso: string) =>
+  new Date(iso).toLocaleString("en-US", {
+    timeZone: "America/Chicago",
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+
+export default function OneTimeEventsList() {
+  const [events, setEvents] = useState<OneTimeEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [futureOnly, setFutureOnly] = useState(true);
+  // Snapshot "now" once on mount — Date.now() is impure and can't run during render.
+  const [now] = useState(() => Date.now());
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch("/api/events")
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setEvents(Array.isArray(data) ? data : []))
+      .catch((err) => console.error(err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return events.filter((e) => {
+      if (futureOnly && new Date(e.end).getTime() < now) return false;
+      if (!q) return true;
+      // Search across name, description, and the displayed date strings.
+      const hay = [e.name, e.description ?? "", fmt(e.start), fmt(e.end)].join(" ").toLowerCase();
+      return hay.includes(q);
+    });
+  }, [events, search, futureOnly, now]);
+
+  return (
+    <Stack>
+      <div>
+        <Title order={1}>One Time Events</Title>
+        <Text c="dimmed">Browse all one-off / standalone events.</Text>
+      </div>
+
+      <Group justify="space-between" align="center" wrap="wrap">
+        <TextInput
+          placeholder="Search events…"
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+          w={320}
+        />
+        <Checkbox
+          label="Future Only"
+          checked={futureOnly}
+          onChange={(e) => setFutureOnly(e.currentTarget.checked)}
+        />
+      </Group>
+
+      {loading ? (
+        <Center py="xl"><Loader /></Center>
+      ) : rows.length === 0 ? (
+        <Card withBorder radius="md" padding="xl" ta="center">
+          <Text c="dimmed">No one-time events found.</Text>
+        </Card>
+      ) : (
+        <Table.ScrollContainer minWidth={600}>
+          <Table highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Name</Table.Th>
+                <Table.Th>Start</Table.Th>
+                <Table.Th>End</Table.Th>
+                <Table.Th>Description</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {rows.map((e) => (
+                <Table.Tr
+                  key={e.id}
+                  onClick={() => router.push(`/admin/events/${e.id}`)}
+                  style={{ cursor: "pointer" }}
+                >
+                  <Table.Td>{e.name}</Table.Td>
+                  <Table.Td>{fmt(e.start)}</Table.Td>
+                  <Table.Td>{fmt(e.end)}</Table.Td>
+                  <Table.Td>{e.description || "—"}</Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      )}
+    </Stack>
+  );
+}

--- a/checkin-app/src/app/program-ops/sessions/new/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/new/page.tsx
@@ -17,7 +17,7 @@ const DAYS_MAP = [
   { label: 'Sat', value: 6 },
 ];
 
-function NewEventForm() {
+export function NewEventForm() {
   const { status } = useSession();
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/checkin-app/src/app/program-ops/sessions/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/page.tsx
@@ -1,59 +1,20 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { Card, SimpleGrid, Stack, Text, Title } from "@mantine/core";
+import { Suspense } from "react";
+import { Center, Loader, Stack, Text, Title } from "@mantine/core";
+import { NewEventForm } from "@/app/program-ops/sessions/new/page";
 
-export default function AdminEventsIndex() {
-  const router = useRouter();
-
-  const sections = [
-    {
-      title: "Visit History",
-      description: "View and edit past check-in/out records.",
-      link: "/facility/visits",
-      icon: "🕒",
-    },
-    {
-      title: "Live Badge Logs",
-      description: "Audit real-time RFID tap events across the facility.",
-      link: "/facility/badges",
-      icon: "📡",
-    },
-    {
-      title: "Create New Event",
-      description: "Schedule a one-off event or manual session.",
-      link: "/program-ops/sessions/new",
-      icon: "➕",
-    },
-  ];
-
+export default function OneTimeEventsIndex() {
   return (
     <Stack>
       <div>
-        <Title order={1}>Events Management</Title>
-        <Text c="dimmed">
-          Manage facility sessions, audit logs, and historical visit records.
-        </Text>
+        <Title order={1}>New One Time Event</Title>
+        <Text c="dimmed">Schedule a one-off event or manual session.</Text>
       </div>
 
-      <SimpleGrid cols={{ base: 1, md: 3 }}>
-        {sections.map((section) => (
-          <Card
-            key={section.link}
-            withBorder
-            radius="md"
-            padding="xl"
-            onClick={() => router.push(section.link)}
-            style={{ cursor: "pointer" }}
-          >
-            <Stack align="center" gap="xs" ta="center">
-              <Text fz={40}>{section.icon}</Text>
-              <Text fw={700} fz="lg">{section.title}</Text>
-              <Text size="sm" c="dimmed">{section.description}</Text>
-            </Stack>
-          </Card>
-        ))}
-      </SimpleGrid>
+      <Suspense fallback={<Center mih="60vh"><Loader /></Center>}>
+        <NewEventForm />
+      </Suspense>
     </Stack>
   );
 }

--- a/checkin-app/src/lib/programNav.ts
+++ b/checkin-app/src/lib/programNav.ts
@@ -17,5 +17,6 @@ export interface ProgramNavLink {
 export const PROGRAM_NAV_LINKS: ProgramNavLink[] = [
   { name: "All Programs", href: "/program-ops/programs", icon: "📚", description: "Browse and manage recurring programs." },
   { name: "New Program", href: "/program-ops/new", icon: "✨", description: "Create a new program or curriculum track." },
-  { name: "Events", href: "/program-ops/sessions", icon: "📅", description: "Schedule sessions and audit facility logs." },
+  { name: "One Time Events", href: "/program-ops/events", icon: "📋", description: "Browse all one-off / standalone events." },
+  { name: "New One Time Event", href: "/program-ops/sessions", icon: "📅", description: "Schedule a one-off event or manual session." },
 ];


### PR DESCRIPTION
## What

Restructures the Program Ops **Events** area around standalone (no-program) events.

### Program Ops tabs
- **New One Time Event** (`/program-ops/sessions`, was "Events") — now inlines the event-creation form (reusing the newly-exported `NewEventForm`) instead of a grid of card buttons. Removed the **Visit History** and **Live Badge Logs** links.
- **One Time Events** (`/program-ops/events`, new) — searchable table of all standalone events with a **Future Only** checkbox (default on, filters by `end ≥ now`). Row click → event detail.

### API
- New `GET /api/events` returning standalone events (`programId == null`), gated to sysadmin/board.

## Notes
- Future/search filtering is client-side (event counts are small). Move server-side if the standalone-event list grows to hundreds.
- Verified locally: tabs render, Future Only + search filter correctly against seeded standalone events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)