### PR TITLE
refactor(schema): prefix boolean fields with `is`

### DIFF
--- a/checkin-app/__tests__/programLifecycle.integration.test.ts
+++ b/checkin-app/__tests__/programLifecycle.integration.test.ts
@@ -118,7 +118,7 @@ describe('Program Lifecycle Integration Tests', () => {
         expect(dbRecord).toBeDefined();
         expect(dbRecord?.status).toBe('PENDING');
         expect(dbRecord?.pendingSince).toBeInstanceOf(Date);
-        expect(dbRecord?.paymentPlanRequested).toBe(false);
+        expect(dbRecord?.isPaymentPlanRequested).toBe(false);
     });
 
     it('Should block Lead Mentors from manually adding participants', async () => {
@@ -212,7 +212,7 @@ describe('Program Lifecycle Integration Tests', () => {
         expect(dbRecord?.pendingSince).toBeNull(); 
     });
 
-     it('Cron job should remove PENDING participants after 7 days, unless paymentPlanRequested is true', async () => {
+     it('Cron job should remove PENDING participants after 7 days, unless isPaymentPlanRequested is true', async () => {
         process.env.CRON_SECRET = 'cron_test_secret';
 
         // 1. Set user to 8 days old PENDING
@@ -221,8 +221,8 @@ describe('Program Lifecycle Integration Tests', () => {
 
         await prisma.programParticipant.upsert({
              where: { programId_participantId: { programId: testProgramId, participantId: testParticipantId } },
-             update: { status: 'PENDING', pendingSince: eightDaysAgo, paymentPlanRequested: false },
-             create: { programId: testProgramId, participantId: testParticipantId, status: 'PENDING', pendingSince: eightDaysAgo, paymentPlanRequested: false }
+             update: { status: 'PENDING', pendingSince: eightDaysAgo, isPaymentPlanRequested: false },
+             create: { programId: testProgramId, participantId: testParticipantId, status: 'PENDING', pendingSince: eightDaysAgo, isPaymentPlanRequested: false }
         });
 
         let req = new Request(`http://localhost/api/cron/pending-participants`, {
@@ -241,9 +241,9 @@ describe('Program Lifecycle Integration Tests', () => {
         });
         expect(dbRecord).toBeNull();
 
-        // 2. Recreate, set to 8 days old PENDING, but paymentPlanRequested = true
+        // 2. Recreate, set to 8 days old PENDING, but isPaymentPlanRequested = true
         await prisma.programParticipant.create({
-            data: { programId: testProgramId, participantId: testParticipantId, status: 'PENDING', pendingSince: eightDaysAgo, paymentPlanRequested: true}
+            data: { programId: testProgramId, participantId: testParticipantId, status: 'PENDING', pendingSince: eightDaysAgo, isPaymentPlanRequested: true}
         });
 
          req = new Request(`http://localhost/api/cron/pending-participants`, {

--- a/checkin-app/prisma/migrations/20260629130000_rename_booleans_is_prefix/migration.sql
+++ b/checkin-app/prisma/migrations/20260629130000_rename_booleans_is_prefix/migration.sql
@@ -1,0 +1,4 @@
+-- Data-preserving column renames (boolean fields -> is* convention).
+-- RENAME COLUMN keeps existing values; Prisma would otherwise drop+add and lose data.
+ALTER TABLE "ProgramParticipant" RENAME COLUMN "paymentPlanRequested" TO "isPaymentPlanRequested";
+ALTER TABLE "BackgroundCheckAttestation" RENAME COLUMN "markedVolunteer" TO "isMarkedVolunteer";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -368,7 +368,7 @@ model BackgroundCheckAttestation {
   /// @sensitivity:internal
   result          AttestationResult
   /// @sensitivity:internal
-  markedVolunteer Boolean           @default(false)
+  isMarkedVolunteer Boolean           @default(false)
   /// @sensitivity:public
   createdAt       DateTime          @default(now())
 
@@ -645,7 +645,7 @@ model ProgramParticipant {
   /// @sensitivity:public
   status               ProgramParticipantStatus @default(PENDING)
   /// @sensitivity:personal
-  paymentPlanRequested Boolean                  @default(false)
+  isPaymentPlanRequested Boolean                  @default(false)
   /// @sensitivity:internal
   pendingSince         DateTime?                @default(now())
 

--- a/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
@@ -10,7 +10,7 @@
  * We seed enrollments with controlled pendingSince so each boundary is hit:
  *   day 1/3/6  -> warned, NOT deleted
  *   day 7      -> deleted
- * paymentPlanRequested:true rows are filtered out of the query entirely and
+ * isPaymentPlanRequested:true rows are filtered out of the query entirely and
  * therefore survive forever.
  */
 
@@ -54,7 +54,7 @@ describe('Cron Pending-Participants API Integration Tests', () => {
         await mkParticipant('day3');
         await mkParticipant('day6');
         await mkParticipant('day7');
-        await mkParticipant('plan'); // paymentPlanRequested -> never swept
+        await mkParticipant('plan'); // isPaymentPlanRequested -> never swept
 
         await prisma.programParticipant.createMany({
             data: [
@@ -62,7 +62,7 @@ describe('Cron Pending-Participants API Integration Tests', () => {
                 { programId, participantId: ids.day3, status: 'PENDING', pendingSince: daysAgo(now, 3) },
                 { programId, participantId: ids.day6, status: 'PENDING', pendingSince: daysAgo(now, 6) },
                 { programId, participantId: ids.day7, status: 'PENDING', pendingSince: daysAgo(now, 7) },
-                { programId, participantId: ids.plan, status: 'PENDING', pendingSince: daysAgo(now, 8), paymentPlanRequested: true },
+                { programId, participantId: ids.plan, status: 'PENDING', pendingSince: daysAgo(now, 8), isPaymentPlanRequested: true },
             ]
         });
     });

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -121,7 +121,7 @@ describe('Membership BG review API', () => {
 
         // rev2 approves with volunteer checkbox -> advances
         as(rev2, { backgroundCheckReviewer: true });
-        const r2 = await ATTEST(req({ processId: proc.processId, result: 'APPROVE', markedVolunteer: true }) as never);
+        const r2 = await ATTEST(req({ processId: proc.processId, result: 'APPROVE', isMarkedVolunteer: true }) as never);
         expect((await r2.json()).outcome.status).toBe('PENDING_PAYMENT');
 
         const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -105,7 +105,7 @@ describe('Nav todo-counts API', () => {
         program1Id = program1.id;
         program2Id = program2.id;
         await prisma.programParticipant.create({ data: { programId: program1Id, participantId: leadId, status: 'PENDING' } });
-        await prisma.programParticipant.create({ data: { programId: program2Id, participantId: secondMemberId, status: 'PENDING', paymentPlanRequested: true } });
+        await prisma.programParticipant.create({ data: { programId: program2Id, participantId: secondMemberId, status: 'PENDING', isPaymentPlanRequested: true } });
 
         // Household B: a board member with no household todos of their own.
         const board = await prisma.participant.create({

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -86,8 +86,8 @@ describe('Program payment-plan routes', () => {
     async function enroll(participantId: number, opts: { requested: boolean }) {
         await prisma.programParticipant.upsert({
             where: { programId_participantId: { programId, participantId } },
-            update: { status: 'PENDING', paymentPlanRequested: opts.requested, pendingSince: new Date() },
-            create: { programId, participantId, status: 'PENDING', paymentPlanRequested: opts.requested, pendingSince: new Date() },
+            update: { status: 'PENDING', isPaymentPlanRequested: opts.requested, pendingSince: new Date() },
+            create: { programId, participantId, status: 'PENDING', isPaymentPlanRequested: opts.requested, pendingSince: new Date() },
         });
     }
 
@@ -111,7 +111,7 @@ describe('Program payment-plan routes', () => {
             expect(res.status).toBe(403);
         });
 
-        it('returns only PENDING + paymentPlanRequested rows to a board member', async () => {
+        it('returns only PENDING + isPaymentPlanRequested rows to a board member', async () => {
             await enroll(selfId, { requested: true });   // should appear
             await enroll(noiseId, { requested: false });  // should NOT appear
             mockSession.mockResolvedValue({ user: { id: boardId, boardMember: true } });
@@ -152,7 +152,7 @@ describe('Program payment-plan routes', () => {
                 where: { programId_participantId: { programId, participantId: selfId } },
             });
             expect(row?.status).toBe('ACTIVE');
-            expect(row?.paymentPlanRequested).toBe(false);
+            expect(row?.isPaymentPlanRequested).toBe(false);
             expect(row?.pendingSince).toBeNull();
         });
     });
@@ -195,7 +195,7 @@ describe('Program payment-plan routes', () => {
             const row = await prisma.programParticipant.findUnique({
                 where: { programId_participantId: { programId, participantId: selfId } },
             });
-            expect(row?.paymentPlanRequested).toBe(false);
+            expect(row?.isPaymentPlanRequested).toBe(false);
         });
 
         it('200 when the participant requests their own payment plan', async () => {
@@ -207,7 +207,7 @@ describe('Program payment-plan routes', () => {
             const row = await prisma.programParticipant.findUnique({
                 where: { programId_participantId: { programId, participantId: selfId } },
             });
-            expect(row?.paymentPlanRequested).toBe(true);
+            expect(row?.isPaymentPlanRequested).toBe(true);
         });
     });
 });

--- a/checkin-app/src/app/api/cron/pending-participants/route.ts
+++ b/checkin-app/src/app/api/cron/pending-participants/route.ts
@@ -11,7 +11,7 @@ export async function GET(req: Request) {
         const pendingParticipants = await prisma.programParticipant.findMany({
             where: {
                 status: 'PENDING',
-                paymentPlanRequested: false,
+                isPaymentPlanRequested: false,
                 pendingSince: { not: null }
             },
             include: {

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -20,7 +20,7 @@ export async function GET() {
     try {
         const requests = await prisma.programParticipant.findMany({
             where: {
-                paymentPlanRequested: true,
+                isPaymentPlanRequested: true,
                 status: 'PENDING'
             },
             include: {
@@ -65,7 +65,7 @@ export async function POST(req: Request) {
             },
             data: {
                 status: 'ACTIVE',
-                paymentPlanRequested: false, // cleared since it's approved
+                isPaymentPlanRequested: false, // cleared since it's approved
                 pendingSince: null // reset
             }
         });

--- a/checkin-app/src/app/api/membership-ops/applications/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/route.ts
@@ -26,7 +26,7 @@ export const GET = handler("GET /api/membership-ops/applications", async () => {
             bgConsentAt: true,
             bgClearedAt: true,
             paidAt: true,
-            attestations: { select: { id: true, result: true, markedVolunteer: true } },
+            attestations: { select: { id: true, result: true, isMarkedVolunteer: true } },
             membership: {
                 select: {
                     householdId: true,

--- a/checkin-app/src/app/api/membership/reviews/route.ts
+++ b/checkin-app/src/app/api/membership/reviews/route.ts
@@ -51,10 +51,10 @@ export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
     return { MembershipProcess: queue };
 });
 
-// POST /api/membership/reviews — submit an attestation { processId, result, markedVolunteer }.
+// POST /api/membership/reviews — submit an attestation { processId, result, isMarkedVolunteer }.
 export const POST = withAuth({ roles: ["backgroundCheckReviewer"] }, async (req, auth) => {
     if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    let body: { processId?: number; result?: "APPROVE" | "REJECT"; markedVolunteer?: boolean };
+    let body: { processId?: number; result?: "APPROVE" | "REJECT"; isMarkedVolunteer?: boolean };
     try {
         body = await req.json();
     } catch {
@@ -64,7 +64,7 @@ export const POST = withAuth({ roles: ["backgroundCheckReviewer"] }, async (req,
         return NextResponse.json({ error: "processId and result (APPROVE|REJECT) are required" }, { status: 400 });
     }
     try {
-        const outcome = await attest(auth.user.id, body.processId, { result: body.result, markedVolunteer: body.markedVolunteer });
+        const outcome = await attest(auth.user.id, body.processId, { result: body.result, isMarkedVolunteer: body.isMarkedVolunteer });
         return NextResponse.json({ outcome });
     } catch (error) {
         if (error instanceof ReviewError) {

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -192,7 +192,7 @@ export const GET = withAuth({}, async (_req, auth) => {
                 where: { status: { not: "ACTIVE" } },
             }),
             prisma.programParticipant.count({
-                where: { status: "PENDING", paymentPlanRequested: true },
+                where: { status: "PENDING", isPaymentPlanRequested: true },
             }),
             prisma.trustedAdultReview.count({
                 where: { status: "PENDING_BOARD_REVIEW" },

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         // Authorization: only the participant themselves, a lead of their household,
         // the program's lead mentor, or a sysadmin/board member may request a payment
         // plan for this enrollment. Without this gate any authenticated user could flip
-        // paymentPlanRequested on an arbitrary participant's enrollment (IDOR).
+        // isPaymentPlanRequested on an arbitrary participant's enrollment (IDOR).
         const currentUserId = (session.user as { id: number }).id;
         const isSelf = currentUserId === participantId;
         const isSysAdminOrBoard = (session.user as { sysadmin?: boolean, boardMember?: boolean })?.sysadmin
@@ -71,7 +71,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                 programId_participantId: { programId, participantId }
             },
             data: {
-                paymentPlanRequested: true
+                isPaymentPlanRequested: true
             }
         });
 

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -13,7 +13,7 @@ interface Participant {
 interface Attestation {
   id: number;
   result: string;
-  markedVolunteer: boolean;
+  isMarkedVolunteer: boolean;
 }
 interface ProcessRow {
   id: number;

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -60,7 +60,7 @@ export default function MembershipReviewPage() {
       const res = await fetch("/api/membership/reviews", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ processId, result, markedVolunteer: !!volunteer[processId] }),
+        body: JSON.stringify({ processId, result, isMarkedVolunteer: !!volunteer[processId] }),
       });
       const data = await res.json();
       if (res.ok) {

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -147,7 +147,7 @@ export async function eligibleReviewProcessIds(reviewerId: number): Promise<numb
 export async function attest(
     reviewerId: number,
     processId: number,
-    input: { result: "APPROVE" | "REJECT"; markedVolunteer?: boolean },
+    input: { result: "APPROVE" | "REJECT"; isMarkedVolunteer?: boolean },
 ) {
     const reviewer = await loadReviewer(reviewerId);
     if (!reviewer?.backgroundCheckReviewer) throw new ReviewError("not_reviewer", "You are not a background-check reviewer.");
@@ -172,7 +172,7 @@ export async function attest(
         if (process.attestations.some((a) => a.reviewer.householdId === reviewer.householdId)) throw new ReviewError("same_household_reviewer", "Another reviewer from your household has already reviewed this application.");
 
         await tx.backgroundCheckAttestation.create({
-            data: { processId, reviewerId, result: input.result, markedVolunteer: !!input.markedVolunteer },
+            data: { processId, reviewerId, result: input.result, isMarkedVolunteer: !!input.isMarkedVolunteer },
         });
 
         if (input.result === "REJECT") {
@@ -223,7 +223,7 @@ async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: nu
     // Stamp the guardians' (household leads') lastBackgroundCheck. Expiry is derived from this
     // plus BoardSettings.bgRecheckMonths at read time (see householdBgIsFresh) — not stored.
     await tx.participant.updateMany({ where: { householdId, householdLeads: { some: { householdId } } }, data: { lastBackgroundCheck: now } });
-    await applyVolunteerStatus(tx, process.membershipId, householdId, process.attestations.some((a) => a.markedVolunteer));
+    await applyVolunteerStatus(tx, process.membershipId, householdId, process.attestations.some((a) => a.isMarkedVolunteer));
 
     await tx.membershipProcess.update({
         where: { id: processId },

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -91,7 +91,7 @@ export const classifications = {
         processId: 'public',
         reviewerId: 'public',
         result: 'internal',
-        markedVolunteer: 'internal',
+        isMarkedVolunteer: 'internal',
         createdAt: 'public',
     },
     VolunteerDesignation: {
@@ -194,7 +194,7 @@ export const classifications = {
         programId: 'public',
         participantId: 'public',
         status: 'public',
-        paymentPlanRequested: 'personal',
+        isPaymentPlanRequested: 'personal',
         pendingSince: 'internal',
     },
     Fee: {


### PR DESCRIPTION
## What

Renames two Prisma boolean fields to the `is*` convention:

- `ProgramParticipant.paymentPlanRequested` → `isPaymentPlanRequested`
- `BackgroundCheckAttestation.markedVolunteer` → `isMarkedVolunteer`

(`isVolunteer` / `isCore` already conformed and are untouched.)

## Why

Naming normalization — booleans should read as predicates. Matches the recent schema cleanup pass.

## Changes

- Schema field renames in `prisma/schema.prisma`.
- All call sites updated: routes, `lib/membership/review.ts`, pages, and integration tests. The whole chain was renamed (including the membership-review API JSON body key) so there's no partial naming mismatch between the DB field and the request contract.
- Regenerated `src/security/generated/classifications.ts` (tiers unchanged).

## Migration

`20260629130000_rename_booleans_is_prefix` uses `ALTER TABLE ... RENAME COLUMN` — **data-preserving**. (Letting Prisma autogenerate would drop+add and lose existing values, since it can't detect renames.)

## Reviewer notes

- No behavior change — pure rename.
- Pre-commit jest reports 0 tests inside git worktrees (`testPathIgnorePatterns` matches the worktree root); CI runs the integration tier normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)