### PR TITLE
refactor(programs): rename ProgramParticipant/ProgramVolunteer FK participantId → personId (A1c)

### DIFF
--- a/checkin-app/__tests__/programLifecycle.integration.test.ts
+++ b/checkin-app/__tests__/programLifecycle.integration.test.ts
@@ -112,9 +112,9 @@ describe('Program Lifecycle Integration Tests', () => {
         expect(data.success).toBe(true);
 
         const dbRecord = await prisma.programParticipant.findUnique({
-            where: { programId_participantId: { programId: testProgramId, participantId: testParticipantId } }
+            where: { programId_personId: { programId: testProgramId, personId: testParticipantId } }
         });
-        
+
         expect(dbRecord).toBeDefined();
         expect(dbRecord?.status).toBe('PENDING');
         expect(dbRecord?.pendingSince).toBeInstanceOf(Date);
@@ -152,7 +152,7 @@ describe('Program Lifecycle Integration Tests', () => {
         mockGetSession.mockResolvedValue({ user: { id: boardAdminId, isBoardMember: true } });
 
         // Clean previous runs
-        await prisma.programParticipant.deleteMany({ where: { programId: testProgramId, participantId: testParticipantId } });
+        await prisma.programParticipant.deleteMany({ where: { programId: testProgramId, personId: testParticipantId } });
 
         const req = new Request(`http://localhost/api/programs/${testProgramId}/participants`, {
             method: 'POST',
@@ -163,9 +163,9 @@ describe('Program Lifecycle Integration Tests', () => {
         expect(res.status).toBe(200);
 
         const dbRecord = await prisma.programParticipant.findUnique({
-            where: { programId_participantId: { programId: testProgramId, participantId: testParticipantId } }
+            where: { programId_personId: { programId: testProgramId, personId: testParticipantId } }
         });
-        
+
         // Overrides by board default to ACTIVE
         expect(dbRecord?.status).toBe('ACTIVE'); 
     });
@@ -174,9 +174,9 @@ describe('Program Lifecycle Integration Tests', () => {
         // 1. Reset user to PENDING state manually to simulate self-enroll flow
         // First, recreate or ensure it exists from the previous test
         await prisma.programParticipant.upsert({
-            where: { programId_participantId: { programId: testProgramId, participantId: testParticipantId } },
+            where: { programId_personId: { programId: testProgramId, personId: testParticipantId } },
             update: { status: 'PENDING', pendingSince: new Date() },
-            create: { programId: testProgramId, participantId: testParticipantId, status: 'PENDING', pendingSince: new Date() }
+            create: { programId: testProgramId, personId: testParticipantId, status: 'PENDING', pendingSince: new Date() }
         });
 
         // 2. Build Shopify webhook payload
@@ -205,11 +205,11 @@ describe('Program Lifecycle Integration Tests', () => {
         expect(res.status).toBe(200);
 
         const dbRecord = await prisma.programParticipant.findUnique({
-            where: { programId_participantId: { programId: testProgramId, participantId: testParticipantId } }
+            where: { programId_personId: { programId: testProgramId, personId: testParticipantId } }
         });
-        
-        expect(dbRecord?.status).toBe('ACTIVE'); 
-        expect(dbRecord?.pendingSince).toBeNull(); 
+
+        expect(dbRecord?.status).toBe('ACTIVE');
+        expect(dbRecord?.pendingSince).toBeNull();
     });
 
      it('Cron job should remove PENDING participants after 7 days, unless isPaymentPlanRequested is true', async () => {
@@ -220,9 +220,9 @@ describe('Program Lifecycle Integration Tests', () => {
         eightDaysAgo.setDate(eightDaysAgo.getDate() - 8);
 
         await prisma.programParticipant.upsert({
-             where: { programId_participantId: { programId: testProgramId, participantId: testParticipantId } },
+             where: { programId_personId: { programId: testProgramId, personId: testParticipantId } },
              update: { status: 'PENDING', pendingSince: eightDaysAgo, isPaymentPlanRequested: false },
-             create: { programId: testProgramId, participantId: testParticipantId, status: 'PENDING', pendingSince: eightDaysAgo, isPaymentPlanRequested: false }
+             create: { programId: testProgramId, personId: testParticipantId, status: 'PENDING', pendingSince: eightDaysAgo, isPaymentPlanRequested: false }
         });
 
         let req = new Request(`http://localhost/api/cron/pending-participants`, {
@@ -237,13 +237,13 @@ describe('Program Lifecycle Integration Tests', () => {
 
         // Verify Delete
         let dbRecord = await prisma.programParticipant.findUnique({
-            where: { programId_participantId: { programId: testProgramId, participantId: testParticipantId } }
+            where: { programId_personId: { programId: testProgramId, personId: testParticipantId } }
         });
         expect(dbRecord).toBeNull();
 
         // 2. Recreate, set to 8 days old PENDING, but isPaymentPlanRequested = true
         await prisma.programParticipant.create({
-            data: { programId: testProgramId, participantId: testParticipantId, status: 'PENDING', pendingSince: eightDaysAgo, isPaymentPlanRequested: true}
+            data: { programId: testProgramId, personId: testParticipantId, status: 'PENDING', pendingSince: eightDaysAgo, isPaymentPlanRequested: true}
         });
 
          req = new Request(`http://localhost/api/cron/pending-participants`, {
@@ -257,7 +257,7 @@ describe('Program Lifecycle Integration Tests', () => {
 
          // Verify Still there
         dbRecord = await prisma.programParticipant.findUnique({
-            where: { programId_participantId: { programId: testProgramId, participantId: testParticipantId } }
+            where: { programId_personId: { programId: testProgramId, personId: testParticipantId } }
         });
         expect(dbRecord).toBeDefined();
     });

--- a/checkin-app/__tests__/programSignupIntegration.test.ts
+++ b/checkin-app/__tests__/programSignupIntegration.test.ts
@@ -182,7 +182,7 @@ describe('Full Program Signup Integration Flow', () => {
         });
         (prisma.participant.findUnique as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId, dateOfBirth: new Date('2015-01-01') });
         (prisma.householdLead.findUnique as jest.Mock).mockResolvedValue({ householdId, participantId: leadUserId });
-        (prisma.programParticipant.create as jest.Mock).mockResolvedValue({ programId, participantId: childParticipantId, status: 'PENDING' });
+        (prisma.programParticipant.create as jest.Mock).mockResolvedValue({ programId, personId: childParticipantId, status: 'PENDING' });
 
         const enrollReq = new Request(`http://localhost/api/programs/${programId}/participants`, {
             method: 'POST',
@@ -192,15 +192,15 @@ describe('Full Program Signup Integration Flow', () => {
         expect(enrollRes.status).toBe(200);
 
         // 7. Verify PENDING status
-        (prisma.programParticipant.findUnique as jest.Mock).mockResolvedValue({ programId, participantId: childParticipantId, status: 'PENDING' });
+        (prisma.programParticipant.findUnique as jest.Mock).mockResolvedValue({ programId, personId: childParticipantId, status: 'PENDING' });
         const participantRecord = await prisma.programParticipant.findUnique({
-            where: { programId_participantId: { programId, participantId: childParticipantId } },
+            where: { programId_personId: { programId, personId: childParticipantId } },
         });
         expect(participantRecord?.status).toBe('PENDING');
 
         // 8. Shopify Webhook call
-        (prisma.programParticipant.findUnique as jest.Mock).mockResolvedValue({ programId, participantId: childParticipantId, status: 'PENDING' });
-        (prisma.programParticipant.update as jest.Mock).mockResolvedValue({ programId, participantId: childParticipantId, status: 'ACTIVE' });
+        (prisma.programParticipant.findUnique as jest.Mock).mockResolvedValue({ programId, personId: childParticipantId, status: 'PENDING' });
+        (prisma.programParticipant.update as jest.Mock).mockResolvedValue({ programId, personId: childParticipantId, status: 'ACTIVE' });
 
         const webhookPayload = JSON.stringify({
             note_attributes: [
@@ -220,9 +220,9 @@ describe('Full Program Signup Integration Flow', () => {
         expect(webhookRes.status).toBe(200);
 
         // 9. Final Verification - ACTIVE status
-        (prisma.programParticipant.findUnique as jest.Mock).mockResolvedValue({ programId, participantId: childParticipantId, status: 'ACTIVE' });
+        (prisma.programParticipant.findUnique as jest.Mock).mockResolvedValue({ programId, personId: childParticipantId, status: 'ACTIVE' });
         const finalParticipantRecord = await prisma.programParticipant.findUnique({
-            where: { programId_participantId: { programId, participantId: childParticipantId } },
+            where: { programId_personId: { programId, personId: childParticipantId } },
         });
         expect(finalParticipantRecord?.status).toBe('ACTIVE');
     });

--- a/checkin-app/prisma/migrations/20260702054422_programenrollment_participantid_to_personid/migration.sql
+++ b/checkin-app/prisma/migrations/20260702054422_programenrollment_participantid_to_personid/migration.sql
@@ -1,0 +1,12 @@
+-- Rename ProgramParticipant.participantId / ProgramVolunteer.participantId -> personId
+-- (Person = Participant). Data-preserving RENAME (not drop/add). The composite
+-- PK (programId, <col>) tracks the column rename automatically; FK constraints
+-- renamed explicitly.
+
+-- AlterTable
+ALTER TABLE "ProgramParticipant" RENAME COLUMN "participantId" TO "personId";
+ALTER TABLE "ProgramParticipant" RENAME CONSTRAINT "ProgramParticipant_participantId_fkey" TO "ProgramParticipant_personId_fkey";
+
+-- AlterTable
+ALTER TABLE "ProgramVolunteer" RENAME COLUMN "participantId" TO "personId";
+ALTER TABLE "ProgramVolunteer" RENAME CONSTRAINT "ProgramVolunteer_participantId_fkey" TO "ProgramVolunteer_personId_fkey";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -633,21 +633,21 @@ model ProgramVolunteer {
   /// @sensitivity:public
   programId     Int
   /// @sensitivity:public
-  participantId Int
+  personId Int
   /// @sensitivity:internal
   isCore        Boolean @default(false)
 
-  program     Program     @relation(fields: [programId], references: [id])
-  participant Participant @relation(fields: [participantId], references: [id])
+  program Program     @relation(fields: [programId], references: [id])
+  person  Participant @relation(fields: [personId], references: [id])
 
-  @@id([programId, participantId])
+  @@id([programId, personId])
 }
 
 model ProgramParticipant {
   /// @sensitivity:public
   programId            Int
   /// @sensitivity:public
-  participantId        Int
+  personId             Int
   /// @sensitivity:public
   status               ProgramParticipantStatus @default(PENDING)
   /// @sensitivity:personal
@@ -655,10 +655,10 @@ model ProgramParticipant {
   /// @sensitivity:internal
   pendingSince         DateTime?                @default(now())
 
-  program     Program     @relation(fields: [programId], references: [id])
-  participant Participant @relation(fields: [participantId], references: [id])
+  program Program     @relation(fields: [programId], references: [id])
+  person  Participant @relation(fields: [personId], references: [id])
 
-  @@id([programId, participantId])
+  @@id([programId, personId])
 }
 
 model Fee {

--- a/checkin-app/src/app/__tests__/autoAssociation.integration.test.ts
+++ b/checkin-app/src/app/__tests__/autoAssociation.integration.test.ts
@@ -95,10 +95,10 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
 
         // Enroll User in A and B
         await prisma.programParticipant.create({
-            data: { programId: programAId, participantId }
+            data: { programId: programAId, personId: participantId }
         });
         await prisma.programParticipant.create({
-            data: { programId: programBId, participantId }
+            data: { programId: programBId, personId: participantId }
         });
     });
 
@@ -205,7 +205,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
         it('should continue to chunk into the first event if the user is not enrolled in subsequent events', async () => {
             // Un-enroll user from B so they are ONLY enrolled in A.
             await prisma.programParticipant.deleteMany({
-                where: { participantId, programId: programBId }
+                where: { personId: participantId, programId: programBId }
             });
 
             // Arrives during A, leaves during B time

--- a/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
@@ -40,7 +40,7 @@ describe('Cron Pending-Participants API Integration Tests', () => {
             select: { id: true }
         });
         const leakedIds = leaked.map(u => u.id);
-        await prisma.programParticipant.deleteMany({ where: { participantId: { in: leakedIds } } });
+        await prisma.programParticipant.deleteMany({ where: { personId: { in: leakedIds } } });
         await prisma.participant.deleteMany({ where: { id: { in: leakedIds } } });
         await prisma.program.deleteMany({ where: { name: { contains: 'Pending Cron Test' } } });
 
@@ -58,11 +58,11 @@ describe('Cron Pending-Participants API Integration Tests', () => {
 
         await prisma.programParticipant.createMany({
             data: [
-                { programId, participantId: ids.day1, status: 'PENDING', pendingSince: daysAgo(now, 1) },
-                { programId, participantId: ids.day3, status: 'PENDING', pendingSince: daysAgo(now, 3) },
-                { programId, participantId: ids.day6, status: 'PENDING', pendingSince: daysAgo(now, 6) },
-                { programId, participantId: ids.day7, status: 'PENDING', pendingSince: daysAgo(now, 7) },
-                { programId, participantId: ids.plan, status: 'PENDING', pendingSince: daysAgo(now, 8), isPaymentPlanRequested: true },
+                { programId, personId: ids.day1, status: 'PENDING', pendingSince: daysAgo(now, 1) },
+                { programId, personId: ids.day3, status: 'PENDING', pendingSince: daysAgo(now, 3) },
+                { programId, personId: ids.day6, status: 'PENDING', pendingSince: daysAgo(now, 6) },
+                { programId, personId: ids.day7, status: 'PENDING', pendingSince: daysAgo(now, 7) },
+                { programId, personId: ids.plan, status: 'PENDING', pendingSince: daysAgo(now, 8), isPaymentPlanRequested: true },
             ]
         });
     });
@@ -109,11 +109,11 @@ describe('Cron Pending-Participants API Integration Tests', () => {
 
             // DB reality: only day7 deleted; the warned rows and the payment-plan row survive.
             const survivors = await prisma.programParticipant.findMany({ where: { programId } });
-            const survivorPids = survivors.map(s => s.participantId).sort((a, b) => a - b);
+            const survivorPids = survivors.map(s => s.personId).sort((a, b) => a - b);
             expect(survivorPids).toEqual([ids.day1, ids.day3, ids.day6, ids.plan].sort((a, b) => a - b));
 
             const day7 = await prisma.programParticipant.findUnique({
-                where: { programId_participantId: { programId, participantId: ids.day7 } }
+                where: { programId_personId: { programId, personId: ids.day7 } }
             });
             expect(day7).toBeNull();
         });

--- a/checkin-app/src/app/__tests__/eventMineAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventMineAPI.integration.test.ts
@@ -31,10 +31,10 @@ describe('My Events API Integration Tests', () => {
             where: { name: { contains: 'Mine Test Event' } }
         });
         await prisma.programParticipant.deleteMany({
-            where: { participant: { email: { contains: 'mine-events-test' } } }
+            where: { person: { email: { contains: 'mine-events-test' } } }
         });
         await prisma.programVolunteer.deleteMany({
-            where: { participant: { email: { contains: 'mine-events-test' } } }
+            where: { person: { email: { contains: 'mine-events-test' } } }
         });
         await prisma.program.deleteMany({
             where: { name: { contains: 'Mine Test Program' } }
@@ -78,7 +78,7 @@ describe('My Events API Integration Tests', () => {
         await prisma.programParticipant.create({
             data: {
                 programId: testProgram1Id,
-                participantId: testUserId
+                personId: testUserId
             }
         });
 
@@ -86,7 +86,7 @@ describe('My Events API Integration Tests', () => {
         await prisma.programVolunteer.create({
             data: {
                 programId: testProgram2Id,
-                participantId: testVolunteerId
+                personId: testVolunteerId
             }
         });
 

--- a/checkin-app/src/app/__tests__/eventRSVPAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventRSVPAPI.integration.test.ts
@@ -31,7 +31,7 @@ describe('Event RSVP API Integration Tests', () => {
             where: { name: 'RSVP Test Event' }
         });
         await prisma.programParticipant.deleteMany({
-            where: { participant: { email: { contains: 'rsvp-test' } } }
+            where: { person: { email: { contains: 'rsvp-test' } } }
         });
         await prisma.program.deleteMany({
             where: { name: 'RSVP Test Program' }
@@ -66,7 +66,7 @@ describe('Event RSVP API Integration Tests', () => {
         await prisma.programParticipant.create({
             data: {
                 programId: testProgramId,
-                participantId: testUserId
+                personId: testUserId
             }
         });
 

--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -66,7 +66,7 @@ describe('Facility trends API', () => {
 
         // Enroll the adult in `programId` (ACTIVE) — this, not their age, makes them a participant.
         await prisma.programParticipant.create({
-            data: { programId, participantId: enrolledAdultId, status: 'ACTIVE' },
+            data: { programId, personId: enrolledAdultId, status: 'ACTIVE' },
         });
 
         // Structured visit (associated to the event): enrolled adult, 3 hours -> participant.

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -112,8 +112,8 @@ describe('Nav todo-counts API', () => {
         const program2 = await prisma.program.create({ data: { name: `Prog2 ${TAG}` } });
         program1Id = program1.id;
         program2Id = program2.id;
-        await prisma.programParticipant.create({ data: { programId: program1Id, participantId: leadId, status: 'PENDING' } });
-        await prisma.programParticipant.create({ data: { programId: program2Id, participantId: secondMemberId, status: 'PENDING', isPaymentPlanRequested: true } });
+        await prisma.programParticipant.create({ data: { programId: program1Id, personId: leadId, status: 'PENDING' } });
+        await prisma.programParticipant.create({ data: { programId: program2Id, personId: secondMemberId, status: 'PENDING', isPaymentPlanRequested: true } });
 
         // The lead also *runs* a program (leadMentorId). Three events: one ended
         // and unconfirmed (the inbox item), one ended but already confirmed, one

--- a/checkin-app/src/app/__tests__/programAgeStartDate.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeStartDate.integration.test.ts
@@ -37,7 +37,7 @@ describe('Program Age Start-Date Basis (authenticated route)', () => {
     let userId: number;
 
     beforeAll(async () => {
-        await prisma.programParticipant.deleteMany({ where: { participant: { email: { contains: 'age-startdate-test' } } } });
+        await prisma.programParticipant.deleteMany({ where: { person: { email: { contains: 'age-startdate-test' } } } });
         await prisma.participant.deleteMany({ where: { email: { contains: 'age-startdate-test' } } });
         await prisma.program.deleteMany({ where: { name: { contains: 'Age StartDate Test' } } });
 

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -91,9 +91,9 @@ describe('Program payment-plan routes', () => {
 
     async function enroll(participantId: number, opts: { requested: boolean }) {
         await prisma.programParticipant.upsert({
-            where: { programId_participantId: { programId, participantId } },
+            where: { programId_personId: { programId, personId: participantId } },
             update: { status: 'PENDING', isPaymentPlanRequested: opts.requested, pendingSince: new Date() },
-            create: { programId, participantId, status: 'PENDING', isPaymentPlanRequested: opts.requested, pendingSince: new Date() },
+            create: { programId, personId: participantId, status: 'PENDING', isPaymentPlanRequested: opts.requested, pendingSince: new Date() },
         });
     }
 
@@ -125,7 +125,7 @@ describe('Program payment-plan routes', () => {
             const res = await PlansGet(nextReq());
             expect(res.status).toBe(200);
             const rows = await res.json();
-            const ids = rows.map((r: { participantId: number }) => r.participantId);
+            const ids = rows.map((r: { personId: number }) => r.personId);
             expect(ids).toContain(selfId);
             expect(ids).not.toContain(noiseId);
         });
@@ -155,7 +155,7 @@ describe('Program payment-plan routes', () => {
             expect(res.status).toBe(200);
 
             const row = await prisma.programParticipant.findUnique({
-                where: { programId_participantId: { programId, participantId: selfId } },
+                where: { programId_personId: { programId, personId: selfId } },
             });
             expect(row?.status).toBe('ACTIVE');
             expect(row?.isPaymentPlanRequested).toBe(false);
@@ -185,7 +185,7 @@ describe('Program payment-plan routes', () => {
         });
 
         it('404 when the participant is not enrolled in the program', async () => {
-            await prisma.programParticipant.deleteMany({ where: { programId, participantId: otherId } });
+            await prisma.programParticipant.deleteMany({ where: { programId, personId: otherId } });
             mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
             const res = await RequestPost(requestReq({ participantId: otherId }), params(programId));
             expect(res.status).toBe(404);
@@ -199,7 +199,7 @@ describe('Program payment-plan routes', () => {
             expect(res.status).toBe(403);
 
             const row = await prisma.programParticipant.findUnique({
-                where: { programId_participantId: { programId, participantId: selfId } },
+                where: { programId_personId: { programId, personId: selfId } },
             });
             expect(row?.isPaymentPlanRequested).toBe(false);
         });
@@ -211,7 +211,7 @@ describe('Program payment-plan routes', () => {
             expect(res.status).toBe(200);
 
             const row = await prisma.programParticipant.findUnique({
-                where: { programId_participantId: { programId, participantId: selfId } },
+                where: { programId_personId: { programId, personId: selfId } },
             });
             expect(row?.isPaymentPlanRequested).toBe(true);
         });

--- a/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
@@ -44,7 +44,7 @@ describe('Eligible Participants API Integration Tests', () => {
             .filter((id): id is number => id !== null && id !== undefined);
 
         await prisma.programParticipant.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         // Memberships live on the household now; scope cleanup to this test's households.
@@ -168,7 +168,7 @@ describe('Eligible Participants API Integration Tests', () => {
 
         if (existingUserIds.length > 0) {
             await prisma.programParticipant.deleteMany({
-                where: { participantId: { in: existingUserIds } }
+                where: { personId: { in: existingUserIds } }
             });
 
             // Memberships are held by households. Scope the cleanup to exactly the

--- a/checkin-app/src/app/__tests__/programsHouseholdEnrollment.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsHouseholdEnrollment.integration.test.ts
@@ -47,7 +47,7 @@ describe('Multi-select household enrollment (integration)', () => {
         const ids = users.map(u => u.id);
         if (ids.length) {
             await prisma.householdLead.deleteMany({ where: { personId: { in: ids } } });
-            await prisma.programParticipant.deleteMany({ where: { participantId: { in: ids } } });
+            await prisma.programParticipant.deleteMany({ where: { personId: { in: ids } } });
             await prisma.auditLog.deleteMany({ where: { actorId: { in: ids } } });
         }
         await prisma.program.deleteMany({ where: { name: { contains: 'Household Enroll Test' } } });
@@ -117,9 +117,9 @@ describe('Multi-select household enrollment (integration)', () => {
 
         const rows = await prisma.programParticipant.findMany({
             where: { programId: freeProgramId },
-            select: { participantId: true }
+            select: { personId: true }
         });
-        expect(rows.map(r => r.participantId).sort((x, y) => x - y))
+        expect(rows.map(r => r.personId).sort((x, y) => x - y))
             .toEqual([leadId, depAId, depBId, depCId].sort((x, y) => x - y));
     });
 
@@ -136,17 +136,17 @@ describe('Multi-select household enrollment (integration)', () => {
         // were all enrolled in (a); use the lead's re-pass shape: drop depB then
         // re-add to prove the new-row path coexists with the 409.)
         await prisma.programParticipant.delete({
-            where: { programId_participantId: { programId: freeProgramId, participantId: depBId } }
+            where: { programId_personId: { programId: freeProgramId, personId: depBId } }
         });
         const fresh = await enroll(freeProgramId, depBId);
         expect(fresh.status).toBe(200);
 
         // Exactly one row for depA (no duplicate) and depB is back.
         expect(await prisma.programParticipant.count({
-            where: { programId: freeProgramId, participantId: depAId }
+            where: { programId: freeProgramId, personId: depAId }
         })).toBe(1);
         expect(await prisma.programParticipant.count({
-            where: { programId: freeProgramId, participantId: depBId }
+            where: { programId: freeProgramId, personId: depBId }
         })).toBe(1);
     });
 
@@ -169,10 +169,10 @@ describe('Multi-select household enrollment (integration)', () => {
 
         const enrolled = await prisma.programParticipant.findMany({
             where: { programId: cappedProgramId },
-            select: { participantId: true }
+            select: { personId: true }
         });
         expect(enrolled).toHaveLength(2);
-        expect(enrolled.map(r => r.participantId).sort((x, y) => x - y))
+        expect(enrolled.map(r => r.personId).sort((x, y) => x - y))
             .toEqual([leadId, depAId].sort((x, y) => x - y));
     });
 });

--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -109,7 +109,7 @@ describe('Individual Program API Integration Tests', () => {
         });
         enrolledId = enrolled.id;
         await prisma.programParticipant.create({
-            data: { programId: publicProgramId, participantId: enrolledId, status: 'ACTIVE' }
+            data: { programId: publicProgramId, personId: enrolledId, status: 'ACTIVE' }
         });
     });
 
@@ -256,7 +256,7 @@ describe('Individual Program API Integration Tests', () => {
 
              const data = await res.json();
              expect(Array.isArray(data.participants)).toBe(true);
-             expect(data.participants.some((p: { participantId: number }) => p.participantId === enrolledId)).toBe(true);
+             expect(data.participants.some((p: { personId: number }) => p.personId === enrolledId)).toBe(true);
              expect(JSON.stringify(data)).toContain(ENROLLED_NAME);
         });
 
@@ -269,7 +269,7 @@ describe('Individual Program API Integration Tests', () => {
 
              const data = await res.json();
              expect(Array.isArray(data.participants)).toBe(true);
-             expect(data.participants.some((p: { participantId: number }) => p.participantId === enrolledId)).toBe(true);
+             expect(data.participants.some((p: { personId: number }) => p.personId === enrolledId)).toBe(true);
         });
     });
 

--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -44,7 +44,7 @@ describe('Program Participants API Integration Tests', () => {
         });
 
         await prisma.programParticipant.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         await prisma.program.deleteMany({
@@ -132,7 +132,7 @@ describe('Program Participants API Integration Tests', () => {
                 enrollmentStatus: 'OPEN',
                 maxParticipants: 1,
                 participants: {
-                    create: { participantId: otherId }
+                    create: { personId: otherId }
                 }
             }
         });
@@ -153,7 +153,7 @@ describe('Program Participants API Integration Tests', () => {
                 where: { personId: { in: existingUserIds } }
             });
             await prisma.programParticipant.deleteMany({
-                where: { participantId: { in: existingUserIds } }
+                where: { personId: { in: existingUserIds } }
             });
         }
 
@@ -214,7 +214,7 @@ describe('Program Participants API Integration Tests', () => {
              
              const data = await res.json();
              expect(data.success).toBe(true);
-             expect(data.enrollment.participantId).toBe(commonId);
+             expect(data.enrollment.personId).toBe(commonId);
              expect(data.enrollment.status).toBe('PENDING');
         });
 
@@ -230,7 +230,7 @@ describe('Program Participants API Integration Tests', () => {
              
              const data = await res.json();
              expect(data.success).toBe(true);
-             expect(data.enrollment.participantId).toBe(commonId);
+             expect(data.enrollment.personId).toBe(commonId);
              expect(data.enrollment.status).toBe('ACTIVE');
         });
 
@@ -367,7 +367,7 @@ describe('Program Participants API Integration Tests', () => {
 
              // No duplicate row, no corruption: exactly one enrollment exists.
              const count = await prisma.programParticipant.count({
-                 where: { programId: freeProgramId, participantId: leadId }
+                 where: { programId: freeProgramId, personId: leadId }
              });
              expect(count).toBe(1);
         });
@@ -411,7 +411,7 @@ describe('Program Participants API Integration Tests', () => {
              
              const data = await res.json();
              expect(data.success).toBe(true);
-             expect(data.enrollment.participantId).toBe(commonId);
+             expect(data.enrollment.personId).toBe(commonId);
         });
         
         it('should allow a common user to drop out of their own program', async () => {

--- a/checkin-app/src/app/__tests__/programsParticipantsConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsConcurrency.integration.test.ts
@@ -45,7 +45,7 @@ describe('POST /api/programs/[id]/participants concurrency (capacity lock)', () 
         });
         const ids = users.map(u => u.id);
         const householdIds = [...new Set(users.map(u => u.householdId))];
-        await prisma.programParticipant.deleteMany({ where: { participantId: { in: ids } } });
+        await prisma.programParticipant.deleteMany({ where: { personId: { in: ids } } });
         await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { personId: { in: ids } } });

--- a/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
@@ -33,7 +33,7 @@ describe('Public Program Registration API Integration Tests', () => {
         const existingUserIds = existingUsers.map(u => u.id);
         
         await prisma.programParticipant.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         await prisma.program.deleteMany({
@@ -83,7 +83,7 @@ describe('Public Program Registration API Integration Tests', () => {
                 enrollmentStatus: 'OPEN',
                 maxParticipants: 1,
                 participants: {
-                    create: { participantId: existingParticipantId } // Pre-fill
+                    create: { personId: existingParticipantId } // Pre-fill
                 }
             }
         });
@@ -122,7 +122,7 @@ describe('Public Program Registration API Integration Tests', () => {
 
         if (existingUserIds.length > 0) {
             await prisma.programParticipant.deleteMany({
-                where: { participantId: { in: existingUserIds } }
+                where: { personId: { in: existingUserIds } }
             });
         }
 
@@ -157,7 +157,7 @@ describe('Public Program Registration API Integration Tests', () => {
                 where: { householdId: { in: householdIds } }
             });
             await prisma.programParticipant.deleteMany({
-                where: { participant: { householdId: { in: householdIds } } }
+                where: { person: { householdId: { in: householdIds } } }
             });
             await prisma.participant.deleteMany({
                 where: { householdId: { in: householdIds } }
@@ -387,7 +387,7 @@ describe('Public Program Registration API Integration Tests', () => {
             // Inline cleanup: this parent email isn't in the afterAll sweep list.
             const p = await prisma.participant.findUnique({ where: { email: inBoundsEmail } });
             if (p) {
-                await prisma.programParticipant.deleteMany({ where: { participant: { householdId: p.householdId } } });
+                await prisma.programParticipant.deleteMany({ where: { person: { householdId: p.householdId } } });
                 await prisma.householdLead.deleteMany({ where: { person: { householdId: p.householdId } } });
                 await prisma.participant.deleteMany({ where: { householdId: p.householdId } });
                 await prisma.household.delete({ where: { id: p.householdId as number } });
@@ -430,7 +430,7 @@ describe('Public Program Registration API Integration Tests', () => {
             expect(householdMembers.length).toBe(2); // Parent + Child (no duplicates)
 
             const enrollments = await prisma.programParticipant.findMany({
-                where: { programId: standardProgramId, participant: { householdId: parent?.householdId } }
+                where: { programId: standardProgramId, person: { householdId: parent?.householdId } }
             });
             expect(enrollments.length).toBe(2);
             expect(enrollments[0].status).toBe('PENDING');
@@ -506,7 +506,7 @@ describe('Public Program Registration API Integration Tests', () => {
             // Clean up the created one immediately for isolation
             const p = await prisma.participant.findUnique({ where: { email: uniqueEmail } });
             if (p) {
-                await prisma.programParticipant.deleteMany({ where: { programId: freeProgramId, participant: { householdId: p.householdId } }});
+                await prisma.programParticipant.deleteMany({ where: { programId: freeProgramId, person: { householdId: p.householdId } }});
                 await prisma.householdLead.deleteMany({ where: { person: { householdId: p.householdId } } });
                 await prisma.participant.deleteMany({ where: { householdId: p.householdId } });
                 await prisma.household.delete({ where: { id: p.householdId as number } });

--- a/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
@@ -195,8 +195,8 @@ describe('Program Settings API Integration Tests', () => {
              // Enroll 2 participants.
              await prisma.programParticipant.createMany({
                  data: [
-                     { programId: targetProgramId, participantId: commonId, status: 'ACTIVE' },
-                     { programId: targetProgramId, participantId: leadId, status: 'PENDING' },
+                     { programId: targetProgramId, personId: commonId, status: 'ACTIVE' },
+                     { programId: targetProgramId, personId: leadId, status: 'PENDING' },
                  ]
              });
 

--- a/checkin-app/src/app/__tests__/programsVolunteersAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsVolunteersAPI.integration.test.ts
@@ -32,7 +32,7 @@ describe('Program Volunteers API Integration Tests', () => {
         const existingUserIds = existingUsers.map(u => u.id);
         
         await prisma.programVolunteer.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         await prisma.program.deleteMany({
@@ -80,7 +80,7 @@ describe('Program Volunteers API Integration Tests', () => {
                 phase: 'RUNNING', 
                 leadMentorId: leadId,
                 volunteers: {
-                    create: { participantId: existingVolunteerId, isCore: false }
+                    create: { personId: existingVolunteerId, isCore: false }
                 }
             }
         });
@@ -92,7 +92,7 @@ describe('Program Volunteers API Integration Tests', () => {
 
         if (existingUserIds.length > 0) {
             await prisma.programVolunteer.deleteMany({
-                where: { participantId: { in: existingUserIds } }
+                where: { personId: { in: existingUserIds } }
             });
         }
 
@@ -154,11 +154,11 @@ describe('Program Volunteers API Integration Tests', () => {
              const data = await res.json();
              expect(data.success).toBe(true);
              expect(data.assignment.isCore).toBe(false); // Default logic
-             expect(data.assignment.participantId).toBe(candidateId);
+             expect(data.assignment.personId).toBe(candidateId);
 
              // Persisted: a ProgramVolunteer row now exists for this pair.
              const row = await prisma.programVolunteer.findUnique({
-                 where: { programId_participantId: { programId: targetProgramId, participantId: candidateId } }
+                 where: { programId_personId: { programId: targetProgramId, personId: candidateId } }
              });
              expect(row).not.toBeNull();
         });
@@ -207,7 +207,7 @@ describe('Program Volunteers API Integration Tests', () => {
              const candidate = await prisma.participant.findUnique({ where: { id: candidateId } });
              expect(candidate?.dateOfBirth).toBeNull();
              const row = await prisma.programVolunteer.findUnique({
-                 where: { programId_participantId: { programId: targetProgramId, participantId: candidateId } }
+                 where: { programId_personId: { programId: targetProgramId, personId: candidateId } }
              });
              expect(row).not.toBeNull();
         });
@@ -278,7 +278,7 @@ describe('Program Volunteers API Integration Tests', () => {
              
              const data = await res.json();
              expect(data.success).toBe(true);
-             expect(data.assignment.participantId).toBe(existingVolunteerId);
+             expect(data.assignment.personId).toBe(existingVolunteerId);
         });
     });
 });

--- a/checkin-app/src/app/__tests__/trustedAdultAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultAPI.integration.test.ts
@@ -52,7 +52,7 @@ describe('Trusted Adults API', () => {
             await prisma.trustedAdult.deleteMany({ where: { householdId: { in: ids } } });
             const parts = await prisma.participant.findMany({ where: { householdId: { in: ids } }, select: { id: true } });
             const pids = parts.map((p) => p.id);
-            await prisma.programParticipant.deleteMany({ where: { participantId: { in: pids } } });
+            await prisma.programParticipant.deleteMany({ where: { personId: { in: pids } } });
             await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
@@ -80,7 +80,7 @@ describe('Trusted Adults API', () => {
         // Program led by programLeadId with the family's child enrolled.
         const prog = await prisma.program.create({ data: { name: `Prog ${TAG}`, leadMentorId: programLeadId } });
         programId = prog.id;
-        await prisma.programParticipant.create({ data: { programId, participantId: childId, status: 'ACTIVE' } });
+        await prisma.programParticipant.create({ data: { programId, personId: childId, status: 'ACTIVE' } });
     });
 
     afterAll(async () => {

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -98,9 +98,9 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
 
     async function setPending(participantId: number) {
         await prisma.programParticipant.upsert({
-            where: { programId_participantId: { programId, participantId } },
+            where: { programId_personId: { programId, personId: participantId } },
             update: { status: 'PENDING', pendingSince: new Date() },
-            create: { programId, participantId, status: 'PENDING', pendingSince: new Date() },
+            create: { programId, personId: participantId, status: 'PENDING', pendingSince: new Date() },
         });
     }
 
@@ -141,13 +141,13 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
 
     it('acknowledges (200) but makes no change when the participant is not enrolled', async () => {
         // p1 has no programParticipant row for this program yet.
-        await prisma.programParticipant.deleteMany({ where: { programId, participantId: p1 } });
+        await prisma.programParticipant.deleteMany({ where: { programId, personId: p1 } });
         const body = programPayload(String(p1));
         const res = await POST(webhookReq(body, sign(body)));
         expect(res.status).toBe(200);
 
         const row = await prisma.programParticipant.findUnique({
-            where: { programId_participantId: { programId, participantId: p1 } },
+            where: { programId_personId: { programId, personId: p1 } },
         });
         expect(row).toBeNull();
     });
@@ -159,7 +159,7 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         const first = await POST(webhookReq(body, sign(body)));
         expect(first.status).toBe(200);
         let row = await prisma.programParticipant.findUnique({
-            where: { programId_participantId: { programId, participantId: p1 } },
+            where: { programId_personId: { programId, personId: p1 } },
         });
         expect(row?.status).toBe('ACTIVE');
         expect(row?.pendingSince).toBeNull();
@@ -168,7 +168,7 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         const second = await POST(webhookReq(body, sign(body)));
         expect(second.status).toBe(200);
         row = await prisma.programParticipant.findUnique({
-            where: { programId_participantId: { programId, participantId: p1 } },
+            where: { programId_personId: { programId, personId: p1 } },
         });
         // Still ACTIVE, still cleared — replay must not error or regress state.
         expect(row?.status).toBe('ACTIVE');
@@ -184,7 +184,7 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         expect(res.status).toBe(200);
 
         const rows = await prisma.programParticipant.findMany({
-            where: { programId, participantId: { in: [p1, p2] } },
+            where: { programId, personId: { in: [p1, p2] } },
         });
         expect(rows).toHaveLength(2);
         expect(rows.every(r => r.status === 'ACTIVE')).toBe(true);

--- a/checkin-app/src/app/api/cron/pending-participants/route.ts
+++ b/checkin-app/src/app/api/cron/pending-participants/route.ts
@@ -11,14 +11,14 @@ export const GET = withCron(async () => {
                 pendingSince: { not: null }
             },
             include: {
-                participant: true,
+                person: true,
                 program: true
             }
         });
 
         let kickedCount = 0;
         let warnedCount = 0;
-        const toDelete: { programId: number; participantId: number }[] = [];
+        const toDelete: { programId: number; personId: number }[] = [];
 
         for (const record of pendingParticipants) {
             if (!record.pendingSince) continue;
@@ -33,24 +33,24 @@ export const GET = withCron(async () => {
                 // Collect IDs for batch deletion
                 toDelete.push({
                     programId: record.programId,
-                    participantId: record.participantId
+                    personId: record.personId
                 });
 
                 kickedCount++;
 
-                console.log(`[CRON] Removed participant ${record.participant.name} from ${record.program.name} after ${diffDays} days.`);
-                console.log(`[EMAIL DISPATCH] To: ${record.participant.email}, Subject: Removed from ${record.program.name} due to non-payment`);
+                console.log(`[CRON] Removed participant ${record.person.name} from ${record.program.name} after ${diffDays} days.`);
+                console.log(`[EMAIL DISPATCH] To: ${record.person.email}, Subject: Removed from ${record.program.name} due to non-payment`);
             } else if (diffDays === 6) {
                 warnedCount++;
-                console.log(`[EMAIL DISPATCH] To: ${record.participant.email}, Subject: FINAL WARNING: 24 hours left to pay for ${record.program.name}`);
+                console.log(`[EMAIL DISPATCH] To: ${record.person.email}, Subject: FINAL WARNING: 24 hours left to pay for ${record.program.name}`);
                 console.log(`[EMAIL DISPATCH] Body: ${warningText}`);
             } else if (diffDays === 3) {
                 warnedCount++;
-                console.log(`[EMAIL DISPATCH] To: ${record.participant.email}, Subject: Please pay for ${record.program.name} within 4 days`);
+                console.log(`[EMAIL DISPATCH] To: ${record.person.email}, Subject: Please pay for ${record.program.name} within 4 days`);
                 console.log(`[EMAIL DISPATCH] Body: ${warningText}`);
             } else if (diffDays === 1) {
                 warnedCount++;
-                console.log(`[EMAIL DISPATCH] To: ${record.participant.email}, Subject: Reminder: Payment required for ${record.program.name}`);
+                console.log(`[EMAIL DISPATCH] To: ${record.person.email}, Subject: Reminder: Payment required for ${record.program.name}`);
                 console.log(`[EMAIL DISPATCH] Body: ${warningText}`);
             }
         }

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -29,10 +29,10 @@ export const GET = handler<{ id: string }>('GET /api/events/[id]', async ({ auth
             program: {
                 include: {
                     volunteers: {
-                        include: { participant: true }
+                        include: { person: true }
                     },
                     participants: {
-                        include: { participant: true }
+                        include: { person: true }
                     }
                 }
             },
@@ -54,7 +54,7 @@ export const GET = handler<{ id: string }>('GET /api/events/[id]', async ({ auth
         auth.user.isSysadmin ||
         auth.user.isBoardMember ||
         event.program?.leadMentorId === auth.user.id ||
-        (event.program?.volunteers?.some(v => v.participantId === auth.user.id && v.isCore) ?? false)
+        (event.program?.volunteers?.some(v => v.personId === auth.user.id && v.isCore) ?? false)
     );
     if (!isStaff) throw forbidden('Forbidden: Not authorized to view this event');
 
@@ -80,7 +80,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
         const userId = auth.user.id;
         const isSysAdminOrBoard = auth.user.isSysadmin || auth.user.isBoardMember;
         const isLeadMentor = event.program?.leadMentorId === userId;
-        const isCoreVolunteer = event.program?.volunteers?.some(v => v.participantId === userId && v.isCore) || false;
+        const isCoreVolunteer = event.program?.volunteers?.some(v => v.personId === userId && v.isCore) || false;
 
         // Action: Confirm Attendance
         if (body.action === 'confirmAttendance') {

--- a/checkin-app/src/app/api/events/[id]/rsvp/route.ts
+++ b/checkin-app/src/app/api/events/[id]/rsvp/route.ts
@@ -51,17 +51,17 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         if (event.programId) {
             const isEnrolled = await prisma.programParticipant.findUnique({
                 where: {
-                    programId_participantId: {
+                    programId_personId: {
                         programId: event.programId,
-                        participantId: currentUserId
+                        personId: currentUserId
                     }
                 }
             });
             const isVolunteer = await prisma.programVolunteer.findUnique({
                 where: {
-                    programId_participantId: {
+                    programId_personId: {
                         programId: event.programId,
-                        participantId: currentUserId
+                        personId: currentUserId
                     }
                 }
             });

--- a/checkin-app/src/app/api/events/mine/route.ts
+++ b/checkin-app/src/app/api/events/mine/route.ts
@@ -18,20 +18,20 @@ export const GET = withAuth({}, async (_req, auth) => {
         // Which household members are tied to which programs (enrolled or volunteering).
         const [enrolled, volunteers] = await Promise.all([
             prisma.programParticipant.findMany({
-                where: { participantId: { in: householdMemberIds } },
-                select: { participantId: true, programId: true }
+                where: { personId: { in: householdMemberIds } },
+                select: { personId: true, programId: true }
             }),
             prisma.programVolunteer.findMany({
-                where: { participantId: { in: householdMemberIds } },
-                select: { participantId: true, programId: true }
+                where: { personId: { in: householdMemberIds } },
+                select: { personId: true, programId: true }
             })
         ]);
 
         const programParticipants = new Map<number, Set<number>>();
-        for (const { programId, participantId } of [...enrolled, ...volunteers]) {
+        for (const { programId, personId } of [...enrolled, ...volunteers]) {
             let set = programParticipants.get(programId);
             if (!set) programParticipants.set(programId, (set = new Set()));
-            set.add(participantId);
+            set.add(personId);
         }
 
         const events = await prisma.event.findMany({

--- a/checkin-app/src/app/api/facility/trends/route.ts
+++ b/checkin-app/src/app/api/facility/trends/route.ts
@@ -111,9 +111,9 @@ export const GET = withAuth(
             // enrollments count — PENDING is applied-but-not-yet-approved, not an enrollee.
             const enrollments = await prisma.programParticipant.findMany({
                 where: { status: "ACTIVE", ...(programId ? { programId } : {}) },
-                select: { participantId: true },
+                select: { personId: true },
             });
-            const enrolledParticipantIds = new Set(enrollments.map(e => e.participantId));
+            const enrolledParticipantIds = new Set(enrollments.map(e => e.personId));
 
             const bucketMap = new Map<string, {
                 label: string;

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -10,7 +10,7 @@ export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
             status: 'PENDING'
         },
         include: {
-            participant: true,
+            person: true,
             program: true
         },
         orderBy: {
@@ -42,7 +42,7 @@ export const POST = withAuth(
             // Scope to the pending request so approving a non-pending/nonexistent
             // request is a no-op error, mirroring the GET queue's filter.
             const { count } = await prisma.programParticipant.updateMany({
-                where: { programId, participantId, isPaymentPlanRequested: true, status: 'PENDING' },
+                where: { programId, personId: participantId, isPaymentPlanRequested: true, status: 'PENDING' },
                 data
             });
 

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -63,7 +63,7 @@ describe("Merge Participants API", () => {
         // they must go before the participants.
         await prisma.feePayment.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
         await prisma.visit.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
-        await prisma.programParticipant.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
+        await prisma.programParticipant.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
         await prisma.householdLead.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
         await prisma.auditLog.deleteMany({ where: { actorId } });
         await prisma.participant.deleteMany({ where: { id: { in: [pKeepId, pMergeId, actorId] } } });
@@ -150,8 +150,8 @@ describe("Merge Participants API", () => {
         createdFeeId = fee.id;
 
         // SAME programId for both → programParticipant conflict.
-        await prisma.programParticipant.create({ data: { programId: program.id, participantId: pKeepId } });
-        await prisma.programParticipant.create({ data: { programId: program.id, participantId: pMergeId } });
+        await prisma.programParticipant.create({ data: { programId: program.id, personId: pKeepId } });
+        await prisma.programParticipant.create({ data: { programId: program.id, personId: pMergeId } });
         // SAME feeId for both → feePayment conflict.
         await prisma.feePayment.create({ data: { feeId: fee.id, personId: pKeepId } });
         await prisma.feePayment.create({ data: { feeId: fee.id, personId: pMergeId } });
@@ -165,13 +165,13 @@ describe("Merge Participants API", () => {
         expect(res.status).toBe(200);
 
         // Keep retains exactly one of each — no duplicate, no double-count.
-        const keepPPs = await prisma.programParticipant.findMany({ where: { participantId: pKeepId, programId: program.id } });
+        const keepPPs = await prisma.programParticipant.findMany({ where: { personId: pKeepId, programId: program.id } });
         expect(keepPPs.length).toBe(1);
         const keepFPs = await prisma.feePayment.findMany({ where: { personId: pKeepId, feeId: fee.id } });
         expect(keepFPs.length).toBe(1);
 
         // The loser's rows were deleted (relink would have violated the composite PK).
-        const mergePPCount = await prisma.programParticipant.count({ where: { participantId: pMergeId } });
+        const mergePPCount = await prisma.programParticipant.count({ where: { personId: pMergeId } });
         expect(mergePPCount).toBe(0);
         const mergeFPCount = await prisma.feePayment.count({ where: { personId: pMergeId } });
         expect(mergeFPCount).toBe(0);

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -91,13 +91,13 @@ export const POST = withAuth(
                 for (const pp of mergeParticipant.programParticipants) {
                     if (!keepParticipant.programParticipants.find(k => k.programId === pp.programId)) {
                         await tx.programParticipant.update({
-                            where: { programId_participantId: { programId: pp.programId, participantId: mergeId } },
-                            data: { participantId: keepId }
+                            where: { programId_personId: { programId: pp.programId, personId: mergeId } },
+                            data: { personId: keepId }
                         });
                         moved.programParticipants.migrated++;
                     } else {
                         await tx.programParticipant.delete({
-                            where: { programId_participantId: { programId: pp.programId, participantId: mergeId } }
+                            where: { programId_personId: { programId: pp.programId, personId: mergeId } }
                         });
                         moved.programParticipants.deleted++;
                     }
@@ -106,13 +106,13 @@ export const POST = withAuth(
                 for (const pv of mergeParticipant.programVolunteers) {
                     if (!keepParticipant.programVolunteers.find(k => k.programId === pv.programId)) {
                         await tx.programVolunteer.update({
-                            where: { programId_participantId: { programId: pv.programId, participantId: mergeId } },
-                            data: { participantId: keepId }
+                            where: { programId_personId: { programId: pv.programId, personId: mergeId } },
+                            data: { personId: keepId }
                         });
                         moved.programVolunteers.migrated++;
                     } else {
                         await tx.programVolunteer.delete({
-                            where: { programId_participantId: { programId: pv.programId, participantId: mergeId } }
+                            where: { programId_personId: { programId: pv.programId, personId: mergeId } }
                         });
                         moved.programVolunteers.deleted++;
                     }

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -164,7 +164,7 @@ export const GET = withAuth({}, async (_req, auth) => {
                 },
             }),
             prisma.programParticipant.findMany({
-                where: { participantId: { in: memberIds }, status: "PENDING" },
+                where: { personId: { in: memberIds }, status: "PENDING" },
                 select: { programId: true, program: { select: { name: true } } },
             }),
         ]);
@@ -238,7 +238,7 @@ export const GET = withAuth({}, async (_req, auth) => {
             prisma.programParticipant.groupBy({
                 by: ["programId"],
                 where: { programId: { in: ledIds }, status: "ACTIVE" },
-                _count: { participantId: true },
+                _count: { personId: true },
             }),
             // All upcoming sessions, ascending; we keep the next 3 per program below.
             prisma.event.findMany({
@@ -249,11 +249,11 @@ export const GET = withAuth({}, async (_req, auth) => {
             // Volunteer roster per program — used to split RSVP tallies by role.
             prisma.programVolunteer.findMany({
                 where: { programId: { in: ledIds } },
-                select: { programId: true, participantId: true },
+                select: { programId: true, personId: true },
             }),
         ]);
-        // (programId, participantId) keys that belong to a volunteer; everyone else on a roster is a participant.
-        const volunteerKeys = new Set(volunteerRows.map((v) => `${v.programId}:${v.participantId}`));
+        // (programId, personId) keys that belong to a volunteer; everyone else on a roster is a participant.
+        const volunteerKeys = new Set(volunteerRows.map((v) => `${v.programId}:${v.personId}`));
 
         const pendingByProgram = new Map<number, TodoItem[]>();
         for (const e of pendingEvents) {
@@ -267,7 +267,7 @@ export const GET = withAuth({}, async (_req, auth) => {
             pendingByProgram.set(e.programId, items);
         }
 
-        const enrolledByProgram = new Map(enrolledCounts.map((g) => [g.programId, g._count.participantId]));
+        const enrolledByProgram = new Map(enrolledCounts.map((g) => [g.programId, g._count.personId]));
 
         // Next 3 future sessions per program (futureEvents is already startAt-asc).
         const upcomingByProgram = new Map<number, { id: number; name: string; startAt: Date }[]>();

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -121,7 +121,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             return tx.programParticipant.create({
                 data: {
                     programId,
-                    participantId,
+                    personId: participantId,
                     status: initialStatus
                 }
             });
@@ -200,9 +200,9 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
 
         const enrollment = await prisma.programParticipant.delete({
             where: {
-                programId_participantId: {
+                programId_personId: {
                     programId,
-                    participantId
+                    personId: participantId
                 }
             }
         });

--- a/checkin-app/src/app/api/programs/[id]/public-register/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/public-register/route.ts
@@ -180,7 +180,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                 const enrollment = await tx.programParticipant.create({
                     data: {
                         programId,
-                        participantId,
+                        personId: participantId,
                         status: initialStatus
                     }
                 });

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -22,12 +22,12 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
 
         const participant = await prisma.programParticipant.findUnique({
             where: {
-                programId_participantId: {
+                programId_personId: {
                     programId,
-                    participantId
+                    personId: participantId
                 }
             },
-            include: { participant: true, program: true }
+            include: { person: true, program: true }
         });
 
         if (!participant) {
@@ -44,11 +44,11 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         const isLeadMentor = participant.program?.leadMentorId === currentUserId;
 
         let isHouseholdLead = false;
-        if (!isSelf && !isSysAdminOrBoard && !isLeadMentor && participant.participant?.householdId) {
+        if (!isSelf && !isSysAdminOrBoard && !isLeadMentor && participant.person?.householdId) {
             const leadRecord = await prisma.householdLead.findUnique({
                 where: {
                     householdId_personId: {
-                        householdId: participant.participant.householdId,
+                        householdId: participant.person.householdId,
                         personId: currentUserId
                     }
                 }
@@ -62,7 +62,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
 
         const updatedParticipant = await prisma.programParticipant.update({
             where: {
-                programId_participantId: { programId, participantId }
+                programId_personId: { programId, personId: participantId }
             },
             data: {
                 isPaymentPlanRequested: true
@@ -71,7 +71,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
 
         // Send email to finances
         // In a real implementation this would trigger an actual email via SendGrid, NodeMailer, etc.
-        console.log(`[EMAIL DISPATCH] To: finances@innovationtreehouse.org, Subject: Payment Plan Request for ${participant.participant?.name || 'User'} in ${participant.program?.name || 'Program'}`);
+        console.log(`[EMAIL DISPATCH] To: finances@innovationtreehouse.org, Subject: Payment Plan Request for ${participant.person?.name || 'User'} in ${participant.program?.name || 'Program'}`);
 
         return NextResponse.json({ success: true, participant: updatedParticipant });
     } catch (error) {

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -12,10 +12,10 @@ export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
     const program = await prisma.program.findUnique({
         where: { id: programId },
         include: {
-            volunteers: { include: { participant: true } },
+            volunteers: { include: { person: true } },
             participants: {
                 include: {
-                    participant: {
+                    person: {
                         include: {
                             household: {
                                 include: {
@@ -46,7 +46,7 @@ export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
     const sessionUser = isSessionUser ? auth.user : undefined;
     const isSysAdminOrBoard = !!(sessionUser?.isSysadmin || sessionUser?.isBoardMember);
     const isLeadMentor = !!sessionUser && sessionUser.id === program.leadMentorId;
-    const isCoreVolunteer = !!sessionUser && program.volunteers.some(v => v.participantId === sessionUser.id && v.isCore);
+    const isCoreVolunteer = !!sessionUser && program.volunteers.some(v => v.personId === sessionUser.id && v.isCore);
     const isPrivileged = isSysAdminOrBoard || isLeadMentor || isCoreVolunteer;
 
     if (program.memberOnly && !isPrivileged) {
@@ -74,8 +74,8 @@ export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
     // The registry orderedView tiers remain as defense-in-depth, stripping
     // pii/personal on the rows for non-staff-but-enrolled callers.
     const isEnrolled = !!sessionUser && program.participants.some(p =>
-        p.participantId === sessionUser.id ||
-        (sessionUser.householdId != null && p.participant?.householdId === sessionUser.householdId)
+        p.personId === sessionUser.id ||
+        (sessionUser.householdId != null && p.person?.householdId === sessionUser.householdId)
     );
     if (!isPrivileged && !isEnrolled) {
         const metadata: Record<string, unknown> = { ...program };

--- a/checkin-app/src/app/api/programs/[id]/volunteers/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/volunteers/route.ts
@@ -38,7 +38,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         const assignment = await prisma.programVolunteer.create({
             data: {
                 programId,
-                participantId,
+                personId: participantId,
                 isCore: false
             }
         });
@@ -110,9 +110,9 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
 
         const assignment = await prisma.programVolunteer.delete({
             where: {
-                programId_participantId: {
+                programId_personId: {
                     programId,
-                    participantId
+                    personId: participantId
                 }
             }
         });
@@ -167,9 +167,9 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
 
         const assignment = await prisma.programVolunteer.update({
             where: {
-                programId_participantId: {
+                programId_personId: {
                     programId,
-                    participantId
+                    personId: participantId
                 }
             },
             data: {

--- a/checkin-app/src/app/api/programs/mine/route.ts
+++ b/checkin-app/src/app/api/programs/mine/route.ts
@@ -15,11 +15,11 @@ export const GET = withAuth({}, async (_req, auth) => {
         const householdMemberIds = householdMembers.map(m => m.id);
 
         const enrollments = await prisma.programParticipant.findMany({
-            where: { participantId: { in: householdMemberIds } },
+            where: { personId: { in: householdMemberIds } },
             select: {
                 programId: true,
-                participantId: true,
-                participant: { select: { id: true, name: true } },
+                personId: true,
+                person: { select: { id: true, name: true } },
                 program: {
                     select: { id: true, name: true, startAt: true, endAt: true }
                 }

--- a/checkin-app/src/app/api/trusted-adults/operational/route.ts
+++ b/checkin-app/src/app/api/trusted-adults/operational/route.ts
@@ -23,15 +23,15 @@ export const GET = handler("GET /api/trusted-adults/operational", async ({ auth 
         // Program leads: households of children enrolled in programs they lead or core-vol.
         const led = await prisma.program.findMany({
             where: { leadMentorId: u.id },
-            select: { participants: { select: { participant: { select: { householdId: true } } } } },
+            select: { participants: { select: { person: { select: { householdId: true } } } } },
         });
         const coreVol = await prisma.programVolunteer.findMany({
-            where: { participantId: u.id, isCore: true },
-            select: { program: { select: { participants: { select: { participant: { select: { householdId: true } } } } } } },
+            where: { personId: u.id, isCore: true },
+            select: { program: { select: { participants: { select: { person: { select: { householdId: true } } } } } } },
         });
         const households = new Set<number>();
-        for (const p of led) for (const pp of p.participants) households.add(pp.participant.householdId);
-        for (const v of coreVol) for (const pp of v.program.participants) households.add(pp.participant.householdId);
+        for (const p of led) for (const pp of p.participants) households.add(pp.person.householdId);
+        for (const v of coreVol) for (const pp of v.program.participants) households.add(pp.person.householdId);
         if (households.size === 0) return { TrustedAdult: [] };
         where.householdId = { in: [...households] };
     }

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -122,14 +122,14 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                     // Find existing participant
                     const existing = await prisma.programParticipant.findUnique({
                         where: {
-                            programId_participantId: { programId, participantId }
+                            programId_personId: { programId, personId: participantId }
                         }
                     });
 
                     if (existing) {
                         await prisma.programParticipant.update({
                             where: {
-                                programId_participantId: { programId, participantId }
+                                programId_personId: { programId, personId: participantId }
                             },
                             data: {
                                 status: 'ACTIVE',

--- a/checkin-app/src/app/finance-ops/payment-plan/__tests__/page.test.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/__tests__/page.test.tsx
@@ -13,9 +13,9 @@ beforeEach(() => resetRtl());
 const requests = [
   {
     programId: 10,
-    participantId: 20,
+    personId: 20,
     pendingSince: "2026-01-01T00:00:00.000Z",
-    participant: { id: 20, name: "Pat Participant", email: "pat@example.com" },
+    person: { id: 20, name: "Pat Participant", email: "pat@example.com" },
     program: { id: 10, name: "Robotics", memberPriceCents: 5000, nonMemberPriceCents: 7500 },
   },
 ];

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -12,9 +12,9 @@ import { formatCents } from '@inventory/money';
 
 type PaymentPlanRequest = {
   programId: number;
-  participantId: number;
+  personId: number;
   pendingSince: string;
-  participant: {
+  person: {
     id: number;
     name: string | null;
     email: string;
@@ -65,7 +65,7 @@ export default function PendingParticipantsPage() {
       });
 
       if (res.ok) {
-        setRequests(prev => prev.filter(r => !(r.programId === programId && r.participantId === participantId)));
+        setRequests(prev => prev.filter(r => !(r.programId === programId && r.personId === participantId)));
         notifyNavRefresh();
       } else {
         const data = await res.json();
@@ -85,11 +85,11 @@ export default function PendingParticipantsPage() {
   const columns: DataTableColumn<PaymentPlanRequest>[] = [
     {
       header: 'Participant',
-      sortBy: (req) => req.participant.name?.toLowerCase() ?? req.participant.email.toLowerCase(),
+      sortBy: (req) => req.person.name?.toLowerCase() ?? req.person.email.toLowerCase(),
       render: (req) => (
         <>
-          <Text fw={500}>{req.participant.name}</Text>
-          <Text size="sm" c="dimmed">{req.participant.email}</Text>
+          <Text fw={500}>{req.person.name}</Text>
+          <Text size="sm" c="dimmed">{req.person.email}</Text>
         </>
       ),
     },
@@ -114,7 +114,7 @@ export default function PendingParticipantsPage() {
       header: 'Actions',
       align: 'right',
       render: (req) => (
-        <Button size="xs" fz={15} color="green" variant="light" onClick={() => handleApprove(req.programId, req.participantId)}>
+        <Button size="xs" fz={15} color="green" variant="light" onClick={() => handleApprove(req.programId, req.personId)}>
           Approve &amp; Mark Active
         </Button>
       ),
@@ -134,7 +134,7 @@ export default function PendingParticipantsPage() {
       <DataTable
         columns={columns}
         rows={requests}
-        getRowKey={(req) => `${req.programId}-${req.participantId}`}
+        getRowKey={(req) => `${req.programId}-${req.personId}`}
         emptyMessage="No pending payment plan requests."
       />
     </Stack>

--- a/checkin-app/src/app/my-activities/programs/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-activities/programs/__tests__/page.test.tsx
@@ -12,7 +12,7 @@ describe("MyProgramsDashboard", () => {
         setSession({ id: 1, householdLead: true });
         mockFetchJson({
             "/api/programs/mine": [
-                { programId: 5, participantId: 100, participant: { id: 100, name: "Kid One" }, program: { id: 5, name: "Robotics Club", startAt: "2026-06-01T00:00:00.000Z", endAt: null } },
+                { programId: 5, personId: 100, person: { id: 100, name: "Kid One" }, program: { id: 5, name: "Robotics Club", startAt: "2026-06-01T00:00:00.000Z", endAt: null } },
             ],
         });
         renderWithProviders(<MyProgramsDashboard />);

--- a/checkin-app/src/app/my-activities/programs/page.tsx
+++ b/checkin-app/src/app/my-activities/programs/page.tsx
@@ -9,8 +9,8 @@ import { formatDate } from '@/lib/time';
 
 type UserProgram = {
   programId: number;
-  participantId: number;
-  participant: { id: number; name: string | null };
+  personId: number;
+  person: { id: number; name: string | null };
   program: {
     id: number;
     name: string;
@@ -85,10 +85,10 @@ export default function MyProgramsDashboard() {
         </Card>
       ) : (
         <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }}>
-          {enrollments.map(({ program, participantId, participant }) => (
-            <Card key={`${program.id}-${participantId}`} withBorder radius="md" padding="lg">
+          {enrollments.map(({ program, personId, person }) => (
+            <Card key={`${program.id}-${personId}`} withBorder radius="md" padding="lg">
               {showMembers && (
-                <Badge variant="light" mb="sm">{participant.name ?? 'Member'}</Badge>
+                <Badge variant="light" mb="sm">{person.name ?? 'Member'}</Badge>
               )}
               <Title order={4} mb="sm">{program.name}</Title>
               <Text c="dimmed" style={{ flex: 1 }}>

--- a/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
@@ -127,13 +127,13 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
         {program.volunteers.length === 0 ? <Text c="dimmed">No volunteers assigned.</Text> : (
           <Stack gap="xs">
             {sortedVolunteers.map(v => (
-              <Group key={v.participantId} justify="space-between" p="sm" style={{ borderRadius: 6, background: 'var(--mantine-color-default-hover)' }}>
+              <Group key={v.personId} justify="space-between" p="sm" style={{ borderRadius: 6, background: 'var(--mantine-color-default-hover)' }}>
                 <Group gap="md" wrap="wrap">
-                  <Text fw={500}>{v.participant.name || 'Unnamed'} <Text component="span" c="dimmed" size="sm">({v.participant.email})</Text></Text>
-                  <Checkbox size="xs" checked={v.isCore} disabled={saving} onChange={e => handleToggleCore(v.participantId, e.currentTarget.checked)}
+                  <Text fw={500}>{v.person.name || 'Unnamed'} <Text component="span" c="dimmed" size="sm">({v.person.email})</Text></Text>
+                  <Checkbox size="xs" checked={v.isCore} disabled={saving} onChange={e => handleToggleCore(v.personId, e.currentTarget.checked)}
                     label={<Text size="sm" c={v.isCore ? 'yellow' : undefined}>Core Volunteer</Text>} />
                 </Group>
-                <Button size="compact-xs" variant="subtle" color="red" onClick={() => handleRemoveVolunteer(v.participantId)}>Remove</Button>
+                <Button size="compact-xs" variant="subtle" color="red" onClick={() => handleRemoveVolunteer(v.personId)}>Remove</Button>
               </Group>
             ))}
           </Stack>
@@ -184,19 +184,19 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
         {activeParticipants.length === 0 ? <Text c="dimmed">No active participants yet.</Text> : (
           <Stack gap="xs">
             {activeParticipants.map(p => (
-              <Card key={p.participantId} withBorder radius="sm" padding="sm">
+              <Card key={p.personId} withBorder radius="sm" padding="sm">
                 <Group justify="space-between">
-                  <Text fw={700} c="blue">{p.participant.name || 'Unnamed'}</Text>
-                  <Button size="compact-xs" variant="subtle" color="red" onClick={() => handleRemoveParticipant(p.participantId)}>Remove</Button>
+                  <Text fw={700} c="blue">{p.person.name || 'Unnamed'}</Text>
+                  <Button size="compact-xs" variant="subtle" color="red" onClick={() => handleRemoveParticipant(p.personId)}>Remove</Button>
                 </Group>
                 <SimpleGrid cols={{ base: 1, sm: 2 }} mt="xs" spacing="xs">
-                  <Text size="sm" c="dimmed"><strong>Email:</strong> {p.participant.email}</Text>
-                  <Text size="sm" c="dimmed"><strong>Phone:</strong> {p.participant.phone ? formatPhone(p.participant.phone) : 'N/A'}</Text>
-                  {p.participant.household && (
+                  <Text size="sm" c="dimmed"><strong>Email:</strong> {p.person.email}</Text>
+                  <Text size="sm" c="dimmed"><strong>Phone:</strong> {p.person.phone ? formatPhone(p.person.phone) : 'N/A'}</Text>
+                  {p.person.household && (
                     <Text size="sm" c="dimmed" style={{ gridColumn: '1 / -1' }}>
-                      <strong>Emergency Contact{(p.participant.household.emergencyContacts?.length ?? 0) > 1 ? 's' : ''}:</strong>{' '}
-                      {p.participant.household.emergencyContacts && p.participant.household.emergencyContacts.length > 0
-                        ? p.participant.household.emergencyContacts.map((c) => `${c.name} - ${formatPhone(c.phone)}`).join('; ')
+                      <strong>Emergency Contact{(p.person.household.emergencyContacts?.length ?? 0) > 1 ? 's' : ''}:</strong>{' '}
+                      {p.person.household.emergencyContacts && p.person.household.emergencyContacts.length > 0
+                        ? p.person.household.emergencyContacts.map((c) => `${c.name} - ${formatPhone(c.phone)}`).join('; ')
                         : 'N/A'}
                     </Text>
                   )}
@@ -213,14 +213,14 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
         {pendingParticipants.length === 0 ? <Text c="dimmed">No pending participants.</Text> : (
           <Stack gap="xs">
             {pendingParticipants.map(p => (
-              <Card key={p.participantId} withBorder radius="sm" padding="sm">
+              <Card key={p.personId} withBorder radius="sm" padding="sm">
                 <Group justify="space-between">
-                  <Text fw={700} c="yellow">{p.participant.name || 'Unnamed'}</Text>
-                  <Button size="compact-xs" variant="subtle" color="red" onClick={() => handleRemoveParticipant(p.participantId)}>Remove</Button>
+                  <Text fw={700} c="yellow">{p.person.name || 'Unnamed'}</Text>
+                  <Button size="compact-xs" variant="subtle" color="red" onClick={() => handleRemoveParticipant(p.personId)}>Remove</Button>
                 </Group>
                 <SimpleGrid cols={{ base: 1, sm: 2 }} mt="xs" spacing="xs">
-                  <Text size="sm" c="dimmed"><strong>Email:</strong> {p.participant.email}</Text>
-                  <Text size="sm" c="dimmed"><strong>Phone:</strong> {p.participant.phone ? formatPhone(p.participant.phone) : 'N/A'}</Text>
+                  <Text size="sm" c="dimmed"><strong>Email:</strong> {p.person.email}</Text>
+                  <Text size="sm" c="dimmed"><strong>Phone:</strong> {p.person.phone ? formatPhone(p.person.phone) : 'N/A'}</Text>
                   <Text size="sm" c="dimmed"><strong>Pending Since:</strong> {p.pendingSince ? formatDateTime(p.pendingSince) : 'Unknown'}</Text>
                 </SimpleGrid>
               </Card>

--- a/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
@@ -34,16 +34,16 @@ const programData = {
   memberOnly: false,
   participants: [
     {
-      participantId: 101, status: "ACTIVE", pendingSince: null,
-      participant: { name: "Alice Kid", email: "alice@example.com", phone: "5125551234" },
+      personId: 101, status: "ACTIVE", pendingSince: null,
+      person: { name: "Alice Kid", email: "alice@example.com", phone: "5125551234" },
     },
     {
-      participantId: 102, status: "PENDING", pendingSince: "2026-01-06T00:00:00.000Z",
-      participant: { name: "Charlie Kid", email: "charlie@example.com" },
+      personId: 102, status: "PENDING", pendingSince: "2026-01-06T00:00:00.000Z",
+      person: { name: "Charlie Kid", email: "charlie@example.com" },
     },
   ],
   volunteers: [
-    { participantId: 201, isCore: true, participant: { name: "Vera Volunteer", email: "vera@example.com" } },
+    { personId: 201, isCore: true, person: { name: "Vera Volunteer", email: "vera@example.com" } },
   ],
   events: [
     { id: 301, name: "Session 1", startAt: "2026-02-01T18:00:00.000Z", endAt: "2026-02-01T20:00:00.000Z", attendanceConfirmedAt: null },

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -26,17 +26,17 @@ export type ProgramDetail = {
   maxParticipants: number | null;
   memberOnly: boolean;
   participants: {
-    participantId: number;
+    personId: number;
     status: string;
     pendingSince: string | null;
-    participant: {
+    person: {
       name: string | null;
       email: string;
       phone?: string | null;
       household?: { emergencyContacts: { id: number; name: string; phone: string; relationship: string | null }[] } | null;
     };
   }[];
-  volunteers: { participantId: number; isCore: boolean; participant: { name: string | null; email: string } }[];
+  volunteers: { personId: number; isCore: boolean; person: { name: string | null; email: string } }[];
   events: { id: number; name: string; startAt: string; endAt: string; attendanceConfirmedAt: string | null }[];
   leadMentor: { name: string | null; email: string } | null;
   memberPriceCents: number | null;

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -42,7 +42,7 @@ function baseProgram(overrides: Record<string, unknown> = {}) {
         endAt: null,
         leadMentorId: 5,
         leadMentor: { name: "Coach K", email: "coach@example.com" },
-        participants: [{ participantId: 100, status: "ENROLLED" }],
+        participants: [{ personId: 100, status: "ENROLLED" }],
         enrollmentStatus: "OPEN",
         memberPriceCents: null,
         nonMemberPriceCents: null,

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -19,7 +19,7 @@ type ProgramDetail = {
   // Absent for non-enrolled callers (route gates the roster); only their own
   // household's rows arrive when enrolled, which is all the "already enrolled"
   // check below needs.
-  participants?: { participantId: number, status?: string }[];
+  participants?: { personId: number, status?: string }[];
   _count?: { participants?: number };
   phase: string;
   maxParticipants: number | null;
@@ -328,7 +328,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                 >
                   <Stack>
                     {householdMembers.map((member) => {
-                      const alreadyEnrolled = (program.participants ?? []).some(p => p.participantId === member.id);
+                      const alreadyEnrolled = (program.participants ?? []).some(p => p.personId === member.id);
 
                       let ageError: string | null = null;
                       if (program.minAge !== null || program.maxAge !== null) {

--- a/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
@@ -32,7 +32,7 @@ describe('attendanceTransitions', () => {
         participantId = p.id;
         householdIds.push(p.householdId);
         await prisma.programParticipant.create({
-            data: { programId, participantId, status: 'ACTIVE', pendingSince: null },
+            data: { programId, personId: participantId, status: 'ACTIVE', pendingSince: null },
         });
 
         const u = await prisma.participant.create({

--- a/checkin-app/src/lib/__tests__/postEventEmails.test.ts
+++ b/checkin-app/src/lib/__tests__/postEventEmails.test.ts
@@ -190,7 +190,7 @@ describe("processPostEventEmails", () => {
                 program: {
                     leadMentorId: null,
                     volunteers: [
-                        { participant: { email: "core@example.com" } }
+                        { person: { email: "core@example.com" } }
                     ]
                 },
                 rsvps: [],

--- a/checkin-app/src/lib/attendanceTransitions.ts
+++ b/checkin-app/src/lib/attendanceTransitions.ts
@@ -18,11 +18,11 @@ type DbClient = PrismaClient | Prisma.TransactionClient;
 async function getRelevantProgramIds(participantId: number, db: DbClient = prisma): Promise<number[]> {
     const [participantPrograms, volunteerPrograms, leadPrograms] = await Promise.all([
         db.programParticipant.findMany({
-            where: { participantId },
+            where: { personId: participantId },
             select: { programId: true }
         }),
         db.programVolunteer.findMany({
-            where: { participantId },
+            where: { personId: participantId },
             select: { programId: true }
         }),
         db.program.findMany({

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -286,7 +286,7 @@ export async function createProgram(prisma: Db): Promise<string> {
     const enrollees = await prisma.participant.findMany({ take: 2, orderBy: { id: "asc" } });
     for (const p of enrollees) {
         await prisma.programParticipant.create({
-            data: { programId: program.id, participantId: p.id, status: "ACTIVE" },
+            data: { programId: program.id, personId: p.id, status: "ACTIVE" },
         });
     }
     return `Created program "Test Program ${tag}" with a fee and ${enrollees.length} participants`;

--- a/checkin-app/src/lib/postEventEmails.ts
+++ b/checkin-app/src/lib/postEventEmails.ts
@@ -49,7 +49,7 @@ export async function processPostEventEmails(options: ProcessPostEventEmailsOpti
                     include: {
                         volunteers: {
                             where: { isCore: true },
-                            include: { participant: true }
+                            include: { person: true }
                         }
                     }
                 },
@@ -100,7 +100,7 @@ export async function processPostEventEmails(options: ProcessPostEventEmailsOpti
                 recipientEmail = leadMentorsMap.get(leadMentorId);
             } else {
                 // Try to fallback to a core volunteer
-                const coreVolunteer = program.volunteers[0]?.participant;
+                const coreVolunteer = program.volunteers[0]?.person;
                 recipientEmail = coreVolunteer?.email;
             }
 

--- a/checkin-app/src/security/__tests__/payment-plans-strip.test.ts
+++ b/checkin-app/src/security/__tests__/payment-plans-strip.test.ts
@@ -47,7 +47,7 @@ const row = {
     participantId: 2,
     status: 'PENDING',
     isPaymentPlanRequested: true,
-    participant: { id: 2, name: 'Member Name', email: 'member@x.test', dateOfBirth: '2000-01-01' },
+    person: { id: 2, name: 'Member Name', email: 'member@x.test', dateOfBirth: '2000-01-01' },
     program: { id: 1, name: 'Woodshop' },
 };
 
@@ -55,7 +55,7 @@ describe('payment-plans field-stripping', () => {
     it('board sees the nested participant email + dateOfBirth (pii)', () => {
         const tokens = tokensFor(ENDPOINT, 'isBoardMember');
         const out = stripValue('ProgramParticipant', row, tokens, ctx()) as Record<string, unknown>;
-        const p = out.participant as Record<string, unknown>;
+        const p = out.person as Record<string, unknown>;
         expect(p.email).toBe('member@x.test');
         expect(p.dateOfBirth).toBe('2000-01-01');
         expect(p.name).toBe('Member Name');
@@ -66,7 +66,7 @@ describe('payment-plans field-stripping', () => {
         // role later granted a member/public-only view of this route.
         const tokens: readonly Token[] = ['member', 'public'];
         const out = stripValue('ProgramParticipant', row, tokens, ctx()) as Record<string, unknown>;
-        const p = out.participant as Record<string, unknown>;
+        const p = out.person as Record<string, unknown>;
         expect(p.email).toBeUndefined();
         expect(p.dateOfBirth).toBeUndefined();
         expect(p.name).toBe('Member Name');
@@ -76,7 +76,7 @@ describe('payment-plans field-stripping', () => {
         // Guards the assumption the test rests on.
         const board = tokensFor(ENDPOINT, 'isBoardMember');
         expect(board).toContain('everyones:pii');
-        const scopes = scopesHeld('Participant', row.participant, ctx());
+        const scopes = scopesHeld('Participant', row.person, ctx());
         expect(scopes.has('everyones')).toBe(true);
     });
 });

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -60,23 +60,23 @@ export async function buildCallerContext(auth: AuthResult): Promise<CallerContex
 
     const ledPrograms = await prisma.program.findMany({
         where: { leadMentorId: auth.user.id },
-        select: { id: true, participants: { select: { participantId: true } } },
+        select: { id: true, participants: { select: { personId: true } } },
     });
     for (const p of ledPrograms) {
         ctx.programsLed.add(p.id);
-        for (const pp of p.participants) ctx.participantIdsInScopePrograms.add(pp.participantId);
+        for (const pp of p.participants) ctx.participantIdsInScopePrograms.add(pp.personId);
     }
 
     const coreVols = await prisma.programVolunteer.findMany({
-        where: { participantId: auth.user.id, isCore: true },
+        where: { personId: auth.user.id, isCore: true },
         select: {
             programId: true,
-            program: { select: { participants: { select: { participantId: true } } } },
+            program: { select: { participants: { select: { personId: true } } } },
         },
     });
     for (const v of coreVols) {
         ctx.programsCoreVolIn.add(v.programId);
-        for (const pp of v.program.participants) ctx.participantIdsInScopePrograms.add(pp.participantId);
+        for (const pp of v.program.participants) ctx.participantIdsInScopePrograms.add(pp.personId);
     }
 
     // Households of the children in the caller's programs — for Trusted Adult

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -188,12 +188,12 @@ export const classifications = {
     },
     ProgramVolunteer: {
         programId: 'public',
-        participantId: 'public',
+        personId: 'public',
         isCore: 'internal',
     },
     ProgramParticipant: {
         programId: 'public',
-        participantId: 'public',
+        personId: 'public',
         status: 'public',
         isPaymentPlanRequested: 'personal',
         pendingSince: 'internal',
@@ -413,11 +413,11 @@ export const relations = {
     },
     ProgramVolunteer: {
         program: { model: 'Program', isList: false },
-        participant: { model: 'Participant', isList: false },
+        person: { model: 'Participant', isList: false },
     },
     ProgramParticipant: {
         program: { model: 'Program', isList: false },
-        participant: { model: 'Participant', isList: false },
+        person: { model: 'Participant', isList: false },
     },
     Fee: {
         program: { model: 'Program', isList: false },

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -61,14 +61,14 @@ export const SCOPE_BINDINGS = {
             field: 'programId',
             inCtx: ['programsLed', 'programsCoreVolIn'],
         },
-        their_own: { field: 'participantId', eqCtx: 'selfId' },
+        their_own: { field: 'personId', eqCtx: 'selfId' },
     },
     ProgramVolunteer: {
         their_program_participants: {
             field: 'programId',
             inCtx: ['programsLed', 'programsCoreVolIn'],
         },
-        their_own: { field: 'participantId', eqCtx: 'selfId' },
+        their_own: { field: 'personId', eqCtx: 'selfId' },
     },
     // Fee + RSVP shared the grouped switch case with ProgramParticipant/
     // ProgramVolunteer, reading BOTH programId and participantId. `Fee` has no

--- a/checkin-app/tests/security/stripper.test.ts
+++ b/checkin-app/tests/security/stripper.test.ts
@@ -446,8 +446,8 @@ describe('Event roster strip (events/[id] view)', () => {
             participants: [
                 {
                     programId: PROGRAM_ID,
-                    participantId: ROSTER_ID,
-                    participant: {
+                    personId: ROSTER_ID,
+                    person: {
                         id: ROSTER_ID,
                         name: 'Youth Kid',     // public
                         email: 'kid@x.com',    // pii
@@ -463,7 +463,7 @@ describe('Event roster strip (events/[id] view)', () => {
     function roster(out: unknown): Record<string, unknown> {
         const program = (out as Record<string, unknown>).program as Record<string, unknown>;
         const participants = program.participants as Array<Record<string, unknown>>;
-        return participants[0].participant as Record<string, unknown>;
+        return participants[0].person as Record<string, unknown>;
     }
 
     it('lead mentor of the event\'s program sees roster pii/personal + internal', () => {


### PR DESCRIPTION
## What

Phase **A1c** of the Participant→Person rename. On the two program-enrollment join models **only** — `ProgramParticipant` and `ProgramVolunteer` — rename the person FK and its relation field. Every other model keeps `participantId`/`participant`.

### Schema
- `participantId Int` → `personId Int`
- `participant Participant @relation(...)` → `person Participant @relation(...)` (model stays `Participant`)
- `@@id([programId, participantId])` → `@@id([programId, personId])` → generated composite where-input `programId_participantId` → `programId_personId`

Migration `20260702054422_programenrollment_participantid_to_personid`: data-preserving `RENAME COLUMN` + FK-constraint rename (matches repo convention, **not** prisma's default drop/add).

## Why

`ProgramParticipant.participantId` is the *person* FK on the enrollee join — it correctly becomes `personId` even though the model name stays `ProgramParticipant` (per Q2 in the umbrella investigation). The heaviest A1 slice by consumer count.

## Reviewer notes

- **Intentionally unchanged:** HTTP request-body field `participantId` (that's Phase B), `Program.participants`/`Program.volunteers` back-relations, and every sibling model's `participantId`/`participant` (RSVP, Visit, FeePayment, ToolStatus, HouseholdLead).
- API **responses** for these two models now expose `person`/`personId`; the frontend consumers were updated to match (program-ops, programs/[id], my-activities/programs, finance-ops/payment-plan).
- Two stale refs `tsc` could **not** catch (a ternary-widened `Promise.all` element in nav/todo-counts; `any`-typed test response accessors) were surfaced by the integration run and fixed.

## Verify

- `npx tsc --noEmit` — clean
- 168 integration tests (`--runInBand`) + 320 unit tests — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)