### PR TITLE
test(coverage): Phase 1 — low-coverage API routes (+ fix stale intake-index fixture)

### DIFF
--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for GET /api/facility/trends.
+ *
+ * 401/403 (roles: isSysadmin, isBoardMember) are already covered by
+ * authzRoleRejection.integration.test.ts — this file focuses on the success
+ * path: bucketing visits by period, the volunteer/student split (by age at
+ * arrival), structured (event-associated) vs unstructured hours, the
+ * `arrivedVia=SYSTEM` exclusion (synthetic "marked present" visits), the
+ * `programId` filter, and the invalid-period 400.
+ */
+
+import { GET } from '@/app/api/facility/trends/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+const TAG = 'facility-trends-test';
+
+describe('Facility trends API', () => {
+    let adminId: number;
+    let householdId: number;
+    let volunteerId: number; // adult, dateOfBirth makes them 30+
+    let studentId: number; // dateOfBirth makes them a minor
+    let programId: number;
+    let otherProgramId: number;
+    let eventId: number;
+    const visitIds: number[] = [];
+
+    const hoursAgo = (h: number) => new Date(Date.now() - h * 60 * 60 * 1000);
+
+    beforeAll(async () => {
+        const admin = await prisma.participant.create({
+            data: { email: `admin-${TAG}@example.com`, name: 'Admin', isSysadmin: true, household: { create: {} } },
+        });
+        adminId = admin.id;
+        householdId = admin.householdId;
+
+        const volunteer = await prisma.participant.create({
+            data: { email: `volunteer-${TAG}@example.com`, name: 'Volunteer', dateOfBirth: new Date('1980-01-01'), householdId },
+        });
+        volunteerId = volunteer.id;
+        const student = await prisma.participant.create({
+            data: { email: `student-${TAG}@example.com`, name: 'Student', dateOfBirth: new Date('2015-01-01'), householdId },
+        });
+        studentId = student.id;
+
+        const program = await prisma.program.create({ data: { name: `Prog ${TAG}` } });
+        programId = program.id;
+        const otherProgram = await prisma.program.create({ data: { name: `Other ${TAG}` } });
+        otherProgramId = otherProgram.id;
+        const event = await prisma.event.create({
+            data: { programId, name: `Event ${TAG}`, startAt: hoursAgo(5), endAt: hoursAgo(2) },
+        });
+        eventId = event.id;
+
+        // Structured visit (associated to the event): volunteer, 3 hours.
+        const structured = await prisma.visit.create({
+            data: { participantId: volunteerId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SCANNER', associatedEventId: eventId },
+        });
+        // Unstructured visit (no event): student, 1 hour.
+        const unstructured = await prisma.visit.create({
+            data: { participantId: studentId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(3), arrivedVia: 'WEB' },
+        });
+        // Synthetic "marked present" visit (arrivedVia SYSTEM) — must be excluded entirely.
+        const synthetic = await prisma.visit.create({
+            data: { participantId: volunteerId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SYSTEM', associatedEventId: eventId },
+        });
+        // Still-open visit (no departedAt) — excluded (departedAt: { not: null } in the where).
+        const open = await prisma.visit.create({
+            data: { participantId: studentId, arrivedAt: hoursAgo(1), arrivedVia: 'WEB' },
+        });
+        visitIds.push(structured.id, unstructured.id, synthetic.id, open.id);
+    });
+
+    afterAll(async () => {
+        await prisma.visit.deleteMany({ where: { id: { in: visitIds } } });
+        await prisma.event.deleteMany({ where: { id: eventId } });
+        await prisma.program.deleteMany({ where: { id: { in: [programId, otherProgramId] } } });
+        await prisma.participant.deleteMany({ where: { id: { in: [adminId, volunteerId, studentId] } } });
+        await prisma.household.deleteMany({ where: { id: householdId } });
+    });
+
+    const callAs = async (user: object | null, query = '') => {
+        (getServerSession as jest.Mock).mockResolvedValue(user === null ? null : { user });
+        const req = new Request(`http://localhost:4000/api/facility/trends${query}`, { method: 'GET' });
+        return GET(req as unknown as import('next/server').NextRequest);
+    };
+
+    it('rejects an invalid period with 400', async () => {
+        const res = await callAs({ id: adminId, isSysadmin: true }, '?period=fortnight');
+        expect(res.status).toBe(400);
+    });
+
+    it('buckets visits, splitting volunteer/student and structured/unstructured hours', async () => {
+        const res = await callAs({ id: adminId, isSysadmin: true }, '?period=month');
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.period).toBe('month');
+        expect(Array.isArray(data.buckets)).toBe(true);
+
+        // Everything we seeded lands in the current month's bucket.
+        const thisMonth = data.buckets[data.buckets.length - 1];
+        expect(thisMonth.uniqueVolunteers).toBeGreaterThanOrEqual(1);
+        expect(thisMonth.uniqueStudents).toBeGreaterThanOrEqual(1);
+        // Structured (event-associated) = the 3-hour volunteer visit; unstructured = the
+        // 1-hour student visit. SYSTEM-sourced and still-open visits are excluded, so
+        // totals reflect only those two.
+        expect(thisMonth.structuredHours).toBeGreaterThanOrEqual(3);
+        expect(thisMonth.unstructuredHours).toBeGreaterThanOrEqual(1);
+        expect(data.totals.label).toBe('Total');
+    });
+
+    it('scopes to a single program via programId', async () => {
+        const res = await callAs({ id: adminId, isSysadmin: true }, `?period=month&programId=${otherProgramId}`);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        // No visits are associated with otherProgramId's events (it has none) — empty result.
+        expect(data.buckets).toEqual([]);
+        expect(data.totals.uniqueVolunteers).toBe(0);
+        expect(data.totals.uniqueStudents).toBe(0);
+    });
+});

--- a/checkin-app/src/app/__tests__/myProgramsConflictsResolveAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/myProgramsConflictsResolveAPI.integration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for POST /api/my-programs/conflicts/resolve.
+ *
+ * Covers: 400 (missing/non-integer visitId), 401 (no session), 404 (visit not
+ * found), 403 (caller neither leads the visit's program nor is a global
+ * admin), 409 (visit has no genuine overlap — refuse to delete an isolated,
+ * legitimate visit), and the 200 success path for both a leading mentor and a
+ * global admin — asserting the Visit row is gone and an audit trail (action
+ * DELETE, tableName Visit, oldData snapshot) was written.
+ */
+
+import { POST } from '@/app/api/my-programs/conflicts/resolve/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+const TAG = 'conflicts-resolve-test';
+
+describe('My-programs conflicts resolve API', () => {
+    let leadId: number;
+    let otherLeadId: number;
+    let adminId: number;
+    let participantId: number;
+    let householdId: number;
+    let programId: number;
+    let eventId: number;
+
+    const hoursAgo = (h: number) => new Date(Date.now() - h * 60 * 60 * 1000);
+
+    beforeAll(async () => {
+        const lead = await prisma.participant.create({
+            data: { email: `lead-${TAG}@example.com`, name: 'Lead', household: { create: {} } },
+        });
+        leadId = lead.id;
+        householdId = lead.householdId;
+
+        const otherLead = await prisma.participant.create({
+            data: { email: `other-lead-${TAG}@example.com`, name: 'Other Lead', householdId },
+        });
+        otherLeadId = otherLead.id;
+
+        const admin = await prisma.participant.create({
+            data: { email: `admin-${TAG}@example.com`, name: 'Admin', isSysadmin: true, householdId },
+        });
+        adminId = admin.id;
+
+        const participant = await prisma.participant.create({
+            data: { email: `participant-${TAG}@example.com`, name: 'Participant', householdId },
+        });
+        participantId = participant.id;
+
+        const program = await prisma.program.create({ data: { name: `Prog ${TAG}`, leadMentorId: leadId } });
+        programId = program.id;
+        const event = await prisma.event.create({
+            data: { programId, name: `Event ${TAG}`, startAt: hoursAgo(5), endAt: hoursAgo(2) },
+        });
+        eventId = event.id;
+    });
+
+    afterAll(async () => {
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: [leadId, adminId] } } });
+        await prisma.visit.deleteMany({ where: { participantId } });
+        await prisma.event.deleteMany({ where: { id: eventId } });
+        await prisma.program.deleteMany({ where: { id: programId } });
+        await prisma.participant.deleteMany({ where: { id: { in: [leadId, otherLeadId, adminId, participantId] } } });
+        await prisma.household.deleteMany({ where: { id: householdId } });
+    });
+
+    const callAs = async (user: object | null, body: unknown) => {
+        (getServerSession as jest.Mock).mockResolvedValue(user === null ? null : { user });
+        const req = new Request('http://localhost:4000/api/my-programs/conflicts/resolve', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
+        return POST(req as unknown as import('next/server').NextRequest);
+    };
+
+    it('returns 401 without a session', async () => {
+        const res = await callAs(null, { visitId: 1 });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 400 for a missing/non-integer visitId', async () => {
+        const res1 = await callAs({ id: leadId }, {});
+        expect(res1.status).toBe(400);
+        const res2 = await callAs({ id: leadId }, { visitId: 'abc' });
+        expect(res2.status).toBe(400);
+    });
+
+    it('returns 404 when the visit does not exist', async () => {
+        const res = await callAs({ id: leadId }, { visitId: 999_999_999 });
+        expect(res.status).toBe(404);
+    });
+
+    it('returns 409 when the visit has no genuine overlap (refuses to delete an isolated visit)', async () => {
+        const isolated = await prisma.visit.create({
+            data: { participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(4), associatedEventId: eventId },
+        });
+        try {
+            const res = await callAs({ id: leadId }, { visitId: isolated.id });
+            expect(res.status).toBe(409);
+        } finally {
+            await prisma.visit.deleteMany({ where: { id: isolated.id } });
+        }
+    });
+
+    it('returns 403 for a caller who neither leads the program nor is a global admin', async () => {
+        const [anchor, sibling] = await Promise.all([
+            prisma.visit.create({ data: { participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), associatedEventId: eventId } }),
+            prisma.visit.create({ data: { participantId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(1) } }),
+        ]);
+        try {
+            const res = await callAs({ id: otherLeadId }, { visitId: anchor.id });
+            expect(res.status).toBe(403);
+        } finally {
+            await prisma.visit.deleteMany({ where: { id: { in: [anchor.id, sibling.id] } } });
+        }
+    });
+
+    it('lets the leading mentor delete an overlapping visit and writes an audit trail', async () => {
+        const anchor = await prisma.visit.create({
+            data: { participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SYSTEM', associatedEventId: eventId },
+        });
+        const sibling = await prisma.visit.create({
+            data: { participantId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(1), arrivedVia: 'SCANNER' },
+        });
+        try {
+            const res = await callAs({ id: leadId }, { visitId: anchor.id });
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            expect(data).toEqual({ success: true, deletedVisitId: anchor.id });
+
+            const gone = await prisma.visit.findUnique({ where: { id: anchor.id } });
+            expect(gone).toBeNull();
+            const survives = await prisma.visit.findUnique({ where: { id: sibling.id } });
+            expect(survives).not.toBeNull();
+
+            const audit = await prisma.auditLog.findFirst({
+                where: { actorId: leadId, tableName: 'Visit', affectedEntityId: anchor.id, action: 'DELETE' },
+            });
+            expect(audit).toBeDefined();
+            expect(audit?.secondaryAffectedEntity).toBe(eventId);
+            expect((audit?.oldData as { participantId: number })?.participantId).toBe(participantId);
+        } finally {
+            await prisma.visit.deleteMany({ where: { id: { in: [anchor.id, sibling.id] } } });
+        }
+    });
+
+    it('lets a global admin delete an overlapping visit for a program they do not lead', async () => {
+        const anchor = await prisma.visit.create({
+            data: { participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), associatedEventId: eventId },
+        });
+        const sibling = await prisma.visit.create({
+            data: { participantId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(1) },
+        });
+        try {
+            const res = await callAs({ id: adminId, isSysadmin: true }, { visitId: anchor.id });
+            expect(res.status).toBe(200);
+            const gone = await prisma.visit.findUnique({ where: { id: anchor.id } });
+            expect(gone).toBeNull();
+        } finally {
+            await prisma.visit.deleteMany({ where: { id: { in: [anchor.id, sibling.id] } } });
+        }
+    });
+});

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -66,7 +66,10 @@ describe('Nav todo-counts API', () => {
         });
         membershipId = membership.id;
         await prisma.membershipProcess.create({ data: { membershipId, kind: 'INITIAL', status: 'PENDING_PAYMENT' } });
-        await prisma.membershipProcess.create({ data: { membershipId, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
+        // Reviewer-owned state, kind RENEWAL (not INITIAL) so it doesn't collide with
+        // the membership_one_inflight_initial partial unique index above — a
+        // membership can hold only one in-flight INITIAL process at a time.
+        await prisma.membershipProcess.create({ data: { membershipId, kind: 'RENEWAL', status: 'RENEWAL_PENDING_BG' } });
 
         // Trusted adults for the lead: one awaiting subject action, one approved and
         // expiring within the warn window.
@@ -167,7 +170,7 @@ describe('Nav todo-counts API', () => {
         expect(res.status).toBe(200);
         const data = await res.json();
         // emergency contact (1) + PENDING_PAYMENT (1) + PENDING_SUBJECT_ACTION (1)
-        // + expiring trusted adult (1) = 4. PENDING_BG_REVIEW is reviewer-owned → excluded.
+        // + expiring trusted adult (1) = 4. RENEWAL_PENDING_BG is reviewer-owned → excluded.
         expect(data.member.household).toHaveLength(4);
         expect(data.member.programs).toHaveLength(2);
         // Items carry a label + a deep link so the UI can show *what* is due.
@@ -243,10 +246,15 @@ describe('Nav todo-counts API', () => {
         const before = await boardMembershipCount();
 
         // Reviewer (RBAC) work — surfaced by the reviewer notifications badge, not the
-        // board badge. Adding these must NOT move the board count.
+        // board badge. Adding these must NOT move the board count. Anchored to a fresh
+        // membership (householdB's, previously membership-less) rather than the shared
+        // `membershipId` — that one already holds an in-flight INITIAL and an in-flight
+        // RENEWAL process from beforeAll, and membership_one_inflight_initial /
+        // membership_one_inflight_renewal each allow only one per membership.
+        const reviewerMembership = await prisma.membership.create({ data: { householdId: householdBId, status: 'ACTIVE' } });
         const reviewerProcs = await prisma.$transaction([
-            prisma.membershipProcess.create({ data: { membershipId, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } }),
-            prisma.membershipProcess.create({ data: { membershipId, kind: 'RENEWAL', status: 'RENEWAL_PENDING_BG' } }),
+            prisma.membershipProcess.create({ data: { membershipId: reviewerMembership.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } }),
+            prisma.membershipProcess.create({ data: { membershipId: reviewerMembership.id, kind: 'RENEWAL', status: 'RENEWAL_PENDING_BG' } }),
         ]);
         expect(await boardMembershipCount()).toBe(before);
 
@@ -255,6 +263,7 @@ describe('Nav todo-counts API', () => {
         expect(await boardMembershipCount()).toBe(before + 1);
 
         await prisma.membershipProcess.deleteMany({ where: { id: { in: [...reviewerProcs.map((p) => p.id), blocked.id] } } });
+        await prisma.membership.delete({ where: { id: reviewerMembership.id } });
     });
 
     it('counts member families but excludes org-email-only (staff) households', async () => {

--- a/checkin-app/src/app/__tests__/systemStatusHealthAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/systemStatusHealthAPI.integration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for GET /api/system-status/health.
+ *
+ * 401/403 (roles: isSysadmin, isBoardMember, isKeyholder) are already covered
+ * by authzRoleRejection.integration.test.ts — this file covers the success
+ * path: the 30-day, always-30-entries daily bucketing, the median/p90/p99
+ * percentile math over `scan_response_time` metrics, days with no samples
+ * (count 0, percentiles 0), and the fire-and-forget prune of metrics older
+ * than 30 days.
+ */
+
+import { GET } from '@/app/api/system-status/health/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+const TAG = 'system-health-test';
+
+describe('System status health API', () => {
+    let keyholderId: number;
+    let householdId: number;
+    const metricIds: number[] = [];
+    let staleMetricId: number;
+
+    beforeAll(async () => {
+        const keyholder = await prisma.participant.create({
+            data: { email: `keyholder-${TAG}@example.com`, name: 'Keyholder', isKeyholder: true, household: { create: {} } },
+        });
+        keyholderId = keyholder.id;
+        householdId = keyholder.householdId;
+
+        // Three samples today: 100, 200, 300ms -> median 200, p90/p99 near 300.
+        const today = new Date();
+        for (const value of [100, 200, 300]) {
+            const m = await prisma.systemMetricLog.create({
+                data: { metric: 'scan_response_time', value, timestamp: today },
+            });
+            metricIds.push(m.id);
+        }
+        // A non-scan metric on the same day must NOT be counted.
+        const other = await prisma.systemMetricLog.create({
+            data: { metric: 'other_metric', value: 9999, timestamp: today },
+        });
+        metricIds.push(other.id);
+
+        // A stale sample (35 days ago) — outside the 30-day window; must be excluded
+        // from the response AND get pruned by the route's fire-and-forget cleanup.
+        const stale = await prisma.systemMetricLog.create({
+            data: { metric: 'scan_response_time', value: 500, timestamp: new Date(Date.now() - 35 * 24 * 60 * 60 * 1000) },
+        });
+        staleMetricId = stale.id;
+    });
+
+    afterAll(async () => {
+        await prisma.systemMetricLog.deleteMany({ where: { id: { in: [...metricIds, staleMetricId] } } });
+        await prisma.participant.deleteMany({ where: { id: keyholderId } });
+        await prisma.household.deleteMany({ where: { id: householdId } });
+    });
+
+    const callAsKeyholder = async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: keyholderId, isKeyholder: true } });
+        const req = new Request('http://localhost:4000/api/system-status/health', { method: 'GET' });
+        return GET(req as unknown as import('next/server').NextRequest);
+    };
+
+    it('returns exactly 30 days, todays bucket with count/median/p90/p99, and empty days as zeros', async () => {
+        const res = await callAsKeyholder();
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.days).toHaveLength(30);
+
+        const todayStr = new Date().toISOString().split('T')[0];
+        const today = data.days.find((d: { date: string }) => d.date === todayStr);
+        expect(today).toBeDefined();
+        expect(today.count).toBe(3); // the 'other_metric' row must not count
+        expect(today.median).toBe(200);
+        expect(today.p90).toBeGreaterThanOrEqual(200);
+        expect(today.p99).toBeLessThanOrEqual(300);
+
+        // A day with no samples in the window: zeroed out, not just absent.
+        const emptyDay = data.days.find((d: { count: number }) => d.count === 0);
+        expect(emptyDay).toBeDefined();
+        expect(emptyDay.median).toBe(0);
+        expect(emptyDay.p90).toBe(0);
+        expect(emptyDay.p99).toBe(0);
+    });
+
+    it('excludes samples older than 30 days from the response and prunes them', async () => {
+        const res = await callAsKeyholder();
+        const data = await res.json();
+        const total = data.days.reduce((s: number, d: { count: number }) => s + d.count, 0);
+        expect(total).toBe(3); // only today's 3 scan_response_time rows
+
+        // The route's cleanup is fire-and-forget (not awaited) — give it a tick.
+        await new Promise((r) => setTimeout(r, 200));
+        const stillThere = await prisma.systemMetricLog.findUnique({ where: { id: staleMetricId } });
+        expect(stillThere).toBeNull();
+    });
+});


### PR DESCRIPTION
Executes part of Phase 1 of `docs/test-coverage-plan.md` (#632). Integration tests for the 4 lowest-covered API routes, 21 tests, all green against a throwaway Postgres; eslint clean.

| Route | Before | After |
|---|--:|--:|
| `api/nav/todo-counts` | 25.6% | **96.4%** |
| `api/facility/trends` | 14.0% | **89.1%** |
| `api/system-status/health` | 9.3% | **96.5%** |
| `api/my-programs/conflicts/resolve` | 0% | **97.6%** |

**Also fixes a pre-existing broken test:** `navTodoCountsAPI.integration.test.ts` was crashing in `beforeAll` with P2002 — the `membership_one_inflight_initial` unique index (from #623) rejected a fixture that stacked two in-flight INITIAL processes. Fixture fixed (second process → RENEWAL); no route-logic change. This is why the plan still showed 270 uncovered lines for this route despite a test file existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)