### PR TITLE
test(logger): cover IntegrationErrorLog write, TTL purges, webhook 500 path

### DIFF
--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -19,7 +19,10 @@ jest.mock('@/lib/membership/payment', () => ({
     activateByProcessId: jest.fn().mockResolvedValue(undefined),
 }));
 
+// Keep the REAL logIntegrationError (it writes to the DB — the 500-catch test
+// below asserts that write) but silence the console logger.
 jest.mock('@/lib/logger', () => ({
+    ...jest.requireActual('@/lib/logger'),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
@@ -71,6 +74,7 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
     });
 
     afterAll(async () => {
+        await prisma.integrationErrorLog.deleteMany({ where: { source: 'shopify-webhook' } });
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.program.delete({ where: { id: programId } });
         await prisma.participant.deleteMany({ where: { id: { in: [p1, p2] } } });
@@ -179,5 +183,23 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         const res = await POST(webhookReq(body, sign(body)));
         expect(res.status).toBe(200);
         expect(activateByProcessId).toHaveBeenCalledWith(42, '98765');
+    });
+
+    it('returns 500 and writes one IntegrationErrorLog row when a handler throws', async () => {
+        // Clean slate so the survivor count is exact.
+        await prisma.integrationErrorLog.deleteMany({ where: { source: 'shopify-webhook' } });
+        (activateByProcessId as jest.Mock).mockRejectedValueOnce(new Error('handler boom'));
+
+        const body = JSON.stringify({
+            id: 13579,
+            note_attributes: [{ name: 'Membership_Process_ID', value: '99' }],
+        });
+        const res = await POST(webhookReq(body, sign(body)));
+        expect(res.status).toBe(500);
+
+        const rows = await prisma.integrationErrorLog.findMany({ where: { source: 'shopify-webhook' } });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].message).toBe('handler boom');
+        expect(rows[0].context).toEqual({ operation: 'POST /api/webhooks/shopify' });
     });
 });

--- a/checkin-app/src/lib/__tests__/logger.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/logger.integration.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the DB-backed loggers in lib/logger.ts. They use the
+ * real prisma client (no mock), so this is an integration test against a live
+ * Postgres — run via `npm run test:integration`.
+ *
+ * Coverage:
+ *   - logIntegrationError writes one IntegrationErrorLog row (source/message/context)
+ *   - the 90-day IntegrationErrorLog purge deletes >90d rows and KEEPS <90d rows
+ *   - the 30-day ErrorLog purge (logBackendError) deletes >30d rows and KEEPS <30d
+ *
+ * Purge boundaries are time-dependent: rows are seeded with EXPLICIT createdAt
+ * timestamps well clear of the cutoff, and survivors are asserted by id (not by
+ * count) because the purge is global and other rows may exist.
+ */
+import prisma from '@/lib/prisma';
+import { logIntegrationError, logBackendError } from '@/lib/logger';
+
+const TAG = 'logger-integration-test';
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('logger DB persistence + TTL purge', () => {
+    afterAll(async () => {
+        await prisma.integrationErrorLog.deleteMany({ where: { source: { contains: TAG } } });
+        await prisma.errorLog.deleteMany({ where: { route: { contains: TAG } } });
+    });
+
+    it('writes one IntegrationErrorLog row with source/message/context populated', async () => {
+        const source = `${TAG}-write`;
+        await logIntegrationError(source, new Error('kaboom'), { programName: 'X', ids: [7, 9] });
+
+        const rows = await prisma.integrationErrorLog.findMany({ where: { source } });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].message).toBe('kaboom');
+        expect(rows[0].context).toEqual({ programName: 'X', ids: [7, 9] });
+    });
+
+    it('purges IntegrationErrorLog rows older than 90 days and keeps newer ones', async () => {
+        const now = Date.now();
+        const old = await prisma.integrationErrorLog.create({
+            data: { source: `${TAG}-old`, message: 'old', timestamp: new Date(now - 100 * DAY) },
+        });
+        const recent = await prisma.integrationErrorLog.create({
+            data: { source: `${TAG}-recent`, message: 'recent', timestamp: new Date(now - 10 * DAY) },
+        });
+
+        // Any write triggers the 90-day purge.
+        await logIntegrationError(`${TAG}-trigger`, 'trigger');
+
+        expect(await prisma.integrationErrorLog.findUnique({ where: { id: old.id } })).toBeNull();
+        expect(await prisma.integrationErrorLog.findUnique({ where: { id: recent.id } })).not.toBeNull();
+    });
+
+    it('purges ErrorLog rows older than 30 days and keeps newer ones', async () => {
+        const now = Date.now();
+        const old = await prisma.errorLog.create({
+            data: { message: 'old', route: `${TAG}-old`, timestamp: new Date(now - 40 * DAY) },
+        });
+        const recent = await prisma.errorLog.create({
+            data: { message: 'recent', route: `${TAG}-recent`, timestamp: new Date(now - 5 * DAY) },
+        });
+
+        // logBackendError writes the new row, then runs the 30-day purge.
+        await logBackendError(new Error('trigger'), `${TAG}-trigger`);
+
+        expect(await prisma.errorLog.findUnique({ where: { id: old.id } })).toBeNull();
+        expect(await prisma.errorLog.findUnique({ where: { id: recent.id } })).not.toBeNull();
+    });
+});


### PR DESCRIPTION
## What

Adds test coverage for `logIntegrationError` and the `IntegrationErrorLog` model — previously zero coverage in checkin-app.

**New `logger.integration.test.ts`** (real prisma client → live DB, integration tier):
- `logIntegrationError` writes exactly one row with `source`/`message`/`context` populated correctly.
- 90-day `IntegrationErrorLog` purge deletes rows older than 90 days and keeps rows within 90 days.
- 30-day `ErrorLog` purge (`logBackendError`) deletes >30d and keeps <30d.

**Extended `webhookShopify.integration.test.ts`:**
- The `@/lib/logger` mock now keeps the real `logIntegrationError` via `jest.requireActual` (it was fully mocked, leaving the export `undefined` — anything hitting the route's 500-catch would have thrown instead of logging).
- New test forces `activateByProcessId` to throw and asserts the route returns **500** and writes **exactly one** `IntegrationErrorLog` row with `source: 'shopify-webhook'` and `context: { operation: 'POST /api/webhooks/shopify' }`.

## Why

The Shopify webhook's 500-catch path persists an integration error and runs a 90-day TTL purge, but nothing exercised either. The purge could silently fail or over-delete unnoticed.

## Reviewer notes

- These are **integration tests** (`INTEGRATION_DB=1`, `npm run test:integration`, `--runInBand`). They are **not** in the default jest run and CI does not gate them — verified locally against a throwaway Postgres: **12 passed**.
- Purge survivors are asserted **by id** (the purge is global, so a count-based assert would be unsafe) and seed rows use **explicit `timestamp` values** well clear of the cutoff to avoid wall-clock flakiness at the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)