### PR TITLE
feat(program-ops): unsaved-changes guard on program & session creation forms

### DIFF
--- a/checkin-app/src/app/program-ops/new/page.tsx
+++ b/checkin-app/src/app/program-ops/new/page.tsx
@@ -7,6 +7,7 @@ import { AlertBanner } from '@/components/admin/AlertBanner';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { EntityPicker } from '@/components/admin/EntityPicker';
+import { useUnsavedGuard, shallowEqual } from '@/components/UnsavedChangesProvider';
 
 type ParticipantOption = {
   id: number;
@@ -29,6 +30,7 @@ export default function CreateProgramPage() {
   const [maxParticipants, setMaxParticipants] = useState("");
   const [memberOnly, setMemberOnly] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const [message, setMessage] = useState("");
   const [messageType, setMessageType] = useState<"success" | "error">("success");
 
@@ -63,6 +65,7 @@ export default function CreateProgramPage() {
 
       if (res.ok) {
         const data = await res.json();
+        setSubmitted(true); // clear unsaved-changes guard before redirect
         router.push(`/program-ops/programs/${data.program.id}`);
       } else {
         const data = await res.json();
@@ -76,6 +79,15 @@ export default function CreateProgramPage() {
       setSaving(false);
     }
   };
+
+  // Dirty = any field changed from the blank creation defaults.
+  const isDirty =
+    !submitted &&
+    !shallowEqual(
+      { name: "", begin: "", end: "", minAge: "", maxAge: "", isFree: true, memberPrice: "", nonMemberPrice: "", maxParticipants: "", memberOnly: false, leadMentorId: "" },
+      { name, begin, end, minAge, maxAge, isFree, memberPrice, nonMemberPrice, maxParticipants, memberOnly, leadMentorId },
+    );
+  useUnsavedGuard(isDirty);
 
   if (authLoading) {
     return <Center mih="60vh"><Loader /></Center>;

--- a/checkin-app/src/app/program-ops/sessions/new/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/new/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Button, Card, Center, Checkbox, Container, Group, Loader, Select, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AlertBanner } from '@/components/admin/AlertBanner';
+import { useUnsavedGuard, shallowEqual } from '@/components/UnsavedChangesProvider';
 
 const DAYS_MAP = [
   { label: 'Sun', value: 0 },
@@ -24,9 +25,10 @@ export function NewEventForm() {
 
   const [programs, setPrograms] = useState<{ id: number, name: string }[]>([]);
 
+  const defaultProgramId = searchParams.get('programId') || ""; // URL-prefilled, not a user edit
   const [name, setName] = useState("");
   const [description] = useState("");
-  const [programId, setProgramId] = useState(searchParams.get('programId') || "");
+  const [programId, setProgramId] = useState(defaultProgramId);
   const [startDate, setStartDate] = useState("");
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
@@ -38,7 +40,18 @@ export function NewEventForm() {
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const [message, setMessage] = useState("");
+
+  // Dirty = any field (incl. recurrence) changed from blank creation defaults.
+  // daysOfWeek joined to a string so it fits shallowEqual's primitive compare.
+  const isDirty =
+    !submitted &&
+    !shallowEqual(
+      { name: "", programId: defaultProgramId, startDate: "", startTime: "", endTime: "", repeats: false, daysOfWeek: "", until: "" },
+      { name, programId, startDate, startTime, endTime, repeats, daysOfWeek: daysOfWeek.join(','), until },
+    );
+  useUnsavedGuard(isDirty);
 
   const fetchPrograms = useCallback(async () => {
     try {
@@ -107,6 +120,7 @@ export function NewEventForm() {
       });
 
       if (res.ok) {
+        setSubmitted(true); // clear unsaved-changes guard before redirect
         router.push(programId ? `/program-ops/programs/${programId}` : '/programs');
       } else {
         const err = await res.json();


### PR DESCRIPTION
## What

Wires PR1's `useUnsavedGuard` into the two program-ops creation forms:

- `program-ops/new/page.tsx` (program creation, ~11 fields)
- `program-ops/sessions/new/page.tsx` (event/session creation, ~8 fields + conditional recurrence)

Editing any field now arms the app-wide guard, so leaving the page (browser close/refresh/back, or in-app nav chokepoints) prompts before discarding edits.

## How

- Each page snapshots its **blank creation defaults** and compares to current state via the shared `shallowEqual` helper to derive `isDirty`. Mirrors the existing `settings/membership` usage.
- Session form folds the conditional recurrence fields (`repeats` toggle, day selection, end date) into the comparison. `daysOfWeek` (a `number[]`) is `.join(',')`-ed to a string so it fits `shallowEqual`'s primitive compare.
- URL-prefilled `programId` is treated as a default, not a user edit.
- Both forms **redirect on success** rather than reset, so a `submitted` flag drops `isDirty` before `router.push` to suppress a spurious prompt.

## Notes for reviewer

- Depends on PR1 guard infra (`UnsavedChangesProvider` / `useUnsavedGuard` / `shallowEqual`).
- No new deps, no custom modal — reuses the native `beforeunload` + `window.confirm` path from PR1.
- No new test: usage is snapshot literals + one `.join`; `shallowEqual` is covered by PR1.
- Verified: `tsc --noEmit` clean (after `prisma generate`), eslint clean on both files. Logic traced (edit → prompt; submit → no prompt); not run in a live browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)