### PR TITLE
test(flow): dockerized dev-server flow tests + AGENTS.md (verifies #428)

### DIFF
--- a/.github/workflows/flow-tests.yml
+++ b/.github/workflows/flow-tests.yml
@@ -1,0 +1,39 @@
+name: Flow tests
+
+# Exercises real user journeys end-to-end over HTTP against a dockerized
+# DEVELOPMENT server (deploy/docker-compose.flow.yml). See AGENTS.md → Flow tests.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flow-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flow:
+    name: User-journey flow tests (docker dev server)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Brings up Postgres + the dev server, installs/seeds, and blocks on their
+      # healthchecks (--wait). start_period in the compose file covers npm ci + seed.
+      - name: Start dockerized dev server + DB
+        run: docker compose -f deploy/docker-compose.flow.yml up -d --wait --wait-timeout 600
+
+      - name: Run flow tests (inside the app container)
+        run: docker compose -f deploy/docker-compose.flow.yml exec -T app sh -lc "cd checkin-app && npm run test:flow"
+
+      - name: App logs on failure
+        if: failure()
+        run: docker compose -f deploy/docker-compose.flow.yml logs --no-color --tail 300 app
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f deploy/docker-compose.flow.yml down -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# AGENTS.md
+
+Orientation for agents working in this repo. The app is a Next.js + Prisma +
+PostgreSQL membership/check-in system under `checkin-app/`.
+
+## Test classes
+
+There are **three** classes of tests. Run all commands from `checkin-app/`.
+
+### 1. Unit tests — `*.test.ts(x)`
+In-process, no database. `@/lib/prisma`, `next-auth`, and `fetch` are mocked in
+`jest.setup.js`. Run: `npm run test:ci` (this is the CI default). These must
+never hit a real DB — the prisma mock rejects real calls.
+
+### 2. Integration tests — `*.integration.test.ts`
+In-process, but talk to a **real Postgres** via `DATABASE_URL` (the prisma mock
+defers to the real client for these). They import service functions directly and
+assert DB state. Excluded from the default run. Run: `npm run test:integration`
+against a live DB. Each suite self-cleans by a unique `TAG`.
+
+### 3. Flow tests — `flow-tests/*.flow.test.ts`  ← read this before adding e2e
+**End-to-end user journeys driven over HTTP against a *running* dev server.** No
+app imports, no DB access, no mocks — a flow test only `fetch()`es the server and
+asserts responses, exactly as a client would. This is how we verify a whole
+journey (intake → review → payment, check-in, etc.) wired through the real
+routes, auth, and DB together.
+
+- **Config:** `jest.flow.config.js` (node env, **skips `jest.setup.js`** so it
+  uses native `fetch` with `getSetCookie` and no prisma/next-auth mocks).
+- **Run locally:** start the app (`npm run dev`, serves `:4000`) against a seeded
+  local DB, then `npm run test:flow`. Override the target with
+  `FLOW_BASE_URL=http://host:port`.
+- **Auth:** `flow-tests/helpers.ts` → `loginAs(email)` signs in via the local
+  **persona-mint** flow (resolves the seeded persona by its stable email, since
+  ids are autoincrement) and returns a cookie jar; `api(session, path, init)`
+  is a thin JSON `fetch` wrapper.
+- **In CI:** the `Flow tests` workflow (`.github/workflows/flow-tests.yml`) brings
+  up `deploy/docker-compose.flow.yml` — Postgres + a **dev-mode** app container
+  (`next dev`) — installs, `prisma db push`, seeds, then runs the flow tests
+  inside that container.
+
+**Gotchas (why it's built this way):**
+- Use the **dev** server, never the production image: persona-mint login is gated
+  on `NODE_ENV != production`, and the prod `Dockerfile` pins `NODE_ENV=production`.
+  So flow tests would have no way to authenticate against the prod image.
+- The server must run with `CHECKIN_ENV=local` (enables persona-mint) and a
+  **freshly seeded** DB (`prisma db seed`) — flow tests assume the seed's baseline
+  personas/households (e.g. `parent.family2@example.com` is a non-member household
+  lead; `boardmember@example.com` is sysadmin+board).
+- Flow tests **mutate** seeded state, so they assume a fresh seed per run (CI
+  reseeds every run). Don't rely on re-running against the same DB locally.
+- `*.flow.test.ts` is excluded from the unit/integration runs (it needs a live
+  server) — keep it that way; run it only via `npm run test:flow`.
+
+To add a journey: drop a `flow-tests/<name>.flow.test.ts` using `loginAs`/`api`,
+keep it to real HTTP calls + response assertions. Prefer routes that don't need
+external integrations (Zoho/Shopify/Averity); use the board/admin manual-action
+routes to advance flows those would otherwise gate. Real journeys are catalogued
+in `docs/designs/CUJS.md` — start there when choosing what to cover.
+
+## Docs map
+
+Read these before changing the relevant area — start here, then follow links.
+
+**Project-wide**
+- `README.md` — what the app is + Quick Start; OS setup: `docs/setup/SETUP_LINUX.md`, `docs/setup/SETUP_MACOS.md`.
+- `CONSTITUTION.md` — project principles//ground rules.
+- `GEMINI.md`, `.jules/sentinel.md` — instructions for other agents (Gemini, Jules); keep cross-consistent with this file.
+- `TRADEMARKS.md` — naming/brand constraints.
+
+**Design & product** (`docs/designs/`)
+- `DESIGN.md` — system design overview.
+- `CUJS.md` — **critical user journeys** (the basis for flow tests).
+- `DEV_INSTANCE_DESIGN.md` — the `CHECKIN_ENV` prod/dev/local model + persona-mint/impersonation (read before touching auth/env).
+- `DEV_DASHBOARD_DESIGN.md` — dev dashboard + seed/reset macros.
+- `PRODUCTION_PLAN.md`, `implementation_plan.md`, `MY_PROGRAMS_SCOPING.md`, `ARCHITECT_IDEAS_*.md` — roadmap/scoping notes.
+
+**Security** (`docs/security/`)
+- `SECURITY-POLICY.md` — the response-stripper / `@sensitivity` registry rules (read before adding API responses or schema fields).
+- `pentest_findings_2026-04-21.md` — prior findings.
+
+**Subprojects** (each has its own `README.md`)
+- `client/` — the Raspberry-Pi kiosk client (Python).
+- `packages/*` (e.g. `monitoring-db`, `pg-test-harness`, `telemetry`), `layers/prisma-runtime/`, and the Lambda `*-function/` dirs (`s-read-function/`, `s-replay-function/`, `monitoring-relay-function/`, `monitoring-watchdog-function/`) — see the README in each; `s-read-function/` also has `MONITORING-PRD.md` + `FUTUREWORK.md`.

--- a/checkin-app/flow-tests/helpers.ts
+++ b/checkin-app/flow-tests/helpers.ts
@@ -1,0 +1,63 @@
+/**
+ * Flow-test helpers: drive the *running* dev server over HTTP (no in-process
+ * imports), authenticating through the local persona-mint flow like a browser.
+ * Used only by `*.flow.test.ts` against a live server (see AGENTS.md → Flow tests).
+ */
+
+export const BASE = process.env.FLOW_BASE_URL || "http://localhost:4000";
+
+type Jar = Map<string, string>;
+
+function absorb(jar: Jar, res: Response): void {
+    for (const c of res.headers.getSetCookie()) {
+        const pair = c.split(";", 1)[0];
+        const eq = pair.indexOf("=");
+        if (eq > 0) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
+    }
+}
+
+const header = (jar: Jar) => [...jar].map(([k, v]) => `${k}=${v}`).join("; ");
+
+export interface Session { jar: Jar; }
+
+/** Sign in as a seeded persona (by email) via persona-mint; returns its cookie jar. */
+export async function loginAs(email: string): Promise<Session> {
+    const jar: Jar = new Map();
+
+    // Persona ids are autoincrement (vary per seed) — resolve by stable email.
+    const list = await (await fetch(`${BASE}/api/auth/dev-personas`)).json();
+    const persona = (list.personas ?? []).find((p: { email: string }) => p.email === email);
+    if (!persona) throw new Error(`dev persona not found: ${email} (need CHECKIN_ENV=local + a seeded DB)`);
+
+    const csrfRes = await fetch(`${BASE}/api/auth/csrf`);
+    absorb(jar, csrfRes);
+    const { csrfToken } = await csrfRes.json();
+
+    const cb = await fetch(`${BASE}/api/auth/callback/persona-mint`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded", cookie: header(jar) },
+        body: new URLSearchParams({ csrfToken, personaId: String(persona.id), mode: "impersonate", callbackUrl: `${BASE}/`, json: "true" }),
+        redirect: "manual",
+    });
+    absorb(jar, cb);
+    if (![...jar.keys()].some((k) => k.includes("session-token"))) {
+        throw new Error(`login failed for ${email}: no session cookie set`);
+    }
+    return { jar };
+}
+
+/** Fetch JSON from the running server, attaching a session's cookies when given. */
+export async function api<T = unknown>(
+    session: Session | null,
+    path: string,
+    init: RequestInit = {},
+): Promise<{ status: number; json: T }> {
+    const headers: Record<string, string> = { ...(init.headers as Record<string, string>) };
+    if (session) headers.cookie = header(session.jar);
+    if (init.body && !headers["content-type"]) headers["content-type"] = "application/json";
+    const res = await fetch(`${BASE}${path}`, { ...init, headers, redirect: "manual" });
+    const text = await res.text();
+    let json: unknown = null;
+    try { json = text ? JSON.parse(text) : null; } catch { json = text; }
+    return { status: res.status, json: json as T };
+}

--- a/checkin-app/flow-tests/membership-bg-nonblocking.flow.test.ts
+++ b/checkin-app/flow-tests/membership-bg-nonblocking.flow.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Flow test for PR #428 — the background check is non-blocking.
+ *
+ * Drives the real user journey over HTTP against a running dev server with a
+ * fresh seed: a non-member applicant fills intake, the board records the two
+ * external actions, and the applicant pays before the check has cleared.
+ *
+ * Asserts the two behaviours the PR introduced end-to-end:
+ *   1. After the external step the application is at PENDING_PAYMENT — payment is
+ *      unblocked (pre-PR it parked at PENDING_BG_REVIEW until reviewers cleared it).
+ *   2. Paying before the check clears holds at PENDING_BG_CLEARANCE with the
+ *      membership still inactive (never ACTIVE without a valid check).
+ *
+ * Assumes a freshly-seeded DB (parent.family2 is a non-member household lead).
+ */
+
+import { loginAs, api } from "./helpers";
+
+type State = { process: { id: number; status: string } | null; membershipStatus: string | null };
+
+describe("flow: membership background check is non-blocking (PR #428)", () => {
+    it("intake → external → PENDING_PAYMENT, and paying before BG clears holds inactive", async () => {
+        const applicant = await loginAs("parent.family2@example.com"); // non-member household lead
+        const board = await loginAs("boardmember@example.com");        // sysadmin + board
+
+        // Start the application (201 new, or 200 if one is already in flight).
+        const start = await api(applicant, "/api/membership", { method: "POST" });
+        expect([200, 201]).toContain(start.status);
+
+        // Fill the minimum required intake, then submit → PENDING_EXTERNAL_ACTION.
+        const save = await api(applicant, "/api/membership/intake", {
+            method: "PATCH",
+            body: JSON.stringify({
+                household: { address: "456 Workshop Drive", emergencyContactName: "Pat Outside", emergencyContactPhone: "555-987-6543" },
+                primaryParent: { name: "Parent Family2" },
+            }),
+        });
+        expect(save.status).toBe(200);
+
+        const submit = await api(applicant, "/api/membership/intake/submit", { method: "POST" });
+        expect(submit.status).toBe(200);
+
+        const afterSubmit = await api<State>(applicant, "/api/membership");
+        expect(afterSubmit.json.process?.status).toBe("PENDING_EXTERNAL_ACTION");
+        const processId = afterSubmit.json.process!.id;
+
+        // Board records the contract + background-check consent (manual fallbacks,
+        // no Zoho/Averity needed). Pre-#428 this advanced to PENDING_BG_REVIEW.
+        const c1 = await api(board, "/api/admin/membership/external", { method: "POST", body: JSON.stringify({ processId, action: "mark-contract" }) });
+        expect(c1.status).toBe(200);
+        const c2 = await api(board, "/api/admin/membership/external", { method: "POST", body: JSON.stringify({ processId, action: "mark-bg-consent" }) });
+        expect(c2.status).toBe(200);
+
+        const afterExternal = await api<State>(applicant, "/api/membership");
+        expect(afterExternal.json.process?.status).toBe("PENDING_PAYMENT"); // ← #428: payment unblocked
+
+        // Pay before the check clears (board certify stands in for the Shopify webhook).
+        const certify = await api(board, "/api/admin/membership/certify-payment", { method: "POST", body: JSON.stringify({ processId }) });
+        expect(certify.status).toBe(200);
+
+        const afterPay = await api<State>(applicant, "/api/membership");
+        expect(afterPay.json.process?.status).toBe("PENDING_BG_CLEARANCE"); // ← #428: paid, awaiting check
+        expect(afterPay.json.membershipStatus).not.toBe("ACTIVE");          // ← #428: never active without a valid check
+    });
+});

--- a/checkin-app/jest.config.js
+++ b/checkin-app/jest.config.js
@@ -29,6 +29,9 @@ const customJestConfig = {
         '/node_modules/',
         '/.claude/worktrees/',
         '\\.integration\\.test\\.[jt]sx?$',
+        // Flow tests drive a running dev server over HTTP — excluded from the
+        // default/unit run; run with `npm run test:flow` (see AGENTS.md).
+        '\\.flow\\.test\\.[jt]sx?$',
     ],
     modulePathIgnorePatterns: [
         '<rootDir>/../.claude/worktrees/',

--- a/checkin-app/jest.flow.config.js
+++ b/checkin-app/jest.flow.config.js
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+// Flow tests drive a RUNNING dev server over HTTP — no app imports, no DB, no
+// mocks. They deliberately skip jest.setup.js, which polyfills fetch with
+// cross-fetch (no getSetCookie) and mocks prisma/next-auth for in-process unit
+// tests. Native Node fetch + a plain node environment is exactly what we want.
+module.exports = createJestConfig({
+    testEnvironment: 'node',
+    setupFilesAfterEnv: [],
+    testMatch: ['<rootDir>/flow-tests/**/*.flow.test.[jt]s'],
+    moduleNameMapper: { '^@/(.*)$': '<rootDir>/src/$1' },
+    // The standalone build nests a package.json named "checkmein" under .next/,
+    // which collides with the app's own in jest's haste map.
+    modulePathIgnorePatterns: ['<rootDir>/.next/'],
+});

--- a/checkin-app/package.json
+++ b/checkin-app/package.json
@@ -10,6 +10,7 @@
     "test": "jest --runInBand --forceExit",
     "test:ci": "jest --ci --runInBand --forceExit",
     "test:integration": "jest --ci --runInBand --forceExit --testPathIgnorePatterns=/node_modules/ --testRegex \"\\.integration\\.test\\.[jt]sx?$\"",
+    "test:flow": "jest --config jest.flow.config.js --ci --runInBand --forceExit",
     "check-route-coverage": "ts-node --project scripts/tsconfig.json scripts/check-route-coverage.ts",
     "import:zoho": "tsx scripts/import-zoho.ts"
   },

--- a/deploy/docker-compose.flow.yml
+++ b/deploy/docker-compose.flow.yml
@@ -1,0 +1,48 @@
+# Dockerized DEVELOPMENT server for flow tests (checkin-app/flow-tests/*.flow.test.ts).
+#
+# Runs the app with `next dev` — NOT the production image (deploy/docker-compose.yml)
+# — on purpose: persona-mint login (how flow tests authenticate) is gated on
+# NODE_ENV != production, and the prod image pins NODE_ENV=production. The app
+# container installs deps, pushes the schema, seeds the debug personas, then
+# serves on :4000. Flow tests run inside this container (see flow-tests.yml).
+services:
+  db:
+    image: public.ecr.aws/docker/library/postgres:15
+    environment:
+      POSTGRES_USER: prisma
+      POSTGRES_PASSWORD: prismapassword
+      POSTGRES_DB: checkmein
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U prisma -d checkmein"]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+
+  app:
+    image: node:24-bookworm-slim
+    working_dir: /repo
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://prisma:prismapassword@db:5432/checkmein?schema=public
+      CHECKIN_ENV: local            # enables persona-mint login + keyless kiosk
+      NEXTAUTH_URL: http://localhost:4000
+      NEXTAUTH_SECRET: flow-test-secret
+      GOOGLE_CLIENT_ID: flow-test    # present-but-dummy; persona-mint doesn't use them
+      GOOGLE_CLIENT_SECRET: flow-test
+    volumes:
+      - ..:/repo
+    ports:
+      - "4000:4000"
+    command:
+      - sh
+      - -lc
+      - npm ci && cd checkin-app && npx prisma generate && npx prisma db push && npx prisma db seed && npm run dev
+    healthcheck:
+      # Up = the dev server answers an auth route. start_period covers npm ci + seed + first compile.
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:4000/api/auth/csrf').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 5s
+      timeout: 10s
+      retries: 60
+      start_period: 240s


### PR DESCRIPTION
Stacked on #428 (base = `feat/bg-check-nonblocking`) because the flow test asserts #428's behaviour and needs that code to pass. Rebase onto `main` once #428 merges.

## A third test class: flow tests

End-to-end **user-journey** tests that drive a *running* dev server over HTTP — no app imports, no DB, no mocks, just `fetch` + response assertions (how a client actually exercises the wired-together routes + auth + DB).

- **`deploy/docker-compose.flow.yml`** — Postgres + a **dev-mode** app container (`next dev`, `CHECKIN_ENV=local`), auto-installed, `prisma db push`-ed, and seeded. Dev mode is required, not incidental: persona-mint login is gated on `NODE_ENV != production`, and the prod image pins `NODE_ENV=production`.
- **`.github/workflows/flow-tests.yml`** — `docker compose up --wait`, run the flow tests inside the app container, dump app logs on failure, `down -v`.
- **`flow-tests/helpers.ts`** — persona-mint login over HTTP (resolves the persona by stable email, since ids are autoincrement) + a small JSON `fetch` wrapper.
- **`jest.flow.config.js`** — node env that **skips `jest.setup.js`** (so native `fetch`/`getSetCookie` work, and prisma/next-auth aren't mocked). Run with `npm run test:flow`. Flow tests are excluded from the unit/integration runs.

## The one journey (initial): verifies PR #428

`flow-tests/membership-bg-nonblocking.flow.test.ts` walks the real journey: a non-member applicant fills intake, the board records the two external actions, and pays before the check clears — asserting:
1. after the external step the application is at **PENDING_PAYMENT** (payment unblocked; pre-#428 it parked at PENDING_BG_REVIEW), and
2. paying before the check clears holds at **PENDING_BG_CLEARANCE** with the membership still inactive.

Verified locally against the dev server (green).

## AGENTS.md

New top-level agent guide: explains the three test classes (unit / integration / flow, with the flow gotchas) and a **docs map** pointing to README, CONSTITUTION, `docs/designs/*` (incl. `CUJS.md` as the journey source), `docs/security/*`, the setup guides, and each subproject's README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)