### PR TITLE
feat(my-household): guard deferred address edits against unsaved-changes loss

### DIFF
--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -12,6 +12,7 @@ import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { isOrgAccount } from '@/lib/orgAccount';
 import { pickAddress, type StructuredAddress } from '@/lib/address';
 import { isValidPhone, PHONE_ERROR } from '@/lib/phone';
+import { useUnsavedGuard, shallowEqual } from '@/components/UnsavedChangesProvider';
 
 const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
 
@@ -46,6 +47,9 @@ export default function HouseholdPage() {
   const [filterDate, setFilterDate] = useState("");
   const [settings, setSettings] = useState({ emailDependentCheckins: false });
   const [address, setAddress] = useState<StructuredAddress>(blankAddress);
+  // Snapshot of the address as last loaded/saved; isDirty compares it to current
+  // state to drive the unsaved-changes guard.
+  const [initialAddress, setInitialAddress] = useState<StructuredAddress>(blankAddress);
   const [savingSettings, setSavingSettings] = useState(false);
 
   const [contacts, setContacts] = useState<EmergencyContact[]>([]);
@@ -75,7 +79,9 @@ export default function HouseholdPage() {
         const data = await res.json();
         setHousehold(data.household);
         const a = pickAddress(data.household);
-        setAddress({ line1: a.line1 ?? "", line2: a.line2 ?? "", city: a.city ?? "", state: a.state ?? "", postalCode: a.postalCode ?? "" });
+        const loaded = { line1: a.line1 ?? "", line2: a.line2 ?? "", city: a.city ?? "", state: a.state ?? "", postalCode: a.postalCode ?? "" };
+        setAddress(loaded);
+        setInitialAddress(loaded);
       }
       if (visitRes.ok) {
         const data = await visitRes.json();
@@ -296,6 +302,13 @@ export default function HouseholdPage() {
       setMessage("Network error promoting member.");
     }
   };
+
+  // ponytail: guard ONLY the deferred Address card (committed by the "Update
+  // Address" button). The member add/edit forms, emergency-contact form, and the
+  // receipts toggle all submit instantly with no pending state — intentionally
+  // excluded so they never raise a spurious unsaved-changes prompt.
+  const isDirty = !shallowEqual({ ...initialAddress }, { ...address });
+  useUnsavedGuard(isDirty);
 
   if (loading || status === "loading") {
     return <Center mih="60vh"><Loader /></Center>;


### PR DESCRIPTION
## What

Wire the app-wide unsaved-changes guard (`useUnsavedGuard`) into the **My Household** page, scoped to the **Household Address** card — the one section that defers its save behind an "Update Address" button. Navigating away mid-edit previously dropped those edits silently.

- Snapshot the address as last loaded/saved (`initialAddress`), set alongside `setAddress` in `fetchHousehold`.
- `isDirty = !shallowEqual(initialAddress, address)` → `useUnsavedGuard(isDirty)`.
- Snapshot re-syncs on every `fetchHousehold`, including the post-save refetch, so dirty clears after a successful save with no extra code.

## Why

The Household Address card is the only **deferred-save** section on this page. Every other write — member add/edit, emergency-contact form, the receipts toggle — submits instantly with no pending state. Without the guard, a lead could fill in their address, click away, and lose it.

## Reviewer notes

- **Dirty is deliberately scoped to address fields only.** The instant-submit sections are excluded so they never raise a spurious prompt — there's a `// ponytail:` comment at the `isDirty` line spelling this out. The notification-pref (`emailDependentCheckins`) toggle is instant (`handleToggleReceipts`), so it is *not* counted toward dirty despite also being re-saved by the Update button.
- `useUnsavedGuard` is called before the page's early returns, keeping hook order stable.
- Depends on the guard infra (`UnsavedChangesProvider` + `useUnsavedGuard` + `shallowEqual`), already on the branch base.
- `tsc --noEmit` and `eslint` are clean on the changed file. No dedicated test added — dirty logic is a single `shallowEqual` over the already-tested helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)