### PR TITLE
refactor(membership): split intake form sections out of page.tsx

### DIFF
--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -13,6 +13,9 @@ import { notifyNavRefresh } from "@/lib/nav-refresh";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
 import { isValidEmail } from "@/lib/emergencyContacts/identity";
 import { useUnsavedGuard, useConfirmNav } from "@/components/UnsavedChangesProvider";
+import AddressForm from "@/components/membership/AddressForm";
+import EmergencyContactForm from "@/components/membership/EmergencyContactForm";
+import ChildrenListForm from "@/components/membership/ChildrenListForm";
 
 const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
 
@@ -523,20 +526,14 @@ export default function MembershipPage() {
                 <Stack gap="lg">
                   <section>
                     <Title order={2} mb="sm">Your household</Title>
-                    <Stack gap="xs">
-                      <TextInput label="Street address" value={address.line1 ?? ""} error={fieldErrors.address} onChange={(e) => { setAddress({ ...address, line1: e.currentTarget.value }); clearErr("address"); }} placeholder="123 Main St" />
-                      <TextInput label="Apt / Suite (optional)" value={address.line2 ?? ""} onChange={(e) => setAddress({ ...address, line2: e.currentTarget.value })} placeholder="Apt 4B" />
-                      <SimpleGrid cols={{ base: 1, sm: 3 }}>
-                        <TextInput label="City" value={address.city ?? ""} onChange={(e) => setAddress({ ...address, city: e.currentTarget.value })} />
-                        <TextInput label="State" maxLength={2} value={address.state ?? ""} onChange={(e) => setAddress({ ...address, state: e.currentTarget.value })} placeholder="TX" />
-                        <TextInput label="ZIP" value={address.postalCode ?? ""} onChange={(e) => setAddress({ ...address, postalCode: e.currentTarget.value })} placeholder="78701" />
-                      </SimpleGrid>
-                    </Stack>
-                    <SimpleGrid cols={{ base: 1, sm: 2 }} mt="md">
-                      <TextInput label="Emergency contact name" value={emName} error={fieldErrors.emName} onChange={(e) => { setEmName(e.currentTarget.value); clearErr("emName"); }} />
-                      <TextInput label="Emergency contact phone" value={emPhone} error={fieldErrors.emPhone} onChange={(e) => { setEmPhone(e.currentTarget.value); clearErr("emPhone"); }} />
-                      <TextInput type="email" label="Emergency contact email (optional)" value={emEmail} error={fieldErrors.emEmail} onChange={(e) => { setEmEmail(e.currentTarget.value); clearErr("emEmail"); }} />
-                    </SimpleGrid>
+                    <AddressForm address={address} onChange={setAddress} error={fieldErrors.address} onErrorClear={() => clearErr("address")} />
+                    <EmergencyContactForm
+                      emName={emName} setEmName={setEmName}
+                      emPhone={emPhone} setEmPhone={setEmPhone}
+                      emEmail={emEmail} setEmEmail={setEmEmail}
+                      errors={fieldErrors}
+                      clearErr={clearErr}
+                    />
                   </section>
 
                   <section>
@@ -566,29 +563,7 @@ export default function MembershipPage() {
                     )}
                   </section>
 
-                  <section>
-                    <Group justify="space-between" align="center" mb="sm">
-                      <Title order={2}>Children</Title>
-                      <Button variant="light" size="xs" fz={15} onClick={addChild}>+ Add child</Button>
-                    </Group>
-                    {children.length === 0 && <Text c="dimmed">No children added yet.</Text>}
-                    <Stack>
-                      {children.map((child, i) => (
-                        <Card key={child.id ?? `new-${i}`} withBorder radius="md" padding="md">
-                          <Group justify="space-between" align="center" mb="xs">
-                            <Text fw={600}>Child {i + 1}</Text>
-                            <Button variant="subtle" color="red" size="compact-sm" onClick={() => removeChild(i)}>Remove</Button>
-                          </Group>
-                          <TextInput label="Full name" value={child.name} onChange={(e) => updateChild(i, "name", e.currentTarget.value)} />
-                          <SimpleGrid cols={{ base: 1, sm: 2 }} mt="sm">
-                            <TextInput type="date" label="Date of birth" value={child.dob} onChange={(e) => updateChild(i, "dob", e.currentTarget.value)} />
-                            <TextInput type="email" label="Email (optional)" value={child.email} onChange={(e) => updateChild(i, "email", e.currentTarget.value)} />
-                          </SimpleGrid>
-                          <TextInput mt="sm" label="Allergies (optional)" value={child.allergies} onChange={(e) => updateChild(i, "allergies", e.currentTarget.value)} />
-                        </Card>
-                      ))}
-                    </Stack>
-                  </section>
+                  <ChildrenListForm items={children} onAdd={addChild} onUpdate={updateChild} onRemove={removeChild} />
 
                   <Group gap="md" wrap="wrap">
                     <Button variant="default" disabled={saving} loading={saving} onClick={save}>Save progress</Button>

--- a/checkin-app/src/components/membership/AddressForm.tsx
+++ b/checkin-app/src/components/membership/AddressForm.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { SimpleGrid, Stack, TextInput } from "@mantine/core";
+import type { StructuredAddress } from "@/lib/address";
+
+export default function AddressForm({
+  address,
+  onChange,
+  error,
+  onErrorClear,
+}: {
+  address: StructuredAddress;
+  onChange: (address: StructuredAddress) => void;
+  error?: string;
+  onErrorClear: () => void;
+}) {
+  return (
+    <Stack gap="xs">
+      <TextInput
+        label="Street address"
+        value={address.line1 ?? ""}
+        error={error}
+        onChange={(e) => { onChange({ ...address, line1: e.currentTarget.value }); onErrorClear(); }}
+        placeholder="123 Main St"
+      />
+      <TextInput label="Apt / Suite (optional)" value={address.line2 ?? ""} onChange={(e) => onChange({ ...address, line2: e.currentTarget.value })} placeholder="Apt 4B" />
+      <SimpleGrid cols={{ base: 1, sm: 3 }}>
+        <TextInput label="City" value={address.city ?? ""} onChange={(e) => onChange({ ...address, city: e.currentTarget.value })} />
+        <TextInput label="State" maxLength={2} value={address.state ?? ""} onChange={(e) => onChange({ ...address, state: e.currentTarget.value })} placeholder="TX" />
+        <TextInput label="ZIP" value={address.postalCode ?? ""} onChange={(e) => onChange({ ...address, postalCode: e.currentTarget.value })} placeholder="78701" />
+      </SimpleGrid>
+    </Stack>
+  );
+}

--- a/checkin-app/src/components/membership/ChildrenListForm.tsx
+++ b/checkin-app/src/components/membership/ChildrenListForm.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Button, Card, Group, SimpleGrid, Stack, Text, TextInput, Title } from "@mantine/core";
+
+interface ChildForm {
+  id?: number;
+  name: string;
+  email: string;
+  dob: string;
+  allergies: string;
+}
+
+export default function ChildrenListForm({
+  items,
+  onAdd,
+  onUpdate,
+  onRemove,
+}: {
+  items: ChildForm[];
+  onAdd: () => void;
+  onUpdate: (i: number, field: keyof ChildForm, value: string) => void;
+  onRemove: (i: number) => void;
+}) {
+  return (
+    <section>
+      <Group justify="space-between" align="center" mb="sm">
+        <Title order={2}>Children</Title>
+        <Button variant="light" size="xs" fz={15} onClick={onAdd}>+ Add child</Button>
+      </Group>
+      {items.length === 0 && <Text c="dimmed">No children added yet.</Text>}
+      <Stack>
+        {items.map((child, i) => (
+          <Card key={child.id ?? `new-${i}`} withBorder radius="md" padding="md">
+            <Group justify="space-between" align="center" mb="xs">
+              <Text fw={600}>Child {i + 1}</Text>
+              <Button variant="subtle" color="red" size="compact-sm" onClick={() => onRemove(i)}>Remove</Button>
+            </Group>
+            <TextInput label="Full name" value={child.name} onChange={(e) => onUpdate(i, "name", e.currentTarget.value)} />
+            <SimpleGrid cols={{ base: 1, sm: 2 }} mt="sm">
+              <TextInput type="date" label="Date of birth" value={child.dob} onChange={(e) => onUpdate(i, "dob", e.currentTarget.value)} />
+              <TextInput type="email" label="Email (optional)" value={child.email} onChange={(e) => onUpdate(i, "email", e.currentTarget.value)} />
+            </SimpleGrid>
+            <TextInput mt="sm" label="Allergies (optional)" value={child.allergies} onChange={(e) => onUpdate(i, "allergies", e.currentTarget.value)} />
+          </Card>
+        ))}
+      </Stack>
+    </section>
+  );
+}

--- a/checkin-app/src/components/membership/EmergencyContactForm.tsx
+++ b/checkin-app/src/components/membership/EmergencyContactForm.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { SimpleGrid, TextInput } from "@mantine/core";
+
+export default function EmergencyContactForm({
+  emName, setEmName,
+  emPhone, setEmPhone,
+  emEmail, setEmEmail,
+  errors,
+  clearErr,
+}: {
+  emName: string; setEmName: (v: string) => void;
+  emPhone: string; setEmPhone: (v: string) => void;
+  emEmail: string; setEmEmail: (v: string) => void;
+  errors: Record<string, string>;
+  clearErr: (key: string) => void;
+}) {
+  return (
+    <SimpleGrid cols={{ base: 1, sm: 2 }} mt="md">
+      <TextInput label="Emergency contact name" value={emName} error={errors.emName} onChange={(e) => { setEmName(e.currentTarget.value); clearErr("emName"); }} />
+      <TextInput label="Emergency contact phone" value={emPhone} error={errors.emPhone} onChange={(e) => { setEmPhone(e.currentTarget.value); clearErr("emPhone"); }} />
+      <TextInput type="email" label="Emergency contact email (optional)" value={emEmail} error={errors.emEmail} onChange={(e) => { setEmEmail(e.currentTarget.value); clearErr("emEmail"); }} />
+    </SimpleGrid>
+  );
+}


### PR DESCRIPTION
## Summary
- `src/app/membership/page.tsx` was a single 703-line component (20+ state vars, inline validation, and 10+ conditional sections). Extracted three presentational children into `src/components/membership/`, following the existing in-file `ExternalTask` pattern:
  - `AddressForm` — address fields
  - `EmergencyContactForm` — emergency-contact fields
  - `ChildrenListForm` — children array add/remove/edit
- `MembershipPage` remains the orchestrator: owns all top-level state, validation (`validateIntake`/`mapServerFields`), payment polling, contract-sign sync, and `serializeMembershipForm`. Children get values + setters/handlers as props.
- Structural split only — no behavior change, no logic rewritten.

## Test plan
- [x] `npx eslint` clean on page.tsx and the new components (had to rename `ChildrenListForm`'s array prop from `children` to `items` — React reserves `children` as a prop name)
- [x] `npm -w checkin-app exec -- jest` on `src/app/membership` and `src/components` — 50 + 69 tests pass unmodified (existing integration-style RTL tests, no mocks of internal components needed)
- [x] `tsc --noEmit` — no new errors introduced (pre-existing unrelated errors from ungenerated Prisma client)

No behavioral bugs found while tracing the file; nothing flagged separately.