### PR TITLE
test(attendance): align audit assertions with per-Visit audit model (#467)

### DIFF
--- a/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
@@ -122,9 +122,10 @@ describe('Event Attendance API Integration Tests', () => {
             where: { participantId: { in: [testParticipant1Id, testParticipant2Id] } }
         });
         // Clear audit rows so each test asserts exactly its own write.
+        // Per-Visit audit rows carry the event in secondaryAffectedEntity;
         // testEventId is fresh per run, so this is leak-proof.
         await prisma.auditLog.deleteMany({
-            where: { tableName: 'Visit', affectedEntityId: testEventId }
+            where: { tableName: 'Visit', secondaryAffectedEntity: testEventId }
         });
     });
 
@@ -193,15 +194,19 @@ describe('Event Attendance API Integration Tests', () => {
             expect(visits[0].arrived).not.toBeNull();
             expect(visits[0].departed).not.toBeNull();
 
-            // Audit: exactly one row crediting the acting lead mentor.
+            // Audit: exactly one row keyed by the new Visit's PK, event in
+            // secondaryAffectedEntity, crediting the acting lead mentor.
             const auditRows = await prisma.auditLog.findMany({
-                where: { tableName: 'Visit', affectedEntityId: testEventId }
+                where: { tableName: 'Visit', secondaryAffectedEntity: testEventId }
             });
             expect(auditRows.length).toBe(1);
             expect(auditRows[0].actorId).toBe(testLeadMentorId);
-            expect(auditRows[0].action).toBe('EDIT');
+            expect(auditRows[0].action).toBe('CREATE');
+            expect(auditRows[0].affectedEntityId).toBe(visits[0].id);
             expect(JSON.parse(auditRows[0].newData as string)).toEqual({
-                validatedParticipants: [testParticipant1Id]
+                participantId: testParticipant1Id,
+                associatedEventId: testEventId,
+                synthetic: true
             });
         });
 
@@ -241,15 +246,19 @@ describe('Event Attendance API Integration Tests', () => {
             expect(visits[0].associatedEventId).toBe(testEventId); // It was successfully linked
             expect(visits[0].arrived.getTime()).toBe(earlyArrival.getTime()); // Validates it used the existing visit
 
-            // Audit: exactly one row crediting the acting admin.
+            // Audit: exactly one row keyed by the linked Visit's PK, event in
+            // secondaryAffectedEntity, crediting the acting admin.
             const auditRows = await prisma.auditLog.findMany({
-                where: { tableName: 'Visit', affectedEntityId: testEventId }
+                where: { tableName: 'Visit', secondaryAffectedEntity: testEventId }
             });
             expect(auditRows.length).toBe(1);
             expect(auditRows[0].actorId).toBe(testAdminId);
             expect(auditRows[0].action).toBe('EDIT');
+            expect(auditRows[0].affectedEntityId).toBe(visits[0].id);
             expect(JSON.parse(auditRows[0].newData as string)).toEqual({
-                validatedParticipants: [testParticipant2Id]
+                participantId: testParticipant2Id,
+                associatedEventId: testEventId,
+                synthetic: false
             });
         });
     });


### PR DESCRIPTION
## What

Fix the failing integration suite `eventAttendanceAPI.integration.test.ts`. Two audit-row assertions (synthetic-visit and link-existing-visit cases) counted 0 rows and failed.

## Why

The suite still asserted the **pre-#467** audit shape — a single `AuditLog` row written after the transaction, keyed by `affectedEntityId: eventId` with `newData: { validatedParticipants }`.

[#467](https://github.com/innovationtreehouse/checkin/pull/467) deliberately replaced that with **one audit row per Visit**, written *inside* the `$transaction`, keyed by the real Visit PK with the event in `secondaryAffectedEntity`, plus a `synthetic` flag and CREATE/EDIT actions per branch (atomic + reverse-lookupable by Visit PK). The route is correct; the test was stale.

Because `*.integration.test.ts` is excluded from CI by `checkin-app/jest.config.js`, the staleness was ungated.

## Changes

Test-only (`eventAttendanceAPI.integration.test.ts`):
- `afterEach` cleanup and both count queries now filter by `secondaryAffectedEntity: testEventId`.
- Synthetic-visit test: action `CREATE`, `affectedEntityId === new visit id`, `newData { participantId, associatedEventId, synthetic: true }`.
- Link-existing-visit test: action `EDIT`, `affectedEntityId === linked visit id`, `newData { ..., synthetic: false }`.

## Verification

Ran the suite against a throwaway Postgres — 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)