### PR TITLE
test(audit): fix stale attendance-validation audit assertion

### DIFF
--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /**
  * Integration Test for Audit Logs
  * Ensures that various actions across the system correctly generate an AuditLog.

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -233,13 +233,15 @@ describe('AuditLog Integration Tests', () => {
         const res = await markAttendance(req, { params: Promise.resolve({ id: testEventId.toString() }) });
         expect(res.status).toBe(200);
 
-        // Verify Audit Log
+        // Verify Audit Log: one row per validated Visit, keyed by the Visit PK
+        // with the event as secondary (see attendance route, commit #467).
         const log = await prisma.auditLog.findFirst({
             where: {
                 actorId: testAdminId,
                 action: 'EDIT',
                 tableName: 'Visit',
-                affectedEntityId: testEventId
+                affectedEntityId: testVisitId,
+                secondaryAffectedEntity: testEventId
             },
             orderBy: { time: 'desc' }
         });
@@ -248,7 +250,8 @@ describe('AuditLog Integration Tests', () => {
         // Prisma Json fields can be returned as string depending on setup, the API explicitly stringified it
         const newDataString = log?.newData as string;
         const newData = JSON.parse(newDataString);
-        expect(newData.validatedParticipants).toContain(testParticipantId);
+        expect(newData.participantId).toBe(testParticipantId);
+        expect(newData.associatedEventId).toBe(testEventId);
     });
 
     it('should generate an AuditLog when an Admin edits participant PII', async () => {


### PR DESCRIPTION
## What

Fix the failing (CI-ungated) integration test
`checkin-app/src/app/__tests__/auditLog.integration.test.ts` →
"should generate an AuditLog when attendance is validated".

## Why

Commit #467 (`fix(attendance): audit each validated Visit by its own PK, inside the tx`)
changed the attendance-validation audit shape from **one aggregate row per
event** to **one row per validated Visit**:

| | before | after (#467) |
|---|---|---|
| `affectedEntityId` | event id | Visit PK |
| `secondaryAffectedEntity` | — | event id |
| `newData` | `{ validatedParticipants: [...] }` | `{ participantId, associatedEventId, synthetic }` |

The test still asserted the old shape (queried `affectedEntityId=eventId`,
expected `newData.validatedParticipants`), so `newData.validatedParticipants`
was `undefined` and the suite failed.

**This is a stale test, not a route regression** — the route writes audit
rows correctly (one per Visit, inside the tx). Audit/compliance path
unaffected.

## Change

Update the assertion to the per-Visit shape: query by Visit PK +
`secondaryAffectedEntity=event`, assert `newData.participantId` and
`newData.associatedEventId`.

## Test

Ran the integration suite against a throwaway Postgres — 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)