### PR TITLE
fix(shop): require authorization to read another member's certifications (L1)

### DIFF
--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -254,6 +254,31 @@ describe('Shop API Integration Tests', () => {
              expect(data.length).toBeGreaterThanOrEqual(1);
         });
 
+        it('enforces object-level authorization on ?participantId (L1 IDOR fix)', async () => {
+            // Self-lookup — always allowed, no participantId gate applies.
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
+            let res = await getCerts(createReq('GET', { searchParams: `participantId=${commonId}` })) as Response;
+            expect(res.status).toBe(200);
+
+            // Plain member reading another member's certifications — forbidden.
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
+            res = await getCerts(createReq('GET', { searchParams: `participantId=${adminId}` })) as Response;
+            expect(res.status).toBe(403);
+
+            // Sysadmin/board reading another member's certifications — allowed.
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+            res = await getCerts(createReq('GET', { searchParams: `participantId=${commonId}` })) as Response;
+            expect(res.status).toBe(200);
+
+            // Certifier (MAY_CERTIFY_OTHERS on the session) reading another member's
+            // certifications — allowed, same derivation as callerHoldsRole('certifier', ...).
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: certifierId, toolStatuses: [{ toolId: mockToolId, level: 'MAY_CERTIFY_OTHERS' }] },
+            });
+            res = await getCerts(createReq('GET', { searchParams: `participantId=${commonId}` })) as Response;
+            expect(res.status).toBe(200);
+        });
+
         it('should return 403 for common users attempting a certification grant', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
 

--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -240,8 +240,10 @@ describe('Shop API Integration Tests', () => {
     });
 
     describe('/api/shop/certifications', () => {
-        it('should allow anyone to GET certifications', async () => {
-             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
+        it('gates the ?toolId roster to staff/certifier — certifier allowed (L1)', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({
+                 user: { id: certifierId, toolStatuses: [{ toolId: mockToolId, level: 'MAY_CERTIFY_OTHERS' }] },
+             });
 
              const req = createReq('GET', { searchParams: `toolId=${mockToolId}` });
              const res = await getCerts(req) as Response;
@@ -252,6 +254,12 @@ describe('Shop API Integration Tests', () => {
 
              // The Certifier automatically has one on the mockToolId
              expect(data.length).toBeGreaterThanOrEqual(1);
+        });
+
+        it('forbids a plain member from reading the ?toolId roster (L1)', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
+             const res = await getCerts(createReq('GET', { searchParams: `toolId=${mockToolId}` })) as Response;
+             expect(res.status).toBe(403);
         });
 
         it('enforces object-level authorization on ?participantId (L1 IDOR fix)', async () => {

--- a/checkin-app/src/app/api/shop/certifications/route.ts
+++ b/checkin-app/src/app/api/shop/certifications/route.ts
@@ -38,6 +38,18 @@ export const GET = withAuth({}, async (req, auth) => {
 
         if (participantIdParam) {
             targetUserId = parseInt(participantIdParam, 10);
+
+            // Looking up someone else's certifications requires admin/board or
+            // certifier standing — mirrors the ?all=true gate above and the same
+            // MAY_CERTIFY_OTHERS derivation used by callerHoldsRole('certifier', ...)
+            // in src/security/access-resolvers.ts. Self-lookups stay open to anyone.
+            if (targetUserId !== session.user.id) {
+                const isCertifier = (session.user.toolStatuses ?? []).some(ts => ts.level === 'MAY_CERTIFY_OTHERS');
+                const isAuthorized = session.user?.isSysadmin || session.user?.isBoardMember || isCertifier;
+                if (!isAuthorized) {
+                    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+                }
+            }
         }
 
         let whereClause: Record<string, NonNullable<unknown> | null | string | number | boolean | Date> = {};

--- a/checkin-app/src/app/api/shop/certifications/route.ts
+++ b/checkin-app/src/app/api/shop/certifications/route.ts
@@ -36,26 +36,31 @@ export const GET = withAuth({}, async (req, auth) => {
 
         let targetUserId = session.user.id;
 
+        // Certifier standing = holds MAY_CERTIFY_OTHERS on any tool — same derivation as
+        // callerHoldsRole('certifier', ...) in src/security/access-resolvers.ts.
+        const isCertifier = (session.user.toolStatuses ?? []).some(ts => ts.level === 'MAY_CERTIFY_OTHERS');
+        const canReadOthers = session.user?.isSysadmin || session.user?.isBoardMember || isCertifier;
+
         if (participantIdParam) {
             targetUserId = parseInt(participantIdParam, 10);
 
-            // Looking up someone else's certifications requires admin/board or
-            // certifier standing — mirrors the ?all=true gate above and the same
-            // MAY_CERTIFY_OTHERS derivation used by callerHoldsRole('certifier', ...)
-            // in src/security/access-resolvers.ts. Self-lookups stay open to anyone.
-            if (targetUserId !== session.user.id) {
-                const isCertifier = (session.user.toolStatuses ?? []).some(ts => ts.level === 'MAY_CERTIFY_OTHERS');
-                const isAuthorized = session.user?.isSysadmin || session.user?.isBoardMember || isCertifier;
-                if (!isAuthorized) {
-                    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-                }
+            // Reading someone else's certifications requires admin/board or certifier
+            // standing — mirrors the ?all=true gate above. Self-lookups stay open to anyone.
+            if (targetUserId !== session.user.id && !canReadOthers) {
+                return NextResponse.json({ error: "Forbidden" }, { status: 403 });
             }
         }
 
         let whereClause: Record<string, NonNullable<unknown> | null | string | number | boolean | Date> = {};
 
         if (toolIdParam) {
-            // If checking who is certified on a tool
+            // The by-tool roster lists every certified member on a tool — the same
+            // cross-member data the participant lookup protects, so gate it identically.
+            // (Its only consumer, shop-ops ToolManagementPanel, is already staff/certifier
+            // gated client-side; without this the roster was readable by any logged-in member.)
+            if (!canReadOthers) {
+                return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+            }
             whereClause = { toolId: parseInt(toolIdParam, 10) };
         } else {
             // Looking up a specific person's certifications


### PR DESCRIPTION
## What
`GET /api/shop/certifications` let any authenticated member read **another** member's tool-certification levels:
- `?participantId=<anyId>` had no ownership check.
- `?toolId=<id>` returned every certified member's name + level for a tool, gated only client-side (shop-ops React), so any logged-in member could enumerate tool ids and reconstruct the same per-person data.

Fix: reading anyone but yourself (`participantId` for others, **or** the `toolId` roster) now requires `isSysadmin || isBoardMember || certifier` (the same `MAY_CERTIFY_OTHERS` derivation as `callerHoldsRole('certifier', …)`). Self-lookups stay open. This matches the roster's only real consumer (`ToolManagementPanel`, already staff/certifier-only).

## Finding
**L1** from the review (IDOR). The `?toolId=` half was surfaced by the adversarial pass.

## Adversarial verdict — CLOSED (after the `?toolId=` gate)
Red-team confirmed the gate runs before the query on every path, params tricks (NaN/negative/float/dup) fail closed, and certifier status is DB-derived in the signed JWT (not client-spoofable).

## Tests
`shopAPI.integration.test.ts`: plain member → 403 on both `?participantId=other` and `?toolId`; certifier/admin/board → 200; self → 200. 16/16 green against a throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
