### PR TITLE
fix(import): set isDeclaredAdult on Zoho-imported primaries (#606)

### DIFF
--- a/checkin-app/src/lib/__tests__/zohoImport.test.ts
+++ b/checkin-app/src/lib/__tests__/zohoImport.test.ts
@@ -170,4 +170,29 @@ describe("buildImport", () => {
         expect(report.minorsAsPrimary).toHaveLength(1);
         expect(report.minorsAsPrimary[0].name).toBe("Ari Mizell");
     });
+
+    it("declares the primary an adult only when Zoho has no DoB (age model, #606)", () => {
+        // Primary WITH a DoB → age derived, not declared. Child (non-primary, no DoB) → unknown, not declared.
+        const withDob = build(
+            [
+                person({ Name: "Pat Lee", Email: "pat@lee.com", Primary_Contact_E_mail: "pat@lee.com", Date_Of_Birth: "05/24/1983", ID: "p1" }),
+                person({ Name: "Kid Lee", Email: "", Primary_Contact_E_mail: "pat@lee.com", ID: "p2" }),
+            ],
+            [family({ Primary_Contact_E_mail: "pat@lee.com", Primary_Contact_Name: "Pat Lee" })],
+            [input({ Primary_Contact_E_mail: "pat@lee.com" })],
+        );
+        const pat = withDob.households[0].members.find((m) => m.name === "Pat Lee")!;
+        const kid = withDob.households[0].members.find((m) => m.name === "Kid Lee")!;
+        expect(pat.isDeclaredAdult).toBe(false); // has a DoB
+        expect(kid.isDeclaredAdult).toBe(false); // non-primary, unknown age
+
+        // Primary with NO DoB → declared adult, and surfaced in the report.
+        const noDob = build(
+            [person({ Name: "Sam Roe", Email: "sam@roe.com", Primary_Contact_E_mail: "sam@roe.com", ID: "p1" })],
+            [family({ Primary_Contact_E_mail: "sam@roe.com", Primary_Contact_Name: "Sam Roe" })],
+            [input({ Primary_Contact_E_mail: "sam@roe.com" })],
+        );
+        expect(noDob.households[0].members[0].isDeclaredAdult).toBe(true);
+        expect(noDob.report.flags.some((f) => f.includes("declared adults"))).toBe(true);
+    });
 });

--- a/checkin-app/src/lib/dev/zoho-import.ts
+++ b/checkin-app/src/lib/dev/zoho-import.ts
@@ -71,6 +71,11 @@ export interface BuiltMember {
     dob: Date | null;
     lastBackgroundCheck: Date | null;
     isPrimary: boolean;
+    /** No DoB in Zoho but treated as an adult — only the household primary contact
+     *  is inferred (they signed the Zoho membership as the responsible adult). Maps
+     *  to Participant.isDeclaredAdult so they show as "Adult", not "Age Unavailable",
+     *  under the new age model (#606). Members WITH a DoB derive age from it. */
+    isDeclaredAdult: boolean;
     /** Provenance / prior-system reference, surfaced into the AuditLog row. */
     source: {
         zohoId: string;
@@ -244,6 +249,10 @@ export function buildImport(files: ZohoFiles, now: Date): BuiltImport {
                 dob,
                 lastBackgroundCheck: bgDate,
                 isPrimary: idx === primaryIdx,
+                // Only the primary contact is inferred adult, and only when Zoho has
+                // no DoB for them (with a DoB, age is derived). Other no-DoB members
+                // stay unknown for board review.
+                isDeclaredAdult: idx === primaryIdx && !dob,
                 source: {
                     zohoId: p.ID,
                     rawEmail: p.Email.trim(),
@@ -299,6 +308,13 @@ export function buildImport(files: ZohoFiles, now: Date): BuiltImport {
     report.flags.push(
         "All households imported without an emergency contact (not present in Zoho) — members/board must fill this in.",
     );
+
+    const declaredAdults = households.reduce((n, h) => n + h.members.filter((m) => m.isDeclaredAdult).length, 0);
+    if (declaredAdults > 0) {
+        report.flags.push(
+            `${declaredAdults} household primary contact(s) had no date of birth in Zoho and were marked as declared adults (shown as "Adult") — board should confirm.`,
+        );
+    }
 
     return { households, report };
 }
@@ -434,6 +450,7 @@ export async function applyImport(
                 ...(m.email ? { email: m.email } : {}),
                 dateOfBirth: m.dob,
                 lastBackgroundCheck: m.lastBackgroundCheck,
+                isDeclaredAdult: m.isDeclaredAdult,
                 householdId,
             };
 


### PR DESCRIPTION
## Analysis
The Zoho import flow is `scripts/import-zoho.ts` (thin CLI) → `src/lib/dev/zoho-import.ts` (`parseZoho` → `buildImport` → `applyImport`). `applyImport` writes: `Household{name, line1}`, `Participant{name, email, dateOfBirth, lastBackgroundCheck, householdId}`, `HouseholdLead`, `Membership{householdId, status}`, `AuditLog`.

I checked each write against the current schema:
- Every field still exists by the same name — the importer was already kept in sync through the `Participant.dob→dateOfBirth` rename (#529), structured addresses (#513), and audit-JSON (#588).
- Verified empirically: `tsc --noEmit` reports **zero** zoho errors, and the transform unit test passes.

The **one** schema change it predates is #606 (`add_participant_is_declared_adult` — "require member age"): `Participant.isDeclaredAdult`. It has `@default(false)`, so the import didn't break — but every imported member without a DoB (including household leads) would render as **"Age Unavailable"** under the new age model.

## Change
Infer `isDeclaredAdult` in the **pure transform** (`buildImport`), so it's covered by the existing no-DB test:
- **Primary contact with no DoB → `true`** (they signed the Zoho membership as the responsible adult → shows as "Adult").
- Primary **with** a DoB → `false` (age is derived from the DoB).
- Any non-primary with no DoB → `false` (unknown age; stays flagged for board review).

`applyImport` persists the field; `buildImport` adds a report flag with the count so the board can confirm the inferred adults.

## Verification
- `npx eslint` clean on both files.
- `zohoImport.test.ts`: 11/11 (added a case covering primary-no-DoB → true, primary-with-DoB → false, child → false, and the report flag).
- `tsc --noEmit`: no zoho errors (the new `applyImport` write typechecks against the generated client).

## Scope note
Left the address as `line1`-only (a deliberate choice from #513 — Zoho's address is one unparsed blob); not touched here. No other schema drift found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
