### PR TITLE
test(coverage): Phase 1 — hooks + nav-config tests

### DIFF
--- a/checkin-app/src/hooks/__tests__/useAutoCycle.test.tsx
+++ b/checkin-app/src/hooks/__tests__/useAutoCycle.test.tsx
@@ -1,0 +1,64 @@
+import { act, renderHook } from "@testing-library/react";
+import { useAutoCycle } from "../useAutoCycle";
+
+describe("useAutoCycle", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts on page 0 with a ref and no transition", () => {
+    const { result } = renderHook(() => useAutoCycle({ items: ["a", "b", "c"] }));
+    expect(result.current.containerRef.current).toBeNull();
+    expect(result.current.currentPage).toBe(0);
+    expect(result.current.isTransitioning).toBe(false);
+    expect(result.current.visibleItems).toEqual(["a"]);
+  });
+
+  it("does not cycle when everything fits on one page", () => {
+    const { result } = renderHook(() => useAutoCycle({ items: ["only"], intervalMs: 1000 }));
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    expect(result.current.currentPage).toBe(0);
+    expect(result.current.totalPages).toBe(1);
+  });
+
+  it("returns no visible items for an empty list", () => {
+    const { result } = renderHook(() => useAutoCycle({ items: [] }));
+    expect(result.current.totalPages).toBe(0);
+    expect(result.current.visibleItems).toEqual([]);
+  });
+
+  it("advances through pages on the interval, fading out then in", () => {
+    const { result } = renderHook(() => useAutoCycle({ items: ["a", "b", "c"], intervalMs: 1000 }));
+    expect(result.current.totalPages).toBe(3);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.isTransitioning).toBe(true);
+    expect(result.current.currentPage).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(result.current.isTransitioning).toBe(false);
+    expect(result.current.currentPage).toBe(1);
+    expect(result.current.visibleItems).toEqual(["b"]);
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(result.current.currentPage).toBe(2);
+
+    // Wraps back to the first page after the last one.
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(result.current.currentPage).toBe(0);
+  });
+});

--- a/checkin-app/src/hooks/__tests__/useConflicts.test.tsx
+++ b/checkin-app/src/hooks/__tests__/useConflicts.test.tsx
@@ -1,0 +1,87 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useConflicts, refreshConflicts } from "../useConflicts";
+import type { AttendanceConflict } from "@/lib/attendanceConflicts";
+
+const makeConflict = (participantId: number): AttendanceConflict =>
+  ({
+    participantId,
+    participantName: "Kid One",
+    eventId: 10,
+    eventName: "Robotics",
+    visits: [],
+  }) as AttendanceConflict;
+
+// Mirrors useTodoCounts's module-level store: one shared snapshot for every
+// consumer. These cases intentionally run in order, each building on the
+// store state the previous case left behind rather than starting fresh.
+describe("useConflicts", () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock;
+  });
+
+  it("returns null and fetches nothing while disabled", () => {
+    const { result } = renderHook(() => useConflicts(false));
+    expect(result.current.conflicts).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches on mount and returns the resolved conflicts", async () => {
+    const conflicts = [makeConflict(1)];
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ conflicts }) });
+
+    const { result } = renderHook(() => useConflicts(true));
+
+    await waitFor(() => expect(result.current.conflicts).toEqual(conflicts));
+    expect(fetchMock).toHaveBeenCalledWith("/api/my-programs/conflicts");
+  });
+
+  it("keeps the last snapshot when a fetch response is not ok", async () => {
+    const priorSnapshot = [makeConflict(1)];
+    fetchMock.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useConflicts(true));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(result.current.conflicts).toEqual(priorSnapshot);
+  });
+
+  it("keeps the last snapshot when a fetch rejects", async () => {
+    const priorSnapshot = [makeConflict(1)];
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useConflicts(true));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(result.current.conflicts).toEqual(priorSnapshot);
+  });
+
+  it("exposes a refresh() that re-fetches and updates every consumer", async () => {
+    const second = [makeConflict(2)];
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ conflicts: second }) });
+
+    const { result } = renderHook(() => useConflicts(true));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const third = [makeConflict(3)];
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ conflicts: third }) });
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => expect(result.current.conflicts).toEqual(third));
+  });
+
+  it("dedupes concurrent refreshConflicts() calls into a single in-flight fetch", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ conflicts: [] }) });
+    fetchMock.mockClear();
+
+    refreshConflicts();
+    refreshConflicts();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+});

--- a/checkin-app/src/hooks/__tests__/useTodoCounts.test.tsx
+++ b/checkin-app/src/hooks/__tests__/useTodoCounts.test.tsx
@@ -1,0 +1,83 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useTodoCounts } from "../useTodoCounts";
+import { NAV_COUNTS_EVENT } from "@/lib/nav-refresh";
+import type { TodoCounts } from "@/app/api/nav/todo-counts/route";
+
+const makeCounts = (building: number): TodoCounts =>
+  ({
+    member: { household: [], programs: [] },
+    building,
+    buildingHousehold: 0,
+    activePrograms: 0,
+  }) as TodoCounts;
+
+// useTodoCounts keeps one shared snapshot in module scope for every consumer
+// (see the hook's own comment). That means these cases can't be reset between
+// tests the way a plain hook could — they intentionally run in order, each
+// building on the store state the previous case left behind, the same way
+// two real badges reading the hook in sequence would.
+describe("useTodoCounts", () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock;
+  });
+
+  it("returns null and fetches nothing while disabled", () => {
+    const { result } = renderHook(() => useTodoCounts(false));
+    expect(result.current).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches on mount and returns the resolved counts", async () => {
+    const data = makeCounts(4);
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve(data) });
+
+    const { result } = renderHook(() => useTodoCounts(true));
+
+    await waitFor(() => expect(result.current).toEqual(data));
+    expect(fetchMock).toHaveBeenCalledWith("/api/nav/todo-counts");
+  });
+
+  it("keeps the last snapshot when a fetch response is not ok", async () => {
+    const priorSnapshot = makeCounts(4); // left behind by the previous test
+    fetchMock.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useTodoCounts(true));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(result.current).toEqual(priorSnapshot);
+  });
+
+  it("keeps the last snapshot when a fetch rejects", async () => {
+    const priorSnapshot = makeCounts(4);
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useTodoCounts(true));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(result.current).toEqual(priorSnapshot);
+  });
+
+  it("refetches and updates every consumer when NAV_COUNTS_EVENT fires", async () => {
+    const updated = makeCounts(9);
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve(updated) });
+    const { result } = renderHook(() => useTodoCounts(true));
+    await waitFor(() => expect(result.current).toEqual(updated));
+
+    const afterEvent = makeCounts(11);
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve(afterEvent) });
+
+    act(() => {
+      window.dispatchEvent(new Event(NAV_COUNTS_EVENT));
+    });
+
+    await waitFor(() => expect(result.current).toEqual(afterEvent));
+  });
+
+  it("returns null while disabled even once a previous consumer populated the store", () => {
+    const { result } = renderHook(() => useTodoCounts(false));
+    expect(result.current).toBeNull();
+  });
+});

--- a/checkin-app/src/lib/__tests__/facilityNav.test.ts
+++ b/checkin-app/src/lib/__tests__/facilityNav.test.ts
@@ -1,0 +1,17 @@
+import { FACILITY_NAV_LINKS } from "../facilityNav";
+
+describe("FACILITY_NAV_LINKS", () => {
+  it("is a non-empty list of nav links with name, href, and icon", () => {
+    expect(FACILITY_NAV_LINKS.length).toBeGreaterThan(0);
+    for (const link of FACILITY_NAV_LINKS) {
+      expect(typeof link.name).toBe("string");
+      expect(link.href.startsWith("/facility-ops/")).toBe(true);
+      expect(typeof link.icon).toBe("string");
+    }
+  });
+
+  it("has unique hrefs", () => {
+    const hrefs = FACILITY_NAV_LINKS.map((l) => l.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});

--- a/checkin-app/src/lib/__tests__/financeNav.test.ts
+++ b/checkin-app/src/lib/__tests__/financeNav.test.ts
@@ -1,0 +1,17 @@
+import { FINANCE_NAV_LINKS } from "../financeNav";
+
+describe("FINANCE_NAV_LINKS", () => {
+  it("is a non-empty list of nav links with name, href, and icon", () => {
+    expect(FINANCE_NAV_LINKS.length).toBeGreaterThan(0);
+    for (const link of FINANCE_NAV_LINKS) {
+      expect(typeof link.name).toBe("string");
+      expect(link.href.startsWith("/finance-ops/")).toBe(true);
+      expect(typeof link.icon).toBe("string");
+    }
+  });
+
+  it("has unique hrefs", () => {
+    const hrefs = FINANCE_NAV_LINKS.map((l) => l.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});

--- a/checkin-app/src/lib/__tests__/membershipOpsNav.test.ts
+++ b/checkin-app/src/lib/__tests__/membershipOpsNav.test.ts
@@ -1,0 +1,21 @@
+import { MEMBERSHIP_OPS_NAV_LINKS } from "../membershipOpsNav";
+
+describe("MEMBERSHIP_OPS_NAV_LINKS", () => {
+  it("is a non-empty list of nav links with name, href, and icon", () => {
+    expect(MEMBERSHIP_OPS_NAV_LINKS.length).toBeGreaterThan(0);
+    for (const link of MEMBERSHIP_OPS_NAV_LINKS) {
+      expect(typeof link.name).toBe("string");
+      expect(link.href.startsWith("/membership-ops/")).toBe(true);
+      expect(typeof link.icon).toBe("string");
+    }
+  });
+
+  it("has unique hrefs", () => {
+    const hrefs = MEMBERSHIP_OPS_NAV_LINKS.map((l) => l.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+
+  it("does not surface the disabled Merge Participants tool", () => {
+    expect(MEMBERSHIP_OPS_NAV_LINKS.some((l) => l.href.includes("merge"))).toBe(false);
+  });
+});

--- a/checkin-app/src/lib/__tests__/myActivitiesNav.test.ts
+++ b/checkin-app/src/lib/__tests__/myActivitiesNav.test.ts
@@ -1,0 +1,17 @@
+import { MY_ACTIVITIES_NAV_LINKS } from "../myActivitiesNav";
+
+describe("MY_ACTIVITIES_NAV_LINKS", () => {
+  it("is a non-empty list of nav links with name, href, and icon", () => {
+    expect(MY_ACTIVITIES_NAV_LINKS.length).toBeGreaterThan(0);
+    for (const link of MY_ACTIVITIES_NAV_LINKS) {
+      expect(typeof link.name).toBe("string");
+      expect(link.href.startsWith("/my-activities/")).toBe(true);
+      expect(typeof link.icon).toBe("string");
+    }
+  });
+
+  it("has unique hrefs", () => {
+    const hrefs = MY_ACTIVITIES_NAV_LINKS.map((l) => l.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});

--- a/checkin-app/src/lib/__tests__/programNav.test.ts
+++ b/checkin-app/src/lib/__tests__/programNav.test.ts
@@ -1,0 +1,17 @@
+import { PROGRAM_NAV_LINKS } from "../programNav";
+
+describe("PROGRAM_NAV_LINKS", () => {
+  it("is a non-empty list of nav links with name, href, and icon", () => {
+    expect(PROGRAM_NAV_LINKS.length).toBeGreaterThan(0);
+    for (const link of PROGRAM_NAV_LINKS) {
+      expect(typeof link.name).toBe("string");
+      expect(link.href.startsWith("/program-ops/")).toBe(true);
+      expect(typeof link.icon).toBe("string");
+    }
+  });
+
+  it("has unique hrefs", () => {
+    const hrefs = PROGRAM_NAV_LINKS.map((l) => l.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});

--- a/checkin-app/src/lib/__tests__/shopNav.test.ts
+++ b/checkin-app/src/lib/__tests__/shopNav.test.ts
@@ -1,0 +1,83 @@
+import { SHOP_NAV_LINKS, shopRoles, defaultShopTab } from "../shopNav";
+import type { Session } from "next-auth";
+
+type SessionUser = Session["user"];
+
+const user = (overrides: Partial<SessionUser> = {}): SessionUser =>
+  ({ id: 1, ...overrides }) as SessionUser;
+
+describe("SHOP_NAV_LINKS", () => {
+  it("lists the three shop-ops tabs with hrefs and visibility predicates", () => {
+    expect(SHOP_NAV_LINKS.map((l) => l.href)).toEqual([
+      "/shop-ops/manage",
+      "/shop-ops/create",
+      "/shop-ops/live",
+    ]);
+    expect(SHOP_NAV_LINKS.every((l) => typeof l.visible === "function")).toBe(true);
+  });
+});
+
+describe("shopRoles", () => {
+  it("treats sysadmins as admin and certifier", () => {
+    expect(shopRoles(user({ isSysadmin: true }))).toEqual({ isAdmin: true, isCertifier: true });
+  });
+
+  it("treats board members as admin and certifier", () => {
+    expect(shopRoles(user({ isBoardMember: true }))).toEqual({ isAdmin: true, isCertifier: true });
+  });
+
+  it("grants certifier (not admin) to a non-admin with a MAY_CERTIFY_OTHERS tool status", () => {
+    expect(
+      shopRoles(user({ toolStatuses: [{ toolId: 1, level: "MAY_CERTIFY_OTHERS" }] })),
+    ).toEqual({ isAdmin: false, isCertifier: true });
+  });
+
+  it("does not grant certifier for a lesser tool status", () => {
+    expect(
+      shopRoles(user({ toolStatuses: [{ toolId: 1, level: "BASIC" }] })),
+    ).toEqual({ isAdmin: false, isCertifier: false });
+  });
+
+  it("denies both for a plain member with no roles or certifications", () => {
+    expect(shopRoles(user())).toEqual({ isAdmin: false, isCertifier: false });
+  });
+
+  it("denies both when there is no session user", () => {
+    expect(shopRoles(undefined)).toEqual({ isAdmin: false, isCertifier: false });
+  });
+});
+
+describe("SHOP_NAV_LINKS visibility filtering by role", () => {
+  it("shows all three tabs to an admin", () => {
+    const roles = shopRoles(user({ isSysadmin: true }));
+    const visible = SHOP_NAV_LINKS.filter((l) => l.visible(roles)).map((l) => l.name);
+    expect(visible).toEqual([
+      "Manage Tools & Certifications",
+      "Create Tool",
+      "Live Certifications Center",
+    ]);
+  });
+
+  it("hides Create Tool from a certifier who isn't an admin", () => {
+    const roles = shopRoles(user({ toolStatuses: [{ toolId: 1, level: "MAY_CERTIFY_OTHERS" }] }));
+    const visible = SHOP_NAV_LINKS.filter((l) => l.visible(roles)).map((l) => l.name);
+    expect(visible).toEqual(["Manage Tools & Certifications", "Live Certifications Center"]);
+  });
+
+  it("shows only the always-visible Live Certifications Center to a plain member", () => {
+    const roles = shopRoles(user());
+    const visible = SHOP_NAV_LINKS.filter((l) => l.visible(roles)).map((l) => l.name);
+    expect(visible).toEqual(["Live Certifications Center"]);
+  });
+});
+
+describe("defaultShopTab", () => {
+  it("lands certifiers (including admins) on Manage", () => {
+    expect(defaultShopTab({ isAdmin: true, isCertifier: true })).toBe("/shop-ops/manage");
+    expect(defaultShopTab({ isAdmin: false, isCertifier: true })).toBe("/shop-ops/manage");
+  });
+
+  it("lands everyone else on Live", () => {
+    expect(defaultShopTab({ isAdmin: false, isCertifier: false })).toBe("/shop-ops/live");
+  });
+});

--- a/checkin-app/src/lib/__tests__/systemStatusNav.test.ts
+++ b/checkin-app/src/lib/__tests__/systemStatusNav.test.ts
@@ -1,0 +1,26 @@
+import { SYSTEM_STATUS_NAV_LINKS } from "../systemStatusNav";
+
+describe("SYSTEM_STATUS_NAV_LINKS", () => {
+  it("is a non-empty list of nav links with name and href", () => {
+    expect(SYSTEM_STATUS_NAV_LINKS.length).toBeGreaterThan(0);
+    for (const link of SYSTEM_STATUS_NAV_LINKS) {
+      expect(typeof link.name).toBe("string");
+      expect(link.href.startsWith("/system-status/")).toBe(true);
+    }
+  });
+
+  it("has unique hrefs", () => {
+    const hrefs = SYSTEM_STATUS_NAV_LINKS.map((l) => l.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+
+  it("flags only Audit Log as sysadmin-only", () => {
+    const sysadminOnly = SYSTEM_STATUS_NAV_LINKS.filter((l) => l.sysadminOnly).map((l) => l.name);
+    expect(sysadminOnly).toEqual(["Audit Log"]);
+  });
+
+  it("leaves the other tabs visible to everyone (sysadminOnly unset)", () => {
+    const everyone = SYSTEM_STATUS_NAV_LINKS.filter((l) => !l.sysadminOnly).map((l) => l.name);
+    expect(everyone).toEqual(["System Status", "Link Status", "Errors"]);
+  });
+});


### PR DESCRIPTION
Executes part of Phase 1 of `docs/test-coverage-plan.md` (#632). 10 new test files, 43 tests, all green; eslint + `tsc` clean. Test-only.

- **Hooks** (`renderHook`, mirrors `useRequireRole.test.tsx`): `useConflicts` 0→**100%**, `useTodoCounts` 0→**92%**, `useAutoCycle` 0→**62%** (resize/layout path left, documented). Handles the module-singleton store with intentionally-ordered narrative tests (verified stable).
- **Nav configs** (pure unit): all 7 (`shopNav`, `facilityNav`, `financeNav`, `membershipOpsNav`, `myActivitiesNav`, `programNav`, `systemStatusNav`) 0→**100%**. `shopNav`'s role predicates tested across sysadmin/board/certifier/member/anon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)