### PR TITLE
fix(program-ops): remove redundant page titles above subtabs

### DIFF
--- a/checkin-app/src/app/program-ops/events/page.tsx
+++ b/checkin-app/src/app/program-ops/events/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Card, Center, Checkbox, Group, Loader, Stack, Table, Text, TextInput, Title } from "@mantine/core";
+import { Card, Center, Checkbox, Group, Loader, Stack, Table, Text, TextInput } from "@mantine/core";
 
 type OneTimeEvent = {
   id: number;
@@ -48,7 +48,6 @@ export default function OneTimeEventsList() {
   return (
     <Stack>
       <div>
-        <Title order={1}>One Time Events</Title>
         <Text c="dimmed">Browse all one-off / standalone events.</Text>
       </div>
 

--- a/checkin-app/src/app/program-ops/sessions/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/page.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { Suspense } from "react";
-import { Center, Loader, Stack, Text, Title } from "@mantine/core";
+import { Center, Loader, Stack, Text } from "@mantine/core";
 import { NewEventForm } from "@/app/program-ops/sessions/new/page";
 
 export default function OneTimeEventsIndex() {
   return (
     <Stack>
       <div>
-        <Title order={1}>New One Time Event</Title>
         <Text c="dimmed">Schedule a one-off event or manual session.</Text>
       </div>
 


### PR DESCRIPTION
## What

Remove the `<Title>` headings on two program-ops pages — they duplicate the subtab label directly above them:

- `/program-ops/sessions` — dropped **"New One Time Event"**
- `/program-ops/events` — dropped **"One Time Events"**

Dimmed description text kept. Unused `Title` imports removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)