### PR TITLE
fix(onboarding): remove nested heading in OnboardingGate modal title

### DIFF
--- a/checkin-app/src/components/OnboardingGate.tsx
+++ b/checkin-app/src/components/OnboardingGate.tsx
@@ -109,7 +109,7 @@ export default function OnboardingGate({ children }: { children: React.ReactNode
         closeOnEscape={false}
         centered
         size="lg"
-        title={<Title order={3}>Action Required</Title>}
+        title="Action Required"
       >
         <Text c="dimmed" mb="lg">
           To ensure the safety of our facility and compliance with our policies, we need a bit


### PR DESCRIPTION
## What

`OnboardingGate` passed `title={<Title order={3}>Action Required</Title>}` to Mantine's `<Modal>`. Mantine's `Modal.Title` already wraps its content in an `<h2>`, so this nested an `<h3>` inside the `<h2>`.

## Why

`<h3>` cannot be a child of `<h2>` — invalid HTML that triggered a React hydration error in the console:

> In HTML, `<h3>` cannot be a child of `<h2>`. This will cause a hydration error.

## Change

Pass a plain string `title="Action Required"` instead. The `Title` import remains (still used elsewhere in the file at line 135).

## Reviewer notes

- Modal title now renders Mantine's default `<h2>` styling rather than the previous `order={3}` look. If the heading size needs to match the old appearance, add `fz`/`fw` props — but visually they're close.