### PR TITLE
refactor(schema): rename Membership.since, Participant.dob, FeePayment.paidOn

### DIFF
--- a/checkin-app/__tests__/programSignupIntegration.test.ts
+++ b/checkin-app/__tests__/programSignupIntegration.test.ts
@@ -180,7 +180,7 @@ describe('Full Program Signup Integration Flow', () => {
             maxParticipants: null,
             _count: { participants: 0 }
         });
-        (prisma.participant.findUnique as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId, dob: new Date('2015-01-01') });
+        (prisma.participant.findUnique as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId, dateOfBirth: new Date('2015-01-01') });
         (prisma.householdLead.findUnique as jest.Mock).mockResolvedValue({ householdId, participantId: leadUserId });
         (prisma.programParticipant.create as jest.Mock).mockResolvedValue({ programId, participantId: childParticipantId, status: 'PENDING' });
 
@@ -237,7 +237,7 @@ describe('Full Program Signup Integration Flow', () => {
             maxParticipants: null,
             _count: { participants: 0 }
         });
-        (prisma.participant.findUnique as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId, dob: new Date('2015-01-01') });
+        (prisma.participant.findUnique as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId, dateOfBirth: new Date('2015-01-01') });
         (prisma.householdLead.findUnique as jest.Mock).mockResolvedValue(null); // Not a lead
 
         const enrollReq = new Request(`http://localhost/api/programs/${programId}/participants`, {

--- a/checkin-app/prisma/migrations/20260629171739_rename_datetime_columns/migration.sql
+++ b/checkin-app/prisma/migrations/20260629171739_rename_datetime_columns/migration.sql
@@ -1,0 +1,11 @@
+-- Rename DateTime columns to normalized names. Data-preserving RENAME (not drop/add).
+-- FeePayment.paidOn -> paidAt; Membership.since -> memberSince; Participant.dob -> dateOfBirth.
+
+-- AlterTable
+ALTER TABLE "FeePayment" RENAME COLUMN "paidOn" TO "paidAt";
+
+-- AlterTable
+ALTER TABLE "Membership" RENAME COLUMN "since" TO "memberSince";
+
+-- AlterTable
+ALTER TABLE "Participant" RENAME COLUMN "dob" TO "dateOfBirth";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -78,7 +78,7 @@ model Participant {
   sessions      Session[]
 
   /// @sensitivity:pii
-  dob                  DateTime?
+  dateOfBirth          DateTime?
   /// @sensitivity:internal
   lastWaiverSign       DateTime?
   /// @sensitivity:internal
@@ -294,7 +294,7 @@ model Membership {
   /// @sensitivity:public
   id          Int              @id @default(autoincrement())
   /// @sensitivity:public
-  since       DateTime         @default(now())
+  memberSince DateTime         @default(now())
   /// @sensitivity:public
   status      MembershipStatus @default(NONE)
   /// @sensitivity:public
@@ -679,7 +679,7 @@ model FeePayment {
   /// @sensitivity:public
   participantId     Int
   /// @sensitivity:personal
-  paidOn            DateTime? @default(now())
+  paidAt            DateTime? @default(now())
   /// @sensitivity:personal
   shopifyLink       String?
   /// @sensitivity:personal

--- a/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
@@ -141,8 +141,8 @@ describe('Bulk import: preview vs commit consistency', () => {
         expect(body.success).toBe(true);
 
         // Commit's Excel-serial branch parses 33239 -> 1991-01-01 (an ADULT)...
-        const anchor = await prisma.participant.findUnique({ where: { email: ANCHOR_EMAIL }, select: { id: true, dob: true } });
-        expect(anchor?.dob?.getUTCFullYear()).toBe(1991);
+        const anchor = await prisma.participant.findUnique({ where: { email: ANCHOR_EMAIL }, select: { id: true, dateOfBirth: true } });
+        expect(anchor?.dateOfBirth?.getUTCFullYear()).toBe(1991);
         // ...and commit therefore makes the adult a household lead.
         const lead = await prisma.householdLead.findFirst({ where: { participantId: anchor!.id } });
         expect(lead).not.toBeNull();

--- a/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
@@ -52,7 +52,7 @@ describe('Admin Roles API Integration Tests', () => {
         testUserId = user.id;
 
         const targetUser = await prisma.participant.create({
-            data: { email: 'target-roles-api-test@example.com', name: 'Target Roles Test', dob: new Date('1990-01-01'), household: { create: {} } }
+            data: { email: 'target-roles-api-test@example.com', name: 'Target Roles Test', dateOfBirth: new Date('1990-01-01'), household: { create: {} } }
         });
         testTargetUserId = targetUser.id;
 
@@ -60,7 +60,7 @@ describe('Admin Roles API Integration Tests', () => {
         const tenYearsAgo = new Date(now.getFullYear() - 10, now.getMonth(), now.getDate());
         
         const student = await prisma.participant.create({
-            data: { email: 'student-roles-api-test@example.com', name: 'Student Roles Test', dob: tenYearsAgo, household: { create: {} } }
+            data: { email: 'student-roles-api-test@example.com', name: 'Student Roles Test', dateOfBirth: tenYearsAgo, household: { create: {} } }
         });
         testStudentId = student.id;
     });
@@ -123,8 +123,8 @@ describe('Admin Roles API Integration Tests', () => {
             const student = data.participants.find((p: { id?: number }) => p.id === testStudentId);
             expect(adult.isYouth).toBe(false);
             expect(student.isYouth).toBe(true);
-            expect(adult).not.toHaveProperty('dob');
-            expect(student).not.toHaveProperty('dob');
+            expect(adult).not.toHaveProperty('dateOfBirth');
+            expect(student).not.toHaveProperty('dateOfBirth');
         });
     });
 

--- a/checkin-app/src/app/__tests__/brokenHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/brokenHouseholdsAPI.integration.test.ts
@@ -50,11 +50,11 @@ describe('Broken Households API Integration Tests', () => {
         const broken = await prisma.household.create({ data: { name: 'Broken API Test HH Broken' } });
         brokenHouseholdId = broken.id;
         const adult = await prisma.participant.create({
-            data: { email: 'adult-broken-api-test@example.com', name: 'Broken Adult', householdId: brokenHouseholdId, dob: new Date('1990-01-01') }
+            data: { email: 'adult-broken-api-test@example.com', name: 'Broken Adult', householdId: brokenHouseholdId, dateOfBirth: new Date('1990-01-01') }
         });
         brokenAdultId = adult.id;
         await prisma.participant.create({
-            data: { email: 'minor-broken-api-test@example.com', name: 'Broken Minor', householdId: brokenHouseholdId, dob: new Date('2015-01-01') }
+            data: { email: 'minor-broken-api-test@example.com', name: 'Broken Minor', householdId: brokenHouseholdId, dateOfBirth: new Date('2015-01-01') }
         });
 
         // 2. Leadless household with no participants -> still broken (included).
@@ -65,7 +65,7 @@ describe('Broken Households API Integration Tests', () => {
         const led = await prisma.household.create({ data: { name: 'Broken API Test HH Led' } });
         ledHouseholdId = led.id;
         const leadMember = await prisma.participant.create({
-            data: { email: 'lead-broken-api-test@example.com', name: 'Existing Lead', householdId: ledHouseholdId, dob: new Date('1985-01-01') }
+            data: { email: 'lead-broken-api-test@example.com', name: 'Existing Lead', householdId: ledHouseholdId, dateOfBirth: new Date('1985-01-01') }
         });
         await prisma.householdLead.create({
             data: { householdId: ledHouseholdId, participantId: leadMember.id }

--- a/checkin-app/src/app/__tests__/directoryBoardAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/directoryBoardAPI.integration.test.ts
@@ -39,7 +39,7 @@ describe('GET /api/directory/board', () => {
                 name: `Board ${TAG}`,
                 email: `board-${TAG}@example.com`,
                 phone: '555-0001',
-                dob: new Date('1980-01-01'),
+                dateOfBirth: new Date('1980-01-01'),
                 googleId: `google-${TAG}`,
                 boardMember: true,
                 household: { create: {} },
@@ -82,7 +82,7 @@ describe('GET /api/directory/board', () => {
         expect(seeded.phone).toBe('555-0001');
         // ...but pii must never ship, for any row.
         for (const row of boardMembers) {
-            expect(row).not.toHaveProperty('dob');
+            expect(row).not.toHaveProperty('dateOfBirth');
             expect(row).not.toHaveProperty('googleId');
         }
     });
@@ -102,7 +102,7 @@ describe('GET /api/directory/board', () => {
         for (const row of boardMembers) {
             expect(row).not.toHaveProperty('email');
             expect(row).not.toHaveProperty('phone');
-            expect(row).not.toHaveProperty('dob');
+            expect(row).not.toHaveProperty('dateOfBirth');
             expect(row).not.toHaveProperty('googleId');
         }
     });

--- a/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
@@ -196,7 +196,7 @@ describe('Household Member API Integration Tests', () => {
             expect(updatedProfile?.name).toBe('Updated Child');
             expect(updatedProfile?.email).toBe('updated-child@example.com');
             expect(updatedProfile?.phone).toBe('555-555-5555');
-            expect(updatedProfile?.dob?.toISOString().startsWith(newDob)).toBe(true);
+            expect(updatedProfile?.dateOfBirth?.toISOString().startsWith(newDob)).toBe(true);
 
             // Verify Audit Trail is populated
             const auditLogs = await prisma.auditLog.findMany({
@@ -223,7 +223,7 @@ describe('Household Member API Integration Tests', () => {
 
             const updatedProfile = await prisma.participant.findUnique({ where: { id: testMemberId } });
             expect(updatedProfile?.email).toBeNull();
-            expect(updatedProfile?.dob).toBeNull();
+            expect(updatedProfile?.dateOfBirth).toBeNull();
             expect(updatedProfile?.phone).toBeNull();
         });
 

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -43,14 +43,14 @@ describe('Nav todo-counts API', () => {
         // Household A: a lead with a full slate of *member-actionable* todos, plus
         // one reviewer-owned membership state that must NOT count for the member.
         const lead = await prisma.participant.create({
-            data: { email: `lead-${TAG}@example.com`, name: 'Lead A', dob: new Date('1985-01-01'), phone: '555-0001', household: { create: {} } },
+            data: { email: `lead-${TAG}@example.com`, name: 'Lead A', dateOfBirth: new Date('1985-01-01'), phone: '555-0001', household: { create: {} } },
         });
         leadId = lead.id;
         householdAId = lead.householdId;
         await prisma.householdLead.create({ data: { householdId: householdAId, participantId: leadId } });
 
         const second = await prisma.participant.create({
-            data: { email: `member2-${TAG}@example.com`, name: 'Member A2', dob: new Date('1987-01-01'), householdId: householdAId },
+            data: { email: `member2-${TAG}@example.com`, name: 'Member A2', dateOfBirth: new Date('1987-01-01'), householdId: householdAId },
         });
         secondMemberId = second.id;
 
@@ -109,7 +109,7 @@ describe('Nav todo-counts API', () => {
 
         // Household B: a board member with no household todos of their own.
         const board = await prisma.participant.create({
-            data: { email: `board-${TAG}@example.com`, name: 'Board B', dob: new Date('1980-01-01'), phone: '555-0000', boardMember: true, household: { create: {} } },
+            data: { email: `board-${TAG}@example.com`, name: 'Board B', dateOfBirth: new Date('1980-01-01'), phone: '555-0000', boardMember: true, household: { create: {} } },
         });
         boardId = board.id;
         householdBId = board.householdId;

--- a/checkin-app/src/app/__tests__/onboardingStatusAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/onboardingStatusAPI.integration.test.ts
@@ -45,7 +45,7 @@ describe('Onboarding Status API Integration Tests', () => {
             data: {
                 email: 'adult-onboarding-status-test@example.com',
                 name: 'Adult No Phone',
-                dob: new Date('1990-01-01'),
+                dateOfBirth: new Date('1990-01-01'),
                 household: { create: {} }
             }
         });
@@ -56,7 +56,7 @@ describe('Onboarding Status API Integration Tests', () => {
             data: {
                 email: 'minor-onboarding-status-test@example.com',
                 name: 'Minor No Phone',
-                dob: minorDob(),
+                dateOfBirth: minorDob(),
                 household: { create: {} }
             }
         });

--- a/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
@@ -50,7 +50,7 @@ describe('Profile API Integration Tests', () => {
             data: {
                 email: 'user-profile-api-test@example.com',
                 name: 'Profile Tester',
-                dob: new Date('1990-01-01'),
+                dateOfBirth: new Date('1990-01-01'),
                 household: { create: {} }
             }
         });

--- a/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
@@ -63,17 +63,17 @@ describe('Program Age Bounds Integration Tests', () => {
         testAdminId = admin.id;
 
         const pValid = await prisma.participant.create({
-            data: { email: 'valid-age-test@example.com', name: 'Valid Age Test', dob: dob16, household: { create: {} } }
+            data: { email: 'valid-age-test@example.com', name: 'Valid Age Test', dateOfBirth: dob16, household: { create: {} } }
         });
         validUserId = pValid.id;
 
         const pUnder = await prisma.participant.create({
-            data: { email: 'underage-test@example.com', name: 'Underage Test', dob: dob12, household: { create: {} } }
+            data: { email: 'underage-test@example.com', name: 'Underage Test', dateOfBirth: dob12, household: { create: {} } }
         });
         underageUserId = pUnder.id;
 
         const pOver = await prisma.participant.create({
-            data: { email: 'overage-test@example.com', name: 'Overage Test', dob: dob20, household: { create: {} } }
+            data: { email: 'overage-test@example.com', name: 'Overage Test', dateOfBirth: dob20, household: { create: {} } }
         });
         overageUserId = pOver.id;
 
@@ -83,22 +83,22 @@ describe('Program Age Bounds Integration Tests', () => {
         noDobUserId = pNoDob.id;
 
         const pExactlyMin = await prisma.participant.create({
-            data: { email: 'exactly-min-age-test@example.com', name: 'Exactly Min Age Test', dob: dobExactly14, household: { create: {} } }
+            data: { email: 'exactly-min-age-test@example.com', name: 'Exactly Min Age Test', dateOfBirth: dobExactly14, household: { create: {} } }
         });
         exactlyMinUserId = pExactlyMin.id;
 
         const pExactlyMax = await prisma.participant.create({
-            data: { email: 'exactly-max-age-test@example.com', name: 'Exactly Max Age Test', dob: dobExactly18, household: { create: {} } }
+            data: { email: 'exactly-max-age-test@example.com', name: 'Exactly Max Age Test', dateOfBirth: dobExactly18, household: { create: {} } }
         });
         exactlyMaxUserId = pExactlyMax.id;
 
         const pTurns14Tomorrow = await prisma.participant.create({
-            data: { email: 'turns-14-tomorrow-age-test@example.com', name: 'Turns 14 Tomorrow Test', dob: dobTurns14Tomorrow, household: { create: {} } }
+            data: { email: 'turns-14-tomorrow-age-test@example.com', name: 'Turns 14 Tomorrow Test', dateOfBirth: dobTurns14Tomorrow, household: { create: {} } }
         });
         turns14TomorrowUserId = pTurns14Tomorrow.id;
 
         const pTurned19Yesterday = await prisma.participant.create({
-            data: { email: 'turned-19-yesterday-age-test@example.com', name: 'Turned 19 Yesterday Test', dob: dobTurned19Yesterday, household: { create: {} } }
+            data: { email: 'turned-19-yesterday-age-test@example.com', name: 'Turned 19 Yesterday Test', dateOfBirth: dobTurned19Yesterday, household: { create: {} } }
         });
         turned19YesterdayUserId = pTurned19Yesterday.id;
 

--- a/checkin-app/src/app/__tests__/programAgeStartDate.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeStartDate.integration.test.ts
@@ -56,7 +56,7 @@ describe('Program Age Start-Date Basis (authenticated route)', () => {
         // Born 2012-04-01: age 13 as of 2026-01-01 (frozen now), turns 14 on
         // 2026-04-01 — BEFORE the 2026-09-01 start. Eligible as of begin only.
         const user = await prisma.participant.create({
-            data: { email: 'turns14-age-startdate-test@example.com', name: 'Turns 14 Before Start', dob: new Date('2012-04-01T00:00:00.000Z'), household: { create: {} } }
+            data: { email: 'turns14-age-startdate-test@example.com', name: 'Turns 14 Before Start', dateOfBirth: new Date('2012-04-01T00:00:00.000Z'), household: { create: {} } }
         });
         userId = user.id;
     });

--- a/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
@@ -87,7 +87,7 @@ describe('Eligible Participants API Integration Tests', () => {
                         membership: {
                             create: {
                                 status: 'ACTIVE',
-                                since: new Date()
+                                memberSince: new Date()
                             }
                         }
                     }
@@ -103,7 +103,7 @@ describe('Eligible Participants API Integration Tests', () => {
                 membership: {
                     create: {
                         status: 'ACTIVE',
-                        since: new Date()
+                        memberSince: new Date()
                     }
                 }
             }

--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -75,7 +75,7 @@ describe('Individual Program API Integration Tests', () => {
                         membership: {
                             create: {
                                 status: 'ACTIVE',
-                                since: new Date()
+                                memberSince: new Date()
                             }
                         }
                     }

--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -76,7 +76,7 @@ describe('Program Participants API Integration Tests', () => {
             data: {
                 email: 'common-partic-api-test@example.com',
                 name: 'Common',
-                dob: new Date(Date.now() - (25 * 31556952000)),
+                dateOfBirth: new Date(Date.now() - (25 * 31556952000)),
                 household: { create: {} }
             }
         });
@@ -87,7 +87,7 @@ describe('Program Participants API Integration Tests', () => {
             data: {
                 email: 'other-partic-api-test@example.com',
                 name: 'Other Underage',
-                dob: new Date(Date.now() - (10 * 31556952000)),
+                dateOfBirth: new Date(Date.now() - (10 * 31556952000)),
                 household: { create: {} }
             }
         });
@@ -104,7 +104,7 @@ describe('Program Participants API Integration Tests', () => {
             data: {
                 email: 'dep-partic-api-test@example.com',
                 name: 'Board Dependent',
-                dob: new Date(Date.now() - (25 * 31556952000)),
+                dateOfBirth: new Date(Date.now() - (25 * 31556952000)),
                 householdId: boardHousehold.id
             }
         });

--- a/checkin-app/src/app/api/admin/broken-households/route.ts
+++ b/checkin-app/src/app/api/admin/broken-households/route.ts
@@ -17,7 +17,7 @@ export const GET = withAuth(
                 where: { leads: { none: {} } },
                 include: {
                     participants: {
-                        select: { id: true, name: true, dob: true },
+                        select: { id: true, name: true, dateOfBirth: true },
                         orderBy: { id: "asc" },
                     },
                 },
@@ -27,7 +27,7 @@ export const GET = withAuth(
             const result = households.map(h => ({
                 id: h.id,
                 name: h.name || `Household #${h.id}`,
-                members: h.participants.map(p => ({ id: p.id, name: p.name, dob: p.dob })),
+                members: h.participants.map(p => ({ id: p.id, name: p.name, dateOfBirth: p.dateOfBirth })),
             }));
 
             return NextResponse.json({ households: result });

--- a/checkin-app/src/app/api/auth/dev-personas/route.ts
+++ b/checkin-app/src/app/api/auth/dev-personas/route.ts
@@ -41,7 +41,7 @@ export async function GET() {
             boardMember: true,
             keyholder: true,
             backgroundCheckReviewer: true,
-            dob: true,
+            dateOfBirth: true,
             householdId: true,
             toolStatuses: {
                 select: {

--- a/checkin-app/src/app/api/facility/trends/route.ts
+++ b/checkin-app/src/app/api/facility/trends/route.ts
@@ -103,7 +103,7 @@ export const GET = withAuth(
             const visits = await prisma.visit.findMany({
                 where: whereClause,
                 include: {
-                    participant: { select: { id: true, dob: true } },
+                    participant: { select: { id: true, dateOfBirth: true } },
                     event: { select: { programId: true } },
                 },
                 orderBy: { arrivedAt: "asc" },
@@ -139,7 +139,7 @@ export const GET = withAuth(
 
                 const bucket = bucketMap.get(key)!;
                 const hours = getHoursBetween(visit.arrivedAt, visit.departedAt);
-                const student = isStudentAtDate(visit.participant.dob, visit.arrivedAt);
+                const student = isStudentAtDate(visit.participant.dateOfBirth, visit.arrivedAt);
 
                 if (student) {
                     bucket.studentIds.add(visit.participant.id);
@@ -172,8 +172,8 @@ export const GET = withAuth(
             const totals: TrendBucket = {
                 label: "Total",
                 periodStart: "",
-                uniqueVolunteers: new Set(visits.filter(v => !isStudentAtDate(v.participant.dob, v.arrivedAt)).map(v => v.participant.id)).size,
-                uniqueStudents: new Set(visits.filter(v => isStudentAtDate(v.participant.dob, v.arrivedAt)).map(v => v.participant.id)).size,
+                uniqueVolunteers: new Set(visits.filter(v => !isStudentAtDate(v.participant.dateOfBirth, v.arrivedAt)).map(v => v.participant.id)).size,
+                uniqueStudents: new Set(visits.filter(v => isStudentAtDate(v.participant.dateOfBirth, v.arrivedAt)).map(v => v.participant.id)).size,
                 totalVolunteerHours: Math.round(buckets.reduce((s, b) => s + b.totalVolunteerHours, 0) * 10) / 10,
                 totalStudentHours: Math.round(buckets.reduce((s, b) => s + b.totalStudentHours, 0) * 10) / 10,
                 structuredHours: Math.round(buckets.reduce((s, b) => s + b.structuredHours, 0) * 10) / 10,

--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -45,7 +45,7 @@ export const PATCH = withAuth(
                 data: {
                     name: name !== undefined ? name : undefined,
                     email: email !== undefined ? (email === "" ? null : email.toLowerCase()) : undefined,
-                    dob: dob !== undefined ? (dob === "" ? null : new Date(dob + "T12:00:00Z")) : undefined,
+                    dateOfBirth: dob !== undefined ? (dob === "" ? null : new Date(dob + "T12:00:00Z")) : undefined,
                     phone: phone !== undefined ? (phone === "" ? null : phone) : undefined,
                 }
             });

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -84,7 +84,7 @@ export const PATCH = withAuth(
                     data: {
                         name: memberName,
                         ...(memberEmail && { email: memberEmail.toLowerCase() }),
-                        dob: memberDob ? new Date(memberDob) : null,
+                        dateOfBirth: memberDob ? new Date(memberDob) : null,
                         householdId: user.householdId,
                     }
                 });

--- a/checkin-app/src/app/api/membership-ops/participants/import/preview/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/preview/route.ts
@@ -254,7 +254,7 @@ export async function POST(req: NextRequest) {
             } else if (!sameHouseholdAs) {
                 // No email, no parent email, no household ref — match by name
                 const matchQuery: Record<string, unknown> = { name: fullName };
-                if (parsedDob) matchQuery.dob = parsedDob;
+                if (parsedDob) matchQuery.dateOfBirth = parsedDob;
 
                 const existing = await prisma.participant.findFirst({
                     where: matchQuery,

--- a/checkin-app/src/app/api/membership-ops/participants/import/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/route.ts
@@ -76,7 +76,7 @@ export async function POST(req: NextRequest) {
                 data: {
                     ...(data.email && { email: data.email }),
                     name: data.name,
-                    dob: data.dob,
+                    dateOfBirth: data.dob,
                     household: {
                         create: {
                             name: `${data.name}'s Household`,
@@ -187,7 +187,7 @@ export async function POST(req: NextRequest) {
                                 where: { id: participant.id },
                                 data: {
                                     name: pr.fullName,
-                                    dob: pr.parsedDob ?? participant.dob,
+                                    dateOfBirth: pr.parsedDob ?? participant.dateOfBirth,
                                 }
                             });
                             await applyAddressToHousehold(participant.householdId, pr.address, tx);
@@ -222,14 +222,14 @@ export async function POST(req: NextRequest) {
                             participant = await tx.participant.update({
                                 where: { id: participant.id },
                                 data: {
-                                    dob: pr.parsedDob ?? participant.dob,
+                                    dateOfBirth: pr.parsedDob ?? participant.dateOfBirth,
                                 }
                             });
                         } else {
                             participant = await tx.participant.create({
                                 data: {
                                     name: pr.fullName,
-                                    dob: pr.parsedDob,
+                                    dateOfBirth: pr.parsedDob,
                                     householdId: parentHouseholdId
                                 }
                             });
@@ -241,8 +241,8 @@ export async function POST(req: NextRequest) {
                         await ensureHouseholdMembership(parentHouseholdId, tx);
                     } else {
                         // No email, no parent email — find by name/DOB
-                        const matchQuery: { name: string; dob?: Date } = { name: pr.fullName };
-                        if (pr.parsedDob) matchQuery.dob = pr.parsedDob;
+                        const matchQuery: { name: string; dateOfBirth?: Date } = { name: pr.fullName };
+                        if (pr.parsedDob) matchQuery.dateOfBirth = pr.parsedDob;
 
                         let participant = await tx.participant.findFirst({ where: matchQuery });
                         if (participant) {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -57,7 +57,7 @@ export const POST = withAuth(
 
             await prisma.$transaction(async (tx) => {
                 const updates: Record<string, NonNullable<unknown> | null | string | number | boolean | Date> = {};
-                const fields = ['googleId', 'email', 'phone', 'name', 'dob', 'image', 'lastWaiverSign', 'lastBackgroundCheck'];
+                const fields = ['googleId', 'email', 'phone', 'name', 'dateOfBirth', 'image', 'lastWaiverSign', 'lastBackgroundCheck'];
                 for (const field of fields) {
                     const keepVal = keepParticipant[field as keyof typeof keepParticipant];
                     const mergeVal = mergeParticipant[field as keyof typeof mergeParticipant];

--- a/checkin-app/src/app/api/membership-ops/participants/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/route.ts
@@ -84,7 +84,7 @@ export async function POST(req: NextRequest) {
                 data: {
                     name,
                     ...(email && { email }),
-                    dob: dob ? new Date(dob).toISOString() : null,
+                    dateOfBirth: dob ? new Date(dob).toISOString() : null,
                     householdId: householdIdToAssign
                 }
             });
@@ -94,7 +94,7 @@ export async function POST(req: NextRequest) {
                 data: {
                     name,
                     ...(email && { email }),
-                    dob: dob ? new Date(dob).toISOString() : null,
+                    dateOfBirth: dob ? new Date(dob).toISOString() : null,
                     household: {
                         create: { name: lastName ? `${lastName} Household` : "Household" }
                     }

--- a/checkin-app/src/app/api/profile/onboarding-status/route.ts
+++ b/checkin-app/src/app/api/profile/onboarding-status/route.ts
@@ -25,7 +25,7 @@ export const GET = withAuth(
             }
 
             // Minors are never required to provide a phone number (issue #169)
-            const needsPhone = !user.phone && !isMinor(user.dob);
+            const needsPhone = !user.phone && !isMinor(user.dateOfBirth);
             const isLead = user.householdId && user.householdLeads.some((lead: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => lead.householdId === user.householdId);
 
             // A lead needs a contact when no valid (non-member, complete) one exists.

--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -39,14 +39,14 @@ export const PATCH = withAuth(
                 data: {
                     name: name !== undefined ? name : undefined,
                     phone: phone !== undefined ? phone : undefined,
-                    dob: dob ? new Date(dob) : undefined,
+                    dateOfBirth: dob ? new Date(dob) : undefined,
                     notificationSettings: notificationSettings !== undefined ? notificationSettings : undefined,
                 },
                 select: {
                     name: true,
                     email: true,
                     phone: true,
-                    dob: true,
+                    dateOfBirth: true,
                     notificationSettings: true,
                 }
             });

--- a/checkin-app/src/app/api/programs/[id]/eligible-participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/eligible-participants/route.ts
@@ -60,7 +60,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 
         const members = await prisma.participant.findMany({
             where: andClauses.length > 0 ? { AND: andClauses } : undefined,
-            select: { id: true, name: true, email: true, dob: true },
+            select: { id: true, name: true, email: true, dateOfBirth: true },
             orderBy: { name: 'asc' },
             take: 50
         });

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
         const participantData = await prisma.participant.findUnique({
             where: { id: participantId },
-            select: { dob: true, householdId: true }
+            select: { dateOfBirth: true, householdId: true }
         });
 
         let isHouseholdLead = false;
@@ -96,11 +96,11 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
             // Check Age
             if (currentProgram.minAge !== null || currentProgram.maxAge !== null) {
-                if (!participantData?.dob) {
+                if (!participantData?.dateOfBirth) {
                     return NextResponse.json({ error: "Participant Date of Birth is missing.", requiresOverride: true }, { status: 400 });
                 }
                 // Age as of program start; now for dateless programs.
-                const age = calculateAge(participantData.dob, currentProgram.begin ?? undefined);
+                const age = calculateAge(participantData.dateOfBirth, currentProgram.begin ?? undefined);
                 if (currentProgram.minAge !== null && age < currentProgram.minAge) {
                     return NextResponse.json({ error: `Participant must be at least ${currentProgram.minAge} years old.`, requiresOverride: true }, { status: 400 });
                 }

--- a/checkin-app/src/app/api/programs/[id]/public-register/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/public-register/route.ts
@@ -168,7 +168,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                     const newParticipant = await tx.participant.create({
                         data: {
                             name: p.name,
-                            dob: p.dob ? new Date(p.dob) : null,
+                            dateOfBirth: p.dob ? new Date(p.dob) : null,
                             householdId: household.id,
                         }
                     });

--- a/checkin-app/src/app/api/roles/route.ts
+++ b/checkin-app/src/app/api/roles/route.ts
@@ -14,7 +14,7 @@ export const GET = withAuth(
                     id: true,
                     email: true,
                     name: true,
-                    dob: true,
+                    dateOfBirth: true,
                     sysadmin: true,
                     boardMember: true,
                     keyholder: true,
@@ -23,9 +23,9 @@ export const GET = withAuth(
                 orderBy: { name: "asc" },
             });
             // Don't leak dob (PII); expose only a youth flag for filtering.
-            const participants = rows.map(({ dob, ...p }: (typeof rows)[number]) => ({
+            const participants = rows.map(({ dateOfBirth, ...p }: (typeof rows)[number]) => ({
                 ...p,
-                isYouth: dob != null && dob > eighteenYearsAgo,
+                isYouth: dateOfBirth != null && dateOfBirth > eighteenYearsAgo,
             }));
             return NextResponse.json({ participants });
         } catch (error) {

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -17,7 +17,7 @@ type Participant = {
   name?: string | null;
   keyholder: boolean;
   sysadmin: boolean;
-  dob?: string | null;
+  dateOfBirth?: string | null;
   householdId?: number | null;
   phone?: string | null;
   household?: { emergencyContacts: { id: number; name: string; phone: string; relationship: string | null }[] } | null;
@@ -79,14 +79,14 @@ function KioskDisplayInner() {
 
   const fullAttendance = isFull ? (data as FullResponse).attendance : [];
   const keyholderList = fullAttendance.filter(v => v.participant.keyholder);
-  const volunteerList = fullAttendance.filter(v => !v.participant.keyholder && !isStudent(v.participant.dob));
-  const studentList = fullAttendance.filter(v => isStudent(v.participant.dob));
+  const volunteerList = fullAttendance.filter(v => !v.participant.keyholder && !isStudent(v.participant.dateOfBirth));
+  const studentList = fullAttendance.filter(v => isStudent(v.participant.dateOfBirth));
 
   const limitedHousehold = !isFull && data ? (data as LimitedResponse).household : [];
   const limitedSelf = !isFull && data ? (data as LimitedResponse).self : null;
   const householdKeyholders = limitedHousehold.filter(v => v.participant.keyholder);
-  const householdVolunteers = limitedHousehold.filter(v => !v.participant.keyholder && !isStudent(v.participant.dob));
-  const householdStudents = limitedHousehold.filter(v => isStudent(v.participant.dob));
+  const householdVolunteers = limitedHousehold.filter(v => !v.participant.keyholder && !isStudent(v.participant.dateOfBirth));
+  const householdStudents = limitedHousehold.filter(v => isStudent(v.participant.dateOfBirth));
 
   const isCheckedIn = isFull
     ? fullAttendance.some(v => v.participant.id === (session?.user as SessionUser)?.id)

--- a/checkin-app/src/app/membership-ops/broken/page.tsx
+++ b/checkin-app/src/app/membership-ops/broken/page.tsx
@@ -5,7 +5,7 @@ import { Badge, Box, Button, Card, Group, Loader, Stack, Text } from "@mantine/c
 import { notifications } from "@mantine/notifications";
 import { formatDate, isMinor } from "@/lib/time";
 
-type Member = { id: number; name: string | null; dob: string | null };
+type Member = { id: number; name: string | null; dateOfBirth: string | null };
 type BrokenHousehold = { id: number; name: string; members: Member[] };
 
 export default function BrokenHouseholdsPage() {
@@ -73,12 +73,12 @@ export default function BrokenHouseholdsPage() {
                       <Group key={m.id} justify="space-between" wrap="nowrap">
                         <Text size="sm">
                           {m.name || "Unnamed"}
-                          {m.dob ? ` • ${formatDate(m.dob)}` : " • no birthdate"}
-                          {isMinor(m.dob) && (
+                          {m.dateOfBirth ? ` • ${formatDate(m.dateOfBirth)}` : " • no birthdate"}
+                          {isMinor(m.dateOfBirth) && (
                             <Badge ml="xs" size="xs" color="gray" variant="light">minor</Badge>
                           )}
                         </Text>
-                        {!isMinor(m.dob) && (
+                        {!isMinor(m.dateOfBirth) && (
                           <Button
                             size="compact-xs"
                             variant="light"

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -15,14 +15,14 @@ import { isValidPhone, PHONE_ERROR } from '@/lib/phone';
 
 const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
 
-type Member = { id: number; name?: string; email?: string; dob?: string; phone?: string };
+type Member = { id: number; name?: string; email?: string; dateOfBirth?: string; phone?: string };
 type EmergencyContact = { id: number; name: string; phone: string; email?: string | null; relationship?: string | null; priority: number; invalid: boolean };
 type HouseholdData = {
   id?: number;
   name?: string;
   leads?: Array<{ participantId: number }>;
   participants?: Member[];
-  membership?: { status?: string; since?: string; isVolunteer?: boolean } | null;
+  membership?: { status?: string; memberSince?: string; isVolunteer?: boolean } | null;
 } & Partial<StructuredAddress> | null;
 
 const blankContactForm = { id: null as number | null, name: "", phone: "", email: "", relationship: "" };
@@ -314,9 +314,9 @@ export default function HouseholdPage() {
     const isLeadA = isLead(a.id) ? 1 : 0;
     const isLeadB = isLead(b.id) ? 1 : 0;
     if (isLeadA !== isLeadB) return isLeadB - isLeadA;
-    if (a.dob && b.dob) return new Date(a.dob).getTime() - new Date(b.dob).getTime();
-    if (a.dob) return -1;
-    if (b.dob) return 1;
+    if (a.dateOfBirth && b.dateOfBirth) return new Date(a.dateOfBirth).getTime() - new Date(b.dateOfBirth).getTime();
+    if (a.dateOfBirth) return -1;
+    if (b.dateOfBirth) return 1;
     return (a.name || "").localeCompare(b.name || "");
   });
 
@@ -331,7 +331,7 @@ export default function HouseholdPage() {
             household.membership?.status === 'ACTIVE' ? (
               <Alert color="green" mb="lg">
                 <Group gap="xs" wrap="wrap">
-                  <Text fw={600}>✓ Member{household.membership.since ? ` since ${formatDate(household.membership.since)}` : ''}</Text>
+                  <Text fw={600}>✓ Member{household.membership.memberSince ? ` since ${formatDate(household.membership.memberSince)}` : ''}</Text>
                   {household.membership.isVolunteer && <Badge color="green" variant="light">Volunteer-only family</Badge>}
                 </Group>
               </Alert>
@@ -359,7 +359,7 @@ export default function HouseholdPage() {
               <SimpleGrid cols={{ base: 1, sm: 2 }} mb="lg">
                 {sortedMembers.map((p) => {
                   const memberIsLead = isLead(p.id);
-                  const isAdult = p.dob && calculateAge(p.dob) >= 18;
+                  const isAdult = p.dateOfBirth && calculateAge(p.dateOfBirth) >= 18;
                   // A household lead needs a phone on file — flag the box so the
                   // lead can see exactly which member to fix (mirrors the nav todo).
                   const leadMissingPhone = memberIsLead && !p.phone;
@@ -395,7 +395,7 @@ export default function HouseholdPage() {
                             {viewerIsLead && (
                               <Button size="compact-xs" variant="subtle" color="gray" onClick={() => {
                                 setEditingMemberId(p.id);
-                                setEditForm({ name: p.name || "", email: p.email || "", dob: p.dob ? new Date(p.dob).toISOString().split('T')[0] : "", phone: p.phone || "", isLead: memberIsLead });
+                                setEditForm({ name: p.name || "", email: p.email || "", dob: p.dateOfBirth ? new Date(p.dateOfBirth).toISOString().split('T')[0] : "", phone: p.phone || "", isLead: memberIsLead });
                               }}>Edit</Button>
                             )}
                           </Group>

--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -39,7 +39,7 @@ export default function ProfilePage() {
           name: data.profile.name || "",
           email: data.profile.email || "",
           phone: data.profile.phone || "",
-          dob: data.profile.dob ? new Date(data.profile.dob).toISOString().split('T')[0] : ""
+          dob: data.profile.dateOfBirth ? new Date(data.profile.dateOfBirth).toISOString().split('T')[0] : ""
         });
       } else {
         setMessage("Failed to load profile.");

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -44,7 +44,7 @@ type ProgramDetail = {
   shopifyProductId: string | null;
 };
 
-type ParticipantOption = { id: number; name: string | null; email: string; dob?: string | null };
+type ParticipantOption = { id: number; name: string | null; email: string; dateOfBirth?: string | null };
 
 const PHASE_BADGE: Record<string, { label: string; color: string }> = {
   PLANNING: { label: 'Planning', color: 'gray' },
@@ -523,8 +523,8 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                         partResults,
                         (p) => { setNewPartId(p.id.toString()); setPartSearch(`${p.name || 'Unnamed'} (${p.email})`); setPartResults([]); },
                         (p) => {
-                          if (!p.dob) return null;
-                          const age = calculateAge(p.dob, program.begin ?? undefined);
+                          if (!p.dateOfBirth) return null;
+                          const age = calculateAge(p.dateOfBirth, program.begin ?? undefined);
                           let warning: string | null = null;
                           if (program.minAge !== null && age < program.minAge) warning = `⚠️ Too Young (${age})`;
                           if (program.maxAge !== null && age > program.maxAge) warning = `⚠️ Too Old (${age})`;

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -40,7 +40,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   const [requiresOverride, setRequiresOverride] = useState(false);
 
   const [showEnrollmentSelection, setShowEnrollmentSelection] = useState(false);
-  const [householdMembers, setHouseholdMembers] = useState<{ id: number; name: string | null; dob: string | null }[]>([]);
+  const [householdMembers, setHouseholdMembers] = useState<{ id: number; name: string | null; dateOfBirth: string | null }[]>([]);
   const [selectedParticipantId, setSelectedParticipantId] = useState<number | null>(null);
   const [loadingHousehold, setLoadingHousehold] = useState(false);
 
@@ -85,16 +85,16 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
           if (me) setSelectedParticipantId(me.id);
           else setSelectedParticipantId(data.household.participants[0]?.id || currentUserId);
         } else {
-          setHouseholdMembers([{ id: currentUserId, name: "Myself", dob: null }]);
+          setHouseholdMembers([{ id: currentUserId, name: "Myself", dateOfBirth: null }]);
           setSelectedParticipantId(currentUserId);
         }
       } else {
-        setHouseholdMembers([{ id: currentUserId, name: "Myself", dob: null }]);
+        setHouseholdMembers([{ id: currentUserId, name: "Myself", dateOfBirth: null }]);
         setSelectedParticipantId(currentUserId);
       }
     } catch {
       const currentUserId = (session.user as SessionUser).id;
-      setHouseholdMembers([{ id: currentUserId, name: "Myself", dob: null }]);
+      setHouseholdMembers([{ id: currentUserId, name: "Myself", dateOfBirth: null }]);
       setSelectedParticipantId(currentUserId);
     } finally {
       setLoadingHousehold(false);
@@ -301,10 +301,10 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
 
                       let ageError: string | null = null;
                       if (program.minAge !== null || program.maxAge !== null) {
-                        if (!member.dob) {
+                        if (!member.dateOfBirth) {
                           ageError = "DOB missing";
                         } else {
-                          const age = calculateAge(member.dob, program.begin ?? undefined);
+                          const age = calculateAge(member.dateOfBirth, program.begin ?? undefined);
                           if (program.minAge !== null && age < program.minAge) ageError = "Too young";
                           if (program.maxAge !== null && age > program.maxAge) ageError = "Too old";
                         }

--- a/checkin-app/src/components/DevLoginPicker.tsx
+++ b/checkin-app/src/components/DevLoginPicker.tsx
@@ -12,7 +12,7 @@ interface Persona {
   boardMember: boolean;
   keyholder: boolean;
   backgroundCheckReviewer: boolean;
-  dob: string | null;
+  dateOfBirth: string | null;
   householdId: number | null;
   toolStatuses: { toolId: number; level: string }[];
 }
@@ -56,8 +56,8 @@ export default function DevLoginPicker() {
     if (p.backgroundCheckReviewer) badges.push({ label: "BG Reviewer", color: "teal" });
     if (p.toolStatuses?.length > 0) badges.push({ label: "Certified", color: "green" });
     if (p.householdId) badges.push({ label: "Household", color: "indigo" });
-    if (p.dob && now !== null) {
-      const age = Math.floor((now - new Date(p.dob).getTime()) / (365.25 * 24 * 60 * 60 * 1000));
+    if (p.dateOfBirth && now !== null) {
+      const age = Math.floor((now - new Date(p.dateOfBirth).getTime()) / (365.25 * 24 * 60 * 60 * 1000));
       if (age < 18) badges.push({ label: `Student (${age})`, color: "pink" });
     }
     return badges;

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -87,11 +87,11 @@ export async function seedBaseline(prisma: Db): Promise<void> {
 
     const childFamily = await prisma.participant.upsert({
         where: { email: "child.family@example.com" },
-        update: { name: "Child Family", dob: yearsAgo(10) },
+        update: { name: "Child Family", dateOfBirth: yearsAgo(10) },
         create: {
             email: "child.family@example.com",
             name: "Child Family",
-            dob: yearsAgo(10),
+            dateOfBirth: yearsAgo(10),
             householdId: household1.id,
         },
     });
@@ -244,7 +244,7 @@ export async function createFamily(prisma: Db): Promise<string> {
             name: `Lead ${tag}`,
             email: `lead.${tag}@example.com`,
             phone: "555-100-0000",
-            dob: yearsAgo(38),
+            dateOfBirth: yearsAgo(38),
             householdId: household.id,
         },
     });
@@ -253,12 +253,12 @@ export async function createFamily(prisma: Db): Promise<string> {
         data: {
             name: `Partner ${tag}`,
             email: `partner.${tag}@example.com`,
-            dob: yearsAgo(36),
+            dateOfBirth: yearsAgo(36),
             householdId: household.id,
         },
     });
     await prisma.participant.create({
-        data: { name: `Kid ${tag}`, dob: yearsAgo(9), householdId: household.id },
+        data: { name: `Kid ${tag}`, dateOfBirth: yearsAgo(9), householdId: household.id },
     });
     return `Created household "Test Family ${tag}" (lead + partner + 1 minor)`;
 }

--- a/checkin-app/src/lib/dev/zoho-import.ts
+++ b/checkin-app/src/lib/dev/zoho-import.ts
@@ -432,7 +432,7 @@ export async function applyImport(
             const data = {
                 name: m.name,
                 ...(m.email ? { email: m.email } : {}),
-                dob: m.dob,
+                dateOfBirth: m.dob,
                 lastBackgroundCheck: m.lastBackgroundCheck,
                 householdId,
             };

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -13,7 +13,7 @@ export async function getFullAttendance() {
                     name: true,
                     keyholder: true,
                     sysadmin: true,
-                    dob: true,
+                    dateOfBirth: true,
                     householdId: true,
                     phone: true,
                     household: {
@@ -41,7 +41,7 @@ export async function getFullAttendance() {
     // Pre-compute isMinor once per visit to avoid repeated calculations
     const minorMap = new Map<number, boolean>();
     for (const v of activeVisits) {
-        minorMap.set(v.id, isMinor(v.participant.dob));
+        minorMap.set(v.id, isMinor(v.participant.dateOfBirth));
     }
 
     const keyholderVisits = activeVisits.filter(v => v.participant.keyholder);

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -98,11 +98,11 @@ export async function getIntakeState(userId: number) {
     const primary = parents.find((p) => p.id === userId) ?? null;
     const secondary = parents.find((p) => p.id !== userId) ?? null;
 
-    const shape = (p: { id: number; name: string | null; email: string | null; dob: Date | null; allergies: string | null }) => ({
+    const shape = (p: { id: number; name: string | null; email: string | null; dateOfBirth: Date | null; allergies: string | null }) => ({
         id: p.id,
         name: p.name,
         email: p.email,
-        dob: p.dob ? p.dob.toISOString().slice(0, 10) : null,
+        dob: p.dateOfBirth ? p.dateOfBirth.toISOString().slice(0, 10) : null,
         allergies: p.allergies,
     });
 
@@ -236,7 +236,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
             where: { id: userId },
             data: {
                 ...(input.primaryParent.name !== undefined && { name: input.primaryParent.name }),
-                ...(input.primaryParent.dob !== undefined && { dob: toDate(input.primaryParent.dob) }),
+                ...(input.primaryParent.dob !== undefined && { dateOfBirth: toDate(input.primaryParent.dob) }),
                 ...(input.primaryParent.allergies !== undefined && { allergies: input.primaryParent.allergies }),
             },
         });
@@ -250,7 +250,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
                 where: { id: sp.id },
                 data: {
                     ...(sp.name !== undefined && { name: sp.name }),
-                    ...(sp.dob !== undefined && { dob: toDate(sp.dob) }),
+                    ...(sp.dob !== undefined && { dateOfBirth: toDate(sp.dob) }),
                     ...(sp.allergies !== undefined && { allergies: sp.allergies }),
                 },
             });
@@ -262,7 +262,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
                     householdId,
                     name: sp.name ?? null,
                     ...(sp.email && { email: sp.email.toLowerCase() }),
-                    dob: toDate(sp.dob),
+                    dateOfBirth: toDate(sp.dob),
                     allergies: sp.allergies ?? null,
                 },
             });
@@ -278,7 +278,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
                 where: { id: child.id },
                 data: {
                     ...(child.name !== undefined && { name: child.name }),
-                    ...(child.dob !== undefined && { dob: toDate(child.dob) }),
+                    ...(child.dob !== undefined && { dateOfBirth: toDate(child.dob) }),
                     ...(child.allergies !== undefined && { allergies: child.allergies }),
                 },
             });
@@ -288,7 +288,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
                     householdId,
                     name: child.name,
                     ...(child.email && { email: child.email.toLowerCase() }),
-                    dob: toDate(child.dob),
+                    dateOfBirth: toDate(child.dob),
                     allergies: child.allergies ?? null,
                 },
             });

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -10,7 +10,7 @@ export const classifications = {
         name: 'public',
         emailVerified: 'internal',
         image: 'public',
-        dob: 'pii',
+        dateOfBirth: 'pii',
         lastWaiverSign: 'internal',
         waiverSignedBy: 'internal',
         lastBackgroundCheck: 'internal',
@@ -62,7 +62,7 @@ export const classifications = {
     },
     Membership: {
         id: 'public',
-        since: 'public',
+        memberSince: 'public',
         status: 'public',
         isVolunteer: 'public',
         householdId: 'public',
@@ -207,7 +207,7 @@ export const classifications = {
     FeePayment: {
         feeId: 'public',
         participantId: 'public',
-        paidOn: 'personal',
+        paidAt: 'personal',
         shopifyLink: 'personal',
         quickBooksInvoice: 'personal',
         customNote: 'personal',

--- a/checkin-app/src/types/attendance.ts
+++ b/checkin-app/src/types/attendance.ts
@@ -13,7 +13,7 @@ export type VisitWithDetails = Prisma.VisitGetPayload<{
                 name: true;
                 keyholder: true;
                 sysadmin: true;
-                dob: true;
+                dateOfBirth: true;
                 householdId: true;
                 phone: true;
                 household: {


### PR DESCRIPTION
## What

Normalize three DateTime column names, full vertical (DB column → Prisma call → raw JSON response → frontend type → usage), no aliasing layer:

| Before | After |
|---|---|
| `Membership.since` | `memberSince` |
| `Participant.dob` | `dateOfBirth` |
| `FeePayment.paidOn` | `paidAt` |

No `@map` — Postgres column name == Prisma field name. Migration uses **`RENAME COLUMN`** (data-preserving), not drop/add.

## Why

Routes return raw Prisma rows as JSON, so a DB column name *is* the JSON key the hand-written frontend types read. With no DTO layer these break silently (no tsc error) on a rename. One vocabulary end to end avoids that.

## The `dob` subtlety (reviewer note)

`dob` appears ~200 times but most are **not** the Prisma field. Classified each hit:

- **Renamed → `dateOfBirth`**: true Prisma reads/writes/selects, and raw-row frontend consumers — `my-household`, `attendance/current`, `membership-ops/broken`, `DevLoginPicker`, `profile` (read), and the two age-check sites `programs/[id]` + `program-ops/programs/[id]` (`calculateAge(member.dateOfBirth, …)`), whose data comes from raw `/api/household` and `/api/.../eligible-participants` rows.
- **Kept as `dob`** (deliberate): intake `ParentInput`/`ChildInput` DTOs, the intake prefill **output** key, `calculateAge`/`isMinor`/`isStudent`/`isStudentAtDate` util params, CSV-import + zoho-import internal structs, and all form state + request bodies (form contract is unchanged).

Several renamed sites are tsc-blind (spread-masked intake writes, loose-`Db` seed helpers, raw-JSON frontend, `Record<string, unknown>` match queries) — hand-fixed.

`since` / `paidOn`: no remaining field refs; `const since` locals and the historical `paidOn` comment/old migration left as-is.

## Verification

- `prisma generate` + `tsc --noEmit` clean
- 352 unit tests pass; 16 renamed-field integration suites (97 tests) pass `--runInBand`
- Migration applied to a throwaway PG, columns confirmed renamed, reseed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)