### PR TITLE
refactor(config): route Shopify + cron env vars through config.ts

### DIFF
--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { activateByProcessId } from "@/lib/membership/payment";
 import { withWebhook } from "@/lib/webhookAuth";
+import { config } from "@/lib/config";
 
 interface ShopifyOrder {
     id?: number | string;
@@ -17,7 +18,7 @@ interface ShopifyOrder {
  * body before it is parsed — re-serializing JSON would change the bytes.
  */
 function verifyShopifyHmac(req: Request, rawBody: string): { ok: true } | { ok: false; status: number; error: string } {
-    const secret = process.env.SHOPIFY_WEBHOOK_SECRET;
+    const secret = config.shopifyWebhookSecret();
     if (!secret) {
         logger.error("Shopify webhook received but SHOPIFY_WEBHOOK_SECRET is not configured.");
         return { ok: false, status: 500, error: "Configuration Error" };

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -111,6 +111,16 @@ export const config = {
     // zohoConfigured() checks so the mock can drive them in dev).
     zohoAvailable: (): boolean => zohoConfiguredEnv() || zohoMockActiveEnv(),
 
+    // Cron — shared secret gating the session-less cron routes (see cronAuth.ts).
+    cronSecret: (): string | null => process.env.CRON_SECRET || null,
+
+    // Shopify — Client Credentials Grant integration (see shopify.ts). All three
+    // null when unset (integration "off").
+    shopifyStoreDomain: (): string | null => process.env.SHOPIFY_STORE_DOMAIN || null,
+    shopifyClientId: (): string | null => process.env.SHOPIFY_CLIENT_ID || null,
+    shopifyClientSecret: (): string | null => process.env.SHOPIFY_CLIENT_SECRET || null,
+    shopifyWebhookSecret: (): string | null => process.env.SHOPIFY_WEBHOOK_SECRET || null,
+
     // App
     checkinEnv: (): CheckinEnv => readCheckinEnv(),
     // Production (default when unset). Consumers should call this rather than

--- a/checkin-app/src/lib/cronAuth.ts
+++ b/checkin-app/src/lib/cronAuth.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import crypto from "crypto";
 import { logger } from "./logger";
+import { config } from "./config";
 
 /**
  * Shared auth gate for the cron routes. Checks `Authorization: Bearer $CRON_SECRET`
@@ -13,7 +14,7 @@ import { logger } from "./logger";
  */
 export function requireCronSecret(req: Request): NextResponse | null {
     const authHeader = req.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
+    const cronSecret = config.cronSecret();
 
     if (!cronSecret || !authHeader) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -64,7 +64,7 @@ export async function ensurePaymentLink(processId: number): Promise<{ amountCent
     const amountCents = membership.isVolunteer ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
 
     const variantId = settings?.membershipVariantId;
-    const storeDomain = process.env.SHOPIFY_STORE_DOMAIN;
+    const storeDomain = config.shopifyStoreDomain();
     if (!variantId || !storeDomain) return { amountCents, checkoutUrl: null };
 
     // TODO(#278): the code is appended to a public cart link, so entitlement is

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { sendEmail } from "@/lib/email";
 import { escapeHtml } from "@/lib/email-templates/base";
 import { logIntegrationError } from "@/lib/logger";
+import { config } from "@/lib/config";
 
 let cachedToken: string | null = null;
 let tokenExpiresAt: number = 0;
@@ -40,9 +41,9 @@ export function resetTokenCache() {
  * Caches the token and refreshes ~5 minutes before expiry.
  */
 async function getAccessToken(): Promise<string | null> {
-  const storeDomain = process.env.SHOPIFY_STORE_DOMAIN;
-  const clientId = process.env.SHOPIFY_CLIENT_ID;
-  const clientSecret = process.env.SHOPIFY_CLIENT_SECRET;
+  const storeDomain = config.shopifyStoreDomain();
+  const clientId = config.shopifyClientId();
+  const clientSecret = config.shopifyClientSecret();
 
   if (!storeDomain || !clientId || !clientSecret) {
     console.warn("Shopify integration is disabled: Missing SHOPIFY_STORE_DOMAIN, SHOPIFY_CLIENT_ID, or SHOPIFY_CLIENT_SECRET in .env");
@@ -90,7 +91,7 @@ async function getAccessToken(): Promise<string | null> {
 }
 
 export async function createShopifyProgramVariants(name: string, memberPriceCents: number | null, nonMemberPriceCents: number | null, maxParticipants: number | null = null) {
-  const storeDomain = process.env.SHOPIFY_STORE_DOMAIN;
+  const storeDomain = config.shopifyStoreDomain();
   const accessToken = await getAccessToken();
 
   if (!storeDomain || !accessToken) {


### PR DESCRIPTION
## Summary
- `config.ts` says all `process.env` access should go through it; `shopify.ts` and `cronAuth.ts` bypassed it. Added getters (`shopifyStoreDomain`, `shopifyClientId`, `shopifyClientSecret`, `shopifyWebhookSecret`, `cronSecret`) and switched callers to use them.
- Swept `src/` for other stragglers and fixed two more found doing the same thing: `membership/payment.ts` (dup `SHOPIFY_STORE_DOMAIN` read) and `api/webhooks/shopify/route.ts` (`SHOPIFY_WEBHOOK_SECRET`).
- Left `NEXT_PUBLIC_*`, `NODE_ENV`, `VERCEL_*`, and `NEXTAUTH_SECRET` in `middleware.ts` untouched — different convention already, or would change failure semantics (config.ts's `nextAuthSecret()` throws on missing; middleware currently doesn't).
- Mechanical refactor, no behavior change.

## Test plan
- [x] `cronAuth.test.ts` + `shopify.test.ts` — 11/11 pass
- [x] `tsc --noEmit` — no new errors introduced by this diff (pre-existing unrelated errors elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)