### PR TITLE
fix(program-ops): remove dead joinedAt UI on program roster

### DIFF
--- a/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
@@ -34,11 +34,11 @@ const programData = {
   memberOnly: false,
   participants: [
     {
-      participantId: 101, status: "ACTIVE", joinedAt: "2026-01-05T00:00:00.000Z", pendingSince: null,
+      participantId: 101, status: "ACTIVE", pendingSince: null,
       participant: { name: "Alice Kid", email: "alice@example.com", phone: "5125551234" },
     },
     {
-      participantId: 102, status: "PENDING", joinedAt: null, pendingSince: "2026-01-06T00:00:00.000Z",
+      participantId: 102, status: "PENDING", pendingSince: "2026-01-06T00:00:00.000Z",
       participant: { name: "Charlie Kid", email: "charlie@example.com" },
     },
   ],

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -29,7 +29,6 @@ type ProgramDetail = {
   participants: {
     participantId: number;
     status: string;
-    joinedAt: string | null;
     pendingSince: string | null;
     participant: {
       name: string | null;
@@ -518,7 +517,6 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                         <SimpleGrid cols={{ base: 1, sm: 2 }} mt="xs" spacing="xs">
                           <Text size="sm" c="dimmed"><strong>Email:</strong> {p.participant.email}</Text>
                           <Text size="sm" c="dimmed"><strong>Phone:</strong> {p.participant.phone ? formatPhone(p.participant.phone) : 'N/A'}</Text>
-                          <Text size="sm" c="dimmed"><strong>Joined:</strong> {p.joinedAt ? formatDateTime(p.joinedAt) : 'N/A'}</Text>
                           {p.participant.household && (
                             <Text size="sm" c="dimmed" style={{ gridColumn: '1 / -1' }}>
                               <strong>Emergency Contact{(p.participant.household.emergencyContacts?.length ?? 0) > 1 ? 's' : ''}:</strong>{' '}


### PR DESCRIPTION
## Summary
- `ProgramParticipant` has no `joinedAt` column and never did — traced via `git log -S` back to commit `2fb12440` (an AI-authored change) which added the "Joined" date UI to the program roster without ever adding the field to `schema.prisma`. It's always rendered "N/A".
- No consumer reads `joinedAt` anywhere else in the codebase, and there's no reporting/billing need for an enrollment-activation timestamp today, so the dead field/render is removed rather than adding an unused DB column + migration.
- Also removed the field from the roster page's TS type and the test mock that had been hand-injecting `joinedAt` into the fake API response (which is why tsc/jest never caught the mismatch).

## Test plan
- [x] `npm -w checkin-app exec -- jest` on the affected suite (`page.test.tsx`) — 4/4 passing
- [x] `tsc --noEmit` clean on the touched file