### PR TITLE
test(roles): align admin roles integration test with isYouth contract

### DIFF
--- a/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
@@ -101,7 +101,7 @@ describe('Admin Roles API Integration Tests', () => {
              expect(data.error).toContain('Forbidden');
         });
 
-        it('should return all adult participants for a sysadmin', async () => {
+        it('should return all participants (youth flagged, dob hidden) for a sysadmin', async () => {
             (getServerSession as jest.Mock).mockResolvedValue({
                 user: { id: testSysAdminId, sysadmin: true }
             });
@@ -117,7 +117,14 @@ describe('Admin Roles API Integration Tests', () => {
 
             const ids = data.participants.map((p: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => p.id);
             expect(ids).toContain(testTargetUserId);
-            expect(ids).not.toContain(testStudentId); // Students are filtered out
+            // Youth are returned (client filters via "Hide Youth"), flagged isYouth; dob is not leaked.
+            expect(ids).toContain(testStudentId);
+            const adult = data.participants.find((p: { id?: number }) => p.id === testTargetUserId);
+            const student = data.participants.find((p: { id?: number }) => p.id === testStudentId);
+            expect(adult.isYouth).toBe(false);
+            expect(student.isYouth).toBe(true);
+            expect(adult).not.toHaveProperty('dob');
+            expect(student).not.toHaveProperty('dob');
         });
     });
 


### PR DESCRIPTION
## What

Fix the failing integration suite `checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts` (test `should return all adult participants for a sysadmin`).

## Why

PR #456 ("add Hide Youth filter to role assignment page") deliberately changed `GET /api/admin/roles`:

- **Before:** the route hard-excluded youth (under 18) at the API layer via a `dob` `where` clause.
- **After:** the route returns **all** participants with a computed `isYouth` boolean and keeps raw `dob` server-side. Filtering moved to a client-side "Hide Youth" checkbox (default on).

The integration test still asserted the old contract (`expect(ids).not.toContain(testStudentId)`), so it failed. Because `*.integration.test.ts` suites are excluded from CI, the failure was ungated.

Investigated whether this was a real PII/access leak: it is **not**. The endpoint is admin-only (`sysadmin`/`boardMember`), `dob` is stripped before serialization, and only the `isYouth` boolean is exposed. The route change is the intended, reviewed behavior.

## Change

Test updated to the current contract:
- youth (student, age 10) is **returned** and flagged `isYouth: true`
- adult is flagged `isYouth: false`
- `dob` is asserted **absent** from the payload for both (PII guard)
- renamed the test to match the contract

## Verification

Ran the suite against a throwaway Postgres — 9/9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)