### PR TITLE
fix(nav): consistent readable font on all count badges

### DIFF
--- a/checkin-app/src/app/membership-audit/layout.tsx
+++ b/checkin-app/src/app/membership-audit/layout.tsx
@@ -64,7 +64,10 @@ export default function MembershipAuditLayout({ children }: { children: React.Re
                     <Badge
                       size="md"
                       color="gray"
-                      variant="filled"
+                      variant="light"
+                      // Light-gray informational count: light fill + dark text. Pinned so the
+                      // active tab's green recolor doesn't turn the number green.
+                      c="var(--mantine-color-gray-7)"
                       aria-label={label}
                     >
                       {count}

--- a/checkin-app/src/app/membership-ops/layout.tsx
+++ b/checkin-app/src/app/membership-ops/layout.tsx
@@ -91,7 +91,10 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
                   ) : showMemberFamilies ? (
                     <Badge
                       size="md"
-                      color="gray"
+                      // Dark-gray total counter: gray.8 is dark enough for white text (plain
+                      // gray filled = gray.6 ≈ #868e96, where white fails contrast). Pinned white
+                      // also survives the active tab's green recolor.
+                      color="gray.8"
                       variant="filled"
                       c="white"
                       aria-label={`${memberFamilies} member famil${memberFamilies === 1 ? "y" : "ies"}`}

--- a/checkin-app/src/app/my-programs/layout.tsx
+++ b/checkin-app/src/app/my-programs/layout.tsx
@@ -59,13 +59,13 @@ export default function MyProgramsLayout({ children }: { children: React.ReactNo
         <ScrollableTabsList>
           <Tabs.Tab
             value="/my-programs"
-            rightSection={pending > 0 ? <Badge size="sm" circle color="treehouseGreen">{pending}</Badge> : undefined}
+            rightSection={pending > 0 ? <Badge size="sm" circle color="treehouseGreen" c="var(--mantine-color-black)">{pending}</Badge> : undefined}
           >
             Attendance
           </Tabs.Tab>
           <Tabs.Tab
             value="/my-programs/conflicts"
-            rightSection={conflictCount > 0 ? <Badge size="sm" circle color="red">{conflictCount}</Badge> : undefined}
+            rightSection={conflictCount > 0 ? <Badge size="sm" circle color="red" c="var(--mantine-color-white)">{conflictCount}</Badge> : undefined}
           >
             Conflicts
           </Tabs.Tab>

--- a/checkin-app/src/app/safety/layout.tsx
+++ b/checkin-app/src/app/safety/layout.tsx
@@ -57,7 +57,9 @@ export default function SafetyLayout({ children }: { children: React.ReactNode }
             <Tabs.Tab
               key={t.href}
               value={t.href}
-              rightSection={t.count ? <Badge size="xs" circle color="green">{t.count}</Badge> : undefined}
+              // Active tab recolors its content to the tabs color (green); pin dark text so the
+              // green count badge isn't rendered green-on-green on the active tab.
+              rightSection={t.count ? <Badge size="xs" circle color="green" c="var(--mantine-color-black)">{t.count}</Badge> : undefined}
             >
               {t.name}
             </Tabs.Tab>

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -308,19 +308,24 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                 rightSection={
                   badges.length > 0 ? (
                     <Group gap={4} wrap="nowrap">
-                      {badges.map((badge) => (
-                        <Badge
-                          key={badge.color}
-                          size="md"
-                          color={badge.color}
-                          variant="filled"
-                          aria-label={badge.label}
-                          // Gray fill is light; white text on it fails contrast. Force dark text.
-                          styles={badge.color === 'gray' ? { label: { color: 'var(--mantine-color-dark-9)' } } : undefined}
-                        >
-                          {badge.count}
-                        </Badge>
-                      ))}
+                      {badges.map((badge) => {
+                        // Two badge shades, each with its own readable font (same convention as
+                        // the membership-ops tabs): green action badges are green fill + dark
+                        // text; gray informational badges are light-gray fill + dark text.
+                        const isGray = badge.color === 'gray';
+                        return (
+                          <Badge
+                            key={badge.color}
+                            size="md"
+                            color={badge.color}
+                            variant={isGray ? 'light' : 'filled'}
+                            c={isGray ? 'var(--mantine-color-gray-7)' : 'var(--mantine-color-black)'}
+                            aria-label={badge.label}
+                          >
+                            {badge.count}
+                          </Badge>
+                        );
+                      })}
                     </Group>
                   ) : undefined
                 }


### PR DESCRIPTION
## What
Audit of every count badge across the **left nav** and the **top sub-tabs**; one consistent, readable font convention applied.

## Why
Two things broke readability:
1. The theme (`brand/treehouse.ts`) sets `autoContrast: true` with a light brand green, so filled badges normally auto-pick a readable label — **but Mantine recolors an active tab's content to the tabs color (green)**, overriding autoContrast and rendering filled badges green-on-green / green-on-gray. #610 fixed only membership-ops; sibling tabs stayed broken.
2. The member-families counter used plain gray fill (`gray.6` ≈ `#868e96`) with white text — ~2.3:1, fails contrast. Only a genuinely dark gray (`gray.8`) carries white text.

## Convention
| Bucket | Fill | Font |
|---|---|---|
| Green action | green | dark (`black`) |
| Light-gray info | `variant="light"` | dark (`gray-7`) |
| Dark-gray total | `gray.8` filled | light (`white`) |

## Changes
- **AppFrame (left nav):** gray badges → light-gray fill + dark text (were filled mid-gray, unreadable); green badges pinned dark text.
- **membership-ops:** member-families counter → `gray.8` so white is legible (was white on `gray.6`). Broken/Applications badges already correct (#610).
- **membership-audit:** gap counts → light-gray + dark text (were filled).
- **safety / my-programs:** pin dark text on green counts; pin white on the red conflicts badge so neither inherits the active tab's green.

## Reviewer note
Judgment call: **member-families** is the only "dark-gray + light font" badge; the audit gap-counts are treated as light-gray. If the intended split is different (e.g. all filled-gray counts should be dark-gray+white), say so and I'll flip them.

Other sub-tab layouts (facility-ops, finance-ops, program-ops, shop-ops, my-activities, system-status) render no counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)