### PR TITLE
refactor(youth): swap "minor" → "youth" in comments/prose (phase 2)

### DIFF
--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -9,7 +9,7 @@ import { handler, notFound, forbidden, badRequest } from "@/security/handler";
 // existence of their enrollment/RSVP/Visit row are all tier 'public'. So the
 // handler's per-FIELD stripping (which protects email/phone/dob) CANNOT hide the
 // association "person <-> this event": stripping a non-staff caller to 'public'
-// still leaks the whole attendee name list (incl. minors). Field-tiering guards
+// still leaks the whole attendee name list (incl. youth). Field-tiering guards
 // fields; only admission guards the association. So we gate admission here.
 //
 // The gate can't live in the registry `authorize`: this route's [id] is an EVENT

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -60,7 +60,7 @@ export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
     // Each ProgramParticipant/ProgramVolunteer row AND Participant.name are tier
     // 'public', so the handler's per-field stripper CANNOT hide the association:
     // the existence of the row + the public name = the enrollment fact (incl.
-    // minors). Only admission can hide it. The registry `authorize` grammar can't
+    // youth). Only admission can hide it. The registry `authorize` grammar can't
     // express "enrolled in THIS program" per-relation, so the gate lives here —
     // mirrors events/[id] (#571); see docs/security/auth-consistency-analysis.md
     // §4 (principled exception) and §5.1a. The route stays `authorize: 'public'`

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -230,7 +230,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
 // Macros — additive one-click scenario seeders (each returns a one-line summary for a toast).
 // ──────────────────────────────────────────────────────────────────────────
 
-/** + Family — a household with a lead adult, a partner, and a minor. */
+/** + Family — a household with a lead adult, a partner, and a youth. */
 export async function createFamily(prisma: Db): Promise<string> {
     const tag = uid();
     const household = await prisma.household.create({
@@ -260,7 +260,7 @@ export async function createFamily(prisma: Db): Promise<string> {
     await prisma.participant.create({
         data: { name: `Kid ${tag}`, dateOfBirth: yearsAgo(9), householdId: household.id },
     });
-    return `Created household "Test Family ${tag}" (lead + partner + 1 minor)`;
+    return `Created household "Test Family ${tag}" (lead + partner + 1 youth)`;
 }
 
 /** + Program — a program with a materials fee and a couple of active participants. */

--- a/checkin-app/src/lib/household/participantProjection.ts
+++ b/checkin-app/src/lib/household/participantProjection.ts
@@ -2,7 +2,7 @@ import type { Prisma } from "@/generated/prisma/client";
 
 /**
  * Fields of a household peer's Participant row that are safe to send to any
- * other member of the same household (including minors) — i.e. what the
+ * other member of the same household (including youth) — i.e. what the
  * my-household member cards and the program-enrollment picker actually
  * render. Excludes INTERNAL-tier fields (role flags, googleId, emailVerified,
  * lastBackgroundCheck, waiverSignedBy, notificationSettings, ...) that a

--- a/checkin-app/src/lib/importDob.ts
+++ b/checkin-app/src/lib/importDob.ts
@@ -3,7 +3,7 @@
  *
  * Shared by the import COMMIT and PREVIEW endpoints so the admin approves the
  * same date that gets imported. If these two ever parse differently again, the
- * preview classifies a person differently than the commit (e.g. minor vs adult).
+ * preview classifies a person differently than the commit (e.g. youth vs adult).
  *
  * xlsx may hand us an Excel serial number (days since 1899-12-30) as a digit
  * string when no bookType is provided, so handle that before falling back to

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -50,7 +50,7 @@ defineRoute({
     ],
 });
 
-// Event roster — embeds participant PII (name/email/phone/dob, incl. minors) for
+// Event roster — embeds participant PII (name/email/phone/dob, incl. youth) for
 // everyone enrolled in / RSVP'd to the program. This route is FAIL-CLOSED,
 // staff-only: the handler fn (events/[id]/route.ts) does an inline event->program
 // lead/core-vol/admin gate and throws 403 for everyone else, so non-staff never


### PR DESCRIPTION
Follow-up to #670. Product rule: **code identifiers AND comments use "youth"; only user-visible copy strings may say "child".** No behavior, schema, or API-contract changes.

## Change — "minor" → "youth"/"under-18" in comments/prose
Pure comment/prose edits, no logic:
- `src/app/api/programs/[id]/route.ts`, `src/app/api/events/[id]/route.ts`
- `src/security/registry.ts`, `src/lib/importDob.ts`
- `src/lib/dev/seed-helpers.ts` (×2), `src/lib/household/participantProjection.ts`

## Dropped from this PR
The membership join-form identifier rename in `src/app/membership/page.tsx` (`ChildForm`→`YouthForm`, `children` state→`youths`, etc.) was reverted — it reached into a spot that isn't valid to rename yet. Deferred to a later phase.

## Verification
- `npx tsc --noEmit` → clean
- `grep -rniE '\bminors?\b' src` (non-test) → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)