### PR TITLE
test(integration): isolate each jest worker on its own Postgres DB

### DIFF
--- a/checkin-app/jest.config.js
+++ b/checkin-app/jest.config.js
@@ -15,6 +15,10 @@ const customJestConfig = {
     // tests that failed by THROWING (schema/mock rot) vs honest assertions.
     reporters: ['default', '<rootDir>/test/failureClassifierReporter.js'],
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+    // Integration tier only (gated by INTEGRATION_DB): clone one Postgres DB per
+    // worker so parallel workers can't corrupt each other. No-op for `test:ci`.
+    globalSetup: '<rootDir>/test/integrationGlobalSetup.js',
+    globalTeardown: '<rootDir>/test/integrationGlobalTeardown.js',
     testEnvironment: 'jest-environment-jsdom',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/checkin-app/jest.setup.js
+++ b/checkin-app/jest.setup.js
@@ -1,6 +1,16 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import '@testing-library/jest-dom'
 
+// Integration tier (A+B): point THIS worker at its own cloned database before
+// any test module loads @/lib/prisma. integrationGlobalSetup.js created one DB
+// per worker, namespaced by run id + worker id; here we just select ours. No-op
+// for unit runs (INTEGRATION_DB unset).
+if (process.env.INTEGRATION_DB && process.env.TEST_BASE_URL && process.env.TEST_RUN_ID) {
+  const u = new URL(process.env.TEST_BASE_URL);
+  u.pathname = `/checkin_test_${process.env.TEST_RUN_ID}_${process.env.JEST_WORKER_ID || '1'}`;
+  process.env.DATABASE_URL = u.toString();
+}
+
 // Tests run as a non-production environment. Previously this was implicit via
 // NODE_ENV=test; under the single CHECKIN_ENV flag we declare it explicitly so
 // prod-only gates (e.g. the scan self-check-in block) stay off during tests.

--- a/checkin-app/package.json
+++ b/checkin-app/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint --max-warnings 0",
     "test": "jest --runInBand --forceExit",
     "test:ci": "jest --ci --runInBand --forceExit",
-    "test:integration": "jest --ci --runInBand --forceExit --testPathIgnorePatterns=/node_modules/ --testRegex \"\\.integration\\.test\\.[jt]sx?$\"",
+    "test:integration": "INTEGRATION_DB=1 jest --ci --forceExit --testPathIgnorePatterns=/node_modules/ --testRegex \"\\.integration\\.test\\.[jt]sx?$\"",
     "check-route-coverage": "ts-node --project scripts/tsconfig.json scripts/check-route-coverage.ts",
     "import:zoho": "tsx scripts/import-zoho.ts"
   },

--- a/checkin-app/test/integrationDb.js
+++ b/checkin-app/test/integrationDb.js
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// Shared helpers for the integration-tier per-worker database machinery (A+B).
+const { Client } = require('pg')
+
+/** Return `base` with its database name swapped for `db`. */
+function withDb(base, db) {
+    const u = new URL(base)
+    u.pathname = `/${db}`
+    return u.toString()
+}
+
+/** A client on the maintenance DB, where CREATE/DROP DATABASE is legal. */
+function adminClient(base) {
+    return new Client({ connectionString: withDb(base, 'postgres') })
+}
+
+/** Per-run DB name: namespaced by run id (B) AND worker id (A) so neither
+ *  parallel workers nor concurrent jest invocations (worktrees, CI shards,
+ *  multiple Bash calls) ever collide on the same database. */
+function workerDbName(runId, workerId) {
+    return `checkin_test_${runId}_${workerId}`
+}
+
+module.exports = { withDb, adminClient, workerDbName }

--- a/checkin-app/test/integrationDb.test.js
+++ b/checkin-app/test/integrationDb.test.js
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// Self-check for the name/URL logic — runs in the unit tier, needs no DB.
+const { withDb, workerDbName } = require('./integrationDb')
+
+describe('integrationDb name logic', () => {
+    it('swaps only the database name, keeps host/port/creds', () => {
+        expect(withDb('postgres://u:p@host:5432/base', 'checkin_test_42_3'))
+            .toBe('postgres://u:p@host:5432/checkin_test_42_3')
+    })
+
+    it('namespaces by run id and worker id (A+B)', () => {
+        // Two workers in one run differ; same worker across two runs differ.
+        expect(workerDbName('111', '1')).toBe('checkin_test_111_1')
+        expect(workerDbName('111', '2')).not.toBe(workerDbName('111', '1'))
+        expect(workerDbName('222', '1')).not.toBe(workerDbName('111', '1'))
+    })
+})

--- a/checkin-app/test/integrationGlobalSetup.js
+++ b/checkin-app/test/integrationGlobalSetup.js
@@ -71,7 +71,6 @@ module.exports = async function integrationGlobalSetup(globalConfig) {
             await admin.query(`DROP DATABASE IF EXISTS "${db}" WITH (FORCE)`)
             await admin.query(`CREATE DATABASE "${db}" TEMPLATE "${template}"`)
         }
-        // eslint-disable-next-line no-console
         console.log(`[integration] ${maxWorkers} worker DB(s) ready (run ${runId})`)
     } finally {
         await admin.end()

--- a/checkin-app/test/integrationGlobalSetup.js
+++ b/checkin-app/test/integrationGlobalSetup.js
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/**
+ * Integration-tier global setup (A + B).
+ *
+ * Runs ONCE in the main jest process, before any worker forks. It:
+ *   1. migrates a fresh template database (committed migrations, once), and
+ *   2. clones one database per worker from that template (file-level copy —
+ *      milliseconds), so every parallel worker gets an isolated DB.
+ *
+ * The run id (main-process PID) namespaces every database, so two concurrent
+ * jest invocations — worktrees, CI shards, or several Bash calls — never share
+ * a database even though both have a "worker 1".
+ *
+ * No-op unless INTEGRATION_DB is set, so the unit run (`test:ci`) never touches
+ * Postgres. Env vars set here are inherited by the workers when they fork.
+ */
+const { execFileSync } = require('node:child_process')
+const { createRequire } = require('node:module')
+const { dirname, resolve } = require('node:path')
+const { adminClient, withDb, workerDbName } = require('./integrationDb')
+
+/** Resolve the Prisma CLI entrypoint as seen from checkin-app (handles hoisting). */
+function resolvePrismaBin(cwd) {
+    const requireFrom = createRequire(resolve(cwd, 'package.json'))
+    const pkgJsonPath = requireFrom.resolve('prisma/package.json')
+    const pkg = requireFrom('prisma/package.json')
+    const binRel = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin.prisma
+    return resolve(dirname(pkgJsonPath), binRel)
+}
+
+module.exports = async function integrationGlobalSetup(globalConfig) {
+    if (!process.env.INTEGRATION_DB) return
+
+    const base = process.env.DATABASE_URL
+    if (!base) {
+        throw new Error(
+            'INTEGRATION_DB is set but DATABASE_URL is empty. Point it at a running Postgres ' +
+            '(e.g. the throwaway docker instance) before `npm run test:integration`.'
+        )
+    }
+
+    const appDir = resolve(__dirname, '..')
+    const runId = String(process.pid)
+    const maxWorkers = Math.max(1, globalConfig.maxWorkers || 1)
+    const template = `checkin_test_tmpl_${runId}`
+
+    // Publish for the workers (inherited at fork) and for teardown (same process).
+    process.env.TEST_RUN_ID = runId
+    process.env.TEST_BASE_URL = base
+    process.env.TEST_MAXW = String(maxWorkers)
+    process.env.TEST_TEMPLATE_DB = template
+
+    const admin = adminClient(base)
+    await admin.connect()
+    try {
+        // Fresh template, migrated once via `migrate deploy` (not db push) so the
+        // test schema is byte-for-byte what production migrations produce.
+        await admin.query(`DROP DATABASE IF EXISTS "${template}" WITH (FORCE)`)
+        await admin.query(`CREATE DATABASE "${template}"`)
+
+        const bin = resolvePrismaBin(appDir)
+        execFileSync(process.execPath, [bin, 'migrate', 'deploy'], {
+            cwd: appDir,
+            env: { ...process.env, DATABASE_URL: withDb(base, template) },
+            stdio: 'inherit',
+        })
+
+        // One DB per worker, cloned from the template.
+        for (let w = 1; w <= maxWorkers; w++) {
+            const db = workerDbName(runId, w)
+            await admin.query(`DROP DATABASE IF EXISTS "${db}" WITH (FORCE)`)
+            await admin.query(`CREATE DATABASE "${db}" TEMPLATE "${template}"`)
+        }
+        // eslint-disable-next-line no-console
+        console.log(`[integration] ${maxWorkers} worker DB(s) ready (run ${runId})`)
+    } finally {
+        await admin.end()
+    }
+}

--- a/checkin-app/test/integrationGlobalTeardown.js
+++ b/checkin-app/test/integrationGlobalTeardown.js
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// Drops every database this run created (worker clones + template). No-op for
+// the unit run. WITH (FORCE) terminates any lingering connection first.
+const { adminClient, workerDbName } = require('./integrationDb')
+
+module.exports = async function integrationGlobalTeardown() {
+    if (!process.env.INTEGRATION_DB) return
+
+    const base = process.env.TEST_BASE_URL
+    const runId = process.env.TEST_RUN_ID
+    if (!base || !runId) return
+
+    const maxWorkers = Number(process.env.TEST_MAXW || 1)
+    const template = process.env.TEST_TEMPLATE_DB
+
+    const admin = adminClient(base)
+    await admin.connect()
+    try {
+        for (let w = 1; w <= maxWorkers; w++) {
+            await admin.query(`DROP DATABASE IF EXISTS "${workerDbName(runId, w)}" WITH (FORCE)`)
+        }
+        if (template) await admin.query(`DROP DATABASE IF EXISTS "${template}" WITH (FORCE)`)
+    } finally {
+        await admin.end()
+    }
+}


### PR DESCRIPTION
## What

Integration tests (`*.integration.test.ts`) all shared one Postgres database, so the suite could only run safely with `--runInBand`. Any parallelism — jest workers, two worktree sessions, or concurrent CI shards — corrupted each other's rows.

This gives every jest worker its own database:

- **`test/integrationGlobalSetup.js`** — runs once per run: migrates a template DB (`migrate deploy`, committed migrations), then clones one DB per worker from it (file-level `CREATE DATABASE ... TEMPLATE`, near-instant).
- **`jest.setup.js`** — repoints the worker's `DATABASE_URL` at its own clone before any test loads `@/lib/prisma`. `prisma.ts` is unchanged.
- **`test/integrationGlobalTeardown.js`** — drops the run's clones + template (`WITH (FORCE)`).
- **`test/integrationDb.js`** — shared name/URL helpers; **`test/integrationDb.test.js`** — unit-tier self-check (no DB).

## Why namespaced by run id *and* worker id

`JEST_WORKER_ID` is unique only within one jest invocation. Database names embed the main-process PID too, so a worker 1 in one run never collides with a worker 1 in another (worktrees, CI shards, parallel invocations).

## Why database-per-worker, not schema-per-worker

Postgres advisory locks are scoped **per-database**. The concurrency suites (`scanConcurrency`, `programsParticipantsConcurrency`, etc.) rely on advisory locks + `FOR UPDATE` as the serializer. Sharing one DB across schemas would make those locks collide across unrelated workers. Separate databases keep them honest.

## Scope / safety

- All machinery gated on `INTEGRATION_DB`, so the unit run (`test:ci`) stays DB-free, as before.
- `test:integration` drops `--runInBand` and sets `INTEGRATION_DB=1`.
- `TEST_DB_POOL_MAX` logic unchanged — it's per-worker now.

## Reviewer notes

- Needs a reachable Postgres via `DATABASE_URL` (already true for the integration tier). Setup connects to the maintenance `postgres` DB to CREATE/DROP.
- Not yet run against a live parallel DB in this environment (worktree has no `node_modules`); name/URL logic verified. Run: \`DATABASE_URL=postgres://...@127.0.0.1:5432/checkin npm -w checkin-app run test:integration\`.
- No connection-count cap on `maxWorkers` yet — add if a high-core CI box exhausts Postgres `max_connections` (`workers × poolMax`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)