### PR TITLE
Explain why program enrollment is closed

### DIFF
--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -20,6 +20,9 @@ type ProgramDetail = {
   // household's rows arrive when enrolled, which is all the "already enrolled"
   // check below needs.
   participants?: { participantId: number, status?: string }[];
+  _count?: { participants?: number };
+  phase: string;
+  maxParticipants: number | null;
   enrollmentStatus: string;
   memberPriceCents: number | null;
   nonMemberPriceCents: number | null;
@@ -240,6 +243,17 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   const isClosed = program.enrollmentStatus === 'CLOSED';
   const hasPrice = !!(program.memberPriceCents || program.nonMemberPriceCents);
 
+  // Why is enrollment closed? Full wins over phase.
+  const enrolledCount = program._count?.participants ?? program.participants?.length ?? 0;
+  const isFull = program.maxParticipants != null && enrolledCount >= program.maxParticipants;
+  const closedReason = !isClosed ? null
+    : isFull ? 'Full'
+    : program.phase === 'RUNNING' ? 'Running'
+    : program.phase === 'UPCOMING' ? 'Upcoming'
+    : program.phase === 'FINISHED' ? 'Ended'
+    : null;
+  const closedSuffix = closedReason && <Text component="span" c="white"> ({closedReason})</Text>;
+
   return (
     <Container size="md" pb="md">
       <Card withBorder radius="md" padding="lg">
@@ -289,13 +303,13 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
             <Group justify="center" wrap="wrap">
               {session ? (
                 <Button size="md" onClick={startEnrollmentProcess} disabled={isClosed}>
-                  {isClosed ? "Enrollment Closed" : "Enroll"}
+                  {isClosed ? <>Enrollment Closed{closedSuffix}</> : "Enroll"}
                 </Button>
               ) : (
                 <>
                   <Button size="md" onClick={() => router.push('/')}>Log In To Enroll</Button>
                   <Button size="md" color="green" onClick={() => router.push(`/programs/${program.id}/register`)} disabled={isClosed}>
-                    {isClosed ? "Registration Closed" : "Register (New User)"}
+                    {isClosed ? <>Registration Closed{closedSuffix}</> : "Register (New User)"}
                   </Button>
                 </>
               )}


### PR DESCRIPTION
## What

On program detail pages (`/programs/[id]`), a closed program's button just said **Enrollment Closed** / **Registration Closed** with no reason. This appends a white `(Reason)` suffix so users know why:

| State | Suffix |
|---|---|
| At capacity (`enrolled ≥ maxParticipants`) | `(Full)` — takes priority over phase |
| `phase === RUNNING` | `(Running)` |
| `phase === UPCOMING` | `(Upcoming)` |
| `phase === FINISHED` | `(Ended)` |
| else (PLANNING) | no suffix |

## Why

"Enrollment Closed" alone is opaque — a user can't tell if they missed the window, arrived late, or the class filled up.

## How

Pure client-side derivation in [page.tsx](checkin-app/src/app/programs/[id]/page.tsx). No API or schema change: `phase`, `maxParticipants`, and `_count.participants` are already `@sensitivity:public` and returned by `GET /api/programs/[id]` to anonymous callers. Suffix applied to both the enroll and register buttons.

## Notes for reviewer

- Full is computed from `_count.participants ?? participants.length ?? 0` vs `maxParticipants` (null max = never full).
- Verified the API delivers all three fields to anonymous callers for closed programs in each phase; tsc clean. Browser render not visually confirmed (Chrome extension was offline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)