### PR TITLE
fix(app-frame): resolve color-scheme toggle hydration mismatch

### DIFF
--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -5,6 +5,7 @@ import {
   ActionIcon,
   AppShell,
   Badge,
+  Box,
   Burger,
   Button,
   Group,
@@ -12,7 +13,6 @@ import {
   Title,
   Tooltip,
   useMantineColorScheme,
-  useComputedColorScheme,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
@@ -146,19 +146,20 @@ function isActive(pathname: string, href: string): boolean {
 }
 
 function ColorSchemeToggle() {
-  const { setColorScheme } = useMantineColorScheme();
-  const computed = useComputedColorScheme('light', { getInitialValueInEffect: true });
-  const isDark = computed === 'dark';
+  const { toggleColorScheme } = useMantineColorScheme();
+  // ponytail: render both icons, let Mantine's light/darkHidden CSS pick.
+  // Branching on the scheme in JS causes an SSR hydration mismatch.
   return (
-    <Tooltip label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}>
+    <Tooltip label="Toggle color scheme">
       <ActionIcon
         variant="subtle"
         color="gray"
         size="lg"
         aria-label="Toggle color scheme"
-        onClick={() => setColorScheme(isDark ? 'light' : 'dark')}
+        onClick={toggleColorScheme}
       >
-        {isDark ? <IconSun size={18} /> : <IconMoon size={18} />}
+        <Box component={IconMoon} size={18} darkHidden />
+        <Box component={IconSun} size={18} lightHidden />
       </ActionIcon>
     </Tooltip>
   );


### PR DESCRIPTION
## What

Fix the React hydration error thrown by `ColorSchemeToggle` in `AppFrame.tsx`.

## Why

The toggle branched on the color scheme at render time (`isDark ? <IconSun/> : <IconMoon/>`). During SSR the scheme defaults to `light`, so the server emitted the light-mode icon; on the client, hydration read the stored `dark` scheme and rendered the other icon. The differing SVG markup tripped:

> Hydration failed because the server rendered HTML didn't match the client.

## How

- Render **both** icons unconditionally and let Mantine's `darkHidden` / `lightHidden` CSS pick the visible one — identical server and client HTML, no JS branch.
- Switch `onClick` to `toggleColorScheme`, so it no longer depends on `isDark`.
- Drop the now-unused `useComputedColorScheme` import.

## Reviewer notes

- Behavior is unchanged: click toggles light/dark; correct icon shows per scheme.
- Verify manually: open the app, toggle the button, confirm no hydration warning in the console.