### PR TITLE
test(coverage): Phase 1 — layout-gate tests (11 layouts)

### DIFF
--- a/checkin-app/src/app/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/__tests__/layout.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import RootLayout from "../layout";
+
+// Root layout is just html/body + provider wiring, no gating of its own — every
+// provider below has its own tests (or is trivial); mock them to passthroughs so
+// this test exercises RootLayout's own composition, not its children's internals.
+jest.mock("@/components/AuthProvider", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock("@/components/EnvProvider", () => ({
+  EnvProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock("@/components/DevImpersonationBar", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("@/components/DevDashboard", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("@/components/OnboardingGate", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock("@/components/RenewalBanner", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("@/components/AppFrame", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock("@/components/UnsavedChangesProvider", () => ({
+  UnsavedChangesProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const CHILD = "child-marker";
+
+describe("RootLayout", () => {
+  it("renders its children inside the provider chrome", () => {
+    render(
+      <RootLayout>
+        <div>{CHILD}</div>
+      </RootLayout>,
+    );
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+  });
+});

--- a/checkin-app/src/app/facility-ops/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/facility-ops/__tests__/layout.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import FacilityLayout from "../layout";
+
+const push = jest.fn();
+let mockPathname = "/facility-ops/visits";
+let mockSession: { data: unknown; status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const CHILD = "child-marker";
+const renderLayout = (pathname: string, session: { data: unknown; status: string }) => {
+  mockPathname = pathname;
+  mockSession = session;
+  return render(
+    <MantineProvider>
+      <FacilityLayout>
+        <div>{CHILD}</div>
+      </FacilityLayout>
+    </MantineProvider>,
+  );
+};
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("FacilityLayout role gate", () => {
+  it("admits a sysadmin", () => {
+    renderLayout("/facility-ops/visits", {
+      data: { user: { id: 1, isSysadmin: true } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("redirects an authenticated user with none of the allowed roles", () => {
+    renderLayout("/facility-ops/visits", {
+      data: { user: { id: 2 } },
+      status: "authenticated",
+    });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects unauthenticated callers", () => {
+    renderLayout("/facility-ops/visits", { data: null, status: "unauthenticated" });
+    expect(push).toHaveBeenCalledWith("/");
+  });
+});

--- a/checkin-app/src/app/finance-ops/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/finance-ops/__tests__/layout.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import FinanceOpsLayout from "../layout";
+
+const push = jest.fn();
+let mockPathname = "/finance-ops/payment-plan";
+let mockSession: { data: unknown; status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const CHILD = "child-marker";
+const renderLayout = (pathname: string, session: { data: unknown; status: string }) => {
+  mockPathname = pathname;
+  mockSession = session;
+  return render(
+    <MantineProvider>
+      <FinanceOpsLayout>
+        <div>{CHILD}</div>
+      </FinanceOpsLayout>
+    </MantineProvider>,
+  );
+};
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("FinanceOpsLayout role gate", () => {
+  it("admits a board member", () => {
+    renderLayout("/finance-ops/payment-plan", {
+      data: { user: { id: 1, isBoardMember: true } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("redirects an authenticated user with none of the allowed roles", () => {
+    renderLayout("/finance-ops/payment-plan", {
+      data: { user: { id: 2 } },
+      status: "authenticated",
+    });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects unauthenticated callers", () => {
+    renderLayout("/finance-ops/payment-plan", { data: null, status: "unauthenticated" });
+    expect(push).toHaveBeenCalledWith("/");
+  });
+});

--- a/checkin-app/src/app/membership-audit/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/membership-audit/__tests__/layout.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import MembershipAuditLayout from "../layout";
+
+const push = jest.fn();
+let mockPathname = "/membership-audit/emergency-contacts";
+let mockSession: { data: unknown; status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+jest.mock("@/hooks/useTodoCounts", () => ({
+  useTodoCounts: () => null,
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const CHILD = "child-marker";
+const renderLayout = (pathname: string, session: { data: unknown; status: string }) => {
+  mockPathname = pathname;
+  mockSession = session;
+  return render(
+    <MantineProvider>
+      <MembershipAuditLayout>
+        <div>{CHILD}</div>
+      </MembershipAuditLayout>
+    </MantineProvider>,
+  );
+};
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("MembershipAuditLayout role gate", () => {
+  it("admits a board member", () => {
+    renderLayout("/membership-audit/emergency-contacts", {
+      data: { user: { id: 1, isBoardMember: true } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("redirects an authenticated user with none of the allowed roles", () => {
+    renderLayout("/membership-audit/emergency-contacts", {
+      data: { user: { id: 2 } },
+      status: "authenticated",
+    });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects unauthenticated callers", () => {
+    renderLayout("/membership-audit/emergency-contacts", { data: null, status: "unauthenticated" });
+    expect(push).toHaveBeenCalledWith("/");
+  });
+});

--- a/checkin-app/src/app/membership-ops/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/membership-ops/__tests__/layout.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import MembershipOpsLayout from "../layout";
+
+const push = jest.fn();
+let mockPathname = "/membership-ops/participants";
+let mockSession: { data: unknown; status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+jest.mock("@/hooks/useTodoCounts", () => ({
+  useTodoCounts: () => null,
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const CHILD = "child-marker";
+const renderLayout = (pathname: string, session: { data: unknown; status: string }) => {
+  mockPathname = pathname;
+  mockSession = session;
+  return render(
+    <MantineProvider>
+      <MembershipOpsLayout>
+        <div>{CHILD}</div>
+      </MembershipOpsLayout>
+    </MantineProvider>,
+  );
+};
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("MembershipOpsLayout role gate", () => {
+  it("admits a sysadmin, showing admin tabs (not the reviewer-only Review tab restriction)", () => {
+    renderLayout("/membership-ops/participants", {
+      data: { user: { id: 1, isSysadmin: true } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(screen.getByText("Applications")).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("admits a background-check-reviewer-only user, scoped to the Review tab", () => {
+    renderLayout("/membership-ops/review", {
+      data: { user: { id: 2, isBackgroundCheckReviewer: true } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(screen.getByText("Background-check Review")).toBeInTheDocument();
+    expect(screen.queryByText("Applications")).not.toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("redirects an authenticated user with none of the allowed roles", () => {
+    renderLayout("/membership-ops/participants", {
+      data: { user: { id: 3 } },
+      status: "authenticated",
+    });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects unauthenticated callers", () => {
+    renderLayout("/membership-ops/participants", { data: null, status: "unauthenticated" });
+    expect(push).toHaveBeenCalledWith("/");
+  });
+});

--- a/checkin-app/src/app/my-activities/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/my-activities/__tests__/layout.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import MyActivitiesLayout from "../layout";
+
+const push = jest.fn();
+let mockPathname = "/my-activities/events";
+let mockSession: { status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const CHILD = "child-marker";
+const renderLayout = (pathname: string, session: { status: string }) => {
+  mockPathname = pathname;
+  mockSession = session;
+  return render(
+    <MantineProvider>
+      <MyActivitiesLayout>
+        <div>{CHILD}</div>
+      </MyActivitiesLayout>
+    </MantineProvider>,
+  );
+};
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("MyActivitiesLayout sign-in gate", () => {
+  it("admits any authenticated caller", () => {
+    renderLayout("/my-activities/events", { status: "authenticated" });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("shows a loader while the session resolves", () => {
+    renderLayout("/my-activities/events", { status: "loading" });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("redirects unauthenticated callers", () => {
+    renderLayout("/my-activities/events", { status: "unauthenticated" });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+});

--- a/checkin-app/src/app/my-programs/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/my-programs/__tests__/layout.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import type { TodoCounts } from "@/app/api/nav/todo-counts/route";
+import MyProgramsLayout from "../layout";
+
+const push = jest.fn();
+let mockPathname = "/my-programs";
+let mockSession: { status: string };
+let mockCounts: TodoCounts | null;
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+jest.mock("@/hooks/useTodoCounts", () => ({
+  useTodoCounts: () => mockCounts,
+}));
+jest.mock("@/hooks/useConflicts", () => ({
+  useConflicts: () => ({ conflicts: [] }),
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const CHILD = "child-marker";
+const renderLayout = (pathname: string, session: { status: string }, counts: TodoCounts | null) => {
+  mockPathname = pathname;
+  mockSession = session;
+  mockCounts = counts;
+  return render(
+    <MantineProvider>
+      <MyProgramsLayout>
+        <div>{CHILD}</div>
+      </MyProgramsLayout>
+    </MantineProvider>,
+  );
+};
+
+const leadCounts = {
+  lead: { programs: [{ id: 1, name: "Robotics", totalEnrolled: 4, pending: [{ id: 1, label: "x" }], upcoming: [] }] },
+} as unknown as TodoCounts;
+
+const noLeadCounts = { lead: { programs: [] } } as unknown as TodoCounts;
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("MyProgramsLayout lead gate", () => {
+  it("admits a program lead mentor", () => {
+    renderLayout("/my-programs", { status: "authenticated" }, leadCounts);
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("redirects an authenticated caller who leads no program (once counts resolve)", () => {
+    renderLayout("/my-programs", { status: "authenticated" }, noLeadCounts);
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects unauthenticated callers", () => {
+    renderLayout("/my-programs", { status: "unauthenticated" }, null);
+    expect(push).toHaveBeenCalledWith("/");
+  });
+});

--- a/checkin-app/src/app/safety/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/safety/__tests__/layout.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import SafetyLayout from "../layout";
+
+const push = jest.fn();
+let mockPathname = "/safety/emergency-contacts";
+let mockSession: { data: unknown; status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+jest.mock("@/hooks/useTodoCounts", () => ({
+  useTodoCounts: () => null,
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const CHILD = "child-marker";
+const renderLayout = (pathname: string, session: { data: unknown; status: string }) => {
+  mockPathname = pathname;
+  mockSession = session;
+  return render(
+    <MantineProvider>
+      <SafetyLayout>
+        <div>{CHILD}</div>
+      </SafetyLayout>
+    </MantineProvider>,
+  );
+};
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("SafetyLayout role gate", () => {
+  it("admits a keyholder but hides the board-only Trusted Adults tab", () => {
+    renderLayout("/safety/emergency-contacts", {
+      data: { user: { id: 1, isKeyholder: true } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(screen.queryByText(/Trusted Adults/)).not.toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("shows the Trusted Adults tab for a board member", () => {
+    renderLayout("/safety/emergency-contacts", {
+      data: { user: { id: 2, isBoardMember: true } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(screen.getByText(/Trusted Adults/)).toBeInTheDocument();
+  });
+
+  it("redirects an authenticated user with none of the allowed roles", () => {
+    renderLayout("/safety/emergency-contacts", {
+      data: { user: { id: 3 } },
+      status: "authenticated",
+    });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects unauthenticated callers", () => {
+    renderLayout("/safety/emergency-contacts", { data: null, status: "unauthenticated" });
+    expect(push).toHaveBeenCalledWith("/");
+  });
+});

--- a/checkin-app/src/app/settings/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/settings/__tests__/layout.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import SettingsLayout from "../layout";
+
+const push = jest.fn();
+let mockSession: { data: unknown; status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+
+const CHILD = "child-marker";
+const renderLayout = (session: { data: unknown; status: string }) => {
+  mockSession = session;
+  return render(
+    <MantineProvider>
+      <SettingsLayout>
+        <div>{CHILD}</div>
+      </SettingsLayout>
+    </MantineProvider>,
+  );
+};
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("SettingsLayout role gate", () => {
+  it("admits a sysadmin (chrome-less passthrough)", () => {
+    renderLayout({ data: { user: { id: 1, isSysadmin: true } }, status: "authenticated" });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("admits a board member", () => {
+    renderLayout({ data: { user: { id: 2, isBoardMember: true } }, status: "authenticated" });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("shows a loader while the session resolves", () => {
+    renderLayout({ data: null, status: "loading" });
+    expect(screen.getByText("Verifying access...")).toBeInTheDocument();
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+  });
+
+  it("redirects an authenticated user with neither role", () => {
+    renderLayout({ data: { user: { id: 3 } }, status: "authenticated" });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects unauthenticated callers", () => {
+    renderLayout({ data: null, status: "unauthenticated" });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+});

--- a/checkin-app/src/app/shop-ops/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/shop-ops/__tests__/layout.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import ShopLayout from "../layout";
+
+const push = jest.fn();
+let mockPathname = "/shop-ops/manage";
+let mockSession: { data: unknown; status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const CHILD = "child-marker";
+const renderLayout = (pathname: string, session: { data: unknown; status: string }) => {
+  mockPathname = pathname;
+  mockSession = session;
+  return render(
+    <MantineProvider>
+      <ShopLayout>
+        <div>{CHILD}</div>
+      </ShopLayout>
+    </MantineProvider>,
+  );
+};
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("ShopLayout role gate", () => {
+  it("redirects unauthenticated callers", () => {
+    renderLayout("/shop-ops/manage", { data: null, status: "unauthenticated" });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("shows Access Denied for an authenticated non-certifier", () => {
+    renderLayout("/shop-ops/live", { data: { user: { id: 1 } }, status: "authenticated" });
+    expect(screen.getByText(/Forbidden/)).toBeInTheDocument();
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+  });
+
+  it("admits an admin (certifier) to a visible tab", () => {
+    renderLayout("/shop-ops/manage", {
+      data: { user: { id: 2, isSysadmin: true } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+  });
+
+  it("blocks a certifier-but-not-admin from an admin-only tab", () => {
+    renderLayout("/shop-ops/create", {
+      data: { user: { id: 3, toolStatuses: [{ level: "MAY_CERTIFY_OTHERS" }] } },
+      status: "authenticated",
+    });
+    expect(screen.getByText("You do not have access to this section.")).toBeInTheDocument();
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+  });
+});

--- a/checkin-app/src/app/system-status/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/system-status/__tests__/layout.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import SystemStatusLayout from "../layout";
+
+const push = jest.fn();
+let mockPathname = "/system-status/health";
+let mockSession: { data: unknown; status: string };
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const CHILD = "child-marker";
+const renderLayout = (pathname: string, session: { data: unknown; status: string }) => {
+  mockPathname = pathname;
+  mockSession = session;
+  return render(
+    <MantineProvider>
+      <SystemStatusLayout>
+        <div>{CHILD}</div>
+      </SystemStatusLayout>
+    </MantineProvider>,
+  );
+};
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+describe("SystemStatusLayout role gate", () => {
+  it("admits a board member but hides the sysadmin-only Audit Log tab", () => {
+    renderLayout("/system-status/health", {
+      data: { user: { id: 1, isBoardMember: true } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(screen.queryByText("Audit Log")).not.toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("shows the Audit Log tab for a sysadmin", () => {
+    renderLayout("/system-status/health", {
+      data: { user: { id: 2, isSysadmin: true } },
+      status: "authenticated",
+    });
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(screen.getByText("Audit Log")).toBeInTheDocument();
+  });
+
+  it("redirects an authenticated user with none of the allowed roles", () => {
+    renderLayout("/system-status/health", {
+      data: { user: { id: 3 } },
+      status: "authenticated",
+    });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects unauthenticated callers", () => {
+    renderLayout("/system-status/health", { data: null, status: "unauthenticated" });
+    expect(push).toHaveBeenCalledWith("/");
+  });
+});


### PR DESCRIPTION
Executes part of Phase 1 of `docs/test-coverage-plan.md` (#632). Adds co-located `__tests__/layout.test.tsx` for all **11** `layout.tsx` files (were ~0%), mirroring `program-ops/__tests__/layout.test.tsx` (mock `useSession`/`next/navigation`, render a child marker, assert the role gate/redirect) + the `DataTable.test.tsx` Mantine setup.

**647 / 757 lines newly covered** across the 11 files (~85% avg; root layout, my-programs, settings → 100%). 37 tests, all green; eslint + `tsc --noEmit` clean. Test-only — no source changes. Self-fetching hooks are mocked directly (the shared `fetch` helper is Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)