### PR TITLE
fix(nav): solid light-gray fill for left-nav count badges

### DIFF
--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -309,17 +309,20 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                   badges.length > 0 ? (
                     <Group gap={4} wrap="nowrap">
                       {badges.map((badge) => {
-                        // Two badge shades, each with its own readable font (same convention as
-                        // the membership-ops tabs): green action badges are green fill + dark
-                        // text; gray informational badges are light-gray fill + dark text.
+                        // Green action badges = green fill + dark text. Gray informational badges
+                        // = SOLID light-gray fill (gray.3) + dark text. The nav sits on a dark
+                        // purple sidebar, so the 'light' variant (a translucent tint) reads dark
+                        // there — a solid light shade keeps the circle actually light-gray. The
+                        // NavLink also forces section text white on the colored sidebar, so pin
+                        // the dark label explicitly.
                         const isGray = badge.color === 'gray';
                         return (
                           <Badge
                             key={badge.color}
                             size="md"
-                            color={badge.color}
-                            variant={isGray ? 'light' : 'filled'}
-                            c={isGray ? 'var(--mantine-color-gray-7)' : 'var(--mantine-color-black)'}
+                            color={isGray ? 'gray.3' : badge.color}
+                            variant="filled"
+                            c="var(--mantine-color-dark-9)"
                             aria-label={badge.label}
                           >
                             {badge.count}


### PR DESCRIPTION
## What
Left-nav count badges (building occupancy, active programs, etc.) now use a **solid light-gray fill** (`gray.3`) with dark text, instead of the Mantine `light` variant merged in #633.

## Why
The left nav renders on a **dark purple sidebar** (`treehousePurple.9`). Mantine's `light` variant is a *translucent* tint — over that dark background it reads as **dark gray**, not light gray. A solid light shade keeps the circle actually light-gray and legible. The NavLink also forces section text white on the colored sidebar, so the dark label is pinned explicitly.

Green action badges keep green fill + dark text.

## Note
Sub-tab gray badges (membership-audit, etc.) correctly stay `variant="light"` — those sit on a white page background where the translucent tint reads light. This change only touches the dark-sidebar left nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)