### PR TITLE
feat(membership): dev/local Zoho Sign mock so contract signing completes offline

### DIFF
--- a/checkin-app/docs/designs/ZOHO_SIGN_DEV_MOCK.md
+++ b/checkin-app/docs/designs/ZOHO_SIGN_DEV_MOCK.md
@@ -1,0 +1,188 @@
+# Zoho Sign — Dev/Local Mock for Membership Contract Signing
+
+**Status:** Proposal (design only — no implementation). Direction chosen — see §7.
+**Scope:** Zoho Sign e-signing seam of the membership EXTERNAL phase. Not S3, not Shopify (noted as sibling gaps in §6).
+**Audience:** maintainer review before any code is written.
+
+**Decisions locked (maintainer, this round):** Option A (provider seam) · skip PDF load when mock active · interstitial page (not instant-bounce) · single `zohoAvailable()` predicate · mock active on both `dev` and `local` · the mock doubles as the test seam · **the interstitial fires the real webhook path in dev** (Q3 resolved — see §4a & §7).
+
+---
+
+## 1. Current flow — how a contract gets signed today
+
+The EXTERNAL phase (`PENDING_EXTERNAL_ACTION`) gates on two things: contract signed **and** background check handled. This proposal only touches the contract half. Once `contractSignedAt` is set **and** a BG condition holds, `advanceExternalIfComplete` flips the process to `PENDING_PAYMENT`.
+
+### 1a. Send-for-signature (applicant clicks "Sign")
+
+`POST /api/membership/contract/sign` → `getOrCreateContractSigningUrl(userId)` (`src/lib/membership/external.ts`):
+
+1. **Gate:** `if (!config.zohoConfigured()) throw ExternalError("not_configured")` → route maps to **503**. *(Wall 1.)*
+2. Resolve the applicant's in-flight process (latest `PENDING_EXTERNAL_ACTION`), assert lead/sysadmin.
+3. `getAccessToken()` — OAuth refresh-token exchange against Zoho (`requireSecrets()` throws if any secret unset).
+4. If no stored `zohoEnvelopeId`/`zohoActionId` yet:
+   - `loadAgreementPdf()` — fetch the agreement PDF from S3. **Also 503s in dev** (`AGREEMENT_PDF_S3_BUCKET` unset → `AgreementUnavailableError` → `agreement_unavailable`). *(Wall 2 — see §5.)*
+   - Non-prod: `stampWatermark(pdf, "DEV TEST — NOT A LEGAL AGREEMENT")` and prefix the request name `[DEV TEST — NOT BINDING]`.
+   - `createRequest(...)` → upload PDF + register the single embedded SIGN recipient → `{ requestId, actionId, documentId }`.
+   - `submitRequest(...)` → attach signature fields.
+   - Atomically claim the process for these ids (`updateMany` on `zohoEnvelopeId/zohoActionId` null) — loser discards its orphaned Zoho request; writes a `zohoEnvelopeId`+`zohoActionId` audit row (actor = applicant).
+5. `getEmbeddedSignUrl(...)` — mint a short-lived embedded signing URL. Returned to the client, which redirects the applicant into the in-app Zoho ceremony.
+
+### 1b. Completion — three ways `contractSignedAt` gets set
+
+All three funnel through `markContractSigned(processId, actorId=0)` → conditional `updateMany` on `contractSignedAt: null` (idempotent, single audit row) → `advanceExternalIfComplete`.
+
+- **Return-sync (primary):** Zoho `redirect_pages` bounce the finished signer to `/membership?signed=1`. The page calls `POST /api/membership/contract/sync` → `syncContractStatus(userId)`, which — **gated on `config.zohoConfigured()`** (Wall 3) — calls `getRequestStatus(token, envelopeId)`; if completed, `markContractSigned(process.id, userId)`. This is the reliable path (doesn't depend on a scale-to-zero instance being awake).
+- **Webhook (backstop):** `POST /api/webhooks/zoho` → `verifyZoho` requires `ZOHO_WEBHOOK_SECRET` (else 500), timing-safe token compare (else 401) → `parseZohoWebhook` → `findProcessByEnvelope` → `markContractSigned(mp.id)` with `SYSTEM_ACTOR = 0`.
+- **Manual board mark:** a board member records the contract signed (also routes through `markContractSigned`).
+
+### 1c. Where dev dies
+
+Three hard stops, all keyed on unset secrets:
+
+| Wall | Location | Symptom in dev |
+|------|----------|----------------|
+| 1 | `getOrCreateContractSigningUrl` `!zohoConfigured()` | Sign button → 503 "check back soon" |
+| 2 | `loadAgreementPdf()` (S3) | even past Wall 1, `agreement_unavailable` 503 |
+| 3 | `syncContractStatus` `!zohoConfigured()` guard | completion never syncs on return |
+
+The webhook path is also dead (no `ZOHO_WEBHOOK_SECRET`), but it's a backstop, not the primary. **An applicant in dev can never reach `PENDING_PAYMENT`.**
+
+---
+
+## 2. Options
+
+### Option A — Mock Zoho client provider selected by CHECKIN_ENV *(recommended)*
+
+Mirror the `BackgroundCheckProvider` pattern (`background-check/provider.ts` + `manual-adapter.ts`): a `ZohoSignProvider` interface with the five client functions (`getAccessToken`, `createRequest`, `submitRequest`, `getEmbeddedSignUrl`, `getRequestStatus`), a real adapter wrapping today's `zohoClient.ts`, and a `MockZohoSignProvider` selected when `isDevInstance() && NODE_ENV !== 'production'`.
+
+Mock behavior:
+- `getAccessToken()` → `"dev-mock-token"`.
+- `createRequest()` → synthetic ids (`dev-req-<processId>`, `dev-act-…`, `dev-doc-…`); ignores the PDF bytes.
+- `submitRequest()` → no-op.
+- `getEmbeddedSignUrl()` → returns the URL of a **dev interstitial page** (§4a), not `?signed=1` directly, so there's a visible signing step.
+- `getRequestStatus()` → `true`.
+
+`external.ts` calls the provider instead of importing `zohoClient` functions directly. The two `zohoConfigured()` gates (Walls 1 & 3) change to a new predicate `config.zohoAvailable()` = `zohoConfigured() || (isDevInstance() && NODE_ENV !== 'production')`. The same dev disjunct also supplies a **dev default `ZOHO_WEBHOOK_SECRET`** so the interstitial can fire the real webhook (§4a) — `zohoWebhookSecret()` returns the dev default in mock mode, its real env value otherwise.
+
+**Tradeoffs.** State machine runs **identically** to prod (real `markContractSigned` → `advanceExternalIfComplete` → audit → `PENDING_PAYMENT`). One clean seam, matches an existing codebase pattern, prod path untouched (real adapter is a thin pass-through). Cost: introduces an interface + two adapters + call-site rewrite in `external.ts`; still needs the Wall-2 PDF bypass (§5).
+
+### Option B — Inline instant-complete stub (no provider interface)
+
+Skip the interface. In `external.ts`, branch on a dev predicate: when dev-mock, short-circuit — skip `getAccessToken`/`createRequest`/`submitRequest`, stamp synthetic ids straight onto the process, and return `/membership?signed=1`. `syncContractStatus` similarly short-circuits to `markContractSigned`.
+
+**Tradeoffs.** Smallest diff, no new files. But scatters `if (dev)` branches through the real service (harder to keep the two paths from diverging), and there's no single "here's the mock" object — less faithful to the existing provider idiom. Behaviorally identical to A downstream.
+
+### Option C — Dev-only "simulate webhook" button
+
+Leave `zohoClient` and `external.ts` untouched. Add a dev-only membership-page button → `POST /api/dev/zoho/complete` (guarded `isDevInstance() && NODE_ENV !== 'production'`) that calls `markContractSigned(processId, SYSTEM_ACTOR)` directly, or replays a signed payload against the webhook with a dev secret.
+
+**Tradeoffs.** Zero change to the send-for-signature path — but that means the Sign button still 503s (Wall 1 unaddressed), so the applicant flow isn't end-to-end; you'd click a separate "mark signed" affordance. Exercises the completion transition and (webhook variant) token verification, but not `createRequest`/embed. Good as a **complement** for webhook fidelity (see §6 open questions), weak as the primary.
+
+### Recommendation
+
+**Option A.** It's the only option that unblocks the applicant end-to-end (Sign button works) while keeping every state-machine transition, audit row, and race guard identical to prod, and it reuses the provider pattern already established for background checks. The real adapter stays a pass-through so prod is behaviorally unchanged. Pair with the Wall-2 PDF bypass in §5.
+
+---
+
+## 3. Prod safety — mock dead by construction
+
+Selection uses the same idiom as persona-mint (`auth-options.ts:104`):
+
+```
+isDevInstance() && process.env.NODE_ENV !== 'production'
+```
+
+Two independent conditions, both server-only:
+- `CHECKIN_ENV` fails safe to `prod` for any unrecognized/unset value (`readCheckinEnv`), and is **not** `NEXT_PUBLIC_` — never in the client bundle.
+- `NODE_ENV !== 'production'` is a second, build-level fuse.
+
+`zohoAvailable()` reduces to plain `zohoConfigured()` in prod (the dev disjunct is false), so prod requires real secrets exactly as today. The mock provider module is only ever *selected* behind that guard; the real adapter is the default export otherwise. No mock code path is reachable in prod. Recommend a unit test asserting the selector returns the real adapter when `CHECKIN_ENV=prod` and when `NODE_ENV=production`.
+
+---
+
+## 4a. The interstitial and the webhook (Q3 resolved)
+
+The mock's `getEmbeddedSignUrl` returns a **dev-only interstitial page** (guarded `isDevInstance() && NODE_ENV !== 'production'`) that stands in for the Zoho signing ceremony: a page labelled "DEV — NOT A LEGAL AGREEMENT" with two buttons — **"Complete signing (DEV)"** and **"Decline (DEV)"**.
+
+It is surfaced under a **single left-nav "Debug" item** → `/dev`, a tab section (mirroring `/system-status`) whose tabs are **Email** (the captured-email inbox from EMAIL_DEV_MOCK.md) and **Sign** (this mock). `/dev` redirects to the first tab; the tabs live in `app/dev/layout.tsx` (source of truth `lib/devToolsNav.ts`). Reached with **no `?rid`** (the Sign tab), the page shows a start/resume entry that POSTs the real `/api/membership/contract/sign` action — in mock mode that hands back this same interstitial URL carrying a `rid`, so the tab drops a developer into the flow without re-clicking Sign on the membership page.
+
+**Decline** mirrors Zoho's `sign_declined` redirect: the button simply navigates to `/membership?declined=1` — no server call. There's no "mark declined" transition in prod either (a declined request just never advances; `parseZohoWebhook` only acts on `completed`), so this exercises the `?declined=1` applicant-facing path with zero new backend.
+
+**Complete signing** does **not** shortcut to `?signed=1`. It POSTs to a dev-only **server** endpoint that:
+1. Synthesizes a Zoho completion payload — `{ requests: { request_id: <stored zohoEnvelopeId>, request_status: "completed" } }`.
+2. Self-fires the **real** webhook path (`verifyZoho` → `parseZohoWebhook` → `findProcessByEnvelope` → `markContractSigned`), signing with a dev `ZOHO_WEBHOOK_SECRET`.
+3. Redirects the browser to `/membership?signed=1`.
+
+**Why fire the webhook instead of the sync path** (the original draft used sync):
+- It exercises the real `verifyZohoToken` timing-safe compare, `parseZohoWebhook` payload parsing, `findProcessByEnvelope` match, and the `withWebhook` wrapper — code the sync path skips entirely.
+- The secret stays **server-side** (the endpoint signs; the browser never sees `ZOHO_WEBHOOK_SECRET`).
+- The webhook gate needs `ZOHO_WEBHOOK_SECRET` — one of the "unset in dev" secrets — so in mock mode `zohoWebhookSecret()` returns a **hardcoded dev default** (see §2 predicate). No env setup, can't-be-forgotten, and it guards nothing real: the payload is self-generated locally, so the secret exists only to give `verifyZohoToken`'s real compare a value. Prod is unaffected (dev disjunct is false → real env value required).
+
+**Idempotency (belt-and-suspenders, same as prod):** the webhook fires `markContractSigned`; then the `?signed=1` redirect triggers `syncContractStatus`, which calls `markContractSigned` again; the conditional `updateMany` on `contractSignedAt: null` sees `count !== 1` the second time → no double audit row, no double advance. Both completion paths coexist exactly as they do against real Zoho.
+
+**Net:** the only prod code left unexercised in dev is the real Zoho **HTTP + OAuth** (`getAccessToken`/`createRequest`/`submitRequest`/`getEmbeddedSignUrl`/`getRequestStatus` network calls) — everything from webhook receipt through state transition is the real path.
+
+---
+
+## 4. Fidelity — what the mock does and doesn't reproduce
+
+**Reproduces (identical to prod):**
+- The full state transition: `PENDING_EXTERNAL_ACTION` → (contract signed via `markContractSigned`) → `advanceExternalIfComplete` → `PENDING_PAYMENT`.
+- `SYSTEM_ACTOR = 0` audit-log rows, idempotent conditional `updateMany` guards, reviewer notification on advance.
+- The applicant round-trip shape: click Sign → redirect → interstitial "Complete signing (DEV)" → back to `/membership?signed=1`.
+- **The inbound webhook path** — `verifyZohoToken` (real timing-safe compare against the dev secret), `parseZohoWebhook`, `findProcessByEnvelope`, `withWebhook` (§4a).
+- Both completion paths coexisting (webhook + `?signed=1` sync) with idempotent single-write semantics.
+- The "not binding" framing — no real signature is ever produced; interstitial + request name carry the DEV/NOT-BINDING labelling.
+
+**Does NOT reproduce:**
+- **Embedded sign UX** — no real Zoho signing ceremony; the interstitial stands in for it.
+- **Real Zoho HTTP + OAuth** — `getAccessToken`/`createRequest`/`submitRequest`/`getEmbeddedSignUrl`/`getRequestStatus` network calls, `ZohoError`/timeout paths, token caching, the 20s fetch deadline.
+- **Real envelope/action ids** — synthetic `dev-*` strings; no real Zoho request exists.
+
+The design deliberately keeps the mock *below* `markContractSigned` and *routes completion through the real webhook*, so the transition logic **and** webhook-receipt logic that tests and workflows care about are the real thing.
+
+---
+
+## 5. Scope note — the S3 PDF coupling (Wall 2)
+
+The Zoho mock alone does **not** unblock dev: `getOrCreateContractSigningUrl` calls `loadAgreementPdf()` (S3) *before* the client, and that 503s in dev too. Two honest options, both minimal:
+
+- **(preferred)** When the mock provider is active, skip the PDF load — the mock `createRequest` ignores bytes anyway. A one-line guard around the `loadAgreementPdf()` call (pass an empty/placeholder buffer in dev-mock mode) keeps the S3 concern out of this change.
+- Or solve the S3 PDF separately (a dev placeholder PDF) — that's the sibling gap below, out of scope here.
+
+This is called out so the maintainer knows the Zoho mock needs a **tiny** PDF-path concession to actually reach `PENDING_PAYMENT`; it does not require solving S3.
+
+**Sibling gaps this pattern could later cover (not solved here):**
+- **S3 agreement PDF** (`agreementDocument.ts`) — same "dev instance, secret unset, 503" shape; a dev placeholder PDF provider.
+- **Shopify orders/paid webhook** — the `PENDING_PAYMENT` → paid transition has the same external-dependency-in-dev problem.
+
+A shared "dev-mock external provider" convention could eventually cover all three, but each is its own proposal.
+
+---
+
+## 6. Decisions (resolved with maintainer)
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | Interstitial vs. instant-advance | **Interstitial** — dev-only "Complete signing (DEV)" page (§4a). |
+| 2 | Predicate shape | **Single `config.zohoAvailable()`** = `zohoConfigured() \|\| dev-mock`; swap the two gates. Same disjunct supplies the dev `ZOHO_WEBHOOK_SECRET`. |
+| 3 | Webhook fidelity | **Fire the real webhook** from the interstitial's server endpoint (§4a) — not the sync path. Exercises `verifyZohoToken`/parse/match. |
+| 4 | PDF concession | **Accept the one-line `loadAgreementPdf` bypass** in dev-mock mode (§5). Full S3 dev-PDF stays a sibling proposal. |
+| 5 | `local` vs `dev` parity | **Both** — selected via `isDevInstance()` (dev + local). |
+| 6 | Test seam | **Reuse** — the mock provider doubles as the injection seam for membership tests. |
+
+### Remaining open items
+- None blocking. Dev webhook secret = **hardcoded dev default** in `config.zohoWebhookSecret()` (no env, guards nothing real in dev; prod uses the real env value). Interstitial ships **both** "Complete signing (DEV)" and "Decline (DEV)".
+
+---
+
+## 7. Chosen direction (summary for the implementer)
+
+1. **`ZohoSignProvider` interface** (5 methods) + `RealZohoSignProvider` (thin wrapper over today's `zohoClient.ts`, prod-unchanged) + `MockZohoSignProvider`. Select the mock only under `isDevInstance() && NODE_ENV !== 'production'`; real adapter otherwise.
+2. **`external.ts`** calls the provider, not `zohoClient` directly. When the mock is active, **skip `loadAgreementPdf()`** (pass a placeholder buffer — the mock ignores bytes).
+3. **`config.zohoAvailable()`** replaces the two `zohoConfigured()` gates (Walls 1 & 3). In mock mode `zohoWebhookSecret()` returns a **hardcoded dev default**; prod uses the real env value.
+4. **Interstitial page** (dev-only) is the mock's `getEmbeddedSignUrl` target, with two buttons: **"Complete signing (DEV)"** POSTs a dev-only **server** endpoint that synthesizes the Zoho completion payload and **fires the real webhook path**, then redirects to `?signed=1`; **"Decline (DEV)"** just navigates to `?declined=1` (no endpoint — mirrors prod's `sign_declined`).
+5. **Mock doubles as the test seam** for membership state-machine tests.
+6. Prod safety: mock, PDF-skip, dev webhook secret, and interstitial route are all behind `isDevInstance() && NODE_ENV !== 'production'`; `zohoAvailable()`/`zohoWebhookSecret()` collapse to their real values in prod. Add a selector unit test asserting the real adapter + real secret under `CHECKIN_ENV=prod` and `NODE_ENV=production`.
+
+**Left unmocked by design:** real Zoho HTTP + OAuth only. Everything from webhook receipt → state transition is real code.

--- a/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
@@ -217,11 +217,16 @@ describe('POST /api/membership/contract/sign', () => {
         await prisma.membershipProcess.update({ where: { id: processId }, data: { status: 'PENDING_EXTERNAL_ACTION' } });
     });
 
-    it('503s when Zoho is not configured', async () => {
+    it('503s when Zoho is not configured (prod — the dev mock is dead here)', async () => {
         delete process.env.ZOHO_CLIENT_ID;
+        // The dev/local mock stands in when Zoho is unconfigured (→ 200), so the
+        // unconfigured-503 contract is prod-only. Pin CHECKIN_ENV=prod to assert it.
+        const prevEnv = process.env.CHECKIN_ENV;
+        process.env.CHECKIN_ENV = 'prod';
         asUser(leadId);
         const res = await SIGN(signReq());
         expect(res.status).toBe(503);
         process.env.ZOHO_CLIENT_ID = 'cid';
+        process.env.CHECKIN_ENV = prevEnv;
     });
 });

--- a/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -159,12 +159,17 @@ describe('Membership EXTERNAL phase API', () => {
     it('rejects (500) a completed Zoho webhook when the secret is unset, with no mutation', async () => {
         const { processId } = await makeProcess(`C ${TAG}`, 'zoho-C');
         delete process.env.ZOHO_WEBHOOK_SECRET;
+        // On a dev/local instance the mock supplies a default webhook secret, so the
+        // unconfigured-500 path is prod-only. Pin CHECKIN_ENV=prod to assert it.
+        const prevEnv = process.env.CHECKIN_ENV;
+        process.env.CHECKIN_ENV = 'prod';
         try {
             const res = await ZOHO_WEBHOOK(zohoReq({ requests: { request_id: 'zoho-C', request_status: 'completed' } }, SECRET));
             // Route bails before token verify when the secret is unconfigured.
             expect(res.status).toBe(500);
         } finally {
             process.env.ZOHO_WEBHOOK_SECRET = SECRET;
+            process.env.CHECKIN_ENV = prevEnv;
         }
         const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
         expect(p?.contractSignedAt).toBeNull();

--- a/checkin-app/src/app/api/dev/zoho-sign/complete/route.ts
+++ b/checkin-app/src/app/api/dev/zoho-sign/complete/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { config } from "@/lib/config";
+import { logger } from "@/lib/logger";
+import { ZOHO_WEBHOOK_HEADER } from "@/lib/membership/contract/zoho";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/dev/zoho-sign/complete — dev-only completion trigger for the Zoho Sign
+ * mock (see docs/designs/ZOHO_SIGN_DEV_MOCK.md §4a). Reached from the dev
+ * interstitial's "Complete signing" button. Rather than shortcut to markContractSigned,
+ * it synthesizes a Zoho completion payload and fires the REAL inbound webhook, so the
+ * mock exercises the same verify → parse → match → advance path prod does. The shared
+ * secret stays server-side (config supplies a dev default in mock mode).
+ *
+ * 404s whenever the mock isn't active — always in prod.
+ */
+export const POST = withAuth({}, async (req, auth) => {
+    if (!config.zohoMockActive()) return NextResponse.json({ error: "Not available" }, { status: 404 });
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { rid } = await req.json().catch(() => ({ rid: undefined }));
+    if (!rid || typeof rid !== "string") return NextResponse.json({ error: "Missing rid" }, { status: 400 });
+
+    const secret = config.zohoWebhookSecret();
+    if (!secret) return NextResponse.json({ error: "No webhook secret" }, { status: 500 });
+
+    const res = await fetch(`${config.baseUrl()}/api/webhooks/zoho`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", [ZOHO_WEBHOOK_HEADER]: secret },
+        body: JSON.stringify({ requests: { request_id: rid, request_status: "completed" } }),
+    });
+    if (!res.ok) {
+        logger.error(`Dev zoho-sign complete: webhook returned ${res.status} for ${rid}`);
+        return NextResponse.json({ error: "Webhook failed", status: res.status }, { status: 502 });
+    }
+    return NextResponse.json({ ok: true });
+});

--- a/checkin-app/src/app/dev/layout.tsx
+++ b/checkin-app/src/app/dev/layout.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { Box, Tabs } from "@mantine/core";
+import { ScrollableTabsList } from "@/components/ui/ScrollableTabsList";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { useIsDevInstance } from "@/components/EnvProvider";
+import { DEV_TOOLS_NAV_LINKS } from "@/lib/devToolsNav";
+
+/**
+ * Persistent top tabs for the dev tools (captured-email inbox + Zoho Sign mock),
+ * mirroring system-status/layout.tsx. No role gate — dev tools are for any signed-in
+ * user on a dev instance (the cloud-dev box is already behind org login; local is
+ * open). Off a dev instance the tabs are hidden and each child page 404s on its own.
+ */
+export default function DevToolsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const isDev = useIsDevInstance();
+
+  if (!isDev) return <>{children}</>;
+
+  const active = DEV_TOOLS_NAV_LINKS.find((link) => pathname === link.href)?.href ?? null;
+
+  return (
+    <PageContainer>
+      <Tabs value={active} onChange={(value) => value && value !== active && router.push(value)} mb="md">
+        <ScrollableTabsList>
+          {DEV_TOOLS_NAV_LINKS.map((link) => (
+            <Tabs.Tab key={link.href} value={link.href}>
+              {link.name}
+            </Tabs.Tab>
+          ))}
+        </ScrollableTabsList>
+      </Tabs>
+      <Box style={{ minWidth: 0 }}>{children}</Box>
+    </PageContainer>
+  );
+}

--- a/checkin-app/src/app/dev/page.tsx
+++ b/checkin-app/src/app/dev/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function DevToolsIndex() {
+    redirect("/dev/sent-mail");
+}

--- a/checkin-app/src/app/dev/sent-mail/page.tsx
+++ b/checkin-app/src/app/dev/sent-mail/page.tsx
@@ -33,7 +33,7 @@ export default async function DevSentMailPage() {
     const emails = await recentSentEmails();
 
     return (
-        <main style={{ maxWidth: 900, margin: "0 auto", padding: "1.5rem" }}>
+        <div style={{ maxWidth: 900 }}>
             <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: "1rem" }}>
                 <h1 style={{ fontSize: "1.5rem", fontWeight: 600, margin: 0 }}>
                     Sent Mail <span style={{ fontWeight: 400, opacity: 0.6 }}>({emails.length})</span>
@@ -74,6 +74,6 @@ export default async function DevSentMailPage() {
                     ))}
                 </ul>
             )}
-        </main>
+        </div>
     );
 }

--- a/checkin-app/src/app/dev/zoho-sign/DevZohoSignClient.tsx
+++ b/checkin-app/src/app/dev/zoho-sign/DevZohoSignClient.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Dev Zoho Sign mock UI. Two modes, both dev-only (the page 404s off a dev instance):
+ *
+ *  - With a request id (?rid, how the mock's getEmbeddedSignUrl redirects here): the
+ *    signing interstitial. "Complete signing (DEV)" fires the real webhook via the dev
+ *    endpoint then lands on ?signed=1 (same as returning from real Zoho); "Decline (DEV)"
+ *    navigates to ?declined=1, mirroring Zoho's sign_declined redirect.
+ *  - Without a rid (reached from the "Debug: Sign" nav item): a start/resume entry that
+ *    POSTs the REAL sign action; in mock mode that hands back this same interstitial URL
+ *    (now carrying a rid), so the nav entry drops you into the flow without re-clicking
+ *    Sign on the membership page.
+ *
+ * Inline styles match the sibling dev tool (dev/sent-mail, EMAIL_DEV_MOCK.md).
+ */
+export default function DevZohoSignClient({ rid }: { rid: string | null }) {
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function complete() {
+        setBusy(true);
+        setError(null);
+        try {
+            const res = await fetch("/api/dev/zoho-sign/complete", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ rid }),
+            });
+            if (!res.ok) {
+                setError(`Completion failed (${res.status}). Check server logs.`);
+                setBusy(false);
+                return;
+            }
+            window.location.href = "/membership?signed=1";
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e));
+            setBusy(false);
+        }
+    }
+
+    async function startSigning() {
+        setBusy(true);
+        setError(null);
+        try {
+            const res = await fetch("/api/membership/contract/sign", { method: "POST" });
+            const data = await res.json().catch(() => ({}));
+            if (res.ok && data.url) {
+                window.location.href = data.url;
+                return;
+            }
+            setError(data.error ? `${data.error} (${res.status})` : `Could not start signing (${res.status}).`);
+            setBusy(false);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e));
+            setBusy(false);
+        }
+    }
+
+    const btn = (bg: string): React.CSSProperties => ({
+        padding: "0.5rem 1rem",
+        borderRadius: 6,
+        border: "none",
+        background: bg,
+        color: "#fff",
+        fontWeight: 600,
+        cursor: busy ? "default" : "pointer",
+        opacity: busy ? 0.5 : 1,
+    });
+
+    return (
+        <div style={{ maxWidth: 640 }}>
+            <h1 style={{ fontSize: "1.5rem", fontWeight: 600, margin: 0 }}>Zoho Sign (mock)</h1>
+            <p style={{ opacity: 0.7, fontSize: "0.85rem", marginTop: "0.5rem" }}>
+                Zoho Sign is mocked on this instance (no OAuth secrets). This stands in for the
+                embedded signing ceremony — <strong>DEV, NOT A LEGAL AGREEMENT</strong>.
+            </p>
+
+            {error && <p style={{ color: "#b91c1c", marginTop: "1rem" }}>{error}</p>}
+
+            {rid ? (
+                <div style={{ marginTop: "1.5rem" }}>
+                    <p style={{ fontSize: "0.85rem", opacity: 0.7 }}>
+                        Request <code>{rid}</code>
+                    </p>
+                    <div style={{ display: "flex", gap: "0.75rem", marginTop: "0.75rem" }}>
+                        <button onClick={complete} disabled={busy} style={btn("#059669")}>
+                            {busy ? "Completing…" : "Complete signing (DEV)"}
+                        </button>
+                        <button
+                            onClick={() => {
+                                window.location.href = "/membership?declined=1";
+                            }}
+                            disabled={busy}
+                            style={{ ...btn("transparent"), color: "#374151", border: "1px solid #d1d5db" }}
+                        >
+                            Decline (DEV)
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <div style={{ marginTop: "1.5rem" }}>
+                    <p style={{ fontSize: "0.9rem" }}>
+                        No signing request in the URL. Start or resume signing for your in-flight
+                        membership application:
+                    </p>
+                    <button onClick={startSigning} disabled={busy} style={{ ...btn("#2563eb"), marginTop: "0.75rem" }}>
+                        {busy ? "Starting…" : "Start / resume signing"}
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/checkin-app/src/app/dev/zoho-sign/page.tsx
+++ b/checkin-app/src/app/dev/zoho-sign/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from "next/navigation";
+import { config } from "@/lib/config";
+import DevZohoSignClient from "./DevZohoSignClient";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Dev-only stand-in for the Zoho embedded signing ceremony (see
+ * docs/designs/ZOHO_SIGN_DEV_MOCK.md §4a). Reached two ways: the mock provider's
+ * getEmbeddedSignUrl redirects the applicant here with ?rid=<zohoEnvelopeId>, and
+ * the "Debug: Sign" dev nav item links here with no rid (a start/resume entry).
+ * 404s the moment the mock isn't active (always in prod) so it can never surface
+ * for real.
+ */
+export default async function DevZohoSignPage({
+    searchParams,
+}: {
+    searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+    if (!config.zohoMockActive()) notFound();
+    const { rid } = await searchParams;
+    return <DevZohoSignClient rid={typeof rid === "string" ? rid : null} />;
+}

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -143,8 +143,9 @@ const NAV_ITEMS: NavItem[] = [
     visible: (u) => !!u?.isSysadmin || !!u?.isBoardMember,
   },
   { href: '/index', label: 'Index', icon: <IconList size={18} />, visible: (_u, signedIn) => signedIn },
-  // Dev tools (captured email inbox, EMAIL_DEV_MOCK.md). Dev instances only.
-  { href: '/dev/sent-mail', label: 'Debug', icon: <IconBug size={18} />, visible: (_u, signedIn) => signedIn, devOnly: true },
+  // Dev tools (dev instances only) — a single entry into the /dev tab section:
+  // captured email inbox (EMAIL_DEV_MOCK.md) + Zoho Sign mock (ZOHO_SIGN_DEV_MOCK.md).
+  { href: '/dev', label: 'Debug', icon: <IconBug size={18} />, visible: (_u, signedIn) => signedIn, devOnly: true },
 ];
 
 function isActive(pathname: string, href: string): boolean {

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -144,5 +144,7 @@ export const REGISTRY_EXCLUDED: string[] = [
   '/settings',               // redirects to /settings/membership
   '/attendance',             // redirects to /attendance/current
   '/my-programs',            // redirects to /my-programs/attendance
+  '/dev',                    // dev-tools hub, redirects to /dev/sent-mail
   '/dev/sent-mail',          // dev-only captured-email inbox (EMAIL_DEV_MOCK.md); 404s off dev
+  '/dev/zoho-sign',          // dev-only Zoho Sign mock interstitial (404 in prod)
 ];

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -30,6 +30,29 @@ function readCheckinEnv(): CheckinEnv {
     return value === 'dev' || value === 'local' ? value : 'prod';
 }
 
+/** True only when all three Zoho OAuth secrets are present. */
+function zohoConfiguredEnv(): boolean {
+    return !!(process.env.ZOHO_CLIENT_ID && process.env.ZOHO_CLIENT_SECRET && process.env.ZOHO_REFRESH_TOKEN);
+}
+
+/**
+ * The dev/local Zoho Sign MOCK is active when the real integration is unconfigured
+ * AND we're on a non-prod instance (see docs/designs/ZOHO_SIGN_DEV_MOCK.md). Two
+ * server-only fuses — CHECKIN_ENV (fails safe to prod) and NODE_ENV — so no mock
+ * path is reachable in prod by construction. Setting real Zoho secrets in dev opts
+ * back into the real client (zohoConfigured wins).
+ */
+function zohoMockActiveEnv(): boolean {
+    return !zohoConfiguredEnv() && readCheckinEnv() !== 'prod' && process.env.NODE_ENV !== 'production';
+}
+
+/**
+ * Fixed shared secret the dev mock signs its self-fired webhook with (§4a of the
+ * design). It guards nothing real — the payload is generated locally — it exists
+ * only so verifyZohoToken's real timing-safe compare has a value in dev.
+ */
+const DEV_MOCK_WEBHOOK_SECRET = 'dev-zoho-mock-webhook-secret';
+
 export const config = {
     // Database
     databaseUrl: () => requireEnv('DATABASE_URL'),
@@ -52,7 +75,10 @@ export const config = {
     averityConsentUrl: (): string | null => process.env.AVERITY_CONSENT_URL || null,
 
     // Zoho Sign webhook shared secret (timing-safe compared in verifyZohoToken).
-    zohoWebhookSecret: (): string | null => process.env.ZOHO_WEBHOOK_SECRET || null,
+    // Falls back to a fixed dev secret only when the mock is active, so the mock's
+    // self-fired webhook (dev interstitial) verifies for real with zero env setup.
+    zohoWebhookSecret: (): string | null =>
+        process.env.ZOHO_WEBHOOK_SECRET || (zohoMockActiveEnv() ? DEV_MOCK_WEBHOOK_SECRET : null),
 
     // AWS — region for SDK clients. Set on the ECS task def (AWS_REGION); the
     // default covers local dev. Credentials come from the task role / local profile.
@@ -74,9 +100,16 @@ export const config = {
     zohoRefreshToken: (): string | null => process.env.ZOHO_REFRESH_TOKEN || null,
     zohoAccountsUrl: (): string => process.env.ZOHO_ACCOUNTS_URL || 'https://accounts.zoho.com',
     zohoSignApi: (): string => process.env.ZOHO_SIGN_API || 'https://sign.zoho.com/api/v1',
-    // True only when all three OAuth secrets are present — gates the sign endpoint.
-    zohoConfigured: (): boolean =>
-        !!(process.env.ZOHO_CLIENT_ID && process.env.ZOHO_CLIENT_SECRET && process.env.ZOHO_REFRESH_TOKEN),
+    // True only when all three OAuth secrets are present — real integration wired.
+    zohoConfigured: (): boolean => zohoConfiguredEnv(),
+    // True when the dev/local mock provider stands in for real Zoho (secrets unset,
+    // non-prod). Selects the mock adapter, skips the S3 PDF load, enables the dev
+    // interstitial + its webhook endpoint. Always false in prod. See zohoMockActiveEnv.
+    zohoMockActive: (): boolean => zohoMockActiveEnv(),
+    // Sign flow is usable when real Zoho is configured OR the dev mock is active.
+    // Gates getOrCreateContractSigningUrl + syncContractStatus (replaces the bare
+    // zohoConfigured() checks so the mock can drive them in dev).
+    zohoAvailable: (): boolean => zohoConfiguredEnv() || zohoMockActiveEnv(),
 
     // App
     checkinEnv: (): CheckinEnv => readCheckinEnv(),

--- a/checkin-app/src/lib/devToolsNav.ts
+++ b/checkin-app/src/lib/devToolsNav.ts
@@ -1,0 +1,14 @@
+/**
+ * Single source of truth for the dev-tools tabs, rendered as persistent top tabs
+ * (app/dev/layout.tsx); /dev redirects to the first tab. Dev instances only — every
+ * target page 404s off a dev instance and the "Debug" nav item is devOnly.
+ */
+export interface DevToolsNavLink {
+  name: string;
+  href: string;
+}
+
+export const DEV_TOOLS_NAV_LINKS: DevToolsNavLink[] = [
+  { name: "Email", href: "/dev/sent-mail" },
+  { name: "Sign", href: "/dev/zoho-sign" },
+];

--- a/checkin-app/src/lib/membership/contract/__tests__/zohoProvider.test.ts
+++ b/checkin-app/src/lib/membership/contract/__tests__/zohoProvider.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment node
+ */
+import { config } from "@/lib/config";
+import { zohoSign } from "@/lib/membership/contract/zohoProvider";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function setEnv(env: Partial<Record<string, string | undefined>>) {
+    for (const [k, v] of Object.entries(env)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+    }
+}
+
+const NO_SECRETS = { ZOHO_CLIENT_ID: undefined, ZOHO_CLIENT_SECRET: undefined, ZOHO_REFRESH_TOKEN: undefined };
+const ALL_SECRETS = { ZOHO_CLIENT_ID: "cid", ZOHO_CLIENT_SECRET: "csec", ZOHO_REFRESH_TOKEN: "rtok" };
+
+describe("zoho mock fuse (config)", () => {
+    beforeEach(() => setEnv({ ...NO_SECRETS, ZOHO_WEBHOOK_SECRET: undefined, CHECKIN_ENV: undefined, NODE_ENV: "test" }));
+    afterAll(() => {
+        process.env = { ...ORIGINAL_ENV };
+    });
+
+    it("active on dev/local with secrets unset", () => {
+        for (const env of ["dev", "local"]) {
+            setEnv({ CHECKIN_ENV: env });
+            expect(config.zohoMockActive()).toBe(true);
+            expect(config.zohoAvailable()).toBe(true);
+            expect(config.zohoConfigured()).toBe(false);
+            // Dev default webhook secret so the self-fired webhook verifies with zero setup.
+            expect(config.zohoWebhookSecret()).toBe("dev-zoho-mock-webhook-secret");
+        }
+    });
+
+    it("dead in prod — no mock, no available, no dev secret", () => {
+        setEnv({ CHECKIN_ENV: "prod" });
+        expect(config.zohoMockActive()).toBe(false);
+        expect(config.zohoAvailable()).toBe(false);
+        expect(config.zohoWebhookSecret()).toBeNull();
+    });
+
+    it("dead when NODE_ENV=production even on a dev instance", () => {
+        setEnv({ CHECKIN_ENV: "dev", NODE_ENV: "production" });
+        expect(config.zohoMockActive()).toBe(false);
+    });
+
+    it("real client wins when secrets are configured in dev", () => {
+        setEnv({ CHECKIN_ENV: "dev", ...ALL_SECRETS });
+        expect(config.zohoMockActive()).toBe(false);
+        expect(config.zohoConfigured()).toBe(true);
+        expect(config.zohoAvailable()).toBe(true);
+    });
+});
+
+describe("mock provider behavior", () => {
+    beforeEach(() => setEnv({ ...NO_SECRETS, CHECKIN_ENV: "local", NODE_ENV: "test" }));
+    afterAll(() => {
+        process.env = { ...ORIGINAL_ENV };
+    });
+
+    it("fabricates ids, points at the dev interstitial, reports completed", async () => {
+        expect(await zohoSign.getAccessToken()).toBe("dev-mock-token");
+
+        const created = await zohoSign.createRequest({} as never);
+        expect(created.requestId).toMatch(/^dev-req-/);
+        expect(created.actionId).toMatch(/^dev-act-/);
+
+        const url = await zohoSign.getEmbeddedSignUrl({
+            token: "t",
+            requestId: created.requestId,
+            actionId: created.actionId,
+            host: "http://localhost:4000",
+        });
+        expect(url).toBe(`http://localhost:4000/dev/zoho-sign?rid=${created.requestId}`);
+
+        expect(await zohoSign.getRequestStatus("t", created.requestId)).toBe(true);
+    });
+});

--- a/checkin-app/src/lib/membership/contract/zohoProvider.ts
+++ b/checkin-app/src/lib/membership/contract/zohoProvider.ts
@@ -1,0 +1,67 @@
+import crypto from "crypto";
+import { config } from "@/lib/config";
+import * as realClient from "@/lib/membership/contract/zohoClient";
+
+/**
+ * Zoho Sign provider seam (see docs/designs/ZOHO_SIGN_DEV_MOCK.md).
+ *
+ * The real adapter is today's zohoClient (network + OAuth), used in prod and any
+ * dev instance with real secrets. The mock adapter stands in on a non-prod
+ * instance with the secrets unset (config.zohoMockActive()): it fabricates ids and
+ * points the applicant at a dev interstitial (/dev/zoho-sign) instead of a real
+ * signing ceremony. Everything BELOW markContractSigned — the webhook path and the
+ * state machine — stays real, so transitions and audit rows are identical to prod.
+ *
+ * The interface is pinned to the real client's signatures via `typeof`, so the mock
+ * can never drift from the shape external.ts calls.
+ */
+export type ZohoSignProvider = {
+    getAccessToken: typeof realClient.getAccessToken;
+    createRequest: typeof realClient.createRequest;
+    submitRequest: typeof realClient.submitRequest;
+    getEmbeddedSignUrl: typeof realClient.getEmbeddedSignUrl;
+    getRequestStatus: typeof realClient.getRequestStatus;
+};
+
+const realProvider: ZohoSignProvider = {
+    getAccessToken: realClient.getAccessToken,
+    createRequest: realClient.createRequest,
+    submitRequest: realClient.submitRequest,
+    getEmbeddedSignUrl: realClient.getEmbeddedSignUrl,
+    getRequestStatus: realClient.getRequestStatus,
+};
+
+const mockProvider: ZohoSignProvider = {
+    async getAccessToken() {
+        return "dev-mock-token";
+    },
+    // Fabricate ids; the PDF is never uploaded (external.ts skips the S3 load in mock
+    // mode). The requestId is what gets stored as zohoEnvelopeId and matched by the
+    // (self-fired) webhook, so it must be unique per signing request.
+    async createRequest() {
+        const id = crypto.randomUUID();
+        return { requestId: `dev-req-${id}`, actionId: `dev-act-${id}`, documentId: `dev-doc-${id}` };
+    },
+    async submitRequest() {
+        /* no-op: no real request to attach fields to */
+    },
+    // Send the applicant to the dev interstitial (§4a) carrying the request id, not
+    // straight to ?signed=1 — the interstitial is where completion is triggered.
+    async getEmbeddedSignUrl({ requestId, host }) {
+        return `${host}/dev/zoho-sign?rid=${encodeURIComponent(requestId)}`;
+    },
+    // The webhook records signing in the mock; this backs the ?signed=1 sync path,
+    // which then no-ops idempotently. Report completed so a sync-only race still lands.
+    async getRequestStatus() {
+        return true;
+    },
+};
+
+/** Per-call selection so tests toggling CHECKIN_ENV / secrets pick up the change. */
+export const zohoSign: ZohoSignProvider = {
+    getAccessToken: (...a) => (config.zohoMockActive() ? mockProvider : realProvider).getAccessToken(...a),
+    createRequest: (...a) => (config.zohoMockActive() ? mockProvider : realProvider).createRequest(...a),
+    submitRequest: (...a) => (config.zohoMockActive() ? mockProvider : realProvider).submitRequest(...a),
+    getEmbeddedSignUrl: (...a) => (config.zohoMockActive() ? mockProvider : realProvider).getEmbeddedSignUrl(...a),
+    getRequestStatus: (...a) => (config.zohoMockActive() ? mockProvider : realProvider).getRequestStatus(...a),
+};

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -3,13 +3,7 @@ import { config } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { backgroundCheckProvider } from "@/lib/membership/background-check/manual-adapter";
 import { notifyReviewers } from "@/lib/membership/review";
-import {
-    createRequest,
-    submitRequest,
-    getAccessToken,
-    getEmbeddedSignUrl,
-    getRequestStatus,
-} from "@/lib/membership/contract/zohoClient";
+import { zohoSign } from "@/lib/membership/contract/zohoProvider";
 import { loadAgreementPdf, stampWatermark, AGREEMENT_FILENAME, AgreementUnavailableError } from "@/lib/membership/contract/agreementDocument";
 import { latestPendingExternal } from "@/lib/membership/phases";
 
@@ -193,10 +187,10 @@ export async function syncContractStatus(userId: number): Promise<ExternalStatus
     const process = latestPendingExternal(user?.household?.membership?.processes);
     if (!process) return null;
 
-    if (!process.contractSignedAt && process.zohoEnvelopeId && config.zohoConfigured()) {
+    if (!process.contractSignedAt && process.zohoEnvelopeId && config.zohoAvailable()) {
         try {
-            const token = await getAccessToken();
-            if (await getRequestStatus(token, process.zohoEnvelopeId)) {
+            const token = await zohoSign.getAccessToken();
+            if (await zohoSign.getRequestStatus(token, process.zohoEnvelopeId)) {
                 await markContractSigned(process.id, userId);
             }
         } catch (e) {
@@ -221,7 +215,7 @@ const CONTRACT_EXPIRATION_DAYS = 15;
  * Returns the embedded sign URL. Throws ExternalError for the caller to map to HTTP.
  */
 export async function getOrCreateContractSigningUrl(userId: number): Promise<string> {
-    if (!config.zohoConfigured()) {
+    if (!config.zohoAvailable()) {
         throw new ExternalError("not_configured", "Agreement signing isn't available yet. Please check back soon.");
     }
 
@@ -250,35 +244,43 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
     const recipientName = user.name?.trim() || user.email || "Applicant";
     if (!recipientEmail) throw new ExternalError("not_found", "Your account has no email on file to sign with.");
 
-    const token = await getAccessToken();
+    const token = await zohoSign.getAccessToken();
 
     // Create the request once; reuse the stored ids on every later click so the
     // document is never re-generated (only the embed session below is ephemeral).
     let requestId = process.zohoEnvelopeId;
     let actionId = process.zohoActionId;
     if (!requestId || !actionId) {
+        // Mock mode never uploads the PDF (its createRequest ignores the bytes), so
+        // skip the S3 load that also 503s in dev — an empty placeholder keeps the
+        // create/submit calls type-identical. See ZOHO_SIGN_DEV_MOCK.md §5.
         let agreement;
-        try {
-            agreement = await loadAgreementPdf();
-        } catch (e) {
-            if (e instanceof AgreementUnavailableError) {
-                throw new ExternalError("agreement_unavailable", "The membership agreement isn't ready yet. Please check back soon.");
+        if (config.zohoMockActive()) {
+            agreement = { pdf: Buffer.alloc(0), lastPageNo: 0, pageWidth: 0, pageHeight: 0 };
+        } else {
+            try {
+                agreement = await loadAgreementPdf();
+            } catch (e) {
+                if (e instanceof AgreementUnavailableError) {
+                    throw new ExternalError("agreement_unavailable", "The membership agreement isn't ready yet. Please check back soon.");
+                }
+                throw e;
             }
-            throw e;
         }
 
         // On non-prod instances, mark the request + document as a DEV test so a
         // signature can never be mistaken for a binding one — baked in server-side
         // (CHECKIN_ENV), not editable by the applicant. Prod stays clean. The
-        // create/submit/embed flow is otherwise identical across envs.
+        // create/submit/embed flow is otherwise identical across envs. (Mock mode
+        // skips the watermark — the empty placeholder PDF is never rendered.)
         const isProd = config.isProd();
-        const pdf = isProd ? agreement.pdf : await stampWatermark(agreement.pdf, "DEV TEST — NOT A LEGAL AGREEMENT");
+        const pdf = isProd || config.zohoMockActive() ? agreement.pdf : await stampWatermark(agreement.pdf, "DEV TEST — NOT A LEGAL AGREEMENT");
         const requestName = `${isProd ? "" : "[DEV TEST — NOT BINDING] "}Membership Agreement — ${recipientName}`;
 
         // Return the embedded signer to checkin when they finish (Zoho navigates
         // the window to these). signed=1 lets the membership page confirm + refresh.
         const membershipUrl = `${config.baseUrl()}/membership`;
-        const created = await createRequest({
+        const created = await zohoSign.createRequest({
             token,
             pdf,
             filename: AGREEMENT_FILENAME,
@@ -293,7 +295,7 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
                 sign_later: membershipUrl,
             },
         });
-        await submitRequest({
+        await zohoSign.submitRequest({
             token,
             requestId: created.requestId,
             actionId: created.actionId,
@@ -348,5 +350,5 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
         }
     }
 
-    return getEmbeddedSignUrl({ token, requestId, actionId, host: config.baseUrl() });
+    return zohoSign.getEmbeddedSignUrl({ token, requestId, actionId, host: config.baseUrl() });
 }


### PR DESCRIPTION
## Problem

In dev/local the three Zoho OAuth secrets are unset, so `POST /api/membership/contract/sign` returns **503** and the membership application **halts at the EXTERNAL phase** — an applicant can never sign the contract, so they never reach `PENDING_PAYMENT`. Three walls, all keyed on unset secrets:

1. `getOrCreateContractSigningUrl` throws `not_configured` when `!zohoConfigured()`.
2. `loadAgreementPdf()` (S3) also 503s in dev — *before* any Zoho call.
3. `syncContractStatus` is gated on `zohoConfigured()`, so completion never records.

This adds a dev-world mock so the workflow runs end-to-end without a real Zoho account, **dead in prod by construction**.

## What changed

- **Provider seam** (`zohoProvider.ts`) mirroring the `BackgroundCheckProvider` pattern. Real adapter is a thin pass-through over today's `zohoClient` (prod unchanged); mock adapter fabricates ids, points the applicant at a dev interstitial, and reports the request completed. Method signatures are pinned to the real client via `typeof` so the mock can't drift.
- **config**: `zohoMockActive()` = `!zohoConfigured() && CHECKIN_ENV!==prod && NODE_ENV!==production` (same two-fuse idiom as persona-mint). `zohoAvailable()` replaces the bare `zohoConfigured()` gates (walls 1 & 3). `zohoWebhookSecret()` falls back to a fixed dev secret only in mock mode.
- **external.ts**: calls the provider instead of `zohoClient` directly; skips the S3 agreement-PDF load + watermark in mock mode (wall 2 — the mock ignores the bytes).
- **Dev interstitial** `/dev/zoho-sign` (`notFound()` unless mock active): stands in for the embedded ceremony. **Complete signing (DEV)** → `POST /api/dev/zoho-sign/complete`, which synthesizes a completion payload and fires the **real** inbound webhook (`verify → parse → match → markContractSigned → advance`), so the mock exercises the same completion code prod does. **Decline (DEV)** mirrors the `sign_declined` redirect.
- **pageRegistry**: `/dev/zoho-sign` added to `REGISTRY_EXCLUDED` (drift guard).

## Prod safety

Mock, PDF-skip, dev secret, interstitial page, and the complete endpoint are all behind the same `isDevInstance() && NODE_ENV !== 'production'` fuse. `zohoAvailable()` / `zohoWebhookSecret()` collapse to their real values in prod. A unit test asserts the fuse is dead in prod, dead when `NODE_ENV=production` on a dev instance, and that real secrets in dev opt back into the real client.

## Fidelity

Everything from **webhook receipt through the state transition** is the real path — `verifyZohoToken`, `parseZohoWebhook`, `findProcessByEnvelope`, `markContractSigned`, `advanceExternalIfComplete`, the `SYSTEM_ACTOR=0` audit rows, and the idempotent race guards. Only the real Zoho **HTTP + OAuth** stay unmocked.

## Reviewer notes

- Design doc: `checkin-app/docs/designs/ZOHO_SIGN_DEV_MOCK.md` (traces the flow, the options considered, and every locked decision).
- The dev webhook secret is a hardcoded constant — it guards nothing real (the payload is generated locally); it exists only so `verifyZohoToken`'s timing-safe compare has a value in dev.
- Sibling gaps intentionally **not** solved here: the S3 agreement PDF and the Shopify orders/paid webhook (same "unset secret → 503 in dev" shape).

## Test / verify

- `tsc --noEmit`: clean. `eslint` on touched files: clean.
- New `zohoProvider.test.ts` (fuse + mock behavior) and the `pageRegistry` drift guard pass.
- Not yet run: a live end-to-end click-through (needs docker PG + seed + dev server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)