### PR TITLE
fix(programs): hide force-enroll override from non-staff users

### DIFF
--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -365,7 +365,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                 )}
               </Stack>
 
-              {requiresOverride && (
+              {requiresOverride && canManage && (
                 <Alert color="yellow" variant="light" mt="lg" title="Warning: Enrollment rules not met.">
                   <Text size="sm" mb="md">
                     As an Admin or Lead Mentor, you can bypass this restriction. Are you sure you want


### PR DESCRIPTION
## What

Gate the "Force Enroll (Override)" warning on the program enrollment page behind the existing `canManage` check (sysadmin || board || program lead mentor).

## Why

The page rendered the override Alert whenever the enroll API returned `requiresOverride: true` (age/DOB/closed/capacity rules not met) — with **no staff check**. So any user, including a youth on `/programs/[id]`, saw:

> Warning: Enrollment rules not met. As an Admin or Lead Mentor, you can bypass this restriction. Are you sure you want to force enroll?

The backend only honors the override for sysadmin/board/lead mentor (`enforceLimits = !override || !isSysAdminOrBoard`), so non-staff could never actually force-enroll — they were just shown a bypass prompt they can't use.

## Change

`{requiresOverride && (` → `{requiresOverride && canManage && (` in `checkin-app/src/app/programs/[id]/page.tsx`.

Non-staff now see the plain error message instead of the override option. No backend change — backend already blocked the action; this only removes the misleading UI.

## Reviewer notes

- Scope is UI-only; this is not a permissions hole (backend was already safe).
- Out of scope: whether youth should be able to self/household-enroll at all — the household self-enroll card itself is unchanged and intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)