### PR TITLE
fix(nav): scroll the left sidebar when it outgrows the viewport

### DIFF
--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -313,10 +313,18 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
           // `default-hover` token, which left white labels invisible (white-on-white, #284).
           // Scope that token to a translucent white so hovering just lightens the purple and the
           // white label stays readable — and it works in dark mode too, unlike a fixed color.
+          //
+          // overflowY:auto: when the nav list outgrows the viewport it scrolls instead of
+          // clipping. The <nav> element persists across route changes (only AppShell.Main's
+          // children swap), so the browser keeps its scrollTop — "back to X" leaves the
+          // sidebar scroll where it was rather than jumping to the top.
           style={
-            onColoredSidebar
-              ? ({ '--mantine-color-default-hover': 'rgba(255, 255, 255, 0.12)' } as React.CSSProperties)
-              : undefined
+            {
+              overflowY: 'auto',
+              ...(onColoredSidebar
+                ? { '--mantine-color-default-hover': 'rgba(255, 255, 255, 0.12)' }
+                : {}),
+            } as React.CSSProperties
           }
         >
           {visibleItems.map((item) => {


### PR DESCRIPTION
## What

Add `overflowY: auto` to the `AppShell.Navbar` root in `AppFrame.tsx` so the left nav scrolls when its item list is taller than the viewport.

## Why

With enough visible nav items (sysadmin/board members see the full set), the list exceeded the viewport height. The navbar's default `overflow: visible` clipped the overflowing items with no way to reach them.

## Scroll-position note for reviewers

The `<nav>` lives in the root layout and is mounted once — route changes only swap `AppShell.Main`'s children. Because the nav DOM node never remounts, the browser preserves its `scrollTop`. Navigating away and using a "back to X" link leaves the sidebar scroll where it was rather than jumping to the top. Native CSS overflow was chosen over Mantine `ScrollArea` precisely so this works for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)