### PR TITLE
refactor(alerts): converge ad-hoc isError/message state onto AlertBanner

### DIFF
--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { Alert, Button, Card, Center, Checkbox, Container, Group, Loader, Stack, Text, Title } from "@mantine/core";
+import { Button, Card, Center, Checkbox, Container, Group, Loader, Stack, Text, Title } from "@mantine/core";
+import { AlertBanner, type AlertTone } from "@/components/admin/AlertBanner";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 
 interface Person {
@@ -28,8 +29,7 @@ export default function MembershipReviewPage() {
   const [forbidden, setForbidden] = useState(false);
   const [busyId, setBusyId] = useState<number | null>(null);
   const [volunteer, setVolunteer] = useState<Record<number, boolean>>({});
-  const [message, setMessage] = useState("");
-  const [isError, setIsError] = useState(false);
+  const [message, setMessage] = useState<{ text: string; tone: AlertTone } | undefined>();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -55,7 +55,7 @@ export default function MembershipReviewPage() {
 
   const submit = async (processId: number, result: "APPROVE" | "REJECT") => {
     setBusyId(processId);
-    setMessage("");
+    setMessage(undefined);
     try {
       const res = await fetch("/api/membership/reviews", {
         method: "POST",
@@ -64,17 +64,14 @@ export default function MembershipReviewPage() {
       });
       const data = await res.json();
       if (res.ok) {
-        setIsError(false);
-        setMessage(result === "APPROVE" ? "Attestation recorded — thank you." : "Recorded. The board has been notified.");
+        setMessage({ text: result === "APPROVE" ? "Attestation recorded — thank you." : "Recorded. The board has been notified.", tone: "success" });
         await load();
         notifyNavRefresh();
       } else {
-        setIsError(true);
-        setMessage(data.error || "Could not record your attestation.");
+        setMessage({ text: data.error || "Could not record your attestation.", tone: "error" });
       }
     } catch {
-      setIsError(true);
-      setMessage("Network error.");
+      setMessage({ text: "Network error.", tone: "error" });
     } finally {
       setBusyId(null);
     }
@@ -108,7 +105,7 @@ export default function MembershipReviewPage() {
         board is notified and the applicant is not told the reason.
       </Text>
 
-      {message && <Alert color={isError ? "red" : "green"} mt="md">{message}</Alert>}
+      <AlertBanner message={message?.text} tone={message?.tone} mt="md" />
 
       {queue.length === 0 ? (
         <Card withBorder radius="md" padding="xl" ta="center" mt="md">

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -8,6 +8,7 @@ import {
   Alert, Anchor, Box, Button, Card, Center, Checkbox, Container, Group, Loader,
   SimpleGrid, Stack, Text, TextInput, ThemeIcon, Title,
 } from "@mantine/core";
+import { AlertBanner, type AlertTone } from "@/components/admin/AlertBanner";
 import MembershipFlowStepper from "@/components/MembershipFlowStepper";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
@@ -98,8 +99,7 @@ export default function MembershipPage() {
   const [state, setState] = useState<IntakeState | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [message, setMessage] = useState("");
-  const [isError, setIsError] = useState(false);
+  const [message, setMessage] = useState<{ text: string; tone: AlertTone } | undefined>();
   // Per-field validation errors, keyed by form field ("address", "emName",
   // "emPhone", "primaryName"). Drives the red-highlighted inputs.
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -207,8 +207,7 @@ export default function MembershipPage() {
     signReturnHandled.current = true;
     window.history.replaceState(null, "", window.location.pathname);
     if (declined) {
-      setMessage("You declined the agreement. You can restart signing when you're ready.");
-      setIsError(true);
+      setMessage({ text: "You declined the agreement. You can restart signing when you're ready.", tone: "error" });
       return;
     }
     (async () => {
@@ -221,12 +220,12 @@ export default function MembershipPage() {
         /* best-effort — the Zoho webhook is still a backstop */
       }
       await load();
-      setMessage(
-        signedNow
+      setMessage({
+        text: signedNow
           ? "Thanks — your signature was received."
           : "Signature received — finalizing. If it doesn't update shortly, use “Refresh status”.",
-      );
-      setIsError(false);
+        tone: "success",
+      });
     })();
   }, [sessionStatus, load]);
 
@@ -242,8 +241,7 @@ export default function MembershipPage() {
   }, [state?.process?.status]);
 
   const flash = (msg: string, error = false) => {
-    setMessage(msg);
-    setIsError(error);
+    setMessage(msg ? { text: msg, tone: error ? "error" : "success" } : undefined);
     // Clear stale warnings when starting an action (msg === "") or on a hard
     // failure; a successful save sets them right after this call.
     if (error || msg === "") setWarnings([]);
@@ -462,7 +460,7 @@ export default function MembershipPage() {
         <Button component={Link} href="/" variant="default" onNavigate={(e) => { if (!confirmNav()) e.preventDefault(); }}>← Home</Button>
       </Group>
 
-      {message && <Alert color={isError ? "red" : "green"} mb="lg">{message}</Alert>}
+      <AlertBanner message={message?.text} tone={message?.tone} mb="lg" />
 
       {warnings.length > 0 && (
         <Alert color="yellow" mb="lg" title="Saved — with a couple of things to know">

--- a/checkin-app/src/app/safety/trusted-adults/page.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback } from "react";
 import {
-    Alert,
     Badge,
     Button,
     Card,
@@ -15,7 +14,7 @@ import {
     Title,
     Tooltip,
 } from "@mantine/core";
-import { IconAlertTriangle } from "@tabler/icons-react";
+import { AlertBanner, type AlertTone } from "@/components/admin/AlertBanner";
 import { TrustedAdultContact } from "@/components/TrustedAdultContact";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { isTrustedAdultConflict } from "@/lib/trusted-adult/conflict";
@@ -70,8 +69,7 @@ export default function AdminTrustedAdultsPage() {
     const [loading, setLoading] = useState(true);
     const [busyId, setBusyId] = useState<number | null>(null);
     const [shared, setShared] = useState<Record<number, string>>({});
-    const [message, setMessage] = useState("");
-    const [isError, setIsError] = useState(false);
+    const [message, setMessage] = useState<{ text: string; tone: AlertTone } | undefined>();
 
     const load = useCallback(async () => {
         setLoading(true);
@@ -92,7 +90,7 @@ export default function AdminTrustedAdultsPage() {
 
     const decide = async (reviewId: number, decision: string, extra?: Record<string, unknown>) => {
         setBusyId(reviewId);
-        setMessage("");
+        setMessage(undefined);
         try {
             const res = await fetch("/api/safety/trusted-adults/decision", {
                 method: "POST",
@@ -101,11 +99,9 @@ export default function AdminTrustedAdultsPage() {
             });
             const body = await res.json().catch(() => ({}));
             if (!res.ok) {
-                setIsError(true);
-                setMessage(body.error ?? "Decision failed.");
+                setMessage({ text: body.error ?? "Decision failed.", tone: "error" });
             } else {
-                setIsError(false);
-                setMessage(`Recorded: ${label(body.status)}.`);
+                setMessage({ text: `Recorded: ${label(body.status)}.`, tone: "success" });
                 await load();
             }
         } finally {
@@ -123,8 +119,7 @@ export default function AdminTrustedAdultsPage() {
             });
             const body = await res.json().catch(() => ({}));
             if (!res.ok) {
-                setIsError(true);
-                setMessage(body.error ?? "Override failed.");
+                setMessage({ text: body.error ?? "Override failed.", tone: "error" });
             } else {
                 await load();
             }
@@ -154,11 +149,7 @@ export default function AdminTrustedAdultsPage() {
                 </Text>
             </div>
 
-            {message && (
-                <Alert color={isError ? "red" : "green"} icon={<IconAlertTriangle size={16} />} withCloseButton onClose={() => setMessage("")}>
-                    {message}
-                </Alert>
-            )}
+            <AlertBanner message={message?.text} tone={message?.tone} onClose={() => setMessage(undefined)} />
 
             {items.length === 0 && <Text c="dimmed">Nothing in the queue.</Text>}
 

--- a/checkin-app/src/components/admin/AlertBanner.tsx
+++ b/checkin-app/src/components/admin/AlertBanner.tsx
@@ -16,6 +16,8 @@ export interface AlertBannerProps {
   tone?: AlertTone;
   title?: string;
   mb?: string | number;
+  mt?: string | number;
+  onClose?: () => void;
 }
 
 /**
@@ -24,10 +26,10 @@ export interface AlertBannerProps {
  * across green/red/cyan/yellow and a `message.includes('success')` heuristic) with one tone→color
  * mapping and a built-in empty-message guard.
  */
-export function AlertBanner({ message, tone = "info", title, mb }: AlertBannerProps) {
+export function AlertBanner({ message, tone = "info", title, mb, mt, onClose }: AlertBannerProps) {
   if (!message) return null;
   return (
-    <Alert color={TONE_COLOR[tone]} title={title} mb={mb}>
+    <Alert color={TONE_COLOR[tone]} title={title} mb={mb} mt={mt} withCloseButton={!!onClose} onClose={onClose}>
       {message}
     </Alert>
   );


### PR DESCRIPTION
## Summary
- Three pages (`membership-ops/review`, `membership`, `safety/trusted-adults`) used a bare `isError` boolean + `message` string with an inline `<Alert color={isError ? "red" : "green"}>` instead of the shared `AlertBanner` component — a third, parallel convention for status banners.
- Merged each into a single typed `{ text, tone } | undefined` message state and rendered via `AlertBanner`, matching the pattern already used on `my-household`.
- `AlertBanner` gains optional `mt` and `onClose` props (mirroring the existing `mb`), since `membership-ops/review` needed top margin and `safety/trusted-adults` needed a dismissible banner (previously via Mantine's `withCloseButton`).
- Static/contextual `<Alert>` usages left untouched (e.g. the yellow "warnings" banner on `membership`).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `jest` run scoped to touched areas (membership-ops, membership, trusted-adults, AlertBanner) — 114/115 passing; the 1 failure is an unrelated flow test requiring a live dev server
- [ ] Manual click-through of each page's success/error/dismiss states