### PR TITLE
fix(trends): split facility hours by program enrollment, not age

### DIFF
--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -6,10 +6,10 @@
  *
  * 401/403 (roles: isSysadmin, isBoardMember) are already covered by
  * authzRoleRejection.integration.test.ts — this file focuses on the success
- * path: bucketing visits by period, the volunteer/student split (by age at
- * arrival), structured (event-associated) vs unstructured hours, the
- * `arrivedVia=SYSTEM` exclusion (synthetic "marked present" visits), the
- * `programId` filter, and the invalid-period 400.
+ * path: bucketing visits by period, the volunteer/participant split (by program
+ * enrollment — ProgramParticipant, NOT age), structured (event-associated) vs
+ * unstructured hours, the `arrivedVia=SYSTEM` exclusion (synthetic "marked
+ * present" visits), the `programId` filter, and the invalid-period 400.
  */
 
 import { GET } from '@/app/api/facility/trends/route';
@@ -25,8 +25,9 @@ const TAG = 'facility-trends-test';
 describe('Facility trends API', () => {
     let adminId: number;
     let householdId: number;
-    let volunteerId: number; // adult, dateOfBirth makes them 30+
-    let studentId: number; // dateOfBirth makes them a youth
+    let volunteerId: number; // adult, not enrolled -> volunteer
+    let enrolledAdultId: number; // adult, ACTIVE ProgramParticipant -> participant (proves age doesn't drive it)
+    let youthId: number; // youth by DOB, not enrolled -> volunteer (proves age doesn't drive it)
     let programId: number;
     let otherProgramId: number;
     let eventId: number;
@@ -45,10 +46,14 @@ describe('Facility trends API', () => {
             data: { email: `volunteer-${TAG}@example.com`, name: 'Volunteer', dateOfBirth: new Date('1980-01-01'), householdId },
         });
         volunteerId = volunteer.id;
-        const student = await prisma.participant.create({
-            data: { email: `student-${TAG}@example.com`, name: 'Student', dateOfBirth: new Date('2015-01-01'), householdId },
+        const enrolledAdult = await prisma.participant.create({
+            data: { email: `enrolled-${TAG}@example.com`, name: 'Enrolled Adult', dateOfBirth: new Date('1985-01-01'), householdId },
         });
-        studentId = student.id;
+        enrolledAdultId = enrolledAdult.id;
+        const youth = await prisma.participant.create({
+            data: { email: `youth-${TAG}@example.com`, name: 'Youth', dateOfBirth: new Date('2015-01-01'), householdId },
+        });
+        youthId = youth.id;
 
         const program = await prisma.program.create({ data: { name: `Prog ${TAG}` } });
         programId = program.id;
@@ -59,13 +64,22 @@ describe('Facility trends API', () => {
         });
         eventId = event.id;
 
-        // Structured visit (associated to the event): volunteer, 3 hours.
-        const structured = await prisma.visit.create({
-            data: { participantId: volunteerId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SCANNER', associatedEventId: eventId },
+        // Enroll the adult in `programId` (ACTIVE) — this, not their age, makes them a participant.
+        await prisma.programParticipant.create({
+            data: { programId, participantId: enrolledAdultId, status: 'ACTIVE' },
         });
-        // Unstructured visit (no event): student, 1 hour.
+
+        // Structured visit (associated to the event): enrolled adult, 3 hours -> participant.
+        const structured = await prisma.visit.create({
+            data: { participantId: enrolledAdultId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SCANNER', associatedEventId: eventId },
+        });
+        // Structured visit (associated to the event): non-enrolled youth, 2 hours -> volunteer.
+        const youthStructured = await prisma.visit.create({
+            data: { participantId: youthId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(3), arrivedVia: 'SCANNER', associatedEventId: eventId },
+        });
+        // Unstructured visit (no event): non-enrolled adult volunteer, 1 hour.
         const unstructured = await prisma.visit.create({
-            data: { participantId: studentId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(3), arrivedVia: 'WEB' },
+            data: { participantId: volunteerId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(3), arrivedVia: 'WEB' },
         });
         // Synthetic "marked present" visit (arrivedVia SYSTEM) — must be excluded entirely.
         const synthetic = await prisma.visit.create({
@@ -73,16 +87,17 @@ describe('Facility trends API', () => {
         });
         // Still-open visit (no departedAt) — excluded (departedAt: { not: null } in the where).
         const open = await prisma.visit.create({
-            data: { participantId: studentId, arrivedAt: hoursAgo(1), arrivedVia: 'WEB' },
+            data: { participantId: youthId, arrivedAt: hoursAgo(1), arrivedVia: 'WEB' },
         });
-        visitIds.push(structured.id, unstructured.id, synthetic.id, open.id);
+        visitIds.push(structured.id, youthStructured.id, unstructured.id, synthetic.id, open.id);
     });
 
     afterAll(async () => {
         await prisma.visit.deleteMany({ where: { id: { in: visitIds } } });
+        await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.event.deleteMany({ where: { id: eventId } });
         await prisma.program.deleteMany({ where: { id: { in: [programId, otherProgramId] } } });
-        await prisma.participant.deleteMany({ where: { id: { in: [adminId, volunteerId, studentId] } } });
+        await prisma.participant.deleteMany({ where: { id: { in: [adminId, volunteerId, enrolledAdultId, youthId] } } });
         await prisma.household.deleteMany({ where: { id: householdId } });
     });
 
@@ -97,7 +112,7 @@ describe('Facility trends API', () => {
         expect(res.status).toBe(400);
     });
 
-    it('buckets visits, splitting volunteer/student and structured/unstructured hours', async () => {
+    it('buckets visits, splitting volunteer/participant and structured/unstructured hours', async () => {
         const res = await callAs({ id: adminId, isSysadmin: true }, '?period=month');
         expect(res.status).toBe(200);
         const data = await res.json();
@@ -107,13 +122,28 @@ describe('Facility trends API', () => {
         // Everything we seeded lands in the current month's bucket.
         const thisMonth = data.buckets[data.buckets.length - 1];
         expect(thisMonth.uniqueVolunteers).toBeGreaterThanOrEqual(1);
-        expect(thisMonth.uniqueStudents).toBeGreaterThanOrEqual(1);
-        // Structured (event-associated) = the 3-hour volunteer visit; unstructured = the
-        // 1-hour student visit. SYSTEM-sourced and still-open visits are excluded, so
-        // totals reflect only those two.
-        expect(thisMonth.structuredHours).toBeGreaterThanOrEqual(3);
+        expect(thisMonth.uniqueParticipants).toBeGreaterThanOrEqual(1);
+        // Structured (event-associated) = the 3h enrolled-adult + 2h youth visits; unstructured =
+        // the 1h volunteer visit. SYSTEM-sourced and still-open visits are excluded.
+        expect(thisMonth.structuredHours).toBeGreaterThanOrEqual(5);
         expect(thisMonth.unstructuredHours).toBeGreaterThanOrEqual(1);
         expect(data.totals.label).toBe('Total');
+    });
+
+    it('splits by program enrollment, not age', async () => {
+        // Scope to `programId` so only this test's event-associated visits are counted
+        // (deterministic — otherProgramId/global data can't leak in). Two visits qualify:
+        // the enrolled adult (3h) and the non-enrolled youth (2h).
+        const res = await callAs({ id: adminId, isSysadmin: true }, `?period=month&programId=${programId}`);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+
+        // Enrolled ADULT counts as a participant — age (35+) does not demote them.
+        expect(data.totals.uniqueParticipants).toBe(1);
+        expect(data.totals.totalParticipantHours).toBe(3);
+        // Non-enrolled YOUTH counts as a volunteer — age (<18) does not make them a participant.
+        expect(data.totals.uniqueVolunteers).toBe(1);
+        expect(data.totals.totalVolunteerHours).toBe(2);
     });
 
     it('scopes to a single program via programId', async () => {
@@ -123,6 +153,6 @@ describe('Facility trends API', () => {
         // No visits are associated with otherProgramId's events (it has none) — empty result.
         expect(data.buckets).toEqual([]);
         expect(data.totals.uniqueVolunteers).toBe(0);
-        expect(data.totals.uniqueStudents).toBe(0);
+        expect(data.totals.uniqueParticipants).toBe(0);
     });
 });

--- a/checkin-app/src/app/api/facility/trends/route.ts
+++ b/checkin-app/src/app/api/facility/trends/route.ts
@@ -2,13 +2,8 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { getAppSettings } from "@/lib/appSettings";
-import { calculateAge } from "@/lib/time";
 
 type PeriodType = "week" | "month" | "quarter" | "year";
-
-function isStudentAtDate(dob: Date | null, refDate: Date): boolean {
-    return dob ? calculateAge(dob, refDate) < 18 : false;
-}
 
 function getHoursBetween(arrived: Date, departed: Date | null): number {
     if (!departed) return 0;
@@ -63,9 +58,9 @@ export interface TrendBucket {
     label: string;
     periodStart: string;
     uniqueVolunteers: number;
-    uniqueStudents: number;
+    uniqueParticipants: number;
     totalVolunteerHours: number;
-    totalStudentHours: number;
+    totalParticipantHours: number;
     structuredHours: number;
     unstructuredHours: number;
 }
@@ -104,19 +99,29 @@ export const GET = withAuth(
             const visits = await prisma.visit.findMany({
                 where: whereClause,
                 include: {
-                    participant: { select: { id: true, dateOfBirth: true } },
+                    participant: { select: { id: true } },
                     event: { select: { programId: true } },
                 },
                 orderBy: { arrivedAt: "asc" },
             });
 
+            // "Participant hours" = hours logged by people ENROLLED in a program
+            // (ProgramParticipant), not an age proxy. Per-program view counts enrollment in
+            // that program; aggregate view counts enrollment in any program. Only ACTIVE
+            // enrollments count — PENDING is applied-but-not-yet-approved, not an enrollee.
+            const enrollments = await prisma.programParticipant.findMany({
+                where: { status: "ACTIVE", ...(programId ? { programId } : {}) },
+                select: { participantId: true },
+            });
+            const enrolledParticipantIds = new Set(enrollments.map(e => e.participantId));
+
             const bucketMap = new Map<string, {
                 label: string;
                 periodStart: Date;
                 volunteerIds: Set<number>;
-                studentIds: Set<number>;
+                participantIds: Set<number>;
                 volunteerHours: number;
-                studentHours: number;
+                participantHours: number;
                 structuredHours: number;
                 unstructuredHours: number;
             }>();
@@ -130,9 +135,9 @@ export const GET = withAuth(
                         label: formatPeriodLabel(periodStart, period, locale),
                         periodStart,
                         volunteerIds: new Set(),
-                        studentIds: new Set(),
+                        participantIds: new Set(),
                         volunteerHours: 0,
-                        studentHours: 0,
+                        participantHours: 0,
                         structuredHours: 0,
                         unstructuredHours: 0,
                     });
@@ -140,11 +145,11 @@ export const GET = withAuth(
 
                 const bucket = bucketMap.get(key)!;
                 const hours = getHoursBetween(visit.arrivedAt, visit.departedAt);
-                const student = isStudentAtDate(visit.participant.dateOfBirth, visit.arrivedAt);
+                const isParticipant = enrolledParticipantIds.has(visit.participant.id);
 
-                if (student) {
-                    bucket.studentIds.add(visit.participant.id);
-                    bucket.studentHours += hours;
+                if (isParticipant) {
+                    bucket.participantIds.add(visit.participant.id);
+                    bucket.participantHours += hours;
                 } else {
                     bucket.volunteerIds.add(visit.participant.id);
                     bucket.volunteerHours += hours;
@@ -163,9 +168,9 @@ export const GET = withAuth(
                     label: b.label,
                     periodStart: b.periodStart.toISOString(),
                     uniqueVolunteers: b.volunteerIds.size,
-                    uniqueStudents: b.studentIds.size,
+                    uniqueParticipants: b.participantIds.size,
                     totalVolunteerHours: Math.round(b.volunteerHours * 10) / 10,
-                    totalStudentHours: Math.round(b.studentHours * 10) / 10,
+                    totalParticipantHours: Math.round(b.participantHours * 10) / 10,
                     structuredHours: Math.round(b.structuredHours * 10) / 10,
                     unstructuredHours: Math.round(b.unstructuredHours * 10) / 10,
                 }));
@@ -173,10 +178,10 @@ export const GET = withAuth(
             const totals: TrendBucket = {
                 label: "Total",
                 periodStart: "",
-                uniqueVolunteers: new Set(visits.filter(v => !isStudentAtDate(v.participant.dateOfBirth, v.arrivedAt)).map(v => v.participant.id)).size,
-                uniqueStudents: new Set(visits.filter(v => isStudentAtDate(v.participant.dateOfBirth, v.arrivedAt)).map(v => v.participant.id)).size,
+                uniqueVolunteers: new Set(visits.filter(v => !enrolledParticipantIds.has(v.participant.id)).map(v => v.participant.id)).size,
+                uniqueParticipants: new Set(visits.filter(v => enrolledParticipantIds.has(v.participant.id)).map(v => v.participant.id)).size,
                 totalVolunteerHours: Math.round(buckets.reduce((s, b) => s + b.totalVolunteerHours, 0) * 10) / 10,
-                totalStudentHours: Math.round(buckets.reduce((s, b) => s + b.totalStudentHours, 0) * 10) / 10,
+                totalParticipantHours: Math.round(buckets.reduce((s, b) => s + b.totalParticipantHours, 0) * 10) / 10,
                 structuredHours: Math.round(buckets.reduce((s, b) => s + b.structuredHours, 0) * 10) / 10,
                 unstructuredHours: Math.round(buckets.reduce((s, b) => s + b.unstructuredHours, 0) * 10) / 10,
             };

--- a/checkin-app/src/app/facility-ops/trends/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/trends/__tests__/page.test.tsx
@@ -11,9 +11,9 @@ beforeEach(() => resetRtl());
 
 const trendsData = {
   buckets: [
-    { label: "Jan 2026", periodStart: "2026-01-01", uniqueVolunteers: 3, uniqueStudents: 5, totalVolunteerHours: 12.5, totalStudentHours: 0.5, structuredHours: 8, unstructuredHours: 4.5 },
+    { label: "Jan 2026", periodStart: "2026-01-01", uniqueVolunteers: 3, uniqueParticipants: 5, totalVolunteerHours: 12.5, totalParticipantHours: 0.5, structuredHours: 8, unstructuredHours: 4.5 },
   ],
-  totals: { label: "Total", periodStart: "", uniqueVolunteers: 3, uniqueStudents: 5, totalVolunteerHours: 12.5, totalStudentHours: 0.5, structuredHours: 8, unstructuredHours: 4.5 },
+  totals: { label: "Total", periodStart: "", uniqueVolunteers: 3, uniqueParticipants: 5, totalVolunteerHours: 12.5, totalParticipantHours: 0.5, structuredHours: 8, unstructuredHours: 4.5 },
 };
 
 function mockRoutes() {
@@ -32,7 +32,7 @@ describe("facility-ops/trends page", () => {
     expect(await screen.findByText("Jan 2026")).toBeInTheDocument();
     expect(screen.getByText("Unique Volunteers")).toBeInTheDocument();
     expect(screen.getAllByText("3").length).toBeGreaterThan(0); // uniqueVolunteers, in both the stat card and table
-    expect(screen.getAllByText("30m").length).toBeGreaterThan(0); // totalStudentHours 0.5h -> "30m"
+    expect(screen.getAllByText("30m").length).toBeGreaterThan(0); // totalParticipantHours 0.5h -> "30m"
   });
 
   it("re-fetches trends when the period changes", async () => {

--- a/checkin-app/src/app/facility-ops/trends/page.tsx
+++ b/checkin-app/src/app/facility-ops/trends/page.tsx
@@ -10,9 +10,9 @@ interface TrendBucket {
   label: string;
   periodStart: string;
   uniqueVolunteers: number;
-  uniqueStudents: number;
+  uniqueParticipants: number;
   totalVolunteerHours: number;
-  totalStudentHours: number;
+  totalParticipantHours: number;
   structuredHours: number;
   unstructuredHours: number;
 }
@@ -79,9 +79,9 @@ export default function ParticipationTrendsPage() {
 
   const stats: { value: string | number; label: string }[] = totals ? [
     { value: totals.uniqueVolunteers, label: "Unique Volunteers" },
-    { value: totals.uniqueStudents, label: "Unique Students" },
+    { value: totals.uniqueParticipants, label: "Unique Participants" },
     { value: fmtHours(totals.totalVolunteerHours), label: "Volunteer Hours" },
-    { value: fmtHours(totals.totalStudentHours), label: "Student Hours" },
+    { value: fmtHours(totals.totalParticipantHours), label: "Participant Hours" },
     { value: fmtHours(totals.structuredHours), label: "Program Hours" },
     { value: fmtHours(totals.unstructuredHours), label: "Unstructured Hours" },
   ] : [];
@@ -130,9 +130,9 @@ export default function ParticipationTrendsPage() {
             <Table.Tr>
               <Table.Th>Period</Table.Th>
               <Table.Th>Volunteers</Table.Th>
-              <Table.Th>Students</Table.Th>
+              <Table.Th>Participants</Table.Th>
               <Table.Th>Vol. Hours</Table.Th>
-              <Table.Th>Stu. Hours</Table.Th>
+              <Table.Th>Part. Hours</Table.Th>
               <Table.Th>Program</Table.Th>
               <Table.Th>Unstructured</Table.Th>
             </Table.Tr>
@@ -149,9 +149,9 @@ export default function ParticipationTrendsPage() {
                 <Table.Tr key={b.periodStart}>
                   <Table.Td>{b.label}</Table.Td>
                   <Table.Td>{b.uniqueVolunteers}</Table.Td>
-                  <Table.Td>{b.uniqueStudents}</Table.Td>
+                  <Table.Td>{b.uniqueParticipants}</Table.Td>
                   <Table.Td>{fmtHours(b.totalVolunteerHours)}</Table.Td>
-                  <Table.Td>{fmtHours(b.totalStudentHours)}</Table.Td>
+                  <Table.Td>{fmtHours(b.totalParticipantHours)}</Table.Td>
                   <Table.Td>{fmtHours(b.structuredHours)}</Table.Td>
                   <Table.Td>{fmtHours(b.unstructuredHours)}</Table.Td>
                 </Table.Tr>
@@ -163,9 +163,9 @@ export default function ParticipationTrendsPage() {
               <Table.Tr>
                 <Table.Th>Total</Table.Th>
                 <Table.Th>{totals.uniqueVolunteers}</Table.Th>
-                <Table.Th>{totals.uniqueStudents}</Table.Th>
+                <Table.Th>{totals.uniqueParticipants}</Table.Th>
                 <Table.Th>{fmtHours(totals.totalVolunteerHours)}</Table.Th>
-                <Table.Th>{fmtHours(totals.totalStudentHours)}</Table.Th>
+                <Table.Th>{fmtHours(totals.totalParticipantHours)}</Table.Th>
                 <Table.Th>{fmtHours(totals.structuredHours)}</Table.Th>
                 <Table.Th>{fmtHours(totals.unstructuredHours)}</Table.Th>
               </Table.Tr>


### PR DESCRIPTION
## The bug
`checkin-app/src/app/api/facility/trends/route.ts` split visit-hours into "volunteer" vs "student" purely by **age** (`<18 = student`). The report's real intent is **participant hours = hours logged by program enrollees**, vs volunteer hours. Age was the wrong proxy: a 30yo enrolled participant counted as "volunteer"; an 11yo who never enrolled counted as "student". The route never touched enrollment.

## What changed
- **route.ts**: removed `isStudentAtDate` (+ unused `calculateAge` import). Split now driven by a single `ProgramParticipant` query → `enrolledParticipantIds` set. Renamed wire keys `uniqueStudents`→`uniqueParticipants`, `totalStudentHours`→`totalParticipantHours`; internal `studentIds`/`studentHours`→`participant*`.
- **facility-ops/trends/page.tsx**: interface + reads + visible labels ("Unique Participants", "Participant Hours", table "Participants"/"Part. Hours").
- **Tests**: integration fixtures now enroll an adult via `ProgramParticipant`; new `splits by program enrollment, not age` case proves an enrolled adult counts as participant and a non-enrolled youth does not. Page test mock keys renamed.

## Design decision
"Participant hours" = hours by program enrollees (`ProgramParticipant`), **status `ACTIVE` only** — `PENDING` = applied-not-approved, not yet an enrollee.
- **per-program view** (`programId` set): enrolled in *that* program.
- **aggregate view**: enrolled in *any* program.

## Out of scope (left untouched — genuinely age-based)
Attendance "Students" column, the two-deep youth safety banner, `getFullAttendance.ts`. Prisma `participant`/`participantId` kept per the vocabulary dictionary.

## Verify
- `npx tsc --noEmit` clean.
- Page test 2/2; integration test 4/4 (throwaway Postgres, `--runInBand`).

## Reviewer notes
- Unblocks the paused **student→youth Phase 2** branch, which will rebase on top once merged.
- Team likely wants to record this in `PARTICIPANT_TERMINOLOGY_PROPOSAL.md` as a new BUG (trends measured age, not enrollment — sibling of BUG-1). Doc **not** edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)