### PR TITLE
refactor(visit): rename Visit FK participantId → personId (Phase A1a)

### DIFF
--- a/checkin-app/prisma/migrations/20260702053421_visit_participantid_to_personid/migration.sql
+++ b/checkin-app/prisma/migrations/20260702053421_visit_participantid_to_personid/migration.sql
@@ -1,0 +1,12 @@
+-- Rename Visit FK column participantId -> personId (Phase A1a of Participant->Person).
+-- Use RENAME (not Prisma's default DROP+ADD) to preserve data AND the raw-SQL
+-- partial unique index "Visit_one_open_per_participant" (the double-checkin backstop
+-- from 20260629180000), which a DROP COLUMN would silently cascade away.
+ALTER TABLE "Visit" RENAME COLUMN "participantId" TO "personId";
+
+-- Keep index + FK constraint names in sync with Prisma's expectations.
+ALTER INDEX "Visit_participantId_departedAt_idx" RENAME TO "Visit_personId_departedAt_idx";
+ALTER TABLE "Visit" RENAME CONSTRAINT "Visit_participantId_fkey" TO "Visit_personId_fkey";
+
+-- Note: partial unique index "Visit_one_open_per_participant" now references the
+-- renamed column automatically; its name is cosmetic and left as-is.

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -760,7 +760,7 @@ model Visit {
   /// @sensitivity:public
   id                Int       @id @default(autoincrement())
   /// @sensitivity:public
-  participantId     Int
+  personId          Int
   /// @sensitivity:personal
   arrivedAt         DateTime
   /// @sensitivity:personal
@@ -772,10 +772,10 @@ model Visit {
   /// @sensitivity:public
   associatedEventId Int?
 
-  participant Participant @relation(fields: [participantId], references: [id])
-  event       Event?      @relation(fields: [associatedEventId], references: [id])
+  person Participant @relation(fields: [personId], references: [id])
+  event  Event?      @relation(fields: [associatedEventId], references: [id])
 
-  @@index([participantId, departedAt]) // Active visits lookup in /api/scan
+  @@index([personId, departedAt]) // Active visits lookup in /api/scan
   // Partial unique index "Visit_one_open_per_participant" — at most one open visit
   // (departedAt IS NULL) per participant. Prisma's DSL can't express a partial
   // unique index, so it lives in the 20260629180000_visit_one_open_per_participant

--- a/checkin-app/prisma/seed_20_users.ts
+++ b/checkin-app/prisma/seed_20_users.ts
@@ -46,7 +46,7 @@ async function main() {
         // Mark them as arrivedAt so they show up as "present" just in case limitToPresent is true
         await prisma.visit.create({
             data: {
-                participantId: participant.id,
+                personId: participant.id,
                 arrivedAt: new Date()
             }
         })

--- a/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
@@ -30,7 +30,7 @@ describe('Admin Visits API Integration Tests', () => {
         const existingUserIds = existingUsers.map(u => u.id);
         
         await prisma.visit.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         
         await prisma.auditLog.deleteMany({
@@ -56,7 +56,7 @@ describe('Admin Visits API Integration Tests', () => {
 
         const visit = await prisma.visit.create({
             data: {
-                participantId: testUserId,
+                personId: testUserId,
                 arrivedAt: new Date(Date.now() - 3600000), // 1 hour ago
             }
         });
@@ -66,7 +66,7 @@ describe('Admin Visits API Integration Tests', () => {
     afterAll(async () => {
         // Clean up
         await prisma.visit.deleteMany({
-            where: { participantId: { in: [testAdminId, testUserId] } }
+            where: { personId: { in: [testAdminId, testUserId] } }
         });
         await prisma.auditLog.deleteMany({
             where: { actorId: { in: [testAdminId, testUserId] } }
@@ -116,9 +116,9 @@ describe('Admin Visits API Integration Tests', () => {
             expect(Array.isArray(data.visits)).toBe(true);
             expect(data.visits.length).toBeGreaterThanOrEqual(1);
 
-            const visitMatches = data.visits.filter((v: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => v.participantId === testUserId);
+            const visitMatches = data.visits.filter((v: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => v.personId === testUserId);
             expect(visitMatches.length).toBe(1);
-            expect(visitMatches[0].participant).toBeDefined();
+            expect(visitMatches[0].person).toBeDefined();
         });
     });
 

--- a/checkin-app/src/app/__tests__/attendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendance.integration.test.ts
@@ -73,7 +73,7 @@ describe('Attendance API Integration Tests', () => {
         testHouseholdMemberId = householdMember.id;
 
         const visit = await prisma.visit.create({
-            data: { participantId: testParticipantId, arrivedAt: new Date() }
+            data: { personId: testParticipantId, arrivedAt: new Date() }
         });
         activeVisitId = visit.id;
     });
@@ -131,7 +131,7 @@ describe('Attendance API Integration Tests', () => {
         it('should allow a household lead to check out a household member', async () => {
             // Setup a visit for the household member
             const memberVisit = await prisma.visit.create({
-                data: { participantId: testHouseholdMemberId, arrivedAt: new Date() }
+                data: { personId: testHouseholdMemberId, arrivedAt: new Date() }
             });
 
             (getServerSession as jest.Mock).mockResolvedValue({
@@ -182,7 +182,7 @@ describe('Attendance API Integration Tests', () => {
 
             // Ensure testHouseholdMemberId is checked out before we check them in
             await prisma.visit.deleteMany({
-                where: { participantId: testHouseholdMemberId }
+                where: { personId: testHouseholdMemberId }
             });
 
             const req = new Request('http://localhost:4000/api/attendance', {
@@ -195,7 +195,7 @@ describe('Attendance API Integration Tests', () => {
 
             const data = await res.json();
             expect(data.success).toBe(true);
-            expect(data.visit.participantId).toBe(testHouseholdMemberId);
+            expect(data.visit.personId).toBe(testHouseholdMemberId);
         });
 
         it('should return 400 when trying to check in an already checked in user', async () => {

--- a/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
@@ -43,7 +43,7 @@ describe('General Attendance API Integration Tests', () => {
             where: { personId: { in: existingUserIds } }
         });
         await prisma.visit.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         await prisma.auditLog.deleteMany({
@@ -113,12 +113,12 @@ describe('General Attendance API Integration Tests', () => {
 
         // Create initial active visits
         const commonVisit = await prisma.visit.create({
-            data: { participantId: commonId, arrivedAt: new Date() }
+            data: { personId: commonId, arrivedAt: new Date() }
         });
         activeVisitId = commonVisit.id;
 
         const childVisit = await prisma.visit.create({
-            data: { participantId: householdChildId, arrivedAt: new Date() }
+            data: { personId: householdChildId, arrivedAt: new Date() }
         });
         childActiveVisitId = childVisit.id;
     });
@@ -131,7 +131,7 @@ describe('General Attendance API Integration Tests', () => {
                 where: { personId: { in: existingUserIds } }
             });
             await prisma.visit.deleteMany({
-                where: { participantId: { in: existingUserIds } }
+                where: { personId: { in: existingUserIds } }
             });
             await prisma.auditLog.deleteMany({
                 where: { actorId: { in: existingUserIds } }
@@ -259,7 +259,7 @@ describe('General Attendance API Integration Tests', () => {
              
              const data = await res.json();
              expect(data.success).toBe(true);
-             expect(data.visit.participantId).toBe(householdChildId);
+             expect(data.visit.personId).toBe(householdChildId);
         });
 
         it('should allow an admin to check in any user', async () => {
@@ -275,7 +275,7 @@ describe('General Attendance API Integration Tests', () => {
              
              const data = await res.json();
              expect(data.success).toBe(true);
-             expect(data.visit.participantId).toBe(householdLeadId);
+             expect(data.visit.personId).toBe(householdLeadId);
         });
     });
 

--- a/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
@@ -28,7 +28,7 @@ describe('Manual Attendance API Integration Tests', () => {
         const existingUserIds = existingUsers.map(u => u.id);
         
         await prisma.visit.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         
         await prisma.auditLog.deleteMany({
@@ -50,7 +50,7 @@ describe('Manual Attendance API Integration Tests', () => {
     afterAll(async () => {
         // Clean up
         await prisma.visit.deleteMany({
-            where: { participantId: testUserId }
+            where: { personId: testUserId }
         });
         await prisma.auditLog.deleteMany({
             where: { actorId: testUserId }
@@ -152,7 +152,7 @@ describe('Manual Attendance API Integration Tests', () => {
             
             expect(data.message).toBe('Manual visit recorded successfully.');
             expect(data.visit).toBeDefined();
-            expect(data.visit.participantId).toBe(testUserId);
+            expect(data.visit.personId).toBe(testUserId);
             expect(new Date(data.visit.arrivedAt).toISOString()).toBe(arrivedAt.toISOString());
             expect(new Date(data.visit.departedAt).toISOString()).toBe(departedAt.toISOString());
 
@@ -208,7 +208,7 @@ describe('Manual Attendance API Integration Tests', () => {
             });
 
             // Isolate: drop any open visit left by earlier tests so the count is unambiguous.
-            await prisma.visit.deleteMany({ where: { participantId: testUserId, departedAt: null } });
+            await prisma.visit.deleteMany({ where: { personId: testUserId, departedAt: null } });
 
             const arrivedAt = new Date(Date.now() - 600000).toISOString(); // 10 min ago, open (no departure)
             const makeReq = () => new Request('http://localhost:4000/api/attendance/manual', {
@@ -230,7 +230,7 @@ describe('Manual Attendance API Integration Tests', () => {
             expect(second.id).toBe(first.id);
 
             const openVisits = await prisma.visit.findMany({
-                where: { participantId: testUserId, departedAt: null }
+                where: { personId: testUserId, departedAt: null }
             });
             expect(openVisits.length).toBe(1);
             expect(openVisits[0].id).toBe(first.id);

--- a/checkin-app/src/app/__tests__/attendanceManualCheckinConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualCheckinConcurrency.integration.test.ts
@@ -39,7 +39,7 @@ function checkinRequest(participantId: number) {
 }
 
 async function openVisitCount(participantId: number) {
-    return prisma.visit.count({ where: { participantId, departedAt: null } });
+    return prisma.visit.count({ where: { personId: participantId, departedAt: null } });
 }
 
 describe('POST /api/attendance MANUAL_CHECKIN concurrency (advisory lock)', () => {
@@ -54,7 +54,7 @@ describe('POST /api/attendance MANUAL_CHECKIN concurrency (advisory lock)', () =
         });
         const leakedIds = leaked.map(p => p.id);
         const leakedHouseholdIds = leaked.map(p => p.householdId);
-        await prisma.visit.deleteMany({ where: { participantId: { in: leakedIds } } });
+        await prisma.visit.deleteMany({ where: { personId: { in: leakedIds } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: leakedIds } } });
         await prisma.participant.deleteMany({ where: { id: { in: leakedIds } } });
         await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
@@ -67,7 +67,7 @@ describe('POST /api/attendance MANUAL_CHECKIN concurrency (advisory lock)', () =
     });
 
     afterAll(async () => {
-        await prisma.visit.deleteMany({ where: { participantId: subjectId } });
+        await prisma.visit.deleteMany({ where: { personId: subjectId } });
         await prisma.auditLog.deleteMany({ where: { actorId: subjectId } });
         await prisma.participant.deleteMany({ where: { id: subjectId } });
         await prisma.household.deleteMany({ where: { id: householdId } });
@@ -75,7 +75,7 @@ describe('POST /api/attendance MANUAL_CHECKIN concurrency (advisory lock)', () =
 
     it('two concurrent MANUAL_CHECKINs → exactly one open visit, no 500', async () => {
         // Fresh state: no open visit before the race.
-        await prisma.visit.deleteMany({ where: { participantId: subjectId } });
+        await prisma.visit.deleteMany({ where: { personId: subjectId } });
         expect(await openVisitCount(subjectId)).toBe(0);
 
         // Subject checks themselves in (isSelf → passes the permission guard).

--- a/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
@@ -43,7 +43,7 @@ function manualRequest(arrivedAt: string) {
 }
 
 async function openVisitCount(participantId: number) {
-    return prisma.visit.count({ where: { participantId, departedAt: null } });
+    return prisma.visit.count({ where: { personId: participantId, departedAt: null } });
 }
 
 describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
@@ -58,7 +58,7 @@ describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
         });
         const leakedIds = leaked.map(p => p.id);
         const leakedHouseholdIds = leaked.map(p => p.householdId);
-        await prisma.visit.deleteMany({ where: { participantId: { in: leakedIds } } });
+        await prisma.visit.deleteMany({ where: { personId: { in: leakedIds } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: leakedIds } } });
         await prisma.participant.deleteMany({ where: { id: { in: leakedIds } } });
         await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
@@ -71,7 +71,7 @@ describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
     });
 
     afterAll(async () => {
-        await prisma.visit.deleteMany({ where: { participantId: subjectId } });
+        await prisma.visit.deleteMany({ where: { personId: subjectId } });
         await prisma.auditLog.deleteMany({ where: { actorId: subjectId } });
         await prisma.participant.deleteMany({ where: { id: subjectId } });
         await prisma.household.deleteMany({ where: { id: householdId } });
@@ -79,7 +79,7 @@ describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
 
     it('two concurrent manual check-ins → exactly one open visit, both responses share it', async () => {
         // Fresh state: no open visit before the race.
-        await prisma.visit.deleteMany({ where: { participantId: subjectId } });
+        await prisma.visit.deleteMany({ where: { personId: subjectId } });
         expect(await openVisitCount(subjectId)).toBe(0);
 
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: subjectId } });

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -92,7 +92,7 @@ describe('AuditLog Integration Tests', () => {
 
         // Clean up
         if (testParticipantId !== undefined) {
-            await prisma.visit.deleteMany({ where: { participantId: testParticipantId } });
+            await prisma.visit.deleteMany({ where: { personId: testParticipantId } });
             await prisma.rSVP.deleteMany({ where: { personId: testParticipantId } });
         }
 
@@ -221,7 +221,7 @@ describe('AuditLog Integration Tests', () => {
         testEventId = event.id;
 
         const visit = await prisma.visit.create({
-            data: { participantId: testParticipantId, arrivedAt: new Date(Date.now() - 100000), departedAt: new Date(Date.now() + 100000) }
+            data: { personId: testParticipantId, arrivedAt: new Date(Date.now() - 100000), departedAt: new Date(Date.now() + 100000) }
         });
         testVisitId = visit.id;
 
@@ -374,7 +374,7 @@ describe('AuditLog Integration Tests', () => {
     it('visit edit (PATCH /admin/visits) writes one AuditLog snapshotting the visit', async () => {
         const owner = await makeParticipant('visit-owner');
         const visit = await prisma.visit.create({
-            data: { participantId: owner.id, arrivedAt: new Date(), departedAt: new Date() },
+            data: { personId: owner.id, arrivedAt: new Date(), departedAt: new Date() },
             select: { id: true },
         });
         createdVisitIds.push(visit.id);

--- a/checkin-app/src/app/__tests__/autoAssociation.integration.test.ts
+++ b/checkin-app/src/app/__tests__/autoAssociation.integration.test.ts
@@ -154,7 +154,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
         it('should not split a visit that falls completely within one event', async () => {
             const visit = await prisma.visit.create({
                 data: {
-                    participantId,
+                    personId: participantId,
                     arrivedAt: new Date(`${baseDateString}10:15:00Z`),
                     associatedEventId: eventAId
                 }
@@ -173,7 +173,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
             const arrivalTime = new Date(`${baseDateString}09:30:00Z`);
             const visit = await prisma.visit.create({
                 data: {
-                    participantId,
+                    personId: participantId,
                     arrivedAt: arrivalTime,
                     associatedEventId: null // We'll say it wasn't associated on entry for testing the chunker
                 }
@@ -212,7 +212,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
             const arrivalTime = new Date(`${baseDateString}10:30:00Z`);
             const visit = await prisma.visit.create({
                 data: {
-                    participantId,
+                    personId: participantId,
                     arrivedAt: arrivalTime,
                     associatedEventId: eventAId
                 }
@@ -236,7 +236,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
             const arrivalTime = new Date(`${baseDateString}13:30:00Z`);
             const visit = await prisma.visit.create({
                 data: {
-                    participantId,
+                    personId: participantId,
                     arrivedAt: arrivalTime
                 }
             });

--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -87,11 +87,11 @@ describe('Cron Nightly API Integration Tests', () => {
 
         // Setup Abandoned Visits
         await prisma.visit.create({
-            data: { participantId: keyholderId, arrivedAt: justEndedStart } // Never departedAt
+            data: { personId: keyholderId, arrivedAt: justEndedStart } // Never departedAt
         });
 
         await prisma.visit.create({
-            data: { participantId: normalUserId, arrivedAt: justEndedStart, associatedEventId: eventId } // Never departedAt
+            data: { personId: normalUserId, arrivedAt: justEndedStart, associatedEventId: eventId } // Never departedAt
         });
     });
 
@@ -102,7 +102,7 @@ describe('Cron Nightly API Integration Tests', () => {
     async function cleanup() {
         // Broad cleanup for nightly tests
         await prisma.rSVP.deleteMany({ where: { person: { email: { contains: '-nightly@' } } } });
-        await prisma.visit.deleteMany({ where: { participant: { email: { contains: '-nightly@' } } } });
+        await prisma.visit.deleteMany({ where: { person: { email: { contains: '-nightly@' } } } });
         await prisma.event.deleteMany({ where: { name: { startsWith: 'Test Event - Nightly' } } });
         await prisma.program.deleteMany({ where: { name: 'Nightly Test Program' } });
         await prisma.auditLog.deleteMany();
@@ -151,7 +151,7 @@ describe('Cron Nightly API Integration Tests', () => {
 
             // Db checks
             const abandonedVisits = await prisma.visit.findMany({
-                where: { departedAt: null, participant: { email: { contains: '-nightly@' } } }
+                where: { departedAt: null, person: { email: { contains: '-nightly@' } } }
             });
             expect(abandonedVisits.length).toBe(0); // Everyone checked out
 
@@ -198,13 +198,13 @@ describe('Cron Nightly API Integration Tests', () => {
             });
 
             const badVisit = await prisma.visit.create({
-                data: { participantId: keyholderId, arrivedAt } // isKeyholder -> triggers board notify
+                data: { personId: keyholderId, arrivedAt } // isKeyholder -> triggers board notify
             });
             const goodVisitA = await prisma.visit.create({
-                data: { participantId: normalUserId, arrivedAt }
+                data: { personId: normalUserId, arrivedAt }
             });
             const goodVisitB = await prisma.visit.create({
-                data: { participantId: extra.id, arrivedAt }
+                data: { personId: extra.id, arrivedAt }
             });
 
             mockBadVisitIds.clear();
@@ -247,8 +247,8 @@ describe('Cron Nightly API Integration Tests', () => {
             await prisma.event.update({ where: { id: eventId }, data: { postEventEmailSent: false } });
 
             const arrivedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
-            await prisma.visit.create({ data: { participantId: keyholderId, arrivedAt } });
-            await prisma.visit.create({ data: { participantId: normalUserId, arrivedAt, associatedEventId: eventId } });
+            await prisma.visit.create({ data: { personId: keyholderId, arrivedAt } });
+            await prisma.visit.create({ data: { personId: normalUserId, arrivedAt, associatedEventId: eventId } });
 
             // --- Run 1: real work happens ---
             const res1 = await GET(cronReq());

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -8,7 +8,7 @@ jest.mock("@/lib/email", () => ({
 
 describe("GET /api/cron/post-event", () => {
     beforeEach(async () => {
-        await prisma.visit.deleteMany({ where: { participant: { email: { contains: 'example.com' } } } });
+        await prisma.visit.deleteMany({ where: { person: { email: { contains: 'example.com' } } } });
         await prisma.rSVP.deleteMany({ where: { person: { email: { contains: 'example.com' } } } });
         await prisma.event.deleteMany({ where: { name: { startsWith: 'Past Event' } } });
         await prisma.event.deleteMany({ where: { name: { startsWith: 'Future Event' } } });
@@ -60,7 +60,7 @@ describe("GET /api/cron/post-event", () => {
         });
 
         await prisma.visit.create({
-            data: { associatedEventId: event.id, participantId: user.id, arrivedAt: pastStart }
+            data: { associatedEventId: event.id, personId: user.id, arrivedAt: pastStart }
         });
 
         process.env.CRON_SECRET = 'test-secret';

--- a/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
@@ -29,7 +29,7 @@ describe('Event Attendance API Integration Tests', () => {
     beforeAll(async () => {
         // Clean up any leaked state
         await prisma.visit.deleteMany({
-            where: { participant: { email: { contains: 'event-attendance-test' } } }
+            where: { person: { email: { contains: 'event-attendance-test' } } }
         });
         await prisma.event.deleteMany({
             where: { name: 'Attendance Test Event' }
@@ -107,7 +107,7 @@ describe('Event Attendance API Integration Tests', () => {
     afterAll(async () => {
         // Clean up
         await prisma.visit.deleteMany({
-            where: { participantId: { in: [testParticipant1Id, testParticipant2Id] } }
+            where: { personId: { in: [testParticipant1Id, testParticipant2Id] } }
         });
         await prisma.event.deleteMany({
             where: { id: testEventId }
@@ -134,7 +134,7 @@ describe('Event Attendance API Integration Tests', () => {
     afterEach(async () => {
         // Clear visits created during tests
         await prisma.visit.deleteMany({
-            where: { participantId: { in: [testParticipant1Id, testParticipant2Id] } }
+            where: { personId: { in: [testParticipant1Id, testParticipant2Id] } }
         });
         // Clear audit rows so each test asserts exactly its own write.
         // Per-Visit audit rows carry the event in secondaryAffectedEntity;
@@ -178,7 +178,7 @@ describe('Event Attendance API Integration Tests', () => {
         // Mirrors fd192fc (trusted-adults "assert no mutation after IDOR 403").
         async function attendanceWriteCount() {
             const visits = await prisma.visit.count({
-                where: { participantId: { in: [testParticipant1Id, testParticipant2Id] }, associatedEventId: testEventId }
+                where: { personId: { in: [testParticipant1Id, testParticipant2Id] }, associatedEventId: testEventId }
             });
             const audits = await prisma.auditLog.count({
                 where: { tableName: 'Visit', secondaryAffectedEntity: testEventId }
@@ -250,7 +250,7 @@ describe('Event Attendance API Integration Tests', () => {
             expect(data.processed).toBe(1);
 
             const visits = await prisma.visit.findMany({
-                where: { participantId: testParticipant1Id, associatedEventId: testEventId }
+                where: { personId: testParticipant1Id, associatedEventId: testEventId }
             });
             expect(visits.length).toBe(1);
             expect(visits[0].arrivedAt).not.toBeNull();
@@ -283,7 +283,7 @@ describe('Event Attendance API Integration Tests', () => {
             
             await prisma.visit.create({
                 data: {
-                    participantId: testParticipant2Id,
+                    personId: testParticipant2Id,
                     arrivedAt: earlyArrival,
                     departedAt: null, // Still active
                 }
@@ -302,7 +302,7 @@ describe('Event Attendance API Integration Tests', () => {
             expect(data.processed).toBe(1);
 
             const visits = await prisma.visit.findMany({
-                where: { participantId: testParticipant2Id }
+                where: { personId: testParticipant2Id }
             });
             expect(visits.length).toBe(1); // Should only be the one we created
             expect(visits[0].associatedEventId).toBe(testEventId); // It was successfully linked

--- a/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
@@ -77,13 +77,13 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
     });
 
     afterEach(async () => {
-        await prisma.visit.deleteMany({ where: { participantId } });
+        await prisma.visit.deleteMany({ where: { personId: participantId } });
         await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
     });
 
     afterAll(async () => {
-        await prisma.visit.deleteMany({ where: { participantId } });
+        await prisma.visit.deleteMany({ where: { personId: participantId } });
         await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
         await prisma.participant.deleteMany({ where: { id: { in: [adminId, participantId] } } });
@@ -110,7 +110,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             const event = await makeEvent('single-cancel', 2 * HOUR);
             await prisma.rSVP.create({ data: { eventId: event.id, personId: participantId, status: 'ATTENDING' } });
             const visit = await prisma.visit.create({
-                data: { participantId, arrivedAt: new Date(), associatedEventId: event.id },
+                data: { personId: participantId, arrivedAt: new Date(), associatedEventId: event.id },
             });
 
             const res = await patch(event.id, { action: 'cancel' });
@@ -158,7 +158,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             const event = await makeEvent('manual-present', -1 * HOUR);
             const openArrival = new Date(Date.now() - 90 * MIN);
             const openVisit = await prisma.visit.create({
-                data: { participantId, arrivedAt: openArrival, departedAt: null, associatedEventId: event.id },
+                data: { personId: participantId, arrivedAt: openArrival, departedAt: null, associatedEventId: event.id },
             });
 
             const newArrival = new Date(Date.now() - 80 * MIN);
@@ -170,7 +170,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             });
             expect(res.status).toBe(200);
 
-            const visits = await prisma.visit.findMany({ where: { participantId, associatedEventId: event.id } });
+            const visits = await prisma.visit.findMany({ where: { personId: participantId, associatedEventId: event.id } });
             expect(visits.length).toBe(1);               // not a second visit
             expect(visits[0].id).toBe(openVisit.id);     // same row, updated in place
             expect(visits[0].arrivedAt.getTime()).toBe(newArrival.getTime());
@@ -183,13 +183,13 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
         it('rejects Absent on a live (open) check-in and keeps the visit', async () => {
             const event = await makeEvent('manual-absent-open', -1 * HOUR);
             await prisma.visit.create({
-                data: { participantId, arrivedAt: new Date(Date.now() - 30 * MIN), departedAt: null, associatedEventId: event.id },
+                data: { personId: participantId, arrivedAt: new Date(Date.now() - 30 * MIN), departedAt: null, associatedEventId: event.id },
             });
 
             const res = await patch(event.id, { action: 'manualEditAttendance', participantId, status: 'Absent' });
             expect(res.status).toBe(400);
 
-            const visits = await prisma.visit.findMany({ where: { participantId, associatedEventId: event.id } });
+            const visits = await prisma.visit.findMany({ where: { personId: participantId, associatedEventId: event.id } });
             expect(visits.length).toBe(1); // open visit survives
         });
 
@@ -197,7 +197,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             const event = await makeEvent('manual-absent-closed', -2 * HOUR);
             await prisma.visit.create({
                 data: {
-                    participantId,
+                    personId: participantId,
                     arrivedAt: new Date(Date.now() - 90 * MIN),
                     departedAt: new Date(Date.now() - 60 * MIN),
                     associatedEventId: event.id,
@@ -207,7 +207,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             const res = await patch(event.id, { action: 'manualEditAttendance', participantId, status: 'Absent' });
             expect(res.status).toBe(200);
 
-            const visits = await prisma.visit.findMany({ where: { participantId, associatedEventId: event.id } });
+            const visits = await prisma.visit.findMany({ where: { personId: participantId, associatedEventId: event.id } });
             expect(visits.length).toBe(0); // closed visit removed
         });
 
@@ -215,21 +215,21 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
             const event = await makeEvent('manual-absent-mix', -2 * HOUR);
             await prisma.visit.create({
                 data: {
-                    participantId,
+                    personId: participantId,
                     arrivedAt: new Date(Date.now() - 110 * MIN),
                     departedAt: new Date(Date.now() - 80 * MIN),
                     associatedEventId: event.id,
                 },
             });
             await prisma.visit.create({
-                data: { participantId, arrivedAt: new Date(Date.now() - 30 * MIN), departedAt: null, associatedEventId: event.id },
+                data: { personId: participantId, arrivedAt: new Date(Date.now() - 30 * MIN), departedAt: null, associatedEventId: event.id },
             });
 
             const res = await patch(event.id, { action: 'manualEditAttendance', participantId, status: 'Absent' });
             expect(res.status).toBe(400);
 
             // All-or-nothing: the open visit blocks the edit, so the closed one stays too.
-            const visits = await prisma.visit.findMany({ where: { participantId, associatedEventId: event.id } });
+            const visits = await prisma.visit.findMany({ where: { personId: participantId, associatedEventId: event.id } });
             expect(visits.length).toBe(2);
         });
     });

--- a/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
@@ -62,13 +62,13 @@ describe('PATCH /api/events/[id] cancel — transaction rollback on partial fail
 
     afterEach(async () => {
         jest.restoreAllMocks();
-        await prisma.visit.deleteMany({ where: { participantId } });
+        await prisma.visit.deleteMany({ where: { personId: participantId } });
         await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
     });
 
     afterAll(async () => {
-        await prisma.visit.deleteMany({ where: { participantId } });
+        await prisma.visit.deleteMany({ where: { personId: participantId } });
         await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
         await prisma.participant.deleteMany({ where: { id: { in: [participantId, adminId] } } });
@@ -94,7 +94,7 @@ describe('PATCH /api/events/[id] cancel — transaction rollback on partial fail
         // (Visit_one_open_per_participant). This test counts visits by
         // associatedEventId, not open-state, so the departure time is irrelevant.
         await prisma.visit.create({
-            data: { participantId, arrivedAt: start, departedAt: new Date(start.getTime() + HOUR), associatedEventId: event.id },
+            data: { personId: participantId, arrivedAt: start, departedAt: new Date(start.getTime() + HOUR), associatedEventId: event.id },
         });
         return event.id;
     }

--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -71,23 +71,23 @@ describe('Facility trends API', () => {
 
         // Structured visit (associated to the event): enrolled adult, 3 hours -> participant.
         const structured = await prisma.visit.create({
-            data: { participantId: enrolledAdultId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SCANNER', associatedEventId: eventId },
+            data: { personId: enrolledAdultId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SCANNER', associatedEventId: eventId },
         });
         // Structured visit (associated to the event): non-enrolled youth, 2 hours -> volunteer.
         const youthStructured = await prisma.visit.create({
-            data: { participantId: youthId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(3), arrivedVia: 'SCANNER', associatedEventId: eventId },
+            data: { personId: youthId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(3), arrivedVia: 'SCANNER', associatedEventId: eventId },
         });
         // Unstructured visit (no event): non-enrolled adult volunteer, 1 hour.
         const unstructured = await prisma.visit.create({
-            data: { participantId: volunteerId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(3), arrivedVia: 'WEB' },
+            data: { personId: volunteerId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(3), arrivedVia: 'WEB' },
         });
         // Synthetic "marked present" visit (arrivedVia SYSTEM) — must be excluded entirely.
         const synthetic = await prisma.visit.create({
-            data: { participantId: volunteerId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SYSTEM', associatedEventId: eventId },
+            data: { personId: volunteerId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SYSTEM', associatedEventId: eventId },
         });
         // Still-open visit (no departedAt) — excluded (departedAt: { not: null } in the where).
         const open = await prisma.visit.create({
-            data: { participantId: youthId, arrivedAt: hoursAgo(1), arrivedVia: 'WEB' },
+            data: { personId: youthId, arrivedAt: hoursAgo(1), arrivedVia: 'WEB' },
         });
         visitIds.push(structured.id, youthStructured.id, unstructured.id, synthetic.id, open.id);
     });

--- a/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
@@ -31,7 +31,7 @@ describe('Household Visits API Integration Tests', () => {
         const existingHouseholdIds = existingUsers.map(u => u.householdId).filter(id => id !== null) as number[];
         
         await prisma.visit.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         await prisma.householdLead.deleteMany({
@@ -97,15 +97,15 @@ describe('Household Visits API Integration Tests', () => {
                 // Closed (departedAt set): leadUser appears twice, but a participant
                 // may have only one OPEN visit (Visit_one_open_per_participant). This
                 // window test filters by arrivedAt, so departure time is irrelevant.
-                { participantId: leadUser.id, arrivedAt: new Date(now.getTime() - 1000), departedAt: new Date(now.getTime() - 500) }, // Just now
-                { participantId: memberUser.id, arrivedAt: new Date(now.getTime() - 86400000), departedAt: new Date(now.getTime() - 86399000) }, // 1 day ago
-                { participantId: leadUser.id, arrivedAt: new Date(now.getTime() - 864000000), departedAt: new Date(now.getTime() - 863999000) }, // 10 days ago (outside 7 day window)
+                { personId: leadUser.id, arrivedAt: new Date(now.getTime() - 1000), departedAt: new Date(now.getTime() - 500) }, // Just now
+                { personId: memberUser.id, arrivedAt: new Date(now.getTime() - 86400000), departedAt: new Date(now.getTime() - 86399000) }, // 1 day ago
+                { personId: leadUser.id, arrivedAt: new Date(now.getTime() - 864000000), departedAt: new Date(now.getTime() - 863999000) }, // 10 days ago (outside 7 day window)
             ]
         });
 
         // Create visit for other household
         await prisma.visit.create({
-            data: { participantId: otherUser.id, arrivedAt: new Date(now.getTime() - 2000) }
+            data: { personId: otherUser.id, arrivedAt: new Date(now.getTime() - 2000) }
         });
     });
 
@@ -119,7 +119,7 @@ describe('Household Visits API Integration Tests', () => {
         const validHouseholdIds = existingUsers.map(u => u.householdId).filter(id => id !== null) as number[];
 
         await prisma.visit.deleteMany({
-            where: { participantId: { in: currentIds } }
+            where: { personId: { in: currentIds } }
         });
 
         await prisma.householdLead.deleteMany({
@@ -181,12 +181,12 @@ describe('Household Visits API Integration Tests', () => {
             expect(data.visits.length).toBe(2);
             
             // Verify no cross-pollution from other household
-            const hasOtherHouseholdVisits = data.visits.some((v: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => v.participantId === testOtherHouseUserId);
+            const hasOtherHouseholdVisits = data.visits.some((v: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => v.personId === testOtherHouseUserId);
             expect(hasOtherHouseholdVisits).toBe(false);
 
             // Verify ordered correctly (descending)
-            expect(data.visits[0].participantId).toBe(testUserId); // Just now
-            expect(data.visits[1].participantId).toBe(testMemberId); // 1 day ago
+            expect(data.visits[0].personId).toBe(testUserId); // Just now
+            expect(data.visits[1].personId).toBe(testMemberId); // 1 day ago
         });
 
         it('should shift the visit window correctly when filter date is provided', async () => {
@@ -204,7 +204,7 @@ describe('Household Visits API Integration Tests', () => {
             
             // It should only capture the 10-days-ago visit, missing the 1-day-ago and just-now visits
             expect(data.visits.length).toBe(1);
-            expect(data.visits[0].participantId).toBe(testUserId);
+            expect(data.visits[0].personId).toBe(testUserId);
             // Verify it was the 10-days-ago visit (can't easily verify the exact MS but logically it is the third visit record)
         });
     });

--- a/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
@@ -38,7 +38,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
         const existingHouseholdIds = existingUsers.map(u => u.householdId).filter((id): id is number => id !== null);
 
         await prisma.visit.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         await prisma.toolStatus.deleteMany({
@@ -79,7 +79,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
         });
 
         await prisma.visit.create({
-            data: { participantId: testUserId, arrivedAt: new Date() }
+            data: { personId: testUserId, arrivedAt: new Date() }
         });
     });
 
@@ -90,7 +90,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
     afterAll(async () => {
         // Clean up
         await prisma.visit.deleteMany({
-            where: { participantId: testUserId }
+            where: { personId: testUserId }
         });
         await prisma.toolStatus.deleteMany({
             where: { personId: testUserId }

--- a/checkin-app/src/app/__tests__/myProgramsConflictsResolveAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/myProgramsConflictsResolveAPI.integration.test.ts
@@ -65,7 +65,7 @@ describe('My-programs conflicts resolve API', () => {
 
     afterAll(async () => {
         await prisma.auditLog.deleteMany({ where: { actorId: { in: [leadId, adminId] } } });
-        await prisma.visit.deleteMany({ where: { participantId } });
+        await prisma.visit.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { id: eventId } });
         await prisma.program.deleteMany({ where: { id: programId } });
         await prisma.participant.deleteMany({ where: { id: { in: [leadId, otherLeadId, adminId, participantId] } } });
@@ -100,7 +100,7 @@ describe('My-programs conflicts resolve API', () => {
 
     it('returns 409 when the visit has no genuine overlap (refuses to delete an isolated visit)', async () => {
         const isolated = await prisma.visit.create({
-            data: { participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(4), associatedEventId: eventId },
+            data: { personId: participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(4), associatedEventId: eventId },
         });
         try {
             const res = await callAs({ id: leadId }, { visitId: isolated.id });
@@ -112,8 +112,8 @@ describe('My-programs conflicts resolve API', () => {
 
     it('returns 403 for a caller who neither leads the program nor is a global admin', async () => {
         const [anchor, sibling] = await Promise.all([
-            prisma.visit.create({ data: { participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), associatedEventId: eventId } }),
-            prisma.visit.create({ data: { participantId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(1) } }),
+            prisma.visit.create({ data: { personId: participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), associatedEventId: eventId } }),
+            prisma.visit.create({ data: { personId: participantId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(1) } }),
         ]);
         try {
             const res = await callAs({ id: otherLeadId }, { visitId: anchor.id });
@@ -125,10 +125,10 @@ describe('My-programs conflicts resolve API', () => {
 
     it('lets the leading mentor delete an overlapping visit and writes an audit trail', async () => {
         const anchor = await prisma.visit.create({
-            data: { participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SYSTEM', associatedEventId: eventId },
+            data: { personId: participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SYSTEM', associatedEventId: eventId },
         });
         const sibling = await prisma.visit.create({
-            data: { participantId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(1), arrivedVia: 'SCANNER' },
+            data: { personId: participantId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(1), arrivedVia: 'SCANNER' },
         });
         try {
             const res = await callAs({ id: leadId }, { visitId: anchor.id });
@@ -146,7 +146,7 @@ describe('My-programs conflicts resolve API', () => {
             });
             expect(audit).toBeDefined();
             expect(audit?.secondaryAffectedEntity).toBe(eventId);
-            expect((audit?.oldData as { participantId: number })?.participantId).toBe(participantId);
+            expect((audit?.oldData as { personId: number })?.personId).toBe(participantId);
         } finally {
             await prisma.visit.deleteMany({ where: { id: { in: [anchor.id, sibling.id] } } });
         }
@@ -154,10 +154,10 @@ describe('My-programs conflicts resolve API', () => {
 
     it('lets a global admin delete an overlapping visit for a program they do not lead', async () => {
         const anchor = await prisma.visit.create({
-            data: { participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), associatedEventId: eventId },
+            data: { personId: participantId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), associatedEventId: eventId },
         });
         const sibling = await prisma.visit.create({
-            data: { participantId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(1) },
+            data: { personId: participantId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(1) },
         });
         try {
             const res = await callAs({ id: adminId, isSysadmin: true }, { visitId: anchor.id });

--- a/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
@@ -29,7 +29,7 @@ describe('Profile API Integration Tests', () => {
         const existingHouseholdIds = existingUsers.map(u => u.householdId).filter((id): id is number => id !== null);
 
         await prisma.visit.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         await prisma.auditLog.deleteMany({
@@ -62,15 +62,15 @@ describe('Profile API Integration Tests', () => {
             data: [
                 // Closed (departedAt set): a participant may have only one OPEN visit
                 // (Visit_one_open_per_participant partial unique index); these are history.
-                { participantId: testUserId, arrivedAt: new Date(Date.now() - 3600000), departedAt: new Date(Date.now() - 3000000) },
-                { participantId: testUserId, arrivedAt: new Date(Date.now() - 7200000), departedAt: new Date(Date.now() - 6600000) }
+                { personId: testUserId, arrivedAt: new Date(Date.now() - 3600000), departedAt: new Date(Date.now() - 3000000) },
+                { personId: testUserId, arrivedAt: new Date(Date.now() - 7200000), departedAt: new Date(Date.now() - 6600000) }
             ]
         });
     });
 
     afterAll(async () => {
         await prisma.visit.deleteMany({
-            where: { participantId: testUserId }
+            where: { personId: testUserId }
         });
 
         await prisma.auditLog.deleteMany({

--- a/checkin-app/src/app/__tests__/profileVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileVisitsAPI.integration.test.ts
@@ -29,7 +29,7 @@ describe('Profile Visits API Integration Tests', () => {
         const existingHouseholdIds = existingUsers.map(u => u.householdId).filter((id): id is number => id !== null);
 
         await prisma.visit.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
 
         // RESTRICT: delete participants before their households
@@ -56,16 +56,16 @@ describe('Profile Visits API Integration Tests', () => {
                 // Closed (departedAt set): a participant may have only one OPEN visit
                 // (Visit_one_open_per_participant partial unique index), and this
                 // window test filters by arrivedAt, so departure time is irrelevant.
-                { participantId: testUserId, arrivedAt: new Date(now.getTime() - 1000), departedAt: new Date(now.getTime() - 500) }, // Just now
-                { participantId: testUserId, arrivedAt: new Date(now.getTime() - 86400000), departedAt: new Date(now.getTime() - 86399000) }, // 1 day ago
-                { participantId: testUserId, arrivedAt: new Date(now.getTime() - 864000000), departedAt: new Date(now.getTime() - 863999000) }, // 10 days ago (outside 7 day window)
+                { personId: testUserId, arrivedAt: new Date(now.getTime() - 1000), departedAt: new Date(now.getTime() - 500) }, // Just now
+                { personId: testUserId, arrivedAt: new Date(now.getTime() - 86400000), departedAt: new Date(now.getTime() - 86399000) }, // 1 day ago
+                { personId: testUserId, arrivedAt: new Date(now.getTime() - 864000000), departedAt: new Date(now.getTime() - 863999000) }, // 10 days ago (outside 7 day window)
             ]
         });
     });
 
     afterAll(async () => {
         await prisma.visit.deleteMany({
-            where: { participantId: testUserId }
+            where: { personId: testUserId }
         });
 
         await prisma.participant.deleteMany({

--- a/checkin-app/src/app/__tests__/scanAuth.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanAuth.integration.test.ts
@@ -111,7 +111,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
         });
 
         afterAll(async () => {
-            await prisma.visit.deleteMany({ where: { participantId: kioskId } });
+            await prisma.visit.deleteMany({ where: { personId: kioskId } });
             await prisma.rawBadgeLog.deleteMany({ where: { personId: kioskId } });
             await prisma.participant.delete({ where: { id: kioskId } });
             await prisma.household.delete({ where: { id: kioskHouseholdId } });
@@ -125,7 +125,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
         });
 
         afterEach(async () => {
-            await prisma.visit.deleteMany({ where: { participantId: kioskId } });
+            await prisma.visit.deleteMany({ where: { personId: kioskId } });
             await prisma.rawBadgeLog.deleteMany({ where: { personId: kioskId } });
         });
 
@@ -146,7 +146,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             expect(json.type).toBe('checkin');
             expect(json.signedRequest).toBe(true);
 
-            const visit = await prisma.visit.findFirst({ where: { participantId: kioskId, departedAt: null } });
+            const visit = await prisma.visit.findFirst({ where: { personId: kioskId, departedAt: null } });
             expect(visit).not.toBeNull();
             const events = await prisma.rawBadgeLog.count({ where: { personId: kioskId } });
             expect(events).toBe(1);
@@ -166,7 +166,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             }));
 
             expect(res.status).toBe(401);
-            const visits = await prisma.visit.count({ where: { participantId: kioskId } });
+            const visits = await prisma.visit.count({ where: { personId: kioskId } });
             expect(visits).toBe(0);
         });
 
@@ -183,7 +183,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             }));
 
             expect(res.status).toBe(401);
-            const visits = await prisma.visit.count({ where: { participantId: kioskId } });
+            const visits = await prisma.visit.count({ where: { personId: kioskId } });
             expect(visits).toBe(0);
         });
 
@@ -222,7 +222,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             const res = await POST(scanReq(body));
 
             expect(res.status).toBe(401);
-            const visits = await prisma.visit.count({ where: { participantId: kioskId } });
+            const visits = await prisma.visit.count({ where: { personId: kioskId } });
             expect(visits).toBe(0);
         });
     });
@@ -265,14 +265,14 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
 
         afterEach(async () => {
             const ids = [pSelf, pSameHH, pOtherHH, pStranger, pKeyholder];
-            await prisma.visit.deleteMany({ where: { participantId: { in: ids } } });
+            await prisma.visit.deleteMany({ where: { personId: { in: ids } } });
             await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: ids } } });
         });
 
         afterAll(async () => {
             const ids = [pSelf, pSameHH, pOtherHH, pStranger, pKeyholder];
             const hs = [hSelf, hLead, hOther, hStranger, hKeyholder];
-            await prisma.visit.deleteMany({ where: { participantId: { in: ids } } });
+            await prisma.visit.deleteMany({ where: { personId: { in: ids } } });
             await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: ids } } });
             await prisma.participant.deleteMany({ where: { id: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: hs } } });
@@ -280,7 +280,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
 
         /** Open the facility so a non-isKeyholder check-in can reach 200. */
         async function openFacility() {
-            await prisma.visit.create({ data: { participantId: pKeyholder, arrivedAt: new Date() } });
+            await prisma.visit.create({ data: { personId: pKeyholder, arrivedAt: new Date() } });
         }
 
         it('non-admin scanning self in prod → 403 (self-check-in gate, must use kiosk)', async () => {
@@ -293,7 +293,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             const json = await res.json();
             expect(json.error).toMatch(/kiosk badge scanner/i);
             // Gate fires before any state change.
-            expect(await prisma.visit.count({ where: { participantId: pSelf } })).toBe(0);
+            expect(await prisma.visit.count({ where: { personId: pSelf } })).toBe(0);
         });
 
         it('household lead scanning another member of their OWN household → 200', async () => {
@@ -307,7 +307,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             expect(res.status).toBe(200);
             const json = await res.json();
             expect(json.type).toBe('checkin');
-            const visit = await prisma.visit.findFirst({ where: { participantId: pSameHH, departedAt: null } });
+            const visit = await prisma.visit.findFirst({ where: { personId: pSameHH, departedAt: null } });
             expect(visit).not.toBeNull();
         });
 
@@ -322,7 +322,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             expect(res.status).toBe(403);
             const json = await res.json();
             expect(json.error).toMatch(/not authorized/i);
-            expect(await prisma.visit.count({ where: { participantId: pOtherHH } })).toBe(0);
+            expect(await prisma.visit.count({ where: { personId: pOtherHH } })).toBe(0);
         });
 
         it('non-admin non-lead scanning an arbitrary stranger → 403', async () => {
@@ -337,7 +337,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             expect(res.status).toBe(403);
             const json = await res.json();
             expect(json.error).toMatch(/not authorized/i);
-            expect(await prisma.visit.count({ where: { participantId: pStranger } })).toBe(0);
+            expect(await prisma.visit.count({ where: { personId: pStranger } })).toBe(0);
         });
     });
 

--- a/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
@@ -60,7 +60,7 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
     });
 
     afterEach(async () => {
-        await prisma.visit.deleteMany({ where: { participantId: { in: [isKeyholder.id, normal.id] } } });
+        await prisma.visit.deleteMany({ where: { personId: { in: [isKeyholder.id, normal.id] } } });
         await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: [isKeyholder.id, normal.id] } } });
     });
 
@@ -90,13 +90,13 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
         await flush(); // let the fire-and-forget dynamic import resolve
         expect(processPostEventEmails).toHaveBeenCalledWith({ forceImmediate: true });
 
-        const open = await prisma.visit.count({ where: { participantId: isKeyholder.id, departedAt: null } });
+        const open = await prisma.visit.count({ where: { personId: isKeyholder.id, departedAt: null } });
         expect(open).toBe(0);
     });
 
     it('force-closes (departing everyone) when a recent double-badge confirms, then sends post-event emails', async () => {
-        const kVisit = await prisma.visit.create({ data: { participantId: isKeyholder.id, arrivedAt: new Date() } });
-        await prisma.visit.create({ data: { participantId: normal.id, arrivedAt: new Date() } });
+        const kVisit = await prisma.visit.create({ data: { personId: isKeyholder.id, arrivedAt: new Date() } });
+        await prisma.visit.create({ data: { personId: normal.id, arrivedAt: new Date() } });
         // Two isKeyholder badge events 5s apart (<=12s) → confirmed force-close.
         await prisma.rawBadgeLog.create({ data: { personId: isKeyholder.id, timestamp: new Date(Date.now() - 5000) } });
         await prisma.rawBadgeLog.create({ data: { personId: isKeyholder.id, timestamp: new Date() } });
@@ -110,14 +110,14 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
 
         // Everyone is departedAt, including the other attendee.
         const openAnyone = await prisma.visit.count({
-            where: { participantId: { in: [isKeyholder.id, normal.id] }, departedAt: null },
+            where: { personId: { in: [isKeyholder.id, normal.id] }, departedAt: null },
         });
         expect(openAnyone).toBe(0);
     });
 
     it('warns instead of closing when others are present and there is no recent double-badge', async () => {
-        const kVisit = await prisma.visit.create({ data: { participantId: isKeyholder.id, arrivedAt: new Date() } });
-        await prisma.visit.create({ data: { participantId: normal.id, arrivedAt: new Date() } });
+        const kVisit = await prisma.visit.create({ data: { personId: isKeyholder.id, arrivedAt: new Date() } });
+        await prisma.visit.create({ data: { personId: normal.id, arrivedAt: new Date() } });
 
         const res = await processCheckout(isKeyholder, kVisit.id, 'kiosk');
         expect(res.status).toBe(400);
@@ -126,7 +126,7 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
 
         // Nothing closed: both visits remain open and no emails fired.
         const open = await prisma.visit.count({
-            where: { participantId: { in: [isKeyholder.id, normal.id] }, departedAt: null },
+            where: { personId: { in: [isKeyholder.id, normal.id] }, departedAt: null },
         });
         expect(open).toBe(2);
         expect(processPostEventEmails).not.toHaveBeenCalled();

--- a/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
@@ -71,12 +71,12 @@ describe('POST /api/scan — real check-in/out logic', () => {
 
     afterEach(async () => {
         // Reset facility state between cases so each test controls who is present.
-        await prisma.visit.deleteMany({ where: { participantId: { in: [keyholderId, normalId] } } });
+        await prisma.visit.deleteMany({ where: { personId: { in: [keyholderId, normalId] } } });
         await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: [keyholderId, normalId] } } });
     });
 
     afterAll(async () => {
-        await prisma.visit.deleteMany({ where: { participantId: { in: [keyholderId, normalId] } } });
+        await prisma.visit.deleteMany({ where: { personId: { in: [keyholderId, normalId] } } });
         await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: [keyholderId, normalId] } } });
         await prisma.participant.deleteMany({ where: { id: { in: [keyholderId, normalId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [keyholderHouseholdId, normalHouseholdId] } } });
@@ -89,7 +89,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
         expect(json.error).toMatch(/Facility is closed/);
 
         // Negative side-effect assertion: no visit row was created.
-        const visits = await prisma.visit.count({ where: { participantId: normalId } });
+        const visits = await prisma.visit.count({ where: { personId: normalId } });
         expect(visits).toBe(0);
     });
 
@@ -99,14 +99,14 @@ describe('POST /api/scan — real check-in/out logic', () => {
         const json = await res.json();
         expect(json.type).toBe('checkin');
 
-        const visit = await prisma.visit.findFirst({ where: { participantId: keyholderId } });
+        const visit = await prisma.visit.findFirst({ where: { personId: keyholderId } });
         expect(visit).not.toBeNull();
         expect(visit?.departedAt).toBeNull();
     });
 
     it('orders check-in then check-out on a second scan: arrivedAt set first, departedAt after', async () => {
         // Seed an open isKeyholder visit so the facility is open for the normal user.
-        await prisma.visit.create({ data: { participantId: keyholderId, arrivedAt: new Date() } });
+        await prisma.visit.create({ data: { personId: keyholderId, arrivedAt: new Date() } });
 
         // First scan → check-in.
         const checkinRes = await POST(scanReq(normalId));
@@ -114,7 +114,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
         expect((await checkinRes.json()).type).toBe('checkin');
 
         const openVisit = await prisma.visit.findFirst({
-            where: { participantId: normalId, departedAt: null },
+            where: { personId: normalId, departedAt: null },
         });
         expect(openVisit).not.toBeNull();
         expect(openVisit?.arrivedAt).toBeInstanceOf(Date);
@@ -131,7 +131,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
         expect((await checkoutRes.json()).type).toBe('checkout');
 
         const closedVisit = await prisma.visit.findFirst({
-            where: { participantId: normalId },
+            where: { personId: normalId },
             orderBy: { arrivedAt: 'desc' },
         });
         expect(closedVisit?.departedAt).toBeInstanceOf(Date);
@@ -140,7 +140,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
     });
 
     it('silently debounces a repeated scan within 3 seconds (no second visit)', async () => {
-        await prisma.visit.create({ data: { participantId: keyholderId, arrivedAt: new Date() } });
+        await prisma.visit.create({ data: { personId: keyholderId, arrivedAt: new Date() } });
 
         const first = await POST(scanReq(normalId));
         expect((await first.json()).type).toBe('checkin');
@@ -151,7 +151,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
         expect(json.type).toBe('ignored_debounce');
 
         // The debounced scan must NOT have flipped the open visit to checked-out.
-        const open = await prisma.visit.count({ where: { participantId: normalId, departedAt: null } });
+        const open = await prisma.visit.count({ where: { personId: normalId, departedAt: null } });
         expect(open).toBe(1);
     });
 

--- a/checkin-app/src/app/__tests__/scanConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanConcurrency.integration.test.ts
@@ -54,7 +54,7 @@ function scanRequest(participantId: number) {
 }
 
 async function openVisitCount(participantId: number) {
-    return prisma.visit.count({ where: { participantId, departedAt: null } });
+    return prisma.visit.count({ where: { personId: participantId, departedAt: null } });
 }
 
 describe('POST /api/scan concurrency (advisory lock)', () => {
@@ -73,7 +73,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         });
         const leakedIds = leaked.map(p => p.id);
         const leakedHouseholdIds = leaked.map(p => p.householdId);
-        await prisma.visit.deleteMany({ where: { participantId: { in: leakedIds } } });
+        await prisma.visit.deleteMany({ where: { personId: { in: leakedIds } } });
         await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: leakedIds } } });
         await prisma.participant.deleteMany({ where: { id: { in: leakedIds } } });
         await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
@@ -84,7 +84,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         keeperId = keeper.id;
         // Keep the isKeyholder checked in so non-isKeyholder check-ins are allowed
         // and non-isKeyholder check-outs skip the last-isKeyholder force-close path.
-        await prisma.visit.create({ data: { participantId: keeperId, arrivedAt: new Date() } });
+        await prisma.visit.create({ data: { personId: keeperId, arrivedAt: new Date() } });
 
         const checkinSubject = await prisma.participant.create({
             data: { email: `checkin-${EMAIL_TAG}@example.com`, name: 'Checkin Subject', household: { create: {} } },
@@ -103,7 +103,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
             where: { id: { in: ids } },
             select: { householdId: true },
         })).map(p => p.householdId);
-        await prisma.visit.deleteMany({ where: { participantId: { in: ids } } });
+        await prisma.visit.deleteMany({ where: { personId: { in: ids } } });
         await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: ids } } });
         await prisma.participant.deleteMany({ where: { id: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: households } } });
@@ -112,7 +112,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
     it('two concurrent check-in scans → exactly one open visit, one checkin + one debounce', async () => {
         // Fresh state: no open visit, no recent badge event (so neither scan is
         // pre-debounced before the race even begins).
-        await prisma.visit.deleteMany({ where: { participantId: checkinSubjectId } });
+        await prisma.visit.deleteMany({ where: { personId: checkinSubjectId } });
         await prisma.rawBadgeLog.deleteMany({ where: { personId: checkinSubjectId } });
         expect(await openVisitCount(checkinSubjectId)).toBe(0);
 
@@ -135,9 +135,9 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
 
     it('two concurrent check-out scans → exactly one successful checkout, no 500, zero open visits', async () => {
         // Fresh state: exactly one open visit, no recent badge event.
-        await prisma.visit.deleteMany({ where: { participantId: checkoutSubjectId } });
+        await prisma.visit.deleteMany({ where: { personId: checkoutSubjectId } });
         await prisma.rawBadgeLog.deleteMany({ where: { personId: checkoutSubjectId } });
-        await prisma.visit.create({ data: { participantId: checkoutSubjectId, arrivedAt: new Date() } });
+        await prisma.visit.create({ data: { personId: checkoutSubjectId, arrivedAt: new Date() } });
         expect(await openVisitCount(checkoutSubjectId)).toBe(1);
 
         const [resA, resB] = await Promise.all([

--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -40,7 +40,7 @@ describe('Shop API Integration Tests', () => {
             where: { personId: { in: existingUserIds } }
         });
         await prisma.visit.deleteMany({
-            where: { participantId: { in: existingUserIds } }
+            where: { personId: { in: existingUserIds } }
         });
         // RESTRICT: delete participants before their households
         await prisma.participant.deleteMany({
@@ -120,7 +120,7 @@ describe('Shop API Integration Tests', () => {
                 where: { personId: { in: existingUserIds } }
             });
             await prisma.visit.deleteMany({
-                where: { participantId: { in: existingUserIds } }
+                where: { personId: { in: existingUserIds } }
             });
             // RESTRICT: delete participants before their households
             await prisma.participant.deleteMany({

--- a/checkin-app/src/app/api/attendance/manual/route.ts
+++ b/checkin-app/src/app/api/attendance/manual/route.ts
@@ -59,14 +59,14 @@ export const POST = withAuth({}, async (req, auth) => {
             // provided) is just a historical record, so multiple are fine.
             if (!departureTime) {
                 const openVisit = await tx.visit.findFirst({
-                    where: { participantId: userId, departedAt: null }
+                    where: { personId: userId, departedAt: null }
                 });
                 if (openVisit) return openVisit;
             }
 
             return await tx.visit.create({
                 data: {
-                    participantId: userId,
+                    personId: userId,
                     arrivedAt: arrivalTime,
                     departedAt: departureTime,
                     arrivedVia: "WEB",

--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -103,7 +103,7 @@ export const DELETE = withAuth({}, async (req, auth) => {
 
         const visit = await prisma.visit.findUnique({
             where: { id: visitId },
-            include: { participant: true }
+            include: { person: true }
         });
 
         if (!visit) {
@@ -114,8 +114,8 @@ export const DELETE = withAuth({}, async (req, auth) => {
         // 1. User checking out themselves
         // 2. User is the household lead checking out a family member
         // 3. User is an admin (isSysadmin, isKeyholder, board member)
-        const isSelf = visit.participantId === Number(user.id);
-        const isHouseholdCheckOut = Boolean(user.householdId && visit.participant.householdId === user.householdId && user.householdLead);
+        const isSelf = visit.personId === Number(user.id);
+        const isHouseholdCheckOut = Boolean(user.householdId && visit.person.householdId === user.householdId && user.householdLead);
         const isAdmin = user.isSysadmin || user.isKeyholder || user.isBoardMember;
 
         if (!isSelf && !isHouseholdCheckOut && !isAdmin) {
@@ -180,7 +180,7 @@ export const POST = withAuth({}, async (req, auth) => {
 
                 const activeVisit = await tx.visit.findFirst({
                     where: {
-                        participantId: participant.id,
+                        personId: participant.id,
                         departedAt: null
                     }
                 });
@@ -191,7 +191,7 @@ export const POST = withAuth({}, async (req, auth) => {
 
                 const visit = await tx.visit.create({
                     data: {
-                        participantId: participant.id,
+                        personId: participant.id,
                         arrivedAt: arrivalTime,
                         arrivedVia: "WEB",
                         associatedEventId: eventId

--- a/checkin-app/src/app/api/cron/nightly/route.ts
+++ b/checkin-app/src/app/api/cron/nightly/route.ts
@@ -13,7 +13,7 @@ export const GET = withCron(async () => {
                 departedAt: null
             },
             include: {
-                participant: true
+                person: true
             }
         });
 
@@ -30,12 +30,12 @@ export const GET = withCron(async () => {
                     checkedOutCount += 1;
                 } else {
                     const visit = abandonedVisits[i];
-                    console.error(`Failed to check out visit ${visit.id} (participant ${visit.participant.email}):`, result.reason);
+                    console.error(`Failed to check out visit ${visit.id} (person ${visit.person.email}):`, result.reason);
                 }
             });
 
             // If at least one was a isKeyholder, the facility was left "Open". We need to alert the board.
-            const abandonedKeyholders = abandonedVisits.filter(v => v.participant.isKeyholder);
+            const abandonedKeyholders = abandonedVisits.filter(v => v.person.isKeyholder);
             
             if (abandonedKeyholders.length > 0) {
                 const boardMembers = await prisma.participant.findMany({
@@ -43,7 +43,7 @@ export const GET = withCron(async () => {
                     select: { email: true }
                 });
 
-                const keyholderNames = abandonedKeyholders.map(v => v.participant.name || v.participant.email).join(', ');
+                const keyholderNames = abandonedKeyholders.map(v => v.person.name || v.person.email).join(', ');
 
                 // System Audit Log for the violation
                 await prisma.auditLog.create({

--- a/checkin-app/src/app/api/events/[id]/attendance/route.ts
+++ b/checkin-app/src/app/api/events/[id]/attendance/route.ts
@@ -42,7 +42,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             // Pre-fetch all overlapping unassociated visits for the participants
             const overlappingVisits = await tx.visit.findMany({
                 where: {
-                    participantId: { in: participantIds },
+                    personId: { in: participantIds },
                     associatedEventId: null,
                     arrivedAt: { lte: event.endAt },
                     OR: [
@@ -56,8 +56,8 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             const visitsByParticipant = new Map();
             for (const visit of overlappingVisits) {
                 // We just need the first matching unassociated visit for each participant.
-                if (!visitsByParticipant.has(visit.participantId)) {
-                    visitsByParticipant.set(visit.participantId, visit);
+                if (!visitsByParticipant.has(visit.personId)) {
+                    visitsByParticipant.set(visit.personId, visit);
                 }
             }
 
@@ -93,7 +93,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
                     // auto-checkout and the one-open-visit-per-participant index.
                     const newVisit = await tx.visit.create({
                         data: {
-                            participantId: pId,
+                            personId: pId,
                             associatedEventId: eventId,
                             arrivedAt: event.startAt,
                             departedAt: event.endAt,

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -212,7 +212,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                 // roster of who's in the building — reject instead.
                 const openVisit = await prisma.visit.findFirst({
                     where: {
-                        participantId: Number(participantId),
+                        personId: Number(participantId),
                         associatedEventId: eventId,
                         departedAt: null
                     }
@@ -223,7 +223,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                 // Only closed visits remain; safe to remove on an Absent correction.
                 await prisma.visit.deleteMany({
                     where: {
-                        participantId: Number(participantId),
+                        personId: Number(participantId),
                         associatedEventId: eventId
                     }
                 });
@@ -235,7 +235,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                 // Check if there is an existing visit
                 const existingVisit = await prisma.visit.findFirst({
                     where: {
-                        participantId: Number(participantId),
+                        personId: Number(participantId),
                         associatedEventId: eventId
                     }
                 });
@@ -253,7 +253,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                 } else {
                     await prisma.visit.create({
                         data: {
-                            participantId: Number(participantId),
+                            personId: Number(participantId),
                             associatedEventId: eventId,
                             arrivedAt: new Date(arrivedAt),
                             departedAt: departedAt ? new Date(departedAt) : null,

--- a/checkin-app/src/app/api/facility/trends/route.ts
+++ b/checkin-app/src/app/api/facility/trends/route.ts
@@ -99,7 +99,7 @@ export const GET = withAuth(
             const visits = await prisma.visit.findMany({
                 where: whereClause,
                 include: {
-                    participant: { select: { id: true } },
+                    person: { select: { id: true } },
                     event: { select: { programId: true } },
                 },
                 orderBy: { arrivedAt: "asc" },
@@ -145,13 +145,13 @@ export const GET = withAuth(
 
                 const bucket = bucketMap.get(key)!;
                 const hours = getHoursBetween(visit.arrivedAt, visit.departedAt);
-                const isParticipant = enrolledParticipantIds.has(visit.participant.id);
+                const isParticipant = enrolledParticipantIds.has(visit.person.id);
 
                 if (isParticipant) {
-                    bucket.participantIds.add(visit.participant.id);
+                    bucket.participantIds.add(visit.person.id);
                     bucket.participantHours += hours;
                 } else {
-                    bucket.volunteerIds.add(visit.participant.id);
+                    bucket.volunteerIds.add(visit.person.id);
                     bucket.volunteerHours += hours;
                 }
 
@@ -178,8 +178,8 @@ export const GET = withAuth(
             const totals: TrendBucket = {
                 label: "Total",
                 periodStart: "",
-                uniqueVolunteers: new Set(visits.filter(v => !enrolledParticipantIds.has(v.participant.id)).map(v => v.participant.id)).size,
-                uniqueParticipants: new Set(visits.filter(v => enrolledParticipantIds.has(v.participant.id)).map(v => v.participant.id)).size,
+                uniqueVolunteers: new Set(visits.filter(v => !enrolledParticipantIds.has(v.person.id)).map(v => v.person.id)).size,
+                uniqueParticipants: new Set(visits.filter(v => enrolledParticipantIds.has(v.person.id)).map(v => v.person.id)).size,
                 totalVolunteerHours: Math.round(buckets.reduce((s, b) => s + b.totalVolunteerHours, 0) * 10) / 10,
                 totalParticipantHours: Math.round(buckets.reduce((s, b) => s + b.totalParticipantHours, 0) * 10) / 10,
                 structuredHours: Math.round(buckets.reduce((s, b) => s + b.structuredHours, 0) * 10) / 10,

--- a/checkin-app/src/app/api/facility/visits/route.ts
+++ b/checkin-app/src/app/api/facility/visits/route.ts
@@ -10,7 +10,7 @@ export const GET = withAuth(
                 take: 50,
                 orderBy: { arrivedAt: "desc" },
                 include: {
-                    participant: {
+                    person: {
                         select: { email: true, name: true, isSysadmin: true, isKeyholder: true },
                     },
                 },

--- a/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
+++ b/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
@@ -125,7 +125,7 @@ describe("Participant PII minimization (M1, M2)", () => {
                 id: 100,
                 arrivedAt: new Date(),
                 departedAt: null,
-                participant: {
+                person: {
                     id: 5,
                     email: "kid5@example.com",
                     name: null,

--- a/checkin-app/src/app/api/household/visits/route.ts
+++ b/checkin-app/src/app/api/household/visits/route.ts
@@ -38,7 +38,7 @@ export const GET = withAuth(
 
             const visits = await prisma.visit.findMany({
                 where: {
-                    participant: {
+                    person: {
                         householdId: user.householdId
                     },
                     arrivedAt: {
@@ -48,7 +48,7 @@ export const GET = withAuth(
                 },
                 orderBy: { arrivedAt: 'desc' },
                 include: {
-                    participant: { select: { id: true, name: true } },
+                    person: { select: { id: true, name: true } },
                     event: { select: { id: true, name: true } }
                 }
             });

--- a/checkin-app/src/app/api/kioskdisplay/certifications/route.ts
+++ b/checkin-app/src/app/api/kioskdisplay/certifications/route.ts
@@ -20,7 +20,7 @@ export const GET = withAuth(
             const activeVisits = await prisma.visit.findMany({
                 where: { departedAt: null },
                 include: {
-                    participant: {
+                    person: {
                         select: {
                             id: true,
                             email: true,
@@ -33,7 +33,7 @@ export const GET = withAuth(
                 },
                 orderBy: { arrivedAt: "desc" }
             });
-            participantsData = activeVisits.map(v => v.participant);
+            participantsData = activeVisits.map(v => v.person);
         } else {
             participantsData = await prisma.participant.findMany({
                 select: {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -62,7 +62,7 @@ describe("Merge Participants API", () => {
         // Cleanup. FeePayment / ProgramParticipant FK participant with RESTRICT, so
         // they must go before the participants.
         await prisma.feePayment.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
-        await prisma.visit.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
+        await prisma.visit.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
         await prisma.programParticipant.deleteMany({ where: { participantId: { in: [pKeepId, pMergeId] } } });
         await prisma.householdLead.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
         await prisma.auditLog.deleteMany({ where: { actorId } });
@@ -84,7 +84,7 @@ describe("Merge Participants API", () => {
         // Add some data to pMerge
         await prisma.visit.create({
             data: {
-                participantId: pMergeId,
+                personId: pMergeId,
                 arrivedAt: new Date()
             }
         });
@@ -101,7 +101,7 @@ describe("Merge Participants API", () => {
         expect(data.success).toBe(true);
 
         // Verify data was moved
-        const visits = await prisma.visit.findMany({ where: { participantId: pKeepId } });
+        const visits = await prisma.visit.findMany({ where: { personId: pKeepId } });
         expect(visits.length).toBe(1);
 
         // Verify kept user got merged user's phone
@@ -117,7 +117,7 @@ describe("Merge Participants API", () => {
 
     it("should write an AuditLog row capturing the merge", async () => {
         await prisma.visit.create({
-            data: { participantId: pMergeId, arrivedAt: new Date() }
+            data: { personId: pMergeId, arrivedAt: new Date() }
         });
 
         const req = new Request("http://localhost/api/membership-ops/participants/merge", {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -83,8 +83,8 @@ export const POST = withAuth(
                 };
 
                 moved.visits = (await tx.visit.updateMany({
-                    where: { participantId: mergeId },
-                    data: { participantId: keepId }
+                    where: { personId: mergeId },
+                    data: { personId: keepId }
                 })).count;
 
                 // Instead of failing on unique constraints, we migrate manually:

--- a/checkin-app/src/app/api/my-programs/conflicts/resolve/route.ts
+++ b/checkin-app/src/app/api/my-programs/conflicts/resolve/route.ts
@@ -49,7 +49,7 @@ export const POST = withAuth({}, async (req, auth) => {
   // Guard: only delete a visit that genuinely overlaps another of the same
   // participant's visits. Refuse to delete an isolated, legitimate visit.
   const siblings = await prisma.visit.findMany({
-    where: { participantId: visit.participantId, id: { not: visit.id } },
+    where: { personId: visit.personId, id: { not: visit.id } },
     select: { arrivedAt: true, departedAt: true },
   });
   const isConflicting = siblings.some((s) => intervalsOverlap(visit, s));
@@ -67,7 +67,7 @@ export const POST = withAuth({}, async (req, auth) => {
         affectedEntityId: visit.id,
         secondaryAffectedEntity: visit.associatedEventId,
         oldData: {
-          participantId: visit.participantId,
+          personId: visit.personId,
           arrivedAt: visit.arrivedAt,
           departedAt: visit.departedAt,
           arrivedVia: visit.arrivedVia,

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -204,7 +204,7 @@ export const GET = withAuth({}, async (_req, auth) => {
     const [building, buildingHousehold, activePrograms] = await Promise.all([
         prisma.visit.count({ where: { departedAt: null } }),
         user.householdId
-            ? prisma.visit.count({ where: { departedAt: null, participant: { householdId: user.householdId } } })
+            ? prisma.visit.count({ where: { departedAt: null, person: { householdId: user.householdId } } })
             : Promise.resolve(0),
         prisma.program.count({ where: { phase: "RUNNING" } }),
     ]);

--- a/checkin-app/src/app/api/profile/visits/route.ts
+++ b/checkin-app/src/app/api/profile/visits/route.ts
@@ -29,7 +29,7 @@ export const GET = withAuth(
 
             const visits = await prisma.visit.findMany({
                 where: {
-                    participantId: userId,
+                    personId: userId,
                     arrivedAt: {
                         gte: startDate,
                         lte: endDate

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -108,7 +108,7 @@ export const POST = withKiosk(
             // 6. Check-in or check-out
             const activeVisit = await tx.visit.findFirst({
                 where: {
-                    participantId: participant.id,
+                    personId: participant.id,
                     departedAt: null,
                 },
                 orderBy: { arrivedAt: "desc" },

--- a/checkin-app/src/app/attendance/household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/attendance/household/__tests__/page.test.tsx
@@ -19,7 +19,7 @@ describe("HouseholdCheckins", () => {
         mockFetchJson({
             "/api/household/visits": {
                 visits: [
-                    { id: 1, participant: { name: "Kid One" }, event: { name: "Open Shop" }, arrivedAt: "2026-06-01T10:00:00.000Z", departedAt: "2026-06-01T11:00:00.000Z" },
+                    { id: 1, person: { name: "Kid One" }, event: { name: "Open Shop" }, arrivedAt: "2026-06-01T10:00:00.000Z", departedAt: "2026-06-01T11:00:00.000Z" },
                 ],
             },
         });

--- a/checkin-app/src/app/attendance/household/page.tsx
+++ b/checkin-app/src/app/attendance/household/page.tsx
@@ -7,7 +7,7 @@ import { useRequireRole } from "@/hooks/useRequireRole";
 import { formatDate, formatVisitRange, formatDateTime } from "@/lib/time";
 import { AttendanceTabs } from "../AttendanceTabs";
 
-type Visit = { id: number; participant?: { name: string }; event?: { name: string }; arrivedAt: string; departedAt?: string };
+type Visit = { id: number; person?: { name: string }; event?: { name: string }; arrivedAt: string; departedAt?: string };
 
 export default function HouseholdCheckins() {
   const { ready, loading: authLoading } = useRequireRole([]);
@@ -68,7 +68,7 @@ export default function HouseholdCheckins() {
           <Table.Tbody>
             {visits.map((v) => (
               <Table.Tr key={v.id}>
-                <Table.Td><Text fw={600} c="blue">{v.participant?.name || 'Unnamed household member'}</Text></Table.Td>
+                <Table.Td><Text fw={600} c="blue">{v.person?.name || 'Unnamed household member'}</Text></Table.Td>
                 <Table.Td>{v.event?.name || 'General Facility Visit'}</Table.Td>
                 <Table.Td>{formatDateTime(v.arrivedAt, { dateStyle: 'short', timeStyle: 'short' })}</Table.Td>
                 <Table.Td>{formatVisitRange(v.arrivedAt, v.departedAt)}</Table.Td>

--- a/checkin-app/src/app/facility-ops/visits/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/visits/__tests__/page.test.tsx
@@ -10,8 +10,8 @@ import AdminVisitsPage from "../page";
 beforeEach(() => resetRtl());
 
 const visits = [
-  { id: 1, arrivedAt: "2026-01-01T14:00:00.000Z", departedAt: "2026-01-01T16:00:00.000Z", arrivedVia: "SCANNER", departedVia: "WEB", participant: { name: "Val Volunteer" }, event: { name: "Open Gym" } },
-  { id: 2, arrivedAt: "2026-01-02T14:00:00.000Z", departedAt: null, arrivedVia: "WEB", participant: { name: "Stu Student" }, event: null },
+  { id: 1, arrivedAt: "2026-01-01T14:00:00.000Z", departedAt: "2026-01-01T16:00:00.000Z", arrivedVia: "SCANNER", departedVia: "WEB", person: { name: "Val Volunteer" }, event: { name: "Open Gym" } },
+  { id: 2, arrivedAt: "2026-01-02T14:00:00.000Z", departedAt: null, arrivedVia: "WEB", person: { name: "Stu Student" }, event: null },
 ];
 
 describe("facility-ops/visits page", () => {

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -15,7 +15,7 @@ type Visit = {
   departedAt?: string | null;
   arrivedVia?: VisitSource | null;
   departedVia?: VisitSource | null;
-  participant?: { name?: string | null; email?: string | null } | null;
+  person?: { name?: string | null; email?: string | null } | null;
   event?: { name?: string | null } | null;
 };
 
@@ -40,7 +40,7 @@ type SortKey = 'id' | 'participant' | 'event' | 'arrivedAt' | 'departedAt';
 const sortValue = (v: Visit, key: SortKey): string | number => {
   switch (key) {
     case 'id': return v.id;
-    case 'participant': return (v.participant?.name || v.participant?.email || '').toLowerCase();
+    case 'participant': return (v.person?.name || v.person?.email || '').toLowerCase();
     case 'event': return (v.event?.name || 'Open Facility').toLowerCase();
     case 'arrivedAt': return v.arrivedAt ? Date.parse(v.arrivedAt) : 0;
     case 'departedAt': return v.departedAt ? Date.parse(v.departedAt) : 0;
@@ -166,7 +166,7 @@ export default function AdminVisitsPage() {
             {sortedVisits.map((v) => (
               <Table.Tr key={v.id}>
                 <Table.Td>{v.id}</Table.Td>
-                <Table.Td>{v.participant?.name || v.participant?.email}</Table.Td>
+                <Table.Td>{v.person?.name || v.person?.email}</Table.Td>
                 <Table.Td>{v.event?.name || 'Open Facility'}</Table.Td>
 
                 {editingVisitId === v.id ? (

--- a/checkin-app/src/app/program-ops/sessions/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/__tests__/page.test.tsx
@@ -42,7 +42,7 @@ function baseEvent(overrides: Record<string, unknown> = {}) {
                 { participantId: 3, participant: { id: 3, name: "Pat Participant", email: "pat@example.com" } },
             ],
         },
-        visits: [{ id: 1, participantId: 3, arrivedAt: "2020-01-01T18:05:00.000Z", departedAt: null }],
+        visits: [{ id: 1, personId: 3, arrivedAt: "2020-01-01T18:05:00.000Z", departedAt: null }],
         rsvps: [{ personId: 3, status: "ATTENDING" }],
         ...overrides,
     };

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -35,7 +35,7 @@ type EventData = {
   };
   visits: {
     id: number;
-    participantId: number;
+    personId: number;
     arrivedAt: string;
     departedAt: string | null;
   }[];
@@ -264,7 +264,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
           </Table.Thead>
           <Table.Tbody>
             {allRoster.map((member) => {
-              const visit = eventData.visits.find(v => v.participantId === member.participantId);
+              const visit = eventData.visits.find(v => v.personId === member.participantId);
               let statusEl;
               if (visit) {
                 const arriveTime = new Date(visit.arrivedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });

--- a/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
@@ -43,7 +43,7 @@ describe('attendanceTransitions', () => {
     });
 
     afterEach(async () => {
-        await prisma.visit.deleteMany({ where: { participantId: { in: [participantId, unenrolledId] } } });
+        await prisma.visit.deleteMany({ where: { personId: { in: [participantId, unenrolledId] } } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
     });
 
@@ -100,7 +100,7 @@ describe('attendanceTransitions', () => {
         it('closes a plain visit with no events into a single departedAt visit', async () => {
             const arrivedAt = new Date(Date.now() - 2 * HOUR);
             const checkout = new Date();
-            const visit = await prisma.visit.create({ data: { participantId, arrivedAt } });
+            const visit = await prisma.visit.create({ data: { personId: participantId, arrivedAt } });
 
             const result = await processVisitCheckout(visit.id, checkout);
             expect(result).toHaveLength(1);
@@ -114,7 +114,7 @@ describe('attendanceTransitions', () => {
             const eventEnd = new Date(t0.getTime() + 2 * HOUR);
             const checkout = new Date(t0.getTime() + 3 * HOUR);
             const ev = await makeEvent('mid', eventStart, eventEnd);
-            const visit = await prisma.visit.create({ data: { participantId, arrivedAt: t0 } });
+            const visit = await prisma.visit.create({ data: { personId: participantId, arrivedAt: t0 } });
 
             const result = await processVisitCheckout(visit.id, checkout);
 
@@ -142,7 +142,7 @@ describe('attendanceTransitions', () => {
             const checkout = new Date(t0.getTime() + 4 * HOUR);
             const e1 = await makeEvent('back1', e1Start, e1End);
             const e2 = await makeEvent('back2', e2Start, e2End);
-            const visit = await prisma.visit.create({ data: { participantId, arrivedAt: t0 } });
+            const visit = await prisma.visit.create({ data: { personId: participantId, arrivedAt: t0 } });
 
             const result = await processVisitCheckout(visit.id, checkout);
 
@@ -158,7 +158,7 @@ describe('attendanceTransitions', () => {
 
         it('returns [] for an already-departedAt visit (idempotent)', async () => {
             const visit = await prisma.visit.create({
-                data: { participantId, arrivedAt: new Date(Date.now() - HOUR), departedAt: new Date() },
+                data: { personId: participantId, arrivedAt: new Date(Date.now() - HOUR), departedAt: new Date() },
             });
             const result = await processVisitCheckout(visit.id, new Date());
             expect(result).toEqual([]);

--- a/checkin-app/src/lib/attendanceConflicts.ts
+++ b/checkin-app/src/lib/attendanceConflicts.ts
@@ -112,31 +112,31 @@ export async function getLeadConflicts(userId: number): Promise<AttendanceConfli
   // conflict in this lead's scope — fetch their full visit set, then cluster.
   const anchored = await prisma.visit.findMany({
     where: { associatedEventId: { in: [...ledEventName.keys()] } },
-    select: { participantId: true },
+    select: { personId: true },
   });
-  const participantIds = [...new Set(anchored.map((v) => v.participantId))];
+  const participantIds = [...new Set(anchored.map((v) => v.personId))];
   if (participantIds.length === 0) return [];
 
   const visits = await prisma.visit.findMany({
-    where: { participantId: { in: participantIds } },
+    where: { personId: { in: participantIds } },
     select: {
       id: true,
-      participantId: true,
+      personId: true,
       arrivedAt: true,
       departedAt: true,
       arrivedVia: true,
       departedVia: true,
       associatedEventId: true,
-      participant: { select: { name: true } },
+      person: { select: { name: true } },
     },
     orderBy: { arrivedAt: "asc" },
   });
 
   const byParticipant = new Map<number, typeof visits>();
   for (const v of visits) {
-    const list = byParticipant.get(v.participantId) ?? [];
+    const list = byParticipant.get(v.personId) ?? [];
     list.push(v);
-    byParticipant.set(v.participantId, list);
+    byParticipant.set(v.personId, list);
   }
 
   const conflicts: AttendanceConflict[] = [];
@@ -146,7 +146,7 @@ export async function getLeadConflicts(userId: number): Promise<AttendanceConfli
       if (!anchor) continue; // overlap exists but not in this lead's scope
       conflicts.push({
         participantId,
-        participantName: pVisits[0].participant.name ?? `Participant ${participantId}`,
+        participantName: pVisits[0].person.name ?? `Participant ${participantId}`,
         eventId: anchor.associatedEventId!,
         eventName: ledEventName.get(anchor.associatedEventId!) ?? `Event ${anchor.associatedEventId}`,
         visits: cluster.map((v) => ({

--- a/checkin-app/src/lib/attendanceTransitions.ts
+++ b/checkin-app/src/lib/attendanceTransitions.ts
@@ -97,7 +97,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
 
     // Chunks recreated below are all segments of one physical visit: they keep
     // the original arrival's source and take `source` as their departure channel.
-    const { participantId, arrivedAt, arrivedVia } = originalVisit;
+    const { personId: participantId, arrivedAt, arrivedVia } = originalVisit;
 
     const relevantProgramIds = await getRelevantProgramIds(participantId, db);
 
@@ -150,7 +150,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
                 if (currentIterStart < gapEnd) {
                     createdVisits.push(await tx.visit.create({
                         data: {
-                            participantId,
+                            personId: participantId,
                             arrivedAt: currentIterStart,
                             departedAt: gapEnd,
                             arrivedVia,
@@ -180,7 +180,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
             if (eventVisitStart < eventVisitEnd) {
                 createdVisits.push(await tx.visit.create({
                     data: {
-                        participantId,
+                        personId: participantId,
                         arrivedAt: eventVisitStart,
                         departedAt: eventVisitEnd,
                         arrivedVia,
@@ -196,7 +196,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
         if (currentIterStart < checkoutTime) {
             createdVisits.push(await tx.visit.create({
                 data: {
-                    participantId,
+                    personId: participantId,
                     arrivedAt: currentIterStart,
                     departedAt: checkoutTime,
                     arrivedVia,

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -328,7 +328,7 @@ export async function createCheckins(prisma: Db): Promise<string> {
         });
         await prisma.visit.create({
             data: {
-                participantId: p.id,
+                personId: p.id,
                 arrivedAt: arrived,
                 // Leave the most recent two still "here" (no departure) for active-visit screens.
                 departedAt: i < 2 ? null : new Date(arrived.getTime() + 90 * 60 * 1000),

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -5,7 +5,7 @@ export async function getFullAttendance() {
     const activeVisits = await prisma.visit.findMany({
         where: { departedAt: null },
         include: {
-            participant: {
+            person: {
                 select: {
                     id: true,
                     // email is read only to resolve the name fallback below and never
@@ -42,12 +42,12 @@ export async function getFullAttendance() {
     // Pre-compute isYouth once per visit to avoid repeated calculations
     const youthMap = new Map<number, boolean>();
     for (const v of activeVisits) {
-        youthMap.set(v.id, isYouth(v.participant.dateOfBirth));
+        youthMap.set(v.id, isYouth(v.person.dateOfBirth));
     }
 
-    const keyholderVisits = activeVisits.filter(v => v.participant.isKeyholder);
+    const keyholderVisits = activeVisits.filter(v => v.person.isKeyholder);
     const youthVisits = activeVisits.filter(v => youthMap.get(v.id)!);
-    const volunteerVisits = activeVisits.filter(v => !v.participant.isKeyholder && !youthMap.get(v.id));
+    const volunteerVisits = activeVisits.filter(v => !v.person.isKeyholder && !youthMap.get(v.id));
 
     const counts = {
         keyholders: keyholderVisits.length,
@@ -58,8 +58,8 @@ export async function getFullAttendance() {
 
     const adultVisits = activeVisits.filter(v => !youthMap.get(v.id));
     const unaccompaniedYouth = youthVisits.filter(sv => {
-        if (!sv.participant.householdId) return true;
-        return !adultVisits.some(av => av.participant.householdId === sv.participant.householdId);
+        if (!sv.person.householdId) return true;
+        return !adultVisits.some(av => av.person.householdId === sv.person.householdId);
     });
     const safety = {
         isLastKeyholder: keyholderVisits.length === 1,
@@ -69,16 +69,18 @@ export async function getFullAttendance() {
     // Drop email/googleId from the wire (M1): resolve the same name-or-email-prefix
     // fallback the UI already falls back to (`name || email.split("@")[0]`) here,
     // server-side, so `name` is always populated and the raw address never ships.
-    const attendance = activeVisits.map(v => ({
+    // Strip the raw included `person` (carries email) out of the spread and re-emit
+    // a sanitized DTO under the unchanged wire key `participant` (API contract).
+    const attendance = activeVisits.map(({ person, ...v }) => ({
         ...v,
         participant: {
-            id: v.participant.id,
-            name: v.participant.name?.trim() || v.participant.email?.split("@")[0] || null,
-            isKeyholder: v.participant.isKeyholder,
-            dateOfBirth: v.participant.dateOfBirth,
-            householdId: v.participant.householdId,
-            phone: v.participant.phone,
-            household: v.participant.household,
+            id: person.id,
+            name: person.name?.trim() || person.email?.split("@")[0] || null,
+            isKeyholder: person.isKeyholder,
+            dateOfBirth: person.dateOfBirth,
+            householdId: person.householdId,
+            phone: person.phone,
+            household: person.household,
         },
     }));
 

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -21,7 +21,7 @@ export async function processCheckin(participant: Participant, authType: string,
         const activeKeyholders = await db.visit.count({
             where: {
                 departedAt: null,
-                participant: { isKeyholder: true }
+                person: { isKeyholder: true }
             }
         });
 
@@ -35,7 +35,7 @@ export async function processCheckin(participant: Participant, authType: string,
 
     const newVisit = await db.visit.create({
         data: {
-            participantId: participant.id,
+            personId: participant.id,
             arrivedAt: arrivalTime,
             arrivedVia: "SCANNER",
             associatedEventId: eventId
@@ -75,7 +75,7 @@ export async function processCheckout(
         const remainingKeyholders = await db.visit.count({
             where: {
                 departedAt: null,
-                participant: { isKeyholder: true },
+                person: { isKeyholder: true },
                 id: { not: activeVisitId }
             }
         });
@@ -86,7 +86,7 @@ export async function processCheckout(
                     departedAt: null,
                     id: { not: activeVisitId }
                 },
-                include: { participant: true }
+                include: { person: true }
             });
 
             if (remainingUsers.length > 0) {
@@ -106,7 +106,7 @@ export async function processCheckout(
                 }
 
                 if (!confirmForceClose) {
-                    const names = remainingUsers.map(u => u.participant.name || u.participant.email).join(", ");
+                    const names = remainingUsers.map(u => u.person.name || u.person.email).join(", ");
                     return apiJson({
                         error: `Warning! You are the last isKeyholder, but others are here:\n${names}\n\nBadge again within 10 seconds to confirm you've checked them and close the facility.`,
                         type: "warning" as const

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -105,9 +105,9 @@ export async function buildCallerContext(auth: AuthResult): Promise<CallerContex
     if (ctx.isKeyholder) {
         const visits = await prisma.visit.findMany({
             where: { departedAt: null },
-            select: { participantId: true },
+            select: { personId: true },
         });
-        for (const v of visits) ctx.activeVisitorIds.add(v.participantId);
+        for (const v of visits) ctx.activeVisitorIds.add(v.personId);
     }
 
     return ctx;

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -239,7 +239,7 @@ export const classifications = {
     },
     Visit: {
         id: 'public',
-        participantId: 'public',
+        personId: 'public',
         arrivedAt: 'personal',
         departedAt: 'personal',
         arrivedVia: 'public',
@@ -441,7 +441,7 @@ export const relations = {
         person: { model: 'Participant', isList: false },
     },
     Visit: {
-        participant: { model: 'Participant', isList: false },
+        person: { model: 'Participant', isList: false },
         event: { model: 'Event', isList: false },
     },
     AuditLog: {

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -93,7 +93,7 @@ export const SCOPE_BINDINGS = {
         their_program_participants: { field: 'personId', inCtx: 'participantIdsInScopePrograms' },
     },
     Visit: {
-        their_own: { field: 'participantId', eqCtx: 'selfId' },
+        their_own: { field: 'personId', eqCtx: 'selfId' },
         all_current_visitors: {
             all: [{ flag: 'isKeyholder' }, { field: 'departedAt', isNull: true }],
         },

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -133,8 +133,8 @@ function referenceScopesHeld(
             break;
         }
         case 'Visit': {
-            const participantId = num(row.participantId);
-            if (participantId !== undefined && participantId === ctx.selfId) scopes.add('their_own');
+            const personId = num(row.personId);
+            if (personId !== undefined && personId === ctx.selfId) scopes.add('their_own');
             if (ctx.isKeyholder && row.departedAt == null) scopes.add('all_current_visitors');
             break;
         }

--- a/checkin-app/tests/security/stripper.test.ts
+++ b/checkin-app/tests/security/stripper.test.ts
@@ -105,8 +105,8 @@ describe('scopesHeld', () => {
         expect(scopesHeld('Participant', { id: 9 }, ctxNoKey).has('all_current_visitors')).toBe(false);
     });
 
-    it('Visit.their_own when row.participantId === selfId', () => {
-        expect(scopesHeld('Visit', { participantId: 5, departedAt: null }, ctx({ selfId: 5 })).has('their_own')).toBe(true);
+    it('Visit.their_own when row.personId === selfId', () => {
+        expect(scopesHeld('Visit', { personId: 5, departedAt: null }, ctx({ selfId: 5 })).has('their_own')).toBe(true);
     });
 
     it('Visit.all_current_visitors requires isKeyholder AND departedAt === null', () => {


### PR DESCRIPTION
## What

First slice (**A1a**) of the Participant→Person rename. Renames **only** the `Visit` model's FK column + relation field. The model stays named `Participant` — Prisma allows `person Participant @relation(fields: [personId], references: [id])` while the model keeps its old name, so this lands *before* the atomic model-name flip.

- `Visit.participantId` → `personId`
- relation `participant` → `person`
- `@@index([participantId, departedAt])` → `@@index([personId, departedAt])`

Every **other** model keeps `participantId` — they are separate slices (A1b–A1f).

## Why

Renaming a Prisma *model* is atomic (kills all ~701 `prisma.participant` accessors at once). Strategy: move everything not tied to the model name out first, in small green slices, so the final flip is purely mechanical. This is the Visit FK slice.

## Migration

`20260702053421_visit_participantid_to_personid` uses `ALTER TABLE RENAME COLUMN` (+ rename index & FK constraint) instead of Prisma's default DROP+ADD. **Why it matters:** a DROP COLUMN would CASCADE-drop the raw-SQL partial unique index `Visit_one_open_per_participant` (the double-checkin backstop from `20260629180000`). RENAME preserves data and the partial index — verified it now sits on `personId`:

```
Visit_one_open_per_participant | ... ON "Visit" (personId) WHERE (departedAt IS NULL)
```

## Reviewer notes

- **tsc is not a complete net here.** Prisma's recursive `WhereInput` suppresses excess-property checks, so a stale `where: { participantId }` / relation-filter on Visit compiles clean and only throws `PrismaClientValidationError` at runtime. The green tsc was backed by a full integration run to catch the `where`-clause sites.
- **getFullAttendance** output DTO key stays `participant` (public API contract for `attendance/current`); the raw `person` is destructured out of the `...v` spread so the M1 email-drop still holds.
- **Security:** `SCOPE_BINDINGS Visit.their_own` → `field: 'personId'`, plus the frozen-switch reference in `scopeBindingsEquivalence.test.ts`.
- **Frontend** consumers of raw-visit JSON updated: `facility-ops/visits`, `attendance/household`, `program-ops/sessions`.
- Audit `newData`/`oldData` JSON left as each route emits (free-form metadata, not a schema contract).
- Expect a rebase around `facility/trends` + `getFullAttendance` (in-flight trends-fix chip).

## Verification

- `npx tsc --noEmit` → **0 errors**
- Integration: **829 / 829** pass (105 suites)
- Unit: **1086 / 1086** pass (182 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)