### PR TITLE
refactor(alerts): replace string-sniffing status alerts with typed AlertBanner

### DIFF
--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { Alert, Anchor, Button, Card, Center, Loader, Stack, Text, TextInput, Title } from '@mantine/core';
+import { Anchor, Button, Card, Center, Loader, Stack, Text, TextInput, Title } from '@mantine/core';
 import { PageContainer } from '@/components/ui/PageContainer';
+import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
 import { isYouth } from '@/lib/time';
 
 export default function ProfilePage() {
@@ -13,7 +14,7 @@ export default function ProfilePage() {
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState<{ text: string; tone: AlertTone } | null>(null);
 
   const [form, setForm] = useState({
     name: "",
@@ -33,10 +34,10 @@ export default function ProfilePage() {
           dob: data.profile.dateOfBirth ? new Date(data.profile.dateOfBirth).toISOString().split('T')[0] : ""
         });
       } else {
-        setMessage("Failed to load profile.");
+        setMessage({ text: "Failed to load profile.", tone: "error" });
       }
     } catch {
-      setMessage("Network error loading profile.");
+      setMessage({ text: "Network error loading profile.", tone: "error" });
     } finally {
       setLoading(false);
     }
@@ -53,7 +54,7 @@ export default function ProfilePage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setSaving(true);
-    setMessage("");
+    setMessage(null);
 
     try {
       const res = await fetch('/api/profile', {
@@ -67,12 +68,12 @@ export default function ProfilePage() {
       });
 
       if (res.ok) {
-        setMessage("Profile updated successfully!");
+        setMessage({ text: "Profile updated successfully!", tone: "success" });
       } else {
-        setMessage("Failed to update profile.");
+        setMessage({ text: "Failed to update profile.", tone: "error" });
       }
     } catch {
-      setMessage("Network error saving profile.");
+      setMessage({ text: "Network error saving profile.", tone: "error" });
     } finally {
       setSaving(false);
     }
@@ -115,7 +116,7 @@ export default function ProfilePage() {
             </Stack>
           </form>
 
-          {message && <Alert color={message.includes('success') ? 'green' : 'red'} mt="md">{message}</Alert>}
+          <AlertBanner message={message?.text} tone={message?.tone} mb="md" />
       </Card>
     </PageContainer>
   );

--- a/checkin-app/src/app/shop-ops/create/page.tsx
+++ b/checkin-app/src/app/shop-ops/create/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Alert, Button, Card, Flex, ScrollArea, Stack, Text, TextInput } from "@mantine/core";
+import { Button, Card, Flex, ScrollArea, Stack, Text, TextInput } from "@mantine/core";
+import { AlertBanner, type AlertTone } from "@/components/admin/AlertBanner";
 
 type ToolListItem = {
   id: number;
@@ -14,7 +15,7 @@ export default function CreateToolPage() {
   const [newToolName, setNewToolName] = useState("");
   const [newToolGuide, setNewToolGuide] = useState("");
   const [saving, setSaving] = useState(false);
-  const [createMessage, setCreateMessage] = useState("");
+  const [createMessage, setCreateMessage] = useState<{ text: string; tone: AlertTone } | null>(null);
   const [tools, setTools] = useState<ToolListItem[]>([]);
 
   const loadTools = useCallback(async () => {
@@ -29,7 +30,7 @@ export default function CreateToolPage() {
   const handleCreateTool = async (e: React.FormEvent) => {
     e.preventDefault();
     setSaving(true);
-    setCreateMessage("");
+    setCreateMessage(null);
 
     try {
       const res = await fetch("/api/shop/tools", {
@@ -39,13 +40,13 @@ export default function CreateToolPage() {
       });
 
       if (res.ok) {
-        setCreateMessage("New tool added successfully!");
+        setCreateMessage({ text: "New tool added successfully!", tone: "success" });
         setNewToolName("");
         setNewToolGuide("");
         loadTools();
       } else {
         const data = await res.json();
-        setCreateMessage(data.error || "Failed to create tool.");
+        setCreateMessage({ text: data.error || "Failed to create tool.", tone: "error" });
       }
     } finally {
       setSaving(false);
@@ -60,9 +61,7 @@ export default function CreateToolPage() {
           authorizing Certifiers, and tracking usage.
         </Text>
 
-        {createMessage && (
-          <Alert color={createMessage.includes("success") ? "green" : "red"} mb="md">{createMessage}</Alert>
-        )}
+        <AlertBanner message={createMessage?.text} tone={createMessage?.tone} mb="md" />
 
         <form onSubmit={handleCreateTool}>
           <Stack>


### PR DESCRIPTION
## Summary
- `profile/page.tsx` and `shop-ops/create/page.tsx` derived alert color from `message.includes('success')` — the same anti-pattern already fixed on `my-household/page.tsx`.
- Converted `message`/`createMessage` state to typed `{text, tone}` (tone: `AlertTone`), set explicitly at each `setMessage`/`setCreateMessage` call site, and swapped the raw Mantine `<Alert>` for the shared `AlertBanner` component.
- No other logic touched.

## Test plan
- [x] `npx tsc --noEmit` — no new errors introduced (repo has pre-existing, unrelated errors from a missing generated Prisma client)
- [x] `npx jest --ci --runInBand` (with worktree exclusion pattern dropped, since this worktree's default config zeroes out test discovery) — 182 suites / 1086 tests pass