### PR TITLE
⚠️ refactor(security): scopesHeld switch → declarative SCOPE_BINDINGS (S0–S2) — SECURITY-SURFACE, needs deep review

### DIFF
--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -15,7 +15,7 @@
  */
 import prisma from '@/lib/prisma';
 import type { AuthResult } from '@/types/auth';
-import type { Authorize, Role, Scope } from './core';
+import type { Authorize, Role } from './core';
 
 export interface CallerContext {
     selfId?: number;
@@ -96,188 +96,19 @@ export async function buildCallerContext(auth: AuthResult): Promise<CallerContex
 }
 
 /**
- * Models whose sensitive fields MUST be gated per-row by a scope key the row
- * carries. If that key isn't present on the (possibly nested) row — e.g. a
- * query selected the row but not its `householdId` — we cannot prove the
- * caller's relationship to it, so `scopesHeld` returns NO scopes (not even
- * `'everyones'`) and the stripper drops every sensitive field. This fails
- * CLOSED: a missing selected column must never let an `everyones:*` (admin/
- * board) view leak a whole row. Each entry also needs a `case` below that
- * derives the row-scoped grant from the same key.
+ * Per-row scope resolver. The imperative `switch (modelName)` that used to live
+ * here is now a declarative `SCOPE_BINDINGS` table interpreted by one engine
+ * (scopes.ts), so the bindings can be checked in CI (field typos, forgotten
+ * models, route-grant seam). Behavior is identical — proved by the S1
+ * equivalence test (tests/security/scopeBindingsEquivalence.test.ts) which
+ * asserted set-equality with the old switch across every persona × model × row
+ * before this swap. Re-exported here so existing call sites
+ * (`import { scopesHeld } from './access-resolvers'`) are unchanged.
+ *
+ * The old `ROW_SCOPE_KEY` fail-closed map moved to scopeBindings.ts (it gates
+ * EmergencyContact: a key-less row yields NO scopes, not even `everyones`).
  */
-const ROW_SCOPE_KEY: Record<string, string> = {
-    EmergencyContact: 'householdId',
-};
-
-/**
- * Per-row scope resolver. Returns the set of Scopes the caller holds on the
- * given row. `'everyones'` is included for non-row-scoped models (unconditional
- * scope); for models in `ROW_SCOPE_KEY` it is granted only once the row's scope
- * key is present, so a key-less row fails closed.
- */
-export function scopesHeld(
-    modelName: string,
-    row: Record<string, unknown> | null | undefined,
-    ctx: CallerContext,
-): Set<Scope> {
-    if (!row || typeof row !== 'object') {
-        // No row to gate on. Row-scoped models fail closed; others get the broad scope.
-        return modelName in ROW_SCOPE_KEY ? new Set<Scope>() : new Set<Scope>(['everyones']);
-    }
-
-    const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : undefined);
-
-    // Defense-in-depth: row-scoped model missing its scope key → fail closed.
-    const scopeKey = ROW_SCOPE_KEY[modelName];
-    if (scopeKey !== undefined && num(row[scopeKey]) === undefined) {
-        return new Set<Scope>();
-    }
-
-    const scopes = new Set<Scope>(['everyones']);
-
-    switch (modelName) {
-        case 'Participant': {
-            const id = num(row.id);
-            const householdId = num(row.householdId);
-            if (id !== undefined && id === ctx.selfId) scopes.add('their_own');
-            if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
-            if (id !== undefined && ctx.participantIdsInScopePrograms.has(id)) {
-                scopes.add('their_program_participants');
-            }
-            if (id !== undefined && ctx.isKeyholder && ctx.activeVisitorIds.has(id)) {
-                scopes.add('all_current_visitors');
-            }
-            break;
-        }
-        case 'Household': {
-            const id = num(row.id);
-            if (id !== undefined && id === ctx.householdId) scopes.add('their_households');
-            break;
-        }
-        case 'EmergencyContact': {
-            // Row-scoped (see ROW_SCOPE_KEY): householdId is guaranteed present
-            // by the fail-closed guard above. Belongs to one household, so the
-            // household's own members/leads see its personal fields.
-            const householdId = num(row.householdId);
-            if (householdId !== undefined && householdId === ctx.householdId) {
-                scopes.add('their_households');
-            }
-            break;
-        }
-        case 'HouseholdLead': {
-            const householdId = num(row.householdId);
-            const participantId = num(row.participantId);
-            if (householdId !== undefined && householdId === ctx.householdId) {
-                scopes.add('their_households');
-            }
-            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
-            break;
-        }
-        case 'Membership': {
-            const householdId = num(row.householdId);
-            if (householdId !== undefined && householdId === ctx.householdId) {
-                scopes.add('their_households');
-            }
-            break;
-        }
-        case 'Program': {
-            const id = num(row.id);
-            if (id !== undefined && (ctx.programsLed.has(id) || ctx.programsCoreVolIn.has(id))) {
-                scopes.add('their_program_participants');
-            }
-            break;
-        }
-        case 'ProgramParticipant':
-        case 'ProgramVolunteer':
-        case 'Fee':
-        case 'RSVP': {
-            const programId = num(row.programId);
-            const participantId = num(row.participantId);
-            if (
-                programId !== undefined &&
-                (ctx.programsLed.has(programId) || ctx.programsCoreVolIn.has(programId))
-            ) {
-                scopes.add('their_program_participants');
-            }
-            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
-            break;
-        }
-        case 'Event': {
-            const programId = num(row.programId);
-            if (
-                programId !== undefined &&
-                (ctx.programsLed.has(programId) || ctx.programsCoreVolIn.has(programId))
-            ) {
-                scopes.add('their_program_participants');
-            }
-            break;
-        }
-        case 'FeePayment': {
-            const participantId = num(row.participantId);
-            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
-            if (participantId !== undefined && ctx.participantIdsInScopePrograms.has(participantId)) {
-                scopes.add('their_program_participants');
-            }
-            break;
-        }
-        case 'Visit': {
-            const participantId = num(row.participantId);
-            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
-            if (ctx.isKeyholder && row.departedAt == null) {
-                scopes.add('all_current_visitors');
-            }
-            break;
-        }
-        case 'RawBadgeLog': {
-            const participantId = num(row.participantId);
-            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
-            break;
-        }
-        case 'ToolStatus': {
-            // ToolStatus renamed userId -> participantId (Person = Participant).
-            const participantId = num(row.participantId);
-            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
-            break;
-        }
-        case 'Account':
-        case 'Session': {
-            // NextAuth-mandated: these keep userId (mapped to participant_id col).
-            const userId = num(row.userId);
-            if (userId !== undefined && userId === ctx.selfId) scopes.add('their_own');
-            break;
-        }
-        case 'TrustedAdult':
-        case 'TrustedAdultReview': {
-            // A Trusted Adult belongs to a household. householdId is denormalized
-            // onto review rows so nested rows resolve the same scopes.
-            //   their_households         → the household's own members/leads (sees
-            //                              familyContext[pii] + notes[personal]).
-            //   their_program_households → a program lead of the household's kids
-            //                              (sees personal-tier notes, NOT pii).
-            //   keyholders               → any isKeyholder, global (personal-tier notes).
-            // The board's familyContext (pii) and decisionNote (internal) are never
-            // granted to the program/isKeyholder scopes.
-            const householdId = num(row.householdId);
-            if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
-            if (householdId !== undefined && ctx.householdIdsInScopePrograms.has(householdId)) {
-                scopes.add('their_program_households');
-            }
-            if (ctx.isKeyholder) scopes.add('keyholders');
-            break;
-        }
-        // MembershipProcess, BackgroundCheckAttestation, Corporation,
-        // CorporationLead, CorporationMember, AuditLog, VerificationToken,
-        // ErrorLog, SystemMetricLog, Tool — no per-row scopes beyond 'everyones'
-        // yet. Admin (isSysadmin/isBoardMember) views grant 'everyones:*' so they
-        // still get through. These SHOULD be row-scoped too (they carry
-        // membershipId / processId / corporationId); until each has a case +
-        // ROW_SCOPE_KEY entry, a non-admin view cannot see them and an admin
-        // view sees them ungated. Add them to ROW_SCOPE_KEY as cases land.
-        // ponytail: EmergencyContact done first (carries householdId);
-        // extend to the rest when a route needs non-admin access to them.
-    }
-    return scopes;
-}
+export { scopesHeld } from './scopeBindings';
 
 export function callerHoldsRole(
     role: Role,

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -1,0 +1,165 @@
+/**
+ * SCOPE_BINDINGS — the declarative per-row scope table.
+ *
+ * Ported 1:1 from the imperative `switch (modelName)` that lived in
+ * access-resolvers.ts (`scopesHeld`). Each entry says: "the caller holds
+ * <scope> on a <Model> row when <Match> holds." The engine (scopes.ts) seeds
+ * `everyones` and applies these; the equivalence test
+ * (scopeBindingsEquivalence.test.ts) proves set-equality with the old switch
+ * across every persona × model × row, which is the contract that this port is
+ * behavior-neutral.
+ *
+ * Field names verified against the LIVE generated map
+ * (./generated/classifications.ts), not the §7.4 doc table. Discrepancies found
+ * vs that table (see docs/security/auth-consistency-analysis.md §7.4/§7.5):
+ *   - Visit:  field is `departedAt` (doc wrote `departed`).            [doc fixed]
+ *   - ToolStatus: field is `participantId` (renamed from `userId`, #564).
+ *   - RawBadgeLog: model is `RawBadgeLog` (doc table wrote `RawBadgeEvent`).
+ *   - Fee / RSVP: the live switch grouped ProgramParticipant, ProgramVolunteer,
+ *     Fee and RSVP under one `case` body that read BOTH `row.programId` and
+ *     `row.participantId`. `Fee` has no `participantId` column and `RSVP` has no
+ *     `programId` column, so on a REAL row those reads are always `undefined`
+ *     and grant nothing. But the resolver is a pure function of an arbitrary
+ *     row, and S1 (set-equality vs the switch) feeds rows that carry those
+ *     fields — so to stay behavior-identical the branches are ported VERBATIM,
+ *     not dropped. Consequence: validateBindings' field-existence check will
+ *     flag `Fee.participantId` and `RSVP.programId` once wired (Step 3). That is
+ *     a real finding about the grouped switch case, surfaced — not silently
+ *     papered over.
+ *
+ * IMPORTANT: This file is CODEOWNERS-gated.
+ */
+import { makeScopesHeld, type ScopeBindings } from './scopes';
+
+export const SCOPE_BINDINGS = {
+    Participant: {
+        their_own: { field: 'id', eqCtx: 'selfId' },
+        their_households: { field: 'householdId', eqCtx: 'householdId' },
+        their_program_participants: { field: 'id', inCtx: 'participantIdsInScopePrograms' },
+        all_current_visitors: {
+            all: [{ flag: 'isKeyholder' }, { field: 'id', inCtx: 'activeVisitorIds' }],
+        },
+    },
+    Household: { their_households: { field: 'id', eqCtx: 'householdId' } },
+    // Row-scoped (see ROW_SCOPE_KEY): a key-less EmergencyContact row fails closed.
+    EmergencyContact: { their_households: { field: 'householdId', eqCtx: 'householdId' } },
+    HouseholdLead: {
+        their_households: { field: 'householdId', eqCtx: 'householdId' },
+        their_own: { field: 'participantId', eqCtx: 'selfId' },
+    },
+    Membership: { their_households: { field: 'householdId', eqCtx: 'householdId' } },
+    Program: {
+        their_program_participants: { field: 'id', inCtx: ['programsLed', 'programsCoreVolIn'] },
+    },
+    ProgramParticipant: {
+        their_program_participants: {
+            field: 'programId',
+            inCtx: ['programsLed', 'programsCoreVolIn'],
+        },
+        their_own: { field: 'participantId', eqCtx: 'selfId' },
+    },
+    ProgramVolunteer: {
+        their_program_participants: {
+            field: 'programId',
+            inCtx: ['programsLed', 'programsCoreVolIn'],
+        },
+        their_own: { field: 'participantId', eqCtx: 'selfId' },
+    },
+    // Fee + RSVP shared the grouped switch case with ProgramParticipant/
+    // ProgramVolunteer — ported VERBATIM (both scopes) so the resolver is
+    // set-equal to the switch on any row shape (S1 proves it). NOTE: `Fee` has
+    // no `participantId` column and `RSVP` has no `programId` column in
+    // classifications.ts, so those two branches never fire on a real row — they
+    // are inert in production but kept for exact switch-equivalence. The
+    // field-existence validator (validateBindings) will flag `Fee.participantId`
+    // and `RSVP.programId` when wired; the team decides then whether to keep the
+    // literal port or narrow the grouped case. See report.
+    Fee: {
+        their_program_participants: {
+            field: 'programId',
+            inCtx: ['programsLed', 'programsCoreVolIn'],
+        },
+        their_own: { field: 'participantId', eqCtx: 'selfId' },
+    },
+    RSVP: {
+        their_program_participants: {
+            field: 'programId',
+            inCtx: ['programsLed', 'programsCoreVolIn'],
+        },
+        their_own: { field: 'participantId', eqCtx: 'selfId' },
+    },
+    Event: {
+        their_program_participants: {
+            field: 'programId',
+            inCtx: ['programsLed', 'programsCoreVolIn'],
+        },
+    },
+    FeePayment: {
+        their_own: { field: 'participantId', eqCtx: 'selfId' },
+        their_program_participants: { field: 'participantId', inCtx: 'participantIdsInScopePrograms' },
+    },
+    Visit: {
+        their_own: { field: 'participantId', eqCtx: 'selfId' },
+        all_current_visitors: {
+            all: [{ flag: 'isKeyholder' }, { field: 'departedAt', isNull: true }],
+        },
+    },
+    RawBadgeLog: { their_own: { field: 'participantId', eqCtx: 'selfId' } },
+    ToolStatus: { their_own: { field: 'participantId', eqCtx: 'selfId' } },
+    Account: { their_own: { field: 'userId', eqCtx: 'selfId' } },
+    Session: { their_own: { field: 'userId', eqCtx: 'selfId' } },
+    TrustedAdult: {
+        their_households: { field: 'householdId', eqCtx: 'householdId' },
+        their_program_households: { field: 'householdId', inCtx: 'householdIdsInScopePrograms' },
+        keyholders: { flag: 'isKeyholder' },
+    },
+    TrustedAdultReview: {
+        their_households: { field: 'householdId', eqCtx: 'householdId' },
+        their_program_households: { field: 'householdId', inCtx: 'householdIdsInScopePrograms' },
+        keyholders: { flag: 'isKeyholder' },
+    },
+} as const satisfies ScopeBindings;
+
+/**
+ * Models whose sensitive fields MUST be gated by a scope key the row carries:
+ * if the key is absent (e.g. a query selected the row but not its `householdId`)
+ * the resolver returns NO scopes — not even `everyones` — so the stripper drops
+ * every sensitive field. Fails CLOSED. This is the old ROW_SCOPE_KEY map; it
+ * moved here with the bindings. The §7.3 engine sketch dropped it, but the live
+ * switch has it and the EmergencyContact fail-closed unit tests require it.
+ */
+export const ROW_SCOPE_KEY: Record<string, string> = {
+    EmergencyContact: 'householdId',
+};
+
+/**
+ * Work queue: models that are sensitive AND scopable (could carry a `their_*`
+ * relationship) but whose scoped route is not built yet, so they are bound
+ * nowhere. A future §9 migration moves each entry OUT of this set and INTO a
+ * real SCOPE_BINDINGS binding, in the same PR that ships its handler() route.
+ * Done when this set is empty.
+ *
+ * There is NO permanent opt-out list — structurally un-scopable models (no
+ * actor FK) are auto-exempt by isScopable() in validateBindings; "never leaves,
+ * even to admins" content is tiered `secret`.
+ *
+ * NOTE — this DIVERGES from the doc §7.5.1 list, which also names
+ * `EmergencyContact`. The live switch already BINDS EmergencyContact (the
+ * ROW_SCOPE_KEY pilot case), so it belongs in SCOPE_BINDINGS, not here — the
+ * doc's listing is stale (it predates that case landing; §9 Step 4 still treats
+ * it as pending). Removed.
+ */
+export const OPT_OUT_PENDING_ROUTE = new Set<string>([
+    'MembershipProcess', // board/admin today; a household-facing status route is plausible
+    'BackgroundCheckAttestation', // bind their_own at migration, keep notes `internal`
+    'Corporation', // has leads→participantId; a corp-lead view is plausible
+    'VolunteerDesignation', // has createdById; confirm whether a self view is warranted
+]);
+
+/**
+ * The per-row scope resolver. Same signature as the old switch
+ * (`(modelName, row, ctx) => Set<Scope>`). access-resolvers.ts re-exports this
+ * so every existing `import { scopesHeld } from './access-resolvers'` keeps
+ * working unchanged.
+ */
+export const scopesHeld = makeScopesHeld(SCOPE_BINDINGS, ROW_SCOPE_KEY);

--- a/checkin-app/src/security/scopes.ts
+++ b/checkin-app/src/security/scopes.ts
@@ -1,0 +1,271 @@
+/**
+ * Declarative scope-resolution engine.
+ *
+ * The per-row scope resolver used to be an imperative `switch (modelName)` in
+ * access-resolvers.ts. This file is the data-driven replacement: a small
+ * `Match` vocabulary, the `evalMatch` interpreter, and `makeScopesHeld` which
+ * turns a binding table into a resolver with the IDENTICAL signature
+ * `(modelName, row, ctx) => Set<Scope>`.
+ *
+ * Why this exists: making resolution *data* (scopeBindings.ts) instead of code
+ * is the minimum needed for the CI security validators below — `validateBindings`
+ * (field-typo + forgotten-model catchers) and `validateRouteGrants` (the
+ * route-grant ↔ binding-scope seam check). None of them can run against an
+ * opaque switch. See docs/security/auth-consistency-analysis.md §7.
+ *
+ * The bindings + table live in scopeBindings.ts; this file is the generic
+ * engine. Kept deliberately local to checkin-app/src/security — no package
+ * extraction (that is §7.7, out of scope).
+ *
+ * IMPORTANT: This file is CODEOWNERS-gated.
+ */
+import { parseToken, type Scope } from './core';
+import type { CallerContext } from './access-resolvers';
+
+// Context accessors a binding may match a row field against. Kept in lockstep
+// with the shape of CallerContext (access-resolvers.ts).
+export type CtxScalar = 'selfId' | 'householdId';
+export type CtxSet =
+    | 'programsLed'
+    | 'programsCoreVolIn'
+    | 'participantIdsInScopePrograms'
+    | 'householdIdsInScopePrograms'
+    | 'activeVisitorIds';
+export type CtxFlag = 'isKeyholder' | 'isKiosk';
+
+export type ScopePredicate = (row: Record<string, unknown>, ctx: CallerContext) => boolean;
+
+/**
+ * One condition under which a caller holds a scope on a row.
+ *
+ *   { field, eqCtx } — row[field] === ctx[scalar]   (number-guarded)
+ *   { field, inCtx } — ctx[set].has(row[field])     (array = OR over sets)
+ *   { flag }         — ctx[flag] === true
+ *   { field, isNull }— row[field] == null
+ *   { all }          — every sub-match (AND)
+ *   { custom }       — escape hatch; SKIPS validation, must be logged
+ */
+export type Match =
+    | { field: string; eqCtx: CtxScalar }
+    | { field: string; inCtx: CtxSet | readonly CtxSet[] }
+    | { flag: CtxFlag }
+    | { field: string; isNull: true }
+    | { all: readonly Match[] }
+    | { custom: ScopePredicate };
+
+export type ScopeBindings = Record<string, Partial<Record<Scope, Match>>>;
+
+/**
+ * Evaluate one Match against a row + caller context.
+ *
+ * The `typeof v === 'number'` guards on eqCtx/inCtx are load-bearing: they
+ * encode the old switch's `x !== undefined` checks. Without them an anonymous
+ * caller (selfId === undefined) would spuriously match a row whose field is
+ * also absent (undefined === undefined).
+ */
+export function evalMatch(m: Match, row: Record<string, unknown>, ctx: CallerContext): boolean {
+    if ('flag' in m) return ctx[m.flag] === true;
+    if ('isNull' in m) return row[m.field] == null;
+    if ('all' in m) return m.all.every(s => evalMatch(s, row, ctx));
+    if ('custom' in m) return m.custom(row, ctx);
+    if ('eqCtx' in m) {
+        const v = row[m.field];
+        return typeof v === 'number' && v === ctx[m.eqCtx];
+    }
+    // inCtx
+    const v = row[m.field];
+    if (typeof v !== 'number') return false;
+    const sets: readonly CtxSet[] = Array.isArray(m.inCtx) ? m.inCtx : [m.inCtx];
+    return sets.some(s => ctx[s].has(v));
+}
+
+/**
+ * Build a per-row scope resolver from a binding table.
+ *
+ * Preserves the live switch's preamble exactly:
+ *   - `everyones` is seeded on every (present) row...
+ *   - ...EXCEPT a row-scoped model (one with a `rowScopeKeys` entry) whose
+ *     scope key is absent or non-numeric, which fails CLOSED — returns NO
+ *     scopes, not even `everyones`, so a missing selected column can never let
+ *     an `everyones:*` (admin/board) view leak a whole row.
+ *   - a null / non-object row: row-scoped models fail closed; others get the
+ *     broad scope.
+ *
+ * `rowScopeKeys` is the new home of the old ROW_SCOPE_KEY map. The §7.3 doc
+ * sketch dropped it; the live switch has it and the equivalence test (and the
+ * existing EmergencyContact fail-closed unit tests) require it.
+ */
+export function makeScopesHeld(
+    bindings: ScopeBindings,
+    rowScopeKeys: Record<string, string> = {},
+) {
+    return (
+        modelName: string,
+        row: Record<string, unknown> | null | undefined,
+        ctx: CallerContext,
+    ): Set<Scope> => {
+        const scopeKey = rowScopeKeys[modelName];
+
+        if (!row || typeof row !== 'object') {
+            return scopeKey !== undefined ? new Set<Scope>() : new Set<Scope>(['everyones']);
+        }
+        // Defense-in-depth: row-scoped model missing its scope key → fail closed.
+        if (scopeKey !== undefined && typeof row[scopeKey] !== 'number') {
+            return new Set<Scope>();
+        }
+
+        const scopes = new Set<Scope>(['everyones']);
+        const modelBindings = bindings[modelName];
+        if (modelBindings) {
+            for (const [scope, match] of Object.entries(modelBindings)) {
+                if (match && evalMatch(match, row, ctx)) scopes.add(scope as Scope);
+            }
+        }
+        return scopes;
+    };
+}
+
+// ─── Validators (authored for CI; NOT wired as gates in this chip — see §7.6) ──
+
+/** Walk a model's scope map, descending into `all` combinators, yielding leaf+compound matches. */
+function allMatches(scopeMap: Partial<Record<Scope, Match>>): Match[] {
+    const out: Match[] = [];
+    const visit = (m: Match) => {
+        out.push(m);
+        if ('all' in m) m.all.forEach(visit);
+    };
+    for (const m of Object.values(scopeMap)) if (m) visit(m);
+    return out;
+}
+
+/**
+ * Column names by which a non-admin actor could own a row. A model with
+ * sensitive fields but NONE of these is structurally un-scopable — no `their_*`
+ * binding is even expressible, so its sensitive fields are reachable only via
+ * `everyones:*` (admin) grants. That is a derivable fact, not a human opt-out.
+ *
+ * ponytail: bare `id` over-broadens this — admin-only models with a PK but no
+ * actor FK (BoardSettings, ErrorLog, DevLedger, AuditLog has actorId) would be
+ * judged "scopable" and demand a binding/pending entry. `id` is a real scope
+ * key only for the actor model (Participant.their_own) and Household, both of
+ * which are already bound (so the coverage loop skips them). Kept as the doc
+ * §7.3 specifies; revisit the exact set when this validator is WIRED (Step 3).
+ */
+const SCOPABLE_FIELDS = new Set([
+    'id',
+    'householdId',
+    'programId',
+    'participantId',
+    'userId',
+    'actorId',
+    'createdById',
+]);
+
+export function isScopable(
+    model: string,
+    classifications: Record<string, Record<string, string>>,
+): boolean {
+    return Object.keys(classifications[model] ?? {}).some(f => SCOPABLE_FIELDS.has(f));
+}
+
+/**
+ * (a) field-existence — every `field:` in a binding must exist on that model
+ *     (the typo catcher: `row.householdID` silently never grants today).
+ * (b) coverage — every sensitive model must be bound, auto-exempt via
+ *     isScopable(), or sitting in the pending-route work queue (the
+ *     forgotten-model catcher).
+ *
+ * Returns the list of errors (empty = clean). Authoring only — not wired.
+ */
+export function validateBindings(
+    bindings: ScopeBindings,
+    classifications: Record<string, Record<string, string>>,
+    pendingRoute: ReadonlySet<string>,
+): string[] {
+    const errors: string[] = [];
+
+    // (a) field-existence
+    for (const [model, scopeMap] of Object.entries(bindings)) {
+        if (!(model in classifications)) {
+            errors.push(`binding for unknown model '${model}'`);
+            continue;
+        }
+        for (const m of allMatches(scopeMap)) {
+            if ('field' in m && !(m.field in classifications[model])) {
+                errors.push(`${model}.${m.field} — no such field`);
+            }
+            if ('custom' in m) {
+                console.warn(`[security] ${model} has a custom (unvalidated) scope binding`);
+            }
+        }
+    }
+
+    // (b) coverage
+    for (const [model, fields] of Object.entries(classifications)) {
+        const hasSensitive = Object.values(fields).some(t => t !== 'public' && t !== 'secret');
+        if (!hasSensitive) continue;
+        if (model in bindings) continue;
+        if (!isScopable(model, classifications)) {
+            console.info(
+                `[security] ${model}: sensitive but un-scopable (no actor FK) — admin-only by construction`,
+            );
+            continue;
+        }
+        if (pendingRoute.has(model)) continue;
+        errors.push(
+            `${model} is sensitive and scopable but has no binding and is not in ` +
+                `OPT_OUT_PENDING_ROUTE — silent over-restriction`,
+        );
+    }
+
+    return errors;
+}
+
+/**
+ * The seam check: every `scope:tier` token a route GRANTS in its orderedView
+ * must be RESOLVABLE on at least one model that route returns — else the grant
+ * silently strips to nothing (over-restriction). See §8.
+ *
+ * NOTE: this cannot be wired as a CI gate until RouteSpec declares a `returns`
+ * field listing the model(s) its bag may contain. That arrives with the
+ * route-migration track (Step 3); this chip deliberately does NOT add `returns`
+ * to RouteSpec. Authored here so it exists and is tested in isolation.
+ */
+export interface RouteGrantSpec {
+    endpoint: string;
+    orderedView: readonly (readonly [unknown, readonly string[]])[];
+    returns: readonly string[];
+}
+
+export function validateRouteGrants(
+    routes: Iterable<RouteGrantSpec>,
+    bindings: ScopeBindings,
+): string[] {
+    const errors: string[] = [];
+    for (const spec of routes) {
+        const grantedScopes = new Set<Scope>();
+        for (const [, tokens] of spec.orderedView) {
+            for (const tok of tokens) {
+                const parsed = parseToken(tok);
+                if (parsed && parsed !== 'public' && parsed !== 'member') {
+                    grantedScopes.add(parsed.scope);
+                }
+            }
+        }
+        for (const scope of grantedScopes) {
+            // 'everyones' is seeded on every row by the engine — never needs a binding.
+            if (scope === 'everyones') continue;
+            const resolvable = spec.returns.some(
+                model => bindings[model] && scope in bindings[model]!,
+            );
+            if (!resolvable) {
+                errors.push(
+                    `${spec.endpoint}: grants '${scope}:*' but none of its returns ` +
+                        `[${spec.returns.join(', ')}] bind '${scope}' — that grant silently ` +
+                        `resolves to nothing (over-restriction).`,
+                );
+            }
+        }
+    }
+    return errors;
+}

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -1,0 +1,258 @@
+/**
+ * S1 — the equivalence gate (the proof the SCOPE_BINDINGS port is behavior-neutral).
+ *
+ * Asserts the new data-driven resolver (`scopesHeldNext`, scopeBindings.ts) is
+ * SET-EQUAL to the live imperative switch (`scopesHeld`, access-resolvers.ts)
+ * for every combination of:
+ *   - 8 caller personas (anonymous … sysadmin),
+ *   - every model in SCOPE_BINDINGS plus unbound + unknown models,
+ *   - representative rows: caller's own / another's / in-program /
+ *     out-of-program / active-visit / departed-visit / missing-key / non-object.
+ *
+ * Pure unit test — no DB, no seed. Both resolvers are pure functions of
+ * (modelName, row, ctx), and buildCallerContext (which builds the ctx from the
+ * DB) is UNCHANGED by this refactor, so hand-built CallerContexts are a complete
+ * and deterministic proof: if the two diverge it is the binding, not the ctx.
+ *
+ * On a mismatch the BINDING is wrong — fix scopeBindings.ts, never this test.
+ *
+ * The old switch has been deleted (S2). `referenceScopesHeld` below is a FROZEN
+ * verbatim copy of it (the snapshot), so this stays a live regression guard:
+ * any future change to scopeBindings.ts that diverges from the original switch
+ * behavior fails here. (Per the task: "compare against a snapshot ... leave it
+ * in for now.")
+ */
+import { type CallerContext } from '@/security/access-resolvers';
+import { scopesHeld, SCOPE_BINDINGS } from '@/security/scopeBindings';
+import type { Scope } from '@/security/core';
+
+// ─── FROZEN reference oracle: verbatim copy of the deleted switch ──────────────
+// Do NOT "simplify" or sync this to scopeBindings.ts — its whole value is being
+// an independent snapshot of the pre-refactor behavior.
+const ROW_SCOPE_KEY: Record<string, string> = { EmergencyContact: 'householdId' };
+
+function referenceScopesHeld(
+    modelName: string,
+    row: Record<string, unknown> | null | undefined,
+    ctx: CallerContext,
+): Set<Scope> {
+    if (!row || typeof row !== 'object') {
+        return modelName in ROW_SCOPE_KEY ? new Set<Scope>() : new Set<Scope>(['everyones']);
+    }
+    const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : undefined);
+    const scopeKey = ROW_SCOPE_KEY[modelName];
+    if (scopeKey !== undefined && num(row[scopeKey]) === undefined) {
+        return new Set<Scope>();
+    }
+    const scopes = new Set<Scope>(['everyones']);
+    switch (modelName) {
+        case 'Participant': {
+            const id = num(row.id);
+            const householdId = num(row.householdId);
+            if (id !== undefined && id === ctx.selfId) scopes.add('their_own');
+            if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
+            if (id !== undefined && ctx.participantIdsInScopePrograms.has(id)) scopes.add('their_program_participants');
+            if (id !== undefined && ctx.isKeyholder && ctx.activeVisitorIds.has(id)) scopes.add('all_current_visitors');
+            break;
+        }
+        case 'Household': {
+            const id = num(row.id);
+            if (id !== undefined && id === ctx.householdId) scopes.add('their_households');
+            break;
+        }
+        case 'EmergencyContact': {
+            const householdId = num(row.householdId);
+            if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
+            break;
+        }
+        case 'HouseholdLead': {
+            const householdId = num(row.householdId);
+            const participantId = num(row.participantId);
+            if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
+            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            break;
+        }
+        case 'Membership': {
+            const householdId = num(row.householdId);
+            if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
+            break;
+        }
+        case 'Program': {
+            const id = num(row.id);
+            if (id !== undefined && (ctx.programsLed.has(id) || ctx.programsCoreVolIn.has(id))) scopes.add('their_program_participants');
+            break;
+        }
+        case 'ProgramParticipant':
+        case 'ProgramVolunteer':
+        case 'Fee':
+        case 'RSVP': {
+            const programId = num(row.programId);
+            const participantId = num(row.participantId);
+            if (programId !== undefined && (ctx.programsLed.has(programId) || ctx.programsCoreVolIn.has(programId))) scopes.add('their_program_participants');
+            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            break;
+        }
+        case 'Event': {
+            const programId = num(row.programId);
+            if (programId !== undefined && (ctx.programsLed.has(programId) || ctx.programsCoreVolIn.has(programId))) scopes.add('their_program_participants');
+            break;
+        }
+        case 'FeePayment': {
+            const participantId = num(row.participantId);
+            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            if (participantId !== undefined && ctx.participantIdsInScopePrograms.has(participantId)) scopes.add('their_program_participants');
+            break;
+        }
+        case 'Visit': {
+            const participantId = num(row.participantId);
+            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            if (ctx.isKeyholder && row.departedAt == null) scopes.add('all_current_visitors');
+            break;
+        }
+        case 'RawBadgeLog': {
+            const participantId = num(row.participantId);
+            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            break;
+        }
+        case 'ToolStatus': {
+            const participantId = num(row.participantId);
+            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            break;
+        }
+        case 'Account':
+        case 'Session': {
+            const userId = num(row.userId);
+            if (userId !== undefined && userId === ctx.selfId) scopes.add('their_own');
+            break;
+        }
+        case 'TrustedAdult':
+        case 'TrustedAdultReview': {
+            const householdId = num(row.householdId);
+            if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
+            if (householdId !== undefined && ctx.householdIdsInScopePrograms.has(householdId)) scopes.add('their_program_households');
+            if (ctx.isKeyholder) scopes.add('keyholders');
+            break;
+        }
+    }
+    return scopes;
+}
+
+function ctx(opts: Partial<CallerContext> = {}): CallerContext {
+    return {
+        selfId: undefined,
+        householdId: undefined,
+        isKeyholder: false,
+        isKiosk: false,
+        programsLed: new Set(),
+        programsCoreVolIn: new Set(),
+        participantIdsInScopePrograms: new Set(),
+        householdIdsInScopePrograms: new Set(),
+        activeVisitorIds: new Set(),
+        ...opts,
+    };
+}
+
+const PERSONAS: Record<string, CallerContext> = {
+    anonymous: ctx(),
+    selfOnlyMember: ctx({ selfId: 5, householdId: 2 }),
+    householdCoMember: ctx({ selfId: 6, householdId: 2 }),
+    programLead: ctx({
+        selfId: 10,
+        householdId: 4,
+        programsLed: new Set([100]),
+        participantIdsInScopePrograms: new Set([9, 5]),
+        householdIdsInScopePrograms: new Set([2]),
+    }),
+    coreVolunteer: ctx({
+        selfId: 11,
+        householdId: 5,
+        programsCoreVolIn: new Set([101]),
+        participantIdsInScopePrograms: new Set([9]),
+        householdIdsInScopePrograms: new Set([2]),
+    }),
+    keyholder: ctx({
+        selfId: 12,
+        householdId: 6,
+        isKeyholder: true,
+        activeVisitorIds: new Set([9, 5]),
+    }),
+    // board/sysadmin privilege lives in the Role/view layer, not CallerContext —
+    // to the per-row resolver they are plain authenticated members.
+    boardMember: ctx({ selfId: 13, householdId: 7 }),
+    sysadmin: ctx({ selfId: 14, householdId: 8 }),
+};
+
+// Representative rows. Each carries every field any binding matches on, so one
+// row exercises all models. Includes the fail-closed / non-object cases.
+const ROWS: Array<{ label: string; row: unknown }> = [
+    { label: 'null', row: null },
+    { label: 'undefined', row: undefined },
+    { label: 'number (non-object)', row: 42 },
+    { label: 'string (non-object)', row: 'nope' },
+    { label: 'empty object', row: {} },
+    { label: 'present but no scope keys', row: { id: 1, name: 'X' } },
+    {
+        label: "caller-5 own / in-program / active",
+        row: { id: 5, householdId: 2, participantId: 5, programId: 100, userId: 5, departedAt: null },
+    },
+    {
+        label: 'household co-member (hh 2)',
+        row: { id: 6, householdId: 2, participantId: 6, programId: 100, userId: 6, departedAt: null },
+    },
+    {
+        label: 'program participant / coreVol prog / active visitor',
+        row: { id: 9, householdId: 2, participantId: 9, programId: 101, userId: 9, departedAt: null },
+    },
+    {
+        label: "another's / out-of-program / departed",
+        row: { id: 7, householdId: 99, participantId: 7, programId: 88, userId: 7, departedAt: new Date() },
+    },
+    {
+        label: "lead's own program (Program row id 100)",
+        row: { id: 100, householdId: 4, participantId: 10, programId: 100, userId: 10, departedAt: null },
+    },
+];
+
+const MODELS = [
+    ...Object.keys(SCOPE_BINDINGS),
+    // unbound-but-sensitive, structurally-unscopable, and unknown — all must
+    // resolve identically (everyones-only, or {} via fail-closed) under both.
+    'Tool',
+    'AuditLog',
+    'BoardSettings',
+    'MembershipProcess',
+    'UnknownModelXYZ',
+];
+
+function eq(a: Set<string>, b: Set<string>): boolean {
+    if (a.size !== b.size) return false;
+    for (const x of a) if (!b.has(x)) return false;
+    return true;
+}
+
+describe('S1 — scopesHeld ≡ frozen switch (set-equality across personas × models × rows)', () => {
+    it('is set-equal for every combination', () => {
+        const mismatches: string[] = [];
+        for (const [pName, pCtx] of Object.entries(PERSONAS)) {
+            for (const model of MODELS) {
+                for (const { label, row } of ROWS) {
+                    const live = referenceScopesHeld(model, row as Record<string, unknown>, pCtx);
+                    const next = scopesHeld(model, row as Record<string, unknown>, pCtx);
+                    if (!eq(live as Set<string>, next as Set<string>)) {
+                        mismatches.push(
+                            `${pName} / ${model} / ${label}: ` +
+                                `switch={${[...live].sort().join(',')}} table={${[...next].sort().join(',')}}`,
+                        );
+                    }
+                }
+            }
+        }
+        expect(mismatches).toEqual([]);
+    });
+
+    it('covers every bound model', () => {
+        // Guard against the row set silently not exercising a model.
+        expect(MODELS).toEqual(expect.arrayContaining(Object.keys(SCOPE_BINDINGS)));
+        expect(Object.keys(SCOPE_BINDINGS).length).toBe(19);
+    });
+});

--- a/checkin-app/tests/security/scopeValidators.test.ts
+++ b/checkin-app/tests/security/scopeValidators.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the CI security validators (scopes.ts). These are authored
+ * but NOT wired as build gates in this chip (see §7.6); these tests prove the
+ * validators detect what they are meant to, so wiring them later (Step 3) is a
+ * one-liner with known-good behavior.
+ */
+import {
+    validateBindings,
+    validateRouteGrants,
+    isScopable,
+    type ScopeBindings,
+    type RouteGrantSpec,
+} from '@/security/scopes';
+import { SCOPE_BINDINGS, OPT_OUT_PENDING_ROUTE } from '@/security/scopeBindings';
+import { classifications } from '@/security/generated/classifications';
+
+const CLS = classifications as unknown as Record<string, Record<string, string>>;
+
+describe('validateBindings — field-existence (typo catcher)', () => {
+    it('flags a binding field absent from the model', () => {
+        const bad: ScopeBindings = { Participant: { their_own: { field: 'householdID', eqCtx: 'householdId' } } };
+        expect(validateBindings(bad, CLS, new Set())).toContain('Participant.householdID — no such field');
+    });
+
+    it('flags an unknown model', () => {
+        const bad: ScopeBindings = { Nope: { their_own: { field: 'id', eqCtx: 'selfId' } } };
+        expect(validateBindings(bad, CLS, new Set())).toContain("binding for unknown model 'Nope'");
+    });
+
+    it('descends into `all` combinators', () => {
+        const bad: ScopeBindings = {
+            Visit: { all_current_visitors: { all: [{ flag: 'isKeyholder' }, { field: 'gone', isNull: true }] } },
+        };
+        expect(validateBindings(bad, CLS, new Set())).toContain('Visit.gone — no such field');
+    });
+});
+
+describe('validateBindings — coverage (forgotten-model catcher)', () => {
+    it('flags a sensitive, scopable, unbound, un-queued model', () => {
+        // MembershipProcess is sensitive + scopable; drop it from the queue → error.
+        const errs = validateBindings(SCOPE_BINDINGS, CLS, new Set());
+        expect(errs.some(e => e.startsWith('MembershipProcess is sensitive and scopable'))).toBe(true);
+    });
+
+    it('does not flag it when queued in OPT_OUT_PENDING_ROUTE', () => {
+        const errs = validateBindings(SCOPE_BINDINGS, CLS, OPT_OUT_PENDING_ROUTE);
+        expect(errs.some(e => e.startsWith('MembershipProcess is sensitive'))).toBe(false);
+    });
+
+    it('isScopable: structurally un-scopable model (no actor FK) is exempt', () => {
+        // VerificationToken: identifier/token/expires — no id, no FK.
+        expect(isScopable('VerificationToken', CLS)).toBe(false);
+    });
+});
+
+describe('validateBindings — known Fee/RSVP literal-port finding', () => {
+    it('flags Fee.participantId and RSVP.programId (fields absent on those models)', () => {
+        // Documents the deliberate literal port: these branches are required for
+        // switch-equivalence (S1) but reference columns the models lack.
+        const errs = validateBindings(SCOPE_BINDINGS, CLS, OPT_OUT_PENDING_ROUTE);
+        expect(errs).toContain('Fee.participantId — no such field');
+        expect(errs).toContain('RSVP.programId — no such field');
+    });
+});
+
+describe('validateRouteGrants — seam check', () => {
+    const bindings: ScopeBindings = { Participant: { their_own: { field: 'id', eqCtx: 'selfId' } } };
+
+    it('flags a granted scope that no returned model binds', () => {
+        const routes: RouteGrantSpec[] = [
+            { endpoint: '/api/x', orderedView: [['authenticated', ['their_households:pii']]], returns: ['Participant'] },
+        ];
+        const errs = validateRouteGrants(routes, bindings);
+        expect(errs.some(e => e.includes("grants 'their_households:*'"))).toBe(true);
+    });
+
+    it('passes when the grant resolves and ignores everyones', () => {
+        const routes: RouteGrantSpec[] = [
+            { endpoint: '/api/y', orderedView: [['authenticated', ['their_own:pii', 'everyones:internal', 'public']]], returns: ['Participant'] },
+        ];
+        expect(validateRouteGrants(routes, bindings)).toEqual([]);
+    });
+});


### PR DESCRIPTION
> ## ⚠️ RISKY — significant review required
> This rewrites the **per-row scope resolver**, the function that decides which fields of every API response reach the wire. A subtle error here is a **silent PII leak or an over-restriction**, neither of which throws. CODEOWNERS-gated (`@dkay`). Do not merge on a skim — review the equivalence proof and the binding table field-by-field.

## What
Convert the imperative `switch (modelName)` in `access-resolvers.ts` (`scopesHeld`) into a declarative `SCOPE_BINDINGS` data table interpreted by one engine. This is the **minimum** needed to make the CI security validators *possible* (field-typo, forgotten-model, route-grant seam) — they can only run against declarative data, not an opaque switch.

Implements **Step 2 / S0–S2** of `docs/security/auth-consistency-analysis.md` §7. **Behavior-preserving**: same fields reach the wire for every caller.

## Scope (and what is deliberately NOT here)
- ✅ Resolver refactor + validator **authoring**.
- ❌ Validators are **NOT wired as CI gates** (that's Step 3).
- ❌ No `RouteSpec.returns` added (arrives with the route-migration track).
- ❌ No library/package extraction, no tier/Role/Token grammar change, no `registry.ts` change (§7.7 out of scope).

## The proof it's safe (review this first)
`tests/security/scopeBindingsEquivalence.test.ts` asserts the new resolver is **set-equal** to a *frozen verbatim copy of the deleted switch* across **8 personas × 24 models × 11 rows = 2112 combinations** (own / another's / in-program / out-of-program / active-visit / departed-visit / missing-key / non-object). This is the contract that the port changed nothing. If you trust one thing, trust this — but also eyeball `scopeBindings.ts` against `classifications.ts`.

## Files
| file | what |
|---|---|
| `scopes.ts` (new) | `Match` + `evalMatch` + `makeScopesHeld`; `validateBindings`/`validateRouteGrants` (authored, unwired) |
| `scopeBindings.ts` (new) | `SCOPE_BINDINGS` (19 models), `ROW_SCOPE_KEY`, `OPT_OUT_PENDING_ROUTE`, `scopesHeld` |
| `access-resolvers.ts` | switch + `ROW_SCOPE_KEY` deleted (−182), re-exports `scopesHeld`; `buildCallerContext`/`resolveAccess` untouched |
| `scopeBindingsEquivalence.test.ts` (new) | S1 equivalence proof + frozen oracle |
| `scopeValidators.test.ts` (new) | validators detect what they target |

## Reviewer must scrutinize
1. **Fail-closed preserved.** The §7.3 doc engine sketch *dropped* the `ROW_SCOPE_KEY` fail-closed preamble; I kept it (`makeScopesHeld(bindings, rowScopeKeys)`). Without it, a key-less `EmergencyContact` row would get `everyones` instead of `{}` → admin view leaks the row. Confirm `EmergencyContact` missing `householdId` → no scopes.
2. **`EmergencyContact` is BOUND, not pending.** Live switch already binds it; doc §7.5.1 stale. Removed from `OPT_OUT_PENDING_ROUTE`. Deviates from the doc's pending list **on purpose**.
3. **Fee/RSVP literal port.** Grouped switch case read `participantId` on `Fee` and `programId` on `RSVP` — columns those models lack. Ported **verbatim** (required for switch-equivalence on arbitrary rows); `validateBindings` flags both — intended typo-catcher behavior, surfaced not hidden.
4. **`number`-guards in `evalMatch`** encode the switch's `!== undefined` checks — an anon caller (`selfId === undefined`) must never match a row whose field is also absent.

## Validator state (unwired this PR)
`validateBindings` returns 8 errors against the real table — all expected and documented: 2 Fee/RSVP field-existence + 6 admin-only logs flagged by the doc's `id`-inclusive `SCOPABLE_FIELDS`. Path to a clean wire is in `scopes.ts` comments (Step 3).

## Related branch (no behavioral conflict)
`claude/silly-khayyam-ee39e3` adds a certifier admission gate + `RouteSpec.returns` — **orthogonal layer** (admission/role, no `Scope`/binding overlap). Single textual merge touchpoint in `access-resolvers.ts` (my deletion vs their `isCertifier` insertion). Their `returns` is the enabler my `validateRouteGrants` waits for. Land either order.

## Verification
- S1 equivalence (2112 combos) ✅ · validators (9) ✅
- stripper / toolstatus / member-tier / resolveAccess / outbound — 89 unit ✅
- `registryAuthz` + `policy.contract` integration — 48, real Postgres `--runInBand` ✅
- `tsc --noEmit` 0 errors · `eslint --max-warnings 0` clean

> Pre-commit `test:ci` finds 0 tests inside a git worktree (`testPathIgnorePatterns` ignores `/.claude/worktrees/`) — known false failure; full suite run manually. CI on a normal checkout runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)