### PR TITLE
fix(membership-ops): guard no-op tab click from firing unsaved-changes confirm

### DIFF
--- a/checkin-app/src/app/membership-ops/layout.tsx
+++ b/checkin-app/src/app/membership-ops/layout.tsx
@@ -62,7 +62,7 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
   return (
     <PageContainer>
       <Stack>
-      <Tabs value={activeTab} onChange={(value) => { if (value && confirmNav()) router.push(value); }}>
+      <Tabs value={activeTab} onChange={(value) => { if (value && value !== activeTab && confirmNav()) router.push(value); }}>
         <ScrollableTabsList>
           {navLinks.map((link) => {
             const todoCount = membershipTodoCountFor(link.href, todoCounts);


### PR DESCRIPTION
## What

Add the `value !== activeTab` self-guard to the `Tabs` `onChange` handler in `membership-ops/layout.tsx`.

Before:
```tsx
<Tabs value={activeTab} onChange={(value) => { if (value && confirmNav()) router.push(value); }}>
```
After:
```tsx
<Tabs value={activeTab} onChange={(value) => { if (value && value !== activeTab && confirmNav()) router.push(value); }}>
```

## Why

The handler only checked `value &&`, so clicking the tab that is **already active** still ran `confirmNav()` — firing the unsaved-changes confirm dialog — and re-pushed the current route. Every other section layout (`system-status`, `my-activities`, `program-ops`, `shop-ops`) already has this self-guard; this brings `membership-ops` in line.

## Notes for reviewer

- One-line change. This file's active-tab variable is named `activeTab` (siblings use `active`).
- `npx tsc --noEmit` shows only pre-existing, unrelated errors (missing generated prisma client in the worktree + `any` params in other files); the edited file is not among them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)