### PR TITLE
fix(nav): align unclaimed-households count to lead-based list query

### DIFF
--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -336,9 +336,14 @@ export const GET = withAuth({}, async (_req, auth) => {
             }),
             countHouseholdsMissingValidContact(),
             // Households with an account created at registration that nobody has
-            // claimed via Google sign-in yet. Mirrors /api/membership-audit/unclaimed-households.
+            // claimed via Google sign-in yet. Mirrors /api/membership-audit/unclaimed-households:
+            // claiming hinges on leads only (kids/members may never log in), so count
+            // households with an email-having lead where no lead has signed in with Google.
             prisma.household.count({
-                where: { participants: { some: { email: { not: null }, googleId: null } } },
+                where: {
+                    leads: { some: { participant: { email: { not: null } } } },
+                    NOT: { leads: { some: { participant: { googleId: { not: null } } } } },
+                },
             }),
             // "Broken" households: no household lead at all. Mirrors
             // /api/admin/broken-households. Includes empty households.


### PR DESCRIPTION
## Problem
The membership-audit tab badge for **Unclaimed Accounts** showed **8** while the `/membership-audit/unclaimed` page listed only **2** households. Math mismatch.

## Cause
Two different definitions of "unclaimed":

- **List** ([unclaimed-households/route.ts](../blob/main/checkin-app/src/app/api/membership-audit/unclaimed-households/route.ts)) — by **leads**: a household with an email-having lead where no lead has signed in with Google.
- **Count** ([todo-counts/route.ts](../blob/main/checkin-app/src/app/api/nav/todo-counts/route.ts)) — by **any participant**: `participants.some({ email not null, googleId null })`. Any kid/member with an email but no Google login inflated the count.

The count's comment even claimed it "Mirrors /api/membership-audit/unclaimed-households" — it didn't.

## Fix
Count now uses the same lead-based `where` as the list. Both surfaces agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)