### PR TITLE
feat(validation): shared phone validator wired to every capture point

### DIFF
--- a/checkin-app/src/app/__tests__/emergencyContactMemberRouteGuard.integration.test.ts
+++ b/checkin-app/src/app/__tests__/emergencyContactMemberRouteGuard.integration.test.ts
@@ -81,7 +81,7 @@ describe("PATCH /api/household/settings — Direction A: reject a member as prim
             data: {
                 email: `member-A-${TAG}@example.com`,
                 name: "Bobby Member",
-                phone: "555-7777",
+                phone: "555-555-7777",
                 householdId,
             },
         });
@@ -91,7 +91,7 @@ describe("PATCH /api/household/settings — Direction A: reject a member as prim
     it("rejects a contact matching a member by name+phone with 400 and writes no contact", async () => {
         asUser(leadId);
         const res = await PATCH_SETTINGS(
-            settingsReq({ emergencyContactName: "Bobby Member", emergencyContactPhone: "555-7777" }),
+            settingsReq({ emergencyContactName: "Bobby Member", emergencyContactPhone: "555-555-7777" }),
         );
         expect(res.status).toBe(400);
         expect((await res.json()).error).toMatch(/part of this household|can't be its emergency contact/i);
@@ -107,7 +107,7 @@ describe("PATCH /api/household/settings — Direction A: reject a member as prim
         // the route surfaces the rejection regardless of which key matched.
         asUser(leadId);
         const res = await PATCH_SETTINGS(
-            settingsReq({ emergencyContactName: "Totally Different", emergencyContactPhone: "(555) 777-7" }),
+            settingsReq({ emergencyContactName: "Totally Different", emergencyContactPhone: "(555) 555-7777" }),
         );
         expect(res.status).toBe(400);
         expect((await res.json()).error).toMatch(/part of this household|can't be its emergency contact/i);
@@ -119,7 +119,7 @@ describe("PATCH /api/household/settings — Direction A: reject a member as prim
     it("positive control: a genuinely external contact is accepted (200) and written", async () => {
         asUser(leadId);
         const res = await PATCH_SETTINGS(
-            settingsReq({ emergencyContactName: "Aunt External", emergencyContactPhone: "555-3030" }),
+            settingsReq({ emergencyContactName: "Aunt External", emergencyContactPhone: "555-303-0303" }),
         );
         expect(res.status).toBe(200);
         const contact = await prisma.emergencyContact.findFirst({ where: { householdId } });

--- a/checkin-app/src/app/__tests__/emergencyContactsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/emergencyContactsAPI.integration.test.ts
@@ -65,7 +65,7 @@ describe("Emergency Contacts API — removal prohibition", () => {
 
     it("blocks removing the only valid contact", async () => {
         asUser(leadId);
-        const created = await (await POST(postReq({ name: "Aunt May", phone: "555-2000" }))).json();
+        const created = await (await POST(postReq({ name: "Aunt May", phone: "555-555-2000" }))).json();
         const res = await DELETE(delReq(), delCtx(created.contact.id));
         expect(res.status).toBe(400);
         expect((await res.json()).error).toMatch(/at least one valid emergency contact|second emergency contact/i);
@@ -76,8 +76,8 @@ describe("Emergency Contacts API — removal prohibition", () => {
 
     it("allows removal once a second valid contact exists", async () => {
         asUser(leadId);
-        const a = await (await POST(postReq({ name: "Aunt May", phone: "555-2000" }))).json();
-        await (await POST(postReq({ name: "Neighbor Bob", phone: "555-4000" }))).json();
+        const a = await (await POST(postReq({ name: "Aunt May", phone: "555-555-2000" }))).json();
+        await (await POST(postReq({ name: "Neighbor Bob", phone: "555-555-4000" }))).json();
         const res = await DELETE(delReq(), delCtx(a.contact.id));
         expect(res.status).toBe(200);
         const list = await (await GET(getReq())).json();
@@ -114,12 +114,12 @@ describe("Emergency Contacts API — removal prohibition", () => {
         const B = await makeHouseholdWithLead("boundaryB");
 
         asUser(B.leadId);
-        const cB = await (await POST(postReq({ name: "B Contact", phone: "555-7000" }))).json();
+        const cB = await (await POST(postReq({ name: "B Contact", phone: "555-555-7000" }))).json();
 
         // Lead of A scopes to A's household; B's contact is invisible -> 404.
         asUser(A.leadId);
         expect((await DELETE(delReq(), delCtx(cB.contact.id))).status).toBe(404);
-        expect((await PATCH(patchReq({ name: "Hacked", phone: "555-0000" }), delCtx(cB.contact.id))).status).toBe(404);
+        expect((await PATCH(patchReq({ name: "Hacked", phone: "555-555-0000" }), delCtx(cB.contact.id))).status).toBe(404);
 
         const still = await prisma.emergencyContact.findUnique({ where: { id: cB.contact.id } });
         expect(still).not.toBeNull();
@@ -129,10 +129,10 @@ describe("Emergency Contacts API — removal prohibition", () => {
     it("the owning lead's DELETE and PATCH each write an audit row with actor + household", async () => {
         const A = await makeHouseholdWithLead("audit");
         asUser(A.leadId);
-        const c1 = await (await POST(postReq({ name: "May", phone: "555-1000" }))).json();
-        const c2 = await (await POST(postReq({ name: "Bob", phone: "555-2000" }))).json();
+        const c1 = await (await POST(postReq({ name: "May", phone: "555-555-1000" }))).json();
+        const c2 = await (await POST(postReq({ name: "Bob", phone: "555-555-2000" }))).json();
 
-        const pr = await PATCH(patchReq({ name: "May Updated", phone: "555-1111" }), delCtx(c1.contact.id));
+        const pr = await PATCH(patchReq({ name: "May Updated", phone: "555-555-1111" }), delCtx(c1.contact.id));
         expect(pr.status).toBe(200);
         const patchLog = await expectAuditRow(prisma, { action: "EDIT", tableName: "EmergencyContact", affectedEntityId: c1.contact.id });
         expect(patchLog.actorId).toBe(A.leadId);

--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { addHouseholdLead, HouseholdLeadLimitError } from "@/lib/household/leads";
 import { reconcileAndWarn } from "@/lib/emergencyContacts/service";
+import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 
 export const PATCH = withAuth(
     {},
@@ -16,6 +17,11 @@ export const PATCH = withAuth(
 
             if (!participantId) {
                 return NextResponse.json({ error: "Participant ID is required" }, { status: 400 });
+            }
+
+            // Phone is optional for a member, but if supplied it must be valid.
+            if (phone !== undefined && phone !== "" && !isValidPhone(phone)) {
+                return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
             }
 
             const user = await prisma.participant.findUnique({ where: { id: userId }, include: { householdLeads: true } });

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { authenticateRequest } from "@/lib/auth";
+import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 
 export async function PUT(
     request: NextRequest,
@@ -26,7 +27,12 @@ export async function PUT(
         const updateData: Record<string, NonNullable<unknown> | null | string | number | boolean | Date> = {};
         if (body.name !== undefined) updateData.name = body.name;
         if (body.email !== undefined) updateData.email = body.email;
-        if (body.phone !== undefined) updateData.phone = body.phone;
+        if (body.phone !== undefined) {
+            if (body.phone !== "" && body.phone !== null && !isValidPhone(body.phone)) {
+                return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
+            }
+            updateData.phone = body.phone;
+        }
 
         if (Object.keys(updateData).length === 0) {
             return NextResponse.json({ error: "No fields to update provided" }, { status: 400 });

--- a/checkin-app/src/app/api/profile/onboarding/route.ts
+++ b/checkin-app/src/app/api/profile/onboarding/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { withAuth } from "@/lib/auth";
 import { upsertPrimaryContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
+import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 
 export const POST = withAuth(
     {},
@@ -23,6 +24,9 @@ export const POST = withAuth(
             }
 
             if (phone !== undefined) {
+                if (phone !== "" && !isValidPhone(phone)) {
+                    return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
+                }
                 await prisma.participant.update({
                     where: { id: userId },
                     data: { phone }

--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { handler, notFound, unauthorized } from "@/security/handler";
+import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 
 export const GET = handler('GET /api/profile', async ({ auth }) => {
     if (auth.type !== 'session') throw unauthorized();
@@ -28,6 +29,10 @@ export const PATCH = withAuth(
 
             const body = await req.json();
             const { name, phone, dob, notificationSettings } = body;
+
+            if (phone !== undefined && phone !== "" && !isValidPhone(phone)) {
+                return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
+            }
 
             const updatedProfile = await prisma.participant.update({
                 where: { id: userId },

--- a/checkin-app/src/app/api/programs/[id]/public-register/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/public-register/route.ts
@@ -7,6 +7,7 @@ import { lockProgramAndCheckCapacity, ProgramCapacityError } from "@/lib/program
 import { createContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
 import { rateLimit, rateLimitEmail } from "@/lib/rate-limit";
 import { calculateAge } from "@/lib/time";
+import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 
 interface ParentInput {
     name: string;
@@ -49,9 +50,13 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         if (!parents || parents.length === 0 || !parents[0].name || !parents[0].email || !parents[0].phone) {
             return NextResponse.json({ error: "Primary parent/guardian information is required." }, { status: 400 });
         }
+        if (!isValidPhone(parents[0].phone)) {
+            return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
+        }
         if (!emergencyContact || !emergencyContact.name || !emergencyContact.phone) {
             return NextResponse.json({ error: "Emergency contact is required." }, { status: 400 });
         }
+        // Emergency-contact phone format is enforced in createContact below.
         if (!participants || participants.length === 0) {
             return NextResponse.json({ error: "At least one participant is required." }, { status: 400 });
         }

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -10,6 +10,7 @@ import TodoCard from '@/components/TodoCard';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { isOrgAccount } from '@/lib/orgAccount';
 import { pickAddress, type StructuredAddress } from '@/lib/address';
+import { isValidPhone, PHONE_ERROR } from '@/lib/phone';
 
 const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
 
@@ -133,6 +134,10 @@ export default function HouseholdPage() {
 
   const handleSaveContact = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!isValidPhone(contactForm.phone)) {
+      setContactError(PHONE_ERROR);
+      return;
+    }
     setSavingContact(true);
     setContactError("");
     try {
@@ -221,6 +226,10 @@ export default function HouseholdPage() {
   const handleEditMember = async (e: React.FormEvent, participantId: number) => {
     e.preventDefault();
     setMessage("");
+    if (editForm.phone && !isValidPhone(editForm.phone)) {
+      setMessage(PHONE_ERROR);
+      return;
+    }
     try {
       const res = await fetch('/api/household/member', {
         method: 'PATCH',
@@ -339,7 +348,7 @@ export default function HouseholdPage() {
                             <TextInput size="xs" label="Name" required value={editForm.name} onChange={(e) => setEditForm({ ...editForm, name: e.currentTarget.value })} />
                             <TextInput size="xs" type="email" label="Email" value={editForm.email} onChange={(e) => setEditForm({ ...editForm, email: e.currentTarget.value })} />
                             <TextInput size="xs" type="date" label="Date of Birth" value={editForm.dob} onChange={(e) => setEditForm({ ...editForm, dob: e.currentTarget.value })} />
-                            <TextInput size="xs" type="tel" label="Phone" value={editForm.phone} onChange={(e) => setEditForm({ ...editForm, phone: e.currentTarget.value })} />
+                            <TextInput size="xs" type="tel" label="Phone" value={editForm.phone} onChange={(e) => setEditForm({ ...editForm, phone: e.currentTarget.value })} error={editForm.phone && !isValidPhone(editForm.phone) ? PHONE_ERROR : undefined} />
                             {p.id !== userId && editForm.dob && calculateAge(editForm.dob) >= 18 && (
                               <Checkbox label="Household Lead" checked={editForm.isLead} onChange={(e) => setEditForm({ ...editForm, isLead: e.currentTarget.checked })} />
                             )}
@@ -483,7 +492,7 @@ export default function HouseholdPage() {
                     <Stack gap="xs" mt="sm">
                       <SimpleGrid cols={{ base: 1, sm: 2 }}>
                         <TextInput label="Contact Name" required value={contactForm.name} onChange={(e) => setContactForm({ ...contactForm, name: e.currentTarget.value })} placeholder="Full Name" />
-                        <TextInput type="tel" label="Phone" required value={contactForm.phone} onChange={(e) => setContactForm({ ...contactForm, phone: e.currentTarget.value })} placeholder="(555) 555-5555" />
+                        <TextInput type="tel" label="Phone" required value={contactForm.phone} onChange={(e) => setContactForm({ ...contactForm, phone: e.currentTarget.value })} placeholder="(555) 555-5555" error={contactForm.phone && !isValidPhone(contactForm.phone) ? PHONE_ERROR : undefined} />
                         <TextInput type="email" label="Email (optional)" value={contactForm.email} onChange={(e) => setContactForm({ ...contactForm, email: e.currentTarget.value })} />
                         <TextInput label="Relationship (optional)" value={contactForm.relationship} onChange={(e) => setContactForm({ ...contactForm, relationship: e.currentTarget.value })} placeholder="Aunt, Neighbor…" />
                       </SimpleGrid>

--- a/checkin-app/src/components/OnboardingGate.tsx
+++ b/checkin-app/src/components/OnboardingGate.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { isValidEmail } from '@/lib/emergencyContacts/identity';
+import { isValidPhone, PHONE_ERROR } from '@/lib/phone';
 import {
   Alert,
   Box,
@@ -64,6 +65,15 @@ export default function OnboardingGate({ children }: { children: React.ReactNode
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (needsPhone && !isValidPhone(phone)) {
+      setError(PHONE_ERROR);
+      return;
+    }
+    if (needsEmergencyContact && !isValidPhone(emergencyContactPhone)) {
+      setError(`Emergency contact: ${PHONE_ERROR}`);
+      return;
+    }
     if (needsEmergencyContact && emergencyContactEmail.trim() && !isValidEmail(emergencyContactEmail)) {
       setError("That emergency contact email doesn't look right.");
       return;
@@ -134,6 +144,7 @@ export default function OnboardingGate({ children }: { children: React.ReactNode
                 placeholder="(555) 123-4567"
                 value={phone}
                 onChange={(e) => setPhone(e.currentTarget.value)}
+                error={phone && !isValidPhone(phone) ? PHONE_ERROR : undefined}
                 required
               />
             )}
@@ -161,6 +172,7 @@ export default function OnboardingGate({ children }: { children: React.ReactNode
                     placeholder="(555) 987-6543"
                     value={emergencyContactPhone}
                     onChange={(e) => setEmergencyContactPhone(e.currentTarget.value)}
+                    error={emergencyContactPhone && !isValidPhone(emergencyContactPhone) ? PHONE_ERROR : undefined}
                     required
                   />
                   <TextInput

--- a/checkin-app/src/lib/__tests__/phone.test.ts
+++ b/checkin-app/src/lib/__tests__/phone.test.ts
@@ -1,0 +1,41 @@
+import { isValidPhone, normalizePhone, assertValidPhone, PhoneValidationError } from "@/lib/phone";
+
+describe("normalizePhone", () => {
+    it("strips all non-digits", () => {
+        expect(normalizePhone("(555) 123-4567")).toBe("5551234567");
+        expect(normalizePhone("+1 555.123.4567")).toBe("15551234567");
+        expect(normalizePhone(null)).toBe("");
+        expect(normalizePhone(undefined)).toBe("");
+    });
+});
+
+describe("isValidPhone", () => {
+    it("accepts 10-digit US numbers in any format", () => {
+        expect(isValidPhone("5551234567")).toBe(true);
+        expect(isValidPhone("(555) 123-4567")).toBe(true);
+        expect(isValidPhone("555.123.4567")).toBe(true);
+    });
+
+    it("accepts 11 digits with leading country code 1", () => {
+        expect(isValidPhone("15551234567")).toBe(true);
+        expect(isValidPhone("+1 (555) 123-4567")).toBe(true);
+    });
+
+    it("rejects too few / too many digits, junk, and blanks", () => {
+        expect(isValidPhone("123")).toBe(false);
+        expect(isValidPhone("555123456")).toBe(false); // 9 digits
+        expect(isValidPhone("25551234567")).toBe(false); // 11 digits, wrong country code
+        expect(isValidPhone("123456789012")).toBe(false); // 12 digits
+        expect(isValidPhone("not a phone")).toBe(false);
+        expect(isValidPhone("")).toBe(false);
+        expect(isValidPhone(null)).toBe(false);
+        expect(isValidPhone(undefined)).toBe(false);
+    });
+});
+
+describe("assertValidPhone", () => {
+    it("throws PhoneValidationError on invalid, passes on valid", () => {
+        expect(() => assertValidPhone("5551234567")).not.toThrow();
+        expect(() => assertValidPhone("bad")).toThrow(PhoneValidationError);
+    });
+});

--- a/checkin-app/src/lib/emergencyContacts/__tests__/service.integration.test.ts
+++ b/checkin-app/src/lib/emergencyContacts/__tests__/service.integration.test.ts
@@ -52,38 +52,38 @@ afterAll(async () => {
 describe("createContact — direction A (hard)", () => {
     it("allows an external contact", async () => {
         const hh = await makeHousehold("ext");
-        await addMember(hh, { name: "Parent One", phone: "555-1000" });
-        const c = await createContact(prisma, hh, { name: "Aunt May", phone: "555-2000" });
+        await addMember(hh, { name: "Parent One", phone: "555-555-1000" });
+        const c = await createContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000" });
         expect(c.id).toBeGreaterThan(0);
-        expect(c.phoneDigits).toBe("5552000");
+        expect(c.phoneDigits).toBe("5555552000");
         expect(c.conflictParticipantId).toBeNull();
     });
 
     it("rejects a contact matching a member by phone (any format)", async () => {
         const hh = await makeHousehold("phone");
-        await addMember(hh, { name: "Parent One", phone: "(555) 100-0" });
-        await expect(createContact(prisma, hh, { name: "Someone Else", phone: "5551000" })).rejects.toBeInstanceOf(EmergencyContactError);
+        await addMember(hh, { name: "Parent One", phone: "(555) 555-1000" });
+        await expect(createContact(prisma, hh, { name: "Someone Else", phone: "5555551000" })).rejects.toBeInstanceOf(EmergencyContactError);
     });
 
     it("rejects a contact matching a member by email", async () => {
         const hh = await makeHousehold("email");
-        await addMember(hh, { name: "Parent One", email: "shared@x.com", phone: "555-1000" });
+        await addMember(hh, { name: "Parent One", email: "shared@x.com", phone: "555-555-1000" });
         await expect(
-            createContact(prisma, hh, { name: "Someone Else", phone: "555-9999", email: "SHARED@x.com" }),
+            createContact(prisma, hh, { name: "Someone Else", phone: "555-555-9999", email: "SHARED@x.com" }),
         ).rejects.toBeInstanceOf(EmergencyContactError);
     });
 
     it("rejects a contact matching a member by name", async () => {
         const hh = await makeHousehold("name");
-        await addMember(hh, { name: "Jane Doe", phone: "555-1000" });
-        await expect(createContact(prisma, hh, { name: "jane doe", phone: "555-9999" })).rejects.toBeInstanceOf(EmergencyContactError);
+        await addMember(hh, { name: "Jane Doe", phone: "555-555-1000" });
+        await expect(createContact(prisma, hh, { name: "jane doe", phone: "555-555-9999" })).rejects.toBeInstanceOf(EmergencyContactError);
     });
 
     it("allows the same phone as a member of a DIFFERENT household", async () => {
         const a = await makeHousehold("cross-a");
         const b = await makeHousehold("cross-b");
-        await addMember(a, { name: "Parent A", phone: "555-7777" });
-        const c = await createContact(prisma, b, { name: "Neighbor", phone: "555-7777" });
+        await addMember(a, { name: "Parent A", phone: "555-555-7777" });
+        const c = await createContact(prisma, b, { name: "Neighbor", phone: "555-555-7777" });
         expect(c.id).toBeGreaterThan(0);
     });
 });
@@ -91,7 +91,7 @@ describe("createContact — direction A (hard)", () => {
 describe("upsertPrimaryContact — partial tolerance + member rejection", () => {
     it("persists a partial contact without the member check", async () => {
         const hh = await makeHousehold("partial");
-        await addMember(hh, { name: "Jane Doe", phone: "555-1000" });
+        await addMember(hh, { name: "Jane Doe", phone: "555-555-1000" });
         // name only, and it equals a member — tolerated because incomplete.
         const c = await upsertPrimaryContact(prisma, hh, { name: "Jane Doe", phone: "" });
         expect(c).not.toBeNull();
@@ -100,8 +100,8 @@ describe("upsertPrimaryContact — partial tolerance + member rejection", () => 
 
     it("rejects a complete contact that is a member", async () => {
         const hh = await makeHousehold("upsert-member");
-        await addMember(hh, { name: "Jane Doe", phone: "555-1000" });
-        await expect(upsertPrimaryContact(prisma, hh, { name: "Jane Doe", phone: "555-1000" })).rejects.toBeInstanceOf(EmergencyContactError);
+        await addMember(hh, { name: "Jane Doe", phone: "555-555-1000" });
+        await expect(upsertPrimaryContact(prisma, hh, { name: "Jane Doe", phone: "555-555-1000" })).rejects.toBeInstanceOf(EmergencyContactError);
     });
 
     it("persists the optional email + its normalized key", async () => {
@@ -113,22 +113,22 @@ describe("upsertPrimaryContact — partial tolerance + member rejection", () => 
 
     it("updates the same primary row on repeat", async () => {
         const hh = await makeHousehold("upsert-update");
-        await upsertPrimaryContact(prisma, hh, { name: "Aunt May", phone: "555-2000" });
-        await upsertPrimaryContact(prisma, hh, { name: "Aunt May", phone: "555-3000" });
+        await upsertPrimaryContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000" });
+        await upsertPrimaryContact(prisma, hh, { name: "Aunt May", phone: "555-555-3000" });
         const all = await prisma.emergencyContact.findMany({ where: { householdId: hh } });
         expect(all).toHaveLength(1);
-        expect(all[0].phone).toBe("555-3000");
+        expect(all[0].phone).toBe("555-555-3000");
     });
 });
 
 describe("reconcileHouseholdConflicts — direction B (soft)", () => {
     it("flags a contact when a matching member is added later, then clears on remediation", async () => {
         const hh = await makeHousehold("recon");
-        const contact = await createContact(prisma, hh, { name: "Aunt May", phone: "555-2000" });
+        const contact = await createContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000" });
         expect(await householdHasValidContact(prisma, hh)).toBe(true);
 
         // A new member turns out to be the emergency contact.
-        await addMember(hh, { name: "Aunt May", phone: "555-2000" });
+        await addMember(hh, { name: "Aunt May", phone: "555-555-2000" });
         const flagged = await reconcileHouseholdConflicts(prisma, hh);
         expect(flagged.map((c) => c.id)).toContain(contact.id);
         expect(await householdHasValidContact(prisma, hh)).toBe(false);
@@ -137,15 +137,15 @@ describe("reconcileHouseholdConflicts — direction B (soft)", () => {
         expect(after?.conflictParticipantId).not.toBeNull();
 
         // Remediation: add a real external replacement -> household valid again.
-        await createContact(prisma, hh, { name: "Neighbor Bob", phone: "555-4000" });
+        await createContact(prisma, hh, { name: "Neighbor Bob", phone: "555-555-4000" });
         expect(await householdHasValidContact(prisma, hh)).toBe(true);
         expect((await listValidContacts(prisma, hh)).map((c) => c.name)).toEqual(["Neighbor Bob"]);
     });
 
     it("reconcileAndWarn returns a warning with hasValidContact=false when the only contact is flagged", async () => {
         const hh = await makeHousehold("warn");
-        await createContact(prisma, hh, { name: "Aunt May", phone: "555-2000" });
-        await addMember(hh, { name: "Aunt May", phone: "555-2000" });
+        await createContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000" });
+        await addMember(hh, { name: "Aunt May", phone: "555-555-2000" });
         const warning = await reconcileAndWarn(prisma, hh);
         expect(warning).not.toBeNull();
         expect(warning!.code).toBe("EMERGENCY_CONTACT_CONFLICT");
@@ -154,8 +154,8 @@ describe("reconcileHouseholdConflicts — direction B (soft)", () => {
 
     it("returns null when nothing changed", async () => {
         const hh = await makeHousehold("noop");
-        await createContact(prisma, hh, { name: "Aunt May", phone: "555-2000" });
-        await addMember(hh, { name: "Unrelated Kid", phone: "555-8888" });
+        await createContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000" });
+        await addMember(hh, { name: "Unrelated Kid", phone: "555-555-8888" });
         expect(await reconcileAndWarn(prisma, hh)).toBeNull();
     });
 });
@@ -163,18 +163,18 @@ describe("reconcileHouseholdConflicts — direction B (soft)", () => {
 describe("updateContact + deleteContact", () => {
     it("clears a conflict flag when the contact is edited to an external person", async () => {
         const hh = await makeHousehold("update-clear");
-        const contact = await createContact(prisma, hh, { name: "Aunt May", phone: "555-2000" });
-        await addMember(hh, { name: "Aunt May", phone: "555-2000" });
+        const contact = await createContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000" });
+        await addMember(hh, { name: "Aunt May", phone: "555-555-2000" });
         await reconcileHouseholdConflicts(prisma, hh);
         expect(await householdHasValidContact(prisma, hh)).toBe(false);
 
-        await updateContact(prisma, hh, contact.id, { name: "Aunt Maybelle", phone: "555-2001" });
+        await updateContact(prisma, hh, contact.id, { name: "Aunt Maybelle", phone: "555-555-2001" });
         expect(await householdHasValidContact(prisma, hh)).toBe(true);
     });
 
     it("deletes a contact", async () => {
         const hh = await makeHousehold("del");
-        const c = await createContact(prisma, hh, { name: "Temp", phone: "555-2000" });
+        const c = await createContact(prisma, hh, { name: "Temp", phone: "555-555-2000" });
         await deleteContact(prisma, hh, c.id);
         expect(await prisma.emergencyContact.findUnique({ where: { id: c.id } })).toBeNull();
     });
@@ -188,8 +188,8 @@ describe("countHouseholdsMissingValidContact — admin alarm", () => {
         const hh = await makeHousehold("alarm-intake");
         const m = await prisma.membership.create({ data: { householdId: hh, status: "NONE" } });
         await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: "INITIAL", status: "INTAKE" } });
-        await createContact(prisma, hh, { name: "Aunt May", phone: "555-2000" });
-        await addMember(hh, { name: "Aunt May", phone: "555-2000" });
+        await createContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000" });
+        await addMember(hh, { name: "Aunt May", phone: "555-555-2000" });
         await reconcileHouseholdConflicts(prisma, hh);
 
         // A non-member household with no contact -> should NOT count.
@@ -198,7 +198,7 @@ describe("countHouseholdsMissingValidContact — admin alarm", () => {
         expect(await countHouseholdsMissingValidContact(prisma)).toBe(baseline + 1);
 
         // Remediate -> count returns to baseline.
-        await createContact(prisma, hh, { name: "Neighbor Bob", phone: "555-4000" });
+        await createContact(prisma, hh, { name: "Neighbor Bob", phone: "555-555-4000" });
         expect(await countHouseholdsMissingValidContact(prisma)).toBe(baseline);
     });
 });

--- a/checkin-app/src/lib/emergencyContacts/identity.ts
+++ b/checkin-app/src/lib/emergencyContacts/identity.ts
@@ -8,10 +8,9 @@
  * (20260612000000_emergency_contact_entity) so stored keys stay comparable.
  */
 
-/** Strip everything but digits. `"(555) 010-0"` -> `"5550100"`. */
-export function normalizePhone(phone: string | null | undefined): string {
-    return (phone ?? "").replace(/\D/g, "");
-}
+/** Strip everything but digits. Shared with the app-wide phone validator. */
+import { normalizePhone } from "@/lib/phone";
+export { normalizePhone };
 
 /** Lowercase + trim; empty -> null. */
 export function normalizeEmail(email: string | null | undefined): string | null {

--- a/checkin-app/src/lib/emergencyContacts/service.ts
+++ b/checkin-app/src/lib/emergencyContacts/service.ts
@@ -1,6 +1,7 @@
 import prisma from "@/lib/prisma";
 import type { Prisma, EmergencyContact } from "@/generated/prisma/client";
 import { identityKeys, sameIdentity, identityMatchReason, normalizeEmail, normalizePhone } from "./identity";
+import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 
 /**
  * Emergency-contact write/read model. Enforces the not-a-household-member rule
@@ -78,6 +79,9 @@ function cleaned(input: ContactInput) {
 function requireComplete(input: ContactInput) {
     if (!input.name?.trim() || !input.phone?.trim()) {
         throw new EmergencyContactError("incomplete", "An emergency contact needs both a name and a phone number.");
+    }
+    if (!isValidPhone(input.phone)) {
+        throw new EmergencyContactError("incomplete", PHONE_ERROR);
     }
 }
 
@@ -169,6 +173,10 @@ export async function upsertPrimaryContact(
     const phone = (fields.phone ?? "").trim();
     const email = (fields.email ?? "").trim() || null;
     if (!name && !phone && !email) return null;
+
+    if (phone && !isValidPhone(phone)) {
+        throw new EmergencyContactError("incomplete", PHONE_ERROR);
+    }
 
     const complete = !!name && !!phone;
     if (complete) await assertExternal(db, householdId, { name, phone, email });

--- a/checkin-app/src/lib/phone.ts
+++ b/checkin-app/src/lib/phone.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared phone-number normalization + validation. One source of truth for every
+ * surface that captures a phone (household members, emergency contacts, user
+ * profile, public registration). Client forms use {@link isValidPhone} for inline
+ * feedback; API/service write boundaries call {@link assertValidPhone} so an
+ * invalid number can never be persisted regardless of the client.
+ */
+
+/** Strip everything but digits. `"(555) 010-0"` -> `"5550100"`. */
+export function normalizePhone(phone: string | null | undefined): string {
+    return (phone ?? "").replace(/\D/g, "");
+}
+
+/**
+ * A valid US phone is exactly 10 digits, or 11 digits with a leading country
+ * code of 1. Formatting characters (spaces, dashes, parens, +) are ignored, so
+ * "(555) 123-4567" and "5551234567" both pass. Blank/missing fails — callers
+ * that allow an optional phone must short-circuit on empty before calling.
+ */
+export function isValidPhone(phone: string | null | undefined): boolean {
+    const d = normalizePhone(phone);
+    return d.length === 10 || (d.length === 11 && d.startsWith("1"));
+}
+
+export const PHONE_ERROR = "Enter a valid 10-digit US phone number.";
+
+/** Throw if invalid; for server-side trust boundaries. */
+export function assertValidPhone(phone: string | null | undefined): void {
+    if (!isValidPhone(phone)) throw new PhoneValidationError();
+}
+
+export class PhoneValidationError extends Error {
+    constructor(message: string = PHONE_ERROR) {
+        super(message);
+        this.name = "PhoneValidationError";
+    }
+}


### PR DESCRIPTION
## What

Phone numbers were accepted **unvalidated** everywhere they're captured. On `/my-household`, both the emergency-contact form and the household-member edit form let you save a malformed number (e.g. `123`), and the backing API routes did no format check either.

This adds one shared validator and wires it to every place a phone is captured.

### New
- `src/lib/phone.ts` — `normalizePhone`, `isValidPhone`, `assertValidPhone`, `PHONE_ERROR`.
  - Rule: **10 digits**, or **11 with a leading `1`**. Formatting (spaces, dashes, parens, `+`) ignored, so `(555) 123-4567` and `5551234567` both pass.
- `src/lib/__tests__/phone.test.ts` — unit coverage for the validator.

### Server-side (the real trust boundary — rejects invalid regardless of client)
- `emergencyContacts/service.ts`: `requireComplete` + `upsertPrimaryContact` reject malformed phones. Centrally covers emergency-contact POST/PATCH, public registration, onboarding, and admin-household contact upsert.
- `api/household/member`, `api/profile`, `api/profile/onboarding`, `api/admin/participants/[id]`, `api/programs/[id]/public-register` — validate phone on write (optional phones only checked when non-empty).

### Client-side (inline UX on the screens in the report)
- `my-household` emergency-contact + member-edit forms, and `OnboardingGate` — inline error + submit guard.

### Refactor
- `normalizePhone` moved into the shared module; `emergencyContacts/identity.ts` re-exports it → one source of truth.

## Notes for reviewer
- Integration-test fixtures that used 7-digit placeholders (`555-2000`) were bumped to valid 10-digit numbers; collision pairs in the not-a-household-member tests were kept equal so those assertions still exercise the match path.
- Remaining client forms (profile, public register, admin) don't have inline pre-submit feedback yet, but the server now rejects invalid input and those forms already display the returned error string — so invalid phones are blocked and surfaced everywhere.

## Testing
- 5 unit tests (validator) pass.
- 67 affected integration tests pass against a real Postgres (emergency-contact service + API, member route guard, household member API, public registration, admin participants, onboarding, membership bg).
- Typecheck + lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)