### PR TITLE
feat(program-ops): add enrollment column, rename Visibility to Access

### DIFF
--- a/checkin-app/src/app/program-ops/programs/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/page.tsx
@@ -10,6 +10,7 @@ type Program = {
   id: number;
   name: string;
   phase?: string;
+  enrollmentStatus?: "OPEN" | "CLOSED";
   memberOnly?: boolean;
   startAt?: string | null;
   endAt?: string | null;
@@ -89,6 +90,15 @@ export default function AdminProgramsIndex() {
       sortBy: (p) => p.phase ?? "",
     },
     {
+      header: "Enrollment",
+      render: (p) => (
+        <Badge color={p.enrollmentStatus === "OPEN" ? "green" : "gray"} variant="light">
+          {p.enrollmentStatus === "OPEN" ? "Open" : "Closed"}
+        </Badge>
+      ),
+      sortBy: (p) => p.enrollmentStatus ?? "CLOSED",
+    },
+    {
       header: "Participants",
       align: "right",
       render: (p) => p._count?.participants ?? 0,
@@ -101,7 +111,7 @@ export default function AdminProgramsIndex() {
       sortBy: (p) => p._count?.events ?? 0,
     },
     {
-      header: "Visibility",
+      header: "Access",
       render: (p) => (
         <Badge color={p.memberOnly ? 'grape' : 'blue'} variant="light">
           {p.memberOnly ? 'Member Only' : 'Public'}


### PR DESCRIPTION
## What

On `/program-ops/programs`:

- **New "Enrollment" column** between Phase and Participants — green "Open" / gray "Closed" badge from each program's `enrollmentStatus`.
- **Renamed "Visibility" → "Access"** (member-only vs public).

## Why

Ops needed enrollment open/closed visible in the index without opening each program's detail page.

## Notes

- No API change — `/api/programs` uses `findMany` with no `select`, so the `enrollmentStatus` scalar was already in the payload. Only the client `Program` type + table columns changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)