### PR TITLE
feat(shop-ops): show existing tools list on create page

### DIFF
--- a/checkin-app/src/app/shop-ops/create/page.tsx
+++ b/checkin-app/src/app/shop-ops/create/page.tsx
@@ -1,13 +1,30 @@
 "use client";
 
-import { useState } from "react";
-import { Alert, Button, Card, Stack, Text, TextInput } from "@mantine/core";
+import { useCallback, useEffect, useState } from "react";
+import { Alert, Button, Card, Flex, ScrollArea, Stack, Text, TextInput } from "@mantine/core";
+
+type ToolListItem = {
+  id: number;
+  name: string;
+  safetyGuide: string | null;
+  _count?: { toolStatuses: number };
+};
 
 export default function CreateToolPage() {
   const [newToolName, setNewToolName] = useState("");
   const [newToolGuide, setNewToolGuide] = useState("");
   const [saving, setSaving] = useState(false);
   const [createMessage, setCreateMessage] = useState("");
+  const [tools, setTools] = useState<ToolListItem[]>([]);
+
+  const loadTools = useCallback(async () => {
+    const res = await fetch("/api/shop/tools");
+    if (res.ok) setTools(await res.json());
+  }, []);
+
+  useEffect(() => {
+    loadTools();
+  }, [loadTools]);
 
   const handleCreateTool = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -25,6 +42,7 @@ export default function CreateToolPage() {
         setCreateMessage("New tool added successfully!");
         setNewToolName("");
         setNewToolGuide("");
+        loadTools();
       } else {
         const data = await res.json();
         setCreateMessage(data.error || "Failed to create tool.");
@@ -35,38 +53,51 @@ export default function CreateToolPage() {
   };
 
   return (
-    <Card withBorder radius="md" padding="lg" maw={520}>
-      <Text c="dimmed" mb="lg">
-        Define a new piece of shop equipment to begin tracking safety certifications,
-        authorizing Certifiers, and tracking usage.
-      </Text>
+    <Flex gap="lg" align="flex-start" wrap="wrap">
+      <Card withBorder radius="md" padding="lg" maw={520}>
+        <Text c="dimmed" mb="lg">
+          Define a new piece of shop equipment to begin tracking safety certifications,
+          authorizing Certifiers, and tracking usage.
+        </Text>
 
-      {createMessage && (
-        <Alert color={createMessage.includes("success") ? "green" : "red"} mb="md">{createMessage}</Alert>
-      )}
+        {createMessage && (
+          <Alert color={createMessage.includes("success") ? "green" : "red"} mb="md">{createMessage}</Alert>
+        )}
 
-      <form onSubmit={handleCreateTool}>
-        <Stack>
-          <TextInput
-            label="Equipment Name"
-            required
-            placeholder="e.g. Table Saw"
-            value={newToolName}
-            onChange={(e) => setNewToolName(e.currentTarget.value)}
-          />
-          <TextInput
-            type="url"
-            label="Safety Guide URL"
-            placeholder="https://example.com/safety-manual"
-            description="Optional link to the required reading or manufacturer manual."
-            value={newToolGuide}
-            onChange={(e) => setNewToolGuide(e.currentTarget.value)}
-          />
-          <Button type="submit" disabled={saving} loading={saving} mt="sm" style={{ alignSelf: "flex-start" }}>
-            Create Tool
-          </Button>
-        </Stack>
-      </form>
-    </Card>
+        <form onSubmit={handleCreateTool}>
+          <Stack>
+            <TextInput
+              label="Equipment Name"
+              required
+              placeholder="e.g. Table Saw"
+              value={newToolName}
+              onChange={(e) => setNewToolName(e.currentTarget.value)}
+            />
+            <TextInput
+              type="url"
+              label="Safety Guide URL"
+              placeholder="https://example.com/safety-manual"
+              description="Optional link to the required reading or manufacturer manual."
+              value={newToolGuide}
+              onChange={(e) => setNewToolGuide(e.currentTarget.value)}
+            />
+            <Button type="submit" disabled={saving} loading={saving} mt="sm" style={{ alignSelf: "flex-start" }}>
+              Create Tool
+            </Button>
+          </Stack>
+        </form>
+      </Card>
+
+      <Card withBorder radius="md" padding="md" w={260}>
+        <Text fw={600} size="sm" mb="xs">Existing tools</Text>
+        <ScrollArea.Autosize mah={420} type="auto">
+          <Stack gap={4}>
+            {tools.map((t) => (
+              <Text key={t.id} size="sm">{t.name}</Text>
+            ))}
+          </Stack>
+        </ScrollArea.Autosize>
+      </Card>
+    </Flex>
   );
 }


### PR DESCRIPTION
## What

Adds a compact, name-only list of existing shop tools beside the create form on `/shop-ops/create`.

## Why

Helps users spot duplicates before adding a new tool. Previously the create page showed only the form, with no visibility into what already existed.

## Details

- Two-column flex layout: create form left, tools list right (260px, scrolls past ~420px height).
- List fetched from existing `GET /api/shop/tools` on mount.
- Refreshes after a successful create so a new tool appears immediately.
- Names only — no count badge, links, or helper text.

## Notes for reviewer

- Reuses the existing tools API; no backend changes.
- Skipped: client-side duplicate-name warning and a search filter — can add if the list grows large.