### PR TITLE
fix(programs): validate + map errors on volunteer assignment route

### DIFF
--- a/checkin-app/src/app/__tests__/programsVolunteersAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsVolunteersAPI.integration.test.ts
@@ -150,11 +150,66 @@ describe('Program Volunteers API Integration Tests', () => {
              });
              const res = await POST(req as unknown as import("next/server").NextRequest, createParams(targetProgramId) as unknown as never);
              expect(res.status).toBe(200);
-             
+
              const data = await res.json();
              expect(data.success).toBe(true);
              expect(data.assignment.isCore).toBe(false); // Default logic
              expect(data.assignment.participantId).toBe(candidateId);
+
+             // Persisted: a ProgramVolunteer row now exists for this pair.
+             const row = await prisma.programVolunteer.findUnique({
+                 where: { programId_participantId: { programId: targetProgramId, participantId: candidateId } }
+             });
+             expect(row).not.toBeNull();
+        });
+
+        it('should return 409, not 500, when assigning an already-assigned volunteer', async () => {
+             // candidateId was assigned by the previous test; re-assigning is a
+             // duplicate (P2002).
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: leadId } });
+
+             const req = new Request(`http://localhost:4000/api/programs/${targetProgramId}/volunteers`, {
+                 method: 'POST',
+                 body: JSON.stringify({ participantId: candidateId })
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest, createParams(targetProgramId) as unknown as never);
+             expect(res.status).toBe(409);
+        });
+
+        it('should return 400 when participantId is missing', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: leadId } });
+
+             const req = new Request(`http://localhost:4000/api/programs/${targetProgramId}/volunteers`, {
+                 method: 'POST',
+                 body: JSON.stringify({})
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest, createParams(targetProgramId) as unknown as never);
+             expect(res.status).toBe(400);
+        });
+
+        it('should return a clean 400, not 500, for a non-existent participant', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: leadId } });
+
+             const req = new Request(`http://localhost:4000/api/programs/${targetProgramId}/volunteers`, {
+                 method: 'POST',
+                 body: JSON.stringify({ participantId: 2147483647 }) // no such Participant row
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest, createParams(targetProgramId) as unknown as never);
+             expect(res.status).toBe(400);
+             expect(res.status).not.toBe(500);
+        });
+
+        it('documents intent: any participant is assignable (no age/membership gate)', async () => {
+             // The candidate has no dateOfBirth and is not a program member, yet
+             // assignment succeeded above. Volunteers are staff, not enrollees —
+             // there is intentionally no eligibility rule. If product adds one,
+             // this test should change deliberately.
+             const candidate = await prisma.participant.findUnique({ where: { id: candidateId } });
+             expect(candidate?.dateOfBirth).toBeNull();
+             const row = await prisma.programVolunteer.findUnique({
+                 where: { programId_participantId: { programId: targetProgramId, participantId: candidateId } }
+             });
+             expect(row).not.toBeNull();
         });
     });
 

--- a/checkin-app/src/app/api/programs/[id]/volunteers/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/volunteers/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         const body = await req.json();
         const { participantId } = body;
 
-        if (!participantId) {
+        if (!participantId || typeof participantId !== 'number') {
             return NextResponse.json({ error: "participantId is required" }, { status: 400 });
         }
 
@@ -37,6 +37,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
             return NextResponse.json({ error: "Forbidden: Not authorized to assign volunteers" }, { status: 403 });
         }
 
+        // ponytail: no eligibility gate (age/membership) on volunteers — they're
+        // staff/mentors, not enrollees. ProgramVolunteer has only isCore; any
+        // participant is assignable. Add a gate here only if product asks for one.
         const assignment = await prisma.programVolunteer.create({
             data: {
                 programId,
@@ -58,9 +61,26 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
         return NextResponse.json({ success: true, assignment });
     } catch (error) {
+        // P2002 = unique violation on @@id([programId, participantId]). Benign
+        // double-submit re-assigns the same volunteer; 409 instead of 500.
+        if (isPrismaError(error, 'P2002')) {
+            return NextResponse.json({ error: "Participant is already a volunteer for this program." }, { status: 409 });
+        }
+        // P2003 = FK violation: participantId points at no Participant row. Bad
+        // input, not a server fault; 400 instead of 500.
+        if (isPrismaError(error, 'P2003')) {
+            return NextResponse.json({ error: "Participant not found" }, { status: 400 });
+        }
         console.error("Volunteer assignment error:", error);
         return NextResponse.json({ error: "Failed to assign volunteer" }, { status: 500 });
     }
+}
+
+// Prisma known-request errors carry a string `code`. Duck-typed so we don't
+// pull in the generated Prisma namespace just for one check.
+function isPrismaError(error: unknown, code: string): boolean {
+    return typeof error === 'object' && error !== null && 'code' in error
+        && (error as { code: unknown }).code === code;
 }
 
 export async function DELETE(req: Request, { params }: { params: Promise<{ id: string }> }) {


### PR DESCRIPTION
## What

Harden `POST /api/programs/[id]/volunteers`, which had no input validation or duplicate handling — bad input fell through to a bare 500.

- `participantId` missing or non-number → **400**
- Duplicate assignment (Prisma **P2002**) → **409**, not 500
- Non-existent participant (FK violation **P2003**) → clean **400**, not 500

Mirrors the sibling `participants` route's pattern and reuses the same duck-typed `isPrismaError` helper.

## Why

The route previously let `null`/invalid `participantId` reach Prisma, and a duplicate assign or non-existent participant surfaced as a generic 500. The participants route already maps P2002→409; this brings volunteers in line.

## Eligibility decision

No eligibility gate (age/membership) added. Volunteers are staff/mentors, not enrollees — `ProgramVolunteer` carries only `isCore` and there is no existing gate. No rule was invented; intent is documented with a test ("any participant is assignable") and a `ponytail:` comment in the route.

## Tests

Added to `programsVolunteersAPI.integration.test.ts`:
- duplicate assign → 409 (not 500)
- missing `participantId` → 400
- non-existent participant → clean 400
- assign succeeds + persists a `ProgramVolunteer` row
- eligibility-intent doc test

Real-Postgres integration suite (`INTEGRATION_DB=1 --runInBand`); not in default jest, not CI-gated. Ran locally — suite passes 12/12.

## Reviewer notes

- DELETE/PATCH left unchanged — they use delete/update (P2025, not P2002) and weren't in scope.
- `test:integration` script lacks `--runInBand`; ran it explicitly per the shared-DB rule. Worth adding to the script separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)