### PR TITLE
fix(membership): guard ← Home link against unsaved intake form

### DIFF
--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -12,7 +12,7 @@ import MembershipFlowStepper from "@/components/MembershipFlowStepper";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
 import { isValidEmail } from "@/lib/emergencyContacts/identity";
-import { useUnsavedGuard } from "@/components/UnsavedChangesProvider";
+import { useUnsavedGuard, useConfirmNav } from "@/components/UnsavedChangesProvider";
 
 const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
 
@@ -429,6 +429,7 @@ export default function MembershipPage() {
   // save/submit re-snapshots, so this flips back to false then.
   const isDirty = savedForm !== null && currentForm !== savedForm;
   useUnsavedGuard(isDirty);
+  const confirmNav = useConfirmNav();
 
   if (sessionStatus === "loading" || loading) {
     return <Center mih="60vh"><Loader /></Center>;
@@ -455,7 +456,7 @@ export default function MembershipPage() {
     <Container size="lg" pb="md">
       <Group justify="space-between" align="center" wrap="wrap" mb="lg">
         <Title order={1}>Treehouse Membership</Title>
-        <Button component={Link} href="/" variant="default">← Home</Button>
+        <Button component={Link} href="/" variant="default" onNavigate={(e) => { if (!confirmNav()) e.preventDefault(); }}>← Home</Button>
       </Group>
 
       {message && <Alert color={isError ? "red" : "green"} mb="lg">{message}</Alert>}


### PR DESCRIPTION
## What

The header **← Home** back-link on `/membership` was a plain Next `<Link>` with no `onNavigate`. Clicking it does a client-side navigation that bypasses **both** the app-wide `confirmNav` unsaved-changes guard **and** `beforeunload` (which doesn't fire on client nav). A user who filled the ~15-field intake form and clicked ← Home lost everything with no prompt.

## Fix

- Import `useConfirmNav` from `@/components/UnsavedChangesProvider`, call it alongside the existing `useUnsavedGuard(isDirty)`.
- Add `onNavigate={(e) => { if (!confirmNav()) e.preventDefault(); }}` to the ← Home link — same shape as the `guardNav` chokepoint in `AppFrame.tsx`.

No new deps, no custom modal — reuses the shared provider's `window.confirm`.

## Reviewer notes

- The in-notice `/my-household` Anchor (link further down the page) is **left unguarded on purpose**: it only renders in the `PENDING_RENEWAL` pre-form state, where no intake form is mounted, so it can never be dirty.
- Line 443 `Go to sign in` untouched — only renders signed-out, no form exists.
- No test added: this wires an already-tested provider helper.

## How to test

1. Sign in → `/membership` → Start application → edit a field.
2. Click ← Home → confirm prompt fires. Cancel → stays, form intact. Confirm → navigates.
3. Clean form (no edits) → ← Home navigates with no prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)