### PR TITLE
fix(settings): guard unsaved changes on localization page

### DIFF
--- a/checkin-app/src/app/settings/localization/page.tsx
+++ b/checkin-app/src/app/settings/localization/page.tsx
@@ -5,6 +5,7 @@ import { Button, Card, Center, Group, Loader, Select, Stack, Text, Title } from 
 import { SettingsTabs } from "@/components/admin/SettingsTabs";
 import { AlertBanner } from "@/components/admin/AlertBanner";
 import { useRequireRole } from "@/hooks/useRequireRole";
+import { useUnsavedGuard, shallowEqual } from "@/components/UnsavedChangesProvider";
 
 interface Settings {
   timezone: string;
@@ -37,6 +38,10 @@ export default function LocalizationSettingsPage() {
   const [timezone, setTimezone] = useState("America/Chicago");
   const [locale, setLocale] = useState("en-US");
 
+  // Snapshot of the values as last loaded/saved; isDirty compares it to current
+  // state to drive the unsaved-changes guard.
+  const [initial, setInitial] = useState<Record<string, string> | null>(null);
+
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
@@ -52,6 +57,7 @@ export default function LocalizationSettingsPage() {
         const { settings } = (await res.json()) as { settings: Settings };
         setTimezone(settings.timezone);
         setLocale(settings.locale);
+        setInitial({ timezone: settings.timezone, locale: settings.locale });
       }
     } finally {
       setLoading(false);
@@ -74,6 +80,9 @@ export default function LocalizationSettingsPage() {
     } catch { flash("Network error.", true); }
     finally { setSaving(false); }
   };
+
+  const isDirty = !!initial && !shallowEqual(initial, { timezone, locale });
+  useUnsavedGuard(isDirty);
 
   if (authLoading) return <Center mih="60vh"><Loader /></Center>;
   if (!ready) return null; // redirect in flight


### PR DESCRIPTION
## What

Wire the localization settings page (`settings/localization`) into the app-wide unsaved-changes guard.

## Why

The localization form is a deferred-save form — two Mantine `Select`s (timezone + locale) bound to `useState`, committed by a Save button — but it never called `useUnsavedGuard`. Browser close/refresh, Settings tab switches, and sidebar nav all passed through silently while edits were pending. Its sibling `settings/membership` was already guarded; this closes the gap.

## How

Mirrors `settings/membership/page.tsx` exactly:
- Snapshot loaded values into `initial` state inside `load()`, straight from the payload.
- `const isDirty = !!initial && !shallowEqual(initial, { timezone, locale })`.
- `useUnsavedGuard(isDirty)` from `@/components/UnsavedChangesProvider`.
- Save re-snapshots via the existing `await load()` on success, so saving then navigating does not prompt.

No new deps, no custom modal (native `beforeunload`/confirm via the shared provider). `shallowEqual` is already covered by `UnsavedChangesProvider.test.ts`, so no new test.

## Reviewer notes

- Diff is 9 lines, one file.
- Typecheck (`tsc --noEmit`) and ESLint on the file both clean.

## Test

1. Open `/settings/localization`, change Timezone or Locale → switch Settings tab / close tab / sidebar nav → prompts.
2. Save → "Settings saved." → navigate → no prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)