### PR TITLE
refactor(schema): rename RSVP/FeePayment participantId FK → personId (Phase A1b)

### DIFF
--- a/checkin-app/prisma/migrations/20260702054206_rsvp_feepayment_participantid_to_personid/migration.sql
+++ b/checkin-app/prisma/migrations/20260702054206_rsvp_feepayment_participantid_to_personid/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  - The primary key for the `FeePayment` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `participantId` on the `FeePayment` table. All the data in the column will be lost.
+  - The primary key for the `RSVP` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `participantId` on the `RSVP` table. All the data in the column will be lost.
+  - Added the required column `personId` to the `FeePayment` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `personId` to the `RSVP` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "FeePayment" DROP CONSTRAINT "FeePayment_participantId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RSVP" DROP CONSTRAINT "RSVP_participantId_fkey";
+
+-- AlterTable
+ALTER TABLE "FeePayment" DROP CONSTRAINT "FeePayment_pkey",
+DROP COLUMN "participantId",
+ADD COLUMN     "personId" INTEGER NOT NULL,
+ADD CONSTRAINT "FeePayment_pkey" PRIMARY KEY ("feeId", "personId");
+
+-- AlterTable
+ALTER TABLE "RSVP" DROP CONSTRAINT "RSVP_pkey",
+DROP COLUMN "participantId",
+ADD COLUMN     "personId" INTEGER NOT NULL,
+ADD CONSTRAINT "RSVP_pkey" PRIMARY KEY ("eventId", "personId");
+
+-- AddForeignKey
+ALTER TABLE "FeePayment" ADD CONSTRAINT "FeePayment_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Participant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RSVP" ADD CONSTRAINT "RSVP_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Participant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -680,7 +680,7 @@ model FeePayment {
   /// @sensitivity:public
   feeId             Int
   /// @sensitivity:public
-  participantId     Int
+  personId          Int
   /// @sensitivity:personal
   paidAt            DateTime? @default(now())
   /// @sensitivity:personal
@@ -691,9 +691,9 @@ model FeePayment {
   customNote        String?
 
   fee         Fee         @relation(fields: [feeId], references: [id])
-  participant Participant @relation(fields: [participantId], references: [id])
+  person      Participant @relation(fields: [personId], references: [id])
 
-  @@id([feeId, participantId])
+  @@id([feeId, personId])
 }
 
 model Event {
@@ -729,16 +729,16 @@ model RSVP {
   /// @sensitivity:public
   eventId       Int
   /// @sensitivity:public
-  participantId Int
+  personId      Int
   /// @sensitivity:public
   status        RSVPStatus
   /// @sensitivity:internal
   reminderSentAt DateTime?
 
   event       Event       @relation(fields: [eventId], references: [id])
-  participant Participant @relation(fields: [participantId], references: [id])
+  person      Participant @relation(fields: [personId], references: [id])
 
-  @@id([eventId, participantId])
+  @@id([eventId, personId])
 }
 
 model RawBadgeLog {

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -93,7 +93,7 @@ describe('AuditLog Integration Tests', () => {
         // Clean up
         if (testParticipantId !== undefined) {
             await prisma.visit.deleteMany({ where: { participantId: testParticipantId } });
-            await prisma.rSVP.deleteMany({ where: { participantId: testParticipantId } });
+            await prisma.rSVP.deleteMany({ where: { personId: testParticipantId } });
         }
 
         if (testProgramId !== undefined) {

--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -82,7 +82,7 @@ describe('Cron Nightly API Integration Tests', () => {
         eventId = event.id;
 
         await prisma.rSVP.create({
-            data: { eventId, participantId: normalUserId, status: 'ATTENDING' }
+            data: { eventId, personId: normalUserId, status: 'ATTENDING' }
         });
 
         // Setup Abandoned Visits
@@ -101,7 +101,7 @@ describe('Cron Nightly API Integration Tests', () => {
 
     async function cleanup() {
         // Broad cleanup for nightly tests
-        await prisma.rSVP.deleteMany({ where: { participant: { email: { contains: '-nightly@' } } } });
+        await prisma.rSVP.deleteMany({ where: { person: { email: { contains: '-nightly@' } } } });
         await prisma.visit.deleteMany({ where: { participant: { email: { contains: '-nightly@' } } } });
         await prisma.event.deleteMany({ where: { name: { startsWith: 'Test Event - Nightly' } } });
         await prisma.program.deleteMany({ where: { name: 'Nightly Test Program' } });

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -9,7 +9,7 @@ jest.mock("@/lib/email", () => ({
 describe("GET /api/cron/post-event", () => {
     beforeEach(async () => {
         await prisma.visit.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
-        await prisma.rSVP.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
+        await prisma.rSVP.deleteMany({ where: { person: { email: { contains: 'example.com' } } } });
         await prisma.event.deleteMany({ where: { name: { startsWith: 'Past Event' } } });
         await prisma.event.deleteMany({ where: { name: { startsWith: 'Future Event' } } });
         await prisma.program.deleteMany({ where: { name: 'Test Program' } });
@@ -56,7 +56,7 @@ describe("GET /api/cron/post-event", () => {
         });
         
         await prisma.rSVP.create({
-            data: { eventId: event.id, participantId: user.id, status: "ATTENDING" }
+            data: { eventId: event.id, personId: user.id, status: "ATTENDING" }
         });
 
         await prisma.visit.create({

--- a/checkin-app/src/app/__tests__/cronRemindersAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronRemindersAPI.integration.test.ts
@@ -33,7 +33,7 @@ describe('Cron Reminders API Integration Tests', () => {
         const existingUserIds = existingUsers.map(u => u.id);
         
         await prisma.rSVP.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         
         await prisma.participant.deleteMany({
@@ -90,9 +90,9 @@ describe('Cron Reminders API Integration Tests', () => {
         // Create RSVPs
         await prisma.rSVP.createMany({
             data: [
-                { eventId: upcomingEventId, participantId: testUserId, status: 'ATTENDING' },
-                { eventId: pastEventId, participantId: testUserId, status: 'ATTENDING' },
-                { eventId: farFutureEventId, participantId: testUserId, status: 'ATTENDING' }
+                { eventId: upcomingEventId, personId: testUserId, status: 'ATTENDING' },
+                { eventId: pastEventId, personId: testUserId, status: 'ATTENDING' },
+                { eventId: farFutureEventId, personId: testUserId, status: 'ATTENDING' }
             ]
         });
     });
@@ -104,7 +104,7 @@ describe('Cron Reminders API Integration Tests', () => {
     afterAll(async () => {
         // Clean up
         await prisma.rSVP.deleteMany({
-            where: { participantId: testUserId }
+            where: { personId: testUserId }
         });
         await prisma.event.deleteMany({
             where: { id: { in: [upcomingEventId, pastEventId, farFutureEventId] } }

--- a/checkin-app/src/app/__tests__/cronRemindersEdge.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronRemindersEdge.integration.test.ts
@@ -52,12 +52,12 @@ describe('GET /api/cron/reminders — auth & window edges', () => {
     });
 
     afterEach(async () => {
-        await prisma.rSVP.deleteMany({ where: { participantId } });
+        await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
     });
 
     afterAll(async () => {
-        await prisma.rSVP.deleteMany({ where: { participantId } });
+        await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
         await prisma.participant.deleteMany({ where: { id: participantId } });
         await prisma.household.deleteMany({ where: { id: householdId } });
@@ -74,7 +74,7 @@ describe('GET /api/cron/reminders — auth & window edges', () => {
             },
         });
         await prisma.rSVP.create({
-            data: { eventId: event.id, participantId, status: 'ATTENDING' },
+            data: { eventId: event.id, personId: participantId, status: 'ATTENDING' },
         });
         return event.id;
     }

--- a/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
@@ -78,13 +78,13 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
 
     afterEach(async () => {
         await prisma.visit.deleteMany({ where: { participantId } });
-        await prisma.rSVP.deleteMany({ where: { participantId } });
+        await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
     });
 
     afterAll(async () => {
         await prisma.visit.deleteMany({ where: { participantId } });
-        await prisma.rSVP.deleteMany({ where: { participantId } });
+        await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
         await prisma.participant.deleteMany({ where: { id: { in: [adminId, participantId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [adminHouseholdId, householdId] } } });
@@ -108,7 +108,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
     describe('cancel — single event', () => {
         it('deletes RSVPs, NULLs visits (does not delete them), and deletes the event', async () => {
             const event = await makeEvent('single-cancel', 2 * HOUR);
-            await prisma.rSVP.create({ data: { eventId: event.id, participantId, status: 'ATTENDING' } });
+            await prisma.rSVP.create({ data: { eventId: event.id, personId: participantId, status: 'ATTENDING' } });
             const visit = await prisma.visit.create({
                 data: { participantId, arrivedAt: new Date(), associatedEventId: event.id },
             });
@@ -118,7 +118,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
 
             // RSVP gone.
             expect(await prisma.rSVP.findUnique({
-                where: { eventId_participantId: { eventId: event.id, participantId } },
+                where: { eventId_personId: { eventId: event.id, personId: participantId } },
             })).toBeNull();
 
             // Visit survives, but its event link is nulled (NOT deleted).
@@ -243,7 +243,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             const event = await makeEvent('past-edit', -2 * HOUR);
             const sentAt = new Date();
             await prisma.rSVP.create({
-                data: { eventId: event.id, participantId, status: 'ATTENDING', reminderSentAt: sentAt },
+                data: { eventId: event.id, personId: participantId, status: 'ATTENDING', reminderSentAt: sentAt },
             });
 
             const newStart = new Date(Date.now() - 90 * MIN);
@@ -252,7 +252,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
 
             // Guard fires before the clear → reminderSentAt preserved.
             const rsvp = await prisma.rSVP.findUnique({
-                where: { eventId_participantId: { eventId: event.id, participantId } },
+                where: { eventId_personId: { eventId: event.id, personId: participantId } },
             });
             expect(rsvp!.reminderSentAt).not.toBeNull();
 

--- a/checkin-app/src/app/__tests__/eventCancelNotification.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelNotification.integration.test.ts
@@ -57,12 +57,12 @@ describe("PATCH /api/events/[id] cancel — attendee notification (characterizat
     });
 
     afterEach(async () => {
-        await prisma.rSVP.deleteMany({ where: { participantId: attendeeId } });
+        await prisma.rSVP.deleteMany({ where: { personId: attendeeId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
     });
 
     afterAll(async () => {
-        await prisma.rSVP.deleteMany({ where: { participantId: attendeeId } });
+        await prisma.rSVP.deleteMany({ where: { personId: attendeeId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
         await prisma.participant.deleteMany({ where: { id: { in: [attendeeId, adminId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [attendeeHouseholdId, adminHouseholdId] } } });
@@ -73,7 +73,7 @@ describe("PATCH /api/events/[id] cancel — attendee notification (characterizat
         const event = await prisma.event.create({
             data: { name: `${TAG} future`, startAt: start, endAt: new Date(start.getTime() + HOUR), description: 'cancel' },
         });
-        await prisma.rSVP.create({ data: { eventId: event.id, participantId: attendeeId, status: 'ATTENDING' } });
+        await prisma.rSVP.create({ data: { eventId: event.id, personId: attendeeId, status: 'ATTENDING' } });
 
         const res = await patch(event.id, { action: 'cancel' });
         expect(res.status).toBe(200);

--- a/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
@@ -63,13 +63,13 @@ describe('PATCH /api/events/[id] cancel — transaction rollback on partial fail
     afterEach(async () => {
         jest.restoreAllMocks();
         await prisma.visit.deleteMany({ where: { participantId } });
-        await prisma.rSVP.deleteMany({ where: { participantId } });
+        await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
     });
 
     afterAll(async () => {
         await prisma.visit.deleteMany({ where: { participantId } });
-        await prisma.rSVP.deleteMany({ where: { participantId } });
+        await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
         await prisma.participant.deleteMany({ where: { id: { in: [participantId, adminId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [householdId, adminHouseholdId] } } });
@@ -87,7 +87,7 @@ describe('PATCH /api/events/[id] cancel — transaction rollback on partial fail
             },
         });
         await prisma.rSVP.create({
-            data: { eventId: event.id, participantId, status: 'ATTENDING' },
+            data: { eventId: event.id, personId: participantId, status: 'ATTENDING' },
         });
         // Closed (departedAt set): makeEvent is called for several events that reuse
         // this one participant, but a participant may have only one OPEN visit

--- a/checkin-app/src/app/__tests__/eventMineAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventMineAPI.integration.test.ts
@@ -25,7 +25,7 @@ describe('My Events API Integration Tests', () => {
     beforeAll(async () => {
         // Clean up any leaked state
         await prisma.rSVP.deleteMany({
-            where: { participant: { email: { contains: 'mine-events-test' } } }
+            where: { person: { email: { contains: 'mine-events-test' } } }
         });
         await prisma.event.deleteMany({
             where: { name: { contains: 'Mine Test Event' } }
@@ -132,7 +132,7 @@ describe('My Events API Integration Tests', () => {
         await prisma.rSVP.create({
             data: {
                 eventId: testEventUpcoming1Id,
-                participantId: testUserId,
+                personId: testUserId,
                 status: 'ATTENDING'
             }
         });
@@ -141,7 +141,7 @@ describe('My Events API Integration Tests', () => {
     afterAll(async () => {
         // Clean up
         await prisma.rSVP.deleteMany({
-            where: { participantId: { in: [testUserId, testVolunteerId] } }
+            where: { personId: { in: [testUserId, testVolunteerId] } }
         });
         await prisma.event.deleteMany({
             where: { id: { in: [testEventUpcoming1Id, testEventUpcoming2Id, testEventPastId] } }

--- a/checkin-app/src/app/__tests__/eventRSVPAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventRSVPAPI.integration.test.ts
@@ -25,7 +25,7 @@ describe('Event RSVP API Integration Tests', () => {
     beforeAll(async () => {
         // Clean up any leaked state
         await prisma.rSVP.deleteMany({
-            where: { participant: { email: { contains: 'rsvp-test' } } }
+            where: { person: { email: { contains: 'rsvp-test' } } }
         });
         await prisma.event.deleteMany({
             where: { name: 'RSVP Test Event' }
@@ -98,7 +98,7 @@ describe('Event RSVP API Integration Tests', () => {
     afterAll(async () => {
         // Clean up
         await prisma.rSVP.deleteMany({
-            where: { participantId: { in: [testUserId, testUnenrolledUserId, foreignLeadId] } }
+            where: { personId: { in: [testUserId, testUnenrolledUserId, foreignLeadId] } }
         });
         await prisma.event.deleteMany({
             where: { id: testEventId }
@@ -191,7 +191,7 @@ describe('Event RSVP API Integration Tests', () => {
         // be the real bug. Re-query to pin it. Mirrors fd192fc.
         function rsvpFor(participantId: number) {
             return prisma.rSVP.findUnique({
-                where: { eventId_participantId: { eventId: testEventId, participantId } }
+                where: { eventId_personId: { eventId: testEventId, personId: participantId } }
             });
         }
 
@@ -240,9 +240,9 @@ describe('Event RSVP API Integration Tests', () => {
 
             const rsvpRecord = await prisma.rSVP.findUnique({
                 where: {
-                    eventId_participantId: {
+                    eventId_personId: {
                         eventId: testEventId,
-                        participantId: testUserId
+                        personId: testUserId
                     }
                 }
             });
@@ -258,15 +258,15 @@ describe('Event RSVP API Integration Tests', () => {
             // Make sure the record exists from the previous test or create it
             await prisma.rSVP.upsert({
                 where: {
-                    eventId_participantId: {
+                    eventId_personId: {
                         eventId: testEventId,
-                        participantId: testUserId
+                        personId: testUserId
                     }
                 },
                 update: { status: 'ATTENDING' },
                 create: {
                     eventId: testEventId,
-                    participantId: testUserId,
+                    personId: testUserId,
                     status: 'ATTENDING'
                 }
             });
@@ -285,9 +285,9 @@ describe('Event RSVP API Integration Tests', () => {
 
             const rsvpRecord = await prisma.rSVP.findUnique({
                 where: {
-                    eventId_participantId: {
+                    eventId_personId: {
                         eventId: testEventId,
-                        participantId: testUserId
+                        personId: testUserId
                     }
                 }
             });

--- a/checkin-app/src/app/__tests__/eventRescheduleClearsReminder.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventRescheduleClearsReminder.integration.test.ts
@@ -81,12 +81,12 @@ describe('PATCH /api/events/[id] editTime — clears reminderSentAt on reschedul
     });
 
     afterEach(async () => {
-        await prisma.rSVP.deleteMany({ where: { participantId } });
+        await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
     });
 
     afterAll(async () => {
-        await prisma.rSVP.deleteMany({ where: { participantId } });
+        await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
         await prisma.participant.deleteMany({ where: { id: { in: [participantId, adminId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [householdId, adminHouseholdId] } } });
@@ -104,14 +104,14 @@ describe('PATCH /api/events/[id] editTime — clears reminderSentAt on reschedul
             },
         });
         await prisma.rSVP.create({
-            data: { eventId: event.id, participantId, status: 'ATTENDING', reminderSentAt: new Date() },
+            data: { eventId: event.id, personId: participantId, status: 'ATTENDING', reminderSentAt: new Date() },
         });
         return event.id;
     }
 
     function reminderSentAt(eventId: number) {
         return prisma.rSVP
-            .findUnique({ where: { eventId_participantId: { eventId, participantId } } })
+            .findUnique({ where: { eventId_personId: { eventId, personId: participantId } } })
             .then(r => r?.reminderSentAt ?? null);
     }
 
@@ -156,7 +156,7 @@ describe('PATCH /api/events/[id] editTime — clears reminderSentAt on reschedul
             },
         });
         await prisma.rSVP.create({
-            data: { eventId: event.id, participantId, status: 'ATTENDING', reminderSentAt: new Date() },
+            data: { eventId: event.id, personId: participantId, status: 'ATTENDING', reminderSentAt: new Date() },
         });
         const before = await reminderSentAt(event.id);
 
@@ -178,7 +178,7 @@ describe('PATCH /api/events/[id] editTime — clears reminderSentAt on reschedul
             },
         });
         await prisma.rSVP.create({
-            data: { eventId: event.id, participantId, status: 'ATTENDING', reminderSentAt: new Date() },
+            data: { eventId: event.id, personId: participantId, status: 'ATTENDING', reminderSentAt: new Date() },
         });
         const before = await reminderSentAt(event.id);
         expect(before).not.toBeNull();

--- a/checkin-app/src/app/api/cron/reminders/route.ts
+++ b/checkin-app/src/app/api/cron/reminders/route.ts
@@ -44,7 +44,7 @@ export const GET = withCron(async () => {
 
         for (const event of upcomingEvents) {
             for (const rsvp of event.rsvps) {
-                const promise = Promise.resolve(sendNotification(rsvp.participantId, 'EVENT_STARTING_SOON', {
+                const promise = Promise.resolve(sendNotification(rsvp.personId, 'EVENT_STARTING_SOON', {
                     eventName: event.name,
                     hours: 2
                 })).then(async (ok) => {
@@ -53,9 +53,9 @@ export const GET = withCron(async () => {
                     if (!ok) return;
                     await prisma.rSVP.update({
                         where: {
-                            eventId_participantId: {
+                            eventId_personId: {
                                 eventId: event.id,
-                                participantId: rsvp.participantId
+                                personId: rsvp.personId
                             }
                         },
                         data: { reminderSentAt: new Date() }

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -38,7 +38,7 @@ export const GET = handler<{ id: string }>('GET /api/events/[id]', async ({ auth
             },
             visits: true,
             rsvps: {
-                include: { participant: true }
+                include: { person: true }
             },
             attendanceConfirmedBy: {
                 select: { name: true }

--- a/checkin-app/src/app/api/events/[id]/rsvp/__tests__/rsvpHouseholdLead.test.ts
+++ b/checkin-app/src/app/api/events/[id]/rsvp/__tests__/rsvpHouseholdLead.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
     jest.clearAllMocks();
     // Program-less event in the future → enrollment check is skipped.
     mockEventFindUnique.mockResolvedValue({ id: 5, programId: null, endAt: new Date(Date.now() + 3600_000) });
-    mockRsvpUpsert.mockResolvedValue({ eventId: 5, participantId: 2, status: 'ATTENDING' });
+    mockRsvpUpsert.mockResolvedValue({ eventId: 5, personId: 2, status: 'ATTENDING' });
 });
 
 it('lets a household lead RSVP for a member of their household', async () => {
@@ -46,7 +46,7 @@ it('lets a household lead RSVP for a member of their household', async () => {
 
     expect(res.status).toBe(200);
     expect(mockRsvpUpsert).toHaveBeenCalledTimes(1);
-    expect(mockRsvpUpsert.mock.calls[0][0].create.participantId).toBe(2);
+    expect(mockRsvpUpsert.mock.calls[0][0].create.personId).toBe(2);
 });
 
 it('forbids a non-lead from RSVPing for someone else', async () => {

--- a/checkin-app/src/app/api/events/[id]/rsvp/route.ts
+++ b/checkin-app/src/app/api/events/[id]/rsvp/route.ts
@@ -73,9 +73,9 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
 
         const rsvp = await prisma.rSVP.upsert({
             where: {
-                eventId_participantId: {
+                eventId_personId: {
                     eventId,
-                    participantId: currentUserId
+                    personId: currentUserId
                 }
             },
             update: {
@@ -83,7 +83,7 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
             },
             create: {
                 eventId,
-                participantId: currentUserId,
+                personId: currentUserId,
                 status: status as RSVPStatus
             }
         });

--- a/checkin-app/src/app/api/events/mine/route.ts
+++ b/checkin-app/src/app/api/events/mine/route.ts
@@ -43,8 +43,8 @@ export const GET = withAuth({}, async (_req, auth) => {
             include: {
                 program: { select: { name: true } },
                 rsvps: {
-                    where: { participantId: { in: householdMemberIds } },
-                    select: { participantId: true, status: true }
+                    where: { personId: { in: householdMemberIds } },
+                    select: { personId: true, status: true }
                 }
             }
         });
@@ -64,7 +64,7 @@ export const GET = withAuth({}, async (_req, auth) => {
                     endAt: ev.endAt,
                     program: ev.program,
                     participant: householdMemberById.get(pid),
-                    rsvp: ev.rsvps.find((r: typeof ev.rsvps[number]) => r.participantId === pid)?.status ?? null
+                    rsvp: ev.rsvps.find((r: typeof ev.rsvps[number]) => r.personId === pid)?.status ?? null
                 }));
         });
 

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -61,7 +61,7 @@ describe("Merge Participants API", () => {
     afterEach(async () => {
         // Cleanup. FeePayment / ProgramParticipant FK participant with RESTRICT, so
         // they must go before the participants.
-        await prisma.feePayment.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
+        await prisma.feePayment.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
         await prisma.visit.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
         await prisma.programParticipant.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
         await prisma.householdLead.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
@@ -153,8 +153,8 @@ describe("Merge Participants API", () => {
         await prisma.programParticipant.create({ data: { programId: program.id, participantId: pKeepId } });
         await prisma.programParticipant.create({ data: { programId: program.id, participantId: pMergeId } });
         // SAME feeId for both → feePayment conflict.
-        await prisma.feePayment.create({ data: { feeId: fee.id, participantId: pKeepId } });
-        await prisma.feePayment.create({ data: { feeId: fee.id, participantId: pMergeId } });
+        await prisma.feePayment.create({ data: { feeId: fee.id, personId: pKeepId } });
+        await prisma.feePayment.create({ data: { feeId: fee.id, personId: pMergeId } });
 
         const req = new Request("http://localhost/api/membership-ops/participants/merge", {
             method: "POST",
@@ -167,13 +167,13 @@ describe("Merge Participants API", () => {
         // Keep retains exactly one of each — no duplicate, no double-count.
         const keepPPs = await prisma.programParticipant.findMany({ where: { participantId: pKeepId, programId: program.id } });
         expect(keepPPs.length).toBe(1);
-        const keepFPs = await prisma.feePayment.findMany({ where: { participantId: pKeepId, feeId: fee.id } });
+        const keepFPs = await prisma.feePayment.findMany({ where: { personId: pKeepId, feeId: fee.id } });
         expect(keepFPs.length).toBe(1);
 
         // The loser's rows were deleted (relink would have violated the composite PK).
         const mergePPCount = await prisma.programParticipant.count({ where: { participantId: pMergeId } });
         expect(mergePPCount).toBe(0);
-        const mergeFPCount = await prisma.feePayment.count({ where: { participantId: pMergeId } });
+        const mergeFPCount = await prisma.feePayment.count({ where: { personId: pMergeId } });
         expect(mergeFPCount).toBe(0);
 
         // And exactly one of each exists overall for this program/fee (no orphan duplicates).

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -121,13 +121,13 @@ export const POST = withAuth(
                 for (const rsvp of mergeParticipant.rsvps) {
                     if (!keepParticipant.rsvps.find(k => k.eventId === rsvp.eventId)) {
                         await tx.rSVP.update({
-                            where: { eventId_participantId: { eventId: rsvp.eventId, participantId: mergeId } },
-                            data: { participantId: keepId }
+                            where: { eventId_personId: { eventId: rsvp.eventId, personId: mergeId } },
+                            data: { personId: keepId }
                         });
                         moved.rsvps.migrated++;
                     } else {
                         await tx.rSVP.delete({
-                            where: { eventId_participantId: { eventId: rsvp.eventId, participantId: mergeId } }
+                            where: { eventId_personId: { eventId: rsvp.eventId, personId: mergeId } }
                         });
                         moved.rsvps.deleted++;
                     }
@@ -136,13 +136,13 @@ export const POST = withAuth(
                 for (const fee of mergeParticipant.feePayments) {
                     if (!keepParticipant.feePayments.find(k => k.feeId === fee.feeId)) {
                         await tx.feePayment.update({
-                            where: { feeId_participantId: { feeId: fee.feeId, participantId: mergeId } },
-                            data: { participantId: keepId }
+                            where: { feeId_personId: { feeId: fee.feeId, personId: mergeId } },
+                            data: { personId: keepId }
                         });
                         moved.feePayments.migrated++;
                     } else {
                         await tx.feePayment.delete({
-                            where: { feeId_participantId: { feeId: fee.feeId, participantId: mergeId } }
+                            where: { feeId_personId: { feeId: fee.feeId, personId: mergeId } }
                         });
                         moved.feePayments.deleted++;
                     }

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -286,7 +286,7 @@ export const GET = withAuth({}, async (_req, auth) => {
         const rsvpRows = upcomingEventIds.length
             ? await prisma.rSVP.findMany({
                   where: { eventId: { in: upcomingEventIds } },
-                  select: { eventId: true, participantId: true, status: true },
+                  select: { eventId: true, personId: true, status: true },
               })
             : [];
         const emptyTally = (): { participants: RsvpTally; volunteers: RsvpTally } => ({
@@ -297,7 +297,7 @@ export const GET = withAuth({}, async (_req, auth) => {
         for (const r of rsvpRows) {
             const t = tallyByEvent.get(r.eventId) ?? emptyTally();
             const programId = eventProgram.get(r.eventId);
-            const bucket = programId !== undefined && volunteerKeys.has(`${programId}:${r.participantId}`) ? t.volunteers : t.participants;
+            const bucket = programId !== undefined && volunteerKeys.has(`${programId}:${r.personId}`) ? t.volunteers : t.participants;
             if (r.status === "ATTENDING") bucket.yes += 1;
             else if (r.status === "MAYBE") bucket.maybe += 1;
             else if (r.status === "NOT_ATTENDING") bucket.no += 1;

--- a/checkin-app/src/app/program-ops/sessions/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/__tests__/page.test.tsx
@@ -43,7 +43,7 @@ function baseEvent(overrides: Record<string, unknown> = {}) {
             ],
         },
         visits: [{ id: 1, participantId: 3, arrivedAt: "2020-01-01T18:05:00.000Z", departedAt: null }],
-        rsvps: [{ participantId: 3, status: "ATTENDING" }],
+        rsvps: [{ personId: 3, status: "ATTENDING" }],
         ...overrides,
     };
 }

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -39,7 +39,7 @@ type EventData = {
     arrivedAt: string;
     departedAt: string | null;
   }[];
-  rsvps: { participantId: number; status: RSVPStatus }[];
+  rsvps: { personId: number; status: RSVPStatus }[];
 };
 
 const RSVP_BADGE: Record<RSVPStatus, { label: string; color: string }> = {
@@ -319,7 +319,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
   const renderRsvpList = () => {
     if (!eventData.program) return null;
 
-    const statusByParticipant = new Map(eventData.rsvps.map(r => [r.participantId, r.status]));
+    const statusByParticipant = new Map(eventData.rsvps.map(r => [r.personId, r.status]));
     const roster = [
       ...eventData.program.volunteers.map(v => ({ ...v, role: v.isCore ? 'Core Volunteer' : 'Volunteer' })),
       ...eventData.program.participants.map(p => ({ ...p, role: 'Participant' })),

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -310,7 +310,7 @@ export async function createEvent(prisma: Db): Promise<string> {
     const attendees = await prisma.participant.findMany({ take: 3, orderBy: { id: "asc" } });
     for (const p of attendees) {
         await prisma.rSVP.create({
-            data: { eventId: event.id, participantId: p.id, status: "ATTENDING" },
+            data: { eventId: event.id, personId: p.id, status: "ATTENDING" },
         });
     }
     const where = latestProgram ? ` under program #${latestProgram.id}` : "";

--- a/checkin-app/src/security/__tests__/rsvp-program-scope.test.ts
+++ b/checkin-app/src/security/__tests__/rsvp-program-scope.test.ts
@@ -39,39 +39,39 @@ const member = ctx({ selfId: 5 }); // no programs
 
 describe('RSVP their_program_participants via eventId', () => {
     it('grants their_program_participants to a lead for an RSVP whose event is in their program', () => {
-        const held = scopesHeld('RSVP', { eventId: 200, participantId: 5 }, lead);
+        const held = scopesHeld('RSVP', { eventId: 200, personId:5 }, lead);
         expect(held.has('their_program_participants')).toBe(true);
     });
 
     it('grants their_program_participants to a core-vol for an in-program event', () => {
-        const held = scopesHeld('RSVP', { eventId: 201, participantId: 5 }, coreVol);
+        const held = scopesHeld('RSVP', { eventId: 201, personId:5 }, coreVol);
         expect(held.has('their_program_participants')).toBe(true);
     });
 
     it('does NOT grant their_program_participants to a plain member', () => {
-        const held = scopesHeld('RSVP', { eventId: 200, participantId: 99 }, member);
+        const held = scopesHeld('RSVP', { eventId: 200, personId:99 }, member);
         expect(held.has('their_program_participants')).toBe(false);
     });
 
     it('does NOT grant a lead access to an RSVP whose event is in a DIFFERENT program', () => {
-        const held = scopesHeld('RSVP', { eventId: 999, participantId: 5 }, lead);
+        const held = scopesHeld('RSVP', { eventId: 999, personId:5 }, lead);
         expect(held.has('their_program_participants')).toBe(false);
     });
 
     it('the RSVP owner still holds their_own (participantId === selfId)', () => {
-        const held = scopesHeld('RSVP', { eventId: 999, participantId: 5 }, member);
+        const held = scopesHeld('RSVP', { eventId: 999, personId:5 }, member);
         expect(held.has('their_own')).toBe(true);
     });
 
     it('a non-owner does NOT hold their_own', () => {
-        const held = scopesHeld('RSVP', { eventId: 999, participantId: 5 }, ctx({ selfId: 6 }));
+        const held = scopesHeld('RSVP', { eventId: 999, personId:5 }, ctx({ selfId: 6 }));
         expect(held.has('their_own')).toBe(false);
     });
 
     it('the stale programId read no longer grants — a row carrying only programId is inert', () => {
         // Old dead binding: a lead of program 100 with a row {programId: 100} used
         // to (try to) match. With the eventId binding it grants nothing.
-        const held = scopesHeld('RSVP', { programId: 100, participantId: 99 }, lead);
+        const held = scopesHeld('RSVP', { programId: 100, personId:99 }, lead);
         expect(held.has('their_program_participants')).toBe(false);
     });
 });

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -207,7 +207,7 @@ export const classifications = {
     },
     FeePayment: {
         feeId: 'public',
-        participantId: 'public',
+        personId: 'public',
         paidAt: 'personal',
         shopifyLink: 'personal',
         quickBooksInvoice: 'personal',
@@ -227,7 +227,7 @@ export const classifications = {
     },
     RSVP: {
         eventId: 'public',
-        participantId: 'public',
+        personId: 'public',
         status: 'public',
         reminderSentAt: 'internal',
     },
@@ -425,7 +425,7 @@ export const relations = {
     },
     FeePayment: {
         fee: { model: 'Fee', isList: false },
-        participant: { model: 'Participant', isList: false },
+        person: { model: 'Participant', isList: false },
     },
     Event: {
         attendanceConfirmedBy: { model: 'Participant', isList: false },
@@ -435,7 +435,7 @@ export const relations = {
     },
     RSVP: {
         event: { model: 'Event', isList: false },
-        participant: { model: 'Participant', isList: false },
+        person: { model: 'Participant', isList: false },
     },
     RawBadgeLog: {
         person: { model: 'Participant', isList: false },

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -79,7 +79,7 @@ export const SCOPE_BINDINGS = {
     // (ctx.eventIdsInScopePrograms) — a deliberate behavior CHANGE, not the dead
     // switch read. See docs/security/auth-consistency-analysis.md §7.5 + §9 Step 3.
     RSVP: {
-        their_own: { field: 'participantId', eqCtx: 'selfId' },
+        their_own: { field: 'personId', eqCtx: 'selfId' },
         their_program_participants: { field: 'eventId', inCtx: 'eventIdsInScopePrograms' },
     },
     Event: {
@@ -89,8 +89,8 @@ export const SCOPE_BINDINGS = {
         },
     },
     FeePayment: {
-        their_own: { field: 'participantId', eqCtx: 'selfId' },
-        their_program_participants: { field: 'participantId', inCtx: 'participantIdsInScopePrograms' },
+        their_own: { field: 'personId', eqCtx: 'selfId' },
+        their_program_participants: { field: 'personId', inCtx: 'participantIdsInScopePrograms' },
     },
     Visit: {
         their_own: { field: 'participantId', eqCtx: 'selfId' },

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -225,23 +225,23 @@ const ROWS: Array<{ label: string; row: unknown }> = [
     { label: 'present but no scope keys', row: { id: 1, name: 'X' } },
     {
         label: "caller-5 own / in-program / active",
-        row: { id: 5, householdId: 2, participantId: 5, programId: 100, eventId: 200, userId: 5, actorId: 5, departedAt: null },
+        row: { id: 5, householdId: 2, participantId: 5, personId: 5, programId: 100, eventId: 200, userId: 5, actorId: 5, departedAt: null },
     },
     {
         label: 'household co-member (hh 2)',
-        row: { id: 6, householdId: 2, participantId: 6, programId: 100, eventId: 200, userId: 6, actorId: 6, departedAt: null },
+        row: { id: 6, householdId: 2, participantId: 6, personId: 6, programId: 100, eventId: 200, userId: 6, actorId: 6, departedAt: null },
     },
     {
         label: 'program participant / coreVol prog / active visitor',
-        row: { id: 9, householdId: 2, participantId: 9, programId: 101, eventId: 201, userId: 9, actorId: 9, departedAt: null },
+        row: { id: 9, householdId: 2, participantId: 9, personId: 9, programId: 101, eventId: 201, userId: 9, actorId: 9, departedAt: null },
     },
     {
         label: "another's / out-of-program / departed",
-        row: { id: 7, householdId: 99, participantId: 7, programId: 88, eventId: 88, userId: 7, actorId: 7, departedAt: new Date() },
+        row: { id: 7, householdId: 99, participantId: 7, personId: 7, programId: 88, eventId: 88, userId: 7, actorId: 7, departedAt: new Date() },
     },
     {
         label: "lead's own program (Program row id 100)",
-        row: { id: 100, householdId: 4, participantId: 10, programId: 100, eventId: 200, userId: 10, actorId: 10, departedAt: null },
+        row: { id: 100, householdId: 4, participantId: 10, personId: 10, programId: 100, eventId: 200, userId: 10, actorId: 10, departedAt: null },
     },
 ];
 


### PR DESCRIPTION
## Phase A1b — Participant→Person rename (RSVP + FeePayment)

Renames **only** the person FK + relation field on `RSVP` and `FeePayment`. The model stays named `Participant` (relation target unchanged), so every other model keeps its own `participantId` — those flip in sibling slices A1c–A1f. See `docs/designs/PERSON_UMBRELLA_INVESTIGATION.md` §f.

### Schema
- **RSVP**: `participantId → personId`; relation `participant → person`; `@@id([eventId, personId])` → where-input `eventId_personId`.
- **FeePayment**: `participantId → personId`; relation `participant → person`; `@@id([feeId, personId])` → where-input `feeId_personId`.

Migration `20260702054206_rsvp_feepayment_participantid_to_personid` drops/re-adds the columns and PKs. Empty-DB safe (DB wiped on deploy).

### Code
- `api/events/[id]/rsvp`, `api/events/[id]`, `api/events/mine`, `api/cron/reminders` — where/data/select/include + composite-key renames.
- `membership-ops/participants/merge` — RSVP + FeePayment relink/delete keys.
- `nav/todo-counts` — RSVP select + tally lookup.
- `lib/dev/seed-helpers` — RSVP create.
- `program-ops/sessions/[id]/page.tsx` — client `EventData.rsvps` type + status-map key follow the renamed relation returned by `/api/events/[id]`.
- Integration + unit tests across test roots updated.

### Verify
- `npx prisma generate` + `npx tsc --noEmit` **clean**.
- Scoped `participantId`/`participant` on other models left untouched (Visit, ProgramParticipant, ProgramVolunteer, HouseholdLead, ToolStatus, RawBadgeLog, Corporation*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)