### PR TITLE
Migrate confirm() dialogs to Mantine Modal for consistency

### DIFF
--- a/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
+++ b/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
@@ -119,18 +119,20 @@ describe("attendance/current page", () => {
   });
 
   it("force-checks-out a user via the sign-out modal", async () => {
-    window.confirm = jest.fn(() => true);
     setAdminSession();
     const fetchMock = mockRoutes();
     renderWithProviders(<KioskDisplay />);
     await screen.findByText("3 People Present");
 
     fireEvent.click(screen.getByRole("button", { name: "Sign out a user" }));
-    const modal = await screen.findByRole("dialog");
+    const modal = await screen.findByRole("dialog", { name: "Sign Out A User" });
     expect(within(modal).getByText("Val Volunteer")).toBeInTheDocument();
     // Rows are sorted alphabetically: Karen, Stu, Val -> Val is the 3rd "Sign Out" button.
     const signOutButtons = within(modal).getAllByRole("button", { name: "Sign Out" });
     fireEvent.click(signOutButtons[2]);
+
+    const confirmModal = await screen.findByRole("dialog", { name: "Force Checkout" });
+    fireEvent.click(within(confirmModal).getByRole("button", { name: "Force Checkout" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
+import { useDisclosure } from "@mantine/hooks";
 import {
   Alert, Anchor, Badge, Box, Button, Card, Center, Group, Loader, Modal, Paper,
   SimpleGrid, Stack, Text, TextInput, Title,
@@ -51,6 +52,8 @@ function KioskDisplayInner() {
   const [showSignOutModal, setShowSignOutModal] = useState(false);
   const [searchSignOutQuery, setSearchSignOutQuery] = useState("");
   const [selectedParticipant, setSelectedParticipant] = useState<Person | null>(null);
+  const [confirmCheckoutOpened, { open: openConfirmCheckout, close: closeConfirmCheckout }] = useDisclosure(false);
+  const [pendingCheckoutVisitId, setPendingCheckoutVisitId] = useState<number | null>(null);
 
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<Person[]>([]);
@@ -193,7 +196,15 @@ function KioskDisplayInner() {
   };
 
   const handleForceCheckout = async (visitId: number, isSelf: boolean = false) => {
-    if (!isSelf && !confirm("Are you sure you want to force checkout this user?")) return;
+    if (!isSelf) {
+      setPendingCheckoutVisitId(visitId);
+      openConfirmCheckout();
+      return;
+    }
+    await doForceCheckout(visitId);
+  };
+
+  const doForceCheckout = async (visitId: number, isSelf: boolean = false) => {
     setCheckingOut(visitId);
     try {
       const res = await fetch("/api/attendance", {
@@ -209,6 +220,14 @@ function KioskDisplayInner() {
     } finally {
       setCheckingOut(null);
     }
+  };
+
+  const confirmForceCheckout = async () => {
+    if (pendingCheckoutVisitId === null) return;
+    closeConfirmCheckout();
+    const visitId = pendingCheckoutVisitId;
+    setPendingCheckoutVisitId(null);
+    await doForceCheckout(visitId);
   };
 
   const handleManualCheckIn = async (participantId: number) => {
@@ -504,6 +523,20 @@ function KioskDisplayInner() {
             </Group>
           </>
         )}
+      </Modal>
+
+      {/* Force Checkout Confirmation Modal */}
+      <Modal
+        opened={confirmCheckoutOpened}
+        onClose={closeConfirmCheckout}
+        title={<Text span fw={700} fz="lg">Force Checkout</Text>}
+        centered
+      >
+        <Text mb="lg">Are you sure you want to force checkout this user?</Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmCheckout}>Cancel</Button>
+          <Button color="red" onClick={confirmForceCheckout}>Force Checkout</Button>
+        </Group>
       </Modal>
     </Box>
   );

--- a/checkin-app/src/app/facility-ops/visits/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/visits/__tests__/page.test.tsx
@@ -3,7 +3,7 @@ jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
 import AdminVisitsPage from "../page";
 
@@ -40,14 +40,14 @@ describe("facility-ops/visits page", () => {
   });
 
   it("edits and saves a visit's arrival/departure", async () => {
-    window.confirm = jest.fn(() => true);
     setSession({ id: 1, isSysadmin: true });
     const fetchMock = mockFetchJson({ "/api/facility/visits": { visits } });
     renderWithProviders(<AdminVisitsPage />);
     await screen.findByText("Val Volunteer");
 
     fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
-    expect(window.confirm).toHaveBeenCalled();
+    const confirmModal = await screen.findByRole("dialog", { name: "Edit Past Visit Record" });
+    fireEvent.click(within(confirmModal).getByRole("button", { name: "Continue" }));
 
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { Button, Center, Group, Loader, Stack, Table, Text, TextInput, Tooltip, UnstyledButton } from '@mantine/core';
+import { Button, Center, Group, Loader, Modal, Stack, Table, Text, TextInput, Tooltip, UnstyledButton } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp, IconDeviceLaptop, IconRobot, IconScan, IconSelector } from '@tabler/icons-react';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AlertBanner } from '@/components/admin/AlertBanner';
@@ -58,6 +59,8 @@ export default function AdminVisitsPage() {
   const [editForm, setEditForm] = useState({ arrivedAt: "", departedAt: "" });
 
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'arrivedAt', dir: 'desc' });
+  const [confirmEditOpened, { open: openConfirmEdit, close: closeConfirmEdit }] = useDisclosure(false);
+  const [pendingEditVisit, setPendingEditVisit] = useState<Visit | null>(null);
 
   const sortedVisits = useMemo(() => {
     return [...visits].sort((a, b) => {
@@ -107,14 +110,19 @@ export default function AdminVisitsPage() {
   }, [ready, fetchVisits]);
 
   const handleEditClick = (visit: Visit) => {
-    const confirmEdit = window.confirm("Warning: You are editing a past visit record using Admin overrides. This will be permanently logged.");
-    if (!confirmEdit) return;
+    setPendingEditVisit(visit);
+    openConfirmEdit();
+  };
 
-    setEditingVisitId(visit.id);
+  const confirmEditClick = () => {
+    if (!pendingEditVisit) return;
+    closeConfirmEdit();
+    setEditingVisitId(pendingEditVisit.id);
     setEditForm({
-      arrivedAt: toDatetimeLocal(visit.arrivedAt),
-      departedAt: toDatetimeLocal(visit.departedAt ?? null)
+      arrivedAt: toDatetimeLocal(pendingEditVisit.arrivedAt),
+      departedAt: toDatetimeLocal(pendingEditVisit.departedAt ?? null)
     });
+    setPendingEditVisit(null);
   };
 
   const handleSaveEdit = async (id: number) => {
@@ -220,6 +228,21 @@ export default function AdminVisitsPage() {
           </Table.Tbody>
         </Table>
       </Table.ScrollContainer>
+
+      <Modal
+        opened={confirmEditOpened}
+        onClose={closeConfirmEdit}
+        title={<Text span fw={700} fz="lg">Edit Past Visit Record</Text>}
+        centered
+      >
+        <Text mb="lg">
+          Warning: You are editing a past visit record using Admin overrides. This will be permanently logged.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmEdit}>Cancel</Button>
+          <Button color="red" onClick={confirmEditClick}>Continue</Button>
+        </Group>
+      </Modal>
     </Stack>
   );
 }

--- a/checkin-app/src/app/finance-ops/payment-plan/__tests__/page.test.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/__tests__/page.test.tsx
@@ -4,7 +4,7 @@ jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
 import PendingParticipantsPage from "../page";
 
@@ -33,7 +33,6 @@ describe("finance-ops/payment-plan page", () => {
   });
 
   it("approves a request and removes it from the list", async () => {
-    window.confirm = jest.fn(() => true);
     setSession({ id: 1, isSysadmin: true });
     const fetchMock = mockFetchJson({
       "/api/finance-ops/payment-plans": () => requests,
@@ -42,6 +41,9 @@ describe("finance-ops/payment-plan page", () => {
     await screen.findByText("Pat Participant");
 
     fireEvent.click(screen.getByRole("button", { name: /Approve/ }));
+
+    const confirmModal = await screen.findByRole("dialog", { name: "Approve Payment Plan" });
+    fireEvent.click(within(confirmModal).getByRole("button", { name: /Approve/ }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { Button, Center, Loader, Stack, Text } from '@mantine/core';
+import { Button, Center, Group, Loader, Modal, Stack, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
@@ -33,6 +34,8 @@ export default function PendingParticipantsPage() {
   const [requests, setRequests] = useState<PaymentPlanRequest[]>([]);
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState("");
+  const [confirmApproveOpened, { open: openConfirmApprove, close: closeConfirmApprove }] = useDisclosure(false);
+  const [pendingApproval, setPendingApproval] = useState<{ programId: number; participantId: number } | null>(null);
 
   const fetchRequests = useCallback(async () => {
     try {
@@ -54,9 +57,12 @@ export default function PendingParticipantsPage() {
     if (ready) fetchRequests();
   }, [ready, fetchRequests]);
 
-  const handleApprove = async (programId: number, participantId: number) => {
-    if (!confirm("Approve this payment plan? This sets the participant's status to ACTIVE and stops automated unpaid warning emails.")) return;
+  const handleApprove = (programId: number, participantId: number) => {
+    setPendingApproval({ programId, participantId });
+    openConfirmApprove();
+  };
 
+  const doApprove = async (programId: number, participantId: number) => {
     try {
       const res = await fetch('/api/finance-ops/payment-plans', {
         method: 'POST',
@@ -74,6 +80,14 @@ export default function PendingParticipantsPage() {
     } catch {
       notifications.show({ color: 'red', message: "Network error processing approval." });
     }
+  };
+
+  const confirmApprove = async () => {
+    if (!pendingApproval) return;
+    closeConfirmApprove();
+    const { programId, participantId } = pendingApproval;
+    setPendingApproval(null);
+    await doApprove(programId, participantId);
   };
 
   if (authLoading || loading) {
@@ -137,6 +151,22 @@ export default function PendingParticipantsPage() {
         getRowKey={(req) => `${req.programId}-${req.participantId}`}
         emptyMessage="No pending payment plan requests."
       />
+
+      <Modal
+        opened={confirmApproveOpened}
+        onClose={closeConfirmApprove}
+        title={<Text span fw={700} fz="lg">Approve Payment Plan</Text>}
+        centered
+      >
+        <Text mb="lg">
+          Approve this payment plan? This sets the participant&apos;s status to ACTIVE and stops
+          automated unpaid warning emails.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmApprove}>Cancel</Button>
+          <Button color="green" onClick={confirmApprove}>Approve &amp; Mark Active</Button>
+        </Group>
+      </Modal>
     </Stack>
   );
 }

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { Button, Center, Group, List, Loader, Stack, Table, Text, TextInput } from '@mantine/core';
+import { Button, Center, Group, List, Loader, Modal, Stack, Table, Text, TextInput } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { AdminEditHouseholdModal } from '@/components/admin/AdminEditHouseholdModal';
@@ -24,6 +25,8 @@ export default function AdminHouseholdsPage() {
   const [error, setError] = useState("");
   const [editHouseholdId, setEditHouseholdId] = useState<number | null>(null);
   const [filter, setFilter] = useState("");
+  const [confirmDenyOpened, { open: openConfirmDeny, close: closeConfirmDeny }] = useDisclosure(false);
+  const [pendingDenyHouseholdId, setPendingDenyHouseholdId] = useState<number | null>(null);
 
   const fetchHouseholds = useCallback(async () => {
     try {
@@ -66,11 +69,15 @@ export default function AdminHouseholdsPage() {
   // Deny blocks login for every member of the household; restore (deny=false) returns it
   // to NONE so they can log in again with no privileges. Separate from grant/revoke.
   const setDenied = async (householdId: number, deny: boolean) => {
-    if (deny && !window.confirm(
-      'Deny membership for this household? Every member will be unable to log in.'
-    )) {
+    if (deny) {
+      setPendingDenyHouseholdId(householdId);
+      openConfirmDeny();
       return;
     }
+    await doSetDenied(householdId, false);
+  };
+
+  const doSetDenied = async (householdId: number, deny: boolean) => {
     try {
       const res = await fetch('/api/membership-ops/households', {
         method: 'POST',
@@ -87,6 +94,14 @@ export default function AdminHouseholdsPage() {
     } catch {
       notifications.show({ color: 'red', message: 'Network error.' });
     }
+  };
+
+  const confirmDeny = async () => {
+    if (pendingDenyHouseholdId === null) return;
+    closeConfirmDeny();
+    const householdId = pendingDenyHouseholdId;
+    setPendingDenyHouseholdId(null);
+    await doSetDenied(householdId, true);
   };
 
   if (authLoading || loading) {
@@ -237,6 +252,19 @@ export default function AdminHouseholdsPage() {
         onClose={() => setEditHouseholdId(null)}
         onSaved={() => fetchHouseholds()}
       />
+
+      <Modal
+        opened={confirmDenyOpened}
+        onClose={closeConfirmDeny}
+        title={<Text span fw={700} fz="lg">Deny Membership</Text>}
+        centered
+      >
+        <Text mb="lg">Deny membership for this household? Every member will be unable to log in.</Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmDeny}>Cancel</Button>
+          <Button color="red" onClick={confirmDeny}>Deny Membership</Button>
+        </Group>
+      </Modal>
     </Stack>
   );
 }

--- a/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useState } from 'react';
-import { Alert, Badge, Box, Button, Card, Checkbox, Group, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import { Alert, Badge, Box, Button, Card, Checkbox, Group, Modal, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { EntityPicker } from '@/components/admin/EntityPicker';
 import { calculateAge, formatDateTime } from '@/lib/time';
 import { formatPhone } from '@/lib/phone';
@@ -21,6 +22,11 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
   const [volLabel, setVolLabel] = useState("");
   const [newPartId, setNewPartId] = useState("");
   const [partLabel, setPartLabel] = useState("");
+  const [confirmRemoveVolOpened, { open: openConfirmRemoveVol, close: closeConfirmRemoveVol }] = useDisclosure(false);
+  const [pendingRemoveVolId, setPendingRemoveVolId] = useState<number | null>(null);
+  const [confirmAddPartOpened, { open: openConfirmAddPart, close: closeConfirmAddPart }] = useDisclosure(false);
+  const [confirmRemovePartOpened, { open: openConfirmRemovePart, close: closeConfirmRemovePart }] = useDisclosure(false);
+  const [pendingRemovePartId, setPendingRemovePartId] = useState<number | null>(null);
 
   const sortedVolunteers = program.volunteers ? [...program.volunteers].sort((a, b) => (b.isCore ? 1 : 0) - (a.isCore ? 1 : 0)) : [];
   const activeParticipants = program.participants.filter(p => p.status === 'ACTIVE');
@@ -49,8 +55,16 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
     }
   };
 
-  const handleRemoveVolunteer = async (participantId: number) => {
-    if (!confirm("Remove this volunteer?")) return;
+  const handleRemoveVolunteer = (participantId: number) => {
+    setPendingRemoveVolId(participantId);
+    openConfirmRemoveVol();
+  };
+
+  const confirmRemoveVolunteer = async () => {
+    if (pendingRemoveVolId === null) return;
+    closeConfirmRemoveVol();
+    const participantId = pendingRemoveVolId;
+    setPendingRemoveVolId(null);
     try {
       await fetch(`/api/programs/${programId}/volunteers`, { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ participantId }) });
       fetchProgram();
@@ -67,14 +81,20 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
     }
   };
 
-  const handleAddParticipant = async (e: React.FormEvent) => {
+  const handleAddParticipant = (e: React.FormEvent) => {
     e.preventDefault();
     if (!newPartId) return;
 
     if (isSysAdminOrBoard) {
-      if (!confirm("Warning: Adding a participant manually bypasses all payment requirements. Are you sure you wish to proceed?")) return;
+      openConfirmAddPart();
+      return;
     }
 
+    doAddParticipant();
+  };
+
+  const doAddParticipant = async () => {
+    closeConfirmAddPart();
     setSaving(true);
     setMessage("");
     try {
@@ -92,8 +112,16 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
     }
   };
 
-  const handleRemoveParticipant = async (participantId: number) => {
-    if (!confirm("Remove this participant?")) return;
+  const handleRemoveParticipant = (participantId: number) => {
+    setPendingRemovePartId(participantId);
+    openConfirmRemovePart();
+  };
+
+  const confirmRemoveParticipant = async () => {
+    if (pendingRemovePartId === null) return;
+    closeConfirmRemovePart();
+    const participantId = pendingRemovePartId;
+    setPendingRemovePartId(null);
     try {
       await fetch(`/api/programs/${programId}/participants`, { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ participantId }) });
       fetchProgram();
@@ -228,6 +256,30 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
           </Stack>
         )}
       </Card>
+
+      <Modal opened={confirmRemoveVolOpened} onClose={closeConfirmRemoveVol} title={<Text span fw={700} fz="lg">Remove Volunteer</Text>} centered>
+        <Text mb="lg">Remove this volunteer?</Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmRemoveVol}>Cancel</Button>
+          <Button color="red" onClick={confirmRemoveVolunteer}>Remove</Button>
+        </Group>
+      </Modal>
+
+      <Modal opened={confirmAddPartOpened} onClose={closeConfirmAddPart} title={<Text span fw={700} fz="lg">Add Participant Manually</Text>} centered>
+        <Text mb="lg">Warning: Adding a participant manually bypasses all payment requirements. Are you sure you wish to proceed?</Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmAddPart}>Cancel</Button>
+          <Button color="red" onClick={doAddParticipant} disabled={saving} loading={saving}>Add Participant</Button>
+        </Group>
+      </Modal>
+
+      <Modal opened={confirmRemovePartOpened} onClose={closeConfirmRemovePart} title={<Text span fw={700} fz="lg">Remove Participant</Text>} centered>
+        <Text mb="lg">Remove this participant?</Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmRemovePart}>Cancel</Button>
+          <Button color="red" onClick={confirmRemoveParticipant}>Remove</Button>
+        </Group>
+      </Modal>
     </Stack>
   );
 }

--- a/checkin-app/src/app/program-ops/sessions/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports -- jest.mock factories are hoisted above imports */
-import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { screen, waitFor, fireEvent, within } from "@testing-library/react";
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 import { renderWithProviders, mockFetchJson, setSession, router, resetRtl } from "@/test-helpers/rtl";
@@ -105,8 +105,10 @@ describe("EventAdminPage", () => {
         expect(await screen.findByText("Event time updated successfully!")).toBeInTheDocument();
 
         fireEvent.click(screen.getByRole("button", { name: "Edit Date / Time" }));
-        window.confirm = jest.fn(() => true);
         fireEvent.click(screen.getByRole("button", { name: "Cancel Event(s)" }));
+
+        const confirmModal = await screen.findByRole("dialog", { name: "Cancel Event" });
+        fireEvent.click(within(confirmModal).getByRole("button", { name: "Cancel Event(s)" }));
         await waitFor(() => expect(router.push).toHaveBeenCalledWith("/program-ops/programs/10"));
     });
 });

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, use, useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { Alert, Badge, Button, Card, Center, Checkbox, Container, Group, Loader, Modal, Select, SimpleGrid, Stack, Table, Text, TextInput, Title } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
 import type { RSVPStatus } from '@/types/rsvp';
@@ -69,6 +70,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
   const [newStart, setNewStart] = useState("");
   const [newEnd, setNewEnd] = useState("");
   const [applyToFuture, setApplyToFuture] = useState(false);
+  const [confirmCancelOpened, { open: openConfirmCancel, close: closeConfirmCancel }] = useDisclosure(false);
 
   // Manual Edit States
   const [editingAttendance, setEditingAttendance] = useState<(ParticipantDetail & { role: string }) | null>(null);
@@ -187,8 +189,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
   };
 
   const handleCancelEvent = async () => {
-    if (!confirm("Are you sure you want to cancel this event? This action cannot be undone.")) return;
-
+    closeConfirmCancel();
     setActionLoading(true);
     try {
       const res = await fetch(`/api/events/${id}`, {
@@ -453,7 +454,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
 
                 <Group>
                   <Button color="green" onClick={handleEditTime} disabled={actionLoading} loading={actionLoading}>Save Time Changes</Button>
-                  <Button color="red" variant="light" onClick={handleCancelEvent} disabled={actionLoading} loading={actionLoading}>Cancel Event(s)</Button>
+                  <Button color="red" variant="light" onClick={openConfirmCancel} disabled={actionLoading} loading={actionLoading}>Cancel Event(s)</Button>
                   <Button variant="default" onClick={() => setEditMode(false)} disabled={actionLoading} ml="auto">Nevermind</Button>
                 </Group>
               </Stack>
@@ -502,6 +503,19 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
             <Button onClick={handleSaveManualAttendance} disabled={actionLoading} loading={actionLoading}>Save</Button>
           </Group>
         </Stack>
+      </Modal>
+
+      <Modal
+        opened={confirmCancelOpened}
+        onClose={closeConfirmCancel}
+        title={<Text span fw={700} fz="lg">Cancel Event</Text>}
+        centered
+      >
+        <Text mb="lg">Are you sure you want to cancel this event? This action cannot be undone.</Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmCancel}>Nevermind</Button>
+          <Button color="red" onClick={handleCancelEvent} disabled={actionLoading} loading={actionLoading}>Cancel Event(s)</Button>
+        </Group>
       </Modal>
     </Container>
   );

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Alert, Button, Card, Center, Checkbox, Group, Loader, Stack, Text, TextInput, Title } from "@mantine/core";
+import { Alert, Button, Card, Center, Checkbox, Group, Loader, Modal, Stack, Text, TextInput, Title } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
 import { SettingsTabs } from "@/components/admin/SettingsTabs";
 import { AlertBanner } from "@/components/admin/AlertBanner";
 import { useUnsavedGuard, shallowEqual } from "@/components/UnsavedChangesProvider";
@@ -44,6 +45,7 @@ export default function MembershipSettingsPage() {
   const [initial, setInitial] = useState<Record<string, string> | null>(null);
 
   const [bulkReminders, setBulkReminders] = useState(false);
+  const [confirmOpenRenewalsOpened, { open: openConfirmOpenRenewals, close: closeConfirmOpenRenewals }] = useDisclosure(false);
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -104,7 +106,7 @@ export default function MembershipSettingsPage() {
   };
 
   const bulkOpenRenewals = async () => {
-    if (!confirm("Open a renewal cycle for ALL active members now? This is a one-time go-live action.")) return;
+    closeConfirmOpenRenewals();
     setSaving(true);
     flash("");
     try {
@@ -242,12 +244,27 @@ export default function MembershipSettingsPage() {
               onChange={(e) => setBulkReminders(e.currentTarget.checked)}
               label="Also email each household a renewal reminder"
             />
-            <Button color="yellow" disabled={saving} loading={saving} onClick={bulkOpenRenewals}>
+            <Button color="yellow" disabled={saving} loading={saving} onClick={openConfirmOpenRenewals}>
               Open renewals for all active members
             </Button>
           </Card>
         </>
       )}
+
+      <Modal
+        opened={confirmOpenRenewalsOpened}
+        onClose={closeConfirmOpenRenewals}
+        title={<Text span fw={700} fz="lg">Open Renewals For All Active Members</Text>}
+        centered
+      >
+        <Text mb="lg">
+          Open a renewal cycle for ALL active members now? This is a one-time go-live action.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmOpenRenewals}>Cancel</Button>
+          <Button color="yellow" onClick={bulkOpenRenewals}>Open Renewals</Button>
+        </Group>
+      </Modal>
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces native `confirm()`/`window.confirm()` at 9 destructive/irreversible-action sites with the Mantine `Modal` + `useDisclosure` pattern already used elsewhere in this codebase (e.g. `sessions/[id]` attendance edit, `attendance/current` sign-out modal).
- Fixes the inconsistency where `program-ops/sessions/[id]` used a native `confirm()` for destructive cancel-event but a full Modal for the reversible attendance edit — backwards from what severity suggests.
- No behavior change: each action does exactly what it did before. Only the confirmation UI changed (click → Modal with Cancel/Confirm buttons instead of a browser confirm() popup).

Sites migrated:
1. `attendance/current/page.tsx` — force-checkout a user (self-checkout still skips confirmation)
2. `settings/membership/page.tsx` — open renewal cycle for ALL active members
3. `membership-ops/households/page.tsx` — deny household
4. `facility-ops/visits/page.tsx` — edit past visit record via admin override
5. `finance-ops/payment-plan/page.tsx` — approve payment plan
6. `program-ops/programs/[id]/ProgramRosterTab.tsx` — remove volunteer
7. `program-ops/programs/[id]/ProgramRosterTab.tsx` — add participant manually (bypasses payment)
8. `program-ops/programs/[id]/ProgramRosterTab.tsx` — remove participant
9. `program-ops/sessions/[id]/page.tsx` — cancel event

## Test plan
- [x] `npx tsc --noEmit` — no new errors in touched files (pre-existing baseline errors are unrelated missing-generated-prisma-client issues)
- [ ] Manual click-through in browser not done this session — dev server wasn't spun up; recommend exercising each of the 9 flows (open modal, cancel, confirm) before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)