### PR TITLE
fix(nav): blue not green for household-in-building attendance badge

### DIFF
--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -37,8 +37,11 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
     }
     case '/attendance': {
       const mine = counts.buildingHousehold;
+      const blue = (n: number, label: string): NavBadge[] =>
+        n > 0 ? [{ count: n, color: 'blue', label }] : [];
       return [
-        ...green(mine, `${mine} from your household currently in the building`),
+        // Blue not green: informational (who's here), not an action to take.
+        ...blue(mine, `${mine} from your household currently in the building`),
         ...gray(counts.building, `${counts.building} people currently in the building`),
       ];
     }


### PR DESCRIPTION
## What

The left-nav attendance badge showing "N from your household currently in the building" used the green action color. That count is informational (who's here), not an action the viewer must take, so green is misleading.

Switch it to blue. The gray "everyone else in the building" badge is unchanged.

## Where

[navBadges.ts](checkin-app/src/components/navBadges.ts) — `/attendance` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)