### PR TITLE
refactor(youth): rename minor/child age identifiers to youth (phase 1)

### DIFF
--- a/checkin-app/src/app/api/profile/onboarding-status/route.ts
+++ b/checkin-app/src/app/api/profile/onboarding-status/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { withAuth } from "@/lib/auth";
-import { isMinor } from "@/lib/time";
+import { isYouth } from "@/lib/time";
 
 export const GET = withAuth(
     {},
@@ -24,8 +24,8 @@ export const GET = withAuth(
                 return NextResponse.json({ error: "Participant not found" }, { status: 404 });
             }
 
-            // Minors are never required to provide a phone number (issue #169)
-            const needsPhone = !user.phone && !isMinor(user.dateOfBirth);
+            // Youth are never required to provide a phone number (issue #169)
+            const needsPhone = !user.phone && !isYouth(user.dateOfBirth);
             const isLead = user.householdId && user.householdLeads.some((lead: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => lead.householdId === user.householdId);
 
             // A lead needs a contact when no valid (non-member, complete) one exists.

--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -3,7 +3,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { handler, notFound, unauthorized } from "@/security/handler";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
-import { isMinor } from "@/lib/time";
+import { isYouth } from "@/lib/time";
 
 export const GET = handler('GET /api/profile', async ({ auth }) => {
     if (auth.type !== 'session') throw unauthorized();
@@ -32,7 +32,7 @@ export const PATCH = withAuth(
                 where: { id: userId },
                 select: { dateOfBirth: true },
             });
-            if (isMinor(me?.dateOfBirth)) {
+            if (isYouth(me?.dateOfBirth)) {
                 return NextResponse.json({ error: "Youth profiles are read-only." }, { status: 403 });
             }
 

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -7,7 +7,7 @@ import {
   Alert, Anchor, Badge, Box, Button, Card, Center, Group, Loader, Modal, Paper,
   SimpleGrid, Stack, Text, TextInput, Title,
 } from "@mantine/core";
-import { formatTime, isMinor } from "@/lib/time";
+import { formatTime, isYouth } from "@/lib/time";
 import { formatPhone } from "@/lib/phone";
 import { getKioskDisplayNames } from "@/lib/kiosk-names";
 import { AttendanceTabs } from "../AttendanceTabs";
@@ -37,7 +37,7 @@ type FullResponse = { access: "full"; attendance: Visit[]; counts: Counts; safet
 type LimitedResponse = { access: "limited"; counts: Counts; safety: SafetyFlags; self: Visit | null; household: Visit[] };
 type AttendanceResponse = FullResponse | LimitedResponse;
 
-const isStudent = (dob: string | undefined | null) => isMinor(dob);
+const isStudent = (dob: string | undefined | null) => isYouth(dob);
 
 type SessionUser = { id: number; isSysadmin?: boolean; isKeyholder?: boolean; isBoardMember?: boolean; householdId?: number | null };
 

--- a/checkin-app/src/app/membership-audit/broken/page.tsx
+++ b/checkin-app/src/app/membership-audit/broken/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Badge, Box, Button, Card, Group, Loader, Stack, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
-import { formatDate, isMinor } from "@/lib/time";
+import { formatDate, isYouth } from "@/lib/time";
 
 type Member = { id: number; name: string | null; dateOfBirth: string | null };
 type BrokenHousehold = { id: number; name: string; members: Member[] };
@@ -74,11 +74,11 @@ export default function BrokenHouseholdsPage() {
                         <Text size="sm">
                           {m.name || "Unnamed"}
                           {m.dateOfBirth ? ` • ${formatDate(m.dateOfBirth)}` : " • no birthdate"}
-                          {isMinor(m.dateOfBirth) && (
-                            <Badge ml="xs" size="xs" color="gray" variant="light">minor</Badge>
+                          {isYouth(m.dateOfBirth) && (
+                            <Badge ml="xs" size="xs" color="gray" variant="light">youth</Badge>
                           )}
                         </Text>
-                        {!isMinor(m.dateOfBirth) && (
+                        {!isYouth(m.dateOfBirth) && (
                           <Button
                             size="compact-xs"
                             variant="light"

--- a/checkin-app/src/app/membership-ops/participants/new/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/page.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { EntityPicker } from '@/components/admin/EntityPicker';
-import { isMinor } from '@/lib/time';
+import { isYouth } from '@/lib/time';
 import { Button, Card, Center, Checkbox, Container, Loader, Paper, Stack, Text, TextInput } from '@mantine/core';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 
@@ -37,7 +37,7 @@ function NewParticipantForm() {
   const [householdId, setHouseholdId] = useState("");
   const [householdSearch, setHouseholdSearch] = useState("");
 
-  const studentSelected = isMinor(dob);
+  const studentSelected = isYouth(dob);
 
   const [alreadyMember, setAlreadyMember] = useState(false);
   const [saving, setSaving] = useState(false);

--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -5,7 +5,7 @@ import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Anchor, Button, Card, Center, Loader, Stack, Text, TextInput, Title } from '@mantine/core';
 import { PageContainer } from '@/components/ui/PageContainer';
-import { isMinor } from '@/lib/time';
+import { isYouth } from '@/lib/time';
 
 export default function ProfilePage() {
   const { data: session, status } = useSession();
@@ -84,7 +84,7 @@ export default function ProfilePage() {
 
   if (!session) return null; // Fallback while router redirects
 
-  const readOnly = isMinor(form.dob);
+  const readOnly = isYouth(form.dob);
 
   return (
     <PageContainer>

--- a/checkin-app/src/lib/__tests__/zohoImport.test.ts
+++ b/checkin-app/src/lib/__tests__/zohoImport.test.ts
@@ -167,8 +167,8 @@ describe("buildImport", () => {
             [family({ Primary_Contact_E_mail: "kailemizell@gmail.com", Primary_Contact_Name: "Ari Mizell" })],
             [input({ Primary_Contact_E_mail: "kailemizell@gmail.com" })],
         );
-        expect(report.minorsAsPrimary).toHaveLength(1);
-        expect(report.minorsAsPrimary[0].name).toBe("Ari Mizell");
+        expect(report.youthAsPrimary).toHaveLength(1);
+        expect(report.youthAsPrimary[0].name).toBe("Ari Mizell");
     });
 
     it("declares the primary an adult only when Zoho has no DoB (age model, #606)", () => {

--- a/checkin-app/src/lib/dev/zoho-import.ts
+++ b/checkin-app/src/lib/dev/zoho-import.ts
@@ -107,7 +107,7 @@ export interface ImportReport {
         rowDob: string;
     }[];
     emailCollisions: { email: string; keptFor: string; nulledFor: string[] }[];
-    minorsAsPrimary: { name: string; dob: string; householdKey: string }[];
+    youthAsPrimary: { name: string; dob: string; householdKey: string }[];
     secondaryAdultsNotPromoted: number;
     flags: string[];
 }
@@ -174,7 +174,7 @@ export function buildImport(files: ZohoFiles, now: Date): BuiltImport {
         activeMemberships: 0,
         blankNamesSkipped: [],
         emailCollisions: [],
-        minorsAsPrimary: [],
+        youthAsPrimary: [],
         secondaryAdultsNotPromoted: 0,
         flags: [],
     };
@@ -271,10 +271,10 @@ export function buildImport(files: ZohoFiles, now: Date): BuiltImport {
             (input?.Payment_Status || "").trim() === "Completed" &&
             (input?.Membership_Agreement_Status || "").trim() === "Completed";
 
-        // Flag minors listed as the household's primary contact.
+        // Flag youth listed as the household's primary contact.
         const primaryAge = ageYears(primary.dob, now);
         if (primaryAge !== null && primaryAge < 18) {
-            report.minorsAsPrimary.push({
+            report.youthAsPrimary.push({
                 name: primary.name,
                 dob: primary.dob?.toISOString().slice(0, 10) ?? "?",
                 householdKey: key,
@@ -541,8 +541,8 @@ export function renderReport(report: ImportReport): string {
     for (const c of report.emailCollisions) {
         lines.push(`    - ${c.email}: kept for ${c.keptFor}; nulled for ${c.nulledFor.join(", ")}`);
     }
-    lines.push(`Minors as primary:   ${report.minorsAsPrimary.length}`);
-    for (const m of report.minorsAsPrimary) lines.push(`    - ${m.name} (DOB ${m.dob}, household ${m.householdKey})`);
+    lines.push(`Youth as primary:   ${report.youthAsPrimary.length}`);
+    for (const m of report.youthAsPrimary) lines.push(`    - ${m.name} (DOB ${m.dob}, household ${m.householdKey})`);
     lines.push(`Secondary adults not promoted to lead: ${report.secondaryAdultsNotPromoted}`);
     lines.push("Flags:");
     for (const f of report.flags) lines.push(`    ! ${f}`);

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -1,5 +1,5 @@
 import prisma from "@/lib/prisma";
-import { isMinor } from "@/lib/time";
+import { isYouth } from "@/lib/time";
 
 export async function getFullAttendance() {
     const activeVisits = await prisma.visit.findMany({
@@ -39,15 +39,15 @@ export async function getFullAttendance() {
         orderBy: { arrivedAt: "desc" },
     });
 
-    // Pre-compute isMinor once per visit to avoid repeated calculations
-    const minorMap = new Map<number, boolean>();
+    // Pre-compute isYouth once per visit to avoid repeated calculations
+    const youthMap = new Map<number, boolean>();
     for (const v of activeVisits) {
-        minorMap.set(v.id, isMinor(v.participant.dateOfBirth));
+        youthMap.set(v.id, isYouth(v.participant.dateOfBirth));
     }
 
     const keyholderVisits = activeVisits.filter(v => v.participant.isKeyholder);
-    const studentVisits = activeVisits.filter(v => minorMap.get(v.id)!);
-    const volunteerVisits = activeVisits.filter(v => !v.participant.isKeyholder && !minorMap.get(v.id));
+    const studentVisits = activeVisits.filter(v => youthMap.get(v.id)!);
+    const volunteerVisits = activeVisits.filter(v => !v.participant.isKeyholder && !youthMap.get(v.id));
 
     const counts = {
         keyholders: keyholderVisits.length,
@@ -56,7 +56,7 @@ export async function getFullAttendance() {
         total: activeVisits.length,
     };
 
-    const adultVisits = activeVisits.filter(v => !minorMap.get(v.id));
+    const adultVisits = activeVisits.filter(v => !youthMap.get(v.id));
     const unaccompaniedStudents = studentVisits.filter(sv => {
         if (!sv.participant.householdId) return true;
         return !adultVisits.some(av => av.participant.householdId === sv.participant.householdId);

--- a/checkin-app/src/lib/time.ts
+++ b/checkin-app/src/lib/time.ts
@@ -89,10 +89,10 @@ export function calculateAge(dob: Date | string, asOf: Date | string = new Date(
 }
 
 /**
- * Returns true if the person with the given DOB is under 18 years old.
+ * Returns true if the person with the given DOB is under 18 years old (youth).
  * Canonical implementation — use this everywhere instead of inline age checks.
  */
-export function isMinor(dob: Date | string | null | undefined): boolean {
+export function isYouth(dob: Date | string | null | undefined): boolean {
     if (!dob) return false;
     return calculateAge(dob) < 18;
 }


### PR DESCRIPTION
## What

Phase 1 of the participant terminology migration: the under-18 age concept becomes the single word **youth**. The synonyms **minor** and **child** are removed from code identifiers.

Pure, mechanical rename — no behavior, schema, or API changes.

### Changes (10 files)
- **`isMinor` → `isYouth`** in `src/lib/time.ts` (body unchanged: `calculateAge(dob) < 18`) plus every import and call site
- `getFullAttendance.ts`: `minorMap` → `youthMap`
- `zoho-import.ts`: report field `minorsAsPrimary` → `youthAsPrimary`, printed label `"Minors as primary:"` → `"Youth as primary:"`
- `membership-audit/broken`: badge text `minor` → `youth`
- Tests updated to reference the renamed symbols

## Why

Single canonical term for the under-18 concept. Sets up later phases (student copy, glossary) without churn.

## Notes for reviewer
- **Deliberately left untouched** (separate phases): parent-facing `child`/`Children` copy (membership, safety/pickup, programs register), and all `student`/`isStudent` identifiers + "Student" copy.
- `src/app/attendance/current/page.tsx` wasn't in the original file list but imported `isMinor` — renamed to keep it compiling; its local `isStudent` wrapper name was preserved.
- Remaining `minor` grep hits are comments and test-local fixture data only (e.g. `minorId`, `"Minor Import Test"`).

## Verify
- `npx tsc --noEmit` passes clean
- `grep -rn 'isMinor' src` → 0 hits
- `grep -rn 'minorsAsPrimary' src` → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)