### PR TITLE
fix(security): row-aware program-ops layout gate (P1-8A)

### DIFF
--- a/checkin-app/src/app/program-ops/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/program-ops/__tests__/layout.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import ProgramOpsLayout from "../layout";
+
+const push = jest.fn();
+let mockPathname = "/program-ops";
+let mockSession: { data: unknown; status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+
+const CHILD = "child-marker";
+const renderLayout = (pathname: string, session: { data: unknown; status: string }) => {
+  mockPathname = pathname;
+  mockSession = session;
+  return render(
+    <ProgramOpsLayout>
+      <div>{CHILD}</div>
+    </ProgramOpsLayout>,
+  );
+};
+
+const leadOfProgram1 = {
+  data: { user: { id: 7, programsLed: [1] } },
+  status: "authenticated",
+};
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("ProgramOpsLayout row-aware gate", () => {
+  it("admits a lead mentor to a program they lead (chrome-less, no redirect)", () => {
+    renderLayout("/program-ops/programs/1", leadOfProgram1);
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("redirects a lead mentor away from a program they do NOT lead", () => {
+    renderLayout("/program-ops/programs/2", leadOfProgram1);
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("admits a global admin to any program (row gate is admin-bypassed)", () => {
+    renderLayout("/program-ops/programs/2", {
+      data: { user: { id: 1, isSysadmin: true, programsLed: [] } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("admits any authenticated caller to a session flow (page enforces Event->program)", () => {
+    renderLayout("/program-ops/sessions/5", {
+      data: { user: { id: 9, programsLed: [] } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("redirects a non-admin off the tabbed hub (no chrome-less escape hatch)", () => {
+    renderLayout("/program-ops", {
+      data: { user: { id: 9, programsLed: [1] } },
+      status: "authenticated",
+    });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects unauthenticated callers", () => {
+    renderLayout("/program-ops/programs/1", { data: null, status: "unauthenticated" });
+    expect(push).toHaveBeenCalledWith("/");
+  });
+});

--- a/checkin-app/src/app/program-ops/layout.tsx
+++ b/checkin-app/src/app/program-ops/layout.tsx
@@ -8,28 +8,44 @@ import { ScrollableTabsList } from "@/components/ui/ScrollableTabsList";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PROGRAM_NAV_LINKS } from "@/lib/programNav";
 
-// Program/session editing is reachable by lead mentors (program.leadMentorId, not a role flag),
-// so those pages bypass the isSysadmin/isBoardMember layout gate and self-authorize.
-const isProgramFlowPath = (pathname: string | null) =>
-  !!(pathname?.match(/^\/program-ops\/programs\/\d+/) ||
-    pathname?.match(/^\/program-ops\/sessions\/(\d+|new)/));
+// A program-edit URL (/program-ops/programs/[id]) carries a PROGRAM id, so the
+// layout can gate it precisely against the caller's led-program set. Session URLs
+// (/program-ops/sessions/[id|new]) carry an EVENT id (or none), which the layout
+// can't resolve to a program without a fetch — those keep a chrome-less admit for
+// any authenticated caller and the page enforces (Event->program 403 in the API).
+const programEditId = (pathname: string | null): number | null => {
+  const m = pathname?.match(/^\/program-ops\/programs\/(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+};
+const isSessionFlowPath = (pathname: string | null) =>
+  !!pathname?.match(/^\/program-ops\/sessions\/(\d+|new)/);
 
 export default function ProgramOpsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
   const { data: session, status } = useSession();
-  const isProgramFlow = isProgramFlowPath(pathname);
 
   const user = session?.user;
   const isGlobalAdmin = !!(user?.isSysadmin || user?.isBoardMember);
 
+  // Row-aware: a lead mentor reaches program-edit only for the programs they lead.
+  const editProgramId = programEditId(pathname);
+  const leadsThisProgram =
+    editProgramId !== null && !!user?.programsLed?.includes(editProgramId);
+  const isSessionFlow = isSessionFlowPath(pathname);
+
+  // Chrome-less (no section tabs) for the lead-mentor edit screens, as under /admin.
+  const isChromeless = editProgramId !== null || isSessionFlow;
+  const authorized =
+    isGlobalAdmin || leadsThisProgram || (isSessionFlow && status === "authenticated");
+
   useEffect(() => {
     if (status === "unauthenticated") {
       router.push("/");
-    } else if (status === "authenticated" && !isGlobalAdmin && !isProgramFlow) {
+    } else if (status === "authenticated" && !authorized) {
       router.push("/");
     }
-  }, [status, isGlobalAdmin, isProgramFlow, router]);
+  }, [status, authorized, router]);
 
   if (status === "loading") {
     return (
@@ -42,10 +58,9 @@ export default function ProgramOpsLayout({ children }: { children: React.ReactNo
     );
   }
 
-  if (!session || (!isGlobalAdmin && !isProgramFlow)) return null;
+  if (!session || !authorized) return null;
 
-  // Lead-mentor editing pages render chrome-less (no section tabs), as they did under /admin.
-  if (isProgramFlow) return <>{children}</>;
+  if (isChromeless) return <>{children}</>;
 
   // Active tab = the longest nav href that prefixes the current route (null on the hub).
   const active =

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -246,6 +246,8 @@ export const authOptions: NextAuthOptions = {
                         },
                         // One row is enough to mark this participant a household lead.
                         householdLeads: { take: 1, select: { participantId: true } },
+                        // Program ids led — drives the client program-ops row gate.
+                        programsLed: { select: { id: true } },
                         household: { include: { membership: true } }
                     }
                 }));
@@ -285,6 +287,8 @@ export const authOptions: NextAuthOptions = {
                         },
                         // One row is enough to mark this participant a household lead.
                         householdLeads: { take: 1, select: { participantId: true } },
+                        // Program ids led — drives the client program-ops row gate.
+                        programsLed: { select: { id: true } },
                         household: { include: { membership: true } }
                     }
                 }));
@@ -313,6 +317,7 @@ export const authOptions: NextAuthOptions = {
                 session.user.isBackgroundCheckReviewer = token.isBackgroundCheckReviewer;
                 session.user.householdId = token.householdId;
                 session.user.householdLead = token.householdLead ?? false;
+                session.user.programsLed = token.programsLed ?? [];
                 session.user.toolStatuses = token.toolStatuses || [];
                 session.user.impersonatedBy = token.impersonatedBy ?? null;
                 // Surface the org-gate claims so dev-only server actions (assertDevActor) can

--- a/checkin-app/src/lib/authClaims.ts
+++ b/checkin-app/src/lib/authClaims.ts
@@ -14,6 +14,9 @@ export type ClaimSourceParticipant = {
     // Any row here means this participant leads a household (the relation is already
     // filtered to their own leads). Empty/absent → not a lead.
     householdLeads?: { participantId: number }[];
+    // Programs this participant is the lead mentor of (Program.leadMentorId === id).
+    // Drives the client-side program-ops row gate; mirrors access-resolvers' programsLed.
+    programsLed?: { id: number }[];
     household?: { membership?: { status: MembershipStatus } | null } | null;
 };
 
@@ -37,4 +40,5 @@ export function assignParticipantClaims(token: JWT, p: ClaimSourceParticipant): 
     token.householdId = p.householdId;
     token.householdLead = denied ? false : (p.householdLeads?.length ?? 0) > 0;
     token.toolStatuses = denied ? [] : p.toolStatuses;
+    token.programsLed = denied ? [] : (p.programsLed?.map((prog) => prog.id) ?? []);
 }

--- a/checkin-app/src/types/next-auth.d.ts
+++ b/checkin-app/src/types/next-auth.d.ts
@@ -16,6 +16,9 @@ declare module "next-auth" {
       isBackgroundCheckReviewer?: boolean;
       householdId?: number | null;
       householdLead?: boolean;
+      // Program ids this user is the lead mentor of. Client-side row gate only
+      // (the API is the real boundary); mirrors access-resolvers' programsLed.
+      programsLed?: number[];
       toolStatuses?: { toolId: number; level: string }[];
       // Inert impersonation provenance — display/audit only, never read by authz.
       impersonatedBy?: string | null;
@@ -56,6 +59,7 @@ declare module "next-auth/jwt" {
     isBackgroundCheckReviewer?: boolean;
     householdId?: number | null;
     householdLead?: boolean;
+    programsLed?: number[];
     toolStatuses?: { toolId: number; level: string }[];
   }
 }


### PR DESCRIPTION
## What

Replace the regex URL-shape gate in `program-ops/layout.tsx` with a row-aware lead-mentor check.

Before: `isProgramFlowPath()` regex-matched `/program-ops/programs/\d+` and `/program-ops/sessions/...` and rendered children for **any** authenticated user whose URL matched. Two problems:
1. Admitted any logged-in user to those URLs at the layout level (no real lead-mentor check).
2. Adding a new lead-mentor route silently broke unless someone updated the regex (route-structure/regex coupling).

After: `/program-ops/programs/[id]` is gated precisely — a lead mentor is admitted only when the program id is in their led-program set (admins bypass). No fetch; the id **is** a program id.

## Source of truth

New `programsLed: number[]` session claim, stamped in `assignParticipantClaims` — the single spot both jwt-callback branches call, so it re-syncs every request (a revoked lead mentor loses access within `updateAge`, not at next sign-in). Mirrors `access-resolvers.ts` `programsLed` (`Program.leadMentorId === id`); reuses the existing `Participant.programsLed` relation, no new query shape, no new endpoint.

Rejected alternatives: `programs/mine` returns enrollments (`programParticipant`), not led programs — wrong notion. A new endpoint — unnecessary, the claim is cheaper and never stale.

## Sessions routes

`/program-ops/sessions/[id|new]` carry an **Event** id (or none), not a program id. Resolving Event→program needs a fetch the layout shouldn't do, so they keep a chrome-less admit for authenticated callers; the page enforces via `GET/PATCH /api/events/[id]`, which already 403s non-staff (`admin || leadMentor || coreVol`). **The API remains the real security boundary — no server check weakened.** This PR fixes correctness + drift of the client gate only.

## Behavior

- Global admins: full access + tabs (unchanged).
- Lead of program A: chrome-less access to `/programs/A` ✓, **redirected** from `/programs/B` ✓ (was: admitted — the bug).
- Sessions flow: authenticated admit, API enforces.
- Everyone else: redirect to `/`.

## Tests

`src/app/program-ops/__tests__/layout.test.tsx` (new, 6 cases, all pass): lead-of-A admitted to `/programs/A` and redirected from `/programs/B`; admin bypass; session-flow admit; hub redirect for non-admins; unauthenticated redirect.

## Reviewer notes

- `confirmNav` onChange untouched (that's P1-8B).
- Files: `authClaims.ts`, `auth-options.ts` (both jwt includes + session callback), `next-auth.d.ts` (Session.user + JWT), `layout.tsx`, plus the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)