### PR TITLE
refactor(schema): rename ToolStatus.userId to participantId

### DIFF
--- a/checkin-app/prisma/migrations/20260629190000_rename_toolstatus_user_to_participant/migration.sql
+++ b/checkin-app/prisma/migrations/20260629190000_rename_toolstatus_user_to_participant/migration.sql
@@ -1,0 +1,8 @@
+-- Rename ToolStatus.userId -> participantId (Person = Participant). Data-preserving RENAME (not drop/add).
+-- PK (ToolStatus_pkey) tracks the column rename automatically; FK constraint renamed explicitly.
+
+-- AlterTable
+ALTER TABLE "ToolStatus" RENAME COLUMN "userId" TO "participantId";
+
+-- RenameForeignKey
+ALTER TABLE "ToolStatus" RENAME CONSTRAINT "ToolStatus_userId_fkey" TO "ToolStatus_participantId_fkey";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -135,16 +135,16 @@ model Tool {
 
 model ToolStatus {
   /// @sensitivity:public
-  userId Int
+  participantId Int
   /// @sensitivity:public
   toolId Int
   /// @sensitivity:member
   level  ToolLevel
 
-  user Participant @relation(fields: [userId], references: [id])
+  participant Participant @relation(fields: [participantId], references: [id])
   tool Tool        @relation(fields: [toolId], references: [id])
 
-  @@id([userId, toolId])
+  @@id([participantId, toolId])
 }
 
 model Household {

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -13,7 +13,7 @@ describe("GET /api/cron/post-event", () => {
         await prisma.event.deleteMany({ where: { name: { startsWith: 'Past Event' } } });
         await prisma.event.deleteMany({ where: { name: { startsWith: 'Future Event' } } });
         await prisma.program.deleteMany({ where: { name: 'Test Program' } });
-        await prisma.toolStatus.deleteMany({ where: { user: { email: { contains: 'example.com' } } } });
+        await prisma.toolStatus.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
         await prisma.householdLead.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
         await prisma.rawBadgeLog.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
         await prisma.participant.deleteMany({ where: { email: { contains: 'example.com' } } });

--- a/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
@@ -42,7 +42,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
         });
 
         await prisma.toolStatus.deleteMany({
-            where: { userId: { in: existingUserIds } }
+            where: { participantId: { in: existingUserIds } }
         });
 
         await prisma.tool.deleteMany({
@@ -72,7 +72,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
 
         await prisma.toolStatus.create({
             data: { 
-                userId: testUserId,
+                participantId: testUserId,
                 toolId: toolId,
                 level: 'CERTIFIED'
             }
@@ -93,7 +93,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
             where: { participantId: testUserId }
         });
         await prisma.toolStatus.deleteMany({
-            where: { userId: testUserId }
+            where: { participantId: testUserId }
         });
         await prisma.participant.deleteMany({
             where: { id: testUserId }

--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -36,7 +36,7 @@ describe('Shop API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         await prisma.toolStatus.deleteMany({
-            where: { userId: { in: existingUserIds } }
+            where: { participantId: { in: existingUserIds } }
         });
         await prisma.visit.deleteMany({
             where: { participantId: { in: existingUserIds } }
@@ -116,7 +116,7 @@ describe('Shop API Integration Tests', () => {
                 where: { actorId: { in: existingUserIds } }
             });
             await prisma.toolStatus.deleteMany({
-                where: { userId: { in: existingUserIds } }
+                where: { participantId: { in: existingUserIds } }
             });
             await prisma.visit.deleteMany({
                 where: { participantId: { in: existingUserIds } }
@@ -255,7 +255,7 @@ describe('Shop API Integration Tests', () => {
              const data = await res.json();
              expect(data.success).toBe(true);
              expect(data.certification.level).toBe('BASIC');
-             expect(data.certification.userId).toBe(commonId);
+             expect(data.certification.participantId).toBe(commonId);
 
              // Audit: first grant on this participant+tool → CREATE, no prior data.
              const auditRows = await prisma.auditLog.findMany({

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -151,13 +151,13 @@ export const POST = withAuth(
                 for (const tool of mergeParticipant.toolStatuses) {
                     if (!keepParticipant.toolStatuses.find(k => k.toolId === tool.toolId)) {
                         await tx.toolStatus.update({
-                            where: { userId_toolId: { toolId: tool.toolId, userId: mergeId } },
-                            data: { userId: keepId }
+                            where: { participantId_toolId: { toolId: tool.toolId, participantId: mergeId } },
+                            data: { participantId: keepId }
                         });
                         moved.toolStatuses.migrated++;
                     } else {
                         await tx.toolStatus.delete({
-                            where: { userId_toolId: { toolId: tool.toolId, userId: mergeId } }
+                            where: { participantId_toolId: { toolId: tool.toolId, participantId: mergeId } }
                         });
                         moved.toolStatuses.deleted++;
                     }

--- a/checkin-app/src/app/api/shop/certifications/route.ts
+++ b/checkin-app/src/app/api/shop/certifications/route.ts
@@ -29,10 +29,10 @@ export async function GET(req: NextRequest) {
                 return NextResponse.json({ error: "Forbidden" }, { status: 403 });
             }
             const certifications = await prisma.toolStatus.findMany({
-                orderBy: [{ tool: { name: 'asc' } }, { user: { name: 'asc' } }],
+                orderBy: [{ tool: { name: 'asc' } }, { participant: { name: 'asc' } }],
                 include: {
                     tool: true,
-                    user: { select: { id: true, name: true, email: true } },
+                    participant: { select: { id: true, name: true, email: true } },
                 },
             });
             return NextResponse.json(certifications);
@@ -51,14 +51,14 @@ export async function GET(req: NextRequest) {
             whereClause = { toolId: parseInt(toolIdParam, 10) };
         } else {
             // Looking up a specific person's certifications
-            whereClause = { userId: targetUserId };
+            whereClause = { participantId: targetUserId };
         }
 
         const certifications = await prisma.toolStatus.findMany({
             where: whereClause,
             include: {
                 tool: true,
-                user: toolIdParam ? { select: { id: true, name: true } } : false
+                participant: toolIdParam ? { select: { id: true, name: true } } : false
             }
         });
 
@@ -98,8 +98,8 @@ export async function POST(req: Request) {
             // Check if user is a certifier for this specific tool
             const currentUserStatus = await prisma.toolStatus.findUnique({
                 where: {
-                    userId_toolId: {
-                        userId: currentUserId,
+                    participantId_toolId: {
+                        participantId: currentUserId,
                         toolId: parseInt(toolId, 10)
                     }
                 }
@@ -125,13 +125,13 @@ export async function POST(req: Request) {
         const pId = parseInt(participantId, 10);
 
         const currentStatus = await prisma.toolStatus.findUnique({
-            where: { userId_toolId: { userId: pId, toolId: tId } }
+            where: { participantId_toolId: { participantId: pId, toolId: tId } }
         });
 
         const upsertedCert = await prisma.toolStatus.upsert({
             where: {
-                userId_toolId: {
-                    userId: pId,
+                participantId_toolId: {
+                    participantId: pId,
                     toolId: tId
                 }
             },
@@ -139,7 +139,7 @@ export async function POST(req: Request) {
                 level: level as 'BASIC' | 'DOF' | 'CERTIFIED' | 'INSTRUCTOR' | 'MAY_CERTIFY_OTHERS'
             },
             create: {
-                userId: pId,
+                participantId: pId,
                 toolId: tId,
                 level: level as 'BASIC' | 'DOF' | 'CERTIFIED' | 'INSTRUCTOR' | 'MAY_CERTIFY_OTHERS'
             }

--- a/checkin-app/src/app/shop-ops/manage/ToolManagementPanel.tsx
+++ b/checkin-app/src/app/shop-ops/manage/ToolManagementPanel.tsx
@@ -18,10 +18,10 @@ type Tool = {
 };
 
 type Certification = {
-  userId: number;
+  participantId: number;
   toolId: number;
   level: "BASIC" | "DOF" | "CERTIFIED" | "INSTRUCTOR" | "MAY_CERTIFY_OTHERS";
-  user?: { id: number; name: string | null };
+  participant?: { id: number; name: string | null };
   tool?: { id: number; name: string };
 };
 
@@ -234,8 +234,8 @@ function ToolsTab({ tools, members, isAdmin, isCertifier, onToolsChange }: {
                       ) : (
                         <Stack gap={6} mb="md">
                           {certs.map((c) => (
-                            <Group key={`${c.userId}-${c.toolId}`} justify="space-between" p="xs" style={{ borderRadius: 6, background: 'var(--mantine-color-default-hover)' }}>
-                              <Text size="sm">{c.user?.name ?? 'Unnamed'}</Text>
+                            <Group key={`${c.participantId}-${c.toolId}`} justify="space-between" p="xs" style={{ borderRadius: 6, background: 'var(--mantine-color-default-hover)' }}>
+                              <Text size="sm">{c.participant?.name ?? 'Unnamed'}</Text>
                               <ToolLevelBadge level={toToolLevel(c.level)} />
                             </Group>
                           ))}
@@ -325,7 +325,7 @@ function PersonTab({ members, tools, isCertifier, isAdmin }: { members: Member[]
                       ) : (
                         <Stack gap={6} mb="md">
                           {certs.map((c) => (
-                            <Group key={`${c.userId}-${c.toolId}`} justify="space-between" p="xs" style={{ borderRadius: 6, background: 'var(--mantine-color-default-hover)' }}>
+                            <Group key={`${c.participantId}-${c.toolId}`} justify="space-between" p="xs" style={{ borderRadius: 6, background: 'var(--mantine-color-default-hover)' }}>
                               <Text size="sm">{c.tool?.name ?? 'Unknown Tool'}</Text>
                               <ToolLevelBadge level={toToolLevel(c.level)} />
                             </Group>
@@ -374,11 +374,11 @@ function AllTab() {
   // Build the person×tool matrix from the flat cert list.
   const memberMap = new Map<number, string>();
   const toolMap = new Map<number, string>();
-  const cell = new Map<string, Certification>(); // `${userId}-${toolId}` -> cert
+  const cell = new Map<string, Certification>(); // `${participantId}-${toolId}` -> cert
   for (const c of certs) {
-    if (c.user) memberMap.set(c.user.id, c.user.name ?? 'Unnamed');
+    if (c.participant) memberMap.set(c.participant.id, c.participant.name ?? 'Unnamed');
     if (c.tool) toolMap.set(c.tool.id, c.tool.name);
-    cell.set(`${c.userId}-${c.toolId}`, c);
+    cell.set(`${c.participantId}-${c.toolId}`, c);
   }
   const byName = (a: [number, string], b: [number, string]) => a[1].localeCompare(b[1]);
   const allMembers = [...memberMap].sort(byName);

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -190,19 +190,19 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         create: { name: "Drill Press", safetyGuide: "https://example.com/drill-press-safety" },
     });
     await prisma.toolStatus.upsert({
-        where: { userId_toolId: { userId: certifiedAdult.id, toolId: tableSaw.id } },
+        where: { participantId_toolId: { participantId: certifiedAdult.id, toolId: tableSaw.id } },
         update: { level: "CERTIFIED" },
-        create: { userId: certifiedAdult.id, toolId: tableSaw.id, level: "CERTIFIED" },
+        create: { participantId: certifiedAdult.id, toolId: tableSaw.id, level: "CERTIFIED" },
     });
     await prisma.toolStatus.upsert({
-        where: { userId_toolId: { userId: certifiedAdult.id, toolId: drillPress.id } },
+        where: { participantId_toolId: { participantId: certifiedAdult.id, toolId: drillPress.id } },
         update: { level: "CERTIFIED" },
-        create: { userId: certifiedAdult.id, toolId: drillPress.id, level: "CERTIFIED" },
+        create: { participantId: certifiedAdult.id, toolId: drillPress.id, level: "CERTIFIED" },
     });
     await prisma.toolStatus.upsert({
-        where: { userId_toolId: { userId: toolCertifier.id, toolId: tableSaw.id } },
+        where: { participantId_toolId: { participantId: toolCertifier.id, toolId: tableSaw.id } },
         update: { level: "MAY_CERTIFY_OTHERS" },
-        create: { userId: toolCertifier.id, toolId: tableSaw.id, level: "MAY_CERTIFY_OTHERS" },
+        create: { participantId: toolCertifier.id, toolId: tableSaw.id, level: "MAY_CERTIFY_OTHERS" },
     });
 
     // 5. Sample program

--- a/checkin-app/src/security/__tests__/toolstatus-self-scope.test.ts
+++ b/checkin-app/src/security/__tests__/toolstatus-self-scope.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * ToolStatus.userId was renamed to participantId (Person = Participant). The
+ * `their_own` stripper branch was SPLIT so ToolStatus reads `participantId`
+ * while Account/Session (NextAuth-mandated) keep reading `userId`. Guards that
+ * split: a member must still self-scope their own ToolStatus rows, and the
+ * Account/Session read must NOT regress.
+ */
+import { scopesHeld, type CallerContext } from '../access-resolvers';
+
+const ctx: CallerContext = {
+    selfId: 7,
+    isKeyholder: false,
+    isKiosk: false,
+    programsLed: new Set(),
+    programsCoreVolIn: new Set(),
+    participantIdsInScopePrograms: new Set(),
+    householdIdsInScopePrograms: new Set(),
+    activeVisitorIds: new Set(),
+};
+
+describe('ToolStatus self-scoping after userId -> participantId rename', () => {
+    it("grants their_own on a ToolStatus row whose participantId is the caller", () => {
+        expect(scopesHeld('ToolStatus', { participantId: 7, toolId: 1 }, ctx).has('their_own')).toBe(true);
+    });
+
+    it('does NOT grant their_own on someone else\'s ToolStatus row', () => {
+        expect(scopesHeld('ToolStatus', { participantId: 99, toolId: 1 }, ctx).has('their_own')).toBe(false);
+    });
+
+    it('reads participantId, not the stale userId, for ToolStatus', () => {
+        // A row carrying only the OLD key must no longer self-scope.
+        expect(scopesHeld('ToolStatus', { userId: 7, toolId: 1 }, ctx).has('their_own')).toBe(false);
+    });
+
+    it('Account/Session still self-scope on userId (NextAuth, unchanged)', () => {
+        expect(scopesHeld('Account', { userId: 7 }, ctx).has('their_own')).toBe(true);
+        expect(scopesHeld('Session', { userId: 7 }, ctx).has('their_own')).toBe(true);
+        expect(scopesHeld('Account', { userId: 99 }, ctx).has('their_own')).toBe(false);
+    });
+});

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -233,9 +233,15 @@ export function scopesHeld(
             if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
             break;
         }
-        case 'ToolStatus':
+        case 'ToolStatus': {
+            // ToolStatus renamed userId -> participantId (Person = Participant).
+            const participantId = num(row.participantId);
+            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            break;
+        }
         case 'Account':
         case 'Session': {
+            // NextAuth-mandated: these keep userId (mapped to participant_id col).
             const userId = num(row.userId);
             if (userId !== undefined && userId === ctx.selfId) scopes.add('their_own');
             break;

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -28,7 +28,7 @@ export const classifications = {
         safetyGuide: 'public',
     },
     ToolStatus: {
-        userId: 'public',
+        participantId: 'public',
         toolId: 'public',
         level: 'member',
     },
@@ -338,7 +338,7 @@ export const relations = {
         toolStatuses: { model: 'ToolStatus', isList: true },
     },
     ToolStatus: {
-        user: { model: 'Participant', isList: false },
+        participant: { model: 'Participant', isList: false },
         tool: { model: 'Tool', isList: false },
     },
     Household: {


### PR DESCRIPTION
## What

Finishes the **Person = Participant** item of the schema-naming refactor: renames `ToolStatus.userId`/`user` → `participantId`/`participant` (column, compound PK, FK constraint, relation). This was one of two remaining pieces; the rest of the refactor already shipped on `main`.

## Why

Consistency with the rest of the schema, where a person is a `Participant`. `ToolStatus` was the last model still calling a participant FK `userId`.

## Changes

- **Schema** (`prisma/schema.prisma`, `ToolStatus` only): `userId Int` → `participantId Int`, `user Participant` → `participant Participant`, `@@id([participantId, toolId])`.
- **Migration** `20260629190000_rename_toolstatus_user_to_participant`: hand-edited **data-safe RENAME** (not Prisma's default drop/add), preserving existing certification rows:
  ```sql
  ALTER TABLE "ToolStatus" RENAME COLUMN "userId" TO "participantId";
  ALTER TABLE "ToolStatus" RENAME CONSTRAINT "ToolStatus_userId_fkey" TO "ToolStatus_participantId_fkey";
  ```
  PK tracks the column rename automatically. `migrate dev --create-only` → empty migration (**zero drift**).
- **Call sites**: cert route, participant-merge route, seed helpers, `ToolManagementPanel` (type + reads), and integration tests — compound unique input `participantId_toolId`, the `participant` relation in `orderBy`/`include`, and a loosely-typed stale `where` key that `tsc` doesn't flag.
- **Security stripper** (`access-resolvers.ts`): **SPLIT** the shared `their_own` case — `ToolStatus` now reads `row.participantId`; `Account`/`Session` (NextAuth, `@map("participant_id")`) keep reading `row.userId`.

## Reviewer notes

- `Account.userId` / `Session.userId` and `session.user.toolStatuses` are **intentionally unchanged** (NextAuth-mandated).
- `src/security/generated/classifications.ts` is generator output (regenerated by `prisma generate`), not hand-edited.
- Stripper read is loosely typed → `tsc` stays green even if self-scoping breaks. Added `src/security/__tests__/toolstatus-self-scope.test.ts` (4 cases) asserting ToolStatus self-scopes on `participantId`, ignores stale `userId`, and Account/Session still scope on `userId`.

## Verification

- `tsc --noEmit`: 0 errors
- Unit: 380 pass (66 suites)
- Integration (serial, throwaway Postgres): 679 pass (100 suites)
- Migration applies clean; drift empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
