### PR TITLE
fix(facility-ops): track AlertBanner tone as typed state

### DIFF
--- a/checkin-app/src/app/facility-ops/badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/badges/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Center, Loader, Stack } from '@mantine/core';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { AlertBanner } from '@/components/admin/AlertBanner';
+import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
 import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
 import { formatDateTime } from '@/lib/time';
 
@@ -27,7 +27,7 @@ export default function AdminBadgesPage() {
 
   const [loading, setLoading] = useState(true);
   const [badges, setBadges] = useState<BadgeEvent[]>([]);
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState<{ text: string; tone: AlertTone } | null>(null);
 
   const fetchBadges = useCallback(async () => {
     try {
@@ -36,10 +36,10 @@ export default function AdminBadgesPage() {
         const data = await res.json();
         setBadges(data.badges);
       } else {
-        setMessage("Failed to load badge events.");
+        setMessage({ text: "Failed to load badge events.", tone: "error" });
       }
     } catch {
-      setMessage("Network error loading badges.");
+      setMessage({ text: "Network error loading badges.", tone: "error" });
     } finally {
       setLoading(false);
     }
@@ -57,7 +57,7 @@ export default function AdminBadgesPage() {
 
   return (
     <Stack>
-      <AlertBanner message={message} tone={message.includes('success') ? 'success' : 'error'} />
+      <AlertBanner message={message?.text} tone={message?.tone} />
 
       <DataTable columns={COLUMNS} rows={badges} getRowKey={(b) => b.id} emptyMessage="No badge events." />
     </Stack>

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button, Center, Group, Loader, Stack, Table, Text, TextInput, Tooltip, UnstyledButton } from '@mantine/core';
 import { IconChevronDown, IconChevronUp, IconDeviceLaptop, IconRobot, IconScan, IconSelector } from '@tabler/icons-react';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { AlertBanner } from '@/components/admin/AlertBanner';
+import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
 import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
 
 type VisitSource = 'SCANNER' | 'WEB' | 'SYSTEM';
@@ -52,7 +52,7 @@ export default function AdminVisitsPage() {
 
   const [loading, setLoading] = useState(true);
   const [visits, setVisits] = useState<Visit[]>([]);
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState<{ text: string; tone: AlertTone } | null>(null);
 
   const [editingVisitId, setEditingVisitId] = useState<number | null>(null);
   const [editForm, setEditForm] = useState({ arrivedAt: "", departedAt: "" });
@@ -93,10 +93,10 @@ export default function AdminVisitsPage() {
         const data = await res.json();
         setVisits(data.visits);
       } else {
-        setMessage("Failed to load visits.");
+        setMessage({ text: "Failed to load visits.", tone: "error" });
       }
     } catch {
-      setMessage("Network error loading visits.");
+      setMessage({ text: "Network error loading visits.", tone: "error" });
     } finally {
       setLoading(false);
     }
@@ -129,14 +129,14 @@ export default function AdminVisitsPage() {
         })
       });
       if (res.ok) {
-        setMessage("Visit updated successfully.");
+        setMessage({ text: "Visit updated successfully.", tone: "success" });
         setEditingVisitId(null);
         fetchVisits();
       } else {
-        setMessage("Failed to update visit.");
+        setMessage({ text: "Failed to update visit.", tone: "error" });
       }
     } catch {
-      setMessage("Network error saving visit.");
+      setMessage({ text: "Network error saving visit.", tone: "error" });
     }
   };
 
@@ -148,7 +148,7 @@ export default function AdminVisitsPage() {
 
   return (
     <Stack>
-      <AlertBanner message={message} tone={message.includes('success') ? 'success' : 'error'} />
+      <AlertBanner message={message?.text} tone={message?.tone} />
 
       <Table.ScrollContainer minWidth={800}>
         <Table verticalSpacing="sm" highlightOnHover>


### PR DESCRIPTION
## Summary
- `facility-ops/badges` and `facility-ops/visits` computed the `AlertBanner` `tone` prop by checking `message.includes('success')` instead of tracking it as state, so any wording change could silently misrender an error as green.
- Converted `message` to typed `{text: string; tone: AlertTone} | null` in both pages, matching the pattern already used in `my-household`. Tone is now set explicitly at each `setMessage` call site based on the actual outcome.

## Test plan
- [x] `npx tsc --noEmit` — no new errors in either changed file (remaining repo errors are pre-existing, unrelated to `@/generated/prisma/client` in this worktree)
- [ ] Manual click-through of badges/visits admin pages to confirm success/error banners still render correctly

Note: pre-commit hook (jest) was bypassed with `--no-verify` — in this worktree, jest's `testPathIgnorePatterns` matches any path under `.claude/worktrees/`, so it discovers 0 tests and exits 1 regardless of the change (confirmed with user before bypassing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)