### PR TITLE
refactor(certifications): cert grid copy participant→people (B4)

### DIFF
--- a/checkin-app/src/app/attendance/certifications/page.tsx
+++ b/checkin-app/src/app/attendance/certifications/page.tsx
@@ -201,14 +201,14 @@ function KioskCertificationsInner() {
         ) : error ? (
           <Alert color="red">{error}</Alert>
         ) : participants.length === 0 || tools.length === 0 ? (
-          <Center py="xl"><Text c="dimmed">No {limitToPresent ? "active participants" : "participants"} found.</Text></Center>
+          <Center py="xl"><Text c="dimmed">No {limitToPresent ? "active people" : "people"} found.</Text></Center>
         ) : (
           <div ref={containerRef} style={{ flex: 1, overflowX: 'hidden', borderRadius: 8, border: cellBorder, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
             <table style={{ borderCollapse: 'collapse', textAlign: 'left', width: '100%', tableLayout: isKioskMode ? 'fixed' : undefined }}>
               <thead style={{ position: 'sticky', top: 0, zIndex: 10 }}>
                 <tr>
                   <th style={{ padding: isKioskMode ? '0.5rem 0.75rem' : '1rem', borderBottom: cellBorder, background: 'var(--mantine-color-default-hover)', position: 'sticky', left: 0, zIndex: 11, borderRight: cellBorder, verticalAlign: 'bottom', width: isKioskMode ? '12%' : 150, fontWeight: 700 }}>
-                    Participant
+                    Name
                   </th>
                   {tools.map((tool) => (
                     <th key={tool.id} style={{ borderBottom: cellBorder, borderRight: cellBorder, background: 'var(--mantine-color-default-hover)', fontSize: isKioskMode ? '0.8rem' : '0.875rem', fontWeight: 700, verticalAlign: 'bottom', padding: isKioskMode ? '0.4rem 0.2rem' : '0.5rem', textAlign: 'center', wordBreak: 'break-word', lineHeight: 1.2 }}>


### PR DESCRIPTION
## Phase B4 — person-umbrella terminology (UI copy only)

The certifications grid shows **every person present** (mixed roles/ages), not program enrollees, so its visible "Participant" copy misreads. `participant` is reserved for program enrollees only.

### Changes (`checkin-app/src/app/attendance/certifications/page.tsx`)
- `<th>` column header `Participant` → `Name`
- empty-state `No active participants / participants found` → `No active people / people found` (kept the `limitToPresent` conditional)

Visible strings only — no logic, no local-type change (already `Person` from A0), no data-shape change. `current/page.tsx` checked: all `participant` refs are variable/field names, zero visible copy — untouched.

### Notes
- Independent of Phase A2 (Prisma `Participant`→`Person` model rename); rebased directly onto `main`.

### Verify
- `npx tsc --noEmit` clean against `main`
- Attendance component tests (all 3 roots): 5 suites / 13 tests pass (cert, current, manual, household, attendance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)