### PR TITLE
refactor(membership): extract latestPendingExternal selector

### DIFF
--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -11,6 +11,7 @@ import {
     getRequestStatus,
 } from "@/lib/membership/contract/zohoClient";
 import { loadAgreementPdf, stampWatermark, AGREEMENT_FILENAME, AgreementUnavailableError } from "@/lib/membership/contract/agreementDocument";
+import { latestPendingExternal } from "@/lib/membership/phases";
 
 /**
  * EXTERNAL-phase service — the actions an applicant completes after intake:
@@ -189,9 +190,7 @@ export async function syncContractStatus(userId: number): Promise<ExternalStatus
         include: { household: { include: { membership: { include: { processes: true } } } } },
     });
     // Same selection as the signing action: the latest process awaiting external action.
-    const process = (user?.household?.membership?.processes ?? [])
-        .filter((p) => p.status === "PENDING_EXTERNAL_ACTION")
-        .sort((a, b) => b.id - a.id)[0];
+    const process = latestPendingExternal(user?.household?.membership?.processes);
     if (!process) return null;
 
     if (!process.contractSignedAt && process.zohoEnvelopeId && config.zohoConfigured()) {
@@ -244,9 +243,7 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
     // re-sign the agreement fresh each cycle. Gating on status alone keeps this in
     // step with getIntakeState/getExternalStatus, which surface the button for any
     // non-ACTIVE process (a kind filter here would render the button then 409).
-    const process = (user.household?.membership?.processes ?? [])
-        .filter((p) => p.status === "PENDING_EXTERNAL_ACTION")
-        .sort((a, b) => b.id - a.id)[0];
+    const process = latestPendingExternal(user.household?.membership?.processes);
     if (!process) throw new ExternalError("wrong_phase", "No application is awaiting your signature.");
 
     const recipientEmail = user.email;

--- a/checkin-app/src/lib/membership/phases.ts
+++ b/checkin-app/src/lib/membership/phases.ts
@@ -1,4 +1,4 @@
-import type { MembershipProcessStatus } from "@/generated/prisma/client";
+import type { MembershipProcess, MembershipProcessStatus } from "@/generated/prisma/client";
 
 /**
  * Applicant-facing phases of an INITIAL membership application, in order.
@@ -59,3 +59,19 @@ export const IN_FLIGHT_INITIAL_STATUSES: MembershipProcessStatus[] = [
     "PENDING_PAYMENT",
     "PENDING_BG_CLEARANCE",
 ];
+
+/**
+ * The latest process awaiting applicant external action (contract signing).
+ * Kind-agnostic by design — INITIAL applications AND renewals both re-sign here,
+ * and gating on status alone keeps the sign button (getOrCreateContractSigningUrl)
+ * in step with the status sync (syncContractStatus); a kind filter would render
+ * the button then 409. Highest id == most recent (autoincrement). Returns
+ * undefined when nothing is awaiting action — callers guard for that.
+ */
+export function latestPendingExternal<T extends Pick<MembershipProcess, "id" | "status">>(
+    processes: T[] | null | undefined,
+): T | undefined {
+    return [...(processes ?? [])]
+        .filter((p) => p.status === "PENDING_EXTERNAL_ACTION")
+        .sort((a, b) => b.id - a.id)[0];
+}


### PR DESCRIPTION
## What

The two "latest `PENDING_EXTERNAL_ACTION` process" selections in `external.ts` were byte-identical and commented as needing to stay "in step":

- `syncContractStatus` — [external.ts:192](checkin-app/src/lib/membership/external.ts#L192)
- `getOrCreateContractSigningUrl` — [external.ts:247](checkin-app/src/lib/membership/external.ts#L247)

Extract the shared predicate + sort into `latestPendingExternal()` in `phases.ts` so the two callers **cannot drift**.

## Why here

`phases.ts` is a dependency-free leaf (only imports a Prisma type) already owning status-level helpers (`phaseIndex`, `stepperActiveIndex`). `external.ts` can import it with no cycle.

## Scope

- Only the byte-identical pair is consolidated (the actual must-stay-in-step risk).
- The genuinely-different predicates in `intake.ts` (`status !== "ACTIVE"`, and `kind === "INITIAL" && status === "INTAKE"`) are left inline — different domain questions, not incidental duplication.
- Helper is kind-agnostic by design (INITIAL + renewals both re-sign here).
- Behavior unchanged; helper spread-copies before sorting so it never mutates the caller's array (originals sorted in place).

## Verification

- `tsc --noEmit` clean (generic infers the full Prisma row type at both call sites).
- All 6 membership integration suites pass (56 tests, `--runInBand`): `membershipExternalAPI`, `ContractSync`, `ContractSignAPI`, `ExternalConcurrency`, `BgNonBlocking`, `IntakeAPI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)