### PR TITLE
docs(schema): clarify membershipVariantId is internal (server-built link)

### DIFF
--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -399,8 +399,11 @@ model BoardSettings {
   /// @sensitivity:public
   membershipYearBoundary     DateTime?
   /// Shopify variant ID of the membership product everyone checks out through.
-  /// The "Pay with Shopify" link is built from it as
-  /// https://<SHOPIFY_STORE_DOMAIN>/cart/<membershipVariantId>:1.
+  /// The "Pay with Shopify" link is built from it SERVER-SIDE (ensurePaymentLink
+  /// in lib/membership/payment.ts) as
+  /// https://<SHOPIFY_STORE_DOMAIN>/cart/<membershipVariantId>:1; the client only
+  /// receives the derived checkoutUrl, never this raw field — hence internal, not
+  /// public (contrast Program.shopify*VariantId, which the browser builds from).
   /// @sensitivity:internal
   membershipVariantId        String?
   /// Discount code (created in Shopify by the board) appended to the checkout


### PR DESCRIPTION
## What

Fixes a misleading doc comment on `BoardSettings.membershipVariantId` in `schema.prisma`. Comment-only; no tier change, no logic change.

## Why

Investigation into Shopify/commerce ID tiering found the field's comment said the "Pay with Shopify" link is *built from* `membershipVariantId` — but omitted that it's built **server-side** (`ensurePaymentLink` in `lib/membership/payment.ts`). The client only ever receives the derived `checkoutUrl`, never the raw variant ID. That is precisely why the field is `internal`, not `public`.

Contrast `Program.shopifyMemberVariantId` / `shopifyNonMemberVariantId`, which are `public` because the **browser** builds the checkout URL from them and therefore must receive the raw value. Without noting this contrast, a future reader could "fix" the apparent inconsistency by promoting `membershipVariantId` to `public`, leaking a field that never needs to leave the server.

## Investigation findings (context, not shipped)

- Three-way Shopify ID tiering (public / internal / personal) is defensible once the rule keys on *does the client need the raw value* rather than *ID class*. No field needs to move.
- `BoardSettings.*` internal tiers are runtime-**inert**: `GET /api/settings/membership` is hand-rolled `withAuth` (role-gated to sysadmin/board), not routed through `handler()`, so the classification never runs.
- `shopifyInvoiceUrl` (personal), `shopifyDraftOrderId`, `shopifyMembershipProductId` have zero consumers — dead/latent.
- `shopify.product.create` outbound spec `tiers: ['public']` is correct and minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)