### PR TITLE
fix(test): close per-file prisma pools so integration tier stops exhausting Postgres connections

### DIFF
--- a/checkin-app/jest.setup.js
+++ b/checkin-app/jest.setup.js
@@ -9,6 +9,19 @@ if (process.env.INTEGRATION_DB && process.env.TEST_BASE_URL && process.env.TEST_
   const u = new URL(process.env.TEST_BASE_URL);
   u.pathname = `/checkin_test_${process.env.TEST_RUN_ID}_${process.env.JEST_WORKER_ID || '1'}`;
   process.env.DATABASE_URL = u.toString();
+
+  // Each integration file builds its own prisma pool (fresh module registry per
+  // file). Close it when the file finishes, or pools accumulate across the
+  // worker's files and exhaust the shared Postgres server's max_connections.
+  // disposeExternalPool (set in prisma.ts under test) makes $disconnect actually
+  // end the pg pool.
+  afterAll(async () => {
+    try {
+      await require('@/lib/prisma').default.$disconnect();
+    } catch {
+      // No prisma loaded in this file, or already disconnected — nothing to free.
+    }
+  });
 }
 
 // Tests run as a non-production environment. Previously this was implicit via

--- a/checkin-app/src/lib/prisma.ts
+++ b/checkin-app/src/lib/prisma.ts
@@ -12,7 +12,12 @@ const poolMax = process.env.NODE_ENV === 'test'
     ? Number(process.env.TEST_DB_POOL_MAX ?? 1)
     : 10
 const pool = new Pool({ connectionString, max: poolMax })
-const adapter = new PrismaPg(pool)
+// In tests every file gets a fresh module registry, so each builds its own pool.
+// Those pools must close on $disconnect or they leak connections until the worker
+// process dies (parallel runs exhaust max_connections; --runInBand crashes). The
+// pg adapter only ends an *external* pool when told to, so opt in under test. Prod
+// keeps its single long-lived pool untouched.
+const adapter = new PrismaPg(pool, process.env.NODE_ENV === 'test' ? { disposeExternalPool: true } : undefined)
 
 const prismaClientSingleton = () => {
     return new PrismaClient({ adapter })


### PR DESCRIPTION
## Why

[#514](https://github.com/innovationtreehouse/checkin/pull/514) isolated integration **data** (one cloned database per jest worker) but not **connections**. Every worker still connects to one Postgres server sharing `max_connections`, and the per-file pools were never released. The integration suite still failed in ways that looked like cross-test interference.

## Root cause

Each integration test **file** gets a fresh jest module registry, so each builds its own `pg` `Pool` via `@/lib/prisma`. Those pools never closed:

- 70 of 94 files never call `$disconnect`, and
- `prisma.ts` built the adapter with an **external** pool and no options, so even the 24 files that *do* `$disconnect` freed nothing — `@prisma/adapter-pg` only ends an external pool when `disposeExternalPool` is set.

Pools accumulated across each worker's sequential files until the worker process died, climbing past the server's `max_connections`:

- **parallel** runs failed with `Too many database connections opened: sorry, too many clients already` — the failing suite set shifted run to run with connection pressure / scheduling, not test logic;
- **`--runInBand`** piled all files into one process and crashed it at the Node level with a `pg` pool dump.

## Fix

Shared harness only — no per-file edits, no test-logic change:

- **`prisma.ts`**: pass `{ disposeExternalPool: true }` to `PrismaPg` under `NODE_ENV==='test'` so `$disconnect` actually ends the pg pool. Prod keeps its single long-lived external pool untouched.
- **`jest.setup.js`**: under `INTEGRATION_DB`, register an `afterAll` that disconnects the prisma singleton, closing each file's pool before the next file loads.

Live connections are now bounded to `workers × pool_max` instead of `files × pool_max`.

## Verification

Throwaway Postgres at default `max_connections=100`, integration tier in **parallel** (the config that failed before):

| | Suites | Tests |
|---|---|---|
| Before | 5 failed | 6 failed / 652 passed — every failure "too many clients" |
| After | 2 failed | 2 failed / 659 passed — **zero** connection failures |

The 2 remaining (`navTodoCountsAPI`, `trustedAdultService`) fail in isolation too → pre-existing logic bugs unrelated to test isolation, tracked on other branches.

## Notes for reviewer

- `disposeExternalPool` is gated to `NODE_ENV==='test'`; production prisma behavior is unchanged.
- A latent secondary issue remains (per-**worker**, not per-**file**, data isolation): files sharing a worker's clone DB can see each other's leftover rows. It stayed latent in this run and is out of scope here. Add a per-file reset only if order-dependent assertion failures surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)