### PR TITLE
fix(finance-ops): guard + audit payment-plan approval

### DIFF
--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -23,26 +23,47 @@ export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
 
 export const POST = withAuth(
     { roles: ['isSysadmin', 'isBoardMember'] },
-    async (req) => {
+    async (req, auth) => {
         try {
             const body = await req.json();
-            const { programId, participantId } = body;
+            const programId = parseInt(body.programId, 10);
+            const participantId = parseInt(body.participantId, 10);
 
-            const updated = await prisma.programParticipant.update({
-                where: {
-                    programId_participantId: {
-                        programId: parseInt(programId, 10),
-                        participantId: parseInt(participantId, 10)
-                    }
-                },
-                data: {
-                    status: 'ACTIVE',
-                    isPaymentPlanRequested: false, // cleared since it's approved
-                    pendingSince: null // reset
-                }
+            if (Number.isNaN(programId) || Number.isNaN(participantId)) {
+                return NextResponse.json({ error: "programId and participantId are required" }, { status: 400 });
+            }
+
+            const data = {
+                status: 'ACTIVE' as const,
+                isPaymentPlanRequested: false, // cleared since it's approved
+                pendingSince: null // reset
+            };
+
+            // Scope to the pending request so approving a non-pending/nonexistent
+            // request is a no-op error, mirroring the GET queue's filter.
+            const { count } = await prisma.programParticipant.updateMany({
+                where: { programId, participantId, isPaymentPlanRequested: true, status: 'PENDING' },
+                data
             });
 
-            return NextResponse.json({ success: true, participant: updated });
+            if (count === 0) {
+                return NextResponse.json({ error: "No pending payment-plan request" }, { status: 409 });
+            }
+
+            if (auth.type === 'session') {
+                await prisma.auditLog.create({
+                    data: {
+                        actorId: auth.user.id,
+                        action: "EDIT",
+                        tableName: "ProgramParticipant",
+                        affectedEntityId: participantId,
+                        secondaryAffectedEntity: programId,
+                        newData: data
+                    }
+                });
+            }
+
+            return NextResponse.json({ success: true });
         } catch (error) {
             console.error("Failed to approve payment plan:", error);
             return NextResponse.json({ error: "Failed to approve payment plan" }, { status: 500 });


### PR DESCRIPTION
## What

The `POST /api/finance-ops/payment-plans` approve handler had a data-integrity bug: it flipped **any** `(programId, participantId)` `ProgramParticipant` to `status: 'ACTIVE'` via `update()`, applying neither guard the sibling `GET` queue applies (`isPaymentPlanRequested: true AND status: 'PENDING'`) and writing no `auditLog` row — so a money/enrollment state change was both unguarded and untraceable.

## Changes

- **Scoped `update` → `updateMany`** with `where: { programId, participantId, isPaymentPlanRequested: true, status: 'PENDING' }`. Returns **409** `"No pending payment-plan request"` when `count === 0`, so approving a non-pending/nonexistent request is a no-op error instead of a silent success.
- **Input validation**: `parseInt` both ids up front; **400** when either is `NaN` (previously `parseInt(undefined,10)` → NaN → generic 500).
- **Audit trail**: writes an `auditLog` row attributed to the acting board member (`auth.user.id`) — action `EDIT`, `tableName: 'ProgramParticipant'`, `affectedEntityId: participantId`, `secondaryAffectedEntity: programId`, `newData`. Mirrors the membership-ops sibling pattern. Added `auth` to the `withAuth` callback signature and gated the write on `auth.type === 'session'`.

Authz (`roles: ['isSysadmin', 'isBoardMember']`) unchanged.

## Reviewer notes

- `action` is `EDIT` (state transition on an existing enrollment), matching the membership-ops status flips.
- The audit write is gated `auth.type === 'session'` like the sibling routes — API-token callers skip the log (no `user.id` to attribute).

## Testing

- `programPaymentPlansAPI.integration.test.ts` — 12/12 pass
- `payment-plans-strip.test.ts` — 3/3 pass
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)