### PR TITLE
feat(my-programs): replace attendance subtabs with name filter

### DIFF
--- a/checkin-app/src/app/my-programs/page.tsx
+++ b/checkin-app/src/app/my-programs/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { useState } from 'react';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
-import { Badge, Button, Card, Group, Stack, Tabs, Text, Title } from '@mantine/core';
-import { IconCalendarCheck } from '@tabler/icons-react';
+import { Badge, Button, Card, Group, Stack, Text, TextInput, Title } from '@mantine/core';
+import { IconCalendarCheck, IconSearch } from '@tabler/icons-react';
 import { useTodoCounts } from '@/hooks/useTodoCounts';
 import type { TodoCounts } from '@/app/api/nav/todo-counts/route';
 
@@ -20,33 +21,38 @@ type LedProgram = NonNullable<TodoCounts['lead']>['programs'][number];
 export default function MyProgramsHome() {
   const { status } = useSession();
   const counts = useTodoCounts(status === 'authenticated');
+  const [filter, setFilter] = useState('');
 
   const programs = counts?.lead?.programs ?? [];
   if (programs.length === 0) return null; // layout shows loader / redirects non-leads
 
   if (programs.length === 1) return <ProgramSection program={programs[0]} />;
 
+  // ponytail: filter over the names already in the payload (program + session).
+  // Participant/volunteer names aren't fetched here — add to todo-counts route to match those.
+  const q = filter.trim().toLowerCase();
+  const shown = q
+    ? programs.filter((p) =>
+        p.name.toLowerCase().includes(q) ||
+        p.upcoming.some((s) => s.name.toLowerCase().includes(q)) ||
+        p.pending.some((i) => i.label.toLowerCase().includes(q)))
+    : programs;
+
   return (
-    <Tabs defaultValue="all">
-      <Tabs.List mb="md">
-        <Tabs.Tab value="all">All Programs</Tabs.Tab>
-        {programs.map((p) => (
-          <Tabs.Tab key={p.id} value={String(p.id)} rightSection={p.pending.length > 0 ? <Badge size="sm" circle color="treehouseGreen">{p.pending.length}</Badge> : undefined}>
-            {p.name}
-          </Tabs.Tab>
-        ))}
-      </Tabs.List>
-      <Tabs.Panel value="all">
-        <Stack>
-          {programs.map((p) => <ProgramSection key={p.id} program={p} />)}
-        </Stack>
-      </Tabs.Panel>
-      {programs.map((p) => (
-        <Tabs.Panel key={p.id} value={String(p.id)}>
-          <ProgramSection program={p} />
-        </Tabs.Panel>
-      ))}
-    </Tabs>
+    <Stack>
+      <TextInput
+        placeholder="Filter by program or session name"
+        leftSection={<IconSearch size={16} />}
+        value={filter}
+        onChange={(e) => setFilter(e.currentTarget.value)}
+        maw={360}
+      />
+      {shown.length === 0 ? (
+        <Text c="dimmed" size="sm">No programs match “{filter}”.</Text>
+      ) : (
+        shown.map((p) => <ProgramSection key={p.id} program={p} />)
+      )}
+    </Stack>
   );
 }
 


### PR DESCRIPTION
## What

Replaces the per-program subtabs on **My Programs → Attendance** with a single text filter.

Lead mentors who run multiple programs previously got one tab per program (plus an "All Programs" tab) and had to click through to find a session. Now a single filter input matches on **program name** or **session name**, rendering all matching program cards inline.

## Why

Subtabs scaled poorly and buried sessions. A filter is faster for the "find this session" task and removes the tab chrome.

## Notes for reviewer

- Filter matches over fields **already in the `todo-counts` payload** (program name, upcoming session names, pending-attendance labels) — no new API calls.
- Single-program leads are unchanged: one card, no filter shown.
- **Participant/volunteer name filtering is intentionally not included.** Those names aren't in the `todo-counts` payload — only RSVP tallies (counts). Adding them means new roster queries plus rendering participant (incl. minor) names on a searchable surface, which is a PII/sensitivity-tier decision. Happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)