### PR TITLE
refactor(person): RawBadgeLog participantId → personId (Phase A1f)

### DIFF
--- a/checkin-app/prisma/migrations/20260702053827_rawbadgelog_participantid_to_personid/migration.sql
+++ b/checkin-app/prisma/migrations/20260702053827_rawbadgelog_participantid_to_personid/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `participantId` on the `RawBadgeLog` table. All the data in the column will be lost.
+  - Added the required column `personId` to the `RawBadgeLog` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "RawBadgeLog" DROP CONSTRAINT "RawBadgeLog_participantId_fkey";
+
+-- DropIndex
+DROP INDEX "RawBadgeLog_participantId_timestamp_idx";
+
+-- AlterTable
+ALTER TABLE "RawBadgeLog" DROP COLUMN "participantId",
+ADD COLUMN     "personId" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "RawBadgeLog_personId_timestamp_idx" ON "RawBadgeLog"("personId", "timestamp");
+
+-- AddForeignKey
+ALTER TABLE "RawBadgeLog" ADD CONSTRAINT "RawBadgeLog_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Participant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -745,15 +745,15 @@ model RawBadgeLog {
   /// @sensitivity:internal
   id            Int      @id @default(autoincrement())
   /// @sensitivity:internal
-  participantId Int
+  personId Int
   /// @sensitivity:personal
   timestamp     DateTime @default(now())
   /// @sensitivity:personal
   location      String?
 
-  participant Participant @relation(fields: [participantId], references: [id])
+  person Participant @relation(fields: [personId], references: [id])
 
-  @@index([participantId, timestamp]) // Double-badge detection in /api/scan
+  @@index([personId, timestamp]) // Double-badge detection in /api/scan
 }
 
 model Visit {

--- a/checkin-app/src/app/__tests__/adminBadgesAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBadgesAPI.integration.test.ts
@@ -24,7 +24,7 @@ describe('Admin Badges API Integration Tests', () => {
         // Clean up any leaked state
         await prisma.rawBadgeLog.deleteMany({
             where: {
-                participant: { email: { contains: 'badges-api-test' } }
+                person: { email: { contains: 'badges-api-test' } }
             }
         });
         await prisma.participant.deleteMany({
@@ -44,7 +44,7 @@ describe('Admin Badges API Integration Tests', () => {
 
         const badgeEvent = await prisma.rawBadgeLog.create({
             data: {
-                participantId: testUserId,
+                personId: testUserId,
                 location: 'Front Door'
             }
         });
@@ -106,9 +106,9 @@ describe('Admin Badges API Integration Tests', () => {
             const foundEvent = data.badges.find((b: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => b.id === testBadgeEventId);
             expect(foundEvent).toBeDefined();
             expect(foundEvent.location).toBe('Front Door');
-            expect(foundEvent.participant).toBeDefined();
-            expect(foundEvent.participant.name).toBe('User Badges Test');
-            expect(foundEvent.participant.email).toBe('user-badges-api-test@example.com');
+            expect(foundEvent.person).toBeDefined();
+            expect(foundEvent.person.name).toBe('User Badges Test');
+            expect(foundEvent.person.email).toBe('user-badges-api-test@example.com');
         });
     });
 });

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -15,7 +15,7 @@ describe("GET /api/cron/post-event", () => {
         await prisma.program.deleteMany({ where: { name: 'Test Program' } });
         await prisma.toolStatus.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
         await prisma.householdLead.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
-        await prisma.rawBadgeLog.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
+        await prisma.rawBadgeLog.deleteMany({ where: { person: { email: { contains: 'example.com' } } } });
         await prisma.participant.deleteMany({ where: { email: { contains: 'example.com' } } });
         // Global participant-less household delete: clear the membership chain for those
         // households first or Membership_householdId_fkey (RESTRICT) blocks the delete.

--- a/checkin-app/src/app/__tests__/scanAuth.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanAuth.integration.test.ts
@@ -112,7 +112,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
 
         afterAll(async () => {
             await prisma.visit.deleteMany({ where: { participantId: kioskId } });
-            await prisma.rawBadgeLog.deleteMany({ where: { participantId: kioskId } });
+            await prisma.rawBadgeLog.deleteMany({ where: { personId: kioskId } });
             await prisma.participant.delete({ where: { id: kioskId } });
             await prisma.household.delete({ where: { id: kioskHouseholdId } });
         });
@@ -126,7 +126,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
 
         afterEach(async () => {
             await prisma.visit.deleteMany({ where: { participantId: kioskId } });
-            await prisma.rawBadgeLog.deleteMany({ where: { participantId: kioskId } });
+            await prisma.rawBadgeLog.deleteMany({ where: { personId: kioskId } });
         });
 
         it('valid signature → 200 and records the check-in', async () => {
@@ -148,7 +148,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
 
             const visit = await prisma.visit.findFirst({ where: { participantId: kioskId, departedAt: null } });
             expect(visit).not.toBeNull();
-            const events = await prisma.rawBadgeLog.count({ where: { participantId: kioskId } });
+            const events = await prisma.rawBadgeLog.count({ where: { personId: kioskId } });
             expect(events).toBe(1);
         });
 
@@ -212,7 +212,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
 
             expect(res2.status).toBe(401);
             // Only the first request checked in; the replay changed nothing.
-            const events = await prisma.rawBadgeLog.count({ where: { participantId: kioskId } });
+            const events = await prisma.rawBadgeLog.count({ where: { personId: kioskId } });
             expect(events).toBe(1);
         });
 
@@ -266,14 +266,14 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
         afterEach(async () => {
             const ids = [pSelf, pSameHH, pOtherHH, pStranger, pKeyholder];
             await prisma.visit.deleteMany({ where: { participantId: { in: ids } } });
-            await prisma.rawBadgeLog.deleteMany({ where: { participantId: { in: ids } } });
+            await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: ids } } });
         });
 
         afterAll(async () => {
             const ids = [pSelf, pSameHH, pOtherHH, pStranger, pKeyholder];
             const hs = [hSelf, hLead, hOther, hStranger, hKeyholder];
             await prisma.visit.deleteMany({ where: { participantId: { in: ids } } });
-            await prisma.rawBadgeLog.deleteMany({ where: { participantId: { in: ids } } });
+            await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: ids } } });
             await prisma.participant.deleteMany({ where: { id: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: hs } } });
         });

--- a/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
@@ -61,7 +61,7 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
 
     afterEach(async () => {
         await prisma.visit.deleteMany({ where: { participantId: { in: [isKeyholder.id, normal.id] } } });
-        await prisma.rawBadgeLog.deleteMany({ where: { participantId: { in: [isKeyholder.id, normal.id] } } });
+        await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: [isKeyholder.id, normal.id] } } });
     });
 
     afterAll(async () => {
@@ -76,7 +76,7 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
 
         // Past the debounce window.
         await prisma.rawBadgeLog.updateMany({
-            where: { participantId: isKeyholder.id },
+            where: { personId: isKeyholder.id },
             data: { timestamp: new Date(Date.now() - 5000) },
         });
 
@@ -98,8 +98,8 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
         const kVisit = await prisma.visit.create({ data: { participantId: isKeyholder.id, arrivedAt: new Date() } });
         await prisma.visit.create({ data: { participantId: normal.id, arrivedAt: new Date() } });
         // Two isKeyholder badge events 5s apart (<=12s) → confirmed force-close.
-        await prisma.rawBadgeLog.create({ data: { participantId: isKeyholder.id, timestamp: new Date(Date.now() - 5000) } });
-        await prisma.rawBadgeLog.create({ data: { participantId: isKeyholder.id, timestamp: new Date() } });
+        await prisma.rawBadgeLog.create({ data: { personId: isKeyholder.id, timestamp: new Date(Date.now() - 5000) } });
+        await prisma.rawBadgeLog.create({ data: { personId: isKeyholder.id, timestamp: new Date() } });
 
         const res = await processCheckout(isKeyholder, kVisit.id, 'kiosk');
         const json = await res.json();

--- a/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
@@ -72,12 +72,12 @@ describe('POST /api/scan — real check-in/out logic', () => {
     afterEach(async () => {
         // Reset facility state between cases so each test controls who is present.
         await prisma.visit.deleteMany({ where: { participantId: { in: [keyholderId, normalId] } } });
-        await prisma.rawBadgeLog.deleteMany({ where: { participantId: { in: [keyholderId, normalId] } } });
+        await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: [keyholderId, normalId] } } });
     });
 
     afterAll(async () => {
         await prisma.visit.deleteMany({ where: { participantId: { in: [keyholderId, normalId] } } });
-        await prisma.rawBadgeLog.deleteMany({ where: { participantId: { in: [keyholderId, normalId] } } });
+        await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: [keyholderId, normalId] } } });
         await prisma.participant.deleteMany({ where: { id: { in: [keyholderId, normalId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [keyholderHouseholdId, normalHouseholdId] } } });
     });
@@ -121,7 +121,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
 
         // Backdate the badge event so the second scan is past the 3s debounce window.
         await prisma.rawBadgeLog.updateMany({
-            where: { participantId: normalId },
+            where: { personId: normalId },
             data: { timestamp: new Date(Date.now() - 5000) },
         });
 

--- a/checkin-app/src/app/__tests__/scanConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanConcurrency.integration.test.ts
@@ -74,7 +74,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         const leakedIds = leaked.map(p => p.id);
         const leakedHouseholdIds = leaked.map(p => p.householdId);
         await prisma.visit.deleteMany({ where: { participantId: { in: leakedIds } } });
-        await prisma.rawBadgeLog.deleteMany({ where: { participantId: { in: leakedIds } } });
+        await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: leakedIds } } });
         await prisma.participant.deleteMany({ where: { id: { in: leakedIds } } });
         await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
 
@@ -104,7 +104,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
             select: { householdId: true },
         })).map(p => p.householdId);
         await prisma.visit.deleteMany({ where: { participantId: { in: ids } } });
-        await prisma.rawBadgeLog.deleteMany({ where: { participantId: { in: ids } } });
+        await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: ids } } });
         await prisma.participant.deleteMany({ where: { id: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: households } } });
     });
@@ -113,7 +113,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         // Fresh state: no open visit, no recent badge event (so neither scan is
         // pre-debounced before the race even begins).
         await prisma.visit.deleteMany({ where: { participantId: checkinSubjectId } });
-        await prisma.rawBadgeLog.deleteMany({ where: { participantId: checkinSubjectId } });
+        await prisma.rawBadgeLog.deleteMany({ where: { personId: checkinSubjectId } });
         expect(await openVisitCount(checkinSubjectId)).toBe(0);
 
         const [resA, resB] = await Promise.all([
@@ -136,7 +136,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
     it('two concurrent check-out scans → exactly one successful checkout, no 500, zero open visits', async () => {
         // Fresh state: exactly one open visit, no recent badge event.
         await prisma.visit.deleteMany({ where: { participantId: checkoutSubjectId } });
-        await prisma.rawBadgeLog.deleteMany({ where: { participantId: checkoutSubjectId } });
+        await prisma.rawBadgeLog.deleteMany({ where: { personId: checkoutSubjectId } });
         await prisma.visit.create({ data: { participantId: checkoutSubjectId, arrivedAt: new Date() } });
         expect(await openVisitCount(checkoutSubjectId)).toBe(1);
 

--- a/checkin-app/src/app/api/facility/badges/route.ts
+++ b/checkin-app/src/app/api/facility/badges/route.ts
@@ -10,7 +10,7 @@ export const GET = withAuth(
                 take: 200,
                 orderBy: { timestamp: "desc" },
                 include: {
-                    participant: {
+                    person: {
                         select: { name: true, email: true },
                     },
                 },

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -82,7 +82,7 @@ export const POST = withKiosk(
             const threeSecondsAgo = new Date(Date.now() - 3000);
             const recentScan = await tx.rawBadgeLog.findFirst({
                 where: {
-                    participantId: participant.id,
+                    personId: participant.id,
                     timestamp: {
                         gte: threeSecondsAgo
                     }
@@ -100,7 +100,7 @@ export const POST = withKiosk(
             // 5. Record raw badge event
             await tx.rawBadgeLog.create({
                 data: {
-                    participantId: participant.id,
+                    personId: participant.id,
                     location: "Main Entrance",
                 },
             });

--- a/checkin-app/src/app/facility-ops/badges/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/badges/__tests__/page.test.tsx
@@ -14,7 +14,7 @@ describe("facility-ops/badges page", () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({
       "/api/facility/badges": {
-        badges: [{ id: 1, timestamp: "2026-01-01T14:00:00.000Z", participant: { name: "Val Volunteer", email: "val@example.com" }, location: "Side Door" }],
+        badges: [{ id: 1, timestamp: "2026-01-01T14:00:00.000Z", person: { name: "Val Volunteer", email: "val@example.com" }, location: "Side Door" }],
       },
     });
     renderWithProviders(<AdminBadgesPage />);

--- a/checkin-app/src/app/facility-ops/badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/badges/page.tsx
@@ -10,15 +10,15 @@ import { formatDateTime } from '@/lib/time';
 type BadgeEvent = {
   id: number;
   timestamp: string;
-  participant?: { name?: string; email?: string };
+  person?: { name?: string; email?: string };
   location?: string;
 };
 
 const COLUMNS: DataTableColumn<BadgeEvent>[] = [
   { header: 'ID', render: (b) => b.id, sortBy: (b) => b.id },
   { header: 'Time', render: (b) => formatDateTime(b.timestamp), sortBy: (b) => b.timestamp },
-  { header: 'Participant', render: (b) => b.participant?.name || 'Unknown', sortBy: (b) => b.participant?.name },
-  { header: 'Email', render: (b) => b.participant?.email, sortBy: (b) => b.participant?.email },
+  { header: 'Participant', render: (b) => b.person?.name || 'Unknown', sortBy: (b) => b.person?.name },
+  { header: 'Email', render: (b) => b.person?.email, sortBy: (b) => b.person?.email },
   { header: 'Location', render: (b) => b.location || 'Front Door', sortBy: (b) => b.location },
 ];
 

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -324,7 +324,7 @@ export async function createCheckins(prisma: Db): Promise<string> {
     for (const [i, p] of people.entries()) {
         const arrived = new Date(Date.now() - (i + 1) * 45 * 60 * 1000); // staggered into the past
         await prisma.rawBadgeLog.create({
-            data: { participantId: p.id, timestamp: arrived, location: "Front Door" },
+            data: { personId: p.id, timestamp: arrived, location: "Front Door" },
         });
         await prisma.visit.create({
             data: {

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -93,7 +93,7 @@ export async function processCheckout(
                 let confirmForceClose = false;
 
                 const recentEvents = await db.rawBadgeLog.findMany({
-                    where: { participantId: participant.id },
+                    where: { personId: participant.id },
                     orderBy: { timestamp: "desc" },
                     take: 2
                 });

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -233,7 +233,7 @@ export const classifications = {
     },
     RawBadgeLog: {
         id: 'internal',
-        participantId: 'internal',
+        personId: 'internal',
         timestamp: 'personal',
         location: 'personal',
     },
@@ -438,7 +438,7 @@ export const relations = {
         participant: { model: 'Participant', isList: false },
     },
     RawBadgeLog: {
-        participant: { model: 'Participant', isList: false },
+        person: { model: 'Participant', isList: false },
     },
     Visit: {
         participant: { model: 'Participant', isList: false },

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -98,7 +98,7 @@ export const SCOPE_BINDINGS = {
             all: [{ flag: 'isKeyholder' }, { field: 'departedAt', isNull: true }],
         },
     },
-    RawBadgeLog: { their_own: { field: 'participantId', eqCtx: 'selfId' } },
+    RawBadgeLog: { their_own: { field: 'personId', eqCtx: 'selfId' } },
     ToolStatus: { their_own: { field: 'participantId', eqCtx: 'selfId' } },
     Account: { their_own: { field: 'userId', eqCtx: 'selfId' } },
     Session: { their_own: { field: 'userId', eqCtx: 'selfId' } },

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -139,8 +139,8 @@ function referenceScopesHeld(
             break;
         }
         case 'RawBadgeLog': {
-            const participantId = num(row.participantId);
-            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            const personId = num(row.personId);
+            if (personId !== undefined && personId === ctx.selfId) scopes.add('their_own');
             break;
         }
         case 'ToolStatus': {


### PR DESCRIPTION
## What

Phase **A1f** of the Participant→Person rename: rename **only** `RawBadgeLog`'s FK column + relation field. The model stays named `Participant` — this is one green slice ahead of the atomic A2 model-name flip.

- `participantId Int` → `personId Int`
- `participant Participant @relation(fields: [participantId])` → `person Participant @relation(fields: [personId])` (relation *target* type unchanged)
- `@@index([participantId, timestamp])` → `@@index([personId, timestamp])` (double-badge detection in `/api/scan`)
- Migration `20260702053827_rawbadgelog_participantid_to_personid`: drop col/FK/index, add `personId` + FK + index.

## Why

Incremental FK-first rename per `PERSON_UMBRELLA_INVESTIGATION.md` §f — moving each FK to `personId` while the model is still `Participant` keeps every slice compiling, so A2 becomes a pure mechanical `model Participant → Person` flip instead of one ~1700-hit megamerge.

## Code touched

- `src/app/api/scan/route.ts` — debounce `findFirst` + badge `create`
- `src/lib/scan-service.ts` — double-badge `findMany`
- `src/app/api/facility/badges/route.ts` — `include: { person }`; consumer `src/app/facility-ops/badges/page.tsx` reads `b.person`
- `src/security/scopeBindings.ts` — RawBadgeLog `their_own` field `personId`
- `src/lib/dev/seed-helpers.ts` — badge seed
- `src/security/generated/classifications.ts` — regenerated (RawBadgeLog `personId` + `person` relation)
- Tests across all three roots: 6 scan integration files, badges page test, `scopeBindingsEquivalence.test.ts`

## Kept as-is (intentional)

- Participant back-relation `rawBadgeLogs` / `_count.rawBadgeLogs`
- Scan API request body `{ participantId }` — input contract, not the column
- `Visit` / `ToolStatus` `participantId` — other models keep it

## Verify

- `npx tsc --noEmit` → **clean (exit 0)** — the safety net for stale RawBadgeLog refs
- Jest: **1912 passed, 1 failed**. Sole failure `membership-bg-nonblocking.flow.test.ts` needs a live server on :4000 (`/api/auth/dev-personas` fetch) — pre-existing infra requirement, file-disjoint from this rename.
- No `$queryRaw`/`$executeRaw` touches the RawBadgeLog column (scan advisory lock uses `participant.id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)