### PR TITLE
fix(program-ops): clarify public-only filter label

### DIFF
--- a/checkin-app/src/app/program-ops/programs/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/page.tsx
@@ -146,7 +146,7 @@ export default function AdminProgramsIndex() {
           onChange={(e) => setActiveOnly(e.currentTarget.checked)}
         />
         <Checkbox
-          label="Only show publicly visible"
+          label="Only show programs available to the public"
           checked={publicOnly}
           onChange={(e) => setPublicOnly(e.currentTarget.checked)}
         />


### PR DESCRIPTION
## What

Rename the programs filter checkbox on `/program-ops/programs` from **"Only show publicly visible"** to **"Only show programs available to the public"**.

## Why

The old label was ambiguous. New wording states plainly what the filter does.

## Notes

Single-line label change in [page.tsx](checkin-app/src/app/program-ops/programs/page.tsx). No logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)