### PR TITLE
fix(renewal): serialize createRenewalProcess so the concurrency guard holds under db push

### DIFF
--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -112,18 +112,34 @@ export async function beginRenewal(processId: number) {
 
 /**
  * Create one PENDING_RENEWAL process (+ audit, optional reminder), or no-op if one
- * is already in flight. The check-then-act in the callers is NOT atomic, so the
- * partial unique index `membership_one_inflight_renewal` is the real guard: a
- * concurrent sweep/admin-button/double-click that wins the insert leaves the loser
- * here catching P2002 and returning null — no duplicate audit row, no duplicate
- * household reminder. Returns null when the create lost the race. The index, not
- * this catch, is the guarantee; we stay lazy and skip the pre-insert advisory lock.
+ * is already in flight. The callers' check-then-act is NOT atomic, so this function
+ * serializes its own check+insert by locking the parent Membership row (SELECT ...
+ * FOR UPDATE): a concurrent sweep/admin-button/double-click blocks until the winner
+ * commits, then sees the winner's in-flight process and returns null — no duplicate
+ * audit row, no duplicate household reminder. This holds in every environment, not
+ * just one provisioned via `migrate deploy` (the partial unique index
+ * `membership_one_inflight_renewal` is migration-only — `prisma db push` and the
+ * integration test DBs don't have it). The index stays as defense-in-depth and the
+ * P2002 catch as a backstop. Returns null when this call lost the race.
  */
 export async function createRenewalProcess(membershipId: number, householdId: number, now: Date, opts: { remind: boolean; boundary: Date }) {
     let process;
     try {
-        process = await prisma.membershipProcess.create({
-            data: { membershipId, kind: "RENEWAL", status: "PENDING_RENEWAL", renewalReminderSentAt: opts.remind ? now : null },
+        process = await prisma.$transaction(async (tx) => {
+            // Lock the membership row so overlapping opens serialize here, not at the INSERT.
+            await tx.$queryRaw`SELECT id FROM "Membership" WHERE id = ${membershipId} FOR UPDATE`;
+            const existing = await tx.membershipProcess.findFirst({
+                where: { membershipId, kind: "RENEWAL", status: { in: ["PENDING_RENEWAL", "RENEWAL_PENDING_BG", "PENDING_PAYMENT"] } },
+                select: { id: true },
+            });
+            if (existing) return null; // someone else already opened the renewal
+            const created = await tx.membershipProcess.create({
+                data: { membershipId, kind: "RENEWAL", status: "PENDING_RENEWAL", renewalReminderSentAt: opts.remind ? now : null },
+            });
+            await tx.auditLog.create({
+                data: { actorId: SYSTEM_ACTOR, action: "CREATE", tableName: "MembershipProcess", affectedEntityId: created.id, newData: JSON.stringify({ kind: "RENEWAL", status: "PENDING_RENEWAL" }) },
+            });
+            return created;
         });
     } catch (e) {
         if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
@@ -132,9 +148,10 @@ export async function createRenewalProcess(membershipId: number, householdId: nu
         }
         throw e;
     }
-    await prisma.auditLog.create({
-        data: { actorId: SYSTEM_ACTOR, action: "CREATE", tableName: "MembershipProcess", affectedEntityId: process.id, newData: JSON.stringify({ kind: "RENEWAL", status: "PENDING_RENEWAL" }) },
-    });
+    if (!process) {
+        logger.info("Renewal already in flight for membership %d — concurrent open, skipping", membershipId);
+        return null;
+    }
     if (opts.remind) await remindHousehold(householdId, opts.boundary);
     return process;
 }


### PR DESCRIPTION
## What

`createRenewalProcess` now serializes its own check-then-insert inside a transaction that locks the parent `Membership` row (`SELECT ... FOR UPDATE`) before checking for an in-flight RENEWAL and inserting. Two concurrent opens serialize at the lock; the loser sees the winner's committed row and returns `null`.

## Why

The "one in-flight RENEWAL per membership" invariant relied **entirely** on the partial unique index `membership_one_inflight_renewal`, which exists only as a migration (`#399`). `prisma db push` reads `schema.prisma`, and Prisma's schema DSL can't express a partial/filtered unique index — so any DB provisioned with `db push` (local dev per the spin-up recipe, and the integration test) **has no index**. There, the non-atomic check-then-insert lets both concurrent `createRenewalProcess` calls win: duplicate `PENDING_RENEWAL` rows → duplicate household reminder emails + a dangling process `beginRenewalForUser` never advances.

Production (`migrate deploy`) had the index, so the guard was silently environment-dependent. Locking the membership row makes the invariant hold in **every** environment regardless of provisioning.

Verified empirically: after `prisma db push`, `MembershipProcess` carries only `pkey` + the two plain `@@index`es — the partial unique index is absent.

## Reviewer notes

- Migration index `membership_one_inflight_renewal` is kept as defense-in-depth; the `P2002` catch stays as a backstop.
- Audit-row creation moved inside the transaction (atomic with the insert). The reminder email stays outside the transaction — only the winner (non-null result) sends, so still exactly one email.
- No schema or migration change.
- Considered the nullable-unique-column trick (the only schema-expressible "partial unique") but rejected it: it requires nulling the key on every status transition out of the in-flight set, touching many call sites. The row lock makes the function correct with a far smaller diff.

## Test

`renewalConcurrency.integration.test.ts` (excluded from CI, so this bug was ungated) now passes; `membershipIntakeAPI.integration.test.ts` (also exercises `createRenewalProcess`) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)