### PR TITLE
feat(kiosk): surface manual time-entry as a tab on attendance

### DIFF
--- a/checkin-app/src/app/attendance/AttendanceTabs.tsx
+++ b/checkin-app/src/app/attendance/AttendanceTabs.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { Tabs } from "@mantine/core";
+
+// Route-based tabs (URLs stay separate, like FacilityLayout). Rendered inside
+// each page rather than a layout.tsx so the Current page can suppress it in
+// kiosk mode and the certifications subroute isn't wrapped.
+const TABS = [
+  { href: "/attendance", label: "Current" },
+  { href: "/attendance/manual", label: "Add Past Visit" },
+];
+
+export function AttendanceTabs() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const active = TABS.find((t) => t.href === pathname)?.href ?? null;
+
+  return (
+    <Tabs
+      value={active}
+      onChange={(value) => { if (value && value !== active) router.push(value); }}
+      mb="md"
+    >
+      <Tabs.List>
+        {TABS.map((t) => (
+          <Tabs.Tab key={t.href} value={t.href}>{t.label}</Tabs.Tab>
+        ))}
+      </Tabs.List>
+    </Tabs>
+  );
+}

--- a/checkin-app/src/app/attendance/manual/page.tsx
+++ b/checkin-app/src/app/attendance/manual/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { Alert, Button, Card, Container, Group, Stack, Text, TextInput, Title } from "@mantine/core";
+import { Alert, Button, Card, Center, Container, Loader, Stack, Text, TextInput, Title } from "@mantine/core";
+import { useRequireRole } from "@/hooks/useRequireRole";
+import { AttendanceTabs } from "../AttendanceTabs";
 
 export default function ManualAttendance() {
-  const router = useRouter();
+  const { ready, loading: authLoading } = useRequireRole([]);
   const [arrived, setArrived] = useState("");
   const [departed, setDeparted] = useState("");
   const [error, setError] = useState("");
@@ -40,15 +41,14 @@ export default function ManualAttendance() {
     }
   };
 
+  if (authLoading) return <Center mih="60vh"><Loader /></Center>;
+  if (!ready) return null;
+
   return (
     <Container size="sm" pb="md">
+      <AttendanceTabs />
       <Card withBorder radius="md" padding="lg">
-        <Group justify="space-between" align="center" wrap="wrap" mb="md">
-          <Title order={1}>Manual Time Entry</Title>
-          <Button variant="default" onClick={() => router.push("/attendance")}>
-            ← Back to Attendance
-          </Button>
-        </Group>
+        <Title order={1} mb="md">Manual Time Entry</Title>
 
         <Text c="dimmed" mb="lg">
           Forgot to scan your badge? You can self-correct your time record here. If you are

--- a/checkin-app/src/app/attendance/page.tsx
+++ b/checkin-app/src/app/attendance/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mantine/core";
 import { formatTime } from "@/lib/time";
 import { getKioskDisplayNames } from "@/lib/kiosk-names";
+import { AttendanceTabs } from "./AttendanceTabs";
 
 type Participant = {
   id: number;
@@ -318,6 +319,11 @@ function KioskDisplayInner() {
 
   return (
     <Box p="md" style={isKioskMode ? { cursor: "none" } : undefined}>
+      {!isKioskMode && (
+        <Box style={{ maxWidth: 1200, margin: "0 auto" }}>
+          <AttendanceTabs />
+        </Box>
+      )}
       <Card withBorder radius="md" padding="lg" style={{ width: "100%", maxWidth: 1200, margin: "0 auto" }}>
         {/* Check-in button — hidden in kiosk mode */}
         {!isKioskMode && (

--- a/checkin-app/src/hooks/useRequireRole.ts
+++ b/checkin-app/src/hooks/useRequireRole.ts
@@ -43,7 +43,9 @@ export function useRequireRole(
   const { data: session, status } = useSession();
   const router = useRouter();
   const user = session?.user;
-  const authorized = !!user && allowed.some((role) => user[role] === true);
+  // Empty `allowed` = any authenticated user (a plain sign-in gate); otherwise
+  // the user must hold one of the listed roles.
+  const authorized = !!user && (allowed.length === 0 || allowed.some((role) => user[role] === true));
 
   useEffect(() => {
     if (status === "unauthenticated") {


### PR DESCRIPTION
## What

The back-dated **arrived+departed** time-correction form at `/kioskdisplay/manual` was an App Router orphan — no inbound `<Link>`, nav, or `router.push` reached it; only typing the URL did. This wires it into the attendance UI as a tab.

- **New `AttendanceTabs`** — route-based tabs **Current ⇄ Add Past Visit**, URLs kept separate, matching the `FacilityLayout` route-tab pattern.
- **Current page** (`/kioskdisplay`) renders the tabs only when `!isKioskMode`.
- **Manual page** (`/kioskdisplay/manual`) renders the tabs in place of its old "← Back to Attendance" button.
- **Member gate** on the manual page via `useRequireRole([])` so an unauthenticated visitor is redirected instead of hitting a 401 at submit. Empty `allowed` roles now means "any authenticated user" (additive — no existing caller passes `[]`).

## Why

The page fills a real gap with no equal elsewhere:

| Surface | Timestamps | Create vs edit | Audience |
|---|---|---|---|
| Inline "Check Me In" (`POST /api/attendance` MANUAL_CHECKIN) | now only, open visit | create | self / household / admin |
| `/kioskdisplay/manual` (`POST /api/attendance/manual`) | **arrived + departed, back-dated** | **create** | any member, own record |
| facility/visits (`PATCH /api/admin/visits`) | edit existing | **edit only** | sysadmin only |

Self-service retroactive time correction (full past visit) existed nowhere else. Surfacing beats deleting working, audited, advisory-locked code. Documented as CUJ 2.4 in `docs/designs/CUJS.md`.

## Reviewer notes

- **Not** implemented as a `layout.tsx` (the usual pattern): a layout can't see the signed-request kiosk flag (set after fetch inside the page), so it'd flash tabs onto live kiosk displays; it'd also wrap the `certifications/` subroute and apply a role gate that breaks anonymous kiosk + limited-user access. Hence a component rendered inside each page.
- The two existing `/api/attendance/manual` integration tests are untouched and still validate the surviving route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)