### PR TITLE
feat(tests): measure test coverage via jest --coverage

### DIFF
--- a/checkin-app/jest.config.js
+++ b/checkin-app/jest.config.js
@@ -15,6 +15,24 @@ const customJestConfig = {
     // tests that failed by THROWING (schema/mock rot) vs honest assertions.
     reporters: ['default', '<rootDir>/test/failureClassifierReporter.js'],
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+    // Coverage (only collected when a run passes --coverage; normal runs are
+    // unaffected). v8 provider because next/jest transforms with SWC, not babel,
+    // so babel-plugin-istanbul never instruments — v8 reads Node's own coverage.
+    coverageProvider: 'v8',
+    coverageDirectory: 'coverage',
+    coverageReporters: ['text-summary', 'lcov', 'json-summary'],
+    // Count every source file, so untested files show as 0% rather than vanishing.
+    collectCoverageFrom: [
+        'src/**/*.{ts,tsx}',
+        '!src/**/*.d.ts',
+        '!src/**/__tests__/**',
+        '!src/**/__mocks__/**',
+        '!src/**/*.test.{ts,tsx}',
+        '!src/generated/**',          // generated Prisma client
+        '!src/security/generated/**', // generated classification mirror
+        '!src/types/**',              // type-only declarations
+        '!src/test-helpers/**',
+    ],
     // Integration tier only (gated by INTEGRATION_DB): clone one Postgres DB per
     // worker so parallel workers can't corrupt each other. No-op for `test:ci`.
     globalSetup: '<rootDir>/test/integrationGlobalSetup.js',

--- a/checkin-app/package.json
+++ b/checkin-app/package.json
@@ -11,6 +11,7 @@
     "test:ci": "jest --ci --runInBand --forceExit",
     "test:flow": "jest --config jest.flow.config.js --ci --runInBand --forceExit",
     "test:integration": "INTEGRATION_DB=1 jest --ci --forceExit --testPathIgnorePatterns=/node_modules/ --testRegex \"\\.integration\\.test\\.[jt]sx?$\"",
+    "test:coverage": "INTEGRATION_DB=1 jest --ci --coverage --forceExit --testPathIgnorePatterns \"/node_modules/|/\\.next/|/\\.claude/worktrees/|\\.flow\\.test\\.\"",
     "check-route-coverage": "ts-node --project scripts/tsconfig.json scripts/check-route-coverage.ts",
     "import:zoho": "tsx scripts/import-zoho.ts"
   },


### PR DESCRIPTION
## What
Add test-coverage measurement using Jest's built-in `--coverage` (no new dependency; `coverage/` is already gitignored).

**`jest.config.js`** — coverage config, only active under `--coverage` (normal runs unaffected):
- `coverageProvider: 'v8'` — next/jest transforms with SWC, so the default babel-istanbul provider never instruments; V8 reads Node's own coverage.
- `coverageReporters: ['text-summary', 'lcov', 'json-summary']` — console summary + `coverage/lcov.info` + browsable HTML (`coverage/lcov-report/`) + machine-readable `coverage-summary.json`.
- `collectCoverageFrom: src/**` with `.d.ts` / tests / `__mocks__` / generated / type-only excludes, so **untested files count as 0%** instead of vanishing.

**`package.json`** — `test:coverage`: runs the **whole suite** (79 unit + 101 integration = 180 files; flow tests and `.claude/worktrees` excluded) with coverage for the true repo-wide number. Needs `DATABASE_URL`, same as `test:integration`.

Unit-only coverage (no DB) is available without a new script: `npm run test:ci -- --coverage`.

## Verified
- Unit-tier coverage run emits `coverage/lcov.info`, `coverage-summary.json`, the HTML report, and the console summary — exit 0.
- `jest --listTests` with `test:coverage`'s patterns lists all 180 unit+integration files, **0** flow, **0** worktree.

## Note on the number
Unit-only is ~20.85% lines — low *because* unit tests mock Prisma; the API routes are exercised by the integration tier, so the full `test:coverage` number (unit + integration) is substantially higher. This PR only *measures*; no `coverageThreshold` gate and no `ci.yml` wiring yet (natural follow-ups if you want coverage enforced / uploaded in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
