### PR TITLE
refactor(events): one card per event, RSVP row per household member

### DIFF
--- a/checkin-app/src/app/my-activities/events/page.tsx
+++ b/checkin-app/src/app/my-activities/events/page.tsx
@@ -21,6 +21,17 @@ type EventData = {
   rsvp: RsvpStatus | null;
 };
 
+// Group (event, member) rows into one bucket per event, preserving first-seen order.
+function groupByEvent(events: EventData[]): EventData[][] {
+  const byId = new Map<number, EventData[]>();
+  for (const ev of events) {
+    const rows = byId.get(ev.id);
+    if (rows) rows.push(ev);
+    else byId.set(ev.id, [ev]);
+  }
+  return [...byId.values()];
+}
+
 const RSVP_OPTIONS: { status: RsvpStatus; label: string; color: string }[] = [
   { status: 'ATTENDING', label: 'Yes', color: 'green' },
   { status: 'MAYBE', label: 'Maybe', color: 'yellow' },
@@ -100,18 +111,17 @@ export default function ParticipantEventsDashboard() {
         </Card>
       ) : (
         <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }}>
-          {events.map((ev) => {
-            const userRSVP = ev.rsvp;
+          {groupByEvent(events).map((rows) => {
+            const ev = rows[0];
             const startStr = formatDateTime(ev.start, { weekday: 'short', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
             const endStr = formatTime(ev.end, { hour: '2-digit', minute: '2-digit' });
+            // Multi-member cards must always show whose RSVP is whose, even for non-leads.
+            const labelMembers = showMembers || rows.length > 1;
 
             return (
-              <Card key={`${ev.id}-${ev.participant.id}`} withBorder radius="md" padding="lg">
+              <Card key={ev.id} withBorder radius="md" padding="lg">
                 <Stack gap="sm" h="100%">
                   <div>
-                    {showMembers && (
-                      <Badge variant="light" mb={4}>{ev.participant.name ?? 'Member'}</Badge>
-                    )}
                     {ev.program && (
                       <Text size="xs" c="cyan" fw={600} tt="uppercase">{ev.program.name}</Text>
                     )}
@@ -123,22 +133,30 @@ export default function ParticipantEventsDashboard() {
                     <Text size="sm" lineClamp={2}>{ev.description}</Text>
                   )}
 
-                  <div style={{ marginTop: 'auto' }}>
-                    <Text size="sm" c="dimmed" mb={4}>RSVP Status:</Text>
-                    <Button.Group>
-                      {RSVP_OPTIONS.map((opt) => (
-                        <Button
-                          key={opt.status}
-                          fullWidth
-                          variant={userRSVP === opt.status ? 'filled' : 'default'}
-                          color={opt.color}
-                          onClick={() => handleRSVP(ev.id, ev.participant.id, opt.status)}
-                        >
-                          {opt.label}
-                        </Button>
-                      ))}
-                    </Button.Group>
-                  </div>
+                  <Stack gap="xs" style={{ marginTop: 'auto' }}>
+                    {rows.map((member) => (
+                      <div key={member.participant.id}>
+                        {labelMembers ? (
+                          <Badge variant="light" mb={4}>{member.participant.name ?? 'Member'}</Badge>
+                        ) : (
+                          <Text size="sm" c="dimmed" mb={4}>RSVP Status:</Text>
+                        )}
+                        <Button.Group>
+                          {RSVP_OPTIONS.map((opt) => (
+                            <Button
+                              key={opt.status}
+                              fullWidth
+                              variant={member.rsvp === opt.status ? 'filled' : 'default'}
+                              color={opt.color}
+                              onClick={() => handleRSVP(ev.id, member.participant.id, opt.status)}
+                            >
+                              {opt.label}
+                            </Button>
+                          ))}
+                        </Button.Group>
+                      </div>
+                    ))}
+                  </Stack>
                 </Stack>
               </Card>
             );


### PR DESCRIPTION
## What

The **My Upcoming Events** list (`my-activities/events`) rendered one `Card` per `(event, household member)` row. When two household members were enrolled in the same event, the page showed two separate boxes for the same event.

This merges them: **one card per event**, each member listed inside with their own RSVP control.

## How

- `groupByEvent()` buckets the `/api/events/mine` rows by `ev.id` (first-seen order preserved).
- One `<Card key={ev.id}>` per event; shared header (program, title, date, description) rendered once.
- Inside, loop members — each gets a name badge + own RSVP `Button.Group` calling `handleRSVP(ev.id, member.participant.id, …)`, `filled` driven by that member's own `rsvp`.
- `labelMembers = showMembers || rows.length > 1` — a multi-member card always distinguishes whose RSVP is whose, even for non-leads; single-member non-lead keeps the old "RSVP Status:" label.

## Scope

Frontend-only. The endpoint still returns one row per `(event, member)` and is consumed as-is. `handleRSVP` is unchanged (keyed by event + participant, so per-member toggles stay independent).

## Verification

Ran locally as a household lead with two members (Parent2 + Child) enrolled in one program with an upcoming event:
- DOM: ONE card, one title, two member badges, two `Button.Group`s.
- Clicked Parent2's "Yes" → Parent2 row `filled`, Child row untouched. Independent. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)