### PR TITLE
refactor(schema): rename Visit.arrived/departed → arrivedAt/departedAt

### DIFF
--- a/checkin-app/prisma/migrations/20260629171140_rename_visit_arrived_departed/migration.sql
+++ b/checkin-app/prisma/migrations/20260629171140_rename_visit_arrived_departed/migration.sql
@@ -1,0 +1,13 @@
+-- Rename Visit.arrived -> arrivedAt and Visit.departed -> departedAt.
+-- Hand-edited from Prisma's default DROP/ADD to RENAME COLUMN so existing
+-- visit data is preserved. The index holds no data, so dropping/recreating it is fine.
+
+-- DropIndex
+DROP INDEX "Visit_participantId_departed_idx";
+
+-- AlterTable
+ALTER TABLE "Visit" RENAME COLUMN "arrived" TO "arrivedAt";
+ALTER TABLE "Visit" RENAME COLUMN "departed" TO "departedAt";
+
+-- CreateIndex
+CREATE INDEX "Visit_participantId_departedAt_idx" ON "Visit"("participantId", "departedAt");

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -759,9 +759,9 @@ model Visit {
   /// @sensitivity:public
   participantId     Int
   /// @sensitivity:personal
-  arrived           DateTime
+  arrivedAt         DateTime
   /// @sensitivity:personal
-  departed          DateTime?
+  departedAt        DateTime?
   /// @sensitivity:public
   arrivedVia        VisitSource?
   /// @sensitivity:public
@@ -772,7 +772,7 @@ model Visit {
   participant Participant @relation(fields: [participantId], references: [id])
   event       Event?      @relation(fields: [associatedEventId], references: [id])
 
-  @@index([participantId, departed]) // Active visits lookup in /api/scan
+  @@index([participantId, departedAt]) // Active visits lookup in /api/scan
 }
 
 model AuditLog {

--- a/checkin-app/prisma/seed_20_users.ts
+++ b/checkin-app/prisma/seed_20_users.ts
@@ -43,11 +43,11 @@ async function main() {
             }
         })
 
-        // Mark them as arrived so they show up as "present" just in case limitToPresent is true
+        // Mark them as arrivedAt so they show up as "present" just in case limitToPresent is true
         await prisma.visit.create({
             data: {
                 participantId: participant.id,
-                arrived: new Date()
+                arrivedAt: new Date()
             }
         })
         

--- a/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
@@ -57,7 +57,7 @@ describe('Admin Visits API Integration Tests', () => {
         const visit = await prisma.visit.create({
             data: {
                 participantId: testUserId,
-                arrived: new Date(Date.now() - 3600000), // 1 hour ago
+                arrivedAt: new Date(Date.now() - 3600000), // 1 hour ago
             }
         });
         testVisitId = visit.id;
@@ -128,7 +128,7 @@ describe('Admin Visits API Integration Tests', () => {
 
             const req = new Request('http://localhost:4000/api/facility/visits', {
                 method: 'PATCH',
-                body: JSON.stringify({ visitId: testVisitId, departed: new Date().toISOString() })
+                body: JSON.stringify({ visitId: testVisitId, departedAt: new Date().toISOString() })
             });
 
             const res = await PATCH(req as unknown as import("next/server").NextRequest);
@@ -142,7 +142,7 @@ describe('Admin Visits API Integration Tests', () => {
 
             const req = new Request('http://localhost:4000/api/facility/visits', {
                 method: 'PATCH',
-                body: JSON.stringify({ visitId: testVisitId, departed: new Date().toISOString() })
+                body: JSON.stringify({ visitId: testVisitId, departedAt: new Date().toISOString() })
             });
 
             const res = await PATCH(req as unknown as import("next/server").NextRequest);
@@ -156,7 +156,7 @@ describe('Admin Visits API Integration Tests', () => {
 
             const req = new Request('http://localhost:4000/api/facility/visits', {
                 method: 'PATCH',
-                body: JSON.stringify({ departed: new Date().toISOString() })
+                body: JSON.stringify({ departedAt: new Date().toISOString() })
             });
 
             const res = await PATCH(req as unknown as import("next/server").NextRequest);
@@ -177,16 +177,16 @@ describe('Admin Visits API Integration Tests', () => {
             const now = new Date();
             const req = new Request('http://localhost:4000/api/facility/visits', {
                 method: 'PATCH',
-                body: JSON.stringify({ visitId: testVisitId, departed: now.toISOString() })
+                body: JSON.stringify({ visitId: testVisitId, departedAt: now.toISOString() })
             });
 
             const res = await PATCH(req as unknown as import("next/server").NextRequest);
             expect(res.status).toBe(200);
             const data = await res.json();
-            expect(new Date(data.visit.departed).toISOString()).toBe(now.toISOString());
+            expect(new Date(data.visit.departedAt).toISOString()).toBe(now.toISOString());
 
             const updatedVisit = await prisma.visit.findUnique({ where: { id: testVisitId } });
-            expect(updatedVisit?.departed?.toISOString()).toBe(now.toISOString());
+            expect(updatedVisit?.departedAt?.toISOString()).toBe(now.toISOString());
 
             const currentAuditLogs = await prisma.auditLog.count({
                 where: { actorId: testAdminId, action: 'EDIT', tableName: 'Visit' }

--- a/checkin-app/src/app/__tests__/attendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendance.integration.test.ts
@@ -73,7 +73,7 @@ describe('Attendance API Integration Tests', () => {
         testHouseholdMemberId = householdMember.id;
 
         const visit = await prisma.visit.create({
-            data: { participantId: testParticipantId, arrived: new Date() }
+            data: { participantId: testParticipantId, arrivedAt: new Date() }
         });
         activeVisitId = visit.id;
     });
@@ -131,7 +131,7 @@ describe('Attendance API Integration Tests', () => {
         it('should allow a household lead to check out a household member', async () => {
             // Setup a visit for the household member
             const memberVisit = await prisma.visit.create({
-                data: { participantId: testHouseholdMemberId, arrived: new Date() }
+                data: { participantId: testHouseholdMemberId, arrivedAt: new Date() }
             });
 
             (getServerSession as jest.Mock).mockResolvedValue({
@@ -153,7 +153,7 @@ describe('Attendance API Integration Tests', () => {
 
             const data = await res.json();
             expect(data.success).toBe(true);
-            expect(data.visit.departed).not.toBeNull();
+            expect(data.visit.departedAt).not.toBeNull();
         });
 
         it('should not allow a regular user to check out someone else', async () => {

--- a/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
@@ -113,12 +113,12 @@ describe('General Attendance API Integration Tests', () => {
 
         // Create initial active visits
         const commonVisit = await prisma.visit.create({
-            data: { participantId: commonId, arrived: new Date() }
+            data: { participantId: commonId, arrivedAt: new Date() }
         });
         activeVisitId = commonVisit.id;
 
         const childVisit = await prisma.visit.create({
-            data: { participantId: householdChildId, arrived: new Date() }
+            data: { participantId: householdChildId, arrivedAt: new Date() }
         });
         childActiveVisitId = childVisit.id;
     });
@@ -238,7 +238,7 @@ describe('General Attendance API Integration Tests', () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: householdLeadId, householdId: 1, householdLead: true } });
 
              // Note: First we must clear the child's visit to simulate checking them back in
-             await prisma.visit.update({ where: { id: childActiveVisitId }, data: { departed: new Date() } });
+             await prisma.visit.update({ where: { id: childActiveVisitId }, data: { departedAt: new Date() } });
 
              const req = new Request(`http://localhost:4000/api/attendance`, {
                  method: 'POST',
@@ -320,7 +320,7 @@ describe('General Attendance API Integration Tests', () => {
         it('should block a common user from checking out another user', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
 
-             // Admin hasn't departed
+             // Admin hasn't departedAt
              const req = new Request(`http://localhost:4000/api/attendance`, {
                  method: 'DELETE',
                  body: JSON.stringify({ visitId: childActiveVisitId }) // the child's visit
@@ -346,7 +346,7 @@ describe('General Attendance API Integration Tests', () => {
              
              const data = await res.json();
              expect(data.success).toBe(true);
-             expect(data.visit.departed).not.toBeNull();
+             expect(data.visit.departedAt).not.toBeNull();
         });
     });
 });

--- a/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
@@ -69,7 +69,7 @@ describe('Manual Attendance API Integration Tests', () => {
 
             const req = new Request('http://localhost:4000/api/attendance/manual', {
                 method: 'POST',
-                body: JSON.stringify({ arrived: new Date().toISOString() })
+                body: JSON.stringify({ arrivedAt: new Date().toISOString() })
             });
 
             const res = await POST(req as unknown as import("next/server").NextRequest);
@@ -85,7 +85,7 @@ describe('Manual Attendance API Integration Tests', () => {
 
             const req = new Request('http://localhost:4000/api/attendance/manual', {
                 method: 'POST',
-                body: JSON.stringify({ departed: new Date().toISOString() }) // No arrived time
+                body: JSON.stringify({ departedAt: new Date().toISOString() }) // No arrivedAt time
             });
 
             const res = await POST(req as unknown as import("next/server").NextRequest);
@@ -101,7 +101,7 @@ describe('Manual Attendance API Integration Tests', () => {
 
             const req = new Request('http://localhost:4000/api/attendance/manual', {
                 method: 'POST',
-                body: JSON.stringify({ arrived: 'not-a-date' })
+                body: JSON.stringify({ arrivedAt: 'not-a-date' })
             });
 
             const res = await POST(req as unknown as import("next/server").NextRequest);
@@ -115,12 +115,12 @@ describe('Manual Attendance API Integration Tests', () => {
                 user: { id: testUserId }
             });
 
-            const arrived = new Date();
-            const departed = new Date(arrived.getTime() - 3600000); // 1 hour BEFORE arrival
+            const arrivedAt = new Date();
+            const departedAt = new Date(arrivedAt.getTime() - 3600000); // 1 hour BEFORE arrival
 
             const req = new Request('http://localhost:4000/api/attendance/manual', {
                 method: 'POST',
-                body: JSON.stringify({ arrived: arrived.toISOString(), departed: departed.toISOString() })
+                body: JSON.stringify({ arrivedAt: arrivedAt.toISOString(), departedAt: departedAt.toISOString() })
             });
 
             const res = await POST(req as unknown as import("next/server").NextRequest);
@@ -129,13 +129,13 @@ describe('Manual Attendance API Integration Tests', () => {
             expect(data.error).toBe('Departure time must be after arrival time');
         });
 
-        it('should successfully record a manual visit with both arrived and departed defined', async () => {
+        it('should successfully record a manual visit with both arrivedAt and departedAt defined', async () => {
             (getServerSession as jest.Mock).mockResolvedValue({
                 user: { id: testUserId }
             });
 
-            const arrived = new Date(Date.now() - 7200000); // 2 hours ago
-            const departed = new Date(Date.now() - 3600000); // 1 hour ago
+            const arrivedAt = new Date(Date.now() - 7200000); // 2 hours ago
+            const departedAt = new Date(Date.now() - 3600000); // 1 hour ago
 
             const previousAuditLogs = await prisma.auditLog.count({
                 where: { actorId: testUserId, action: 'CREATE', tableName: 'Visit' }
@@ -143,7 +143,7 @@ describe('Manual Attendance API Integration Tests', () => {
 
             const req = new Request('http://localhost:4000/api/attendance/manual', {
                 method: 'POST',
-                body: JSON.stringify({ arrived: arrived.toISOString(), departed: departed.toISOString() })
+                body: JSON.stringify({ arrivedAt: arrivedAt.toISOString(), departedAt: departedAt.toISOString() })
             });
 
             const res = await POST(req as unknown as import("next/server").NextRequest);
@@ -153,8 +153,8 @@ describe('Manual Attendance API Integration Tests', () => {
             expect(data.message).toBe('Manual visit recorded successfully.');
             expect(data.visit).toBeDefined();
             expect(data.visit.participantId).toBe(testUserId);
-            expect(new Date(data.visit.arrived).toISOString()).toBe(arrived.toISOString());
-            expect(new Date(data.visit.departed).toISOString()).toBe(departed.toISOString());
+            expect(new Date(data.visit.arrivedAt).toISOString()).toBe(arrivedAt.toISOString());
+            expect(new Date(data.visit.departedAt).toISOString()).toBe(departedAt.toISOString());
 
             const currentAuditLogs = await prisma.auditLog.count({
                 where: { actorId: testUserId, action: 'CREATE', tableName: 'Visit' }
@@ -162,16 +162,16 @@ describe('Manual Attendance API Integration Tests', () => {
             expect(currentAuditLogs).toBe(previousAuditLogs + 1);
         });
 
-        it('should successfully record a manual visit with arrived only', async () => {
+        it('should successfully record a manual visit with arrivedAt only', async () => {
             (getServerSession as jest.Mock).mockResolvedValue({
                 user: { id: testUserId }
             });
 
-            const arrived = new Date(Date.now() - 1800000); // 30 minutes ago
+            const arrivedAt = new Date(Date.now() - 1800000); // 30 minutes ago
 
             const req = new Request('http://localhost:4000/api/attendance/manual', {
                 method: 'POST',
-                body: JSON.stringify({ arrived: arrived.toISOString() })
+                body: JSON.stringify({ arrivedAt: arrivedAt.toISOString() })
             });
 
             const res = await POST(req as unknown as import("next/server").NextRequest);
@@ -180,8 +180,8 @@ describe('Manual Attendance API Integration Tests', () => {
             
             expect(data.message).toBe('Manual visit recorded successfully.');
             expect(data.visit).toBeDefined();
-            expect(new Date(data.visit.arrived).toISOString()).toBe(arrived.toISOString());
-            expect(data.visit.departed).toBeNull();
+            expect(new Date(data.visit.arrivedAt).toISOString()).toBe(arrivedAt.toISOString());
+            expect(data.visit.departedAt).toBeNull();
         });
 
         it('dedups a SERIAL double-submit: second POST returns the same open visit, only one in DB', async () => {
@@ -190,12 +190,12 @@ describe('Manual Attendance API Integration Tests', () => {
             });
 
             // Isolate: drop any open visit left by earlier tests so the count is unambiguous.
-            await prisma.visit.deleteMany({ where: { participantId: testUserId, departed: null } });
+            await prisma.visit.deleteMany({ where: { participantId: testUserId, departedAt: null } });
 
-            const arrived = new Date(Date.now() - 600000).toISOString(); // 10 min ago, open (no departure)
+            const arrivedAt = new Date(Date.now() - 600000).toISOString(); // 10 min ago, open (no departure)
             const makeReq = () => new Request('http://localhost:4000/api/attendance/manual', {
                 method: 'POST',
-                body: JSON.stringify({ arrived })
+                body: JSON.stringify({ arrivedAt })
             }) as unknown as import("next/server").NextRequest;
 
             // Two submits, strictly one after the other (not the pool-2 concurrency harness):
@@ -212,7 +212,7 @@ describe('Manual Attendance API Integration Tests', () => {
             expect(second.id).toBe(first.id);
 
             const openVisits = await prisma.visit.findMany({
-                where: { participantId: testUserId, departed: null }
+                where: { participantId: testUserId, departedAt: null }
             });
             expect(openVisits.length).toBe(1);
             expect(openVisits[0].id).toBe(first.id);

--- a/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
@@ -4,7 +4,7 @@
 /**
  * Concurrency regression test for POST /api/attendance/manual.
  *
- * Creating an open visit (arrived, no departure) is a read-modify-write on a
+ * Creating an open visit (arrivedAt, no departure) is a read-modify-write on a
  * participant's visit state, same as /api/scan. Before the per-participant
  * advisory lock (route.ts ~line 40), two near-simultaneous manual check-ins for
  * one participant could both pass the open-visit re-check and both create a
@@ -35,15 +35,15 @@ jest.mock('next-auth/next', () => ({
 
 const EMAIL_TAG = 'manual-attendance-concurrency-test';
 
-function manualRequest(arrived: string) {
+function manualRequest(arrivedAt: string) {
     return new Request('http://localhost:4000/api/attendance/manual', {
         method: 'POST',
-        body: JSON.stringify({ arrived }),
+        body: JSON.stringify({ arrivedAt }),
     }) as unknown as import('next/server').NextRequest;
 }
 
 async function openVisitCount(participantId: number) {
-    return prisma.visit.count({ where: { participantId, departed: null } });
+    return prisma.visit.count({ where: { participantId, departedAt: null } });
 }
 
 describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
@@ -84,11 +84,11 @@ describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
 
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: subjectId } });
 
-        const arrived = new Date(Date.now() - 1800000).toISOString(); // 30 min ago
+        const arrivedAt = new Date(Date.now() - 1800000).toISOString(); // 30 min ago
 
         const [resA, resB] = await Promise.all([
-            POST(manualRequest(arrived)) as Promise<Response>,
-            POST(manualRequest(arrived)) as Promise<Response>,
+            POST(manualRequest(arrivedAt)) as Promise<Response>,
+            POST(manualRequest(arrivedAt)) as Promise<Response>,
         ]);
 
         // Neither request errors (loser no-ops by returning the existing visit).

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -220,7 +220,7 @@ describe('AuditLog Integration Tests', () => {
         testEventId = event.id;
 
         const visit = await prisma.visit.create({
-            data: { participantId: testParticipantId, arrived: new Date(Date.now() - 100000), departed: new Date(Date.now() + 100000) }
+            data: { participantId: testParticipantId, arrivedAt: new Date(Date.now() - 100000), departedAt: new Date(Date.now() + 100000) }
         });
         testVisitId = visit.id;
 
@@ -374,7 +374,7 @@ describe('AuditLog Integration Tests', () => {
     it('visit edit (PATCH /admin/visits) writes one AuditLog snapshotting the visit', async () => {
         const owner = await makeParticipant('visit-owner');
         const visit = await prisma.visit.create({
-            data: { participantId: owner.id, arrived: new Date(), departed: new Date() },
+            data: { participantId: owner.id, arrivedAt: new Date(), departedAt: new Date() },
             select: { id: true },
         });
         createdVisitIds.push(visit.id);
@@ -382,7 +382,7 @@ describe('AuditLog Integration Tests', () => {
         const newArrived = new Date('2020-01-01T10:00:00.000Z');
         const req = new Request('http://localhost:4000/api/facility/visits', {
             method: 'PATCH',
-            body: JSON.stringify({ visitId: visit.id, arrived: newArrived.toISOString() }),
+            body: JSON.stringify({ visitId: visit.id, arrivedAt: newArrived.toISOString() }),
         });
 
         const res = await updateVisit(req as never);

--- a/checkin-app/src/app/__tests__/autoAssociation.integration.test.ts
+++ b/checkin-app/src/app/__tests__/autoAssociation.integration.test.ts
@@ -155,7 +155,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
             const visit = await prisma.visit.create({
                 data: {
                     participantId,
-                    arrived: new Date(`${baseDateString}10:15:00Z`),
+                    arrivedAt: new Date(`${baseDateString}10:15:00Z`),
                     associatedEventId: eventAId
                 }
             });
@@ -165,7 +165,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
 
             expect(finalVisits.length).toBe(1);
             expect(finalVisits[0].associatedEventId).toBe(eventAId);
-            expect(finalVisits[0].departed).toEqual(checkoutTime);
+            expect(finalVisits[0].departedAt).toEqual(checkoutTime);
         });
 
         it('should split a visit spanning back-to-back enrolled events', async () => {
@@ -174,7 +174,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
             const visit = await prisma.visit.create({
                 data: {
                     participantId,
-                    arrived: arrivalTime,
+                    arrivedAt: arrivalTime,
                     associatedEventId: null // We'll say it wasn't associated on entry for testing the chunker
                 }
             });
@@ -189,16 +189,16 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
             
             expect(finalVisits.length).toBe(3);
             
-            expect(finalVisits[0].arrived).toEqual(arrivalTime);
-            expect(finalVisits[0].departed).toEqual(new Date(`${baseDateString}10:00:00Z`));
+            expect(finalVisits[0].arrivedAt).toEqual(arrivalTime);
+            expect(finalVisits[0].departedAt).toEqual(new Date(`${baseDateString}10:00:00Z`));
             expect(finalVisits[0].associatedEventId).toBeNull();
 
-            expect(finalVisits[1].arrived).toEqual(new Date(`${baseDateString}10:00:00Z`));
-            expect(finalVisits[1].departed).toEqual(new Date(`${baseDateString}12:00:00Z`));
+            expect(finalVisits[1].arrivedAt).toEqual(new Date(`${baseDateString}10:00:00Z`));
+            expect(finalVisits[1].departedAt).toEqual(new Date(`${baseDateString}12:00:00Z`));
             expect(finalVisits[1].associatedEventId).toBe(eventAId);
 
-            expect(finalVisits[2].arrived).toEqual(new Date(`${baseDateString}12:00:00Z`));
-            expect(finalVisits[2].departed).toEqual(checkoutTime);
+            expect(finalVisits[2].arrivedAt).toEqual(new Date(`${baseDateString}12:00:00Z`));
+            expect(finalVisits[2].departedAt).toEqual(checkoutTime);
             expect(finalVisits[2].associatedEventId).toBe(eventBId);
         });
 
@@ -213,7 +213,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
             const visit = await prisma.visit.create({
                 data: {
                     participantId,
-                    arrived: arrivalTime,
+                    arrivedAt: arrivalTime,
                     associatedEventId: eventAId
                 }
             });
@@ -227,8 +227,8 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
             expect(finalVisits.length).toBe(1);
 
             expect(finalVisits[0].associatedEventId).toBe(eventAId);
-            expect(finalVisits[0].arrived).toEqual(arrivalTime);
-            expect(finalVisits[0].departed).toEqual(checkoutTime);
+            expect(finalVisits[0].arrivedAt).toEqual(arrivalTime);
+            expect(finalVisits[0].departedAt).toEqual(checkoutTime);
         });
 
         it('should chunk into Event D if user is lead mentor', async () => {
@@ -237,7 +237,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
             const visit = await prisma.visit.create({
                 data: {
                     participantId,
-                    arrived: arrivalTime
+                    arrivedAt: arrivalTime
                 }
             });
 
@@ -248,11 +248,11 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
 
             // 1. Unassociated gap (13:30 -> 14:00)
             expect(finalVisits[0].associatedEventId).toBeNull();
-            expect(finalVisits[0].departed).toEqual(new Date(`${baseDateString}14:00:00Z`));
+            expect(finalVisits[0].departedAt).toEqual(new Date(`${baseDateString}14:00:00Z`));
 
             // 2. Event D (14:00 -> 15:00)
             expect(finalVisits[1].associatedEventId).toBe(eventDId);
-            expect(finalVisits[1].departed).toEqual(checkoutTime);
+            expect(finalVisits[1].departedAt).toEqual(checkoutTime);
         });
     });
 });

--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -87,11 +87,11 @@ describe('Cron Nightly API Integration Tests', () => {
 
         // Setup Abandoned Visits
         await prisma.visit.create({
-            data: { participantId: keyholderId, arrived: justEndedStart } // Never departed
+            data: { participantId: keyholderId, arrivedAt: justEndedStart } // Never departedAt
         });
 
         await prisma.visit.create({
-            data: { participantId: normalUserId, arrived: justEndedStart, associatedEventId: eventId } // Never departed
+            data: { participantId: normalUserId, arrivedAt: justEndedStart, associatedEventId: eventId } // Never departedAt
         });
     });
 
@@ -151,7 +151,7 @@ describe('Cron Nightly API Integration Tests', () => {
 
             // Db checks
             const abandonedVisits = await prisma.visit.findMany({
-                where: { departed: null, participant: { email: { contains: '-nightly@' } } }
+                where: { departedAt: null, participant: { email: { contains: '-nightly@' } } }
             });
             expect(abandonedVisits.length).toBe(0); // Everyone checked out
 
@@ -174,11 +174,11 @@ describe('Cron Nightly API Integration Tests', () => {
         };
 
         // Close any visit still open from a prior test so the route's global
-        // `departed: null` sweep counts only the visits this test creates.
+        // `departedAt: null` sweep counts only the visits this test creates.
         async function closeAllOpenVisits() {
             await prisma.visit.updateMany({
-                where: { departed: null },
-                data: { departed: new Date() }
+                where: { departedAt: null },
+                data: { departedAt: new Date() }
             });
         }
 
@@ -189,22 +189,22 @@ describe('Cron Nightly API Integration Tests', () => {
             await closeAllOpenVisits();
             await prisma.auditLog.deleteMany();
 
-            const arrived = new Date(Date.now() - 2 * 60 * 60 * 1000);
+            const arrivedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
 
             // An extra plain participant (no program enrollment -> simple close path)
-            // so we have two GOOD visits whose `departed` we can assert by id.
+            // so we have two GOOD visits whose `departedAt` we can assert by id.
             const extra = await prisma.participant.create({
                 data: { email: 'extra-nightly@example.com', name: 'Extra User', household: { create: {} } }
             });
 
             const badVisit = await prisma.visit.create({
-                data: { participantId: keyholderId, arrived } // keyholder -> triggers board notify
+                data: { participantId: keyholderId, arrivedAt } // keyholder -> triggers board notify
             });
             const goodVisitA = await prisma.visit.create({
-                data: { participantId: normalUserId, arrived }
+                data: { participantId: normalUserId, arrivedAt }
             });
             const goodVisitB = await prisma.visit.create({
-                data: { participantId: extra.id, arrived }
+                data: { participantId: extra.id, arrivedAt }
             });
 
             mockBadVisitIds.clear();
@@ -226,13 +226,13 @@ describe('Cron Nightly API Integration Tests', () => {
                 expect(data.facilityClose.boardNotified).toBe(true);
                 expect(await systemNotifyCount()).toBe(1);
 
-                // Good visits really departed; the failed one stays open.
+                // Good visits really departedAt; the failed one stays open.
                 const a = await prisma.visit.findUnique({ where: { id: goodVisitA.id } });
                 const b = await prisma.visit.findUnique({ where: { id: goodVisitB.id } });
                 const bad = await prisma.visit.findUnique({ where: { id: badVisit.id } });
-                expect(a?.departed).not.toBeNull();
-                expect(b?.departed).not.toBeNull();
-                expect(bad?.departed).toBeNull();
+                expect(a?.departedAt).not.toBeNull();
+                expect(b?.departedAt).not.toBeNull();
+                expect(bad?.departedAt).toBeNull();
             } finally {
                 mockBadVisitIds.clear();
             }
@@ -246,9 +246,9 @@ describe('Cron Nightly API Integration Tests', () => {
             // Let the post-event email fire again on run 1 so we can prove run 2 does not re-send.
             await prisma.event.update({ where: { id: eventId }, data: { postEventEmailSent: false } });
 
-            const arrived = new Date(Date.now() - 2 * 60 * 60 * 1000);
-            await prisma.visit.create({ data: { participantId: keyholderId, arrived } });
-            await prisma.visit.create({ data: { participantId: normalUserId, arrived, associatedEventId: eventId } });
+            const arrivedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+            await prisma.visit.create({ data: { participantId: keyholderId, arrivedAt } });
+            await prisma.visit.create({ data: { participantId: normalUserId, arrivedAt, associatedEventId: eventId } });
 
             // --- Run 1: real work happens ---
             const res1 = await GET(cronReq());

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -60,7 +60,7 @@ describe("GET /api/cron/post-event", () => {
         });
 
         await prisma.visit.create({
-            data: { associatedEventId: event.id, participantId: user.id, arrived: pastStart }
+            data: { associatedEventId: event.id, participantId: user.id, arrivedAt: pastStart }
         });
 
         process.env.CRON_SECRET = 'test-secret';

--- a/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
@@ -191,8 +191,8 @@ describe('Event Attendance API Integration Tests', () => {
                 where: { participantId: testParticipant1Id, associatedEventId: testEventId }
             });
             expect(visits.length).toBe(1);
-            expect(visits[0].arrived).not.toBeNull();
-            expect(visits[0].departed).not.toBeNull();
+            expect(visits[0].arrivedAt).not.toBeNull();
+            expect(visits[0].departedAt).not.toBeNull();
 
             // Audit: exactly one row keyed by the new Visit's PK, event in
             // secondaryAffectedEntity, crediting the acting lead mentor.
@@ -222,8 +222,8 @@ describe('Event Attendance API Integration Tests', () => {
             await prisma.visit.create({
                 data: {
                     participantId: testParticipant2Id,
-                    arrived: earlyArrival,
-                    departed: null, // Still active
+                    arrivedAt: earlyArrival,
+                    departedAt: null, // Still active
                 }
             });
 
@@ -244,7 +244,7 @@ describe('Event Attendance API Integration Tests', () => {
             });
             expect(visits.length).toBe(1); // Should only be the one we created
             expect(visits[0].associatedEventId).toBe(testEventId); // It was successfully linked
-            expect(visits[0].arrived.getTime()).toBe(earlyArrival.getTime()); // Validates it used the existing visit
+            expect(visits[0].arrivedAt.getTime()).toBe(earlyArrival.getTime()); // Validates it used the existing visit
 
             // Audit: exactly one row keyed by the linked Visit's PK, event in
             // secondaryAffectedEntity, crediting the acting admin.

--- a/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
@@ -12,7 +12,7 @@
  * Harness mirrors eventRescheduleClearsReminder.integration.test.ts.
  *
  * BUG 2 (manual "Absent" deleting a live/open check-in) is now FIXED: an Absent
- * edit against an OPEN visit (departed = null) is rejected with 400 so the row
+ * edit against an OPEN visit (departedAt = null) is rejected with 400 so the row
  * proving the participant is physically on-site survives. Only CLOSED visits are
  * removed on an Absent correction. See the manualEditAttendance block below.
  */
@@ -110,7 +110,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             const event = await makeEvent('single-cancel', 2 * HOUR);
             await prisma.rSVP.create({ data: { eventId: event.id, participantId, status: 'ATTENDING' } });
             const visit = await prisma.visit.create({
-                data: { participantId, arrived: new Date(), associatedEventId: event.id },
+                data: { participantId, arrivedAt: new Date(), associatedEventId: event.id },
             });
 
             const res = await patch(event.id, { action: 'cancel' });
@@ -158,7 +158,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             const event = await makeEvent('manual-present', -1 * HOUR);
             const openArrival = new Date(Date.now() - 90 * MIN);
             const openVisit = await prisma.visit.create({
-                data: { participantId, arrived: openArrival, departed: null, associatedEventId: event.id },
+                data: { participantId, arrivedAt: openArrival, departedAt: null, associatedEventId: event.id },
             });
 
             const newArrival = new Date(Date.now() - 80 * MIN);
@@ -166,24 +166,24 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
                 action: 'manualEditAttendance',
                 participantId,
                 status: 'Present',
-                arrived: newArrival.toISOString(),
+                arrivedAt: newArrival.toISOString(),
             });
             expect(res.status).toBe(200);
 
             const visits = await prisma.visit.findMany({ where: { participantId, associatedEventId: event.id } });
             expect(visits.length).toBe(1);               // not a second visit
             expect(visits[0].id).toBe(openVisit.id);     // same row, updated in place
-            expect(visits[0].arrived.getTime()).toBe(newArrival.getTime());
+            expect(visits[0].arrivedAt.getTime()).toBe(newArrival.getTime());
         });
     });
 
     describe('manualEditAttendance — Absent vs open/closed visits', () => {
-        // An OPEN visit (departed = null) is proof the participant physically
+        // An OPEN visit (departedAt = null) is proof the participant physically
         // scanned in and is still on-site. Marking them Absent must NOT erase it.
         it('rejects Absent on a live (open) check-in and keeps the visit', async () => {
             const event = await makeEvent('manual-absent-open', -1 * HOUR);
             await prisma.visit.create({
-                data: { participantId, arrived: new Date(Date.now() - 30 * MIN), departed: null, associatedEventId: event.id },
+                data: { participantId, arrivedAt: new Date(Date.now() - 30 * MIN), departedAt: null, associatedEventId: event.id },
             });
 
             const res = await patch(event.id, { action: 'manualEditAttendance', participantId, status: 'Absent' });
@@ -193,13 +193,13 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             expect(visits.length).toBe(1); // open visit survives
         });
 
-        it('deletes a closed (departed) visit when marking Absent', async () => {
+        it('deletes a closed (departedAt) visit when marking Absent', async () => {
             const event = await makeEvent('manual-absent-closed', -2 * HOUR);
             await prisma.visit.create({
                 data: {
                     participantId,
-                    arrived: new Date(Date.now() - 90 * MIN),
-                    departed: new Date(Date.now() - 60 * MIN),
+                    arrivedAt: new Date(Date.now() - 90 * MIN),
+                    departedAt: new Date(Date.now() - 60 * MIN),
                     associatedEventId: event.id,
                 },
             });
@@ -216,13 +216,13 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             await prisma.visit.create({
                 data: {
                     participantId,
-                    arrived: new Date(Date.now() - 110 * MIN),
-                    departed: new Date(Date.now() - 80 * MIN),
+                    arrivedAt: new Date(Date.now() - 110 * MIN),
+                    departedAt: new Date(Date.now() - 80 * MIN),
                     associatedEventId: event.id,
                 },
             });
             await prisma.visit.create({
-                data: { participantId, arrived: new Date(Date.now() - 30 * MIN), departed: null, associatedEventId: event.id },
+                data: { participantId, arrivedAt: new Date(Date.now() - 30 * MIN), departedAt: null, associatedEventId: event.id },
             });
 
             const res = await patch(event.id, { action: 'manualEditAttendance', participantId, status: 'Absent' });

--- a/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
@@ -90,7 +90,7 @@ describe('PATCH /api/events/[id] cancel — transaction rollback on partial fail
             data: { eventId: event.id, participantId, status: 'ATTENDING' },
         });
         await prisma.visit.create({
-            data: { participantId, arrived: start, associatedEventId: event.id },
+            data: { participantId, arrivedAt: start, associatedEventId: event.id },
         });
         return event.id;
     }

--- a/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
@@ -94,15 +94,15 @@ describe('Household Visits API Integration Tests', () => {
         // Create visits for the test household
         await prisma.visit.createMany({
             data: [
-                { participantId: leadUser.id, arrived: new Date(now.getTime() - 1000) }, // Just now
-                { participantId: memberUser.id, arrived: new Date(now.getTime() - 86400000) }, // 1 day ago
-                { participantId: leadUser.id, arrived: new Date(now.getTime() - 864000000) }, // 10 days ago (outside 7 day window)
+                { participantId: leadUser.id, arrivedAt: new Date(now.getTime() - 1000) }, // Just now
+                { participantId: memberUser.id, arrivedAt: new Date(now.getTime() - 86400000) }, // 1 day ago
+                { participantId: leadUser.id, arrivedAt: new Date(now.getTime() - 864000000) }, // 10 days ago (outside 7 day window)
             ]
         });
 
         // Create visit for other household
         await prisma.visit.create({
-            data: { participantId: otherUser.id, arrived: new Date(now.getTime() - 2000) }
+            data: { participantId: otherUser.id, arrivedAt: new Date(now.getTime() - 2000) }
         });
     });
 

--- a/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
@@ -79,7 +79,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
         });
 
         await prisma.visit.create({
-            data: { participantId: testUserId, arrived: new Date() }
+            data: { participantId: testUserId, arrivedAt: new Date() }
         });
     });
 

--- a/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
@@ -60,8 +60,8 @@ describe('Profile API Integration Tests', () => {
         // Create visits for history testing
         await prisma.visit.createMany({
             data: [
-                { participantId: testUserId, arrived: new Date(Date.now() - 3600000) },
-                { participantId: testUserId, arrived: new Date(Date.now() - 7200000) }
+                { participantId: testUserId, arrivedAt: new Date(Date.now() - 3600000) },
+                { participantId: testUserId, arrivedAt: new Date(Date.now() - 7200000) }
             ]
         });
     });

--- a/checkin-app/src/app/__tests__/profileVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileVisitsAPI.integration.test.ts
@@ -53,9 +53,9 @@ describe('Profile Visits API Integration Tests', () => {
         // Create visits for the test user
         await prisma.visit.createMany({
             data: [
-                { participantId: testUserId, arrived: new Date(now.getTime() - 1000) }, // Just now
-                { participantId: testUserId, arrived: new Date(now.getTime() - 86400000) }, // 1 day ago
-                { participantId: testUserId, arrived: new Date(now.getTime() - 864000000) }, // 10 days ago (outside 7 day window)
+                { participantId: testUserId, arrivedAt: new Date(now.getTime() - 1000) }, // Just now
+                { participantId: testUserId, arrivedAt: new Date(now.getTime() - 86400000) }, // 1 day ago
+                { participantId: testUserId, arrivedAt: new Date(now.getTime() - 864000000) }, // 10 days ago (outside 7 day window)
             ]
         });
     });

--- a/checkin-app/src/app/__tests__/scanAuth.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanAuth.integration.test.ts
@@ -146,7 +146,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             expect(json.type).toBe('checkin');
             expect(json.signedRequest).toBe(true);
 
-            const visit = await prisma.visit.findFirst({ where: { participantId: kioskId, departed: null } });
+            const visit = await prisma.visit.findFirst({ where: { participantId: kioskId, departedAt: null } });
             expect(visit).not.toBeNull();
             const events = await prisma.rawBadgeLog.count({ where: { participantId: kioskId } });
             expect(events).toBe(1);
@@ -280,7 +280,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
 
         /** Open the facility so a non-keyholder check-in can reach 200. */
         async function openFacility() {
-            await prisma.visit.create({ data: { participantId: pKeyholder, arrived: new Date() } });
+            await prisma.visit.create({ data: { participantId: pKeyholder, arrivedAt: new Date() } });
         }
 
         it('non-admin scanning self in prod → 403 (self-check-in gate, must use kiosk)', async () => {
@@ -307,7 +307,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             expect(res.status).toBe(200);
             const json = await res.json();
             expect(json.type).toBe('checkin');
-            const visit = await prisma.visit.findFirst({ where: { participantId: pSameHH, departed: null } });
+            const visit = await prisma.visit.findFirst({ where: { participantId: pSameHH, departedAt: null } });
             expect(visit).not.toBeNull();
         });
 

--- a/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
@@ -90,13 +90,13 @@ describe('Scan causal chain — last keyholder closes facility', () => {
         await flush(); // let the fire-and-forget dynamic import resolve
         expect(processPostEventEmails).toHaveBeenCalledWith({ forceImmediate: true });
 
-        const open = await prisma.visit.count({ where: { participantId: keyholder.id, departed: null } });
+        const open = await prisma.visit.count({ where: { participantId: keyholder.id, departedAt: null } });
         expect(open).toBe(0);
     });
 
     it('force-closes (departing everyone) when a recent double-badge confirms, then sends post-event emails', async () => {
-        const kVisit = await prisma.visit.create({ data: { participantId: keyholder.id, arrived: new Date() } });
-        await prisma.visit.create({ data: { participantId: normal.id, arrived: new Date() } });
+        const kVisit = await prisma.visit.create({ data: { participantId: keyholder.id, arrivedAt: new Date() } });
+        await prisma.visit.create({ data: { participantId: normal.id, arrivedAt: new Date() } });
         // Two keyholder badge events 5s apart (<=12s) → confirmed force-close.
         await prisma.rawBadgeLog.create({ data: { participantId: keyholder.id, time: new Date(Date.now() - 5000) } });
         await prisma.rawBadgeLog.create({ data: { participantId: keyholder.id, time: new Date() } });
@@ -108,16 +108,16 @@ describe('Scan causal chain — last keyholder closes facility', () => {
         await flush();
         expect(processPostEventEmails).toHaveBeenCalledWith({ forceImmediate: true });
 
-        // Everyone is departed, including the other attendee.
+        // Everyone is departedAt, including the other attendee.
         const openAnyone = await prisma.visit.count({
-            where: { participantId: { in: [keyholder.id, normal.id] }, departed: null },
+            where: { participantId: { in: [keyholder.id, normal.id] }, departedAt: null },
         });
         expect(openAnyone).toBe(0);
     });
 
     it('warns instead of closing when others are present and there is no recent double-badge', async () => {
-        const kVisit = await prisma.visit.create({ data: { participantId: keyholder.id, arrived: new Date() } });
-        await prisma.visit.create({ data: { participantId: normal.id, arrived: new Date() } });
+        const kVisit = await prisma.visit.create({ data: { participantId: keyholder.id, arrivedAt: new Date() } });
+        await prisma.visit.create({ data: { participantId: normal.id, arrivedAt: new Date() } });
 
         const res = await processCheckout(keyholder, kVisit.id, 'kiosk');
         expect(res.status).toBe(400);
@@ -126,7 +126,7 @@ describe('Scan causal chain — last keyholder closes facility', () => {
 
         // Nothing closed: both visits remain open and no emails fired.
         const open = await prisma.visit.count({
-            where: { participantId: { in: [keyholder.id, normal.id] }, departed: null },
+            where: { participantId: { in: [keyholder.id, normal.id] }, departedAt: null },
         });
         expect(open).toBe(2);
         expect(processPostEventEmails).not.toHaveBeenCalled();

--- a/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
@@ -101,12 +101,12 @@ describe('POST /api/scan — real check-in/out logic', () => {
 
         const visit = await prisma.visit.findFirst({ where: { participantId: keyholderId } });
         expect(visit).not.toBeNull();
-        expect(visit?.departed).toBeNull();
+        expect(visit?.departedAt).toBeNull();
     });
 
-    it('orders check-in then check-out on a second scan: arrived set first, departed after', async () => {
+    it('orders check-in then check-out on a second scan: arrivedAt set first, departedAt after', async () => {
         // Seed an open keyholder visit so the facility is open for the normal user.
-        await prisma.visit.create({ data: { participantId: keyholderId, arrived: new Date() } });
+        await prisma.visit.create({ data: { participantId: keyholderId, arrivedAt: new Date() } });
 
         // First scan → check-in.
         const checkinRes = await POST(scanReq(normalId));
@@ -114,10 +114,10 @@ describe('POST /api/scan — real check-in/out logic', () => {
         expect((await checkinRes.json()).type).toBe('checkin');
 
         const openVisit = await prisma.visit.findFirst({
-            where: { participantId: normalId, departed: null },
+            where: { participantId: normalId, departedAt: null },
         });
         expect(openVisit).not.toBeNull();
-        expect(openVisit?.arrived).toBeInstanceOf(Date);
+        expect(openVisit?.arrivedAt).toBeInstanceOf(Date);
 
         // Backdate the badge event so the second scan is past the 3s debounce window.
         await prisma.rawBadgeLog.updateMany({
@@ -132,15 +132,15 @@ describe('POST /api/scan — real check-in/out logic', () => {
 
         const closedVisit = await prisma.visit.findFirst({
             where: { participantId: normalId },
-            orderBy: { arrived: 'desc' },
+            orderBy: { arrivedAt: 'desc' },
         });
-        expect(closedVisit?.departed).toBeInstanceOf(Date);
+        expect(closedVisit?.departedAt).toBeInstanceOf(Date);
         // Ordering invariant: departure never precedes arrival.
-        expect(closedVisit!.departed!.getTime()).toBeGreaterThanOrEqual(closedVisit!.arrived.getTime());
+        expect(closedVisit!.departedAt!.getTime()).toBeGreaterThanOrEqual(closedVisit!.arrivedAt.getTime());
     });
 
     it('silently debounces a repeated scan within 3 seconds (no second visit)', async () => {
-        await prisma.visit.create({ data: { participantId: keyholderId, arrived: new Date() } });
+        await prisma.visit.create({ data: { participantId: keyholderId, arrivedAt: new Date() } });
 
         const first = await POST(scanReq(normalId));
         expect((await first.json()).type).toBe('checkin');
@@ -151,7 +151,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
         expect(json.type).toBe('ignored_debounce');
 
         // The debounced scan must NOT have flipped the open visit to checked-out.
-        const open = await prisma.visit.count({ where: { participantId: normalId, departed: null } });
+        const open = await prisma.visit.count({ where: { participantId: normalId, departedAt: null } });
         expect(open).toBe(1);
     });
 

--- a/checkin-app/src/app/__tests__/scanConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanConcurrency.integration.test.ts
@@ -54,7 +54,7 @@ function scanRequest(participantId: number) {
 }
 
 async function openVisitCount(participantId: number) {
-    return prisma.visit.count({ where: { participantId, departed: null } });
+    return prisma.visit.count({ where: { participantId, departedAt: null } });
 }
 
 describe('POST /api/scan concurrency (advisory lock)', () => {
@@ -84,7 +84,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         keeperId = keeper.id;
         // Keep the keyholder checked in so non-keyholder check-ins are allowed
         // and non-keyholder check-outs skip the last-keyholder force-close path.
-        await prisma.visit.create({ data: { participantId: keeperId, arrived: new Date() } });
+        await prisma.visit.create({ data: { participantId: keeperId, arrivedAt: new Date() } });
 
         const checkinSubject = await prisma.participant.create({
             data: { email: `checkin-${EMAIL_TAG}@example.com`, name: 'Checkin Subject', household: { create: {} } },
@@ -137,7 +137,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         // Fresh state: exactly one open visit, no recent badge event.
         await prisma.visit.deleteMany({ where: { participantId: checkoutSubjectId } });
         await prisma.rawBadgeLog.deleteMany({ where: { participantId: checkoutSubjectId } });
-        await prisma.visit.create({ data: { participantId: checkoutSubjectId, arrived: new Date() } });
+        await prisma.visit.create({ data: { participantId: checkoutSubjectId, arrivedAt: new Date() } });
         expect(await openVisitCount(checkoutSubjectId)).toBe(1);
 
         const [resA, resB] = await Promise.all([

--- a/checkin-app/src/app/api/attendance/manual/route.ts
+++ b/checkin-app/src/app/api/attendance/manual/route.ts
@@ -15,14 +15,14 @@ export async function POST(req: NextRequest) {
 
         const userId = session.user.id;
         const body = await req.json();
-        const { arrived, departed } = body;
+        const { arrivedAt, departedAt } = body;
 
-        if (!arrived) {
+        if (!arrivedAt) {
             return NextResponse.json({ error: "Arrival time is required" }, { status: 400 });
         }
 
-        const arrivalTime = new Date(arrived);
-        const departureTime = departed ? new Date(departed) : null;
+        const arrivalTime = new Date(arrivedAt);
+        const departureTime = departedAt ? new Date(departedAt) : null;
 
         if (isNaN(arrivalTime.getTime())) {
             return NextResponse.json({ error: "Invalid arrival time" }, { status: 400 });
@@ -50,7 +50,7 @@ export async function POST(req: NextRequest) {
             // provided) is just a historical record, so multiple are fine.
             if (!departureTime) {
                 const openVisit = await tx.visit.findFirst({
-                    where: { participantId: userId, departed: null }
+                    where: { participantId: userId, departedAt: null }
                 });
                 if (openVisit) return openVisit;
             }
@@ -58,8 +58,8 @@ export async function POST(req: NextRequest) {
             return await tx.visit.create({
                 data: {
                     participantId: userId,
-                    arrived: arrivalTime,
-                    departed: departureTime,
+                    arrivedAt: arrivalTime,
+                    departedAt: departureTime,
                     arrivedVia: "WEB",
                     departedVia: departureTime ? "WEB" : null,
                     associatedEventId: eventId
@@ -82,7 +82,7 @@ export async function POST(req: NextRequest) {
                 action: "CREATE",
                 tableName: "Visit",
                 affectedEntityId: visit.id,
-                newData: JSON.stringify({ arrived, departed, type: "manual_entry" })
+                newData: JSON.stringify({ arrivedAt, departedAt, type: "manual_entry" })
             }
         });
 

--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -173,7 +173,7 @@ export async function POST(req: Request) {
             const activeVisit = await prisma.visit.findFirst({
                 where: {
                     participantId: participant.id,
-                    departed: null
+                    departedAt: null
                 }
             });
 
@@ -187,7 +187,7 @@ export async function POST(req: Request) {
             const newVisit = await prisma.visit.create({
                 data: {
                     participantId: participant.id,
-                    arrived: arrivalTime,
+                    arrivedAt: arrivalTime,
                     arrivedVia: "WEB",
                     associatedEventId: eventId
                 }

--- a/checkin-app/src/app/api/cron/nightly/route.ts
+++ b/checkin-app/src/app/api/cron/nightly/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: Request) {
         // 1. Find all users who are currently checked in (abandoned visits)
         const abandonedVisits = await prisma.visit.findMany({
             where: {
-                departed: null
+                departedAt: null
             },
             include: {
                 participant: true

--- a/checkin-app/src/app/api/events/[id]/attendance/route.ts
+++ b/checkin-app/src/app/api/events/[id]/attendance/route.ts
@@ -49,10 +49,10 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                 where: {
                     participantId: { in: participantIds },
                     associatedEventId: null,
-                    arrived: { lte: event.end },
+                    arrivedAt: { lte: event.end },
                     OR: [
-                        { departed: null },
-                        { departed: { gte: event.start } }
+                        { departedAt: null },
+                        { departedAt: { gte: event.start } }
                     ]
                 }
             });
@@ -93,8 +93,8 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                         data: {
                             participantId: pId,
                             associatedEventId: eventId,
-                            arrived: event.start,
-                            departed: event.end,
+                            arrivedAt: event.start,
+                            departedAt: event.end,
                             arrivedVia: "WEB",
                             departedVia: "WEB"
                         }

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -198,21 +198,21 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
                 return NextResponse.json({ error: "Forbidden: Not authorized to edit attendance" }, { status: 403 });
             }
 
-            const { participantId, status, arrived, departed } = body;
+            const { participantId, status, arrivedAt, departedAt } = body;
 
             if (!participantId || !status) {
                 return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
             }
 
             if (status === 'Absent') {
-                // An open visit (departed = null) means they physically scanned in
+                // An open visit (departedAt = null) means they physically scanned in
                 // and are currently on-site. Deleting it would destroy the live
                 // roster of who's in the building — reject instead.
                 const openVisit = await prisma.visit.findFirst({
                     where: {
                         participantId: Number(participantId),
                         associatedEventId: eventId,
-                        departed: null
+                        departedAt: null
                     }
                 });
                 if (openVisit) {
@@ -226,7 +226,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
                     }
                 });
             } else if (status === 'Present') {
-                if (!arrived) {
+                if (!arrivedAt) {
                     return NextResponse.json({ error: "Arrival time is required for Present status" }, { status: 400 });
                 }
 
@@ -242,10 +242,10 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
                     await prisma.visit.update({
                         where: { id: existingVisit.id },
                         data: {
-                            arrived: new Date(arrived),
-                            departed: departed ? new Date(departed) : null,
+                            arrivedAt: new Date(arrivedAt),
+                            departedAt: departedAt ? new Date(departedAt) : null,
                             arrivedVia: "WEB",
-                            departedVia: departed ? "WEB" : null
+                            departedVia: departedAt ? "WEB" : null
                         }
                     });
                 } else {
@@ -253,10 +253,10 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
                         data: {
                             participantId: Number(participantId),
                             associatedEventId: eventId,
-                            arrived: new Date(arrived),
-                            departed: departed ? new Date(departed) : null,
+                            arrivedAt: new Date(arrivedAt),
+                            departedAt: departedAt ? new Date(departedAt) : null,
                             arrivedVia: "WEB",
-                            departedVia: departed ? "WEB" : null
+                            departedVia: departedAt ? "WEB" : null
                         }
                     });
                 }

--- a/checkin-app/src/app/api/facility/trends/route.ts
+++ b/checkin-app/src/app/api/facility/trends/route.ts
@@ -92,8 +92,8 @@ export const GET = withAuth(
             const since = new Date(Date.now() - lookbackMs);
 
             const whereClause: Record<string, unknown> = {
-                arrived: { gte: since },
-                departed: { not: null },
+                arrivedAt: { gte: since },
+                departedAt: { not: null },
             };
 
             if (programId) {
@@ -106,7 +106,7 @@ export const GET = withAuth(
                     participant: { select: { id: true, dob: true } },
                     event: { select: { programId: true } },
                 },
-                orderBy: { arrived: "asc" },
+                orderBy: { arrivedAt: "asc" },
             });
 
             const bucketMap = new Map<string, {
@@ -121,7 +121,7 @@ export const GET = withAuth(
             }>();
 
             for (const visit of visits) {
-                const periodStart = getPeriodStart(visit.arrived, period);
+                const periodStart = getPeriodStart(visit.arrivedAt, period);
                 const key = periodStart.toISOString();
 
                 if (!bucketMap.has(key)) {
@@ -138,8 +138,8 @@ export const GET = withAuth(
                 }
 
                 const bucket = bucketMap.get(key)!;
-                const hours = getHoursBetween(visit.arrived, visit.departed);
-                const student = isStudentAtDate(visit.participant.dob, visit.arrived);
+                const hours = getHoursBetween(visit.arrivedAt, visit.departedAt);
+                const student = isStudentAtDate(visit.participant.dob, visit.arrivedAt);
 
                 if (student) {
                     bucket.studentIds.add(visit.participant.id);
@@ -172,8 +172,8 @@ export const GET = withAuth(
             const totals: TrendBucket = {
                 label: "Total",
                 periodStart: "",
-                uniqueVolunteers: new Set(visits.filter(v => !isStudentAtDate(v.participant.dob, v.arrived)).map(v => v.participant.id)).size,
-                uniqueStudents: new Set(visits.filter(v => isStudentAtDate(v.participant.dob, v.arrived)).map(v => v.participant.id)).size,
+                uniqueVolunteers: new Set(visits.filter(v => !isStudentAtDate(v.participant.dob, v.arrivedAt)).map(v => v.participant.id)).size,
+                uniqueStudents: new Set(visits.filter(v => isStudentAtDate(v.participant.dob, v.arrivedAt)).map(v => v.participant.id)).size,
                 totalVolunteerHours: Math.round(buckets.reduce((s, b) => s + b.totalVolunteerHours, 0) * 10) / 10,
                 totalStudentHours: Math.round(buckets.reduce((s, b) => s + b.totalStudentHours, 0) * 10) / 10,
                 structuredHours: Math.round(buckets.reduce((s, b) => s + b.structuredHours, 0) * 10) / 10,

--- a/checkin-app/src/app/api/facility/visits/route.ts
+++ b/checkin-app/src/app/api/facility/visits/route.ts
@@ -8,7 +8,7 @@ export const GET = withAuth(
         try {
             const visits = await prisma.visit.findMany({
                 take: 50,
-                orderBy: { arrived: "desc" },
+                orderBy: { arrivedAt: "desc" },
                 include: {
                     participant: {
                         select: { email: true, name: true, sysadmin: true, keyholder: true },
@@ -28,7 +28,7 @@ export const PATCH = withAuth(
     { roles: ['sysadmin', 'boardMember'] },
     async (req, auth) => {
         try {
-            const { visitId, arrived, departed } = await req.json();
+            const { visitId, arrivedAt, departedAt } = await req.json();
 
             if (!visitId) {
                 return NextResponse.json({ error: "visitId is required." }, { status: 400 });
@@ -37,8 +37,8 @@ export const PATCH = withAuth(
             const updatedVisit = await prisma.visit.update({
                 where: { id: visitId },
                 data: {
-                    ...(arrived ? { arrived: new Date(arrived), arrivedVia: "WEB" } : {}),
-                    ...(departed ? { departed: new Date(departed), departedVia: "WEB" } : {}),
+                    ...(arrivedAt ? { arrivedAt: new Date(arrivedAt), arrivedVia: "WEB" } : {}),
+                    ...(departedAt ? { departedAt: new Date(departedAt), departedVia: "WEB" } : {}),
                 },
             });
 

--- a/checkin-app/src/app/api/household/visits/route.ts
+++ b/checkin-app/src/app/api/household/visits/route.ts
@@ -41,12 +41,12 @@ export const GET = withAuth(
                     participant: {
                         householdId: user.householdId
                     },
-                    arrived: {
+                    arrivedAt: {
                         gte: startDate,
                         lte: endDate
                     }
                 },
-                orderBy: { arrived: 'desc' },
+                orderBy: { arrivedAt: 'desc' },
                 include: {
                     participant: { select: { id: true, name: true } },
                     event: { select: { id: true, name: true } }

--- a/checkin-app/src/app/api/kioskdisplay/certifications/route.ts
+++ b/checkin-app/src/app/api/kioskdisplay/certifications/route.ts
@@ -18,7 +18,7 @@ export const GET = withAuth(
 
         if (limitToPresent) {
             const activeVisits = await prisma.visit.findMany({
-                where: { departed: null },
+                where: { departedAt: null },
                 include: {
                     participant: {
                         select: {
@@ -31,7 +31,7 @@ export const GET = withAuth(
                         }
                     }
                 },
-                orderBy: { arrived: "desc" }
+                orderBy: { arrivedAt: "desc" }
             });
             participantsData = activeVisits.map(v => v.participant);
         } else {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -85,7 +85,7 @@ describe("Merge Participants API", () => {
         await prisma.visit.create({
             data: {
                 participantId: pMergeId,
-                arrived: new Date()
+                arrivedAt: new Date()
             }
         });
 
@@ -117,7 +117,7 @@ describe("Merge Participants API", () => {
 
     it("should write an AuditLog row capturing the merge", async () => {
         await prisma.visit.create({
-            data: { participantId: pMergeId, arrived: new Date() }
+            data: { participantId: pMergeId, arrivedAt: new Date() }
         });
 
         const req = new Request("http://localhost/api/membership-ops/participants/merge", {

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -167,9 +167,9 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     // Global informational counts (not scoped to the caller).
     const [building, buildingHousehold, activePrograms] = await Promise.all([
-        prisma.visit.count({ where: { departed: null } }),
+        prisma.visit.count({ where: { departedAt: null } }),
         user.householdId
-            ? prisma.visit.count({ where: { departed: null, participant: { householdId: user.householdId } } })
+            ? prisma.visit.count({ where: { departedAt: null, participant: { householdId: user.householdId } } })
             : Promise.resolve(0),
         prisma.program.count({ where: { phase: "RUNNING" } }),
     ]);

--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -9,7 +9,7 @@ export const GET = handler('GET /api/profile', async ({ auth }) => {
         where: { id: auth.user.id },
         include: {
             visits: {
-                orderBy: { arrived: 'desc' },
+                orderBy: { arrivedAt: 'desc' },
                 take: 50,
                 include: { event: true },
             },

--- a/checkin-app/src/app/api/profile/visits/route.ts
+++ b/checkin-app/src/app/api/profile/visits/route.ts
@@ -30,16 +30,16 @@ export const GET = withAuth(
             const visits = await prisma.visit.findMany({
                 where: {
                     participantId: userId,
-                    arrived: {
+                    arrivedAt: {
                         gte: startDate,
                         lte: endDate
                     }
                 },
-                orderBy: { arrived: 'desc' },
+                orderBy: { arrivedAt: 'desc' },
                 select: {
                     id: true,
-                    arrived: true,
-                    departed: true,
+                    arrivedAt: true,
+                    departedAt: true,
                     event: { select: { name: true } }
                 }
             });

--- a/checkin-app/src/app/api/safety/emergency-contacts/route.ts
+++ b/checkin-app/src/app/api/safety/emergency-contacts/route.ts
@@ -15,7 +15,7 @@ export const GET = withAuth(
                             name: true,
                             email: true,
                             visits: {
-                                where: { departed: null },
+                                where: { departedAt: null },
                                 select: { id: true }
                             }
                         }

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -128,9 +128,9 @@ export async function POST(req: NextRequest) {
             const activeVisit = await tx.visit.findFirst({
                 where: {
                     participantId: participant.id,
-                    departed: null,
+                    departedAt: null,
                 },
-                orderBy: { arrived: "desc" },
+                orderBy: { arrivedAt: "desc" },
             });
 
             if (activeVisit) {

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -25,7 +25,7 @@ type Participant = {
 
 type Visit = {
   id: number;
-  arrived: string;
+  arrivedAt: string;
   participant: Participant;
   event?: { program?: { id: number; name: string } };
 };
@@ -273,7 +273,7 @@ function KioskDisplayInner() {
               {isKioskMode ? (kioskDisplayNames.get(visit.participant.id) || visit.participant.name || visit.participant.email.split("@")[0]) : (visit.participant.name || visit.participant.email.split("@")[0])}
             </Text>
             <Group gap={6} align="center">
-              <Text c="dimmed" size="xs">{formatTime(visit.arrived)}</Text>
+              <Text c="dimmed" size="xs">{formatTime(visit.arrivedAt)}</Text>
               {visit.event?.program?.name && (
                 <Badge size="xs" variant="light" style={{ background: `hsl(${hue}, 60%, 20%)`, color: `hsl(${hue}, 80%, 80%)` }} title={visit.event.program.name}>
                   {visit.event.program.name}
@@ -459,7 +459,7 @@ function KioskDisplayInner() {
                   <Group justify="space-between">
                     <div>
                       <Text fw={500}>{v.participant.name || v.participant.email.split('@')[0]}</Text>
-                      <Text size="xs" c="dimmed">Arrived: {formatTime(v.arrived)}</Text>
+                      <Text size="xs" c="dimmed">Arrived: {formatTime(v.arrivedAt)}</Text>
                     </div>
                     <Button color="red" variant="light" onClick={() => handleForceCheckout(v.id)} disabled={checkingOut === v.id}>
                       {checkingOut === v.id ? "Signing Out..." : "Sign Out"}

--- a/checkin-app/src/app/attendance/manual/page.tsx
+++ b/checkin-app/src/app/attendance/manual/page.tsx
@@ -8,8 +8,8 @@ import { AttendanceTabs } from "../AttendanceTabs";
 
 export default function ManualAttendance() {
   const { ready, loading: authLoading } = useRequireRole([]);
-  const [arrived, setArrived] = useState("");
-  const [departed, setDeparted] = useState("");
+  const [arrivedAt, setArrived] = useState("");
+  const [departedAt, setDeparted] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState("");
@@ -24,7 +24,7 @@ export default function ManualAttendance() {
       const res = await fetch("/api/attendance/manual", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ arrived, departed }),
+        body: JSON.stringify({ arrivedAt, departedAt }),
       });
 
       const data = await res.json();
@@ -64,17 +64,17 @@ export default function ManualAttendance() {
             <TextInput
               type="datetime-local"
               label="Arrival Time (Required)"
-              value={arrived}
+              value={arrivedAt}
               onChange={(e) => setArrived(e.currentTarget.value)}
               required
             />
             <TextInput
               type="datetime-local"
               label="Departure Time (Optional)"
-              value={departed}
+              value={departedAt}
               onChange={(e) => setDeparted(e.currentTarget.value)}
             />
-            <Button type="submit" disabled={loading || !arrived} loading={loading} mt="sm">
+            <Button type="submit" disabled={loading || !arrivedAt} loading={loading} mt="sm">
               Record Time Entry
             </Button>
           </Stack>

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -11,8 +11,8 @@ type VisitSource = 'SCANNER' | 'WEB' | 'SYSTEM';
 
 type Visit = {
   id: number;
-  arrived: string | null;
-  departed?: string | null;
+  arrivedAt: string | null;
+  departedAt?: string | null;
   arrivedVia?: VisitSource | null;
   departedVia?: VisitSource | null;
   participant?: { name?: string | null; email?: string | null } | null;
@@ -35,15 +35,15 @@ const SourceIcon = ({ via }: { via?: VisitSource | null }) => {
   );
 };
 
-type SortKey = 'id' | 'participant' | 'event' | 'arrived' | 'departed';
+type SortKey = 'id' | 'participant' | 'event' | 'arrivedAt' | 'departedAt';
 
 const sortValue = (v: Visit, key: SortKey): string | number => {
   switch (key) {
     case 'id': return v.id;
     case 'participant': return (v.participant?.name || v.participant?.email || '').toLowerCase();
     case 'event': return (v.event?.name || 'Open Facility').toLowerCase();
-    case 'arrived': return v.arrived ? Date.parse(v.arrived) : 0;
-    case 'departed': return v.departed ? Date.parse(v.departed) : 0;
+    case 'arrivedAt': return v.arrivedAt ? Date.parse(v.arrivedAt) : 0;
+    case 'departedAt': return v.departedAt ? Date.parse(v.departedAt) : 0;
   }
 };
 
@@ -55,9 +55,9 @@ export default function AdminVisitsPage() {
   const [message, setMessage] = useState("");
 
   const [editingVisitId, setEditingVisitId] = useState<number | null>(null);
-  const [editForm, setEditForm] = useState({ arrived: "", departed: "" });
+  const [editForm, setEditForm] = useState({ arrivedAt: "", departedAt: "" });
 
-  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'arrived', dir: 'desc' });
+  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'arrivedAt', dir: 'desc' });
 
   const sortedVisits = useMemo(() => {
     return [...visits].sort((a, b) => {
@@ -112,8 +112,8 @@ export default function AdminVisitsPage() {
 
     setEditingVisitId(visit.id);
     setEditForm({
-      arrived: toDatetimeLocal(visit.arrived),
-      departed: toDatetimeLocal(visit.departed ?? null)
+      arrivedAt: toDatetimeLocal(visit.arrivedAt),
+      departedAt: toDatetimeLocal(visit.departedAt ?? null)
     });
   };
 
@@ -124,8 +124,8 @@ export default function AdminVisitsPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           visitId: id,
-          arrived: editForm.arrived ? fromDatetimeLocal(editForm.arrived) : undefined,
-          departed: editForm.departed ? fromDatetimeLocal(editForm.departed) : undefined
+          arrivedAt: editForm.arrivedAt ? fromDatetimeLocal(editForm.arrivedAt) : undefined,
+          departedAt: editForm.departedAt ? fromDatetimeLocal(editForm.departedAt) : undefined
         })
       });
       if (res.ok) {
@@ -157,8 +157,8 @@ export default function AdminVisitsPage() {
               <SortableTh k="id" label="ID" />
               <SortableTh k="participant" label="Participant" />
               <SortableTh k="event" label="Event" />
-              <SortableTh k="arrived" label="Arrived" />
-              <SortableTh k="departed" label="Departed" />
+              <SortableTh k="arrivedAt" label="Arrived" />
+              <SortableTh k="departedAt" label="Departed" />
               <Table.Th>Actions</Table.Th>
             </Table.Tr>
           </Table.Thead>
@@ -175,16 +175,16 @@ export default function AdminVisitsPage() {
                       <TextInput
                         type="datetime-local"
                         size="xs"
-                        value={editForm.arrived}
-                        onChange={(e) => setEditForm({ ...editForm, arrived: e.currentTarget.value })}
+                        value={editForm.arrivedAt}
+                        onChange={(e) => setEditForm({ ...editForm, arrivedAt: e.currentTarget.value })}
                       />
                     </Table.Td>
                     <Table.Td>
                       <TextInput
                         type="datetime-local"
                         size="xs"
-                        value={editForm.departed}
-                        onChange={(e) => setEditForm({ ...editForm, departed: e.currentTarget.value })}
+                        value={editForm.departedAt}
+                        onChange={(e) => setEditForm({ ...editForm, departedAt: e.currentTarget.value })}
                       />
                     </Table.Td>
                     <Table.Td>
@@ -198,14 +198,14 @@ export default function AdminVisitsPage() {
                   <>
                     <Table.Td>
                       <Group gap={6} wrap="nowrap">
-                        <span>{formatDateTime(v.arrived)}</span>
+                        <span>{formatDateTime(v.arrivedAt)}</span>
                         <SourceIcon via={v.arrivedVia} />
                       </Group>
                     </Table.Td>
                     <Table.Td>
-                      {v.departed ? (
+                      {v.departedAt ? (
                         <Group gap={6} wrap="nowrap">
-                          <span>{formatDateTime(v.departed)}</span>
+                          <span>{formatDateTime(v.departedAt)}</span>
                           <SourceIcon via={v.departedVia} />
                         </Group>
                       ) : <Text component="span" c="yellow">Active</Text>}

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -25,7 +25,7 @@ type HouseholdData = {
 } & Partial<StructuredAddress> | null;
 
 const blankContactForm = { id: null as number | null, name: "", phone: "", email: "", relationship: "" };
-type Visit = { id: number; participant?: { name: string }; event?: { name: string }; arrived: string; departed?: string };
+type Visit = { id: number; participant?: { name: string }; event?: { name: string }; arrivedAt: string; departedAt?: string };
 
 export default function HouseholdPage() {
   const { data: session, status } = useSession();
@@ -560,9 +560,9 @@ export default function HouseholdPage() {
                       <div>
                         <Text fw={600} c="blue">{v.participant?.name || 'Unnamed Member'}</Text>
                         <Text size="sm" component="span">{v.event?.name || 'General Facility Visit'} </Text>
-                        <Text size="sm" c="dimmed" component="span">• {formatDateTime(v.arrived, { dateStyle: 'short', timeStyle: 'short' })} • {formatVisitRange(v.arrived, v.departed)}</Text>
+                        <Text size="sm" c="dimmed" component="span">• {formatDateTime(v.arrivedAt, { dateStyle: 'short', timeStyle: 'short' })} • {formatVisitRange(v.arrivedAt, v.departedAt)}</Text>
                       </div>
-                      {!v.departed && (
+                      {!v.departedAt && (
                         <Text size="sm" component="span" c="yellow">Active Visit</Text>
                       )}
                     </Group>

--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -8,8 +8,8 @@ import { formatDate, formatTime, formatDateTime } from '@/lib/time';
 
 type ProfileVisit = {
   id: number;
-  arrived: string;
-  departed?: string | null;
+  arrivedAt: string;
+  departedAt?: string | null;
   event?: { name?: string | null } | null;
 };
 
@@ -162,11 +162,11 @@ export default function ProfilePage() {
                   <Group justify="space-between" wrap="wrap">
                     <div>
                       <Text fw={600}>{v.event?.name || 'General Facility Visit'}</Text>
-                      <Text size="sm" c="dimmed">{formatDateTime(v.arrived)}</Text>
+                      <Text size="sm" c="dimmed">{formatDateTime(v.arrivedAt)}</Text>
                     </div>
                     <Text size="sm">
-                      {v.departed ? (
-                        <Text component="span" c="green">Departed {formatTime(v.departed)}</Text>
+                      {v.departedAt ? (
+                        <Text component="span" c="green">Departed {formatTime(v.departedAt)}</Text>
                       ) : (
                         <Text component="span" c="yellow">Active Visit</Text>
                       )}

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -35,8 +35,8 @@ type EventData = {
   visits: {
     id: number;
     participantId: number;
-    arrived: string;
-    departed: string | null;
+    arrivedAt: string;
+    departedAt: string | null;
   }[];
 };
 
@@ -151,8 +151,8 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
           action: 'manualEditAttendance',
           participantId: editingAttendance.participantId,
           status: manualStatus,
-          arrived: manualStatus === 'Present' ? fromDatetimeLocal(manualArrived) : null,
-          departed: manualStatus === 'Present' && manualDeparted ? fromDatetimeLocal(manualDeparted) : null
+          arrivedAt: manualStatus === 'Present' ? fromDatetimeLocal(manualArrived) : null,
+          departedAt: manualStatus === 'Present' && manualDeparted ? fromDatetimeLocal(manualDeparted) : null
         })
       });
       if (res.ok) {
@@ -249,9 +249,9 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
               const visit = eventData.visits.find(v => v.participantId === member.participantId);
               let statusEl;
               if (visit) {
-                const arriveTime = new Date(visit.arrived).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-                const leaveTime = visit.departed ? new Date(visit.departed).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : 'Still Here';
-                statusEl = <Text component="span" c="green">Arrived: {arriveTime} {visit.departed ? `| Left: ${leaveTime}` : ''}</Text>;
+                const arriveTime = new Date(visit.arrivedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+                const leaveTime = visit.departedAt ? new Date(visit.departedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : 'Still Here';
+                statusEl = <Text component="span" c="green">Arrived: {arriveTime} {visit.departedAt ? `| Left: ${leaveTime}` : ''}</Text>;
               } else {
                 statusEl = <Text component="span" c="red">Absent</Text>;
               }
@@ -273,8 +273,8 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
                           setEditingAttendance(member);
                           if (visit) {
                             setManualStatus("Present");
-                            setManualArrived(toDatetimeLocal(visit.arrived));
-                            setManualDeparted(visit.departed ? toDatetimeLocal(visit.departed) : "");
+                            setManualArrived(toDatetimeLocal(visit.arrivedAt));
+                            setManualDeparted(visit.departedAt ? toDatetimeLocal(visit.departedAt) : "");
                           } else {
                             setManualStatus("Absent");
                             setManualArrived(toDatetimeLocal(eventData.start));

--- a/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
@@ -97,14 +97,14 @@ describe('attendanceTransitions', () => {
     });
 
     describe('processVisitCheckout', () => {
-        it('closes a plain visit with no events into a single departed visit', async () => {
-            const arrived = new Date(Date.now() - 2 * HOUR);
+        it('closes a plain visit with no events into a single departedAt visit', async () => {
+            const arrivedAt = new Date(Date.now() - 2 * HOUR);
             const checkout = new Date();
-            const visit = await prisma.visit.create({ data: { participantId, arrived } });
+            const visit = await prisma.visit.create({ data: { participantId, arrivedAt } });
 
             const result = await processVisitCheckout(visit.id, checkout);
             expect(result).toHaveLength(1);
-            expect(result[0].departed).toEqual(checkout);
+            expect(result[0].departedAt).toEqual(checkout);
             expect(result[0].associatedEventId).toBeNull();
         });
 
@@ -114,7 +114,7 @@ describe('attendanceTransitions', () => {
             const eventEnd = new Date(t0.getTime() + 2 * HOUR);
             const checkout = new Date(t0.getTime() + 3 * HOUR);
             const ev = await makeEvent('mid', eventStart, eventEnd);
-            const visit = await prisma.visit.create({ data: { participantId, arrived: t0 } });
+            const visit = await prisma.visit.create({ data: { participantId, arrivedAt: t0 } });
 
             const result = await processVisitCheckout(visit.id, checkout);
 
@@ -127,10 +127,10 @@ describe('attendanceTransitions', () => {
             expect(gap).toBeDefined();
             expect(eventVisit).toBeDefined();
             // Gap covers arrival → event start; event visit covers event start → checkout.
-            expect(gap!.arrived).toEqual(t0);
-            expect(gap!.departed).toEqual(eventStart);
-            expect(eventVisit!.arrived).toEqual(eventStart);
-            expect(eventVisit!.departed).toEqual(checkout);
+            expect(gap!.arrivedAt).toEqual(t0);
+            expect(gap!.departedAt).toEqual(eventStart);
+            expect(eventVisit!.arrivedAt).toEqual(eventStart);
+            expect(eventVisit!.departedAt).toEqual(checkout);
         });
 
         it('splits back-to-back events into adjacent event visits at the handoff', async () => {
@@ -142,7 +142,7 @@ describe('attendanceTransitions', () => {
             const checkout = new Date(t0.getTime() + 4 * HOUR);
             const e1 = await makeEvent('back1', e1Start, e1End);
             const e2 = await makeEvent('back2', e2Start, e2End);
-            const visit = await prisma.visit.create({ data: { participantId, arrived: t0 } });
+            const visit = await prisma.visit.create({ data: { participantId, arrivedAt: t0 } });
 
             const result = await processVisitCheckout(visit.id, checkout);
 
@@ -151,14 +151,14 @@ describe('attendanceTransitions', () => {
             expect(v1).toBeDefined();
             expect(v2).toBeDefined();
             // Handoff: e1 visit ends exactly where e2 visit begins.
-            expect(v1!.departed).toEqual(e2Start);
-            expect(v2!.arrived).toEqual(e2Start);
-            expect(v2!.departed).toEqual(checkout);
+            expect(v1!.departedAt).toEqual(e2Start);
+            expect(v2!.arrivedAt).toEqual(e2Start);
+            expect(v2!.departedAt).toEqual(checkout);
         });
 
-        it('returns [] for an already-departed visit (idempotent)', async () => {
+        it('returns [] for an already-departedAt visit (idempotent)', async () => {
             const visit = await prisma.visit.create({
-                data: { participantId, arrived: new Date(Date.now() - HOUR), departed: new Date() },
+                data: { participantId, arrivedAt: new Date(Date.now() - HOUR), departedAt: new Date() },
             });
             const result = await processVisitCheckout(visit.id, new Date());
             expect(result).toEqual([]);

--- a/checkin-app/src/lib/attendanceTransitions.ts
+++ b/checkin-app/src/lib/attendanceTransitions.ts
@@ -91,13 +91,13 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
         where: { id: visitId }
     });
 
-    if (!originalVisit || originalVisit.departed) {
+    if (!originalVisit || originalVisit.departedAt) {
         return []; // Already checked out or doesn't exist
     }
 
     // Chunks recreated below are all segments of one physical visit: they keep
     // the original arrival's source and take `source` as their departure channel.
-    const { participantId, arrived, arrivedVia } = originalVisit;
+    const { participantId, arrivedAt, arrivedVia } = originalVisit;
 
     const relevantProgramIds = await getRelevantProgramIds(participantId, db);
 
@@ -105,7 +105,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
         // No programs enrolled, just close the visit normally
         return [await db.visit.update({
             where: { id: visitId },
-            data: { departed: checkoutTime, departedVia: source }
+            data: { departedAt: checkoutTime, departedVia: source }
         })];
     }
 
@@ -115,7 +115,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
             programId: { in: relevantProgramIds },
             // An event overlaps if it starts before checkout time AND ends after arrival time
             start: { lt: checkoutTime },
-            end: { gt: arrived }
+            end: { gt: arrivedAt }
         },
         orderBy: { start: 'asc' }
     });
@@ -124,7 +124,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
         // No relevant events during their stay, just close normally
         return [await db.visit.update({
             where: { id: visitId },
-            data: { departed: checkoutTime, departedVia: source }
+            data: { departedAt: checkoutTime, departedVia: source }
         })];
     }
 
@@ -137,7 +137,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
         });
 
         const createdVisits = [];
-        let currentIterStart = arrived;
+        let currentIterStart = arrivedAt;
 
         for (let i = 0; i < eventsDuringStay.length; i++) {
             const event = eventsDuringStay[i];
@@ -151,8 +151,8 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
                     createdVisits.push(await tx.visit.create({
                         data: {
                             participantId,
-                            arrived: currentIterStart,
-                            departed: gapEnd,
+                            arrivedAt: currentIterStart,
+                            departedAt: gapEnd,
                             arrivedVia,
                             departedVia: source,
                             associatedEventId: null
@@ -181,8 +181,8 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
                 createdVisits.push(await tx.visit.create({
                     data: {
                         participantId,
-                        arrived: eventVisitStart,
-                        departed: eventVisitEnd,
+                        arrivedAt: eventVisitStart,
+                        departedAt: eventVisitEnd,
                         arrivedVia,
                         departedVia: source,
                         associatedEventId: event.id
@@ -197,8 +197,8 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
             createdVisits.push(await tx.visit.create({
                 data: {
                     participantId,
-                    arrived: currentIterStart,
-                    departed: checkoutTime,
+                    arrivedAt: currentIterStart,
+                    departedAt: checkoutTime,
                     arrivedVia,
                     departedVia: source,
                     associatedEventId: null

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -329,9 +329,9 @@ export async function createCheckins(prisma: Db): Promise<string> {
         await prisma.visit.create({
             data: {
                 participantId: p.id,
-                arrived,
+                arrivedAt: arrived,
                 // Leave the most recent two still "here" (no departure) for active-visit screens.
-                departed: i < 2 ? null : new Date(arrived.getTime() + 90 * 60 * 1000),
+                departedAt: i < 2 ? null : new Date(arrived.getTime() + 90 * 60 * 1000),
             },
         });
         count++;

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -3,7 +3,7 @@ import { isMinor } from "@/lib/time";
 
 export async function getFullAttendance() {
     const activeVisits = await prisma.visit.findMany({
-        where: { departed: null },
+        where: { departedAt: null },
         include: {
             participant: {
                 select: {
@@ -35,7 +35,7 @@ export async function getFullAttendance() {
                 }
             }
         },
-        orderBy: { arrived: "desc" },
+        orderBy: { arrivedAt: "desc" },
     });
 
     // Pre-compute isMinor once per visit to avoid repeated calculations

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -20,7 +20,7 @@ export async function processCheckin(participant: Participant, authType: string,
     if (!participant.keyholder) {
         const activeKeyholders = await db.visit.count({
             where: {
-                departed: null,
+                departedAt: null,
                 participant: { keyholder: true }
             }
         });
@@ -36,7 +36,7 @@ export async function processCheckin(participant: Participant, authType: string,
     const newVisit = await db.visit.create({
         data: {
             participantId: participant.id,
-            arrived: arrivalTime,
+            arrivedAt: arrivalTime,
             arrivedVia: "SCANNER",
             associatedEventId: eventId
         },
@@ -74,7 +74,7 @@ export async function processCheckout(
     if (participant.keyholder) {
         const remainingKeyholders = await db.visit.count({
             where: {
-                departed: null,
+                departedAt: null,
                 participant: { keyholder: true },
                 id: { not: activeVisitId }
             }
@@ -83,7 +83,7 @@ export async function processCheckout(
         if (remainingKeyholders === 0) {
             const remainingUsers = await db.visit.findMany({
                 where: {
-                    departed: null,
+                    departedAt: null,
                     id: { not: activeVisitId }
                 },
                 include: { participant: true }
@@ -148,8 +148,8 @@ export async function processCheckout(
  *  a single atomic statement, so it needs no wrapping transaction. */
 async function closeAllOpenVisits(db: DbClient) {
     await db.visit.updateMany({
-        where: { departed: null },
-        data: { departed: new Date(), departedVia: "SYSTEM" },
+        where: { departedAt: null },
+        data: { departedAt: new Date(), departedVia: "SYSTEM" },
     });
 }
 

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -86,7 +86,7 @@ export async function buildCallerContext(auth: AuthResult): Promise<CallerContex
 
     if (ctx.isKeyholder) {
         const visits = await prisma.visit.findMany({
-            where: { departed: null },
+            where: { departedAt: null },
             select: { participantId: true },
         });
         for (const v of visits) ctx.activeVisitorIds.add(v.participantId);
@@ -223,7 +223,7 @@ export function scopesHeld(
         case 'Visit': {
             const participantId = num(row.participantId);
             if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
-            if (ctx.isKeyholder && row.departed == null) {
+            if (ctx.isKeyholder && row.departedAt == null) {
                 scopes.add('all_current_visitors');
             }
             break;

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -239,8 +239,8 @@ export const classifications = {
     Visit: {
         id: 'public',
         participantId: 'public',
-        arrived: 'personal',
-        departed: 'personal',
+        arrivedAt: 'personal',
+        departedAt: 'personal',
         arrivedVia: 'public',
         departedVia: 'public',
         associatedEventId: 'public',

--- a/checkin-app/tests/security/stripper.test.ts
+++ b/checkin-app/tests/security/stripper.test.ts
@@ -105,14 +105,14 @@ describe('scopesHeld', () => {
     });
 
     it('Visit.their_own when row.participantId === selfId', () => {
-        expect(scopesHeld('Visit', { participantId: 5, departed: null }, ctx({ selfId: 5 })).has('their_own')).toBe(true);
+        expect(scopesHeld('Visit', { participantId: 5, departedAt: null }, ctx({ selfId: 5 })).has('their_own')).toBe(true);
     });
 
-    it('Visit.all_current_visitors requires keyholder AND departed === null', () => {
+    it('Visit.all_current_visitors requires keyholder AND departedAt === null', () => {
         const keyCtx = ctx({ isKeyholder: true });
-        expect(scopesHeld('Visit', { participantId: 7, departed: null }, keyCtx).has('all_current_visitors')).toBe(true);
-        expect(scopesHeld('Visit', { participantId: 7, departed: new Date() }, keyCtx).has('all_current_visitors')).toBe(false);
-        expect(scopesHeld('Visit', { participantId: 7, departed: null }, ctx()).has('all_current_visitors')).toBe(false);
+        expect(scopesHeld('Visit', { participantId: 7, departedAt: null }, keyCtx).has('all_current_visitors')).toBe(true);
+        expect(scopesHeld('Visit', { participantId: 7, departedAt: new Date() }, keyCtx).has('all_current_visitors')).toBe(false);
+        expect(scopesHeld('Visit', { participantId: 7, departedAt: null }, ctx()).has('all_current_visitors')).toBe(false);
     });
 
     it('Household.their_households when row.id === caller.householdId', () => {


### PR DESCRIPTION
## What

Renames the two `Visit` DateTime columns to the `*At` convention:

| Before | After |
|---|---|
| `Visit.arrived` | `Visit.arrivedAt` |
| `Visit.departed` | `Visit.departedAt` |
| `@@index([participantId, departed])` | `@@index([participantId, departedAt])` |

No `@map` — Postgres column name == Prisma field name.

## Why / design

Routes return **raw Prisma rows** as JSON (`NextResponse.json({ visits })`) — no DTO/mapping layer. So the DB column name *is* the JSON response key, read by **hand-written** frontend types (`type Visit = { arrived: string }`). Those break silently (no tsc error, types aren't Prisma-derived). Decision: **full vertical rename, no aliasing** — one vocabulary end to end. Single Next app, frontend + API deploy together, no external consumer → atomic, not a breaking change.

Renamed across the whole flow: DB column → Prisma calls → raw JSON → frontend types/usages → inbound request bodies.

### Request bodies renamed on **both** ends
- Manual attendance: `attendance/manual/page.tsx` ↔ `api/attendance/manual/route.ts`
- Admin visit edit: `facility-ops/visits/page.tsx` ↔ `api/facility/visits/route.ts`
- Manual event attendance: `program-ops/sessions/[id]/page.tsx` ↔ `api/events/[id]/route.ts`

### tsc-blind spots handled by hand
`DbClient` union types and loose `Db` type disable excess-property checks; raw JSON frontend types aren't checked at all:
- `scan-service.ts` (facility open/close `departedAt: null`), `attendanceTransitions.ts`, `seed-helpers.ts`, `access-resolvers.ts` raw row read, all frontend pages.

### Deliberately left as `arrived`/`departed`
Generic util **parameters** (concept names, not the field): `getHoursBetween(...)` in `facility/trends`, `formatVisitRange(...)` in `lib/time.ts`.

## Migration

`prisma/migrations/20260629171140_rename_visit_arrived_departed/` — hand-edited from Prisma's default DROP+ADD (data loss) to:

\`\`\`sql
ALTER TABLE "Visit" RENAME COLUMN "arrived" TO "arrivedAt";
ALTER TABLE "Visit" RENAME COLUMN "departed" TO "departedAt";
\`\`\`

Index dropped/recreated (holds no data). **Verified data-safe**: a probe Visit row inserted under the old columns survived the migration intact under the new names.

## Verification
- `npx tsc --noEmit` — clean.
- Integration suite (serial `--runInBand`): **661/663 pass**. The 2 failures are in `householdLeadAPI.integration.test.ts` (board-member promotion message) — untouched by this PR, zero `arrived`/`departed` refs, **pre-existing**.
- Seed runs clean on the new names.

## Reviewer notes
- Sibling efforts are renaming other columns separately; this PR stays strictly in the `Visit.arrived`/`departed` lane. Test-merged clean against `claude/inspiring-dijkstra-93b86d`.
- Regenerate `prisma generate` after merge if `classifications.ts` drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)