### PR TITLE
feat(profile): make youth profiles read-only

### DIFF
--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { handler, notFound, unauthorized } from "@/security/handler";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
+import { isMinor } from "@/lib/time";
 
 export const GET = handler('GET /api/profile', async ({ auth }) => {
     if (auth.type !== 'session') throw unauthorized();
@@ -26,6 +27,14 @@ export const PATCH = withAuth(
         try {
             if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
             const userId = auth.user.id;
+
+            const me = await prisma.participant.findUnique({
+                where: { id: userId },
+                select: { dateOfBirth: true },
+            });
+            if (isMinor(me?.dateOfBirth)) {
+                return NextResponse.json({ error: "Youth profiles are read-only." }, { status: 403 });
+            }
 
             const body = await req.json();
             const { name, phone, dob, notificationSettings } = body;

--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Anchor, Button, Card, Center, Loader, Stack, Text, TextInput, Title } from '@mantine/core';
 import { PageContainer } from '@/components/ui/PageContainer';
+import { isMinor } from '@/lib/time';
 
 export default function ProfilePage() {
   const { data: session, status } = useSession();
@@ -83,26 +84,34 @@ export default function ProfilePage() {
 
   if (!session) return null; // Fallback while router redirects
 
+  const readOnly = isMinor(form.dob);
+
   return (
     <PageContainer>
       <Card withBorder radius="md" padding="lg" maw={620}>
         <Title order={1}>My Profile</Title>
-          <Text c="dimmed" mb="lg">Manage your personal information and contact details.</Text>
+          <Text c="dimmed" mb="lg">
+            {readOnly
+              ? "View your personal information. Ask a parent or staff member to make changes."
+              : "Manage your personal information and contact details."}
+          </Text>
 
           <form onSubmit={handleSubmit}>
             <Stack>
               <TextInput label="Email Address" value={form.email} disabled title="Email cannot be changed here." />
-              <TextInput label="Full Name" required value={form.name} onChange={(e) => setForm({ ...form, name: e.currentTarget.value })} placeholder="e.g. Jane Doe" />
-              <TextInput type="tel" label="Phone Number" required value={form.phone} onChange={(e) => setForm({ ...form, phone: e.currentTarget.value })} placeholder="(555) 123-4567" />
-              <TextInput type="date" label="Date of Birth" value={form.dob} onChange={(e) => setForm({ ...form, dob: e.currentTarget.value })} />
+              <TextInput label="Full Name" required value={form.name} onChange={(e) => setForm({ ...form, name: e.currentTarget.value })} placeholder="e.g. Jane Doe" disabled={readOnly} />
+              <TextInput type="tel" label="Phone Number" required value={form.phone} onChange={(e) => setForm({ ...form, phone: e.currentTarget.value })} placeholder="(555) 123-4567" disabled={readOnly} />
+              <TextInput type="date" label="Date of Birth" value={form.dob} onChange={(e) => setForm({ ...form, dob: e.currentTarget.value })} disabled={readOnly} />
 
               <Text size="sm" c="dimmed">
                 Your address is managed on the <Anchor href="/my-household">Household</Anchor> page.
               </Text>
 
-              <Button type="submit" disabled={saving} loading={saving} mt="sm">
-                Save Profile
-              </Button>
+              {!readOnly && (
+                <Button type="submit" disabled={saving} loading={saving} mt="sm">
+                  Save Profile
+                </Button>
+              )}
             </Stack>
           </form>
 


### PR DESCRIPTION
## What

Youth (participants under 18) now get a read-only view at `/profile` and cannot alter any of their own data.

## Why

A minor's profile should be edited by a parent or staff member, not the youth themselves.

## Changes

**Server — the real enforcement boundary** (`checkin-app/src/app/api/profile/route.ts`)
- `PATCH /api/profile` loads the caller's `dateOfBirth` and returns `403` when `isMinor`. Blocks direct API calls regardless of the UI.

**Client** (`checkin-app/src/app/profile/page.tsx`)
- `readOnly = isMinor(form.dob)` disables the Name, Phone, and DOB inputs (Email was already locked for everyone), hides the Save button, and swaps the subtitle to "ask a parent or staff member."

Youth = under 18 via the canonical `isMinor` helper (`src/lib/time.ts`).

## Reviewer notes
- Two-layer: client hides controls, server rejects — so a crafted PATCH still 403s.
- No tests added. Suggested coverage: minor PATCH → 403, adult PATCH → 200.