### PR TITLE
fix(communication): correct newsletter cadence label to monthly

### DIFF
--- a/checkin-app/src/app/communication/page.tsx
+++ b/checkin-app/src/app/communication/page.tsx
@@ -98,7 +98,7 @@ export default function CommunicationPage() {
           <Checkbox
             checked={settings.emailNewsletter}
             onChange={(e) => persist({ emailNewsletter: e.currentTarget.checked })}
-            label="Subscribe to the weekly newsletter"
+            label="Subscribe to the monthly newsletter"
           />
           <Checkbox
             checked={settings.notifyNewPrograms}


### PR DESCRIPTION
## What

Change the email newsletter subscription checkbox label on `/communication` from "Subscribe to the weekly newsletter" to "Subscribe to the monthly newsletter".

## Why

The newsletter ships monthly, not weekly. The label was misleading users about cadence.

## Notes

Label-only change ([communication/page.tsx:101](checkin-app/src/app/communication/page.tsx)). No behavior/state change — checkbox still binds `settings.emailNewsletter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)