### PR TITLE
fix(safety): block board self-override of own household's trusted-adult review

### DIFF
--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -29,6 +29,7 @@ describe('Trusted Adults service', () => {
     let leadId = 0;
     let outsiderId = 0;
     let boardId = 0;
+    let boardLeadId = 0; // board member who is ALSO a lead of householdId — the self-conflict actor
 
     async function wipe() {
         const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
@@ -49,6 +50,14 @@ describe('Trusted Adults service', () => {
         const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
         await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+
+        // A board member who is also a lead of the disclosing household: overriding this
+        // household's own review is a conflict of interest (force-approve Grandma for their kids).
+        const boardLead = await prisma.participant.create({
+            data: { name: 'BoardLead', email: `boardlead-${TAG}@ex.com`, boardMember: true, householdId: hh.id },
+        });
+        boardLeadId = boardLead.id;
+        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: boardLead.id } });
 
         const outHh = await prisma.household.create({ data: { name: `Outsider HH ${TAG}` } });
         outsiderId = (await prisma.participant.create({ data: { name: 'Outsider', householdId: outHh.id } })).id;
@@ -285,6 +294,42 @@ describe('Trusted Adults service', () => {
         const audit = await latestAudit(ta.id);
         expect(JSON.parse(String(audit?.oldData))).toMatchObject({ status: 'REVOKED' });
         expect(JSON.parse(String(audit?.newData))).toMatchObject({ status: 'APPROVED', override: 'approve' });
+    });
+
+    // Conflict of interest on the OVERRIDE path — mirrors decideReview's rule. A board
+    // member who leads the disclosing household must not override its own review (they'd
+    // force-approve their own trusted adult). Only a sysadmin is the remedy that bypasses.
+    it('refuses a board member overriding their OWN household review, leaving DB + audit untouched', async () => {
+        const ta = await discloseOne();
+        const reviewId = ta.reviews[0].id;
+        const before = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } });
+        const auditBefore = await latestAudit(ta.id);
+
+        await expect(overrideReview(reviewId, boardLeadId, 'approve', SHARED)).rejects.toMatchObject({ code: 'forbidden' });
+
+        // State machine and audit log both unchanged — the rejected override wrote nothing.
+        const after = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } });
+        expect(after!.status).toBe(before!.status);
+        expect(after!.decidedById).toBeNull();
+        const auditAfter = await latestAudit(ta.id);
+        expect(auditAfter?.id).toBe(auditBefore?.id); // no new audit row appended
+    });
+
+    it('allows a sysadmin to override their own household review (the deliberate remedy)', async () => {
+        const ta = await discloseOne();
+        // Same actor whose board role is conflicted, but acting AS sysadmin → bypass.
+        const approved = await overrideReview(ta.reviews[0].id, boardLeadId, 'approve', SHARED, { isSysadmin: true });
+        expect(approved.status).toBe('APPROVED');
+
+        const audit = await latestAudit(ta.id);
+        expect(audit?.actorId).toBe(boardLeadId);
+        expect(JSON.parse(String(audit?.newData))).toMatchObject({ status: 'APPROVED', override: 'approve' });
+    });
+
+    it('allows a cross-household board member to override (no conflict)', async () => {
+        const ta = await discloseOne(); // householdId; boardId lives in a different household
+        const revoked = await overrideReview(ta.reviews[0].id, boardId, 'revoke');
+        expect(revoked.status).toBe('REVOKED');
     });
 });
 

--- a/checkin-app/src/app/api/safety/trusted-adults/override/route.ts
+++ b/checkin-app/src/app/api/safety/trusted-adults/override/route.ts
@@ -28,7 +28,9 @@ export const POST = withAuth({ roles: ["boardMember", "sysadmin"] }, async (req,
         return NextResponse.json({ error: "reviewId and action (approve|deny|revoke) are required" }, { status: 400 });
     }
     try {
-        const outcome = await overrideReview(body.reviewId, auth.user.id, body.action!, body.sharedNote);
+        const outcome = await overrideReview(body.reviewId, auth.user.id, body.action!, body.sharedNote, {
+            isSysadmin: auth.user.sysadmin === true,
+        });
         return NextResponse.json({ status: outcome.status });
     } catch (error) {
         if (error instanceof TrustedAdultError) {

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -264,10 +264,40 @@ export async function decideReview(reviewId: number, boardMemberId: number, inpu
     return result.updated;
 }
 
-/** Board / sysadmin override: force a review to a terminal state regardless of phase. */
-export async function overrideReview(reviewId: number, actorId: number, action: "approve" | "deny" | "revoke", sharedNote?: string | null) {
-    const review = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } });
+/**
+ * Board / sysadmin override: force a review to a terminal state regardless of phase.
+ *
+ * Same conflict-of-interest rule as decideReview — a board member may not override
+ * their OWN household's review (else they could force-approve their own trusted adult,
+ * the very thing decideReview forbids). A sysadmin is the deliberate remedy and bypasses
+ * the check (opts.isSysadmin); the route sets it only when the actor holds that role.
+ */
+export async function overrideReview(
+    reviewId: number,
+    actorId: number,
+    action: "approve" | "deny" | "revoke",
+    sharedNote?: string | null,
+    opts?: { isSysadmin?: boolean },
+) {
+    const review = await prisma.trustedAdultReview.findUnique({
+        where: { id: reviewId },
+        include: { trustedAdult: { select: { householdId: true, counterpartyParticipantId: true } } },
+    });
     if (!review) throw new TrustedAdultError("not_found", "Review not found.");
+
+    if (!opts?.isSysadmin) {
+        const me = await prisma.participant.findUnique({ where: { id: actorId }, select: { householdId: true } });
+        if (
+            isTrustedAdultConflict({
+                actorParticipantId: actorId,
+                actorHouseholdId: me?.householdId,
+                taHouseholdId: review.trustedAdult.householdId,
+                taCounterpartyParticipantId: review.trustedAdult.counterpartyParticipantId,
+            })
+        ) {
+            throw new TrustedAdultError("forbidden", "You can't override your own household's trusted-adult review — a sysadmin must.");
+        }
+    }
 
     const now = new Date();
     const data: Record<string, unknown> = { decidedById: actorId };


### PR DESCRIPTION
## Problem

`decideReview` enforces a conflict-of-interest check (`isTrustedAdultConflict` + household scope, added in #500): a board member can't decide a trusted-adult review for their **own** household.

`overrideReview` — the force-to-terminal-state path used by `POST /api/safety/trusted-adults/override` — had **no** such check. The only gate was the route's `roles: ["boardMember","sysadmin"]`. So a board member who leads the disclosing household could force-approve their own trusted adult (e.g. approve Grandma for their own kids) by hitting the override route directly — exactly what `decideReview` forbids.

The asymmetry was invisible because every existing test passed a cross-household actor id.

## Intent

#500 added the conflict rule to `decideReview` but never touched `overrideReview` (which predates it, from #258). This is a **gap, not a deliberate bypass**. Chosen contract:

- **boardMember** must respect the same conflict rule on override.
- **sysadmin** is the deliberate remedy and bypasses it.

## Changes

- `overrideReview` now runs `isTrustedAdultConflict` (own household or being the counterparty), gated by a new `opts.isSysadmin` bypass; throws `forbidden` otherwise. Mirrors `decideReview`.
- Override route passes `isSysadmin: auth.user.sysadmin === true`. The role gate already restricts the route to `boardMember`/`sysadmin`.
- Integration tests (`trustedAdultService.integration.test.ts`):
  - board member overriding their **own** household → rejected, with DB `status` + `decidedById` + audit row all **unchanged**;
  - sysadmin overriding own household → allowed (the remedy);
  - cross-household board member → allowed.

## Verification

Ran locally (`INTEGRATION_DB=1 --runInBand` against a throwaway Postgres): the new self-conflict test **fails without the fix**, all 19 pass with it. Note: this repo's CI does **not** gate integration tests, so they were verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)