### PR TITLE
fix(db): add connection/lock timeouts to close the local DB hang

### DIFF
--- a/checkin-app/src/lib/prisma.ts
+++ b/checkin-app/src/lib/prisma.ts
@@ -11,7 +11,26 @@ const connectionString = `${process.env.DATABASE_URL}`
 const poolMax = process.env.NODE_ENV === 'test'
     ? Number(process.env.TEST_DB_POOL_MAX ?? 1)
     : 10
-const pool = new Pool({ connectionString, max: poolMax })
+const pool = new Pool({
+    connectionString,
+    max: poolMax,
+    // Fail fast rather than hang forever if the pool can't get a connection (the
+    // pg driver has NO default here — an exhausted/unresponsive server otherwise
+    // blocks a new connection attempt indefinitely, with no error, no timeout).
+    connectionTimeoutMillis: 10_000,
+    // Off by default in the pg driver. Without it, a connection whose peer died
+    // abruptly (SIGKILL'd process, torn-down background job — not a graceful
+    // $disconnect()) looks alive to Postgres forever: no FIN was ever sent, and
+    // nothing here ever probes it. If that connection was mid-transaction holding
+    // a lock (e.g. the scan route's `pg_advisory_xact_lock`, checkin-app/src/app/api/scan/route.ts),
+    // the lock is held until Postgres's OWN keepalive notices — which never
+    // happens without this — so any later query needing that same lock hangs
+    // indefinitely (issue #688: "20+ min no response", not fixed by --forceExit,
+    // since that only governs whether the LATER run's own process exits, not
+    // whether an EARLIER orphaned one is still silently holding a lock).
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10_000,
+})
 // In tests every file gets a fresh module registry, so each builds its own pool.
 // Those pools must close on $disconnect or they leak connections until the worker
 // process dies (parallel runs exhaust max_connections; --runInBand crashes). The

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,6 +11,20 @@ services:
       - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    # Server-side safety net (issue #688): a jest process killed abruptly (not a
+    # graceful $disconnect() — e.g. an orphaned background worktree run) leaves
+    # its Postgres backend "alive" from the server's own point of view, holding
+    # whatever lock/transaction it was mid-way through (e.g. the scan route's
+    # pg_advisory_xact_lock) forever. The client-side keepAlive fix in
+    # checkin-app/src/lib/prisma.ts only helps OTHER connections detect a dead
+    # peer; it can't force a truly-orphaned session's own stuck transaction to
+    # end. This does: Postgres kills the session itself once it's sat idle
+    # inside an open transaction, or a single statement has run, past these
+    # limits — turning a permanent hang into, at worst, a multi-minute wait.
+    command: >
+      postgres
+      -c idle_in_transaction_session_timeout=120000
+      -c statement_timeout=60000
 
   web:
     # Context is the repo root (one level up from deploy/) so the workspace


### PR DESCRIPTION
Fixes #688 ("Integration Tests Hang Locally... 20+ minutes no response, especially [run] in the background").

## Root cause
Nothing in the DB connection stack has a timeout, at either layer:

1. **`checkin-app/src/lib/prisma.ts`** — the `pg.Pool` sets no `connectionTimeoutMillis` (the driver has *no default* for it — a new connection attempt against an unresponsive/exhausted server hangs forever, no error), and `keepAlive` defaults to `false` (a connection whose peer died abruptly — a killed process, an orphaned background worktree run, not a graceful `$disconnect()` — looks alive to Postgres forever; no FIN was sent and nothing here ever probes it).
2. **`deploy/docker-compose.yml`** — the local Postgres has no `idle_in_transaction_session_timeout`/`statement_timeout`. If that orphaned connection was mid-transaction holding a lock — e.g. the scan route's `pg_advisory_xact_lock(participant.id)` (`checkin-app/src/app/api/scan/route.ts:78`, a *transaction-scoped* advisory lock, released only on commit/rollback or backend termination) — the lock is held until Postgres itself notices the backend is gone, which without keepalive can be effectively never. Any later query needing the same lock (a subsequent scan-concurrency test run, or a real scan) then hangs too.

This is exactly why removing `--forceExit` (#626) didn't fix it (per the issue's own comment) — `--forceExit` only governs whether a run's *own* process exits cleanly after finishing. It's the wrong layer: a *new* run isn't hanging on its own handles, it's blocked waiting on a lock held by an *earlier* run that never actually died.

## Fix
- `prisma.ts`: `connectionTimeoutMillis: 10_000`, `keepAlive: true`, `keepAliveInitialDelayMillis: 10_000`. Applies to prod too — fail-fast-on-connect and TCP keepalive are good practice regardless.
- `docker-compose.yml`: `idle_in_transaction_session_timeout=120000`, `statement_timeout=60000` on the local Postgres — a server-side backstop that kills the stuck session even if the client-side fix never gets exercised (e.g. the OS never sent a probe at all).

Values are generous relative to this repo's real workload (the full suite completes in ~30s total) but tight enough to turn a permanent hang into a bounded wait.

## Verified
- Full `test:coverage` suite (287 suites, 1915 tests) passes unchanged with both fixes active.
- The scan-concurrency test (the one directly exercising `pg_advisory_xact_lock`) still correctly serializes concurrent scans — 2/2 passing.
- Recreated the local Postgres container to pick up the new flags; confirmed via `SHOW idle_in_transaction_session_timeout`/`SHOW statement_timeout`; confirmed existing data survived (named volume).

**Honest caveat**: I could not literally reproduce the original 20-minute hang (that needs a genuinely orphaned background process) to prove this closes the loop end-to-end. This is a well-reasoned mitigation based on the diagnosed mechanism (confirmed via the actual `pg`/`pg-pool` source and the actual advisory-lock call site), not an empirically-reproduced-then-fixed bug.

#689 ("tests requiring local infra") is a separate, bigger test-architecture question — not addressed here, left for its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
