### PR TITLE
refactor(email): extract shared email fan-out helpers

### DIFF
--- a/checkin-app/src/lib/emailRecipients.ts
+++ b/checkin-app/src/lib/emailRecipients.ts
@@ -1,0 +1,43 @@
+import prisma from "@/lib/prisma";
+import { sendEmail } from "@/lib/email";
+import { logger } from "@/lib/logger";
+
+/**
+ * Email fan-out helpers. Kept dependency-free (prisma + email + logger only) so
+ * any path can resolve-and-send without an import cycle. Callers build their own
+ * subject/html (with NEXTAUTH_URL base, escapeHtml, etc.) and pass a distinct
+ * errorLabel; these helpers only resolve recipients and swallow send/query errors.
+ */
+
+/** Send one email to each recipient; per-send errors are logged and swallowed. */
+function fanOutEmails(emails: string[], subject: string, html: string, errorLabel: string): Promise<unknown[]> {
+    return Promise.all(emails.map((email) => sendEmail(email, subject, html).catch((e) => logger.error(errorLabel, e))));
+}
+
+/** Email every lead of a household. Resolve + fan-out; all errors logged and swallowed. */
+export async function emailHouseholdLeads(householdId: number, subject: string, html: string, errorLabel: string): Promise<void> {
+    try {
+        const leads = await prisma.householdLead.findMany({
+            where: { householdId },
+            select: { participant: { select: { email: true } } },
+        });
+        const emails = leads.map((l) => l.participant?.email).filter((e): e is string => !!e);
+        await fanOutEmails(emails, subject, html, errorLabel);
+    } catch (e) {
+        logger.error(errorLabel, e);
+    }
+}
+
+/** Email every board member with an address on file. Resolve + fan-out; all errors logged and swallowed. */
+export async function emailBoardMembers(subject: string, html: string, errorLabel: string): Promise<void> {
+    try {
+        const board = await prisma.participant.findMany({
+            where: { isBoardMember: true, email: { not: null } },
+            select: { email: true },
+        });
+        const emails = board.map((b) => b.email).filter((e): e is string => !!e);
+        await fanOutEmails(emails, subject, html, errorLabel);
+    } catch (e) {
+        logger.error(errorLabel, e);
+    }
+}

--- a/checkin-app/src/lib/membership/boardAlerts.ts
+++ b/checkin-app/src/lib/membership/boardAlerts.ts
@@ -1,11 +1,10 @@
-import prisma from "@/lib/prisma";
-import { sendEmail } from "@/lib/email";
-import { logger } from "@/lib/logger";
+import { emailBoardMembers } from "@/lib/emailRecipients";
 
 /**
- * Board-facing membership email alerts. Kept dependency-free (prisma + email +
- * logger only) so both the review path (review.ts) and the payment path
- * (payment.ts) can fire them without an import cycle.
+ * Board-facing membership email alerts. Kept dependency-free (delegates to the
+ * prisma + email + logger only emailRecipients helper) so both the review path
+ * (review.ts) and the payment path (payment.ts) can fire them without an import
+ * cycle.
  */
 
 /**
@@ -16,24 +15,10 @@ import { logger } from "@/lib/logger";
  * automatically.)
  */
 export async function notifyBoardPaidReject(processId: number): Promise<void> {
-    try {
-        const board = await prisma.participant.findMany({
-            where: { isBoardMember: true, email: { not: null } },
-            select: { email: true },
-        });
-        const base = process.env.NEXTAUTH_URL ?? "";
-        await Promise.all(
-            board.map((b) =>
-                b.email
-                    ? sendEmail(
-                          b.email,
-                          "Membership: a paid application was blocked at background check",
-                          `<p>A household that already paid did not pass background-check review (application #${processId}). The membership has <strong>not</strong> been activated and a refund may be needed — please review and contact the household. <a href="${base}/membership-ops/applications">Open applications</a></p>`,
-                      ).catch((e) => logger.error("Paid-reject board ping failed:", e))
-                    : Promise.resolve(),
-            ),
-        );
-    } catch (e) {
-        logger.error("notifyBoardPaidReject failed:", e);
-    }
+    const base = process.env.NEXTAUTH_URL ?? "";
+    await emailBoardMembers(
+        "Membership: a paid application was blocked at background check",
+        `<p>A household that already paid did not pass background-check review (application #${processId}). The membership has <strong>not</strong> been activated and a refund may be needed — please review and contact the household. <a href="${base}/membership-ops/applications">Open applications</a></p>`,
+        "Paid-reject board ping failed:",
+    );
 }

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -1,6 +1,6 @@
 import prisma from "@/lib/prisma";
-import { sendEmail } from "@/lib/email";
 import { logger } from "@/lib/logger";
+import { emailHouseholdLeads } from "@/lib/emailRecipients";
 import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
 
 /**
@@ -248,25 +248,11 @@ export async function activateByProcessId(processId: number, shopifyOrderId: str
 
 /** Send the one "welcome — your membership is active" email to a household's leads. */
 export async function sendCongrats(householdId: number) {
-    try {
-        const leads = await prisma.householdLead.findMany({
-            where: { householdId },
-            select: { participant: { select: { email: true, name: true } } },
-        });
-        const base = process.env.NEXTAUTH_URL ?? "";
-        await Promise.all(
-            leads
-                .map((l) => l.participant?.email)
-                .filter((e): e is string => !!e)
-                .map((email) =>
-                    sendEmail(
-                        email,
-                        "Welcome to the Treehouse — your membership is active!",
-                        `<p>Congratulations! Your household membership is now active. Welcome to the Innovation Treehouse community.</p><p><a href="${base}">Visit your dashboard</a></p>`,
-                    ).catch((e) => logger.error("Congrats email failed:", e)),
-                ),
-        );
-    } catch (e) {
-        logger.error("sendCongrats failed:", e);
-    }
+    const base = process.env.NEXTAUTH_URL ?? "";
+    await emailHouseholdLeads(
+        householdId,
+        "Welcome to the Treehouse — your membership is active!",
+        `<p>Congratulations! Your household membership is now active. Welcome to the Innovation Treehouse community.</p><p><a href="${base}">Visit your dashboard</a></p>`,
+        "Congrats email failed:",
+    );
 }

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -1,7 +1,7 @@
 import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
-import { sendEmail } from "@/lib/email";
 import { logger } from "@/lib/logger";
+import { emailHouseholdLeads } from "@/lib/emailRecipients";
 import { notifyReviewers } from "@/lib/membership/review";
 
 /**
@@ -213,23 +213,12 @@ export async function householdBgIsFresh(householdId: number, boundary: Date, re
 }
 
 async function remindHousehold(householdId: number, boundary: Date) {
-    try {
-        const leads = await prisma.householdLead.findMany({ where: { householdId }, select: { participant: { select: { email: true } } } });
-        const base = process.env.NEXTAUTH_URL ?? "";
-        const due = boundary.toISOString().slice(0, 10);
-        await Promise.all(
-            leads
-                .map((l) => l.participant?.email)
-                .filter((e): e is string => !!e)
-                .map((email) =>
-                    sendEmail(
-                        email,
-                        "Time to renew your Treehouse membership",
-                        `<p>Your household membership is up for renewal by ${due}. Please sign in to renew: <a href="${base}/membership">${base}/membership</a></p>`,
-                    ).catch((e) => logger.error("Renewal reminder failed:", e)),
-                ),
-        );
-    } catch (e) {
-        logger.error("remindHousehold failed:", e);
-    }
+    const base = process.env.NEXTAUTH_URL ?? "";
+    const due = boundary.toISOString().slice(0, 10);
+    await emailHouseholdLeads(
+        householdId,
+        "Time to renew your Treehouse membership",
+        `<p>Your household membership is up for renewal by ${due}. Please sign in to renew: <a href="${base}/membership">${base}/membership</a></p>`,
+        "Renewal reminder failed:",
+    );
 }

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -1,8 +1,7 @@
 import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
-import { sendEmail } from "@/lib/email";
 import { escapeHtml } from "@/lib/email-templates/base";
-import { logger } from "@/lib/logger";
+import { emailBoardMembers, emailHouseholdLeads } from "@/lib/emailRecipients";
 import { isTrustedAdultConflict } from "@/lib/trusted-adult/conflict";
 import { validateContact } from "@/lib/trusted-adult/contact";
 
@@ -376,46 +375,19 @@ export async function assertHouseholdLead(householdId: number, actorId: number) 
 
 /** Email every board member that a trusted-adult review is waiting. */
 async function notifyBoard(): Promise<void> {
-    try {
-        const board = await prisma.participant.findMany({
-            where: { isBoardMember: true, email: { not: null } },
-            select: { email: true },
-        });
-        const base = process.env.NEXTAUTH_URL ?? "";
-        await Promise.all(
-            board.map((b) =>
-                b.email
-                    ? sendEmail(
-                          b.email,
-                          "Trusted adult: a disclosure needs board review",
-                          `<p>A trusted-adult disclosure is awaiting board review. <a href="${base}/safety/trusted-adults">Review it</a>.</p>`,
-                      ).catch((e) => logger.error("Board trusted-adult ping failed:", e))
-                    : Promise.resolve(),
-            ),
-        );
-    } catch (e) {
-        logger.error("notifyBoard failed:", e);
-    }
+    const base = process.env.NEXTAUTH_URL ?? "";
+    await emailBoardMembers(
+        "Trusted adult: a disclosure needs board review",
+        `<p>A trusted-adult disclosure is awaiting board review. <a href="${base}/safety/trusted-adults">Review it</a>.</p>`,
+        "Board trusted-adult ping failed:",
+    );
 }
 
 /** Email the household's leads (the "family"). */
 async function notifyHouseholdFamily(householdId: number, subject: string, body?: string): Promise<void> {
-    try {
-        const leads = await prisma.householdLead.findMany({
-            where: { householdId },
-            select: { participant: { select: { email: true } } },
-        });
-        const base = process.env.NEXTAUTH_URL ?? "";
-        const html = `<p>${escapeHtml(body ?? "")}</p><p><a href="${base}/trusted-adults">View your trusted adults</a>.</p>`;
-        await Promise.all(
-            leads
-                .map((l) => l.participant?.email)
-                .filter((e): e is string => !!e)
-                .map((email) => sendEmail(email, subject, html).catch((e) => logger.error("Family trusted-adult ping failed:", e))),
-        );
-    } catch (e) {
-        logger.error("notifyHouseholdFamily failed:", e);
-    }
+    const base = process.env.NEXTAUTH_URL ?? "";
+    const html = `<p>${escapeHtml(body ?? "")}</p><p><a href="${base}/trusted-adults">View your trusted adults</a>.</p>`;
+    await emailHouseholdLeads(householdId, subject, html, "Family trusted-adult ping failed:");
 }
 
 function audit(


### PR DESCRIPTION
## What

Extracts the copy-pasted email fan-out boilerplate — *resolve recipients → map emails → null-filter → `Promise.all(send.catch(log))` → outer `try/catch`* — that was duplicated across 5 functions in two shapes.

New module `checkin-app/src/lib/emailRecipients.ts` (imports **prisma + email + logger only**, so no import cycle):
- `emailHouseholdLeads(householdId, subject, html, errorLabel)` — Shape A (household leads)
- `emailBoardMembers(subject, html, errorLabel)` — Shape B (board members)
- private `fanOutEmails(emails, subject, html, errorLabel)` — the shared send loop

Rewritten call sites (each now just builds `base`+subject+html and calls a helper):
- `membership/payment.ts` `sendCongrats`
- `membership/renewal.ts` `remindHousehold`
- `trusted-adult/service.ts` `notifyBoard` + `notifyHouseholdFamily`
- `membership/boardAlerts.ts` `notifyBoardPaidReject`

Dropped now-unused imports (`sendEmail` ×3, `logger` in service.ts).

## Why

Five near-identical fan-out blocks were drifting independently. One shared primitive per shape shrinks each function to a few lines and gives a single place to change send/error behavior.

## Behavior preserved

- Same query `where` clauses byte-for-byte, same null-filter, same subjects/bodies.
- Each caller keeps building its own `html` (base URL, `escapeHtml`, per-caller paths) — bodies were **not** moved into the helper.
- Each caller keeps its distinct per-send `errorLabel`.
- Query + fan-out both wrapped in `try/catch`, so a Prisma throw is still swallowed (matches the old outer-try).

## Reviewer notes

- **`notifications.ts` intentionally untouched** — its recipient set is per-lead conditional (per-lead opt-in + skip-self), not the same primitive.
- **`boardAlerts.ts` stays dependency-free** — it now delegates to the helper but still imports nothing from membership/review/payment, preserving its deliberate no-cycle property.
- **One deliberate divergence:** the outer-catch log label collapses to the single `errorLabel` (old code logged a distinct `"<fnName> failed:"` there). Only fires on a Prisma query throw; no unit test exercises that path.

## Testing

- `npx tsc --noEmit` — clean for touched files (remaining errors are pre-existing `implicitly any` noise in `*.integration.test.ts` / seed / scripts).
- `npx jest` (worktree ignore overridden) — **118 suites / 916 tests pass**, including `email.test`, `notifications.test`, `postEventEmails.test`, `membership/payment.test`.
- Integration tests need live Postgres — not run; covered by unit suites + tsc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)