### PR TITLE
fix(security): gate denied households out of program-edit and certify writes (GAP-1)

### DIFF
--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -319,9 +319,29 @@ describe('Individual Program API Integration Tests', () => {
              });
              const res = await PATCH(req as unknown as import("next/server").NextRequest, createParams(publicProgramId) as unknown as never);
              expect(res.status).toBe(200);
-             
+
              const data = await res.json();
              expect(data.program.phase).toBe('FINISHED');
+        });
+
+        // Denied-household lockout (auth-consistency §5 risk #2 / GAP-1). A denied
+        // lead mentor keeps `user.id`, so the leadMentorId-match gate would still
+        // pass — the denied check must reject before any mutation. No write occurs.
+        it('blocks a denied lead mentor from editing their own program (401, no mutation)', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: leadId, denied: true } });
+
+             const before = await prisma.program.findUnique({ where: { id: publicProgramId } });
+
+             const req = new Request(`http://localhost:4000/api/programs/${publicProgramId}`, {
+                 method: 'PATCH',
+                 body: JSON.stringify({ name: 'Denied Hack' })
+             });
+             const res = await PATCH(req as unknown as import("next/server").NextRequest, createParams(publicProgramId) as unknown as never);
+             expect(res.status).toBe(401);
+
+             const after = await prisma.program.findUnique({ where: { id: publicProgramId } });
+             expect(after?.name).toBe(before?.name);
+             expect(after?.name).not.toBe('Denied Hack');
         });
     });
 });

--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -282,6 +282,25 @@ describe('Shop API Integration Tests', () => {
              expect(auditRows[0].oldData).toBeNull();
         });
 
+        // Denied-household lockout (auth-consistency §5 risk #2 / GAP-1). Certifier
+        // status is re-queried from the DB, bypassing the denial-stripped session,
+        // so a denied certifier would still pass the MAY_CERTIFY_OTHERS gate. The
+        // denied check must reject before the lookup. No certification row is written.
+        it('blocks a denied certifier from granting a certification (401, no write)', async () => {
+             const tool = await prisma.tool.create({ data: { name: 'Shop Test Tool Denied' } });
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: certifierId, denied: true } });
+
+             const req = createReq('POST', { body: { participantId: commonId, toolId: tool.id, level: 'BASIC' } });
+             const res = await postCerts(req) as Response;
+             expect(res.status).toBe(401);
+
+             // No toolStatus row was written for this fresh (participant, tool) pair.
+             const written = await prisma.toolStatus.findUnique({
+                 where: { participantId_toolId: { participantId: commonId, toolId: tool.id } }
+             });
+             expect(written).toBeNull();
+        });
+
         it('should forbid a Certifier from promoting someone to MAY_CERTIFY_OTHERS', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: certifierId } });
 

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -93,6 +93,12 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // A denied household is locked out of the whole app (auth flags stripped but id kept).
+    // Gate here because this handler authorizes on user.id (leadMentorId match), which survives denial.
+    if (session.user?.denied) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {

--- a/checkin-app/src/app/api/shop/certifications/route.ts
+++ b/checkin-app/src/app/api/shop/certifications/route.ts
@@ -74,6 +74,12 @@ export async function POST(req: Request) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // A denied household is locked out of the whole app (auth flags stripped but id kept).
+    // Gate here because certifier status is re-queried from the DB, bypassing the denial-stripped session.
+    if (session.user?.denied) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     try {
         const body = await req.json();
         const { participantId, toolId, level } = body;


### PR DESCRIPTION
## What

Two `getServerSession` write paths let a **denied household** through because they gate on a signal that survives denial, not on the denial-stripped role flags.

On denial, [`authClaims.ts:33`](checkin-app/src/lib/authClaims.ts:33) forces role flags `false` and clears `toolStatuses` — but keeps `user.id` so the session still resolves. The two handlers leaned on that surviving signal:

1. **`programs/[id]` PATCH** authorized on `program.leadMentorId === user.id`. `user.id` is not cleared on denial → a denied lead mentor could still edit their own program.
2. **`shop/certifications` POST** re-queries the DB for the caller's `MAY_CERTIFY_OTHERS` status instead of reading the (stripped) session → a denied certifier could still certify.

## Fix

One guard in each handler, right after the session null-check and before any authorization or mutation — mirroring the existing correct pattern at [`attendance/route.ts:21`](checkin-app/src/app/api/attendance/route.ts:21):

```ts
if (session.user?.denied) {
    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
}
```

- [`api/programs/[id]/route.ts:96`](checkin-app/src/app/api/programs/[id]/route.ts:96)
- [`api/shop/certifications/route.ts:77`](checkin-app/src/app/api/shop/certifications/route.ts:77)

No refactor to `withAuth`/`handler` in this PR — that is separate cleanup. This is the minimal security fix.

## Tests

- `programsIdAPI.integration.test.ts` — denied lead mentor PATCH → **401**, program **unmutated** (reads before/after, asserts `name` unchanged).
- `shopAPI.integration.test.ts` — denied certifier POST → **401**, **no** `toolStatus` row written (fresh tool, `findUnique` is `null`).

Both suites green locally (real Postgres, `--runInBand`): 29 passed. `tsc --noEmit` clean.

## Reviewer note

Re-grown instance of auth-consistency **§5 risk #2 / GAP-1** (`docs/security/auth-consistency-analysis.md` on `claude/dazzling-noyce-f31a8c`). Systemic prevention — a CI check banning new `getServerSession` use in route files — is the **Step 7 drift-guard**, tracked separately. This PR just closes the two live holes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)