### PR TITLE
feat(communication): disable email prefs when user has no email

### DIFF
--- a/checkin-app/src/app/communication/page.tsx
+++ b/checkin-app/src/app/communication/page.tsx
@@ -3,12 +3,21 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { Alert, Card, Center, Checkbox, Loader, Stack, Text, Title } from '@mantine/core';
+import { Alert, Card, Center, Checkbox, Loader, Stack, Text, Title, Tooltip } from '@mantine/core';
 import { PageContainer } from '@/components/ui/PageContainer';
+
+const OPTIONS = [
+  { key: 'emailCheckinReceipts', label: 'Email me when I check in or out' },
+  { key: 'emailDependentCheckins', label: 'Email me realtime receipts when my dependents check in/out' },
+  { key: 'emailNewsletter', label: 'Subscribe to the monthly newsletter' },
+  { key: 'notifyNewPrograms', label: 'Notify me when a new program is announced' },
+  { key: 'notifyEventReminders', label: 'Notify me before my events start' },
+] as const;
 
 export default function CommunicationPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const hasEmail = !!session?.user?.email;
 
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState("");
@@ -85,31 +94,21 @@ export default function CommunicationPage() {
         <Text c="dimmed" mb="lg">Manage your email and notification preferences.</Text>
 
         <Stack>
-          <Checkbox
-            checked={settings.emailCheckinReceipts}
-            onChange={(e) => persist({ emailCheckinReceipts: e.currentTarget.checked })}
-            label="Email me when I check in or out"
-          />
-          <Checkbox
-            checked={settings.emailDependentCheckins}
-            onChange={(e) => persist({ emailDependentCheckins: e.currentTarget.checked })}
-            label="Email me realtime receipts when my dependents check in/out"
-          />
-          <Checkbox
-            checked={settings.emailNewsletter}
-            onChange={(e) => persist({ emailNewsletter: e.currentTarget.checked })}
-            label="Subscribe to the monthly newsletter"
-          />
-          <Checkbox
-            checked={settings.notifyNewPrograms}
-            onChange={(e) => persist({ notifyNewPrograms: e.currentTarget.checked })}
-            label="Notify me when a new program is announced"
-          />
-          <Checkbox
-            checked={settings.notifyEventReminders}
-            onChange={(e) => persist({ notifyEventReminders: e.currentTarget.checked })}
-            label="Notify me before my events start"
-          />
+          {/* Every preference is delivered by email, so all are disabled without one. */}
+          {OPTIONS.map((opt) => (
+            <Tooltip
+              key={opt.key}
+              label="Add an email to enable communication"
+              disabled={hasEmail}
+            >
+              <Checkbox
+                checked={settings[opt.key]}
+                disabled={!hasEmail}
+                onChange={(e) => persist({ [opt.key]: e.currentTarget.checked })}
+                label={opt.label}
+              />
+            </Tooltip>
+          ))}
         </Stack>
 
         {message && <Alert color="red" mt="md">{message}</Alert>}


### PR DESCRIPTION
## What

On `/communication`, all five preferences are delivered by email. They are now disabled (grayed out) when the signed-in user has no email address, with a tooltip: **"Add an email to enable communication."**

Also collapses the five repeated `<Checkbox>` blocks into a single `OPTIONS` map.

## Why

The page was inconsistent — the "Notify me…" items are also email-delivered, but nothing stopped an emailless user from toggling settings that could never fire.

## Reviewer notes

- `hasEmail` derives from `session.user.email`.
- Tooltip's `disabled={hasEmail}` so it only appears when the controls are blocked. Mantine disables the input while the root div still receives hover, so the tooltip fires over a disabled checkbox.
- UI-only guard; no server-side PATCH change. Add a backend guard if emailless users hitting `/api/profile` directly becomes a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)