### PR TITLE
refactor(auth): extract withKiosk HOF for the signed-actor route family (P0-B)

### DIFF
--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -1,41 +1,22 @@
-import { NextRequest } from "next/server";
 import prisma from "@/lib/prisma";
-import { authenticateRequest } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { processCheckin, processCheckout, finalizeFacilityClose } from "@/lib/scan-service";
-import { logBackendError } from "@/lib/logger";
 import { config } from "@/lib/config";
-import { rateLimit } from "@/lib/rate-limit";
+import { withKiosk } from "@/lib/kioskAuth";
 
-export async function POST(req: NextRequest) {
+// High cap: kiosks burst and a whole facility may share one NAT IP. withKiosk
+// reads the raw body, authenticates it (kiosk signature OR session), rejects
+// unauthenticated, and hands us the parsed body + actor. We own authorization.
+export const POST = withKiosk(
+    { rateLimit: { name: "scan", limit: 300 } },
+    async (_req, body: { participantId?: unknown }, auth) => {
     const startTime = Date.now();
 
-    // High cap: kiosks burst and a whole facility may share one NAT IP.
-    const limited = rateLimit(req, { name: "scan", limit: 300, windowMs: 60_000 });
-    if (limited) return limited;
-
     try {
-        const rawBody = await req.text();
-
-        // 1. Authenticate
-        const auth = await authenticateRequest(req, rawBody);
-
-        let body;
-        try {
-            body = JSON.parse(rawBody);
-        } catch {
-            return apiError("Invalid JSON payload.", 400);
-        }
-
         const participantId = body.participantId;
 
         if (!participantId || typeof participantId !== 'number') {
             return apiError("A valid numeric participantId is required.", 400);
-        }
-
-        // 2. Authorization
-        if (auth.type === 'unauthenticated') {
-            return apiError("Unauthorized: Missing kiosk signature or invalid session", 401);
         }
 
         // Web session: check if user can scan this participant
@@ -154,11 +135,9 @@ export async function POST(req: NextRequest) {
         await finalizeFacilityClose(res);
 
         return res;
-    } catch (error) {
-        console.error("Scan processing error:", error);
-        await logBackendError(error, "POST /api/scan");
-        return apiError("Internal Server Error while processing scan.", 500);
     } finally {
+        // Errors propagate to withKiosk's top-level catch/500; this finally only
+        // records the metric. Times the handler body (post-auth), not rate-limit.
         const durationMs = Date.now() - startTime;
         prisma.systemMetricLog.create({
             data: {
@@ -167,4 +146,4 @@ export async function POST(req: NextRequest) {
             }
         }).catch((err: unknown) => console.error("Failed to log scan_response_time metric:", err));
     }
-}
+});

--- a/checkin-app/src/lib/__tests__/kioskAuth.test.ts
+++ b/checkin-app/src/lib/__tests__/kioskAuth.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ *
+ * Direct unit test for the withKiosk wrapper (src/lib/kioskAuth.ts) — the
+ * multi-actor, signed-body sibling of withAuth. Unlike withAuth, it reads the
+ * raw body and authenticates against it (the kiosk HMAC covers the body bytes),
+ * so the key thing to pin is: a valid kiosk signature is admitted, an
+ * unsigned/cookie-less non-local request is rejected 401, and the RAW body
+ * actually reaches the verifier. authenticateRequest runs for real here; only
+ * its lower primitives (kiosk verify, session, isLocal) are mocked.
+ */
+
+import { NextResponse } from 'next/server';
+import { withKiosk } from '@/lib/kioskAuth';
+import { getServerSession } from 'next-auth/next';
+import { getKioskPublicKeys, verifyKioskSignature } from '@/lib/verify-kiosk';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/auth-options', () => ({ authOptions: {} }));
+jest.mock('@/lib/verify-kiosk', () => ({
+    getKioskPublicKeys: jest.fn(),
+    verifyKioskSignature: jest.fn(),
+}));
+// Non-local: disables authenticateRequest's keyless local-dev kiosk fallback so
+// an unsigned request must fail closed, exactly like prod/dev.
+jest.mock('@/lib/config', () => ({ config: { isLocal: () => false, isProd: () => false } }));
+
+const mockSession = getServerSession as jest.Mock;
+const mockPubKeys = getKioskPublicKeys as jest.Mock;
+const mockVerify = verifyKioskSignature as jest.Mock;
+
+const handler = jest.fn(async () => NextResponse.json({ ok: true }, { status: 200 }));
+const route = withKiosk({ rateLimit: { name: 'kiosk-test', limit: 300 } }, handler);
+
+const post = (init: RequestInit) =>
+    route(new Request('http://localhost/api/scan', { method: 'POST', ...init }) as never);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockPubKeys.mockReturnValue([]);
+    mockVerify.mockReturnValue({ ok: false });
+    mockSession.mockResolvedValue(null);
+});
+
+describe('withKiosk', () => {
+    it('admits a valid kiosk signature and passes the parsed body + actor to the handler', async () => {
+        mockPubKeys.mockReturnValue(['key']);
+        mockVerify.mockReturnValue({ ok: true });
+
+        const res = await post({
+            headers: { 'x-kiosk-signature': 'sig' },
+            body: JSON.stringify({ participantId: 5 }),
+        });
+
+        expect(res.status).toBe(200);
+        expect(handler).toHaveBeenCalledTimes(1);
+        const call = handler.mock.calls[0] as unknown[];
+        expect(call[1]).toEqual({ participantId: 5 });   // parsed body
+        expect(call[2]).toEqual({ type: 'kiosk' });        // signed actor
+    });
+
+    it('feeds the RAW request body to the kiosk verifier (HMAC covers the bytes)', async () => {
+        mockPubKeys.mockReturnValue(['key']);
+        mockVerify.mockReturnValue({ ok: true });
+        const raw = JSON.stringify({ participantId: 7 });
+
+        await post({ headers: { 'x-kiosk-signature': 'sig' }, body: raw });
+
+        expect(mockVerify).toHaveBeenCalledTimes(1);
+        // verifyKioskSignature(method, path, body, ts, sig, nonce, keys) — body is arg 2.
+        expect((mockVerify.mock.calls[0] as unknown[])[2]).toBe(raw);
+    });
+
+    it('rejects an unsigned, cookie-less non-local request with 401 and skips the handler', async () => {
+        const res = await post({ body: JSON.stringify({ participantId: 5 }) });
+
+        expect(res.status).toBe(401);
+        expect(handler).not.toHaveBeenCalled();
+    });
+});

--- a/checkin-app/src/lib/kioskAuth.ts
+++ b/checkin-app/src/lib/kioskAuth.ts
@@ -1,0 +1,69 @@
+import { NextRequest } from "next/server";
+import { authenticateRequest } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { logBackendError } from "@/lib/logger";
+import { rateLimit } from "@/lib/rate-limit";
+import type { AuthResult } from "@/types/auth";
+
+/** AuthResult minus the unauthenticated case — what the handler is guaranteed. */
+export type SignedActor = Exclude<AuthResult, { type: "unauthenticated" }>;
+
+/**
+ * Higher-order wrapper for the kiosk/signed-actor route family — the multi-actor
+ * sibling of {@link withAuth}/{@link withCron}/{@link withWebhook}.
+ *
+ * Why this can't be withAuth: withAuth calls authenticateRequest(req) with NO
+ * body, so it can only ever see the session. The kiosk HMAC signs the exact
+ * request BODY bytes, so a signed-kiosk request can only be authenticated by
+ * reading the raw body first and passing it to authenticateRequest(req, rawBody).
+ * That is the one thing this wrapper does that withAuth structurally cannot. The
+ * authenticated actor may therefore be a kiosk signature OR a logged-in session;
+ * both reach the handler, which owns its own actor-specific authorization.
+ *
+ * Pipeline:
+ *   1. per-IP rate limit BEFORE any work;
+ *   2. read raw body → authenticateRequest(req, rawBody);
+ *   3. reject unauthenticated → 401;
+ *   4. JSON parse (malformed → 400);
+ *   5. top-level catch → logBackendError + 500, so a handler throw can't escape.
+ *
+ *   export const POST = withKiosk(
+ *       { rateLimit: { name: "scan", limit: 300 } },
+ *       async (req, body, auth) => { ... },
+ *   );
+ */
+export function withKiosk<T = unknown>(
+    opts: { rateLimit: { name: string; limit: number; windowMs?: number } },
+    handler: (req: NextRequest, body: T, auth: SignedActor) => Promise<Response>,
+) {
+    return async (req: NextRequest): Promise<Response> => {
+        // Guard BEFORE reading/verifying so a flood can't burn CPU on signature checks.
+        const limited = rateLimit(req, { windowMs: 60_000, ...opts.rateLimit });
+        if (limited) return limited;
+
+        try {
+            const rawBody = await req.text();
+
+            // Authenticate against the RAW body (kiosk HMAC covers the exact bytes),
+            // before parsing untrusted input.
+            const auth = await authenticateRequest(req, rawBody);
+            if (auth.type === "unauthenticated") {
+                return apiError("Unauthorized: Missing kiosk signature or invalid session", 401);
+            }
+
+            let body: T;
+            try {
+                body = JSON.parse(rawBody) as T;
+            } catch {
+                return apiError("Invalid JSON payload.", 400);
+            }
+
+            return await handler(req, body, auth);
+        } catch (error) {
+            const route = `${req.method} ${new URL(req.url).pathname}`;
+            console.error(`Kiosk route error (${route}):`, error);
+            await logBackendError(error, route);
+            return apiError("Internal Server Error", 500);
+        }
+    };
+}


### PR DESCRIPTION
## What

Extracts a `withKiosk` higher-order wrapper (`checkin-app/src/lib/kioskAuth.ts`) for the kiosk/signed-actor route family, and converts `scan/route.ts` to use it. After this, `authenticateRequest` is an internal primitive called only by `auth.ts` and the wrappers — no route file imports it directly.

## Why

`scan/route.ts` was the **only** route still calling `authenticateRequest()` directly, and it had to be:

1. **Multi-actor** — kiosk signature OR session.
2. **Body-signed** — the kiosk HMAC covers the request **body**, so it calls `authenticateRequest(req, rawBody)`. `withAuth` calls `authenticateRequest(req)` with **no body**, so it structurally cannot authenticate a signed-kiosk request.

`withKiosk` is the multi-actor sibling of `withAuth` / `withCron` / `withWebhook`. Pipeline:

```
rate-limit → read raw body → authenticateRequest(req, rawBody)
  → 401 if unauthenticated → JSON parse (400) → handler(req, body, auth)
  → top-level catch/500
```

The handler receives the parsed body and the non-unauthenticated `AuthResult` (`kiosk | session`) and owns its own actor-specific authorization.

## Reviewer notes

- **One behavior shift:** 401 now fires *before* JSON parse, so an unauthenticated + malformed-body request returns **401** (was 400). Authenticated + malformed body is still 400. This is the task-specified order (auth before parsing untrusted input).
- The `scan_response_time` metric stays in the scan handler's `finally` (errors propagate to the wrapper's catch), keeping `kioskAuth` prisma-free like its siblings. Timing scope drops the rate-limit/auth prelude (~µs).
- `verify-kiosk.ts` and the local-dev fallback in `authenticateRequest` are unchanged — this is a behavior-preserving wrapper extraction.

## Tests

- New `kioskAuth` unit test: valid kiosk signature admitted (body + actor forwarded), raw body reaches the verifier, unsigned/cookie-less non-local request → 401.
- Existing `scanRoute` unit test still green.
- `scanAuth` (real auth wiring, 10 tests) + `scanCheckin` / `scanConcurrency` / `scanCausalChain` integration suites all pass.
- `tsc --noEmit` clean.

Context: `docs/security/auth-consistency-analysis.md` §4 step 2 — part of the P0-B auth-consolidation campaign; `withCron`/`withWebhook` are the sibling wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)