### PR TITLE
fix(api): stop over-returning Participant PII in household & attendance (M1, M2)

### DIFF
--- a/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
+++ b/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment node
+ *
+ * Regression test for M1/M2 (Participant rows over-returned): household peers
+ * and the full-access attendance feed must not carry INTERNAL-tier Participant
+ * fields (role-flag booleans, googleId, lastBackgroundCheck, ...) or, for
+ * attendance specifically, the raw email/googleId. Mocks prisma the way
+ * scanRoute.test.ts / withAuth.test.ts do, so this runs in the default
+ * (non-integration) suite with no live DB.
+ */
+
+import type { NextRequest } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { getKioskPublicKeys, verifyKioskSignature } from "@/lib/verify-kiosk";
+import prisma from "@/lib/prisma";
+import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
+import { GET as householdGET } from "@/app/api/household/route";
+import { GET as attendanceGET } from "@/app/api/attendance/route";
+
+jest.mock("next-auth/next", () => ({ getServerSession: jest.fn() }));
+jest.mock("@/lib/auth-options", () => ({ authOptions: {} }));
+jest.mock("@/lib/verify-kiosk", () => ({
+    getKioskPublicKeys: jest.fn(),
+    verifyKioskSignature: jest.fn(),
+}));
+jest.mock("@/lib/logger", () => ({ logBackendError: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+    __esModule: true,
+    default: {
+        participant: { findUnique: jest.fn() },
+        visit: { findMany: jest.fn() },
+    },
+}));
+
+const mockSession = getServerSession as jest.Mock;
+const mockPubKeys = getKioskPublicKeys as jest.Mock;
+const mockVerify = verifyKioskSignature as jest.Mock;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockPubKeys.mockReturnValue([]);
+    mockVerify.mockReturnValue({ ok: false });
+    mockSession.mockResolvedValue(null);
+});
+
+describe("Participant PII minimization (M1, M2)", () => {
+    it("GET /api/household does not leak a peer's internal-tier fields", async () => {
+        mockSession.mockResolvedValue({ user: { id: 1 } });
+
+        // Full raw row as it exists in the DB, including everything a household
+        // peer must never see (M2). The mock applies whatever `select` the route
+        // actually requests — same as Prisma would — so this fails if the route
+        // ever regresses back to `participants: true`.
+        const rawPeer = {
+            id: 2,
+            name: "Kid Two",
+            email: "kid2@example.com",
+            phone: "5551112222",
+            dateOfBirth: new Date("2012-01-01"),
+            isDeclaredAdult: false,
+            isSysadmin: true,
+            isBoardMember: false,
+            isKeyholder: false,
+            isBackgroundCheckReviewer: false,
+            googleId: "g-123",
+            emailVerified: new Date(),
+            lastBackgroundCheck: new Date("2024-01-01"),
+            waiverSignedBy: 1,
+            notificationSettings: null,
+            householdId: 10,
+        } as Record<string, unknown>;
+
+        (prisma.participant.findUnique as jest.Mock).mockImplementation((args) => {
+            const peerSelect = args.include.household.include.participants.select as Record<string, boolean>;
+            const projected = Object.fromEntries(
+                Object.keys(peerSelect).filter((k) => peerSelect[k]).map((k) => [k, rawPeer[k]])
+            );
+            return Promise.resolve({
+                id: 1,
+                householdId: 10,
+                household: {
+                    id: 10,
+                    name: "Test Household",
+                    leads: [{ householdId: 10, participantId: 1 }],
+                    membership: { id: 1, status: "ACTIVE", memberSince: new Date(), isVolunteer: false, householdId: 10 },
+                    participants: [projected],
+                },
+            });
+        });
+
+        const req = new Request("http://localhost/api/household") as unknown as NextRequest;
+        const res = await householdGET(req);
+        expect(res.status).toBe(200);
+
+        const data = await res.json();
+        const peer = data.household.participants[0];
+
+        // Safe fields survive.
+        expect(peer.name).toBe("Kid Two");
+        expect(peer.email).toBe("kid2@example.com");
+
+        // INTERNAL-tier fields do not.
+        expect(peer.isSysadmin).toBeUndefined();
+        expect(peer.isBoardMember).toBeUndefined();
+        expect(peer.isKeyholder).toBeUndefined();
+        expect(peer.isBackgroundCheckReviewer).toBeUndefined();
+        expect(peer.googleId).toBeUndefined();
+        expect(peer.emailVerified).toBeUndefined();
+        expect(peer.lastBackgroundCheck).toBeUndefined();
+        expect(peer.waiverSignedBy).toBeUndefined();
+        expect(peer.notificationSettings).toBeUndefined();
+
+        // Pin the actual query shape, not just this test's mock.
+        const callArgs = (prisma.participant.findUnique as jest.Mock).mock.calls[0][0];
+        expect(callArgs.include.household.include.participants).toEqual({ select: HOUSEHOLD_PEER_SELECT });
+    });
+
+    it("GET /api/attendance (full access) does not leak email/googleId", async () => {
+        // No session — admitted via a verified kiosk signature instead.
+        mockPubKeys.mockReturnValue(["dummy-key"]);
+        mockVerify.mockReturnValue({ ok: true });
+
+        (prisma.visit.findMany as jest.Mock).mockResolvedValue([
+            {
+                id: 100,
+                arrivedAt: new Date(),
+                departedAt: null,
+                participant: {
+                    id: 5,
+                    email: "kid5@example.com",
+                    name: null,
+                    isKeyholder: false,
+                    dateOfBirth: new Date("2015-06-01"),
+                    householdId: 10,
+                    phone: "5559998888",
+                    household: { id: 10, emergencyContacts: [] },
+                },
+                event: null,
+            },
+        ]);
+
+        const req = new Request("http://localhost/api/attendance", {
+            headers: {
+                "x-kiosk-signature": "sig",
+                "x-kiosk-timestamp": "ts",
+                "x-kiosk-nonce": "nonce",
+            },
+        }) as unknown as NextRequest;
+
+        const res = await attendanceGET(req);
+        expect(res.status).toBe(200);
+
+        const data = await res.json();
+        expect(data.access).toBe("full");
+
+        const participant = data.attendance[0].participant;
+        expect(participant.email).toBeUndefined();
+        expect(participant.googleId).toBeUndefined();
+        // Server-resolved name-or-email-prefix fallback still renders (M1).
+        expect(participant.name).toBe("kid5");
+    });
+});

--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth";
 import { addHouseholdLead, HouseholdLeadLimitError } from "@/lib/household/leads";
 import { reconcileAndWarn } from "@/lib/emergencyContacts/service";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
+import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
 
 export const PATCH = withAuth(
     {},
@@ -49,7 +50,8 @@ export const PATCH = withAuth(
                     phone: phone !== undefined ? (phone === "" ? null : formatPhone(phone)) : undefined,
                     // A real DoB supersedes the 25+ flag; otherwise honor the checkbox.
                     isDeclaredAdult: over25 !== undefined ? (dob ? false : !!over25) : undefined,
-                }
+                },
+                select: HOUSEHOLD_PEER_SELECT,
             });
 
             // Set when the field edits saved but the requested promotion to lead

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth";
 import { reconcileAndWarn } from "@/lib/emergencyContacts/service";
 import { isValidEmail } from "@/lib/emergencyContacts/identity";
 import { isOrgAccount } from "@/lib/orgAccount";
+import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
 
 export const GET = withAuth(
     {},
@@ -14,7 +15,15 @@ export const GET = withAuth(
 
             const user = await prisma.participant.findUnique({
                 where: { id: userId },
-                include: { household: { include: { participants: true, leads: true, membership: true } } }
+                include: {
+                    household: {
+                        include: {
+                            participants: { select: HOUSEHOLD_PEER_SELECT },
+                            leads: true,
+                            membership: true,
+                        }
+                    }
+                }
             });
 
             if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
@@ -74,7 +83,8 @@ export const PATCH = withAuth(
 
                     targetMember = await prisma.participant.update({
                         where: { id: targetMember.id },
-                        data: { householdId: user.householdId }
+                        data: { householdId: user.householdId },
+                        select: HOUSEHOLD_PEER_SELECT,
                     });
                 }
             }
@@ -92,7 +102,8 @@ export const PATCH = withAuth(
                         dateOfBirth: memberDob ? new Date(memberDob) : null,
                         isDeclaredAdult: !memberDob && !!memberOver25,
                         householdId: user.householdId,
-                    }
+                    },
+                    select: HOUSEHOLD_PEER_SELECT,
                 });
             }
 

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -8,11 +8,12 @@ export async function getFullAttendance() {
             participant: {
                 select: {
                     id: true,
-                    googleId: true,
+                    // email is read only to resolve the name fallback below and never
+                    // leaves this function (M1) — same pattern as the certifications
+                    // grid (#329). googleId/isSysadmin aren't rendered anywhere downstream.
                     email: true,
                     name: true,
                     isKeyholder: true,
-                    isSysadmin: true,
                     dateOfBirth: true,
                     householdId: true,
                     phone: true,
@@ -65,6 +66,22 @@ export async function getFullAttendance() {
         isTwoDeepViolation: unaccompaniedStudents.length > 0 && adultVisits.length < 2,
     };
 
-    return { attendance: activeVisits, counts, safety };
+    // Drop email/googleId from the wire (M1): resolve the same name-or-email-prefix
+    // fallback the UI already falls back to (`name || email.split("@")[0]`) here,
+    // server-side, so `name` is always populated and the raw address never ships.
+    const attendance = activeVisits.map(v => ({
+        ...v,
+        participant: {
+            id: v.participant.id,
+            name: v.participant.name?.trim() || v.participant.email?.split("@")[0] || null,
+            isKeyholder: v.participant.isKeyholder,
+            dateOfBirth: v.participant.dateOfBirth,
+            householdId: v.participant.householdId,
+            phone: v.participant.phone,
+            household: v.participant.household,
+        },
+    }));
+
+    return { attendance, counts, safety };
 }
 

--- a/checkin-app/src/lib/household/participantProjection.ts
+++ b/checkin-app/src/lib/household/participantProjection.ts
@@ -1,0 +1,18 @@
+import type { Prisma } from "@/generated/prisma/client";
+
+/**
+ * Fields of a household peer's Participant row that are safe to send to any
+ * other member of the same household (including minors) — i.e. what the
+ * my-household member cards and the program-enrollment picker actually
+ * render. Excludes INTERNAL-tier fields (role flags, googleId, emailVerified,
+ * lastBackgroundCheck, waiverSignedBy, notificationSettings, ...) that a
+ * household peer has no business seeing (M2).
+ */
+export const HOUSEHOLD_PEER_SELECT = {
+    id: true,
+    name: true,
+    email: true,
+    phone: true,
+    dateOfBirth: true,
+    isDeclaredAdult: true,
+} satisfies Prisma.ParticipantSelect;

--- a/checkin-app/src/lib/household/participantProjection.ts
+++ b/checkin-app/src/lib/household/participantProjection.ts
@@ -14,5 +14,8 @@ export const HOUSEHOLD_PEER_SELECT = {
     email: true,
     phone: true,
     dateOfBirth: true,
+    // Deliberate exception: isDeclaredAdult is @sensitivity:internal, but a household
+    // peer legitimately needs it to render each member's age badge / pre-fill the edit
+    // form (my-household). It's an age-status flag, not a role/audit/security flag.
     isDeclaredAdult: true,
 } satisfies Prisma.ParticipantSelect;

--- a/checkin-app/src/types/attendance.ts
+++ b/checkin-app/src/types/attendance.ts
@@ -2,17 +2,17 @@ import type { Prisma } from '@/generated/prisma/client';
 
 /**
  * Visit with included participant and event data, as returned by getFullAttendance.
+ * PII-minimized (M1): email/googleId and role flags are deliberately NOT part of this
+ * shape — getFullAttendance resolves the display name server-side and strips them, so a
+ * consumer typed against this can't reach back for the raw address/identifiers.
  */
 export type VisitWithDetails = Prisma.VisitGetPayload<{
     include: {
         participant: {
             select: {
                 id: true;
-                googleId: true;
-                email: true;
                 name: true;
                 isKeyholder: true;
-                isSysadmin: true;
                 dateOfBirth: true;
                 householdId: true;
                 phone: true;


### PR DESCRIPTION
## What
Two API surfaces over-returned `Participant` rows:
- **`GET /api/household`** (+ `PATCH /api/household`, `PATCH /api/household/member`) returned full peer rows to any household member (incl. minors), leaking `isSysadmin`/`isBoardMember`/`isKeyholder`/`isBackgroundCheckReviewer`, `googleId`, `emailVerified`, `lastBackgroundCheck`, `waiverSignedBy`.
- **`GET /api/attendance`** returned `email`/`googleId` for every checked-in participant to any keyholder **or** kiosk-signed caller.

Fix: a shared `HOUSEHOLD_PEER_SELECT` projection for the household routes, and a sanitized attendance payload that drops `email`/`googleId` and resolves the display name server-side (same pattern as the kiosk-certs #329 fix).

## Findings
**M1 + M2 (HIGH)** from the review.

## Adversarial verdict — CLOSED
Red-team confirmed every returned-row path now goes through the projection / sanitized mapper (GET + both PATCH echoes + the attendance limited-access branch), no consumer regression (removed fields are unread or dead-by-construction). Follow-up commit syncs the stale `VisitWithDetails` type so it can't seed a future re-leak; `isDeclaredAdult`'s deliberate inclusion is documented.

## Tests
`participantPiiMinimization.test.ts`: household GET omits internal-tier fields for a peer (pins the `select` shape), attendance full-access omits `email`/`googleId`. 2/2 green.

## Out of scope (noted)
`participants/search` still does `household.participants: true` but is **admin-gated** — a different risk class; candidate for a later cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
