### PR TITLE
fix(attendance): mark synthetic visits SYSTEM so fabricated duration isn't counted as measured

### DIFF
--- a/checkin-app/src/app/api/events/[id]/attendance/route.ts
+++ b/checkin-app/src/app/api/events/[id]/attendance/route.ts
@@ -88,15 +88,22 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                         }
                     });
                 } else {
-                    // Create a synthetic visit since they were marked attended but didn't badge in
+                    // Create a synthetic visit since they were marked attended but didn't badge in.
+                    // arrivedVia/departedVia = SYSTEM flags this as fabricated, not measured: the
+                    // event window is a placeholder, not a real badge-in/out duration. SYSTEM on
+                    // *arrivedVia* is the unique marker — real visits only ever use SCANNER/WEB there
+                    // (cron uses SYSTEM only on departedVia). Building-hours analytics (facility/trends)
+                    // exclude arrivedVia=SYSTEM so this placeholder window isn't counted as real hours.
+                    // Keep departedAt set (not null): null would mark it "open", tripping the nightly
+                    // auto-checkout and the one-open-visit-per-participant index.
                     const newVisit = await tx.visit.create({
                         data: {
                             participantId: pId,
                             associatedEventId: eventId,
                             arrivedAt: event.startAt,
                             departedAt: event.endAt,
-                            arrivedVia: "WEB",
-                            departedVia: "WEB"
+                            arrivedVia: "SYSTEM",
+                            departedVia: "SYSTEM"
                         }
                     });
                     actions.push(newVisit);

--- a/checkin-app/src/app/api/facility/trends/route.ts
+++ b/checkin-app/src/app/api/facility/trends/route.ts
@@ -94,6 +94,10 @@ export const GET = withAuth(
             const whereClause: Record<string, unknown> = {
                 arrivedAt: { gte: since },
                 departedAt: { not: null },
+                // Exclude synthetic "marked present" visits (events attendance route): their
+                // arrivedAt/departedAt is the event window, not a measured duration. arrivedVia=SYSTEM
+                // is the marker — real visits use SCANNER/WEB on arrival.
+                arrivedVia: { not: "SYSTEM" },
             };
 
             if (programId) {


### PR DESCRIPTION
## What

When a lead mentor marks a participant present at an event but that participant never badged in, the event-attendance `POST` handler creates a **synthetic** `Visit` stamped `arrivedAt = event.start`, `departedAt = event.end`. Previously these used `arrivedVia/departedVia = "WEB"`, making a fabricated full-event window indistinguishable from a real badge-in/badge-out.

This PR marks synthetic visits with `VisitSource.SYSTEM` and excludes them from building-hours analytics.

## Why

Downstream consumers (visit-duration reports, occupancy, `facility/trends` building-hours) summed the fabricated full-event window as if it were a measured stay. A participant who was only *marked present* inflated occupancy/hours by the entire event length — data that was never actually measured.

## Changes

- **`events/[id]/attendance/route.ts`** — synthetic visits now use `arrivedVia="SYSTEM"`, `departedVia="SYSTEM"`. `arrivedVia=SYSTEM` is the unique fabricated-arrival marker: real visits only ever use `SCANNER`/`WEB` on arrival, and the nightly cron uses `SYSTEM` only on *departure*.
- **`facility/trends/route.ts`** — building-hours aggregation now excludes `arrivedVia=SYSTEM`, so placeholder windows aren't counted as measured occupancy.

## Reviewer notes

- **Why not `departedAt=null`?** Null marks a visit "open" → the nightly auto-checkout would re-stamp departure at "now" (a *worse* fabricated duration), and it collides with the `Visit_one_open_per_participant` partial unique index. The window is deliberately kept closed.
- **No schema change** — `VisitSource.SYSTEM` already exists and already means "system-generated, not measured" (cron auto-checkout uses it).
- **Out of scope / untouched:** duplicate/overlapping-visit detection (my-programs conflicts).
- Existing `eventAttendanceAPI.integration.test.ts` asserts synthetic `departedAt` is non-null (still holds) and does not assert `arrivedVia` (safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)