### PR TITLE
fix(membership-ops): restore BG-check review access; board = implicit reviewer

### DIFF
--- a/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
@@ -214,18 +214,18 @@ describe('Protected-route role rejection', () => {
         });
     });
 
-    // ---- membership/reviews POST — isBackgroundCheckReviewer PII boundary -------
-    // The attestation surface exposes applicant parents' names/emails. A
-    // isKeyholder or isBoardMember WITHOUT isBackgroundCheckReviewer status must be
-    // denied (mirror participants/search rejecting a isKeyholder). The 401/403/
-    // /plain cases are covered in the roleGated table above; this proves a
-    // privileged-but-wrong-role user does not slip through.
-    describe('POST /api/membership/reviews — non-reviewer privileged user', () => {
-        it('403 for a isBoardMember without isBackgroundCheckReviewer', async () => {
+    // ---- membership/reviews POST — reviewer PII boundary ----------------------
+    // The attestation surface exposes applicant parents' names/emails. Reviewers
+    // AND board members (implicit reviewers, canReviewBackgroundChecks) may pass;
+    // any other privileged-but-wrong role (e.g. isKeyholder) must be denied. A
+    // board member clears the role gate and stops at body validation (400, not
+    // 403); a keyholder is rejected at the gate.
+    describe('POST /api/membership/reviews — privileged role gate', () => {
+        it('board member passes the role gate (400 bad body, not 403)', async () => {
             as(plainId, { householdId: plainHh, isBoardMember: true });
-            expect((await REVIEWS_POST(nreq('http://localhost/api/membership/reviews', 'POST', {}))).status).toBe(403);
+            expect((await REVIEWS_POST(nreq('http://localhost/api/membership/reviews', 'POST', {}))).status).toBe(400);
         });
-        it('403 for a isKeyholder without isBackgroundCheckReviewer', async () => {
+        it('403 for a isKeyholder without reviewer/board role', async () => {
             as(plainId, { householdId: plainHh, isKeyholder: true });
             expect((await REVIEWS_POST(nreq('http://localhost/api/membership/reviews', 'POST', {}))).status).toBe(403);
         });

--- a/checkin-app/src/app/__tests__/notificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsAPI.integration.test.ts
@@ -63,11 +63,11 @@ describe('Membership notifications API', () => {
         expect(data.membership.blocked).toBe(0); // not board
     });
 
-    it('a board member sees the blocked count', async () => {
+    it('a board member sees the blocked count and (as an implicit reviewer) pending reviews', async () => {
         as(boardId, { isBoardMember: true });
         const data = await (await NOTIFS(req())).json();
         expect(data.membership.blocked).toBeGreaterThanOrEqual(1);
-        expect(data.membership.pendingReviews).toBe(0); // not a reviewer
+        expect(data.membership.pendingReviews).toBeGreaterThanOrEqual(1); // board is an implicit reviewer
     });
 
     it('a plain user sees nothing', async () => {

--- a/checkin-app/src/app/api/membership/reviews/route.ts
+++ b/checkin-app/src/app/api/membership/reviews/route.ts
@@ -52,7 +52,8 @@ export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
 });
 
 // POST /api/membership/reviews — submit an attestation { processId, result, isMarkedVolunteer }.
-export const POST = withAuth({ roles: ["isBackgroundCheckReviewer"] }, async (req, auth) => {
+// Board members are implicit reviewers (see canReviewBackgroundChecks); attest() re-checks.
+export const POST = withAuth({ roles: ["isBackgroundCheckReviewer", "isBoardMember"] }, async (req, auth) => {
     if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     let body: { processId?: number; result?: "APPROVE" | "REJECT"; isMarkedVolunteer?: boolean };
     try {

--- a/checkin-app/src/app/membership-ops/layout.tsx
+++ b/checkin-app/src/app/membership-ops/layout.tsx
@@ -25,12 +25,17 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
   const confirmNav = useConfirmNav();
   const { data: session } = useSession();
   const sessionUser = session?.user as { isSysadmin?: boolean; isBoardMember?: boolean; isBackgroundCheckReviewer?: boolean } | undefined;
-  const { loading, ready } = useRequireRole(["isSysadmin", "isBoardMember"]);
-  const todoCounts = useTodoCounts(!!(sessionUser?.isSysadmin || sessionUser?.isBoardMember));
+  const isAdmin = !!(sessionUser?.isSysadmin || sessionUser?.isBoardMember);
+  // Reviewers are let in so they can reach the Review tab (linked from their notifications);
+  // the admin tools below stay scoped to sysadmin/board and each page 403s independently.
+  const { loading, ready } = useRequireRole(["isSysadmin", "isBoardMember", "isBackgroundCheckReviewer"]);
+  const todoCounts = useTodoCounts(isAdmin);
 
-  // Background-check Review tab is reviewer-only; the page itself 403s non-reviewers.
-  const navLinks = MEMBERSHIP_OPS_NAV_LINKS.filter(
-    (l) => l.href !== "/membership-ops/review" || sessionUser?.isBackgroundCheckReviewer,
+  // Review tab is for reviewers + board members (implicit reviewers); all other tabs
+  // are admin-only. A reviewer-only user therefore sees just the Review tab.
+  const canReview = !!(sessionUser?.isBackgroundCheckReviewer || sessionUser?.isBoardMember);
+  const navLinks = MEMBERSHIP_OPS_NAV_LINKS.filter((l) =>
+    l.href === "/membership-ops/review" ? canReview : isAdmin,
   );
 
   // Total member families, shown as a gray counter on the Manage Memberships tab.

--- a/checkin-app/src/lib/membership/notifications.ts
+++ b/checkin-app/src/lib/membership/notifications.ts
@@ -1,5 +1,5 @@
 import prisma from "@/lib/prisma";
-import { eligibleReviewProcessIds } from "@/lib/membership/review";
+import { canReviewBackgroundChecks, eligibleReviewProcessIds } from "@/lib/membership/review";
 
 export interface MembershipNotifications {
     /** Applications this background-check reviewer may currently attest. */
@@ -19,7 +19,7 @@ export async function getMembershipNotifications(user: {
     isSysadmin?: boolean;
     isBoardMember?: boolean;
 }): Promise<MembershipNotifications> {
-    const pendingReviews = user.isBackgroundCheckReviewer ? (await eligibleReviewProcessIds(user.id)).length : 0;
+    const pendingReviews = canReviewBackgroundChecks(user) ? (await eligibleReviewProcessIds(user.id)).length : 0;
     const blocked =
         user.isSysadmin || user.isBoardMember
             ? await prisma.membershipProcess.count({ where: { status: "BLOCKED" } })

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -28,6 +28,19 @@ type TxClient = Prisma.TransactionClient;
 const SYSTEM_ACTOR = 0;
 const REQUIRED_APPROVALS = 2;
 
+/**
+ * Board members are implicit background-check reviewers (small-org policy):
+ * anywhere an explicit reviewer is required — the queue, PII visibility, the
+ * attestation, and the reviewer notification — a board member qualifies too.
+ * Single source of truth so the API gate, the service, and the UI can't drift.
+ */
+export function canReviewBackgroundChecks(u: {
+    isBackgroundCheckReviewer?: boolean | null;
+    isBoardMember?: boolean | null;
+}): boolean {
+    return Boolean(u.isBackgroundCheckReviewer || u.isBoardMember);
+}
+
 export class ReviewError extends Error {
     constructor(
         public readonly code:
@@ -83,7 +96,7 @@ export function normalizeEmail(email: string): string {
 export async function notifyReviewers(): Promise<void> {
     try {
         const reviewers = await prisma.participant.findMany({
-            where: { isBackgroundCheckReviewer: true, email: { not: null } },
+            where: { email: { not: null }, OR: [{ isBackgroundCheckReviewer: true }, { isBoardMember: true }] },
             select: { email: true },
         });
         const base = process.env.NEXTAUTH_URL ?? "";
@@ -104,7 +117,7 @@ export async function notifyReviewers(): Promise<void> {
 }
 
 async function loadReviewer(reviewerId: number) {
-    return prisma.participant.findUnique({ where: { id: reviewerId }, select: { id: true, householdId: true, isBackgroundCheckReviewer: true } });
+    return prisma.participant.findUnique({ where: { id: reviewerId }, select: { id: true, householdId: true, isBackgroundCheckReviewer: true, isBoardMember: true } });
 }
 
 /**
@@ -117,7 +130,7 @@ async function loadReviewer(reviewerId: number) {
  */
 export async function eligibleReviewProcessIds(reviewerId: number): Promise<number[]> {
     const reviewer = await loadReviewer(reviewerId);
-    if (!reviewer?.isBackgroundCheckReviewer) return [];
+    if (!reviewer || !canReviewBackgroundChecks(reviewer)) return [];
 
     const processes = await prisma.membershipProcess.findMany({
         where: AWAITING_BG_WHERE,
@@ -150,7 +163,7 @@ export async function attest(
     input: { result: "APPROVE" | "REJECT"; isMarkedVolunteer?: boolean },
 ) {
     const reviewer = await loadReviewer(reviewerId);
-    if (!reviewer?.isBackgroundCheckReviewer) throw new ReviewError("not_reviewer", "You are not a background-check reviewer.");
+    if (!reviewer || !canReviewBackgroundChecks(reviewer)) throw new ReviewError("not_reviewer", "You are not a background-check reviewer.");
 
     // Re-check eligibility, create the attestation, recompute approvals, and converge
     // all inside one transaction. FOR UPDATE on the MembershipProcess row serializes

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -137,16 +137,18 @@ defineRoute({
 
 // Background-check reviewers' queue. Reviewers must see applicant parents' names
 // + emails (to look them up on Averity) but NOT internal/personal fields — so the
-// grant is deliberately limited to pii + public.
+// grant is deliberately limited to pii + public. Board members are implicit
+// reviewers (canReviewBackgroundChecks) and get the same limited band.
 defineRoute({
     endpoint: 'GET /api/membership/reviews',
-    authorize: { anyRole: ['isBackgroundCheckReviewer'] },
+    authorize: { anyRole: ['isBackgroundCheckReviewer', 'isBoardMember'] },
     envelope: 'queue',
     // Bag: { MembershipProcess } with membership (Membership → household Household
     // → leads HouseholdLead → participant Participant).
     returns: ['MembershipProcess', 'Membership', 'Household', 'HouseholdLead', 'Participant'],
     orderedView: [
         ['isBackgroundCheckReviewer', ['everyones:pii', 'member', 'public']],
+        ['isBoardMember', ['everyones:pii', 'member', 'public']],
     ],
 });
 


### PR DESCRIPTION
## What

The background-check review view (`/membership-ops/review`) was effectively unreachable, and board members — the org's actual reviewers — couldn't see it. This makes **board members full implicit background-check reviewers** and restores access.

## Why it was broken

Two compounding gates:
1. The membership-ops **layout** gated the whole section on `isSysadmin | isBoardMember`, so a `isBackgroundCheckReviewer` who wasn't also an admin was redirected to `/` before the page rendered — even though their in-app notification links straight to it.
2. #607 **hid the Review tab** from everyone but explicit reviewers, so board members lost access.

Net: only a user who was *both* an admin *and* an explicit reviewer could reach the view. To the reporter (a board member) it looked "completely missing."

## The fix

Single source of truth — `canReviewBackgroundChecks(u) = isBackgroundCheckReviewer || isBoardMember` in `src/lib/membership/review.ts` — applied at every gate so UI, API, and service can't drift:

- **Service** — queue eligibility (`eligibleReviewProcessIds`), `attest()`, and the reviewer email ping.
- **API** — `POST /api/membership/reviews` role gate (`isBackgroundCheckReviewer`, `isBoardMember`).
- **Security registry** — `GET /api/membership/reviews` `authorize` + PII field grant. Board gets the **same limited `pii + public` band** as reviewers — applicant parents' names/emails for the Averity lookup, **not** internal/personal fields.
- **Notifications** — the pending-review red-dot count.
- **Layout** — reviewers are admitted to the section; the Review tab shows to reviewers **and** board; a reviewer-only user sees just that tab.

## Reviewer notes

- **This widens a PII boundary** (per session decision): board members can now see applicant parents' PII and attest, counting toward the 2-reviewer quorum. Deliberate — board members are the reviewers.
- **Sysadmin is intentionally *not* an implicit reviewer** — attestation is a governance action; only board was requested.
- Flipped the two authz tests that encoded the old boundary: board now clears the role gate (→ 400 bad-body, not 403); keyholder still 403. Updated the notifications test (board now sees pending reviews).
- **533 tests pass** (authz, review API, notifications, security registry, concurrency suites) against a throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)