### PR TITLE
fix(security): return 400 (not 404) for bad-parse id in program/event PATCH (P1-3)

### DIFF
--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -285,6 +285,21 @@ describe('Individual Program API Integration Tests', () => {
              expect(res.status).toBe(401);
         });
 
+        // P1-3: bad-parse id (malformed input) returns 400, matching GET — NOT the
+        // 404 reserved for a valid id with no matching row. Checked before the
+        // not-found/forbidden gates, so even an admin gets 400.
+        it('returns 400 for an unparseable program ID (not 404)', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+             const badParams = { params: Promise.resolve({ id: 'abc' }) };
+             const req = new Request('http://localhost:4000/api/programs/abc', {
+                 method: 'PATCH',
+                 body: JSON.stringify({ name: 'Nope' })
+             });
+             const res = await PATCH(req as unknown as import("next/server").NextRequest, badParams as unknown as never);
+             expect(res.status).toBe(400);
+        });
+
         it('should block common users from updating a program', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
 

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -66,6 +66,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
 
     const resolvedParams = await params;
     const eventId = parseInt(resolvedParams.id, 10);
+    if (isNaN(eventId)) return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
     const body = await req.json();
 
     try {

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -119,6 +119,9 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
                 return NextResponse.json({ error: "Lead Mentor is required" }, { status: 400 });
             }
             leadMentorId = parseInt(leadMentorId);
+            if (isNaN(leadMentorId)) {
+                return NextResponse.json({ error: "Invalid lead mentor" }, { status: 400 });
+            }
         }
 
         const updateData: Record<string, unknown> = {


### PR DESCRIPTION
## What

Audit item **P1-3**: invalid-id handling was inconsistent *within* two route files. The GET handlers correctly return **400** for an unparseable `[id]`; the PATCH handlers in the same files returned **404** (or fell through to it), and one numeric parse had no NaN guard.

Enforce the invariant: **bad-parse (malformed input) = 400; valid id but no such row = 404.**

### Changes

**`src/app/api/events/[id]/route.ts`** — PATCH
- An unparseable id parsed to `NaN` and fell through to `findUnique` → no row → 404. Added `if (isNaN(eventId)) return 400 "Invalid event ID"` right after the parse, matching GET.
- Genuine missing-row 404 left untouched.

**`src/app/api/programs/[id]/route.ts`** — PATCH
- `leadMentorId` was `parseInt`'d after only a falsy check, so a non-numeric string (`"abc"`) flowed into `updateData.leadMentorId` as `NaN`. Added an `isNaN` guard → 400 "Invalid lead mentor".
- The id bad-parse path here already returned 400 (no change).
- Genuine missing-row 404 left untouched.

Each handler keeps its existing response mechanism (`handler()` for GET, `NextResponse.json` for PATCH). Minimal diff (+19 lines).

## Why

Same-file GET/PATCH divergence: a malformed id on PATCH masqueraded as "not found", and a non-numeric `leadMentorId` could silently corrupt an update with `NaN`.

## Reviewer notes

- No existing tests asserted the old 404-on-bad-parse — sibling routes already use 400; grep of all three test roots found zero conflicting assertions.
- Added one regression test in `programsIdAPI.integration.test.ts`: unparseable program id on PATCH → 400.
- Verified locally against a throwaway Postgres: `programsIdAPI` 16/16 pass (incl. new test); `eventsAPI` + `eventCancelAndManualAttendance` + `eventAttendanceAPI` 17/17 pass.
- Pre-existing GET test named *"should return 404 ... for invalid program ID"* actually uses id `999999` (valid parse, missing row) → 404 is correct; misleading name, left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)