### PR TITLE
refactor(person): rename local Participant TS types to Person (Phase A0)

### DIFF
--- a/checkin-app/src/app/attendance/certifications/page.tsx
+++ b/checkin-app/src/app/attendance/certifications/page.tsx
@@ -9,7 +9,7 @@ import { ToolLevelBadge, toToolLevel, toolLevelDot } from "@/components/ToolLeve
 
 type ToolStatusLevel = "BASIC" | "DOF" | "CERTIFIED" | "INSTRUCTOR" | "MAY_CERTIFY_OTHERS";
 
-type Participant = {
+type Person = {
   id: number;
   // Display name resolved server-side (real name, else email-prefix); never the raw email (#329).
   name: string;
@@ -39,7 +39,7 @@ function KioskCertificationsInner() {
   const searchParams = useSearchParams();
   const limitToPresent = searchParams.get('limit_to_present') !== 'false';
   const [isKioskMode, setIsKioskMode] = useState(searchParams.get('mode') === 'kiosk' || !!searchParams.get('sig'));
-  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [participants, setParticipants] = useState<Person[]>([]);
   const [tools, setTools] = useState<Tool[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -101,7 +101,7 @@ function KioskCertificationsInner() {
   };
 
   // Sort users alphabetically by first name (name is server-resolved, email-prefix included)
-  const sortAlphabetically = (a: Participant, b: Participant) => {
+  const sortAlphabetically = (a: Person, b: Person) => {
     const nameA = a.name;
     const nameB = b.name;
     const getFirstName = (name: string) => {
@@ -127,7 +127,7 @@ function KioskCertificationsInner() {
 
   const cellBorder = '1px solid var(--mantine-color-default-border)';
 
-  const renderVisitRow = (participant: Participant, index: number) => (
+  const renderVisitRow = (participant: Person, index: number) => (
     <tr key={participant.id} style={{ borderBottom: index % 2 === 1 ? '3px solid var(--mantine-color-default-border)' : cellBorder }}>
       <td style={{ padding: isKioskMode ? '0.5rem 0.75rem' : '0.75rem 1rem', position: 'sticky', left: 0, background: 'var(--mantine-color-body)', zIndex: 5, borderRight: cellBorder }}>
         <Text fw={isKioskMode ? 700 : 500} fz={isKioskMode ? '1.1rem' : undefined} truncate>

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -12,7 +12,7 @@ import { formatPhone } from "@/lib/phone";
 import { getKioskDisplayNames } from "@/lib/kiosk-names";
 import { AttendanceTabs } from "../AttendanceTabs";
 
-type Participant = {
+type Person = {
   id: number;
   email: string;
   name?: string | null;
@@ -27,7 +27,7 @@ type Participant = {
 type Visit = {
   id: number;
   arrivedAt: string;
-  participant: Participant;
+  participant: Person;
   event?: { program?: { id: number; name: string } };
 };
 
@@ -49,13 +49,13 @@ function KioskDisplayInner() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [checkingOut, setCheckingOut] = useState<number | null>(null);
-  const [household, setHousehold] = useState<{ leads: { participantId: number }[], participants: Participant[] } | null>(null);
+  const [household, setHousehold] = useState<{ leads: { participantId: number }[], participants: Person[] } | null>(null);
   const [showSignOutModal, setShowSignOutModal] = useState(false);
   const [searchSignOutQuery, setSearchSignOutQuery] = useState("");
-  const [selectedParticipant, setSelectedParticipant] = useState<Participant | null>(null);
+  const [selectedParticipant, setSelectedParticipant] = useState<Person | null>(null);
 
   const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<Participant[]>([]);
+  const [searchResults, setSearchResults] = useState<Person[]>([]);
   const [checkingInId, setCheckingInId] = useState<number | null>(null);
 
   const currentUserIsSysadmin = (session?.user as SessionUser)?.isSysadmin || false;
@@ -162,7 +162,7 @@ function KioskDisplayInner() {
         if (res.ok) {
           const data = await res.json();
           const filtered = data.participants.filter(
-            (p: Participant) =>
+            (p: Person) =>
               (p.name || "").toLowerCase().includes((searchQuery || "").toLowerCase()) ||
               (p.email || "").toLowerCase().includes((searchQuery || "").toLowerCase())
           );

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -5,7 +5,7 @@ import { Alert, Badge, Button, Card, Center, Group, Loader, Stack, Text } from "
 import { AlertBanner } from "@/components/admin/AlertBanner";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 
-interface Participant {
+interface Person {
   id: number;
   name: string | null;
   email: string | null;
@@ -29,7 +29,7 @@ interface ProcessRow {
   membership: {
     householdId: number;
     isVolunteer: boolean;
-    household: { name: string | null; participants: Participant[]; leads: { participantId: number }[] } | null;
+    household: { name: string | null; participants: Person[]; leads: { participantId: number }[] } | null;
   } | null;
 }
 

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -6,7 +6,7 @@ import { useSession } from "next-auth/react";
 import { Alert, Button, Card, Center, Checkbox, Container, Group, Loader, Stack, Text, Title } from "@mantine/core";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 
-interface Participant {
+interface Person {
     id: number;
     name: string | null;
     email: string | null;
@@ -15,7 +15,7 @@ interface Participant {
 // Only the household leads (parents) are returned — children are never sent.
 interface QueueItem {
   id: number;
-  membership: { household: { name: string | null; leads: { participant: Participant }[] } | null } | null;
+  membership: { household: { name: string | null; leads: { participant: Person }[] } | null } | null;
   _count: { attestations: number };
 }
 

--- a/checkin-app/src/app/programs/[id]/register/dirty.ts
+++ b/checkin-app/src/app/programs/[id]/register/dirty.ts
@@ -6,12 +6,12 @@
  */
 type Parent = { name: string; email: string; phone: string };
 type EmergencyContact = { name: string; phone: string };
-type Participant = { name: string; dob: string };
+type Person = { name: string; dob: string };
 
 export function isRegistrationDirty(
   parents: Parent[],
   emergencyContact: EmergencyContact,
-  participants: Participant[],
+  participants: Person[],
 ): boolean {
   const filled = (v: string) => v.trim() !== '';
   return (


### PR DESCRIPTION
## What

Phase A0 of the `Participant` → `Person` umbrella rename. Renames the 5 hand-rolled **local** client-side `type`/`interface Participant` declarations (JSON shapes, independent of the Prisma model) to `Person`, plus every type-position reference to them in the same file.

- `attendance/current/page.tsx` — `type Participant` → `Person` (6 type-position refs)
- `attendance/certifications/page.tsx` — `type Participant` → `Person` (4)
- `membership-ops/review/page.tsx` — `interface Participant` → `Person` (2)
- `membership-ops/applications/page.tsx` — `interface Participant` → `Person` (2)
- `programs/[id]/register/dirty.ts` — `type Participant` → `Person` (2)

## Why

Prep for the later **atomic** `Participant` → `Person` Prisma model rename. These local types are independent of Prisma and compile green on their own, so renaming them now shrinks the later atomic diff.

## Not touched (other phases / other concerns)

- No Prisma: no schema, no `prisma.participant`, no imported generated types.
- Data keys kept: `participantId`, and the `participant:` object property key in review/applications.
- Local var/state names kept: `selectedParticipant`, `participants`, `searchResults`, etc.
- JSX column header text "Participant" (certifications) left for Phase B UI copy.

## Verification

- `npx tsc --noEmit` → clean (exit 0)
- 5 affected test suites, 19 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)