### PR TITLE
fix(security): pin board directory field set with explicit Prisma select

### DIFF
--- a/checkin-app/src/app/__tests__/directoryBoardAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/directoryBoardAPI.integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Regression guard for GET /api/directory/board.
+ *
+ * Pins the field set leaving the board directory. The endpoint must NEVER ship
+ * pii (`dob`, `googleId`) regardless of caller — this is enforced twice: the
+ * route's explicit Prisma `select` (defense in depth) AND the outbound stripper.
+ * Reverting the `select` makes the board-member assertions fail, which is the
+ * point: this test guards the leak.
+ */
+import { GET } from '@/app/api/directory/board/route';
+import prisma from '@/lib/prisma';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockSession = require('next-auth/next').getServerSession;
+
+const TAG = 'directory-board-test';
+
+function req() {
+    return new Request('http://localhost/api/directory/board') as unknown as import('next/server').NextRequest;
+}
+
+describe('GET /api/directory/board', () => {
+    let boardId: number;
+    let keyholderId: number;
+    const householdIds: number[] = [];
+
+    beforeAll(async () => {
+        // A board member WITH non-null pii, so "must not leak dob/googleId" is a
+        // meaningful assertion (an all-null fixture would pass vacuously).
+        const board = await prisma.participant.create({
+            data: {
+                name: `Board ${TAG}`,
+                email: `board-${TAG}@example.com`,
+                phone: '555-0001',
+                dob: new Date('1980-01-01'),
+                googleId: `google-${TAG}`,
+                boardMember: true,
+                household: { create: {} },
+            },
+        });
+        boardId = board.id;
+        householdIds.push(board.householdId);
+
+        const keyholder = await prisma.participant.create({
+            data: {
+                name: `Keyholder ${TAG}`,
+                email: `keyholder-${TAG}@example.com`,
+                keyholder: true,
+                household: { create: {} },
+            },
+        });
+        keyholderId = keyholder.id;
+        householdIds.push(keyholder.householdId);
+    });
+
+    beforeEach(() => jest.clearAllMocks());
+
+    afterAll(async () => {
+        await prisma.participant.deleteMany({ where: { id: { in: [boardId, keyholderId] } } });
+        await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
+    });
+
+    it('a board member gets rows that never contain dob or googleId', async () => {
+        mockSession.mockResolvedValue({ user: { id: boardId, boardMember: true } });
+
+        const res = await GET(req());
+        expect(res.status).toBe(200);
+        const { boardMembers } = await res.json();
+
+        expect(Array.isArray(boardMembers)).toBe(true);
+        const seeded = boardMembers.find((r: { id: number }) => r.id === boardId);
+        expect(seeded).toBeDefined();
+        // Board legitimately sees contact fields...
+        expect(seeded.email).toBe(`board-${TAG}@example.com`);
+        expect(seeded.phone).toBe('555-0001');
+        // ...but pii must never ship, for any row.
+        for (const row of boardMembers) {
+            expect(row).not.toHaveProperty('dob');
+            expect(row).not.toHaveProperty('googleId');
+        }
+    });
+
+    it('a keyholder gets only public/member fields — no email/phone/dob/googleId', async () => {
+        mockSession.mockResolvedValue({ user: { id: keyholderId, keyholder: true } });
+
+        const res = await GET(req());
+        expect(res.status).toBe(200);
+        const { boardMembers } = await res.json();
+
+        const seeded = boardMembers.find((r: { id: number }) => r.id === boardId);
+        expect(seeded).toBeDefined();
+        // Public fields survive.
+        expect(seeded.name).toBe(`Board ${TAG}`);
+        // Stripper clears contact pii for keyholders.
+        for (const row of boardMembers) {
+            expect(row).not.toHaveProperty('email');
+            expect(row).not.toHaveProperty('phone');
+            expect(row).not.toHaveProperty('dob');
+            expect(row).not.toHaveProperty('googleId');
+        }
+    });
+});

--- a/checkin-app/src/app/api/directory/board/route.ts
+++ b/checkin-app/src/app/api/directory/board/route.ts
@@ -4,6 +4,10 @@ import { handler } from "@/security/handler";
 export const GET = handler('GET /api/directory/board', async () => {
     const boardMembers = await prisma.participant.findMany({
         where: { boardMember: true },
+        // Defense in depth: a directory must never load pii (dob, googleId) even
+        // for callers the stripper would clear. Select only what a board
+        // directory needs; email/phone still get stripped for keyholders.
+        select: { id: true, name: true, boardMember: true, email: true, phone: true },
         orderBy: { name: 'asc' },
     });
     return { Participant: boardMembers };


### PR DESCRIPTION
## What

Harden `GET /api/directory/board` with an explicit Prisma `select` and pin the leaving field set with an integration test.

## Why

The board directory `findMany` had **no `select`**, so the full `Participant` row — including `dob` and `googleId`, both `@sensitivity:pii` — was loaded and handed to the outbound stripper. Board callers hold the `everyones:pii` token, so the stripper **ships `dob`/`googleId` to them**. A directory should never carry pii regardless of caller. Defense in depth: don't load what a directory has no business returning.

## Changes

- `src/app/api/directory/board/route.ts` — explicit `select: { id, name, boardMember, email, phone }`. `dob`/`googleId` never loaded. Wrapper key stays `Participant` (the model key the stripper resolves on; the registry `envelope` still re-wraps the payload to `boardMembers`).
- `src/app/__tests__/directoryBoardAPI.integration.test.ts` — new integration test:
  - Board caller → rows never contain `dob`/`googleId`; `email`/`phone` present.
  - Keyholder caller → only public/member fields (no `email`/`phone`/`dob`/`googleId`), also exercising the stripper tier.
  - Fixture seeds a board member with non-null `dob` + `googleId` so the assertion is non-vacuous.

## Verification

Ran against a live Postgres (`npm run test:integration`-equivalent). Both cases pass. Reverted the `select` → board test fails with the leaked `dob` value, confirming the test guards the leak (the stripper alone does **not** stop it for board callers). Restored → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)