### PR TITLE
fix(program-ops): match Create Program box width to sessions page

### DIFF
--- a/checkin-app/src/app/program-ops/new/page.tsx
+++ b/checkin-app/src/app/program-ops/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Alert, Button, Card, Center, Checkbox, Container, Group, Loader, NumberInput, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
+import { Alert, Box, Button, Card, Center, Checkbox, Group, Loader, NumberInput, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
@@ -99,7 +99,7 @@ export default function CreateProgramPage() {
   if (!ready) return null;
 
   return (
-    <Container size="md" pb="md">
+    <Box pb="md">
       <Card withBorder radius="md" padding="lg">
         <AdminPageHeader title="Create Program" mb="md" />
 
@@ -221,6 +221,6 @@ export default function CreateProgramPage() {
           </Stack>
         </form>
       </Card>
-    </Container>
+    </Box>
   );
 }


### PR DESCRIPTION
## What

`/program-ops/new` (Create Program) box was narrower + mis-padded vs the reference `/program-ops/sessions` page.

## Root cause

The ProgramOps `layout.tsx` already wraps every page in `PageContainer` (maxWidth 1200, full width). `new/page.tsx` added a *second* `<Container size="md">`, narrowing the Card and adding extra horizontal padding. Sessions page has no inner Container, so it filled the full width.

## Fix

Dropped the redundant `<Container size="md" pb="md">`, replaced with `<Box pb="md">`. Box now fills `PageContainer` width, matching sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)