### PR TITLE
feat(address): structured address fields for Household & Corporation

### DIFF
--- a/checkin-app/prisma/migrations/20260629000000_structured_address/migration.sql
+++ b/checkin-app/prisma/migrations/20260629000000_structured_address/migration.sql
@@ -1,0 +1,25 @@
+-- Structured address: replace free-text `address` with line1/line2/city/state/postalCode
+-- on Household and Corporation.
+
+-- AlterTable: Household
+ALTER TABLE "Household" ADD COLUMN "line1" TEXT;
+ALTER TABLE "Household" ADD COLUMN "line2" TEXT;
+ALTER TABLE "Household" ADD COLUMN "city" TEXT;
+ALTER TABLE "Household" ADD COLUMN "state" TEXT;
+ALTER TABLE "Household" ADD COLUMN "postalCode" TEXT;
+
+-- AlterTable: Corporation
+ALTER TABLE "Corporation" ADD COLUMN "line1" TEXT;
+ALTER TABLE "Corporation" ADD COLUMN "line2" TEXT;
+ALTER TABLE "Corporation" ADD COLUMN "city" TEXT;
+ALTER TABLE "Corporation" ADD COLUMN "state" TEXT;
+ALTER TABLE "Corporation" ADD COLUMN "postalCode" TEXT;
+
+-- Backfill: old free-text address moves verbatim into line1. Parsing arbitrary
+-- free text into components is unreliable; an honest single line beats a wrong split.
+-- Members re-enter structured fields on next edit.
+UPDATE "Household" SET "line1" = "address" WHERE "address" IS NOT NULL;
+UPDATE "Corporation" SET "line1" = "address" WHERE "address" IS NOT NULL;
+
+ALTER TABLE "Household" DROP COLUMN "address";
+ALTER TABLE "Corporation" DROP COLUMN "address";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -145,7 +145,15 @@ model Household {
   /// @sensitivity:public
   name    String?
   /// @sensitivity:personal
-  address String?
+  line1      String?
+  /// @sensitivity:personal
+  line2      String?
+  /// @sensitivity:personal
+  city       String?
+  /// @sensitivity:personal
+  state      String?
+  /// @sensitivity:personal
+  postalCode String?
 
   participants      Participant[]
   leads             HouseholdLead[]
@@ -501,7 +509,15 @@ model Corporation {
   /// @sensitivity:pii
   primaryEmail String?
   /// @sensitivity:personal
-  address      String?
+  line1      String?
+  /// @sensitivity:personal
+  line2      String?
+  /// @sensitivity:personal
+  city       String?
+  /// @sensitivity:personal
+  state      String?
+  /// @sensitivity:personal
+  postalCode String?
 
   leads   CorporationLead[]
   members CorporationMember[]

--- a/checkin-app/prisma/seed_20_users.ts
+++ b/checkin-app/prisma/seed_20_users.ts
@@ -15,7 +15,7 @@ async function main() {
     for (let i = 1; i <= 20; i++) {
         // Create household
         const household = await prisma.household.create({
-            data: { name: `Test Family ${i}`, address: `123 Test St ${i}` }
+            data: { name: `Test Family ${i}`, line1: `123 Test St ${i}` }
         })
 
         // Create participant

--- a/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
@@ -161,7 +161,7 @@ describe('Ownership-boundary authorization', () => {
 
     // ---- household/settings (PATCH) — lead-only --------------------------------
     describe('PATCH /api/household/settings', () => {
-        const body = { address: '1 New St' };
+        const body = { line1: '1 New St' };
         it('401 unauthenticated', async () => {
             anon();
             expect((await SETTINGS_PATCH(jsonReq(body))).status).toBe(401);

--- a/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
@@ -54,7 +54,7 @@ describe('Household API Integration Tests', () => {
 
         // Setup mock database records
         const household = await prisma.household.create({
-            data: { name: 'Lead User Household', address: '123 Main' }
+            data: { name: 'Lead User Household', line1: '123 Main' }
         });
         householdId = household.id;
 

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -191,7 +191,7 @@ describe('background check is non-blocking', () => {
         const { processId, membershipId, householdId } = await makeApplicant('PENDING_EXTERNAL_ACTION', { lastBackgroundCheck: new Date() });
         // Reset the process to INTAKE with the household fully filled so submitIntake passes validation.
         await prisma.membershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
-        await prisma.household.update({ where: { id: householdId }, data: { address: '123 Test St' } });
+        await prisma.household.update({ where: { id: householdId }, data: { line1: '123 Test St' } });
         await prisma.emergencyContact.create({ data: { householdId, name: 'Out Of House', phone: '555-555-1212', phoneDigits: '5555551212', priority: 0 } });
         const lead = await prisma.participant.findFirst({ where: { householdId, householdLeads: { some: { householdId } } } });
 

--- a/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
@@ -130,7 +130,7 @@ describe('Membership Intake API', () => {
         const patchReq = new Request('http://localhost:4000/api/membership/intake', {
             method: 'PATCH',
             body: JSON.stringify({
-                household: { address: '1 Treehouse Way', emergencyContactName: 'Aunt May', emergencyContactPhone: '555-0100' },
+                household: { line1: '1 Treehouse Way', emergencyContactName: 'Aunt May', emergencyContactPhone: '555-0100' },
                 primaryParent: { name: 'Lead Parent', dob: '1985-04-01', allergies: 'peanuts' },
                 children: [{ name: 'Kid One', dob: '2015-06-01' }],
             }),
@@ -139,7 +139,7 @@ describe('Membership Intake API', () => {
         expect(res.status).toBe(200);
 
         const state = await (await GET(req() as never)).json();
-        expect(state.prefill.household.address).toBe('1 Treehouse Way');
+        expect(state.prefill.household.line1).toBe('1 Treehouse Way');
         expect(state.prefill.primaryParent.allergies).toBe('peanuts');
         // Children are non-lead members; the household already has the non-lead
         // fixture, so assert Kid One is among them rather than an exact count.
@@ -166,7 +166,7 @@ describe('Membership Intake API', () => {
         asUser(nonLeadId);
         const patchReq = new Request('http://localhost:4000/api/membership/intake', {
             method: 'PATCH',
-            body: JSON.stringify({ household: { address: 'hacker lane' } }),
+            body: JSON.stringify({ household: { line1: 'hacker lane' } }),
         });
         const res = await PATCH(patchReq as never);
         expect(res.status).toBe(403);
@@ -199,7 +199,7 @@ describe('Membership Intake API', () => {
         const patch = new Request('http://localhost:4000/api/membership/intake', {
             method: 'PATCH',
             body: JSON.stringify({
-                household: { address: '9 Audit Way', emergencyContactName: 'Aunt Audit', emergencyContactPhone: '555-9001' },
+                household: { line1: '9 Audit Way', emergencyContactName: 'Aunt Audit', emergencyContactPhone: '555-9001' },
                 primaryParent: { name: 'Audit Lead' },
             }),
         });

--- a/checkin-app/src/app/api/household/settings/route.ts
+++ b/checkin-app/src/app/api/household/settings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { upsertPrimaryContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
+import { normalizeAddressInput, pickAddress } from "@/lib/address";
 
 export const PATCH = withAuth(
     {},
@@ -11,7 +12,8 @@ export const PATCH = withAuth(
             const userId = auth.user.id;
 
             const body = await req.json();
-            const { emergencyContactName, emergencyContactPhone, address } = body;
+            const { emergencyContactName, emergencyContactPhone } = body;
+            const addressData = normalizeAddressInput(body);
 
             const user = await prisma.participant.findUnique({
                 where: { id: userId },
@@ -29,7 +31,7 @@ export const PATCH = withAuth(
 
             const updatedHousehold = await prisma.household.update({
                 where: { id: user.householdId },
-                data: { address: address !== undefined ? address : undefined },
+                data: addressData,
             });
 
             // Emergency contact is a separate entity; the settings form edits the
@@ -47,7 +49,7 @@ export const PATCH = withAuth(
                     action: "EDIT",
                     tableName: "Household",
                     affectedEntityId: user.householdId,
-                    newData: JSON.stringify({ emergencyContactName, emergencyContactPhone, address })
+                    newData: JSON.stringify({ emergencyContactName, emergencyContactPhone, ...pickAddress(updatedHousehold) })
                 }
             });
 

--- a/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { authenticateRequest } from "@/lib/auth";
 import { upsertPrimaryContact, getPrimaryValidContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
+import { normalizeAddressInput, pickAddress, type StructuredAddress } from "@/lib/address";
 
 /**
  * Admin edit of a household's own info (name, address, emergency contact).
@@ -36,9 +37,9 @@ export async function PATCH(
         }
 
         const body = await request.json();
-        const data: { name?: string | null; address?: string | null } = {};
+        const data: { name?: string | null } & Partial<StructuredAddress> = {};
         if (body.name !== undefined) data.name = body.name;
-        if (body.address !== undefined) data.address = body.address;
+        Object.assign(data, normalizeAddressInput(body));
 
         const editsContact = body.emergencyContactName !== undefined || body.emergencyContactPhone !== undefined;
         if (Object.keys(data).length === 0 && !editsContact) {
@@ -66,7 +67,7 @@ export async function PATCH(
                 affectedEntityId: id,
                 oldData: JSON.stringify({
                     name: existing.name,
-                    address: existing.address,
+                    ...pickAddress(existing),
                     emergencyContactName: priorContact?.name ?? null,
                     emergencyContactPhone: priorContact?.phone ?? null,
                 }),

--- a/checkin-app/src/app/api/membership-ops/participants/import/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/route.ts
@@ -93,11 +93,13 @@ export async function POST(req: NextRequest) {
 
         // Helper: addresses live on the household, not the participant.
         // A CSV address overwrites the row's household address when provided.
+        // ponytail: legacy CSV has one free-text address column → goes to line1
+        // verbatim. Bulk import is being redone; structured columns land then.
         const applyAddressToHousehold = async (householdId: number, address: string, db: Prisma.TransactionClient = prisma) => {
             if (!address) return;
             await db.household.update({
                 where: { id: householdId },
-                data: { address }
+                data: { line1: address }
             });
         };
 

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -10,6 +10,9 @@ import {
 } from "@mantine/core";
 import MembershipFlowStepper from "@/components/MembershipFlowStepper";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
+import { pickAddress, type StructuredAddress } from "@/lib/address";
+
+const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
 
 interface PersonPrefill {
   id: number;
@@ -33,7 +36,7 @@ interface IntakeState {
   process: { id: number; kind: string; status: MembershipProcessStatus } | null;
   external: ExternalStatus | null;
   prefill: {
-    household: { name: string | null; address: string | null; emergencyContactName: string | null; emergencyContactPhone: string | null } | null;
+    household: ({ name: string | null; emergencyContactName: string | null; emergencyContactPhone: string | null } & Partial<StructuredAddress>) | null;
     primaryParent: PersonPrefill | null;
     secondaryParent: PersonPrefill | null;
     children: PersonPrefill[];
@@ -80,7 +83,7 @@ export default function MembershipPage() {
   const [warnings, setWarnings] = useState<string[]>([]);
 
   // Intake form fields
-  const [address, setAddress] = useState("");
+  const [address, setAddress] = useState<StructuredAddress>(blankAddress);
   const [emName, setEmName] = useState("");
   const [emPhone, setEmPhone] = useState("");
   const [primaryName, setPrimaryName] = useState("");
@@ -98,7 +101,8 @@ export default function MembershipPage() {
   const hydrate = useCallback((s: IntakeState) => {
     setState(s);
     const h = s.prefill.household;
-    setAddress(h?.address ?? "");
+    const a = pickAddress(h);
+    setAddress({ line1: a.line1 ?? "", line2: a.line2 ?? "", city: a.city ?? "", state: a.state ?? "", postalCode: a.postalCode ?? "" });
     setEmName(h?.emergencyContactName ?? "");
     setEmPhone(h?.emergencyContactPhone ?? "");
     const p = s.prefill.primaryParent;
@@ -212,7 +216,7 @@ export default function MembershipPage() {
   // gets instant red-box feedback on every environment (no round-trip needed).
   const validateIntake = (): Record<string, string> => {
     const errs: Record<string, string> = {};
-    if (!address.trim()) errs.address = "Home address is required.";
+    if (!address.line1?.trim()) errs.address = "Home address is required.";
     if (!emName.trim()) errs.emName = "Emergency contact name is required.";
     if (!emPhone.trim()) errs.emPhone = "Emergency contact phone is required.";
     if (!primaryName.trim()) errs.primaryName = "Your name is required.";
@@ -251,7 +255,7 @@ export default function MembershipPage() {
   };
 
   const buildPayload = () => ({
-    household: { address, emergencyContactName: emName, emergencyContactPhone: emPhone },
+    household: { ...address, emergencyContactName: emName, emergencyContactPhone: emPhone },
     primaryParent: { name: primaryName, dob: primaryDob || null, allergies: primaryAllergies || null },
     secondaryParent: hasSecondary
       ? { id: secondaryId, name: secondaryName, email: secondaryEmail || undefined, dob: secondaryDob || null, allergies: secondaryAllergies || null }
@@ -462,7 +466,15 @@ export default function MembershipPage() {
                 <Stack gap="lg">
                   <section>
                     <Title order={2} mb="sm">Your household</Title>
-                    <TextInput label="Home address" value={address} error={fieldErrors.address} onChange={(e) => { setAddress(e.currentTarget.value); clearErr("address"); }} placeholder="123 Main St, City, State ZIP" />
+                    <Stack gap="xs">
+                      <TextInput label="Street address" value={address.line1 ?? ""} error={fieldErrors.address} onChange={(e) => { setAddress({ ...address, line1: e.currentTarget.value }); clearErr("address"); }} placeholder="123 Main St" />
+                      <TextInput label="Apt / Suite (optional)" value={address.line2 ?? ""} onChange={(e) => setAddress({ ...address, line2: e.currentTarget.value })} placeholder="Apt 4B" />
+                      <SimpleGrid cols={{ base: 1, sm: 3 }}>
+                        <TextInput label="City" value={address.city ?? ""} onChange={(e) => setAddress({ ...address, city: e.currentTarget.value })} />
+                        <TextInput label="State" maxLength={2} value={address.state ?? ""} onChange={(e) => setAddress({ ...address, state: e.currentTarget.value })} placeholder="TX" />
+                        <TextInput label="ZIP" value={address.postalCode ?? ""} onChange={(e) => setAddress({ ...address, postalCode: e.currentTarget.value })} placeholder="78701" />
+                      </SimpleGrid>
+                    </Stack>
                     <SimpleGrid cols={{ base: 1, sm: 2 }} mt="md">
                       <TextInput label="Emergency contact name" value={emName} error={fieldErrors.emName} onChange={(e) => { setEmName(e.currentTarget.value); clearErr("emName"); }} />
                       <TextInput label="Emergency contact phone" value={emPhone} error={fieldErrors.emPhone} onChange={(e) => { setEmPhone(e.currentTarget.value); clearErr("emPhone"); }} />

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -9,6 +9,9 @@ import TrustedAdultPanel from '@/components/TrustedAdultPanel';
 import TodoCard from '@/components/TodoCard';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { isOrgAccount } from '@/lib/orgAccount';
+import { pickAddress, type StructuredAddress } from '@/lib/address';
+
+const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
 
 type Member = { id: number; name?: string; email?: string; dob?: string; phone?: string };
 type EmergencyContact = { id: number; name: string; phone: string; email?: string | null; relationship?: string | null; priority: number; invalid: boolean };
@@ -18,8 +21,7 @@ type HouseholdData = {
   leads?: Array<{ participantId: number }>;
   participants?: Member[];
   membership?: { status?: string; since?: string; isVolunteer?: boolean } | null;
-  address?: string;
-} | null;
+} & Partial<StructuredAddress> | null;
 
 const blankContactForm = { id: null as number | null, name: "", phone: "", email: "", relationship: "" };
 type Visit = { id: number; participant?: { name: string }; event?: { name: string }; arrived: string; departed?: string };
@@ -41,7 +43,7 @@ export default function HouseholdPage() {
   const [visits, setVisits] = useState<Visit[]>([]);
   const [filterDate, setFilterDate] = useState("");
   const [settings, setSettings] = useState({ emailDependentCheckins: false });
-  const [address, setAddress] = useState("");
+  const [address, setAddress] = useState<StructuredAddress>(blankAddress);
   const [savingSettings, setSavingSettings] = useState(false);
 
   const [contacts, setContacts] = useState<EmergencyContact[]>([]);
@@ -70,7 +72,8 @@ export default function HouseholdPage() {
       if (res.ok) {
         const data = await res.json();
         setHousehold(data.household);
-        setAddress(data.household?.address || "");
+        const a = pickAddress(data.household);
+        setAddress({ line1: a.line1 ?? "", line2: a.line2 ?? "", city: a.city ?? "", state: a.state ?? "", postalCode: a.postalCode ?? "" });
       }
       if (visitRes.ok) {
         const data = await visitRes.json();
@@ -111,7 +114,7 @@ export default function HouseholdPage() {
       const householdRes = await fetch('/api/household/settings', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ address })
+        body: JSON.stringify(address)
       });
 
       if (res.ok && householdRes.ok) {
@@ -411,7 +414,15 @@ export default function HouseholdPage() {
               <Card withBorder radius="md" padding="md">
                 <Title order={5} c="blue">Primary Address</Title>
                 <Text size="sm" c="dimmed" mb="sm">The main address associated with this household.</Text>
-                <TextInput label="Address" value={address} onChange={(e) => setAddress(e.currentTarget.value)} placeholder="123 Main St, City, ST 12345" />
+                <Stack gap="xs">
+                  <TextInput label="Street Address" value={address.line1 ?? ""} onChange={(e) => setAddress({ ...address, line1: e.currentTarget.value })} placeholder="123 Main St" />
+                  <TextInput label="Apt / Suite (optional)" value={address.line2 ?? ""} onChange={(e) => setAddress({ ...address, line2: e.currentTarget.value })} placeholder="Apt 4B" />
+                  <SimpleGrid cols={{ base: 1, sm: 3 }}>
+                    <TextInput label="City" value={address.city ?? ""} onChange={(e) => setAddress({ ...address, city: e.currentTarget.value })} />
+                    <TextInput label="State" maxLength={2} value={address.state ?? ""} onChange={(e) => setAddress({ ...address, state: e.currentTarget.value })} placeholder="TX" />
+                    <TextInput label="ZIP" value={address.postalCode ?? ""} onChange={(e) => setAddress({ ...address, postalCode: e.currentTarget.value })} placeholder="78701" />
+                  </SimpleGrid>
+                </Stack>
                 <Button onClick={handleSaveSettings} disabled={savingSettings} loading={savingSettings} color="green" fullWidth mt="md">
                   Update Household Settings
                 </Button>

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -3,23 +3,27 @@
 import { useEffect, useState } from "react";
 import { Alert, Button, Group, Loader, Modal, SimpleGrid, Stack, Text, TextInput, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
+import { pickAddress, type StructuredAddress } from "@/lib/address";
 
 export type AdminHousehold = {
   id: number;
   name: string | null;
-  address: string | null;
   emergencyContactName: string | null;
   emergencyContactPhone: string | null;
-};
+} & Partial<StructuredAddress>;
 
 type FormState = {
   name: string;
-  address: string;
+  line1: string;
+  line2: string;
+  city: string;
+  state: string;
+  postalCode: string;
   emergencyContactName: string;
   emergencyContactPhone: string;
 };
 
-const EMPTY: FormState = { name: "", address: "", emergencyContactName: "", emergencyContactPhone: "" };
+const EMPTY: FormState = { name: "", line1: "", line2: "", city: "", state: "", postalCode: "", emergencyContactName: "", emergencyContactPhone: "" };
 
 /**
  * Admin/board editor for a household's own info. Denser than the member-facing
@@ -58,9 +62,10 @@ export function AdminEditHouseholdModal({
         const h: AdminHousehold | null = data.household;
         if (cancelled) return;
         if (h) {
+          const a = pickAddress(h);
           setForm({
             name: h.name || "",
-            address: h.address || "",
+            line1: a.line1 ?? "", line2: a.line2 ?? "", city: a.city ?? "", state: a.state ?? "", postalCode: a.postalCode ?? "",
             emergencyContactName: h.emergencyContactName || "",
             emergencyContactPhone: h.emergencyContactPhone || "",
           });
@@ -129,11 +134,22 @@ export function AdminEditHouseholdModal({
               placeholder="The Smith Family"
             />
             <TextInput
-              label="Primary Address"
-              value={form.address}
-              onChange={(e) => update({ address: e.currentTarget.value })}
-              placeholder="123 Main St, City, ST 12345"
+              label="Street Address"
+              value={form.line1}
+              onChange={(e) => update({ line1: e.currentTarget.value })}
+              placeholder="123 Main St"
             />
+            <TextInput
+              label="Apt / Suite (optional)"
+              value={form.line2}
+              onChange={(e) => update({ line2: e.currentTarget.value })}
+              placeholder="Apt 4B"
+            />
+            <SimpleGrid cols={{ base: 1, sm: 3 }}>
+              <TextInput label="City" value={form.city} onChange={(e) => update({ city: e.currentTarget.value })} />
+              <TextInput label="State" maxLength={2} value={form.state} onChange={(e) => update({ state: e.currentTarget.value })} placeholder="TX" />
+              <TextInput label="ZIP" value={form.postalCode} onChange={(e) => update({ postalCode: e.currentTarget.value })} placeholder="78701" />
+            </SimpleGrid>
             <SimpleGrid cols={{ base: 1, sm: 2 }}>
               <TextInput
                 label="Emergency Contact Name"

--- a/checkin-app/src/lib/address.ts
+++ b/checkin-app/src/lib/address.ts
@@ -1,0 +1,76 @@
+/**
+ * Structured postal address (US-only for now). Lives inline on Household and
+ * Corporation as five nullable columns; this module is the one place that knows
+ * how to normalize, format, and extract them.
+ *
+ * ponytail: US-only — `state` is a 2-letter code, no country field. Add country
+ * + per-country validation when a non-US member actually needs it.
+ */
+
+export const ADDRESS_FIELDS = ["line1", "line2", "city", "state", "postalCode"] as const;
+export type AddressField = (typeof ADDRESS_FIELDS)[number];
+
+export interface StructuredAddress {
+    line1: string | null;
+    line2: string | null;
+    city: string | null;
+    state: string | null;
+    postalCode: string | null;
+}
+
+/** Pull just the address fields off a wider record (e.g. a Household row). */
+export function pickAddress(src: Partial<StructuredAddress> | null | undefined): StructuredAddress {
+    return {
+        line1: src?.line1 ?? null,
+        line2: src?.line2 ?? null,
+        city: src?.city ?? null,
+        state: src?.state ?? null,
+        postalCode: src?.postalCode ?? null,
+    };
+}
+
+/** True when every component is empty/absent. */
+export function isAddressEmpty(a: Partial<StructuredAddress> | null | undefined): boolean {
+    return ADDRESS_FIELDS.every((f) => !a?.[f]?.trim());
+}
+
+/**
+ * Normalize caller-supplied address fields for storage. Only the keys present on
+ * `input` are returned, so callers can do partial updates (`data: normalizeAddressInput(body)`).
+ * Trims everything; upper-cases the 2-letter state; empty strings become null.
+ */
+export function normalizeAddressInput(input: Partial<Record<AddressField, unknown>>): Partial<StructuredAddress> {
+    const out: Partial<StructuredAddress> = {};
+    for (const f of ADDRESS_FIELDS) {
+        if (input[f] === undefined) continue;
+        const raw = input[f];
+        let v = raw == null ? "" : String(raw).trim();
+        if (f === "state") v = v.toUpperCase();
+        out[f] = v === "" ? null : v;
+    }
+    return out;
+}
+
+/** Single-line display, skipping blank components. e.g. "123 Main St, Apt 2, Austin, TX 78701". */
+export function formatAddress(a: Partial<StructuredAddress> | null | undefined): string {
+    if (!a) return "";
+    const cityStateZip = [a.city?.trim(), [a.state?.trim(), a.postalCode?.trim()].filter(Boolean).join(" ")]
+        .filter(Boolean)
+        .join(", ");
+    return [a.line1?.trim(), a.line2?.trim(), cityStateZip].filter(Boolean).join(", ");
+}
+
+// ponytail: one runnable self-check, not a suite. `npx tsx src/lib/address.ts`.
+if (process.argv[1] && process.argv[1].endsWith("address.ts")) {
+    const assert = (c: boolean, m: string) => { if (!c) throw new Error("address self-check: " + m); };
+    const n = normalizeAddressInput({ line1: " 1 A St ", state: "tx", city: "", postalCode: "78701" });
+    assert(n.line1 === "1 A St", "trim line1");
+    assert(n.state === "TX", "upper state");
+    assert(n.city === null, "empty -> null");
+    assert(!("line2" in n), "absent key stays absent");
+    assert(formatAddress({ line1: "1 A St", line2: null, city: "Austin", state: "TX", postalCode: "78701" }) === "1 A St, Austin, TX 78701", "format skips blanks");
+    assert(formatAddress({ line1: "1 A St", line2: "Apt 2", city: "Austin", state: "TX", postalCode: "78701" }) === "1 A St, Apt 2, Austin, TX 78701", "format full");
+    assert(isAddressEmpty({ line1: " ", state: null }), "empty detection");
+    assert(!isAddressEmpty({ line1: "x" }), "non-empty detection");
+    console.log("address self-check OK");
+}

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -38,14 +38,14 @@ export async function seedBaseline(prisma: Db): Promise<void> {
     let household1 = await prisma.household.findFirst({ where: { name: "Family" } });
     if (!household1) {
         household1 = await prisma.household.create({
-            data: { name: "Family", address: "123 Maker Lane" },
+            data: { name: "Family", line1: "123 Maker Lane" },
         });
     }
 
     let household2 = await prisma.household.findFirst({ where: { name: "Family2" } });
     if (!household2) {
         household2 = await prisma.household.create({
-            data: { name: "Family2", address: "456 Workshop Drive" },
+            data: { name: "Family2", line1: "456 Workshop Drive" },
         });
     }
 
@@ -234,7 +234,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
 export async function createFamily(prisma: Db): Promise<string> {
     const tag = uid();
     const household = await prisma.household.create({
-        data: { name: `Test Family ${tag}`, address: `${tag} Maker Way` },
+        data: { name: `Test Family ${tag}`, line1: `${tag} Maker Way` },
     });
     await prisma.membership.create({
         data: { householdId: household.id, status: "ACTIVE" },

--- a/checkin-app/src/lib/dev/zoho-import.ts
+++ b/checkin-app/src/lib/dev/zoho-import.ts
@@ -407,7 +407,7 @@ export async function applyImport(
 
         if (householdId === null) {
             const created = await tx.household.create({
-                data: { name: h.name, address: h.address },
+                data: { name: h.name, line1: h.address },
             });
             householdId = created.id;
             res.householdsCreated++;
@@ -417,7 +417,7 @@ export async function applyImport(
                 source: { system: "Zoho", familyId: h.source.familyZohoId, primaryEmail: h.source.rawPrimaryEmail },
             });
         } else {
-            await tx.household.update({ where: { id: householdId }, data: { name: h.name, address: h.address } });
+            await tx.household.update({ where: { id: householdId }, data: { name: h.name, line1: h.address } });
             res.householdsUpdated++;
             await audit(tx, actorId, "EDIT", "Household", householdId, {
                 name: h.name,

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -4,6 +4,7 @@ import { getExternalStatus } from "@/lib/membership/external";
 import { householdBgIsFresh, nextBoundary } from "@/lib/membership/renewal";
 import { addHouseholdLead, HouseholdLeadLimitError, MAX_HOUSEHOLD_LEADS } from "@/lib/household/leads";
 import { upsertPrimaryContact, reconcileHouseholdConflicts } from "@/lib/emergencyContacts/service";
+import { normalizeAddressInput, pickAddress, type StructuredAddress } from "@/lib/address";
 
 /**
  * Membership intake service — the write/read model behind the "Join the
@@ -48,7 +49,7 @@ type ParentInput = { id?: number; name?: string; email?: string; dob?: string | 
 type ChildInput = { id?: number; name?: string; email?: string | null; dob?: string | null; allergies?: string | null };
 
 export interface IntakeSaveInput {
-    household?: { address?: string; emergencyContactName?: string; emergencyContactPhone?: string };
+    household?: Partial<StructuredAddress> & { emergencyContactName?: string; emergencyContactPhone?: string };
     primaryParent?: ParentInput;
     secondaryParent?: ParentInput | null;
     children?: ChildInput[];
@@ -116,7 +117,7 @@ export async function getIntakeState(userId: number) {
             household: household
                 ? {
                       name: household.name,
-                      address: household.address,
+                      ...pickAddress(household),
                       // The primary (lowest-priority) contact backs the single-field
                       // form. Shown even when flagged invalid so the lead can fix it.
                       emergencyContactName: household.emergencyContacts[0]?.name ?? null,
@@ -207,8 +208,9 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
     };
 
     if (input.household) {
-        if (input.household.address !== undefined) {
-            await prisma.household.update({ where: { id: householdId }, data: { address: input.household.address } });
+        const addressData = normalizeAddressInput(input.household);
+        if (Object.keys(addressData).length > 0) {
+            await prisma.household.update({ where: { id: householdId }, data: addressData });
         }
         // Emergency contact lives in its own table now; the single-field intake
         // form maps onto the household's primary contact. Tolerant of partial
@@ -312,7 +314,7 @@ export async function submitIntake(userId: number) {
     // Each missing requirement carries the form field key to highlight + a label
     // for the summary message.
     const missing: { field: string; label: string }[] = [];
-    if (!household.address?.trim()) missing.push({ field: "address", label: "home address" });
+    if (!household.line1?.trim()) missing.push({ field: "address", label: "home address" });
     // A household must keep >= 1 valid (non-member, complete) emergency contact.
     const hasValidContact = household.emergencyContacts.some(
         (c) => c.conflictParticipantId === null && c.name.trim() && c.phone.trim(),

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -35,7 +35,11 @@ export const classifications = {
     Household: {
         id: 'public',
         name: 'public',
-        address: 'personal',
+        line1: 'personal',
+        line2: 'personal',
+        city: 'personal',
+        state: 'personal',
+        postalCode: 'personal',
     },
     EmergencyContact: {
         id: 'public',
@@ -141,7 +145,11 @@ export const classifications = {
     Corporation: {
         id: 'public',
         primaryEmail: 'pii',
-        address: 'personal',
+        line1: 'personal',
+        line2: 'personal',
+        city: 'personal',
+        state: 'personal',
+        postalCode: 'personal',
     },
     CorporationLead: {
         corporationId: 'public',

--- a/checkin-app/tests/security/outbound.test.ts
+++ b/checkin-app/tests/security/outbound.test.ts
@@ -127,7 +127,7 @@ describe('outboundCall — secret is unconditionally stripped', () => {
 
 describe('outboundCall — nested relations', () => {
     it('strips a nested relation by ITS model tiers, not the parent key', async () => {
-        // pii surface: Household.address is 'personal' → must be stripped even
+        // pii surface: Household.line1 is 'personal' → must be stripped even
         // though the parent Participant carries pii the surface allows.
         const out = (await capture('email.admin-notify', {
             Participant: {
@@ -136,8 +136,8 @@ describe('outboundCall — nested relations', () => {
                 email: 'me@x.com', // pii → kept
                 household: {
                     id: 2,
-                    name: 'Home',          // public → kept
-                    address: 'private st', // personal → stripped
+                    name: 'Home',        // public → kept
+                    line1: 'private st', // personal → stripped
                 },
             },
         })) as { Participant: Record<string, unknown> };
@@ -145,7 +145,7 @@ describe('outboundCall — nested relations', () => {
         const hh = out.Participant.household as Record<string, unknown>;
         expect(hh.id).toBe(2);
         expect(hh.name).toBe('Home');
-        expect(hh.address).toBeUndefined();
+        expect(hh.line1).toBeUndefined();
     });
 
     it('recurses into list relations (Household.emergencyContacts)', async () => {

--- a/checkin-app/tests/security/stripper.test.ts
+++ b/checkin-app/tests/security/stripper.test.ts
@@ -228,27 +228,27 @@ describe('stripValue — nested relations', () => {
             id: 5,
             name: 'Me',
             email: 'me@x.com',
-            household: { id: 2, name: 'Home', address: 'private street' },
+            household: { id: 2, name: 'Home', line1: 'private street' },
         };
         const out = stripValue('Participant', row, tokens, callerCtx) as Record<string, unknown>;
         expect(out.email).toBe('me@x.com');
         const household = out.household as Record<string, unknown>;
         expect(household.id).toBe(2);
         expect(household.name).toBe('Home');
-        expect(household.address).toBeUndefined(); // personal — no token grants it
+        expect(household.line1).toBeUndefined(); // personal — no token grants it
     });
 
-    it('grants household.address when their_households:personal is in the view', () => {
+    it('grants household.line1 when their_households:personal is in the view', () => {
         const callerCtx = ctx({ selfId: 5, householdId: 2 });
         const tokens = ['their_own:pii', 'their_households:personal', 'public'] as const;
         const row = {
             id: 5,
             email: 'me@x.com',
-            household: { id: 2, name: 'Home', address: 'private street' },
+            household: { id: 2, name: 'Home', line1: 'private street' },
         };
         const out = stripValue('Participant', row, tokens, callerCtx) as Record<string, unknown>;
         const household = out.household as Record<string, unknown>;
-        expect(household.address).toBe('private street');
+        expect(household.line1).toBe('private street');
     });
 });
 
@@ -399,12 +399,12 @@ describe('stripBag', () => {
         const out = stripBag(
             {
                 Participant: { id: 5, name: 'Me', email: 'me@x.com' },
-                Household: { id: 2, name: 'Home', address: 'street' },
+                Household: { id: 2, name: 'Home', line1: 'street' },
             },
             ['their_own:pii', 'their_households:personal', 'public'],
             ctx({ selfId: 5, householdId: 2 }),
         );
         expect((out.Participant as Record<string, unknown>).email).toBe('me@x.com');
-        expect((out.Household as Record<string, unknown>).address).toBe('street');
+        expect((out.Household as Record<string, unknown>).line1).toBe('street');
     });
 });


### PR DESCRIPTION
## ⚠️ Potentially controversial

This is a **breaking schema change with a destructive migration**. Flagging for careful review before merge:

- **Drops the `address` column** on `Household` and `Corporation` after backfill. The migration is one-way — old free-text is preserved only as `line1`.
- **Backfill is naive**: the entire old free-text address goes into `line1` verbatim (no parsing into city/state/zip). Existing members will show a full address string in the street field until they re-enter it. We chose this over a heuristic split because parsing arbitrary free text is unreliable.
- **US-only assumption**: no `country` field; `state` is a 2-letter code. Non-US addresses aren't modeled yet.
- Migration + drop ship in **one PR** (no two-phase deploy). Verify the backfill on production data before merging.

## What

Replace the single free-text `address` column with structured fields:
`line1`, `line2`, `city`, `state`, `postalCode` (all `@sensitivity:personal`).

## Changes

- **Schema + migration** (`20260629000000_structured_address`): add 5 columns to Household & Corporation, backfill `line1` from `address`, drop `address`.
- **`src/lib/address.ts`**: shared `normalizeAddressInput` / `formatAddress` / `pickAddress` helpers + self-check.
- **APIs**: `household/settings`, `admin/households/[id]`, membership `intake.ts` — accept/return structured fields; audit snapshots updated; intake requires `line1`.
- **UI**: `my-household`, `membership` intake, `AdminEditHouseholdModal` — split single input into street/apt/city/state/zip.
- **Dev/seed/import**: zoho-import, seed-helpers, seed_20_users, CSV admin import map to `line1` (bulk import to be redone, marked).
- **Tests**: security stripper/outbound now assert `line1` stripping at personal tier; integration fixtures updated.

## Verification

- `tsc --noEmit` clean.
- Migration applies clean on a fresh Postgres.
- 50 security unit tests + 58 address-path integration tests pass (intake, householdAPI, authz, bg, adminParticipantHousehold). zoho/import/audit suites green (1 pre-existing, unrelated attendance-audit flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)