### PR TITLE
fix(attendance): relabel adults column + align top margin

### DIFF
--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -319,7 +319,7 @@ function KioskDisplayInner() {
   const userId = (session?.user as SessionUser)?.id;
 
   return (
-    <Box style={isKioskMode ? { cursor: "none", marginTop: -12, paddingLeft: 8 } : { marginTop: -12, paddingLeft: 8 }}>
+    <Box style={isKioskMode ? { cursor: "none", marginTop: -25, paddingLeft: 8 } : { marginTop: -25, paddingLeft: 8 }}>
       {!isKioskMode && (
         <Box style={{ maxWidth: 1200, margin: "0 auto" }}>
           <AttendanceTabs />
@@ -423,7 +423,7 @@ function KioskDisplayInner() {
         ) : (
           <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
             {renderColumn("🔑", counts.keyholders, "Keyholders", "blue", isFull ? keyholderList : householdKeyholders)}
-            {renderColumn("🤝", counts.volunteers, "Volunteers", "teal", isFull ? volunteerList : householdVolunteers)}
+            {renderColumn("🤝", counts.volunteers, "Volunteers/Adults", "teal", isFull ? volunteerList : householdVolunteers)}
             {renderColumn("🎓", counts.students, "Students", "grape", isFull ? studentList : householdStudents)}
           </SimpleGrid>
         )}


### PR DESCRIPTION
## What

- Rename the **Volunteers** column on `/attendance/current` to **Volunteers/Adults**.
- Bump the page's top margin from `-12` to `-25` to match the standard `PageContainer` offset.

## Why

- The column lists every checked-in non-keyholder adult (`!isKeyholder && !isStudent`), not actual program volunteers — labeling them all "Volunteers" was misleading. The kiosk renders the same page, so it's corrected there too.
- `/attendance/current` sat lower than the rest of the attendance tabs (e.g. `/attendance/manual`, which uses `PageContainer` at `marginTop: -25`). Aligning the offset stops headings from shifting when switching tabs.

## Notes for reviewer

- Counts are still bucketed by keyholder / student / adult; the label is now accurate but true volunteer status isn't tracked on visits (would need the program-volunteer join). Out of scope here.