### PR TITLE
fix(attendance): show past-arrival departure error on the field

### DIFF
--- a/checkin-app/src/app/attendance/manual/page.tsx
+++ b/checkin-app/src/app/attendance/manual/page.tsx
@@ -45,6 +45,8 @@ export default function ManualAttendance() {
   if (authLoading) return <Center mih="60vh"><Loader /></Center>;
   if (!ready) return null;
 
+  const departureError = error === "Departure time is required for past arrivals.";
+
   return (
     <PageContainer>
       <AttendanceTabs />
@@ -56,7 +58,7 @@ export default function ManualAttendance() {
           currently in the building, leave the departure time blank.
         </Text>
 
-        {error && <Alert color="red" mb="md">{error}</Alert>}
+        {error && !departureError && <Alert color="red" mb="md">{error}</Alert>}
         {success && <Alert color="green" mb="md">{success}</Alert>}
 
         <form onSubmit={handleSubmit}>
@@ -73,6 +75,7 @@ export default function ManualAttendance() {
               label="Departure Time (Optional)"
               value={departedAt}
               onChange={(e) => setDeparted(e.currentTarget.value)}
+              error={departureError ? error : undefined}
             />
             <Button type="submit" disabled={loading || !arrivedAt} loading={loading} mt="sm">
               Record Time Entry


### PR DESCRIPTION
## What

Manual time entry form (\`/attendance/manual\`) now shows the **"Departure time is required for past arrivals."** error on the Departure Time field — red border + message underneath — instead of a generic red alert chip at the top of the card.

## Why

The message is specific to the departure input, so anchoring it there points the user straight at the field to fix. The old top-of-card alert forced the user to map a generic error back to the right input.

## How

- Compute \`departureError = error === "Departure time is required for past arrivals."\`
- Suppress the top \`Alert\` for that specific case (still shown for all other errors)
- Pass the message into the Departure \`TextInput\`'s \`error\` prop (Mantine renders red border + helper text)

## Notes

- Server validation in \`api/attendance/manual/route.ts\` unchanged; this is display-only routing of the existing message.
- String-match on the message is intentional and minimal; if more field-specific errors get added later, consider returning a field key from the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)