### PR TITLE
fix(membership-ops): make households member-family count readable

### DIFF
--- a/checkin-app/src/app/membership-ops/layout.tsx
+++ b/checkin-app/src/app/membership-ops/layout.tsx
@@ -87,8 +87,8 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
                     <Badge
                       size="md"
                       color="gray"
-                      variant="light"
-                      c="var(--mantine-color-gray-7)"
+                      variant="filled"
+                      c="white"
                       aria-label={`${memberFamilies} member famil${memberFamilies === 1 ? "y" : "ies"}`}
                     >
                       {memberFamilies}


### PR DESCRIPTION
## What

The member-family counter badge on the **Manage Memberships** (households) subtab rendered gray text on a light-gray background (poor contrast). Switch it from `variant="light"` gray + gray-7 text to `variant="filled"` gray + white text.

## Why

Reported as unreadable gray-on-gray. `light` gives a near-white background, so white text alone wouldn't fix it — the filled solid-gray background is what makes white text readable.

## Scope

Only the households `memberFamilies` badge changes. The applications count (gray light) and broken-households count (filled green, black text) badges are untouched, so their dark text is preserved.