### PR TITLE
fix(auth): gate NextAuth debug to dev instances

### DIFF
--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -71,7 +71,7 @@ const BOOTSTRAP_SYSADMINS = (process.env.BOOTSTRAP_SYSADMINS || "")
     .filter(Boolean);
 
 export const authOptions: NextAuthOptions = {
-    debug: true,
+    debug: config.isDevInstance(),
     adapter: patchedAdapter,
     providers: [
         GoogleProvider({


### PR DESCRIPTION
## What

`checkin-app/src/lib/auth-options.ts` had `debug: true` hardcoded on the `authOptions` object. Changed to `debug: config.isDevInstance()`.

## Why

Unconditional `debug: true` makes NextAuth emit verbose auth internals — callback payloads, token/profile contents, provider errors — to the server logger in **all** environments, including production. That's sensitive data leaking into prod logs.

`config.isDevInstance()` returns true for dev + local, false for prod, and fails safe to false on unset `CHECKIN_ENV`. So debug logging stays on in dev/local and off in prod.

## Notes for reviewer

- One-line change. `config` was already imported (line 9) and `config.isDevInstance()` already used elsewhere in the file (line 104), so this matches existing conventions.
- No test added — config flag flip. No existing test asserts on the `debug` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)