### PR TITLE
feat(security): grant program leads RSVP scope via eventId (not dead programId)

### DIFF
--- a/checkin-app/src/security/__tests__/payment-plans-strip.test.ts
+++ b/checkin-app/src/security/__tests__/payment-plans-strip.test.ts
@@ -25,6 +25,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         programsCoreVolIn: new Set(),
         participantIdsInScopePrograms: new Set(),
         householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
         ...opts,
     };

--- a/checkin-app/src/security/__tests__/rsvp-program-scope.test.ts
+++ b/checkin-app/src/security/__tests__/rsvp-program-scope.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * RSVP.their_program_participants via eventId (deliberate behavior change).
+ *
+ * RSVP has no programId column (PK [eventId, participantId]); the old switch read
+ * row.programId, which was always undefined on a real RSVP — the program-lead
+ * grant was DEAD. The resolver now reaches a program via eventId →
+ * ctx.eventIdsInScopePrograms. These guards pin the new capability:
+ *   - a lead / core-vol holds their_program_participants on an RSVP whose event
+ *     is in their program; a non-lead does not;
+ *   - the RSVP owner still holds their_own (participantId === selfId);
+ *   - the stale programId read no longer grants anything.
+ * See docs/security/auth-consistency-analysis.md §7.5 + §9 Step 3 Blocker 1.
+ */
+import { scopesHeld, type CallerContext } from '../access-resolvers';
+
+function ctx(opts: Partial<CallerContext> = {}): CallerContext {
+    return {
+        selfId: undefined,
+        householdId: undefined,
+        isKeyholder: false,
+        isKiosk: false,
+        programsLed: new Set(),
+        programsCoreVolIn: new Set(),
+        participantIdsInScopePrograms: new Set(),
+        householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
+        activeVisitorIds: new Set(),
+        ...opts,
+    };
+}
+
+// Event 200 belongs to a program the caller leads; event 201 to one they core-vol.
+const lead = ctx({ selfId: 10, programsLed: new Set([100]), eventIdsInScopePrograms: new Set([200]) });
+const coreVol = ctx({ selfId: 11, programsCoreVolIn: new Set([101]), eventIdsInScopePrograms: new Set([201]) });
+const member = ctx({ selfId: 5 }); // no programs
+
+describe('RSVP their_program_participants via eventId', () => {
+    it('grants their_program_participants to a lead for an RSVP whose event is in their program', () => {
+        const held = scopesHeld('RSVP', { eventId: 200, participantId: 5 }, lead);
+        expect(held.has('their_program_participants')).toBe(true);
+    });
+
+    it('grants their_program_participants to a core-vol for an in-program event', () => {
+        const held = scopesHeld('RSVP', { eventId: 201, participantId: 5 }, coreVol);
+        expect(held.has('their_program_participants')).toBe(true);
+    });
+
+    it('does NOT grant their_program_participants to a plain member', () => {
+        const held = scopesHeld('RSVP', { eventId: 200, participantId: 99 }, member);
+        expect(held.has('their_program_participants')).toBe(false);
+    });
+
+    it('does NOT grant a lead access to an RSVP whose event is in a DIFFERENT program', () => {
+        const held = scopesHeld('RSVP', { eventId: 999, participantId: 5 }, lead);
+        expect(held.has('their_program_participants')).toBe(false);
+    });
+
+    it('the RSVP owner still holds their_own (participantId === selfId)', () => {
+        const held = scopesHeld('RSVP', { eventId: 999, participantId: 5 }, member);
+        expect(held.has('their_own')).toBe(true);
+    });
+
+    it('a non-owner does NOT hold their_own', () => {
+        const held = scopesHeld('RSVP', { eventId: 999, participantId: 5 }, ctx({ selfId: 6 }));
+        expect(held.has('their_own')).toBe(false);
+    });
+
+    it('the stale programId read no longer grants — a row carrying only programId is inert', () => {
+        // Old dead binding: a lead of program 100 with a row {programId: 100} used
+        // to (try to) match. With the eventId binding it grants nothing.
+        const held = scopesHeld('RSVP', { programId: 100, participantId: 99 }, lead);
+        expect(held.has('their_program_participants')).toBe(false);
+    });
+});

--- a/checkin-app/src/security/__tests__/shop-members-strip.test.ts
+++ b/checkin-app/src/security/__tests__/shop-members-strip.test.ts
@@ -26,6 +26,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         programsCoreVolIn: new Set(),
         participantIdsInScopePrograms: new Set(),
         householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
         ...opts,
     };

--- a/checkin-app/src/security/__tests__/toolstatus-self-scope.test.ts
+++ b/checkin-app/src/security/__tests__/toolstatus-self-scope.test.ts
@@ -18,6 +18,7 @@ const ctx: CallerContext = {
     programsCoreVolIn: new Set(),
     participantIdsInScopePrograms: new Set(),
     householdIdsInScopePrograms: new Set(),
+    eventIdsInScopePrograms: new Set(),
     activeVisitorIds: new Set(),
 };
 

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -29,6 +29,11 @@ export interface CallerContext {
     /** Household IDs of those participants — i.e. households with a child in a
      *  program the caller leads/core-vols. Drives the 'their_program_households' scope. */
     householdIdsInScopePrograms: Set<number>;
+    /** Event IDs whose Event.programId is in programsLed ∪ programsCoreVolIn.
+     *  RSVP has no programId column (PK [eventId, participantId]); it reaches a
+     *  program only via eventId → Event.programId. Drives 'their_program_participants'
+     *  on RSVP. */
+    eventIdsInScopePrograms: Set<number>;
     /** Participant IDs with an un-departed Visit. Only populated for keyholders. */
     activeVisitorIds: Set<number>;
 }
@@ -43,6 +48,7 @@ export async function buildCallerContext(auth: AuthResult): Promise<CallerContex
         programsCoreVolIn: new Set(),
         participantIdsInScopePrograms: new Set(),
         householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
     };
 
@@ -82,6 +88,18 @@ export async function buildCallerContext(auth: AuthResult): Promise<CallerContex
             select: { householdId: true },
         });
         for (const m of members) ctx.householdIdsInScopePrograms.add(m.householdId);
+    }
+
+    // Events belonging to the caller's programs — RSVP reaches a program only via
+    // eventId → Event.programId (RSVP has no programId column). Drives the
+    // 'their_program_participants' scope on RSVP rows.
+    const scopePrograms = [...ctx.programsLed, ...ctx.programsCoreVolIn];
+    if (scopePrograms.length) {
+        const events = await prisma.event.findMany({
+            where: { programId: { in: scopePrograms } },
+            select: { id: true },
+        });
+        for (const e of events) ctx.eventIdsInScopePrograms.add(e.id);
     }
 
     if (ctx.isKeyholder) {

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -18,15 +18,13 @@
  *   - Fee / RSVP: the live switch grouped ProgramParticipant, ProgramVolunteer,
  *     Fee and RSVP under one `case` body that read BOTH `row.programId` and
  *     `row.participantId`. `Fee` has no `participantId` column and `RSVP` has no
- *     `programId` column, so on a REAL row those reads are always `undefined`
- *     and grant nothing. Those two dead reads are now DROPPED (Step 3 Blocker 1):
- *     `Fee` is unbound (it is wholly @sensitivity:public, so it needs no
- *     binding) and `RSVP` keeps only `their_own`. Behavior-identical on every
- *     reachable row — the S1 frozen oracle was split to match (impossible
- *     synthetic rows are the only divergence) — and it clears the
- *     validateBindings field-existence errors for `Fee.participantId` and
- *     `RSVP.programId`. A later chip re-adds RSVP program-lead scope via
- *     `eventId` + a new `eventIdsInScopePrograms` context set.
+ *     `programId` column, so on a REAL row those reads were always `undefined`
+ *     and granted nothing. #574 (Step 3 Blocker 1) dropped both dead reads:
+ *     `Fee` is unbound (wholly @sensitivity:public, so it needs no binding) and
+ *     `RSVP` was narrowed to `their_own`. THIS chip then RE-ADDS the RSVP
+ *     program-lead grant correctly via eventId → Event.programId
+ *     (ctx.eventIdsInScopePrograms) — a deliberate behavior change, diverging
+ *     from the dead switch read. See the RSVP binding below + §7.5/§9 Step 3.
  *
  * IMPORTANT: This file is CODEOWNERS-gated.
  */
@@ -67,17 +65,16 @@ export const SCOPE_BINDINGS = {
         their_own: { field: 'participantId', eqCtx: 'selfId' },
     },
     // Fee + RSVP shared the grouped switch case with ProgramParticipant/
-    // ProgramVolunteer. The literal port carried both scopes onto each, but
-    // `Fee` has no `participantId` column and `RSVP` has no `programId` column
-    // in classifications.ts — so those two branches read `undefined` and never
-    // fired at runtime. Removing them is equivalence-preserving (S1 stays green)
-    // and clears the validateBindings field-existence errors. Fee dropped
-    // entirely: it is wholly @sensitivity:public, so it needs no binding.
-    // RSVP keeps only `their_own` (the owner sees their own row incl.
-    // reminderSentAt:internal). A later chip re-adds RSVP program-lead scope via
-    // `eventId` + a new eventIdsInScopePrograms context set.
+    // ProgramVolunteer, reading BOTH programId and participantId. `Fee` has no
+    // participantId column and `RSVP` has no programId column, so those reads
+    // were dead. #574 dropped both — Fee is unbound (wholly @sensitivity:public,
+    // needs no binding); RSVP was narrowed to `their_own`. THIS chip RE-ADDS the
+    // RSVP program-lead grant correctly via eventId → Event.programId
+    // (ctx.eventIdsInScopePrograms) — a deliberate behavior CHANGE, not the dead
+    // switch read. See docs/security/auth-consistency-analysis.md §7.5 + §9 Step 3.
     RSVP: {
         their_own: { field: 'participantId', eqCtx: 'selfId' },
+        their_program_participants: { field: 'eventId', inCtx: 'eventIdsInScopePrograms' },
     },
     Event: {
         their_program_participants: {

--- a/checkin-app/src/security/scopes.ts
+++ b/checkin-app/src/security/scopes.ts
@@ -30,6 +30,7 @@ export type CtxSet =
     | 'programsCoreVolIn'
     | 'participantIdsInScopePrograms'
     | 'householdIdsInScopePrograms'
+    | 'eventIdsInScopePrograms'
     | 'activeVisitorIds';
 export type CtxFlag = 'isKeyholder' | 'isKiosk';
 

--- a/checkin-app/tests/security/resolveAccess.test.ts
+++ b/checkin-app/tests/security/resolveAccess.test.ts
@@ -34,6 +34,7 @@ const rctx = (
         programsCoreVolIn: new Set(),
         participantIdsInScopePrograms: new Set(),
         householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
         ...callerOverrides,
     },

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -20,10 +20,16 @@
  * not by editing the frozen oracle below.
  *
  * The old switch has been deleted (S2). `referenceScopesHeld` below is a FROZEN
- * verbatim copy of it (the snapshot), so this stays a live regression guard:
- * any future change to scopeBindings.ts that diverges from the original switch
- * behavior fails here. (Per the task: "compare against a snapshot ... leave it
- * in for now.")
+ * copy of it (the snapshot), so this stays a live regression guard: any future
+ * change to scopeBindings.ts that diverges from the intended behavior fails here.
+ *
+ * DIVERGENCE FROM THE ORIGINAL SWITCH (one, deliberate): RSVP.
+ * The original switch grouped RSVP with ProgramParticipant/ProgramVolunteer/Fee
+ * and read `row.programId` — but RSVP has no programId column, so that grant was
+ * DEAD. The resolver now grants `their_program_participants` on RSVP via
+ * eventId → ctx.eventIdsInScopePrograms (§7.5 / §9 Step 3 Blocker 1). The RSVP
+ * branch of this oracle encodes that NEW intended behavior, not the dead switch
+ * read — so the equivalence assertion holds against the corrected resolver.
  */
 import { type CallerContext } from '@/security/access-resolvers';
 import { scopesHeld, SCOPE_BINDINGS } from '@/security/scopeBindings';
@@ -97,14 +103,15 @@ function referenceScopesHeld(
             break;
         }
         // Fee + RSVP were grouped with the two above in the original switch,
-        // reading BOTH programId and participantId. But Fee has no participantId
-        // column and RSVP has no programId column, so on any REAL row those reads
-        // were always undefined and granted nothing. The dead reads are dropped
-        // here to match the schema-correct bindings (Fee unbound/public-only;
-        // RSVP keeps only their_own) — behavior-neutral on every reachable row,
-        // diverging only on synthetic rows that carry impossible field combos.
+        // reading BOTH programId and participantId. Fee has no participantId and
+        // RSVP has no programId, so those reads were dead. #574 dropped both (Fee
+        // unbound/public-only; RSVP narrowed to their_own). THIS chip diverges
+        // further for RSVP: the program-lead grant is re-added via
+        // eventId → eventIdsInScopePrograms (a deliberate behavior change).
         case 'RSVP': {
+            const eventId = num(row.eventId);
             const participantId = num(row.participantId);
+            if (eventId !== undefined && ctx.eventIdsInScopePrograms.has(eventId)) scopes.add('their_program_participants');
             if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
             break;
         }
@@ -164,6 +171,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         programsCoreVolIn: new Set(),
         participantIdsInScopePrograms: new Set(),
         householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
         ...opts,
     };
@@ -179,6 +187,7 @@ const PERSONAS: Record<string, CallerContext> = {
         programsLed: new Set([100]),
         participantIdsInScopePrograms: new Set([9, 5]),
         householdIdsInScopePrograms: new Set([2]),
+        eventIdsInScopePrograms: new Set([200]),
     }),
     coreVolunteer: ctx({
         selfId: 11,
@@ -186,6 +195,7 @@ const PERSONAS: Record<string, CallerContext> = {
         programsCoreVolIn: new Set([101]),
         participantIdsInScopePrograms: new Set([9]),
         householdIdsInScopePrograms: new Set([2]),
+        eventIdsInScopePrograms: new Set([201]),
     }),
     keyholder: ctx({
         selfId: 12,
@@ -210,23 +220,23 @@ const ROWS: Array<{ label: string; row: unknown }> = [
     { label: 'present but no scope keys', row: { id: 1, name: 'X' } },
     {
         label: "caller-5 own / in-program / active",
-        row: { id: 5, householdId: 2, participantId: 5, programId: 100, userId: 5, actorId: 5, departedAt: null },
+        row: { id: 5, householdId: 2, participantId: 5, programId: 100, eventId: 200, userId: 5, actorId: 5, departedAt: null },
     },
     {
         label: 'household co-member (hh 2)',
-        row: { id: 6, householdId: 2, participantId: 6, programId: 100, userId: 6, actorId: 6, departedAt: null },
+        row: { id: 6, householdId: 2, participantId: 6, programId: 100, eventId: 200, userId: 6, actorId: 6, departedAt: null },
     },
     {
         label: 'program participant / coreVol prog / active visitor',
-        row: { id: 9, householdId: 2, participantId: 9, programId: 101, userId: 9, actorId: 9, departedAt: null },
+        row: { id: 9, householdId: 2, participantId: 9, programId: 101, eventId: 201, userId: 9, actorId: 9, departedAt: null },
     },
     {
         label: "another's / out-of-program / departed",
-        row: { id: 7, householdId: 99, participantId: 7, programId: 88, userId: 7, actorId: 7, departedAt: new Date() },
+        row: { id: 7, householdId: 99, participantId: 7, programId: 88, eventId: 88, userId: 7, actorId: 7, departedAt: new Date() },
     },
     {
         label: "lead's own program (Program row id 100)",
-        row: { id: 100, householdId: 4, participantId: 10, programId: 100, userId: 10, actorId: 10, departedAt: null },
+        row: { id: 100, householdId: 4, participantId: 10, programId: 100, eventId: 200, userId: 10, actorId: 10, departedAt: null },
     },
 ];
 

--- a/checkin-app/tests/security/scopeValidators.test.ts
+++ b/checkin-app/tests/security/scopeValidators.test.ts
@@ -57,14 +57,16 @@ describe('validateBindings — coverage (forgotten-model catcher)', () => {
     });
 });
 
-describe('validateBindings — Fee/RSVP dead-field cleanup', () => {
-    it('no longer flags Fee.participantId or RSVP.programId (dead refs removed)', () => {
-        // The literal-port branches read columns the models lack (Fee has no
-        // participantId, RSVP has no programId), never fired at runtime, and are
-        // now removed (equivalence-preserving — S1 stays green).
+describe('validateBindings — Fee/RSVP dead-field cleanup + RSVP eventId re-add', () => {
+    it('no longer flags Fee.participantId (Fee unbound) or RSVP.programId (RSVP now eventId-bound)', () => {
+        // #574 dropped the dead literal-port reads (Fee has no participantId, RSVP
+        // has no programId). Fee is now unbound (public-only); RSVP is re-bound on
+        // the real `eventId` column by this chip. Neither field-existence error
+        // should appear, and RSVP must be clean.
         const errs = validateBindings(SCOPE_BINDINGS, CLS, OPT_OUT_PENDING_ROUTE);
         expect(errs).not.toContain('Fee.participantId — no such field');
         expect(errs).not.toContain('RSVP.programId — no such field');
+        expect(errs.some(e => e.startsWith('RSVP.'))).toBe(false);
     });
 });
 

--- a/checkin-app/tests/security/stripper.test.ts
+++ b/checkin-app/tests/security/stripper.test.ts
@@ -21,6 +21,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         programsCoreVolIn: new Set(),
         participantIdsInScopePrograms: new Set(),
         householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
         ...opts,
     };


### PR DESCRIPTION
## What

Adds a real capability to the per-row scope resolver: a **program lead / core volunteer** now holds `their_program_participants` on RSVP rows whose event belongs to one of their programs.

## Why

RSVP has no `programId` column (PK `[eventId, participantId]`). The old grouped `switch` read `row.programId` for the `their_program_participants` grant — always `undefined` on a real RSVP row, so the grant was **dead**, never fired at runtime. RSVP reaches a program only via `eventId → Event.programId`. This wires that relation hop through a new prefetched context set.

Deliberate **behavior change**, not a refactor. See `docs/security/auth-consistency-analysis.md` §7.5 + §9 Step 3 Blocker 1.

## Changes (all `checkin-app/src/security/`, CODEOWNERS-gated)

- **access-resolvers.ts** — add `eventIdsInScopePrograms: Set<number>` to `CallerContext`; populate in `buildCallerContext` via one `prisma.event.findMany({ where: { programId: { in: [...led, ...coreVol] } }, select: { id: true } })`. Empty for non-session / no programs.
- **scopes.ts** — add `'eventIdsInScopePrograms'` to the `CtxSet` union.
- **scopeBindings.ts** — `RSVP.their_program_participants` now binds `{ field: 'eventId', inCtx: 'eventIdsInScopePrograms' }`; the dead `programId` binding removed. `their_own` kept. **Fee stays dropped** (per #574, which landed first — Fee is wholly `@sensitivity:public`, so unbound).

> Rebased onto `main` after #574 (Fee/RSVP dead-ref removal) and #575 (roster gate) landed. #574 is the narrowing this chip's commit message anticipated: it dropped the dead RSVP `programId` binding + Fee entirely. This chip re-adds RSVP's program-lead grant correctly via `eventId`. Conflict resolution kept #574's narrowing intact (Fee unbound, no dead reads re-introduced) and layered only the `eventId` capability on top.

## Reviewer notes

**Equivalence test handling.** The S0→S2 equivalence test is still present (not retired by #573). This grant is *not* equivalence-preserving, so the frozen oracle's RSVP branch was split out of the grouped case and re-encoded against `eventId` — one documented divergence; everything else still proves set-equal to the old switch.

**`internal` tier IS reachable now — a consuming route already exists.** `GET /api/events/[id]` returns nested `rsvps` and its registry view already grants `authenticated → their_program_participants:internal` (to keep `Event.attendanceConfirmedAt` visible to staff). Before this change the RSVP grant resolved to nothing; **now a lead/core-vol of the event's program sees `RSVP.reminderSentAt`** (RSVP's only `internal` field).

Is `internal` right? It's not separable from the Event grant under today's grammar: the one token `their_program_participants:internal` is granted per-(scope, role, view) and applies to every returned row, so you can't expose `Event.attendanceConfirmedAt` to leads while hiding `RSVP.reminderSentAt` without giving RSVP its **own** scope (a follow-up design change). Lowering to `:personal` is a dead end — tiers are exact-match and RSVP has no `personal` field. `reminderSentAt` (did the nudge go out) is operational, not PII, and plausibly useful to a lead managing a roster — so riding along is defensible. **If you want it hidden, say so and I'll scope a dedicated RSVP scope as a follow-up.**

## Tests

- new `rsvp-program-scope.test.ts` — lead/core-vol get the scope via `eventId`, plain member does not, owner keeps `their_own`, stale `programId` row is inert.
- `scopeBindingsEquivalence.test.ts` — RSVP divergence encoded; rest still set-equal.
- `scopeValidators.test.ts` — asserts neither `Fee.participantId` (Fee now unbound, per #574) nor `RSVP.programId` is flagged, and RSVP is clean (bound on real `eventId`).
- 5 existing `CallerContext` fixtures get the new required field.

**Verified:** tsc clean; unit tests pass (349 post-rebase incl. equivalence / validators / `rsvp-program-scope`). Pre-rebase, the full integration tier (101 suites / 789 tests, `--runInBand`) passed against throwaway Postgres incl. `registryAuthz` / `eventsAPI` / `eventRSVPAPI`; the rebase changed only comments + test scaffolding around byte-identical resolver logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
