### PR TITLE
refactor(auth): adopt useRequireRole on client auth-gated pages

### DIFF
--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
+import { useRequireRole } from '@/hooks/useRequireRole';
 import { Alert, Badge, Button, Card, Center, Checkbox, Group, Loader, Paper, SimpleGrid, Stack, Text, TextInput, Title } from '@mantine/core';
 import { PageContainer } from '@/components/ui/PageContainer';
 import { formatDate, calculateAge } from '@/lib/time';
@@ -55,7 +55,7 @@ type HouseholdData = {
 const blankContactForm = { id: null as number | null, name: "", phone: "", email: "", relationship: "" };
 
 export default function HouseholdPage() {
-  const { data: session, status } = useSession();
+  const { user: sessionUser, loading: authLoading, ready } = useRequireRole([]);
   const router = useRouter();
 
   const [loading, setLoading] = useState(true);
@@ -119,13 +119,11 @@ export default function HouseholdPage() {
   }, []);
 
   useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    } else if (status === "authenticated") {
+    if (ready) {
       fetchHousehold();
       fetchContacts();
     }
-  }, [status, router, fetchHousehold, fetchContacts]);
+  }, [ready, fetchHousehold, fetchContacts]);
 
   const handleSaveSettings = async () => {
     const errors = validateAddress(address);
@@ -315,16 +313,16 @@ export default function HouseholdPage() {
   const isDirty = !shallowEqual({ ...initialAddress }, { ...address });
   useUnsavedGuard(isDirty);
 
-  if (loading || status === "loading") {
+  if (loading || authLoading) {
     return <Center mih="60vh"><Loader /></Center>;
   }
 
-  if (!session) return null;
+  if (!ready) return null;
 
-  const userId = (session.user as { id: number })?.id;
+  const userId = (sessionUser as { id: number })?.id;
   // Staff (@innovationtreehouse.org) accounts aren't real member families; the add-member
   // control is hidden for them (server also enforces this — see /api/household PATCH).
-  const isStaffAccount = isOrgAccount(session.user as { hd?: string | null; email?: string | null });
+  const isStaffAccount = isOrgAccount(sessionUser as { hd?: string | null; email?: string | null });
   const isLead = (pid: number) => household?.leads?.some((l) => l.participantId === pid) ?? false;
   const viewerIsLead = isLead(userId);
 

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { use, useState, useEffect, useCallback } from 'react';
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
+import { useRequireRole } from '@/hooks/useRequireRole';
 import Link from 'next/link';
 import {
   Alert, Anchor, Badge, Box, Button, Card, Center, Checkbox, Container, Divider, Group,
@@ -56,7 +56,7 @@ const PHASE_BADGE: Record<string, { label: string; color: string }> = {
 
 export default function ProgramDetailsPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { data: session, status } = useSession();
+  const { user: sessionUser, loading: authLoading, ready } = useRequireRole([]);
   const router = useRouter();
 
   const [program, setProgram] = useState<ProgramDetail | null>(null);
@@ -128,12 +128,8 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
   }, [id]);
 
   useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    } else if (status === "authenticated") {
-      fetchProgram();
-    }
-  }, [status, router, fetchProgram]);
+    if (ready) fetchProgram();
+  }, [ready, fetchProgram]);
 
   const searchParticipants = useCallback(async (
     query: string,
@@ -264,7 +260,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
     e.preventDefault();
     if (!newPartId) return;
 
-    const u = session?.user as { isSysadmin?: boolean; isBoardMember?: boolean } | undefined;
+    const u = sessionUser as { isSysadmin?: boolean; isBoardMember?: boolean } | undefined;
     if (u?.isSysadmin || u?.isBoardMember) {
       if (!confirm("Warning: Adding a participant manually bypasses all payment requirements. Are you sure you wish to proceed?")) return;
     }
@@ -294,11 +290,13 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
     } catch { }
   };
 
-  if (loading || status === "loading") {
+  if (loading || authLoading) {
     return <Center mih="60vh"><Loader /></Center>;
   }
 
-  if (!session || !program) return (
+  if (!ready) return null;
+
+  if (!program) return (
     <Container size="sm" py="xl">
       <Card withBorder radius="md" padding="xl" ta="center">
         <Title order={3}>{message || "Not Found"}</Title>
@@ -307,7 +305,9 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
     </Container>
   );
 
-  const user = session.user as unknown as { id: number; isSysadmin?: boolean; isBoardMember?: boolean };
+  // Ownership gate stays inline — it needs the loaded program (lead-mentor id)
+  // to decide, which useRequireRole (a static role gate) can't express.
+  const user = sessionUser as unknown as { id: number; isSysadmin?: boolean; isBoardMember?: boolean };
   const isAuthorized = program.leadMentorId === user?.id || user?.isSysadmin || user?.isBoardMember;
   const activeParticipants = program.participants.filter(p => p.status === 'ACTIVE');
   const pendingParticipants = program.participants.filter(p => p.status === 'PENDING');

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useEffect, use, useCallback } from 'react';
-import { useSession } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useRequireRole } from '@/hooks/useRequireRole';
 import { Alert, Badge, Button, Card, Center, Checkbox, Container, Group, Loader, Modal, Select, SimpleGrid, Stack, Table, Text, TextInput, Title } from '@mantine/core';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
@@ -52,7 +52,7 @@ const RSVP_BADGE: Record<RSVPStatus, { label: string; color: string }> = {
 
 export default function EventAdminPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { data: session, status } = useSession();
+  const { user: sessionUser, loading: authLoading, ready } = useRequireRole([]);
   const router = useRouter();
   // Leads reach this screen from their My Programs inbox (?from=my-programs).
   // When they do, "back" and post-confirm return there instead of the board's
@@ -100,12 +100,8 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
   }, [id]);
 
   useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    } else if (status === "authenticated") {
-      fetchEvent();
-    }
-  }, [status, router, id, fetchEvent]);
+    if (ready) fetchEvent();
+  }, [ready, fetchEvent]);
 
   const handleConfirmAttendance = async () => {
     setActionLoading(true);
@@ -214,11 +210,13 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
     }
   };
 
-  if (loading || status === "loading") {
+  if (loading || authLoading) {
     return <Center mih="60vh"><Loader /></Center>;
   }
 
-  if (!session || !eventData) {
+  if (!ready) return null;
+
+  if (!eventData) {
     return (
       <Container size="sm" py="xl">
         <Card withBorder radius="md" padding="xl" ta="center">
@@ -229,7 +227,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
     );
   }
 
-  const user = session?.user as unknown as { id: number; isSysadmin?: boolean; isBoardMember?: boolean };
+  const user = sessionUser as unknown as { id: number; isSysadmin?: boolean; isBoardMember?: boolean };
   const userId = user?.id;
   const isSysAdminOrBoard = user?.isSysadmin || user?.isBoardMember;
   const isLeadMentor = eventData.program?.leadMentorId === userId;

--- a/checkin-app/src/app/shop-ops/manage/ToolManagementPanel.tsx
+++ b/checkin-app/src/app/shop-ops/manage/ToolManagementPanel.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from 'react';
-import { useSession } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
+import { useRequireRole } from '@/hooks/useRequireRole';
 import {
   Alert, Anchor, Button, Card, Center, Collapse, Group, Loader,
   Modal, Select, Stack, Table, Tabs, Text, TextInput,
@@ -493,8 +492,7 @@ function AllTab({ tools }: { tools: Tool[] }) {
 // ---- Embeddable panel (no outer Container/header) ----
 
 export function ToolManagementPanel() {
-  const { data: session, status } = useSession();
-  const router = useRouter();
+  const { user, loading: authLoading, ready } = useRequireRole([]);
   const hasFetched = useRef(false);
 
   const [tab, setTab] = useState<Tab>('tools');
@@ -503,8 +501,7 @@ export function ToolManagementPanel() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (status === "unauthenticated") router.push('/');
-    else if (status === "authenticated" && !hasFetched.current) {
+    if (ready && !hasFetched.current) {
       hasFetched.current = true;
       Promise.all([
         fetch('/api/shop/tools').then(r => r.ok ? r.json() : []),
@@ -514,18 +511,20 @@ export function ToolManagementPanel() {
         setMembers(memberData.members ?? []);
       }).finally(() => setLoading(false));
     }
-  }, [status, router]);
+  }, [ready]);
 
-  if (loading || status === "loading") {
+  if (loading || authLoading) {
     return <Center mih="40vh"><Loader /></Center>;
   }
 
-  const isSysadmin = session?.user?.isSysadmin;
-  const isBoardMember = session?.user?.isBoardMember;
+  // Role gate stays inline: this renders a Forbidden alert (not a redirect),
+  // so useRequireRole can only own the generic sign-in gate above.
+  const isSysadmin = user?.isSysadmin;
+  const isBoardMember = user?.isBoardMember;
   const isAdmin = isSysadmin || isBoardMember;
 
-  const isKeyholder = session?.user?.isKeyholder;
-  const hasCertifierAuth = (session?.user?.toolStatuses ?? []).some((ts: { level?: string }) => ts.level === 'MAY_CERTIFY_OTHERS');
+  const isKeyholder = user?.isKeyholder;
+  const hasCertifierAuth = (user?.toolStatuses ?? []).some((ts: { level?: string }) => ts.level === 'MAY_CERTIFY_OTHERS');
   const isCertifier = isSysadmin || isBoardMember || hasCertifierAuth;
   const canSeeAll = isCertifier || isKeyholder;
 


### PR DESCRIPTION
## What

Migrate client pages that hand-roll the `authenticated? load : redirect('/')` `useEffect` boilerplate to the shared `useRequireRole` hook (already adopted by 20+ admin pages).

| Page | Outcome |
|------|---------|
| `my-household/page.tsx` | **Full** — plain authenticated gate → `useRequireRole([])` |
| `program-ops/sessions/[id]/page.tsx` | **Full** (auth gate) — kept the `!eventData` resource "Not Found" card |
| `shop-ops/manage/ToolManagementPanel.tsx` | **Partial** — hook owns the sign-in redirect; the certifier/admin **Forbidden alert** stays inline |
| `program-ops/programs/[id]/page.tsx` | **Partial** — hook owns the generic gate; the ownership check stays inline |

## Why

Removes copy-pasted `useSession` + `useEffect(redirect)` + role-cast blocks. Two pages are partial because the remaining check can't be expressed by a static role gate:
- **ToolManagementPanel**: the role failure renders an inline `Alert` (not a redirect), which `useRequireRole` only-redirects can't do.
- **programs/[id]**: authorization is `leadMentorId === user.id || isSysadmin || isBoardMember` — it needs the *fetched program* to decide, so it stays inline after load.

## Behavior preservation

- Same redirect target (`/`) and same required roles — every converted page was a plain authenticated gate (`[]`).
- Same loading state (`loading || authLoading`).
- Resource-load-failure cards (`!eventData`, `!program`) kept; split out of the old `!session || !data` so unauthenticated users now render `null` during redirect flight instead of briefly flashing the "Not Found" card (same redirect, sub-second flash only).
- Removed now-unused `useSession` (and `useRouter` in ToolManagementPanel).

## Not converted (reported, not papered over)

- `membership/page.tsx` — **skipped**: unauth renders an in-place "Please sign in" card, no redirect. The hook would redirect to `/` and delete that card (gate change).
- `attendance/current/page.tsx` — **skipped**: no auth gate at all; kiosk mode runs unauthenticated via signed requests. The hook would redirect and break the kiosk.

## Verification

- `npx tsc --noEmit` — clean.
- `jest` (the 4 affected suites + related) — 33/33 pass, incl. `useRequireRole.test.tsx` and the sessions/[id] "redirects unauthenticated without fetching" case.
- `routeAuthDrift` security test — 313/313 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)