### PR TITLE
fix(kiosk): bind signing proxy to localhost, not 0.0.0.0 (H1)

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -683,8 +683,8 @@ def main():
     KioskHandler.backend = backend
     KioskHandler.kiosk_path = kiosk_path
     KioskHandler.disable_blackout = disable_blackout
-    server = ThreadingHTTPServer(("0.0.0.0", port), KioskHandler)
-    log.info(f"Proxy running on http://0.0.0.0:{port}")
+    server = ThreadingHTTPServer(("127.0.0.1", port), KioskHandler)
+    log.info(f"Proxy running on http://127.0.0.1:{port}")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/client/test_client.py
+++ b/client/test_client.py
@@ -1,5 +1,6 @@
+import inspect
 import unittest
-from client import BackendClient
+from client import BackendClient, main
 
 class TestBackendClient(unittest.TestCase):
     def test_required_methods_exist(self):
@@ -7,10 +8,17 @@ class TestBackendClient(unittest.TestCase):
         # We don't need real keys or URLs for structural method existence checks
         # So we can pass strings and None.
         client = BackendClient("http://fake", "fake_key")
-        
+
         self.assertTrue(hasattr(client, "post_scan"), "BackendClient is missing post_scan method")
         self.assertTrue(hasattr(client, "get_attendance"), "BackendClient is missing get_attendance method")
         self.assertTrue(hasattr(client, "_headers"), "BackendClient is missing _headers method")
+
+class TestProxyBindsLocalhostOnly(unittest.TestCase):
+    def test_server_binds_127_0_0_1_not_0_0_0_0(self):
+        """H1: signing proxy must not be reachable over the LAN."""
+        src = inspect.getsource(main)
+        self.assertIn('"127.0.0.1"', src, "proxy must bind 127.0.0.1")
+        self.assertNotIn("0.0.0.0", src, "proxy must not bind 0.0.0.0 (LAN-exposed kiosk-signature oracle)")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What
The Raspberry Pi kiosk client's request-signing proxy bound to `0.0.0.0`, so **any device on the facility LAN** could POST to it and have arbitrary requests signed with the kiosk's Ed25519 key — forging badge scans (corrupting the live evacuation count), reading the tool-cert roster, and creating trusted-adult disclosures, with no key access or physical badge. Bind to `127.0.0.1`, matching the documented design (`client/README.md`).

## Finding
**H1 (HIGH)** from the RBAC / access-control / information-model review.

## Adversarial verdict — CLOSED
Red-team confirmed: the `ThreadingHTTPServer` is the only listener in `client/`; the host is a hardcoded literal (no `config.json`/env/CLI override path); `kiosk.sh` runs on bare Pi OS (no container port-forward caveat).

## Tests
`client/test_client.py::TestProxyBindsLocalhostOnly` asserts the bind is `127.0.0.1` and not `0.0.0.0`; `py_compile` + `unittest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
