### PR TITLE
fix(layout): align settings/membership-audit/attendance margins to PageContainer

### DIFF
--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -319,7 +319,7 @@ function KioskDisplayInner() {
   const userId = (session?.user as SessionUser)?.id;
 
   return (
-    <Box style={isKioskMode ? { cursor: "none", marginTop: -25, paddingLeft: 8 } : { marginTop: -25, paddingLeft: 8 }}>
+    <Box style={isKioskMode ? { cursor: "none", marginTop: -25, paddingLeft: 8, display: "flow-root" } : { maxWidth: 1200, margin: "0 auto", marginTop: -25, paddingLeft: 8, display: "flow-root" }}>
       {!isKioskMode && (
         <Box style={{ maxWidth: 1200, margin: "0 auto" }}>
           <AttendanceTabs />

--- a/checkin-app/src/app/membership-audit/emergency-contacts/page.tsx
+++ b/checkin-app/src/app/membership-audit/emergency-contacts/page.tsx
@@ -50,7 +50,7 @@ export default function MissingEmergencyContactsPage() {
   }
 
   return (
-    <Stack maw={1000} mx="auto">
+    <Stack>
       <Card withBorder radius="md" padding="lg">
         <Text c="dimmed">
           Active or in-intake households with no valid emergency contact. A contact is

--- a/checkin-app/src/app/membership-audit/unclaimed/page.tsx
+++ b/checkin-app/src/app/membership-audit/unclaimed/page.tsx
@@ -28,7 +28,7 @@ export default function UnclaimedHouseholdsIndex() {
   }, []);
 
   return (
-    <Stack maw={1000} mx="auto">
+    <Stack>
       <div>
         <Text c="dimmed">Households where no household lead has ever signed in with Google.</Text>
       </div>

--- a/checkin-app/src/app/settings/layout.tsx
+++ b/checkin-app/src/app/settings/layout.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useEffect } from "react";
 import { Center, Loader, Stack, Text } from "@mantine/core";
+import { PageContainer } from "@/components/ui/PageContainer";
 
 type SettingsUser = { isSysadmin?: boolean; isBoardMember?: boolean };
 
@@ -38,5 +39,5 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
     return null;
   }
 
-  return <>{children}</>;
+  return <PageContainer>{children}</PageContainer>;
 }


### PR DESCRIPTION
## What

Fix wrong margins on pages that diverged from the canonical `PageContainer` wrapper (template: `/system-status/health`).

| Page(s) | Symptom | Fix |
|---|---|---|
| `/settings/membership`, `/settings/roles`, `/settings/localization` | wrong top margin above subtabs, wrong left margin on content | `settings/layout.tsx` wraps children in `PageContainer` |
| `/membership-audit/emergency-contacts`, `/membership-audit/unclaimed` | wrong side margins | drop page-level `<Stack maw={1000} mx="auto">` so content fills the 1200 container |
| `/attendance/current` | wrong top margin | inline wrapper gains `display:flow-root` + outer `maxWidth:1200, margin:0 auto`, matching `PageContainer` siblings (`manual`, `household`) |

## Notes

- `attendance/current` keeps its inline Box (kiosk branch needs `cursor:none`/full-bleed); non-kiosk style now matches `PageContainer` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)