### PR TITLE
refactor(terminology): sense-B household person → householdMember (phase 3)

### DIFF
--- a/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
@@ -152,7 +152,7 @@ describe('Household Member API Integration Tests', () => {
             const res = await PATCH(req as unknown as import("next/server").NextRequest);
             expect(res.status).toBe(403);
             const data = await res.json();
-            expect(data.error).toBe('Only household leads can edit members');
+            expect(data.error).toBe('Only household leads can edit household members');
         });
 
         it('should return 404 Not Found if trying to edit a member outside of your household', async () => {
@@ -166,7 +166,7 @@ describe('Household Member API Integration Tests', () => {
             const res = await PATCH(req as unknown as import("next/server").NextRequest);
             expect(res.status).toBe(404);
             const data = await res.json();
-            expect(data.error).toBe('Member not found in your household');
+            expect(data.error).toBe('That household member was not found');
         });
 
         it('should successfully update a household member', async () => {
@@ -188,8 +188,8 @@ describe('Household Member API Integration Tests', () => {
             expect(res.status).toBe(200);
             
             const data = await res.json();
-            expect(data.member).toBeDefined();
-            expect(data.message).toBe('Member updated successfully.');
+            expect(data.householdMember).toBeDefined();
+            expect(data.message).toBe('Household member updated successfully.');
 
             // Validate the changes
             const updatedProfile = await prisma.participant.findUnique({ where: { id: testMemberId } });

--- a/checkin-app/src/app/api/events/mine/route.ts
+++ b/checkin-app/src/app/api/events/mine/route.ts
@@ -11,50 +11,50 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     try {
         // Self, or every household member when the session is a household lead.
-        const members = await activityMembers(session);
-        const memberIds = members.map(m => m.id);
-        const memberById = new Map(members.map(m => [m.id, m]));
+        const householdMembers = await activityMembers(session);
+        const householdMemberIds = householdMembers.map(m => m.id);
+        const householdMemberById = new Map(householdMembers.map(m => [m.id, m]));
 
-        // Which members are tied to which programs (enrolled or volunteering).
+        // Which household members are tied to which programs (enrolled or volunteering).
         const [enrolled, volunteers] = await Promise.all([
             prisma.programParticipant.findMany({
-                where: { participantId: { in: memberIds } },
+                where: { participantId: { in: householdMemberIds } },
                 select: { participantId: true, programId: true }
             }),
             prisma.programVolunteer.findMany({
-                where: { participantId: { in: memberIds } },
+                where: { participantId: { in: householdMemberIds } },
                 select: { participantId: true, programId: true }
             })
         ]);
 
-        const programMembers = new Map<number, Set<number>>();
+        const programParticipants = new Map<number, Set<number>>();
         for (const { programId, participantId } of [...enrolled, ...volunteers]) {
-            let set = programMembers.get(programId);
-            if (!set) programMembers.set(programId, (set = new Set()));
+            let set = programParticipants.get(programId);
+            if (!set) programParticipants.set(programId, (set = new Set()));
             set.add(participantId);
         }
 
         const events = await prisma.event.findMany({
             where: {
-                programId: { in: [...programMembers.keys()] },
+                programId: { in: [...programParticipants.keys()] },
                 endAt: { gte: new Date() } // Only upcoming
             },
             orderBy: { startAt: "asc" },
             include: {
                 program: { select: { name: true } },
                 rsvps: {
-                    where: { participantId: { in: memberIds } },
+                    where: { participantId: { in: householdMemberIds } },
                     select: { participantId: true, status: true }
                 }
             }
         });
 
-        // One card per (event, member-in-that-program), each with that member's
-        // own RSVP — so a household lead can respond for each family member.
+        // One card per (event, participant-in-that-program), each with that
+        // participant's own RSVP — so a household lead can respond for each one.
         const rows = events.flatMap((ev: typeof events[number]) => {
-            const attendees = ev.programId ? programMembers.get(ev.programId) : undefined;
+            const attendees = ev.programId ? programParticipants.get(ev.programId) : undefined;
             if (!attendees) return [];
-            return memberIds
+            return householdMemberIds
                 .filter(id => attendees.has(id))
                 .map(pid => ({
                     id: ev.id,
@@ -63,7 +63,7 @@ export const GET = withAuth({}, async (_req, auth) => {
                     startAt: ev.startAt,
                     endAt: ev.endAt,
                     program: ev.program,
-                    participant: memberById.get(pid),
+                    participant: householdMemberById.get(pid),
                     rsvp: ev.rsvps.find((r: typeof ev.rsvps[number]) => r.participantId === pid)?.status ?? null
                 }));
         });

--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -34,15 +34,15 @@ export const PATCH = withAuth(
             // Leads/sysadmins edit anyone; anyone may edit their own record.
             const isCurrentUserLead = user.householdLeads.some(lead => lead.householdId === user.householdId);
             if (!isCurrentUserLead && !user.isSysadmin && participantId !== userId) {
-                return NextResponse.json({ error: "Only household leads can edit members" }, { status: 403 });
+                return NextResponse.json({ error: "Only household leads can edit household members" }, { status: 403 });
             }
 
-            const targetMember = await prisma.participant.findUnique({ where: { id: participantId } });
-            if (!targetMember || targetMember.householdId !== user.householdId) {
-                return NextResponse.json({ error: "Member not found in your household" }, { status: 404 });
+            const targetHouseholdMember = await prisma.participant.findUnique({ where: { id: participantId } });
+            if (!targetHouseholdMember || targetHouseholdMember.householdId !== user.householdId) {
+                return NextResponse.json({ error: "That household member was not found" }, { status: 404 });
             }
 
-            const updatedMember = await prisma.participant.update({
+            const updatedHouseholdMember = await prisma.participant.update({
                 where: { id: participantId },
                 data: {
                     name: name !== undefined ? name : undefined,
@@ -114,8 +114,8 @@ export const PATCH = withAuth(
                     actorId: userId,
                     action: "EDIT",
                     tableName: "Participant",
-                    affectedEntityId: targetMember.id,
-                    newData: updatedMember
+                    affectedEntityId: targetHouseholdMember.id,
+                    newData: updatedHouseholdMember
                 }
             });
 
@@ -124,8 +124,8 @@ export const PATCH = withAuth(
             const warning = await reconcileAndWarn(prisma, user.householdId);
 
             return NextResponse.json({
-                member: updatedMember,
-                message: leadRejection ? "Member updated, but not added as a lead." : "Member updated successfully.",
+                householdMember: updatedHouseholdMember,
+                message: leadRejection ? "Household member updated, but not added as a lead." : "Household member updated successfully.",
                 leadRejection,
                 warning,
             }, { status: 200 });

--- a/checkin-app/src/app/api/programs/mine/route.ts
+++ b/checkin-app/src/app/api/programs/mine/route.ts
@@ -11,11 +11,11 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     try {
         // Self, or every household member when the session is a household lead.
-        const members = await activityMembers(session);
-        const memberIds = members.map(m => m.id);
+        const householdMembers = await activityMembers(session);
+        const householdMemberIds = householdMembers.map(m => m.id);
 
         const enrollments = await prisma.programParticipant.findMany({
-            where: { participantId: { in: memberIds } },
+            where: { participantId: { in: householdMemberIds } },
             select: {
                 programId: true,
                 participantId: true,

--- a/checkin-app/src/app/attendance/household/page.tsx
+++ b/checkin-app/src/app/attendance/household/page.tsx
@@ -58,7 +58,7 @@ export default function HouseholdCheckins() {
         <Table striped highlightOnHover>
           <Table.Thead>
             <Table.Tr>
-              <Table.Th>Member</Table.Th>
+              <Table.Th>Household Member</Table.Th>
               <Table.Th>Event</Table.Th>
               <Table.Th>Arrived</Table.Th>
               <Table.Th>Duration</Table.Th>
@@ -68,7 +68,7 @@ export default function HouseholdCheckins() {
           <Table.Tbody>
             {visits.map((v) => (
               <Table.Tr key={v.id}>
-                <Table.Td><Text fw={600} c="blue">{v.participant?.name || 'Unnamed Member'}</Text></Table.Td>
+                <Table.Td><Text fw={600} c="blue">{v.participant?.name || 'Unnamed household member'}</Text></Table.Td>
                 <Table.Td>{v.event?.name || 'General Facility Visit'}</Table.Td>
                 <Table.Td>{formatDateTime(v.arrivedAt, { dateStyle: 'short', timeStyle: 'short' })}</Table.Td>
                 <Table.Td>{formatVisitRange(v.arrivedAt, v.departedAt)}</Table.Td>

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -55,7 +55,7 @@ describe("HouseholdPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "+ Add Household Member" }));
     fireEvent.change(screen.getByLabelText("Full Name"), { target: { value: "Robin Smith" } });
     fireEvent.click(screen.getByLabelText("Individual is over 25"));
-    fireEvent.click(screen.getByRole("button", { name: "Save / Invite Member" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save / Invite Household Member" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -24,7 +24,7 @@ const DOB_ERROR = "Date of birth is required for anyone under 25.";
 
 // Shared client validation for the member add/edit forms. Returns red-ring +
 // subtext errors keyed by field; empty object means valid.
-function validateMemberFields(f: { name: string; email: string; dob: string; over25: boolean }) {
+function validateHouseholdMemberFields(f: { name: string; email: string; dob: string; over25: boolean }) {
   const e: { name?: string; email?: string; dob?: string } = {};
   if (!f.name.trim()) e.name = "Name is required.";
   if (f.email && !isValidEmail(f.email)) e.email = EMAIL_ERROR;
@@ -34,7 +34,7 @@ function validateMemberFields(f: { name: string; email: string; dob: string; ove
 
 // Upper-right age chip for a member card. A DoB drives an exact age; absent a
 // DoB we trust the 25+ declaration, else the age is unknown and flagged red.
-function ageBadge(p: Member): { label: string; color: string; variant: string } {
+function ageBadge(p: HouseholdMember): { label: string; color: string; variant: string } {
   if (p.dateOfBirth) {
     const age = calculateAge(p.dateOfBirth);
     return age < 18 ? { label: `Age (${age})`, color: 'blue', variant: 'light' } : { label: 'Adult', color: 'gray', variant: 'light' };
@@ -43,13 +43,13 @@ function ageBadge(p: Member): { label: string; color: string; variant: string } 
   return { label: 'Age Unavailable', color: 'red', variant: 'filled' };
 }
 
-type Member = { id: number; name?: string; email?: string; dateOfBirth?: string; phone?: string; isDeclaredAdult?: boolean };
+type HouseholdMember = { id: number; name?: string; email?: string; dateOfBirth?: string; phone?: string; isDeclaredAdult?: boolean };
 type EmergencyContact = { id: number; name: string; phone: string; email?: string | null; relationship?: string | null; priority: number; invalid: boolean };
 type HouseholdData = {
   id?: number;
   name?: string;
   leads?: Array<{ participantId: number }>;
-  participants?: Member[];
+  participants?: HouseholdMember[];
   membership?: { status?: string; memberSince?: string; isVolunteer?: boolean } | null;
 } & Partial<StructuredAddress> | null;
 
@@ -67,12 +67,12 @@ export default function HouseholdPage() {
   const ok = (text: string) => setMessage({ text, tone: "success" });
   const err = (text: string) => setMessage({ text, tone: "error" });
   const warn = (text: string) => setMessage({ text, tone: "warning" });
-  const [addingMember, setAddingMember] = useState(false);
+  const [addingHouseholdMember, setAddingHouseholdMember] = useState(false);
 
-  const [memberForm, setMemberForm] = useState({ name: "", email: "", dob: "", over25: false });
-  const [memberErrors, setMemberErrors] = useState<{ name?: string; email?: string; dob?: string }>({});
+  const [householdMemberForm, setHouseholdMemberForm] = useState({ name: "", email: "", dob: "", over25: false });
+  const [householdMemberErrors, setHouseholdMemberErrors] = useState<{ name?: string; email?: string; dob?: string }>({});
 
-  const [editingMemberId, setEditingMemberId] = useState<number | null>(null);
+  const [editingHouseholdMemberId, setEditingHouseholdMemberId] = useState<number | null>(null);
   const [editForm, setEditForm] = useState({ name: "", email: "", dob: "", phone: "", isLead: false, over25: false });
   // Errors for the inline edit form. phone shown only after a Save attempt, so
   // the red ring never appears mid-typing.
@@ -233,37 +233,37 @@ export default function HouseholdPage() {
     setShowContactForm(true);
   };
 
-  const handleAddMember = async (e: React.FormEvent) => {
+  const handleAddHouseholdMember = async (e: React.FormEvent) => {
     e.preventDefault();
     setMessage(null);
-    const errs = validateMemberFields(memberForm);
-    setMemberErrors(errs);
+    const errs = validateHouseholdMemberFields(householdMemberForm);
+    setHouseholdMemberErrors(errs);
     if (Object.keys(errs).length > 0) return;
     try {
       const res = await fetch('/api/household', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ memberName: memberForm.name, memberEmail: memberForm.email, memberDob: memberForm.over25 ? "" : memberForm.dob, memberOver25: memberForm.over25 })
+        body: JSON.stringify({ memberName: householdMemberForm.name, memberEmail: householdMemberForm.email, memberDob: householdMemberForm.over25 ? "" : householdMemberForm.dob, memberOver25: householdMemberForm.over25 })
       });
       const data = await res.json();
       if (res.ok) {
-        setMemberForm({ name: "", email: "", dob: "", over25: false });
-        setMemberErrors({});
-        setAddingMember(false);
+        setHouseholdMemberForm({ name: "", email: "", dob: "", over25: false });
+        setHouseholdMemberErrors({});
+        setAddingHouseholdMember(false);
         fetchHousehold();
-        if (!applyContactWarning(data.warning)) ok(data.message || "Member added successfully!");
+        if (!applyContactWarning(data.warning)) ok(data.message || "Household member added successfully!");
       } else {
-        err(data.error || "Failed to add member.");
+        err(data.error || "Failed to add household member.");
       }
     } catch {
-      err("Network error adding member.");
+      err("Network error adding household member.");
     }
   };
 
-  const handleEditMember = async (e: React.FormEvent, participantId: number) => {
+  const handleEditHouseholdMember = async (e: React.FormEvent, participantId: number) => {
     e.preventDefault();
     setMessage(null);
-    const errs: { name?: string; email?: string; dob?: string; phone?: string } = validateMemberFields(editForm);
+    const errs: { name?: string; email?: string; dob?: string; phone?: string } = validateHouseholdMemberFields(editForm);
     if (editForm.phone && !isValidPhone(editForm.phone)) errs.phone = PHONE_ERROR;
     setEditErrors(errs);
     if (Object.keys(errs).length > 0) return;
@@ -276,7 +276,7 @@ export default function HouseholdPage() {
       const data = await res.json();
       if (res.ok) {
         setEditErrors({});
-        setEditingMemberId(null);
+        setEditingHouseholdMemberId(null);
         fetchHousehold();
         notifyNavRefresh();
         // A member edit can both collide with an emergency contact (warning,
@@ -284,14 +284,14 @@ export default function HouseholdPage() {
         // promotion (leadRejection). Surface the contact warning first since
         // it's the more urgent, then the lead caveat, else a plain success.
         if (!applyContactWarning(data.warning)) {
-          if (data.leadRejection) warn(`Member updated, but not added as a lead — ${data.leadRejection}`);
-          else ok(data.message || "Member updated successfully!");
+          if (data.leadRejection) warn(`Household member updated, but not added as a lead — ${data.leadRejection}`);
+          else ok(data.message || "Household member updated successfully!");
         }
       } else {
-        err(data.error || "Failed to update member.");
+        err(data.error || "Failed to update household member.");
       }
     } catch {
-      err("Network error updating member.");
+      err("Network error updating household member.");
     }
   };
 
@@ -301,13 +301,13 @@ export default function HouseholdPage() {
       const res = await fetch('/api/household/lead', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ participantId }) });
       const data = await res.json();
       if (res.ok) {
-        ok("Member promoted to lead successfully!");
+        ok("Household member promoted to lead successfully!");
         fetchHousehold();
       } else {
-        err(data.error || "Failed to promote member.");
+        err(data.error || "Failed to promote household member.");
       }
     } catch {
-      err("Network error promoting member.");
+      err("Network error promoting household member.");
     }
   };
 
@@ -331,7 +331,7 @@ export default function HouseholdPage() {
   const isLead = (pid: number) => household?.leads?.some((l) => l.participantId === pid) ?? false;
   const viewerIsLead = isLead(userId);
 
-  const sortedMembers = (household?.participants || []).slice().sort((a, b) => {
+  const sortedHouseholdMembers = (household?.participants || []).slice().sort((a, b) => {
     const isLeadA = isLead(a.id) ? 1 : 0;
     const isLeadB = isLead(b.id) ? 1 : 0;
     if (isLeadA !== isLeadB) return isLeadB - isLeadA;
@@ -378,16 +378,16 @@ export default function HouseholdPage() {
             <>
               <Title order={3} mb="md">Household Members</Title>
               <SimpleGrid cols={{ base: 1, sm: 2 }} mb="lg">
-                {sortedMembers.map((p) => {
-                  const memberIsLead = isLead(p.id);
+                {sortedHouseholdMembers.map((p) => {
+                  const householdMemberIsLead = isLead(p.id);
                   const isAdult = (p.dateOfBirth && calculateAge(p.dateOfBirth) >= 18) || p.isDeclaredAdult;
                   // A household lead needs a phone on file — flag the box so the
                   // lead can see exactly which member to fix (mirrors the nav todo).
-                  const leadMissingPhone = memberIsLead && !p.phone;
+                  const leadMissingPhone = householdMemberIsLead && !p.phone;
                   return (
                     <Card key={p.id} withBorder radius="md" padding="md" bg={leadMissingPhone ? 'var(--mantine-color-red-light)' : undefined}>
-                      {editingMemberId === p.id ? (
-                        <form onSubmit={(e) => handleEditMember(e, p.id)}>
+                      {editingHouseholdMemberId === p.id ? (
+                        <form onSubmit={(e) => handleEditHouseholdMember(e, p.id)}>
                           <Stack gap="xs">
                             <TextInput size="xs" label="Name" value={editForm.name} error={editErrors.name} onChange={(e) => { setEditForm({ ...editForm, name: e.currentTarget.value }); setEditErrors({ ...editErrors, name: undefined }); }} />
                             <TextInput size="xs" inputMode="email" label="Email" value={editForm.email} error={editErrors.email} onChange={(e) => { setEditForm({ ...editForm, email: e.currentTarget.value }); setEditErrors({ ...editErrors, email: undefined }); }} />
@@ -401,7 +401,7 @@ export default function HouseholdPage() {
                             )}
                             <Group gap="xs">
                               <Button type="submit" size="xs" fz={15} color="green">Save</Button>
-                              <Button type="button" size="xs" fz={15} variant="default" onClick={() => { setEditingMemberId(null); setEditErrors({}); }}>Cancel</Button>
+                              <Button type="button" size="xs" fz={15} variant="default" onClick={() => { setEditingHouseholdMemberId(null); setEditErrors({}); }}>Cancel</Button>
                             </Group>
                           </Stack>
                         </form>
@@ -415,15 +415,15 @@ export default function HouseholdPage() {
                           {p.phone && <Text size="sm" c="dimmed" style={{ wordBreak: 'break-word' }}>{formatPhone(p.phone)}</Text>}
                           {leadMissingPhone && <Badge color="red" variant="filled" mt="xs">TODO: Add phone number</Badge>}
                           <Group gap="xs" mt="sm">
-                            {memberIsLead && <Badge color="grape" variant="light">Household Lead</Badge>}
-                            {!memberIsLead && isAdult && viewerIsLead && (
+                            {householdMemberIsLead && <Badge color="grape" variant="light">Household Lead</Badge>}
+                            {!householdMemberIsLead && isAdult && viewerIsLead && (
                               <Button size="compact-xs" variant="light" onClick={() => handleMakeLead(p.id)}>Make Lead</Button>
                             )}
                             {(viewerIsLead || p.id === userId) && (
                               <Button size="compact-xs" variant="subtle" color="gray" onClick={() => {
-                                setEditingMemberId(p.id);
+                                setEditingHouseholdMemberId(p.id);
                                 setEditErrors({});
-                                setEditForm({ name: p.name || "", email: p.email || "", dob: p.dateOfBirth ? new Date(p.dateOfBirth).toISOString().split('T')[0] : "", phone: p.phone || "", isLead: memberIsLead, over25: !p.dateOfBirth && !!p.isDeclaredAdult });
+                                setEditForm({ name: p.name || "", email: p.email || "", dob: p.dateOfBirth ? new Date(p.dateOfBirth).toISOString().split('T')[0] : "", phone: p.phone || "", isLead: householdMemberIsLead, over25: !p.dateOfBirth && !!p.isDeclaredAdult });
                               }}>Edit</Button>
                             )}
                           </Group>
@@ -434,11 +434,11 @@ export default function HouseholdPage() {
                 })}
               </SimpleGrid>
 
-              {(isStaffAccount || !viewerIsLead) ? null : !addingMember ? (
-                <Button variant="light" onClick={() => { setMemberErrors({}); setAddingMember(true); }}>+ Add Household Member</Button>
+              {(isStaffAccount || !viewerIsLead) ? null : !addingHouseholdMember ? (
+                <Button variant="light" onClick={() => { setHouseholdMemberErrors({}); setAddingHouseholdMember(true); }}>+ Add Household Member</Button>
               ) : (
                 <Card withBorder radius="md" padding="lg">
-                  <form onSubmit={handleAddMember}>
+                  <form onSubmit={handleAddHouseholdMember}>
                     <Title order={4}>Household Member Registration</Title>
                     <Text c="dimmed" size="sm" mb="lg">
                       If you enter an email address, their account will be correctly linked to this
@@ -446,15 +446,15 @@ export default function HouseholdPage() {
                       are a student dependent who will not sign in themselves.
                     </Text>
                     <Stack>
-                      <TextInput label="Full Name" value={memberForm.name} error={memberErrors.name} onChange={(e) => { setMemberForm({ ...memberForm, name: e.currentTarget.value }); setMemberErrors({ ...memberErrors, name: undefined }); }} />
-                      <TextInput inputMode="email" label="Email (Optional)" value={memberForm.email} error={memberErrors.email} onChange={(e) => { setMemberForm({ ...memberForm, email: e.currentTarget.value }); setMemberErrors({ ...memberErrors, email: undefined }); }} placeholder="spouse@example.com" />
-                      <Checkbox label="Individual is over 25" checked={memberForm.over25} onChange={(e) => { setMemberForm({ ...memberForm, over25: e.currentTarget.checked, dob: e.currentTarget.checked ? "" : memberForm.dob }); setMemberErrors({ ...memberErrors, dob: undefined }); }} />
-                      {!memberForm.over25 && (
-                        <TextInput type="date" label="Date of Birth" value={memberForm.dob} error={memberErrors.dob} onChange={(e) => { setMemberForm({ ...memberForm, dob: e.currentTarget.value }); setMemberErrors({ ...memberErrors, dob: undefined }); }} />
+                      <TextInput label="Full Name" value={householdMemberForm.name} error={householdMemberErrors.name} onChange={(e) => { setHouseholdMemberForm({ ...householdMemberForm, name: e.currentTarget.value }); setHouseholdMemberErrors({ ...householdMemberErrors, name: undefined }); }} />
+                      <TextInput inputMode="email" label="Email (Optional)" value={householdMemberForm.email} error={householdMemberErrors.email} onChange={(e) => { setHouseholdMemberForm({ ...householdMemberForm, email: e.currentTarget.value }); setHouseholdMemberErrors({ ...householdMemberErrors, email: undefined }); }} placeholder="spouse@example.com" />
+                      <Checkbox label="Individual is over 25" checked={householdMemberForm.over25} onChange={(e) => { setHouseholdMemberForm({ ...householdMemberForm, over25: e.currentTarget.checked, dob: e.currentTarget.checked ? "" : householdMemberForm.dob }); setHouseholdMemberErrors({ ...householdMemberErrors, dob: undefined }); }} />
+                      {!householdMemberForm.over25 && (
+                        <TextInput type="date" label="Date of Birth" value={householdMemberForm.dob} error={householdMemberErrors.dob} onChange={(e) => { setHouseholdMemberForm({ ...householdMemberForm, dob: e.currentTarget.value }); setHouseholdMemberErrors({ ...householdMemberErrors, dob: undefined }); }} />
                       )}
                       <Group grow>
-                        <Button type="submit" color="green">Save / Invite Member</Button>
-                        <Button type="button" variant="default" onClick={() => { setAddingMember(false); setMemberErrors({}); }}>Cancel</Button>
+                        <Button type="submit" color="green">Save / Invite Household Member</Button>
+                        <Button type="button" variant="default" onClick={() => { setAddingHouseholdMember(false); setHouseholdMemberErrors({}); }}>Cancel</Button>
                       </Group>
                     </Stack>
                   </form>

--- a/checkin-app/src/app/safety/emergency-contacts/__tests__/page.test.tsx
+++ b/checkin-app/src/app/safety/emergency-contacts/__tests__/page.test.tsx
@@ -54,7 +54,7 @@ describe("safety/emergency-contacts page", () => {
     renderWithProviders(<EmergencyContactsPage />);
     await screen.findByText("Keyholder House");
 
-    fireEvent.change(screen.getByPlaceholderText("Search by Household Name, Parent Name, or Member Name..."), {
+    fireEvent.change(screen.getByPlaceholderText("Search by Household Name, Parent Name, or Household Member Name..."), {
       target: { value: "Away" },
     });
 

--- a/checkin-app/src/app/safety/emergency-contacts/page.tsx
+++ b/checkin-app/src/app/safety/emergency-contacts/page.tsx
@@ -108,7 +108,7 @@ export default function EmergencyContactsPage() {
         <TextInput
           mt="md"
           size="md"
-          placeholder="Search by Household Name, Parent Name, or Member Name..."
+          placeholder="Search by Household Name, Parent Name, or Household Member Name..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.currentTarget.value)}
         />
@@ -130,7 +130,7 @@ export default function EmergencyContactsPage() {
                   <Text fw={600} fz="lg">{h.name || `Household #${h.id}`}</Text>
                   {h.isPresent && <Badge color="cyan" variant="light">Present Now</Badge>}
                 </Group>
-                <Text size="sm" c="dimmed">Members:</Text>
+                <Text size="sm" c="dimmed">Household members:</Text>
                 {h.participants.length > 0 ? (
                   <List size="sm">
                     {h.participants.map((p) => (
@@ -141,7 +141,7 @@ export default function EmergencyContactsPage() {
                     ))}
                   </List>
                 ) : (
-                  <Text size="sm" c="dimmed" fs="italic">No enrolled members</Text>
+                  <Text size="sm" c="dimmed" fs="italic">No household members</Text>
                 )}
               </div>
 

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -211,7 +211,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
     if (!user) throw new IntakeError("no_household", "User not found.");
     assertLead(user);
     const householdId = user.householdId!;
-    const householdParticipantIds = new Set((user.household?.participants ?? []).map((p) => p.id));
+    const householdMemberIds = new Set((user.household?.participants ?? []).map((p) => p.id));
 
     const toDate = (d?: string | null) => (d ? new Date(d) : null);
 
@@ -274,7 +274,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
     // Secondary parent: update if it belongs to this household, else create.
     if (input.secondaryParent) {
         const sp = input.secondaryParent;
-        if (sp.id && householdParticipantIds.has(sp.id)) {
+        if (sp.id && householdMemberIds.has(sp.id)) {
             await prisma.participant.update({
                 where: { id: sp.id },
                 data: {
@@ -302,7 +302,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
     // Children are non-lead household members. Update existing (own household
     // only), create the rest. Never delete; never add a HouseholdLead row.
     for (const child of input.children ?? []) {
-        if (child.id && householdParticipantIds.has(child.id)) {
+        if (child.id && householdMemberIds.has(child.id)) {
             await prisma.participant.update({
                 where: { id: child.id },
                 data: {


### PR DESCRIPTION
## What

Phase 3 of the participant-terminology migration. Retires the ambiguous sense-B **member** (any person in a household) in favor of **householdMember** in code / **"household member"** in UI. No logic changes.

## Canonical dictionary (agreed this session)

A Person in a Household is a *household member* (the Household Membership relationship). Bare `member` / `Membership` is banned in both code and UI — always qualified by *which* membership:

| Concept | Relationship | UI word | Code |
|---|---|---|---|
| Person | the human | name | `Participant` model |
| **Org Membership (A)** | Person/household ↔ Org | "Treehouse Member" | `Membership` → `OrgMembership` *(later phase)* |
| Household | grouping | "household" / "family" | `Household` |
| **Household Membership (B)** | Person ↔ Household | **"household member"** | **`householdMember`** ← this PR |
| **Program relationship** | Person ↔ Program | **"participant"** | `ProgramParticipant` |

This supersedes an earlier attempt that renamed sense B → `participant`; that put "participant" on the household relationship and collided with the Program one. Reverted and redone as `householdMember`.

## Changed

- **Route** stays `PATCH /api/household/member` (the `/household/` segment qualifies it). Vars → `targetHouseholdMember`/`updatedHouseholdMember`; response key `{ member }` → `{ householdMember }`; messages qualified ("…edit household members", "That household member was not found", "Household member updated…").
- **`my-household/page.tsx`**: sense-B identifiers → `householdMember*` (`type HouseholdMember`, `householdMemberForm`/`Errors`, `adding`/`editing`/`sorted`, `validate`/`handleAdd`/`handleEdit`). Parent-facing toasts qualified to "household member".
- **`events/mine`, `programs/mine`**: household-scoped locals → `householdMembers`/`householdMemberIds`/`householdMemberById`. **Kept `programParticipants`** (that IS the Program relationship) and the Prisma `participant`/`participantId` fields. `activityMembers` helper kept.
- **`membership/intake.ts`**: local `householdParticipantIds` → `householdMemberIds`.
- **`attendance/household`, `safety/emergency-contacts`**: UI copy qualified — "Household Member" / "household members" (no bare "Member").
- **Tests**: integration file `householdMemberAPI`, import/URLs/`{householdMember}` key/message assertions; `my-household` + `safety` page-test mock keys and labels.

## Deliberately out of scope

- **Sense A (Org Membership)**: `Membership` → `OrgMembership`, `isActiveMember` → `isActiveOrgMember`, UI "Member Price"/"become a member" → "Treehouse Member". That's a **schema migration** — its own later phase.
- Kept per design: `participantId` (Person id), the `participants` relation field from `/api/household`, `tableName: "Participant"`, `activityMembers`/`ActivityMember`, `ToolManagementPanel` local `Member`.

## Verification

- `npx tsc --noEmit` clean.
- No `api/household/participant` or `HouseholdParticipant` left in `src`.
- Route dir `api/household/member/route.ts` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)