### PR TITLE
fix(events): validate attendance targets belong to the event's program (IDOR)

### DIFF
--- a/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
@@ -102,6 +102,16 @@ describe('Event Attendance API Integration Tests', () => {
             }
         });
         testEventId = event.id;
+
+        // Attendance can only be written for participants enrolled (or volunteering)
+        // in the event's program — enroll the two targets so the happy-path writes
+        // are authorized. testUserId is deliberately left unenrolled (IDOR target).
+        await prisma.programParticipant.createMany({
+            data: [
+                { programId: testProgramId, personId: testParticipant1Id },
+                { programId: testProgramId, personId: testParticipant2Id },
+            ]
+        });
     });
 
     afterAll(async () => {
@@ -111,6 +121,10 @@ describe('Event Attendance API Integration Tests', () => {
         });
         await prisma.event.deleteMany({
             where: { id: testEventId }
+        });
+        // FK: enrollments reference the program — clear before deleting it.
+        await prisma.programParticipant.deleteMany({
+            where: { programId: { in: [testProgramId, foreignProgramId] } }
         });
         await prisma.program.deleteMany({
             where: { id: { in: [testProgramId, foreignProgramId] } }
@@ -322,6 +336,25 @@ describe('Event Attendance API Integration Tests', () => {
                 associatedEventId: testEventId,
                 synthetic: false
             });
+        });
+
+        it('IDOR: the event lead cannot fabricate attendance for a participant NOT enrolled in the program (400, no Visit written)', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testLeadMentorId, isSysadmin: false, isBoardMember: false, isKeyholder: false }
+            });
+
+            // testUserId is a real participant but enrolled in no program.
+            const before = await prisma.visit.count({ where: { personId: testUserId, associatedEventId: testEventId } });
+
+            const req = new Request(`http://localhost:4000/api/events/${testEventId}/attendance`, {
+                method: 'POST',
+                body: JSON.stringify({ participantIds: [testUserId] })
+            });
+            const res = await POST(req as unknown as import("next/server").NextRequest, { params: Promise.resolve({ id: String(testEventId) }) });
+
+            expect(res.status).toBe(400);
+            const after = await prisma.visit.count({ where: { personId: testUserId, associatedEventId: testEventId } });
+            expect(after).toBe(before);
         });
     });
 });

--- a/checkin-app/src/app/api/events/[id]/attendance/route.ts
+++ b/checkin-app/src/app/api/events/[id]/attendance/route.ts
@@ -36,32 +36,70 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             return NextResponse.json({ error: "participantIds array is required" }, { status: 400 });
         }
 
+        // Authz on the TARGETS: only participants enrolled or volunteering in
+        // this event's program may have attendance written. Without this a lead
+        // mentor of program A could fabricate presence records for anyone in the
+        // system (other households/programs). Enrollment/volunteer membership —
+        // not an existing overlapping Visit — is the authority; unknown ids are
+        // rejected (a genuine unenrolled walk-in needs a separate manual step).
+        // A program-less event is reachable only by admin/board (the lead/core-vol
+        // gate above requires a program), so there is no cross-program IDOR there
+        // and no enrollment set to check — skip the filter in that case.
+        const programId = event.programId;
+        if (programId != null) {
+            const [enrolled, volunteering] = await Promise.all([
+                prisma.programParticipant.findMany({ where: { programId }, select: { personId: true } }),
+                prisma.programVolunteer.findMany({ where: { programId }, select: { personId: true } }),
+            ]);
+            const allowedIds = new Set<number>([...enrolled, ...volunteering].map(r => r.personId));
+            const unknownIds = participantIds.filter(pId => !allowedIds.has(pId));
+            if (unknownIds.length > 0) {
+                return NextResponse.json({ error: `Participants not enrolled or volunteering in this program: ${unknownIds.join(", ")}` }, { status: 400 });
+            }
+        }
+
+        // Dedupe within the request so a repeated id can't double-write.
+        const uniqueParticipantIds = [...new Set<number>(participantIds)];
+
         const results = await prisma.$transaction(async (tx) => {
             const actions = [];
 
-            // Pre-fetch all overlapping unassociated visits for the participants
-            const overlappingVisits = await tx.visit.findMany({
+            // Pre-fetch, for these participants: visits already recorded for THIS
+            // event (skip — avoids duplicate synthetic rows on concurrent submits)
+            // and overlapping unassociated walk-in visits (adopt into the event).
+            const relevantVisits = await tx.visit.findMany({
                 where: {
-                    personId: { in: participantIds },
-                    associatedEventId: null,
-                    arrivedAt: { lte: event.endAt },
+                    personId: { in: uniqueParticipantIds },
                     OR: [
-                        { departedAt: null },
-                        { departedAt: { gte: event.startAt } }
+                        { associatedEventId: eventId },
+                        {
+                            associatedEventId: null,
+                            arrivedAt: { lte: event.endAt },
+                            OR: [
+                                { departedAt: null },
+                                { departedAt: { gte: event.startAt } }
+                            ]
+                        }
                     ]
                 }
             });
 
-            // Map them by participantId for O(1) lookups
+            // Map by participantId for O(1) lookups.
+            const alreadyRecorded = new Set<number>();
             const visitsByParticipant = new Map();
-            for (const visit of overlappingVisits) {
-                // We just need the first matching unassociated visit for each participant.
-                if (!visitsByParticipant.has(visit.personId)) {
+            for (const visit of relevantVisits) {
+                if (visit.associatedEventId === eventId) {
+                    alreadyRecorded.add(visit.personId);
+                } else if (!visitsByParticipant.has(visit.personId)) {
+                    // First matching unassociated visit for each participant.
                     visitsByParticipant.set(visit.personId, visit);
                 }
             }
 
-            for (const pId of participantIds) {
+            for (const pId of uniqueParticipantIds) {
+                // Already attributed to this event → nothing to do (no dup row).
+                if (alreadyRecorded.has(pId)) continue;
+
                 const visit = visitsByParticipant.get(pId);
 
                 if (visit) {

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -206,6 +206,22 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                 return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
             }
 
+            // Authz on the TARGET: the participant must be enrolled or volunteering
+            // in this event's program. Without this a lead mentor could write a
+            // presence record for anyone in the system (see attendance POST). A
+            // program-less event is reachable only by admin/board (lead/core-vol
+            // authz above requires a program), so there is no IDOR to guard there.
+            const targetId = Number(participantId);
+            if (event.programId != null) {
+                const [enrolled, volunteering] = await Promise.all([
+                    prisma.programParticipant.findFirst({ where: { programId: event.programId, personId: targetId }, select: { personId: true } }),
+                    prisma.programVolunteer.findFirst({ where: { programId: event.programId, personId: targetId }, select: { personId: true } }),
+                ]);
+                if (!enrolled && !volunteering) {
+                    return NextResponse.json({ error: "Participant is not enrolled or volunteering in this program" }, { status: 400 });
+                }
+            }
+
             if (status === 'Absent') {
                 // An open visit (departedAt = null) means they physically scanned in
                 // and are currently on-site. Deleting it would destroy the live


### PR DESCRIPTION
## What

Close an IDOR / data-integrity hole in the two event-attendance write paths. Both accepted a client-supplied participant id and created `Visit` (attendance) rows **without checking the target belongs to the event's program**. A lead mentor of program A could fabricate child-safeguarding presence records for any participant in the system (other households/programs).

Caller-side authz (caller is this event's lead mentor / core-vol / admin) was already correct and is unchanged — the gap was validating the **target** ids.

## Changes

- **`POST /api/events/[id]/attendance`** — load the program's enrolled (`ProgramParticipant`) + volunteer (`ProgramVolunteer`) id set once; 400 any submitted id not in it. Enrollment/volunteer membership is the authority, **not** an existing overlapping `Visit` (a legit unenrolled walk-in needs a separate manual step, so unknown ids are rejected, not silently accepted). Also dedupe within the request and skip participants already recorded for this event (prefetch `associatedEventId: eventId`) to avoid duplicate synthetic rows on concurrent submits.
- **`manualEditAttendance` in `PATCH /api/events/[id]`** — same class, single target: reject a `participantId` not enrolled/volunteering in the program.
- A **program-less event** (`programId == null`) skips the filter: it's reachable only by admin/board (the lead/core-vol gate requires a program), so there's no cross-program IDOR and no enrollment set to check.

## Tests

- Updated `eventAttendanceAPI.integration.test.ts`: the happy-path fixtures never enrolled their targets — i.e. they asserted the exact vulnerable behavior. Enrolled the two targets; added an IDOR guard test (event lead submits an unenrolled id → 400, no `Visit` written).
- Ran the event attendance/manual integration suites foreground + serial (`--runInBand`) against a throwaway Postgres. All green (full suite: 1916 passed). The one unrelated failure (`membership-bg-nonblocking.flow.test.ts`) needs a live server on `:4000` — environmental, pre-existing.

## Consistency note (analysis, no code change here)

Per-participant "attended" in the sessions view is always `Visit`-backed (`visits.find(...)` → Arrived/Absent); RSVP and `ProgramParticipant.status` do not feed it, so per-person display and the `Visit` table cannot disagree. The event-level `attendanceConfirmedAt`/`By` is a reviewer **sign-off** with no `Visit` read/write, so it *can* be set on an event with zero visits — but no consumer treats `confirmedAt` as attendance data (`todo-counts` uses it as a work-flag; `postEventEmails` counts `visits.length` separately). Latent trap, not a current bug; a follow-up could document `confirmAttendance` as sign-off-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)