### PR TITLE
refactor(person): rename HouseholdLead + ToolStatus participantId → personId (A1d)

### DIFF
--- a/checkin-app/prisma/migrations/20260702053826_householdlead_toolstatus_participantid_to_personid/migration.sql
+++ b/checkin-app/prisma/migrations/20260702053826_householdlead_toolstatus_participantid_to_personid/migration.sql
@@ -1,0 +1,15 @@
+-- Rename HouseholdLead.participantId -> personId and ToolStatus.participantId -> personId
+-- (Person = Participant). Data-preserving RENAME (not drop/add).
+-- PK (composite) tracks the column rename automatically; FK constraints renamed explicitly.
+
+-- AlterTable
+ALTER TABLE "HouseholdLead" RENAME COLUMN "participantId" TO "personId";
+
+-- RenameForeignKey
+ALTER TABLE "HouseholdLead" RENAME CONSTRAINT "HouseholdLead_participantId_fkey" TO "HouseholdLead_personId_fkey";
+
+-- AlterTable
+ALTER TABLE "ToolStatus" RENAME COLUMN "participantId" TO "personId";
+
+-- RenameForeignKey
+ALTER TABLE "ToolStatus" RENAME CONSTRAINT "ToolStatus_participantId_fkey" TO "ToolStatus_personId_fkey";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -138,16 +138,16 @@ model Tool {
 
 model ToolStatus {
   /// @sensitivity:public
-  participantId Int
+  personId Int
   /// @sensitivity:public
   toolId Int
   /// @sensitivity:member
   level  ToolLevel
 
-  participant Participant @relation(fields: [participantId], references: [id])
+  person Participant @relation(fields: [personId], references: [id])
   tool Tool        @relation(fields: [toolId], references: [id])
 
-  @@id([participantId, toolId])
+  @@id([personId, toolId])
 }
 
 model Household {
@@ -223,12 +223,12 @@ model HouseholdLead {
   /// @sensitivity:public
   householdId   Int
   /// @sensitivity:public
-  participantId Int
+  personId Int
 
   household   Household   @relation(fields: [householdId], references: [id])
-  participant Participant @relation(fields: [participantId], references: [id])
+  person Participant @relation(fields: [personId], references: [id])
 
-  @@id([householdId, participantId])
+  @@id([householdId, personId])
 }
 
 enum MembershipStatus {

--- a/checkin-app/prisma/seed_20_users.ts
+++ b/checkin-app/prisma/seed_20_users.ts
@@ -31,7 +31,7 @@ async function main() {
         await prisma.householdLead.create({
             data: {
                 householdId: household.id,
-                participantId: participant.id,
+                personId: participant.id,
             }
         });
 

--- a/checkin-app/scripts/dues-diff-volunteer-match.ts
+++ b/checkin-app/scripts/dues-diff-volunteer-match.ts
@@ -44,14 +44,14 @@ async function main() {
         // Household leads with an email — mirrors applyVolunteerStatus's parent query:
         // participant is a lead of the household AND householdId matches.
         const leads = await prisma.householdLead.findMany({
-            select: { householdId: true, participant: { select: { householdId: true, email: true } } },
+            select: { householdId: true, person: { select: { householdId: true, email: true } } },
         });
 
         // Group parent emails by household (lead-of-own-household, non-null email).
         const byHousehold = new Map<number, string[]>();
         for (const l of leads) {
-            if (l.participant.householdId !== l.householdId) continue;
-            const email = l.participant.email;
+            if (l.person.householdId !== l.householdId) continue;
+            const email = l.person.email;
             if (!email) continue;
             const list = byHousehold.get(l.householdId) ?? [];
             list.push(email);

--- a/checkin-app/src/app/__tests__/adminBulkImport.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImport.integration.test.ts
@@ -224,7 +224,7 @@ describe('Admin Bulk Import API Integration Tests', () => {
             expect(adult).not.toBeNull();
             expect(adult!.householdId).not.toBeNull();
             
-            const adultLead = await prisma.householdLead.findFirst({ where: { participantId: adult!.id } });
+            const adultLead = await prisma.householdLead.findFirst({ where: { personId: adult!.id } });
             // In some environments, lead assignment might delay or fail if the household creation isn't atomic.
             // But here it should be present.
             expect(adultLead).not.toBeNull();
@@ -232,12 +232,12 @@ describe('Admin Bulk Import API Integration Tests', () => {
             const youth = await prisma.participant.findFirst({ where: { name: 'Youth Import Test' } });
             expect(youth).not.toBeNull();
             expect(youth!.householdId).not.toBeNull();
-            const youthLead = await prisma.householdLead.findFirst({ where: { participantId: youth!.id } });
+            const youthLead = await prisma.householdLead.findFirst({ where: { personId: youth!.id } });
             expect(youthLead).toBeNull();
 
             const defaultAdult = await prisma.participant.findFirst({ where: { name: 'Default Import Test' } });
             expect(defaultAdult?.householdId).not.toBeNull();
-            const defaultLead = await prisma.householdLead.findFirst({ where: { participantId: defaultAdult?.id } });
+            const defaultLead = await prisma.householdLead.findFirst({ where: { personId: defaultAdult?.id } });
             expect(defaultLead).not.toBeNull();
         });
     });

--- a/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
@@ -144,7 +144,7 @@ describe('Bulk import: preview vs commit consistency', () => {
         const anchor = await prisma.participant.findUnique({ where: { email: ANCHOR_EMAIL }, select: { id: true, dateOfBirth: true } });
         expect(anchor?.dateOfBirth?.getUTCFullYear()).toBe(1991);
         // ...and commit therefore makes the adult a household lead.
-        const lead = await prisma.householdLead.findFirst({ where: { participantId: anchor!.id } });
+        const lead = await prisma.householdLead.findFirst({ where: { personId: anchor!.id } });
         expect(lead).not.toBeNull();
 
         // Preview must agree Anchor is an adult: NO "Student (under 18)" warning.

--- a/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
@@ -137,7 +137,7 @@ describe('Admin Participant Household API Integration Tests', () => {
 
             // Check if they are a lead
             const lead = await prisma.householdLead.findFirst({
-                where: { participantId: testParticipantId, householdId: newHouseholdId }
+                where: { personId: testParticipantId, householdId: newHouseholdId }
             });
             expect(lead).not.toBeNull();
         });

--- a/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
@@ -57,7 +57,7 @@ describe('Admin Unclaimed Households API Integration Tests', () => {
             data: { email: 'member1-unclaimed-api-test@example.com', name: 'Unclaimed Lead', householdId: testUnclaimedHouseholdId, googleId: null }
         });
         await prisma.householdLead.create({
-            data: { householdId: testUnclaimedHouseholdId, participantId: unclaimedLead.id }
+            data: { householdId: testUnclaimedHouseholdId, personId: unclaimedLead.id }
         });
 
         // 2. Lead HAS a googleId -> claimed, even though a student member never signs in.
@@ -68,7 +68,7 @@ describe('Admin Unclaimed Households API Integration Tests', () => {
             data: { email: 'member2-unclaimed-api-test@example.com', name: 'Claimed Lead', householdId: testClaimedHouseholdId, googleId: 'unclaimed-test-google-id' }
         });
         await prisma.householdLead.create({
-            data: { householdId: testClaimedHouseholdId, participantId: claimedLead.id }
+            data: { householdId: testClaimedHouseholdId, personId: claimedLead.id }
         });
         // Student in the claimed household with an email but no googleId (never signs in).
         await prisma.participant.create({

--- a/checkin-app/src/app/__tests__/attendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendance.integration.test.ts
@@ -60,7 +60,7 @@ describe('Attendance API Integration Tests', () => {
 
         // Make participant the household lead
         await prisma.householdLead.create({
-            data: { householdId: testHouseholdId, participantId: testParticipantId }
+            data: { householdId: testHouseholdId, personId: testParticipantId }
         });
 
         const householdMember = await prisma.participant.create({

--- a/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
@@ -40,7 +40,7 @@ describe('General Attendance API Integration Tests', () => {
         const existingUserIds = existingUsers.map(u => u.id);
         
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         await prisma.visit.deleteMany({
             where: { participantId: { in: existingUserIds } }
@@ -128,7 +128,7 @@ describe('General Attendance API Integration Tests', () => {
 
         if (existingUserIds.length > 0) {
             await prisma.householdLead.deleteMany({
-                where: { participantId: { in: existingUserIds } }
+                where: { personId: { in: existingUserIds } }
             });
             await prisma.visit.deleteMany({
                 where: { participantId: { in: existingUserIds } }

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -83,7 +83,7 @@ describe('AuditLog Integration Tests', () => {
             await prisma.visit.deleteMany({ where: { id: { in: createdVisitIds } } });
         }
         if (createdParticipantIds.length > 0) {
-            await prisma.householdLead.deleteMany({ where: { participantId: { in: createdParticipantIds } } });
+            await prisma.householdLead.deleteMany({ where: { personId: { in: createdParticipantIds } } });
             await prisma.participant.deleteMany({ where: { id: { in: createdParticipantIds } } });
         }
         if (createdHouseholdIds.length > 0) {

--- a/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
@@ -113,7 +113,7 @@ describe('Ownership-boundary authorization', () => {
     }
     async function mkMember(householdId: number, name: string, lead = false) {
         const p = await prisma.participant.create({ data: { name: `${name} ${TAG}`, householdId } });
-        if (lead) await prisma.householdLead.create({ data: { householdId, participantId: p.id } });
+        if (lead) await prisma.householdLead.create({ data: { householdId, personId: p.id } });
         return p.id;
     }
     async function mkPendingProcess(householdId: number, status: 'PENDING_PAYMENT' | 'PENDING_RENEWAL', kind: 'INITIAL' | 'RENEWAL') {

--- a/checkin-app/src/app/__tests__/brokenHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/brokenHouseholdsAPI.integration.test.ts
@@ -68,7 +68,7 @@ describe('Broken Households API Integration Tests', () => {
             data: { email: 'lead-broken-api-test@example.com', name: 'Existing Lead', householdId: ledHouseholdId, dateOfBirth: new Date('1985-01-01') }
         });
         await prisma.householdLead.create({
-            data: { householdId: ledHouseholdId, participantId: leadMember.id }
+            data: { householdId: ledHouseholdId, personId: leadMember.id }
         });
     });
 
@@ -107,7 +107,7 @@ describe('Broken Households API Integration Tests', () => {
         expect(res.status).toBe(200);
 
         const lead = await prisma.householdLead.findUnique({
-            where: { householdId_participantId: { householdId: brokenHouseholdId, participantId: brokenAdultId } }
+            where: { householdId_personId: { householdId: brokenHouseholdId, personId: brokenAdultId } }
         });
         expect(lead).not.toBeNull();
 

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -13,8 +13,8 @@ describe("GET /api/cron/post-event", () => {
         await prisma.event.deleteMany({ where: { name: { startsWith: 'Past Event' } } });
         await prisma.event.deleteMany({ where: { name: { startsWith: 'Future Event' } } });
         await prisma.program.deleteMany({ where: { name: 'Test Program' } });
-        await prisma.toolStatus.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
-        await prisma.householdLead.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
+        await prisma.toolStatus.deleteMany({ where: { person: { email: { contains: 'example.com' } } } });
+        await prisma.householdLead.deleteMany({ where: { person: { email: { contains: 'example.com' } } } });
         await prisma.rawBadgeLog.deleteMany({ where: { person: { email: { contains: 'example.com' } } } });
         await prisma.participant.deleteMany({ where: { email: { contains: 'example.com' } } });
         // Global participant-less household delete: clear the membership chain for those

--- a/checkin-app/src/app/__tests__/emergencyContactMemberRouteGuard.integration.test.ts
+++ b/checkin-app/src/app/__tests__/emergencyContactMemberRouteGuard.integration.test.ts
@@ -76,7 +76,7 @@ describe("PATCH /api/household/settings — Direction A: reject a member as prim
         });
         leadId = lead.id;
         householdId = lead.householdId!;
-        await prisma.householdLead.create({ data: { householdId, participantId: leadId } });
+        await prisma.householdLead.create({ data: { householdId, personId: leadId } });
         const member = await prisma.participant.create({
             data: {
                 email: `member-A-${TAG}@example.com`,
@@ -144,7 +144,7 @@ describe("PATCH /api/household — Direction B: adding a member that collides wi
         });
         leadId = lead.id;
         householdId = lead.householdId!;
-        await prisma.householdLead.create({ data: { householdId, participantId: leadId } });
+        await prisma.householdLead.create({ data: { householdId, personId: leadId } });
         // A pre-existing VALID emergency contact (not yet a member).
         const contact = await prisma.emergencyContact.create({
             data: { householdId, name: "Grandma Ext", phone: "555-1111", phoneDigits: "5551111", priority: 0 },

--- a/checkin-app/src/app/__tests__/emergencyContactsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/emergencyContactsAPI.integration.test.ts
@@ -55,7 +55,7 @@ describe("Emergency Contacts API — removal prohibition", () => {
         });
         leadId = lead.id;
         householdId = lead.householdId!;
-        await prisma.householdLead.create({ data: { householdId, participantId: leadId } });
+        await prisma.householdLead.create({ data: { householdId, personId: leadId } });
     });
 
     afterAll(async () => {
@@ -96,7 +96,7 @@ describe("Emergency Contacts API — removal prohibition", () => {
         // Fresh household to isolate state.
         const hh = await prisma.household.create({ data: { name: `HH2 ${TAG}` } });
         const p = await prisma.participant.create({ data: { email: `lead2-${TAG}@example.com`, name: "Lead Two", householdId: hh.id } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: p.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: p.id } });
         // A contact that is flagged invalid (simulate a direction-B conflict).
         const member = await prisma.participant.create({ data: { name: "Clashy", householdId: hh.id } });
         const invalid = await prisma.emergencyContact.create({
@@ -112,7 +112,7 @@ describe("Emergency Contacts API — removal prohibition", () => {
         const lead = await prisma.participant.create({
             data: { email: `lead-${label}-${TAG}@example.com`, name: `Lead ${label}`, householdId: hh.id },
         });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         return { hhId: hh.id, leadId: lead.id };
     }
 

--- a/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
@@ -32,7 +32,7 @@ describe('Household API Integration Tests', () => {
         const existingHouseholdIds = existingUsers.map(u => u.householdId).filter(id => id !== null) as number[];
         
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         
         await prisma.membership.deleteMany({
@@ -64,7 +64,7 @@ describe('Household API Integration Tests', () => {
         testUserId = leadUser.id;
 
         await prisma.householdLead.create({
-            data: { householdId: household.id, participantId: leadUser.id }
+            data: { householdId: household.id, personId: leadUser.id }
         });
 
         const memberUser = await prisma.participant.create({
@@ -103,7 +103,7 @@ describe('Household API Integration Tests', () => {
         ])].filter((id): id is number => id !== undefined && id !== null);
 
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: currentIds } }
+            where: { personId: { in: currentIds } }
         });
 
         await prisma.membership.deleteMany({

--- a/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
@@ -34,7 +34,7 @@ describe('Household Lead API Integration Tests', () => {
         const existingHouseholdIds = existingUsers.map(u => u.householdId).filter(id => id !== null) as number[];
         
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         
         await prisma.membership.deleteMany({
@@ -66,7 +66,7 @@ describe('Household Lead API Integration Tests', () => {
         testLeadId = leadUser.id;
 
         await prisma.householdLead.create({
-            data: { householdId: household.id, participantId: leadUser.id }
+            data: { householdId: household.id, personId: leadUser.id }
         });
 
         const adultUser = await prisma.participant.create({
@@ -90,7 +90,7 @@ describe('Household Lead API Integration Tests', () => {
         testOtherLeadId = otherLead.id;
 
         await prisma.householdLead.create({
-            data: { householdId: otherHousehold.id, participantId: otherLead.id }
+            data: { householdId: otherHousehold.id, personId: otherLead.id }
         });
 
         const otherMember = await prisma.participant.create({
@@ -104,7 +104,7 @@ describe('Household Lead API Integration Tests', () => {
         const validHouseholdIds = [householdId, otherHouseholdId];
 
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: currentIds } }
+            where: { personId: { in: currentIds } }
         });
         
         await prisma.membership.deleteMany({
@@ -196,9 +196,9 @@ describe('Household Lead API Integration Tests', () => {
             // Validate the changes
             const newLead = await prisma.householdLead.findUnique({ 
                 where: { 
-                    householdId_participantId: {
+                    householdId_personId: {
                         householdId: householdId,
-                        participantId: testAdultId
+                        personId: testAdultId
                     }
                 } 
             });
@@ -228,7 +228,7 @@ describe('Household Lead API Integration Tests', () => {
 
             // No lead row should have been created for the third member.
             const noLead = await prisma.householdLead.findUnique({
-                where: { householdId_participantId: { householdId, participantId: testChildId } }
+                where: { householdId_personId: { householdId, personId: testChildId } }
             });
             expect(noLead).toBeNull();
         });
@@ -292,9 +292,9 @@ describe('Household Lead API Integration Tests', () => {
             // Validate the changes
             const demotedLead = await prisma.householdLead.findUnique({ 
                 where: { 
-                    householdId_participantId: {
+                    householdId_personId: {
                         householdId: householdId,
-                        participantId: testAdultId
+                        personId: testAdultId
                     }
                 } 
             });
@@ -312,7 +312,7 @@ describe('Household Lead API Integration Tests', () => {
                 data: { email: 'board-lead-api-test@example.com', name: 'Board User', isBoardMember: true, householdId: boardHousehold.id }
             });
             await prisma.householdLead.create({
-                data: { householdId: otherHouseholdId, participantId: testOtherMemberId }
+                data: { householdId: otherHouseholdId, personId: testOtherMemberId }
             });
 
             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardUser.id } });
@@ -325,7 +325,7 @@ describe('Household Lead API Integration Tests', () => {
             expect(res.status).toBe(200);
 
             const removed = await prisma.householdLead.findUnique({
-                where: { householdId_participantId: { householdId: otherHouseholdId, participantId: testOtherLeadId } }
+                where: { householdId_personId: { householdId: otherHouseholdId, personId: testOtherLeadId } }
             });
             expect(removed).toBeNull();
         });

--- a/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
@@ -33,7 +33,7 @@ describe('Household Member API Integration Tests', () => {
         const existingHouseholdIds = existingUsers.map(u => u.householdId).filter(id => id !== null) as number[];
         
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         
         await prisma.membership.deleteMany({
@@ -65,7 +65,7 @@ describe('Household Member API Integration Tests', () => {
         testLeadId = leadUser.id;
 
         await prisma.householdLead.create({
-            data: { householdId: household.id, participantId: leadUser.id }
+            data: { householdId: household.id, personId: leadUser.id }
         });
 
         const memberUser = await prisma.participant.create({
@@ -94,7 +94,7 @@ describe('Household Member API Integration Tests', () => {
         const validHouseholdIds = [householdId, otherHouseholdId];
 
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: currentIds } }
+            where: { personId: { in: currentIds } }
         });
         
         await prisma.membership.deleteMany({
@@ -243,7 +243,7 @@ describe('Household Member API Integration Tests', () => {
 
              // Verify they are now a lead
              const leadRecord = await prisma.householdLead.findUnique({
-                 where: { householdId_participantId: { householdId: householdId, participantId: testNonLeadId } }
+                 where: { householdId_personId: { householdId: householdId, personId: testNonLeadId } }
              });
              expect(leadRecord).not.toBeNull();
         });
@@ -264,7 +264,7 @@ describe('Household Member API Integration Tests', () => {
 
              // Verify they are no longer a lead
              const leadRecord = await prisma.householdLead.findUnique({
-                 where: { householdId_participantId: { householdId: householdId, participantId: testNonLeadId } }
+                 where: { householdId_personId: { householdId: householdId, personId: testNonLeadId } }
              });
              expect(leadRecord).toBeNull();
         });
@@ -285,7 +285,7 @@ describe('Household Member API Integration Tests', () => {
 
              // Verify they are STILL a lead
              const leadRecord = await prisma.householdLead.findUnique({
-                 where: { householdId_participantId: { householdId: householdId, participantId: testLeadId } }
+                 where: { householdId_personId: { householdId: householdId, personId: testLeadId } }
              });
              expect(leadRecord).not.toBeNull();
         });

--- a/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
@@ -35,7 +35,7 @@ describe('Household Visits API Integration Tests', () => {
         });
 
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         
         await prisma.membership.deleteMany({
@@ -66,7 +66,7 @@ describe('Household Visits API Integration Tests', () => {
         testUserId = leadUser.id;
 
         await prisma.householdLead.create({
-            data: { householdId: household.id, participantId: leadUser.id }
+            data: { householdId: household.id, personId: leadUser.id }
         });
 
         const memberUser = await prisma.participant.create({
@@ -123,7 +123,7 @@ describe('Household Visits API Integration Tests', () => {
         });
 
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: currentIds } }
+            where: { personId: { in: currentIds } }
         });
         
         await prisma.membership.deleteMany({

--- a/checkin-app/src/app/__tests__/intakeConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/intakeConcurrency.integration.test.ts
@@ -47,7 +47,7 @@ describe('intake start concurrency', () => {
         householdId = hh.id;
         const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
     });
 
     afterAll(wipe);

--- a/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
@@ -42,7 +42,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
         });
 
         await prisma.toolStatus.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         await prisma.tool.deleteMany({
@@ -72,7 +72,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
 
         await prisma.toolStatus.create({
             data: { 
-                participantId: testUserId,
+                personId: testUserId,
                 toolId: toolId,
                 level: 'CERTIFIED'
             }
@@ -93,7 +93,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
             where: { participantId: testUserId }
         });
         await prisma.toolStatus.deleteMany({
-            where: { participantId: testUserId }
+            where: { personId: testUserId }
         });
         await prisma.participant.deleteMany({
             where: { id: testUserId }

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -50,7 +50,7 @@ async function makeFreshRenewal() {
     const lead = await prisma.participant.create({
         data: { email: `rlead-${Math.random()}-${TAG}@example.com`, name: 'R Lead', householdId: hh.id, lastBackgroundCheck: new Date() },
     });
-    await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+    await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
     const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
     const proc = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
     return { membershipId: m.id, processId: proc.id };
@@ -62,7 +62,7 @@ async function makeApplicant(status: 'PENDING_EXTERNAL_ACTION', extra: { lastBac
     const lead = await prisma.participant.create({
         data: { email: `lead-${Math.random()}-${TAG}@example.com`, name: 'Lead Parent', householdId: hh.id, lastBackgroundCheck: extra.lastBackgroundCheck ?? null },
     });
-    await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+    await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
     const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
     const proc = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status } });
     return { householdId: hh.id, membershipId: m.id, processId: proc.id, leadId: lead.id };

--- a/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
@@ -71,7 +71,7 @@ describe('POST /api/membership/contract/sign', () => {
         const hh = await prisma.household.create({ data: { name: `HH ${TAG}` } });
         const lead = await prisma.participant.create({ data: { email: `lead-${TAG}@example.com`, name: 'Lead Parent', householdId: hh.id } });
         const nonLead = await prisma.participant.create({ data: { email: `member-${TAG}@example.com`, name: 'Member', householdId: hh.id } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         const proc = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
         leadId = lead.id;
@@ -122,7 +122,7 @@ describe('POST /api/membership/contract/sign', () => {
     it('lets a RENEWAL process in the EXTERNAL phase sign (renewals re-sign fresh)', async () => {
         const hh = await prisma.household.create({ data: { name: `HH renewal ${TAG}` } });
         const rLead = await prisma.participant.create({ data: { email: `rlead-${TAG}@example.com`, name: 'Renewing Lead', householdId: hh.id } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: rLead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: rLead.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
         await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'RENEWAL', status: 'PENDING_EXTERNAL_ACTION' } });
 
@@ -179,7 +179,7 @@ describe('POST /api/membership/contract/sign', () => {
         // Household whose lead is someone else; the signer is a isSysadmin member, not a lead.
         const hh = await prisma.household.create({ data: { name: `HH isSysadmin ${TAG}` } });
         const otherLead = await prisma.participant.create({ data: { email: `otherlead-${TAG}@example.com`, name: 'Other Lead', householdId: hh.id } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: otherLead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: otherLead.id } });
         const isSysadmin = await prisma.participant.create({ data: { email: `isSysadmin-${TAG}@example.com`, name: 'Sys Admin', householdId: hh.id, isSysadmin: true } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
@@ -195,7 +195,7 @@ describe('POST /api/membership/contract/sign', () => {
         // which loads the agreement PDF; make that throw AgreementUnavailableError.
         const hh = await prisma.household.create({ data: { name: `HH noagreement ${TAG}` } });
         const lead = await prisma.participant.create({ data: { email: `noagr-lead-${TAG}@example.com`, name: 'NoAgr Lead', householdId: hh.id } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
 

--- a/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
@@ -60,7 +60,7 @@ describe('Membership Intake API', () => {
         });
         leadId = lead.id;
         leadHouseholdId = lead.householdId!;
-        await prisma.householdLead.create({ data: { householdId: leadHouseholdId, participantId: leadId } });
+        await prisma.householdLead.create({ data: { householdId: leadHouseholdId, personId: leadId } });
 
         const nonLead = await prisma.participant.create({
             data: { email: `nonlead-${TAG}@example.com`, name: 'Non Lead', householdId: leadHouseholdId },
@@ -75,7 +75,7 @@ describe('Membership Intake API', () => {
             },
         });
         activeLeadId = activeLead.id;
-        await prisma.householdLead.create({ data: { householdId: activeLead.householdId!, participantId: activeLeadId } });
+        await prisma.householdLead.create({ data: { householdId: activeLead.householdId!, personId: activeLeadId } });
     });
 
     afterAll(async () => {
@@ -148,7 +148,7 @@ describe('Membership Intake API', () => {
         // Kid One was created as a non-lead (child).
         const kid = await prisma.participant.findFirst({ where: { householdId: leadHouseholdId, name: 'Kid One' } });
         expect(kid).not.toBeNull();
-        const kidLead = await prisma.householdLead.findFirst({ where: { householdId: leadHouseholdId, participantId: kid!.id } });
+        const kidLead = await prisma.householdLead.findFirst({ where: { householdId: leadHouseholdId, personId: kid!.id } });
         expect(kidLead).toBeNull();
     });
 
@@ -184,7 +184,7 @@ describe('Membership Intake API', () => {
         const lead = await prisma.participant.create({
             data: { email: `audit-lead-${TAG}@example.com`, name: 'Audit Lead', household: { create: { name: 'Audit Intake HH' } } },
         });
-        await prisma.householdLead.create({ data: { householdId: lead.householdId!, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: lead.householdId!, personId: lead.id } });
         asUser(lead.id);
 
         const startRes = await POST(req() as never);

--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -54,7 +54,7 @@ describe('Membership payment API', () => {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
         if (withLead) {
             const lead = await prisma.participant.create({ data: { email: `lead-${TAG}@example.com`, name: 'Lead', householdId: hh.id } });
-            await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+            await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
             leadId = lead.id;
         }
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer } });
@@ -202,7 +202,7 @@ describe('Membership payment API', () => {
         // Fresh proc with a lead so a congrats email would fire.
         const hh = await prisma.household.create({ data: { name: `Concurrent ${TAG}` } });
         const lead = await prisma.participant.create({ data: { email: `concurrent-${TAG}@example.com`, name: 'C Lead', householdId: hh.id } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer: false } });
         // bgClearedAt set so paying activates (and the one congrats email fires).
         const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() } });

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -34,7 +34,7 @@ describe('Membership renewal', () => {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
         // The guardian is a household lead (drives the 3-yr BG-freshness check).
         const parent = await prisma.participant.create({ data: { name: `${label} Parent`, householdId: hh.id, lastBackgroundCheck: parentBg ?? undefined } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: parent.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
         return { householdId: hh.id, membershipId: m.id };
     }

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -33,7 +33,7 @@ describe('Membership BG review API', () => {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
         // A parent/guardian is a household lead.
         const parent = await prisma.participant.create({ data: { name: `${label} Parent`, householdId: hh.id, ...(parentEmail ? { email: parentEmail } : {}) } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: parent.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
         return { householdId: hh.id, membershipId: m.id, processId: p.id };
@@ -43,7 +43,7 @@ describe('Membership BG review API', () => {
     async function makeProcess(label: string, kind: 'INITIAL' | 'RENEWAL', status: 'PENDING_PAYMENT' | 'RENEWAL_PENDING_BG') {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
         const parent = await prisma.participant.create({ data: { name: `${label} Parent`, householdId: hh.id } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: parent.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind, status } });
         return { householdId: hh.id, membershipId: m.id, processId: p.id };
@@ -285,7 +285,7 @@ describe('Membership BG review API', () => {
         // Self-contained applicant household: one parent (lead) + one child (non-lead).
         const hh = await prisma.household.create({ data: { name: `ChildExcl ${TAG}` } });
         const parent = await prisma.participant.create({ data: { name: 'Excl Parent', email: `exclparent-${TAG}@example.com`, householdId: hh.id } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: parent.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
         await prisma.participant.create({ data: { name: 'Excl Child', email: `exclchild-${TAG}@example.com`, householdId: hh.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -52,7 +52,7 @@ describe('Nav todo-counts API', () => {
         });
         leadId = lead.id;
         householdAId = lead.householdId;
-        await prisma.householdLead.create({ data: { householdId: householdAId, participantId: leadId } });
+        await prisma.householdLead.create({ data: { householdId: householdAId, personId: leadId } });
 
         const second = await prisma.participant.create({
             data: { email: `member2-${TAG}@example.com`, name: 'Member A2', dateOfBirth: new Date('1987-01-01'), householdId: householdAId },

--- a/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
@@ -48,7 +48,7 @@ describe("sendCheckinNotifications()", () => {
         leadId = lead.id;
 
         await prisma.householdLead.create({
-            data: { householdId, participantId: leadId }
+            data: { householdId, personId: leadId }
         });
 
         // Create Dependent

--- a/checkin-app/src/app/__tests__/notificationsCheckin.perf.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsCheckin.perf.test.ts
@@ -20,7 +20,7 @@ jest.mock("@/lib/prisma", () => ({
     householdLead: {
         findMany: jest.fn().mockResolvedValue(
             Array.from({ length: 10 }).map((_, i) => ({
-                participant: {
+                person: {
                     id: 2 + i,
                     name: `Lead ${i}`,
                     email: `lead${i}@example.com`,

--- a/checkin-app/src/app/__tests__/programsHouseholdEnrollment.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsHouseholdEnrollment.integration.test.ts
@@ -46,7 +46,7 @@ describe('Multi-select household enrollment (integration)', () => {
         });
         const ids = users.map(u => u.id);
         if (ids.length) {
-            await prisma.householdLead.deleteMany({ where: { participantId: { in: ids } } });
+            await prisma.householdLead.deleteMany({ where: { personId: { in: ids } } });
             await prisma.programParticipant.deleteMany({ where: { participantId: { in: ids } } });
             await prisma.auditLog.deleteMany({ where: { actorId: { in: ids } } });
         }
@@ -77,7 +77,7 @@ describe('Multi-select household enrollment (integration)', () => {
         depBId = await mkDep('b');
         depCId = await mkDep('c');
         await prisma.householdLead.create({
-            data: { householdId: household.id, participantId: leadId }
+            data: { householdId: household.id, personId: leadId }
         });
 
         const free = await prisma.program.create({

--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -40,7 +40,7 @@ describe('Program Participants API Integration Tests', () => {
         const existingUserIds = existingUsers.map(u => u.id);
 
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         await prisma.programParticipant.deleteMany({
@@ -110,7 +110,7 @@ describe('Program Participants API Integration Tests', () => {
         });
         depId = dependent.id;
         await prisma.householdLead.create({
-            data: { householdId: boardHousehold.id, participantId: boardId }
+            data: { householdId: boardHousehold.id, personId: boardId }
         });
 
         // Create mock programs
@@ -150,7 +150,7 @@ describe('Program Participants API Integration Tests', () => {
 
         if (existingUserIds.length > 0) {
             await prisma.householdLead.deleteMany({
-                where: { participantId: { in: existingUserIds } }
+                where: { personId: { in: existingUserIds } }
             });
             await prisma.programParticipant.deleteMany({
                 where: { participantId: { in: existingUserIds } }

--- a/checkin-app/src/app/__tests__/programsParticipantsConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsConcurrency.integration.test.ts
@@ -48,7 +48,7 @@ describe('POST /api/programs/[id]/participants concurrency (capacity lock)', () 
         await prisma.programParticipant.deleteMany({ where: { participantId: { in: ids } } });
         await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: ids } } });
-        await prisma.householdLead.deleteMany({ where: { participantId: { in: ids } } });
+        await prisma.householdLead.deleteMany({ where: { personId: { in: ids } } });
         await prisma.participant.deleteMany({ where: { id: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
     }
@@ -63,7 +63,7 @@ describe('POST /api/programs/[id]/participants concurrency (capacity lock)', () 
             data: { email: `lead-${TAG}@example.com`, name: 'Lead', householdId },
         });
         leadId = lead.id;
-        await prisma.householdLead.create({ data: { householdId, participantId: leadId } });
+        await prisma.householdLead.create({ data: { householdId, personId: leadId } });
 
         const m1 = await prisma.participant.create({
             data: { email: `m1-${TAG}@example.com`, name: 'Member One', householdId },

--- a/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
@@ -45,7 +45,7 @@ describe('Public Program Registration API Integration Tests', () => {
         });
 
         await prisma.householdLead.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         
         await prisma.participant.deleteMany({
@@ -141,7 +141,7 @@ describe('Public Program Registration API Integration Tests', () => {
             });
 
             await prisma.householdLead.deleteMany({
-                where: { participantId: { in: existingUserIds } }
+                where: { personId: { in: existingUserIds } }
             });
 
             await prisma.participant.deleteMany({
@@ -388,7 +388,7 @@ describe('Public Program Registration API Integration Tests', () => {
             const p = await prisma.participant.findUnique({ where: { email: inBoundsEmail } });
             if (p) {
                 await prisma.programParticipant.deleteMany({ where: { participant: { householdId: p.householdId } } });
-                await prisma.householdLead.deleteMany({ where: { participant: { householdId: p.householdId } } });
+                await prisma.householdLead.deleteMany({ where: { person: { householdId: p.householdId } } });
                 await prisma.participant.deleteMany({ where: { householdId: p.householdId } });
                 await prisma.household.delete({ where: { id: p.householdId as number } });
             }
@@ -507,7 +507,7 @@ describe('Public Program Registration API Integration Tests', () => {
             const p = await prisma.participant.findUnique({ where: { email: uniqueEmail } });
             if (p) {
                 await prisma.programParticipant.deleteMany({ where: { programId: freeProgramId, participant: { householdId: p.householdId } }});
-                await prisma.householdLead.deleteMany({ where: { participant: { householdId: p.householdId } } });
+                await prisma.householdLead.deleteMany({ where: { person: { householdId: p.householdId } } });
                 await prisma.participant.deleteMany({ where: { householdId: p.householdId } });
                 await prisma.household.delete({ where: { id: p.householdId as number } });
             }

--- a/checkin-app/src/app/__tests__/renewalConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/renewalConcurrency.integration.test.ts
@@ -44,7 +44,7 @@ describe('renewal opening concurrency', () => {
         const hh = await prisma.household.create({ data: { name: `Family ${TAG}` } });
         householdId = hh.id;
         const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         membershipId = (await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } })).id;
     });
 

--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -37,7 +37,7 @@ describe('Shop API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         await prisma.toolStatus.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         await prisma.visit.deleteMany({
             where: { participantId: { in: existingUserIds } }
@@ -117,7 +117,7 @@ describe('Shop API Integration Tests', () => {
                 where: { actorId: { in: existingUserIds } }
             });
             await prisma.toolStatus.deleteMany({
-                where: { participantId: { in: existingUserIds } }
+                where: { personId: { in: existingUserIds } }
             });
             await prisma.visit.deleteMany({
                 where: { participantId: { in: existingUserIds } }
@@ -272,7 +272,7 @@ describe('Shop API Integration Tests', () => {
              const data = await res.json();
              expect(data.success).toBe(true);
              expect(data.certification.level).toBe('BASIC');
-             expect(data.certification.participantId).toBe(commonId);
+             expect(data.certification.personId).toBe(commonId);
 
              // Audit: first grant on this participant+tool → CREATE, no prior data.
              const auditRows = await prisma.auditLog.findMany({
@@ -297,7 +297,7 @@ describe('Shop API Integration Tests', () => {
 
              // No toolStatus row was written for this fresh (participant, tool) pair.
              const written = await prisma.toolStatus.findUnique({
-                 where: { participantId_toolId: { participantId: commonId, toolId: tool.id } }
+                 where: { personId_toolId: { personId: commonId, toolId: tool.id } }
              });
              expect(written).toBeNull();
         });

--- a/checkin-app/src/app/__tests__/trustedAdultAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultAPI.integration.test.ts
@@ -65,7 +65,7 @@ describe('Trusted Adults API', () => {
         const fhh = await prisma.household.create({ data: { name: `Family HH ${TAG}` } });
         familyHh = fhh.id;
         leadId = (await prisma.participant.create({ data: { name: 'Lead', householdId: familyHh } })).id;
-        await prisma.householdLead.create({ data: { householdId: familyHh, participantId: leadId } });
+        await prisma.householdLead.create({ data: { householdId: familyHh, personId: leadId } });
         childId = (await prisma.participant.create({ data: { name: 'Child', householdId: familyHh } })).id;
 
         boardHh = (await prisma.household.create({ data: { name: `Board HH ${TAG}` } })).id;

--- a/checkin-app/src/app/__tests__/trustedAdultAtomicity.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultAtomicity.integration.test.ts
@@ -76,7 +76,7 @@ describe('Trusted Adults — mutation + audit are atomic', () => {
         householdId = hh.id;
         const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         const boardHh = await prisma.household.create({ data: { name: `Board HH ${TAG}` } });
         boardId = (await prisma.participant.create({ data: { name: 'Boardie', isBoardMember: true, householdId: boardHh.id } })).id;
     });

--- a/checkin-app/src/app/__tests__/trustedAdultConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultConcurrency.integration.test.ts
@@ -55,7 +55,7 @@ describe('trusted-adult mutation concurrency', () => {
         householdId = hh.id;
         const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         const boardHh = await prisma.household.create({ data: { name: `Board HH ${TAG}` } });
         boardId = (await prisma.participant.create({ data: { name: 'Boardie', isBoardMember: true, householdId: boardHh.id } })).id;
     });

--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -50,7 +50,7 @@ describe('Trusted Adults service', () => {
         householdId = hh.id;
         const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
 
         // A board member who is also a lead of the disclosing household: overriding this
         // household's own review is a conflict of interest (force-approve Grandma for their kids).
@@ -58,7 +58,7 @@ describe('Trusted Adults service', () => {
             data: { name: 'BoardLead', email: `boardlead-${TAG}@ex.com`, isBoardMember: true, householdId: hh.id },
         });
         boardLeadId = boardLead.id;
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: boardLead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: boardLead.id } });
 
         const outHh = await prisma.household.create({ data: { name: `Outsider HH ${TAG}` } });
         outsiderId = (await prisma.participant.create({ data: { name: 'Outsider', householdId: outHh.id } })).id;
@@ -422,7 +422,7 @@ describe('runExpirySweep edge cases', () => {
         householdId = hh.id;
         const lead = await prisma.participant.create({ data: { name: 'SweepLead', email: `sweeplead-${SWEEP_TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
-        await prisma.householdLead.create({ data: { householdId: hh.id, participantId: lead.id } });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
     });
 
     afterAll(async () => {

--- a/checkin-app/src/app/api/household/lead/route.ts
+++ b/checkin-app/src/app/api/household/lead/route.ts
@@ -108,15 +108,15 @@ export const DELETE = withAuth(
                 where: { householdId: targetHouseholdId }
             });
 
-            if (allLeads.length <= 1 && allLeads.some(l => l.participantId === participantId)) {
+            if (allLeads.length <= 1 && allLeads.some(l => l.personId === participantId)) {
                 return NextResponse.json({ error: "Cannot remove the last lead of a household." }, { status: 400 });
             }
 
             const existingLead = await prisma.householdLead.findUnique({
                 where: {
-                    householdId_participantId: {
+                    householdId_personId: {
                         householdId: targetHouseholdId,
-                        participantId: participantId
+                        personId: participantId
                     }
                 }
             });
@@ -127,9 +127,9 @@ export const DELETE = withAuth(
 
             await prisma.householdLead.delete({
                 where: {
-                    householdId_participantId: {
+                    householdId_personId: {
                         householdId: targetHouseholdId,
-                        participantId: participantId
+                        personId: participantId
                     }
                 }
             });

--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -64,7 +64,7 @@ export const PATCH = withAuth(
             if (isLead !== undefined && participantId !== userId) {
                 const currentLead = await prisma.householdLead.findUnique({
                     where: {
-                        householdId_participantId: { householdId: user.householdId, participantId }
+                        householdId_personId: { householdId: user.householdId, personId: participantId }
                     }
                 });
 
@@ -92,7 +92,7 @@ export const PATCH = withAuth(
                     if (leadCount > 1) {
                         await prisma.householdLead.delete({
                              where: {
-                                 householdId_participantId: { householdId: user.householdId, participantId }
+                                 householdId_personId: { householdId: user.householdId, personId: participantId }
                              }
                         });
                         

--- a/checkin-app/src/app/api/membership-audit/households-missing-contact/route.ts
+++ b/checkin-app/src/app/api/membership-audit/households-missing-contact/route.ts
@@ -20,7 +20,7 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
         include: {
             leads: {
                 include: {
-                    participant: { select: { id: true, name: true, phone: true, email: true } },
+                    person: { select: { id: true, name: true, phone: true, email: true } },
                 },
             },
         },
@@ -31,10 +31,10 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
         id: h.id,
         name: h.name,
         leads: h.leads.map((l) => ({
-            id: l.participant.id,
-            name: l.participant.name,
-            phone: l.participant.phone,
-            email: l.participant.email,
+            id: l.person.id,
+            name: l.person.name,
+            phone: l.person.phone,
+            email: l.person.email,
         })),
     }));
 

--- a/checkin-app/src/app/api/membership-audit/unclaimed-households/route.ts
+++ b/checkin-app/src/app/api/membership-audit/unclaimed-households/route.ts
@@ -14,19 +14,19 @@ export const GET = withAuth(
             // yet, but at least one lead has an email we can chase.
             const households = await prisma.household.findMany({
                 where: {
-                    leads: { some: { participant: { email: { not: null } } } },
-                    NOT: { leads: { some: { participant: { googleId: { not: null } } } } }
+                    leads: { some: { person: { email: { not: null } } } },
+                    NOT: { leads: { some: { person: { googleId: { not: null } } } } }
                 },
-                include: { leads: { include: { participant: true } } }
+                include: { leads: { include: { person: true } } }
             });
 
             const result = households.map(h => ({
                 id: h.id,
                 name: h.name
-                    || h.leads.find(l => l.participant.name)?.participant.name
+                    || h.leads.find(l => l.person.name)?.person.name
                     || `Household #${h.id}`,
                 members: h.leads
-                    .map(l => l.participant)
+                    .map(l => l.person)
                     .filter(p => p.email !== null)
                     .map(p => ({ id: p.id, name: p.name, email: p.email }))
             }));

--- a/checkin-app/src/app/api/membership-ops/applications/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/route.ts
@@ -35,7 +35,7 @@ export const GET = handler("GET /api/membership-ops/applications", async () => {
                         select: {
                             name: true,
                             participants: { select: { id: true, name: true, email: true } },
-                            leads: { select: { participantId: true } },
+                            leads: { select: { personId: true } },
                         },
                     },
                 },

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -31,7 +31,7 @@ export const GET = withAuth(
                         participants: {
                             select: { id: true, name: true, email: true }
                         },
-                        householdLeads: { select: { participantId: true } },
+                        householdLeads: { select: { personId: true } },
                         membership: true,
                         emergencyContacts: {
                             where: PRIMARY_CONTACT_WHERE,

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/household/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/household/route.ts
@@ -37,7 +37,7 @@ export const POST = withAuth<{ params: Promise<{ id: string }> }>(
                     name: `${participant.name || 'User'}'s Household`,
                     leads: {
                         create: {
-                            participantId: participant.id
+                            personId: participant.id
                         }
                     }
                 }
@@ -77,7 +77,7 @@ export const POST = withAuth<{ params: Promise<{ id: string }> }>(
         if (participant.householdId && participant.householdId !== targetHouseholdId) {
             await prisma.householdLead.deleteMany({
                 where: {
-                    participantId: participant.id,
+                    personId: participant.id,
                     householdId: participant.householdId
                 }
             });

--- a/checkin-app/src/app/api/membership-ops/participants/import/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/route.ts
@@ -344,10 +344,10 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                         const projectedLeadIds = new Set(
                             (await prisma.householdLead.findMany({
                                 where: { householdId: targetHouseholdId },
-                                select: { participantId: true }
-                            })).map((l) => l.participantId)
+                                select: { personId: true }
+                            })).map((l) => l.personId)
                         );
-                        for (const l of sourceLeads) projectedLeadIds.add(l.participantId);
+                        for (const l of sourceLeads) projectedLeadIds.add(l.personId);
                         if (pr.email) projectedLeadIds.add(participantId);
                         if (projectedLeadIds.size > MAX_HOUSEHOLD_LEADS) {
                             throw new HouseholdLeadLimitError(targetHouseholdId);
@@ -364,7 +364,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
 
                             // Move all leads from source to target
                             for (const lead of sourceLeads) {
-                                await addHouseholdLead(tx, targetHouseholdId, lead.participantId);
+                                await addHouseholdLead(tx, targetHouseholdId, lead.personId);
                             }
 
                             // Delete memberships and leads from the old source household

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -64,7 +64,7 @@ describe("Merge Participants API", () => {
         await prisma.feePayment.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
         await prisma.visit.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
         await prisma.programParticipant.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
-        await prisma.householdLead.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
+        await prisma.householdLead.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
         await prisma.auditLog.deleteMany({ where: { actorId } });
         await prisma.participant.deleteMany({ where: { id: { in: [pKeepId, pMergeId, actorId] } } });
         if (createdFeeId) {
@@ -184,7 +184,7 @@ describe("Merge Participants API", () => {
     it("should fail to merge if merged user is the lead of a household with other members", async () => {
         // Both users already share a household (from beforeEach); make merge user the lead
         await prisma.householdLead.create({
-            data: { householdId, participantId: pMergeId }
+            data: { householdId, personId: pMergeId }
         });
 
         const req = new Request("http://localhost/api/membership-ops/participants/merge", {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -151,20 +151,20 @@ export const POST = withAuth(
                 for (const tool of mergeParticipant.toolStatuses) {
                     if (!keepParticipant.toolStatuses.find(k => k.toolId === tool.toolId)) {
                         await tx.toolStatus.update({
-                            where: { participantId_toolId: { toolId: tool.toolId, participantId: mergeId } },
-                            data: { participantId: keepId }
+                            where: { personId_toolId: { toolId: tool.toolId, personId: mergeId } },
+                            data: { personId: keepId }
                         });
                         moved.toolStatuses.migrated++;
                     } else {
                         await tx.toolStatus.delete({
-                            where: { participantId_toolId: { toolId: tool.toolId, participantId: mergeId } }
+                            where: { personId_toolId: { toolId: tool.toolId, personId: mergeId } }
                         });
                         moved.toolStatuses.deleted++;
                     }
                 }
 
                 await tx.householdLead.deleteMany({
-                    where: { participantId: mergeId }
+                    where: { personId: mergeId }
                 });
 
                 // householdId stays pointing at the old household: every

--- a/checkin-app/src/app/api/membership/reviews/route.ts
+++ b/checkin-app/src/app/api/membership/reviews/route.ts
@@ -40,7 +40,7 @@ export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
                     household: {
                         select: {
                             name: true,
-                            leads: { select: { participant: { select: { id: true, name: true, email: true } } } },
+                            leads: { select: { person: { select: { id: true, name: true, email: true } } } },
                         },
                     },
                 },

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -114,8 +114,8 @@ export const GET = withAuth({}, async (_req, auth) => {
         const isLead =
             user.householdLead ??
             (await prisma.householdLead.findFirst({
-                where: { householdId, participantId: user.id },
-                select: { participantId: true },
+                where: { householdId, personId: user.id },
+                select: { personId: true },
             })) !== null;
 
         const [hh, leadsMissingPhone, membersMissingAge, membershipProcs, trustedAdultAction, trustedAdultExpiring, pendingPrograms] = await Promise.all([
@@ -137,8 +137,8 @@ export const GET = withAuth({}, async (_req, auth) => {
             // page highlights the member box; this drives the nav badge count.
             isLead
                 ? prisma.householdLead.findMany({
-                      where: { householdId, OR: [{ participant: { phone: null } }, { participant: { phone: "" } }] },
-                      select: { participant: { select: { id: true, name: true } } },
+                      where: { householdId, OR: [{ person: { phone: null } }, { person: { phone: "" } }] },
+                      select: { person: { select: { id: true, name: true } } },
                   })
                 : Promise.resolve([]),
             // A member with no DoB and no 25+ declaration shows "Age Unavailable"
@@ -173,7 +173,7 @@ export const GET = withAuth({}, async (_req, auth) => {
             householdTodos.push({ key: "emergency-contact", label: "Add a household emergency contact", href: "/my-household#emergency-contact" });
         }
         for (const l of leadsMissingPhone) {
-            householdTodos.push({ key: `lead-phone-${l.participant.id}`, label: `Add a phone number for ${l.participant.name ?? "the household lead"}`, href: "/my-household" });
+            householdTodos.push({ key: `lead-phone-${l.person.id}`, label: `Add a phone number for ${l.person.name ?? "the household lead"}`, href: "/my-household" });
         }
         for (const m of membersMissingAge) {
             householdTodos.push({ key: `member-age-${m.id}`, label: `Add a date of birth for ${m.name ?? "a household member"}`, href: "/my-household" });
@@ -341,8 +341,8 @@ export const GET = withAuth({}, async (_req, auth) => {
             // households with an email-having lead where no lead has signed in with Google.
             prisma.household.count({
                 where: {
-                    leads: { some: { participant: { email: { not: null } } } },
-                    NOT: { leads: { some: { participant: { googleId: { not: null } } } } },
+                    leads: { some: { person: { email: { not: null } } } },
+                    NOT: { leads: { some: { person: { googleId: { not: null } } } } },
                 },
             }),
             // "Broken" households: no household lead at all. Mirrors

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -44,9 +44,9 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         if (participantData?.householdId) {
             const leadRecord = await prisma.householdLead.findUnique({
                 where: {
-                    householdId_participantId: {
+                    householdId_personId: {
                         householdId: participantData.householdId,
-                        participantId: currentUserId
+                        personId: currentUserId
                     }
                 }
             });

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -47,9 +47,9 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         if (!isSelf && !isSysAdminOrBoard && !isLeadMentor && participant.participant?.householdId) {
             const leadRecord = await prisma.householdLead.findUnique({
                 where: {
-                    householdId_participantId: {
+                    householdId_personId: {
                         householdId: participant.participant.householdId,
-                        participantId: currentUserId
+                        personId: currentUserId
                     }
                 }
             });

--- a/checkin-app/src/app/api/safety/emergency-contacts/route.ts
+++ b/checkin-app/src/app/api/safety/emergency-contacts/route.ts
@@ -22,7 +22,7 @@ export const GET = withAuth(
                     },
                     leads: {
                         include: {
-                            participant: {
+                            person: {
                                 select: {
                                     id: true,
                                     name: true,
@@ -65,10 +65,10 @@ export const GET = withAuth(
                         isPresent: p.visits.length > 0
                     })),
                     leads: h.leads.map(l => ({
-                        id: l.participant.id,
-                        name: l.participant.name,
-                        phone: l.participant.phone,
-                        email: l.participant.email
+                        id: l.person.id,
+                        name: l.person.name,
+                        phone: l.person.phone,
+                        email: l.person.email
                     }))
                 };
             });

--- a/checkin-app/src/app/api/safety/trusted-adults/route.ts
+++ b/checkin-app/src/app/api/safety/trusted-adults/route.ts
@@ -25,7 +25,7 @@ export const GET = handler("GET /api/safety/trusted-adults", async () => {
             familyContext: true,
             origin: true,
             createdAt: true,
-            household: { select: { id: true, name: true, leads: { select: { participant: { select: { id: true, name: true, email: true } } } } } },
+            household: { select: { id: true, name: true, leads: { select: { person: { select: { id: true, name: true, email: true } } } } } },
             counterparty: { select: { id: true, name: true, email: true } },
             reviews: {
                 orderBy: { id: "desc" },

--- a/checkin-app/src/app/api/shop/certifications/route.ts
+++ b/checkin-app/src/app/api/shop/certifications/route.ts
@@ -33,10 +33,10 @@ export const GET = handler('GET /api/shop/certifications', async ({ req, auth })
         const isAuthorized = user.isSysadmin || user.isBoardMember || user.isKeyholder || hasCertifierAuth;
         if (!isAuthorized) throw forbidden();
         const certifications = await prisma.toolStatus.findMany({
-            orderBy: [{ tool: { name: 'asc' } }, { participant: { name: 'asc' } }],
+            orderBy: [{ tool: { name: 'asc' } }, { person: { name: 'asc' } }],
             include: {
                 tool: true,
-                participant: { select: { id: true, name: true } },
+                person: { select: { id: true, name: true } },
             },
         });
         return { ToolStatus: certifications };
@@ -45,13 +45,13 @@ export const GET = handler('GET /api/shop/certifications', async ({ req, auth })
     const targetUserId = participantIdParam ? parseInt(participantIdParam, 10) : user.id;
     const whereClause = toolIdParam
         ? { toolId: parseInt(toolIdParam, 10) }
-        : { participantId: targetUserId };
+        : { personId: targetUserId };
 
     const certifications = await prisma.toolStatus.findMany({
         where: whereClause,
         include: {
             tool: true,
-            participant: toolIdParam ? { select: { id: true, name: true } } : false,
+            person: toolIdParam ? { select: { id: true, name: true } } : false,
         },
     });
 
@@ -89,8 +89,8 @@ export const POST = withAuth({}, async (req, auth) => {
             // Check if user is a certifier for this specific tool
             const currentUserStatus = await prisma.toolStatus.findUnique({
                 where: {
-                    participantId_toolId: {
-                        participantId: currentUserId,
+                    personId_toolId: {
+                        personId: currentUserId,
                         toolId: parseInt(toolId, 10)
                     }
                 }
@@ -116,13 +116,13 @@ export const POST = withAuth({}, async (req, auth) => {
         const pId = parseInt(participantId, 10);
 
         const currentStatus = await prisma.toolStatus.findUnique({
-            where: { participantId_toolId: { participantId: pId, toolId: tId } }
+            where: { personId_toolId: { personId: pId, toolId: tId } }
         });
 
         const upsertedCert = await prisma.toolStatus.upsert({
             where: {
-                participantId_toolId: {
-                    participantId: pId,
+                personId_toolId: {
+                    personId: pId,
                     toolId: tId
                 }
             },
@@ -130,7 +130,7 @@ export const POST = withAuth({}, async (req, auth) => {
                 level: level as 'BASIC' | 'DOF' | 'CERTIFIED' | 'INSTRUCTOR' | 'MAY_CERTIFY_OTHERS'
             },
             create: {
-                participantId: pId,
+                personId: pId,
                 toolId: tId,
                 level: level as 'BASIC' | 'DOF' | 'CERTIFIED' | 'INSTRUCTOR' | 'MAY_CERTIFY_OTHERS'
             }

--- a/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
@@ -8,7 +8,7 @@ import AdminMembershipPage from "../page";
 beforeEach(() => resetRtl());
 
 function household(name: string, id: number) {
-    return { name, participants: [{ id: 1, name: "Lead One", email: "lead@example.com" }], leads: [{ participantId: 1 }], householdId: id };
+    return { name, participants: [{ id: 1, name: "Lead One", email: "lead@example.com" }], leads: [{ personId: 1 }], householdId: id };
 }
 
 const rows = [

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -29,7 +29,7 @@ interface ProcessRow {
   membership: {
     householdId: number;
     isVolunteer: boolean;
-    household: { name: string | null; participants: Person[]; leads: { participantId: number }[] } | null;
+    household: { name: string | null; participants: Person[]; leads: { personId: number }[] } | null;
   } | null;
 }
 
@@ -161,7 +161,7 @@ export default function AdminMembershipPage() {
   const householdLabel = (r: ProcessRow) => {
     const hh = r.membership?.household;
     if (!hh) return `Household #${r.membership?.householdId ?? "?"}`;
-    const leadIds = new Set((hh.leads || []).map((l) => l.participantId));
+    const leadIds = new Set((hh.leads || []).map((l) => l.personId));
     const parents = (hh.participants || []).filter((p) => leadIds.has(p.id)).map((p) => p.name || p.email).filter(Boolean);
     return hh.name || parents.join(" & ") || `Household #${r.membership?.householdId}`;
   };

--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -184,7 +184,7 @@ export default function MergeParticipants() {
           <List size="sm">
             {(p.household.participants as { id: number, name: string | null }[]).map((hp) => (
               <List.Item key={hp.id}>
-                {hp.name} {hp.id === p.id && "(This)"} {((p.household!.leads as unknown) as { participantId: number }[]).find((l) => l.participantId === hp.id) && "[Lead]"}
+                {hp.name} {hp.id === p.id && "(This)"} {((p.household!.leads as unknown) as { personId: number }[]).find((l) => l.personId === hp.id) && "[Lead]"}
               </List.Item>
             ))}
           </List>
@@ -229,7 +229,7 @@ export default function MergeParticipants() {
 
   let isLeadWithOthers = false;
   if (mergeParticipant && !previewMode) {
-    const isLead = mergeParticipant.household?.leads.find((l: { participantId?: number;[key: string]: unknown }) => l.participantId === mergeParticipant.id);
+    const isLead = mergeParticipant.household?.leads.find((l: { personId?: number;[key: string]: unknown }) => l.personId === mergeParticipant.id);
     const othersCount = (mergeParticipant.household?.participants as { id: number }[] | undefined)?.filter((p) => p.id !== mergeParticipant.id).length || 0;
     isLeadWithOthers = !!isLead && othersCount > 0;
   }

--- a/checkin-app/src/lib/__tests__/authClaims.test.ts
+++ b/checkin-app/src/lib/__tests__/authClaims.test.ts
@@ -57,7 +57,7 @@ describe('assignParticipantClaims — household login gate', () => {
 describe('assignParticipantClaims — householdLead claim', () => {
     it('stamps householdLead=true when a HouseholdLead row exists', () => {
         const token = {} as JWT;
-        assignParticipantClaims(token, participant({ householdLeads: [{ participantId: 7 }] }));
+        assignParticipantClaims(token, participant({ householdLeads: [{ personId: 7 }] }));
         expect(token.householdLead).toBe(true);
     });
 
@@ -70,7 +70,7 @@ describe('assignParticipantClaims — householdLead claim', () => {
     it('forces householdLead=false for a DENIED household even with a lead row', () => {
         const token = {} as JWT;
         assignParticipantClaims(token, participant({
-            householdLeads: [{ participantId: 7 }],
+            householdLeads: [{ personId: 7 }],
             household: { membership: { status: 'DENIED' } },
         }));
         expect(token.householdLead).toBe(false);

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -248,7 +248,7 @@ export const authOptions: NextAuthOptions = {
                             }
                         },
                         // One row is enough to mark this participant a household lead.
-                        householdLeads: { take: 1, select: { participantId: true } },
+                        householdLeads: { take: 1, select: { personId: true } },
                         // Program ids led — drives the client program-ops row gate.
                         programsLed: { select: { id: true } },
                         household: { include: { membership: true } }
@@ -289,7 +289,7 @@ export const authOptions: NextAuthOptions = {
                             }
                         },
                         // One row is enough to mark this participant a household lead.
-                        householdLeads: { take: 1, select: { participantId: true } },
+                        householdLeads: { take: 1, select: { personId: true } },
                         // Program ids led — drives the client program-ops row gate.
                         programsLed: { select: { id: true } },
                         household: { include: { membership: true } }

--- a/checkin-app/src/lib/authClaims.ts
+++ b/checkin-app/src/lib/authClaims.ts
@@ -13,7 +13,7 @@ export type ClaimSourceParticipant = {
     toolStatuses: { toolId: number; level: string }[];
     // Any row here means this participant leads a household (the relation is already
     // filtered to their own leads). Empty/absent → not a lead.
-    householdLeads?: { participantId: number }[];
+    householdLeads?: { personId: number }[];
     // Programs this participant is the lead mentor of (Program.leadMentorId === id).
     // Drives the client-side program-ops row gate; mirrors access-resolvers' programsLed.
     programsLed?: { id: number }[];

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -190,19 +190,19 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         create: { name: "Drill Press", safetyGuide: "https://example.com/drill-press-safety" },
     });
     await prisma.toolStatus.upsert({
-        where: { participantId_toolId: { participantId: certifiedAdult.id, toolId: tableSaw.id } },
+        where: { personId_toolId: { personId: certifiedAdult.id, toolId: tableSaw.id } },
         update: { level: "CERTIFIED" },
-        create: { participantId: certifiedAdult.id, toolId: tableSaw.id, level: "CERTIFIED" },
+        create: { personId: certifiedAdult.id, toolId: tableSaw.id, level: "CERTIFIED" },
     });
     await prisma.toolStatus.upsert({
-        where: { participantId_toolId: { participantId: certifiedAdult.id, toolId: drillPress.id } },
+        where: { personId_toolId: { personId: certifiedAdult.id, toolId: drillPress.id } },
         update: { level: "CERTIFIED" },
-        create: { participantId: certifiedAdult.id, toolId: drillPress.id, level: "CERTIFIED" },
+        create: { personId: certifiedAdult.id, toolId: drillPress.id, level: "CERTIFIED" },
     });
     await prisma.toolStatus.upsert({
-        where: { participantId_toolId: { participantId: toolCertifier.id, toolId: tableSaw.id } },
+        where: { personId_toolId: { personId: toolCertifier.id, toolId: tableSaw.id } },
         update: { level: "MAY_CERTIFY_OTHERS" },
-        create: { participantId: toolCertifier.id, toolId: tableSaw.id, level: "MAY_CERTIFY_OTHERS" },
+        create: { personId: toolCertifier.id, toolId: tableSaw.id, level: "MAY_CERTIFY_OTHERS" },
     });
 
     // 5. Sample program

--- a/checkin-app/src/lib/dev/zoho-import.ts
+++ b/checkin-app/src/lib/dev/zoho-import.ts
@@ -496,8 +496,8 @@ export async function applyImport(
         // The primary contact is the household lead.
         if (primaryParticipantId !== null) {
             await tx.householdLead.upsert({
-                where: { householdId_participantId: { householdId, participantId: primaryParticipantId } },
-                create: { householdId, participantId: primaryParticipantId },
+                where: { householdId_personId: { householdId, personId: primaryParticipantId } },
+                create: { householdId, personId: primaryParticipantId },
                 update: {},
             });
         }

--- a/checkin-app/src/lib/emailRecipients.ts
+++ b/checkin-app/src/lib/emailRecipients.ts
@@ -19,9 +19,9 @@ export async function emailHouseholdLeads(householdId: number, subject: string, 
     try {
         const leads = await prisma.householdLead.findMany({
             where: { householdId },
-            select: { participant: { select: { email: true } } },
+            select: { person: { select: { email: true } } },
         });
-        const emails = leads.map((l) => l.participant?.email).filter((e): e is string => !!e);
+        const emails = leads.map((l) => l.person?.email).filter((e): e is string => !!e);
         await fanOutEmails(emails, subject, html, errorLabel);
     } catch (e) {
         logger.error(errorLabel, e);

--- a/checkin-app/src/lib/household/__tests__/householdLeadsConcurrency.integration.test.ts
+++ b/checkin-app/src/lib/household/__tests__/householdLeadsConcurrency.integration.test.ts
@@ -37,7 +37,7 @@ async function cleanup() {
     });
     const ids = users.map(u => u.id);
     const householdIds = [...new Set(users.map(u => u.householdId))];
-    await prisma.householdLead.deleteMany({ where: { participantId: { in: ids } } });
+    await prisma.householdLead.deleteMany({ where: { personId: { in: ids } } });
     await prisma.participant.deleteMany({ where: { id: { in: ids } } });
     await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
 }
@@ -53,7 +53,7 @@ async function makeHousehold(label: string, existingLeads: number, spares: numbe
         const p = await prisma.participant.create({
             data: { email: `lead-${i}-${label}-${TAG}@example.com`, name: `Lead ${i}`, householdId: household.id },
         });
-        await prisma.householdLead.create({ data: { householdId: household.id, participantId: p.id } });
+        await prisma.householdLead.create({ data: { householdId: household.id, personId: p.id } });
         leadIds.push(p.id);
     }
     const spareIds: number[] = [];

--- a/checkin-app/src/lib/household/leads.ts
+++ b/checkin-app/src/lib/household/leads.ts
@@ -42,7 +42,7 @@ async function addHouseholdLeadTx(
     await tx.$queryRaw`SELECT id FROM "Household" WHERE id = ${householdId} FOR UPDATE`;
 
     const existing = await tx.householdLead.findUnique({
-        where: { householdId_participantId: { householdId, participantId } },
+        where: { householdId_personId: { householdId, personId: participantId } },
     });
     if (existing) return { created: false };
 
@@ -51,7 +51,7 @@ async function addHouseholdLeadTx(
         throw new HouseholdLeadLimitError(householdId);
     }
 
-    await tx.householdLead.create({ data: { householdId, participantId } });
+    await tx.householdLead.create({ data: { householdId, personId: participantId } });
     return { created: true };
 }
 

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -93,7 +93,7 @@ export async function getIntakeState(userId: number) {
         .sort((a, b) => b.id - a.id)[0] ?? null;
 
     // Parents/guardians are the household leads; children are non-lead members.
-    const leadIds = new Set((household?.leads ?? []).map((l) => l.participantId));
+    const leadIds = new Set((household?.leads ?? []).map((l) => l.personId));
     const parents = (household?.participants ?? []).filter((p) => leadIds.has(p.id));
     const children = (household?.participants ?? []).filter((p) => !leadIds.has(p.id));
     const primary = parents.find((p) => p.id === userId) ?? null;

--- a/checkin-app/src/lib/notifications.ts
+++ b/checkin-app/src/lib/notifications.ts
@@ -131,7 +131,7 @@ export async function sendCheckinNotifications(participantId: number, type: 'che
             const householdLeads = await prisma.householdLead.findMany({
                 where: { householdId: participant.householdId },
                 include: {
-                    participant: {
+                    person: {
                         select: {
                             id: true,
                             email: true,
@@ -144,19 +144,19 @@ export async function sendCheckinNotifications(participantId: number, type: 'che
 
             for (const lead of householdLeads) {
                 // Don't double-notify if the lead IS the participant
-                if (lead.participant.id === participant.id) continue;
+                if (lead.person.id === participant.id) continue;
 
-                const leadSettings = lead.participant.notificationSettings as unknown as Record<string, boolean>;
-                if (leadSettings?.emailDependentCheckins && lead.participant.email) {
+                const leadSettings = lead.person.notificationSettings as unknown as Record<string, boolean>;
+                if (leadSettings?.emailDependentCheckins && lead.person.email) {
                     const subject = `${emoji} ${name} ${action} Innovation Treehouse`;
                     const html = householdMemberTemplate({
-                        leadName: lead.participant.name || 'there',
+                        leadName: lead.person.name || 'there',
                         memberName: name,
                         type,
                         date: dateStr,
                         time: timeStr
                     });
-                    emailPromises.push(sendEmail(lead.participant.email, subject, html));
+                    emailPromises.push(sendEmail(lead.person.email, subject, html));
                 }
             }
         }

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -368,8 +368,8 @@ export async function runExpirySweep(now: Date) {
 /** Actor must be a lead of the given household. */
 export async function assertHouseholdLead(householdId: number, actorId: number) {
     const lead = await prisma.householdLead.findFirst({
-        where: { householdId, participantId: actorId },
-        select: { participantId: true },
+        where: { householdId, personId: actorId },
+        select: { personId: true },
     });
     if (!lead) throw new TrustedAdultError("forbidden", "You must be a lead of this household.");
 }

--- a/checkin-app/src/security/__tests__/shop-certifications-strip.test.ts
+++ b/checkin-app/src/security/__tests__/shop-certifications-strip.test.ts
@@ -4,10 +4,10 @@
 /**
  * Strip-assertion for GET /api/shop/certifications. Cert status is PUBLIC BY
  * DESIGN (posted in the shop), but the participant's email is not. A bag row is
- * a ToolStatus with nested tool (Tool) + participant (Participant):
+ * a ToolStatus with nested tool (Tool) + person (Participant):
  *
- *   - board/sysadmin (everyones:pii) → level + tool + participant name + email.
- *   - member/certifier (member+public) → level + tool + participant name;
+ *   - board/sysadmin (everyones:pii) → level + tool + person name + email.
+ *   - member/certifier (member+public) → level + tool + person name;
  *                                        email (pii) STRIPPED.
  *
  * `level` is @sensitivity:member, so it is visible to any authenticated member
@@ -49,25 +49,25 @@ function tokensFor(endpoint: string, role: Role): readonly Token[] {
 }
 
 const ENDPOINT = 'GET /api/shop/certifications';
-// The route currently selects participant {id, name} only — no client needs
+// The route currently selects person {id, name} only — no client needs
 // email. This fixture includes email to lock the DECLARED policy: if a future
 // edit adds email to the select, the stripper must still gate it to staff.
 // A cert row for some OTHER member (id !== selfId → only the 'everyones' scope applies).
 const row = () => ({
-    participantId: 99,
+    personId: 99,
     toolId: 7,
     level: 'CERTIFIED',
     tool: { id: 7, name: 'Lathe', safetyGuide: null },
-    participant: { id: 99, name: 'Other Member', email: 'other@x.test' },
+    person: { id: 99, name: 'Other Member', email: 'other@x.test' },
 });
 
 describe('shop/certifications field-stripping', () => {
-    it('board sees level + tool + participant name + email (pii)', () => {
+    it('board sees level + tool + person name + email (pii)', () => {
         const tokens = tokensFor(ENDPOINT, 'isBoardMember');
         const out = stripValue('ToolStatus', row(), tokens, ctx()) as Record<string, unknown>;
         expect(out.level).toBe('CERTIFIED');
         expect((out.tool as Record<string, unknown>).name).toBe('Lathe');
-        const p = out.participant as Record<string, unknown>;
+        const p = out.person as Record<string, unknown>;
         expect(p.name).toBe('Other Member');
         expect(p.email).toBe('other@x.test');
     });
@@ -78,9 +78,9 @@ describe('shop/certifications field-stripping', () => {
         // cert status stays public-by-design:
         expect(out.level).toBe('CERTIFIED');
         expect((out.tool as Record<string, unknown>).name).toBe('Lathe');
-        const p = out.participant as Record<string, unknown>;
+        const p = out.person as Record<string, unknown>;
         expect(p.name).toBe('Other Member');
-        // ...but the participant's email does not leak to non-staff:
+        // ...but the person's email does not leak to non-staff:
         expect(p.email).toBeUndefined();
     });
 

--- a/checkin-app/src/security/__tests__/toolstatus-self-scope.test.ts
+++ b/checkin-app/src/security/__tests__/toolstatus-self-scope.test.ts
@@ -2,11 +2,11 @@
  * @jest-environment node
  */
 /**
- * ToolStatus.userId was renamed to participantId (Person = Participant). The
- * `their_own` stripper branch was SPLIT so ToolStatus reads `participantId`
- * while Account/Session (NextAuth-mandated) keep reading `userId`. Guards that
- * split: a member must still self-scope their own ToolStatus rows, and the
- * Account/Session read must NOT regress.
+ * ToolStatus.userId was renamed userId->participantId->personId (Person =
+ * Participant). The `their_own` stripper branch was SPLIT so ToolStatus reads
+ * `personId` while Account/Session (NextAuth-mandated) keep reading `userId`.
+ * Guards that split: a member must still self-scope their own ToolStatus rows,
+ * and the Account/Session read must NOT regress.
  */
 import { scopesHeld, type CallerContext } from '../access-resolvers';
 
@@ -22,18 +22,18 @@ const ctx: CallerContext = {
     activeVisitorIds: new Set(),
 };
 
-describe('ToolStatus self-scoping after userId -> participantId rename', () => {
-    it("grants their_own on a ToolStatus row whose participantId is the caller", () => {
-        expect(scopesHeld('ToolStatus', { participantId: 7, toolId: 1 }, ctx).has('their_own')).toBe(true);
+describe('ToolStatus self-scoping after participantId -> personId rename', () => {
+    it("grants their_own on a ToolStatus row whose personId is the caller", () => {
+        expect(scopesHeld('ToolStatus', { personId: 7, toolId: 1 }, ctx).has('their_own')).toBe(true);
     });
 
     it('does NOT grant their_own on someone else\'s ToolStatus row', () => {
-        expect(scopesHeld('ToolStatus', { participantId: 99, toolId: 1 }, ctx).has('their_own')).toBe(false);
+        expect(scopesHeld('ToolStatus', { personId: 99, toolId: 1 }, ctx).has('their_own')).toBe(false);
     });
 
-    it('reads participantId, not the stale userId, for ToolStatus', () => {
+    it('reads personId, not the stale participantId, for ToolStatus', () => {
         // A row carrying only the OLD key must no longer self-scope.
-        expect(scopesHeld('ToolStatus', { userId: 7, toolId: 1 }, ctx).has('their_own')).toBe(false);
+        expect(scopesHeld('ToolStatus', { participantId: 7, toolId: 1 }, ctx).has('their_own')).toBe(false);
     });
 
     it('Account/Session still self-scope on userId (NextAuth, unchanged)', () => {

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -29,7 +29,7 @@ export const classifications = {
         safetyGuide: 'public',
     },
     ToolStatus: {
-        participantId: 'public',
+        personId: 'public',
         toolId: 'public',
         level: 'member',
     },
@@ -59,7 +59,7 @@ export const classifications = {
     },
     HouseholdLead: {
         householdId: 'public',
-        participantId: 'public',
+        personId: 'public',
     },
     Membership: {
         id: 'public',
@@ -347,7 +347,7 @@ export const relations = {
         toolStatuses: { model: 'ToolStatus', isList: true },
     },
     ToolStatus: {
-        participant: { model: 'Participant', isList: false },
+        person: { model: 'Participant', isList: false },
         tool: { model: 'Tool', isList: false },
     },
     Household: {
@@ -362,7 +362,7 @@ export const relations = {
     },
     HouseholdLead: {
         household: { model: 'Household', isList: false },
-        participant: { model: 'Participant', isList: false },
+        person: { model: 'Participant', isList: false },
     },
     Membership: {
         household: { model: 'Household', isList: false },

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -13,7 +13,7 @@
  * (./generated/classifications.ts), not the §7.4 doc table. Discrepancies found
  * vs that table (see docs/security/auth-consistency-analysis.md §7.4/§7.5):
  *   - Visit:  field is `departedAt` (doc wrote `departed`).            [doc fixed]
- *   - ToolStatus: field is `participantId` (renamed from `userId`, #564).
+ *   - ToolStatus: field is `personId` (renamed userId→participantId #564, then participantId→personId).
  *   - RawBadgeLog: model is `RawBadgeLog` (doc table wrote `RawBadgeEvent`).
  *   - Fee / RSVP: the live switch grouped ProgramParticipant, ProgramVolunteer,
  *     Fee and RSVP under one `case` body that read BOTH `row.programId` and
@@ -50,7 +50,7 @@ export const SCOPE_BINDINGS = {
     },
     HouseholdLead: {
         their_households: { field: 'householdId', eqCtx: 'householdId' },
-        their_own: { field: 'participantId', eqCtx: 'selfId' },
+        their_own: { field: 'personId', eqCtx: 'selfId' },
     },
     Membership: { their_households: { field: 'householdId', eqCtx: 'householdId' } },
     Program: {
@@ -99,7 +99,7 @@ export const SCOPE_BINDINGS = {
         },
     },
     RawBadgeLog: { their_own: { field: 'personId', eqCtx: 'selfId' } },
-    ToolStatus: { their_own: { field: 'participantId', eqCtx: 'selfId' } },
+    ToolStatus: { their_own: { field: 'personId', eqCtx: 'selfId' } },
     Account: { their_own: { field: 'userId', eqCtx: 'selfId' } },
     Session: { their_own: { field: 'userId', eqCtx: 'selfId' } },
     // Bound for coverage; admin-only by tier-grant control (no route grants

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -84,9 +84,9 @@ function referenceScopesHeld(
         }
         case 'HouseholdLead': {
             const householdId = num(row.householdId);
-            const participantId = num(row.participantId);
+            const personId = num(row.personId);
             if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
-            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            if (personId !== undefined && personId === ctx.selfId) scopes.add('their_own');
             break;
         }
         case 'Membership': {
@@ -144,8 +144,8 @@ function referenceScopesHeld(
             break;
         }
         case 'ToolStatus': {
-            const participantId = num(row.participantId);
-            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            const personId = num(row.personId);
+            if (personId !== undefined && personId === ctx.selfId) scopes.add('their_own');
             break;
         }
         case 'Account':
@@ -225,23 +225,23 @@ const ROWS: Array<{ label: string; row: unknown }> = [
     { label: 'present but no scope keys', row: { id: 1, name: 'X' } },
     {
         label: "caller-5 own / in-program / active",
-        row: { id: 5, householdId: 2, participantId: 5, programId: 100, eventId: 200, userId: 5, actorId: 5, departedAt: null },
+        row: { id: 5, householdId: 2, participantId: 5, personId: 5, programId: 100, eventId: 200, userId: 5, actorId: 5, departedAt: null },
     },
     {
         label: 'household co-member (hh 2)',
-        row: { id: 6, householdId: 2, participantId: 6, programId: 100, eventId: 200, userId: 6, actorId: 6, departedAt: null },
+        row: { id: 6, householdId: 2, participantId: 6, personId: 6, programId: 100, eventId: 200, userId: 6, actorId: 6, departedAt: null },
     },
     {
         label: 'program participant / coreVol prog / active visitor',
-        row: { id: 9, householdId: 2, participantId: 9, programId: 101, eventId: 201, userId: 9, actorId: 9, departedAt: null },
+        row: { id: 9, householdId: 2, participantId: 9, personId: 9, programId: 101, eventId: 201, userId: 9, actorId: 9, departedAt: null },
     },
     {
         label: "another's / out-of-program / departed",
-        row: { id: 7, householdId: 99, participantId: 7, programId: 88, eventId: 88, userId: 7, actorId: 7, departedAt: new Date() },
+        row: { id: 7, householdId: 99, participantId: 7, personId: 7, programId: 88, eventId: 88, userId: 7, actorId: 7, departedAt: new Date() },
     },
     {
         label: "lead's own program (Program row id 100)",
-        row: { id: 100, householdId: 4, participantId: 10, programId: 100, eventId: 200, userId: 10, actorId: 10, departedAt: null },
+        row: { id: 100, householdId: 4, participantId: 10, personId: 10, programId: 100, eventId: 200, userId: 10, actorId: 10, departedAt: null },
     },
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -807,7 +807,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -817,7 +817,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -851,7 +851,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -1149,7 +1149,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -5313,7 +5313,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -13768,7 +13768,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",


### PR DESCRIPTION
## What

Phase **A1d** of the Participant→Person rename. Renames only the FK + forward relation field on the **HouseholdLead** and **ToolStatus** child models:

- `participantId Int` → `personId Int`
- relation `participant Participant` → `person Participant`
- composite `@@id`: `householdId_participantId` → `householdId_personId`, `participantId_toolId` → `personId_toolId`

## Why

Incremental slice of the umbrella Participant→Person model rename. Scoped to two child models so each phase stays reviewable and behavior-neutral.

## Scope guardrails

- Model stays named `Participant` (`person Participant @relation(...)`). **Not** a global rename — every other model keeps `participantId`.
- Back-relations `Participant.householdLeads` / `Participant.toolStatuses` are unchanged; only the child forward field renamed. `session.user.toolStatuses` read is that back-relation and stays.

## Migration

Data-preserving `RENAME COLUMN` + `RENAME CONSTRAINT` (rewrote Prisma's default drop/add, matching the repo's prior rename migrations). Verified all 38 migrations apply clean from scratch with correct PK/FK.

## Beyond the two model files

- **Security:** `scopeBindings.ts` HouseholdLead/ToolStatus `their_own` → `personId`; regenerated `classifications.ts`.
- **Consumers:** household lead/member routes, membership-audit (unclaimed / missing-contact), nav todo-counts, notifications, `dues-diff` script, `authClaims` type.
- **Tests:** updated across all three roots + reference-oracle scope tests (`scopeBindingsEquivalence`, `toolstatus-self-scope`, `shop-certifications-strip`).

## Verification

- `npx tsc --noEmit` → **0 errors**.
- Unit suite: 1083/1085 pass. The 2 failures (`membership-bg-nonblocking.flow`, `notificationsCheckin.perf`) are pre-existing, need a live dev server on `localhost:4000`, and contain no `participantId`/`personId` refs.
- Full integration suite (`--runInBand`) not completed in-session; tsc-green + migration replay verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)