### PR TITLE
fix(modals): fix invalid <h4>-in-<h2> nesting in Modal titles

### DIFF
--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -440,7 +440,7 @@ function KioskDisplayInner() {
       </Card>
 
       {/* Admin Sign Out Modal */}
-      <Modal opened={showSignOutModal} onClose={() => setShowSignOutModal(false)} title={<Title order={4}>Sign Out A User</Title>} size="lg">
+      <Modal opened={showSignOutModal} onClose={() => setShowSignOutModal(false)} title={<Text span fw={700} fz="lg">Sign Out A User</Text>} size="lg">
         <TextInput
           placeholder="Search checked-in users..."
           value={searchSignOutQuery}
@@ -476,7 +476,7 @@ function KioskDisplayInner() {
       <Modal
         opened={!!selectedParticipant}
         onClose={() => setSelectedParticipant(null)}
-        title={<Title order={4} c="yellow">🆘 Emergency Contact Info</Title>}
+        title={<Text span fw={700} fz="lg" c="yellow">🆘 Emergency Contact Info</Text>}
         centered
       >
         {selectedParticipant && (

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Alert, Box, Button, Card, Group, Modal, Paper, Stack, Table, Text, TextInput, Title, UnstyledButton } from "@mantine/core";
+import { Alert, Box, Button, Card, Group, Modal, Paper, Stack, Table, Text, TextInput, UnstyledButton } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons-react";
 import { EntityPicker } from "@/components/admin/EntityPicker";
@@ -259,7 +259,7 @@ export default function AdminParticipantsIndex() {
       </Card>
 
       {/* Assign household modal */}
-      <Modal opened={assignModalOpen} onClose={closeAssign} title={<Title order={4}>Assign Household to {selectedParticipant?.name}</Title>} size="lg">
+      <Modal opened={assignModalOpen} onClose={closeAssign} title={<Text span fw={700} fz="lg">Assign Household to {selectedParticipant?.name}</Text>} size="lg">
         {selectedParticipant?.household && (
           <Paper withBorder radius="md" p="md" mb="md">
             <Text size="sm" fw={600} c="dimmed" mb="xs">Current Household: {selectedParticipant.household.name}</Text>
@@ -318,7 +318,7 @@ export default function AdminParticipantsIndex() {
       </Modal>
 
       {/* Edit participant modal */}
-      <Modal opened={editModalOpen} onClose={() => { setEditModalOpen(false); setEditingParticipant(null); }} title={<Title order={4}>Edit Participant</Title>} size="lg">
+      <Modal opened={editModalOpen} onClose={() => { setEditModalOpen(false); setEditingParticipant(null); }} title={<Text span fw={700} fz="lg">Edit Participant</Text>} size="lg">
         <form onSubmit={handleEditParticipant}>
           <Stack>
             <TextInput label="Name" required value={editForm.name} onChange={(e) => setEditForm(f => ({ ...f, name: e.currentTarget.value }))} />

--- a/checkin-app/src/app/page.tsx
+++ b/checkin-app/src/app/page.tsx
@@ -272,7 +272,7 @@ export default function Home() {
       <Modal
         opened={showBoardDirectory}
         onClose={() => setShowBoardDirectory(false)}
-        title={<Title order={4}>Board Directory</Title>}
+        title={<Text span fw={700} fz="lg">Board Directory</Text>}
         centered
       >
         {loadingBoard ? (

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -483,7 +483,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
       <Modal
         opened={!!editingAttendance}
         onClose={() => !actionLoading && setEditingAttendance(null)}
-        title={<Title order={4}>Manual Edit: {editingAttendance?.participant.name}</Title>}
+        title={<Text span fw={700} fz="lg">Manual Edit: {editingAttendance?.participant.name}</Text>}
         centered
       >
         <Stack>


### PR DESCRIPTION
## What

Six modals passed `<Title order={4}>` as the Mantine `Modal` `title` prop. Mantine wraps that title in an `<h2>`, so the `<Title>` (an `<h4>`) became a heading nested inside a heading — invalid HTML that triggered a React hydration error:

> In HTML, `<h4>` cannot be a child of `<h2>`.

Swapped each to `<Text span fw={700} fz="lg">`, which renders inline (phrasing content, valid inside `<h2>`) while preserving the order-4 size/weight. Removed the now-unused `Title` import in `participants/page.tsx`.

## Files

- `src/app/page.tsx` — Board Directory modal
- `src/app/attendance/current/page.tsx` — Sign Out + Emergency Contact modals
- `src/app/membership-ops/participants/page.tsx` — Assign Household + Edit Participant modals (+ dropped `Title` import)
- `src/app/program-ops/sessions/[id]/page.tsx` — Manual Edit modal

## Notes for reviewer

- `fz="lg"` ≈ Mantine h4 font-size (~1.125rem); visual should match. Flag if any title looks off.
- Pre-existing `tsc` errors around `@/generated/prisma/client` in `api/` routes are unrelated (Prisma not generated in worktree); no new errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)