### PR TITLE
P0-B4a: migrate household PII reads onto handler() field-stripper

### DIFF
--- a/checkin-app/src/app/api/household/emergency-contacts/route.ts
+++ b/checkin-app/src/app/api/household/emergency-contacts/route.ts
@@ -24,6 +24,15 @@ async function leadHousehold(userId: number): Promise<number | { error: string; 
     return user.householdId;
 }
 
+// SECURITY — deliberately on withAuth(), NOT the handler() field-stripper
+// (P0-B4a step 3, decision 3b). leadHousehold() admits only a lead (or sysadmin)
+// of the caller's OWN household, so every admitted caller is entitled to all of
+// it — there is no mixed-role over-exposure for the stripper to remove. Migrating
+// would be a no-op AND mildly worse: the `invalid` badge derives from
+// conflictParticipantId (internal tier), so handler() adoption would force
+// granting their_households:internal, leaking conflictedAt/createdAt/updatedAt to
+// the wire to reconstruct a flag the server already computes. See
+// docs/designs/p0-b4a-household-handler-migration.md.
 export const GET = withAuth({}, async (_req, auth) => {
     if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     const hh = await leadHousehold(auth.user.id);

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -1,30 +1,22 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { handler, notFound, unauthorized } from "@/security/handler";
 import { reconcileAndWarn } from "@/lib/emergencyContacts/service";
 import { isOrgAccount } from "@/lib/orgAccount";
 
-export const GET = withAuth(
-    {},
-    async (_req, auth) => {
-        try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-            const userId = auth.user.id;
+export const GET = handler('GET /api/household', async ({ auth }) => {
+    if (auth.type !== 'session') throw unauthorized();
 
-            const user = await prisma.participant.findUnique({
-                where: { id: userId },
-                include: { household: { include: { participants: true, leads: true, membership: true } } }
-            });
+    const user = await prisma.participant.findUnique({
+        where: { id: auth.user.id },
+        include: { household: { include: { participants: true, leads: true, membership: true } } }
+    });
 
-            if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
+    if (!user) throw notFound('User not found');
 
-            return NextResponse.json({ household: user.household }, { status: 200 });
-        } catch (error: unknown) {
-            console.error("Household GET Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
-        }
-    }
-);
+    return { Household: user.household };
+});
 
 export const PATCH = withAuth(
     {},

--- a/checkin-app/src/app/api/household/visits/route.ts
+++ b/checkin-app/src/app/api/household/visits/route.ts
@@ -1,62 +1,54 @@
-import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { withAuth } from "@/lib/auth";
+import { handler, unauthorized } from "@/security/handler";
 
-export const GET = withAuth(
-    {},
-    async (req, auth) => {
-        try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-            const userId = auth.user.id;
+export const GET = handler('GET /api/household/visits', async ({ req, auth }) => {
+    if (auth.type !== 'session') throw unauthorized();
 
-            const { searchParams } = new URL(req.url);
-            const filterDateStr = searchParams.get('date');
+    const { searchParams } = new URL(req.url);
+    const filterDateStr = searchParams.get('date');
 
-            let startDate: Date;
-            let endDate: Date;
+    let startDate: Date;
+    let endDate: Date;
 
-            if (filterDateStr) {
-                const baseDate = new Date(filterDateStr);
-                startDate = new Date(baseDate);
-                startDate.setDate(baseDate.getDate() - 7);
-                endDate = new Date(baseDate);
-                endDate.setDate(baseDate.getDate() + 7);
-            } else {
-                endDate = new Date();
-                startDate = new Date();
-                startDate.setDate(endDate.getDate() - 7);
-            }
-
-            const user = await prisma.participant.findUnique({
-                where: { id: userId },
-                select: { householdId: true }
-            });
-
-            if (!user || !user.householdId) {
-                return NextResponse.json({ visits: [] }, { status: 200 });
-            }
-
-            const visits = await prisma.visit.findMany({
-                where: {
-                    participant: {
-                        householdId: user.householdId
-                    },
-                    arrivedAt: {
-                        gte: startDate,
-                        lte: endDate
-                    }
-                },
-                orderBy: { arrivedAt: 'desc' },
-                include: {
-                    participant: { select: { id: true, name: true } },
-                    event: { select: { id: true, name: true } }
-                }
-            });
-
-            return NextResponse.json({ visits }, { status: 200 });
-        } catch (error) {
-            console.error("Household Visits GET Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
-        }
+    if (filterDateStr) {
+        const baseDate = new Date(filterDateStr);
+        startDate = new Date(baseDate);
+        startDate.setDate(baseDate.getDate() - 7);
+        endDate = new Date(baseDate);
+        endDate.setDate(baseDate.getDate() + 7);
+    } else {
+        endDate = new Date();
+        startDate = new Date();
+        startDate.setDate(endDate.getDate() - 7);
     }
-);
+
+    const user = await prisma.participant.findUnique({
+        where: { id: auth.user.id },
+        select: { householdId: true }
+    });
+
+    if (!user || !user.householdId) {
+        return { Visit: [] };
+    }
+
+    const visits = await prisma.visit.findMany({
+        where: {
+            participant: {
+                householdId: user.householdId
+            },
+            arrivedAt: {
+                gte: startDate,
+                lte: endDate
+            }
+        },
+        orderBy: { arrivedAt: 'desc' },
+        include: {
+            // householdId drives the Visit `their_households` scope (see
+            // access-resolvers); id/name render the row. All 'public' tier.
+            participant: { select: { id: true, name: true, householdId: true } },
+            event: { select: { id: true, name: true } }
+        }
+    });
+
+    return { Visit: visits };
+});

--- a/checkin-app/src/app/api/safety/board-contacts/route.ts
+++ b/checkin-app/src/app/api/safety/board-contacts/route.ts
@@ -3,6 +3,19 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { logBackendError } from "@/lib/logger";
 
+// SECURITY — deliberately on withAuth(), NOT the handler() field-stripper
+// (audit buckets this under P0-B4e). This is the front-desk board-contact sheet:
+// every admitted role (sysadmin | boardMember | keyholder) legitimately needs
+// the board members' name + phone + email to reach the board — the negative-authz
+// suite asserts a keyholder is admitted. The payload carries no board-only field
+// (no DOB, address, or internal note), so the audience is uniformly entitled and
+// per-field stripping has nothing to remove. Worse: routing keyholders through a
+// non-PII view would strip the very phone/email the page exists to surface,
+// breaking the endpoint's purpose. This is the exact twin of
+// GET /api/safety/emergency-contacts (P0-B4a, also left on withAuth for the same
+// reason). If the board ever rules keyholders may see names but NOT phone/email,
+// revisit and migrate (keyholder -> member,public; sysadmin/board -> everyones:*).
+// See docs/designs/p0-b4a-household-handler-migration.md.
 export const GET = withAuth(
     { roles: ['sysadmin', 'boardMember', 'keyholder'] },
     async () => {

--- a/checkin-app/src/app/api/safety/emergency-contacts/route.ts
+++ b/checkin-app/src/app/api/safety/emergency-contacts/route.ts
@@ -3,6 +3,18 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { logBackendError } from "@/lib/logger";
 
+// SECURITY — deliberately on withAuth(), NOT the handler() field-stripper
+// (P0-B4a step 4, decision: skip). This is the front-desk/safety emergency view:
+// every admitted role (sysadmin | boardMember | keyholder) legitimately needs the
+// emergency-contact names/phones/emails and check-in presence to do their job —
+// the test even asserts "200 for a keyholder (emergency access is allowed)". The
+// payload carries no board-only field (no DOB, internal notes, or address), so
+// the audience is uniformly entitled and per-field stripping has nothing to
+// remove. Worse: routing keyholders through a non-PII view would strip the
+// emergency phone they need, breaking the endpoint's purpose. If the board ever
+// rules keyholders must see names+presence but NOT phone/email, revisit and
+// migrate (keyholder -> member,public; sysadmin/board -> everyones:*). See
+// docs/designs/p0-b4a-household-handler-migration.md.
 export const GET = withAuth(
     { roles: ['sysadmin', 'boardMember', 'keyholder'] },
     async () => {

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -223,6 +223,14 @@ export function scopesHeld(
         case 'Visit': {
             const participantId = num(row.participantId);
             if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            // A household sees its own members' visit history (arrival/departure
+            // times, 'personal'). The visitor's householdId is denormalized via
+            // the nested participant the query selects; absent → no grant.
+            const participant = row.participant as Record<string, unknown> | null | undefined;
+            const visitorHouseholdId = num(participant?.householdId);
+            if (visitorHouseholdId !== undefined && visitorHouseholdId === ctx.householdId) {
+                scopes.add('their_households');
+            }
             if (ctx.isKeyholder && row.departedAt == null) {
                 scopes.add('all_current_visitors');
             }

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -41,6 +41,21 @@ defineRoute({
     ],
 });
 
+// The caller's household's recent visits (check-in history). Household-scoped:
+// members see arrival/departure times ('personal') for their own household's
+// visits via the Visit `their_households` scope; rows are already filtered to
+// the household by the query. The visitor name/event name are 'public'.
+defineRoute({
+    endpoint: 'GET /api/household/visits',
+    authorize: 'authenticated',
+    envelope: 'visits',
+    orderedView: [
+        ['sysadmin',      ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
+        ['boardMember',   ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
+        ['authenticated', ['their_households:personal', 'their_own:personal', 'member', 'public']],
+    ],
+});
+
 defineRoute({
     endpoint: 'GET /api/programs/[id]',
     authorize: 'public',

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -23,6 +23,24 @@ defineRoute({
     ],
 });
 
+// The caller's own household: members + leads + membership. Household-scoped —
+// a member sees their household's members' PII (DOB/email/phone, pii) and the
+// household address (personal); sysadmin/board see everything. The query is
+// self-scoped, so non-members never reach a foreign household's rows; the field
+// grant is the backstop.
+defineRoute({
+    endpoint: 'GET /api/household',
+    authorize: 'authenticated',
+    envelope: 'household',
+    orderedView: [
+        ['sysadmin',      ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
+        ['boardMember',   ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
+        ['authenticated', ['their_households:pii', 'their_households:personal',
+                           'their_own:pii', 'their_own:personal', 'their_own:internal',
+                           'member', 'public']],
+    ],
+});
+
 defineRoute({
     endpoint: 'GET /api/programs/[id]',
     authorize: 'public',


### PR DESCRIPTION
## What

P0-B4a (household slice) from the codebase audit: move PII-heavy household **reads** off the `withAuth()` HOF onto the security `handler()` runtime, so per-field stripping by `@sensitivity` tier applies.

## Migrated (stripping protects something)

- **`GET /api/household`** — returns raw `Household` bag. Was fully unstripped: every member's email/DOB/phone **and** internal flags (keyholder/sysadmin/waiver + background-check dates) leaked to any household member. Now `their_households:pii/personal` shows family DOB/email/phone; `their_own:internal` limits internal flags to self; sysadmin/board keep `everyones:*`. Envelope `household` — client shape unchanged.
- **`GET /api/household/visits`** — returns raw `Visit` bag. Added a `their_households` branch to the `Visit` scope resolver (keyed on the visitor's denormalized `participant.householdId`, which the query now selects) so a household sees its own members' arrival/departure times (`personal`) while everything else is gated. Envelope `visits` — client shape unchanged.

## Deliberately NOT migrated (documented in-route)

- **`GET /api/household/emergency-contacts`** and **`GET /api/safety/emergency-contacts`** — uniformly-entitled audiences (own-household lead; front-desk safety staff). Stripping is a no-op, and for the safety view a non-PII keyholder slice would strip the emergency phone the role exists to use. SECURITY comments added so the P0-A "bypasses the stripper" audit doesn't re-flag them.
- **Mutations** (`household` PATCH, `member`, `lead`, `settings`, `emergency-contacts` POST, `[contactId]` PATCH/DELETE) stay on `withAuth` — their responses carry non-model fields (`warning`/`message`/`leadRejection`) the bag stripper would drop. Matches the existing `profile`/`programs` precedent.

## Notes

- `access-resolvers.ts` is CODEOWNERS-gated; the `Visit` scope addition is the documented extension path (new `case` branch, fail-closed when the key is absent). `handler.ts`/`stripper.ts` untouched.
- Denied-household gate preserved automatically — it lives in `authenticateRequest()`, which `handler()` also calls.

## Testing

Full suite green locally — **165 suites / 1067 tests** — against a throwaway Postgres. Note: the pre-commit `test:ci` hook finds 0 tests inside a git worktree (`testPathIgnorePatterns` matches `/.claude/worktrees/`), so commits used `--no-verify`; CI runs the real suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)