### PR TITLE
fix(nav): dark text on light-gray count badges

### DIFF
--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -314,6 +314,8 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                           color={badge.color}
                           variant="filled"
                           aria-label={badge.label}
+                          // Gray fill is light; white text on it fails contrast. Force dark text.
+                          styles={badge.color === 'gray' ? { label: { color: 'var(--mantine-color-dark-9)' } } : undefined}
                         >
                           {badge.count}
                         </Badge>


### PR DESCRIPTION
## What
Gray informational count badges in the nav bar now render dark text instead of white.

## Why
The gray badges use Mantine's `filled` variant, whose light-gray fill left white text nearly unreadable (contrast failure). Dark text (`dark-9`) is now forced on gray badges only.

## Notes for reviewer
- Change is scoped to `AppFrame.tsx`: a conditional `styles.label` override applied only when `badge.color === 'gray'`.
- Green (`treehouseGreen`) action badges are untouched — their darker fill reads fine with white text.
- If a second light-fill badge color is ever added, swap the `=== 'gray'` check for a set.