### PR TITLE
test: pin negative-state paths in membership + trusted-adult review

### DIFF
--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -243,4 +243,9 @@ describe('background check is non-blocking', () => {
         expect(proc?.status).toBe('PENDING_EXTERNAL_ACTION');
         expect(proc?.paidAt).toBeNull();
     });
+
+    it('markContractSigned / markBgConsent on a non-existent process throw not_found', async () => {
+        await expect(markContractSigned(999999999)).rejects.toMatchObject({ code: 'not_found' });
+        await expect(markBgConsent(999999999, revA)).rejects.toMatchObject({ code: 'not_found' });
+    });
 });

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -234,6 +234,38 @@ describe('Membership BG review API', () => {
         expect(res.status).toBe(403);
     });
 
+    it('attest on an already-decided (BLOCKED) process is rejected (409 wrong_phase), no new attestation or audit', async () => {
+        const proc = await makeApplicantProcess('AlreadyDecided');
+        as(rev1, { backgroundCheckReviewer: true });
+        await ATTEST(req({ processId: proc.processId, result: 'REJECT' }) as never); // → BLOCKED (1 attestation, 1 audit)
+        const attBefore = await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } });
+        const auditBefore = await prisma.auditLog.count({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId } });
+
+        // A fresh eligible reviewer (different household) tries to attest the now-decided app.
+        as(rev2, { backgroundCheckReviewer: true });
+        const res = await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
+        expect(res.status).toBe(409);
+        expect((await res.json()).code).toBe('wrong_phase');
+
+        // The phase guard precedes the attestation create, so nothing was written.
+        expect(await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } })).toBe(attBefore);
+        expect(await prisma.auditLog.count({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId } })).toBe(auditBefore);
+    });
+
+    it('attest on a non-existent process returns 404 not_found', async () => {
+        as(rev1, { backgroundCheckReviewer: true });
+        const res = await ATTEST(req({ processId: 999999999, result: 'APPROVE' }) as never);
+        expect(res.status).toBe(404);
+        expect((await res.json()).code).toBe('not_found');
+    });
+
+    it('override on a non-existent process returns 404 not_found', async () => {
+        as(board, { boardMember: true });
+        const res = await OVERRIDE(req({ processId: 999999999, action: 'reset' }) as never);
+        expect(res.status).toBe(404);
+        expect((await res.json()).code).toBe('not_found');
+    });
+
     it('queue lists eligible apps for a reviewer and excludes their own-household applicants', async () => {
         as(rev2, { backgroundCheckReviewer: true });
         const res = await REVIEW_QUEUE(req({}) as never);

--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -331,6 +331,43 @@ describe('Trusted Adults service', () => {
         const revoked = await overrideReview(ta.reviews[0].id, boardId, 'revoke');
         expect(revoked.status).toBe('REVOKED');
     });
+
+    // decideReview acts ONLY on PENDING_BOARD_REVIEW (unlike overrideReview, which has
+    // no phase guard). Deciding any other state is a no-op 409 — pin that for each
+    // non-pending status, asserting the status is untouched and no audit row is written.
+    it('decideReview on a non-PENDING_BOARD_REVIEW review is wrong_phase, status unchanged, no new audit', async () => {
+        for (const status of ['APPROVED', 'DENIED', 'REVOKED', 'EXPIRED', 'PENDING_SUBJECT_ACTION'] as const) {
+            const ta = await discloseOne();
+            const reviewId = ta.reviews[0].id;
+            await prisma.trustedAdultReview.update({ where: { id: reviewId }, data: { status } });
+            const auditBefore = await prisma.auditLog.count({ where: { tableName: 'TrustedAdult', affectedEntityId: ta.id } });
+
+            // DENY needs no sharedNote, so it reaches the phase guard (not bad_input first).
+            await expect(decideReview(reviewId, boardId, { decision: 'DENY' })).rejects.toMatchObject({ code: 'wrong_phase' });
+
+            const after = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } });
+            expect(after!.status).toBe(status); // untouched
+            expect(await prisma.auditLog.count({ where: { tableName: 'TrustedAdult', affectedEntityId: ta.id } })).toBe(auditBefore);
+        }
+    });
+
+    // PENDING_SUBJECT_ACTION (board asked for info) is a dead-end in the service: there is
+    // NO resubmit/re-decide path. The board can't re-decide (wrong_phase), the family can't
+    // open a fresh review (already_open) — the only exits are withdraw or board override.
+    it('PENDING_SUBJECT_ACTION is a dead-end: no re-decide, no renew; only withdraw/override exits it', async () => {
+        const ta = await discloseOne();
+        const reviewId = ta.reviews[0].id;
+        await decideReview(reviewId, boardId, { decision: 'REQUEST_INFO', note: 'Need dates.' });
+        expect((await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } }))!.status).toBe('PENDING_SUBJECT_ACTION');
+
+        // Board can't re-decide it; family can't open a parallel review while one is in flight.
+        await expect(decideReview(reviewId, boardId, { decision: 'DENY' })).rejects.toMatchObject({ code: 'wrong_phase' });
+        await expect(renewTrustedAdult(ta.id, leadId)).rejects.toMatchObject({ code: 'already_open' });
+
+        // The escape hatch: a lead can withdraw it → REVOKED.
+        const withdrawn = await withdrawTrustedAdult(ta.id, leadId);
+        expect(withdrawn.status).toBe('REVOKED');
+    });
 });
 
 // Edge cases for the nightly expiry sweep. runExpirySweep returns DB-wide


### PR DESCRIPTION
## What

Adds direct tests for `wrong_phase` / `not_found` branches in two review flows. These paths exist in source and are mapped to HTTP codes, but were previously only reached as race side-effects inside concurrency tests — no test pinned them on their own.

### Membership BG review (`src/lib/membership/review.ts`, `external.ts`)
- **attest on an already-decided process**: reject → BLOCKED, then a fresh eligible reviewer attests → **409 `wrong_phase`**; asserts attestation count and audit count unchanged (the phase guard runs before the attestation `create`, so nothing is written).
- **404 `not_found`** for `attest`, `overrideBlocked`, `markBgConsent`, `markContractSigned` against a non-existent `processId`. Only `certify` had a 404 test before.

### Trusted-adult `decideReview` (`src/lib/trusted-adult/service.ts`)
- Deciding a **non-`PENDING_BOARD_REVIEW`** review (`APPROVED` / `DENIED` / `REVOKED` / `EXPIRED` / `PENDING_SUBJECT_ACTION`) → **`wrong_phase`**, status unchanged, no new audit row. Uses `DENY` so it reaches the phase guard rather than the `APPROVE` shared-note `bad_input`.
- Documents the **`PENDING_SUBJECT_ACTION` exit path**. It is a dead-end: board can't re-decide (`wrong_phase`), family can't open a fresh review (`already_open`). The only exits are withdraw (→ `REVOKED`) or board override. There is no resubmit path in the code — the test pins that.

## Reviewer notes
- Integration-only — `INTEGRATION_DB=1 --runInBand` (`checkin-app` `test:integration`). Not in the default jest run; **CI does not gate these**. Run locally against real Postgres.
- Verified locally: all 43 tests across the three touched suites pass.
- Test-only change; no source behavior modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)