### PR TITLE
chore: remove dead phaseIndex, computeDuesCents, and nav description fields

### DIFF
--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -11,7 +11,7 @@ import crypto from 'crypto';
 import { normalizeAuditData } from '@/lib/auditPayload';
 import { POST as SHOPIFY_WEBHOOK } from '@/app/api/webhooks/shopify/route';
 import { POST as CERTIFY } from '@/app/api/membership-ops/applications/certify-payment/route';
-import { computeDuesCents, ensurePaymentLink, ensurePaymentLinkForUser, activate } from '@/lib/membership/payment';
+import { ensurePaymentLink, ensurePaymentLinkForUser, activate } from '@/lib/membership/payment';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import { sendEmail } from '@/lib/email';
@@ -111,11 +111,6 @@ describe('Membership payment API', () => {
         if (prevStoreDomain === undefined) delete process.env.SHOPIFY_STORE_DOMAIN;
         else process.env.SHOPIFY_STORE_DOMAIN = prevStoreDomain;
         await prisma.$disconnect();
-    });
-
-    it('computes dues by tier from BoardSettings', async () => {
-        expect(await computeDuesCents(false)).toBe(10000);
-        expect(await computeDuesCents(true)).toBe(2500);
     });
 
     it('builds a checkout link to the membership product (no discount for normal)', async () => {

--- a/checkin-app/src/lib/facilityNav.ts
+++ b/checkin-app/src/lib/facilityNav.ts
@@ -6,13 +6,11 @@ export interface FacilityNavLink {
   name: string;
   href: string;
   icon: string;
-  /** One-line description shown on the hub landing grid (not in the tabs). */
-  description?: string;
 }
 
 export const FACILITY_NAV_LINKS: FacilityNavLink[] = [
-  { name: "Visit History", href: "/facility-ops/visits", icon: "🕒", description: "View and edit past visit records." },
-  { name: "Raw Badge Events", href: "/facility-ops/badges", icon: "📡", description: "Audit the raw RFID badge tap log." },
-  { name: "Print ID Badges", href: "/facility-ops/print-badges", icon: "🖨️", description: "Generate printable participant ID badges." },
-  { name: "Participation Trends", href: "/facility-ops/trends", icon: "📈", description: "Attendance and participation analytics." },
+  { name: "Visit History", href: "/facility-ops/visits", icon: "🕒" },
+  { name: "Raw Badge Events", href: "/facility-ops/badges", icon: "📡" },
+  { name: "Print ID Badges", href: "/facility-ops/print-badges", icon: "🖨️" },
+  { name: "Participation Trends", href: "/facility-ops/trends", icon: "📈" },
 ];

--- a/checkin-app/src/lib/financeNav.ts
+++ b/checkin-app/src/lib/financeNav.ts
@@ -6,10 +6,8 @@ export interface FinanceNavLink {
   name: string;
   href: string;
   icon: string;
-  /** One-line description shown on the hub landing grid (not in the tabs). */
-  description?: string;
 }
 
 export const FINANCE_NAV_LINKS: FinanceNavLink[] = [
-  { name: "Payment Plan", href: "/finance-ops/payment-plan", icon: "⏳", description: "Review and approve payment-plan requests." },
+  { name: "Payment Plan", href: "/finance-ops/payment-plan", icon: "⏳" },
 ];

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -25,12 +25,6 @@ export class PaymentError extends Error {
     }
 }
 
-/** Annual dues in cents for this membership tier (volunteer families pay the lower rate). */
-export async function computeDuesCents(isVolunteer: boolean): Promise<number> {
-    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    return isVolunteer ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
-}
-
 /**
  * Build the Shopify cart-permalink checkout link for a membership process. Both
  * tiers point at the same product variant; volunteers get `discount=<code>`

--- a/checkin-app/src/lib/membership/phases.ts
+++ b/checkin-app/src/lib/membership/phases.ts
@@ -24,11 +24,6 @@ export const INITIAL_PHASES: IntakePhase[] = [
     { status: "ACTIVE", label: "Member", description: "Welcome to the Treehouse!" },
 ];
 
-/** Index of a status within the INITIAL flow, or -1 if it isn't a flow phase. */
-export function phaseIndex(status: MembershipProcessStatus): number {
-    return INITIAL_PHASES.findIndex((p) => p.status === status);
-}
-
 /**
  * Stepper position for a status: how many INITIAL_PHASES steps are complete.
  * PENDING_BG_CLEARANCE (paid, awaiting the check) sits between Payment and

--- a/checkin-app/src/lib/membershipOpsNav.ts
+++ b/checkin-app/src/lib/membershipOpsNav.ts
@@ -7,11 +7,10 @@ export interface MembershipOpsNavLink {
   name: string;
   href: string;
   icon: string;
-  description?: string;
 }
 
 export const MEMBERSHIP_OPS_NAV_LINKS: MembershipOpsNavLink[] = [
-  { name: "Participants", href: "/membership-ops/participants", icon: "👥", description: "Browse and manage participant profiles." },
+  { name: "Participants", href: "/membership-ops/participants", icon: "👥" },
   // HIDDEN: "Merge Participants" is unlinked until the merge API reconciles join-table
   // collisions instead of blind-deleting the merge-side row.
   // The merge route (src/app/api/membership-ops/participants/merge/route.ts, lines 82-145) resolves
@@ -28,11 +27,11 @@ export const MEMBERSHIP_OPS_NAV_LINKS: MembershipOpsNavLink[] = [
   // hidden so admins cannot silently corrupt certification/enrollment data via a merge. Page and
   // API route are kept intact. See it.failing cases ("should keep the HIGHER" / "should keep the
   // ACTIVE") in src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts.
-  // { name: "Merge Participants", href: "/membership-ops/participants/merge", icon: "🔗", description: "Combine duplicate participant records." },
-  { name: "Households", href: "/membership-ops/households", icon: "🏠", description: "Grant or revoke household facility membership." },
-  { name: "Volunteer Memberships", href: "/membership-ops/volunteer-memberships", icon: "🙋", description: "Designate volunteer-only emails for reduced dues." },
-  { name: "Applications", href: "/membership-ops/applications", icon: "📋", description: "Review and approve membership applications." },
+  // { name: "Merge Participants", href: "/membership-ops/participants/merge", icon: "🔗" },
+  { name: "Households", href: "/membership-ops/households", icon: "🏠" },
+  { name: "Volunteer Memberships", href: "/membership-ops/volunteer-memberships", icon: "🙋" },
+  { name: "Applications", href: "/membership-ops/applications", icon: "📋" },
   // "Unclaimed Accounts" moved to Membership Audit (/membership-audit/unclaimed).
-  { name: "Background-check Review", href: "/membership-ops/review", icon: "🔍", description: "Review submitted membership background checks." },
+  { name: "Background-check Review", href: "/membership-ops/review", icon: "🔍" },
   // "Broken Households" moved to Membership Audit (/membership-audit/broken).
 ];

--- a/checkin-app/src/lib/programNav.ts
+++ b/checkin-app/src/lib/programNav.ts
@@ -10,13 +10,11 @@ export interface ProgramNavLink {
   name: string;
   href: string;
   icon: string;
-  /** One-line description shown on the hub landing grid (not in the tabs). */
-  description?: string;
 }
 
 export const PROGRAM_NAV_LINKS: ProgramNavLink[] = [
-  { name: "All Programs", href: "/program-ops/programs", icon: "📚", description: "Browse and manage recurring programs." },
-  { name: "New Program", href: "/program-ops/new", icon: "✨", description: "Create a new program or curriculum track." },
-  { name: "One Time Events", href: "/program-ops/events", icon: "📋", description: "Browse all one-off / standalone events." },
-  { name: "New One Time Event", href: "/program-ops/sessions", icon: "📅", description: "Schedule a one-off event or manual session." },
+  { name: "All Programs", href: "/program-ops/programs", icon: "📚" },
+  { name: "New Program", href: "/program-ops/new", icon: "✨" },
+  { name: "One Time Events", href: "/program-ops/events", icon: "📋" },
+  { name: "New One Time Event", href: "/program-ops/sessions", icon: "📅" },
 ];


### PR DESCRIPTION
## Summary
- Remove `phaseIndex` from `phases.ts` — zero non-test callers; `stepperActiveIndex` is the function actually used for stepper position.
- Remove `computeDuesCents` from `payment.ts` — test-only, and its logic is already inlined in `ensurePaymentLink` (which already fetches `boardSettings` for `membershipVariantId`, so wiring it in would add a redundant query).
- Remove the dead `description` field from the nav-link arrays in `facilityNav.ts`, `financeNav.ts`, `programNav.ts`, `membershipOpsNav.ts` — it was meant for a hub landing grid, but all four hub `page.tsx` are now bare `redirect(...)`s with no layout that reads `.description`.

Verified each via grep before/after deletion (zero non-comment references remain). Left `INITIAL_PHASES`, `stepperActiveIndex`, and `ensurePaymentLink`'s logic untouched. Did not touch `shopNav.ts` / `systemStatusNav.ts` / `myActivitiesNav.ts` (gating logic / no description field).

Removed `computeDuesCents`'s isolated test case from `membershipPaymentAPI.integration.test.ts`; confirmed the volunteer/normal dues-by-tier assertions (`amountCents` 10000 / 2500) still run end-to-end via the existing `ensurePaymentLink` test cases, so coverage is preserved.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Nav unit tests (`facilityNav`, `financeNav`, `programNav`, `membershipOpsNav`) — 9/9 pass
- [x] `membershipPaymentAPI.integration.test.ts` (throwaway Postgres, `--runInBand`) — 11/11 pass, dues-by-tier still asserted via `ensurePaymentLink`
- [x] No `phases.ts` test suite existed to update (no callers of `phaseIndex` in tests either)

🤖 Generated with [Claude Code](https://claude.com/claude-code)