### PR TITLE
refactor(corp): rename participantId→personId on CorporationLead/Member (phase A1e)

### DIFF
--- a/checkin-app/prisma/migrations/20260702053437_corporation_participantid_to_personid/migration.sql
+++ b/checkin-app/prisma/migrations/20260702053437_corporation_participantid_to_personid/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  - The primary key for the `CorporationLead` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `participantId` on the `CorporationLead` table. All the data in the column will be lost.
+  - The primary key for the `CorporationMember` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `participantId` on the `CorporationMember` table. All the data in the column will be lost.
+  - Added the required column `personId` to the `CorporationLead` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `personId` to the `CorporationMember` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "CorporationLead" DROP CONSTRAINT "CorporationLead_participantId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CorporationMember" DROP CONSTRAINT "CorporationMember_participantId_fkey";
+
+-- AlterTable
+ALTER TABLE "CorporationLead" DROP CONSTRAINT "CorporationLead_pkey",
+DROP COLUMN "participantId",
+ADD COLUMN     "personId" INTEGER NOT NULL,
+ADD CONSTRAINT "CorporationLead_pkey" PRIMARY KEY ("corporationId", "personId");
+
+-- AlterTable
+ALTER TABLE "CorporationMember" DROP CONSTRAINT "CorporationMember_pkey",
+DROP COLUMN "participantId",
+ADD COLUMN     "personId" INTEGER NOT NULL,
+ADD CONSTRAINT "CorporationMember_pkey" PRIMARY KEY ("corporationId", "personId");
+
+-- AddForeignKey
+ALTER TABLE "CorporationLead" ADD CONSTRAINT "CorporationLead_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Participant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CorporationMember" ADD CONSTRAINT "CorporationMember_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Participant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -560,24 +560,24 @@ model CorporationLead {
   /// @sensitivity:public
   corporationId Int
   /// @sensitivity:public
-  participantId Int
+  personId Int
 
   corporation Corporation @relation(fields: [corporationId], references: [id])
-  participant Participant @relation(fields: [participantId], references: [id])
+  person      Participant @relation(fields: [personId], references: [id])
 
-  @@id([corporationId, participantId])
+  @@id([corporationId, personId])
 }
 
 model CorporationMember {
   /// @sensitivity:public
   corporationId Int
   /// @sensitivity:public
-  participantId Int
+  personId Int
 
   corporation Corporation @relation(fields: [corporationId], references: [id])
-  participant Participant @relation(fields: [participantId], references: [id])
+  person      Participant @relation(fields: [personId], references: [id])
 
-  @@id([corporationId, participantId])
+  @@id([corporationId, personId])
 }
 
 model Program {

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -161,11 +161,11 @@ export const classifications = {
     },
     CorporationLead: {
         corporationId: 'public',
-        participantId: 'public',
+        personId: 'public',
     },
     CorporationMember: {
         corporationId: 'public',
-        participantId: 'public',
+        personId: 'public',
     },
     Program: {
         id: 'public',
@@ -398,11 +398,11 @@ export const relations = {
     },
     CorporationLead: {
         corporation: { model: 'Corporation', isList: false },
-        participant: { model: 'Participant', isList: false },
+        person: { model: 'Participant', isList: false },
     },
     CorporationMember: {
         corporation: { model: 'Corporation', isList: false },
-        participant: { model: 'Participant', isList: false },
+        person: { model: 'Participant', isList: false },
     },
     Program: {
         leadMentor: { model: 'Participant', isList: false },


### PR DESCRIPTION
## What

Phase **A1e** of the Participant→Person umbrella rename. Renames the FK + relation field on **CorporationLead** and **CorporationMember** only.

- `participantId Int` → `personId Int`
- relation `participant Participant` → `person Participant @relation(fields: [personId])`
- composite PK `@@id([corporationId, participantId])` → `@@id([corporationId, personId])`, so the generated where-input `corporationId_participantId` → `corporationId_personId`

Migration: `20260702053437_corporation_participantid_to_personid`.

## Why

Incremental slice of the model-wide Participant→Person rename (see `docs/designs/PERSON_UMBRELLA_INVESTIGATION.md` §f, A1e). Scoped to two models per plan to keep each slice reviewable.

## Reviewer notes

- Model stays named `Participant` — only the FK/relation on these two child models change. Other 8 models keep `participantId` intentionally.
- No app-code consumers: no `prisma.corporationLead`/`corporationMember` calls, no tests reference either model. Only regenerated artifact is `src/security/generated/classifications.ts` (`personId: 'public'`).
- Migration is DROP col + ADD col (not a rename) — destroys any existing corp rows. Matches prior rename slices' dev-migration convention; corp tables are empty in current envs.
- Verify: `npm install` → `prisma generate` → `tsc --noEmit` clean (EXIT 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)