### PR TITLE
test(integration): fix stale fixtures for phone validator + household-lead authz

### DIFF
--- a/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
@@ -131,7 +131,7 @@ describe('Ownership-boundary authorization', () => {
         // Trusted adults owned by HH_A.
         const taW = await prisma.trustedAdult.create({
             data: {
-                householdId: hhA, counterpartyName: 'Aunt May', counterpartyPhone: '555-0001',
+                householdId: hhA, counterpartyName: 'Aunt May', counterpartyPhone: '555-555-0001',
                 familyContext: 'ctx', disclosedById: leadA,
                 reviews: { create: { householdId: hhA, kind: 'INITIAL', status: 'PENDING_BOARD_REVIEW' } },
             },
@@ -139,7 +139,7 @@ describe('Ownership-boundary authorization', () => {
         taWithdrawId = taW.id;
         const taR = await prisma.trustedAdult.create({
             data: {
-                householdId: hhA, counterpartyName: 'Uncle Ben', counterpartyPhone: '555-0002',
+                householdId: hhA, counterpartyName: 'Uncle Ben', counterpartyPhone: '555-555-0002',
                 familyContext: 'ctx', disclosedById: leadA,
                 reviews: { create: { householdId: hhA, kind: 'INITIAL', status: 'APPROVED' } },
             },
@@ -148,8 +148,8 @@ describe('Ownership-boundary authorization', () => {
 
         // Two emergency contacts in HH_A (DELETE needs a second valid contact to exist).
         as(leadA, { householdId: hhA });
-        contact1 = (await (await EC_POST(jsonReq({ name: 'Contact One', phone: '555-1111' }, 'POST'))).json()).contact.id;
-        contact2 = (await (await EC_POST(jsonReq({ name: 'Contact Two', phone: '555-2222' }, 'POST'))).json()).contact.id;
+        contact1 = (await (await EC_POST(jsonReq({ name: 'Contact One', phone: '555-555-1111' }, 'POST'))).json()).contact.id;
+        contact2 = (await (await EC_POST(jsonReq({ name: 'Contact Two', phone: '555-555-2222' }, 'POST'))).json()).contact.id;
     });
 
     afterAll(async () => {
@@ -188,7 +188,7 @@ describe('Ownership-boundary authorization', () => {
         });
         it('403 for a non-lead member (POST)', async () => {
             as(memberA, { householdId: hhA });
-            expect((await EC_POST(jsonReq({ name: 'X', phone: '555-9' }, 'POST'))).status).toBe(403);
+            expect((await EC_POST(jsonReq({ name: 'X', phone: '555-555-0009' }, 'POST'))).status).toBe(403);
         });
         it('200 for the lead (GET)', async () => {
             as(leadA, { householdId: hhA });
@@ -214,13 +214,13 @@ describe('Ownership-boundary authorization', () => {
             as(leadB, { householdId: hhB });
             // leadB is a lead (passes the lead gate for THEIR household) but the contact
             // belongs to HH_A — the service must not find/update it for HH_B.
-            const res = await EC_PATCH(jsonReq({ name: 'Hijack', phone: '555-6666' }), ecCtx(contact1));
+            const res = await EC_PATCH(jsonReq({ name: 'Hijack', phone: '555-555-6666' }), ecCtx(contact1));
             expect(res.status).not.toBe(200);
             expect(res.status).toBe(404);
         });
         it('200 for the owning lead (PATCH)', async () => {
             as(leadA, { householdId: hhA });
-            expect((await EC_PATCH(jsonReq({ name: 'Contact One Edited', phone: '555-1111' }), ecCtx(contact1))).status).toBe(200);
+            expect((await EC_PATCH(jsonReq({ name: 'Contact One Edited', phone: '555-555-1111' }), ecCtx(contact1))).status).toBe(200);
         });
         it('200 for the owning lead (DELETE, second valid contact present)', async () => {
             as(leadA, { householdId: hhA });

--- a/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
@@ -148,10 +148,10 @@ describe('Household Lead API Integration Tests', () => {
             const res = await POST(req as unknown as import("next/server").NextRequest);
             expect(res.status).toBe(403);
             const data = await res.json();
-            expect(data.error).toBe('Only household leads or sysadmins can promote members');
+            expect(data.error).toBe('Only household leads, board members, or sysadmins can promote members');
         });
 
-        it('should return 404 Not Found if trying to promote a member outside of your household', async () => {
+        it('should return 403 Forbidden if a non-privileged lead tries to promote a member outside of their household', async () => {
             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: testLeadId } });
 
             const req = new Request('http://localhost:4000/api/household/lead', {
@@ -160,9 +160,9 @@ describe('Household Lead API Integration Tests', () => {
             });
 
             const res = await POST(req as unknown as import("next/server").NextRequest);
-            expect(res.status).toBe(404);
+            expect(res.status).toBe(403);
             const data = await res.json();
-            expect(data.error).toBe('Member not found in your household');
+            expect(data.error).toBe('Only household leads, board members, or sysadmins can promote members');
         });
 
         it('should return successfully when user is already a lead', async () => {

--- a/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
@@ -130,7 +130,7 @@ describe('Membership Intake API', () => {
         const patchReq = new Request('http://localhost:4000/api/membership/intake', {
             method: 'PATCH',
             body: JSON.stringify({
-                household: { line1: '1 Treehouse Way', emergencyContactName: 'Aunt May', emergencyContactPhone: '555-0100' },
+                household: { line1: '1 Treehouse Way', emergencyContactName: 'Aunt May', emergencyContactPhone: '555-555-0100' },
                 primaryParent: { name: 'Lead Parent', dob: '1985-04-01', allergies: 'peanuts' },
                 children: [{ name: 'Kid One', dob: '2015-06-01' }],
             }),
@@ -199,7 +199,7 @@ describe('Membership Intake API', () => {
         const patch = new Request('http://localhost:4000/api/membership/intake', {
             method: 'PATCH',
             body: JSON.stringify({
-                household: { line1: '9 Audit Way', emergencyContactName: 'Aunt Audit', emergencyContactPhone: '555-9001' },
+                household: { line1: '9 Audit Way', emergencyContactName: 'Aunt Audit', emergencyContactPhone: '555-555-9001' },
                 primaryParent: { name: 'Audit Lead' },
             }),
         });

--- a/checkin-app/src/lib/emergencyContacts/__tests__/service.integration.test.ts
+++ b/checkin-app/src/lib/emergencyContacts/__tests__/service.integration.test.ts
@@ -106,7 +106,7 @@ describe("upsertPrimaryContact — partial tolerance + member rejection", () => 
 
     it("persists the optional email + its normalized key", async () => {
         const hh = await makeHousehold("upsert-email");
-        const c = await upsertPrimaryContact(prisma, hh, { name: "Aunt May", phone: "555-4000", email: "  Aunt.May@Example.COM " });
+        const c = await upsertPrimaryContact(prisma, hh, { name: "Aunt May", phone: "555-555-4009", email: "  Aunt.May@Example.COM " });
         expect(c?.email).toBe("Aunt.May@Example.COM");
         expect(c?.emailNorm).toBe("aunt.may@example.com");
     });


### PR DESCRIPTION
## What

Fixes the integration suite, which had **4 failing suites / 36 tests**. All failures were test-side staleness — **no application code changed**.

## Why

Two independent causes, both tests lagging behind merged behavior:

1. **Phone fixtures** (`service`, `membershipIntake`, `authzOwnership` suites) — fixtures used 7–8 digit fake numbers (`555-0001`, `555-4000`, …). The shared phone validator from #503 now requires 10/11 digits, so writes were rejected. In `authzOwnership` these seeded emergency contacts in `beforeAll`, so the entire suite cascaded to failure (even `401 unauthenticated` cases). Bumped to 10-digit `555-555-XXXX`.

2. **household-lead authz** (`householdLeadAPI` suite) — asserted the pre-change contract. The route now authorizes **board members** and returns **403 (not 404)** for a non-privileged lead promoting a member outside their household. That's the IDOR-safe contract (doesn't leak member existence) per the route's own comment. Updated the assertions + one test name to match.

## Reviewer notes

- Security-relevant: the 404→403 change in test 2 reflects a *more* conservative route contract; updating the test is correct, not masking a regression. Verify against `checkin-app/src/app/api/household/lead/route.ts:31-38`.
- `package-lock.json` was intentionally **not** committed (incidental churn from a worktree `npm install`).

## Verification

Run serial (`--runInBand`) per repo convention:

```
Unit:        61 suites / 359 tests  ✅
Integration: 98 suites / 663 tests  ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)