### PR TITLE
fix(membership): lock INITIAL intake against duplicate in-flight process (M3)

### DIFF
--- a/checkin-app/prisma/migrations/20260630010000_membership_one_inflight_initial/migration.sql
+++ b/checkin-app/prisma/migrations/20260630010000_membership_one_inflight_initial/migration.sql
@@ -9,6 +9,27 @@
 -- "In flight" is the status-based set IN_FLIGHT_INITIAL_STATUSES (phases.ts), the
 -- same set startIntake's own check already used. Prisma's schema DSL can't
 -- express a partial unique index with a WHERE on enum status, so this is raw SQL.
+
+-- Pre-step: neutralize any pre-existing duplicate in-flight INITIAL processes (from
+-- the pre-fix race) so the index can be created on already-affected data — else
+-- CREATE UNIQUE INDEX fails on deploy. Keep the NEWEST (MAX id) per membership: that's
+-- the row startIntake returns (orderBy id desc) and the one saveIntake wrote the
+-- applicant's data onto. Move older duplicate(s) to BLOCKED — there is no CANCELLED
+-- status, BLOCKED is the only non-in-flight terminal state, and this preserves the
+-- row + audit trail rather than deleting (FK-safe vs BackgroundCheckAttestation).
+-- Mirrors the visit_one_open_per_participant precedent's pre-step.
+UPDATE "MembershipProcess" p
+SET "status" = 'BLOCKED'
+WHERE p."kind" = 'INITIAL'
+  AND p."status" IN ('INTAKE', 'PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW', 'PENDING_PAYMENT', 'PENDING_BG_CLEARANCE')
+  AND EXISTS (
+    SELECT 1 FROM "MembershipProcess" o
+    WHERE o."membershipId" = p."membershipId"
+      AND o."kind" = 'INITIAL'
+      AND o."status" IN ('INTAKE', 'PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW', 'PENDING_PAYMENT', 'PENDING_BG_CLEARANCE')
+      AND o."id" > p."id"
+  );
+
 CREATE UNIQUE INDEX "membership_one_inflight_initial"
     ON "MembershipProcess" ("membershipId")
     WHERE "kind" = 'INITIAL'

--- a/checkin-app/prisma/migrations/20260630010000_membership_one_inflight_initial/migration.sql
+++ b/checkin-app/prisma/migrations/20260630010000_membership_one_inflight_initial/migration.sql
@@ -1,0 +1,15 @@
+-- One in-flight INITIAL process per membership. startIntake's check-then-act
+-- (does an in-flight INITIAL process already exist?) is NOT atomic on its own —
+-- a double-click or two tabs can both read zero open processes and both INSERT,
+-- yielding duplicate INTAKE rows. startIntake now serializes its own check+insert
+-- by locking the parent Membership row (SELECT ... FOR UPDATE), same as
+-- createRenewalProcess. This partial unique index is the multi-instance
+-- guarantee: the second concurrent insert hits P2002.
+--
+-- "In flight" is the status-based set IN_FLIGHT_INITIAL_STATUSES (phases.ts), the
+-- same set startIntake's own check already used. Prisma's schema DSL can't
+-- express a partial unique index with a WHERE on enum status, so this is raw SQL.
+CREATE UNIQUE INDEX "membership_one_inflight_initial"
+    ON "MembershipProcess" ("membershipId")
+    WHERE "kind" = 'INITIAL'
+      AND "status" IN ('INTAKE', 'PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW', 'PENDING_PAYMENT', 'PENDING_BG_CLEARANCE');

--- a/checkin-app/src/app/__tests__/intakeConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/intakeConcurrency.integration.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Concurrency test for INITIAL intake opening (M3). startIntake read-then-created
+ * with no lock, so a double-click / two tabs could both pass the "already in
+ * flight?" guard and both INSERT — duplicate INTAKE rows for one Membership.
+ * startIntake now re-runs the check+create inside a transaction holding a
+ * `SELECT ... FOR UPDATE` lock on the parent Membership row, so the loser blocks
+ * until the winner commits, then re-reads under the lock and returns the winner's
+ * process instead of inserting a second one. We drive that directly: two
+ * concurrent startIntake calls for the same household lead.
+ *
+ * The FOR UPDATE lock is the guarantee here (the loser returns the existing
+ * process, never reaching the INSERT), so this holds whether or not the
+ * push-provisioned test DB carries the partial unique index — same as
+ * renewalConcurrency. TEST_DB_POOL_MAX=2 (jest.setup.js) puts the two calls on
+ * separate connections so the row lock, not $transaction's own serialization, is
+ * what's exercised.
+ */
+
+import { startIntake } from '@/lib/membership/intake';
+import { IN_FLIGHT_INITIAL_STATUSES } from '@/lib/membership/phases';
+import prisma from '@/lib/prisma';
+
+const TAG = 'intake-concurrency-test';
+
+async function wipe() {
+    const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+    const ids = hhs.map((h) => h.id);
+    if (ids.length) {
+        await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
+        await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: ids } } });
+    }
+}
+
+describe('intake start concurrency', () => {
+    let leadId = 0;
+    let householdId = 0;
+
+    beforeAll(async () => {
+        await wipe();
+        const hh = await prisma.household.create({ data: { name: `Family ${TAG}` } });
+        householdId = hh.id;
+        const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
+        leadId = lead.id;
+        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+    });
+
+    afterAll(wipe);
+
+    it('two concurrent startIntake calls yield exactly one in-flight INITIAL process', async () => {
+        const results = await Promise.all([startIntake(leadId), startIntake(leadId)]);
+
+        // Both return the SAME winning process — the loser re-checked under the lock.
+        expect(results[0].id).toBe(results[1].id);
+
+        const inflight = await prisma.membershipProcess.findMany({
+            where: { membership: { householdId }, kind: 'INITIAL', status: { in: IN_FLIGHT_INITIAL_STATUSES } },
+            select: { id: true },
+        });
+        expect(inflight).toHaveLength(1); // no duplicate from the loser
+
+        // Exactly one CREATE audit row for the winner — no orphan from the loser.
+        const created = await prisma.auditLog.count({
+            where: { tableName: 'MembershipProcess', action: 'CREATE', affectedEntityId: results[0].id },
+        });
+        expect(created).toBe(1);
+    });
+});

--- a/checkin-app/src/lib/membership/__tests__/intake.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/intake.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit test for startIntake's race guard (M3): the check+create now runs inside
+ * a transaction holding a FOR UPDATE lock on the Membership row, so a second
+ * in-flight INITIAL process is never created — the tx's own re-check (via `tx`,
+ * not the caller's stale pre-tx read) finds the winner and returns it. Mirrors
+ * renewal's createRenewalProcess / renewalConcurrency.integration.test.ts intent,
+ * but as a mocked-prisma unit test since this worktree has no DB.
+ */
+import { startIntake } from '@/lib/membership/intake';
+
+const txMembershipProcess = { findFirst: jest.fn(), create: jest.fn() };
+const txAuditLog = { create: jest.fn() };
+const txQueryRaw = jest.fn();
+const tx = { $queryRaw: txQueryRaw, membershipProcess: txMembershipProcess, auditLog: txAuditLog };
+
+jest.mock('@/lib/prisma', () => ({
+    __esModule: true,
+    default: {
+        participant: { findUnique: jest.fn() },
+        membership: { upsert: jest.fn() },
+        $transaction: jest.fn((cb: (tx: unknown) => unknown) => cb(tx)),
+    },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const prisma = require('@/lib/prisma').default;
+
+const user = {
+    id: 1,
+    householdId: 7,
+    isSysadmin: false,
+    householdLeads: [{ householdId: 7 }],
+    household: { membership: null },
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.participant.findUnique.mockResolvedValue(user);
+    prisma.membership.upsert.mockResolvedValue({ id: 42, householdId: 7, status: 'NONE' });
+});
+
+describe('startIntake race guard', () => {
+    it('a second in-flight INITIAL start (existing found under the lock) returns the existing process, no duplicate create', async () => {
+        const existingProcess = { id: 99, membershipId: 42, kind: 'INITIAL', status: 'INTAKE' };
+        txMembershipProcess.findFirst.mockResolvedValue(existingProcess);
+
+        const result = await startIntake(1);
+
+        expect(result).toBe(existingProcess);
+        // Lock taken before the in-flight check, inside the same transaction.
+        expect(txQueryRaw).toHaveBeenCalledTimes(1);
+        // No duplicate process/audit row created for the loser of the race.
+        expect(txMembershipProcess.create).not.toHaveBeenCalled();
+        expect(txAuditLog.create).not.toHaveBeenCalled();
+    });
+
+    it('no in-flight process → creates one INTAKE process + audit row inside the same transaction', async () => {
+        txMembershipProcess.findFirst.mockResolvedValue(null);
+        const created = { id: 100, membershipId: 42, kind: 'INITIAL', status: 'INTAKE' };
+        txMembershipProcess.create.mockResolvedValue(created);
+
+        const result = await startIntake(1);
+
+        expect(result).toBe(created);
+        expect(txMembershipProcess.create).toHaveBeenCalledWith({
+            data: { membershipId: 42, kind: 'INITIAL', status: 'INTAKE' },
+        });
+        expect(txAuditLog.create).toHaveBeenCalledTimes(1);
+    });
+});

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -136,6 +136,14 @@ export async function getIntakeState(userId: number) {
  * Begin (or resume) an INITIAL application for the caller's household. Ensures a
  * household exists, anchors a Membership (status NONE), and opens a
  * MembershipProcess at INTAKE. Idempotent: an in-flight process is returned as-is.
+ *
+ * The caller's own read of `user.household.membership.processes` (above) is stale
+ * the instant it's read, so a double-click or two tabs can both pass it and both
+ * reach the create. Mirrors renewal's createRenewalProcess: the check+create is
+ * re-run inside a transaction holding a `SELECT ... FOR UPDATE` lock on the
+ * Membership row, so a concurrent caller blocks until the winner commits, then
+ * sees the winner's in-flight process instead of inserting a duplicate. The
+ * partial unique index `membership_one_inflight_initial` is defense-in-depth.
  */
 export async function startIntake(userId: number) {
     const user = await loadUserWithHousehold(userId);
@@ -148,32 +156,37 @@ export async function startIntake(userId: number) {
         throw new IntakeError("already_member", "Your household is already an active member.");
     }
 
-    const existing = user.household?.membership?.processes
-        .filter((p) => p.kind === "INITIAL" && IN_FLIGHT_INITIAL_STATUSES.includes(p.status))
-        .sort((a, b) => b.id - a.id)[0];
-    if (existing) return existing;
-
     const membership = await prisma.membership.upsert({
         where: { householdId },
         create: { householdId, status: "NONE" },
         update: {},
     });
 
-    const process = await prisma.membershipProcess.create({
-        data: { membershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
-    });
+    return prisma.$transaction(async (tx) => {
+        // Lock the membership row so overlapping starts serialize here, not at the INSERT.
+        await tx.$queryRaw`SELECT id FROM "Membership" WHERE id = ${membership.id} FOR UPDATE`;
+        const existing = await tx.membershipProcess.findFirst({
+            where: { membershipId: membership.id, kind: "INITIAL", status: { in: IN_FLIGHT_INITIAL_STATUSES } },
+            orderBy: { id: "desc" },
+        });
+        if (existing) return existing;
 
-    await prisma.auditLog.create({
-        data: {
-            actorId: userId,
-            action: "CREATE",
-            tableName: "MembershipProcess",
-            affectedEntityId: process.id,
-            newData: { membershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
-        },
-    });
+        const process = await tx.membershipProcess.create({
+            data: { membershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
+        });
 
-    return process;
+        await tx.auditLog.create({
+            data: {
+                actorId: userId,
+                action: "CREATE",
+                tableName: "MembershipProcess",
+                affectedEntityId: process.id,
+                newData: { membershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
+            },
+        });
+
+        return process;
+    });
 }
 
 /** Persist intake form data onto the caller's household + participants. Resumable; never deletes. */

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prisma";
+import { Prisma } from "@/generated/prisma/client";
 import { IN_FLIGHT_INITIAL_STATUSES } from "@/lib/membership/phases";
 import { getExternalStatus } from "@/lib/membership/external";
 import { householdBgIsFresh, nextBoundary } from "@/lib/membership/renewal";
@@ -162,31 +163,46 @@ export async function startIntake(userId: number) {
         update: {},
     });
 
-    return prisma.$transaction(async (tx) => {
-        // Lock the membership row so overlapping starts serialize here, not at the INSERT.
-        await tx.$queryRaw`SELECT id FROM "Membership" WHERE id = ${membership.id} FOR UPDATE`;
-        const existing = await tx.membershipProcess.findFirst({
-            where: { membershipId: membership.id, kind: "INITIAL", status: { in: IN_FLIGHT_INITIAL_STATUSES } },
-            orderBy: { id: "desc" },
-        });
-        if (existing) return existing;
+    try {
+        return await prisma.$transaction(async (tx) => {
+            // Lock the membership row so overlapping starts serialize here, not at the INSERT.
+            await tx.$queryRaw`SELECT id FROM "Membership" WHERE id = ${membership.id} FOR UPDATE`;
+            const existing = await tx.membershipProcess.findFirst({
+                where: { membershipId: membership.id, kind: "INITIAL", status: { in: IN_FLIGHT_INITIAL_STATUSES } },
+                orderBy: { id: "desc" },
+            });
+            if (existing) return existing;
 
-        const process = await tx.membershipProcess.create({
-            data: { membershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
-        });
+            const process = await tx.membershipProcess.create({
+                data: { membershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
+            });
 
-        await tx.auditLog.create({
-            data: {
-                actorId: userId,
-                action: "CREATE",
-                tableName: "MembershipProcess",
-                affectedEntityId: process.id,
-                newData: { membershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
-            },
-        });
+            await tx.auditLog.create({
+                data: {
+                    actorId: userId,
+                    action: "CREATE",
+                    tableName: "MembershipProcess",
+                    affectedEntityId: process.id,
+                    newData: { membershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
+                },
+            });
 
-        return process;
-    });
+            return process;
+        });
+    } catch (e) {
+        // The FOR UPDATE lock serializes same-version callers, but a rolling deploy can
+        // leave a pre-fix instance (no lock) inserting concurrently — the partial unique
+        // index membership_one_inflight_initial then rejects the duplicate with P2002.
+        // Return the winner instead of surfacing a 500 to the applicant (mirrors renewal).
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+            const winner = await prisma.membershipProcess.findFirst({
+                where: { membershipId: membership.id, kind: "INITIAL", status: { in: IN_FLIGHT_INITIAL_STATUSES } },
+                orderBy: { id: "desc" },
+            });
+            if (winner) return winner;
+        }
+        throw e;
+    }
 }
 
 /** Persist intake form data onto the caller's household + participants. Resumable; never deletes. */


### PR DESCRIPTION
## What
`startIntake` did a check-then-create with no lock, so a double-click / two tabs could both pass the "already in flight?" guard and create **two** INTAKE `MembershipProcess` rows for one membership. Serialize the check+create inside a transaction holding a `SELECT … FOR UPDATE` on the parent `Membership` row, plus a partial unique index — exactly mirroring the already-shipped `createRenewalProcess` fix.

## Finding
**M3 (MEDIUM, data integrity)** from the review.

## Adversarial verdict — CLOSED (with hardening added)
Red-team confirmed the lock is on the right row, taken before the re-check (via `tx`), no alternate `kind:'INITIAL'` creation path, no deadlock. Three residuals it raised are addressed in the follow-up commit:
1. **Deploy safety:** the migration now has a **pre-step** that neutralizes any pre-existing duplicate in-flight INITIAL rows (keep newest, others → `BLOCKED`) so `CREATE UNIQUE INDEX` can't fail on already-affected data — mirroring the `visit_one_open_per_participant` precedent.
2. **P2002 backstop:** `startIntake` now catches the unique-violation (rolling-deploy race with a pre-fix instance) and returns the winner instead of a 500 — mirrors renewal.
3. **Concurrency test:** added `intakeConcurrency.integration.test.ts`.

## Tests
Unit (race branch) + `intakeConcurrency.integration.test.ts` (two concurrent starts → exactly one in-flight process) green. `migrate deploy` applied the new migration cleanly, validating the SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
