### PR TITLE
feat(audit-log): stack date above time to save horizontal space

### DIFF
--- a/checkin-app/src/components/admin/AuditLogPanel.tsx
+++ b/checkin-app/src/components/admin/AuditLogPanel.tsx
@@ -130,7 +130,7 @@ export function AuditLogPanel() {
             <Table striped highlightOnHover withTableBorder verticalSpacing={4} fz="xs">
               <Table.Thead>
                 <Table.Tr>
-                  <Table.Th w={150}>Time</Table.Th>
+                  <Table.Th w={110}>Time</Table.Th>
                   <Table.Th w={90}>Action</Table.Th>
                   <Table.Th>Entity</Table.Th>
                   <Table.Th>Actor</Table.Th>
@@ -141,7 +141,8 @@ export function AuditLogPanel() {
                 {data.logs.map((l) => (
                   <Table.Tr key={l.id}>
                     <Table.Td style={{ whiteSpace: "nowrap" }}>
-                      {new Date(l.time).toLocaleString()}
+                      <div>{new Date(l.time).toLocaleDateString()}</div>
+                      <div>{new Date(l.time).toLocaleTimeString()}</div>
                     </Table.Td>
                     <Table.Td>
                       <Badge size="sm" color={ACTION_COLOR[l.action]}>


### PR DESCRIPTION
## What changed
Audit log (`/system-status/audit-log`) timestamp column rendered date and time together on one line via `toLocaleString()`. Now date and time are stacked (date on top, time below) and the column width is narrowed 150→110px.

## Why
Reclaims horizontal space for the wider columns (Entity, Actor, Changes).

## Notes for reviewer
- Single file: `checkin-app/src/components/admin/AuditLogPanel.tsx`.
- Still locale-formatted (`toLocaleDateString()` / `toLocaleTimeString()`), local timezone, unchanged behavior otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)