### PR TITLE
feat(public-register): rate limiting + double opt-in, close enumeration oracle

### DIFF
--- a/checkin-app/src/app/__tests__/programsPublicRegisterConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublicRegisterConcurrency.integration.test.ts
@@ -2,25 +2,29 @@
  * @jest-environment node
  */
 /**
- * Concurrency regression test for POST /api/programs/[id]/public-register.
+ * Concurrency regression test for the public registration capacity lock.
  *
  * Capacity used to be checked against a `_count` read BEFORE the create
- * transaction. Two near-simultaneous public registrations for the last seat
- * both read count==max-1, both passed, and both inserted — overfilling the
- * program. This endpoint is public/unauthenticated, so it is trivially raced.
+ * transaction. Two near-simultaneous registrations for the last seat both read
+ * count==max-1, both passed, and both inserted — overfilling the program. This
+ * flow is public/unauthenticated, so it is trivially raced.
  *
- * The fix locks the Program row (SELECT ... FOR UPDATE) and re-counts INSIDE
- * the existing transaction before creating enrollments. This test fires two
- * concurrent registrations for a 1-seat program and asserts exactly one
- * succeeds and the program is not overfilled.
+ * The fix locks the Program row (SELECT ... FOR UPDATE) and re-counts INSIDE the
+ * create transaction. That transaction now lives in the double-opt-in *confirm*
+ * step, so this test fires two concurrent confirmations (with pre-built tokens,
+ * which is exactly what the confirmation links carry) for a 1-seat program and
+ * asserts exactly one succeeds and the program is not overfilled.
  *
  * (jest.setup.js gives this suite TEST_DB_POOL_MAX=2 so the two transactions
  * run on separate connections; the FOR UPDATE lock is then the only thing
  * serializing them, exactly as in production. With pool 1 the assertions pass
  * even without the lock.)
  */
-import { POST } from '@/app/api/programs/[id]/public-register/route';
+import { POST as CONFIRM } from '@/app/api/programs/[id]/public-register/confirm/route';
+import { encodeRegistrationToken } from '@/lib/registrationToken';
 import prisma from '@/lib/prisma';
+
+process.env.NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET || 'test-secret-conc';
 
 jest.mock('@/lib/notifications', () => ({
     sendNotification: jest.fn().mockResolvedValue(true),
@@ -28,7 +32,7 @@ jest.mock('@/lib/notifications', () => ({
 
 const NAME_TAG = 'PublicRegConcurrency Test';
 
-describe('POST /api/programs/[id]/public-register concurrency (capacity lock)', () => {
+describe('public-register/confirm concurrency (capacity lock)', () => {
     let programId: number;
 
     async function cleanup() {
@@ -71,21 +75,24 @@ describe('POST /api/programs/[id]/public-register concurrency (capacity lock)', 
 
     const params = (id: number) => ({ params: Promise.resolve({ id: id.toString() }) });
 
-    function registration(idx: number) {
-        return new Request(`http://localhost:4000/api/programs/${programId}/public-register`, {
+    // A confirmation request carrying the same payload the email link would.
+    function confirmation(idx: number) {
+        const token = encodeRegistrationToken({
+            programId,
+            parents: [{ name: `Parent ${idx}`, email: `pubreg-conc-${idx}@example.com`, phone: `555-000-000${idx}` }],
+            emergencyContact: { name: `Aunt ${idx}`, phone: `555-111-222${idx}` },
+            participants: [{ name: `Kid ${idx}`, dob: '2015-01-01' }],
+        });
+        return new Request(`http://localhost:4000/api/programs/${programId}/public-register/confirm`, {
             method: 'POST',
-            body: JSON.stringify({
-                parents: [{ name: `Parent ${idx}`, email: `pubreg-conc-${idx}@example.com`, phone: `555-000-000${idx}` }],
-                emergencyContact: { name: `Aunt ${idx}`, phone: `555-111-222${idx}` },
-                participants: [{ name: `Kid ${idx}`, dob: '2015-01-01' }],
-            }),
+            body: JSON.stringify({ token }),
         });
     }
 
-    it('two concurrent registrations for the last seat → exactly one succeeds, no overfill', async () => {
+    it('two concurrent confirmations for the last seat → exactly one succeeds, no overfill', async () => {
         const [resA, resB] = await Promise.all([
-            POST(registration(1) as unknown as import('next/server').NextRequest, params(programId) as unknown as never),
-            POST(registration(2) as unknown as import('next/server').NextRequest, params(programId) as unknown as never),
+            CONFIRM(confirmation(1) as unknown as import('next/server').NextRequest, params(programId) as unknown as never),
+            CONFIRM(confirmation(2) as unknown as import('next/server').NextRequest, params(programId) as unknown as never),
         ]);
 
         const statuses = [resA.status, resB.status].sort();

--- a/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
@@ -2,17 +2,29 @@
  * @jest-environment node
  */
 /**
- * Integration Tests for Public Program Registration API
- * Tests POST /api/programs/[id]/public-register
+ * Integration Tests for Public Program Registration API (double opt-in).
+ * Step 1: POST /api/programs/[id]/public-register        — validate + email a token, no writes.
+ * Step 2: POST /api/programs/[id]/public-register/confirm — token → create everything.
  */
 
 import { POST } from '@/app/api/programs/[id]/public-register/route';
+import { POST as CONFIRM } from '@/app/api/programs/[id]/public-register/confirm/route';
 import prisma from '@/lib/prisma';
+
+// A signing secret is required for the confirmation token.
+process.env.NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET || 'test-secret-public-reg';
 
 // Mock Notifications
 jest.mock('@/lib/notifications', () => ({
     sendNotification: jest.fn().mockResolvedValue(true)
 }));
+
+// Mock the mailer so we can capture the confirmation token out of the email.
+jest.mock('@/lib/email', () => ({
+    sendEmail: jest.fn().mockResolvedValue(true)
+}));
+import { sendEmail } from '@/lib/email';
+const mockedSendEmail = sendEmail as jest.Mock;
 
 describe('Public Program Registration API Integration Tests', () => {
     let standardProgramId: number;
@@ -31,7 +43,7 @@ describe('Public Program Registration API Integration Tests', () => {
             select: { id: true }
         });
         const existingUserIds = existingUsers.map(u => u.id);
-        
+
         await prisma.programParticipant.deleteMany({
             where: { personId: { in: existingUserIds } }
         });
@@ -39,7 +51,7 @@ describe('Public Program Registration API Integration Tests', () => {
         await prisma.program.deleteMany({
             where: { name: { contains: 'Public Reg Test' } }
         });
-        
+
         await prisma.auditLog.deleteMany({
             where: { actorId: { in: existingUserIds } }
         });
@@ -47,7 +59,7 @@ describe('Public Program Registration API Integration Tests', () => {
         await prisma.householdLead.deleteMany({
             where: { personId: { in: existingUserIds } }
         });
-        
+
         await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
@@ -60,11 +72,11 @@ describe('Public Program Registration API Integration Tests', () => {
 
         // Create mock programs
         const standardProgram = await prisma.program.create({
-            data: { 
-                name: 'Standard Public Reg Test', 
-                phase: 'RUNNING', 
-                enrollmentStatus: 'OPEN', 
-                orgMemberPriceCents: 1000, 
+            data: {
+                name: 'Standard Public Reg Test',
+                phase: 'RUNNING',
+                enrollmentStatus: 'OPEN',
+                orgMemberPriceCents: 1000,
                 nonOrgMemberPriceCents: 1500,
                 shopifyNonOrgMemberVariantId: '123456789'
             }
@@ -77,9 +89,9 @@ describe('Public Program Registration API Integration Tests', () => {
         freeProgramId = freeProgram.id;
 
         const fullProgram = await prisma.program.create({
-            data: { 
-                name: 'Full Public Reg Test', 
-                phase: 'RUNNING', 
+            data: {
+                name: 'Full Public Reg Test',
+                phase: 'RUNNING',
                 enrollmentStatus: 'OPEN',
                 maxParticipants: 1,
                 participants: {
@@ -134,7 +146,7 @@ describe('Public Program Registration API Integration Tests', () => {
                 where: { id: { in: validProgramIds } }
             });
         }
-        
+
         if (existingUserIds.length > 0) {
             await prisma.auditLog.deleteMany({
                 where: { actorId: { in: existingUserIds } }
@@ -168,84 +180,59 @@ describe('Public Program Registration API Integration Tests', () => {
         }
     });
 
+    beforeEach(() => mockedSendEmail.mockClear());
+
     const createParams = (id: number) => ({ params: Promise.resolve({ id: id.toString() }) });
 
-    describe('POST /api/programs/[id]/public-register', () => {
+    // Each request gets a distinct client IP so the per-IP rate limiter (module
+    // global) doesn't bleed across the many calls this suite makes.
+    let ipSeq = 0;
+    const makeReq = (id: number, body: unknown, suffix = '') =>
+        new Request(`http://localhost:4000/api/programs/${id}/public-register${suffix}`, {
+            method: 'POST',
+            headers: { 'x-forwarded-for': `10.0.0.${++ipSeq}` },
+            body: JSON.stringify(body),
+        });
+
+    // Run step 1 (request) and return the confirmation token captured from the email.
+    const requestAndGetToken = async (id: number, body: unknown): Promise<string> => {
+        const res = await POST(makeReq(id, body) as unknown as never, createParams(id) as unknown as never);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.pending).toBe(true);
+        expect(data.checkoutUrl).toBeUndefined(); // no writes / no checkout at request time
+        const html = mockedSendEmail.mock.calls.at(-1)?.[2] as string;
+        const m = html.match(/token=([^"&]+)/);
+        if (!m) throw new Error('no confirmation token found in email');
+        return decodeURIComponent(m[1]);
+    };
+
+    // Run step 2 (confirm) for a token.
+    const confirm = (id: number, token: string) =>
+        CONFIRM(makeReq(id, { token }, '/confirm') as unknown as never, createParams(id) as unknown as never);
+
+    describe('Step 1: POST /api/programs/[id]/public-register', () => {
 
         it('should block if primary parent is missing', async () => {
-            const req = new Request(`http://localhost:4000/api/programs/${standardProgramId}/public-register`, {
-                method: 'POST',
-                body: JSON.stringify({
-                    parents: [],
-                    emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
-                    participants: [{ name: 'Timmy', dob: '2010-01-01' }]
-                })
-            });
-            const res = await POST(req as unknown as import("next/server").NextRequest, createParams(standardProgramId) as unknown as never);
+            const res = await POST(makeReq(standardProgramId, {
+                parents: [],
+                emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
+                participants: [{ name: 'Timmy', dob: '2010-01-01' }]
+            }) as unknown as never, createParams(standardProgramId) as unknown as never);
             expect(res.status).toBe(400);
-            const data = await res.json();
-            expect(data.error).toMatch(/Primary parent/i);
-        });
-
-        it('should block if emergency phone matches parent phone', async () => {
-            const req = new Request(`http://localhost:4000/api/programs/${standardProgramId}/public-register`, {
-                method: 'POST',
-                body: JSON.stringify({
-                    parents: [{ name: 'Dad', email: 'dad@test.com', phone: '(555) 123-4567' }],
-                    emergencyContact: { name: 'Aunt Sue', phone: '5551234567' }, // Same digits
-                    participants: [{ name: 'Timmy', dob: '2010-01-01' }]
-                })
-            });
-            const res = await POST(req as unknown as import("next/server").NextRequest, createParams(standardProgramId) as unknown as never);
-            expect(res.status).toBe(400);
-            const data = await res.json();
-            // The not-a-household-member rule now blocks this (matched on phone) with a unified message.
-            expect(data.error).toMatch(/can't be its emergency contact|outside the household/i);
-        });
-
-        it('should block if parent email already exists', async () => {
-            const req = new Request(`http://localhost:4000/api/programs/${standardProgramId}/public-register`, {
-                method: 'POST',
-                body: JSON.stringify({
-                    parents: [{ name: 'Dad', email: 'existing-user-test@example.com', phone: '555-111-2222' }],
-                    emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
-                    participants: [{ name: 'Timmy', dob: '2010-01-01' }]
-                })
-            });
-            const res = await POST(req as unknown as import("next/server").NextRequest, createParams(standardProgramId) as unknown as never);
-            expect(res.status).toBe(400);
-            const data = await res.json();
-            expect(data.error).toMatch(/already exists/i);
-        });
-
-        it('should block if program is full', async () => {
-            const req = new Request(`http://localhost:4000/api/programs/${fullProgramId}/public-register`, {
-                method: 'POST',
-                body: JSON.stringify({
-                    parents: [{ name: 'Mom', email: 'mom1@test.com', phone: '555-111-2222' }],
-                    emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
-                    participants: [{ name: 'Timmy', dob: '2010-01-01' }]
-                })
-            });
-            const res = await POST(req as unknown as import("next/server").NextRequest, createParams(fullProgramId) as unknown as never);
-            expect(res.status).toBe(400);
-            const data = await res.json();
-            expect(data.error).toMatch(/open spots/i);
+            expect((await res.json()).error).toMatch(/Primary parent/i);
+            expect(mockedSendEmail).not.toHaveBeenCalled();
         });
 
         it('should block if participant does not meet age constraints', async () => {
-            const req = new Request(`http://localhost:4000/api/programs/${exactAgeProgramId}/public-register`, {
-                method: 'POST',
-                body: JSON.stringify({
-                    parents: [{ name: 'Mom', email: 'mom2@test.com', phone: '555-111-2222' }],
-                    emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
-                    participants: [{ name: 'Timmy', dob: '2015-01-01' }] // Under 18
-                })
-            });
-            const res = await POST(req as unknown as import("next/server").NextRequest, createParams(exactAgeProgramId) as unknown as never);
+            const res = await POST(makeReq(exactAgeProgramId, {
+                parents: [{ name: 'Mom', email: 'mom2@test.com', phone: '555-111-2222' }],
+                emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
+                participants: [{ name: 'Timmy', dob: '2015-01-01' }] // Under 18
+            }) as unknown as never, createParams(exactAgeProgramId) as unknown as never);
             expect(res.status).toBe(400);
-            const data = await res.json();
-            expect(data.error).toMatch(/at least 18/i);
+            expect((await res.json()).error).toMatch(/at least 18/i);
+            expect(mockedSendEmail).not.toHaveBeenCalled();
         });
 
         // Regression: the old inline epoch-delta age math
@@ -394,22 +381,76 @@ describe('Public Program Registration API Integration Tests', () => {
             }
         });
 
-        it('should successfully register a family with correct PENDING status and return Shopify URL', async () => {
-            const req = new Request(`http://localhost:4000/api/programs/${standardProgramId}/public-register`, {
-                method: 'POST',
-                headers: { 'x-forwarded-for': '203.0.113.1' }, // own rate-limit bucket so earlier block tests don't 429 this
-                body: JSON.stringify({
-                    parents: [{ name: 'Test Primary Parent', email: 'test-primary-parent@example.com', phone: '555-123-4444' }],
-                    emergencyContact: { name: 'Aunt Sue', phone: '555-999-8888' },
-                    participants: [
-                        { name: 'Test Primary Parent' }, // implicitly matches parent by name
-                        { name: 'Timmy Test', dob: '2010-05-05' }
-                    ]
-                })
+        it('returns the same neutral response whether or not the email exists (no enumeration)', async () => {
+            const known = await POST(makeReq(standardProgramId, {
+                parents: [{ name: 'Dad', email: 'existing-user-test@example.com', phone: '555-111-2222' }],
+                emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
+                participants: [{ name: 'Timmy', dob: '2010-01-01' }]
+            }) as unknown as never, createParams(standardProgramId) as unknown as never);
+            const unknownEmail = await POST(makeReq(standardProgramId, {
+                parents: [{ name: 'Dad', email: 'brand-new-nobody@example.com', phone: '555-111-2222' }],
+                emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
+                participants: [{ name: 'Timmy', dob: '2010-01-01' }]
+            }) as unknown as never, createParams(standardProgramId) as unknown as never);
+            expect(known.status).toBe(unknownEmail.status);
+            expect(await known.json()).toEqual(await unknownEmail.json());
+        });
+    });
+
+    describe('Step 2: POST /api/programs/[id]/public-register/confirm', () => {
+
+        it('rejects an invalid / garbage token', async () => {
+            const res = await confirm(standardProgramId, 'not-a-real-token');
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toMatch(/invalid or has expired/i);
+        });
+
+        it('should block if parent email already exists', async () => {
+            const token = await requestAndGetToken(standardProgramId, {
+                parents: [{ name: 'Dad', email: 'existing-user-test@example.com', phone: '555-111-2222' }],
+                emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
+                participants: [{ name: 'Timmy', dob: '2010-01-01' }]
             });
-            const res = await POST(req as unknown as import("next/server").NextRequest, createParams(standardProgramId) as unknown as never);
+            const res = await confirm(standardProgramId, token);
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toMatch(/already exists/i);
+        });
+
+        it('should block if emergency phone matches parent phone', async () => {
+            const token = await requestAndGetToken(standardProgramId, {
+                parents: [{ name: 'Dad', email: 'dad@test.com', phone: '(555) 123-4567' }],
+                emergencyContact: { name: 'Aunt Sue', phone: '5551234567' }, // Same digits
+                participants: [{ name: 'Timmy', dob: '2010-01-01' }]
+            });
+            const res = await confirm(standardProgramId, token);
+            expect(res.status).toBe(400);
+            // The not-a-household-member rule blocks this (matched on phone).
+            expect((await res.json()).error).toMatch(/can't be its emergency contact|outside the household/i);
+        });
+
+        it('should block if program is full', async () => {
+            const token = await requestAndGetToken(fullProgramId, {
+                parents: [{ name: 'Mom', email: 'mom1@test.com', phone: '555-111-2222' }],
+                emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
+                participants: [{ name: 'Timmy', dob: '2010-01-01' }]
+            });
+            const res = await confirm(fullProgramId, token);
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toMatch(/open spots/i);
+        });
+
+        it('should successfully register a family with PENDING status and return Shopify URL', async () => {
+            const token = await requestAndGetToken(standardProgramId, {
+                parents: [{ name: 'Test Primary Parent', email: 'test-primary-parent@example.com', phone: '555-123-4444' }],
+                emergencyContact: { name: 'Aunt Sue', phone: '555-999-8888' },
+                participants: [
+                    { name: 'Test Primary Parent' }, // implicitly matches parent by name
+                    { name: 'Timmy Test', dob: '2010-05-05' }
+                ]
+            });
+            const res = await confirm(standardProgramId, token);
             expect(res.status).toBe(200);
-            
+
             const data = await res.json();
             expect(data.success).toBe(true);
             expect(data.checkoutUrl).toContain('123456789:2'); // Variant ID : quantity
@@ -448,21 +489,18 @@ describe('Public Program Registration API Integration Tests', () => {
             const overflowEmail = `overflow-parent-${Date.now()}@test.com`;
             const householdsBefore = await prisma.household.count();
             try {
-                const req = new Request(`http://localhost:4000/api/programs/${overflowProgram.id}/public-register`, {
-                    method: 'POST',
-                    headers: { 'x-forwarded-for': '203.0.113.30' }, // own rate-limit bucket
-                    body: JSON.stringify({
-                        parents: [{ name: 'Overflow Parent', email: overflowEmail, phone: '555-300-1111' }],
-                        emergencyContact: { name: 'Aunt Sue', phone: '555-300-2222' },
-                        // 3 children into a 2-seat program: 0 enrolled + 3 > 2.
-                        participants: [
-                            { name: 'Kid A', dob: '2012-01-01' },
-                            { name: 'Kid B', dob: '2013-01-01' },
-                            { name: 'Kid C', dob: '2014-01-01' },
-                        ]
-                    })
+                // Capacity + the all-or-nothing rollback live in the confirm step now.
+                const token = await requestAndGetToken(overflowProgram.id, {
+                    parents: [{ name: 'Overflow Parent', email: overflowEmail, phone: '555-300-1111' }],
+                    emergencyContact: { name: 'Aunt Sue', phone: '555-300-2222' },
+                    // 3 children into a 2-seat program: 0 enrolled + 3 > 2.
+                    participants: [
+                        { name: 'Kid A', dob: '2012-01-01' },
+                        { name: 'Kid B', dob: '2013-01-01' },
+                        { name: 'Kid C', dob: '2014-01-01' },
+                    ]
                 });
-                const res = await POST(req as unknown as import("next/server").NextRequest, createParams(overflowProgram.id) as unknown as never);
+                const res = await confirm(overflowProgram.id, token);
                 expect(res.status).toBe(400);
                 const data = await res.json();
                 expect(data.error).toMatch(/open spots/i);
@@ -484,20 +522,15 @@ describe('Public Program Registration API Integration Tests', () => {
         });
 
         it('should set status to ACTIVE if the program is free', async () => {
-            // Need a new unique parent because the first one is already generated
             const uniqueEmail = `mom-free-${Date.now()}@test.com`;
-            const req = new Request(`http://localhost:4000/api/programs/${freeProgramId}/public-register`, {
-                method: 'POST',
-                headers: { 'x-forwarded-for': '203.0.113.2' }, // own rate-limit bucket so earlier block tests don't 429 this
-                body: JSON.stringify({
-                    parents: [{ name: 'Mom Free', email: uniqueEmail, phone: '555-111-3333' }],
-                    emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
-                    participants: [{ name: 'Timmy', dob: '2010-01-01' }]
-                })
+            const token = await requestAndGetToken(freeProgramId, {
+                parents: [{ name: 'Mom Free', email: uniqueEmail, phone: '555-111-3333' }],
+                emergencyContact: { name: 'Aunt Sue', phone: '555-999-9999' },
+                participants: [{ name: 'Timmy', dob: '2010-01-01' }]
             });
-            const res = await POST(req as unknown as import("next/server").NextRequest, createParams(freeProgramId) as unknown as never);
+            const res = await confirm(freeProgramId, token);
             expect(res.status).toBe(200);
-            
+
             const data = await res.json();
             expect(data.success).toBe(true);
             expect(data.checkoutUrl).toBeNull();

--- a/checkin-app/src/app/api/programs/[id]/public-register/confirm/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/public-register/confirm/route.ts
@@ -1,0 +1,187 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { sendNotification } from "@/lib/notifications";
+import { logBackendError, logger } from "@/lib/logger";
+import { addHouseholdLead, HouseholdLeadLimitError } from "@/lib/household/leads";
+import { lockProgramAndCheckCapacity, ProgramCapacityError } from "@/lib/program/capacity";
+import { createContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
+import { rateLimit } from "@/lib/rate-limit";
+import { decodeRegistrationToken } from "@/lib/registrationToken";
+import { apiError } from "@/lib/api-response";
+
+interface ParentInput {
+    name: string;
+    email?: string | null;
+    phone?: string | null;
+}
+
+interface RegistrationPayload {
+    programId: number;
+    parents: ParentInput[];
+    emergencyContact: { name: string; phone: string; email?: string | null };
+    participants: { name: string; dob?: string | null }[];
+}
+
+// Double opt-in, step 2 of 2. The recipient clicked the tokenized link, proving
+// they control the email, so we now do the actual writes. Everything here was
+// already shape/age-validated at request time and the token is tamper-proof, so
+// we re-check only the time-sensitive things: enrollment status, capacity (under
+// a row lock), and the email-already-exists / household-member rules.
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+    const { id } = await params;
+
+    const limited = rateLimit(req, { name: "public-register-confirm", limit: 10, windowMs: 60_000 });
+    if (limited) return limited;
+
+    try {
+        const programId = parseInt(id, 10);
+        const { token } = await req.json();
+        const payload = decodeRegistrationToken<RegistrationPayload>(token);
+
+        if (!payload || payload.programId !== programId) {
+            return apiError("This confirmation link is invalid or has expired.", 400);
+        }
+
+        const { parents, emergencyContact, participants } = payload;
+
+        const currentProgram = await prisma.program.findUnique({ where: { id: programId } });
+        if (!currentProgram) {
+            return apiError("Program not found", 404);
+        }
+        if (currentProgram.enrollmentStatus === 'CLOSED') {
+            return apiError("Program enrollment is currently closed.", 400);
+        }
+
+        // Now safe to check existence: the caller proved control of the email by
+        // clicking the link, so this is not an enumeration oracle. Also makes a
+        // replayed confirm link idempotent (second click → "already exists").
+        const emailsToCheck = parents.map((p) => p.email).filter(Boolean) as string[];
+        if (emailsToCheck.length > 0) {
+            const existingUsers = await prisma.person.findMany({
+                where: { email: { in: emailsToCheck } }
+            });
+            if (existingUsers.length > 0) {
+                return apiError("An account with that email already exists. Please log in to enroll.", 400);
+            }
+        }
+
+        const isFree = currentProgram.orgMemberPriceCents === null && currentProgram.nonOrgMemberPriceCents === null;
+        const initialStatus = isFree ? 'ACTIVE' : 'PENDING';
+
+        // Transactionally create everything
+        const result = await prisma.$transaction(async (tx) => {
+            // 0. Lock the program and re-check capacity against the committed
+            //    enrollment count, serializing concurrent registrations.
+            await lockProgramAndCheckCapacity(tx, programId, participants.length, currentProgram.maxParticipants);
+
+            // 1. Create Household
+            const household = await tx.household.create({
+                data: {
+                    name: `${parents[0].name.split(' ').pop() || parents[0].name}'s Household`,
+                }
+            });
+
+            // 2. Create Parents
+            const createdParents = [];
+            for (const parent of parents) {
+                if (!parent.name) continue;
+                const newParent = await tx.person.create({
+                    data: {
+                        name: parent.name,
+                        email: parent.email || null,
+                        phone: parent.phone || null,
+                        householdId: household.id,
+                    }
+                });
+                createdParents.push(newParent);
+
+                // Make them lead
+                await addHouseholdLead(tx, household.id, newParent.id);
+            }
+
+            // 3. Create Participants & Enrollments
+            const enrolledParticipantIds: number[] = [];
+
+            for (const p of participants) {
+                let participantId: number;
+
+                const matchedParent = createdParents.find(cp => cp.name && cp.name.toLowerCase().trim() === p.name.toLowerCase().trim());
+
+                if (matchedParent) {
+                    participantId = matchedParent.id;
+                } else {
+                    const newParticipant = await tx.person.create({
+                        data: {
+                            name: p.name,
+                            dateOfBirth: p.dob ? new Date(p.dob) : null,
+                            householdId: household.id,
+                        }
+                    });
+                    participantId = newParticipant.id;
+                }
+
+                enrolledParticipantIds.push(participantId);
+
+                const enrollment = await tx.programParticipant.create({
+                    data: {
+                        programId,
+                        personId: participantId,
+                        status: initialStatus
+                    }
+                });
+
+                await tx.auditLog.create({
+                    data: {
+                        actorId: createdParents[0].id, // Self-serve
+                        action: 'CREATE',
+                        tableName: 'ProgramParticipant',
+                        affectedEntityId: participantId,
+                        secondaryAffectedEntity: programId,
+                        newData: enrollment
+                    }
+                });
+            }
+
+            // 4. Create the emergency contact now that members exist, so the
+            //    not-a-household-member check runs against the full household.
+            await createContact(tx, household.id, {
+                name: emergencyContact.name,
+                phone: emergencyContact.phone,
+                email: emergencyContact.email ?? null,
+            });
+
+            return { householdId: household.id, enrolledParticipantIds, primaryParent: createdParents[0] };
+        });
+
+        // 5. Send Notifications
+        for (const participantId of result.enrolledParticipantIds) {
+            await sendNotification(participantId, 'PROGRAM_ENROLLMENT', { programName: currentProgram.name }).catch(e => logger.error(e));
+        }
+
+        // 6. Build Checkout URL if not free
+        let checkoutUrl = null;
+        if (!isFree && currentProgram.shopifyNonOrgMemberVariantId) {
+            const storeDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
+            const accountIdsStr = result.enrolledParticipantIds.join(',');
+            const quantity = result.enrolledParticipantIds.length;
+            checkoutUrl = `https://${storeDomain}/cart/${currentProgram.shopifyNonOrgMemberVariantId}:${quantity}?attributes[CheckMeIn_Account_ID]=${accountIdsStr}&attributes[Program_ID]=${programId}`;
+        }
+
+        return NextResponse.json({
+            success: true,
+            isFree,
+            checkoutUrl,
+            message: isFree ? "Enrollment complete." : "Redirecting to Shopify for payment."
+        });
+
+    } catch (error) {
+        if (error instanceof ProgramCapacityError) {
+            return apiError(`Not enough open spots. Only ${error.spotsLeft} spots left.`, 400);
+        }
+        if (error instanceof HouseholdLeadLimitError || error instanceof EmergencyContactError) {
+            return apiError(error.message, 400);
+        }
+        await logBackendError(error, "POST /api/programs/[id]/public-register/confirm");
+        return apiError("An error occurred during registration.", 500);
+    }
+}

--- a/checkin-app/src/app/api/programs/[id]/public-register/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/public-register/route.ts
@@ -1,14 +1,14 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { sendNotification } from "@/lib/notifications";
-import { logBackendError, logger } from "@/lib/logger";
-import { addHouseholdLead, HouseholdLeadLimitError } from "@/lib/household/leads";
-import { lockProgramAndCheckCapacity, ProgramCapacityError } from "@/lib/program/capacity";
-import { createContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
+import { logBackendError } from "@/lib/logger";
+import { sendEmail } from "@/lib/email";
+import { config } from "@/lib/config";
 import { rateLimit, rateLimitEmail } from "@/lib/rate-limit";
 import { calculateAge } from "@/lib/time";
-import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
+import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 import { apiError } from "@/lib/api-response";
+import { encodeRegistrationToken } from "@/lib/registrationToken";
+import { registrationConfirmTemplate } from "@/lib/email-templates/registration-confirm";
 
 interface ParentInput {
     name: string;
@@ -21,11 +21,19 @@ interface ParticipantInput {
     dob?: string | null;
 }
 
+// Double opt-in, step 1 of 2 (see confirm/route.ts for step 2).
+//
+// This endpoint is fully unauthenticated. To avoid being used to spam the DB or
+// bomb a third party's inbox, it writes NOTHING and sends only ONE confirmation
+// email to the entered address. The household/participants/enrollments are
+// created only when the recipient clicks the tokenized link, proving they
+// control the address. It also returns the SAME neutral response whether or not
+// the email already has an account, so it can't be used to enumerate accounts.
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
 
-    // Unauthenticated + writes to the DB and emails a caller-supplied address:
-    // the email-bomb / DB-spam target. Cap per source IP before any work.
+    // Unauthenticated and emails a caller-supplied address: the email-bomb target.
+    // Cap per source IP before any work.
     const ipLimited = rateLimit(req, { name: "public-register", limit: 5, windowMs: 60_000 });
     if (ipLimited) return ipLimited;
 
@@ -35,8 +43,6 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
             return apiError("Invalid program ID", 400);
         }
 
-        // Capacity is counted under a row lock inside the registration
-        // transaction below, so no _count is fetched here.
         const currentProgram = await prisma.program.findUnique({
             where: { id: programId }
         });
@@ -67,37 +73,24 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         const emailLimited = rateLimitEmail(parents[0].email, { name: "public-register", limit: 3, windowMs: 3_600_000 });
         if (emailLimited) return emailLimited;
 
-        // The not-a-household-member rule (phone/email/name) is enforced when the
-        // contact is created inside the transaction, against every household
-        // member — see createContact below.
+        // NOTE: we deliberately do NOT check whether the email already exists here.
+        // Branching the response on existence would leak which emails have accounts
+        // to an anonymous caller. That check (and the household-member rule for the
+        // emergency contact, and capacity) runs at confirm time, after the address
+        // is proven and a row lock is held.
 
-        // Check for existing emails to prevent Unique Constraint violations
-        const emailsToCheck = parents.map((p: ParentInput) => p.email).filter(Boolean);
-        if (emailsToCheck.length > 0) {
-            const existingUsers = await prisma.person.findMany({
-                where: { email: { in: emailsToCheck } }
-            });
-            if (existingUsers.length > 0) {
-                return apiError("An account with that email already exists. Please log in to enroll.", 400);
-            }
-        }
-
-        // Capacity is re-checked under a row lock INSIDE the transaction below
-        // (this endpoint is public/unauthenticated, so it is trivially raced).
-        // The _count read above is stale by the time we write.
-
-        // Check Enrollment Status
         if (currentProgram.enrollmentStatus === 'CLOSED') {
             return apiError("Program enrollment is currently closed.", 400);
         }
 
-        // Check Age constraints
+        // Age constraints — validated now so we don't email a confirmation for an
+        // ineligible registration. The token is tamper-proof, so confirm trusts it.
         if (currentProgram.minAge !== null || currentProgram.maxAge !== null) {
             for (const p of participants as ParticipantInput[]) {
                 const isMatchingParent = parents.some((parent: ParentInput) => parent.name.toLowerCase().trim() === p.name.toLowerCase().trim());
                 if (isMatchingParent) {
                     // It's an adult parent. Assume they are over 18.
-                    const age = 30; 
+                    const age = 30;
                     if (currentProgram.minAge !== null && age < currentProgram.minAge) {
                         return apiError(`Participant ${p.name} does not meet minimum age restriction.`, 400);
                     }
@@ -121,122 +114,24 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
             }
         }
 
-        const isFree = currentProgram.orgMemberPriceCents === null && currentProgram.nonOrgMemberPriceCents === null;
-        const initialStatus = isFree ? 'ACTIVE' : 'PENDING';
+        // Stash the validated registration in a tamper-proof, self-expiring token
+        // and email it. No DB writes happen until confirm.
+        const token = encodeRegistrationToken({ programId, parents, emergencyContact, participants });
+        const confirmUrl = `${config.baseUrl()}/programs/${programId}/register/confirm?token=${encodeURIComponent(token)}`;
+        await sendEmail(
+            parents[0].email,
+            "Confirm your registration",
+            registrationConfirmTemplate({ programName: currentProgram.name, confirmUrl })
+        );
 
-        // Transactionally create everything
-        const result = await prisma.$transaction(async (tx) => {
-            // 0. Lock the program and re-check capacity against the committed
-            //    enrollment count, serializing concurrent registrations.
-            await lockProgramAndCheckCapacity(tx, programId, participants.length, currentProgram.maxParticipants);
-
-            // 1. Create Household
-            const household = await tx.household.create({
-                data: {
-                    name: `${parents[0].name.split(' ').pop() || parents[0].name}'s Household`,
-                }
-            });
-
-            // 2. Create Parents
-            const createdParents = [];
-            for (const parent of parents) {
-                if (!parent.name) continue;
-                const newParent = await tx.person.create({
-                    data: {
-                        name: parent.name,
-                        email: parent.email || null,
-                        phone: parent.phone ? formatPhone(parent.phone) : null,
-                        householdId: household.id,
-                    }
-                });
-                createdParents.push(newParent);
-
-                // Make them lead
-                await addHouseholdLead(tx, household.id, newParent.id);
-            }
-
-            // 3. Create Participants & Enrollments
-            const enrolledParticipantIds: number[] = [];
-            
-            for (const p of participants) {
-                let participantId: number;
-                
-                const matchedParent = createdParents.find(cp => cp.name && cp.name.toLowerCase().trim() === p.name.toLowerCase().trim());
-
-                if (matchedParent) {
-                    participantId = matchedParent.id;
-                } else {
-                    const newParticipant = await tx.person.create({
-                        data: {
-                            name: p.name,
-                            dateOfBirth: p.dob ? new Date(p.dob) : null,
-                            householdId: household.id,
-                        }
-                    });
-                    participantId = newParticipant.id;
-                }
-
-                enrolledParticipantIds.push(participantId);
-
-                const enrollment = await tx.programParticipant.create({
-                    data: {
-                        programId,
-                        personId: participantId,
-                        status: initialStatus
-                    }
-                });
-
-                await tx.auditLog.create({
-                    data: {
-                        actorId: createdParents[0].id, // Self-serve
-                        action: 'CREATE',
-                        tableName: 'ProgramParticipant',
-                        affectedEntityId: participantId,
-                        secondaryAffectedEntity: programId,
-                        newData: enrollment
-                    }
-                });
-            }
-
-            // 4. Create the emergency contact now that members exist, so the
-            //    not-a-household-member check runs against the full household.
-            await createContact(tx, household.id, {
-                name: emergencyContact.name,
-                phone: emergencyContact.phone,
-                email: emergencyContact.email ?? null,
-            });
-
-            return { householdId: household.id, enrolledParticipantIds, primaryParent: createdParents[0] };
-        });
-
-        // 4. Send Notifications
-        for (const participantId of result.enrolledParticipantIds) {
-            await sendNotification(participantId, 'PROGRAM_ENROLLMENT', { programName: currentProgram.name }).catch(e => logger.error(e));
-        }
-
-        // 5. Build Checkout URL if not free
-        let checkoutUrl = null;
-        if (!isFree && currentProgram.shopifyNonOrgMemberVariantId) {
-            const storeDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
-            const accountIdsStr = result.enrolledParticipantIds.join(',');
-            const quantity = result.enrolledParticipantIds.length;
-            checkoutUrl = `https://${storeDomain}/cart/${currentProgram.shopifyNonOrgMemberVariantId}:${quantity}?attributes[CheckMeIn_Account_ID]=${accountIdsStr}&attributes[Program_ID]=${programId}`;
-        }
-
-        return NextResponse.json({ 
-            success: true, 
-            isFree,
-            checkoutUrl,
-            message: isFree ? "Enrollment complete." : "Redirecting to Shopify for payment."
+        // Neutral response — identical regardless of whether the email exists.
+        return NextResponse.json({
+            success: true,
+            pending: true,
+            message: "Almost done! Check your email for a link to confirm your registration."
         });
 
     } catch (error) {
-        if (error instanceof ProgramCapacityError) {
-            return apiError(`Not enough open spots. Only ${error.spotsLeft} spots left.`, 400);
-        }
-        if (error instanceof HouseholdLeadLimitError || error instanceof EmergencyContactError) {
-            return apiError(error.message, 400);
-        }
         await logBackendError(error, "POST /api/programs/[id]/public-register");
         return apiError("An error occurred during registration.", 500);
     }

--- a/checkin-app/src/app/programs/[id]/register/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/register/__tests__/page.test.tsx
@@ -170,9 +170,12 @@ describe("PublicRegistrationPage", () => {
     );
   });
 
-  it("redirects to Shopify checkout when registration returns a checkout URL", async () => {
+  it("shows the check-your-email prompt on successful submit (double opt-in, no immediate redirect)", async () => {
+    // Double opt-in: submitting enrolls nothing and never redirects to checkout —
+    // it emails a confirmation link, and the checkout redirect (for paid programs)
+    // happens on the confirm page after the writes succeed.
     mockFetchJson({
-      "/api/programs/1/public-register": { checkoutUrl: "https://shop.example.com/checkout" },
+      "/api/programs/1/public-register": { success: true, pending: true, message: "Almost done! Check your email for a link to confirm your registration." },
       "/api/programs/1": program,
     });
     renderPage();
@@ -181,7 +184,8 @@ describe("PublicRegistrationPage", () => {
     fireEvent.change(screen.getAllByLabelText("Full Name", { exact: false })[1], { target: { value: "Jane Doe" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Pay & Register via Shopify" }));
-    expect(await screen.findByText("Registration started! Redirecting you to checkout...")).toBeInTheDocument();
+    expect(await screen.findByText(/check your email/i)).toBeInTheDocument();
+    expect(router.push).not.toHaveBeenCalled();
   });
 
   it("shows a server error message when registration fails", async () => {

--- a/checkin-app/src/app/programs/[id]/register/confirm/page.tsx
+++ b/checkin-app/src/app/programs/[id]/register/confirm/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { use, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Alert, Button, Card, Center, Container, Loader, Stack, Text, Title } from '@mantine/core';
+
+// Double opt-in, the page the confirmation email links to. We require an
+// explicit click here rather than auto-confirming on load, so email link
+// scanners / prefetchers don't complete the registration on the user's behalf.
+export default function ConfirmRegistrationPage({ params }: { params: Promise<{ id: string }> }) {
+    const { id } = use(params);
+    const router = useRouter();
+
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState("");
+    const [success, setSuccess] = useState("");
+
+    const confirm = async () => {
+        // Read the token at click time (client-only), so there's no effect/state
+        // syncing the URL into React just to read it back on the next click.
+        const token = new URLSearchParams(window.location.search).get("token");
+        if (!token) {
+            setError("No confirmation token found. Please use the link from your email.");
+            return;
+        }
+        setSubmitting(true);
+        setError("");
+        try {
+            const res = await fetch(`/api/programs/${id}/public-register/confirm`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ token }),
+            });
+            const data = await res.json();
+            if (res.ok) {
+                if (data.checkoutUrl) {
+                    setSuccess("Confirmed! Redirecting you to checkout...");
+                    window.location.href = data.checkoutUrl;
+                } else {
+                    setSuccess("Enrollment complete! You're all set.");
+                    setTimeout(() => router.push(`/programs/${id}`), 3000);
+                }
+            } else {
+                setError(data.error || "Failed to confirm registration.");
+                setSubmitting(false);
+            }
+        } catch {
+            setError("Network error occurred.");
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <Container size="sm" py="xl">
+            <Card withBorder radius="md" padding="xl" ta="center">
+                <Stack align="center">
+                    <Title order={2}>Confirm your registration</Title>
+                    {success ? (
+                        <Alert color="green" w="100%">{success}</Alert>
+                    ) : (
+                        <>
+                            {error && <Alert color="red" w="100%">{error}</Alert>}
+                            {submitting ? (
+                                <Center><Loader /></Center>
+                            ) : (
+                                <>
+                                    <Text c="dimmed">Click below to finish enrolling.</Text>
+                                    <Button size="md" onClick={confirm}>Confirm registration</Button>
+                                </>
+                            )}
+                        </>
+                    )}
+                </Stack>
+            </Card>
+        </Container>
+    );
+}

--- a/checkin-app/src/app/programs/[id]/register/page.tsx
+++ b/checkin-app/src/app/programs/[id]/register/page.tsx
@@ -143,16 +143,11 @@ export default function PublicRegistrationPage({ params }: { params: Promise<{ i
 
       const data = await res.json();
       if (res.ok) {
-        setSubmitted(true); // clears the unsaved-changes guard before any redirect
-        if (data.checkoutUrl) {
-          setSuccess("Registration started! Redirecting you to checkout...");
-          // Defer one tick so React flushes the guard effect (dirty→false)
-          // before the full-page nav, else beforeunload would still prompt.
-          setTimeout(() => { window.location.href = data.checkoutUrl; }, 0);
-        } else {
-          setSuccess("Registration successful! Check your email for confirmation.");
-          setTimeout(() => router.push(`/programs/${id}`), 3000);
-        }
+        setSubmitted(true); // clears the unsaved-changes guard now the form is done
+        // Double opt-in: nothing is enrolled until the confirmation link is
+        // clicked, so always send the user to check their inbox (the checkout
+        // redirect now happens on the confirm page after the writes succeed).
+        setSuccess(data.message || "Almost done! Check your email for a link to confirm your registration.");
       } else {
         setError(data.error || "Failed to register.");
         setSubmitting(false);

--- a/checkin-app/src/lib/__tests__/registrationToken.test.ts
+++ b/checkin-app/src/lib/__tests__/registrationToken.test.ts
@@ -1,0 +1,36 @@
+import { encodeRegistrationToken, decodeRegistrationToken } from "../registrationToken";
+
+// key() reads NEXTAUTH_SECRET; set a deterministic one for the test.
+process.env.NEXTAUTH_SECRET = "test-secret-for-registration-tokens";
+
+describe("registrationToken", () => {
+    const payload = { programId: 7, parents: [{ name: "Dad", email: "d@x.com" }] };
+
+    it("round-trips a payload within the window", () => {
+        const now = 1_000_000;
+        const token = encodeRegistrationToken(payload, now);
+        const decoded = decodeRegistrationToken<typeof payload & { exp: number }>(token, now + 1000);
+        expect(decoded).toMatchObject(payload);
+    });
+
+    it("returns null once expired", () => {
+        const now = 1_000_000;
+        const token = encodeRegistrationToken(payload, now);
+        // TTL is 24h; jump past it.
+        expect(decodeRegistrationToken(token, now + 25 * 60 * 60 * 1000)).toBeNull();
+    });
+
+    it("returns null when the ciphertext is tampered", () => {
+        const now = 1_000_000;
+        const token = encodeRegistrationToken(payload, now);
+        // Flip a character in the middle (still valid base64url, bad auth tag).
+        const i = Math.floor(token.length / 2);
+        const swap = token[i] === "A" ? "B" : "A";
+        const tampered = token.slice(0, i) + swap + token.slice(i + 1);
+        expect(decodeRegistrationToken(tampered, now)).toBeNull();
+    });
+
+    it("returns null for garbage input", () => {
+        expect(decodeRegistrationToken("not-a-real-token", 0)).toBeNull();
+    });
+});

--- a/checkin-app/src/lib/email-templates/registration-confirm.ts
+++ b/checkin-app/src/lib/email-templates/registration-confirm.ts
@@ -1,0 +1,23 @@
+import { baseEmailLayout, escapeHtml } from './base';
+
+interface RegistrationConfirmParams {
+    programName: string;
+    confirmUrl: string;
+}
+
+/**
+ * Double-opt-in email: nothing is enrolled until the recipient clicks through.
+ * This is the ONLY email an unconfirmed (possibly attacker-supplied) address can
+ * trigger, which is why it's a single, plain confirmation rather than a cascade.
+ */
+export function registrationConfirmTemplate({ programName, confirmUrl }: RegistrationConfirmParams): string {
+    return baseEmailLayout(`
+        <h2 style="color: #6366f1;">Confirm your registration</h2>
+        <p>You're almost done registering for <strong>${escapeHtml(programName)}</strong>.</p>
+        <p>Click the button below to confirm. This link expires in 24 hours.</p>
+        <p style="margin: 24px 0;">
+            <a href="${escapeHtml(confirmUrl)}" style="background: #6366f1; color: #fff; padding: 12px 20px; border-radius: 6px; text-decoration: none; display: inline-block;">Confirm registration</a>
+        </p>
+        <p style="color: #6b7280; font-size: 13px;">If you didn't request this, you can safely ignore this email — nothing was created.</p>
+    `);
+}

--- a/checkin-app/src/lib/registrationToken.ts
+++ b/checkin-app/src/lib/registrationToken.ts
@@ -1,0 +1,59 @@
+import crypto from "crypto";
+
+// Confirmation token for the public-registration double-opt-in flow.
+//
+// The token carries the entire pending registration (parents, participants,
+// emergency contact) so NO database row is written until the email is confirmed.
+// It is AES-256-GCM encrypted, which gives us three things at once:
+//   - confidentiality: child PII never appears in the emailed URL (mail-server
+//     logs, browser history, Referer headers see only ciphertext);
+//   - integrity: any tampering fails the auth tag, so the payload can't be
+//     edited to enroll under a different program or skip validation;
+//   - self-expiry: the `exp` field inside the encrypted body bounds the window.
+//
+// ponytail: stateless — no DB row, no GC cron. Trade-off: tokens aren't
+// single-use, so a confirm link can be replayed. The confirm route is
+// idempotent (the unique participant.email constraint + existing-email
+// short-circuit make a replay a no-op), which covers it. If strict single-use
+// is ever needed (e.g. revocation), add a consumed-token table then.
+
+const ALGO = "aes-256-gcm";
+const TTL_MS = 24 * 60 * 60 * 1000; // 24h to click the confirmation link
+
+function key(): Buffer {
+    const secret = process.env.NEXTAUTH_SECRET;
+    if (!secret) throw new Error("NEXTAUTH_SECRET is required to encrypt registration tokens");
+    // Derive a 32-byte key from the app secret (the secret itself is variable length).
+    return crypto.createHash("sha256").update(secret).digest();
+}
+
+export function encodeRegistrationToken(payload: Record<string, unknown>, now = Date.now()): string {
+    const body = JSON.stringify({ ...payload, exp: now + TTL_MS });
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv(ALGO, key(), iv);
+    const ct = Buffer.concat([cipher.update(body, "utf8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    // [12-byte iv][16-byte tag][ciphertext], URL-safe.
+    return Buffer.concat([iv, tag, ct]).toString("base64url");
+}
+
+/**
+ * Decrypt and validate a token. Returns the payload, or null if the token is
+ * malformed, tampered, encrypted under a different key, or expired.
+ */
+export function decodeRegistrationToken<T = Record<string, unknown>>(token: string, now = Date.now()): T | null {
+    try {
+        const raw = Buffer.from(token, "base64url");
+        const iv = raw.subarray(0, 12);
+        const tag = raw.subarray(12, 28);
+        const ct = raw.subarray(28);
+        const decipher = crypto.createDecipheriv(ALGO, key(), iv);
+        decipher.setAuthTag(tag);
+        const body = Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8");
+        const obj = JSON.parse(body);
+        if (typeof obj.exp !== "number" || obj.exp < now) return null;
+        return obj as T;
+    } catch {
+        return null;
+    }
+}

--- a/checkin-app/tests/security/routeAuthDrift.test.ts
+++ b/checkin-app/tests/security/routeAuthDrift.test.ts
@@ -58,6 +58,11 @@ const ALLOWLIST = new Set<string>([
     // getOptionalSessionUser doesn't apply. Abuse is bounded by IP + email rate
     // limits inside the handler (see the "email-bomb / DB-spam target" comment).
     'programs/[id]/public-register/route.ts',
+    // Step 2 of the same deliberately-anonymous public registration flow. Auth is
+    // the encrypted, tamper-proof confirmation token (proves email control), not a
+    // session — so withAuth would 401 the public and it isn't a session read.
+    // Abuse is bounded by the IP rate limit inside the handler.
+    'programs/[id]/public-register/confirm/route.ts',
 ]);
 
 const HTTP_METHODS = 'GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS';


### PR DESCRIPTION
## ⚠️ Potentially controversial — read before merging

This adds abuse controls to the public, unauthenticated registration surface. The judgment call is a **UX-vs-risk tradeoff on the customer intake flow**, and reasonable people may disagree:

- **The change:** public registration is now **double opt-in** — submitting the form no longer enrolls anyone. It sends one confirmation email, and the household/participants/enrollments are created only after the parent clicks the link.
- **What we gain:** the endpoint can no longer be used to spam the DB or **bomb a third party's inbox** (it used to create rows + send enrollment email per call, fully unauthenticated). It also stops leaking which emails have accounts.
- **What it costs:** one extra step (and an email round-trip) before a new family is enrolled. That is friction added to the **top of the intake funnel** — some families will drop off at "check your email," and paid-program checkout now happens after the confirm click instead of immediately on submit.

**The core disagreement to resolve:** is the spam / email-bomb / enumeration risk worth adding a confirmation step to new-customer signup? If we decide the intake-funnel friction outweighs the abuse risk, the rate limiting alone (already a separate, merged change on `main`) may be considered sufficient and the double-opt-in half could be dropped. Flagging explicitly rather than deciding it unilaterally.

---

## What's in here

Built on top of the already-merged rate limiter (`src/lib/rate-limit.ts`, IP with IPv6 /64 collapsing + normalized-email keying). This PR adds the registration-flow hardening.

### Double opt-in for `POST /api/programs/[id]/public-register`
- **Request step** (`route.ts`): validate input, apply IP **and** per-normalized-email rate limits, then email an **AES-256-GCM token** carrying the pending registration. **Zero DB writes.** Returns a neutral "check your email" response.
- **Confirm step** (`public-register/confirm/route.ts`): the tokenized link proves email control → runs the original transaction (household + participants + enrollments + emergency contact), notifications, and Shopify checkout URL.
- Token is encrypted (child PII never appears in the emailed URL), tamper-proof, and self-expiring (24h). Stateless — no migration, no GC. Confirm is idempotent against link replay via the unique-email short-circuit.

### Enumeration oracle closed
The request step returns an **identical neutral response** whether or not the email already has an account. The existing-email check moved to confirm, where the caller has already proven inbox control — so it's no longer an anonymous oracle.

### UI
- Register page: success now means "check your email" (no immediate enroll/redirect).
- New confirm page (`register/confirm/page.tsx`): explicit confirm button (no prefetch/scanner auto-submit), handles the checkout redirect after writes succeed.

## Tests
- **Unit:** AES token round-trip / expiry / tamper (`registrationToken.test.ts`).
- **Integration:** `public-register` suites rewritten to drive request→confirm, including the capacity-race regression now exercised on the confirm step. Kept `main`'s `calculateAge` age-boundary regression tests (run at the request step).
- Verified locally against a throwaway Postgres: **13 unit + 15 integration passing.**

## Deploy notes
- No new dependency, no new env var (reuses `NEXTAUTH_SECRET`).
- Rate limiter is process-local (`ponytail:` ceiling noted) — fine for the single `standalone` container; revisit if we ever scale to multiple instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
