### PR TITLE
refactor(schema): rename log timestamp fields to `timestamp`

### DIFF
--- a/checkin-app/prisma/migrations/20260629130000_rename_log_timestamps/migration.sql
+++ b/checkin-app/prisma/migrations/20260629130000_rename_log_timestamps/migration.sql
@@ -1,0 +1,16 @@
+-- Normalize log timestamp columns to `timestamp`. Data-preserving: columns and
+-- indexes are renamed in place (no DROP/CREATE), so existing rows survive.
+
+-- RawBadgeLog.time -> timestamp
+ALTER TABLE "RawBadgeLog" RENAME COLUMN "time" TO "timestamp";
+ALTER INDEX "RawBadgeLog_participantId_time_idx" RENAME TO "RawBadgeLog_participantId_timestamp_idx";
+
+-- AuditLog.time -> timestamp
+ALTER TABLE "AuditLog" RENAME COLUMN "time" TO "timestamp";
+
+-- ErrorLog.createdAt -> timestamp
+ALTER TABLE "ErrorLog" RENAME COLUMN "createdAt" TO "timestamp";
+
+-- IntegrationErrorLog.createdAt -> timestamp (resolvedAt left as-is: state change, not log time)
+ALTER TABLE "IntegrationErrorLog" RENAME COLUMN "createdAt" TO "timestamp";
+ALTER INDEX "IntegrationErrorLog_resolvedAt_createdAt_idx" RENAME TO "IntegrationErrorLog_resolvedAt_timestamp_idx";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -744,13 +744,13 @@ model RawBadgeLog {
   /// @sensitivity:internal
   participantId Int
   /// @sensitivity:personal
-  time          DateTime @default(now())
+  timestamp     DateTime @default(now())
   /// @sensitivity:personal
   location      String?
 
   participant Participant @relation(fields: [participantId], references: [id])
 
-  @@index([participantId, time]) // Double-badge detection in /api/scan
+  @@index([participantId, timestamp]) // Double-badge detection in /api/scan
 }
 
 model Visit {
@@ -779,7 +779,7 @@ model AuditLog {
   /// @sensitivity:internal
   id                      Int         @id @default(autoincrement())
   /// @sensitivity:internal
-  time                    DateTime    @default(now())
+  timestamp               DateTime    @default(now())
   /// @sensitivity:internal
   actorId                 Int
   /// @sensitivity:internal
@@ -854,7 +854,7 @@ model ErrorLog {
   /// @sensitivity:internal
   id        Int      @id @default(autoincrement())
   /// @sensitivity:internal
-  createdAt DateTime @default(now())
+  timestamp DateTime @default(now())
   /// @sensitivity:internal
   route     String?
   /// @sensitivity:internal
@@ -889,11 +889,11 @@ model IntegrationErrorLog {
   /// @sensitivity:internal
   context    Json?
   /// @sensitivity:internal
-  createdAt  DateTime  @default(now())
+  timestamp  DateTime  @default(now())
   /// @sensitivity:internal
   resolvedAt DateTime?
 
-  @@index([resolvedAt, createdAt])
+  @@index([resolvedAt, timestamp])
 }
 
 /// Dev-instance activity ledger (DEV_DASHBOARD_DESIGN.md §6). Lives only in checkin_dev; records

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -154,7 +154,7 @@ describe('AuditLog Integration Tests', () => {
                 tableName: 'Program',
                 affectedEntityId: testProgramId
             },
-            orderBy: { time: 'desc' }
+            orderBy: { timestamp: 'desc' }
         });
 
         expect(log).toBeDefined();
@@ -178,7 +178,7 @@ describe('AuditLog Integration Tests', () => {
                 tableName: 'Program',
                 affectedEntityId: testProgramId
             },
-            orderBy: { time: 'desc' }
+            orderBy: { timestamp: 'desc' }
         });
 
         expect(log).toBeDefined();
@@ -206,7 +206,7 @@ describe('AuditLog Integration Tests', () => {
                 affectedEntityId: testParticipantId,
                 secondaryAffectedEntity: testProgramId
             },
-            orderBy: { time: 'desc' }
+            orderBy: { timestamp: 'desc' }
         });
 
         expect(log).toBeDefined();
@@ -242,7 +242,7 @@ describe('AuditLog Integration Tests', () => {
                 affectedEntityId: testVisitId,
                 secondaryAffectedEntity: testEventId
             },
-            orderBy: { time: 'desc' }
+            orderBy: { timestamp: 'desc' }
         });
 
         expect(log).toBeDefined();

--- a/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
@@ -77,7 +77,7 @@ describe('Scan causal chain — last keyholder closes facility', () => {
         // Past the debounce window.
         await prisma.rawBadgeLog.updateMany({
             where: { participantId: keyholder.id },
-            data: { time: new Date(Date.now() - 5000) },
+            data: { timestamp: new Date(Date.now() - 5000) },
         });
 
         // Check out → last keyholder, nobody else present → facility closes.
@@ -98,8 +98,8 @@ describe('Scan causal chain — last keyholder closes facility', () => {
         const kVisit = await prisma.visit.create({ data: { participantId: keyholder.id, arrived: new Date() } });
         await prisma.visit.create({ data: { participantId: normal.id, arrived: new Date() } });
         // Two keyholder badge events 5s apart (<=12s) → confirmed force-close.
-        await prisma.rawBadgeLog.create({ data: { participantId: keyholder.id, time: new Date(Date.now() - 5000) } });
-        await prisma.rawBadgeLog.create({ data: { participantId: keyholder.id, time: new Date() } });
+        await prisma.rawBadgeLog.create({ data: { participantId: keyholder.id, timestamp: new Date(Date.now() - 5000) } });
+        await prisma.rawBadgeLog.create({ data: { participantId: keyholder.id, timestamp: new Date() } });
 
         const res = await processCheckout(keyholder, kVisit.id, 'kiosk');
         const json = await res.json();

--- a/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
@@ -122,7 +122,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
         // Backdate the badge event so the second scan is past the 3s debounce window.
         await prisma.rawBadgeLog.updateMany({
             where: { participantId: normalId },
-            data: { time: new Date(Date.now() - 5000) },
+            data: { timestamp: new Date(Date.now() - 5000) },
         });
 
         // Second scan → check-out.

--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -203,7 +203,7 @@ export async function POST(req: Request) {
                 where: {
                     tableName: 'SYSTEM_NOTIFY',
                     action: 'CREATE',
-                    time: { gte: fiveMinutesAgo }
+                    timestamp: { gte: fiveMinutesAgo }
                 }
             });
 

--- a/checkin-app/src/app/api/facility/badges/route.ts
+++ b/checkin-app/src/app/api/facility/badges/route.ts
@@ -8,7 +8,7 @@ export const GET = withAuth(
         try {
             const badges = await prisma.rawBadgeLog.findMany({
                 take: 200,
-                orderBy: { time: "desc" },
+                orderBy: { timestamp: "desc" },
                 include: {
                     participant: {
                         select: { name: true, email: true },

--- a/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -98,7 +98,7 @@ describe('POST /api/scan', () => {
         }) as unknown as import('next/server').NextRequest;
 
         (prisma.participant.findUnique as jest.Mock).mockResolvedValue({ id: 1 });
-        (prisma.rawBadgeLog.findFirst as jest.Mock).mockResolvedValue({ time: new Date(Date.now() - 1000) });
+        (prisma.rawBadgeLog.findFirst as jest.Mock).mockResolvedValue({ timestamp: new Date(Date.now() - 1000) });
 
         const res = await POST(req);
         expect(res.status).toBe(200);

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -102,7 +102,7 @@ export async function POST(req: NextRequest) {
             const recentScan = await tx.rawBadgeLog.findFirst({
                 where: {
                     participantId: participant.id,
-                    time: {
+                    timestamp: {
                         gte: threeSecondsAgo
                     }
                 }

--- a/checkin-app/src/app/api/system-status/audit-log/route.ts
+++ b/checkin-app/src/app/api/system-status/audit-log/route.ts
@@ -33,16 +33,16 @@ export const GET = withAuth(
             const from = sp.get("from");
             const to = sp.get("to");
             if (from || to) {
-                where.time = {};
-                if (from) where.time.gte = new Date(`${from}T00:00:00.000`);
-                if (to) where.time.lte = new Date(`${to}T23:59:59.999`);
+                where.timestamp = {};
+                if (from) where.timestamp.gte = new Date(`${from}T00:00:00.000`);
+                if (to) where.timestamp.lte = new Date(`${to}T23:59:59.999`);
             }
 
             const [total, rows, tableRows] = await Promise.all([
                 prisma.auditLog.count({ where }),
                 prisma.auditLog.findMany({
                     where,
-                    orderBy: { time: 'desc' },
+                    orderBy: { timestamp: 'desc' },
                     skip: (page - 1) * PAGE_SIZE,
                     take: PAGE_SIZE,
                 }),

--- a/checkin-app/src/app/api/system-status/errors/route.ts
+++ b/checkin-app/src/app/api/system-status/errors/route.ts
@@ -7,7 +7,7 @@ export const GET = withAuth(
     async () => {
         try {
             const errors = await prisma.errorLog.findMany({
-                orderBy: { createdAt: "desc" },
+                orderBy: { timestamp: "desc" },
                 take: 100,
             });
             return NextResponse.json({ errors });

--- a/checkin-app/src/app/api/system-status/links/route.ts
+++ b/checkin-app/src/app/api/system-status/links/route.ts
@@ -11,11 +11,11 @@ export const GET = withAuth(
             const ninetyDaysAgo = new Date();
             ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
             prisma.integrationErrorLog
-                .deleteMany({ where: { createdAt: { lt: ninetyDaysAgo } } })
+                .deleteMany({ where: { timestamp: { lt: ninetyDaysAgo } } })
                 .catch((err: unknown) => console.error("Failed to purge old integration errors:", err));
 
             const errors = await prisma.integrationErrorLog.findMany({
-                orderBy: [{ resolvedAt: "asc" }, { createdAt: "desc" }],
+                orderBy: [{ resolvedAt: "asc" }, { timestamp: "desc" }],
                 take: 200,
             });
 

--- a/checkin-app/src/app/facility-ops/badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/badges/page.tsx
@@ -9,14 +9,14 @@ import { formatDateTime } from '@/lib/time';
 
 type BadgeEvent = {
   id: number;
-  time: string;
+  timestamp: string;
   participant?: { name?: string; email?: string };
   location?: string;
 };
 
 const COLUMNS: DataTableColumn<BadgeEvent>[] = [
   { header: 'ID', render: (b) => b.id, sortBy: (b) => b.id },
-  { header: 'Time', render: (b) => formatDateTime(b.time), sortBy: (b) => b.time },
+  { header: 'Time', render: (b) => formatDateTime(b.timestamp), sortBy: (b) => b.timestamp },
   { header: 'Participant', render: (b) => b.participant?.name || 'Unknown', sortBy: (b) => b.participant?.name },
   { header: 'Email', render: (b) => b.participant?.email, sortBy: (b) => b.participant?.email },
   { header: 'Location', render: (b) => b.location || 'Front Door', sortBy: (b) => b.location },

--- a/checkin-app/src/components/admin/AuditLogPanel.tsx
+++ b/checkin-app/src/components/admin/AuditLogPanel.tsx
@@ -17,7 +17,7 @@ import {
 
 type AuditLog = {
   id: number;
-  time: string;
+  timestamp: string;
   actorId: number;
   actorName: string | null;
   action: "CREATE" | "EDIT" | "DELETE" | "BECOME_ADMIN";
@@ -141,8 +141,8 @@ export function AuditLogPanel() {
                 {data.logs.map((l) => (
                   <Table.Tr key={l.id}>
                     <Table.Td style={{ whiteSpace: "nowrap" }}>
-                      <div>{new Date(l.time).toLocaleDateString()}</div>
-                      <div>{new Date(l.time).toLocaleTimeString()}</div>
+                      <div>{new Date(l.timestamp).toLocaleDateString()}</div>
+                      <div>{new Date(l.timestamp).toLocaleTimeString()}</div>
                     </Table.Td>
                     <Table.Td>
                       <Badge size="sm" color={ACTION_COLOR[l.action]}>

--- a/checkin-app/src/components/admin/ErrorLogPanel.tsx
+++ b/checkin-app/src/components/admin/ErrorLogPanel.tsx
@@ -5,7 +5,7 @@ import { Card, Center, Code, Loader, Stack, Table, Text, Title } from "@mantine/
 
 type ErrorLogRow = {
   id: number;
-  createdAt: string;
+  timestamp: string;
   route: string | null;
   message: string;
   stack: string | null;
@@ -70,7 +70,7 @@ export function ErrorLogPanel() {
                   style={{ cursor: "pointer" }}
                 >
                   <Table.Td style={{ whiteSpace: "nowrap" }}>
-                    {new Date(e.createdAt).toLocaleString()}
+                    {new Date(e.timestamp).toLocaleString()}
                   </Table.Td>
                   <Table.Td>{e.route ? <Code>{e.route}</Code> : <Text c="dimmed">—</Text>}</Table.Td>
                   <Table.Td>{e.message}</Table.Td>

--- a/checkin-app/src/components/admin/LinkStatusPanel.tsx
+++ b/checkin-app/src/components/admin/LinkStatusPanel.tsx
@@ -18,7 +18,7 @@ type IntegrationError = {
   source: string;
   message: string;
   context: unknown;
-  createdAt: string;
+  timestamp: string;
   resolvedAt: string | null;
 };
 
@@ -90,7 +90,7 @@ export function LinkStatusPanel() {
                   </Badge>
                 )}
                 <Text size="xs" c="dimmed">
-                  {new Date(e.createdAt).toLocaleString()}
+                  {new Date(e.timestamp).toLocaleString()}
                 </Text>
               </Group>
               <Text size="sm">{e.message}</Text>

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -324,7 +324,7 @@ export async function createCheckins(prisma: Db): Promise<string> {
     for (const [i, p] of people.entries()) {
         const arrived = new Date(Date.now() - (i + 1) * 45 * 60 * 1000); // staggered into the past
         await prisma.rawBadgeLog.create({
-            data: { participantId: p.id, time: arrived, location: "Front Door" },
+            data: { participantId: p.id, timestamp: arrived, location: "Front Door" },
         });
         await prisma.visit.create({
             data: {

--- a/checkin-app/src/lib/logger.ts
+++ b/checkin-app/src/lib/logger.ts
@@ -34,7 +34,7 @@ export async function logBackendError(error: unknown, route?: string, context?: 
 
         await prisma.errorLog.deleteMany({
             where: {
-                createdAt: {
+                timestamp: {
                     lt: thirtyDaysAgo
                 }
             }
@@ -70,7 +70,7 @@ export async function logIntegrationError(source: string, error: unknown, contex
         const ninetyDaysAgo = new Date();
         ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
         await prisma.integrationErrorLog.deleteMany({
-            where: { createdAt: { lt: ninetyDaysAgo } },
+            where: { timestamp: { lt: ninetyDaysAgo } },
         });
     } catch (loggingError) {
         console.error("Failed to log integration error to database:", loggingError);

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -94,12 +94,12 @@ export async function processCheckout(
 
                 const recentEvents = await db.rawBadgeLog.findMany({
                     where: { participantId: participant.id },
-                    orderBy: { time: "desc" },
+                    orderBy: { timestamp: "desc" },
                     take: 2
                 });
 
                 if (recentEvents.length === 2) {
-                    const timeDiff = recentEvents[0].time.getTime() - recentEvents[1].time.getTime();
+                    const timeDiff = recentEvents[0].timestamp.getTime() - recentEvents[1].timestamp.getTime();
                     if (timeDiff <= 12000) {
                         confirmForceClose = true;
                     }

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -233,7 +233,7 @@ export const classifications = {
     RawBadgeLog: {
         id: 'internal',
         participantId: 'internal',
-        time: 'personal',
+        timestamp: 'personal',
         location: 'personal',
     },
     Visit: {
@@ -247,7 +247,7 @@ export const classifications = {
     },
     AuditLog: {
         id: 'internal',
-        time: 'internal',
+        timestamp: 'internal',
         actorId: 'internal',
         action: 'internal',
         tableName: 'internal',
@@ -283,7 +283,7 @@ export const classifications = {
     },
     ErrorLog: {
         id: 'internal',
-        createdAt: 'internal',
+        timestamp: 'internal',
         route: 'internal',
         message: 'internal',
         stack: 'internal',
@@ -300,7 +300,7 @@ export const classifications = {
         source: 'internal',
         message: 'internal',
         context: 'internal',
-        createdAt: 'internal',
+        timestamp: 'internal',
         resolvedAt: 'internal',
     },
     DevLedger: {

--- a/checkin-app/src/test-helpers/expectAuditRow.ts
+++ b/checkin-app/src/test-helpers/expectAuditRow.ts
@@ -21,9 +21,9 @@ export async function expectAuditRow(
             affectedEntityId: q.affectedEntityId,
             ...(q.secondaryAffectedEntity !== undefined && { secondaryAffectedEntity: q.secondaryAffectedEntity }),
         },
-        // time can tie at ms resolution within a fast test; id breaks the tie so
-        // we always return the genuinely newest row.
-        orderBy: [{ time: "desc" }, { id: "desc" }],
+        // timestamp can tie at ms resolution within a fast test; id breaks the tie
+        // so we always return the genuinely newest row.
+        orderBy: [{ timestamp: "desc" }, { id: "desc" }],
     });
     if (!row) {
         const sec = q.secondaryAffectedEntity !== undefined ? ` secondary=${q.secondaryAffectedEntity}` : "";


### PR DESCRIPTION
## What

Normalizes the event-log models' time columns to a single `timestamp` convention:

| Model | Change |
|---|---|
| `RawBadgeLog.time` | → `timestamp` |
| `AuditLog.time` | → `timestamp` |
| `ErrorLog.createdAt` | → `timestamp` |
| `IntegrationErrorLog.createdAt` | → `timestamp` (kept `resolvedAt` — that's a state change, not the log time) |
| `SystemMetricLog.timestamp` | already correct, untouched |

Indexes renamed to match (`RawBadgeLog_participantId_timestamp_idx`, `IntegrationErrorLog_resolvedAt_timestamp_idx`).

## Why

Consistent naming across the log models (follows the `*Log` model rename that landed separately). One name for "when this log row happened" instead of three.

## Migration — data-safe

`20260629130000_rename_log_timestamps` uses `ALTER TABLE ... RENAME COLUMN` and `ALTER INDEX ... RENAME` (no drop/create), so existing rows survive. Verified against a throwaway Postgres: full chain applies and `prisma migrate diff` reports **zero drift** (the migration reproduces the schema exactly).

## Call sites

Updated every reference: scan/facility/attendance routes, `system-status/{errors,links,audit-log}`, `logger`, `scan-service`, seed helpers, the admin panels (`AuditLogPanel`, `ErrorLogPanel`, `LinkStatusPanel`), the badges page, `expectAuditRow`, and the affected integration/unit tests. Regenerated the Prisma client + security classifications.

## NextAuth quirk — `emailVerified` deliberately NOT renamed

`Participant.emailVerified` → `emailVerifiedAt` was requested but **reverted**: `@auth/prisma-adapter`'s `createUser` passes `emailVerified` by the Prisma **field name** (`prisma.user.create({ data })`), so a `@map` can't shield it — renaming breaks user creation / auth. Left as a documented NextAuth quirk. (The `emailVerified` refs in auth-options/middleware/token are a separate boolean derived from Google's `email_verified`, not this column.)

## Verification

- `tsc --noEmit` clean
- Unit suite: 349 passing
- Integration suites touching the renamed columns (audit, scan*, badges, attendance) all pass
- Seed runs clean against the new names

🤖 Generated with [Claude Code](https://claude.com/claude-code)