### PR TITLE
fix(s-ingest-core): resilient bulk JSONL parse + persist-before-parse

### DIFF
--- a/packages/s-ingest-core/src/ingest/bulkOrders.ts
+++ b/packages/s-ingest-core/src/ingest/bulkOrders.ts
@@ -13,16 +13,53 @@
 import type { PrismaClient } from "../db/client.js";
 import { EventSource, ObjectType } from "../generated/prisma/client.js";
 import { legacyIdFromGid } from "../dates.js";
+import { logger } from "../logger.js";
 import type { OrderNode } from "../shopify/schemas.js";
 import { ingestNode } from "./ingestNode.js";
 
-/** Split a JSONL blob into parsed records, ignoring blank lines. */
-export function parseBulkJsonl(text: string): Record<string, unknown>[] {
-  return text
-    .split("\n")
-    .filter((l) => l.trim().length > 0)
-    .map((l) => JSON.parse(l) as Record<string, unknown>);
+/** A single JSONL line that failed `JSON.parse`, retained for diagnosis instead of aborting. */
+export interface BadJsonlLine {
+  /** 1-based line number within the blob. */
+  line: number;
+  /** The raw, unparseable line content. */
+  raw: string;
+  error: string;
 }
+
+export interface ParsedBulkJsonl {
+  records: Record<string, unknown>[];
+  /** Lines that failed to parse. Empty on a clean export. */
+  badLines: BadJsonlLine[];
+}
+
+/**
+ * Split a JSONL blob into parsed records, ignoring blank lines. A line that fails to parse
+ * (truncated/garbled byte from Shopify) is SKIPPED and collected into `badLines` rather than
+ * throwing — one bad line must not abort the whole orders backfill. Callers decide the failure
+ * policy from `badLines` (ingestBulkOrders fails loudly only when a large fraction is bad).
+ */
+export function parseBulkJsonl(text: string): ParsedBulkJsonl {
+  const records: Record<string, unknown>[] = [];
+  const badLines: BadJsonlLine[] = [];
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    if (raw.trim().length === 0) continue;
+    try {
+      records.push(JSON.parse(raw) as Record<string, unknown>);
+    } catch (err) {
+      badLines.push({ line: i + 1, raw, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return { records, badLines };
+}
+
+/**
+ * If more than this fraction of non-empty lines fail to parse, the export is treated as corrupt
+ * (likely truncated) and the run fails loudly — a mostly-broken export must not masquerade as a
+ * successful partial import. A handful of bad lines below the threshold is logged and imported.
+ */
+const MAX_BAD_LINE_FRACTION = 0.1;
 
 function childGid(child: unknown): string {
   return String((child as { id?: unknown } | null | undefined)?.id ?? "");
@@ -112,6 +149,8 @@ export interface IngestBulkOrdersResult {
   exportId: bigint;
   recordCount: number;
   ingested: number;
+  /** Lines skipped because they failed to parse — surfaced on the sync_run so a partial parse is visible. */
+  badLineCount: number;
   maxOccurredAt: Date | null;
 }
 
@@ -123,8 +162,9 @@ export async function ingestBulkOrders(
   prisma: PrismaClient,
   args: IngestBulkOrdersArgs,
 ): Promise<IngestBulkOrdersResult> {
-  const records = parseBulkJsonl(args.jsonl);
-
+  // Persist the verbatim JSONL FIRST so a parse/reassembly bug always leaves the offending
+  // payload behind for reingestBulkExports to replay. recordCount counts non-empty lines here
+  // (parse-independent) — the durable count of records present, including any that don't parse.
   const exp = await prisma.shopifyBulkExport.create({
     data: {
       storeId: args.storeId,
@@ -132,11 +172,30 @@ export async function ingestBulkOrders(
       bulkOperationId: args.bulkOperationId,
       source: args.source,
       syncRunId: args.syncRunId ?? null,
-      recordCount: records.length,
+      recordCount: args.jsonl.split("\n").filter((l) => l.trim().length > 0).length,
       jsonl: args.jsonl,
     },
     select: { id: true },
   });
+
+  const { records, badLines } = parseBulkJsonl(args.jsonl);
+  const total = records.length + badLines.length;
+  if (badLines.length > 0) {
+    logger.warn("bulk orders JSONL had unparseable lines", {
+      storeId: args.storeId,
+      exportId: exp.id.toString(),
+      badLineCount: badLines.length,
+      total,
+      firstBadLines: badLines.slice(0, 5).map((b) => b.line),
+    });
+    // A truncated / mostly-broken export must fail the run, not look like a partial success.
+    if (badLines.length / total > MAX_BAD_LINE_FRACTION) {
+      throw Object.assign(
+        new Error(`bulk orders export unparseable: ${badLines.length}/${total} lines failed to parse`),
+        { partialCounts: { exportId: exp.id.toString(), recordCount: total, parsed: records.length, badLineCount: badLines.length } },
+      );
+    }
+  }
 
   let ingested = 0;
   let maxOccurredAt: Date | null = null;
@@ -152,7 +211,7 @@ export async function ingestBulkOrders(
     if (res.occurredAt && (!maxOccurredAt || res.occurredAt > maxOccurredAt)) maxOccurredAt = res.occurredAt;
   }
 
-  return { exportId: exp.id, recordCount: records.length, ingested, maxOccurredAt };
+  return { exportId: exp.id, recordCount: records.length, ingested, badLineCount: badLines.length, maxOccurredAt };
 }
 
 export interface ReingestBulkExportsArgs {
@@ -191,7 +250,7 @@ export async function reingestBulkExports(
   for (const { id } of ids) {
     const row = await prisma.shopifyBulkExport.findUnique({ where: { id }, select: { storeId: true, jsonl: true } });
     if (!row) continue;
-    for (const node of reassembleOrders(parseBulkJsonl(row.jsonl))) {
+    for (const node of reassembleOrders(parseBulkJsonl(row.jsonl).records)) {
       await ingestNode(prisma, {
         storeId: row.storeId,
         objectType: ObjectType.ORDER,

--- a/packages/s-ingest-core/src/sync/run.ts
+++ b/packages/s-ingest-core/src/sync/run.ts
@@ -165,7 +165,16 @@ export async function withSyncRun<T extends Record<string, unknown>>(
       });
       logger.error("sync run failed", { runId: run.id.toString(), kind, objectScope, partialCounts, err });
       if (heartbeat) {
-        await pushHeartbeat(heartbeat, { storeId, kind, status: SyncStatus.FAILED, finishedAt, error: message });
+        // Forward partialCounts (e.g. a bulk export's badLineCount) so the watchdog sees how far
+        // a failed run got, not just that it failed.
+        await pushHeartbeat(heartbeat, {
+          storeId,
+          kind,
+          status: SyncStatus.FAILED,
+          finishedAt,
+          error: message,
+          ...(partialCounts ? { counts: partialCounts } : {}),
+        });
       }
       throw err;
     }

--- a/packages/s-ingest-core/test/unit/reassemble.test.ts
+++ b/packages/s-ingest-core/test/unit/reassemble.test.ts
@@ -6,24 +6,63 @@
  * bulkOrders.ts). Previously it was exercised only indirectly through one DB test.
  */
 import { describe, it, expect } from "vitest";
-import { parseBulkJsonl, reassembleOrders } from "../../src/ingest/bulkOrders.js";
+import { parseBulkJsonl, reassembleOrders, ingestBulkOrders } from "../../src/ingest/bulkOrders.js";
 import { normalizeOrder } from "../../src/shopify/schemas.js";
+import { EventSource } from "../../src/generated/prisma/client.js";
 
 const orderId = "gid://shopify/Order/7001";
 
 describe("parseBulkJsonl", () => {
   it("parses one record per non-blank line", () => {
     const text = ['{"id":"a"}', "", "   ", '{"id":"b"}', ""].join("\n");
-    expect(parseBulkJsonl(text)).toEqual([{ id: "a" }, { id: "b" }]);
+    expect(parseBulkJsonl(text)).toEqual({ records: [{ id: "a" }, { id: "b" }], badLines: [] });
   });
 
-  it("returns [] for an empty or whitespace-only blob", () => {
-    expect(parseBulkJsonl("")).toEqual([]);
-    expect(parseBulkJsonl("\n   \n")).toEqual([]);
+  it("returns no records for an empty or whitespace-only blob", () => {
+    expect(parseBulkJsonl("")).toEqual({ records: [], badLines: [] });
+    expect(parseBulkJsonl("\n   \n")).toEqual({ records: [], badLines: [] });
   });
 
-  it("throws on a malformed JSON line (corrupt export must not pass silently)", () => {
-    expect(() => parseBulkJsonl('{"id":"a"}\n{not json}')).toThrow();
+  it("skips a malformed line, keeps the good ones, and records the bad one (no throw)", () => {
+    const text = ['{"id":"a"}', "{not json}", '{"id":"b"}'].join("\n");
+    const { records, badLines } = parseBulkJsonl(text);
+    expect(records).toEqual([{ id: "a" }, { id: "b" }]);
+    expect(badLines).toHaveLength(1);
+    expect(badLines[0]).toMatchObject({ line: 2, raw: "{not json}" });
+    expect(badLines[0].error).toBeTruthy();
+  });
+
+  it("collects every bad line for an all-garbage / truncated blob", () => {
+    const { records, badLines } = parseBulkJsonl("{oops\n}also bad\n{trunc");
+    expect(records).toEqual([]);
+    expect(badLines.map((b) => b.line)).toEqual([1, 2, 3]);
+  });
+});
+
+describe("ingestBulkOrders failure policy", () => {
+  // Minimal fake: only shopifyBulkExport.create is reachable before the loud-fail throw.
+  const fakePrisma = (capture: { jsonl?: string } = {}) =>
+    ({
+      shopifyBulkExport: {
+        create: async ({ data }: { data: { jsonl: string } }) => {
+          capture.jsonl = data.jsonl;
+          return { id: 1n };
+        },
+      },
+    }) as unknown as Parameters<typeof ingestBulkOrders>[0];
+
+  it("fails loudly on a mostly-broken export, AFTER persisting the raw payload", async () => {
+    const jsonl = ["{bad1}", "{bad2}", '{"id":"gid://shopify/Order/1"}'].join("\n"); // 2/3 bad > 10%
+    const capture: { jsonl?: string } = {};
+    await expect(
+      ingestBulkOrders(fakePrisma(capture), {
+        storeId: "s",
+        jsonl,
+        bulkOperationId: "op",
+        source: EventSource.BACKFILL,
+      }),
+    ).rejects.toThrow(/unparseable/);
+    expect(capture.jsonl).toBe(jsonl); // raw payload captured before the throw → replayable
   });
 });
 

--- a/s-read-function/src/sync/backfill.ts
+++ b/s-read-function/src/sync/backfill.ts
@@ -34,6 +34,8 @@ export interface OrdersBulkStatus {
   objectCount?: string | null;
   errorCode?: string | null;
   ingested?: number;
+  /** JSONL lines skipped because they failed to parse (partial-parse visibility on the sync_run). */
+  badLines?: number;
 }
 
 export interface BackfillResult extends Record<string, unknown> {
@@ -92,6 +94,7 @@ async function stepOrdersBulk(
 
   if (op.status === "COMPLETED") {
     let ingested = 0;
+    let badLines = 0;
     if (op.url) {
       // Capture the verbatim JSONL durably, then reassemble + ingest from it (one core path).
       const jsonl = await downloadBulkJsonl(op.url);
@@ -103,15 +106,17 @@ async function stepOrdersBulk(
         syncRunId,
       });
       ingested = res.ingested;
+      badLines = res.badLineCount;
       await advanceWatermark(prisma, storeId, ObjectType.ORDER, res.maxOccurredAt);
       logger.info("orders backfill captured + ingested", {
         exportId: res.exportId.toString(),
         records: res.recordCount,
         ingested,
+        badLines,
       });
     }
     await setBulkState(prisma, storeId, ObjectType.ORDER, { bulkOperationId: null, bulkStatus: "COMPLETED" });
-    return { action: "INGESTED", status: "COMPLETED", ingested };
+    return { action: "INGESTED", status: "COMPLETED", ingested, badLines };
   }
 
   if (op.status === "FAILED" || op.status === "CANCELED" || op.status === "EXPIRED") {

--- a/s-read-function/test/unit/backfill.test.ts
+++ b/s-read-function/test/unit/backfill.test.ts
@@ -87,7 +87,7 @@ it("downloads + ingests a COMPLETED op, advances the watermark, clears state, re
   vi.mocked(getBulkState).mockResolvedValue({ bulkOperationId: "gid://op/1", bulkStatus: "RUNNING" });
   vi.mocked(getCurrentBulkOperation).mockResolvedValue({ id: "gid://op/1", status: "COMPLETED", url: "https://storage.googleapis.com/shopify-bulk/result.jsonl" });
   vi.mocked(downloadBulkJsonl).mockResolvedValue('{"id":"gid://shopify/Order/1"}\n');
-  vi.mocked(ingestBulkOrders).mockResolvedValue({ exportId: 7n, recordCount: 1, ingested: 1, maxOccurredAt });
+  vi.mocked(ingestBulkOrders).mockResolvedValue({ exportId: 7n, recordCount: 1, ingested: 1, badLineCount: 0, maxOccurredAt });
 
   const res = await run();
 
@@ -103,7 +103,7 @@ it("downloads + ingests a COMPLETED op, advances the watermark, clears state, re
     bulkOperationId: null,
     bulkStatus: "COMPLETED",
   });
-  expect(res.ordersBulk).toEqual({ action: "INGESTED", status: "COMPLETED", ingested: 1 });
+  expect(res.ordersBulk).toEqual({ action: "INGESTED", status: "COMPLETED", ingested: 1, badLines: 0 });
 });
 
 it("clears state without ingesting when COMPLETED carries no url", async () => {
@@ -115,7 +115,7 @@ it("clears state without ingesting when COMPLETED carries no url", async () => {
   expect(downloadBulkJsonl).not.toHaveBeenCalled();
   expect(ingestBulkOrders).not.toHaveBeenCalled();
   expect(advanceWatermark).not.toHaveBeenCalled();
-  expect(res.ordersBulk).toEqual({ action: "INGESTED", status: "COMPLETED", ingested: 0 });
+  expect(res.ordersBulk).toEqual({ action: "INGESTED", status: "COMPLETED", ingested: 0, badLines: 0 });
 });
 
 it.each(["FAILED", "CANCELED", "EXPIRED"])("clears state and returns FAILED for a %s op", async (status) => {


### PR DESCRIPTION
## Problem

Two reliability gaps in the orders bulk-export backfill (`packages/s-ingest-core`):

1. **Fragile parse** — `parseBulkJsonl` mapped `JSON.parse` over every line. A single truncated/garbled line from a Shopify bulk download threw `SyntaxError` and aborted the *whole* orders backfill. `withSyncRun` caught it (marks the run FAILED, no dangling RUNNING), but there was zero per-line resilience — one bad byte wedged the import until Shopify re-exported cleanly.
2. **Payload not captured for diagnosis** — `ingestBulkOrders` parsed *before* `shopifyBulkExport.create`, so a parse/reassembly failure left nothing for `reingestBulkExports` to replay.

## Fix

- **`parseBulkJsonl`** — per-line `try/catch`; bad lines are skipped and collected (`{line, raw, error}`) instead of throwing. Returns `{ records, badLines }`.
- **`ingestBulkOrders`** — persist the verbatim JSONL (`shopifyBulkExport.create`) **before** parsing, so a bad payload is always captured and replayable. `recordCount` comes from a parse-independent non-blank line count (no second write).
- **Failure policy** — log bad lines (count + first 5 line numbers); fail the run **loudly** when `>10%` of lines fail. A truncated/corrupt export must not masquerade as a successful partial import. An empty export stays a clean 0-record success. A few bad lines below the threshold import partial — downstream upsert is idempotent by GID, so a short batch is silent data loss (not an error) and must be *visible*, not fatal. Loud-fail attaches `partialCounts` to the thrown error (already persisted to the FAILED `sync_run` by `withSyncRun`).
- **Surface the count** — `badLineCount` flows: `ingestBulkOrders` result → `backfill` `ordersBulk.badLines` → COMPLETED `sync_run` counts/heartbeat. FAILED heartbeat now also forwards `partialCounts` so the watchdog sees how far a failed run got.

## Reviewer notes

- Threshold = 10% (`MAX_BAD_LINE_FRACTION`). Rationale: downstream `ingestNode` upsert is idempotent by GID, so a short batch silently drops orders — needs to be visible, but a mostly-broken export must hard-fail.
- `reingestBulkExports` (recovery path) uses `.records` — lenient by design; replays whatever parses from an already-stored payload.

## Tests

- `parseBulkJsonl`: skip-bad/keep-good, all-garbage collects every bad line (no throw).
- `ingestBulkOrders`: fails loudly on a mostly-broken export **after** persisting the raw payload (fake prisma asserts capture precedes the throw).
- `backfill` mocks/assertions updated for `badLineCount`/`badLines`.
- Verified locally: 14 unit + 2 integration (s-ingest-core), 9 unit (s-read-function) pass; both packages typecheck clean (one pre-existing `globalSetup.ts` TS4082, confirmed on stash — unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)