### PR TITLE
fix(trusted-adult): fix pre-existing board-ping integration test failure

### DIFF
--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -53,7 +53,7 @@ describe('Trusted Adults service', () => {
         const outHh = await prisma.household.create({ data: { name: `Outsider HH ${TAG}` } });
         outsiderId = (await prisma.participant.create({ data: { name: 'Outsider', householdId: outHh.id } })).id;
         const boardHh = await prisma.household.create({ data: { name: `Board HH ${TAG}` } });
-        boardId = (await prisma.participant.create({ data: { name: 'Boardie', boardMember: true, householdId: boardHh.id } })).id;
+        boardId = (await prisma.participant.create({ data: { name: 'Boardie', email: `board-${TAG}@ex.com`, boardMember: true, householdId: boardHh.id } })).id;
     });
 
     afterAll(async () => {


### PR DESCRIPTION
## What

The integration test *"creates a trusted adult with an INITIAL review pending board review and pings the board"* was failing (1 failed / 15 passed in the suite). One-line fix: the test's board-member fixture now has an email.

## Why

`notifyBoard()` ([service.ts](checkin-app/src/lib/trusted-adult/service.ts)) queries recipients as:

```ts
where: { boardMember: true, email: { not: null } }
```

The test created its board member ("Boardie") **without** an email, so the recipient set was empty and `sendEmail` was never called — failing `expect(sendEmail).toHaveBeenCalled()`.

The defect was in the test fixture, not the service. The query is correct: emailing a `null` address would be the real bug.

## Verification

Ran the suite in isolation against a throwaway Postgres — **16/16 pass**.

Note: `sendEmail` is jest-mocked in this suite, so `CHECKIN_ENV` does not gate it (red herring from the original diagnosis notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)