### PR TITLE
refactor(youth): rename age-based "student" identifiers → youth (phase 2, BUG-1)

### DIFF
--- a/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
+++ b/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
@@ -16,7 +16,7 @@ const attendanceData = {
     { id: 202, arrivedAt: "2026-07-01T14:05:00.000Z", participant: { id: 60, email: "val@example.com", name: "Val Volunteer", isKeyholder: false, isSysadmin: false, dateOfBirth: "1990-01-01", householdId: 7 } },
     { id: 203, arrivedAt: "2026-07-01T14:10:00.000Z", participant: { id: 70, email: "stu@example.com", name: "Stu Student", isKeyholder: false, isSysadmin: false, dateOfBirth: "2012-01-01", householdId: 8 } },
   ],
-  counts: { keyholders: 1, volunteers: 1, students: 1, total: 3 },
+  counts: { keyholders: 1, volunteers: 1, youth: 1, total: 3 },
   safety: { isLastKeyholder: false, isTwoDeepViolation: false },
 };
 

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -31,13 +31,11 @@ type Visit = {
   event?: { program?: { id: number; name: string } };
 };
 
-type Counts = { keyholders: number; volunteers: number; students: number; total: number };
+type Counts = { keyholders: number; volunteers: number; youth: number; total: number };
 type SafetyFlags = { isLastKeyholder: boolean; isTwoDeepViolation: boolean };
 type FullResponse = { access: "full"; attendance: Visit[]; counts: Counts; safety: SafetyFlags };
 type LimitedResponse = { access: "limited"; counts: Counts; safety: SafetyFlags; self: Visit | null; household: Visit[] };
 type AttendanceResponse = FullResponse | LimitedResponse;
-
-const isStudent = (dob: string | undefined | null) => isYouth(dob);
 
 type SessionUser = { id: number; isSysadmin?: boolean; isKeyholder?: boolean; isBoardMember?: boolean; householdId?: number | null };
 
@@ -67,19 +65,19 @@ function KioskDisplayInner() {
   const canCheckInHousehold = Boolean(currentUserHouseholdId);
 
   const isFull = data?.access === "full";
-  const counts = data?.counts || { keyholders: 0, volunteers: 0, students: 0, total: 0 };
+  const counts = data?.counts || { keyholders: 0, volunteers: 0, youth: 0, total: 0 };
   const safety = data?.safety || { isLastKeyholder: false, isTwoDeepViolation: false };
 
   const fullAttendance = isFull ? (data as FullResponse).attendance : [];
   const keyholderList = fullAttendance.filter(v => v.participant.isKeyholder);
-  const volunteerList = fullAttendance.filter(v => !v.participant.isKeyholder && !isStudent(v.participant.dateOfBirth));
-  const studentList = fullAttendance.filter(v => isStudent(v.participant.dateOfBirth));
+  const volunteerList = fullAttendance.filter(v => !v.participant.isKeyholder && !isYouth(v.participant.dateOfBirth));
+  const youthList = fullAttendance.filter(v => isYouth(v.participant.dateOfBirth));
 
   const limitedHousehold = !isFull && data ? (data as LimitedResponse).household : [];
   const limitedSelf = !isFull && data ? (data as LimitedResponse).self : null;
   const householdKeyholders = limitedHousehold.filter(v => v.participant.isKeyholder);
-  const householdVolunteers = limitedHousehold.filter(v => !v.participant.isKeyholder && !isStudent(v.participant.dateOfBirth));
-  const householdStudents = limitedHousehold.filter(v => isStudent(v.participant.dateOfBirth));
+  const householdVolunteers = limitedHousehold.filter(v => !v.participant.isKeyholder && !isYouth(v.participant.dateOfBirth));
+  const householdYouth = limitedHousehold.filter(v => isYouth(v.participant.dateOfBirth));
 
   const isCheckedIn = isFull
     ? fullAttendance.some(v => v.participant.id === (session?.user as SessionUser)?.id)
@@ -244,9 +242,9 @@ function KioskDisplayInner() {
 
   const kioskDisplayNames = useMemo(() => {
     if (!isKioskMode) return new Map<number, string>();
-    const allVisits = [...keyholderList, ...volunteerList, ...studentList];
+    const allVisits = [...keyholderList, ...volunteerList, ...youthList];
     return getKioskDisplayNames(allVisits.map(v => ({ id: v.participant.id, name: v.participant.name || null, email: v.participant.email })));
-  }, [isKioskMode, keyholderList, volunteerList, studentList]);
+  }, [isKioskMode, keyholderList, volunteerList, youthList]);
 
   const canSeeNames = !isKioskMode && (currentUserIsKeyholder || currentUserIsSysadmin || currentUserIsBoardMember);
 
@@ -395,7 +393,7 @@ function KioskDisplayInner() {
         {/* Safety warnings */}
         {safety.isTwoDeepViolation && (
           <Alert color="red" icon="🚨" title="Critical Warning" mb="lg">
-            Two-Deep Compliance is failing! An unaccompanied student is present without sufficient
+            Two-Deep Compliance is failing! An unaccompanied youth is present without sufficient
             adult supervision.
           </Alert>
         )}
@@ -416,7 +414,7 @@ function KioskDisplayInner() {
           <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
             {renderColumn("🔑", counts.keyholders, "Keyholders", "blue", isFull ? keyholderList : householdKeyholders)}
             {renderColumn("🤝", counts.volunteers, "Volunteers/Adults", "teal", isFull ? volunteerList : householdVolunteers)}
-            {renderColumn("🎓", counts.students, "Students", "grape", isFull ? studentList : householdStudents)}
+            {renderColumn("🎓", counts.youth, "Students", "grape", isFull ? youthList : householdYouth)}
           </SimpleGrid>
         )}
 

--- a/checkin-app/src/app/membership-ops/participants/new/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/page.tsx
@@ -37,7 +37,7 @@ function NewParticipantForm() {
   const [householdId, setHouseholdId] = useState("");
   const [householdSearch, setHouseholdSearch] = useState("");
 
-  const studentSelected = isYouth(dob);
+  const isYouthSelected = isYouth(dob);
 
   const [alreadyMember, setAlreadyMember] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -86,7 +86,7 @@ function NewParticipantForm() {
         body: JSON.stringify({
           name,
           email: email || null,
-          parentEmail: studentSelected ? parentEmail : null,
+          parentEmail: isYouthSelected ? parentEmail : null,
           dob: dob || null,
           householdId: householdId ? parseInt(householdId) : null,
           alreadyMember: !householdId && alreadyMember
@@ -116,7 +116,7 @@ function NewParticipantForm() {
     }
   };
 
-  const submitDisabled = saving || (!studentSelected && !email && !householdId) || (studentSelected && !parentEmail && !householdId);
+  const submitDisabled = saving || (!isYouthSelected && !email && !householdId) || (isYouthSelected && !parentEmail && !householdId);
 
   return (
     <Container size="md" pb="md">
@@ -143,7 +143,7 @@ function NewParticipantForm() {
             <TextInput
               type="date"
               label="Date of Birth"
-              description={studentSelected ? 'Student Detected' : undefined}
+              description={isYouthSelected ? 'Student Detected' : undefined}
               value={dob}
               onChange={(e) => setDob(e.currentTarget.value)}
               maw={300}
@@ -151,20 +151,20 @@ function NewParticipantForm() {
 
             <TextInput
               type="email"
-              label={`Participant Google Email ${studentSelected ? '(Optional for Students)' : ''}`}
-              required={!studentSelected && !householdId}
+              label={`Participant Google Email ${isYouthSelected ? '(Optional for Students)' : ''}`}
+              required={!isYouthSelected && !householdId}
               value={email}
               onChange={(e) => setEmail(e.currentTarget.value)}
               placeholder="jane.doe@example.com"
             />
 
-            {studentSelected && (
+            {isYouthSelected && (
               <Paper withBorder radius="md" p="md" bg="var(--mantine-color-grape-light)">
                 <TextInput
                   type="email"
                   label={`Parent / Guardian Google Email ${!householdId ? '' : '(Optional)'}`}
                   description="Because the participant is under 18, a parent or guardian's email is required to associate their accounts — unless you assign them to an existing household below."
-                  required={studentSelected && !householdId}
+                  required={isYouthSelected && !householdId}
                   value={parentEmail}
                   onChange={(e) => setParentEmail(e.currentTarget.value)}
                   placeholder="parent@example.com"

--- a/checkin-app/src/app/page.tsx
+++ b/checkin-app/src/app/page.tsx
@@ -159,7 +159,7 @@ export default function Home() {
               {/* Operational Warnings */}
               {isTwoDeepViolation && (
                 <Alert color="red" icon={<IconAlertTriangle size={18} />} title="Critical Warning">
-                  Two-Deep Compliance is failing. An unaccompanied student is present without
+                  Two-Deep Compliance is failing. An unaccompanied youth is present without
                   sufficient adult supervision.
                 </Alert>
               )}

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -46,24 +46,24 @@ export async function getFullAttendance() {
     }
 
     const keyholderVisits = activeVisits.filter(v => v.participant.isKeyholder);
-    const studentVisits = activeVisits.filter(v => youthMap.get(v.id)!);
+    const youthVisits = activeVisits.filter(v => youthMap.get(v.id)!);
     const volunteerVisits = activeVisits.filter(v => !v.participant.isKeyholder && !youthMap.get(v.id));
 
     const counts = {
         keyholders: keyholderVisits.length,
         volunteers: volunteerVisits.length,
-        students: studentVisits.length,
+        youth: youthVisits.length,
         total: activeVisits.length,
     };
 
     const adultVisits = activeVisits.filter(v => !youthMap.get(v.id));
-    const unaccompaniedStudents = studentVisits.filter(sv => {
+    const unaccompaniedYouth = youthVisits.filter(sv => {
         if (!sv.participant.householdId) return true;
         return !adultVisits.some(av => av.participant.householdId === sv.participant.householdId);
     });
     const safety = {
         isLastKeyholder: keyholderVisits.length === 1,
-        isTwoDeepViolation: unaccompaniedStudents.length > 0 && adultVisits.length < 2,
+        isTwoDeepViolation: unaccompaniedYouth.length > 0 && adultVisits.length < 2,
     };
 
     // Drop email/googleId from the wire (M1): resolve the same name-or-email-prefix

--- a/checkin-app/src/types/attendance.ts
+++ b/checkin-app/src/types/attendance.ts
@@ -45,7 +45,7 @@ export type VisitWithDetails = Prisma.VisitGetPayload<{
 export interface AttendanceCounts {
     keyholders: number;
     volunteers: number;
-    students: number;
+    youth: number;
     total: number;
 }
 


### PR DESCRIPTION
## What
Phase 2 of the terminology migration. Renames the **age-based** `student` identifiers to `youth` so the word "student" is freed for a future program-enrollee concept. **No logic change** — the two-deep unaccompanied-minor rule stays age-based.

Fixes **BUG-1**: `student` was computed purely from age (`isYouth(dob)`) and even drove the two-deep safety check — the identifiers lied by calling an age concept "student".

## Scope note
This PR covers only the **age/safety** site. The facility **trends** report — which was *also* mislabeled "student" but is really about **participant (program-enrollee) hours**, not age — is a separate logic fix on its own branch/PR (`fix(trends): split facility hours by program enrollment, not age`). The two changesets touch disjoint files.

## Changes (identifiers/keys — mechanical)
- `getFullAttendance.ts`: `studentVisits→youthVisits`, `unaccompaniedStudents→unaccompaniedYouth`, `counts.students→counts.youth`
- `types/attendance.ts`: `AttendanceCounts.students→youth`
- `attendance/current/page.tsx`: dropped the local `isStudent` wrapper (calls lib `isYouth` directly), `studentList→youthList`, `householdStudents→householdYouth`, `Counts.students→youth`
- `membership-ops/participants/new/page.tsx`: `studentSelected→isYouthSelected`
- tests updated to match

## Visible copy (decided with reviewer)
- **Kept** the attendance dashboard **"Students"** column label.
- **Switched** the two-deep safety banner → **"unaccompanied youth"** (`page.tsx`, `attendance/current`).
- **Kept** the new-participant data-entry hints "Student Detected" / "(Optional for Students)".

## Verify
- `npx tsc --noEmit` clean.
- Non-test grep: zero `student` **identifiers/keys** remain; only deliberately-kept visible copy + other-phase strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)