### PR TITLE
fix(events): reject events where end time is not after start (P1-5)

### DIFF
--- a/checkin-app/src/app/__tests__/eventsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventsAPI.integration.test.ts
@@ -130,6 +130,32 @@ describe('Events API Integration Tests', () => {
             expect(data.error).toBe('Missing required fields');
         });
 
+        it('should return 400 if end time is not after start time', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true, isBoardMember: false }
+            });
+
+            const req = new Request('http://localhost:4000/api/events', {
+                method: 'POST',
+                body: JSON.stringify({
+                    name: 'Test Event Bad Times',
+                    programId: testProgramId,
+                    startDate: '2026-10-01',
+                    startTime: '15:00',
+                    endTime: '15:00' // end == start
+                })
+            });
+
+            const res = await POST(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(400);
+            const data = await res.json();
+            expect(data.error).toBe('Event end time must be after start time');
+
+            // Nothing created.
+            const events = await prisma.event.findMany({ where: { name: 'Test Event Bad Times' } });
+            expect(events.length).toBe(0);
+        });
+
         it('should successfully create a single event as admin', async () => {
             (getServerSession as jest.Mock).mockResolvedValue({
                 user: { id: testAdminId, isSysadmin: true, isBoardMember: false }

--- a/checkin-app/src/app/api/events/route.ts
+++ b/checkin-app/src/app/api/events/route.ts
@@ -53,6 +53,12 @@ export const POST = withAuth({}, async (req, auth) => {
         const [startHr, startMin] = startTime.split(':').map(Number);
         const [endHr, endMin] = endTime.split(':').map(Number);
 
+        // Each event (single or recurring) spans one day's wall-clock window, so
+        // compare time-of-day once here rather than per-iteration. End must be after start.
+        if (endHr * 60 + endMin <= startHr * 60 + startMin) {
+            return NextResponse.json({ error: "Event end time must be after start time" }, { status: 400 });
+        }
+
         const eventsToCreate = [];
 
         if (!recurrence || !recurrence.daysOfWeek || recurrence.daysOfWeek.length === 0 || !recurrence.until) {


### PR DESCRIPTION
## What

`POST /api/events` validated that `startTime`/`endTime` were present but never that the window is valid, so an event with `endTime <= startTime` would be created (audit item **P1-5**). The sibling `/api/attendance/manual` route already guards `departure <= arrival`; this matches that style.

## Change

- One validation block in [route.ts](checkin-app/src/app/api/events/route.ts), placed once after the start/end times are parsed and **before** the create loop, so it covers **both** the single-event and recurring-event paths:

  ```ts
  if (endHr * 60 + endMin <= startHr * 60 + startMin) {
      return NextResponse.json({ error: "Event end time must be after start time" }, { status: 400 });
  }
  ```

- Compares **time-of-day** (minutes-of-day), not calendar dates. Both code paths build each event's window via `setHours/setMinutes` on the same `currentIterDate`, so every event is a same-day window — the model has no multi-day span, and recurrence reuses the same wall-clock times each day. A same-day `end <= start` is the only failure mode; no valid input is rejected.

- Returns **400**, consistent with the route's other validation responses.

## Tests

Added an integration test in [eventsAPI.integration.test.ts](checkin-app/src/app/__tests__/eventsAPI.integration.test.ts): `end == start` -> 400 with the expected message, and asserts nothing was created. Existing single + recurring create tests still pass (6/6 green against a throwaway Postgres).

## Reviewer notes

- Behavior-preserving for valid input; minimal diff, single validation block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)