### PR TITLE
fix(membership-ops): rename tabs + fix invisible Broken Households count

### DIFF
--- a/checkin-app/src/app/membership-ops/layout.tsx
+++ b/checkin-app/src/app/membership-ops/layout.tsx
@@ -71,6 +71,9 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
                       size="md"
                       color={isBroken ? "treehouseGreen" : "gray"}
                       variant={isBroken ? "filled" : "light"}
+                      // Active tab recolors its content to the tabs color (green); pin a readable
+                      // label color so the count isn't rendered green-on-green on the active tab.
+                      c={isBroken ? "var(--mantine-color-black)" : "var(--mantine-color-gray-7)"}
                       aria-label={isBroken ? `${todoCount} household${todoCount === 1 ? "" : "s"} without a lead` : `${todoCount} application${todoCount === 1 ? "" : "s"}`}
                     >
                       {todoCount}
@@ -80,6 +83,7 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
                       size="md"
                       color="gray"
                       variant="light"
+                      c="var(--mantine-color-gray-7)"
                       aria-label={`${memberFamilies} member famil${memberFamilies === 1 ? "y" : "ies"}`}
                     >
                       {memberFamilies}

--- a/checkin-app/src/lib/membershipOpsNav.ts
+++ b/checkin-app/src/lib/membershipOpsNav.ts
@@ -29,9 +29,9 @@ export const MEMBERSHIP_OPS_NAV_LINKS: MembershipOpsNavLink[] = [
   // API route are kept intact. See it.failing cases ("should keep the HIGHER" / "should keep the
   // ACTIVE") in src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts.
   // { name: "Merge Participants", href: "/membership-ops/participants/merge", icon: "🔗", description: "Combine duplicate participant records." },
-  { name: "Manage Memberships", href: "/membership-ops/households", icon: "🏠", description: "Grant or revoke household facility membership." },
+  { name: "Households", href: "/membership-ops/households", icon: "🏠", description: "Grant or revoke household facility membership." },
   { name: "Volunteer Memberships", href: "/membership-ops/volunteer-memberships", icon: "🙋", description: "Designate volunteer-only emails for reduced dues." },
-  { name: "Membership Applications", href: "/membership-ops/applications", icon: "📋", description: "Review and approve membership applications." },
+  { name: "Applications", href: "/membership-ops/applications", icon: "📋", description: "Review and approve membership applications." },
   // "Unclaimed Accounts" moved to Membership Audit (/membership-audit/unclaimed).
   { name: "Background-check Review", href: "/membership-ops/review", icon: "🔍", description: "Review submitted membership background checks." },
   { name: "Broken Households", href: "/membership-ops/broken", icon: "⚠️", description: "Households with no lead — assign one so the family can be claimed." },


### PR DESCRIPTION
## What

- Rename Membership Ops top tabs: **Manage Memberships → Households**, **Membership Applications → Applications**.
- Fix the Broken Households count badge showing a green dot with no number on the active tab.

## Why

The count badge was rendering **green-on-green**. Mantine recolors an active tab's content to the tabs color (`treehouseGreen`); the Broken Households badge is `variant="filled" color="treehouseGreen"`, so its number inherited green text on a green background — present in the DOM (`<span>6</span>`) but invisible. The same count showed fine in the left sidebar, where the label inherits white/dark instead of green.

Fix pins an explicit, readable label color (`c=`) on the tab count badges so the number no longer inherits the active tab's green.

## Notes for reviewer

- Applied the color pin to all three tab count badges (broken, applications, member-families) so the active-tab green bleed can't recur on any of them.
- No data/logic changes — the counts themselves were always correct (they already showed in the left nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)