### PR TITLE
refactor(person): rename Prisma model Participant → Person (A2, atomic)

### DIFF
--- a/checkin-app/__tests__/programLifecycle.integration.test.ts
+++ b/checkin-app/__tests__/programLifecycle.integration.test.ts
@@ -26,7 +26,7 @@ describe('Program Lifecycle Integration Tests', () => {
         // Setup initial db state for test scope
         
         // 1. Create a board member
-        const adminUser = await prisma.participant.create({
+        const adminUser = await prisma.person.create({
             data: {
                 name: "Board Tester",
                 email: "board@test.com",
@@ -40,7 +40,7 @@ describe('Program Lifecycle Integration Tests', () => {
         boardAdminId = adminUser.id;
 
         // 2. Create a Lead Mentor
-        const mentorUser = await prisma.participant.create({
+        const mentorUser = await prisma.person.create({
             data: {
                 name: "Mentor Tester",
                 email: "mentor@test.com",
@@ -52,7 +52,7 @@ describe('Program Lifecycle Integration Tests', () => {
         leadMentorId = mentorUser.id;
 
         // 3. Create a standard participant
-        const standardUser = await prisma.participant.create({
+        const standardUser = await prisma.person.create({
             data: {
                 name: "Standard Tester",
                 email: "participant@test.com",
@@ -88,7 +88,7 @@ describe('Program Lifecycle Integration Tests', () => {
 
         const idsToDelete = [testParticipantId, leadMentorId, boardAdminId].filter(id => id);
         if (idsToDelete.length > 0) {
-            await prisma.participant.deleteMany({ where: { id: { in: idsToDelete } } });
+            await prisma.person.deleteMany({ where: { id: { in: idsToDelete } } });
         }
     });
 

--- a/checkin-app/__tests__/programSignupIntegration.test.ts
+++ b/checkin-app/__tests__/programSignupIntegration.test.ts
@@ -27,7 +27,7 @@ jest.mock('@/lib/shopify', () => ({
 // Mock Prisma
 jest.mock('@/lib/prisma', () => {
   const mock = {
-    participant: {
+    person: {
       create: jest.fn(),
       findUnique: jest.fn(),
       findMany: jest.fn(),
@@ -153,10 +153,10 @@ describe('Full Program Signup Integration Flow', () => {
 
         // 4. Lead user (who already has a household from signup) adds a child member
         mockGetSession.mockResolvedValue({ user: { id: leadUserId } });
-        (prisma.participant.findUnique as jest.Mock).mockResolvedValueOnce({ id: leadUserId, householdId, householdLeads: [{ householdId, participantId: leadUserId }] });
-        (prisma.participant.create as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId });
+        (prisma.person.findUnique as jest.Mock).mockResolvedValueOnce({ id: leadUserId, householdId, householdLeads: [{ householdId, participantId: leadUserId }] });
+        (prisma.person.create as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId });
         // Adding a member reconciles emergency contacts (direction B); no contacts/members to flag here.
-        (prisma.participant.findMany as jest.Mock).mockResolvedValue([]);
+        (prisma.person.findMany as jest.Mock).mockResolvedValue([]);
         (prisma.emergencyContact.findMany as jest.Mock).mockResolvedValue([]);
 
         const addChildReq = new Request('http://localhost/api/household', {
@@ -180,7 +180,7 @@ describe('Full Program Signup Integration Flow', () => {
             maxParticipants: null,
             _count: { participants: 0 }
         });
-        (prisma.participant.findUnique as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId, dateOfBirth: new Date('2015-01-01') });
+        (prisma.person.findUnique as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId, dateOfBirth: new Date('2015-01-01') });
         (prisma.householdLead.findUnique as jest.Mock).mockResolvedValue({ householdId, participantId: leadUserId });
         (prisma.programParticipant.create as jest.Mock).mockResolvedValue({ programId, personId: childParticipantId, status: 'PENDING' });
 
@@ -237,7 +237,7 @@ describe('Full Program Signup Integration Flow', () => {
             maxParticipants: null,
             _count: { participants: 0 }
         });
-        (prisma.participant.findUnique as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId, dateOfBirth: new Date('2015-01-01') });
+        (prisma.person.findUnique as jest.Mock).mockResolvedValue({ id: childParticipantId, householdId, dateOfBirth: new Date('2015-01-01') });
         (prisma.householdLead.findUnique as jest.Mock).mockResolvedValue(null); // Not a lead
 
         const enrollReq = new Request(`http://localhost/api/programs/${programId}/participants`, {

--- a/checkin-app/prisma/migrations/20260702153433_rename_participant_model_to_person/migration.sql
+++ b/checkin-app/prisma/migrations/20260702153433_rename_participant_model_to_person/migration.sql
@@ -1,0 +1,153 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Participant` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Account" DROP CONSTRAINT "Account_participant_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "BackgroundCheckAttestation" DROP CONSTRAINT "BackgroundCheckAttestation_reviewerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CorporationLead" DROP CONSTRAINT "CorporationLead_personId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CorporationMember" DROP CONSTRAINT "CorporationMember_personId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Event" DROP CONSTRAINT "Event_attendanceConfirmedById_fkey";
+
+-- DropForeignKey
+ALTER TABLE "FeePayment" DROP CONSTRAINT "FeePayment_personId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "HouseholdLead" DROP CONSTRAINT "HouseholdLead_personId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Participant" DROP CONSTRAINT "Participant_householdId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Program" DROP CONSTRAINT "Program_leadMentorId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ProgramParticipant" DROP CONSTRAINT "ProgramParticipant_personId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ProgramVolunteer" DROP CONSTRAINT "ProgramVolunteer_personId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RSVP" DROP CONSTRAINT "RSVP_personId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RawBadgeLog" DROP CONSTRAINT "RawBadgeLog_personId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Session" DROP CONSTRAINT "Session_participant_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ToolStatus" DROP CONSTRAINT "ToolStatus_personId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TrustedAdult" DROP CONSTRAINT "TrustedAdult_counterpartyParticipantId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TrustedAdult" DROP CONSTRAINT "TrustedAdult_disclosedById_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TrustedAdultReview" DROP CONSTRAINT "TrustedAdultReview_decidedById_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Visit" DROP CONSTRAINT "Visit_personId_fkey";
+
+-- DropTable
+DROP TABLE "Participant";
+
+-- CreateTable
+CREATE TABLE "Person" (
+    "id" SERIAL NOT NULL,
+    "googleId" TEXT,
+    "email" TEXT,
+    "phone" TEXT,
+    "name" TEXT,
+    "emailVerified" TIMESTAMP(3),
+    "image" TEXT,
+    "dateOfBirth" TIMESTAMP(3),
+    "isDeclaredAdult" BOOLEAN NOT NULL DEFAULT false,
+    "lastWaiverSign" TIMESTAMP(3),
+    "waiverSignedBy" INTEGER,
+    "lastBackgroundCheck" TIMESTAMP(3),
+    "notificationSettings" JSONB,
+    "householdId" INTEGER NOT NULL,
+    "allergies" TEXT,
+    "isSysadmin" BOOLEAN NOT NULL DEFAULT false,
+    "isBoardMember" BOOLEAN NOT NULL DEFAULT false,
+    "isKeyholder" BOOLEAN NOT NULL DEFAULT false,
+    "isBackgroundCheckReviewer" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "Person_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Person_googleId_key" ON "Person"("googleId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Person_email_key" ON "Person"("email");
+
+-- AddForeignKey
+ALTER TABLE "Person" ADD CONSTRAINT "Person_householdId_fkey" FOREIGN KEY ("householdId") REFERENCES "Household"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ToolStatus" ADD CONSTRAINT "ToolStatus_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HouseholdLead" ADD CONSTRAINT "HouseholdLead_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BackgroundCheckAttestation" ADD CONSTRAINT "BackgroundCheckAttestation_reviewerId_fkey" FOREIGN KEY ("reviewerId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TrustedAdult" ADD CONSTRAINT "TrustedAdult_counterpartyParticipantId_fkey" FOREIGN KEY ("counterpartyParticipantId") REFERENCES "Person"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TrustedAdult" ADD CONSTRAINT "TrustedAdult_disclosedById_fkey" FOREIGN KEY ("disclosedById") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TrustedAdultReview" ADD CONSTRAINT "TrustedAdultReview_decidedById_fkey" FOREIGN KEY ("decidedById") REFERENCES "Person"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CorporationLead" ADD CONSTRAINT "CorporationLead_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CorporationMember" ADD CONSTRAINT "CorporationMember_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Program" ADD CONSTRAINT "Program_leadMentorId_fkey" FOREIGN KEY ("leadMentorId") REFERENCES "Person"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProgramVolunteer" ADD CONSTRAINT "ProgramVolunteer_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProgramParticipant" ADD CONSTRAINT "ProgramParticipant_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeePayment" ADD CONSTRAINT "FeePayment_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Event" ADD CONSTRAINT "Event_attendanceConfirmedById_fkey" FOREIGN KEY ("attendanceConfirmedById") REFERENCES "Person"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RSVP" ADD CONSTRAINT "RSVP_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RawBadgeLog" ADD CONSTRAINT "RawBadgeLog_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Visit" ADD CONSTRAINT "Visit_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Account" ADD CONSTRAINT "Account_participant_id_fkey" FOREIGN KEY ("participant_id") REFERENCES "Person"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_participant_id_fkey" FOREIGN KEY ("participant_id") REFERENCES "Person"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -59,7 +59,7 @@ enum ProgramParticipantStatus {
   ACTIVE
 }
 
-model Participant {
+model Person {
   /// @sensitivity:public
   id            Int       @id @default(autoincrement())
   /// @sensitivity:pii
@@ -144,7 +144,7 @@ model ToolStatus {
   /// @sensitivity:member
   level  ToolLevel
 
-  person Participant @relation(fields: [personId], references: [id])
+  person Person @relation(fields: [personId], references: [id])
   tool Tool        @relation(fields: [toolId], references: [id])
 
   @@id([personId, toolId])
@@ -166,7 +166,7 @@ model Household {
   /// @sensitivity:personal
   postalCode String?
 
-  participants      Participant[]
+  participants      Person[]
   leads             HouseholdLead[]
   membership        Membership?
   trustedAdults     TrustedAdult[]
@@ -226,7 +226,7 @@ model HouseholdLead {
   personId Int
 
   household   Household   @relation(fields: [householdId], references: [id])
-  person Participant @relation(fields: [personId], references: [id])
+  person Person @relation(fields: [personId], references: [id])
 
   @@id([householdId, personId])
 }
@@ -367,7 +367,7 @@ model BackgroundCheckAttestation {
   process         MembershipProcess @relation(fields: [processId], references: [id])
   /// @sensitivity:public
   reviewerId      Int
-  reviewer        Participant       @relation("BgAttestations", fields: [reviewerId], references: [id])
+  reviewer        Person       @relation("BgAttestations", fields: [reviewerId], references: [id])
   /// @sensitivity:internal
   result          AttestationResult
   /// @sensitivity:internal
@@ -444,9 +444,9 @@ model AppSettings {
 }
 
 /// Trusted Adult Management (Trusted Adults). A board-reviewed disclosure that
-/// one individual (the subject, always a Participant) holds an external
+/// one individual (the subject, always a Person) holds an external
 /// relationship — familial, romantic, guardianship, financial, legal-restriction,
-/// etc. — with a counterparty who may be another Participant or someone outside
+/// etc. — with a counterparty who may be another Person or someone outside
 /// the org. The durable relationship facts live here, entered once; each annual
 /// review cycle is a TrustedAdultReview row (like Membership/MembershipProcess), so
 /// a renewal reuses the facts without re-entry.
@@ -461,7 +461,7 @@ model TrustedAdult {
   /// The trusted adult, if they are also a participant in the system.
   /// @sensitivity:public
   counterpartyParticipantId Int?
-  counterparty              Participant?       @relation("TrustedAdultCounterparty", fields: [counterpartyParticipantId], references: [id])
+  counterparty              Person?       @relation("TrustedAdultCounterparty", fields: [counterpartyParticipantId], references: [id])
   /// @sensitivity:personal
   counterpartyName          String
   /// The trusted adult's phone and/or email. At least one is required (enforced
@@ -481,7 +481,7 @@ model TrustedAdult {
   origin                    TrustedAdultOrigin @default(SELF_DISCLOSED)
   /// @sensitivity:internal
   disclosedById             Int
-  disclosedBy               Participant        @relation("TrustedAdultDiscloser", fields: [disclosedById], references: [id])
+  disclosedBy               Person        @relation("TrustedAdultDiscloser", fields: [disclosedById], references: [id])
   /// @sensitivity:public
   createdAt                 DateTime           @default(now())
   /// @sensitivity:internal
@@ -511,7 +511,7 @@ model TrustedAdultReview {
   status               TrustedAdultReviewStatus @default(PENDING_BOARD_REVIEW)
   /// @sensitivity:internal
   decidedById          Int?
-  decidedBy            Participant?             @relation("TrustedAdultDecider", fields: [decidedById], references: [id])
+  decidedBy            Person?             @relation("TrustedAdultDecider", fields: [decidedById], references: [id])
   /// @sensitivity:internal
   decision             TrustedAdultDecisionKind?
   /// The board's PRIVATE reasoning. Board/sysadmin only (internal tier).
@@ -566,7 +566,7 @@ model CorporationLead {
   personId Int
 
   corporation Corporation @relation(fields: [corporationId], references: [id])
-  person      Participant @relation(fields: [personId], references: [id])
+  person      Person @relation(fields: [personId], references: [id])
 
   @@id([corporationId, personId])
 }
@@ -578,7 +578,7 @@ model CorporationMember {
   personId Int
 
   corporation Corporation @relation(fields: [corporationId], references: [id])
-  person      Participant @relation(fields: [personId], references: [id])
+  person      Person @relation(fields: [personId], references: [id])
 
   @@id([corporationId, personId])
 }
@@ -590,7 +590,7 @@ model Program {
   name                           String
   /// @sensitivity:public
   leadMentorId                   Int?
-  leadMentor                     Participant?     @relation("ProgramLeadMentor", fields: [leadMentorId], references: [id])
+  leadMentor                     Person?     @relation("ProgramLeadMentor", fields: [leadMentorId], references: [id])
   /// @sensitivity:public
   startAt                        DateTime?
   /// @sensitivity:public
@@ -638,7 +638,7 @@ model ProgramVolunteer {
   isCore        Boolean @default(false)
 
   program Program     @relation(fields: [programId], references: [id])
-  person  Participant @relation(fields: [personId], references: [id])
+  person  Person @relation(fields: [personId], references: [id])
 
   @@id([programId, personId])
 }
@@ -656,7 +656,7 @@ model ProgramParticipant {
   pendingSince         DateTime?                @default(now())
 
   program Program     @relation(fields: [programId], references: [id])
-  person  Participant @relation(fields: [personId], references: [id])
+  person  Person @relation(fields: [personId], references: [id])
 
   @@id([programId, personId])
 }
@@ -694,7 +694,7 @@ model FeePayment {
   customNote        String?
 
   fee         Fee         @relation(fields: [feeId], references: [id])
-  person      Participant @relation(fields: [personId], references: [id])
+  person      Person @relation(fields: [personId], references: [id])
 
   @@id([feeId, personId])
 }
@@ -717,7 +717,7 @@ model Event {
   attendanceConfirmedAt   DateTime?
   /// @sensitivity:internal
   attendanceConfirmedById Int?
-  attendanceConfirmedBy   Participant? @relation("EventAttendanceConfirmer", fields: [attendanceConfirmedById], references: [id])
+  attendanceConfirmedBy   Person? @relation("EventAttendanceConfirmer", fields: [attendanceConfirmedById], references: [id])
   /// @sensitivity:internal
   postEventEmailSent      Boolean      @default(false)
   /// @sensitivity:public
@@ -739,7 +739,7 @@ model RSVP {
   reminderSentAt DateTime?
 
   event       Event       @relation(fields: [eventId], references: [id])
-  person      Participant @relation(fields: [personId], references: [id])
+  person      Person @relation(fields: [personId], references: [id])
 
   @@id([eventId, personId])
 }
@@ -754,7 +754,7 @@ model RawBadgeLog {
   /// @sensitivity:personal
   location      String?
 
-  person Participant @relation(fields: [personId], references: [id])
+  person Person @relation(fields: [personId], references: [id])
 
   @@index([personId, timestamp]) // Double-badge detection in /api/scan
 }
@@ -775,7 +775,7 @@ model Visit {
   /// @sensitivity:public
   associatedEventId Int?
 
-  person Participant @relation(fields: [personId], references: [id])
+  person Person @relation(fields: [personId], references: [id])
   event  Event?      @relation(fields: [associatedEventId], references: [id])
 
   @@index([personId, departedAt]) // Active visits lookup in /api/scan
@@ -832,7 +832,7 @@ model Account {
   /// @sensitivity:internal
   session_state     String?
 
-  user Participant @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user Person @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
 }
@@ -846,7 +846,7 @@ model Session {
   userId       Int         @map("participant_id")
   /// @sensitivity:internal
   expires      DateTime
-  user         Participant @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user         Person @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model VerificationToken {

--- a/checkin-app/prisma/seed_20_users.ts
+++ b/checkin-app/prisma/seed_20_users.ts
@@ -19,7 +19,7 @@ async function main() {
         })
 
         // Create participant
-        const participant = await prisma.participant.create({
+        const participant = await prisma.person.create({
             data: {
                 email: `testmember${i}@example.com`,
                 name: `Test Member ${i}`,

--- a/checkin-app/scripts/import-zoho.ts
+++ b/checkin-app/scripts/import-zoho.ts
@@ -53,7 +53,7 @@ async function main() {
     const prisma = new PrismaClient({ adapter });
     try {
         // Confirm the audit actor exists before writing anything.
-        const actor = await prisma.participant.findUnique({ where: { id: actorId } });
+        const actor = await prisma.person.findUnique({ where: { id: actorId } });
         if (!actor) throw new Error(`--actor ${actorId} is not an existing Participant.`);
 
         const result = await prisma.$transaction((tx) => applyImport(tx, built, actorId), {

--- a/checkin-app/src/app/__tests__/adminAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminAuditAPI.integration.test.ts
@@ -21,7 +21,7 @@ describe('Admin Audit API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'audit-api-test' } },
             select: { id: true }
         });
@@ -31,18 +31,18 @@ describe('Admin Audit API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
         // Create Admin
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-audit-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
         });
         adminId = admin.id;
 
         // Create Common User
-        const commonUser = await prisma.participant.create({
+        const commonUser = await prisma.person.create({
             data: { email: 'common-audit-api-test@example.com', name: 'Common', household: { create: {} } }
         });
         commonId = commonUser.id;
@@ -67,7 +67,7 @@ describe('Admin Audit API Integration Tests', () => {
                 where: { actorId: { in: existingUserIds } }
             });
 
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { id: { in: existingUserIds } }
             });
         }

--- a/checkin-app/src/app/__tests__/adminBadgesAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBadgesAPI.integration.test.ts
@@ -27,17 +27,17 @@ describe('Admin Badges API Integration Tests', () => {
                 person: { email: { contains: 'badges-api-test' } }
             }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'badges-api-test' } }
         });
 
         // Setup mock database records
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-badges-api-test@example.com', name: 'Admin Badges Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
 
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-badges-api-test@example.com', name: 'User Badges Test', household: { create: {} } }
         });
         testUserId = user.id;
@@ -56,7 +56,7 @@ describe('Admin Badges API Integration Tests', () => {
         await prisma.rawBadgeLog.deleteMany({
             where: { id: testBadgeEventId }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: [testAdminId, testUserId] } }
         });
     });

--- a/checkin-app/src/app/__tests__/adminBulkImport.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImport.integration.test.ts
@@ -25,10 +25,10 @@ describe('Admin Bulk Import API Integration Tests', () => {
             // Clean up any leaked state
             await prisma.membership.deleteMany({});
             await prisma.householdLead.deleteMany({});
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { email: { contains: 'import-test' } }
             });
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { name: { contains: 'Import Test' } }
             });
             await prisma.household.deleteMany({
@@ -40,12 +40,12 @@ describe('Admin Bulk Import API Integration Tests', () => {
         } catch {}
 
         // Setup mock database records
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-import-test@example.com', name: 'Admin Import Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
 
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-import-test@example.com', name: 'User Import Test', household: { create: {} } }
         });
         testUserId = user.id;
@@ -56,10 +56,10 @@ describe('Admin Bulk Import API Integration Tests', () => {
             // Clean up
             await prisma.membership.deleteMany({});
             await prisma.householdLead.deleteMany({});
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { email: { contains: 'import-test' } }
             });
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { name: { contains: 'Import Test' } }
             });
             await prisma.household.deleteMany({
@@ -76,10 +76,10 @@ describe('Admin Bulk Import API Integration Tests', () => {
             // Clean up participants created during tests
             await prisma.membership.deleteMany({});
             await prisma.householdLead.deleteMany({});
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { email: { contains: 'batch-import-test' } }
             });
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { name: { contains: 'Batch Import Test' } }
             });
             await prisma.household.deleteMany({
@@ -183,17 +183,17 @@ describe('Admin Bulk Import API Integration Tests', () => {
             expect(data.message).toContain('3 participants');
 
             // Verify Alice
-            const alice = await prisma.participant.findUnique({ where: { email: 'alice-batch-import-test@example.com' } });
+            const alice = await prisma.person.findUnique({ where: { email: 'alice-batch-import-test@example.com' } });
             expect(alice).toBeDefined();
             expect(alice?.householdId).not.toBeNull();
 
             // Verify Bob
-            const bob = await prisma.participant.findFirst({ where: { name: 'Bob Batch Import Test' } });
+            const bob = await prisma.person.findFirst({ where: { name: 'Bob Batch Import Test' } });
             expect(bob).toBeDefined();
             expect(bob?.householdId).toBe(alice?.householdId);
 
             // Verify Charlie
-            const charlie = await prisma.participant.findUnique({ where: { email: 'charlie-batch-import-test@example.com' } });
+            const charlie = await prisma.person.findUnique({ where: { email: 'charlie-batch-import-test@example.com' } });
             expect(charlie).toBeDefined();
             expect(charlie?.householdId).toBe(alice?.householdId);
         });
@@ -220,7 +220,7 @@ describe('Admin Bulk Import API Integration Tests', () => {
             if (data.errors) console.log("Import Errors:", data.errors);
             expect(res.status).toBe(200);
             
-            const adult = await prisma.participant.findFirst({ where: { name: 'Adult Import Test' } });
+            const adult = await prisma.person.findFirst({ where: { name: 'Adult Import Test' } });
             expect(adult).not.toBeNull();
             expect(adult!.householdId).not.toBeNull();
             
@@ -229,13 +229,13 @@ describe('Admin Bulk Import API Integration Tests', () => {
             // But here it should be present.
             expect(adultLead).not.toBeNull();
 
-            const youth = await prisma.participant.findFirst({ where: { name: 'Youth Import Test' } });
+            const youth = await prisma.person.findFirst({ where: { name: 'Youth Import Test' } });
             expect(youth).not.toBeNull();
             expect(youth!.householdId).not.toBeNull();
             const youthLead = await prisma.householdLead.findFirst({ where: { personId: youth!.id } });
             expect(youthLead).toBeNull();
 
-            const defaultAdult = await prisma.participant.findFirst({ where: { name: 'Default Import Test' } });
+            const defaultAdult = await prisma.person.findFirst({ where: { name: 'Default Import Test' } });
             expect(defaultAdult?.householdId).not.toBeNull();
             const defaultLead = await prisma.householdLead.findFirst({ where: { personId: defaultAdult?.id } });
             expect(defaultLead).not.toBeNull();

--- a/checkin-app/src/app/__tests__/adminBulkImportMalformedRow.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportMalformedRow.integration.test.ts
@@ -25,15 +25,15 @@ describe('Bulk import: malformed row among valid rows', () => {
         try {
             await prisma.membership.deleteMany({});
             await prisma.householdLead.deleteMany({});
-            await prisma.participant.deleteMany({ where: { email: { contains: 'malrow-import-test' } } });
-            await prisma.participant.deleteMany({ where: { name: { contains: 'Malrow Import Test' } } });
+            await prisma.person.deleteMany({ where: { email: { contains: 'malrow-import-test' } } });
+            await prisma.person.deleteMany({ where: { name: { contains: 'Malrow Import Test' } } });
             await prisma.household.deleteMany({ where: { participants: { none: {} } } });
         } catch {}
     };
 
     beforeAll(async () => {
         await cleanup();
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-malrow-import-test@example.com', name: 'Admin Malrow Import Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
@@ -78,15 +78,15 @@ describe('Bulk import: malformed row among valid rows', () => {
         expect(data.success).toBe(true);
 
         // Valid rows persisted...
-        const valid1 = await prisma.participant.findUnique({ where: { email: 'valid1-malrow-import-test@example.com' } });
-        const valid3 = await prisma.participant.findUnique({ where: { email: 'valid3-malrow-import-test@example.com' } });
+        const valid1 = await prisma.person.findUnique({ where: { email: 'valid1-malrow-import-test@example.com' } });
+        const valid3 = await prisma.person.findUnique({ where: { email: 'valid3-malrow-import-test@example.com' } });
         expect(valid1).not.toBeNull();
         expect(valid3).not.toBeNull();
 
         // ...bad row NOT persisted.
-        const bad = await prisma.participant.findFirst({ where: { name: 'Bad Malrow Import Test' } });
+        const bad = await prisma.person.findFirst({ where: { name: 'Bad Malrow Import Test' } });
         expect(bad).toBeNull();
-        const importedCount = await prisma.participant.count({ where: { name: { contains: 'Malrow Import Test' }, NOT: { name: 'Admin Malrow Import Test' } } });
+        const importedCount = await prisma.person.count({ where: { name: { contains: 'Malrow Import Test' }, NOT: { name: 'Admin Malrow Import Test' } } });
         expect(importedCount).toBe(2);
 
         // Bad row surfaced in errors[], naming the right sheet row (the 2nd data row = "Row 3").
@@ -110,14 +110,14 @@ describe('Bulk import: malformed row among valid rows', () => {
         expect(res.status).toBe(200);
         expect(data.success).toBe(true);
 
-        const valid1 = await prisma.participant.findUnique({ where: { email: 'valid1-malrow-import-test@example.com' } });
-        const valid3 = await prisma.participant.findUnique({ where: { email: 'valid3-malrow-import-test@example.com' } });
+        const valid1 = await prisma.person.findUnique({ where: { email: 'valid1-malrow-import-test@example.com' } });
+        const valid3 = await prisma.person.findUnique({ where: { email: 'valid3-malrow-import-test@example.com' } });
         expect(valid1).not.toBeNull();
         expect(valid3).not.toBeNull();
 
-        const bad = await prisma.participant.findFirst({ where: { name: 'BadParent Malrow Import Test' } });
+        const bad = await prisma.person.findFirst({ where: { name: 'BadParent Malrow Import Test' } });
         expect(bad).toBeNull();
-        const importedCount = await prisma.participant.count({ where: { name: { contains: 'Malrow Import Test' }, NOT: { name: 'Admin Malrow Import Test' } } });
+        const importedCount = await prisma.person.count({ where: { name: { contains: 'Malrow Import Test' }, NOT: { name: 'Admin Malrow Import Test' } } });
         expect(importedCount).toBe(2);
 
         expect(data.errors).toHaveLength(1);

--- a/checkin-app/src/app/__tests__/adminBulkImportMergeRollback.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportMergeRollback.integration.test.ts
@@ -35,7 +35,7 @@ describe('Bulk import merge rollback', () => {
             await prisma.trustedAdult.deleteMany({ where: { counterpartyName: 'Grandma Mergeroll' } });
             await prisma.membership.deleteMany({});
             await prisma.householdLead.deleteMany({});
-            await prisma.participant.deleteMany({ where: { email: { contains: 'mergeroll-test' } } });
+            await prisma.person.deleteMany({ where: { email: { contains: 'mergeroll-test' } } });
             await prisma.household.deleteMany({ where: { participants: { none: {} } } });
         } catch {}
     };
@@ -43,18 +43,18 @@ describe('Bulk import merge rollback', () => {
     beforeAll(async () => {
         await cleanup();
 
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-mergeroll-test@example.com', name: 'Admin Mergeroll Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
 
-        const target = await prisma.participant.create({
+        const target = await prisma.person.create({
             data: { email: TARGET_EMAIL, name: 'Target Anchor Mergeroll Test', household: { create: {} } },
             select: { householdId: true }
         });
         targetHouseholdId = target.householdId;
 
-        const source = await prisma.participant.create({
+        const source = await prisma.person.create({
             data: { email: SOURCE_EMAIL, name: 'Source Member Mergeroll Test', household: { create: {} } },
             select: { id: true, householdId: true }
         });
@@ -111,7 +111,7 @@ describe('Bulk import merge rollback', () => {
         expect(data.errors.join(' ')).toContain('Household linking error');
 
         // NO partial move: source member still in the source household...
-        const source = await prisma.participant.findUnique({
+        const source = await prisma.person.findUnique({
             where: { id: sourceMemberId },
             select: { householdId: true }
         });

--- a/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
@@ -47,15 +47,15 @@ describe('Bulk import: preview vs commit consistency', () => {
         try {
             await prisma.membership.deleteMany({});
             await prisma.householdLead.deleteMany({});
-            await prisma.participant.deleteMany({ where: { email: { contains: 'consist-import-test' } } });
-            await prisma.participant.deleteMany({ where: { name: { contains: 'Consist Import Test' } } });
+            await prisma.person.deleteMany({ where: { email: { contains: 'consist-import-test' } } });
+            await prisma.person.deleteMany({ where: { name: { contains: 'Consist Import Test' } } });
             await prisma.household.deleteMany({ where: { participants: { none: {} } } });
         } catch {}
     };
 
     beforeAll(async () => {
         await cleanup();
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-consist-import-test@example.com', name: 'Admin Consist Import Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
@@ -121,11 +121,11 @@ describe('Bulk import: preview vs commit consistency', () => {
 
         // Dup detection: commit collapses the two Anchor-email rows into ONE participant
         // (the second row updates the first), matching preview's "duplicate" signal.
-        const anchorRecords = await prisma.participant.findMany({ where: { email: ANCHOR_EMAIL } });
+        const anchorRecords = await prisma.person.findMany({ where: { email: ANCHOR_EMAIL } });
         expect(anchorRecords).toHaveLength(1);
 
         // Household resolution: Ref actually lands in Anchor's household, matching preview's "will link".
-        const ref = await prisma.participant.findUnique({ where: { email: REF_EMAIL }, select: { householdId: true } });
+        const ref = await prisma.person.findUnique({ where: { email: REF_EMAIL }, select: { householdId: true } });
         expect(ref?.householdId).toBe(anchorRecords[0].householdId);
     });
 
@@ -141,7 +141,7 @@ describe('Bulk import: preview vs commit consistency', () => {
         expect(body.success).toBe(true);
 
         // Commit's Excel-serial branch parses 33239 -> 1991-01-01 (an ADULT)...
-        const anchor = await prisma.participant.findUnique({ where: { email: ANCHOR_EMAIL }, select: { id: true, dateOfBirth: true } });
+        const anchor = await prisma.person.findUnique({ where: { email: ANCHOR_EMAIL }, select: { id: true, dateOfBirth: true } });
         expect(anchor?.dateOfBirth?.getUTCFullYear()).toBe(1991);
         // ...and commit therefore makes the adult a household lead.
         const lead = await prisma.householdLead.findFirst({ where: { personId: anchor!.id } });

--- a/checkin-app/src/app/__tests__/adminHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminHouseholdsAPI.integration.test.ts
@@ -24,7 +24,7 @@ describe('Admin Households API Integration Tests', () => {
     beforeAll(async () => {
         // Clean up any leaked state
         await prisma.membership.deleteMany({});
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'households-api-test' } }
         });
         await prisma.household.deleteMany({
@@ -32,7 +32,7 @@ describe('Admin Households API Integration Tests', () => {
         });
 
         // Setup mock database records
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-households-api-test@example.com', name: 'Admin Households Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
@@ -48,7 +48,7 @@ describe('Admin Households API Integration Tests', () => {
         testHousehold2Id = household2.id;
 
         // Add user to household 2 for search testing
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-households-api-test@example.com', name: 'User Households Test', householdId: testHousehold2Id }
         });
         testUserId = user.id;
@@ -67,7 +67,7 @@ describe('Admin Households API Integration Tests', () => {
         await prisma.membership.deleteMany({
             where: { householdId: { in: [testHousehold1Id, testHousehold2Id] } }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: [testAdminId, testUserId] } }
         });
         await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
@@ -20,19 +20,19 @@ describe('Admin Participant Household API Integration Tests', () => {
         // Clean up any leaked state
         await prisma.membership.deleteMany({});
         await prisma.householdLead.deleteMany({});
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'household-api-test' } }
         });
         await prisma.household.deleteMany({
             where: { name: { contains: 'Household API Test' } }
         });
 
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-household-api-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
 
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-household-api-test@example.com', name: 'User Test', household: { create: {} } }
         });
         testUserId = user.id;
@@ -46,7 +46,7 @@ describe('Admin Participant Household API Integration Tests', () => {
     afterAll(async () => {
         await prisma.membership.deleteMany({});
         await prisma.householdLead.deleteMany({});
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'household-api-test' } }
         });
         await prisma.household.deleteMany({
@@ -55,7 +55,7 @@ describe('Admin Participant Household API Integration Tests', () => {
     });
 
     beforeEach(async () => {
-        const participant = await prisma.participant.create({
+        const participant = await prisma.person.create({
             data: { email: 'subject-household-api-test@example.com', name: 'Subject Test', household: { create: {} } }
         });
         testParticipantId = participant.id;
@@ -64,7 +64,7 @@ describe('Admin Participant Household API Integration Tests', () => {
     afterEach(async () => {
         await prisma.membership.deleteMany({});
         await prisma.householdLead.deleteMany({});
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { name: 'Subject Test' }
         });
     });
@@ -89,7 +89,7 @@ describe('Admin Participant Household API Integration Tests', () => {
                 user: { id: testAdminId, isSysadmin: true, isBoardMember: false }
             });
 
-            const subjectBefore = await prisma.participant.findUnique({ where: { id: testParticipantId } });
+            const subjectBefore = await prisma.person.findUnique({ where: { id: testParticipantId } });
             const priorHouseholdId = subjectBefore!.householdId;
 
             const req = new Request(`http://localhost:4000/api/membership-ops/participants/${testParticipantId}/household`, {
@@ -104,7 +104,7 @@ describe('Admin Participant Household API Integration Tests', () => {
             expect(data.success).toBe(true);
             expect(data.participant.householdId).toBe(testHouseholdId);
 
-            const updatedParticipant = await prisma.participant.findUnique({ where: { id: testParticipantId } });
+            const updatedParticipant = await prisma.person.findUnique({ where: { id: testParticipantId } });
             expect(updatedParticipant?.householdId).toBe(testHouseholdId);
 
             // The move MUST be audited with the acting admin and the prior→new

--- a/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
@@ -43,13 +43,13 @@ describe('Admin Participants API Integration Tests', () => {
 
     /** Delete participants matching `filters`, their memberships/leads, then sweep any household left empty. */
     async function wipe(filters: Array<Record<string, unknown>>) {
-        const rows = await prisma.participant.findMany({ where: { OR: filters }, select: { householdId: true } });
+        const rows = await prisma.person.findMany({ where: { OR: filters }, select: { householdId: true } });
         const householdIds = [...new Set(rows.map((r) => r.householdId).filter((id): id is number => id != null))];
         if (householdIds.length) {
             await prisma.membership.deleteMany({ where: { householdId: { in: householdIds } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: householdIds } } });
         }
-        await prisma.participant.deleteMany({ where: { OR: filters } });
+        await prisma.person.deleteMany({ where: { OR: filters } });
         // Only sweep households the deletion above emptied — a household this file
         // doesn't own could share a similar name (e.g. "Test Household"), and the
         // Participant->Household FK is RESTRICT.
@@ -63,12 +63,12 @@ describe('Admin Participants API Integration Tests', () => {
         await wipe(PERSISTENT_EMAIL_FILTERS);
 
         // Setup mock database records
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-participants-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
 
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-participants-test@example.com', name: 'User Test', household: { create: {} } }
         });
         testUserId = user.id;
@@ -163,7 +163,7 @@ describe('Admin Participants API Integration Tests', () => {
 
             // The API returns the participant created BEFORE the household is linked since it does not refetch
             // We should just verify it exists in the DB correctly
-            const updatedParticipant = await prisma.participant.findUnique({
+            const updatedParticipant = await prisma.person.findUnique({
                 where: { id: data.participant.id }
             });
             expect(updatedParticipant?.householdId).not.toBeNull();
@@ -199,7 +199,7 @@ describe('Admin Participants API Integration Tests', () => {
             expect(res.status).toBe(200);
             const data = await res.json();
 
-            const created = await prisma.participant.findUnique({
+            const created = await prisma.person.findUnique({
                 where: { id: data.participant.id }
             });
             const membership = await prisma.membership.findUnique({
@@ -231,7 +231,7 @@ describe('Admin Participants API Integration Tests', () => {
             expect(data.participant.householdId).not.toBeNull();
 
             // Verify the parent was created
-            const parent = await prisma.participant.findUnique({
+            const parent = await prisma.person.findUnique({
                 where: { email: 'new-parent-participants-test@example.com' }
             });
             expect(parent).toBeDefined();
@@ -260,7 +260,7 @@ describe('Admin Participants API Integration Tests', () => {
             });
 
             // Create a disposable user just for this edit test
-            const editUser = await prisma.participant.create({
+            const editUser = await prisma.person.create({
                 data: { email: 'edit-test-user@example.com', name: 'Original Name', household: { create: {} } }
             });
 
@@ -279,7 +279,7 @@ describe('Admin Participants API Integration Tests', () => {
             expect(data.participant.phone).toBe('555-123-4567');
 
             // Verify the DB actually saved it
-            const dbCheck = await prisma.participant.findUnique({ where: { id: editUser.id } });
+            const dbCheck = await prisma.person.findUnique({ where: { id: editUser.id } });
             expect(dbCheck?.name).toBe('Updated Name');
             expect(dbCheck?.phone).toBe('555-123-4567');
 

--- a/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
@@ -24,34 +24,34 @@ describe('Admin Roles API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'roles-api-test' } },
             select: { id: true }
         });
         await prisma.auditLog.deleteMany({
             where: { actorId: { in: existingUsers.map(u => u.id) } }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'roles-api-test' } }
         });
 
         // Setup mock database records
-        const isSysadmin = await prisma.participant.create({
+        const isSysadmin = await prisma.person.create({
             data: { email: 'sysadmin-roles-api-test@example.com', name: 'Admin Roles Test', isSysadmin: true, household: { create: {} } }
         });
         testSysAdminId = isSysadmin.id;
 
-        const isBoardMember = await prisma.participant.create({
+        const isBoardMember = await prisma.person.create({
             data: { email: 'board-roles-api-test@example.com', name: 'Board Roles Test', isBoardMember: true, household: { create: {} } }
         });
         testBoardMemberId = isBoardMember.id;
 
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-roles-api-test@example.com', name: 'User Roles Test', household: { create: {} } }
         });
         testUserId = user.id;
 
-        const targetUser = await prisma.participant.create({
+        const targetUser = await prisma.person.create({
             data: { email: 'target-roles-api-test@example.com', name: 'Target Roles Test', dateOfBirth: new Date('1990-01-01'), household: { create: {} } }
         });
         testTargetUserId = targetUser.id;
@@ -59,7 +59,7 @@ describe('Admin Roles API Integration Tests', () => {
         const now = new Date();
         const tenYearsAgo = new Date(now.getFullYear() - 10, now.getMonth(), now.getDate());
         
-        const student = await prisma.participant.create({
+        const student = await prisma.person.create({
             data: { email: 'student-roles-api-test@example.com', name: 'Student Roles Test', dateOfBirth: tenYearsAgo, household: { create: {} } }
         });
         testStudentId = student.id;
@@ -72,7 +72,7 @@ describe('Admin Roles API Integration Tests', () => {
                 where: { actorId: { in: [testSysAdminId, testBoardMemberId] } }
             });
         }
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: [testSysAdminId, testBoardMemberId, testUserId, testTargetUserId, testStudentId] } }
         });
     });
@@ -203,7 +203,7 @@ describe('Admin Roles API Integration Tests', () => {
             expect(data.message).toBe("Roles updated successfully");
             expect(data.user.isBoardMember).toBe(true);
 
-            const userRef = await prisma.participant.findUnique({ where: { id: testTargetUserId } });
+            const userRef = await prisma.person.findUnique({ where: { id: testTargetUserId } });
             expect(userRef?.isBoardMember).toBe(true);
         });
 
@@ -223,7 +223,7 @@ describe('Admin Roles API Integration Tests', () => {
             const data = await res.json();
             expect(data.user.isSysadmin).toBe(true);
 
-            const userRef = await prisma.participant.findUnique({ where: { id: testTargetUserId } });
+            const userRef = await prisma.person.findUnique({ where: { id: testTargetUserId } });
             expect(userRef?.isSysadmin).toBe(true);
         });
     });

--- a/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
@@ -29,7 +29,7 @@ describe('Admin Unclaimed Households API Integration Tests', () => {
         await prisma.householdLead.deleteMany({
             where: { household: { name: { contains: 'Unclaimed API Test' } } }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'unclaimed-api-test' } }
         });
         await prisma.household.deleteMany({
@@ -40,12 +40,12 @@ describe('Admin Unclaimed Households API Integration Tests', () => {
     beforeAll(async () => {
         await cleanup();
 
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-unclaimed-api-test@example.com', name: 'Admin Unclaimed Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
 
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-unclaimed-api-test@example.com', name: 'User Unclaimed Test', isSysadmin: false, household: { create: {} } }
         });
         testUserId = user.id;
@@ -53,7 +53,7 @@ describe('Admin Unclaimed Households API Integration Tests', () => {
         // 1. Lead has an email but NO googleId -> unclaimed
         const unclaimed = await prisma.household.create({ data: { name: 'Unclaimed API Test HH Unclaimed' } });
         testUnclaimedHouseholdId = unclaimed.id;
-        const unclaimedLead = await prisma.participant.create({
+        const unclaimedLead = await prisma.person.create({
             data: { email: 'member1-unclaimed-api-test@example.com', name: 'Unclaimed Lead', householdId: testUnclaimedHouseholdId, googleId: null }
         });
         await prisma.householdLead.create({
@@ -64,14 +64,14 @@ describe('Admin Unclaimed Households API Integration Tests', () => {
         // This is the case that must NOT appear: a claimed lead covers the household.
         const claimed = await prisma.household.create({ data: { name: 'Unclaimed API Test HH Claimed' } });
         testClaimedHouseholdId = claimed.id;
-        const claimedLead = await prisma.participant.create({
+        const claimedLead = await prisma.person.create({
             data: { email: 'member2-unclaimed-api-test@example.com', name: 'Claimed Lead', householdId: testClaimedHouseholdId, googleId: 'unclaimed-test-google-id' }
         });
         await prisma.householdLead.create({
             data: { householdId: testClaimedHouseholdId, personId: claimedLead.id }
         });
         // Student in the claimed household with an email but no googleId (never signs in).
-        await prisma.participant.create({
+        await prisma.person.create({
             data: { email: 'student-unclaimed-api-test@example.com', name: 'Student', householdId: testClaimedHouseholdId, googleId: null }
         });
     });

--- a/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
@@ -22,7 +22,7 @@ describe('Admin Visits API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'visits-api-test' } },
             select: { id: true }
         });
@@ -37,19 +37,19 @@ describe('Admin Visits API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'visits-api-test' } }
         });
 
         // Setup mock database records
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-visits-api-test@example.com', name: 'Admin Visits Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
-        const checkAdmin = await prisma.participant.findUnique({ where: { id: testAdminId } });
+        const checkAdmin = await prisma.person.findUnique({ where: { id: testAdminId } });
         console.log("Check Admin:", checkAdmin);
 
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-visits-api-test@example.com', name: 'User Visits Test', household: { create: {} } }
         });
         testUserId = user.id;
@@ -71,7 +71,7 @@ describe('Admin Visits API Integration Tests', () => {
         await prisma.auditLog.deleteMany({
             where: { actorId: { in: [testAdminId, testUserId] } }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: [testAdminId, testUserId] } }
         });
     });

--- a/checkin-app/src/app/__tests__/attendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendance.integration.test.ts
@@ -30,7 +30,7 @@ describe('Attendance API Integration Tests', () => {
         // Clean up any leaked state
         await prisma.visit.deleteMany({});
         await prisma.householdLead.deleteMany({});
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'attendance-test' } }
         });
         await prisma.household.deleteMany({
@@ -43,13 +43,13 @@ describe('Attendance API Integration Tests', () => {
         });
         testHouseholdId = household.id;
 
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-attendance-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
         testAdminHouseholdId = admin.householdId;
 
-        const participant = await prisma.participant.create({
+        const participant = await prisma.person.create({
             data: { 
                 email: 'participant-attendance-test@example.com', 
                 name: 'Participant Test',
@@ -63,7 +63,7 @@ describe('Attendance API Integration Tests', () => {
             data: { householdId: testHouseholdId, personId: testParticipantId }
         });
 
-        const householdMember = await prisma.participant.create({
+        const householdMember = await prisma.person.create({
             data: { 
                 email: 'member-attendance-test@example.com', 
                 name: 'Household Member Test',
@@ -84,7 +84,7 @@ describe('Attendance API Integration Tests', () => {
         await prisma.householdLead.deleteMany({
             where: { householdId: testHouseholdId }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: [testAdminId, testParticipantId, testHouseholdMemberId] } }
         });
         await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
@@ -33,7 +33,7 @@ describe('General Attendance API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'attend-api-test' } },
             select: { id: true }
         });
@@ -52,12 +52,12 @@ describe('General Attendance API Integration Tests', () => {
 
         // Capture households before participants are removed (RESTRICT requires
         // participants to be deleted before their household).
-        const existingHouseholdIds = (await prisma.participant.findMany({
+        const existingHouseholdIds = (await prisma.person.findMany({
             where: { id: { in: existingUserIds } },
             select: { householdId: true }
         })).map(p => p.householdId);
 
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
@@ -70,19 +70,19 @@ describe('General Attendance API Integration Tests', () => {
         });
 
         // Create Admin
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-attend-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
         });
         adminId = admin.id;
 
         // Create Board Member
-        const isBoardMember = await prisma.participant.create({
+        const isBoardMember = await prisma.person.create({
             data: { email: 'board-attend-api-test@example.com', name: 'Board Member', isBoardMember: true, household: { create: {} } }
         });
         boardMemberId = isBoardMember.id;
 
         // Create Common User
-        const commonUser = await prisma.participant.create({
+        const commonUser = await prisma.person.create({
             data: { email: 'common-attend-api-test@example.com', name: 'Common', household: { create: {} } }
         });
         commonId = commonUser.id;
@@ -92,7 +92,7 @@ describe('General Attendance API Integration Tests', () => {
             data: { name: 'Attend API Household Test' }
         });
 
-        const householdLead = await prisma.participant.create({
+        const householdLead = await prisma.person.create({
             data: { 
                 email: 'lead-attend-api-test@example.com', 
                 name: 'Household Lead',
@@ -102,7 +102,7 @@ describe('General Attendance API Integration Tests', () => {
         });
         householdLeadId = householdLead.id;
 
-        const householdChild = await prisma.participant.create({
+        const householdChild = await prisma.person.create({
             data: { 
                 email: 'child-attend-api-test@example.com', 
                 name: 'Household Child',
@@ -138,12 +138,12 @@ describe('General Attendance API Integration Tests', () => {
             });
 
             // RESTRICT: delete participants before their households.
-            const existingHouseholdIds = (await prisma.participant.findMany({
+            const existingHouseholdIds = (await prisma.person.findMany({
                 where: { id: { in: existingUserIds } },
                 select: { householdId: true }
             })).map(p => p.householdId);
 
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { id: { in: existingUserIds } }
             });
             await prisma.household.deleteMany({
@@ -249,7 +249,7 @@ describe('General Attendance API Integration Tests', () => {
 
              // We actually have to mock the user having the *correct* householdId matching the child in the DB
              // The mock user object should have the actual household.id
-             const childRecord = await prisma.participant.findUnique({ where: { id: householdChildId } });
+             const childRecord = await prisma.person.findUnique({ where: { id: householdChildId } });
              (getServerSession as jest.Mock).mockResolvedValue({ 
                  user: { id: householdLeadId, householdId: childRecord!.householdId, householdLead: true } 
              });

--- a/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
@@ -20,7 +20,7 @@ describe('Manual Attendance API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'manual-attendance-test' } },
             select: { id: true }
         });
@@ -35,12 +35,12 @@ describe('Manual Attendance API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'manual-attendance-test' } }
         });
 
         // Setup mock database records
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-manual-attendance-test@example.com', name: 'User Manual Attendance Test', household: { create: {} } }
         });
         testUserId = user.id;
@@ -55,7 +55,7 @@ describe('Manual Attendance API Integration Tests', () => {
         await prisma.auditLog.deleteMany({
             where: { actorId: testUserId }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: testUserId }
         });
         await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/attendanceManualCheckinConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualCheckinConcurrency.integration.test.ts
@@ -48,7 +48,7 @@ describe('POST /api/attendance MANUAL_CHECKIN concurrency (advisory lock)', () =
 
     beforeAll(async () => {
         // Clean any leaked state from a prior run.
-        const leaked = await prisma.participant.findMany({
+        const leaked = await prisma.person.findMany({
             where: { email: { contains: EMAIL_TAG } },
             select: { id: true, householdId: true },
         });
@@ -56,10 +56,10 @@ describe('POST /api/attendance MANUAL_CHECKIN concurrency (advisory lock)', () =
         const leakedHouseholdIds = leaked.map(p => p.householdId);
         await prisma.visit.deleteMany({ where: { personId: { in: leakedIds } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: leakedIds } } });
-        await prisma.participant.deleteMany({ where: { id: { in: leakedIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: leakedIds } } });
         await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
 
-        const subject = await prisma.participant.create({
+        const subject = await prisma.person.create({
             data: { email: `subject-${EMAIL_TAG}@example.com`, name: 'Manual Checkin Concurrency Subject', household: { create: {} } },
         });
         subjectId = subject.id;
@@ -69,7 +69,7 @@ describe('POST /api/attendance MANUAL_CHECKIN concurrency (advisory lock)', () =
     afterAll(async () => {
         await prisma.visit.deleteMany({ where: { personId: subjectId } });
         await prisma.auditLog.deleteMany({ where: { actorId: subjectId } });
-        await prisma.participant.deleteMany({ where: { id: subjectId } });
+        await prisma.person.deleteMany({ where: { id: subjectId } });
         await prisma.household.deleteMany({ where: { id: householdId } });
     });
 

--- a/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
@@ -52,7 +52,7 @@ describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
 
     beforeAll(async () => {
         // Clean any leaked state from a prior run.
-        const leaked = await prisma.participant.findMany({
+        const leaked = await prisma.person.findMany({
             where: { email: { contains: EMAIL_TAG } },
             select: { id: true, householdId: true },
         });
@@ -60,10 +60,10 @@ describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
         const leakedHouseholdIds = leaked.map(p => p.householdId);
         await prisma.visit.deleteMany({ where: { personId: { in: leakedIds } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: leakedIds } } });
-        await prisma.participant.deleteMany({ where: { id: { in: leakedIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: leakedIds } } });
         await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
 
-        const subject = await prisma.participant.create({
+        const subject = await prisma.person.create({
             data: { email: `subject-${EMAIL_TAG}@example.com`, name: 'Manual Concurrency Subject', household: { create: {} } },
         });
         subjectId = subject.id;
@@ -73,7 +73,7 @@ describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
     afterAll(async () => {
         await prisma.visit.deleteMany({ where: { personId: subjectId } });
         await prisma.auditLog.deleteMany({ where: { actorId: subjectId } });
-        await prisma.participant.deleteMany({ where: { id: subjectId } });
+        await prisma.person.deleteMany({ where: { id: subjectId } });
         await prisma.household.deleteMany({ where: { id: householdId } });
     });
 

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -41,7 +41,7 @@ describe('AuditLog Integration Tests', () => {
     const createdVisitIds: number[] = [];
 
     async function makeParticipant(suffix: string) {
-        const p = await prisma.participant.create({
+        const p = await prisma.person.create({
             // 'audit-test' substring also matches the beforeAll backstop sweep.
             data: { email: `${TAG}-${suffix}-audit-test@example.com`, name: `${TAG} ${suffix}`, household: { create: {} } },
             select: { id: true, householdId: true },
@@ -60,17 +60,17 @@ describe('AuditLog Integration Tests', () => {
         await prisma.programVolunteer.deleteMany({});
         await prisma.event.deleteMany({});
         await prisma.program.deleteMany({});
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'audit-test' } }
         });
 
         // Setup mock database records
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-audit-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
 
-        const participant = await prisma.participant.create({
+        const participant = await prisma.person.create({
             data: { email: 'participant-audit-test@example.com', name: 'Participant Test', household: { create: {} } }
         });
         testParticipantId = participant.id;
@@ -84,7 +84,7 @@ describe('AuditLog Integration Tests', () => {
         }
         if (createdParticipantIds.length > 0) {
             await prisma.householdLead.deleteMany({ where: { personId: { in: createdParticipantIds } } });
-            await prisma.participant.deleteMany({ where: { id: { in: createdParticipantIds } } });
+            await prisma.person.deleteMany({ where: { id: { in: createdParticipantIds } } });
         }
         if (createdHouseholdIds.length > 0) {
             await prisma.household.deleteMany({ where: { id: { in: createdHouseholdIds } } });
@@ -109,12 +109,12 @@ describe('AuditLog Integration Tests', () => {
             });
 
             // RESTRICT: delete participants before their households.
-            const householdIds = (await prisma.participant.findMany({
+            const householdIds = (await prisma.person.findMany({
                 where: { id: { in: actorIds } },
                 select: { householdId: true }
             })).map(p => p.householdId);
 
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { id: { in: actorIds } }
             });
             await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
@@ -103,7 +103,7 @@ describe('Ownership-boundary authorization', () => {
             await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
             await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
     }
@@ -112,7 +112,7 @@ describe('Ownership-boundary authorization', () => {
         return (await prisma.household.create({ data: { name: `${label} ${TAG}` } })).id;
     }
     async function mkMember(householdId: number, name: string, lead = false) {
-        const p = await prisma.participant.create({ data: { name: `${name} ${TAG}`, householdId } });
+        const p = await prisma.person.create({ data: { name: `${name} ${TAG}`, householdId } });
         if (lead) await prisma.householdLead.create({ data: { householdId, personId: p.id } });
         return p.id;
     }

--- a/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
@@ -108,7 +108,7 @@ describe('Protected-route role rejection', () => {
         await prisma.event.deleteMany({ where: { program: { name: { contains: TAG } } } });
         await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
         if (ids.length) {
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
     }
@@ -116,7 +116,7 @@ describe('Protected-route role rejection', () => {
     beforeAll(async () => {
         await wipe();
         plainHh = (await prisma.household.create({ data: { name: `Plain HH ${TAG}` } })).id;
-        plainId = (await prisma.participant.create({ data: { name: `Plain ${TAG}`, householdId: plainHh } })).id;
+        plainId = (await prisma.person.create({ data: { name: `Plain ${TAG}`, householdId: plainHh } })).id;
         // A real event so events/[id] GET reaches its in-handler staff gate
         // (a missing event short-circuits to 404 before the 403).
         const prog = await prisma.program.create({ data: { name: `Prog ${TAG}` } });
@@ -129,13 +129,13 @@ describe('Protected-route role rejection', () => {
         // plus foreignLead who leads a SEPARATE program (privileged elsewhere, but
         // not staff of ownedEvent — the cross-program attacker).
         const ownerHh = (await prisma.household.create({ data: { name: `Owner HH ${TAG}` } })).id;
-        ownerLeadId = (await prisma.participant.create({ data: { name: `OwnerLead ${TAG}`, householdId: ownerHh } })).id;
+        ownerLeadId = (await prisma.person.create({ data: { name: `OwnerLead ${TAG}`, householdId: ownerHh } })).id;
         const ownedProgram = await prisma.program.create({ data: { name: `Owned Prog ${TAG}`, leadMentorId: ownerLeadId } });
         ownedEventId = (await prisma.event.create({
             data: { programId: ownedProgram.id, name: `Owned Evt ${TAG}`, startAt: new Date('2030-02-01T10:00:00Z'), endAt: new Date('2030-02-01T12:00:00Z') },
         })).id;
         const foreignHh = (await prisma.household.create({ data: { name: `Foreign HH ${TAG}` } })).id;
-        foreignLeadId = (await prisma.participant.create({ data: { name: `ForeignLead ${TAG}`, householdId: foreignHh } })).id;
+        foreignLeadId = (await prisma.person.create({ data: { name: `ForeignLead ${TAG}`, householdId: foreignHh } })).id;
         await prisma.program.create({ data: { name: `Foreign Prog ${TAG}`, leadMentorId: foreignLeadId } });
     });
 

--- a/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
@@ -35,19 +35,19 @@ describe('Sensitive route authorization', () => {
     const ENV_BEFORE = process.env.CHECKIN_ENV;
 
     beforeAll(async () => {
-        const plain = await prisma.participant.create({
+        const plain = await prisma.person.create({
             data: { name: 'Authz Plain', email: `plain-${TAG}@example.com`, household: { create: {} } },
         });
         plainId = plain.id;
         householdIds.push(plain.householdId);
 
-        const target = await prisma.participant.create({
+        const target = await prisma.person.create({
             data: { name: `ZZTarget ${TAG}`, email: `target-${TAG}@example.com`, phone: '555-0101', household: { create: {} } },
         });
         searchTargetId = target.id;
         householdIds.push(target.householdId);
 
-        const persona = await prisma.participant.create({
+        const persona = await prisma.person.create({
             data: { name: 'Persona One', email: `persona-${TAG}@example.com`, isSysadmin: true, household: { create: {} } },
         });
         personaId = persona.id;
@@ -61,7 +61,7 @@ describe('Sensitive route authorization', () => {
 
     afterAll(async () => {
         process.env.CHECKIN_ENV = ENV_BEFORE;
-        await prisma.participant.deleteMany({ where: { id: { in: [plainId, searchTargetId, personaId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [plainId, searchTargetId, personaId] } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
     });
 

--- a/checkin-app/src/app/__tests__/autoAssociation.integration.test.ts
+++ b/checkin-app/src/app/__tests__/autoAssociation.integration.test.ts
@@ -25,12 +25,12 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
         await prisma.programParticipant.deleteMany();
         await prisma.event.deleteMany();
         await prisma.program.deleteMany();
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: 'auto-assoc-test@example.com' }
         });
 
         // Setup User
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'auto-assoc-test@example.com', name: 'Auto Assoc Tester', household: { create: {} } }
         });
         participantId = user.id;
@@ -108,7 +108,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
         await prisma.programParticipant.deleteMany();
         await prisma.event.deleteMany();
         await prisma.program.deleteMany();
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: participantId }
         });
         await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/brokenHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/brokenHouseholdsAPI.integration.test.ts
@@ -29,7 +29,7 @@ describe('Broken Households API Integration Tests', () => {
         await prisma.householdLead.deleteMany({
             where: { household: { name: { contains: 'Broken API Test' } } }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'broken-api-test' } }
         });
         await prisma.household.deleteMany({
@@ -41,7 +41,7 @@ describe('Broken Households API Integration Tests', () => {
         await cleanup();
 
         // Acting board member (not a member of any test household below).
-        const board = await prisma.participant.create({
+        const board = await prisma.person.create({
             data: { email: 'board-broken-api-test@example.com', name: 'Board Broken Test', isBoardMember: true, household: { create: {} } }
         });
         boardId = board.id;
@@ -49,11 +49,11 @@ describe('Broken Households API Integration Tests', () => {
         // 1. Leadless household with an adult + a youth -> broken.
         const broken = await prisma.household.create({ data: { name: 'Broken API Test HH Broken' } });
         brokenHouseholdId = broken.id;
-        const adult = await prisma.participant.create({
+        const adult = await prisma.person.create({
             data: { email: 'adult-broken-api-test@example.com', name: 'Broken Adult', householdId: brokenHouseholdId, dateOfBirth: new Date('1990-01-01') }
         });
         brokenAdultId = adult.id;
-        await prisma.participant.create({
+        await prisma.person.create({
             data: { email: 'youth-broken-api-test@example.com', name: 'Broken Youth', householdId: brokenHouseholdId, dateOfBirth: new Date('2015-01-01') }
         });
 
@@ -64,7 +64,7 @@ describe('Broken Households API Integration Tests', () => {
         // 3. Household that already has a lead -> NOT broken.
         const led = await prisma.household.create({ data: { name: 'Broken API Test HH Led' } });
         ledHouseholdId = led.id;
-        const leadMember = await prisma.participant.create({
+        const leadMember = await prisma.person.create({
             data: { email: 'lead-broken-api-test@example.com', name: 'Existing Lead', householdId: ledHouseholdId, dateOfBirth: new Date('1985-01-01') }
         });
         await prisma.householdLead.create({

--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -41,17 +41,17 @@ describe('Cron Nightly API Integration Tests', () => {
         await cleanup();
 
         // Setup Users
-        const board = await prisma.participant.create({
+        const board = await prisma.person.create({
             data: { email: 'board-nightly@example.com', name: 'Board Member', isBoardMember: true, household: { create: {} } }
         });
         boardMemberId = board.id;
 
-        const isKeyholder = await prisma.participant.create({
+        const isKeyholder = await prisma.person.create({
             data: { email: 'keyholder-nightly@example.com', name: 'Forgetful Keyholder', isKeyholder: true, household: { create: {} } }
         });
         keyholderId = isKeyholder.id;
 
-        const normalUser = await prisma.participant.create({
+        const normalUser = await prisma.person.create({
             data: { email: 'user-nightly@example.com', name: 'Normal User', household: { create: {} } }
         });
         normalUserId = normalUser.id;
@@ -108,12 +108,12 @@ describe('Cron Nightly API Integration Tests', () => {
         await prisma.auditLog.deleteMany();
 
         // RESTRICT: delete participants before their (auto-created) households.
-        const householdIds = (await prisma.participant.findMany({
+        const householdIds = (await prisma.person.findMany({
             where: { email: { contains: '-nightly@' } },
             select: { householdId: true }
         })).map(p => p.householdId);
 
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: '-nightly@' } }
         });
         await prisma.household.deleteMany({
@@ -193,7 +193,7 @@ describe('Cron Nightly API Integration Tests', () => {
 
             // An extra plain participant (no program enrollment -> simple close path)
             // so we have two GOOD visits whose `departedAt` we can assert by id.
-            const extra = await prisma.participant.create({
+            const extra = await prisma.person.create({
                 data: { email: 'extra-nightly@example.com', name: 'Extra User', household: { create: {} } }
             });
 

--- a/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
@@ -26,7 +26,7 @@ describe('Cron Pending-Participants API Integration Tests', () => {
     const ids: Record<string, number> = {};
 
     const mkParticipant = async (key: string) => {
-        const p = await prisma.participant.create({
+        const p = await prisma.person.create({
             data: { email: `${key}-pending-cron-test@example.com`, name: `${key} Pending Cron`, household: { create: {} } }
         });
         ids[key] = p.id;
@@ -35,13 +35,13 @@ describe('Cron Pending-Participants API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const leaked = await prisma.participant.findMany({
+        const leaked = await prisma.person.findMany({
             where: { email: { contains: 'pending-cron-test' } },
             select: { id: true }
         });
         const leakedIds = leaked.map(u => u.id);
         await prisma.programParticipant.deleteMany({ where: { personId: { in: leakedIds } } });
-        await prisma.participant.deleteMany({ where: { id: { in: leakedIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: leakedIds } } });
         await prisma.program.deleteMany({ where: { name: { contains: 'Pending Cron Test' } } });
 
         const program = await prisma.program.create({
@@ -70,7 +70,7 @@ describe('Cron Pending-Participants API Integration Tests', () => {
     afterAll(async () => {
         const idList = Object.values(ids);
         await prisma.programParticipant.deleteMany({ where: { programId } });
-        await prisma.participant.deleteMany({ where: { id: { in: idList } } });
+        await prisma.person.deleteMany({ where: { id: { in: idList } } });
         await prisma.program.deleteMany({ where: { id: programId } });
     });
 

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -16,7 +16,7 @@ describe("GET /api/cron/post-event", () => {
         await prisma.toolStatus.deleteMany({ where: { person: { email: { contains: 'example.com' } } } });
         await prisma.householdLead.deleteMany({ where: { person: { email: { contains: 'example.com' } } } });
         await prisma.rawBadgeLog.deleteMany({ where: { person: { email: { contains: 'example.com' } } } });
-        await prisma.participant.deleteMany({ where: { email: { contains: 'example.com' } } });
+        await prisma.person.deleteMany({ where: { email: { contains: 'example.com' } } });
         // Global participant-less household delete: clear the membership chain for those
         // households first or Membership_householdId_fkey (RESTRICT) blocks the delete.
         await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { participants: { none: {} } } } } } });
@@ -28,7 +28,7 @@ describe("GET /api/cron/post-event", () => {
 
     it("should send emails for finished events and mark them as sent", async () => {
         // Setup data
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: "lead@example.com", name: "Lead Mentor", household: { create: {} } }
         });
 
@@ -51,7 +51,7 @@ describe("GET /api/cron/post-event", () => {
         });
 
         // Add some RSVPs and Visits
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: "user@example.com", name: "User", household: { create: {} } }
         });
         

--- a/checkin-app/src/app/__tests__/cronRemindersAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronRemindersAPI.integration.test.ts
@@ -25,7 +25,7 @@ describe('Cron Reminders API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'cron-reminders-test' } },
             select: { id: true }
         });
@@ -36,7 +36,7 @@ describe('Cron Reminders API Integration Tests', () => {
             where: { personId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'cron-reminders-test' } }
         });
 
@@ -45,7 +45,7 @@ describe('Cron Reminders API Integration Tests', () => {
         });
 
         // Setup mock database records
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-cron-reminders-test@example.com', name: 'User Cron Reminders Test', household: { create: {} } }
         });
         testUserId = user.id;
@@ -109,7 +109,7 @@ describe('Cron Reminders API Integration Tests', () => {
         await prisma.event.deleteMany({
             where: { id: { in: [upcomingEventId, pastEventId, farFutureEventId] } }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: testUserId }
         });
         await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/cronRemindersEdge.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronRemindersEdge.integration.test.ts
@@ -39,7 +39,7 @@ describe('GET /api/cron/reminders — auth & window edges', () => {
     let householdId: number;
 
     beforeAll(async () => {
-        const p = await prisma.participant.create({
+        const p = await prisma.person.create({
             data: { name: 'Reminders Edge', email: `p-${TAG}@example.com`, household: { create: {} } },
         });
         participantId = p.id;
@@ -59,7 +59,7 @@ describe('GET /api/cron/reminders — auth & window edges', () => {
     afterAll(async () => {
         await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
-        await prisma.participant.deleteMany({ where: { id: participantId } });
+        await prisma.person.deleteMany({ where: { id: participantId } });
         await prisma.household.deleteMany({ where: { id: householdId } });
     });
 

--- a/checkin-app/src/app/__tests__/directoryBoardAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/directoryBoardAPI.integration.test.ts
@@ -34,7 +34,7 @@ describe('GET /api/directory/board', () => {
     beforeAll(async () => {
         // A board member WITH non-null pii, so "must not leak dob/googleId" is a
         // meaningful assertion (an all-null fixture would pass vacuously).
-        const board = await prisma.participant.create({
+        const board = await prisma.person.create({
             data: {
                 name: `Board ${TAG}`,
                 email: `board-${TAG}@example.com`,
@@ -48,7 +48,7 @@ describe('GET /api/directory/board', () => {
         boardId = board.id;
         householdIds.push(board.householdId);
 
-        const isKeyholder = await prisma.participant.create({
+        const isKeyholder = await prisma.person.create({
             data: {
                 name: `Keyholder ${TAG}`,
                 email: `isKeyholder-${TAG}@example.com`,
@@ -63,7 +63,7 @@ describe('GET /api/directory/board', () => {
     beforeEach(() => jest.clearAllMocks());
 
     afterAll(async () => {
-        await prisma.participant.deleteMany({ where: { id: { in: [boardId, keyholderId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [boardId, keyholderId] } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
     });
 

--- a/checkin-app/src/app/__tests__/emergencyContactMemberRouteGuard.integration.test.ts
+++ b/checkin-app/src/app/__tests__/emergencyContactMemberRouteGuard.integration.test.ts
@@ -46,12 +46,12 @@ async function wipe() {
     const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
     const ids = hhs.map((h) => h.id);
     if (!ids.length) return;
-    const members = await prisma.participant.findMany({ where: { householdId: { in: ids } }, select: { id: true } });
+    const members = await prisma.person.findMany({ where: { householdId: { in: ids } }, select: { id: true } });
     const memberIds = members.map((m) => m.id);
     await prisma.emergencyContact.deleteMany({ where: { householdId: { in: ids } } });
     if (memberIds.length) await prisma.auditLog.deleteMany({ where: { actorId: { in: memberIds } } });
     await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-    await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+    await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
     await prisma.household.deleteMany({ where: { id: { in: ids } } });
 }
 
@@ -67,7 +67,7 @@ describe("PATCH /api/household/settings — Direction A: reject a member as prim
     let memberId: number;
 
     beforeAll(async () => {
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: {
                 email: `lead-A-${TAG}@example.com`,
                 name: "Lead A",
@@ -77,7 +77,7 @@ describe("PATCH /api/household/settings — Direction A: reject a member as prim
         leadId = lead.id;
         householdId = lead.householdId!;
         await prisma.householdLead.create({ data: { householdId, personId: leadId } });
-        const member = await prisma.participant.create({
+        const member = await prisma.person.create({
             data: {
                 email: `member-A-${TAG}@example.com`,
                 name: "Bobby Member",
@@ -135,7 +135,7 @@ describe("PATCH /api/household — Direction B: adding a member that collides wi
     let contactId: number;
 
     beforeAll(async () => {
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: {
                 email: `lead-B-${TAG}@example.com`,
                 name: "Lead B",

--- a/checkin-app/src/app/__tests__/emergencyContactsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/emergencyContactsAPI.integration.test.ts
@@ -40,7 +40,7 @@ async function wipe() {
     await prisma.emergencyContact.deleteMany({ where: { householdId: { in: ids } } });
     await prisma.auditLog.deleteMany({ where: { tableName: "EmergencyContact", secondaryAffectedEntity: { in: ids } } });
     await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-    await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+    await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
     await prisma.household.deleteMany({ where: { id: { in: ids } } });
 }
 
@@ -50,7 +50,7 @@ describe("Emergency Contacts API — removal prohibition", () => {
 
     beforeAll(async () => {
         await wipe();
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: `lead-${TAG}@example.com`, name: "Lead Person", household: { create: { name: `HH ${TAG}` } } },
         });
         leadId = lead.id;
@@ -95,10 +95,10 @@ describe("Emergency Contacts API — removal prohibition", () => {
         asUser(leadId);
         // Fresh household to isolate state.
         const hh = await prisma.household.create({ data: { name: `HH2 ${TAG}` } });
-        const p = await prisma.participant.create({ data: { email: `lead2-${TAG}@example.com`, name: "Lead Two", householdId: hh.id } });
+        const p = await prisma.person.create({ data: { email: `lead2-${TAG}@example.com`, name: "Lead Two", householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: p.id } });
         // A contact that is flagged invalid (simulate a direction-B conflict).
-        const member = await prisma.participant.create({ data: { name: "Clashy", householdId: hh.id } });
+        const member = await prisma.person.create({ data: { name: "Clashy", householdId: hh.id } });
         const invalid = await prisma.emergencyContact.create({
             data: { householdId: hh.id, name: "Clashy", phone: "555-9000", phoneDigits: "5559000", conflictParticipantId: member.id, conflictedAt: new Date() },
         });
@@ -109,7 +109,7 @@ describe("Emergency Contacts API — removal prohibition", () => {
 
     async function makeHouseholdWithLead(label: string) {
         const hh = await prisma.household.create({ data: { name: `HH ${label} ${TAG}` } });
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: `lead-${label}-${TAG}@example.com`, name: `Lead ${label}`, householdId: hh.id },
         });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });

--- a/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
@@ -37,32 +37,32 @@ describe('Event Attendance API Integration Tests', () => {
         await prisma.program.deleteMany({
             where: { name: 'Attendance Test Program' }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'event-attendance-test' } }
         });
 
         // Setup mock database records
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-event-attendance-test@example.com', name: 'Admin Att Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
 
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-event-attendance-test@example.com', name: 'User Att Test', household: { create: {} } }
         });
         testUserId = user.id;
 
-        const mentor = await prisma.participant.create({
+        const mentor = await prisma.person.create({
             data: { email: 'mentor-event-attendance-test@example.com', name: 'Mentor Att Test', household: { create: {} } }
         });
         testLeadMentorId = mentor.id;
 
-        const participant1 = await prisma.participant.create({
+        const participant1 = await prisma.person.create({
             data: { email: 'p1-event-attendance-test@example.com', name: 'P1 Att Test', household: { create: {} } }
         });
         testParticipant1Id = participant1.id;
 
-        const participant2 = await prisma.participant.create({
+        const participant2 = await prisma.person.create({
             data: { email: 'p2-event-attendance-test@example.com', name: 'P2 Att Test', household: { create: {} } }
         });
         testParticipant2Id = participant2.id;
@@ -80,7 +80,7 @@ describe('Event Attendance API Integration Tests', () => {
 
         // A lead of an UNRELATED program — the cross-tenant attacker for the IDOR
         // tests. Privileged in their own program, but not lead/staff of testEvent's.
-        const foreignLead = await prisma.participant.create({
+        const foreignLead = await prisma.person.create({
             data: { email: 'foreignlead-event-attendance-test@example.com', name: 'Foreign Lead Att Test', household: { create: {} } }
         });
         foreignLeadId = foreignLead.id;
@@ -118,12 +118,12 @@ describe('Event Attendance API Integration Tests', () => {
         const participantIds = [testAdminId, testUserId, testLeadMentorId, testParticipant1Id, testParticipant2Id, foreignLeadId];
 
         // RESTRICT: delete participants before their (auto-created) households.
-        const householdIds = (await prisma.participant.findMany({
+        const householdIds = (await prisma.person.findMany({
             where: { id: { in: participantIds } },
             select: { householdId: true }
         })).map(p => p.householdId);
 
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: participantIds } }
         });
         await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
@@ -57,13 +57,13 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
     let householdId: number;
 
     beforeAll(async () => {
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { name: 'Cancel Admin', email: `admin-${TAG}@example.com`, isSysadmin: true, household: { create: {} } },
         });
         adminId = admin.id;
         adminHouseholdId = admin.householdId;
 
-        const p = await prisma.participant.create({
+        const p = await prisma.person.create({
             data: { name: 'Cancel Attendee', email: `attendee-${TAG}@example.com`, household: { create: {} } },
         });
         participantId = p.id;
@@ -86,7 +86,7 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
         await prisma.visit.deleteMany({ where: { personId: participantId } });
         await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
-        await prisma.participant.deleteMany({ where: { id: { in: [adminId, participantId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [adminId, participantId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [adminHouseholdId, householdId] } } });
     });
 

--- a/checkin-app/src/app/__tests__/eventCancelNotification.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelNotification.integration.test.ts
@@ -38,13 +38,13 @@ describe("PATCH /api/events/[id] cancel — attendee notification (characterizat
     let adminHouseholdId: number;
 
     beforeAll(async () => {
-        const a = await prisma.participant.create({
+        const a = await prisma.person.create({
             data: { name: 'Notify Attendee', email: `attendee-${TAG}@example.com`, household: { create: {} } },
         });
         attendeeId = a.id;
         attendeeHouseholdId = a.householdId;
 
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { name: 'Notify Admin', email: `admin-${TAG}@example.com`, household: { create: {} } },
         });
         adminId = admin.id;
@@ -64,7 +64,7 @@ describe("PATCH /api/events/[id] cancel — attendee notification (characterizat
     afterAll(async () => {
         await prisma.rSVP.deleteMany({ where: { personId: attendeeId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
-        await prisma.participant.deleteMany({ where: { id: { in: [attendeeId, adminId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [attendeeId, adminId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [attendeeHouseholdId, adminHouseholdId] } } });
     });
 

--- a/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
@@ -42,13 +42,13 @@ describe('PATCH /api/events/[id] cancel — transaction rollback on partial fail
     let adminHouseholdId: number;
 
     beforeAll(async () => {
-        const p = await prisma.participant.create({
+        const p = await prisma.person.create({
             data: { name: 'Cancel Attendee', email: `attendee-${TAG}@example.com`, household: { create: {} } },
         });
         participantId = p.id;
         householdId = p.householdId;
 
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { name: 'Cancel Admin', email: `admin-${TAG}@example.com`, household: { create: {} } },
         });
         adminId = admin.id;
@@ -71,7 +71,7 @@ describe('PATCH /api/events/[id] cancel — transaction rollback on partial fail
         await prisma.visit.deleteMany({ where: { personId: participantId } });
         await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
-        await prisma.participant.deleteMany({ where: { id: { in: [participantId, adminId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [participantId, adminId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [householdId, adminHouseholdId] } } });
     });
 

--- a/checkin-app/src/app/__tests__/eventMineAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventMineAPI.integration.test.ts
@@ -39,17 +39,17 @@ describe('My Events API Integration Tests', () => {
         await prisma.program.deleteMany({
             where: { name: { contains: 'Mine Test Program' } }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'mine-events-test' } }
         });
 
         // Setup mock database records
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-mine-events-test@example.com', name: 'User Mine Test', household: { create: {} } }
         });
         testUserId = user.id;
 
-        const volunteer = await prisma.participant.create({
+        const volunteer = await prisma.person.create({
             data: { email: 'volunteer-mine-events-test@example.com', name: 'Volunteer Mine Test', household: { create: {} } }
         });
         testVolunteerId = volunteer.id;
@@ -156,12 +156,12 @@ describe('My Events API Integration Tests', () => {
             where: { id: { in: [testProgram1Id, testProgram2Id] } }
         });
         // RESTRICT: delete participants before their (auto-created) households.
-        const householdIds = (await prisma.participant.findMany({
+        const householdIds = (await prisma.person.findMany({
             where: { id: { in: [testUserId, testVolunteerId] } },
             select: { householdId: true }
         })).map(p => p.householdId);
 
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: [testUserId, testVolunteerId] } }
         });
         await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/eventRSVPAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventRSVPAPI.integration.test.ts
@@ -36,17 +36,17 @@ describe('Event RSVP API Integration Tests', () => {
         await prisma.program.deleteMany({
             where: { name: 'RSVP Test Program' }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'rsvp-test' } }
         });
 
         // Setup mock database records
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'enrolled-user-rsvp-test@example.com', name: 'Enrolled RSVP Test', household: { create: {} } }
         });
         testUserId = user.id;
 
-        const unenrolledUser = await prisma.participant.create({
+        const unenrolledUser = await prisma.person.create({
             data: { email: 'unenrolled-user-rsvp-test@example.com', name: 'Unenrolled RSVP Test', household: { create: {} } }
         });
         testUnenrolledUserId = unenrolledUser.id;
@@ -72,7 +72,7 @@ describe('Event RSVP API Integration Tests', () => {
 
         // A lead of an UNRELATED program — the cross-tenant attacker. Privileged in
         // their own program but not enrolled/volunteering in testEvent's program.
-        const foreignLead = await prisma.participant.create({
+        const foreignLead = await prisma.person.create({
             data: { email: 'foreignlead-rsvp-test@example.com', name: 'Foreign Lead RSVP Test', household: { create: {} } }
         });
         foreignLeadId = foreignLead.id;
@@ -111,12 +111,12 @@ describe('Event RSVP API Integration Tests', () => {
         });
         // RESTRICT: delete participants before their (auto-created) households.
         const allParticipantIds = [testUserId, testUnenrolledUserId, foreignLeadId];
-        const householdIds = (await prisma.participant.findMany({
+        const householdIds = (await prisma.person.findMany({
             where: { id: { in: allParticipantIds } },
             select: { householdId: true }
         })).map(p => p.householdId);
 
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: allParticipantIds } }
         });
         await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/eventRescheduleClearsReminder.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventRescheduleClearsReminder.integration.test.ts
@@ -61,13 +61,13 @@ describe('PATCH /api/events/[id] editTime — clears reminderSentAt on reschedul
     let adminHouseholdId: number;
 
     beforeAll(async () => {
-        const p = await prisma.participant.create({
+        const p = await prisma.person.create({
             data: { name: 'Reschedule Attendee', email: `attendee-${TAG}@example.com`, household: { create: {} } },
         });
         participantId = p.id;
         householdId = p.householdId;
 
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { name: 'Reschedule Admin', email: `admin-${TAG}@example.com`, household: { create: {} } },
         });
         adminId = admin.id;
@@ -88,7 +88,7 @@ describe('PATCH /api/events/[id] editTime — clears reminderSentAt on reschedul
     afterAll(async () => {
         await prisma.rSVP.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
-        await prisma.participant.deleteMany({ where: { id: { in: [participantId, adminId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [participantId, adminId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [householdId, adminHouseholdId] } } });
     });
 

--- a/checkin-app/src/app/__tests__/eventsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventsAPI.integration.test.ts
@@ -30,22 +30,22 @@ describe('Events API Integration Tests', () => {
         await prisma.program.deleteMany({
             where: { name: 'Events Test Program' }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'events-api-test' } }
         });
 
         // Setup mock database records
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-events-api-test@example.com', name: 'Admin Events Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
 
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-events-api-test@example.com', name: 'User Events Test', household: { create: {} } }
         });
         testUserId = user.id;
 
-        const mentor = await prisma.participant.create({
+        const mentor = await prisma.person.create({
             data: { email: 'mentor-events-api-test@example.com', name: 'Mentor Events Test', household: { create: {} } }
         });
         testLeadMentorId = mentor.id;
@@ -71,7 +71,7 @@ describe('Events API Integration Tests', () => {
             where: { id: testProgramId }
         });
         // RESTRICT: delete participants before their (auto-created) households.
-        const householdIds = (await prisma.participant.findMany({
+        const householdIds = (await prisma.person.findMany({
             where: { id: { in: [testAdminId, testUserId, testLeadMentorId] } },
             select: { householdId: true }
         })).map(p => p.householdId);
@@ -79,7 +79,7 @@ describe('Events API Integration Tests', () => {
         await prisma.auditLog.deleteMany({
             where: { actorId: { in: [testAdminId, testUserId, testLeadMentorId] } }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: [testAdminId, testUserId, testLeadMentorId] } }
         });
         await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -36,21 +36,21 @@ describe('Facility trends API', () => {
     const hoursAgo = (h: number) => new Date(Date.now() - h * 60 * 60 * 1000);
 
     beforeAll(async () => {
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: `admin-${TAG}@example.com`, name: 'Admin', isSysadmin: true, household: { create: {} } },
         });
         adminId = admin.id;
         householdId = admin.householdId;
 
-        const volunteer = await prisma.participant.create({
+        const volunteer = await prisma.person.create({
             data: { email: `volunteer-${TAG}@example.com`, name: 'Volunteer', dateOfBirth: new Date('1980-01-01'), householdId },
         });
         volunteerId = volunteer.id;
-        const enrolledAdult = await prisma.participant.create({
+        const enrolledAdult = await prisma.person.create({
             data: { email: `enrolled-${TAG}@example.com`, name: 'Enrolled Adult', dateOfBirth: new Date('1985-01-01'), householdId },
         });
         enrolledAdultId = enrolledAdult.id;
-        const youth = await prisma.participant.create({
+        const youth = await prisma.person.create({
             data: { email: `youth-${TAG}@example.com`, name: 'Youth', dateOfBirth: new Date('2015-01-01'), householdId },
         });
         youthId = youth.id;
@@ -97,7 +97,7 @@ describe('Facility trends API', () => {
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.event.deleteMany({ where: { id: eventId } });
         await prisma.program.deleteMany({ where: { id: { in: [programId, otherProgramId] } } });
-        await prisma.participant.deleteMany({ where: { id: { in: [adminId, volunteerId, enrolledAdultId, youthId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [adminId, volunteerId, enrolledAdultId, youthId] } } });
         await prisma.household.deleteMany({ where: { id: householdId } });
     });
 

--- a/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
@@ -23,7 +23,7 @@ describe('Household API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'household-api-test' } },
             select: { id: true, householdId: true }
         });
@@ -44,7 +44,7 @@ describe('Household API Integration Tests', () => {
         });
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
@@ -58,7 +58,7 @@ describe('Household API Integration Tests', () => {
         });
         householdId = household.id;
 
-        const leadUser = await prisma.participant.create({
+        const leadUser = await prisma.person.create({
             data: { email: 'lead-user-household-api-test@example.com', name: 'Lead User', householdId: household.id }
         });
         testUserId = leadUser.id;
@@ -67,7 +67,7 @@ describe('Household API Integration Tests', () => {
             data: { householdId: household.id, personId: leadUser.id }
         });
 
-        const memberUser = await prisma.participant.create({
+        const memberUser = await prisma.person.create({
             data: { email: 'member-user-household-api-test@example.com', name: 'Member User', householdId: household.id }
         });
         testMemberId = memberUser.id;
@@ -77,7 +77,7 @@ describe('Household API Integration Tests', () => {
         });
         otherHouseholdId = otherHousehold.id;
 
-        const otherUser = await prisma.participant.create({
+        const otherUser = await prisma.person.create({
             data: { email: 'other-household-api-test@example.com', name: 'Other User', householdId: otherHousehold.id }
         });
         testOtherHouseUserId = otherUser.id;
@@ -85,14 +85,14 @@ describe('Household API Integration Tests', () => {
 
     afterAll(async () => {
         // Find trailing records created during test
-        const newDobs = await prisma.participant.findMany({
+        const newDobs = await prisma.person.findMany({
             where: { email: { contains: 'child-household-api-test' } },
             select: { id: true, householdId: true }
         });
         const currentIds = [testUserId, testMemberId, testOtherHouseUserId, ...(newDobs.map(u => u.id))];
 
         // Collect every household referenced by the test participants (incl. the no-house user's own household)
-        const participants = await prisma.participant.findMany({
+        const participants = await prisma.person.findMany({
             where: { id: { in: currentIds } },
             select: { householdId: true }
         });
@@ -117,7 +117,7 @@ describe('Household API Integration Tests', () => {
         // RESTRICT: delete participants before their households. Sweep by household
         // too, so members the API created without a tracked id/email (e.g. a 25+
         // member with no email) don't leave a dangling FK to a household below.
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { OR: [{ id: { in: currentIds } }, { householdId: { in: validHouseholdIds } }] }
         });
 
@@ -211,7 +211,7 @@ describe('Household API Integration Tests', () => {
 
             // householdId is deliberately not on the wire (HOUSEHOLD_PEER_SELECT, M2
             // PII minimization) — verify the attachment directly against the DB instead.
-            const created = await prisma.participant.findUnique({ where: { id: data.member.id } });
+            const created = await prisma.person.findUnique({ where: { id: data.member.id } });
             expect(created?.householdId).toBe(householdId);
         });
 

--- a/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
@@ -25,7 +25,7 @@ describe('Household Lead API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'lead-api-test' } },
             select: { id: true, householdId: true }
         });
@@ -46,7 +46,7 @@ describe('Household Lead API Integration Tests', () => {
         });
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
@@ -60,7 +60,7 @@ describe('Household Lead API Integration Tests', () => {
         });
         householdId = household.id;
 
-        const leadUser = await prisma.participant.create({
+        const leadUser = await prisma.person.create({
             data: { email: 'lead-lead-api-test@example.com', name: 'Lead User', householdId: household.id }
         });
         testLeadId = leadUser.id;
@@ -69,12 +69,12 @@ describe('Household Lead API Integration Tests', () => {
             data: { householdId: household.id, personId: leadUser.id }
         });
 
-        const adultUser = await prisma.participant.create({
+        const adultUser = await prisma.person.create({
             data: { email: 'adult-lead-api-test@example.com', name: 'Adult User', householdId: household.id }
         });
         testAdultId = adultUser.id;
 
-        const childUser = await prisma.participant.create({
+        const childUser = await prisma.person.create({
             data: { email: 'child-lead-api-test@example.com', name: 'Child User', householdId: household.id }
         });
         testChildId = childUser.id;
@@ -84,7 +84,7 @@ describe('Household Lead API Integration Tests', () => {
         });
         otherHouseholdId = otherHousehold.id;
         
-        const otherLead = await prisma.participant.create({
+        const otherLead = await prisma.person.create({
             data: { email: 'other-lead-lead-api-test@example.com', name: 'Other Lead User', householdId: otherHousehold.id }
         });
         testOtherLeadId = otherLead.id;
@@ -93,7 +93,7 @@ describe('Household Lead API Integration Tests', () => {
             data: { householdId: otherHousehold.id, personId: otherLead.id }
         });
 
-        const otherMember = await prisma.participant.create({
+        const otherMember = await prisma.person.create({
             data: { email: 'other-adult-lead-api-test@example.com', name: 'Other Adult', householdId: otherHousehold.id }
         });
         testOtherMemberId = otherMember.id;
@@ -116,7 +116,7 @@ describe('Household Lead API Integration Tests', () => {
         });
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: currentIds } }
         });
 
@@ -308,7 +308,7 @@ describe('Household Lead API Integration Tests', () => {
             const boardHousehold = await prisma.household.create({
                 data: { name: 'Board Lead Test Household' }
             });
-            const boardUser = await prisma.participant.create({
+            const boardUser = await prisma.person.create({
                 data: { email: 'board-lead-api-test@example.com', name: 'Board User', isBoardMember: true, householdId: boardHousehold.id }
             });
             await prisma.householdLead.create({

--- a/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
@@ -24,7 +24,7 @@ describe('Household Member API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'member-api-test' } },
             select: { id: true, householdId: true }
         });
@@ -45,7 +45,7 @@ describe('Household Member API Integration Tests', () => {
         });
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
@@ -59,7 +59,7 @@ describe('Household Member API Integration Tests', () => {
         });
         householdId = household.id;
 
-        const leadUser = await prisma.participant.create({
+        const leadUser = await prisma.person.create({
             data: { email: 'lead-member-api-test@example.com', name: 'Lead User', householdId: household.id }
         });
         testLeadId = leadUser.id;
@@ -68,12 +68,12 @@ describe('Household Member API Integration Tests', () => {
             data: { householdId: household.id, personId: leadUser.id }
         });
 
-        const memberUser = await prisma.participant.create({
+        const memberUser = await prisma.person.create({
             data: { email: 'child-member-api-test@example.com', name: 'Child User', householdId: household.id }
         });
         testMemberId = memberUser.id;
 
-        const nonLeadUser = await prisma.participant.create({
+        const nonLeadUser = await prisma.person.create({
             data: { email: 'nonlead-member-api-test@example.com', name: 'Non-Lead Adult', householdId: household.id }
         });
         testNonLeadId = nonLeadUser.id;
@@ -83,7 +83,7 @@ describe('Household Member API Integration Tests', () => {
         });
         otherHouseholdId = otherHousehold.id;
 
-        const otherMember = await prisma.participant.create({
+        const otherMember = await prisma.person.create({
             data: { email: 'other-child-member-api-test@example.com', name: 'Other Child', householdId: otherHousehold.id }
         });
         testOtherMemberId = otherMember.id;
@@ -106,7 +106,7 @@ describe('Household Member API Integration Tests', () => {
         });
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: currentIds } }
         });
 
@@ -192,7 +192,7 @@ describe('Household Member API Integration Tests', () => {
             expect(data.message).toBe('Household member updated successfully.');
 
             // Validate the changes
-            const updatedProfile = await prisma.participant.findUnique({ where: { id: testMemberId } });
+            const updatedProfile = await prisma.person.findUnique({ where: { id: testMemberId } });
             expect(updatedProfile?.name).toBe('Updated Child');
             expect(updatedProfile?.email).toBe('updated-child@example.com');
             expect(updatedProfile?.phone).toBe('555-555-5555');
@@ -221,7 +221,7 @@ describe('Household Member API Integration Tests', () => {
             const res = await PATCH(req as unknown as import("next/server").NextRequest);
             expect(res.status).toBe(200);
 
-            const updatedProfile = await prisma.participant.findUnique({ where: { id: testMemberId } });
+            const updatedProfile = await prisma.person.findUnique({ where: { id: testMemberId } });
             expect(updatedProfile?.email).toBeNull();
             expect(updatedProfile?.dateOfBirth).toBeNull();
             expect(updatedProfile?.phone).toBeNull();

--- a/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
@@ -22,7 +22,7 @@ describe('Household Visits API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'house-visits-api-test' } },
             select: { id: true, householdId: true }
         });
@@ -47,7 +47,7 @@ describe('Household Visits API Integration Tests', () => {
         });
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
@@ -60,7 +60,7 @@ describe('Household Visits API Integration Tests', () => {
             data: { name: 'Visits Test Household' }
         });
 
-        const leadUser = await prisma.participant.create({
+        const leadUser = await prisma.person.create({
             data: { email: 'lead-house-visits-api-test@example.com', name: 'Lead User', householdId: household.id }
         });
         testUserId = leadUser.id;
@@ -69,7 +69,7 @@ describe('Household Visits API Integration Tests', () => {
             data: { householdId: household.id, personId: leadUser.id }
         });
 
-        const memberUser = await prisma.participant.create({
+        const memberUser = await prisma.person.create({
             data: { email: 'child-house-visits-api-test@example.com', name: 'Child User', householdId: household.id }
         });
         testMemberId = memberUser.id;
@@ -78,13 +78,13 @@ describe('Household Visits API Integration Tests', () => {
             data: { name: 'Other Visits Test Household' }
         });
 
-        const otherUser = await prisma.participant.create({
+        const otherUser = await prisma.person.create({
             data: { email: 'other-house-visits-api-test@example.com', name: 'Other User', householdId: otherHousehold.id }
         });
         testOtherHouseUserId = otherUser.id;
 
         // Every participant now belongs to a household; this user's own household simply has no visits.
-        const noHouseUser = await prisma.participant.create({
+        const noHouseUser = await prisma.person.create({
             data: { email: 'nohouse-visits-api-test@example.com', name: 'No House User', household: { create: {} } }
         });
         testNoHouseId = noHouseUser.id;
@@ -112,7 +112,7 @@ describe('Household Visits API Integration Tests', () => {
     afterAll(async () => {
         const currentIds = [testUserId, testMemberId, testOtherHouseUserId, testNoHouseId].filter(id => id !== undefined);
         
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { id: { in: currentIds } },
             select: { householdId: true }
         });
@@ -135,7 +135,7 @@ describe('Household Visits API Integration Tests', () => {
         });
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: currentIds } }
         });
 

--- a/checkin-app/src/app/__tests__/householdsDenyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsDenyAPI.integration.test.ts
@@ -33,39 +33,39 @@ describe('POST /api/membership-ops/households — Deny Membership', () => {
     let boardHouseholdId: number;
 
     beforeAll(async () => {
-        const leaked = await prisma.participant.findMany({
+        const leaked = await prisma.person.findMany({
             where: { email: { contains: TAG } }, select: { id: true },
         });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: leaked.map(u => u.id) } } });
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
 
         // Acting board member (in their own household).
-        const board = await prisma.participant.create({
+        const board = await prisma.person.create({
             data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, household: { create: {} } },
         });
         boardId = board.id;
 
         // A plain household to deny.
-        const member = await prisma.participant.create({
+        const member = await prisma.person.create({
             data: { email: `member-${TAG}@example.com`, name: 'Plain Member', household: { create: {} } },
         });
         plainMemberId = member.id;
         plainHouseholdId = member.householdId;
 
         // A household that contains a board member — must be undeniable.
-        const protectedBoard = await prisma.participant.create({
+        const protectedBoard = await prisma.person.create({
             data: { email: `protected-${TAG}@example.com`, name: 'Protected Board', isBoardMember: true, household: { create: {} } },
         });
         boardHouseholdId = protectedBoard.householdId;
     });
 
     afterAll(async () => {
-        const ids = await prisma.participant.findMany({
+        const ids = await prisma.person.findMany({
             where: { email: { contains: TAG } }, select: { id: true, householdId: true },
         });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: ids.map(u => u.id) } } });
         await prisma.membership.deleteMany({ where: { householdId: { in: ids.map(u => u.householdId) } } });
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
         await prisma.household.deleteMany({ where: { id: { in: ids.map(u => u.householdId) } } });
     });
 

--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -31,26 +31,26 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
     let activeHouseholdId: number;
 
     beforeAll(async () => {
-        const leaked = await prisma.participant.findMany({
+        const leaked = await prisma.person.findMany({
             where: { email: { contains: TAG } }, select: { id: true },
         });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: leaked.map(u => u.id) } } });
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
 
         // Acting board member (in their own household).
-        const board = await prisma.participant.create({
+        const board = await prisma.person.create({
             data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, household: { create: {} } },
         });
         boardId = board.id;
 
         // A household with no membership row → will be granted (ACTIVE).
-        const inactive = await prisma.participant.create({
+        const inactive = await prisma.person.create({
             data: { email: `inactive-${TAG}@example.com`, name: 'Inactive Member', household: { create: {} } },
         });
         inactiveHouseholdId = inactive.householdId;
 
         // A household that is already ACTIVE → will be revoked (REVOKED).
-        const active = await prisma.participant.create({
+        const active = await prisma.person.create({
             data: { email: `active-${TAG}@example.com`, name: 'Active Member', household: { create: {} } },
         });
         activeHouseholdId = active.householdId;
@@ -58,12 +58,12 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
     });
 
     afterAll(async () => {
-        const ids = await prisma.participant.findMany({
+        const ids = await prisma.person.findMany({
             where: { email: { contains: TAG } }, select: { id: true, householdId: true },
         });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: ids.map(u => u.id) } } });
         await prisma.membership.deleteMany({ where: { householdId: { in: ids.map(u => u.householdId) } } });
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
         await prisma.household.deleteMany({ where: { id: { in: ids.map(u => u.householdId) } } });
     });
 

--- a/checkin-app/src/app/__tests__/intakeConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/intakeConcurrency.integration.test.ts
@@ -32,7 +32,7 @@ async function wipe() {
         await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
         await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
 }
@@ -45,7 +45,7 @@ describe('intake start concurrency', () => {
         await wipe();
         const hh = await prisma.household.create({ data: { name: `Family ${TAG}` } });
         householdId = hh.id;
-        const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
+        const lead = await prisma.person.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
     });

--- a/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
@@ -29,7 +29,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'certifications-api-test' } },
             select: { id: true, householdId: true }
         });
@@ -50,7 +50,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
         });
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'certifications-api-test' } }
         });
 
@@ -59,7 +59,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
         });
 
         // Setup mock database records
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-certifications-api-test@example.com', name: 'User Kiosk Test', household: { create: {} } }
         });
         testUserId = user.id;
@@ -95,7 +95,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
         await prisma.toolStatus.deleteMany({
             where: { personId: testUserId }
         });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: testUserId }
         });
         // RESTRICT: delete the household only after its participant is gone

--- a/checkin-app/src/app/__tests__/localizationSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/localizationSettingsAPI.integration.test.ts
@@ -35,20 +35,20 @@ describe('Localization settings API', () => {
         const existing = await prisma.appSettings.findUnique({ where: { id: 1 } });
         prevSettings = existing ? { timezone: existing.timezone, locale: existing.locale } : null;
 
-        adminId = (await prisma.participant.create({
+        adminId = (await prisma.person.create({
             data: { email: 'admin-loc-test@example.com', name: 'Loc Admin', isSysadmin: true, household: { create: {} } },
         })).id;
-        plainId = (await prisma.participant.create({
+        plainId = (await prisma.person.create({
             data: { email: 'plain-loc-test@example.com', name: 'Loc Plain', household: { create: {} } },
         })).id;
     });
 
     afterAll(async () => {
         await prisma.auditLog.deleteMany({ where: { actorId: { in: [adminId, plainId] } } });
-        const hhIds = (await prisma.participant.findMany({
+        const hhIds = (await prisma.person.findMany({
             where: { id: { in: [adminId, plainId] } }, select: { householdId: true },
         })).map((p) => p.householdId);
-        await prisma.participant.deleteMany({ where: { id: { in: [adminId, plainId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [adminId, plainId] } } });
         await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
         // Restore the singleton so other suites see the original values.
         if (prevSettings) await prisma.appSettings.update({ where: { id: 1 }, data: prevSettings });

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -25,7 +25,7 @@ jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }
 const TAG = 'bg-nonblocking-test';
 
 async function makeReviewer(label: string): Promise<number> {
-    const r = await prisma.participant.create({
+    const r = await prisma.person.create({
         data: {
             email: `${label}-${TAG}@example.com`,
             name: label,
@@ -38,7 +38,7 @@ async function makeReviewer(label: string): Promise<number> {
 
 /** A board member (notifyBoardPaidReject's recipient) in their own household. */
 async function makeBoardMember(): Promise<number> {
-    const r = await prisma.participant.create({
+    const r = await prisma.person.create({
         data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } },
     });
     return r.id;
@@ -47,7 +47,7 @@ async function makeBoardMember(): Promise<number> {
 /** ACTIVE membership + lead with a valid prior check + a PENDING_RENEWAL process. */
 async function makeFreshRenewal() {
     const hh = await prisma.household.create({ data: { name: `Renewal ${TAG} ${Math.random()}` } });
-    const lead = await prisma.participant.create({
+    const lead = await prisma.person.create({
         data: { email: `rlead-${Math.random()}-${TAG}@example.com`, name: 'R Lead', householdId: hh.id, lastBackgroundCheck: new Date() },
     });
     await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
@@ -59,7 +59,7 @@ async function makeFreshRenewal() {
 /** Applicant household + a lead + membership + a process at the given status. */
 async function makeApplicant(status: 'PENDING_EXTERNAL_ACTION', extra: { lastBackgroundCheck?: Date } = {}) {
     const hh = await prisma.household.create({ data: { name: `Applicant ${TAG} ${Math.random()}` } });
-    const lead = await prisma.participant.create({
+    const lead = await prisma.person.create({
         data: { email: `lead-${Math.random()}-${TAG}@example.com`, name: 'Lead Parent', householdId: hh.id, lastBackgroundCheck: extra.lastBackgroundCheck ?? null },
     });
     await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
@@ -83,10 +83,10 @@ async function wipe() {
         await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.emergencyContact.deleteMany({ where: { householdId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
-    await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+    await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
 }
 
 describe('background check is non-blocking', () => {
@@ -132,7 +132,7 @@ describe('background check is non-blocking', () => {
         expect(await statusOf(processId)).toBe('ACTIVE');
         expect(await membershipStatusOf(membershipId)).toBe('ACTIVE');
         // Guardians' lastBackgroundCheck stamped.
-        const lead = await prisma.participant.findUnique({ where: { id: leadId } });
+        const lead = await prisma.person.findUnique({ where: { id: leadId } });
         expect(lead?.lastBackgroundCheck).not.toBeNull();
         expect(householdId).toBeGreaterThan(0);
     });
@@ -194,7 +194,7 @@ describe('background check is non-blocking', () => {
         await prisma.membershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
         await prisma.household.update({ where: { id: householdId }, data: { line1: '123 Test St' } });
         await prisma.emergencyContact.create({ data: { householdId, name: 'Out Of House', phone: '555-555-1212', phoneDigits: '5555551212', priority: 0 } });
-        const lead = await prisma.participant.findFirst({ where: { householdId, householdLeads: { some: { householdId } } } });
+        const lead = await prisma.person.findFirst({ where: { householdId, householdLeads: { some: { householdId } } } });
 
         await submitIntake(lead!.id);
         const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });

--- a/checkin-app/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
@@ -45,19 +45,19 @@ describe('Bulk renewal migration', () => {
         if (ids.length) {
             await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
             await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
     }
 
     beforeAll(async () => {
         const maxRow = await prisma.membershipProcess.findFirst({ orderBy: { id: 'desc' }, select: { id: true } });
         preMaxProcessId = maxRow?.id ?? 0;
         await wipe();
-        sysId = (await prisma.participant.create({ data: { email: `sys-${TAG}@example.com`, name: 'Sys', isSysadmin: true, household: { create: { name: `Sys HH ${TAG}` } } } })).id;
-        boardId = (await prisma.participant.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
-        plainId = (await prisma.participant.create({ data: { email: `plain-${TAG}@example.com`, name: 'Plain', household: { create: { name: `Plain HH ${TAG}` } } } })).id;
+        sysId = (await prisma.person.create({ data: { email: `sys-${TAG}@example.com`, name: 'Sys', isSysadmin: true, household: { create: { name: `Sys HH ${TAG}` } } } })).id;
+        boardId = (await prisma.person.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
+        plainId = (await prisma.person.create({ data: { email: `plain-${TAG}@example.com`, name: 'Plain', household: { create: { name: `Plain HH ${TAG}` } } } })).id;
         mA = await makeActive('A');
         mB = await makeActive('B');
     });

--- a/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
@@ -57,7 +57,7 @@ describe('POST /api/membership/contract/sign', () => {
             await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
             await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
     }
@@ -69,8 +69,8 @@ describe('POST /api/membership/contract/sign', () => {
         await wipe();
 
         const hh = await prisma.household.create({ data: { name: `HH ${TAG}` } });
-        const lead = await prisma.participant.create({ data: { email: `lead-${TAG}@example.com`, name: 'Lead Parent', householdId: hh.id } });
-        const nonLead = await prisma.participant.create({ data: { email: `member-${TAG}@example.com`, name: 'Member', householdId: hh.id } });
+        const lead = await prisma.person.create({ data: { email: `lead-${TAG}@example.com`, name: 'Lead Parent', householdId: hh.id } });
+        const nonLead = await prisma.person.create({ data: { email: `member-${TAG}@example.com`, name: 'Member', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         const proc = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
@@ -121,7 +121,7 @@ describe('POST /api/membership/contract/sign', () => {
 
     it('lets a RENEWAL process in the EXTERNAL phase sign (renewals re-sign fresh)', async () => {
         const hh = await prisma.household.create({ data: { name: `HH renewal ${TAG}` } });
-        const rLead = await prisma.participant.create({ data: { email: `rlead-${TAG}@example.com`, name: 'Renewing Lead', householdId: hh.id } });
+        const rLead = await prisma.person.create({ data: { email: `rlead-${TAG}@example.com`, name: 'Renewing Lead', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: rLead.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
         await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'RENEWAL', status: 'PENDING_EXTERNAL_ACTION' } });
@@ -178,9 +178,9 @@ describe('POST /api/membership/contract/sign', () => {
     it('lets a isSysadmin who is NOT a household lead sign (isSysadmin bypass)', async () => {
         // Household whose lead is someone else; the signer is a isSysadmin member, not a lead.
         const hh = await prisma.household.create({ data: { name: `HH isSysadmin ${TAG}` } });
-        const otherLead = await prisma.participant.create({ data: { email: `otherlead-${TAG}@example.com`, name: 'Other Lead', householdId: hh.id } });
+        const otherLead = await prisma.person.create({ data: { email: `otherlead-${TAG}@example.com`, name: 'Other Lead', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: otherLead.id } });
-        const isSysadmin = await prisma.participant.create({ data: { email: `isSysadmin-${TAG}@example.com`, name: 'Sys Admin', householdId: hh.id, isSysadmin: true } });
+        const isSysadmin = await prisma.person.create({ data: { email: `isSysadmin-${TAG}@example.com`, name: 'Sys Admin', householdId: hh.id, isSysadmin: true } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
 
@@ -194,7 +194,7 @@ describe('POST /api/membership/contract/sign', () => {
         // Fresh process with no stored Zoho ids → the route takes the create path,
         // which loads the agreement PDF; make that throw AgreementUnavailableError.
         const hh = await prisma.household.create({ data: { name: `HH noagreement ${TAG}` } });
-        const lead = await prisma.participant.create({ data: { email: `noagr-lead-${TAG}@example.com`, name: 'NoAgr Lead', householdId: hh.id } });
+        const lead = await prisma.person.create({ data: { email: `noagr-lead-${TAG}@example.com`, name: 'NoAgr Lead', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });

--- a/checkin-app/src/app/__tests__/membershipContractSync.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSync.integration.test.ts
@@ -52,7 +52,7 @@ async function makeApplicant(data: Record<string, unknown> = {}): Promise<{ user
             ...data,
         },
     });
-    const user = await prisma.participant.create({
+    const user = await prisma.person.create({
         data: { email: `lead-${proc.id}-${TAG}@example.com`, name: 'Lead', householdId: hh.id },
     });
     return { userId: user.id, processId: proc.id };
@@ -76,10 +76,10 @@ async function wipe() {
     if (ids.length) {
         await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
         await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
-    await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+    await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
 }
 
 describe('syncContractStatus', () => {

--- a/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -68,19 +68,19 @@ describe('Membership EXTERNAL phase API', () => {
         if (ids.length) {
             await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
             await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
     }
 
     beforeAll(async () => {
         process.env.ZOHO_WEBHOOK_SECRET = SECRET;
         await wipe();
 
-        const board = await prisma.participant.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: {} } } });
+        const board = await prisma.person.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: {} } } });
         boardId = board.id;
-        const user = await prisma.participant.create({ data: { email: `user-${TAG}@example.com`, name: 'User', household: { create: {} } } });
+        const user = await prisma.person.create({ data: { email: `user-${TAG}@example.com`, name: 'User', household: { create: {} } } });
         plainUserId = user.id;
 
         const a = await makeProcess(`A ${TAG}`, 'zoho-A');
@@ -94,7 +94,7 @@ describe('Membership EXTERNAL phase API', () => {
     afterAll(async () => {
         await wipe();
         // boardId/userId households
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
         if (prevSecret === undefined) delete process.env.ZOHO_WEBHOOK_SECRET;
         else process.env.ZOHO_WEBHOOK_SECRET = prevSecret;
         await prisma.$disconnect();

--- a/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
@@ -37,37 +37,37 @@ describe('Membership Intake API', () => {
     let activeLeadId: number;
 
     async function wipe() {
-        const tagged = await prisma.participant.findMany({ where: { email: { contains: TAG } }, select: { householdId: true } });
+        const tagged = await prisma.person.findMany({ where: { email: { contains: TAG } }, select: { householdId: true } });
         const hhIds = tagged.map((u) => u.householdId).filter((x): x is number => x !== null);
         if (hhIds.length === 0) return;
         // Include participants created mid-flow (children/second parents lack the TAG email).
-        const inHh = await prisma.participant.findMany({ where: { householdId: { in: hhIds } }, select: { id: true } });
+        const inHh = await prisma.person.findMany({ where: { householdId: { in: hhIds } }, select: { id: true } });
         const allIds = inHh.map((p) => p.id);
         await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: hhIds } } } } });
         await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: hhIds } } } });
         await prisma.membership.deleteMany({ where: { householdId: { in: hhIds } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: hhIds } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: allIds } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: hhIds } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: hhIds } } });
         await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
     }
 
     beforeAll(async () => {
         await wipe();
 
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: `lead-${TAG}@example.com`, name: 'Lead Parent', household: { create: { name: 'Intake Flow HH' } } },
         });
         leadId = lead.id;
         leadHouseholdId = lead.householdId!;
         await prisma.householdLead.create({ data: { householdId: leadHouseholdId, personId: leadId } });
 
-        const nonLead = await prisma.participant.create({
+        const nonLead = await prisma.person.create({
             data: { email: `nonlead-${TAG}@example.com`, name: 'Non Lead', householdId: leadHouseholdId },
         });
         nonLeadId = nonLead.id;
 
-        const activeLead = await prisma.participant.create({
+        const activeLead = await prisma.person.create({
             data: {
                 email: `active-${TAG}@example.com`,
                 name: 'Active Lead',
@@ -146,7 +146,7 @@ describe('Membership Intake API', () => {
         expect(state.prefill.children.some((c: { name: string }) => c.name === 'Kid One')).toBe(true);
 
         // Kid One was created as a non-lead (child).
-        const kid = await prisma.participant.findFirst({ where: { householdId: leadHouseholdId, name: 'Kid One' } });
+        const kid = await prisma.person.findFirst({ where: { householdId: leadHouseholdId, name: 'Kid One' } });
         expect(kid).not.toBeNull();
         const kidLead = await prisma.householdLead.findFirst({ where: { householdId: leadHouseholdId, personId: kid!.id } });
         expect(kidLead).toBeNull();
@@ -181,7 +181,7 @@ describe('Membership Intake API', () => {
     });
 
     it('intake start writes a CREATE audit and submit an EDIT audit, both bound to the lead', async () => {
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: `audit-lead-${TAG}@example.com`, name: 'Audit Lead', household: { create: { name: 'Audit Intake HH' } } },
         });
         await prisma.householdLead.create({ data: { householdId: lead.householdId!, personId: lead.id } });
@@ -214,7 +214,7 @@ describe('Membership Intake API', () => {
     });
 
     it('createRenewalProcess writes a SYSTEM_ACTOR CREATE; beginRenewal a SYSTEM_ACTOR EDIT', async () => {
-        const owner = await prisma.participant.create({
+        const owner = await prisma.person.create({
             data: {
                 email: `renew-lead-${TAG}@example.com`, name: 'Renew Lead',
                 household: { create: { name: 'Renew HH', membership: { create: { status: 'ACTIVE' } } } },

--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -53,7 +53,7 @@ describe('Membership payment API', () => {
     async function makeProc(label: string, isVolunteer: boolean, withLead = false) {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
         if (withLead) {
-            const lead = await prisma.participant.create({ data: { email: `lead-${TAG}@example.com`, name: 'Lead', householdId: hh.id } });
+            const lead = await prisma.person.create({ data: { email: `lead-${TAG}@example.com`, name: 'Lead', householdId: hh.id } });
             await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
             leadId = lead.id;
         }
@@ -72,10 +72,10 @@ describe('Membership payment API', () => {
             await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
             await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
     }
 
     beforeAll(async () => {
@@ -201,7 +201,7 @@ describe('Membership payment API', () => {
     it('concurrent activate() of the same process sends one email and writes one audit row', async () => {
         // Fresh proc with a lead so a congrats email would fire.
         const hh = await prisma.household.create({ data: { name: `Concurrent ${TAG}` } });
-        const lead = await prisma.participant.create({ data: { email: `concurrent-${TAG}@example.com`, name: 'C Lead', householdId: hh.id } });
+        const lead = await prisma.person.create({ data: { email: `concurrent-${TAG}@example.com`, name: 'C Lead', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer: false } });
         // bgClearedAt set so paying activates (and the one congrats email fires).

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -33,7 +33,7 @@ describe('Membership renewal', () => {
     async function makeActiveMembership(label: string, parentBg: Date | null) {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
         // The guardian is a household lead (drives the 3-yr BG-freshness check).
-        const parent = await prisma.participant.create({ data: { name: `${label} Parent`, householdId: hh.id, lastBackgroundCheck: parentBg ?? undefined } });
+        const parent = await prisma.person.create({ data: { name: `${label} Parent`, householdId: hh.id, lastBackgroundCheck: parentBg ?? undefined } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
         return { householdId: hh.id, membershipId: m.id };
@@ -47,10 +47,10 @@ describe('Membership renewal', () => {
             await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
             await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
     }
 
     // A real Treehouse-style interval (~2.6yr) so the BG-freshness rule has a configured value.
@@ -71,9 +71,9 @@ describe('Membership renewal', () => {
         const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
         prevBoundary = existing?.membershipYearBoundary ?? null;
         await wipe();
-        const r1 = await prisma.participant.create({ data: { email: `rev1-${TAG}@example.com`, name: 'Rev1', isBackgroundCheckReviewer: true, household: { create: { name: `Rev1 HH ${TAG}` } } } });
+        const r1 = await prisma.person.create({ data: { email: `rev1-${TAG}@example.com`, name: 'Rev1', isBackgroundCheckReviewer: true, household: { create: { name: `Rev1 HH ${TAG}` } } } });
         rev1 = r1.id;
-        rev2 = (await prisma.participant.create({ data: { email: `rev2-${TAG}@example.com`, name: 'Rev2', isBackgroundCheckReviewer: true, household: { create: { name: `Rev2 HH ${TAG}` } } } })).id;
+        rev2 = (await prisma.person.create({ data: { email: `rev2-${TAG}@example.com`, name: 'Rev2', isBackgroundCheckReviewer: true, household: { create: { name: `Rev2 HH ${TAG}` } } } })).id;
     });
 
     afterAll(async () => {

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -32,7 +32,7 @@ describe('Membership BG review API', () => {
     async function makeApplicantProcess(label: string, parentEmail?: string) {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
         // A parent/guardian is a household lead.
-        const parent = await prisma.participant.create({ data: { name: `${label} Parent`, householdId: hh.id, ...(parentEmail ? { email: parentEmail } : {}) } });
+        const parent = await prisma.person.create({ data: { name: `${label} Parent`, householdId: hh.id, ...(parentEmail ? { email: parentEmail } : {}) } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
@@ -42,7 +42,7 @@ describe('Membership BG review API', () => {
     // Build a process in an arbitrary kind/status (for non-BLOCKED + renewal-branch tests).
     async function makeProcess(label: string, kind: 'INITIAL' | 'RENEWAL', status: 'PENDING_PAYMENT' | 'RENEWAL_PENDING_BG') {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
-        const parent = await prisma.participant.create({ data: { name: `${label} Parent`, householdId: hh.id } });
+        const parent = await prisma.person.create({ data: { name: `${label} Parent`, householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind, status } });
@@ -57,11 +57,11 @@ describe('Membership BG review API', () => {
             await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
             await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
         await prisma.volunteerDesignation.deleteMany({ where: { email: { contains: TAG } } });
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
     }
 
     beforeAll(async () => {
@@ -70,7 +70,7 @@ describe('Membership BG review API', () => {
             const data = householdId
                 ? { email: `${slug}-${TAG}@example.com`, name: slug, householdId, ...role }
                 : { email: `${slug}-${TAG}@example.com`, name: slug, household: { create: { name: `${slug} HH ${TAG}` } }, ...role };
-            return prisma.participant.create({ data });
+            return prisma.person.create({ data });
         };
         const r1 = await mk('rev1', { isBackgroundCheckReviewer: true });
         rev1 = r1.id;
@@ -129,7 +129,7 @@ describe('Membership BG review API', () => {
         expect(updated?.status).toBe('PENDING_PAYMENT');
         const membership = await prisma.membership.findUnique({ where: { id: proc.membershipId } });
         expect(membership?.isVolunteer).toBe(true);
-        const parent = await prisma.participant.findFirst({ where: { householdId: proc.householdId, householdLeads: { some: { householdId: proc.householdId } } } });
+        const parent = await prisma.person.findFirst({ where: { householdId: proc.householdId, householdLeads: { some: { householdId: proc.householdId } } } });
         expect(parent?.lastBackgroundCheck).not.toBeNull();
 
         // The advance audit records the reviewer whose attestation triggered it (rev2), not rev1/SYSTEM.
@@ -284,9 +284,9 @@ describe('Membership BG review API', () => {
     it('queue returns only parents (leads) and never exposes children', async () => {
         // Self-contained applicant household: one parent (lead) + one child (non-lead).
         const hh = await prisma.household.create({ data: { name: `ChildExcl ${TAG}` } });
-        const parent = await prisma.participant.create({ data: { name: 'Excl Parent', email: `exclparent-${TAG}@example.com`, householdId: hh.id } });
+        const parent = await prisma.person.create({ data: { name: 'Excl Parent', email: `exclparent-${TAG}@example.com`, householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
-        await prisma.participant.create({ data: { name: 'Excl Child', email: `exclchild-${TAG}@example.com`, householdId: hh.id } });
+        await prisma.person.create({ data: { name: 'Excl Child', email: `exclchild-${TAG}@example.com`, householdId: hh.id } });
         const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
         await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
 

--- a/checkin-app/src/app/__tests__/membershipReviewConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewConcurrency.integration.test.ts
@@ -19,7 +19,7 @@ const TAG = 'review-concurrency-test';
 
 /** A background-check reviewer in their own (distinct) household. */
 async function makeReviewer(label: string): Promise<number> {
-    const r = await prisma.participant.create({
+    const r = await prisma.person.create({
         data: {
             email: `${label}-${TAG}@example.com`,
             name: label,
@@ -51,10 +51,10 @@ async function wipe() {
         await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
         await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
-    await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+    await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
 }
 
 describe('attest() concurrency', () => {

--- a/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
@@ -35,10 +35,10 @@ describe('Membership settings + volunteer designations API', () => {
         if (ids.length) {
             await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
     }
 
     beforeAll(async () => {
@@ -46,11 +46,11 @@ describe('Membership settings + volunteer designations API', () => {
         prevSettings = existing ? { normalDuesCents: existing.normalDuesCents, volunteerDuesCents: existing.volunteerDuesCents } : null;
         await wipe();
 
-        boardId = (await prisma.participant.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
-        plainId = (await prisma.participant.create({ data: { email: `plain-${TAG}@example.com`, name: 'Plain', household: { create: { name: `Plain HH ${TAG}` } } } })).id;
+        boardId = (await prisma.person.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
+        plainId = (await prisma.person.create({ data: { email: `plain-${TAG}@example.com`, name: 'Plain', household: { create: { name: `Plain HH ${TAG}` } } } })).id;
 
         // A full-price active member, for the designation warning.
-        await prisma.participant.create({
+        await prisma.person.create({
             data: { email: `fullmember-${TAG}@example.com`, name: 'Full', household: { create: { name: `Full HH ${TAG}`, membership: { create: { status: 'ACTIVE', isVolunteer: false } } } } },
         });
     });

--- a/checkin-app/src/app/__tests__/myProgramsConflictsResolveAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/myProgramsConflictsResolveAPI.integration.test.ts
@@ -34,23 +34,23 @@ describe('My-programs conflicts resolve API', () => {
     const hoursAgo = (h: number) => new Date(Date.now() - h * 60 * 60 * 1000);
 
     beforeAll(async () => {
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: `lead-${TAG}@example.com`, name: 'Lead', household: { create: {} } },
         });
         leadId = lead.id;
         householdId = lead.householdId;
 
-        const otherLead = await prisma.participant.create({
+        const otherLead = await prisma.person.create({
             data: { email: `other-lead-${TAG}@example.com`, name: 'Other Lead', householdId },
         });
         otherLeadId = otherLead.id;
 
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: `admin-${TAG}@example.com`, name: 'Admin', isSysadmin: true, householdId },
         });
         adminId = admin.id;
 
-        const participant = await prisma.participant.create({
+        const participant = await prisma.person.create({
             data: { email: `participant-${TAG}@example.com`, name: 'Participant', householdId },
         });
         participantId = participant.id;
@@ -68,7 +68,7 @@ describe('My-programs conflicts resolve API', () => {
         await prisma.visit.deleteMany({ where: { personId: participantId } });
         await prisma.event.deleteMany({ where: { id: eventId } });
         await prisma.program.deleteMany({ where: { id: programId } });
-        await prisma.participant.deleteMany({ where: { id: { in: [leadId, otherLeadId, adminId, participantId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [leadId, otherLeadId, adminId, participantId] } } });
         await prisma.household.deleteMany({ where: { id: householdId } });
     });
 

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -47,14 +47,14 @@ describe('Nav todo-counts API', () => {
     beforeAll(async () => {
         // Household A: a lead with a full slate of *member-actionable* todos, plus
         // one reviewer-owned membership state that must NOT count for the member.
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: `lead-${TAG}@example.com`, name: 'Lead A', dateOfBirth: new Date('1985-01-01'), phone: '555-0001', household: { create: {} } },
         });
         leadId = lead.id;
         householdAId = lead.householdId;
         await prisma.householdLead.create({ data: { householdId: householdAId, personId: leadId } });
 
-        const second = await prisma.participant.create({
+        const second = await prisma.person.create({
             data: { email: `member2-${TAG}@example.com`, name: 'Member A2', dateOfBirth: new Date('1987-01-01'), householdId: householdAId },
         });
         secondMemberId = second.id;
@@ -134,7 +134,7 @@ describe('Nav todo-counts API', () => {
         futureEventId = futureEvent.id;
 
         // Household B: a board member with no household todos of their own.
-        const board = await prisma.participant.create({
+        const board = await prisma.person.create({
             data: { email: `board-${TAG}@example.com`, name: 'Board B', dateOfBirth: new Date('1980-01-01'), phone: '555-0000', isBoardMember: true, household: { create: {} } },
         });
         boardId = board.id;
@@ -150,7 +150,7 @@ describe('Nav todo-counts API', () => {
         await prisma.membershipProcess.deleteMany({ where: { membershipId } });
         await prisma.membership.deleteMany({ where: { id: membershipId } });
         await prisma.householdLead.deleteMany({ where: { householdId: householdAId } });
-        await prisma.participant.deleteMany({ where: { id: { in: [leadId, secondMemberId, boardId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [leadId, secondMemberId, boardId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [householdAId, householdBId] } } });
     });
 
@@ -205,7 +205,7 @@ describe('Nav todo-counts API', () => {
     });
 
     it('surfaces a household todo for a member with no DoB and no 25+ declaration', async () => {
-        const noAge = await prisma.participant.create({
+        const noAge = await prisma.person.create({
             data: { name: 'No Age M', householdId: householdAId },
         });
         try {
@@ -217,7 +217,7 @@ describe('Nav todo-counts API', () => {
                 ]),
             );
         } finally {
-            await prisma.participant.delete({ where: { id: noAge.id } });
+            await prisma.person.delete({ where: { id: noAge.id } });
         }
     });
 
@@ -274,18 +274,18 @@ describe('Nav todo-counts API', () => {
         const before = await memberFamilies();
 
         // Staff household: only an org-email participant → must NOT count.
-        const staff = await prisma.participant.create({
+        const staff = await prisma.person.create({
             data: { email: `staff-${TAG}@${ORG_DOMAIN}`, name: 'Staff', household: { create: {} } },
         });
         expect(await memberFamilies()).toBe(before);
 
         // Member family: a non-org email → +1.
-        const member = await prisma.participant.create({
+        const member = await prisma.person.create({
             data: { email: `family-${TAG}@example.com`, name: 'Family', household: { create: {} } },
         });
         expect(await memberFamilies()).toBe(before + 1);
 
-        await prisma.participant.deleteMany({ where: { id: { in: [staff.id, member.id] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [staff.id, member.id] } } });
         await prisma.household.deleteMany({ where: { id: { in: [staff.householdId, member.householdId] } } });
     });
 });

--- a/checkin-app/src/app/__tests__/notificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsAPI.integration.test.ts
@@ -28,17 +28,17 @@ describe('Membership notifications API', () => {
         if (ids.length) {
             await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
             await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
-        await prisma.participant.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
     }
 
     beforeAll(async () => {
         await wipe();
-        reviewerId = (await prisma.participant.create({ data: { email: `rev-${TAG}@example.com`, name: 'Rev', isBackgroundCheckReviewer: true, household: { create: { name: `Rev HH ${TAG}` } } } })).id;
-        boardId = (await prisma.participant.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
-        plainId = (await prisma.participant.create({ data: { email: `plain-${TAG}@example.com`, name: 'Plain', household: { create: { name: `Plain HH ${TAG}` } } } })).id;
+        reviewerId = (await prisma.person.create({ data: { email: `rev-${TAG}@example.com`, name: 'Rev', isBackgroundCheckReviewer: true, household: { create: { name: `Rev HH ${TAG}` } } } })).id;
+        boardId = (await prisma.person.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
+        plainId = (await prisma.person.create({ data: { email: `plain-${TAG}@example.com`, name: 'Plain', household: { create: { name: `Plain HH ${TAG}` } } } })).id;
 
         // An application awaiting review (eligible for the reviewer — different household).
         const appHh = await prisma.household.create({ data: { name: `App HH ${TAG}` } });

--- a/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
@@ -18,7 +18,7 @@ describe("sendCheckinNotifications()", () => {
         // for those households must go first or Membership_householdId_fkey blocks it.
         await prisma.visit.deleteMany();
         await prisma.householdLead.deleteMany();
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: "notify-test" } }
         });
         await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { participants: { none: {} } } } } } });
@@ -34,7 +34,7 @@ describe("sendCheckinNotifications()", () => {
         householdId = hh.id;
 
         // Create Lead
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: {
                 email: "lead-notify-test@example.com",
                 name: "Test Lead",
@@ -52,7 +52,7 @@ describe("sendCheckinNotifications()", () => {
         });
 
         // Create Dependent
-        const dependent = await prisma.participant.create({
+        const dependent = await prisma.person.create({
             data: {
                 email: "dependent-notify-test@example.com",
                 name: "Test Dependent",
@@ -69,7 +69,7 @@ describe("sendCheckinNotifications()", () => {
     afterAll(async () => {
         await prisma.visit.deleteMany();
         await prisma.householdLead.deleteMany();
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: "notify-test" } }
         });
         await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { participants: { none: {} } } } } } });

--- a/checkin-app/src/app/__tests__/notificationsCheckin.perf.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsCheckin.perf.test.ts
@@ -6,7 +6,7 @@ jest.mock("@/lib/email", () => ({
 }));
 
 jest.mock("@/lib/prisma", () => ({
-    participant: {
+    person: {
         findUnique: jest.fn().mockResolvedValue({
             id: 1,
             name: "Test Participant",

--- a/checkin-app/src/app/__tests__/onboardingStatusAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/onboardingStatusAPI.integration.test.ts
@@ -30,7 +30,7 @@ describe('Onboarding Status API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'onboarding-status-test' } },
             select: { id: true, householdId: true }
         });
@@ -38,10 +38,10 @@ describe('Onboarding Status API Integration Tests', () => {
         const existingHouseholdIds = existingUsers.map(u => u.householdId).filter((id): id is number => id !== null);
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({ where: { id: { in: existingUserIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: existingUserIds } } });
         await prisma.household.deleteMany({ where: { id: { in: existingHouseholdIds } } });
 
-        const adult = await prisma.participant.create({
+        const adult = await prisma.person.create({
             data: {
                 email: 'adult-onboarding-status-test@example.com',
                 name: 'Adult No Phone',
@@ -52,7 +52,7 @@ describe('Onboarding Status API Integration Tests', () => {
         adultId = adult.id;
         householdIds.push(adult.householdId);
 
-        const youth = await prisma.participant.create({
+        const youth = await prisma.person.create({
             data: {
                 email: 'youth-onboarding-status-test@example.com',
                 name: 'Youth No Phone',
@@ -63,7 +63,7 @@ describe('Onboarding Status API Integration Tests', () => {
         youthId = youth.id;
         householdIds.push(youth.householdId);
 
-        const noDob = await prisma.participant.create({
+        const noDob = await prisma.person.create({
             data: {
                 email: 'nodob-onboarding-status-test@example.com',
                 name: 'No DOB No Phone',
@@ -76,7 +76,7 @@ describe('Onboarding Status API Integration Tests', () => {
 
     afterAll(async () => {
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: [adultId, youthId, noDobId] } }
         });
         await prisma.household.deleteMany({
@@ -121,7 +121,7 @@ describe('Onboarding Status API Integration Tests', () => {
         });
 
         it('should not require a phone once one is set', async () => {
-            await prisma.participant.update({
+            await prisma.person.update({
                 where: { id: adultId },
                 data: { phone: '555-123-4567' }
             });

--- a/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
@@ -20,7 +20,7 @@ describe('Profile API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'profile-api-test' } },
             select: { id: true, householdId: true }
         });
@@ -37,7 +37,7 @@ describe('Profile API Integration Tests', () => {
         });
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
@@ -46,7 +46,7 @@ describe('Profile API Integration Tests', () => {
         });
 
         // Setup mock database records
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: {
                 email: 'user-profile-api-test@example.com',
                 name: 'Profile Tester',
@@ -77,7 +77,7 @@ describe('Profile API Integration Tests', () => {
             where: { actorId: testUserId }
         });
 
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: testUserId }
         });
 

--- a/checkin-app/src/app/__tests__/profileVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileVisitsAPI.integration.test.ts
@@ -20,7 +20,7 @@ describe('Profile Visits API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'profile-visits-api-test' } },
             select: { id: true, householdId: true }
         });
@@ -33,7 +33,7 @@ describe('Profile Visits API Integration Tests', () => {
         });
 
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
@@ -42,7 +42,7 @@ describe('Profile Visits API Integration Tests', () => {
         });
 
         // Setup mock database records
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'user-profile-visits-test@example.com', name: 'Profile Visits Tester', household: { create: {} } }
         });
         testUserId = user.id;
@@ -68,7 +68,7 @@ describe('Profile Visits API Integration Tests', () => {
             where: { personId: testUserId }
         });
 
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: testUserId }
         });
 

--- a/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
@@ -52,52 +52,52 @@ describe('Program Age Bounds Integration Tests', () => {
         await prisma.programVolunteer.deleteMany({});
         await prisma.event.deleteMany({});
         await prisma.program.deleteMany({});
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { email: { contains: 'age-test' } }
         });
 
         // Setup mock database records
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-age-test@example.com', name: 'Admin Age Test', isSysadmin: true, household: { create: {} } }
         });
         testAdminId = admin.id;
 
-        const pValid = await prisma.participant.create({
+        const pValid = await prisma.person.create({
             data: { email: 'valid-age-test@example.com', name: 'Valid Age Test', dateOfBirth: dob16, household: { create: {} } }
         });
         validUserId = pValid.id;
 
-        const pUnder = await prisma.participant.create({
+        const pUnder = await prisma.person.create({
             data: { email: 'underage-test@example.com', name: 'Underage Test', dateOfBirth: dob12, household: { create: {} } }
         });
         underageUserId = pUnder.id;
 
-        const pOver = await prisma.participant.create({
+        const pOver = await prisma.person.create({
             data: { email: 'overage-test@example.com', name: 'Overage Test', dateOfBirth: dob20, household: { create: {} } }
         });
         overageUserId = pOver.id;
 
-        const pNoDob = await prisma.participant.create({
+        const pNoDob = await prisma.person.create({
             data: { email: 'no-dob-test@example.com', name: 'No DOB Test', household: { create: {} } }
         });
         noDobUserId = pNoDob.id;
 
-        const pExactlyMin = await prisma.participant.create({
+        const pExactlyMin = await prisma.person.create({
             data: { email: 'exactly-min-age-test@example.com', name: 'Exactly Min Age Test', dateOfBirth: dobExactly14, household: { create: {} } }
         });
         exactlyMinUserId = pExactlyMin.id;
 
-        const pExactlyMax = await prisma.participant.create({
+        const pExactlyMax = await prisma.person.create({
             data: { email: 'exactly-max-age-test@example.com', name: 'Exactly Max Age Test', dateOfBirth: dobExactly18, household: { create: {} } }
         });
         exactlyMaxUserId = pExactlyMax.id;
 
-        const pTurns14Tomorrow = await prisma.participant.create({
+        const pTurns14Tomorrow = await prisma.person.create({
             data: { email: 'turns-14-tomorrow-age-test@example.com', name: 'Turns 14 Tomorrow Test', dateOfBirth: dobTurns14Tomorrow, household: { create: {} } }
         });
         turns14TomorrowUserId = pTurns14Tomorrow.id;
 
-        const pTurned19Yesterday = await prisma.participant.create({
+        const pTurned19Yesterday = await prisma.person.create({
             data: { email: 'turned-19-yesterday-age-test@example.com', name: 'Turned 19 Yesterday Test', dateOfBirth: dobTurned19Yesterday, household: { create: {} } }
         });
         turned19YesterdayUserId = pTurned19Yesterday.id;
@@ -127,7 +127,7 @@ describe('Program Age Bounds Integration Tests', () => {
             await prisma.auditLog.deleteMany({
                 where: { actorId: { in: actorIds } }
             });
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { id: { in: actorIds } }
             });
         }

--- a/checkin-app/src/app/__tests__/programAgeStartDate.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeStartDate.integration.test.ts
@@ -38,7 +38,7 @@ describe('Program Age Start-Date Basis (authenticated route)', () => {
 
     beforeAll(async () => {
         await prisma.programParticipant.deleteMany({ where: { person: { email: { contains: 'age-startdate-test' } } } });
-        await prisma.participant.deleteMany({ where: { email: { contains: 'age-startdate-test' } } });
+        await prisma.person.deleteMany({ where: { email: { contains: 'age-startdate-test' } } });
         await prisma.program.deleteMany({ where: { name: { contains: 'Age StartDate Test' } } });
 
         // minAge 14, begins 2026-09-01. Free (no prices) so enrollment is allowed.
@@ -55,7 +55,7 @@ describe('Program Age Start-Date Basis (authenticated route)', () => {
 
         // Born 2012-04-01: age 13 as of 2026-01-01 (frozen now), turns 14 on
         // 2026-04-01 — BEFORE the 2026-09-01 start. Eligible as of startAt only.
-        const user = await prisma.participant.create({
+        const user = await prisma.person.create({
             data: { email: 'turns14-age-startdate-test@example.com', name: 'Turns 14 Before Start', dateOfBirth: new Date('2012-04-01T00:00:00.000Z'), household: { create: {} } }
         });
         userId = user.id;
@@ -64,7 +64,7 @@ describe('Program Age Start-Date Basis (authenticated route)', () => {
     afterAll(async () => {
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.program.deleteMany({ where: { id: programId } });
-        await prisma.participant.deleteMany({ where: { id: userId } });
+        await prisma.person.deleteMany({ where: { id: userId } });
     });
 
     afterEach(async () => {

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -40,7 +40,7 @@ describe('Program payment-plan routes', () => {
     const householdIds: number[] = [];
 
     beforeAll(async () => {
-        const mentor = await prisma.participant.create({
+        const mentor = await prisma.person.create({
             data: { name: 'PP Mentor', email: `mentor-${TAG}@example.com`, household: { create: {} } },
         });
         mentorId = mentor.id;
@@ -51,25 +51,25 @@ describe('Program payment-plan routes', () => {
         });
         programId = program.id;
 
-        const board = await prisma.participant.create({
+        const board = await prisma.person.create({
             data: { name: 'PP Board', email: `board-${TAG}@example.com`, isBoardMember: true, household: { create: {} } },
         });
         boardId = board.id;
         householdIds.push(board.householdId);
 
-        const self = await prisma.participant.create({
+        const self = await prisma.person.create({
             data: { name: 'PP Self', email: `self-${TAG}@example.com`, household: { create: {} } },
         });
         selfId = self.id;
         householdIds.push(self.householdId);
 
-        const other = await prisma.participant.create({
+        const other = await prisma.person.create({
             data: { name: 'PP Other', email: `other-${TAG}@example.com`, household: { create: {} } },
         });
         otherId = other.id;
         householdIds.push(other.householdId);
 
-        const noise = await prisma.participant.create({
+        const noise = await prisma.person.create({
             data: { name: 'PP Noise', email: `noise-${TAG}@example.com`, household: { create: {} } },
         });
         noiseId = noise.id;
@@ -83,7 +83,7 @@ describe('Program payment-plan routes', () => {
     afterAll(async () => {
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.program.delete({ where: { id: programId } });
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: [mentorId, boardId, selfId, otherId, noiseId] } },
         });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });

--- a/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
@@ -35,7 +35,7 @@ describe('Program price round-trip (dollars -> cents) Integration Tests', () => 
     let leadId: number;
 
     beforeAll(async () => {
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'price-roundtrip-test' } },
             select: { id: true },
         });
@@ -43,14 +43,14 @@ describe('Program price round-trip (dollars -> cents) Integration Tests', () => 
 
         await prisma.program.deleteMany({ where: { name: { contains: PROGRAM_NAME_TAG } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: existingUserIds } } });
-        await prisma.participant.deleteMany({ where: { id: { in: existingUserIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: existingUserIds } } });
 
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-price-roundtrip-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } },
         });
         adminId = admin.id;
 
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: 'lead-price-roundtrip-test@example.com', name: 'Lead', household: { create: {} } },
         });
         leadId = lead.id;
@@ -60,7 +60,7 @@ describe('Program price round-trip (dollars -> cents) Integration Tests', () => 
         const ids = [adminId, leadId];
         await prisma.program.deleteMany({ where: { name: { contains: PROGRAM_NAME_TAG } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { id: { in: ids } } });
+        await prisma.person.deleteMany({ where: { id: { in: ids } } });
     });
 
     describe('CREATE: POST /api/programs', () => {

--- a/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
@@ -25,7 +25,7 @@ describe('Programs API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'programs-api-test' } },
             select: { id: true }
         });
@@ -39,24 +39,24 @@ describe('Programs API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
         // Create Admin
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-programs-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
         });
         adminId = admin.id;
 
         // Create Lead
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: 'lead-programs-api-test@example.com', name: 'Lead', household: { create: {} } }
         });
         leadId = lead.id;
 
         // Create Common User
-        const commonUser = await prisma.participant.create({
+        const commonUser = await prisma.person.create({
             data: { email: 'common-programs-api-test@example.com', name: 'Common', household: { create: {} } }
         });
         commonId = commonUser.id;
@@ -82,7 +82,7 @@ describe('Programs API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
     });

--- a/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
@@ -34,7 +34,7 @@ describe('Eligible Participants API Integration Tests', () => {
         // 'dev' so unauthenticated stays unauthenticated (401), like registryAuthz.
         process.env.CHECKIN_ENV = 'dev';
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'elig-api-test' } },
             select: { id: true, householdId: true }
         });
@@ -60,30 +60,30 @@ describe('Eligible Participants API Integration Tests', () => {
             where: { name: { contains: 'Elig API Test' } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
         // Create Admin
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-elig-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
         });
         adminId = admin.id;
 
         // Create Lead
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: 'lead-elig-api-test@example.com', name: 'Lead', household: { create: {} } }
         });
         leadId = lead.id;
 
         // Create Common User
-        const commonUser = await prisma.participant.create({
+        const commonUser = await prisma.person.create({
             data: { email: 'common-elig-api-test@example.com', name: 'Common', household: { create: {} } }
         });
         commonId = commonUser.id;
 
         // Create Active Member — membership now lives on the household (status ACTIVE).
-        const activeMember = await prisma.participant.create({
+        const activeMember = await prisma.person.create({
             data: {
                 email: 'active-member-elig-api-test@example.com',
                 name: 'Active Member Candidate',
@@ -115,7 +115,7 @@ describe('Eligible Participants API Integration Tests', () => {
         });
         testHouseholdId = household.id;
 
-        const householdMember = await prisma.participant.create({
+        const householdMember = await prisma.person.create({
             data: { 
                 email: 'household-member-elig-api-test@example.com', 
                 name: 'Household Member Candidate',
@@ -125,7 +125,7 @@ describe('Eligible Participants API Integration Tests', () => {
         householdMemberId = householdMember.id;
 
         // Create Non-Member
-        const nonMember = await prisma.participant.create({
+        const nonMember = await prisma.person.create({
             data: {
                 email: 'non-member-elig-api-test@example.com',
                 name: 'Non Member Candidate',
@@ -146,7 +146,7 @@ describe('Eligible Participants API Integration Tests', () => {
         memberOnlyProgramId = memberOnlyProgram.id;
 
         // Create already enrolled participant for public program
-        const alreadyEnrolled = await prisma.participant.create({
+        const alreadyEnrolled = await prisma.person.create({
             data: {
                 email: 'enrolled-elig-api-test@example.com',
                 name: 'Already Enrolled Candidate',
@@ -174,7 +174,7 @@ describe('Eligible Participants API Integration Tests', () => {
             // Memberships are held by households. Scope the cleanup to exactly the
             // households this test touched: each test participant's household plus the
             // explicitly created Elig API Test household.
-            const testParticipants = await prisma.participant.findMany({
+            const testParticipants = await prisma.person.findMany({
                 where: { id: { in: existingUserIds } },
                 select: { householdId: true }
             });
@@ -193,7 +193,7 @@ describe('Eligible Participants API Integration Tests', () => {
         }
 
         if (existingUserIds.length > 0) {
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { id: { in: existingUserIds } }
             });
         }

--- a/checkin-app/src/app/__tests__/programsEnrollClosed.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsEnrollClosed.integration.test.ts
@@ -26,19 +26,19 @@ describe('Enroll into a CLOSED program is rejected (both paths)', () => {
         const progIds = progs.map(p => p.id);
         await prisma.programParticipant.deleteMany({ where: { programId: { in: progIds } } });
         // Households spawned by public-register (reached via enrolled members) + the test user.
-        const members = await prisma.participant.findMany({ where: { OR: [{ email: { contains: TAG } }, { programParticipants: { some: { programId: { in: progIds } } } }] }, select: { id: true, householdId: true } });
+        const members = await prisma.person.findMany({ where: { OR: [{ email: { contains: TAG } }, { programParticipants: { some: { programId: { in: progIds } } } }] }, select: { id: true, householdId: true } });
         const hhIds = [...new Set(members.map(m => m.householdId).filter((x): x is number => x != null))];
         await prisma.auditLog.deleteMany({ where: { actorId: { in: members.map(m => m.id) } } });
         await prisma.emergencyContact.deleteMany({ where: { householdId: { in: hhIds } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: hhIds } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: hhIds } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: hhIds } } });
         await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
         await prisma.program.deleteMany({ where: { id: { in: progIds } } });
     }
 
     beforeAll(async () => {
         await cleanup();
-        const user = await prisma.participant.create({ data: { email: `user-${TAG}@example.com`, name: 'Self Enroller', household: { create: {} } } });
+        const user = await prisma.person.create({ data: { email: `user-${TAG}@example.com`, name: 'Self Enroller', household: { create: {} } } });
         userId = user.id;
         const program = await prisma.program.create({
             data: { name: `Closed ${TAG}`, phase: 'RUNNING', enrollmentStatus: 'CLOSED', memberPriceCents: null, nonMemberPriceCents: null },

--- a/checkin-app/src/app/__tests__/programsHouseholdEnrollment.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsHouseholdEnrollment.integration.test.ts
@@ -40,7 +40,7 @@ describe('Multi-select household enrollment (integration)', () => {
     const TAG = 'household-enroll-test';
 
     const cleanup = async () => {
-        const users = await prisma.participant.findMany({
+        const users = await prisma.person.findMany({
             where: { email: { contains: TAG } },
             select: { id: true }
         });
@@ -52,7 +52,7 @@ describe('Multi-select household enrollment (integration)', () => {
         }
         await prisma.program.deleteMany({ where: { name: { contains: 'Household Enroll Test' } } });
         if (ids.length) {
-            await prisma.participant.deleteMany({ where: { id: { in: ids } } });
+            await prisma.person.deleteMany({ where: { id: { in: ids } } });
         }
     };
 
@@ -61,11 +61,11 @@ describe('Multi-select household enrollment (integration)', () => {
 
         // One household: a lead + three adult dependents (no age limits in play).
         const household = await prisma.household.create({ data: {} });
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: `lead-${TAG}@example.com`, name: 'HH Lead', householdId: household.id }
         });
         leadId = lead.id;
-        const mkDep = async (label: string) => (await prisma.participant.create({
+        const mkDep = async (label: string) => (await prisma.person.create({
             data: {
                 email: `${label}-${TAG}@example.com`,
                 name: `Dep ${label}`,

--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -29,7 +29,7 @@ describe('Individual Program API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'prog-id-api-test' } },
             select: { id: true, householdId: true }
         });
@@ -48,30 +48,30 @@ describe('Individual Program API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
         // Create Admin
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-prog-id-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
         });
         adminId = admin.id;
 
         // Create Lead
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: 'lead-prog-id-api-test@example.com', name: 'Lead', household: { create: {} } }
         });
         leadId = lead.id;
 
         // Create Common User (no membership)
-        const commonUser = await prisma.participant.create({
+        const commonUser = await prisma.person.create({
             data: { email: 'common-prog-id-api-test@example.com', name: 'Common', household: { create: {} } }
         });
         commonId = commonUser.id;
 
         // Create Member User (household holds an active membership)
-        const memberUser = await prisma.participant.create({
+        const memberUser = await prisma.person.create({
             data: {
                 email: 'member-prog-id-api-test@example.com',
                 name: 'Member',
@@ -104,7 +104,7 @@ describe('Individual Program API Integration Tests', () => {
 
         // Enroll a participant with a recognizable name into the public program so
         // the leak tests have a roster identity to look for.
-        const enrolled = await prisma.participant.create({
+        const enrolled = await prisma.person.create({
             data: { email: 'enrolled-prog-id-api-test@example.com', name: ENROLLED_NAME, household: { create: {} } }
         });
         enrolledId = enrolled.id;
@@ -137,7 +137,7 @@ describe('Individual Program API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
     });

--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -33,7 +33,7 @@ describe('Program Participants API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'partic-api-test' } },
             select: { id: true }
         });
@@ -55,24 +55,24 @@ describe('Program Participants API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
         // Create Admin
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-partic-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
         });
         adminId = admin.id;
 
         // Create Lead
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: 'lead-partic-api-test@example.com', name: 'Lead', household: { create: {} } }
         });
         leadId = lead.id;
 
         // Create Common User (25 years old)
-        const commonUser = await prisma.participant.create({
+        const commonUser = await prisma.person.create({
             data: {
                 email: 'common-partic-api-test@example.com',
                 name: 'Common',
@@ -83,7 +83,7 @@ describe('Program Participants API Integration Tests', () => {
         commonId = commonUser.id;
 
         // Create Other User (underage: 10 years old)
-        const otherUser = await prisma.participant.create({
+        const otherUser = await prisma.person.create({
             data: {
                 email: 'other-partic-api-test@example.com',
                 name: 'Other Underage',
@@ -96,11 +96,11 @@ describe('Program Participants API Integration Tests', () => {
         // Board member who leads a household containing a 25yo dependent. The
         // board flag lives on the session, not the DB row — see the mocks below.
         const boardHousehold = await prisma.household.create({ data: {} });
-        const board = await prisma.participant.create({
+        const board = await prisma.person.create({
             data: { email: 'board-partic-api-test@example.com', name: 'Board Parent', householdId: boardHousehold.id }
         });
         boardId = board.id;
-        const dependent = await prisma.participant.create({
+        const dependent = await prisma.person.create({
             data: {
                 email: 'dep-partic-api-test@example.com',
                 name: 'Board Dependent',
@@ -168,7 +168,7 @@ describe('Program Participants API Integration Tests', () => {
                 where: { actorId: { in: existingUserIds } }
             });
 
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { id: { in: existingUserIds } }
             });
         }

--- a/checkin-app/src/app/__tests__/programsParticipantsConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsConcurrency.integration.test.ts
@@ -39,7 +39,7 @@ describe('POST /api/programs/[id]/participants concurrency (capacity lock)', () 
     let programId: number;
 
     async function cleanup() {
-        const users = await prisma.participant.findMany({
+        const users = await prisma.person.findMany({
             where: { email: { contains: TAG } },
             select: { id: true, householdId: true },
         });
@@ -49,7 +49,7 @@ describe('POST /api/programs/[id]/participants concurrency (capacity lock)', () 
         await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { personId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { id: { in: ids } } });
+        await prisma.person.deleteMany({ where: { id: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
     }
 
@@ -59,17 +59,17 @@ describe('POST /api/programs/[id]/participants concurrency (capacity lock)', () 
         const household = await prisma.household.create({ data: { name: `${TAG} household` } });
         householdId = household.id;
 
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: `lead-${TAG}@example.com`, name: 'Lead', householdId },
         });
         leadId = lead.id;
         await prisma.householdLead.create({ data: { householdId, personId: leadId } });
 
-        const m1 = await prisma.participant.create({
+        const m1 = await prisma.person.create({
             data: { email: `m1-${TAG}@example.com`, name: 'Member One', householdId },
         });
         member1Id = m1.id;
-        const m2 = await prisma.participant.create({
+        const m2 = await prisma.person.create({
             data: { email: `m2-${TAG}@example.com`, name: 'Member Two', householdId },
         });
         member2Id = m2.id;

--- a/checkin-app/src/app/__tests__/programsPublicRegisterConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublicRegisterConcurrency.integration.test.ts
@@ -38,7 +38,7 @@ describe('POST /api/programs/[id]/public-register concurrency (capacity lock)', 
         });
         const progIds = progs.map(p => p.id);
         // Households created by registrations: reached via their enrolled members.
-        const members = await prisma.participant.findMany({
+        const members = await prisma.person.findMany({
             where: { programParticipants: { some: { programId: { in: progIds } } } },
             select: { id: true, householdId: true },
         });
@@ -47,7 +47,7 @@ describe('POST /api/programs/[id]/public-register concurrency (capacity lock)', 
         await prisma.emergencyContact.deleteMany({ where: { householdId: { in: householdIds } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: householdIds } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: members.map(m => m.id) } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: householdIds } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: householdIds } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
         await prisma.program.deleteMany({ where: { id: { in: progIds } } });
     }

--- a/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublicRegistrationAPI.integration.test.ts
@@ -26,7 +26,7 @@ describe('Public Program Registration API Integration Tests', () => {
     beforeAll(async () => {
         // Clean up any leaked state
         const testEmails = ['test-primary-parent@example.com', 'existing-user-test@example.com', 'max-age-boundary-parent@example.com', 'start-basis-parent@example.com'];
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { in: testEmails } },
             select: { id: true }
         });
@@ -48,12 +48,12 @@ describe('Public Program Registration API Integration Tests', () => {
             where: { personId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
         // Create an existing user to test unique email constraints
-        const existingUser = await prisma.participant.create({
+        const existingUser = await prisma.person.create({
             data: { email: 'existing-user-test@example.com', name: 'Existing User', household: { create: {} } }
         });
         existingParticipantId = existingUser.id;
@@ -111,7 +111,7 @@ describe('Public Program Registration API Integration Tests', () => {
 
     afterAll(async () => {
         const testEmails = ['test-primary-parent@example.com', 'existing-user-test@example.com', 'max-age-boundary-parent@example.com', 'start-basis-parent@example.com'];
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { in: testEmails } },
             select: { id: true, householdId: true }
         });
@@ -144,7 +144,7 @@ describe('Public Program Registration API Integration Tests', () => {
                 where: { personId: { in: existingUserIds } }
             });
 
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { id: { in: existingUserIds } }
             });
         }
@@ -159,7 +159,7 @@ describe('Public Program Registration API Integration Tests', () => {
             await prisma.programParticipant.deleteMany({
                 where: { person: { householdId: { in: householdIds } } }
             });
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { householdId: { in: householdIds } }
             });
             await prisma.household.deleteMany({
@@ -385,11 +385,11 @@ describe('Public Program Registration API Integration Tests', () => {
             }
 
             // Inline cleanup: this parent email isn't in the afterAll sweep list.
-            const p = await prisma.participant.findUnique({ where: { email: inBoundsEmail } });
+            const p = await prisma.person.findUnique({ where: { email: inBoundsEmail } });
             if (p) {
                 await prisma.programParticipant.deleteMany({ where: { person: { householdId: p.householdId } } });
                 await prisma.householdLead.deleteMany({ where: { person: { householdId: p.householdId } } });
-                await prisma.participant.deleteMany({ where: { householdId: p.householdId } });
+                await prisma.person.deleteMany({ where: { householdId: p.householdId } });
                 await prisma.household.delete({ where: { id: p.householdId as number } });
             }
         });
@@ -417,14 +417,14 @@ describe('Public Program Registration API Integration Tests', () => {
             expect(data.isFree).toBe(false);
 
             // Verify db
-            const parent = await prisma.participant.findUnique({
+            const parent = await prisma.person.findUnique({
                 where: { email: 'test-primary-parent@example.com' },
                 include: { householdLeads: true }
             });
             expect(parent).not.toBeNull();
             expect(parent?.householdLeads.length).toBe(1);
 
-            const householdMembers = await prisma.participant.findMany({
+            const householdMembers = await prisma.person.findMany({
                 where: { householdId: parent?.householdId }
             });
             expect(householdMembers.length).toBe(2); // Parent + Child (no duplicates)
@@ -472,7 +472,7 @@ describe('Public Program Registration API Integration Tests', () => {
                 expect(enrollments).toBe(0);
 
                 // No orphan parent/child Participant rows (whole tx rolled back).
-                const parent = await prisma.participant.findUnique({ where: { email: overflowEmail } });
+                const parent = await prisma.person.findUnique({ where: { email: overflowEmail } });
                 expect(parent).toBeNull();
 
                 // No orphan Household row left behind.
@@ -504,11 +504,11 @@ describe('Public Program Registration API Integration Tests', () => {
             expect(data.isFree).toBe(true);
 
             // Clean up the created one immediately for isolation
-            const p = await prisma.participant.findUnique({ where: { email: uniqueEmail } });
+            const p = await prisma.person.findUnique({ where: { email: uniqueEmail } });
             if (p) {
                 await prisma.programParticipant.deleteMany({ where: { programId: freeProgramId, person: { householdId: p.householdId } }});
                 await prisma.householdLead.deleteMany({ where: { person: { householdId: p.householdId } } });
-                await prisma.participant.deleteMany({ where: { householdId: p.householdId } });
+                await prisma.person.deleteMany({ where: { householdId: p.householdId } });
                 await prisma.household.delete({ where: { id: p.householdId as number } });
             }
         });

--- a/checkin-app/src/app/__tests__/programsPublishAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublishAPI.integration.test.ts
@@ -25,7 +25,7 @@ describe('Program Publish API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'publish-api-test' } },
             select: { id: true }
         });
@@ -43,24 +43,24 @@ describe('Program Publish API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
         // Create Admin
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-publish-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
         });
         adminId = admin.id;
 
         // Create Lead
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: 'lead-publish-api-test@example.com', name: 'Lead', household: { create: {} } }
         });
         leadId = lead.id;
 
         // Create Common User
-        const commonUser = await prisma.participant.create({
+        const commonUser = await prisma.person.create({
             data: { email: 'common-publish-api-test@example.com', name: 'Common', household: { create: {} } }
         });
         commonId = commonUser.id;
@@ -142,7 +142,7 @@ describe('Program Publish API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
     });

--- a/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
@@ -23,7 +23,7 @@ describe('Program Settings API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'settings-api-test' } },
             select: { id: true }
         });
@@ -37,30 +37,30 @@ describe('Program Settings API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
         // Create Admin
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-settings-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
         });
         adminId = admin.id;
 
         // Create Lead
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: 'lead-settings-api-test@example.com', name: 'Lead', household: { create: {} } }
         });
         leadId = lead.id;
 
         // Create New Lead Candidate
-        const newLead = await prisma.participant.create({
+        const newLead = await prisma.person.create({
             data: { email: 'newlead-settings-api-test@example.com', name: 'New Lead', household: { create: {} } }
         });
         newLeadId = newLead.id;
 
         // Create Common User
-        const commonUser = await prisma.participant.create({
+        const commonUser = await prisma.person.create({
             data: { email: 'common-settings-api-test@example.com', name: 'Common', household: { create: {} } }
         });
         commonId = commonUser.id;
@@ -89,7 +89,7 @@ describe('Program Settings API Integration Tests', () => {
                 where: { actorId: { in: existingUserIds } }
             });
             
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { id: { in: existingUserIds } }
             });
         }

--- a/checkin-app/src/app/__tests__/programsVolunteersAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsVolunteersAPI.integration.test.ts
@@ -25,7 +25,7 @@ describe('Program Volunteers API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'volun-api-test' } },
             select: { id: true }
         });
@@ -43,32 +43,32 @@ describe('Program Volunteers API Integration Tests', () => {
             where: { actorId: { in: existingUserIds } }
         });
         
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
 
         // Create Roles
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-volun-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
         });
         adminId = admin.id;
 
-        const lead = await prisma.participant.create({
+        const lead = await prisma.person.create({
             data: { email: 'lead-volun-api-test@example.com', name: 'Lead', household: { create: {} } }
         });
         leadId = lead.id;
 
-        const commonUser = await prisma.participant.create({
+        const commonUser = await prisma.person.create({
             data: { email: 'common-volun-api-test@example.com', name: 'Common', household: { create: {} } }
         });
         commonId = commonUser.id;
 
-        const candidate = await prisma.participant.create({
+        const candidate = await prisma.person.create({
             data: { email: 'candidate-volun-api-test@example.com', name: 'Candidate', household: { create: {} } }
         });
         candidateId = candidate.id;
 
-        const existingVol = await prisma.participant.create({
+        const existingVol = await prisma.person.create({
             data: { email: 'existing-volun-api-test@example.com', name: 'Existing Volunteer', household: { create: {} } }
         });
         existingVolunteerId = existingVol.id;
@@ -107,7 +107,7 @@ describe('Program Volunteers API Integration Tests', () => {
                 where: { actorId: { in: existingUserIds } }
             });
             
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { id: { in: existingUserIds } }
             });
         }
@@ -204,7 +204,7 @@ describe('Program Volunteers API Integration Tests', () => {
              // assignment succeeded above. Volunteers are staff, not enrollees —
              // there is intentionally no eligibility rule. If product adds one,
              // this test should change deliberately.
-             const candidate = await prisma.participant.findUnique({ where: { id: candidateId } });
+             const candidate = await prisma.person.findUnique({ where: { id: candidateId } });
              expect(candidate?.dateOfBirth).toBeNull();
              const row = await prisma.programVolunteer.findUnique({
                  where: { programId_personId: { programId: targetProgramId, personId: candidateId } }

--- a/checkin-app/src/app/__tests__/renewalConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/renewalConcurrency.integration.test.ts
@@ -30,7 +30,7 @@ async function wipe() {
         await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
         await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
 }
@@ -43,7 +43,7 @@ describe('renewal opening concurrency', () => {
         await wipe();
         const hh = await prisma.household.create({ data: { name: `Family ${TAG}` } });
         householdId = hh.id;
-        const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
+        const lead = await prisma.person.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         membershipId = (await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } })).id;
     });

--- a/checkin-app/src/app/__tests__/scanAuth.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanAuth.integration.test.ts
@@ -98,7 +98,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
         beforeAll(async () => {
             // A isKeyholder so a valid kiosk check-in opens the facility → always 200,
             // independent of facility state.
-            const k = await prisma.participant.create({
+            const k = await prisma.person.create({
                 data: {
                     name: 'Kiosk Keyholder',
                     email: `kiosk-${TAG}@example.com`,
@@ -113,7 +113,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
         afterAll(async () => {
             await prisma.visit.deleteMany({ where: { personId: kioskId } });
             await prisma.rawBadgeLog.deleteMany({ where: { personId: kioskId } });
-            await prisma.participant.delete({ where: { id: kioskId } });
+            await prisma.person.delete({ where: { id: kioskId } });
             await prisma.household.delete({ where: { id: kioskHouseholdId } });
         });
 
@@ -245,7 +245,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             delete process.env.KIOSK_PUBLIC_KEY;
 
             const mk = async (name: string, extra: object = {}) => {
-                const p = await prisma.participant.create({
+                const p = await prisma.person.create({
                     data: {
                         name,
                         email: `${name.replace(/\s+/g, '-').toLowerCase()}-${TAG}@example.com`,
@@ -274,7 +274,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
             const hs = [hSelf, hLead, hOther, hStranger, hKeyholder];
             await prisma.visit.deleteMany({ where: { personId: { in: ids } } });
             await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { id: { in: ids } } });
+            await prisma.person.deleteMany({ where: { id: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: hs } } });
         });
 

--- a/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
@@ -12,7 +12,7 @@ import { processCheckout } from '@/lib/scan-service';
 import prisma from '@/lib/prisma';
 import { authenticateRequest } from '@/lib/auth';
 import { processPostEventEmails } from '@/lib/postEventEmails';
-import type { Participant } from '@/generated/prisma/client';
+import type { Person } from '@/generated/prisma/client';
 
 jest.mock('@/lib/auth', () => ({ authenticateRequest: jest.fn() }));
 jest.mock('@/lib/notifications', () => ({
@@ -38,17 +38,17 @@ function scanReq(participantId: number) {
 }
 
 describe('Scan causal chain — last isKeyholder closes facility', () => {
-    let isKeyholder: Participant;
-    let normal: Participant;
+    let isKeyholder: Person;
+    let normal: Person;
     const householdIds: number[] = [];
 
     beforeAll(async () => {
         (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'kiosk' });
-        isKeyholder = await prisma.participant.create({
+        isKeyholder = await prisma.person.create({
             data: { name: 'Causal Key', email: `key-${TAG}@example.com`, isKeyholder: true, household: { create: {} } },
         });
         householdIds.push(isKeyholder.householdId);
-        normal = await prisma.participant.create({
+        normal = await prisma.person.create({
             data: { name: 'Causal Normal', email: `normal-${TAG}@example.com`, household: { create: {} } },
         });
         householdIds.push(normal.householdId);
@@ -65,7 +65,7 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
     });
 
     afterAll(async () => {
-        await prisma.participant.deleteMany({ where: { id: { in: [isKeyholder.id, normal.id] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [isKeyholder.id, normal.id] } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
     });
 

--- a/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
@@ -47,7 +47,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
     beforeAll(async () => {
         (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'kiosk' });
 
-        const isKeyholder = await prisma.participant.create({
+        const isKeyholder = await prisma.person.create({
             data: {
                 name: 'Keyholder Scan',
                 email: `isKeyholder-${TAG}@example.com`,
@@ -58,7 +58,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
         keyholderId = isKeyholder.id;
         keyholderHouseholdId = isKeyholder.householdId;
 
-        const normal = await prisma.participant.create({
+        const normal = await prisma.person.create({
             data: {
                 name: 'Normal Scan',
                 email: `normal-${TAG}@example.com`,
@@ -78,7 +78,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
     afterAll(async () => {
         await prisma.visit.deleteMany({ where: { personId: { in: [keyholderId, normalId] } } });
         await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: [keyholderId, normalId] } } });
-        await prisma.participant.deleteMany({ where: { id: { in: [keyholderId, normalId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [keyholderId, normalId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [keyholderHouseholdId, normalHouseholdId] } } });
     });
 

--- a/checkin-app/src/app/__tests__/scanConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanConcurrency.integration.test.ts
@@ -67,7 +67,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'kiosk' });
 
         // Clean any leaked state from a prior run.
-        const leaked = await prisma.participant.findMany({
+        const leaked = await prisma.person.findMany({
             where: { email: { contains: EMAIL_TAG } },
             select: { id: true, householdId: true },
         });
@@ -75,10 +75,10 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         const leakedHouseholdIds = leaked.map(p => p.householdId);
         await prisma.visit.deleteMany({ where: { personId: { in: leakedIds } } });
         await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: leakedIds } } });
-        await prisma.participant.deleteMany({ where: { id: { in: leakedIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: leakedIds } } });
         await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
 
-        const keeper = await prisma.participant.create({
+        const keeper = await prisma.person.create({
             data: { email: `keeper-${EMAIL_TAG}@example.com`, name: 'Keeper', isKeyholder: true, household: { create: {} } },
         });
         keeperId = keeper.id;
@@ -86,12 +86,12 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         // and non-isKeyholder check-outs skip the last-isKeyholder force-close path.
         await prisma.visit.create({ data: { personId: keeperId, arrivedAt: new Date() } });
 
-        const checkinSubject = await prisma.participant.create({
+        const checkinSubject = await prisma.person.create({
             data: { email: `checkin-${EMAIL_TAG}@example.com`, name: 'Checkin Subject', household: { create: {} } },
         });
         checkinSubjectId = checkinSubject.id;
 
-        const checkoutSubject = await prisma.participant.create({
+        const checkoutSubject = await prisma.person.create({
             data: { email: `checkout-${EMAIL_TAG}@example.com`, name: 'Checkout Subject', household: { create: {} } },
         });
         checkoutSubjectId = checkoutSubject.id;
@@ -99,13 +99,13 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
 
     afterAll(async () => {
         const ids = [keeperId, checkinSubjectId, checkoutSubjectId].filter(id => id !== undefined);
-        const households = (await prisma.participant.findMany({
+        const households = (await prisma.person.findMany({
             where: { id: { in: ids } },
             select: { householdId: true },
         })).map(p => p.householdId);
         await prisma.visit.deleteMany({ where: { personId: { in: ids } } });
         await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { id: { in: ids } } });
+        await prisma.person.deleteMany({ where: { id: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: households } } });
     });
 

--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -26,7 +26,7 @@ describe('Shop API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        const existingUsers = await prisma.participant.findMany({
+        const existingUsers = await prisma.person.findMany({
             where: { email: { contains: 'shop-api-test' } },
             select: { id: true, householdId: true }
         });
@@ -43,7 +43,7 @@ describe('Shop API Integration Tests', () => {
             where: { personId: { in: existingUserIds } }
         });
         // RESTRICT: delete participants before their households
-        await prisma.participant.deleteMany({
+        await prisma.person.deleteMany({
             where: { id: { in: existingUserIds } }
         });
         // Memberships belong to the household; remove them before deleting households.
@@ -62,19 +62,19 @@ describe('Shop API Integration Tests', () => {
         });
 
         // Create Admin
-        const admin = await prisma.participant.create({
+        const admin = await prisma.person.create({
             data: { email: 'admin-shop-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
         });
         adminId = admin.id;
 
         // Create Board Member
-        const board = await prisma.participant.create({
+        const board = await prisma.person.create({
             data: { email: 'board-shop-api-test@example.com', name: 'Board', isBoardMember: true, household: { create: {} } }
         });
         boardId = board.id;
 
         // Create Common User
-        const commonUser = await prisma.participant.create({
+        const commonUser = await prisma.person.create({
             data: {
                 email: 'common-shop-api-test@example.com',
                 name: 'Common',
@@ -90,7 +90,7 @@ describe('Shop API Integration Tests', () => {
         mockToolId = tool.id;
 
         // Create Certifier (A user who has MAY_CERTIFY_OTHERS on a tool)
-        const certifier = await prisma.participant.create({
+        const certifier = await prisma.person.create({
             data: {
                 email: 'certifier-shop-api-test@example.com',
                 name: 'Certifier',
@@ -107,7 +107,7 @@ describe('Shop API Integration Tests', () => {
         const existingUserIds = [adminId, boardId, certifierId, commonId].filter(id => id !== undefined);
 
         if (existingUserIds.length > 0) {
-            const participants = await prisma.participant.findMany({
+            const participants = await prisma.person.findMany({
                 where: { id: { in: existingUserIds } },
                 select: { householdId: true }
             });
@@ -123,7 +123,7 @@ describe('Shop API Integration Tests', () => {
                 where: { personId: { in: existingUserIds } }
             });
             // RESTRICT: delete participants before their households
-            await prisma.participant.deleteMany({
+            await prisma.person.deleteMany({
                 where: { id: { in: existingUserIds } }
             });
             if (householdIds.length > 0) {
@@ -335,7 +335,7 @@ describe('Shop API Integration Tests', () => {
         it('re-cert by a certifier writes an EDIT audit row with the prior level in oldData and the acting certifier as actor', async () => {
             // Self-contained: a fresh tool the certifier may certify on, a fresh target.
             const tool = await prisma.tool.create({ data: { name: 'Shop Test Tool Recert' } });
-            const reCertifier = await prisma.participant.create({
+            const reCertifier = await prisma.person.create({
                 data: {
                     email: 'recert-certifier-shop-api-test@example.com',
                     name: 'Recert Certifier',
@@ -343,7 +343,7 @@ describe('Shop API Integration Tests', () => {
                     toolStatuses: { create: { toolId: tool.id, level: 'MAY_CERTIFY_OTHERS' } },
                 },
             });
-            const target = await prisma.participant.create({
+            const target = await prisma.person.create({
                 data: { email: 'recert-target-shop-api-test@example.com', name: 'Recert Target', household: { create: {} } },
             });
 
@@ -380,7 +380,7 @@ describe('Shop API Integration Tests', () => {
                 await prisma.toolStatus.deleteMany({ where: { toolId: tool.id } });
                 await prisma.tool.deleteMany({ where: { id: tool.id } });
                 const hhIds = [reCertifier.householdId, target.householdId].filter((id): id is number => id !== null);
-                await prisma.participant.deleteMany({ where: { id: { in: [reCertifier.id, target.id] } } });
+                await prisma.person.deleteMany({ where: { id: { in: [reCertifier.id, target.id] } } });
                 await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
             }
         });

--- a/checkin-app/src/app/__tests__/systemStatusHealthAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/systemStatusHealthAPI.integration.test.ts
@@ -29,7 +29,7 @@ describe('System status health API', () => {
     let staleMetricId: number;
 
     beforeAll(async () => {
-        const keyholder = await prisma.participant.create({
+        const keyholder = await prisma.person.create({
             data: { email: `keyholder-${TAG}@example.com`, name: 'Keyholder', isKeyholder: true, household: { create: {} } },
         });
         keyholderId = keyholder.id;
@@ -67,7 +67,7 @@ describe('System status health API', () => {
 
     afterAll(async () => {
         await prisma.systemMetricLog.deleteMany({ where: { id: { in: [...metricIds, staleMetricId] } } });
-        await prisma.participant.deleteMany({ where: { id: keyholderId } });
+        await prisma.person.deleteMany({ where: { id: keyholderId } });
         await prisma.household.deleteMany({ where: { id: householdId } });
     });
 

--- a/checkin-app/src/app/__tests__/trustedAdultAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultAPI.integration.test.ts
@@ -50,12 +50,12 @@ describe('Trusted Adults API', () => {
         if (ids.length) {
             await prisma.trustedAdultReview.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.trustedAdult.deleteMany({ where: { householdId: { in: ids } } });
-            const parts = await prisma.participant.findMany({ where: { householdId: { in: ids } }, select: { id: true } });
+            const parts = await prisma.person.findMany({ where: { householdId: { in: ids } }, select: { id: true } });
             const pids = parts.map((p) => p.id);
             await prisma.programParticipant.deleteMany({ where: { personId: { in: pids } } });
             await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-            await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         }
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
@@ -64,18 +64,18 @@ describe('Trusted Adults API', () => {
         await wipe();
         const fhh = await prisma.household.create({ data: { name: `Family HH ${TAG}` } });
         familyHh = fhh.id;
-        leadId = (await prisma.participant.create({ data: { name: 'Lead', householdId: familyHh } })).id;
+        leadId = (await prisma.person.create({ data: { name: 'Lead', householdId: familyHh } })).id;
         await prisma.householdLead.create({ data: { householdId: familyHh, personId: leadId } });
-        childId = (await prisma.participant.create({ data: { name: 'Child', householdId: familyHh } })).id;
+        childId = (await prisma.person.create({ data: { name: 'Child', householdId: familyHh } })).id;
 
         boardHh = (await prisma.household.create({ data: { name: `Board HH ${TAG}` } })).id;
-        boardId = (await prisma.participant.create({ data: { name: 'Board', isBoardMember: true, householdId: boardHh } })).id;
+        boardId = (await prisma.person.create({ data: { name: 'Board', isBoardMember: true, householdId: boardHh } })).id;
         keyholderHh = (await prisma.household.create({ data: { name: `Key HH ${TAG}` } })).id;
-        keyholderId = (await prisma.participant.create({ data: { name: 'Key', isKeyholder: true, householdId: keyholderHh } })).id;
+        keyholderId = (await prisma.person.create({ data: { name: 'Key', isKeyholder: true, householdId: keyholderHh } })).id;
         programLeadHh = (await prisma.household.create({ data: { name: `PL HH ${TAG}` } })).id;
-        programLeadId = (await prisma.participant.create({ data: { name: 'PL', householdId: programLeadHh } })).id;
+        programLeadId = (await prisma.person.create({ data: { name: 'PL', householdId: programLeadHh } })).id;
         outsiderHh = (await prisma.household.create({ data: { name: `Out HH ${TAG}` } })).id;
-        outsiderId = (await prisma.participant.create({ data: { name: 'Out', householdId: outsiderHh } })).id;
+        outsiderId = (await prisma.person.create({ data: { name: 'Out', householdId: outsiderHh } })).id;
 
         // Program led by programLeadId with the family's child enrolled.
         const prog = await prisma.program.create({ data: { name: `Prog ${TAG}`, leadMentorId: programLeadId } });

--- a/checkin-app/src/app/__tests__/trustedAdultAtomicity.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultAtomicity.integration.test.ts
@@ -66,7 +66,7 @@ describe('Trusted Adults — mutation + audit are atomic', () => {
             await prisma.trustedAdult.deleteMany({ where: { householdId: { in: ids } } });
         }
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
 
@@ -74,11 +74,11 @@ describe('Trusted Adults — mutation + audit are atomic', () => {
         await wipe();
         const hh = await prisma.household.create({ data: { name: `Family HH ${TAG}` } });
         householdId = hh.id;
-        const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
+        const lead = await prisma.person.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         const boardHh = await prisma.household.create({ data: { name: `Board HH ${TAG}` } });
-        boardId = (await prisma.participant.create({ data: { name: 'Boardie', isBoardMember: true, householdId: boardHh.id } })).id;
+        boardId = (await prisma.person.create({ data: { name: 'Boardie', isBoardMember: true, householdId: boardHh.id } })).id;
     });
 
     afterAll(async () => {

--- a/checkin-app/src/app/__tests__/trustedAdultConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultConcurrency.integration.test.ts
@@ -35,7 +35,7 @@ async function wipe() {
         await prisma.trustedAdultReview.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.trustedAdult.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
 }
@@ -53,11 +53,11 @@ describe('trusted-adult mutation concurrency', () => {
         await wipe();
         const hh = await prisma.household.create({ data: { name: `Family HH ${TAG}` } });
         householdId = hh.id;
-        const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
+        const lead = await prisma.person.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
         const boardHh = await prisma.household.create({ data: { name: `Board HH ${TAG}` } });
-        boardId = (await prisma.participant.create({ data: { name: 'Boardie', isBoardMember: true, householdId: boardHh.id } })).id;
+        boardId = (await prisma.person.create({ data: { name: 'Boardie', isBoardMember: true, householdId: boardHh.id } })).id;
     });
 
     afterAll(async () => {

--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -40,7 +40,7 @@ describe('Trusted Adults service', () => {
             await prisma.trustedAdult.deleteMany({ where: { householdId: { in: ids } } });
         }
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
 
@@ -48,22 +48,22 @@ describe('Trusted Adults service', () => {
         await wipe();
         const hh = await prisma.household.create({ data: { name: `Family HH ${TAG}` } });
         householdId = hh.id;
-        const lead = await prisma.participant.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
+        const lead = await prisma.person.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
 
         // A board member who is also a lead of the disclosing household: overriding this
         // household's own review is a conflict of interest (force-approve Grandma for their kids).
-        const boardLead = await prisma.participant.create({
+        const boardLead = await prisma.person.create({
             data: { name: 'BoardLead', email: `boardlead-${TAG}@ex.com`, isBoardMember: true, householdId: hh.id },
         });
         boardLeadId = boardLead.id;
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: boardLead.id } });
 
         const outHh = await prisma.household.create({ data: { name: `Outsider HH ${TAG}` } });
-        outsiderId = (await prisma.participant.create({ data: { name: 'Outsider', householdId: outHh.id } })).id;
+        outsiderId = (await prisma.person.create({ data: { name: 'Outsider', householdId: outHh.id } })).id;
         const boardHh = await prisma.household.create({ data: { name: `Board HH ${TAG}` } });
-        boardId = (await prisma.participant.create({ data: { name: 'Boardie', email: `board-${TAG}@ex.com`, isBoardMember: true, householdId: boardHh.id } })).id;
+        boardId = (await prisma.person.create({ data: { name: 'Boardie', email: `board-${TAG}@ex.com`, isBoardMember: true, householdId: boardHh.id } })).id;
     });
 
     afterAll(async () => {
@@ -391,7 +391,7 @@ describe('runExpirySweep edge cases', () => {
             await prisma.trustedAdult.deleteMany({ where: { householdId: { in: ids } } });
         }
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
-        await prisma.participant.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
 
@@ -420,7 +420,7 @@ describe('runExpirySweep edge cases', () => {
         await wipe();
         const hh = await prisma.household.create({ data: { name: `Sweep HH ${SWEEP_TAG}` } });
         householdId = hh.id;
-        const lead = await prisma.participant.create({ data: { name: 'SweepLead', email: `sweeplead-${SWEEP_TAG}@ex.com`, householdId: hh.id } });
+        const lead = await prisma.person.create({ data: { name: 'SweepLead', email: `sweeplead-${SWEEP_TAG}@ex.com`, householdId: hh.id } });
         leadId = lead.id;
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
     });

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -59,12 +59,12 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         });
         programId = program.id;
 
-        const a = await prisma.participant.create({
+        const a = await prisma.person.create({
             data: { name: 'Hook P1', email: `p1-${TAG}@example.com`, household: { create: {} } },
         });
         p1 = a.id;
         h1 = a.householdId;
-        const b = await prisma.participant.create({
+        const b = await prisma.person.create({
             data: { name: 'Hook P2', email: `p2-${TAG}@example.com`, household: { create: {} } },
         });
         p2 = b.id;
@@ -92,7 +92,7 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         await prisma.integrationErrorLog.deleteMany({ where: { source: 'shopify-webhook' } });
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.program.delete({ where: { id: programId } });
-        await prisma.participant.deleteMany({ where: { id: { in: [p1, p2] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [p1, p2] } } });
         await prisma.household.deleteMany({ where: { id: { in: [h1, h2] } } });
     });
 

--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -149,7 +149,7 @@ export const POST = withAuth({}, async (req, auth) => {
             }
 
             // Verify participant exists
-            const participant = await prisma.participant.findUnique({
+            const participant = await prisma.person.findUnique({
                 where: { id: participantId }
             });
 
@@ -227,7 +227,7 @@ export const POST = withAuth({}, async (req, auth) => {
             }
 
             // Find all board members
-            const boardMembers = await prisma.participant.findMany({
+            const boardMembers = await prisma.person.findMany({
                 where: { isBoardMember: true },
                 select: { email: true, name: true }
             });

--- a/checkin-app/src/app/api/auth/dev-personas/route.ts
+++ b/checkin-app/src/app/api/auth/dev-personas/route.ts
@@ -37,7 +37,7 @@ export async function GET() {
         }
     }
 
-    const personas = await prisma.participant.findMany({
+    const personas = await prisma.person.findMany({
         where: {
             email: { endsWith: "@example.com" },
         },

--- a/checkin-app/src/app/api/cron/nightly/route.ts
+++ b/checkin-app/src/app/api/cron/nightly/route.ts
@@ -38,7 +38,7 @@ export const GET = withCron(async () => {
             const abandonedKeyholders = abandonedVisits.filter(v => v.person.isKeyholder);
             
             if (abandonedKeyholders.length > 0) {
-                const boardMembers = await prisma.participant.findMany({
+                const boardMembers = await prisma.person.findMany({
                     where: { isBoardMember: true },
                     select: { email: true }
                 });

--- a/checkin-app/src/app/api/directory/board/route.ts
+++ b/checkin-app/src/app/api/directory/board/route.ts
@@ -2,7 +2,7 @@ import prisma from "@/lib/prisma";
 import { handler } from "@/security/handler";
 
 export const GET = handler('GET /api/directory/board', async () => {
-    const boardMembers = await prisma.participant.findMany({
+    const boardMembers = await prisma.person.findMany({
         where: { isBoardMember: true },
         // Defense in depth: a directory must never load pii (dob, googleId) even
         // for callers the stripper would clear. Select only what a board
@@ -10,5 +10,5 @@ export const GET = handler('GET /api/directory/board', async () => {
         select: { id: true, name: true, isBoardMember: true, email: true, phone: true },
         orderBy: { name: 'asc' },
     });
-    return { Participant: boardMembers };
+    return { Person: boardMembers };
 });

--- a/checkin-app/src/app/api/events/[id]/rsvp/__tests__/rsvpHouseholdLead.test.ts
+++ b/checkin-app/src/app/api/events/[id]/rsvp/__tests__/rsvpHouseholdLead.test.ts
@@ -18,7 +18,7 @@ const mockRsvpUpsert = jest.fn();
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
     default: {
-        participant: { findMany: (...a: unknown[]) => mockParticipantFindMany(...a) },
+        person: { findMany: (...a: unknown[]) => mockParticipantFindMany(...a) },
         event: { findUnique: (...a: unknown[]) => mockEventFindUnique(...a) },
         programParticipant: { findUnique: jest.fn() },
         programVolunteer: { findUnique: jest.fn() },

--- a/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
+++ b/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
@@ -27,7 +27,7 @@ jest.mock("@/lib/logger", () => ({ logBackendError: jest.fn() }));
 jest.mock("@/lib/prisma", () => ({
     __esModule: true,
     default: {
-        participant: { findUnique: jest.fn() },
+        person: { findUnique: jest.fn() },
         visit: { findMany: jest.fn() },
     },
 }));
@@ -70,7 +70,7 @@ describe("Participant PII minimization (M1, M2)", () => {
             householdId: 10,
         } as Record<string, unknown>;
 
-        (prisma.participant.findUnique as jest.Mock).mockImplementation((args) => {
+        (prisma.person.findUnique as jest.Mock).mockImplementation((args) => {
             const peerSelect = args.include.household.include.participants.select as Record<string, boolean>;
             const projected = Object.fromEntries(
                 Object.keys(peerSelect).filter((k) => peerSelect[k]).map((k) => [k, rawPeer[k]])
@@ -111,7 +111,7 @@ describe("Participant PII minimization (M1, M2)", () => {
         expect(peer.notificationSettings).toBeUndefined();
 
         // Pin the actual query shape, not just this test's mock.
-        const callArgs = (prisma.participant.findUnique as jest.Mock).mock.calls[0][0];
+        const callArgs = (prisma.person.findUnique as jest.Mock).mock.calls[0][0];
         expect(callArgs.include.household.include.participants).toEqual({ select: HOUSEHOLD_PEER_SELECT });
     });
 

--- a/checkin-app/src/app/api/household/emergency-contacts/[contactId]/route.ts
+++ b/checkin-app/src/app/api/household/emergency-contacts/[contactId]/route.ts
@@ -4,7 +4,7 @@ import { withAuth } from "@/lib/auth";
 import { updateContact, deleteContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
 
 async function leadHousehold(userId: number): Promise<number | { error: string; status: number }> {
-    const user = await prisma.participant.findUnique({ where: { id: userId }, include: { householdLeads: true } });
+    const user = await prisma.person.findUnique({ where: { id: userId }, include: { householdLeads: true } });
     if (!user?.householdId) return { error: "You must create a household first.", status: 400 };
     const isLead = user.householdLeads.some((l) => l.householdId === user.householdId);
     if (!isLead && !user.isSysadmin) return { error: "Only household leads can manage emergency contacts.", status: 403 };

--- a/checkin-app/src/app/api/household/emergency-contacts/route.ts
+++ b/checkin-app/src/app/api/household/emergency-contacts/route.ts
@@ -18,7 +18,7 @@ function present(c: { id: number; name: string; phone: string; email: string | n
 }
 
 async function leadHousehold(userId: number): Promise<number | { error: string; status: number }> {
-    const user = await prisma.participant.findUnique({ where: { id: userId }, include: { householdLeads: true } });
+    const user = await prisma.person.findUnique({ where: { id: userId }, include: { householdLeads: true } });
     if (!user?.householdId) return { error: "You must create a household first.", status: 400 };
     const isLead = user.householdLeads.some((l) => l.householdId === user.householdId);
     if (!isLead && !user.isSysadmin) return { error: "Only household leads can manage emergency contacts.", status: 403 };

--- a/checkin-app/src/app/api/household/lead/route.ts
+++ b/checkin-app/src/app/api/household/lead/route.ts
@@ -17,12 +17,12 @@ export const POST = withAuth(
                 return NextResponse.json({ error: "Participant ID is required" }, { status: 400 });
             }
 
-            const user = await prisma.participant.findUnique({
+            const user = await prisma.person.findUnique({
                 where: { id: userId },
                 include: { householdLeads: true }
             });
 
-            const targetMember = await prisma.participant.findUnique({ where: { id: participantId } });
+            const targetMember = await prisma.person.findUnique({ where: { id: participantId } });
             if (!targetMember) {
                 return NextResponse.json({ error: "Participant not found" }, { status: 404 });
             }
@@ -81,12 +81,12 @@ export const DELETE = withAuth(
                 return NextResponse.json({ error: "Participant ID is required" }, { status: 400 });
             }
 
-            const user = await prisma.participant.findUnique({
+            const user = await prisma.person.findUnique({
                 where: { id: userId },
                 include: { householdLeads: true }
             });
 
-            const targetMember = await prisma.participant.findUnique({ where: { id: participantId } });
+            const targetMember = await prisma.person.findUnique({ where: { id: participantId } });
             if (!targetMember) {
                 return NextResponse.json({ error: "Participant not found" }, { status: 404 });
             }

--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -25,7 +25,7 @@ export const PATCH = withAuth(
                 return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
             }
 
-            const user = await prisma.participant.findUnique({ where: { id: userId }, include: { householdLeads: true } });
+            const user = await prisma.person.findUnique({ where: { id: userId }, include: { householdLeads: true } });
 
             if (!user?.householdId) {
                 return NextResponse.json({ error: "You must create a household first" }, { status: 400 });
@@ -37,13 +37,13 @@ export const PATCH = withAuth(
                 return NextResponse.json({ error: "Only household leads can edit household members" }, { status: 403 });
             }
 
-            const targetHouseholdMember = await prisma.participant.findUnique({ where: { id: participantId } });
+            const targetHouseholdMember = await prisma.person.findUnique({ where: { id: participantId } });
             if (!targetHouseholdMember || targetHouseholdMember.householdId !== user.householdId) {
                 return NextResponse.json({ error: "That household member was not found" }, { status: 404 });
             }
 
             const { updatedHouseholdMember, leadRejection, warning } = await prisma.$transaction(async (tx) => {
-                const updatedHouseholdMember = await tx.participant.update({
+                const updatedHouseholdMember = await tx.person.update({
                     where: { id: participantId },
                     data: {
                         name: name !== undefined ? name : undefined,

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -13,7 +13,7 @@ export const GET = withAuth(
             if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
             const userId = auth.user.id;
 
-            const user = await prisma.participant.findUnique({
+            const user = await prisma.person.findUnique({
                 where: { id: userId },
                 include: {
                     household: {
@@ -56,7 +56,7 @@ export const PATCH = withAuth(
             const body = await req.json();
             const { memberName, memberEmail, memberDob, memberOver25 } = body;
 
-            const user = await prisma.participant.findUnique({ where: { id: userId }, include: { householdLeads: true } });
+            const user = await prisma.person.findUnique({ where: { id: userId }, include: { householdLeads: true } });
 
             if (!user?.householdId) {
                 return NextResponse.json({ error: "You must create a household first" }, { status: 400 });
@@ -71,10 +71,10 @@ export const PATCH = withAuth(
                 return NextResponse.json({ error: "Invalid email format" }, { status: 400 });
             }
 
-            let targetMember: Awaited<ReturnType<typeof prisma.participant.findUnique>> = null;
+            let targetMember: Awaited<ReturnType<typeof prisma.person.findUnique>> = null;
 
             if (memberEmail) {
-                targetMember = await prisma.participant.findUnique({ where: { email: memberEmail.toLowerCase() } });
+                targetMember = await prisma.person.findUnique({ where: { email: memberEmail.toLowerCase() } });
 
                 if (targetMember && targetMember.householdId) {
                     return NextResponse.json({ error: "A user with this email already belongs to a household." }, { status: 400 });
@@ -91,12 +91,12 @@ export const PATCH = withAuth(
 
             const { member, warning } = await prisma.$transaction(async (tx) => {
                 const member = targetMember
-                    ? await tx.participant.update({
+                    ? await tx.person.update({
                         where: { id: targetMember.id },
                         data: { householdId },
                         select: HOUSEHOLD_PEER_SELECT,
                     })
-                    : await tx.participant.create({
+                    : await tx.person.create({
                         data: {
                             name: memberName,
                             ...(memberEmail && { email: memberEmail.toLowerCase() }),

--- a/checkin-app/src/app/api/household/settings/route.ts
+++ b/checkin-app/src/app/api/household/settings/route.ts
@@ -19,7 +19,7 @@ export const PATCH = withAuth(
             // whole address must be complete + valid.
             if (Object.keys(addressData).length > 0) assertValidAddress(addressData);
 
-            const user = await prisma.participant.findUnique({
+            const user = await prisma.person.findUnique({
                 where: { id: userId },
                 include: { householdLeads: true }
             });

--- a/checkin-app/src/app/api/household/visits/route.ts
+++ b/checkin-app/src/app/api/household/visits/route.ts
@@ -27,7 +27,7 @@ export const GET = withAuth(
                 startDate.setDate(endDate.getDate() - 7);
             }
 
-            const user = await prisma.participant.findUnique({
+            const user = await prisma.person.findUnique({
                 where: { id: userId },
                 select: { householdId: true }
             });

--- a/checkin-app/src/app/api/kioskdisplay/certifications/route.ts
+++ b/checkin-app/src/app/api/kioskdisplay/certifications/route.ts
@@ -35,7 +35,7 @@ export const GET = withAuth(
             });
             participantsData = activeVisits.map(v => v.person);
         } else {
-            participantsData = await prisma.participant.findMany({
+            participantsData = await prisma.person.findMany({
                 select: {
                     id: true,
                     email: true,

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -102,7 +102,7 @@ export const POST = withAuth(
                     // Two separate legal actions → two separate software actions: a household
                     // containing a board member cannot be denied. Remove the board role first.
                     // Enforced server-side; the UI's disabled button is only a courtesy.
-                    const boardMemberInHousehold = await prisma.participant.findFirst({
+                    const boardMemberInHousehold = await prisma.person.findFirst({
                         where: { householdId, isBoardMember: true },
                         select: { id: true }
                     });

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/household/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/household/route.ts
@@ -24,7 +24,7 @@ export const POST = withAuth<{ params: Promise<{ id: string }> }>(
             return NextResponse.json({ error: "Must provide either householdId or createNew boolean" }, { status: 400 });
         }
 
-        const participant = await prisma.participant.findUnique({ where: { id: participantId } });
+        const participant = await prisma.person.findUnique({ where: { id: participantId } });
         if (!participant) {
             return NextResponse.json({ error: "Participant not found" }, { status: 404 });
         }
@@ -57,7 +57,7 @@ export const POST = withAuth<{ params: Promise<{ id: string }> }>(
             }
         }
 
-        const updatedParticipant = await prisma.participant.update({
+        const updatedParticipant = await prisma.person.update({
             where: { id: participantId },
             data: { householdId: targetHouseholdId },
             include: { household: true }

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
@@ -33,12 +33,12 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
             return NextResponse.json({ error: "No fields to update provided" }, { status: 400 });
         }
 
-        const prior = await prisma.participant.findUnique({
+        const prior = await prisma.person.findUnique({
             where: { id },
             select: { name: true, email: true, phone: true },
         });
 
-        const updatedParticipant = await prisma.participant.update({
+        const updatedParticipant = await prisma.person.update({
             where: { id },
             data: updateData,
             include: {

--- a/checkin-app/src/app/api/membership-ops/participants/import/preview/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/preview/route.ts
@@ -173,7 +173,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                 
                 // 2. Try to resolve the reference via DB
                 if (!found && sameHouseholdAs.includes('@')) {
-                    const byEmail = await prisma.participant.findUnique({
+                    const byEmail = await prisma.person.findUnique({
                         where: { email: sameHouseholdAs },
                         select: { id: true, name: true, householdId: true }
                     });
@@ -187,7 +187,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                     }
                 }
                 if (!found) {
-                    const byName = await prisma.participant.findFirst({
+                    const byName = await prisma.person.findFirst({
                         where: { name: { equals: sameHouseholdAs, mode: 'insensitive' } },
                         select: { id: true, name: true, householdId: true }
                     });
@@ -207,7 +207,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
 
             // Check against existing DB records
             if (email) {
-                const existing = await prisma.participant.findUnique({
+                const existing = await prisma.person.findUnique({
                     where: { email },
                     select: { id: true, name: true, householdId: true },
                 });
@@ -222,14 +222,14 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                     action += "Create new participant with email + household + membership";
                 }
             } else if (parentEmail) {
-                const parent = await prisma.participant.findUnique({
+                const parent = await prisma.person.findUnique({
                     where: { email: parentEmail },
                     select: { id: true, name: true, householdId: true },
                 });
 
                 if (parent) {
                     if (parent.householdId) {
-                        const existingChild = await prisma.participant.findFirst({
+                        const existingChild = await prisma.person.findFirst({
                             where: { householdId: parent.householdId, name: fullName },
                             select: { id: true, name: true },
                         });
@@ -252,7 +252,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                 const matchQuery: Record<string, unknown> = { name: fullName };
                 if (parsedDob) matchQuery.dateOfBirth = parsedDob;
 
-                const existing = await prisma.participant.findFirst({
+                const existing = await prisma.person.findFirst({
                     where: matchQuery,
                     select: { id: true, name: true },
                 });

--- a/checkin-app/src/app/api/membership-ops/participants/import/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/route.ts
@@ -54,7 +54,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         // Helper: look up a participant's household. Every participant has one
         // (householdId is a required FK).
         const ensureHousehold = async (participantId: number, db: Prisma.TransactionClient = prisma): Promise<number> => {
-            const participant = await db.participant.findUnique({ where: { id: participantId } });
+            const participant = await db.person.findUnique({ where: { id: participantId } });
             if (!participant) throw new Error(`Participant ${participantId} not found`);
             return participant.householdId;
         };
@@ -68,7 +68,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
             address?: string;
         }, db: Prisma.TransactionClient = prisma) => {
             const isAdult = !data.dob || calculateAge(data.dob) >= 18;
-            const participant = await db.participant.create({
+            const participant = await db.person.create({
                 data: {
                     ...(data.email && { email: data.email }),
                     name: data.name,
@@ -177,9 +177,9 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                     let participantId: number;
 
                     if (pr.email) {
-                        let participant = await tx.participant.findUnique({ where: { email: pr.email } });
+                        let participant = await tx.person.findUnique({ where: { email: pr.email } });
                         if (participant) {
-                            participant = await tx.participant.update({
+                            participant = await tx.person.update({
                                 where: { id: participant.id },
                                 data: {
                                     name: pr.fullName,
@@ -199,7 +199,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                         participantByEmail.set(pr.email.toLowerCase(), participantId);
                     } else if (pr.parentEmail) {
                         // Ensure parent exists (new parents get their own household)
-                        let parent = await tx.participant.findUnique({ where: { email: pr.parentEmail } });
+                        let parent = await tx.person.findUnique({ where: { email: pr.parentEmail } });
                         if (!parent) {
                             parent = await createParticipantWithHousehold({
                                 email: pr.parentEmail,
@@ -211,18 +211,18 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                         const parentHouseholdId = await ensureHousehold(parent.id, tx);
 
                         // Find or create child in that household
-                        let participant = await tx.participant.findFirst({
+                        let participant = await tx.person.findFirst({
                             where: { householdId: parentHouseholdId, name: pr.fullName }
                         });
                         if (participant) {
-                            participant = await tx.participant.update({
+                            participant = await tx.person.update({
                                 where: { id: participant.id },
                                 data: {
                                     dateOfBirth: pr.parsedDob ?? participant.dateOfBirth,
                                 }
                             });
                         } else {
-                            participant = await tx.participant.create({
+                            participant = await tx.person.create({
                                 data: {
                                     name: pr.fullName,
                                     dateOfBirth: pr.parsedDob,
@@ -240,7 +240,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                         const matchQuery: { name: string; dateOfBirth?: Date } = { name: pr.fullName };
                         if (pr.parsedDob) matchQuery.dateOfBirth = pr.parsedDob;
 
-                        let participant = await tx.participant.findFirst({ where: matchQuery });
+                        let participant = await tx.person.findFirst({ where: matchQuery });
                         if (participant) {
                             await applyAddressToHousehold(participant.householdId, pr.address, tx);
                         } else {
@@ -279,7 +279,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                     const hhId = await ensureHousehold(batchId);
                     return { householdId: hhId, refParticipantId: batchId };
                 }
-                const byEmail = await prisma.participant.findUnique({
+                const byEmail = await prisma.person.findUnique({
                     where: { email: trimmed },
                     select: { id: true, householdId: true }
                 });
@@ -295,7 +295,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                 return { householdId: hhId, refParticipantId: batchId };
             }
 
-            const byName = await prisma.participant.findFirst({
+            const byName = await prisma.person.findFirst({
                 where: { name: { equals: trimmed, mode: 'insensitive' } },
                 select: { id: true, householdId: true }
             });
@@ -322,7 +322,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                         const targetHouseholdId = resolved.householdId;
                         
                         // Get the participant's current household (might have just been created in Pass 1)
-                        const participant = await prisma.participant.findUnique({
+                        const participant = await prisma.person.findUnique({
                             where: { id: participantId },
                             select: { householdId: true }
                         });
@@ -357,7 +357,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                         // participants are never left half-moved between households.
                         await prisma.$transaction(async (tx) => {
                             // Move all participants from source to target
-                            await tx.participant.updateMany({
+                            await tx.person.updateMany({
                                 where: { householdId: sourceHouseholdId },
                                 data: { householdId: targetHouseholdId }
                             });
@@ -389,7 +389,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                 // Every participant got a household in pass 1 (or already had
                 // one) — just make sure the membership exists.
                 else {
-                    const participant = await prisma.participant.findUnique({ where: { id: participantId } });
+                    const participant = await prisma.person.findUnique({ where: { id: participantId } });
                     if (participant) {
                         await ensureHouseholdMembership(participant.householdId);
                     }

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -22,7 +22,7 @@ describe("Merge Participants API", () => {
         householdId = hh.id;
 
         // The acting board member — audit rows record actorId from the session.
-        const actor = await prisma.participant.create({
+        const actor = await prisma.person.create({
             data: {
                 name: "Board Actor",
                 email: "actor@checkme.in",
@@ -38,7 +38,7 @@ describe("Merge Participants API", () => {
         });
 
         // Create two participants
-        const pKeep = await prisma.participant.create({
+        const pKeep = await prisma.person.create({
             data: {
                 name: "Keep User",
                 email: "keep@example.com",
@@ -47,7 +47,7 @@ describe("Merge Participants API", () => {
         });
         pKeepId = pKeep.id;
 
-        const pMerge = await prisma.participant.create({
+        const pMerge = await prisma.person.create({
             data: {
                 name: "Merge User",
                 email: "merge@example.com",
@@ -66,7 +66,7 @@ describe("Merge Participants API", () => {
         await prisma.programParticipant.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
         await prisma.householdLead.deleteMany({ where: { personId: { in: [pKeepId, pMergeId] } } });
         await prisma.auditLog.deleteMany({ where: { actorId } });
-        await prisma.participant.deleteMany({ where: { id: { in: [pKeepId, pMergeId, actorId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [pKeepId, pMergeId, actorId] } } });
         if (createdFeeId) {
             await prisma.fee.deleteMany({ where: { id: createdFeeId } });
             createdFeeId = undefined;
@@ -105,11 +105,11 @@ describe("Merge Participants API", () => {
         expect(visits.length).toBe(1);
 
         // Verify kept user got merged user's phone
-        const kept = await prisma.participant.findUnique({ where: { id: pKeepId } });
+        const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
         expect(kept?.phone).toBe("123-456-7890");
 
         // Verify merged user was tombstoned
-        const merged = await prisma.participant.findUnique({ where: { id: pMergeId } });
+        const merged = await prisma.person.findUnique({ where: { id: pMergeId } });
         expect(merged?.email).toContain("merged-");
         expect(merged?.email).toContain("@deleted.checkme.in");
         expect(merged?.phone).toBeNull();

--- a/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
@@ -17,7 +17,7 @@ export const GET = withAuth(
             }
 
             const getParticipant = async (id: number) => {
-                const p = await prisma.participant.findUnique({
+                const p = await prisma.person.findUnique({
                     where: { id },
                     include: {
                         household: {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -16,7 +16,7 @@ export const POST = withAuth(
                 return NextResponse.json({ error: "Invalid participant IDs provided." }, { status: 400 });
             }
 
-            const keepParticipant = await prisma.participant.findUnique({
+            const keepParticipant = await prisma.person.findUnique({
                 where: { id: keepId },
                 include: {
                     programParticipants: true,
@@ -27,7 +27,7 @@ export const POST = withAuth(
                 }
             });
 
-            const mergeParticipant = await prisma.participant.findUnique({
+            const mergeParticipant = await prisma.person.findUnique({
                 where: { id: mergeId },
                 include: {
                     programParticipants: true,
@@ -67,7 +67,7 @@ export const POST = withAuth(
                 }
 
                 if (Object.keys(updates).length > 0) {
-                    await tx.participant.update({
+                    await tx.person.update({
                         where: { id: keepId },
                         data: updates
                     });
@@ -170,7 +170,7 @@ export const POST = withAuth(
                 // householdId stays pointing at the old household: every
                 // participant must belong to a household, and merged-away
                 // records are tombstoned rather than deleted.
-                await tx.participant.update({
+                await tx.person.update({
                     where: { id: mergeId },
                     data: {
                         googleId: null,

--- a/checkin-app/src/app/api/membership-ops/participants/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/route.ts
@@ -29,7 +29,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         }
 
         if (email) {
-            const existingUser = await prisma.participant.findUnique({
+            const existingUser = await prisma.person.findUnique({
                 where: { email }
             });
 
@@ -44,12 +44,12 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         let householdIdToAssign: number | null = null;
 
         if (parentEmail) {
-            let parent = await prisma.participant.findUnique({
+            let parent = await prisma.person.findUnique({
                 where: { email: parentEmail }
             });
 
             if (!parent) {
-                parent = await prisma.participant.create({
+                parent = await prisma.person.create({
                     data: {
                         email: parentEmail,
                         household: {
@@ -75,7 +75,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
 
         let newParticipant;
         if (householdIdToAssign) {
-            newParticipant = await prisma.participant.create({
+            newParticipant = await prisma.person.create({
                 data: {
                     name,
                     ...(email && { email }),
@@ -85,7 +85,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
             });
         } else {
             const lastName = (name || "").trim().split(/\s+/).pop() || "";
-            newParticipant = await prisma.participant.create({
+            newParticipant = await prisma.person.create({
                 data: {
                     name,
                     ...(email && { email }),

--- a/checkin-app/src/app/api/membership/renewal-status/route.ts
+++ b/checkin-app/src/app/api/membership/renewal-status/route.ts
@@ -13,7 +13,7 @@ export const dynamic = "force-dynamic";
 export const GET = withAuth({}, async (_req, auth) => {
     if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    const user = await prisma.participant.findUnique({
+    const user = await prisma.person.findUnique({
         where: { id: auth.user.id },
         select: { householdId: true, householdLeads: { select: { householdId: true } } },
     });

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -105,7 +105,7 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     if (user.householdId) {
         const householdId = user.householdId;
-        const members = await prisma.participant.findMany({
+        const members = await prisma.person.findMany({
             where: { householdId },
             select: { id: true },
         });
@@ -144,7 +144,7 @@ export const GET = withAuth({}, async (_req, auth) => {
             // A member with no DoB and no 25+ declaration shows "Age Unavailable"
             // on the household page; the lead must add one or the other.
             isLead
-                ? prisma.participant.findMany({
+                ? prisma.person.findMany({
                       where: { householdId, dateOfBirth: null, isDeclaredAdult: false },
                       select: { id: true, name: true },
                   })

--- a/checkin-app/src/app/api/participants/search/route.ts
+++ b/checkin-app/src/app/api/participants/search/route.ts
@@ -15,7 +15,7 @@ export const GET = withAuth(
             const eighteenYearsAgo = new Date();
             eighteenYearsAgo.setFullYear(eighteenYearsAgo.getFullYear() - 18);
 
-            const participants = await prisma.participant.findMany({
+            const participants = await prisma.person.findMany({
                 where: q ? {
                     OR: [
                         { name: { contains: q, mode: 'insensitive' } },

--- a/checkin-app/src/app/api/profile/onboarding-status/route.ts
+++ b/checkin-app/src/app/api/profile/onboarding-status/route.ts
@@ -10,7 +10,7 @@ export const GET = withAuth(
         const userId = auth.user.id;
 
         try {
-            const user = await prisma.participant.findUnique({
+            const user = await prisma.person.findUnique({
                 where: { id: userId },
                 include: {
                     householdLeads: true,

--- a/checkin-app/src/app/api/profile/onboarding/route.ts
+++ b/checkin-app/src/app/api/profile/onboarding/route.ts
@@ -14,7 +14,7 @@ export const POST = withAuth(
             const body = await req.json();
             const { phone, emergencyContactName, emergencyContactPhone, emergencyContactEmail } = body;
 
-            const user = await prisma.participant.findUnique({
+            const user = await prisma.person.findUnique({
                 where: { id: userId },
                 include: { householdLeads: true }
             });
@@ -27,7 +27,7 @@ export const POST = withAuth(
                 if (phone !== "" && !isValidPhone(phone)) {
                     return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
                 }
-                await prisma.participant.update({
+                await prisma.person.update({
                     where: { id: userId },
                     data: { phone: phone === "" ? null : formatPhone(phone) }
                 });

--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -7,7 +7,7 @@ import { isYouth } from "@/lib/time";
 
 export const GET = handler('GET /api/profile', async ({ auth }) => {
     if (auth.type !== 'session') throw unauthorized();
-    const profile = await prisma.participant.findUnique({
+    const profile = await prisma.person.findUnique({
         where: { id: auth.user.id },
         include: {
             visits: {
@@ -18,7 +18,7 @@ export const GET = handler('GET /api/profile', async ({ auth }) => {
         },
     });
     if (!profile) throw notFound('Profile not found');
-    return { Participant: profile };
+    return { Person: profile };
 });
 
 export const PATCH = withAuth(
@@ -28,7 +28,7 @@ export const PATCH = withAuth(
             if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
             const userId = auth.user.id;
 
-            const me = await prisma.participant.findUnique({
+            const me = await prisma.person.findUnique({
                 where: { id: userId },
                 select: { dateOfBirth: true },
             });
@@ -43,7 +43,7 @@ export const PATCH = withAuth(
                 return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
             }
 
-            const updatedProfile = await prisma.participant.update({
+            const updatedProfile = await prisma.person.update({
                 where: { id: userId },
                 data: {
                     name: name !== undefined ? name : undefined,

--- a/checkin-app/src/app/api/programs/[id]/eligible-participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/eligible-participants/route.ts
@@ -21,7 +21,7 @@ export const GET = handler<{ id: string }>('GET /api/programs/[id]/eligible-part
     // new URL(req.url) (not req.nextUrl) so the handler works on a plain Request too.
     const q = new URL(req.url).searchParams.get("q") || "";
 
-    const andClauses: Prisma.ParticipantWhereInput[] = [
+    const andClauses: Prisma.PersonWhereInput[] = [
         {
             NOT: {
                 OR: [
@@ -45,12 +45,12 @@ export const GET = handler<{ id: string }>('GET /api/programs/[id]/eligible-part
         andClauses.push(ACTIVE_MEMBER_PARTICIPANT_WHERE);
     }
 
-    const members = await prisma.participant.findMany({
+    const members = await prisma.person.findMany({
         where: andClauses.length > 0 ? { AND: andClauses } : undefined,
         select: { id: true, name: true, email: true, dateOfBirth: true },
         orderBy: { name: 'asc' },
         take: 50
     });
 
-    return { Participant: members };
+    return { Person: members };
 });

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -35,7 +35,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         const isSelfEnrollment = currentUserId === participantId;
         const isSysAdminOrBoard = auth.user.isSysadmin || auth.user.isBoardMember;
 
-        const participantData = await prisma.participant.findUnique({
+        const participantData = await prisma.person.findUnique({
             where: { id: participantId },
             select: { dateOfBirth: true, householdId: true }
         });

--- a/checkin-app/src/app/api/programs/[id]/public-register/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/public-register/route.ts
@@ -73,7 +73,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         // Check for existing emails to prevent Unique Constraint violations
         const emailsToCheck = parents.map((p: ParentInput) => p.email).filter(Boolean);
         if (emailsToCheck.length > 0) {
-            const existingUsers = await prisma.participant.findMany({
+            const existingUsers = await prisma.person.findMany({
                 where: { email: { in: emailsToCheck } }
             });
             if (existingUsers.length > 0) {
@@ -140,7 +140,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
             const createdParents = [];
             for (const parent of parents) {
                 if (!parent.name) continue;
-                const newParent = await tx.participant.create({
+                const newParent = await tx.person.create({
                     data: {
                         name: parent.name,
                         email: parent.email || null,
@@ -165,7 +165,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                 if (matchedParent) {
                     participantId = matchedParent.id;
                 } else {
-                    const newParticipant = await tx.participant.create({
+                    const newParticipant = await tx.person.create({
                         data: {
                             name: p.name,
                             dateOfBirth: p.dob ? new Date(p.dob) : null,

--- a/checkin-app/src/app/api/roles/route.ts
+++ b/checkin-app/src/app/api/roles/route.ts
@@ -9,7 +9,7 @@ export const GET = withAuth(
             const eighteenYearsAgo = new Date();
             eighteenYearsAgo.setFullYear(eighteenYearsAgo.getFullYear() - 18);
 
-            const rows = await prisma.participant.findMany({
+            const rows = await prisma.person.findMany({
                 select: {
                     id: true,
                     email: true,
@@ -66,7 +66,7 @@ export const PATCH = withAuth(
                 return NextResponse.json({ error: "No valid role fields provided" }, { status: 400 });
             }
 
-            const updated = await prisma.participant.update({
+            const updated = await prisma.person.update({
                 where: { id: targetUserId },
                 data: updateData,
                 select: {

--- a/checkin-app/src/app/api/safety/board-contacts/route.ts
+++ b/checkin-app/src/app/api/safety/board-contacts/route.ts
@@ -7,7 +7,7 @@ export const GET = withAuth(
     { roles: ['isSysadmin', 'isBoardMember', 'isKeyholder'] },
     async () => {
         try {
-            const members = await prisma.participant.findMany({
+            const members = await prisma.person.findMany({
                 where: { isBoardMember: true },
                 select: { id: true, name: true, phone: true, email: true },
                 orderBy: { name: "asc" },

--- a/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -11,7 +11,7 @@ jest.mock('@/lib/auth', () => ({
 
 jest.mock('@/lib/prisma', () => {
     const mock = {
-        participant: {
+        person: {
             findUnique: jest.fn(),
         },
         rawBadgeLog: {
@@ -97,7 +97,7 @@ describe('POST /api/scan', () => {
             body: JSON.stringify({ participantId: 1 })
         }) as unknown as import('next/server').NextRequest;
 
-        (prisma.participant.findUnique as jest.Mock).mockResolvedValue({ id: 1 });
+        (prisma.person.findUnique as jest.Mock).mockResolvedValue({ id: 1 });
         (prisma.rawBadgeLog.findFirst as jest.Mock).mockResolvedValue({ timestamp: new Date(Date.now() - 1000) });
 
         const res = await POST(req);

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -42,7 +42,7 @@ export const POST = withKiosk(
         }
 
         // 3. Lookup participant
-        const participant = await prisma.participant.findUnique({
+        const participant = await prisma.person.findUnique({
             where: { id: participantId },
         });
 

--- a/checkin-app/src/app/api/settings/membership/volunteer-designations/route.ts
+++ b/checkin-app/src/app/api/settings/membership/volunteer-designations/route.ts
@@ -34,7 +34,7 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
 
     // Non-blocking warning: is this email already an active full-price member?
     let warning: string | undefined;
-    const participant = await prisma.participant.findFirst({
+    const participant = await prisma.person.findFirst({
         where: { email: { equals: email, mode: "insensitive" } },
         select: { household: { select: { membership: { select: { status: true, isVolunteer: true } } } } },
     });

--- a/checkin-app/src/app/api/shop/members/route.ts
+++ b/checkin-app/src/app/api/shop/members/route.ts
@@ -8,7 +8,7 @@ export const GET = handler('GET /api/shop/members', async () => {
     // Select email too: admins/board are granted everyones:pii and see it. For a
     // certifier the view holds only member+public, so the stripper drops email
     // and keeps name. Field-stripping — not the query — decides who sees what.
-    const members = await prisma.participant.findMany({
+    const members = await prisma.person.findMany({
         where: ACTIVE_MEMBER_PARTICIPANT_WHERE,
         select: {
             id: true,
@@ -20,5 +20,5 @@ export const GET = handler('GET /api/shop/members', async () => {
         }
     });
 
-    return { Participant: members };
+    return { Person: members };
 });

--- a/checkin-app/src/app/api/system-status/audit-log/route.ts
+++ b/checkin-app/src/app/api/system-status/audit-log/route.ts
@@ -56,7 +56,7 @@ export const GET = withAuth(
 
             // Resolve actor ids to names (one batched lookup). id 0 / missing => System.
             const actorIds = [...new Set(rows.map((r) => r.actorId))];
-            const actors = await prisma.participant.findMany({
+            const actors = await prisma.person.findMany({
                 where: { id: { in: actorIds } },
                 select: { id: true, name: true },
             });

--- a/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
@@ -26,7 +26,7 @@ describe('attendanceTransitions', () => {
         });
         programId = program.id;
 
-        const p = await prisma.participant.create({
+        const p = await prisma.person.create({
             data: { name: 'AT Enrolled', email: `enrolled-${TAG}@example.com`, household: { create: {} } },
         });
         participantId = p.id;
@@ -35,7 +35,7 @@ describe('attendanceTransitions', () => {
             data: { programId, personId: participantId, status: 'ACTIVE', pendingSince: null },
         });
 
-        const u = await prisma.participant.create({
+        const u = await prisma.person.create({
             data: { name: 'AT Unenrolled', email: `unenrolled-${TAG}@example.com`, household: { create: {} } },
         });
         unenrolledId = u.id;
@@ -50,7 +50,7 @@ describe('attendanceTransitions', () => {
     afterAll(async () => {
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.program.delete({ where: { id: programId } });
-        await prisma.participant.deleteMany({ where: { id: { in: [participantId, unenrolledId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [participantId, unenrolledId] } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
     });
 

--- a/checkin-app/src/lib/__tests__/auth-options-authorize.test.ts
+++ b/checkin-app/src/lib/__tests__/auth-options-authorize.test.ts
@@ -59,7 +59,7 @@ jest.mock('@/lib/dev/ledger', () => ({ recordLedger: jest.fn() }));
 
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
-    default: { participant: { findUnique: jest.fn(), findFirst: jest.fn() } },
+    default: { person: { findUnique: jest.fn(), findFirst: jest.fn() } },
 }));
 
 // jest.setup.js globally mocks @/lib/auth-options to `{}` (it normally pulls GoogleProvider's heavy
@@ -73,10 +73,10 @@ import { authOptions, PERSONA_MINT_PROVIDER_ID } from '@/lib/auth-options';
 const mockGetToken = getToken as jest.Mock;
 const mockEvaluateMint = evaluateMint as jest.Mock;
 const mockRecordLedger = recordLedger as jest.Mock;
-const mockFindUnique = (prisma as unknown as { participant: { findUnique: jest.Mock } })
-    .participant.findUnique;
-const mockFindFirst = (prisma as unknown as { participant: { findFirst: jest.Mock } })
-    .participant.findFirst;
+const mockFindUnique = (prisma as unknown as { person: { findUnique: jest.Mock } })
+    .person.findUnique;
+const mockFindFirst = (prisma as unknown as { person: { findFirst: jest.Mock } })
+    .person.findFirst;
 const mockCheckinEnv = config.checkinEnv as jest.Mock;
 
 // next-auth v4 CredentialsProvider returns { id: "credentials", authorize: () => null, options }:

--- a/checkin-app/src/lib/__tests__/auth-options-jwt.test.ts
+++ b/checkin-app/src/lib/__tests__/auth-options-jwt.test.ts
@@ -38,7 +38,7 @@ jest.mock('@/lib/config', () => {
 
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
-    default: { participant: { findUnique: jest.fn(), update: jest.fn() } },
+    default: { person: { findUnique: jest.fn(), update: jest.fn() } },
 }));
 
 // jest.setup.js globally mocks @/lib/auth-options to `{}`; unmock to get the real callbacks.
@@ -46,8 +46,8 @@ jest.unmock('@/lib/auth-options');
 
 import { authOptions } from '@/lib/auth-options';
 
-const mockFindUnique = (prisma as unknown as { participant: { findUnique: jest.Mock } })
-    .participant.findUnique;
+const mockFindUnique = (prisma as unknown as { person: { findUnique: jest.Mock } })
+    .person.findUnique;
 
 type JwtCallback = NonNullable<NonNullable<typeof authOptions.callbacks>['jwt']>;
 const jwt: JwtCallback = authOptions.callbacks!.jwt!;

--- a/checkin-app/src/lib/__tests__/canActFor.test.ts
+++ b/checkin-app/src/lib/__tests__/canActFor.test.ts
@@ -13,7 +13,7 @@ import { canActFor } from '@/lib/household/activityMembers';
 const mockParticipantFindMany = jest.fn();
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
-    default: { participant: { findMany: (...a: unknown[]) => mockParticipantFindMany(...a) } },
+    default: { person: { findMany: (...a: unknown[]) => mockParticipantFindMany(...a) } },
 }));
 
 const session = (u: { id: number; householdId?: number; householdLead?: boolean }) =>

--- a/checkin-app/src/lib/__tests__/notifications.test.ts
+++ b/checkin-app/src/lib/__tests__/notifications.test.ts
@@ -5,11 +5,11 @@ import prisma from '../prisma';
 jest.mock('../email', () => ({ sendEmail: jest.fn() }));
 jest.mock('../prisma', () => ({
     __esModule: true,
-    default: { participant: { findUnique: jest.fn() } },
+    default: { person: { findUnique: jest.fn() } },
 }));
 
 const mockSendEmail = sendEmail as jest.Mock;
-const mockFindUnique = (prisma as unknown as { participant: { findUnique: jest.Mock } }).participant.findUnique;
+const mockFindUnique = (prisma as unknown as { person: { findUnique: jest.Mock } }).person.findUnique;
 
 describe('sendNotification return contract', () => {
     beforeEach(() => jest.clearAllMocks());

--- a/checkin-app/src/lib/__tests__/postEventEmails.bench.test.ts
+++ b/checkin-app/src/lib/__tests__/postEventEmails.bench.test.ts
@@ -7,21 +7,21 @@ jest.mock('../email', () => ({
 
 describe('Performance benchmark for processPostEventEmails', () => {
     let origFindMany: typeof prisma.event.findMany;
-    let origFindUnique: typeof prisma.participant.findUnique;
-    let origParticipantFindMany: typeof prisma.participant.findMany;
+    let origFindUnique: typeof prisma.person.findUnique;
+    let origParticipantFindMany: typeof prisma.person.findMany;
     let origEventUpdate: typeof prisma.event.update;
 
     beforeAll(() => {
         origFindMany = prisma.event.findMany;
-        origFindUnique = prisma.participant.findUnique;
-        origParticipantFindMany = prisma.participant.findMany;
+        origFindUnique = prisma.person.findUnique;
+        origParticipantFindMany = prisma.person.findMany;
         origEventUpdate = prisma.event.update;
     });
 
     afterAll(() => {
         prisma.event.findMany = origFindMany;
-        prisma.participant.findUnique = origFindUnique;
-        prisma.participant.findMany = origParticipantFindMany;
+        prisma.person.findUnique = origFindUnique;
+        prisma.person.findMany = origParticipantFindMany;
         prisma.event.update = origEventUpdate;
     });
 
@@ -51,14 +51,14 @@ describe('Performance benchmark for processPostEventEmails', () => {
         prisma.event.update = jest.fn().mockImplementation(async () => { return {} as unknown as never; });
 
         let uniqueCalls = 0;
-        prisma.participant.findUnique = jest.fn().mockImplementation(async ({ where }: { where: { id: number } }) => {
+        prisma.person.findUnique = jest.fn().mockImplementation(async ({ where }: { where: { id: number } }) => {
             uniqueCalls++;
             await new Promise(resolve => setTimeout(resolve, 5));
             return { email: `lead${where.id}@example.com` } as unknown as never;
         });
 
         let manyCalls = 0;
-        prisma.participant.findMany = jest.fn().mockImplementation(async ({ where }: { where: { id: { in: number[] } } }) => {
+        prisma.person.findMany = jest.fn().mockImplementation(async ({ where }: { where: { id: { in: number[] } } }) => {
             manyCalls++;
             await new Promise(resolve => setTimeout(resolve, 10));
             const ids = where.id.in as number[];

--- a/checkin-app/src/lib/__tests__/postEventEmails.test.ts
+++ b/checkin-app/src/lib/__tests__/postEventEmails.test.ts
@@ -12,7 +12,7 @@ jest.mock("@/lib/prisma", () => {
                 findMany: jest.fn(),
                 update: jest.fn(),
             },
-            participant: {
+            person: {
                 findUnique: jest.fn(),
                 findMany: jest.fn(),
             }
@@ -107,7 +107,7 @@ describe("processPostEventEmails", () => {
             .mockResolvedValueOnce(batch2)
             .mockResolvedValueOnce([]); // end loop
 
-        (prisma.participant.findMany as jest.Mock).mockResolvedValue([{ id: 100, email: "lead@example.com" }]);
+        (prisma.person.findMany as jest.Mock).mockResolvedValue([{ id: 100, email: "lead@example.com" }]);
         (sendEmail as jest.Mock).mockResolvedValue(true);
 
         const result = await processPostEventEmails({ batchSize: 2 });
@@ -150,12 +150,12 @@ describe("processPostEventEmails", () => {
                 visits: [{}, {}]
             }
         ]).mockResolvedValueOnce([]);
-        (prisma.participant.findMany as jest.Mock).mockResolvedValue([{ id: 100, email: "lead@example.com" }]);
+        (prisma.person.findMany as jest.Mock).mockResolvedValue([{ id: 100, email: "lead@example.com" }]);
         (sendEmail as jest.Mock).mockResolvedValue(true);
 
         const result = await processPostEventEmails();
 
-        expect(prisma.participant.findMany).toHaveBeenCalledWith({
+        expect(prisma.person.findMany).toHaveBeenCalledWith({
             where: { id: { in: [100] } },
             select: { id: true, email: true }
         });
@@ -199,10 +199,10 @@ describe("processPostEventEmails", () => {
         ]).mockResolvedValueOnce([]);
         (sendEmail as jest.Mock).mockResolvedValue(true);
 
-        (prisma.participant.findMany as jest.Mock).mockResolvedValue([]);
+        (prisma.person.findMany as jest.Mock).mockResolvedValue([]);
         const result = await processPostEventEmails();
 
-        expect(prisma.participant.findMany).not.toHaveBeenCalled();
+        expect(prisma.person.findMany).not.toHaveBeenCalled();
         expect(sendEmail).toHaveBeenCalledWith(
             "core@example.com",
             expect.any(String),
@@ -241,11 +241,11 @@ describe("processPostEventEmails", () => {
                 visits: []
             }
         ]).mockResolvedValueOnce([]);
-        (prisma.participant.findMany as jest.Mock).mockResolvedValue([{ id: 101, email: null }]);
+        (prisma.person.findMany as jest.Mock).mockResolvedValue([{ id: 101, email: null }]);
 
         const result = await processPostEventEmails();
 
-        expect(prisma.participant.findMany).toHaveBeenCalledWith({
+        expect(prisma.person.findMany).toHaveBeenCalledWith({
             where: { id: { in: [101] } },
             select: { id: true, email: true }
         });
@@ -263,7 +263,7 @@ describe("processPostEventEmails", () => {
                 visits: []
             }
         ]).mockResolvedValueOnce([]);
-        (prisma.participant.findMany as jest.Mock).mockResolvedValue([{ id: 100, email: "lead@example.com" }]);
+        (prisma.person.findMany as jest.Mock).mockResolvedValue([{ id: 100, email: "lead@example.com" }]);
         (sendEmail as jest.Mock).mockResolvedValue(false); // sending fails
 
         const result = await processPostEventEmails();

--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -9,7 +9,7 @@ jest.mock('../email', () => ({
 jest.mock('../prisma', () => ({
     __esModule: true,
     default: {
-        participant: {
+        person: {
             findMany: jest.fn()
         }
     }
@@ -104,13 +104,13 @@ describe('createShopifyProgramVariants', () => {
             { email: 'board1@test.com' }
         ];
 
-        (prisma.participant.findMany as jest.Mock).mockResolvedValueOnce(mockAdmins);
+        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce(mockAdmins);
 
         const result = await createShopifyProgramVariants('Test Error Program', 10, 20);
 
         expect(result).toBeNull();
 
-        expect(prisma.participant.findMany).toHaveBeenCalledWith({
+        expect(prisma.person.findMany).toHaveBeenCalledWith({
             where: {
                 OR: [{ isSysadmin: true }, { isBoardMember: true }],
                 email: { not: null }
@@ -137,7 +137,7 @@ describe('createShopifyProgramVariants', () => {
             { email: 'admin@test.com' }
         ];
 
-        (prisma.participant.findMany as jest.Mock).mockResolvedValueOnce(mockAdmins);
+        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce(mockAdmins);
 
         const result = await createShopifyProgramVariants('Test Network Error', 10, 20);
 
@@ -178,7 +178,7 @@ describe('createShopifyProgramVariants', () => {
                 signal.addEventListener('abort', () => reject(signal.reason));
             }),
         );
-        (prisma.participant.findMany as jest.Mock).mockResolvedValueOnce([{ email: 'admin@test.com' }]);
+        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce([{ email: 'admin@test.com' }]);
 
         const p = createShopifyProgramVariants('Test Hang', 10, 20);
         deadline.abort(new DOMException('The operation timed out', 'TimeoutError'));

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -37,7 +37,7 @@ async function createParticipantWithHousehold(data: {
         const household = await tx.household.create({
             data: { name: data.name ?? data.email ?? null },
         });
-        const participant = await tx.participant.create({
+        const participant = await tx.person.create({
             data: { ...data, householdId: household.id },
         });
         await addHouseholdLead(tx, household.id, participant.id);
@@ -58,7 +58,7 @@ const patchedAdapter = {
     getUser: async (id: string) => {
         const numericId = parseInt(id, 10);
         if (isNaN(numericId)) return null;
-        const user = await prisma.participant.findUnique({ where: { id: numericId } });
+        const user = await prisma.person.findUnique({ where: { id: numericId } });
         return user ? { ...user, id: String(user.id), email: user.email || "" } : null;
     },
 };
@@ -163,7 +163,7 @@ export const authOptions: NextAuthOptions = {
                     // Resolve the target participant (fake data only — must already exist).
                     let dbParticipant;
                     if (mode === "return") {
-                        dbParticipant = await prisma.participant.findUnique({
+                        dbParticipant = await prisma.person.findUnique({
                             where: { email: decision.targetEmail! },
                         });
                     } else {
@@ -172,7 +172,7 @@ export const authOptions: NextAuthOptions = {
                         // Restrict the mintable target to seeded @example.com personas (matches the
                         // dev-personas picker's filter) so a caller can never mint a real participant,
                         // even if one exists in the dev DB.
-                        dbParticipant = await prisma.participant.findFirst({
+                        dbParticipant = await prisma.person.findFirst({
                             where: { id: personaId, email: { endsWith: "@example.com" } },
                         });
                     }
@@ -238,7 +238,7 @@ export const authOptions: NextAuthOptions = {
             // + impersonatedBy so the dev gate passes and "Return to me" works.
             if (user?.email) {
                 const email = user.email;
-                const dbParticipant = await withAuroraResumeRetry(() => prisma.participant.findUnique({
+                const dbParticipant = await withAuroraResumeRetry(() => prisma.person.findUnique({
                     where: { email },
                     include: {
                         toolStatuses: {
@@ -261,7 +261,7 @@ export const authOptions: NextAuthOptions = {
                         dbParticipant.email &&
                         BOOTSTRAP_SYSADMINS.includes(dbParticipant.email.toLowerCase())
                     ) {
-                        await prisma.participant.update({
+                        await prisma.person.update({
                             where: { id: dbParticipant.id },
                             data: { isSysadmin: true },
                         });
@@ -279,7 +279,7 @@ export const authOptions: NextAuthOptions = {
                 // read at sign-in, which let a revoked isSysadmin/isKeyholder keep their
                 // privileges (including the /api/roles endpoint) until the JWT
                 // aged out — up to 30 days.
-                const dbParticipant = await withAuroraResumeRetry(() => prisma.participant.findUnique({
+                const dbParticipant = await withAuroraResumeRetry(() => prisma.person.findUnique({
                     where: { id: token.id as number },
                     include: {
                         toolStatuses: {

--- a/checkin-app/src/lib/dev/__tests__/seed-helpers.integration.test.ts
+++ b/checkin-app/src/lib/dev/__tests__/seed-helpers.integration.test.ts
@@ -37,17 +37,17 @@ describe("dev seed-helpers (integration)", () => {
     });
 
     it("seedBaseline creates the standard personas + sample program", async () => {
-        const personas = await prisma.participant.count();
+        const personas = await prisma.person.count();
         expect(personas).toBeGreaterThanOrEqual(9);
         expect(await prisma.program.count()).toBeGreaterThanOrEqual(1);
-        expect(await prisma.participant.findUnique({ where: { email: "boardmember@example.com" } })).not.toBeNull();
+        expect(await prisma.person.findUnique({ where: { email: "boardmember@example.com" } })).not.toBeNull();
     });
 
     it("+ Family adds a household with a lead, a partner, and a youth", async () => {
-        const before = await prisma.participant.count();
+        const before = await prisma.person.count();
         const summary = await createFamily(prisma);
         expect(summary).toMatch(/Test Family/);
-        expect(await prisma.participant.count()).toBe(before + 3);
+        expect(await prisma.person.count()).toBe(before + 3);
         // The created household has exactly one lead.
         const household = await prisma.household.findFirst({
             where: { name: { startsWith: "Test Family" } },
@@ -103,7 +103,7 @@ describe("dev seed-helpers (integration)", () => {
         expect(await prisma.program.findFirst({ where: { name: { startsWith: "Test Program" } } })).toBeNull();
         expect(await prisma.household.findFirst({ where: { name: { startsWith: "Test Family" } } })).toBeNull();
         // …baseline is back…
-        expect(await prisma.participant.findUnique({ where: { email: "boardmember@example.com" } })).not.toBeNull();
+        expect(await prisma.person.findUnique({ where: { email: "boardmember@example.com" } })).not.toBeNull();
         // …and the ledger survived the truncation.
         expect(await prisma.devLedger.count()).toBe(ledgerBefore);
 

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -50,7 +50,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
     }
 
     // 2. The 9 debug personas (solo personas get a single-person household of their own)
-    const isBoardMember = await prisma.participant.upsert({
+    const isBoardMember = await prisma.person.upsert({
         where: { email: "boardmember@example.com" },
         update: { name: "Board Member", phone: "555-555-0001", isSysadmin: true, isBoardMember: true },
         create: {
@@ -63,7 +63,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         },
     });
 
-    const parentFamily = await prisma.participant.upsert({
+    const parentFamily = await prisma.person.upsert({
         where: { email: "parent.family@example.com" },
         update: { name: "Parent Family", phone: "555-555-0002" },
         create: {
@@ -74,7 +74,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         },
     });
 
-    const parent2Family = await prisma.participant.upsert({
+    const parent2Family = await prisma.person.upsert({
         where: { email: "parent2.family@example.com" },
         update: { name: "Parent2 Family", phone: "555-555-0003" },
         create: {
@@ -85,7 +85,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         },
     });
 
-    const childFamily = await prisma.participant.upsert({
+    const childFamily = await prisma.person.upsert({
         where: { email: "child.family@example.com" },
         update: { name: "Child Family", dateOfBirth: yearsAgo(10) },
         create: {
@@ -96,7 +96,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         },
     });
 
-    const parentFamily2 = await prisma.participant.upsert({
+    const parentFamily2 = await prisma.person.upsert({
         where: { email: "parent.family2@example.com" },
         update: { name: "Parent Family2", phone: "555-555-0004" },
         create: {
@@ -107,7 +107,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         },
     });
 
-    await prisma.participant.upsert({
+    await prisma.person.upsert({
         where: { email: "keyholder1@example.com" },
         update: { name: "Keyholder One", phone: "555-555-0005", isKeyholder: true },
         create: {
@@ -119,7 +119,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         },
     });
 
-    await prisma.participant.upsert({
+    await prisma.person.upsert({
         where: { email: "keyholder2@example.com" },
         update: { name: "Keyholder Two", phone: "555-555-0006", isKeyholder: true },
         create: {
@@ -131,7 +131,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         },
     });
 
-    const certifiedAdult = await prisma.participant.upsert({
+    const certifiedAdult = await prisma.person.upsert({
         where: { email: "certified.adult@example.com" },
         update: { name: "Certified Adult", phone: "555-555-0007" },
         create: {
@@ -145,7 +145,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
     // No carte-blanche "may certify others" role exists. This persona is a plain
     // member who holds the MAY_CERTIFY_OTHERS certification on a single tool (granted
     // below), exercising the per-tool certifier path.
-    const toolCertifier = await prisma.participant.upsert({
+    const toolCertifier = await prisma.person.upsert({
         where: { email: "tool.certifier@example.com" },
         update: { name: "Tool Certifier", phone: "555-555-0008" },
         create: {
@@ -156,7 +156,7 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         },
     });
 
-    await prisma.participant.upsert({
+    await prisma.person.upsert({
         where: { email: "bg.reviewer@example.com" },
         update: { name: "BG Reviewer", phone: "555-555-0009", isBackgroundCheckReviewer: true },
         create: {
@@ -169,13 +169,13 @@ export async function seedBaseline(prisma: Db): Promise<void> {
     });
 
     // 3. Household assignments & leads
-    await prisma.participant.update({ where: { id: parentFamily.id }, data: { householdId: household1.id } });
-    await prisma.participant.update({ where: { id: parent2Family.id }, data: { householdId: household1.id } });
-    await prisma.participant.update({ where: { id: childFamily.id }, data: { householdId: household1.id } });
+    await prisma.person.update({ where: { id: parentFamily.id }, data: { householdId: household1.id } });
+    await prisma.person.update({ where: { id: parent2Family.id }, data: { householdId: household1.id } });
+    await prisma.person.update({ where: { id: childFamily.id }, data: { householdId: household1.id } });
 
     await addHouseholdLead(prisma, household1.id, parentFamily.id);
 
-    await prisma.participant.update({ where: { id: parentFamily2.id }, data: { householdId: household2.id } });
+    await prisma.person.update({ where: { id: parentFamily2.id }, data: { householdId: household2.id } });
     await addHouseholdLead(prisma, household2.id, parentFamily2.id);
 
     // 4. Tools & certifications
@@ -239,7 +239,7 @@ export async function createFamily(prisma: Db): Promise<string> {
     await prisma.membership.create({
         data: { householdId: household.id, status: "ACTIVE" },
     });
-    const lead = await prisma.participant.create({
+    const lead = await prisma.person.create({
         data: {
             name: `Lead ${tag}`,
             email: `lead.${tag}@example.com`,
@@ -249,7 +249,7 @@ export async function createFamily(prisma: Db): Promise<string> {
         },
     });
     await addHouseholdLead(prisma, household.id, lead.id);
-    await prisma.participant.create({
+    await prisma.person.create({
         data: {
             name: `Partner ${tag}`,
             email: `partner.${tag}@example.com`,
@@ -257,7 +257,7 @@ export async function createFamily(prisma: Db): Promise<string> {
             householdId: household.id,
         },
     });
-    await prisma.participant.create({
+    await prisma.person.create({
         data: { name: `Kid ${tag}`, dateOfBirth: yearsAgo(9), householdId: household.id },
     });
     return `Created household "Test Family ${tag}" (lead + partner + 1 youth)`;
@@ -283,7 +283,7 @@ export async function createProgram(prisma: Db): Promise<string> {
         // Integer cents: $25.00 member / $40.00 non-member.
         data: { programId: program.id, name: "Materials", memberPriceCents: 2500, nonMemberPriceCents: 4000 },
     });
-    const enrollees = await prisma.participant.findMany({ take: 2, orderBy: { id: "asc" } });
+    const enrollees = await prisma.person.findMany({ take: 2, orderBy: { id: "asc" } });
     for (const p of enrollees) {
         await prisma.programParticipant.create({
             data: { programId: program.id, personId: p.id, status: "ACTIVE" },
@@ -307,7 +307,7 @@ export async function createEvent(prisma: Db): Promise<string> {
             description: "Auto-generated dev event",
         },
     });
-    const attendees = await prisma.participant.findMany({ take: 3, orderBy: { id: "asc" } });
+    const attendees = await prisma.person.findMany({ take: 3, orderBy: { id: "asc" } });
     for (const p of attendees) {
         await prisma.rSVP.create({
             data: { eventId: event.id, personId: p.id, status: "ATTENDING" },
@@ -319,7 +319,7 @@ export async function createEvent(prisma: Db): Promise<string> {
 
 /** + Check-ins — recent visits + badge events so attendance screens have data. */
 export async function createCheckins(prisma: Db): Promise<string> {
-    const people = await prisma.participant.findMany({ take: 5, orderBy: { id: "asc" } });
+    const people = await prisma.person.findMany({ take: 5, orderBy: { id: "asc" } });
     let count = 0;
     for (const [i, p] of people.entries()) {
         const arrived = new Date(Date.now() - (i + 1) * 45 * 60 * 1000); // staggered into the past

--- a/checkin-app/src/lib/dev/zoho-import.ts
+++ b/checkin-app/src/lib/dev/zoho-import.ts
@@ -414,7 +414,7 @@ export async function applyImport(
         let householdId: number | null = null;
         for (const m of h.members) {
             if (!m.email) continue;
-            const existing = await tx.participant.findUnique({ where: { email: m.email } });
+            const existing = await tx.person.findUnique({ where: { email: m.email } });
             if (existing) {
                 householdId = existing.householdId;
                 break;
@@ -454,9 +454,9 @@ export async function applyImport(
                 householdId,
             };
 
-            let participant = m.email ? await tx.participant.findUnique({ where: { email: m.email } }) : null;
+            let participant = m.email ? await tx.person.findUnique({ where: { email: m.email } }) : null;
             if (!participant) {
-                participant = await tx.participant.findFirst({ where: { householdId, name: m.name } });
+                participant = await tx.person.findFirst({ where: { householdId, name: m.name } });
             }
 
             const bg = m.lastBackgroundCheck
@@ -471,7 +471,7 @@ export async function applyImport(
                 : {};
 
             if (participant) {
-                participant = await tx.participant.update({ where: { id: participant.id }, data });
+                participant = await tx.person.update({ where: { id: participant.id }, data });
                 res.participantsUpdated++;
                 await audit(tx, actorId, "EDIT", "Participant", participant.id, {
                     name: m.name,
@@ -480,7 +480,7 @@ export async function applyImport(
                     ...bg,
                 });
             } else {
-                participant = await tx.participant.create({ data });
+                participant = await tx.person.create({ data });
                 res.participantsCreated++;
                 await audit(tx, actorId, "CREATE", "Participant", participant.id, {
                     name: m.name,

--- a/checkin-app/src/lib/emailRecipients.ts
+++ b/checkin-app/src/lib/emailRecipients.ts
@@ -31,7 +31,7 @@ export async function emailHouseholdLeads(householdId: number, subject: string, 
 /** Email every board member with an address on file. Resolve + fan-out; all errors logged and swallowed. */
 export async function emailBoardMembers(subject: string, html: string, errorLabel: string): Promise<void> {
     try {
-        const board = await prisma.participant.findMany({
+        const board = await prisma.person.findMany({
             where: { isBoardMember: true, email: { not: null } },
             select: { email: true },
         });

--- a/checkin-app/src/lib/emergencyContacts/__tests__/service.integration.test.ts
+++ b/checkin-app/src/lib/emergencyContacts/__tests__/service.integration.test.ts
@@ -30,7 +30,7 @@ async function wipe() {
     await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: hhIds } } } });
     await prisma.membership.deleteMany({ where: { householdId: { in: hhIds } } });
     await prisma.householdLead.deleteMany({ where: { householdId: { in: hhIds } } });
-    await prisma.participant.deleteMany({ where: { householdId: { in: hhIds } } });
+    await prisma.person.deleteMany({ where: { householdId: { in: hhIds } } });
     await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
 }
 
@@ -40,7 +40,7 @@ async function makeHousehold(suffix: string) {
 }
 
 async function addMember(householdId: number, data: { name?: string; email?: string; phone?: string }) {
-    return prisma.participant.create({ data: { householdId, ...data } });
+    return prisma.person.create({ data: { householdId, ...data } });
 }
 
 beforeAll(wipe);

--- a/checkin-app/src/lib/emergencyContacts/service.ts
+++ b/checkin-app/src/lib/emergencyContacts/service.ts
@@ -50,7 +50,7 @@ export interface EmergencyContactWarning {
 type MemberLike = { id: number; name: string | null; email: string | null; phone: string | null };
 
 function loadMembers(db: Db, householdId: number): Promise<MemberLike[]> {
-    return db.participant.findMany({
+    return db.person.findMany({
         where: { householdId },
         select: { id: true, name: true, email: true, phone: true },
     });

--- a/checkin-app/src/lib/household/__tests__/householdLeadsConcurrency.integration.test.ts
+++ b/checkin-app/src/lib/household/__tests__/householdLeadsConcurrency.integration.test.ts
@@ -31,14 +31,14 @@ import {
 const TAG = 'hh-lead-conc-test';
 
 async function cleanup() {
-    const users = await prisma.participant.findMany({
+    const users = await prisma.person.findMany({
         where: { email: { contains: TAG } },
         select: { id: true, householdId: true },
     });
     const ids = users.map(u => u.id);
     const householdIds = [...new Set(users.map(u => u.householdId))];
     await prisma.householdLead.deleteMany({ where: { personId: { in: ids } } });
-    await prisma.participant.deleteMany({ where: { id: { in: ids } } });
+    await prisma.person.deleteMany({ where: { id: { in: ids } } });
     await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
 }
 
@@ -50,7 +50,7 @@ async function makeHousehold(label: string, existingLeads: number, spares: numbe
     });
     const leadIds: number[] = [];
     for (let i = 0; i < existingLeads; i++) {
-        const p = await prisma.participant.create({
+        const p = await prisma.person.create({
             data: { email: `lead-${i}-${label}-${TAG}@example.com`, name: `Lead ${i}`, householdId: household.id },
         });
         await prisma.householdLead.create({ data: { householdId: household.id, personId: p.id } });
@@ -58,7 +58,7 @@ async function makeHousehold(label: string, existingLeads: number, spares: numbe
     }
     const spareIds: number[] = [];
     for (let i = 0; i < spares; i++) {
-        const p = await prisma.participant.create({
+        const p = await prisma.person.create({
             data: { email: `spare-${i}-${label}-${TAG}@example.com`, name: `Spare ${i}`, householdId: household.id },
         });
         spareIds.push(p.id);

--- a/checkin-app/src/lib/household/activityMembers.ts
+++ b/checkin-app/src/lib/household/activityMembers.ts
@@ -17,7 +17,7 @@ export async function activityMembers(session: Session): Promise<ActivityMember[
     if (!session.user.householdLead || !session.user.householdId) {
         return [{ id: selfId, name: session.user.name ?? null }];
     }
-    return prisma.participant.findMany({
+    return prisma.person.findMany({
         where: { householdId: session.user.householdId },
         select: { id: true, name: true },
         orderBy: { id: "asc" },

--- a/checkin-app/src/lib/household/participantProjection.ts
+++ b/checkin-app/src/lib/household/participantProjection.ts
@@ -1,7 +1,7 @@
 import type { Prisma } from "@/generated/prisma/client";
 
 /**
- * Fields of a household peer's Participant row that are safe to send to any
+ * Fields of a household peer's Person row that are safe to send to any
  * other member of the same household (including youth) — i.e. what the
  * my-household member cards and the program-enrollment picker actually
  * render. Excludes INTERNAL-tier fields (role flags, googleId, emailVerified,
@@ -18,4 +18,4 @@ export const HOUSEHOLD_PEER_SELECT = {
     // peer legitimately needs it to render each member's age badge / pre-fill the edit
     // form (my-household). It's an age-status flag, not a role/audit/security flag.
     isDeclaredAdult: true,
-} satisfies Prisma.ParticipantSelect;
+} satisfies Prisma.PersonSelect;

--- a/checkin-app/src/lib/membership.ts
+++ b/checkin-app/src/lib/membership.ts
@@ -9,7 +9,7 @@ import prisma from "@/lib/prisma";
  * source of truth for member gating — route every "is member?" check through
  * here so a child or second parent in an active household is honored.
  */
-export const ACTIVE_MEMBER_PARTICIPANT_WHERE: Prisma.ParticipantWhereInput = {
+export const ACTIVE_MEMBER_PARTICIPANT_WHERE: Prisma.PersonWhereInput = {
     household: { membership: { status: "ACTIVE" } },
 };
 
@@ -21,7 +21,7 @@ export const ACTIVE_MEMBER_PARTICIPANT_WHERE: Prisma.ParticipantWhereInput = {
  */
 export const ACTIVE_MEMBER_INCLUDE = {
     household: { include: { membership: true } },
-} satisfies Prisma.ParticipantInclude;
+} satisfies Prisma.PersonInclude;
 
 /**
  * Does the Participant with this id currently count as an active member?
@@ -29,7 +29,7 @@ export const ACTIVE_MEMBER_INCLUDE = {
  */
 export async function isActiveMember(participantId: number): Promise<boolean> {
     if (!Number.isInteger(participantId)) return false;
-    const match = await prisma.participant.findFirst({
+    const match = await prisma.person.findFirst({
         where: { AND: [{ id: participantId }, ACTIVE_MEMBER_PARTICIPANT_WHERE] },
         select: { id: true },
     });

--- a/checkin-app/src/lib/membership/__tests__/intake.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/intake.test.ts
@@ -19,7 +19,7 @@ const tx = { $queryRaw: txQueryRaw, membershipProcess: txMembershipProcess, audi
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
     default: {
-        participant: { findUnique: jest.fn() },
+        person: { findUnique: jest.fn() },
         membership: { upsert: jest.fn() },
         $transaction: jest.fn((cb: (tx: unknown) => unknown) => cb(tx)),
     },
@@ -38,7 +38,7 @@ const user = {
 
 beforeEach(() => {
     jest.clearAllMocks();
-    prisma.participant.findUnique.mockResolvedValue(user);
+    prisma.person.findUnique.mockResolvedValue(user);
     prisma.membership.upsert.mockResolvedValue({ id: 42, householdId: 7, status: 'NONE' });
 });
 

--- a/checkin-app/src/lib/membership/__tests__/renewal.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/renewal.test.ts
@@ -12,7 +12,7 @@ import { householdBgIsFresh, beginRenewal, RenewalError } from '@/lib/membership
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
     default: {
-        participant: { findFirst: jest.fn() },
+        person: { findFirst: jest.fn() },
         membershipProcess: { findUnique: jest.fn() },
         membership: { findUnique: jest.fn() },
         boardSettings: { findUnique: jest.fn() },
@@ -36,22 +36,22 @@ describe('householdBgIsFresh', () => {
 
     it('recheckMonths = 0 → not fresh, and never queries (policy unset)', async () => {
         // Even a recent check on file must not count when the board hasn't set the policy.
-        prisma.participant.findFirst.mockResolvedValue({ id: 1 });
+        prisma.person.findFirst.mockResolvedValue({ id: 1 });
 
         const result = await householdBgIsFresh(42, boundary, 0);
 
         expect(result).toBe(false);
-        expect(prisma.participant.findFirst).not.toHaveBeenCalled();
+        expect(prisma.person.findFirst).not.toHaveBeenCalled();
     });
 
     it('a lead with a check at exactly the threshold → fresh (gte boundary)', async () => {
-        prisma.participant.findFirst.mockResolvedValue({ id: 1 });
+        prisma.person.findFirst.mockResolvedValue({ id: 1 });
 
         const result = await householdBgIsFresh(42, boundary, 12);
 
         expect(result).toBe(true);
         // The boundary is inclusive (gte), and the threshold is boundary - recheckMonths.
-        expect(prisma.participant.findFirst).toHaveBeenCalledWith(
+        expect(prisma.person.findFirst).toHaveBeenCalledWith(
             expect.objectContaining({
                 where: expect.objectContaining({
                     householdId: 42,
@@ -62,7 +62,7 @@ describe('householdBgIsFresh', () => {
     });
 
     it('no lead with a fresh-enough check → not fresh', async () => {
-        prisma.participant.findFirst.mockResolvedValue(null);
+        prisma.person.findFirst.mockResolvedValue(null);
         expect(await householdBgIsFresh(42, boundary, 12)).toBe(false);
     });
 });

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -179,7 +179,7 @@ export async function findProcessByEnvelope(requestId: string) {
  * in-flight signing process.
  */
 export async function syncContractStatus(userId: number): Promise<ExternalStatus | null> {
-    const user = await prisma.participant.findUnique({
+    const user = await prisma.person.findUnique({
         where: { id: userId },
         include: { household: { include: { membership: { include: { processes: true } } } } },
     });
@@ -219,7 +219,7 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
         throw new ExternalError("not_configured", "Agreement signing isn't available yet. Please check back soon.");
     }
 
-    const user = await prisma.participant.findUnique({
+    const user = await prisma.person.findUnique({
         where: { id: userId },
         include: {
             householdLeads: true,

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -57,7 +57,7 @@ export interface IntakeSaveInput {
 }
 
 async function loadUserWithHousehold(userId: number) {
-    return prisma.participant.findUnique({
+    return prisma.person.findUnique({
         where: { id: userId },
         include: {
             householdLeads: true,
@@ -261,7 +261,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
     // Primary parent is always the caller.
     if (input.primaryParent) {
         // The primary applicant is already a household lead (set at startIntake).
-        await prisma.participant.update({
+        await prisma.person.update({
             where: { id: userId },
             data: {
                 ...(input.primaryParent.name !== undefined && { name: input.primaryParent.name }),
@@ -275,7 +275,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
     if (input.secondaryParent) {
         const sp = input.secondaryParent;
         if (sp.id && householdMemberIds.has(sp.id)) {
-            await prisma.participant.update({
+            await prisma.person.update({
                 where: { id: sp.id },
                 data: {
                     ...(sp.name !== undefined && { name: sp.name }),
@@ -286,7 +286,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
             // A second guardian is a household lead (parent).
             await addLeadOrRecord(sp.id);
         } else if (sp.name || sp.email) {
-            const created = await prisma.participant.create({
+            const created = await prisma.person.create({
                 data: {
                     householdId,
                     name: sp.name ?? null,
@@ -303,7 +303,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
     // only), create the rest. Never delete; never add a HouseholdLead row.
     for (const child of input.children ?? []) {
         if (child.id && householdMemberIds.has(child.id)) {
-            await prisma.participant.update({
+            await prisma.person.update({
                 where: { id: child.id },
                 data: {
                     ...(child.name !== undefined && { name: child.name }),
@@ -312,7 +312,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
                 },
             });
         } else if (child.name) {
-            await prisma.participant.create({
+            await prisma.person.create({
                 data: {
                     householdId,
                     name: child.name,

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -79,7 +79,7 @@ export async function ensurePaymentLink(processId: number): Promise<{ amountCent
 
 /** Resolve the caller's household PENDING_PAYMENT process and ensure its payment link. */
 export async function ensurePaymentLinkForUser(userId: number) {
-    const user = await prisma.participant.findUnique({ where: { id: userId }, select: { householdId: true } });
+    const user = await prisma.person.findUnique({ where: { id: userId }, select: { householdId: true } });
     if (!user?.householdId) throw new PaymentError("not_found", "You are not in a household.");
     const process = await prisma.membershipProcess.findFirst({
         where: { membership: { householdId: user.householdId }, status: "PENDING_PAYMENT" },

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -188,7 +188,7 @@ export async function openRenewalsForAllActive(now: Date, opts: { sendReminders?
 
 /** Resolve and begin the caller's household renewal. */
 export async function beginRenewalForUser(userId: number) {
-    const user = await prisma.participant.findUnique({ where: { id: userId }, select: { householdId: true } });
+    const user = await prisma.person.findUnique({ where: { id: userId }, select: { householdId: true } });
     if (!user?.householdId) throw new RenewalError("not_found", "You are not in a household.");
     const process = await prisma.membershipProcess.findFirst({
         where: { membership: { householdId: user.householdId }, status: "PENDING_RENEWAL" },
@@ -206,7 +206,7 @@ export async function beginRenewalForUser(userId: number) {
 export async function householdBgIsFresh(householdId: number, boundary: Date, recheckMonths: number): Promise<boolean> {
     if (recheckMonths <= 0) return false;
     const threshold = monthsBefore(boundary, recheckMonths);
-    const fresh = await prisma.participant.findFirst({
+    const fresh = await prisma.person.findFirst({
         where: { householdId, householdLeads: { some: { householdId } }, lastBackgroundCheck: { gte: threshold } },
         select: { id: true },
     });

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -86,7 +86,7 @@ export const AWAITING_BG_WHERE: Prisma.MembershipProcessWhereInput = {
 /** Email every background-check reviewer that an application awaits review. */
 export async function notifyReviewers(): Promise<void> {
     try {
-        const reviewers = await prisma.participant.findMany({
+        const reviewers = await prisma.person.findMany({
             where: { email: { not: null }, OR: [{ isBackgroundCheckReviewer: true }, { isBoardMember: true }] },
             select: { email: true },
         });
@@ -108,7 +108,7 @@ export async function notifyReviewers(): Promise<void> {
 }
 
 async function loadReviewer(reviewerId: number) {
-    return prisma.participant.findUnique({ where: { id: reviewerId }, select: { id: true, householdId: true, isBackgroundCheckReviewer: true, isBoardMember: true } });
+    return prisma.person.findUnique({ where: { id: reviewerId }, select: { id: true, householdId: true, isBackgroundCheckReviewer: true, isBoardMember: true } });
 }
 
 /**
@@ -226,7 +226,7 @@ async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: nu
 
     // Stamp the guardians' (household leads') lastBackgroundCheck. Expiry is derived from this
     // plus BoardSettings.bgRecheckMonths at read time (see householdBgIsFresh) — not stored.
-    await tx.participant.updateMany({ where: { householdId, householdLeads: { some: { householdId } } }, data: { lastBackgroundCheck: now } });
+    await tx.person.updateMany({ where: { householdId, householdLeads: { some: { householdId } } }, data: { lastBackgroundCheck: now } });
     await applyVolunteerStatus(tx, process.membershipId, householdId, process.attestations.some((a) => a.isMarkedVolunteer));
 
     await tx.membershipProcess.update({
@@ -260,7 +260,7 @@ export function matchesVolunteerDesignation(parentEmails: string[], designationE
 export async function applyVolunteerStatus(db: TxClient | typeof prisma, membershipId: number, householdId: number, markedByReviewer: boolean) {
     let isVolunteer = markedByReviewer;
     if (!isVolunteer) {
-        const parents = await db.participant.findMany({ where: { householdId, householdLeads: { some: { householdId } }, email: { not: null } }, select: { email: true } });
+        const parents = await db.person.findMany({ where: { householdId, householdLeads: { some: { householdId } }, email: { not: null } }, select: { email: true } });
         const designations = await db.volunteerDesignation.findMany({ select: { email: true } });
         isVolunteer = matchesVolunteerDesignation(parents.map((p) => p.email!), designations.map((d) => d.email));
     }

--- a/checkin-app/src/lib/notifications.ts
+++ b/checkin-app/src/lib/notifications.ts
@@ -25,7 +25,7 @@ export type NotificationEvent =
  */
 export async function sendNotification(userId: number, eventType: NotificationEvent, payload: Record<string, unknown>): Promise<boolean> {
     try {
-        const user = await prisma.participant.findUnique({
+        const user = await prisma.person.findUnique({
             where: { id: userId },
             select: { email: true, notificationSettings: true, name: true }
         });
@@ -87,7 +87,7 @@ export async function sendNotification(userId: number, eventType: NotificationEv
  */
 export async function sendCheckinNotifications(participantId: number, type: 'checkin' | 'checkout') {
     try {
-        const participant = await prisma.participant.findUnique({
+        const participant = await prisma.person.findUnique({
             where: { id: participantId },
             select: {
                 id: true,

--- a/checkin-app/src/lib/postEventEmails.ts
+++ b/checkin-app/src/lib/postEventEmails.ts
@@ -74,7 +74,7 @@ export async function processPostEventEmails(options: ProcessPostEventEmailsOpti
         // Batch fetch all lead mentors at once
         const leadMentorsMap = new Map<number, string | null>();
         if (leadMentorIds.length > 0) {
-            const leadMentors = await prisma.participant.findMany({
+            const leadMentors = await prisma.person.findMany({
                 where: {
                     id: { in: leadMentorIds }
                 },

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -2,7 +2,7 @@ import prisma from "@/lib/prisma";
 import { findAssociatedEventAt, processVisitCheckout } from "@/lib/attendanceTransitions";
 import { sendCheckinNotifications } from "@/lib/notifications";
 import { apiError, apiJson } from "@/lib/api-response";
-import type { Participant, PrismaClient, Prisma } from "@/generated/prisma/client";
+import type { Person, PrismaClient, Prisma } from "@/generated/prisma/client";
 
 /** Global client or a caller-supplied transaction-scoped client. */
 type DbClient = PrismaClient | Prisma.TransactionClient;
@@ -15,7 +15,7 @@ type DbClient = PrismaClient | Prisma.TransactionClient;
  * unit tests) `db` defaults to the global prisma client. Fire-and-forget side
  * effects (notifications) intentionally run off the global client either way.
  */
-export async function processCheckin(participant: Participant, authType: string, db: DbClient = prisma) {
+export async function processCheckin(participant: Person, authType: string, db: DbClient = prisma) {
     // Non-keyholders require an open facility (at least 1 isKeyholder present)
     if (!participant.isKeyholder) {
         const activeKeyholders = await db.visit.count({
@@ -64,7 +64,7 @@ export async function processCheckin(participant: Participant, authType: string,
  * advisory lock) or, when called standalone, the global prisma client.
  */
 export async function processCheckout(
-    participant: Participant,
+    participant: Person,
     activeVisitId: number,
     authType: string,
     db: DbClient = prisma

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -239,7 +239,7 @@ export async function createShopifyProgramVariants(name: string, memberPriceCent
     });
 
     try {
-        const admins = await prisma.participant.findMany({
+        const admins = await prisma.person.findMany({
             where: {
                 OR: [{ isSysadmin: true }, { isBoardMember: true }],
                 email: { not: null }

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -207,7 +207,7 @@ export async function decideReview(reviewId: number, boardMemberId: number, inpu
     // Conflict of interest: a board member may not decide a trusted-adult review for
     // their own household, nor one where they are the counterparty. The UI disables the
     // buttons off the same rule; this is the real enforcement — a direct POST bypasses the UI.
-    const me = await prisma.participant.findUnique({ where: { id: boardMemberId }, select: { householdId: true } });
+    const me = await prisma.person.findUnique({ where: { id: boardMemberId }, select: { householdId: true } });
     if (
         isTrustedAdultConflict({
             actorParticipantId: boardMemberId,
@@ -286,7 +286,7 @@ export async function overrideReview(
     if (!review) throw new TrustedAdultError("not_found", "Review not found.");
 
     if (!opts?.isSysadmin) {
-        const me = await prisma.participant.findUnique({ where: { id: actorId }, select: { householdId: true } });
+        const me = await prisma.person.findUnique({ where: { id: actorId }, select: { householdId: true } });
         if (
             isTrustedAdultConflict({
                 actorParticipantId: actorId,

--- a/checkin-app/src/security/__tests__/payment-plans-strip.test.ts
+++ b/checkin-app/src/security/__tests__/payment-plans-strip.test.ts
@@ -72,11 +72,11 @@ describe('payment-plans field-stripping', () => {
         expect(p.name).toBe('Member Name');
     });
 
-    it('Participant.email is pii, so everyones:pii is required to see it', () => {
+    it('Person.email is pii, so everyones:pii is required to see it', () => {
         // Guards the assumption the test rests on.
         const board = tokensFor(ENDPOINT, 'isBoardMember');
         expect(board).toContain('everyones:pii');
-        const scopes = scopesHeld('Participant', row.person, ctx());
+        const scopes = scopesHeld('Person', row.person, ctx());
         expect(scopes.has('everyones')).toBe(true);
     });
 });

--- a/checkin-app/src/security/__tests__/shop-certifications-strip.test.ts
+++ b/checkin-app/src/security/__tests__/shop-certifications-strip.test.ts
@@ -4,7 +4,7 @@
 /**
  * Strip-assertion for GET /api/shop/certifications. Cert status is PUBLIC BY
  * DESIGN (posted in the shop), but the participant's email is not. A bag row is
- * a ToolStatus with nested tool (Tool) + person (Participant):
+ * a ToolStatus with nested tool (Tool) + person (Person):
  *
  *   - board/sysadmin (everyones:pii) → level + tool + person name + email.
  *   - member/certifier (member+public) → level + tool + person name;

--- a/checkin-app/src/security/__tests__/shop-members-strip.test.ts
+++ b/checkin-app/src/security/__tests__/shop-members-strip.test.ts
@@ -47,14 +47,14 @@ const member = { id: 99, name: 'Other Member', email: 'other@x.test' };
 describe('shop/members field-stripping', () => {
     it('board sees name + email (pii)', () => {
         const tokens = tokensFor(ENDPOINT, 'isBoardMember');
-        const out = stripValue('Participant', member, tokens, ctx()) as Record<string, unknown>;
+        const out = stripValue('Person', member, tokens, ctx()) as Record<string, unknown>;
         expect(out.name).toBe('Other Member');
         expect(out.email).toBe('other@x.test');
     });
 
     it('certifier sees name only — email is stripped', () => {
         const tokens = tokensFor(ENDPOINT, 'certifier');
-        const out = stripValue('Participant', member, tokens, ctx()) as Record<string, unknown>;
+        const out = stripValue('Person', member, tokens, ctx()) as Record<string, unknown>;
         expect(out.name).toBe('Other Member');
         expect(out.email).toBeUndefined();
     });

--- a/checkin-app/src/security/__tests__/toolstatus-self-scope.test.ts
+++ b/checkin-app/src/security/__tests__/toolstatus-self-scope.test.ts
@@ -3,7 +3,7 @@
  */
 /**
  * ToolStatus.userId was renamed userId->participantId->personId (Person =
- * Participant). The `their_own` stripper branch was SPLIT so ToolStatus reads
+ * Person). The `their_own` stripper branch was SPLIT so ToolStatus reads
  * `personId` while Account/Session (NextAuth-mandated) keep reading `userId`.
  * Guards that split: a member must still self-scope their own ToolStatus rows,
  * and the Account/Session read must NOT regress.

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -34,7 +34,7 @@ export interface CallerContext {
      *  program only via eventId → Event.programId. Drives 'their_program_participants'
      *  on RSVP. */
     eventIdsInScopePrograms: Set<number>;
-    /** Participant IDs with an un-departed Visit. Only populated for keyholders. */
+    /** Person IDs with an un-departed Visit. Only populated for keyholders. */
     activeVisitorIds: Set<number>;
 }
 
@@ -83,7 +83,7 @@ export async function buildCallerContext(auth: AuthResult): Promise<CallerContex
     // pickup-note visibility (program leads see operational notes for the
     // households whose kids they oversee).
     if (ctx.participantIdsInScopePrograms.size) {
-        const members = await prisma.participant.findMany({
+        const members = await prisma.person.findMany({
             where: { id: { in: [...ctx.participantIdsInScopePrograms] } },
             select: { householdId: true },
         });

--- a/checkin-app/src/security/core.ts
+++ b/checkin-app/src/security/core.ts
@@ -67,7 +67,7 @@ export type Role =
     | 'isBoardMember'
     | 'isKeyholder'
     | 'isBackgroundCheckReviewer'
-    // Holds a MAY_CERTIFY_OTHERS toolStatus (a shop certifier). Not a Participant
+    // Holds a MAY_CERTIFY_OTHERS toolStatus (a shop certifier). Not a Person
     // role boolean — derived from session.user.toolStatuses (see callerHoldsRole).
     | 'certifier'
     | 'householdLead'
@@ -124,7 +124,7 @@ export type Authorize =
     | { anyRole: BusinessRole[] }
     // Shop certifier (a MAY_CERTIFY_OTHERS toolStatus). Admits certifiers OR
     // admins (isSysadmin/isBoardMember) — see resolveAccess. Backed by a
-    // predicate because 'certifier' is not a Participant role boolean.
+    // predicate because 'certifier' is not a Person role boolean.
     | 'certifier'
     | 'program-lead-mentor'
     | 'program-core-volunteer'

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -2,7 +2,7 @@
 // Re-run `prisma generate` after editing /// @sensitivity comments.
 
 export const classifications = {
-    Participant: {
+    Person: {
         id: 'public',
         googleId: 'pii',
         email: 'pii',
@@ -322,7 +322,7 @@ export const classifications = {
 } as const;
 
 export const relations = {
-    Participant: {
+    Person: {
         accounts: { model: 'Account', isList: true },
         sessions: { model: 'Session', isList: true },
         household: { model: 'Household', isList: false },
@@ -347,11 +347,11 @@ export const relations = {
         toolStatuses: { model: 'ToolStatus', isList: true },
     },
     ToolStatus: {
-        person: { model: 'Participant', isList: false },
+        person: { model: 'Person', isList: false },
         tool: { model: 'Tool', isList: false },
     },
     Household: {
-        participants: { model: 'Participant', isList: true },
+        participants: { model: 'Person', isList: true },
         leads: { model: 'HouseholdLead', isList: true },
         membership: { model: 'Membership', isList: false },
         trustedAdults: { model: 'TrustedAdult', isList: true },
@@ -362,7 +362,7 @@ export const relations = {
     },
     HouseholdLead: {
         household: { model: 'Household', isList: false },
-        person: { model: 'Participant', isList: false },
+        person: { model: 'Person', isList: false },
     },
     Membership: {
         household: { model: 'Household', isList: false },
@@ -374,7 +374,7 @@ export const relations = {
     },
     BackgroundCheckAttestation: {
         process: { model: 'MembershipProcess', isList: false },
-        reviewer: { model: 'Participant', isList: false },
+        reviewer: { model: 'Person', isList: false },
     },
     VolunteerDesignation: {
     },
@@ -384,13 +384,13 @@ export const relations = {
     },
     TrustedAdult: {
         household: { model: 'Household', isList: false },
-        counterparty: { model: 'Participant', isList: false },
-        disclosedBy: { model: 'Participant', isList: false },
+        counterparty: { model: 'Person', isList: false },
+        disclosedBy: { model: 'Person', isList: false },
         reviews: { model: 'TrustedAdultReview', isList: true },
     },
     TrustedAdultReview: {
         trustedAdult: { model: 'TrustedAdult', isList: false },
-        decidedBy: { model: 'Participant', isList: false },
+        decidedBy: { model: 'Person', isList: false },
     },
     Corporation: {
         leads: { model: 'CorporationLead', isList: true },
@@ -398,14 +398,14 @@ export const relations = {
     },
     CorporationLead: {
         corporation: { model: 'Corporation', isList: false },
-        person: { model: 'Participant', isList: false },
+        person: { model: 'Person', isList: false },
     },
     CorporationMember: {
         corporation: { model: 'Corporation', isList: false },
-        person: { model: 'Participant', isList: false },
+        person: { model: 'Person', isList: false },
     },
     Program: {
-        leadMentor: { model: 'Participant', isList: false },
+        leadMentor: { model: 'Person', isList: false },
         volunteers: { model: 'ProgramVolunteer', isList: true },
         participants: { model: 'ProgramParticipant', isList: true },
         fees: { model: 'Fee', isList: true },
@@ -413,11 +413,11 @@ export const relations = {
     },
     ProgramVolunteer: {
         program: { model: 'Program', isList: false },
-        person: { model: 'Participant', isList: false },
+        person: { model: 'Person', isList: false },
     },
     ProgramParticipant: {
         program: { model: 'Program', isList: false },
-        person: { model: 'Participant', isList: false },
+        person: { model: 'Person', isList: false },
     },
     Fee: {
         program: { model: 'Program', isList: false },
@@ -425,32 +425,32 @@ export const relations = {
     },
     FeePayment: {
         fee: { model: 'Fee', isList: false },
-        person: { model: 'Participant', isList: false },
+        person: { model: 'Person', isList: false },
     },
     Event: {
-        attendanceConfirmedBy: { model: 'Participant', isList: false },
+        attendanceConfirmedBy: { model: 'Person', isList: false },
         program: { model: 'Program', isList: false },
         rsvps: { model: 'RSVP', isList: true },
         visits: { model: 'Visit', isList: true },
     },
     RSVP: {
         event: { model: 'Event', isList: false },
-        person: { model: 'Participant', isList: false },
+        person: { model: 'Person', isList: false },
     },
     RawBadgeLog: {
-        person: { model: 'Participant', isList: false },
+        person: { model: 'Person', isList: false },
     },
     Visit: {
-        person: { model: 'Participant', isList: false },
+        person: { model: 'Person', isList: false },
         event: { model: 'Event', isList: false },
     },
     AuditLog: {
     },
     Account: {
-        user: { model: 'Participant', isList: false },
+        user: { model: 'Person', isList: false },
     },
     Session: {
-        user: { model: 'Participant', isList: false },
+        user: { model: 'Person', isList: false },
     },
     VerificationToken: {
     },

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -15,8 +15,8 @@ defineRoute({
     endpoint: 'GET /api/profile',
     authorize: 'self',
     envelope: 'profile',
-    // Bag: { Participant } with nested visits (Visit) → event (Event).
-    returns: ['Participant', 'Visit', 'Event'],
+    // Bag: { Person } with nested visits (Visit) → event (Event).
+    returns: ['Person', 'Visit', 'Event'],
     orderedView: [
         [
             'authenticated',
@@ -29,11 +29,11 @@ defineRoute({
     endpoint: 'GET /api/programs/[id]',
     authorize: 'public',
     envelope: null,
-    // Bag: { Program } with volunteers (ProgramVolunteer → participant Participant),
-    // participants (ProgramParticipant → participant Participant → household Household
+    // Bag: { Program } with volunteers (ProgramVolunteer → participant Person),
+    // participants (ProgramParticipant → participant Person → household Household
     // → emergencyContacts EmergencyContact), events (Event), fees (Fee), leadMentor
-    // (Participant).
-    returns: ['Program', 'ProgramParticipant', 'ProgramVolunteer', 'Participant', 'Household', 'EmergencyContact', 'Event', 'Fee'],
+    // (Person).
+    returns: ['Program', 'ProgramParticipant', 'ProgramVolunteer', 'Person', 'Household', 'EmergencyContact', 'Event', 'Fee'],
     orderedView: [
         ['isSysadmin',             ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember',          ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
@@ -70,9 +70,9 @@ defineRoute({
     authorize: 'authenticated',
     envelope: null,
     // Bag: { Event } with program (Program → volunteers ProgramVolunteer → participant
-    // Participant; participants ProgramParticipant → participant Participant), visits
-    // (Visit), rsvps (RSVP → participant Participant), attendanceConfirmedBy (Participant).
-    returns: ['Event', 'Program', 'ProgramVolunteer', 'ProgramParticipant', 'Participant', 'Visit', 'RSVP'],
+    // Person; participants ProgramParticipant → participant Person), visits
+    // (Visit), rsvps (RSVP → participant Person), attendanceConfirmedBy (Person).
+    returns: ['Event', 'Program', 'ProgramVolunteer', 'ProgramParticipant', 'Person', 'Visit', 'RSVP'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
@@ -98,8 +98,8 @@ defineRoute({
     endpoint: 'GET /api/programs/[id]/eligible-participants',
     authorize: 'program-lead-mentor',
     envelope: 'members',
-    // Bag: { Participant }.
-    returns: ['Participant'],
+    // Bag: { Person }.
+    returns: ['Person'],
     orderedView: [
         ['isSysadmin',        ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember',     ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
@@ -111,8 +111,8 @@ defineRoute({
     endpoint: 'GET /api/directory/board',
     authorize: { anyRole: ['isSysadmin', 'isBoardMember', 'isKeyholder'] },
     envelope: 'boardMembers',
-    // Bag: { Participant }.
-    returns: ['Participant'],
+    // Bag: { Person }.
+    returns: ['Person'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
@@ -128,9 +128,9 @@ defineRoute({
     authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
     envelope: 'processes',
     // Bag: { MembershipProcess } with attestations (BackgroundCheckAttestation),
-    // membership (Membership → household Household → participants Participant,
+    // membership (Membership → household Household → participants Person,
     // leads HouseholdLead).
-    returns: ['MembershipProcess', 'BackgroundCheckAttestation', 'Membership', 'Household', 'Participant', 'HouseholdLead'],
+    returns: ['MembershipProcess', 'BackgroundCheckAttestation', 'Membership', 'Household', 'Person', 'HouseholdLead'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
@@ -146,8 +146,8 @@ defineRoute({
     authorize: { anyRole: ['isBackgroundCheckReviewer', 'isBoardMember'] },
     envelope: 'queue',
     // Bag: { MembershipProcess } with membership (Membership → household Household
-    // → leads HouseholdLead → participant Participant).
-    returns: ['MembershipProcess', 'Membership', 'Household', 'HouseholdLead', 'Participant'],
+    // → leads HouseholdLead → participant Person).
+    returns: ['MembershipProcess', 'Membership', 'Household', 'HouseholdLead', 'Person'],
     orderedView: [
         ['isBackgroundCheckReviewer', ['everyones:pii', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'member', 'public']],
@@ -175,8 +175,8 @@ defineRoute({
     authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
     envelope: 'trustedAdults',
     // Bag: { TrustedAdult } with household (Household → leads HouseholdLead →
-    // participant Participant), counterparty (Participant), reviews (TrustedAdultReview).
-    returns: ['TrustedAdult', 'Household', 'HouseholdLead', 'Participant', 'TrustedAdultReview'],
+    // participant Person), counterparty (Person), reviews (TrustedAdultReview).
+    returns: ['TrustedAdult', 'Household', 'HouseholdLead', 'Person', 'TrustedAdultReview'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
@@ -213,7 +213,7 @@ defineRoute({
     endpoint: 'GET /api/finance-ops/payment-plans',
     authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
     envelope: null,
-    returns: ['ProgramParticipant', 'Participant', 'Program'],
+    returns: ['ProgramParticipant', 'Person', 'Program'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
@@ -228,7 +228,7 @@ defineRoute({
     endpoint: 'GET /api/shop/members',
     authorize: 'certifier',
     envelope: 'members',
-    returns: ['Participant'],
+    returns: ['Person'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
@@ -250,8 +250,8 @@ defineRoute({
     endpoint: 'GET /api/shop/certifications',
     authorize: 'authenticated',
     envelope: null,
-    // Bag: { ToolStatus } with tool (Tool) and participant (Participant).
-    returns: ['ToolStatus', 'Tool', 'Participant'],
+    // Bag: { ToolStatus } with tool (Tool) and participant (Person).
+    returns: ['ToolStatus', 'Tool', 'Person'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -31,7 +31,7 @@
 import { makeScopesHeld, type ScopeBindings } from './scopes';
 
 export const SCOPE_BINDINGS = {
-    Participant: {
+    Person: {
         their_own: { field: 'id', eqCtx: 'selfId' },
         their_households: { field: 'householdId', eqCtx: 'householdId' },
         their_program_participants: { field: 'id', inCtx: 'participantIdsInScopePrograms' },

--- a/checkin-app/src/security/scopes.ts
+++ b/checkin-app/src/security/scopes.ts
@@ -148,7 +148,7 @@ function allMatches(scopeMap: Partial<Record<Scope, Match>>): Match[] {
  * `id` is intentionally excluded: it is a bare primary key on every model, so
  * judging on it makes isScopable true everywhere and falsely demands a binding
  * for admin-only log/settings models (BoardSettings, ErrorLog, etc.). It IS a
- * real scope field for Participant/Household/Program (`field: 'id'`), but all
+ * real scope field for Person/Household/Program (`field: 'id'`), but all
  * three are BOUND, and the coverage loop skips bound models BEFORE isScopable
  * runs — so isScopable only ever judges UNBOUND models, where `id` carries no
  * actor meaning. The truth about id-as-scope lives in SCOPE_BINDINGS, not here.

--- a/checkin-app/tests/security/outbound.test.ts
+++ b/checkin-app/tests/security/outbound.test.ts
@@ -39,9 +39,9 @@ describe('outboundCall — public-only surface (shopify.product.create)', () => 
         expect(out.Program.leadMentorNotificationSettings).toBeUndefined();
     });
 
-    it('strips pii (email/phone/dob) and internal from a Participant', async () => {
+    it('strips pii (email/phone/dob) and internal from a Person', async () => {
         const out = (await capture('shopify.product.create', {
-            Participant: {
+            Person: {
                 id: 5,
                 name: 'Me',                // public
                 email: 'me@x.com',         // pii
@@ -50,14 +50,14 @@ describe('outboundCall — public-only surface (shopify.product.create)', () => 
                 notificationSettings: { x: 1 }, // personal
                 emailVerified: '2026-01-01',    // internal
             },
-        })) as { Participant: Record<string, unknown> };
-        expect(out.Participant.id).toBe(5);
-        expect(out.Participant.name).toBe('Me');
-        expect(out.Participant.email).toBeUndefined();
-        expect(out.Participant.phone).toBeUndefined();
-        expect(out.Participant.dob).toBeUndefined();
-        expect(out.Participant.notificationSettings).toBeUndefined();
-        expect(out.Participant.emailVerified).toBeUndefined();
+        })) as { Person: Record<string, unknown> };
+        expect(out.Person.id).toBe(5);
+        expect(out.Person.name).toBe('Me');
+        expect(out.Person.email).toBeUndefined();
+        expect(out.Person.phone).toBeUndefined();
+        expect(out.Person.dob).toBeUndefined();
+        expect(out.Person.notificationSettings).toBeUndefined();
+        expect(out.Person.emailVerified).toBeUndefined();
     });
 });
 
@@ -66,7 +66,7 @@ describe('outboundCall — public-only surface (shopify.product.create)', () => 
 describe('outboundCall — pii surface (email.admin-notify)', () => {
     it('keeps public + pii, still drops personal/internal', async () => {
         const out = (await capture('email.admin-notify', {
-            Participant: {
+            Person: {
                 id: 5,
                 name: 'Me',                // public  → kept
                 email: 'me@x.com',         // pii     → kept
@@ -75,14 +75,14 @@ describe('outboundCall — pii surface (email.admin-notify)', () => {
                 emailVerified: '2026-01-01',    // internal → dropped
                 isSysadmin: true,                 // internal → dropped
             },
-        })) as { Participant: Record<string, unknown> };
-        expect(out.Participant.id).toBe(5);
-        expect(out.Participant.name).toBe('Me');
-        expect(out.Participant.email).toBe('me@x.com');
-        expect(out.Participant.phone).toBe('555');
-        expect(out.Participant.notificationSettings).toBeUndefined();
-        expect(out.Participant.emailVerified).toBeUndefined();
-        expect(out.Participant.isSysadmin).toBeUndefined();
+        })) as { Person: Record<string, unknown> };
+        expect(out.Person.id).toBe(5);
+        expect(out.Person.name).toBe('Me');
+        expect(out.Person.email).toBe('me@x.com');
+        expect(out.Person.phone).toBe('555');
+        expect(out.Person.notificationSettings).toBeUndefined();
+        expect(out.Person.emailVerified).toBeUndefined();
+        expect(out.Person.isSysadmin).toBeUndefined();
     });
 });
 
@@ -128,9 +128,9 @@ describe('outboundCall — secret is unconditionally stripped', () => {
 describe('outboundCall — nested relations', () => {
     it('strips a nested relation by ITS model tiers, not the parent key', async () => {
         // pii surface: Household.line1 is 'personal' → must be stripped even
-        // though the parent Participant carries pii the surface allows.
+        // though the parent Person carries pii the surface allows.
         const out = (await capture('email.admin-notify', {
-            Participant: {
+            Person: {
                 id: 5,
                 name: 'Me',
                 email: 'me@x.com', // pii → kept
@@ -140,9 +140,9 @@ describe('outboundCall — nested relations', () => {
                     line1: 'private st', // personal → stripped
                 },
             },
-        })) as { Participant: Record<string, unknown> };
-        expect(out.Participant.email).toBe('me@x.com');
-        const hh = out.Participant.household as Record<string, unknown>;
+        })) as { Person: Record<string, unknown> };
+        expect(out.Person.email).toBe('me@x.com');
+        const hh = out.Person.household as Record<string, unknown>;
         expect(hh.id).toBe(2);
         expect(hh.name).toBe('Home');
         expect(hh.line1).toBeUndefined();

--- a/checkin-app/tests/security/personas.ts
+++ b/checkin-app/tests/security/personas.ts
@@ -21,9 +21,9 @@ async function ensure(
     }>,
 ) {
     const email = `policy-persona-${emailSuffix}@example.test`;
-    let p = await prisma.participant.findUnique({ where: { email } });
+    let p = await prisma.person.findUnique({ where: { email } });
     if (!p) {
-        p = await prisma.participant.create({
+        p = await prisma.person.create({
             data: {
                 email,
                 name: mutate.name ?? emailSuffix,
@@ -32,7 +32,7 @@ async function ensure(
             },
         });
     } else {
-        p = await prisma.participant.update({ where: { id: p.id }, data: mutate });
+        p = await prisma.person.update({ where: { id: p.id }, data: mutate });
     }
     return p;
 }

--- a/checkin-app/tests/security/registryAuthz.integration.test.ts
+++ b/checkin-app/tests/security/registryAuthz.integration.test.ts
@@ -87,7 +87,7 @@ describe('Registry route admission gates', () => {
         // unsigned request as kiosk — that would turn our 401 cases into kiosk.
         process.env.CHECKIN_ENV = 'dev';
 
-        const plain = await prisma.participant.create({
+        const plain = await prisma.person.create({
             data: {
                 name: 'Authz Plain',
                 email: `plain-${TAG}@example.com`,
@@ -130,7 +130,7 @@ describe('Registry route admission gates', () => {
         process.env.CHECKIN_ENV = ENV_BEFORE;
         await prisma.event.deleteMany({ where: { id: eventId } });
         await prisma.program.deleteMany({ where: { id: programId } });
-        await prisma.participant.deleteMany({ where: { id: { in: participantIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: participantIds } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
     });
 

--- a/checkin-app/tests/security/routeAuthDrift.test.ts
+++ b/checkin-app/tests/security/routeAuthDrift.test.ts
@@ -130,7 +130,7 @@ const EDGE_MODELS = new Set(['ProgramParticipant', 'ProgramVolunteer', 'RSVP', '
 
 /** The generated relations map, typed: ParentModel → relationKey → target. This
  * is what makes the scan parent-AWARE: the same key (`participants`) resolves to
- * ProgramParticipant under Program (edge) but Participant under Household (not),
+ * ProgramParticipant under Program (edge) but Person under Household (not),
  * so we must know the enclosing model — a flat key match can't, and would either
  * miss the Program case (the #575 leak class) or false-flag the Household case. */
 const REL = relations as Record<string, Record<string, { model: string }>>;
@@ -365,7 +365,7 @@ describe('route auth drift-guard — every app/api/**/route.ts', () => {
             // The whole point: same key, different model by parent. If this map
             // shape changes, the parent-aware walk's assumptions broke.
             expect(REL.Program?.participants?.model).toBe('ProgramParticipant'); // edge
-            expect(REL.Household?.participants?.model).toBe('Participant'); // not edge
+            expect(REL.Household?.participants?.model).toBe('Person'); // not edge
         });
 
         for (const { rel, code } of routeFiles) {
@@ -469,13 +469,13 @@ describe('route auth drift-guard — detectors catch violations', () => {
         expect(findEdgeReadsInReads(stripComments(synthetic))).toEqual([]);
     });
 
-    it('does NOT flag Household.participants (same key, resolves to Participant — not edge)', () => {
+    it('does NOT flag Household.participants (same key, resolves to Person — not edge)', () => {
         const synthetic = `export const GET = withAuth({}, async () => prisma.household.findUnique({ include: { participants: true } }));`;
         expect(findEdgeReadsInReads(stripComments(synthetic))).toEqual([]);
     });
 
     it('does NOT flag an edge relation used only as a where-filter (no rows returned)', () => {
-        const synthetic = `export const GET = withAuth({}, async () => prisma.participant.findMany({ where: { programParticipants: { some: { programId: 1 } } } }));`;
+        const synthetic = `export const GET = withAuth({}, async () => prisma.person.findMany({ where: { programParticipants: { some: { programId: 1 } } } }));`;
         expect(findEdgeReadsInReads(stripComments(synthetic))).toEqual([]);
     });
 });

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -58,7 +58,7 @@ function referenceScopesHeld(
     }
     const scopes = new Set<Scope>(['everyones']);
     switch (modelName) {
-        case 'Participant': {
+        case 'Person': {
             const id = num(row.id);
             const householdId = num(row.householdId);
             if (id !== undefined && id === ctx.selfId) scopes.add('their_own');

--- a/checkin-app/tests/security/scopeValidators.test.ts
+++ b/checkin-app/tests/security/scopeValidators.test.ts
@@ -22,8 +22,8 @@ const CLS = classifications as unknown as Record<string, Record<string, string>>
 
 describe('validateBindings — field-existence (typo catcher)', () => {
     it('flags a binding field absent from the model', () => {
-        const bad: ScopeBindings = { Participant: { their_own: { field: 'householdID', eqCtx: 'householdId' } } };
-        expect(validateBindings(bad, CLS, new Set())).toContain('Participant.householdID — no such field');
+        const bad: ScopeBindings = { Person: { their_own: { field: 'householdID', eqCtx: 'householdId' } } };
+        expect(validateBindings(bad, CLS, new Set())).toContain('Person.householdID — no such field');
     });
 
     it('flags an unknown model', () => {
@@ -75,11 +75,11 @@ describe('validateBindings — Fee/RSVP dead-field cleanup + RSVP eventId re-add
 });
 
 describe('validateRouteGrants — seam check', () => {
-    const bindings: ScopeBindings = { Participant: { their_own: { field: 'id', eqCtx: 'selfId' } } };
+    const bindings: ScopeBindings = { Person: { their_own: { field: 'id', eqCtx: 'selfId' } } };
 
     it('flags a granted scope that no returned model binds', () => {
         const routes: RouteGrantSpec[] = [
-            { endpoint: '/api/x', orderedView: [['authenticated', ['their_households:pii']]], returns: ['Participant'] },
+            { endpoint: '/api/x', orderedView: [['authenticated', ['their_households:pii']]], returns: ['Person'] },
         ];
         const errs = validateRouteGrants(routes, bindings);
         expect(errs.some(e => e.includes("grants 'their_households:*'"))).toBe(true);
@@ -87,7 +87,7 @@ describe('validateRouteGrants — seam check', () => {
 
     it('passes when the grant resolves and ignores everyones', () => {
         const routes: RouteGrantSpec[] = [
-            { endpoint: '/api/y', orderedView: [['authenticated', ['their_own:pii', 'everyones:internal', 'public']]], returns: ['Participant'] },
+            { endpoint: '/api/y', orderedView: [['authenticated', ['their_own:pii', 'everyones:internal', 'public']]], returns: ['Person'] },
         ];
         expect(validateRouteGrants(routes, bindings)).toEqual([]);
     });

--- a/checkin-app/tests/security/stripper.test.ts
+++ b/checkin-app/tests/security/stripper.test.ts
@@ -72,37 +72,37 @@ describe('scopesHeld', () => {
         expect(scopesHeld('Tool', { id: 1 }, ctx())).toEqual(new Set(['everyones']));
     });
 
-    it('Participant.their_own when row.id === caller.selfId', () => {
-        const s = scopesHeld('Participant', { id: 5 }, ctx({ selfId: 5 }));
+    it('Person.their_own when row.id === caller.selfId', () => {
+        const s = scopesHeld('Person', { id: 5 }, ctx({ selfId: 5 }));
         expect(s.has('their_own')).toBe(true);
     });
 
-    it('Participant.their_own NOT held when row.id !== caller.selfId', () => {
-        const s = scopesHeld('Participant', { id: 7 }, ctx({ selfId: 5 }));
+    it('Person.their_own NOT held when row.id !== caller.selfId', () => {
+        const s = scopesHeld('Person', { id: 7 }, ctx({ selfId: 5 }));
         expect(s.has('their_own')).toBe(false);
     });
 
-    it('Participant.their_households when householdIds match', () => {
-        const s = scopesHeld('Participant', { id: 9, householdId: 2 }, ctx({ selfId: 5, householdId: 2 }));
+    it('Person.their_households when householdIds match', () => {
+        const s = scopesHeld('Person', { id: 9, householdId: 2 }, ctx({ selfId: 5, householdId: 2 }));
         expect(s.has('their_households')).toBe(true);
     });
 
-    it('Participant.their_program_participants when row.id in scope-programs set', () => {
+    it('Person.their_program_participants when row.id in scope-programs set', () => {
         const s = scopesHeld(
-            'Participant',
+            'Person',
             { id: 9 },
             ctx({ selfId: 5, participantIdsInScopePrograms: new Set([9, 10]) }),
         );
         expect(s.has('their_program_participants')).toBe(true);
     });
 
-    it('Participant.all_current_visitors requires isKeyholder AND row in active set', () => {
+    it('Person.all_current_visitors requires isKeyholder AND row in active set', () => {
         const ctxWithKey = ctx({ isKeyholder: true, activeVisitorIds: new Set([9]) });
-        expect(scopesHeld('Participant', { id: 9 }, ctxWithKey).has('all_current_visitors')).toBe(true);
-        expect(scopesHeld('Participant', { id: 99 }, ctxWithKey).has('all_current_visitors')).toBe(false);
+        expect(scopesHeld('Person', { id: 9 }, ctxWithKey).has('all_current_visitors')).toBe(true);
+        expect(scopesHeld('Person', { id: 99 }, ctxWithKey).has('all_current_visitors')).toBe(false);
 
         const ctxNoKey = ctx({ isKeyholder: false, activeVisitorIds: new Set([9]) });
-        expect(scopesHeld('Participant', { id: 9 }, ctxNoKey).has('all_current_visitors')).toBe(false);
+        expect(scopesHeld('Person', { id: 9 }, ctxNoKey).has('all_current_visitors')).toBe(false);
     });
 
     it('Visit.their_own when row.personId === selfId', () => {
@@ -136,20 +136,20 @@ describe('scopesHeld', () => {
 
 // ─── stripValue (the contributor-handler scenario) ─────────────────────────
 
-describe('stripValue — Participant', () => {
+describe('stripValue — Person', () => {
     const callerCtx = ctx({ selfId: 5 });
     const tokens = ['their_own:pii', 'their_own:personal', 'public'] as const;
 
     it('exposes pii on self row', () => {
         const row = { id: 5, name: 'Me', email: 'me@x.com', phone: '555' };
-        const out = stripValue('Participant', row, tokens, callerCtx);
+        const out = stripValue('Person', row, tokens, callerCtx);
         expect(out).toEqual({ id: 5, name: 'Me', email: 'me@x.com', phone: '555' });
     });
 
     it('strips pii on non-self row (THE buggy-handler case)', () => {
         // Simulates a contributor handler that fetched the wrong row.
         const row = { id: 7, name: 'Other', email: 'leaked@x.com', phone: '555' };
-        const out = stripValue('Participant', row, tokens, callerCtx) as Record<string, unknown>;
+        const out = stripValue('Person', row, tokens, callerCtx) as Record<string, unknown>;
         expect(out.id).toBe(7);
         expect(out.name).toBe('Other');
         expect(out.email).toBeUndefined();
@@ -158,7 +158,7 @@ describe('stripValue — Participant', () => {
 
     it('public-only view strips even name without "public" token', () => {
         const row = { id: 5, name: 'Me' };
-        const out = stripValue('Participant', row, ['their_own:pii'], callerCtx) as Record<string, unknown>;
+        const out = stripValue('Person', row, ['their_own:pii'], callerCtx) as Record<string, unknown>;
         expect(out.id).toBeUndefined();
         expect(out.name).toBeUndefined();
     });
@@ -166,7 +166,7 @@ describe('stripValue — Participant', () => {
     it('everyones:pii exposes pii on every row regardless of caller', () => {
         const stranger = ctx(); // no selfId
         const row = { id: 99, name: 'X', email: 'x@x.com' };
-        const out = stripValue('Participant', row, ['everyones:pii', 'public'], stranger) as Record<string, unknown>;
+        const out = stripValue('Person', row, ['everyones:pii', 'public'], stranger) as Record<string, unknown>;
         expect(out.email).toBe('x@x.com');
     });
 
@@ -175,21 +175,21 @@ describe('stripValue — Participant', () => {
         const leadCtx = ctx({ selfId: 5, programsLed: new Set([10]), participantIdsInScopePrograms: new Set([9]) });
         const row = { id: 9, name: 'P', email: 'p@x.com' };
         // View only grants the program-scoped pii, not their_own.
-        const out = stripValue('Participant', row, ['their_program_participants:pii', 'public'], leadCtx) as Record<string, unknown>;
+        const out = stripValue('Person', row, ['their_program_participants:pii', 'public'], leadCtx) as Record<string, unknown>;
         expect(out.email).toBe('p@x.com');
         // Same view but a row outside the program — email stripped.
         const outsider = { id: 999, name: 'Q', email: 'q@x.com' };
-        const out2 = stripValue('Participant', outsider, ['their_program_participants:pii', 'public'], leadCtx) as Record<string, unknown>;
+        const out2 = stripValue('Person', outsider, ['their_program_participants:pii', 'public'], leadCtx) as Record<string, unknown>;
         expect(out2.email).toBeUndefined();
     });
 
     it('their_households grants household members on self/household rows', () => {
         const homeCtx = ctx({ selfId: 5, householdId: 2 });
         const sibling = { id: 6, name: 'Sib', householdId: 2, notificationSettings: { emailNewsletter: true } };
-        const out = stripValue('Participant', sibling, ['their_households:personal', 'public'], homeCtx) as Record<string, unknown>;
+        const out = stripValue('Person', sibling, ['their_households:personal', 'public'], homeCtx) as Record<string, unknown>;
         expect(out.notificationSettings).toEqual({ emailNewsletter: true });
         const stranger = { id: 7, name: 'X', householdId: 99, notificationSettings: { emailNewsletter: true } };
-        const out2 = stripValue('Participant', stranger, ['their_households:personal', 'public'], homeCtx) as Record<string, unknown>;
+        const out2 = stripValue('Person', stranger, ['their_households:personal', 'public'], homeCtx) as Record<string, unknown>;
         expect(out2.notificationSettings).toBeUndefined();
     });
 });
@@ -214,7 +214,7 @@ describe('stripValue — arrays', () => {
             { id: 5, name: 'me', email: 'me@x.com' },
             { id: 7, name: 'them', email: 'them@x.com' },
         ];
-        const out = stripValue('Participant', rows, tokens, callerCtx) as Record<string, unknown>[];
+        const out = stripValue('Person', rows, tokens, callerCtx) as Record<string, unknown>[];
         expect(out[0].email).toBe('me@x.com');
         expect(out[1].email).toBeUndefined();
         expect(out[1].name).toBe('them');
@@ -222,7 +222,7 @@ describe('stripValue — arrays', () => {
 });
 
 describe('stripValue — nested relations', () => {
-    it('recursively strips household relation on a Participant', () => {
+    it('recursively strips household relation on a Person', () => {
         const callerCtx = ctx({ selfId: 5, householdId: 2 });
         const tokens = ['their_own:pii', 'public'] as const; // no household:personal granted
         const row = {
@@ -231,7 +231,7 @@ describe('stripValue — nested relations', () => {
             email: 'me@x.com',
             household: { id: 2, name: 'Home', line1: 'private street' },
         };
-        const out = stripValue('Participant', row, tokens, callerCtx) as Record<string, unknown>;
+        const out = stripValue('Person', row, tokens, callerCtx) as Record<string, unknown>;
         expect(out.email).toBe('me@x.com');
         const household = out.household as Record<string, unknown>;
         expect(household.id).toBe(2);
@@ -247,7 +247,7 @@ describe('stripValue — nested relations', () => {
             email: 'me@x.com',
             household: { id: 2, name: 'Home', line1: 'private street' },
         };
-        const out = stripValue('Participant', row, tokens, callerCtx) as Record<string, unknown>;
+        const out = stripValue('Person', row, tokens, callerCtx) as Record<string, unknown>;
         const household = out.household as Record<string, unknown>;
         expect(household.line1).toBe('private street');
     });
@@ -334,16 +334,16 @@ describe('stripValue — nested EmergencyContact (the leak)', () => {
 describe('stripValue — _count gating', () => {
     it('preserves _count for a relation the view can see (Visit has a public field)', () => {
         const row = { id: 5, name: 'Me', _count: { visits: 3 } };
-        const out = stripValue('Participant', row, ['public'], ctx({ selfId: 5 })) as Record<string, unknown>;
+        const out = stripValue('Person', row, ['public'], ctx({ selfId: 5 })) as Record<string, unknown>;
         expect(out._count).toEqual({ visits: 3 });
     });
 
     it('strips a _count the low-privilege view has no grant on', () => {
         // RawBadgeLog has no public field — its fields are personal/internal.
         // A view with only `public` cannot see any RawBadgeLog field, so the
-        // count of a Participant's rawBadgeLogs must not leak.
+        // count of a Person's rawBadgeLogs must not leak.
         const row = { id: 5, name: 'Me', _count: { rawBadgeLogs: 9 } };
-        const out = stripValue('Participant', row, ['public'], ctx({ selfId: 5 })) as Record<string, unknown>;
+        const out = stripValue('Person', row, ['public'], ctx({ selfId: 5 })) as Record<string, unknown>;
         expect(out._count).toBeUndefined();
     });
 
@@ -351,32 +351,32 @@ describe('stripValue — _count gating', () => {
         // `their_own:personal` on the caller's own row grants RawBadgeLog's
         // personal-tier fields (time/location), so the count is now visible.
         const row = { id: 5, name: 'Me', _count: { rawBadgeLogs: 9 } };
-        const out = stripValue('Participant', row, ['their_own:personal', 'public'], ctx({ selfId: 5 })) as Record<string, unknown>;
+        const out = stripValue('Person', row, ['their_own:personal', 'public'], ctx({ selfId: 5 })) as Record<string, unknown>;
         expect(out._count).toEqual({ rawBadgeLogs: 9 });
     });
 
     it('strips only the ungranted keys from a mixed _count', () => {
         const row = { id: 5, name: 'Me', _count: { visits: 3, rawBadgeLogs: 9 } };
-        const out = stripValue('Participant', row, ['public'], ctx({ selfId: 5 })) as Record<string, unknown>;
+        const out = stripValue('Person', row, ['public'], ctx({ selfId: 5 })) as Record<string, unknown>;
         expect(out._count).toEqual({ visits: 3 });
     });
 
     it('drops unknown relation keys (fail-closed)', () => {
         const row = { id: 5, name: 'Me', _count: { notARelation: 7 } };
-        const out = stripValue('Participant', row, ['public'], ctx({ selfId: 5 })) as Record<string, unknown>;
+        const out = stripValue('Person', row, ['public'], ctx({ selfId: 5 })) as Record<string, unknown>;
         expect(out._count).toBeUndefined();
     });
 });
 
 describe('stripValue — edge cases', () => {
     it('null and undefined pass through unchanged', () => {
-        expect(stripValue('Participant', null, ['public'], ctx())).toBeNull();
-        expect(stripValue('Participant', undefined, ['public'], ctx())).toBeUndefined();
+        expect(stripValue('Person', null, ['public'], ctx())).toBeNull();
+        expect(stripValue('Person', undefined, ['public'], ctx())).toBeUndefined();
     });
 
     it('empty tokens strip everything to an empty object', () => {
         const row = { id: 5, name: 'Me', email: 'me@x.com' };
-        const out = stripValue('Participant', row, [], ctx({ selfId: 5 })) as Record<string, unknown>;
+        const out = stripValue('Person', row, [], ctx({ selfId: 5 })) as Record<string, unknown>;
         expect(out).toEqual({});
     });
 
@@ -390,8 +390,8 @@ describe('stripValue — edge cases', () => {
 
 describe('stripBag', () => {
     it('drops unknown-model bag entries with a warn', () => {
-        const out = stripBag({ Participant: { id: 5, name: 'Me' }, NotAModel: { foo: 'bar' } }, ['public'], ctx({ selfId: 5 }));
-        expect(out.Participant).toEqual({ id: 5, name: 'Me' });
+        const out = stripBag({ Person: { id: 5, name: 'Me' }, NotAModel: { foo: 'bar' } }, ['public'], ctx({ selfId: 5 }));
+        expect(out.Person).toEqual({ id: 5, name: 'Me' });
         expect(out.NotAModel).toBeUndefined();
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'NotAModel'"));
     });
@@ -399,13 +399,13 @@ describe('stripBag', () => {
     it('strips each known model with the same tokens/context', () => {
         const out = stripBag(
             {
-                Participant: { id: 5, name: 'Me', email: 'me@x.com' },
+                Person: { id: 5, name: 'Me', email: 'me@x.com' },
                 Household: { id: 2, name: 'Home', line1: 'street' },
             },
             ['their_own:pii', 'their_households:personal', 'public'],
             ctx({ selfId: 5, householdId: 2 }),
         );
-        expect((out.Participant as Record<string, unknown>).email).toBe('me@x.com');
+        expect((out.Person as Record<string, unknown>).email).toBe('me@x.com');
         expect((out.Household as Record<string, unknown>).line1).toBe('street');
     });
 });


### PR DESCRIPTION
## Phase A2 — atomic model rename `Participant` → `Person`

Final, atomic slice of the Person-umbrella rename. A0 + all six A1 FK slices already landed, so every FK column is `personId`; this flips **only** the model name and everything Prisma derives from it. Renaming the model breaks every `prisma.participant` accessor and `Prisma.Participant*` type at once — tsc stays red until all change, so this is one pass.

## What changed

**Schema (`prisma/schema.prisma`)**
- `model Participant` → `model Person`; all **19 relation target types** `Participant` → `Person`.
- Unchanged (Phase B): relation FIELD names, FK columns, wire keys (`participantId`, `participant_id`, `ProgramParticipant*`, `maxParticipants`), and `@relation("…")` name strings.
- Migration `rename_participant_model_to_person` drop+recreates the table (DB wiped on deploy — no data care).

**Mechanical code**
- `prisma.participant` **and** `tx.participant` / `db.participant.<method>` delegate accessors → `.person`.
- `Prisma.Participant*` generated types → `Prisma.Person*`.
- Imported generated `Participant` type (`scan-service.ts`, `scanCausalChain`).
- `participantProjection.ts` type + prose → Person.

**Security config (tsc-blind — string model keys)**
- `scopeBindings.ts` model key `Participant:` → `Person:`.
- `registry.ts` `returns:[…'Participant'…]` bags + comments → `Person`.
- 4 handler/outbound bag envelopes `{ Participant: … }` → `{ Person: … }` — internal tier-stripping key; client wire envelope comes from `spec.envelope`, so **frontend contract is unaffected**.
- Generated `classifications.ts` regenerated by `prisma generate` → Person.
- Security test oracles (outbound / stripper / scopeValidators / scopeBindingsEquivalence / routeAuthDrift) + prisma-delegate mock keys across 13 test files.

**Left for Phase B (intentionally unchanged):** audit `tableName: "Participant"` labels, `participantId` wire keys, program-enrollee `participant` UI copy.

## Reviewer notes
- tsc alone is **not** sufficient here — two surfaces compiled green but failed at runtime and were caught only by full jest: the 4 bag-envelope keys and the security oracles (matches this repo's prior rename history).
- Bag-key rename is client-safe: verified `handler.ts` discards the internal bag key and emits `spec.envelope`.

## Verification
- `tsc --noEmit`: **clean**
- jest unit: **182 suites / 1086 tests pass**
- jest integration (throwaway Postgres, `--runInBand`): **105 suites / 830 tests pass**
- Residue greps (`prisma.participant`, `.participant.<method>`, `Prisma.Participant`, `model Participant`, generated-`Participant` import): all **0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)