### PR TITLE
fix(household): wrap member write + audit log + reconcile in one transaction

### DIFF
--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -42,86 +42,90 @@ export const PATCH = withAuth(
                 return NextResponse.json({ error: "That household member was not found" }, { status: 404 });
             }
 
-            const updatedHouseholdMember = await prisma.participant.update({
-                where: { id: participantId },
-                data: {
-                    name: name !== undefined ? name : undefined,
-                    email: email !== undefined ? (email === "" ? null : email.toLowerCase()) : undefined,
-                    dateOfBirth: dob !== undefined ? (dob === "" ? null : new Date(dob + "T12:00:00Z")) : undefined,
-                    phone: phone !== undefined ? (phone === "" ? null : formatPhone(phone)) : undefined,
-                    // A real DoB supersedes the 25+ flag; otherwise honor the checkbox.
-                    isDeclaredAdult: over25 !== undefined ? (dob ? false : !!over25) : undefined,
-                },
-                select: HOUSEHOLD_PEER_SELECT,
-            });
+            const { updatedHouseholdMember, leadRejection, warning } = await prisma.$transaction(async (tx) => {
+                const updatedHouseholdMember = await tx.participant.update({
+                    where: { id: participantId },
+                    data: {
+                        name: name !== undefined ? name : undefined,
+                        email: email !== undefined ? (email === "" ? null : email.toLowerCase()) : undefined,
+                        dateOfBirth: dob !== undefined ? (dob === "" ? null : new Date(dob + "T12:00:00Z")) : undefined,
+                        phone: phone !== undefined ? (phone === "" ? null : formatPhone(phone)) : undefined,
+                        // A real DoB supersedes the 25+ flag; otherwise honor the checkbox.
+                        isDeclaredAdult: over25 !== undefined ? (dob ? false : !!over25) : undefined,
+                    },
+                    select: HOUSEHOLD_PEER_SELECT,
+                });
 
-            // Set when the field edits saved but the requested promotion to lead
-            // was declined by the per-household cap (#269). We report this back
-            // rather than 400 the whole edit, so the form can say the member's
-            // details were saved even though they weren't made a lead.
-            let leadRejection: string | null = null;
+                // Set when the field edits saved but the requested promotion to lead
+                // was declined by the per-household cap (#269). We report this back
+                // rather than 400 the whole edit, so the form can say the member's
+                // details were saved even though they weren't made a lead.
+                let leadRejection: string | null = null;
 
-            if (isLead !== undefined && participantId !== userId) {
-                const currentLead = await prisma.householdLead.findUnique({
-                    where: {
-                        householdId_personId: { householdId: user.householdId, personId: participantId }
+                if (isLead !== undefined && participantId !== userId) {
+                    const currentLead = await tx.householdLead.findUnique({
+                        where: {
+                            householdId_personId: { householdId: user.householdId, personId: participantId }
+                        }
+                    });
+
+                    if (isLead && !currentLead) {
+                        try {
+                            await addHouseholdLead(tx, user.householdId, participantId);
+                            await tx.auditLog.create({
+                                data: {
+                                    actorId: userId,
+                                    action: "CREATE",
+                                    tableName: "HouseholdLead",
+                                    affectedEntityId: user.householdId,
+                                    secondaryAffectedEntity: participantId
+                                }
+                            });
+                        } catch (e) {
+                            if (e instanceof HouseholdLeadLimitError) {
+                                leadRejection = e.message;
+                            } else {
+                                throw e;
+                            }
+                        }
+                    } else if (!isLead && currentLead) {
+                        const leadCount = await tx.householdLead.count({ where: { householdId: user.householdId } });
+                        if (leadCount > 1) {
+                            await tx.householdLead.delete({
+                                 where: {
+                                     householdId_personId: { householdId: user.householdId, personId: participantId }
+                                 }
+                            });
+
+                            await tx.auditLog.create({
+                                data: {
+                                    actorId: userId,
+                                    action: "DELETE",
+                                    tableName: "HouseholdLead",
+                                    affectedEntityId: user.householdId,
+                                    secondaryAffectedEntity: participantId
+                                }
+                            });
+                        }
+                    }
+                }
+
+                await tx.auditLog.create({
+                    data: {
+                        actorId: userId,
+                        action: "EDIT",
+                        tableName: "Participant",
+                        affectedEntityId: targetHouseholdMember.id,
+                        newData: updatedHouseholdMember
                     }
                 });
 
-                if (isLead && !currentLead) {
-                    try {
-                        await addHouseholdLead(prisma, user.householdId, participantId);
-                        await prisma.auditLog.create({
-                            data: {
-                                actorId: userId,
-                                action: "CREATE",
-                                tableName: "HouseholdLead",
-                                affectedEntityId: user.householdId,
-                                secondaryAffectedEntity: participantId
-                            }
-                        });
-                    } catch (e) {
-                        if (e instanceof HouseholdLeadLimitError) {
-                            leadRejection = e.message;
-                        } else {
-                            throw e;
-                        }
-                    }
-                } else if (!isLead && currentLead) {
-                    const leadCount = await prisma.householdLead.count({ where: { householdId: user.householdId } });
-                    if (leadCount > 1) {
-                        await prisma.householdLead.delete({
-                             where: {
-                                 householdId_personId: { householdId: user.householdId, personId: participantId }
-                             }
-                        });
-                        
-                        await prisma.auditLog.create({
-                            data: {
-                                actorId: userId,
-                                action: "DELETE",
-                                tableName: "HouseholdLead",
-                                affectedEntityId: user.householdId,
-                                secondaryAffectedEntity: participantId
-                            }
-                        });
-                    }
-                }
-            }
+                // Edits to a member's name/phone/email can make them match an
+                // emergency contact (direction B): re-evaluate and warn if so.
+                const warning = await reconcileAndWarn(tx, user.householdId);
 
-            await prisma.auditLog.create({
-                data: {
-                    actorId: userId,
-                    action: "EDIT",
-                    tableName: "Participant",
-                    affectedEntityId: targetHouseholdMember.id,
-                    newData: updatedHouseholdMember
-                }
+                return { updatedHouseholdMember, leadRejection, warning };
             });
-
-            // Edits to a member's name/phone/email can make them match an
-            // emergency contact (direction B): re-evaluate and warn if so.
-            const warning = await reconcileAndWarn(prisma, user.householdId);
 
             return NextResponse.json({
                 householdMember: updatedHouseholdMember,

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -71,57 +71,60 @@ export const PATCH = withAuth(
                 return NextResponse.json({ error: "Invalid email format" }, { status: 400 });
             }
 
-            let targetMember;
+            let targetMember: Awaited<ReturnType<typeof prisma.participant.findUnique>> = null;
 
             if (memberEmail) {
                 targetMember = await prisma.participant.findUnique({ where: { email: memberEmail.toLowerCase() } });
 
-                if (targetMember) {
-                    if (targetMember.householdId) {
-                        return NextResponse.json({ error: "A user with this email already belongs to a household." }, { status: 400 });
-                    }
-
-                    targetMember = await prisma.participant.update({
-                        where: { id: targetMember.id },
-                        data: { householdId: user.householdId },
-                        select: HOUSEHOLD_PEER_SELECT,
-                    });
+                if (targetMember && targetMember.householdId) {
+                    return NextResponse.json({ error: "A user with this email already belongs to a household." }, { status: 400 });
                 }
             }
 
-            if (!targetMember) {
+            if (!targetMember && !memberDob && !memberOver25) {
                 // A new member's age must be known: either a DoB, or an explicit
                 // "25+" declaration (mirrors the client form's requirement).
-                if (!memberDob && !memberOver25) {
-                    return NextResponse.json({ error: "Date of birth is required for anyone under 25." }, { status: 400 });
-                }
-                targetMember = await prisma.participant.create({
-                    data: {
-                        name: memberName,
-                        ...(memberEmail && { email: memberEmail.toLowerCase() }),
-                        dateOfBirth: memberDob ? new Date(memberDob) : null,
-                        isDeclaredAdult: !memberDob && !!memberOver25,
-                        householdId: user.householdId,
-                    },
-                    select: HOUSEHOLD_PEER_SELECT,
-                });
+                return NextResponse.json({ error: "Date of birth is required for anyone under 25." }, { status: 400 });
             }
 
-            await prisma.auditLog.create({
-                data: {
-                    actorId: userId,
-                    action: "EDIT",
-                    tableName: "Participant",
-                    affectedEntityId: targetMember.id,
-                    newData: { householdId: user.householdId, email: targetMember.email, name: targetMember.name }
-                }
+            const householdId = user.householdId;
+
+            const { member, warning } = await prisma.$transaction(async (tx) => {
+                const member = targetMember
+                    ? await tx.participant.update({
+                        where: { id: targetMember.id },
+                        data: { householdId },
+                        select: HOUSEHOLD_PEER_SELECT,
+                    })
+                    : await tx.participant.create({
+                        data: {
+                            name: memberName,
+                            ...(memberEmail && { email: memberEmail.toLowerCase() }),
+                            dateOfBirth: memberDob ? new Date(memberDob) : null,
+                            isDeclaredAdult: !memberDob && !!memberOver25,
+                            householdId,
+                        },
+                        select: HOUSEHOLD_PEER_SELECT,
+                    });
+
+                await tx.auditLog.create({
+                    data: {
+                        actorId: userId,
+                        action: "EDIT",
+                        tableName: "Participant",
+                        affectedEntityId: member.id,
+                        newData: { householdId, email: member.email, name: member.name }
+                    }
+                });
+
+                // A newly-added member may be an existing emergency contact (direction
+                // B): flag the colliding contact and warn the lead to add a replacement.
+                const warning = await reconcileAndWarn(tx, householdId);
+
+                return { member, warning };
             });
 
-            // A newly-added member may be an existing emergency contact (direction
-            // B): flag the colliding contact and warn the lead to add a replacement.
-            const warning = await reconcileAndWarn(prisma, user.householdId);
-
-            return NextResponse.json({ member: targetMember, warning }, { status: 200 });
+            return NextResponse.json({ member, warning }, { status: 200 });
         } catch (error: unknown) {
             console.error("Household PATCH Error:", error);
             return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });


### PR DESCRIPTION
## Summary
- `household/route.ts` and `household/member/route.ts` each did a Participant write, `AuditLog.create`, and `reconcileAndWarn` (Direction B emergency-contact conflict flagging) as separate un-transacted calls on the root `prisma` client. A failure between the member write and reconcile (or partway through reconcile's per-contact updates) could leave a member persisted with stale/unreconciled conflict flags.
- Wrapped the member write + audit log(s) + `reconcileAndWarn` call in `prisma.$transaction(async (tx) => {...})` in both routes, threading `tx` through every write in the block (including `addHouseholdLead` in the member route, which already supports joining an outer transaction).
- No signature changes to `reconcileAndWarn` or `addHouseholdLead` — both already accept `Prisma.TransactionClient | typeof prisma`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Unit tests (non-DB) touching these routes: 17/17 pass
- [x] Integration tests (real Postgres, `--runInBand`): 15 suites / 87 tests pass, including `householdAPI.integration.test.ts`, `householdMemberAPI.integration.test.ts`, `emergencyContactsAPI.integration.test.ts`, `emergencyContactMemberRouteGuard.integration.test.ts`, `householdLeadsConcurrency.integration.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)