### PR TITLE
test(reminders): fix sendNotification mock in reschedule integration suite

### DIFF
--- a/checkin-app/src/app/__tests__/eventRescheduleClearsReminder.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventRescheduleClearsReminder.integration.test.ts
@@ -26,7 +26,9 @@ jest.mock('next-auth/next', () => ({
 }));
 
 jest.mock('@/lib/notifications', () => ({
-    sendNotification: jest.fn().mockResolvedValue(undefined),
+    // sendNotification resolves boolean delivery status; cron stamps reminderSentAt
+    // only on a truthy result, so the mock must mimic a successful send.
+    sendNotification: jest.fn().mockResolvedValue(true),
 }));
 
 const TAG = 'reschedule-clears-test';


### PR DESCRIPTION
## What

Fixes the failing integration suite `eventRescheduleClearsReminder.integration.test.ts` (the "clears reminderSentAt when the start moves, and the cron re-notifies" case).

## Why

Integration tests (`*.integration.test.ts`) are excluded from CI by `checkin-app/jest.config.js`, so this drift went ungated.

Since #392, the reminders cron stamps `RSVP.reminderSentAt` **only when `sendNotification` resolves truthy**:

```ts
.then(async (ok) => {
    if (!ok) return;            // falsy → skip the stamp
    await prisma.rSVP.update({ ... data: { reminderSentAt: new Date() } });
});
```

`sendNotification` now returns `Promise<boolean>`. The test mock still resolved `undefined` (falsy), so the cron sent the notification (call count assertion passed) but never wrote the stamp — making the post-cron `reminderSentAt(eventId).not.toBeNull()` assertion fail with `null`.

This is **test-only drift**. The cron, the `PATCH editTime` route, and the schema field are all correct and unchanged.

## Change

Mock `sendNotification` to resolve `true`, mimicking a successful send.

## Verification

Ran the suite against a throwaway Postgres 16 — all 5 tests pass:

```
PASS src/app/__tests__/eventRescheduleClearsReminder.integration.test.ts
  ✓ clears reminderSentAt when the start moves, and the cron re-notifies
  ✓ does NOT clear reminderSentAt for an end-only edit
  ✓ does NOT clear when the supplied start equals the current start
  ✓ rejects editTime on a past event and leaves reminderSentAt untouched
  ✓ clears reminderSentAt across a series when applyToFuture shifts the start
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)