### PR TITLE
fix(email): absolute links in emails via config.baseUrl()

### DIFF
--- a/checkin-app/src/lib/membership/boardAlerts.ts
+++ b/checkin-app/src/lib/membership/boardAlerts.ts
@@ -1,4 +1,5 @@
 import { emailBoardMembers } from "@/lib/emailRecipients";
+import { config } from "@/lib/config";
 
 /**
  * Board-facing membership email alerts. Kept dependency-free (delegates to the
@@ -15,7 +16,7 @@ import { emailBoardMembers } from "@/lib/emailRecipients";
  * automatically.)
  */
 export async function notifyBoardPaidReject(processId: number): Promise<void> {
-    const base = process.env.NEXTAUTH_URL ?? "";
+    const base = config.baseUrl();
     await emailBoardMembers(
         "Membership: a paid application was blocked at background check",
         `<p>A household that already paid did not pass background-check review (application #${processId}). The membership has <strong>not</strong> been activated and a refund may be needed — please review and contact the household. <a href="${base}/membership-ops/applications">Open applications</a></p>`,

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -2,6 +2,7 @@ import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { emailHouseholdLeads } from "@/lib/emailRecipients";
 import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
+import { config } from "@/lib/config";
 
 /**
  * Payment phase (PENDING_PAYMENT -> ACTIVE).
@@ -242,7 +243,7 @@ export async function activateByProcessId(processId: number, shopifyOrderId: str
 
 /** Send the one "welcome — your membership is active" email to a household's leads. */
 export async function sendCongrats(householdId: number) {
-    const base = process.env.NEXTAUTH_URL ?? "";
+    const base = config.baseUrl();
     await emailHouseholdLeads(
         householdId,
         "Welcome to the Treehouse — your membership is active!",

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { emailHouseholdLeads } from "@/lib/emailRecipients";
 import { notifyReviewers } from "@/lib/membership/review";
+import { config } from "@/lib/config";
 
 /**
  * Annual renewal. A common membership-year boundary (BoardSettings) drives every
@@ -213,7 +214,7 @@ export async function householdBgIsFresh(householdId: number, boundary: Date, re
 }
 
 async function remindHousehold(householdId: number, boundary: Date) {
-    const base = process.env.NEXTAUTH_URL ?? "";
+    const base = config.baseUrl();
     const due = boundary.toISOString().slice(0, 10);
     await emailHouseholdLeads(
         householdId,

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -4,6 +4,7 @@ import { sendEmail } from "@/lib/email";
 import { logger } from "@/lib/logger";
 import { sendCongrats } from "@/lib/membership/payment";
 import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
+import { config } from "@/lib/config";
 
 type TxClient = Prisma.TransactionClient;
 
@@ -99,7 +100,7 @@ export async function notifyReviewers(): Promise<void> {
             where: { email: { not: null }, OR: [{ isBackgroundCheckReviewer: true }, { isBoardMember: true }] },
             select: { email: true },
         });
-        const base = process.env.NEXTAUTH_URL ?? "";
+        const base = config.baseUrl();
         await Promise.all(
             reviewers.map((r) =>
                 r.email

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { escapeHtml } from "@/lib/email-templates/base";
 import { emailBoardMembers, emailHouseholdLeads } from "@/lib/emailRecipients";
 import { isTrustedAdultConflict } from "@/lib/trusted-adult/conflict";
+import { config } from "@/lib/config";
 import { validateContact } from "@/lib/trusted-adult/contact";
 
 type TxClient = Prisma.TransactionClient;
@@ -375,7 +376,7 @@ export async function assertHouseholdLead(householdId: number, actorId: number) 
 
 /** Email every board member that a trusted-adult review is waiting. */
 async function notifyBoard(): Promise<void> {
-    const base = process.env.NEXTAUTH_URL ?? "";
+    const base = config.baseUrl();
     await emailBoardMembers(
         "Trusted adult: a disclosure needs board review",
         `<p>A trusted-adult disclosure is awaiting board review. <a href="${base}/safety/trusted-adults">Review it</a>.</p>`,
@@ -385,7 +386,7 @@ async function notifyBoard(): Promise<void> {
 
 /** Email the household's leads (the "family"). */
 async function notifyHouseholdFamily(householdId: number, subject: string, body?: string): Promise<void> {
-    const base = process.env.NEXTAUTH_URL ?? "";
+    const base = config.baseUrl();
     const html = `<p>${escapeHtml(body ?? "")}</p><p><a href="${base}/trusted-adults">View your trusted adults</a>.</p>`;
     await emailHouseholdLeads(householdId, subject, html, "Family trusted-adult ping failed:");
 }


### PR DESCRIPTION
## What

Six email-sending call sites built link hrefs from `process.env.NEXTAUTH_URL ?? ""`. Swapped each to `config.baseUrl()`.

## Why

When `NEXTAUTH_URL` is unset the `""` fallback yields **root-relative** hrefs (e.g. `/membership`) that don't resolve in an email client — broken for links a recipient must click. `config.baseUrl()` (checkin-app/src/lib/config.ts) already encodes the `VERCEL_URL → NEXTAUTH_URL → localhost:4000` precedence, so links become absolute and correct in every environment.

## Sites changed

- `lib/trusted-adult/service.ts` (2 sites)
- `lib/membership/payment.ts`
- `lib/membership/review.ts`
- `lib/membership/boardAlerts.ts`
- `lib/membership/renewal.ts`

`lib/postEventEmails.ts` already used `config.baseUrl()` — left untouched.

## Notes for reviewer

- `grep -rn 'NEXTAUTH_URL ?? ""' checkin-app/src` → no matches after.
- `tsc --noEmit` clean on all 5 touched files (after `prisma generate`).
- Link-correctness only; no email dev-mock added. Flagged in `docs/designs/EMAIL_DEV_MOCK.md §6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)