### PR TITLE
fix(program-ops): block program creation with end date before start

### DIFF
--- a/checkin-app/src/app/program-ops/new/page.tsx
+++ b/checkin-app/src/app/program-ops/new/page.tsx
@@ -38,9 +38,12 @@ export default function CreateProgramPage() {
   const [leadMentorId, setLeadMentorId] = useState("");
   const [mentorSearch, setMentorSearch] = useState("");
 
+  // End date before start date is invalid (ISO date strings compare lexically).
+  const datesInvalid = Boolean(startAt && endAt && endAt < startAt);
+
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name) return;
+    if (!name || datesInvalid) return;
 
     setSaving(true);
     setMessage("");
@@ -142,8 +145,22 @@ export default function CreateProgramPage() {
             </SimpleGrid>
 
             <SimpleGrid cols={{ base: 1, sm: 2 }}>
-              <TextInput type="date" label="Start Date" value={startAt} onChange={(e) => setStartAt(e.currentTarget.value)} />
-              <TextInput type="date" label="End Date" value={endAt} onChange={(e) => setEndAt(e.currentTarget.value)} />
+              <TextInput
+                type="date"
+                label="Start Date"
+                value={startAt}
+                onChange={(e) => setStartAt(e.currentTarget.value)}
+                error={datesInvalid}
+                styles={datesInvalid ? { input: { color: 'var(--mantine-color-red-7)' } } : undefined}
+              />
+              <TextInput
+                type="date"
+                label="End Date"
+                value={endAt}
+                onChange={(e) => setEndAt(e.currentTarget.value)}
+                error={datesInvalid ? 'End date must be on or after start date.' : false}
+                styles={datesInvalid ? { input: { color: 'var(--mantine-color-red-7)' } } : undefined}
+              />
             </SimpleGrid>
 
             <Card withBorder radius="md" padding="md">
@@ -197,7 +214,7 @@ export default function CreateProgramPage() {
             />
 
             <Group justify="flex-end">
-              <Button type="submit" color="green" disabled={saving || !name.trim() || !leadMentorId} loading={saving}>
+              <Button type="submit" color="green" disabled={saving || !name.trim() || !leadMentorId || datesInvalid} loading={saving}>
                 Create Program
               </Button>
             </Group>


### PR DESCRIPTION
## What

The Create Program form (`/program-ops/new`) allowed a program to be created with an **end date earlier than the start date**.

## Changes
- Added `datesInvalid` check (`endAt < startAt`, ISO date strings compare lexically — no `Date` parse needed).
- Both date fields get a **red border** (`error` prop) and **red date text** (`styles`) when the range is invalid.
- End Date field shows the message: *"End date must be on or after start date."*
- Create button is disabled and the submit handler early-returns while invalid.

## Notes for reviewer
- Client-side only. The `/api/programs` endpoint is not guarded — the form is currently the only caller. Add a server check if defense-in-depth is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)