### PR TITLE
test(coverage): Phase 2+3 — RTL tests for components & top pages

### DIFF
--- a/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
+++ b/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
@@ -1,0 +1,142 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import KioskDisplay from "../page";
+
+beforeEach(() => resetRtl());
+
+const attendanceData = {
+  access: "full",
+  attendance: [
+    { id: 201, arrivedAt: "2026-07-01T14:00:00.000Z", participant: { id: 50, email: "karen@example.com", name: "Karen Keyholder", isKeyholder: true, isSysadmin: false, dateOfBirth: "1985-01-01", householdId: 6 } },
+    { id: 202, arrivedAt: "2026-07-01T14:05:00.000Z", participant: { id: 60, email: "val@example.com", name: "Val Volunteer", isKeyholder: false, isSysadmin: false, dateOfBirth: "1990-01-01", householdId: 7 } },
+    { id: 203, arrivedAt: "2026-07-01T14:10:00.000Z", participant: { id: 70, email: "stu@example.com", name: "Stu Student", isKeyholder: false, isSysadmin: false, dateOfBirth: "2012-01-01", householdId: 8 } },
+  ],
+  counts: { keyholders: 1, volunteers: 1, students: 1, total: 3 },
+  safety: { isLastKeyholder: false, isTwoDeepViolation: false },
+};
+
+const householdData = {
+  household: {
+    leads: [{ participantId: 1 }],
+    participants: [{ id: 90, name: "Jamie Kid", email: "jamie@example.com" }],
+  },
+};
+
+function mockRoutes(overrides: Record<string, unknown | (() => unknown)> = {}) {
+  return mockFetchJson({
+    "/api/household": householdData,
+    "/api/roles": { participants: [{ id: 555, name: "Wendy West", email: "wendy@example.com", isKeyholder: false, isSysadmin: false }] },
+    "/api/attendance": attendanceData,
+    ...overrides,
+  });
+}
+
+// The admin (id 1, sysadmin + keyholder) is not checked in and has a household,
+// so both the self check-in button and the household check-in row render.
+function setAdminSession() {
+  setSession({ id: 1, isSysadmin: true, isKeyholder: true, householdId: 5 });
+}
+
+describe("attendance/current page", () => {
+  it("loads and renders the attendance columns", async () => {
+    setAdminSession();
+    mockRoutes();
+    renderWithProviders(<KioskDisplay />);
+
+    expect(await screen.findByText("3 People Present")).toBeInTheDocument();
+    expect(screen.getByText("Karen Keyholder")).toBeInTheDocument();
+    expect(screen.getByText("Val Volunteer")).toBeInTheDocument();
+    expect(screen.getByText("Stu Student")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Check Me In" })).toBeInTheDocument();
+  });
+
+  it("checks the current admin in", async () => {
+    setAdminSession();
+    const fetchMock = mockRoutes();
+    renderWithProviders(<KioskDisplay />);
+    await screen.findByText("3 People Present");
+
+    fireEvent.click(screen.getByRole("button", { name: "Check Me In" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/attendance",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ type: "MANUAL_CHECKIN", participantId: 1 }),
+        }),
+      ),
+    );
+  });
+
+  it("checks in a household member from the household row", async () => {
+    setAdminSession();
+    const fetchMock = mockRoutes();
+    renderWithProviders(<KioskDisplay />);
+    await screen.findByText("3 People Present");
+
+    expect(await screen.findByText("Check In Household Members")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Jamie Kid" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/attendance",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ type: "MANUAL_CHECKIN", participantId: 90 }),
+        }),
+      ),
+    );
+  });
+
+  it("searches and manually checks in a match", async () => {
+    setAdminSession();
+    const fetchMock = mockRoutes();
+    renderWithProviders(<KioskDisplay />);
+    await screen.findByText("3 People Present");
+
+    fireEvent.change(screen.getByPlaceholderText("Manually check someone in (Search by name or email)..."), {
+      target: { value: "Wendy" },
+    });
+
+    expect(await screen.findByText("Wendy West")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Check In" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/attendance",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ type: "MANUAL_CHECKIN", participantId: 555 }),
+        }),
+      ),
+    );
+  });
+
+  it("force-checks-out a user via the sign-out modal", async () => {
+    window.confirm = jest.fn(() => true);
+    setAdminSession();
+    const fetchMock = mockRoutes();
+    renderWithProviders(<KioskDisplay />);
+    await screen.findByText("3 People Present");
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out a user" }));
+    const modal = await screen.findByRole("dialog");
+    expect(within(modal).getByText("Val Volunteer")).toBeInTheDocument();
+    // Rows are sorted alphabetically: Karen, Stu, Val -> Val is the 3rd "Sign Out" button.
+    const signOutButtons = within(modal).getAllByRole("button", { name: "Sign Out" });
+    fireEvent.click(signOutButtons[2]);
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/attendance",
+        expect.objectContaining({ method: "DELETE", body: JSON.stringify({ visitId: 202 }) }),
+      ),
+    );
+  });
+});

--- a/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-require-imports -- jest.mock factories are hoisted above imports */
+import { screen, fireEvent } from "@testing-library/react";
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import AdminMembershipPage from "../page";
+
+beforeEach(() => resetRtl());
+
+function household(name: string, id: number) {
+    return { name, participants: [{ id: 1, name: "Lead One", email: "lead@example.com" }], leads: [{ participantId: 1 }], householdId: id };
+}
+
+const rows = [
+    {
+        id: 1,
+        kind: "NEW",
+        status: "PENDING_EXTERNAL_ACTION",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        zohoEnvelopeId: null,
+        contractSignedAt: null,
+        bgConsentAt: null,
+        bgClearedAt: null,
+        paidAt: null,
+        attestations: [],
+        membership: { householdId: 1, isVolunteer: false, household: household("Awaiting Family", 1) },
+    },
+    {
+        id: 2,
+        kind: "RENEWAL",
+        status: "PENDING_PAYMENT",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        zohoEnvelopeId: "env-1",
+        contractSignedAt: "2026-01-02T00:00:00.000Z",
+        bgConsentAt: "2026-01-02T00:00:00.000Z",
+        bgClearedAt: null,
+        paidAt: null,
+        attestations: [{ id: 1, result: "APPROVE", isMarkedVolunteer: false }],
+        membership: { householdId: 2, isVolunteer: true, household: household("Payment Family", 2) },
+    },
+    {
+        id: 3,
+        kind: "NEW",
+        status: "BLOCKED",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        zohoEnvelopeId: "env-3",
+        contractSignedAt: "2026-01-02T00:00:00.000Z",
+        bgConsentAt: "2026-01-02T00:00:00.000Z",
+        bgClearedAt: null,
+        paidAt: "2026-01-03T00:00:00.000Z",
+        attestations: [],
+        membership: { householdId: 3, isVolunteer: false, household: household("Blocked Family", 3) },
+    },
+];
+
+describe("AdminMembershipPage", () => {
+    it("renders in-flight applications and their status counts", async () => {
+        mockFetchJson({ "/api/membership-ops/applications": { processes: rows } });
+        renderWithProviders(<AdminMembershipPage />);
+
+        expect(await screen.findByText("Awaiting Family")).toBeInTheDocument();
+        expect(screen.getByText("Payment Family")).toBeInTheDocument();
+        expect(screen.getByText("Blocked Family")).toBeInTheDocument();
+        expect(screen.getByText(/1 application\(s\) blocked/)).toBeInTheDocument();
+        expect(screen.getByText(/This household already paid/)).toBeInTheDocument();
+    });
+
+    it("shows an empty state when there are no in-flight applications", async () => {
+        mockFetchJson({ "/api/membership-ops/applications": { processes: [] } });
+        renderWithProviders(<AdminMembershipPage />);
+        expect(await screen.findByText("No in-flight membership applications.")).toBeInTheDocument();
+    });
+
+    it("drives the external-action, certify, and override controls", async () => {
+        mockFetchJson({
+            "/api/membership-ops/applications": { processes: rows },
+            "/api/membership-ops/applications/external": { ok: true },
+            "/api/membership-ops/applications/certify-payment": { ok: true },
+            "/api/membership-ops/applications/review-override": { ok: true },
+        });
+        renderWithProviders(<AdminMembershipPage />);
+        await screen.findByText("Awaiting Family");
+
+        fireEvent.click(screen.getByRole("button", { name: "Confirm contract signed" }));
+        expect(await screen.findByText("Updated.")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Confirm BG consent" }));
+        expect(await screen.findByText("Updated.")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /Certify payment plan/ }));
+        expect(await screen.findByText("Certified — membership activated.")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Reset for re-review" }));
+        expect(await screen.findByText("Sent back for re-review.")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /Override/ }));
+        expect(await screen.findByText("Overridden to payment.")).toBeInTheDocument();
+    });
+});

--- a/checkin-app/src/app/membership-ops/participants/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/__tests__/page.test.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-require-imports -- jest.mock factories are hoisted above imports */
+import { screen, waitFor, fireEvent, within } from "@testing-library/react";
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+import { notifications } from "@mantine/notifications";
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import AdminParticipantsIndex from "../page";
+
+beforeEach(() => {
+    resetRtl();
+    (notifications.show as jest.Mock).mockClear();
+});
+
+const alice = { id: 1, name: "Alice A", email: "alice@example.com", phone: "555-1111", household: null };
+const bob = {
+    id: 2,
+    name: "Bob B",
+    email: null,
+    phone: null,
+    household: { id: 20, name: "The B Family", participants: [{ id: 2, name: "Bob B", email: null }, { id: 3, name: "Sis B", email: "sis@example.com" }] },
+};
+const carol = { id: 3, name: "Carol C", email: null, phone: null, household: null };
+
+describe("AdminParticipantsIndex", () => {
+    it("searches, sorts, and edits a participant's details", async () => {
+        mockFetchJson({
+            "/api/participants/search": { participants: [alice, bob] },
+            "/api/membership-ops/participants/1": { participant: { id: 1, name: "Alice A", email: "alice@new.com", phone: "555-2222" } },
+        });
+        renderWithProviders(<AdminParticipantsIndex />);
+
+        expect(await screen.findByText("Alice A")).toBeInTheDocument();
+        expect(screen.getByText("Bob B")).toBeInTheDocument();
+        expect(screen.getByText("The B Family")).toBeInTheDocument();
+        expect(screen.getByText("No email")).toBeInTheDocument();
+
+        // toggle sort by name both directions (this reorders the rows, hence the
+        // row lookup by text below rather than a fixed row index)
+        fireEvent.click(screen.getByRole("button", { name: /Name/ }));
+        fireEvent.click(screen.getByRole("button", { name: /Name/ }));
+
+        fireEvent.change(screen.getByPlaceholderText("Search by name or email..."), { target: { value: "ali" } });
+        await waitFor(() => expect(screen.getByPlaceholderText("Search by name or email...")).toHaveValue("ali"));
+
+        // Scope to Alice's row rather than a fixed index — the sort toggles above can reorder rows.
+        const aliceRow = screen.getByText("Alice A").closest("tr")!;
+        fireEvent.click(within(aliceRow).getByRole("button", { name: "Details" }));
+
+        expect(await screen.findByText("Edit Participant")).toBeInTheDocument();
+        const emailInput = screen.getByLabelText("Email Address");
+        fireEvent.change(emailInput, { target: { value: "alice@new.com" } });
+        fireEvent.click(screen.getByRole("button", { name: "Save Details" }));
+
+        await waitFor(() => expect(screen.queryByText("Edit Participant")).not.toBeInTheDocument());
+        expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Participant updated successfully!" }));
+    });
+
+    it("assigns a new household to a participant with none", async () => {
+        mockFetchJson({
+            "/api/participants/search": { participants: [carol] },
+            "/api/membership-ops/participants/3/household": {
+                participant: { ...carol, household: { id: 50, name: "Carol Household", participants: [{ id: 3, name: "Carol C", email: null }] } },
+            },
+        });
+        renderWithProviders(<AdminParticipantsIndex />);
+
+        expect(await screen.findByText("Carol C")).toBeInTheDocument();
+        fireEvent.click(screen.getByRole("button", { name: "Assign" }));
+        expect(await screen.findByText("Assign Household to Carol C")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Create New Household" }));
+
+        await waitFor(() => expect(screen.queryByText("Assign Household to Carol C")).not.toBeInTheDocument());
+        expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Household assigned successfully!" }));
+    });
+});

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -1,0 +1,106 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import HouseholdPage from "../page";
+
+beforeEach(() => resetRtl());
+
+const householdData = {
+  id: 55,
+  name: "Smith Household",
+  leads: [{ participantId: 10 }],
+  participants: [
+    { id: 10, name: "Sam Smith", email: "sam@example.com", phone: "5125551234", dateOfBirth: "1980-01-01" },
+    { id: 11, name: "Jamie Smith", email: "", dateOfBirth: "2012-05-01" },
+  ],
+  membership: { status: "ACTIVE", memberSince: "2024-01-01T00:00:00.000Z", isVolunteer: false },
+  line1: "123 Main St", line2: "", city: "Austin", state: "TX", postalCode: "78701",
+};
+
+function mockRoutes(overrides: Record<string, unknown | (() => unknown)> = {}) {
+  return mockFetchJson({
+    "/api/household/emergency-contacts": { contacts: [] },
+    "/api/household/settings": {},
+    "/api/household/member": {},
+    "/api/household/lead": {},
+    "/api/household": { household: householdData },
+    ...overrides,
+  });
+}
+
+describe("HouseholdPage", () => {
+  it("loads and renders household members", async () => {
+    setSession({ id: 10, email: "sam@example.com" });
+    mockRoutes();
+    renderWithProviders(<HouseholdPage />);
+
+    expect(await screen.findByRole("heading", { name: "Smith Household", level: 1 })).toBeInTheDocument();
+    expect(screen.getByText(/Member since/)).toBeInTheDocument();
+    expect(screen.getByText("Sam Smith")).toBeInTheDocument();
+    expect(screen.getByText("Jamie Smith")).toBeInTheDocument();
+    expect(screen.getByText("Household Lead")).toBeInTheDocument();
+    expect(screen.getByText("No emergency contact on file. Add at least one.")).toBeInTheDocument();
+  });
+
+  it("adds a household member", async () => {
+    setSession({ id: 10, email: "sam@example.com" });
+    const fetchMock = mockRoutes();
+    renderWithProviders(<HouseholdPage />);
+    await screen.findByRole("heading", { name: "Smith Household", level: 1 });
+
+    fireEvent.click(screen.getByRole("button", { name: "+ Add Household Member" }));
+    fireEvent.change(screen.getByLabelText("Full Name"), { target: { value: "Robin Smith" } });
+    fireEvent.click(screen.getByLabelText("Individual is over 25"));
+    fireEvent.click(screen.getByRole("button", { name: "Save / Invite Member" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/household",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ memberName: "Robin Smith", memberEmail: "", memberDob: "", memberOver25: true }),
+        }),
+      ),
+    );
+  });
+
+  it("saves the household address", async () => {
+    setSession({ id: 10, email: "sam@example.com" });
+    const fetchMock = mockRoutes();
+    renderWithProviders(<HouseholdPage />);
+    await screen.findByRole("heading", { name: "Smith Household", level: 1 });
+
+    fireEvent.click(screen.getByRole("button", { name: "Update Address" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/household/settings",
+        expect.objectContaining({ method: "PATCH" }),
+      ),
+    );
+    expect(await screen.findByText("Settings updated successfully!")).toBeInTheDocument();
+  });
+
+  it("adds an emergency contact", async () => {
+    setSession({ id: 10, email: "sam@example.com" });
+    const fetchMock = mockRoutes();
+    renderWithProviders(<HouseholdPage />);
+    await screen.findByRole("heading", { name: "Smith Household", level: 1 });
+
+    fireEvent.click(screen.getByRole("button", { name: "+ Add Contact" }));
+    fireEvent.change(screen.getByLabelText("Contact Name"), { target: { value: "Pat Neighbor" } });
+    fireEvent.change(screen.getByLabelText("Phone"), { target: { value: "5125559999" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add Contact" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/household/emergency-contacts",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+  });
+});

--- a/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
@@ -1,0 +1,124 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import ProgramDetailsPage from "../page";
+
+// React's `use()` suspends on a bare Promise until its microtask settles, which
+// needs an async act() the RTL render() doesn't provide. Pre-tagging the promise
+// as already-fulfilled (the same fields React's `use()` checks) makes `use()`
+// return the value synchronously, so a plain render() works.
+function resolvedParams(value: { id: string }): Promise<{ id: string }> {
+  const p = Promise.resolve(value) as Promise<{ id: string }> & { status?: string; value?: unknown };
+  p.status = "fulfilled";
+  p.value = value;
+  return p;
+}
+
+beforeEach(() => resetRtl());
+
+const programData = {
+  id: 1,
+  name: "Robotics Club",
+  startAt: "2026-01-10T00:00:00.000Z",
+  endAt: "2026-05-10T00:00:00.000Z",
+  leadMentorId: 5,
+  phase: "RUNNING",
+  enrollmentStatus: "OPEN",
+  minAge: 10,
+  maxAge: 18,
+  maxParticipants: 20,
+  memberOnly: false,
+  participants: [
+    {
+      participantId: 101, status: "ACTIVE", joinedAt: "2026-01-05T00:00:00.000Z", pendingSince: null,
+      participant: { name: "Alice Kid", email: "alice@example.com", phone: "5125551234" },
+    },
+    {
+      participantId: 102, status: "PENDING", joinedAt: null, pendingSince: "2026-01-06T00:00:00.000Z",
+      participant: { name: "Charlie Kid", email: "charlie@example.com" },
+    },
+  ],
+  volunteers: [
+    { participantId: 201, isCore: true, participant: { name: "Vera Volunteer", email: "vera@example.com" } },
+  ],
+  events: [
+    { id: 301, name: "Session 1", startAt: "2026-02-01T18:00:00.000Z", endAt: "2026-02-01T20:00:00.000Z", attendanceConfirmedAt: null },
+  ],
+  leadMentor: { name: "Mandy Mentor", email: "mandy@example.com" },
+  memberPriceCents: null,
+  nonMemberPriceCents: null,
+  shopifyProductId: null,
+};
+
+function renderPage() {
+  return renderWithProviders(<ProgramDetailsPage params={resolvedParams({ id: "1" })} />);
+}
+
+describe("ProgramDetailsPage", () => {
+  it("loads and renders the general tab for an authorized admin", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/programs/1": programData });
+    renderPage();
+
+    expect(await screen.findByRole("heading", { name: "Robotics Club", level: 1 })).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.getByText("2 / 20")).toBeInTheDocument();
+    expect(screen.getByText("Mandy Mentor (mandy@example.com)")).toBeInTheDocument();
+  });
+
+  it("switches to the roster tab and shows volunteers/participants", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/programs/1": programData });
+    renderPage();
+    await screen.findByRole("heading", { name: "Robotics Club", level: 1 });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Roster" }));
+    expect(await screen.findByText(/Vera Volunteer/)).toBeInTheDocument();
+    expect(screen.getByText(/Alice Kid/)).toBeInTheDocument();
+    expect(screen.getByText(/Charlie Kid/)).toBeInTheDocument();
+  });
+
+  it("searches and adds a volunteer", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({
+      "/api/programs/1/eligible-participants": { members: [{ id: 555, name: "Wendy West", email: "wendy@example.com" }] },
+      "/api/programs/1/volunteers": {},
+      "/api/programs/1": programData,
+    });
+    renderPage();
+    await screen.findByRole("heading", { name: "Robotics Club", level: 1 });
+    fireEvent.click(screen.getByRole("tab", { name: "Roster" }));
+
+    const volunteerSearch = (await screen.findAllByPlaceholderText("Start typing to search..."))[0];
+    fireEvent.change(volunteerSearch, { target: { value: "Wendy" } });
+
+    expect(await screen.findByText("Wendy West")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Wendy West"));
+
+    const addButtons = screen.getAllByRole("button", { name: "Add" });
+    fireEvent.click(addButtons[0]);
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/programs/1/volunteers",
+        expect.objectContaining({ method: "POST", body: JSON.stringify({ participantId: 555 }) }),
+      ),
+    );
+  });
+
+  it("shows scheduled events on the events tab", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/programs/1": programData });
+    renderPage();
+    await screen.findByRole("heading", { name: "Robotics Club", level: 1 });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Events" }));
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+    // Event ended in the past with no attendanceConfirmedAt -> needs confirmation.
+    expect(screen.getByRole("link", { name: "Confirm Attendance" })).toBeInTheDocument();
+  });
+});

--- a/checkin-app/src/app/program-ops/sessions/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/__tests__/page.test.tsx
@@ -1,0 +1,112 @@
+/* eslint-disable @typescript-eslint/no-require-imports -- jest.mock factories are hoisted above imports */
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+import { renderWithProviders, mockFetchJson, setSession, router, resetRtl } from "@/test-helpers/rtl";
+import EventAdminPage from "../page";
+
+beforeEach(() => resetRtl());
+
+// `use(params)` suspends on any promise it hasn't already tracked, even one that
+// resolved microtasks ago — pre-mark it "fulfilled" (React's own thenable-caching
+// shape) so `use` returns synchronously and the page doesn't need a Suspense
+// boundary/act(async) dance in every test.
+function paramsFor(id: string): Promise<{ id: string }> {
+    const p = Promise.resolve({ id }) as Promise<{ id: string }> & { status?: string; value?: unknown };
+    p.status = "fulfilled";
+    p.value = { id };
+    return p;
+}
+
+function renderPage(params: Promise<{ id: string }>) {
+    return renderWithProviders(<EventAdminPage params={params} />);
+}
+
+function baseEvent(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 5,
+        name: "Robotics Session",
+        startAt: "2020-01-01T18:00:00.000Z",
+        endAt: "2020-01-01T20:00:00.000Z",
+        attendanceConfirmedAt: null,
+        attendanceConfirmedBy: null,
+        recurringGroupId: null,
+        program: {
+            id: 10,
+            name: "Robotics",
+            leadMentorId: 1,
+            volunteers: [
+                { participantId: 2, participant: { id: 2, name: "Val Volunteer", email: "val@example.com" }, isCore: true },
+            ],
+            participants: [
+                { participantId: 3, participant: { id: 3, name: "Pat Participant", email: "pat@example.com" } },
+            ],
+        },
+        visits: [{ id: 1, participantId: 3, arrivedAt: "2020-01-01T18:05:00.000Z", departedAt: null }],
+        rsvps: [{ participantId: 3, status: "ATTENDING" }],
+        ...overrides,
+    };
+}
+
+const params = paramsFor("5");
+
+describe("EventAdminPage", () => {
+    it("redirects unauthenticated users without fetching", async () => {
+        setSession(null, "unauthenticated");
+        const fetchSpy = mockFetchJson({});
+        renderPage(params);
+        await waitFor(() => expect(router.push).toHaveBeenCalledWith("/"));
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("shows a not-found card when the event fetch fails", async () => {
+        setSession({ id: 1, isSysadmin: true });
+        mockFetchJson({});
+        renderPage(params);
+        expect(await screen.findByText("Failed to load event.")).toBeInTheDocument();
+        fireEvent.click(screen.getByRole("button", { name: "Go Back" }));
+        expect(router.back).toHaveBeenCalled();
+    });
+
+    it("past event: renders roster/RSVPs, confirms attendance, and saves a manual edit", async () => {
+        setSession({ id: 1, isSysadmin: true });
+        mockFetchJson({ "/api/events/5": baseEvent() });
+        renderPage(params);
+
+        expect(await screen.findByText("Robotics Session")).toBeInTheDocument();
+        expect(screen.getAllByText("Pat Participant").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Val Volunteer").length).toBeGreaterThan(0);
+        expect(screen.getByText("Attending")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Confirm Attendance" }));
+        expect(await screen.findByText("Attendance confirmed successfully!")).toBeInTheDocument();
+
+        fireEvent.click(screen.getAllByRole("button", { name: "Manual Edit" })[0]);
+        expect(await screen.findByText(/Manual Edit:/)).toBeInTheDocument();
+        fireEvent.click(screen.getByRole("button", { name: "Save" }));
+        expect(await screen.findByText("Attendance updated successfully!")).toBeInTheDocument();
+    });
+
+    it("future event: edit mode saves a time change and cancels the event", async () => {
+        setSession({ id: 1, isSysadmin: true });
+        const future = baseEvent({
+            startAt: "2999-01-01T18:00:00.000Z",
+            endAt: "2999-01-01T20:00:00.000Z",
+            recurringGroupId: "series-1",
+        });
+        mockFetchJson({ "/api/events/5": future });
+        renderPage(params);
+
+        await screen.findByText("Robotics Session");
+        fireEvent.click(screen.getByRole("button", { name: "Edit Date / Time" }));
+        expect(screen.getByLabelText(/Apply to Series/)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Save Time Changes" }));
+        expect(await screen.findByText("Event time updated successfully!")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Edit Date / Time" }));
+        window.confirm = jest.fn(() => true);
+        fireEvent.click(screen.getByRole("button", { name: "Cancel Event(s)" }));
+        await waitFor(() => expect(router.push).toHaveBeenCalledWith("/program-ops/programs/10"));
+    });
+});

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-require-imports -- jest.mock factories are hoisted above imports */
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+import { renderWithProviders, mockFetchJson, setSession, router, resetRtl } from "@/test-helpers/rtl";
+import ProgramEnrollmentPage from "../page";
+
+beforeEach(() => resetRtl());
+
+// `use(params)` suspends on any promise it hasn't already tracked, even one that
+// resolved microtasks ago — pre-mark it "fulfilled" (React's own thenable-caching
+// shape) so `use` returns synchronously and the page doesn't need a Suspense
+// boundary/act(async) dance in every test.
+function paramsFor(id: string): Promise<{ id: string }> {
+    const p = Promise.resolve({ id }) as Promise<{ id: string }> & { status?: string; value?: unknown };
+    p.status = "fulfilled";
+    p.value = { id };
+    return p;
+}
+
+const params = paramsFor("10");
+
+function renderPage() {
+    return renderWithProviders(<ProgramEnrollmentPage params={params} />);
+}
+
+const household = {
+    household: {
+        participants: [
+            { id: 100, name: "Jamie Guardian", dateOfBirth: "1990-01-01" },
+            { id: 101, name: "Kid One", dateOfBirth: "2015-01-01" },
+            { id: 102, name: "Too Young", dateOfBirth: "2023-01-01" },
+        ],
+    },
+};
+
+function baseProgram(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 10,
+        name: "Robotics Club",
+        startAt: "2026-06-01T00:00:00.000Z",
+        endAt: null,
+        leadMentorId: 5,
+        leadMentor: { name: "Coach K", email: "coach@example.com" },
+        participants: [{ participantId: 100, status: "ENROLLED" }],
+        enrollmentStatus: "OPEN",
+        memberPriceCents: null,
+        nonMemberPriceCents: null,
+        shopifyMemberVariantId: null,
+        shopifyNonMemberVariantId: null,
+        minAge: 5,
+        maxAge: 18,
+        ...overrides,
+    };
+}
+
+describe("ProgramEnrollmentPage", () => {
+    it("free program: enrolls the signed-in household member", async () => {
+        setSession({ id: 101 });
+        mockFetchJson({
+            "/api/programs/10/participants": { ok: true },
+            "/api/household": household,
+            "/api/programs/10": baseProgram(),
+        });
+        renderPage();
+
+        expect(await screen.findByText("Robotics Club")).toBeInTheDocument();
+        expect(screen.getByText("Coach K")).toBeInTheDocument();
+        expect(screen.getByText("Open")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+        expect(await screen.findByText("Which of your household wants to enroll?")).toBeInTheDocument();
+        expect(screen.getByText("(Already Enrolled)")).toBeInTheDocument();
+        expect(screen.getByText("(Too young)")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
+        expect(await screen.findByText("Successfully enrolled!")).toBeInTheDocument();
+    });
+
+    it("priced program with no Shopify variant configured falls back to a direct enroll message", async () => {
+        setSession({ id: 101 });
+        mockFetchJson({
+            "/api/programs/10/participants": { ok: true },
+            "/api/household": household,
+            "/api/programs/10": baseProgram({ memberPriceCents: 5000, nonMemberPriceCents: 7000, minAge: null, maxAge: null }),
+        });
+        renderPage();
+
+        await screen.findByText("Robotics Club");
+        expect(screen.getByText("Member Price:")).toBeInTheDocument();
+        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+        await screen.findByText("Which of your household wants to enroll?");
+
+        fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
+        expect(await screen.findByText("Enrolled! (Note: No pricing variant configured for this tier)")).toBeInTheDocument();
+    });
+
+    it("shows a not-found card and navigates back to the directory", async () => {
+        setSession(null, "unauthenticated");
+        mockFetchJson({});
+        renderPage();
+
+        expect(await screen.findByText("Program not found.")).toBeInTheDocument();
+        fireEvent.click(screen.getByRole("button", { name: "Back to Directory" }));
+        expect(router.push).toHaveBeenCalledWith("/programs");
+    });
+
+    it("prompts a logged-out visitor to log in or register instead of enrolling", async () => {
+        setSession(null, "unauthenticated");
+        mockFetchJson({ "/api/programs/10": baseProgram() });
+        renderPage();
+
+        await screen.findByText("Robotics Club");
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: "Log In To Enroll" })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Register (New User)" })).toBeInTheDocument();
+        });
+    });
+});

--- a/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
@@ -43,7 +43,7 @@ describe("MembershipSettingsPage", () => {
       expect(fetchMock).toHaveBeenCalledWith("/api/settings/membership", expect.objectContaining({ method: "PUT" }));
     });
     const [, putOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PUT")!;
-    expect(JSON.parse(putOpts.body as string)).toEqual(expect.objectContaining({ normalDuesCents: 20000 }));
+    expect(JSON.parse(putOpts!.body as string)).toEqual(expect.objectContaining({ normalDuesCents: 20000 }));
 
     expect(await screen.findByText("Settings saved.")).toBeInTheDocument();
   });

--- a/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
@@ -1,0 +1,50 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import MembershipSettingsPage from "../page";
+
+const SETTINGS = {
+  normalDuesCents: 15000,
+  volunteerDuesCents: 5000,
+  membershipYearBoundary: "2025-09-01T00:00:00.000Z",
+  membershipVariantId: "123456",
+  volunteerDiscountCode: "VOLUNTEER",
+  bgRecheckMonths: 24,
+};
+
+beforeEach(() => resetRtl());
+
+describe("MembershipSettingsPage", () => {
+  it("loads and renders the current settings", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/settings/membership": { settings: SETTINGS } });
+    renderWithProviders(<MembershipSettingsPage />);
+
+    expect(await screen.findByDisplayValue("150.00")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("50.00")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("123456")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("VOLUNTEER")).toBeInTheDocument();
+  });
+
+  it("edits a field and saves, PUTting the updated value", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({ "/api/settings/membership": { settings: SETTINGS } });
+    renderWithProviders(<MembershipSettingsPage />);
+
+    const normalDues = await screen.findByDisplayValue("150.00");
+    fireEvent.change(normalDues, { target: { value: "200.00" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/settings/membership", expect.objectContaining({ method: "PUT" }));
+    });
+    const [, putOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PUT")!;
+    expect(JSON.parse(putOpts.body as string)).toEqual(expect.objectContaining({ normalDuesCents: 20000 }));
+
+    expect(await screen.findByText("Settings saved.")).toBeInTheDocument();
+  });
+});

--- a/checkin-app/src/app/shop-ops/manage/__tests__/ToolManagementPanel.test.tsx
+++ b/checkin-app/src/app/shop-ops/manage/__tests__/ToolManagementPanel.test.tsx
@@ -1,0 +1,120 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import { ToolManagementPanel } from "../ToolManagementPanel";
+
+// ponytail: GrantForm's Select-based certify flow isn't exercised — Mantine
+// Select needs Combobox option clicks, not fireEvent.change; skipped as a
+// modal/validation branch per the coverage plan's scope. Add if it regresses.
+//
+// Note: GrantForm's member/tool Select mounts its option list in the DOM even
+// closed, so a name that's also a Select option (e.g. "Alice" as a member
+// option) matches twice. Where that collides, assertions below scope to the
+// Mantine <Text> ("p") that renders the roster row, not the Select's <span>.
+
+const TABLE_SAW = { id: 1, name: "Table Saw", safetyGuide: null, _count: { toolStatuses: 2 } };
+const LASER = { id: 2, name: "Laser Cutter", safetyGuide: "https://example.com/guide", _count: { toolStatuses: 0 } };
+const MEMBERS = [
+  { id: 10, name: "Alice", email: "alice@example.com" },
+  { id: 11, name: "Bob", email: "bob@example.com" },
+];
+
+beforeEach(() => resetRtl());
+
+describe("ToolManagementPanel", () => {
+  it("loads and renders the tool list", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({
+      "/api/shop/tools": [TABLE_SAW, LASER],
+      "/api/shop/members": { members: MEMBERS },
+    });
+    renderWithProviders(<ToolManagementPanel />);
+
+    expect(await screen.findByText("Table Saw")).toBeInTheDocument();
+    expect(screen.getByText("Laser Cutter")).toBeInTheDocument();
+    expect(screen.getByText("2 certified")).toBeInTheDocument();
+  });
+
+  it("expanding a tool fetches and shows its certified-members roster", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({
+      "/api/shop/certifications?toolId=1": [
+        { participantId: 10, toolId: 1, level: "CERTIFIED", participant: { id: 10, name: "Alice" } },
+      ],
+      "/api/shop/tools": [TABLE_SAW],
+      "/api/shop/members": { members: MEMBERS },
+    });
+    renderWithProviders(<ToolManagementPanel />);
+
+    fireEvent.click(await screen.findByText("Table Saw"));
+
+    expect(await screen.findByText("Alice", { selector: "p" })).toBeInTheDocument();
+  });
+
+  it("edits a tool's safety guide URL (PATCH) and shows the success message", async () => {
+    // Single tool in the list: ToolsTab's certs Collapse content stays mounted
+    // (just visually hidden) for every card, so a second tool here would make
+    // "Edit guide" ambiguous.
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({
+      "/api/shop/tools/1": { success: true, tool: { ...TABLE_SAW, safetyGuide: "https://new.example.com" } },
+      "/api/shop/tools": [TABLE_SAW],
+      "/api/shop/members": { members: MEMBERS },
+    });
+    renderWithProviders(<ToolManagementPanel />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Edit guide" }));
+    // Modal mounts a tick after the click (Mantine portal), not synchronously.
+    fireEvent.change(await screen.findByPlaceholderText("https://..."), { target: { value: "https://new.example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/shop/tools/1", expect.objectContaining({ method: "PATCH" }));
+    });
+    expect(await screen.findByText("Safety guide updated.")).toBeInTheDocument();
+  });
+
+  it("By Person tab: lists members and loads a member's certifications on expand", async () => {
+    // Single member: same shared-Collapse-content reasoning as the tool list above.
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({
+      "/api/shop/certifications?participantId=10": [
+        { participantId: 10, toolId: 1, level: "CERTIFIED", tool: { id: 1, name: "Table Saw" } },
+      ],
+      "/api/shop/tools": [TABLE_SAW],
+      "/api/shop/members": { members: [MEMBERS[0]] },
+    });
+    renderWithProviders(<ToolManagementPanel />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: "By Person" }));
+    fireEvent.click(await screen.findByText("Alice"));
+
+    expect(await screen.findByText("Table Saw", { selector: "p" })).toBeInTheDocument();
+  });
+
+  it("All Assignments tab: renders the person x tool matrix from ?all=true", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({
+      "/api/shop/certifications?all=true": [
+        {
+          participantId: 10,
+          toolId: 1,
+          level: "CERTIFIED",
+          participant: { id: 10, name: "Alice" },
+          tool: { id: 1, name: "Table Saw" },
+        },
+      ],
+      "/api/shop/tools": [TABLE_SAW],
+      "/api/shop/members": { members: MEMBERS },
+    });
+    renderWithProviders(<ToolManagementPanel />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: "All Assignments" }));
+
+    expect(await screen.findByText("1 assignment")).toBeInTheDocument();
+  });
+});

--- a/checkin-app/src/components/__tests__/AppFrame.test.tsx
+++ b/checkin-app/src/components/__tests__/AppFrame.test.tsx
@@ -1,0 +1,150 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@/hooks/useTodoCounts", () => ({ useTodoCounts: jest.fn(() => null) }));
+
+import { screen, fireEvent } from "@testing-library/react";
+import {
+  renderWithProviders,
+  setSession,
+  setPathname,
+  setSearchParams,
+  router,
+  resetRtl,
+} from "@/test-helpers/rtl";
+import { signIn, signOut } from "next-auth/react";
+import { useTodoCounts } from "@/hooks/useTodoCounts";
+import AppFrame from "../AppFrame";
+
+const mockedUseTodoCounts = useTodoCounts as jest.Mock;
+
+beforeEach(() => {
+  resetRtl();
+  mockedUseTodoCounts.mockReturnValue(null);
+});
+
+const renderFrame = () => renderWithProviders(<AppFrame>{<div>PAGE CONTENT</div>}</AppFrame>);
+
+describe("AppFrame", () => {
+  it("renders core nav items for a signed-in non-admin, hides admin-only sections", async () => {
+    setSession({ id: 1 });
+    renderFrame();
+
+    expect(await screen.findByText("PAGE CONTENT")).toBeInTheDocument();
+    expect(screen.getByText("My Household")).toBeInTheDocument();
+    expect(screen.getByText("My Activities")).toBeInTheDocument();
+    expect(screen.getByText("Attendance")).toBeInTheDocument();
+    expect(screen.getByText("Programs")).toBeInTheDocument();
+    expect(screen.getByText("Communication")).toBeInTheDocument();
+    expect(screen.getByText("Index")).toBeInTheDocument();
+
+    // Role-gated sections stay hidden for a plain signed-in user.
+    expect(screen.queryByText("Safety")).not.toBeInTheDocument();
+    expect(screen.queryByText("Shop Ops")).not.toBeInTheDocument();
+    expect(screen.queryByText("Facility Ops")).not.toBeInTheDocument();
+    expect(screen.queryByText("Membership Ops")).not.toBeInTheDocument();
+    expect(screen.queryByText("Program Ops")).not.toBeInTheDocument();
+
+    expect(screen.getAllByRole("button", { name: /Sign Out/i }).length).toBeGreaterThan(0);
+  });
+
+  it("shows admin-only sections for a sysadmin", () => {
+    setSession({ id: 1, isSysadmin: true });
+    renderFrame();
+
+    expect(screen.getByText("Safety")).toBeInTheDocument();
+    expect(screen.getByText("Shop Ops")).toBeInTheDocument();
+    expect(screen.getByText("Facility Ops")).toBeInTheDocument();
+    expect(screen.getByText("Membership Ops")).toBeInTheDocument();
+    expect(screen.getByText("Membership Audit")).toBeInTheDocument();
+    expect(screen.getByText("Program Ops")).toBeInTheDocument();
+    expect(screen.getByText("Finance Ops")).toBeInTheDocument();
+    expect(screen.getByText("System Status")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("shows Shop Ops for a certifier without admin flags, and My Programs when leading a program", () => {
+    setSession({ id: 2, toolStatuses: [{ level: "MAY_CERTIFY_OTHERS" }] });
+    mockedUseTodoCounts.mockReturnValue({
+      member: { household: [], programs: [] },
+      building: 0,
+      buildingHousehold: 0,
+      activePrograms: 0,
+      lead: { programs: [{ id: 9, pending: [] }] },
+    });
+    renderFrame();
+
+    expect(screen.getByText("Shop Ops")).toBeInTheDocument();
+    expect(screen.getByText("My Programs")).toBeInTheDocument();
+    expect(screen.queryByText("Facility Ops")).not.toBeInTheDocument();
+  });
+
+  it("highlights the active nav item based on pathname", () => {
+    setSession({ id: 1 });
+    setPathname("/attendance");
+    renderFrame();
+
+    const attendanceLink = screen.getByText("Attendance").closest("a");
+    const programsLink = screen.getByText("Programs").closest("a");
+    expect(attendanceLink).toHaveAttribute("data-active", "true");
+    expect(programsLink).not.toHaveAttribute("data-active");
+  });
+
+  it("renders full-screen with no chrome in kiosk mode", () => {
+    setSession({ id: 1 });
+    setSearchParams("mode=kiosk");
+    renderFrame();
+
+    expect(screen.getByText("PAGE CONTENT")).toBeInTheDocument();
+    expect(screen.queryByText("Attendance")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign Out")).not.toBeInTheDocument();
+  });
+
+  it("hides the nav sidebar (but still shows sign-in) on the signed-out homepage", () => {
+    setSession(null);
+    setPathname("/");
+    renderFrame();
+
+    expect(screen.queryByText("Programs")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Sign In To Dashboard/i })).toBeInTheDocument();
+  });
+
+  it("shows the nav (Programs visible to everyone) when signed out on a non-home path", () => {
+    setSession(null);
+    setPathname("/programs");
+    renderFrame();
+
+    expect(screen.getByText("Programs")).toBeInTheDocument();
+    expect(screen.queryByText("My Household")).not.toBeInTheDocument();
+  });
+
+  it("sign-out button calls signOut with the home callback", async () => {
+    setSession({ id: 1 });
+    renderFrame();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Sign Out/i })[0]);
+    expect(signOut).toHaveBeenCalledWith({ callbackUrl: "/" });
+  });
+
+  it("sign-in button calls signIn('google')", async () => {
+    setSession(null);
+    setPathname("/attendance");
+    renderFrame();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Sign In To Dashboard/i })[0]);
+    expect(signIn).toHaveBeenCalledWith("google");
+  });
+
+  it("clicking a nav link does not block navigation (no unsaved changes)", () => {
+    setSession({ id: 1 });
+    renderFrame();
+
+    const link = screen.getByText("Programs").closest("a")!;
+    fireEvent.click(link);
+    // No confirm/guard is registered, so clicking just leaves router untouched here
+    // (Link handles real navigation in the browser) — this exercises guardNav's
+    // pass-through branch without throwing.
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});

--- a/checkin-app/src/components/__tests__/OnboardingGate.test.tsx
+++ b/checkin-app/src/components/__tests__/OnboardingGate.test.tsx
@@ -1,0 +1,101 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import OnboardingGate from "../OnboardingGate";
+
+const CHILD = "child-marker";
+const renderGate = () =>
+  renderWithProviders(
+    <OnboardingGate>
+      <div>{CHILD}</div>
+    </OnboardingGate>,
+  );
+
+beforeEach(() => {
+  resetRtl();
+  sessionStorage.clear();
+});
+
+describe("OnboardingGate", () => {
+  it("lets a signed-in, fully-onboarded user through with no modal", async () => {
+    setSession({ id: 1 });
+    mockFetchJson({ "/api/profile/onboarding-status": { needsPhone: false, needsEmergencyContact: false } });
+    renderGate();
+
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    // Give the status fetch a tick to resolve, then confirm the modal never opens.
+    await waitFor(() => expect(screen.queryByText("Action Required")).not.toBeInTheDocument());
+  });
+
+  it("renders children immediately (no fetch) when unauthenticated", () => {
+    setSession(null);
+    const fetchSpy = mockFetchJson({});
+    renderGate();
+
+    expect(screen.getByText(CHILD)).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks with the onboarding modal when the profile needs a phone number", async () => {
+    setSession({ id: 1 });
+    mockFetchJson({ "/api/profile/onboarding-status": { needsPhone: true, needsEmergencyContact: false } });
+    renderGate();
+
+    expect(await screen.findByText("Action Required")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Your Phone Number/i)).toBeInTheDocument();
+    expect(screen.queryByText("Household Emergency Contact")).not.toBeInTheDocument();
+  });
+
+  it("submits a valid phone and POSTs onboarding data", async () => {
+    setSession({ id: 1 });
+    const fetchSpy = mockFetchJson({
+      "/api/profile/onboarding-status": { needsPhone: true, needsEmergencyContact: false },
+      "/api/profile/onboarding": { ok: true },
+    });
+    renderGate();
+
+    await screen.findByText("Action Required");
+    fireEvent.change(screen.getByLabelText(/Your Phone Number/i), { target: { value: "5551234567" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }));
+
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/profile/onboarding",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+  });
+
+  it("shows a validation error instead of submitting an invalid phone", async () => {
+    setSession({ id: 1 });
+    const fetchSpy = mockFetchJson({
+      "/api/profile/onboarding-status": { needsPhone: true, needsEmergencyContact: false },
+    });
+    renderGate();
+
+    await screen.findByText("Action Required");
+    fireEvent.change(screen.getByLabelText(/Your Phone Number/i), { target: { value: "123" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save & Continue/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Enter a valid 10-digit US phone number.");
+    // Only the initial status fetch happened; the invalid submit never posted.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("'Ask me next time' dismisses the modal and remembers the skip in sessionStorage", async () => {
+    setSession({ id: 1 });
+    mockFetchJson({ "/api/profile/onboarding-status": { needsPhone: true, needsEmergencyContact: false } });
+    renderGate();
+
+    await screen.findByText("Action Required");
+    fireEvent.click(screen.getByRole("button", { name: /Ask me next time/i }));
+
+    // Mantine's Modal unmounts its content after an exit transition (not instant in jsdom).
+    await waitFor(() => expect(screen.queryByText("Action Required")).not.toBeInTheDocument());
+    expect(sessionStorage.getItem("onboarding_skipped")).toBe("true");
+  });
+});

--- a/checkin-app/src/components/__tests__/TrustedAdultPanel.test.tsx
+++ b/checkin-app/src/components/__tests__/TrustedAdultPanel.test.tsx
@@ -1,0 +1,96 @@
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import TrustedAdultPanel from "../TrustedAdultPanel";
+
+beforeEach(() => resetRtl());
+
+const trustedAdult = (overrides: Partial<{ id: number; status: string }> = {}) => ({
+  id: overrides.id ?? 1,
+  counterpartyName: "Jane Doe",
+  counterpartyPhone: "555-010-0000",
+  counterpartyEmail: null,
+  familyContext: "Aunt, may pick up the kids.",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  reviews: [
+    {
+      id: 1,
+      kind: "INITIAL",
+      status: overrides.status ?? "APPROVED",
+      sharedNote: null,
+      effectiveFrom: "2026-01-01T00:00:00.000Z",
+      reviewBy: "2027-01-01T00:00:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  ],
+});
+
+describe("TrustedAdultPanel", () => {
+  it("loads and renders the list from the mine endpoint", async () => {
+    mockFetchJson({ "/api/trusted-adults/mine": { trustedAdults: [trustedAdult()] } });
+    renderWithProviders(<TrustedAdultPanel />);
+
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(await screen.findByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("Approved")).toBeInTheDocument();
+    expect(screen.getByText("Phone: 555-010-0000")).toBeInTheDocument();
+    expect(screen.queryByText("No trusted adults added yet.")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are none", async () => {
+    mockFetchJson({ "/api/trusted-adults/mine": { trustedAdults: [] } });
+    renderWithProviders(<TrustedAdultPanel />);
+
+    expect(await screen.findByText("No trusted adults added yet.")).toBeInTheDocument();
+  });
+
+  it("opens the add modal, blocks submit until the form is valid, then POSTs and reloads", async () => {
+    const fetchSpy = mockFetchJson({
+      "/api/trusted-adults/mine": () => ({ trustedAdults: [] }),
+      "/api/trusted-adults": { id: 2 },
+    });
+    renderWithProviders(<TrustedAdultPanel />);
+    await screen.findByText("No trusted adults added yet.");
+
+    fireEvent.click(screen.getByRole("button", { name: /Add a trusted adult/i }));
+    const submitBtn = await screen.findByRole("button", { name: /Submit for board review/i });
+    // Nothing filled in yet: submit is blocked (no POST fires).
+    fireEvent.click(submitBtn);
+    expect(fetchSpy).not.toHaveBeenCalledWith("/api/trusted-adults", expect.anything());
+
+    fireEvent.change(screen.getByLabelText(/Trusted adult's name/i), { target: { value: "Uncle Bob" } });
+    fireEvent.change(screen.getByLabelText(/Their phone/i), { target: { value: "555-222-3333" } });
+    fireEvent.change(
+      screen.getByLabelText(/For the board: what may this adult do, and any limits\?/i),
+      { target: { value: "May pick up on Fridays." } },
+    );
+
+    fireEvent.click(submitBtn);
+
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/trusted-adults",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+    // Submitting closes the modal and reloads the list.
+    await waitFor(() => expect(screen.queryByRole("button", { name: /Submit for board review/i })).not.toBeInTheDocument());
+  });
+
+  it("withdraws an approved entry via the action endpoint", async () => {
+    const fetchSpy = mockFetchJson({
+      "/api/trusted-adults/mine": { trustedAdults: [trustedAdult()] },
+      "/api/trusted-adults/1/withdraw": {},
+    });
+    renderWithProviders(<TrustedAdultPanel />);
+
+    const card = (await screen.findByText("Jane Doe")).closest(".mantine-Card-root") as HTMLElement;
+    fireEvent.click(within(card).getByRole("button", { name: /Withdraw/i }));
+
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/trusted-adults/1/withdraw",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+  });
+});

--- a/checkin-app/src/components/admin/__tests__/AuditLogPanel.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/AuditLogPanel.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import { AuditLogPanel } from "../AuditLogPanel";
+
+beforeEach(() => resetRtl());
+
+const page1 = {
+  logs: [
+    {
+      id: 1,
+      timestamp: "2026-06-01T12:00:00Z",
+      actorId: 5,
+      actorName: "Jo Admin",
+      action: "EDIT" as const,
+      tableName: "Household",
+      affectedEntityId: 42,
+      secondaryAffectedEntity: null,
+      oldData: { name: "old" },
+      newData: { name: "new" },
+    },
+  ],
+  total: 1,
+  page: 1,
+  pageSize: 25,
+  tables: ["Household", "Person"],
+};
+
+describe("AuditLogPanel", () => {
+  it("renders loaded rows and the total count", async () => {
+    mockFetchJson({ "/api/system-status/audit-log": page1 });
+    renderWithProviders(<AuditLogPanel />);
+    expect(await screen.findByText("EDIT")).toBeInTheDocument();
+    expect(screen.getByText("Household #42")).toBeInTheDocument();
+    expect(screen.getByText("Jo Admin")).toBeInTheDocument();
+    expect(screen.getByText("1 change — forensic trail, read-only.")).toBeInTheDocument();
+  });
+
+  it("shows the empty message when no logs match the filters", async () => {
+    mockFetchJson({ "/api/system-status/audit-log": { ...page1, logs: [], total: 0 } });
+    renderWithProviders(<AuditLogPanel />);
+    expect(await screen.findByText("No audit entries match these filters.")).toBeInTheDocument();
+  });
+
+  it("shows a failure message when the fetch fails", async () => {
+    mockFetchJson({});
+    renderWithProviders(<AuditLogPanel />);
+    expect(await screen.findByText("Failed to load audit log.")).toBeInTheDocument();
+  });
+
+  it("refetches with the from-date filter and resets to page 1", async () => {
+    const fetchFn = mockFetchJson({ "/api/system-status/audit-log": page1 });
+    const { container } = renderWithProviders(<AuditLogPanel />);
+    await screen.findByText("EDIT");
+
+    const [fromInput] = container.querySelectorAll('input[type="date"]');
+    fireEvent.change(fromInput, { target: { value: "2026-01-01" } });
+
+    await waitFor(() => {
+      const lastUrl = fetchFn.mock.calls.at(-1)?.[0] as string;
+      expect(lastUrl).toContain("from=2026-01-01");
+      expect(lastUrl).toContain("page=1");
+    });
+  });
+});

--- a/checkin-app/src/components/admin/__tests__/BadgeDocument.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/BadgeDocument.test.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, resetRtl } from "@/test-helpers/rtl";
+import BadgeDocument from "../BadgeDocument";
+
+beforeEach(() => resetRtl());
+
+// @react-pdf/renderer is pure ESM (untransformed by jest, see badgeNames.ts) and its
+// primitives target a non-DOM reconciler, so swap them for plain DOM stand-ins to
+// exercise BadgeDocument's own layout/branching logic via RTL.
+jest.mock("@react-pdf/renderer", () => ({
+  Document: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Page: ({ children }: { children?: ReactNode }) => <div data-testid="pdf-page">{children}</div>,
+  View: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  // eslint-disable-next-line @next/next/no-img-element -- test stand-in, not app UI
+  Image: ({ src }: { src?: string }) => <img alt="" src={src} />,
+  StyleSheet: { create: (styles: unknown) => styles },
+  Font: { register: jest.fn() },
+}));
+
+describe("BadgeDocument", () => {
+  it("renders names, role pills, and chunks front/back pages of 8", () => {
+    const badges = Array.from({ length: 9 }, (_, i) => ({
+      id: i + 1,
+      name: `Person ${i + 1}`,
+      isMember: true,
+      isBoardMember: i === 0,
+      isKeyholder: i === 1,
+      qrDataUri: `data:image/png;base64,QR${i}`,
+    }));
+
+    renderWithProviders(<BadgeDocument badges={badges} />);
+
+    expect(screen.getByText("Person 1")).toBeInTheDocument();
+    expect(screen.getByText("Person 9")).toBeInTheDocument();
+    expect(screen.getByText("BOARD")).toBeInTheDocument();
+    expect(screen.getByText("KEYHOLDER")).toBeInTheDocument();
+    expect(screen.getByText("ID: 1")).toBeInTheDocument();
+    expect(screen.getByText("ID: 9")).toBeInTheDocument();
+    expect(screen.getAllByText(/^\d{4}-\d{4}$/).length).toBeGreaterThan(0);
+
+    // 9 badges -> 2 chunks of front+back = 4 pages.
+    expect(screen.getAllByTestId("pdf-page")).toHaveLength(4);
+  });
+});

--- a/checkin-app/src/components/admin/__tests__/ErrorLogPanel.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/ErrorLogPanel.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import { ErrorLogPanel } from "../ErrorLogPanel";
+
+beforeEach(() => resetRtl());
+
+const errors = [
+  {
+    id: 1,
+    timestamp: "2026-06-01T12:00:00Z",
+    route: "/api/checkin",
+    message: "Boom",
+    stack: "Error: Boom\n  at x",
+    context: { userId: 9 },
+  },
+];
+
+describe("ErrorLogPanel", () => {
+  it("renders loaded rows", async () => {
+    mockFetchJson({ "/api/system-status/errors": { errors } });
+    renderWithProviders(<ErrorLogPanel />);
+    expect(await screen.findByText("Boom")).toBeInTheDocument();
+    expect(screen.getByText("/api/checkin")).toBeInTheDocument();
+  });
+
+  it("expands and collapses a row to show stack/context", async () => {
+    mockFetchJson({ "/api/system-status/errors": { errors } });
+    renderWithProviders(<ErrorLogPanel />);
+    const row = await screen.findByText("Boom");
+
+    fireEvent.click(row);
+    expect(await screen.findByText(/Error: Boom/)).toBeInTheDocument();
+
+    fireEvent.click(row);
+    expect(screen.queryByText(/Error: Boom/)).not.toBeInTheDocument();
+  });
+
+  it("shows the empty message when there are no errors", async () => {
+    mockFetchJson({ "/api/system-status/errors": { errors: [] } });
+    renderWithProviders(<ErrorLogPanel />);
+    expect(await screen.findByText(/No backend errors logged\./)).toBeInTheDocument();
+  });
+
+  it("shows a failure message when the fetch fails", async () => {
+    mockFetchJson({});
+    renderWithProviders(<ErrorLogPanel />);
+    expect(await screen.findByText("Failed to load error log.")).toBeInTheDocument();
+  });
+});

--- a/checkin-app/src/components/admin/__tests__/LinkStatusPanel.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/LinkStatusPanel.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import { LinkStatusPanel } from "../LinkStatusPanel";
+
+beforeEach(() => resetRtl());
+
+const errors = [
+  {
+    id: 1,
+    source: "Shopify",
+    message: "Timed out",
+    context: { orderId: 7 },
+    timestamp: "2026-06-01T12:00:00Z",
+    resolvedAt: null,
+  },
+];
+
+describe("LinkStatusPanel", () => {
+  it("renders loaded errors", async () => {
+    mockFetchJson({ "/api/system-status/links": { errors } });
+    renderWithProviders(<LinkStatusPanel />);
+    expect(await screen.findByText("Shopify")).toBeInTheDocument();
+    expect(screen.getByText("Timed out")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Mark resolved" })).toBeInTheDocument();
+  });
+
+  it("shows the empty message when there are no errors", async () => {
+    mockFetchJson({ "/api/system-status/links": { errors: [] } });
+    renderWithProviders(<LinkStatusPanel />);
+    expect(await screen.findByText("● No integration errors logged.")).toBeInTheDocument();
+  });
+
+  it("shows a failure message when the fetch fails", async () => {
+    mockFetchJson({});
+    renderWithProviders(<LinkStatusPanel />);
+    expect(await screen.findByText("Failed to load link status.")).toBeInTheDocument();
+  });
+
+  it("PATCHes resolved on click", async () => {
+    const fetchFn = mockFetchJson({ "/api/system-status/links": { errors } });
+    renderWithProviders(<LinkStatusPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: "Mark resolved" }));
+
+    await waitFor(() => {
+      const patchCall = fetchFn.mock.calls.find((c) => (c[1] as RequestInit | undefined)?.method === "PATCH");
+      expect(patchCall?.[0]).toContain("/api/system-status/links/1");
+      expect(JSON.parse((patchCall?.[1] as RequestInit).body as string)).toEqual({ resolved: true });
+    });
+  });
+});

--- a/checkin-app/src/components/admin/__tests__/StickerDocument.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/StickerDocument.test.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, resetRtl } from "@/test-helpers/rtl";
+import StickerDocument from "../StickerDocument";
+
+beforeEach(() => resetRtl());
+
+// See BadgeDocument.test.tsx: @react-pdf/renderer is ESM/non-DOM, so stub its
+// primitives with plain DOM stand-ins to exercise the layout logic via RTL.
+jest.mock("@react-pdf/renderer", () => ({
+  Document: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Page: ({ children }: { children?: ReactNode }) => <div data-testid="pdf-page">{children}</div>,
+  View: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  // eslint-disable-next-line @next/next/no-img-element -- test stand-in, not app UI
+  Image: ({ src }: { src?: string }) => <img alt="" src={src} />,
+  StyleSheet: { create: (styles: unknown) => styles },
+  Font: { register: jest.fn() },
+}));
+
+describe("StickerDocument", () => {
+  it("renders names (falling back to User #id) and chunks pages of 12", () => {
+    const badges = [
+      ...Array.from({ length: 12 }, (_, i) => ({
+        id: i + 1,
+        name: `Kid ${i + 1}`,
+        qrDataUri: `data:image/png;base64,Q${i}`,
+      })),
+      { id: 13, name: "", qrDataUri: "data:image/png;base64,Q13" },
+    ];
+
+    renderWithProviders(<StickerDocument badges={badges} />);
+
+    expect(screen.getByText("Kid 1")).toBeInTheDocument();
+    expect(screen.getByText("Kid 12")).toBeInTheDocument();
+    expect(screen.getByText("User #13")).toBeInTheDocument();
+    // 13 badges -> 2 pages of 12.
+    expect(screen.getAllByTestId("pdf-page")).toHaveLength(2);
+  });
+});

--- a/checkin-app/src/components/admin/__tests__/SystemHealthPanels.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/SystemHealthPanels.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import { SystemVersionBox, BadgeScanChart } from "../SystemHealthPanels";
+
+beforeEach(() => resetRtl());
+
+describe("SystemVersionBox", () => {
+  it("shows up to date when the running version matches the latest commit", async () => {
+    mockFetchJson({
+      "/api/system-status/kiosk-version": { version: "abc1234" },
+      "commits/main": { sha: "abc1234" },
+    });
+    renderWithProviders(<SystemVersionBox />);
+    expect(await screen.findByText(/System is up to date/)).toBeInTheDocument();
+  });
+
+  it("shows an update banner + commit list when behind main", async () => {
+    mockFetchJson({
+      "/api/system-status/kiosk-version": { version: "aaa1111" },
+      "commits/main": { sha: "bbb2222" },
+      "compare/": { commits: [{ sha: "ccc3333", html_url: "https://x/ccc3333", commit: { message: "Fix the thing\nmore detail" } }] },
+    });
+    renderWithProviders(<SystemVersionBox />);
+    expect(await screen.findByText(/Update Available!/)).toBeInTheDocument();
+    expect(screen.getByText(/Fix the thing/)).toBeInTheDocument();
+  });
+});
+
+describe("BadgeScanChart", () => {
+  it("renders the latency chart legend once stats load", async () => {
+    mockFetchJson({
+      "/api/system-status/health": {
+        days: [
+          { date: "2026-06-01", count: 10, median: 20, p90: 40, p99: 60 },
+          { date: "2026-06-02", count: 12, median: 22, p90: 41, p99: 61 },
+          { date: "2026-06-03", count: 9, median: 19, p90: 39, p99: 58 },
+        ],
+      },
+    });
+    renderWithProviders(<BadgeScanChart />);
+    expect(await screen.findByText("Median")).toBeInTheDocument();
+    expect(screen.getByText("P90")).toBeInTheDocument();
+    expect(screen.getByText("P99")).toBeInTheDocument();
+  });
+
+  it("shows a failure message when the health endpoint has no data", async () => {
+    mockFetchJson({});
+    renderWithProviders(<BadgeScanChart />);
+    expect(await screen.findByText("Failed to load metrics.")).toBeInTheDocument();
+  });
+});

--- a/checkin-app/src/test-helpers/__tests__/rtl.smoke.test.tsx
+++ b/checkin-app/src/test-helpers/__tests__/rtl.smoke.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Smoke test for the shared RTL harness (test-helpers/rtl). Proves the Mantine
+ * wrap, fetch stub, and nav/auth mocks work, so page/component tests can rely on it.
+ */
+import { screen } from "@testing-library/react";
+import { Button } from "@mantine/core";
+import { renderWithProviders, mockFetchJson, navMock, authMock, setSession, setPathname, resetRtl, router } from "../rtl";
+
+beforeEach(() => resetRtl());
+
+describe("rtl test-helper", () => {
+    it("renderWithProviders renders a Mantine component (matchMedia/ResizeObserver polyfilled)", () => {
+        renderWithProviders(<Button>Hi</Button>);
+        expect(screen.getByRole("button", { name: "Hi" })).toBeInTheDocument();
+    });
+
+    it("mockFetchJson routes by URL substring (data + factory + miss)", async () => {
+        const fn = mockFetchJson({ "/api/foo": { a: 1 }, "/api/bar": () => ({ b: 2 }) });
+        expect(await (await fetch("/api/foo")).json()).toEqual({ a: 1 });
+        expect(await (await fetch("/api/bar")).json()).toEqual({ b: 2 });
+        const miss = await fetch("/api/nope");
+        expect(miss.ok).toBe(false);
+        expect(miss.status).toBe(404);
+        expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it("nav/auth mocks expose controllable state", () => {
+        setPathname("/x");
+        setSession({ id: 1, isSysadmin: true });
+        expect(navMock().usePathname()).toBe("/x");
+        expect(navMock().useRouter()).toBe(router);
+        expect(authMock().useSession()).toEqual({ data: { user: { id: 1, isSysadmin: true } }, status: "authenticated" });
+    });
+
+    it("resetRtl clears router spies and state", () => {
+        router.push("/a");
+        setSession({ id: 9 });
+        resetRtl();
+        expect(router.push).not.toHaveBeenCalled();
+        expect(authMock().useSession()).toEqual({ data: null, status: "unauthenticated" });
+    });
+});

--- a/checkin-app/src/test-helpers/rtl.tsx
+++ b/checkin-app/src/test-helpers/rtl.tsx
@@ -107,7 +107,10 @@ export function resetRtl() {
  * Returns the jest.fn so callers can assert on it.
  */
 export function mockFetchJson(routes: Record<string, unknown | (() => unknown)>) {
-    const fn = jest.fn(async (input: RequestInfo | URL) => {
+    // The unused `init` param types `.mock.calls[N][1]` as the RequestInit so tests
+    // can assert on the request's method/body.
+    const fn = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        void init;
         const url = typeof input === "string" ? input : input.toString();
         const key = Object.keys(routes).find((k) => url.includes(k));
         const raw = key !== undefined ? routes[key] : undefined;

--- a/checkin-app/src/test-helpers/rtl.tsx
+++ b/checkin-app/src/test-helpers/rtl.tsx
@@ -1,0 +1,124 @@
+/**
+ * Shared React Testing Library harness for page/component tests (Phase 2+ of the
+ * coverage plan). Lives under test-helpers/ (excluded from coverage) so ~60 page
+ * tests don't each reinvent the Mantine + next-auth + next/navigation + fetch
+ * mocking.
+ *
+ * Usage in a test file (jest.mock is hoisted, so the factory must `require`):
+ *
+ *   jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+ *   jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+ *   import { renderWithProviders, mockFetchJson, setSession, setPathname, router } from "@/test-helpers/rtl";
+ *
+ *   beforeEach(() => resetRtl());
+ *   it("...", () => { setSession({ id: 1, isSysadmin: true }); mockFetchJson({ "/api/x": {...} }); renderWithProviders(<Page />); });
+ */
+import { render, type RenderOptions } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import type { ReactElement, ReactNode } from "react";
+
+// jsdom lacks matchMedia + ResizeObserver, which Mantine's ScrollArea/Table use.
+// Install once at import time; guarded so node-env (integration) files that happen
+// to import this don't crash on the missing `window`.
+if (typeof window !== "undefined") {
+    window.matchMedia =
+        window.matchMedia ||
+        ((query: string) =>
+            ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addEventListener: () => {},
+                removeEventListener: () => {},
+                addListener: () => {},
+                removeListener: () => {},
+                dispatchEvent: () => false,
+            }) as unknown as MediaQueryList);
+    globalThis.ResizeObserver =
+        globalThis.ResizeObserver ||
+        (class {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as unknown as typeof ResizeObserver);
+}
+
+/** Render `ui` wrapped in a MantineProvider (required by any Mantine component). */
+export function renderWithProviders(ui: ReactElement, options?: RenderOptions) {
+    return render(<MantineProvider>{ui}</MantineProvider>, options);
+}
+
+// ── next/navigation + next-auth/react mocks ──────────────────────────────────
+export const router = {
+    push: jest.fn(),
+    replace: jest.fn(),
+    refresh: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    prefetch: jest.fn(),
+};
+let pathname = "/";
+let searchParams = new URLSearchParams();
+let session: { data: unknown; status: string } = { data: null, status: "unauthenticated" };
+
+/** Factory for `jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock())`. */
+export function navMock() {
+    return {
+        useRouter: () => router,
+        usePathname: () => pathname,
+        useSearchParams: () => searchParams,
+        useParams: () => ({}),
+        redirect: jest.fn(),
+        notFound: jest.fn(),
+    };
+}
+/** Factory for `jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock())`. */
+export function authMock() {
+    return {
+        useSession: () => session,
+        signIn: jest.fn(),
+        signOut: jest.fn(),
+        SessionProvider: ({ children }: { children: ReactNode }) => children,
+    };
+}
+
+export function setPathname(p: string) {
+    pathname = p;
+}
+export function setSearchParams(sp: URLSearchParams | string) {
+    searchParams = typeof sp === "string" ? new URLSearchParams(sp) : sp;
+}
+/** Set the mocked session user (pass null for signed-out). */
+export function setSession(user: Record<string, unknown> | null, status = user ? "authenticated" : "unauthenticated") {
+    session = { data: user ? { user } : null, status };
+}
+/** Reset router spies + pathname/search/session between tests. */
+export function resetRtl() {
+    Object.values(router).forEach((fn) => (fn as jest.Mock).mockClear());
+    pathname = "/";
+    searchParams = new URLSearchParams();
+    session = { data: null, status: "unauthenticated" };
+}
+
+// ── fetch stub ───────────────────────────────────────────────────────────────
+/**
+ * Stub `global.fetch`, routing by URL substring. Values may be data or a
+ * `() => data` factory. A matched route → 200 + json; unmatched → 404.
+ * Returns the jest.fn so callers can assert on it.
+ */
+export function mockFetchJson(routes: Record<string, unknown | (() => unknown)>) {
+    const fn = jest.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const key = Object.keys(routes).find((k) => url.includes(k));
+        const raw = key !== undefined ? routes[key] : undefined;
+        const body = typeof raw === "function" ? (raw as () => unknown)() : raw;
+        return {
+            ok: key !== undefined,
+            status: key !== undefined ? 200 : 404,
+            json: async () => body ?? {},
+            text: async () => JSON.stringify(body ?? {}),
+        } as Response;
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    return fn;
+}


### PR DESCRIPTION
Executes Phases 2–3 of the coverage plan (#632), built on the shared RTL harness (**#637** — merge that first; it shows in this diff until then).

**16 components/pages, 75 tests, all green together; eslint + tsc clean.** ~5,300 newly-covered lines.

| Area | Files | Coverage |
|---|---|---|
| Core shell | `AppFrame`, `OnboardingGate`, `TrustedAdultPanel` | 93–97% |
| Admin panels | SystemHealth, AuditLog, LinkStatus, ErrorLog, Badge/Sticker docs | 98–100% |
| Shop | `ToolManagementPanel`, `settings/membership` | 92–94% |
| Pages A | `program-ops/programs/[id]`, `my-household`, `attendance/current` | 72–92% |
| Pages B | `sessions/[id]`, `programs/[id]`, `participants`, `applications` | 81–93% |

All use the `test-helpers/rtl` harness (Mantine + session/router + fetch mocks). Deep modal/error/validation branches deliberately left uncovered per the plan's line-coverage-ROI guidance. `@react-pdf/renderer` primitives are mocked (ESM / non-DOM reconciler).

Note: the CI fix in the latest commit adds the `init` param to the harness fetch mock so tests can type-check assertions on `mock.calls[N][1]` (was failing `tsc --noEmit`, not jest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
