### PR TITLE
feat(programs): multi-select household enrollment on public program page

### DIFF
--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { use, useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { Alert, Anchor, Button, Card, Center, Container, Divider, Group, Loader, Radio, Stack, Text, Title } from '@mantine/core';
+import { Alert, Anchor, Button, Card, Center, Checkbox, Container, Divider, Group, Loader, Stack, Text, Title } from '@mantine/core';
 import { formatDate, calculateAge } from '@/lib/time';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { formatCents } from '@inventory/money';
@@ -41,7 +41,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
 
   const [showEnrollmentSelection, setShowEnrollmentSelection] = useState(false);
   const [householdMembers, setHouseholdMembers] = useState<{ id: number; name: string | null; dateOfBirth: string | null }[]>([]);
-  const [selectedParticipantId, setSelectedParticipantId] = useState<number | null>(null);
+  const [selectedParticipantIds, setSelectedParticipantIds] = useState<number[]>([]);
   const [loadingHousehold, setLoadingHousehold] = useState(false);
 
   const fetchProgram = useCallback(async () => {
@@ -82,58 +82,66 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
         if (data.household && data.household.participants) {
           setHouseholdMembers(data.household.participants);
           const me = data.household.participants.find((p: { id: number }) => p.id === currentUserId);
-          if (me) setSelectedParticipantId(me.id);
-          else setSelectedParticipantId(data.household.participants[0]?.id || currentUserId);
+          setSelectedParticipantIds([me ? me.id : (data.household.participants[0]?.id || currentUserId)]);
         } else {
           setHouseholdMembers([{ id: currentUserId, name: "Myself", dateOfBirth: null }]);
-          setSelectedParticipantId(currentUserId);
+          setSelectedParticipantIds([currentUserId]);
         }
       } else {
         setHouseholdMembers([{ id: currentUserId, name: "Myself", dateOfBirth: null }]);
-        setSelectedParticipantId(currentUserId);
+        setSelectedParticipantIds([currentUserId]);
       }
     } catch {
       const currentUserId = (session.user as SessionUser).id;
       setHouseholdMembers([{ id: currentUserId, name: "Myself", dateOfBirth: null }]);
-      setSelectedParticipantId(currentUserId);
+      setSelectedParticipantIds([currentUserId]);
     } finally {
       setLoadingHousehold(false);
     }
   };
 
   const handleRequestPaymentPlan = async () => {
-    if (!session || !selectedParticipantId) return router.push('/');
+    if (!session || selectedParticipantIds.length === 0) return router.push('/');
 
     setEnrolling(true);
     setMessage("");
 
-    try {
-      let res = await fetch(`/api/programs/${id}/participants`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantId: selectedParticipantId })
-      });
+    const errors: string[] = [];
+    let anyRequested = false;
 
-      if (!res.ok) {
-        const data = await res.json();
-        setMessage(data.error || "Failed to start enrollment.");
-        setEnrolling(false);
-        return;
+    try {
+      for (const participantId of selectedParticipantIds) {
+        let res = await fetch(`/api/programs/${id}/participants`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantId })
+        });
+
+        if (!res.ok) {
+          const data = await res.json();
+          errors.push(data.error || "Failed to start enrollment.");
+          continue;
+        }
+
+        res = await fetch(`/api/programs/${id}/request-payment-plan`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantId })
+        });
+
+        if (res.ok) {
+          anyRequested = true;
+        } else {
+          errors.push("Enrolled as pending, but failed to alert the finance committee for one member. Please email them directly.");
+        }
       }
 
-      res = await fetch(`/api/programs/${id}/request-payment-plan`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantId: selectedParticipantId })
-      });
-
-      if (res.ok) {
+      if (anyRequested) {
         setSuccessMessage("Requested! Please check your email for communication from the finance committee of the board.");
         fetchProgram();
         notifyNavRefresh();
-      } else {
-        setMessage("Enrolled as pending, but failed to alert the finance committee. Please email them directly.");
       }
+      if (errors.length > 0) setMessage(errors.join(" "));
     } catch {
       setMessage("Network error requesting payment plan.");
     } finally {
@@ -142,7 +150,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   };
 
   const handleEnroll = async (override = false) => {
-    if (!session || !selectedParticipantId) {
+    if (!session || selectedParticipantIds.length === 0) {
       router.push('/');
       return;
     }
@@ -152,14 +160,30 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
     setEnrolling(true);
     setMessage("");
 
-    try {
-      const res = await fetch(`/api/programs/${id}/participants`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantId: selectedParticipantId, override })
-      });
+    const errors: string[] = [];
+    const enrolledIds: number[] = [];
+    let needsOverride = false;
 
-      if (res.ok) {
+    try {
+      for (const participantId of selectedParticipantIds) {
+        const res = await fetch(`/api/programs/${id}/participants`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantId, override })
+        });
+
+        // 409 = already enrolled = desired end state (covers override retries of
+        // members that succeeded on the first pass), so treat it as enrolled.
+        if (res.ok || res.status === 409) {
+          enrolledIds.push(participantId);
+          continue;
+        }
+        const data = await res.json();
+        if (data.requiresOverride) needsOverride = true;
+        errors.push(data.error || "Failed to enroll in program.");
+      }
+
+      if (enrolledIds.length > 0) {
         notifyNavRefresh();
         if (isPayingOnShopify && program) {
           setSuccessMessage("Redirecting to Shopify for secure payment...");
@@ -175,26 +199,31 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
 
           if (variantId) {
             const storeDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
-            const checkoutUrl = `https://${storeDomain}/cart/${variantId}:1?attributes[CheckMeIn_Account_ID]=${selectedParticipantId}&attributes[Program_ID]=${id}`;
+            // ponytail: Shopify cart attributes are cart-level, not per-line-item, so
+            // N participants can't each carry their own account id on separate lines.
+            // But membership is household-level → every selected member shares ONE
+            // variant tier, so we charge qty=N of that single variant and pass all
+            // account ids comma-joined. The orders/paid webhook splits
+            // CheckMeIn_Account_ID on ',' and activates each (webhooks/shopify/route.ts,
+            // covered by webhookShopify.integration.test.ts). Constraint: this only
+            // holds while one household = one membership tier = one variant.
+            const accountIds = enrolledIds.join(',');
+            const checkoutUrl = `https://${storeDomain}/cart/${variantId}:${enrolledIds.length}?attributes[CheckMeIn_Account_ID]=${accountIds}&attributes[Program_ID]=${id}`;
             window.location.href = checkoutUrl;
+            return;
           } else {
             setSuccessMessage("Enrolled! (Note: No pricing variant configured for this tier)");
             fetchProgram();
           }
         } else {
-          setSuccessMessage("Successfully enrolled!");
+          setSuccessMessage(enrolledIds.length > 1 ? `Successfully enrolled ${enrolledIds.length} members!` : "Successfully enrolled!");
           setRequiresOverride(false);
           fetchProgram();
         }
-      } else {
-        const data = await res.json();
-        if (data.requiresOverride) {
-          setRequiresOverride(true);
-          setMessage(data.error);
-        } else {
-          setMessage(data.error || "Failed to enroll in program.");
-        }
       }
+
+      if (needsOverride) setRequiresOverride(true);
+      if (errors.length > 0) setMessage(errors.join(" "));
     } catch {
       setMessage("Network error during enrollment.");
     } finally {
@@ -221,7 +250,6 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   const canManage = !!(session && (user?.sysadmin || user?.boardMember || user?.id === program.leadMentorId));
   const isClosed = program.enrollmentStatus === 'CLOSED';
   const hasPrice = !!(program.memberPriceCents || program.nonMemberPriceCents);
-  const alreadySelected = selectedParticipantId !== null && program.participants.some(p => p.participantId === selectedParticipantId);
 
   return (
     <Container size="md" pb="md">
@@ -290,9 +318,9 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
               {loadingHousehold ? (
                 <Center py="md"><Loader size="sm" /></Center>
               ) : (
-                <Radio.Group
-                  value={selectedParticipantId !== null ? String(selectedParticipantId) : null}
-                  onChange={(v) => setSelectedParticipantId(Number(v))}
+                <Checkbox.Group
+                  value={selectedParticipantIds.map(String)}
+                  onChange={(vals) => setSelectedParticipantIds(vals.map(Number))}
                   mb="lg"
                 >
                   <Stack>
@@ -315,7 +343,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                       return (
                         <Card key={member.id} withBorder radius="md" padding="sm" opacity={disabled ? 0.5 : 1}>
                           <Group justify="space-between">
-                            <Radio
+                            <Checkbox
                               value={String(member.id)}
                               disabled={disabled}
                               label={member.name || 'Unnamed Participant'}
@@ -327,7 +355,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                       );
                     })}
                   </Stack>
-                </Radio.Group>
+                </Checkbox.Group>
               )}
 
               <Stack align="center">
@@ -335,7 +363,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                   fullWidth
                   size="md"
                   onClick={() => handleEnroll(false)}
-                  disabled={enrolling || !selectedParticipantId || alreadySelected || loadingHousehold}
+                  disabled={enrolling || selectedParticipantIds.length === 0 || loadingHousehold}
                   loading={enrolling}
                 >
                   {hasPrice ? "Pay on Shopify" : "Complete Enrollment"}


### PR DESCRIPTION
## What

The public program page's "Which of your household wants to enroll?" picker was single-choice (Mantine `Radio`), so a parent could only enroll one household member per visit. This makes it multi-select (`Checkbox`) — a household can enroll several members at once.

## Why

A single `selectedParticipantId` drove three handlers plus the Shopify checkout URL. All now support multiple participants.

## Changes (`checkin-app/src/app/programs/[id]/page.tsx`)

- **State**: `selectedParticipantId: number | null` → `selectedParticipantIds: number[]`. Init effect defaults to **just the current user**, not all members.
- **UI**: `Radio.Group`/`Radio` → `Checkbox.Group`/`Checkbox`. Per-member disabled logic (already-enrolled + age min/max via `calculateAge`) and the "(Already Enrolled)" / age-error labels are unchanged; disabled members stay unselectable.
- **`handleEnroll` / `handleRequestPaymentPlan`**: loop the `/participants` POST per selected id, aggregate errors, handle `requiresOverride` per participant. A `409` (already enrolled) is treated as success so the force-enroll override retry is idempotent.
- **Enroll button** disabled logic updated for the array; dropped the now-moot `alreadySelected` check.

## The money path (reviewer note)

Shopify cart attributes are **cart-level, not per-line-item**, so N participants can't each carry their own `CheckMeIn_Account_ID` on separate lines. But **membership is household-level**, so every selected member shares one variant tier. The chosen approach: charge **qty = N** of that single variant and pass all account ids **comma-joined** in `CheckMeIn_Account_ID`.

This requires no webhook change — the `orders/paid` handler (`api/webhooks/shopify/route.ts`) already splits `CheckMeIn_Account_ID` on `,` and activates each participant, and that path is covered by `webhookShopify.integration.test.ts` ("activates every id in a comma-separated CheckMeIn_Account_ID list"). Billing stays correct: parent is charged N × the tier price. The constraint (one household = one membership tier = one variant) is documented in a `ponytail:` comment at the checkout-URL site.

## Verification

- `tsc` clean (file), eslint clean, page serves 200 with no module crash after the Mantine swap.
- Webhook multi-id round-trip already covered by existing test; the participants and request-payment-plan APIs are **unchanged** (the client just loops them).
- Live click-through of the three flows (free multi, payment-plan multi, paid with 2 members) was **not** run in this environment — no browser driver available. Recommend a manual pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)