### PR TITLE
docs(flow-tests): standalone runner + loud failure when no server up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,14 @@ routes, auth, and DB together.
 
 - **Config:** `jest.flow.config.js` (node env, **skips `jest.setup.js`** so it
   uses native `fetch` with `getSetCookie` and no prisma/next-auth mocks).
-- **Run locally:** start the app (`npm run dev`, serves `:4000`) against a seeded
-  local DB, then `npm run test:flow`. Override the target with
+- **Run locally, no setup:** `npm run test:flow:standalone` (from `checkin-app/`)
+  — brings up `deploy/docker-compose.flow.yml` (Postgres + seeded dev server),
+  runs the suite inside that container, tears down. This is what CI does; use
+  it unless you already have a dev server running.
+- **Run against a server you already have up:** start the app (`npm run dev`,
+  serves `:4000`) against a seeded local DB, then `npm run test:flow`. Bare
+  `test:flow` does NOT start anything — it assumes `:4000` is already live and
+  fails with a connection error otherwise. Override the target with
   `FLOW_BASE_URL=http://host:port`.
 - **Auth:** `flow-tests/helpers.ts` → `loginAs(email)` signs in via the local
   **persona-mint** flow (resolves the seeded persona by its stable email, since

--- a/checkin-app/flow-tests/helpers.ts
+++ b/checkin-app/flow-tests/helpers.ts
@@ -25,7 +25,15 @@ export async function loginAs(email: string): Promise<Session> {
     const jar: Jar = new Map();
 
     // Persona ids are autoincrement (vary per seed) — resolve by stable email.
-    const list = await (await fetch(`${BASE}/api/auth/dev-personas`)).json();
+    const res = await fetch(`${BASE}/api/auth/dev-personas`).catch(() => null);
+    if (!res) {
+        throw new Error(
+            `no server reachable at ${BASE}. Flow tests don't start one — run ` +
+            `'npm run test:flow:standalone' (spins Postgres + a seeded dev server via ` +
+            `docker), or start 'npm run dev' yourself first and rerun 'npm run test:flow'.`,
+        );
+    }
+    const list = await res.json();
     const persona = (list.personas ?? []).find((p: { email: string }) => p.email === email);
     if (!persona) throw new Error(`dev persona not found: ${email} (need CHECKIN_ENV=local + a seeded DB)`);
 

--- a/checkin-app/package.json
+++ b/checkin-app/package.json
@@ -10,6 +10,7 @@
     "test": "jest --runInBand",
     "test:ci": "jest --ci --runInBand",
     "test:flow": "jest --config jest.flow.config.js --ci --runInBand --forceExit",
+    "test:flow:standalone": "docker compose -f ../deploy/docker-compose.flow.yml up -d --wait --wait-timeout 600 && docker compose -f ../deploy/docker-compose.flow.yml exec -T app sh -lc \"cd checkin-app && npm run test:flow\"; ec=$?; docker compose -f ../deploy/docker-compose.flow.yml down -v; exit $ec",
     "test:integration": "INTEGRATION_DB=1 jest --ci --testPathIgnorePatterns=/node_modules/ --testRegex \"\\.integration\\.test\\.[jt]sx?$\"",
     "test:coverage": "INTEGRATION_DB=1 jest --ci --coverage --testPathIgnorePatterns \"/node_modules/|/\\.next/|/\\.claude/worktrees/|\\.flow\\.test\\.\"",
     "check-route-coverage": "ts-node --project scripts/tsconfig.json scripts/check-route-coverage.ts",


### PR DESCRIPTION
## Summary
- Add `npm run test:flow:standalone` — spins up `deploy/docker-compose.flow.yml` (seeded Postgres + dev server), runs the flow suite inside the container, tears down. Mirrors what CI already does; no need to hand-start `npm run dev` first.
- `flow-tests/helpers.ts`'s `loginAs` now throws a clear error naming both run options when nothing answers on the target host, instead of an opaque `ECONNREFUSED`/fetch failure.
- `AGENTS.md` Flow tests section documents both paths (standalone vs. bring-your-own-server).

## Why
Bare `npm run test:flow` assumes a dev server is already live on `:4000` and gives no signal when it isn't — locally reproducible as "system claims nothing is running on port 4000." Nothing in the repo pointed at the docker-compose CI already uses for this, so the standalone option existed but wasn't discoverable.

## Test plan
- [x] `npm run test:flow:standalone` run end-to-end locally: pulled images, brought up Postgres + seeded dev server, ran `membership-bg-nonblocking.flow.test.ts` (passed), tore down cleanly.
- [x] `npx tsc --noEmit` clean on `helpers.ts` changes.