### PR TITLE
test(programs): fix stale dob field in programLifecycle integration test

### DIFF
--- a/checkin-app/__tests__/programLifecycle.integration.test.ts
+++ b/checkin-app/__tests__/programLifecycle.integration.test.ts
@@ -33,7 +33,7 @@ describe('Program Lifecycle Integration Tests', () => {
                 googleId: "test-auth-board",
                 sysadmin: false,
                 boardMember: true,
-                dob: new Date('1990-01-01'),
+                dateOfBirth: new Date('1990-01-01'),
                 household: { create: {} }
             }
         });
@@ -45,7 +45,7 @@ describe('Program Lifecycle Integration Tests', () => {
                 name: "Mentor Tester",
                 email: "mentor@test.com",
                 googleId: "test-auth-mentor",
-                dob: new Date('1985-01-01'),
+                dateOfBirth: new Date('1985-01-01'),
                 household: { create: {} }
             }
         });
@@ -57,7 +57,7 @@ describe('Program Lifecycle Integration Tests', () => {
                 name: "Standard Tester",
                 email: "participant@test.com",
                 googleId: "test-auth-std",
-                dob: new Date('2000-01-01'),
+                dateOfBirth: new Date('2000-01-01'),
                 household: { create: {} }
             }
         });


### PR DESCRIPTION
## What

`programLifecycle.integration.test.ts` called `prisma.participant.create({ data: { dob, ... } })`, but the `Participant.dob` field was renamed to `dateOfBirth`. All 6 cases in the suite failed with a `PrismaClientValidationError: Unknown argument \`dob\``. Renamed the three usages to `dateOfBirth`.

## Why

Stale test left behind by a schema field rename. It was the only failing suite — the other 96 integration suites pass.

## Verification

Full integration suite, serial (`--runInBand`):

```
Test Suites: 97 passed, 97 total
Tests:       665 passed, 665 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)