### PR TITLE
feat(program-ops): surface RSVPs to lead mentors

### DIFF
--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -65,7 +65,21 @@ export type TodoCounts = {
     // visibility and its green badge (sum of pending attendance to confirm).
     // `pending` mirrors the post-event email's targets (ended events not yet
     // confirmed), deep-linked to the existing confirm screen. No new capability.
-    lead?: { programs: { id: number; name: string; pending: TodoItem[] }[] };
+    lead?: { programs: LedProgram[] };
+};
+
+/** RSVP tally (Yes/Maybe/No; NO_RESPONSE omitted). */
+export type RsvpTally = { yes: number; maybe: number; no: number };
+
+/** One upcoming session, with RSVP tallies split by roster role. */
+export type UpcomingSession = { eventId: number; name: string; startAt: string; participants: RsvpTally; volunteers: RsvpTally };
+
+export type LedProgram = {
+    id: number;
+    name: string;
+    totalEnrolled: number;
+    pending: TodoItem[];
+    upcoming: UpcomingSession[];
 };
 
 // What a member-actionable membership process means, in plain terms.
@@ -201,15 +215,35 @@ export const GET = withAuth({}, async (_req, auth) => {
         select: { id: true, name: true },
     });
     if (ledPrograms.length > 0) {
-        const pendingEvents = await prisma.event.findMany({
-            where: {
-                programId: { in: ledPrograms.map((p) => p.id) },
-                endAt: { lte: new Date() },
-                attendanceConfirmedAt: null,
-            },
-            select: { id: true, name: true, programId: true },
-            orderBy: { endAt: "asc" },
-        });
+        const ledIds = ledPrograms.map((p) => p.id);
+        const now = new Date();
+        const [pendingEvents, enrolledCounts, futureEvents, volunteerRows] = await Promise.all([
+            prisma.event.findMany({
+                where: { programId: { in: ledIds }, endAt: { lte: now }, attendanceConfirmedAt: null },
+                select: { id: true, name: true, programId: true },
+                orderBy: { endAt: "asc" },
+            }),
+            // "Total Enrolled" = active (not PENDING) participants per program.
+            prisma.programParticipant.groupBy({
+                by: ["programId"],
+                where: { programId: { in: ledIds }, status: "ACTIVE" },
+                _count: { participantId: true },
+            }),
+            // All upcoming sessions, ascending; we keep the next 3 per program below.
+            prisma.event.findMany({
+                where: { programId: { in: ledIds }, startAt: { gt: now } },
+                select: { id: true, name: true, startAt: true, programId: true },
+                orderBy: { startAt: "asc" },
+            }),
+            // Volunteer roster per program — used to split RSVP tallies by role.
+            prisma.programVolunteer.findMany({
+                where: { programId: { in: ledIds } },
+                select: { programId: true, participantId: true },
+            }),
+        ]);
+        // (programId, participantId) keys that belong to a volunteer; everyone else on a roster is a participant.
+        const volunteerKeys = new Set(volunteerRows.map((v) => `${v.programId}:${v.participantId}`));
+
         const pendingByProgram = new Map<number, TodoItem[]>();
         for (const e of pendingEvents) {
             if (e.programId === null) continue;
@@ -221,8 +255,55 @@ export const GET = withAuth({}, async (_req, auth) => {
             });
             pendingByProgram.set(e.programId, items);
         }
+
+        const enrolledByProgram = new Map(enrolledCounts.map((g) => [g.programId, g._count.participantId]));
+
+        // Next 3 future sessions per program (futureEvents is already startAt-asc).
+        const upcomingByProgram = new Map<number, { id: number; name: string; startAt: Date }[]>();
+        for (const e of futureEvents) {
+            if (e.programId === null) continue;
+            const list = upcomingByProgram.get(e.programId) ?? [];
+            if (list.length < 3) list.push({ id: e.id, name: e.name, startAt: e.startAt });
+            upcomingByProgram.set(e.programId, list);
+        }
+
+        // RSVP rows for just those next-3 events. Raw rows (not groupBy) so each
+        // response can be bucketed volunteer-vs-participant by its (program, participant) key.
+        const upcomingEventIds = [...upcomingByProgram.values()].flat().map((e) => e.id);
+        const eventProgram = new Map<number, number>();
+        for (const [programId, evs] of upcomingByProgram) for (const e of evs) eventProgram.set(e.id, programId);
+        const rsvpRows = upcomingEventIds.length
+            ? await prisma.rSVP.findMany({
+                  where: { eventId: { in: upcomingEventIds } },
+                  select: { eventId: true, participantId: true, status: true },
+              })
+            : [];
+        const emptyTally = (): { participants: RsvpTally; volunteers: RsvpTally } => ({
+            participants: { yes: 0, maybe: 0, no: 0 },
+            volunteers: { yes: 0, maybe: 0, no: 0 },
+        });
+        const tallyByEvent = new Map<number, { participants: RsvpTally; volunteers: RsvpTally }>();
+        for (const r of rsvpRows) {
+            const t = tallyByEvent.get(r.eventId) ?? emptyTally();
+            const programId = eventProgram.get(r.eventId);
+            const bucket = programId !== undefined && volunteerKeys.has(`${programId}:${r.participantId}`) ? t.volunteers : t.participants;
+            if (r.status === "ATTENDING") bucket.yes += 1;
+            else if (r.status === "MAYBE") bucket.maybe += 1;
+            else if (r.status === "NOT_ATTENDING") bucket.no += 1;
+            tallyByEvent.set(r.eventId, t);
+        }
+
         result.lead = {
-            programs: ledPrograms.map((p) => ({ id: p.id, name: p.name, pending: pendingByProgram.get(p.id) ?? [] })),
+            programs: ledPrograms.map((p) => ({
+                id: p.id,
+                name: p.name,
+                totalEnrolled: enrolledByProgram.get(p.id) ?? 0,
+                pending: pendingByProgram.get(p.id) ?? [],
+                upcoming: (upcomingByProgram.get(p.id) ?? []).map((e) => {
+                    const t = tallyByEvent.get(e.id) ?? emptyTally();
+                    return { eventId: e.id, name: e.name, startAt: e.startAt.toISOString(), participants: t.participants, volunteers: t.volunteers };
+                }),
+            })),
         };
     }
 

--- a/checkin-app/src/app/my-programs/page.tsx
+++ b/checkin-app/src/app/my-programs/page.tsx
@@ -50,15 +50,51 @@ export default function MyProgramsHome() {
   );
 }
 
+const fmtSession = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-US", { timeZone: "America/Chicago", month: "short", day: "numeric" });
+
+type RsvpTally = LedProgram['upcoming'][number]['participants'];
+
+function RsvpRow({ label, tally }: { label: string; tally: RsvpTally }) {
+  return (
+    <Group justify="space-between" wrap="nowrap" mt={4}>
+      <Text size="xs" c="dimmed" w={90}>{label}</Text>
+      <Group gap="xs" wrap="nowrap">
+        <Badge color="green" variant="light">Yes {tally.yes}</Badge>
+        <Badge color="yellow" variant="light">Maybe {tally.maybe}</Badge>
+        <Badge color="red" variant="light">No {tally.no}</Badge>
+      </Group>
+    </Group>
+  );
+}
+
 function ProgramSection({ program }: { program: LedProgram }) {
   return (
     <Card withBorder radius="md" padding="lg">
-      <Group justify="space-between" mb="sm">
+      <Group justify="space-between" align="flex-start" mb="sm">
         <Title order={3}>{program.name}</Title>
         <Button component={Link} href={`/program-ops/programs/${program.id}`} variant="subtle" size="xs">
           Manage
         </Button>
       </Group>
+
+      <Text ta="center" fw={600} mb="md">
+        Total Enrolled: {program.totalEnrolled}
+      </Text>
+
+      {program.upcoming.length > 0 && (
+        <Stack gap="sm" mb="md">
+          <Text fw={600} size="sm">Next sessions</Text>
+          {program.upcoming.map((s) => (
+            <div key={s.eventId}>
+              <Text size="sm" fw={500}>{fmtSession(s.startAt)} — {s.name}</Text>
+              <RsvpRow label="Participants" tally={s.participants} />
+              <RsvpRow label="Volunteers" tally={s.volunteers} />
+            </div>
+          ))}
+        </Stack>
+      )}
+
       {program.pending.length === 0 ? (
         <Text c="dimmed" size="sm">No attendance to confirm.</Text>
       ) : (

--- a/checkin-app/src/app/program-ops/events/page.tsx
+++ b/checkin-app/src/app/program-ops/events/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { useRouter } from "next/navigation";
 import { Card, Center, Checkbox, Group, Loader, Stack, Table, Text, TextInput, Title } from "@mantine/core";
 
 type OneTimeEvent = {
@@ -26,7 +25,6 @@ export default function OneTimeEventsList() {
   const [futureOnly, setFutureOnly] = useState(true);
   // Snapshot "now" once on mount — Date.now() is impure and can't run during render.
   const [now] = useState(() => Date.now());
-  const router = useRouter();
 
   useEffect(() => {
     fetch("/api/events")
@@ -87,11 +85,7 @@ export default function OneTimeEventsList() {
             </Table.Thead>
             <Table.Tbody>
               {rows.map((e) => (
-                <Table.Tr
-                  key={e.id}
-                  onClick={() => router.push(`/admin/events/${e.id}`)}
-                  style={{ cursor: "pointer" }}
-                >
+                <Table.Tr key={e.id}>
                   <Table.Td>{e.name}</Table.Td>
                   <Table.Td>{fmt(e.startAt)}</Table.Td>
                   <Table.Td>{fmt(e.endAt)}</Table.Td>

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -17,6 +17,8 @@ type ParticipantDetail = {
   isCore?: boolean;
 };
 
+type RSVPStatus = "ATTENDING" | "NOT_ATTENDING" | "NO_RESPONSE" | "MAYBE";
+
 type EventData = {
   id: number;
   name: string;
@@ -38,6 +40,14 @@ type EventData = {
     arrivedAt: string;
     departedAt: string | null;
   }[];
+  rsvps: { participantId: number; status: RSVPStatus }[];
+};
+
+const RSVP_BADGE: Record<RSVPStatus, { label: string; color: string }> = {
+  ATTENDING: { label: 'Attending', color: 'green' },
+  MAYBE: { label: 'Maybe', color: 'yellow' },
+  NOT_ATTENDING: { label: 'Not attending', color: 'red' },
+  NO_RESPONSE: { label: 'No response', color: 'gray' },
 };
 
 export default function EventAdminPage({ params }: { params: Promise<{ id: string }> }) {
@@ -309,6 +319,61 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
     );
   };
 
+  const renderRsvpList = () => {
+    if (!eventData.program) return null;
+
+    const statusByParticipant = new Map(eventData.rsvps.map(r => [r.participantId, r.status]));
+    const roster = [
+      ...eventData.program.volunteers.map(v => ({ ...v, role: v.isCore ? 'Core Volunteer' : 'Volunteer' })),
+      ...eventData.program.participants.map(p => ({ ...p, role: 'Participant' })),
+    ];
+    const ROLE_RANK: Record<string, number> = { 'Core Volunteer': 1, 'Volunteer': 2, 'Participant': 3 };
+    roster.sort((a, b) =>
+      ROLE_RANK[a.role] !== ROLE_RANK[b.role]
+        ? ROLE_RANK[a.role] - ROLE_RANK[b.role]
+        : (a.participant.name || "").localeCompare(b.participant.name || "")
+    );
+
+    return (
+      <Card withBorder radius="md" padding="lg" mb="lg">
+        <Title order={4} mb="md">RSVPs</Title>
+        <Table.ScrollContainer minWidth={400}>
+          <Table verticalSpacing="sm">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Name</Table.Th>
+                <Table.Th>Role</Table.Th>
+                <Table.Th>RSVP</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {roster.map((member) => {
+                const badge = RSVP_BADGE[statusByParticipant.get(member.participantId) ?? 'NO_RESPONSE'];
+                return (
+                  <Table.Tr key={`${member.role}-${member.participantId}`}>
+                    <Table.Td>
+                      <Text fw={500}>{member.participant.name || 'Unnamed'}</Text>
+                      <Text size="xs" c="dimmed">{member.participant.email}</Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={member.role === 'Participant' ? 'cyan' : 'yellow'} variant="light">{member.role}</Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={badge.color} variant="light">{badge.label}</Badge>
+                    </Table.Td>
+                  </Table.Tr>
+                );
+              })}
+              {roster.length === 0 && (
+                <Table.Tr><Table.Td colSpan={3} ta="center"><Text c="dimmed" py="md">No roster found for this program.</Text></Table.Td></Table.Tr>
+              )}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      </Card>
+    );
+  };
+
   return (
     <Container size="lg" pb="md">
       <Card withBorder radius="md" padding="lg">
@@ -358,6 +423,9 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
             {renderRosterGrid()}
           </Card>
         )}
+
+        {/* ENROLLED INDIVIDUALS + RSVP STATUS */}
+        {renderRsvpList()}
 
         {/* FUTURE EVENT: EDIT / CANCEL */}
         {!isPastEvent && canManageEventInfo && (

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -10,6 +10,10 @@ const base: TodoCounts = {
 
 const item = (id: number) => ({ key: `attendance-${id}`, label: `Confirm attendance for E${id}`, href: `/program-ops/sessions/${id}` });
 
+// These tests only exercise pending-attendance counts; totalEnrolled/upcoming are filled to satisfy the type.
+const prog = (id: number, name: string, pending: ReturnType<typeof item>[] = []) =>
+  ({ id, name, pending, totalEnrolled: 0, upcoming: [] });
+
 describe('staff My Programs nav gate', () => {
   it('hidden when there is no lead bucket', () => {
     expect(leadsAnyProgram(null)).toBe(false);
@@ -21,7 +25,7 @@ describe('staff My Programs nav gate', () => {
   });
 
   it('shown once the caller leads ≥1 program — even with zero pending items', () => {
-    const counts: TodoCounts = { ...base, lead: { programs: [{ id: 1, name: 'A', pending: [] }] } };
+    const counts: TodoCounts = { ...base, lead: { programs: [prog(1, 'A')] } };
     expect(leadsAnyProgram(counts)).toBe(true);
   });
 });
@@ -32,9 +36,9 @@ describe('My Programs badge count', () => {
       ...base,
       lead: {
         programs: [
-          { id: 1, name: 'A', pending: [item(10), item(11)] },
-          { id: 2, name: 'B', pending: [item(20)] },
-          { id: 3, name: 'C', pending: [] },
+          prog(1, 'A', [item(10), item(11)]),
+          prog(2, 'B', [item(20)]),
+          prog(3, 'C'),
         ],
       },
     };
@@ -44,12 +48,12 @@ describe('My Programs badge count', () => {
   });
 
   it('renders no badge when nothing is pending (green is action-only)', () => {
-    const counts: TodoCounts = { ...base, lead: { programs: [{ id: 1, name: 'A', pending: [] }] } };
+    const counts: TodoCounts = { ...base, lead: { programs: [prog(1, 'A')] } };
     expect(navBadgeFor('/my-programs', counts)).toEqual([]);
   });
 
   it('singularizes the label for a single pending item', () => {
-    const counts: TodoCounts = { ...base, lead: { programs: [{ id: 1, name: 'A', pending: [item(10)] }] } };
+    const counts: TodoCounts = { ...base, lead: { programs: [prog(1, 'A', [item(10)])] } };
     expect(navBadgeFor('/my-programs', counts)[0].label).toBe('1 attendance item to confirm');
   });
 });


### PR DESCRIPTION
## What

Lead mentors had **no UI to see who RSVP'd** to their sessions. The `/api/events/[id]` payload already carried the roster but no page rendered it, and the `program-ops/events` list linked rows to a `/admin/events/[id]` page that never existed.

### Session detail (`program-ops/sessions/[id]`)
- New **RSVPs** card above the *Manage Event* bubble: lists enrolled **participants + volunteers** with a Role column (Core Volunteer / Volunteer / Participant).
- Status pulled from the existing payload; missing rows render as **No response**.

### My Programs (`my-programs`)
- Each program bubble now shows **Total Enrolled** (centered, upper area).
- For the **next 3 future sessions**, Yes / Maybe / No RSVP tallies — split into **Participants** vs **Volunteers** — shown **above** the attendance-confirm block.

### API (`/api/nav/todo-counts`)
- Lead surface extended with `totalEnrolled` (ACTIVE participants) and per-session, role-split RSVP tallies.
- Switched the tally query from `groupBy` to raw rows so each response can be bucketed volunteer-vs-participant by its `(program, participant)` key.

### Cleanup
- Removed the dead `program-ops/events` row link to the nonexistent `/admin/events/[id]`, plus the now-unused `useRouter`.

## Why
Leads can confirm attendance but couldn't see RSVPs at all — the data was already in the payload, just never surfaced.

## Reviewer notes
- `RSVPStatus.NO_RESPONSE` is intentionally omitted from the Yes/Maybe/No tallies (counts only explicit responses); it still renders as a badge on the detail roster.
- Volunteer vs participant split keys off `ProgramVolunteer` membership; core vs non-core volunteers are **not** separated in the my-programs tally.
- Enrollment surfaces are `@sensitivity:public` and the detail route is already staff-gated (see header comment in `events/[id]/route.ts`) — no new PII exposure.
- No tests added: changes are presentational + aggregations mirroring existing patterns in the same files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)