### PR TITLE
fix(attendance): require departure for stale manual arrivals

### DIFF
--- a/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
@@ -162,6 +162,24 @@ describe('Manual Attendance API Integration Tests', () => {
             expect(currentAuditLogs).toBe(previousAuditLogs + 1);
         });
 
+        it('should return 400 if departure is blank and arrival is a stale past day', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testUserId }
+            });
+
+            const arrivedAt = new Date(Date.now() - 2 * 24 * 3600000); // 2 days ago, no departure
+
+            const req = new Request('http://localhost:4000/api/attendance/manual', {
+                method: 'POST',
+                body: JSON.stringify({ arrivedAt: arrivedAt.toISOString() })
+            });
+
+            const res = await POST(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(400);
+            const data = await res.json();
+            expect(data.error).toBe('Departure time is required for past arrivals.');
+        });
+
         it('should successfully record a manual visit with arrivedAt only', async () => {
             (getServerSession as jest.Mock).mockResolvedValue({
                 user: { id: testUserId }

--- a/checkin-app/src/app/api/attendance/manual/route.ts
+++ b/checkin-app/src/app/api/attendance/manual/route.ts
@@ -30,6 +30,20 @@ export const POST = withAuth({}, async (req, auth) => {
             return NextResponse.json({ error: "Departure time must be after arrival time" }, { status: 400 });
         }
 
+        // Blank departure means "still in the building" → an open visit. Only allow
+        // that for a recent arrival: today (same calendar day) or within the last
+        // 6 hours (covers arriving late last night and still being here). A stale
+        // arrival with no departure would create a permanent open visit nobody
+        // scanned out of, so require a departure for it.
+        if (!departureTime) {
+            const now = new Date();
+            const withinSixHours = now.getTime() - arrivalTime.getTime() <= 6 * 60 * 60 * 1000;
+            const sameDay = arrivalTime.toDateString() === now.toDateString();
+            if (!withinSixHours && !sameDay) {
+                return NextResponse.json({ error: "Departure time is required for past arrivals." }, { status: 400 });
+            }
+        }
+
         const eventId = await findAssociatedEventAt(userId, arrivalTime);
 
         // Creating an open visit (no departure) is a read-modify-write on this


### PR DESCRIPTION
## What

Manual time entry (`/attendance/manual`) left **departure time unconditionally optional**. A blank departure creates an *open visit* ("still in the building"). Nothing stopped a stale past arrival (e.g. 3 weeks ago) with a blank departure from creating a **permanent open visit** that no scan-out ever closes.

## Change

Guard in `POST /api/attendance/manual` ([route.ts](https://github.com/innovationtreehouse/checkin/blob/claude/exciting-cohen-195f6e/checkin-app/src/app/api/attendance/manual/route.ts)): a blank departure is now allowed only when the arrival is:

- the **current calendar day**, OR
- **within the last 6 hours** (covers arriving late last night and still being present).

Otherwise → `400 "Departure time is required for past arrivals."`

Existing guards (arrival required, departure-after-arrival) unchanged. Closed visits (departure provided) still accept any past date.

## Test

Added integration test: stale arrival (2 days ago) + blank departure → 400. Existing "arrivedAt only" (30 min ago) and dedup (10 min ago) cases stay green — both inside the window.

## Reviewer notes

- Backend guard is the trust boundary; frontend help text unchanged.
- Calendar-day check uses **server TZ** (ops-dev = UTC). The 6h window covers cross-midnight regardless, so no user-facing gap. Switch to TZ-aware day only if mentors hit off-by-one near midnight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)