### PR TITLE
fix(safety): remove redundant Board Contact Info heading

### DIFF
--- a/checkin-app/src/app/safety/board-contacts/page.tsx
+++ b/checkin-app/src/app/safety/board-contacts/page.tsx
@@ -57,8 +57,7 @@ export default function BoardContactInfoPage() {
   return (
     <Stack>
       <Card withBorder radius="md" padding="lg">
-        <Title order={1}>📞 Board Contact Info</Title>
-        <Text c="dimmed" mt="xs">
+        <Text c="dimmed">
           Directory of current board members and their contact details.
         </Text>
       </Card>


### PR DESCRIPTION
## Summary
- Removed the `📞 Board Contact Info` page heading on `/safety/board-contacts` — it duplicated the top tab label.
- Kept the dimmed description text below it.

## Test plan
- Visit `/safety/board-contacts`; heading gone, description remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)