### PR TITLE
fix(admin): stop nesting heading in modal title

### DIFF
--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Alert, Button, Group, Loader, Modal, SimpleGrid, Stack, Text, TextInput, Title } from "@mantine/core";
+import { Alert, Button, Group, Loader, Modal, SimpleGrid, Stack, Text, TextInput } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
 
@@ -132,7 +132,7 @@ export function AdminEditHouseholdModal({
         opened={opened}
         onClose={requestClose}
         size="lg"
-        title={<Title order={4}>Edit Household Info{displayName ? ` — ${displayName}` : ""}</Title>}
+        title={<Text fw={600} size="lg">Edit Household Info{displayName ? ` — ${displayName}` : ""}</Text>}
       >
         {loading ? (
           <Group justify="center" py="xl">
@@ -198,7 +198,7 @@ export function AdminEditHouseholdModal({
         onClose={() => setConfirming(false)}
         size="sm"
         zIndex={1100}
-        title={<Title order={5}>Use admin powers?</Title>}
+        title={<Text fw={600}>Use admin powers?</Text>}
       >
         <Alert color="orange" mb="md">
           You&apos;re editing <strong>{displayName}</strong>, a household you&apos;re not a member of. This


### PR DESCRIPTION
## What

Mantine `Modal` renders the `title` prop inside an `<h2>`. The two modal titles in `AdminEditHouseholdModal` passed `<Title order={4|5}>`, emitting an `<h4>`/`<h5>` nested inside that `<h2>` — invalid HTML that throws a React hydration error in the console.

## Fix

Swap both `<Title>` for `<Text fw={600}>` (renders a `<div>`), keeping the heading look without a nested heading tag. Dropped the now-unused `Title` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)