### PR TITLE
style(shop-ops): bold "Existing tools" panel title on create page

### DIFF
--- a/checkin-app/src/app/shop-ops/create/page.tsx
+++ b/checkin-app/src/app/shop-ops/create/page.tsx
@@ -89,7 +89,7 @@ export default function CreateToolPage() {
       </Card>
 
       <Card withBorder radius="md" padding="md" w={260}>
-        <Text fw={600} size="sm" mb="xs">Existing tools</Text>
+        <Text fw={700} size="sm" mb="xs">Existing tools</Text>
         <ScrollArea.Autosize mah={420} type="auto">
           <Stack gap={4}>
             {tools.map((t) => (


### PR DESCRIPTION
## What
Bold the **Existing tools** panel title on `/shop-ops/create`. Heading goes `fw={600}` → `fw={700}`.

## Why
Requested — make the title read as bold while leaving the tool list rows at normal weight.

## Notes
- One-line change in `checkin-app/src/app/shop-ops/create/page.tsx`.
- Tool rows untouched.