### PR TITLE
refactor(nav): rename programsPending todo-count to paymentPlanPending

### DIFF
--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -232,7 +232,7 @@ describe('Nav todo-counts API', () => {
         // membership = BLOCKED only (see delta test below); the seeded PENDING_BG_REVIEW
         // is reviewer work and no longer counts, so just assert it's a number.
         expect(typeof data.admin.membership).toBe('number');
-        expect(data.admin.programsPending).toBeGreaterThanOrEqual(1); // payment-plan requested
+        expect(data.admin.paymentPlanPending).toBeGreaterThanOrEqual(1); // payment-plan requested
         expect(data.admin.trustedAdults).toBeGreaterThanOrEqual(1); // the PENDING_BOARD_REVIEW review
         expect(typeof data.admin.unclaimedHouseholds).toBe('number'); // households with an unclaimed account
     });

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -59,7 +59,7 @@ export type TodoCounts = {
     // `memberFamilies` = total member families (gray), shown on the Manage Memberships tab:
     // households with >=1 non-org-email (or null-email) participant. Staff households hold
     // only the org-email lead, so they fall out.
-    admin?: { membership: number; applicationsTotal: number; programsPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; memberFamilies: number };
+    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; memberFamilies: number };
     // Lead surface: programs the caller runs (program.leadMentorId). Present only
     // when they lead ≥1 program — drives the staff "My Programs" nav item's
     // visibility and its green badge (sum of pending attendance to confirm).
@@ -320,7 +320,7 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     // ---- Admin surface (board's own queue) — only for board/isSysadmin ----
     if (user.isSysadmin || user.isBoardMember) {
-        const [membership, applicationsTotal, programsPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies] = await Promise.all([
+        const [membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies] = await Promise.all([
             prisma.membershipProcess.count({
                 where: { status: { in: BOARD_ACTIONABLE_MEMBERSHIP } },
             }),
@@ -361,7 +361,7 @@ export const GET = withAuth({}, async (_req, auth) => {
                 },
             }),
         ]);
-        result.admin = { membership, applicationsTotal, programsPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies };
+        result.admin = { membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies };
     }
 
     return NextResponse.json(result);

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -62,7 +62,7 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
     }
     case '/finance-ops':
       // Pending participants awaiting payment-plan approval.
-      return green(counts.admin ? counts.admin.programsPending : 0, 'Pending payment-plan approvals');
+      return green(counts.admin ? counts.admin.paymentPlanPending : 0, 'Pending payment-plan approvals');
     case '/safety':
       // Trusted-adult disclosures awaiting board review.
       return green(counts.admin ? counts.admin.trustedAdults : 0, 'Trusted-adult disclosures to review');


### PR DESCRIPTION
## What

Rename the nav todo-count field `programsPending` → `paymentPlanPending` across all 5 references.

## Why

The name was misleading: `programsPending` does **not** count programs. The underlying query counts pending payment-plan requests:

```ts
prisma.programParticipant.count({ where: { status: "PENDING", isPaymentPlanRequested: true } })
```

It renders as the Finance Ops **"Pending payment-plan approvals"** badge. `paymentPlanPending` matches what it actually measures.

## Changes (pure rename — no logic change)

- `route.ts` — admin type field, Promise.all destructure binding, and `result.admin` shorthand key
- `navBadges.ts` — badge count read
- `navTodoCountsAPI.integration.test.ts` — assertion

Query logic and `Promise.all` ordering untouched.

## Verification

- `grep -rn programsPending checkin-app/src` → 0 hits
- `npx tsc --noEmit` → clean