### PR TITLE
refactor(people): rename /api/participants/search → /api/people/search (B2)

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -78,7 +78,7 @@ const AUTHZ_TESTED = new Set<string>([
     'membership-ops/participants/merge',
     'membership-ops/participants/merge/analyze',
     'membership/reviews',
-    'participants/search',
+    'people/search',
     'programs',
     'roles',
     'safety/board-contacts',

--- a/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
@@ -5,11 +5,11 @@
  * Authorization-boundary tests for sensitive (PII / impersonation) routes that
  * previously had no integration coverage. Focus: who is rejected.
  *   - GET /api/safety/emergency-contacts   (isSysadmin | isBoardMember | isKeyholder)
- *   - GET /api/participants/search  (isSysadmin | isBoardMember — isKeyholder MUST be denied)
+ *   - GET /api/people/search  (isSysadmin | isBoardMember — isKeyholder MUST be denied)
  *   - GET /api/auth/dev-personas          (impersonation surface; 404 outside dev)
  */
 import { GET as EmergencyGet } from '@/app/api/safety/emergency-contacts/route';
-import { GET as SearchGet } from '@/app/api/participants/search/route';
+import { GET as SearchGet } from '@/app/api/people/search/route';
 import { GET as DevPersonasGet } from '@/app/api/auth/dev-personas/route';
 import { GET as CertsGet } from '@/app/api/kioskdisplay/certifications/route';
 import prisma from '@/lib/prisma';
@@ -85,8 +85,8 @@ describe('Sensitive route authorization', () => {
         });
     });
 
-    describe('GET /api/participants/search', () => {
-        const url = `http://localhost/api/participants/search?q=ZZTarget`;
+    describe('GET /api/people/search', () => {
+        const url = `http://localhost/api/people/search?q=ZZTarget`;
 
         it('401 when unauthenticated', async () => {
             mockSession.mockResolvedValue(null);
@@ -108,7 +108,7 @@ describe('Sensitive route authorization', () => {
             const res = await SearchGet(req(url));
             expect(res.status).toBe(200);
             const json = await res.json();
-            const hit = json.participants.find((p: { id: number }) => p.id === searchTargetId);
+            const hit = json.people.find((p: { id: number }) => p.id === searchTargetId);
             expect(hit).toBeDefined();
             expect(hit.phone).toBe('555-0101');
         });

--- a/checkin-app/src/app/api/people/search/route.ts
+++ b/checkin-app/src/app/api/people/search/route.ts
@@ -15,7 +15,7 @@ export const GET = withAuth(
             const eighteenYearsAgo = new Date();
             eighteenYearsAgo.setFullYear(eighteenYearsAgo.getFullYear() - 18);
 
-            const participants = await prisma.person.findMany({
+            const people = await prisma.person.findMany({
                 where: q ? {
                     OR: [
                         { name: { contains: q, mode: 'insensitive' } },
@@ -34,7 +34,7 @@ export const GET = withAuth(
                 }
             });
 
-            const formatted = participants.map(p => ({
+            const formatted = people.map(p => ({
                 id: p.id,
                 name: p.name,
                 email: p.email,
@@ -45,10 +45,10 @@ export const GET = withAuth(
                 household: p.household,
             }));
 
-            return NextResponse.json({ participants: formatted });
+            return NextResponse.json({ people: formatted });
         } catch (error) {
-            console.error("Failed to fetch participants:", error);
-            return NextResponse.json({ error: "Failed to fetch participants" }, { status: 500 });
+            console.error("Failed to fetch people:", error);
+            return NextResponse.json({ error: "Failed to fetch people" }, { status: 500 });
         }
     }
 );

--- a/checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx
@@ -38,7 +38,7 @@ const participants = [
 describe("facility-ops/print-badges page", () => {
   it("loads and renders the participant roster", async () => {
     setSession({ id: 1, isSysadmin: true });
-    mockFetchJson({ "/api/participants/search": { participants } });
+    mockFetchJson({ "/api/people/search": { people: participants } });
     renderWithProviders(<PrintBadgesPage />);
 
     expect(await screen.findByText("Kim Keyholder")).toBeInTheDocument();
@@ -49,7 +49,7 @@ describe("facility-ops/print-badges page", () => {
 
   it("re-searches participants as the search box changes", async () => {
     setSession({ id: 1, isSysadmin: true });
-    const fetchMock = mockFetchJson({ "/api/participants/search": { participants } });
+    const fetchMock = mockFetchJson({ "/api/people/search": { people: participants } });
     renderWithProviders(<PrintBadgesPage />);
     await screen.findByText("Kim Keyholder");
 
@@ -62,7 +62,7 @@ describe("facility-ops/print-badges page", () => {
 
   it("selects participants and generates a badge PDF", async () => {
     setSession({ id: 1, isSysadmin: true });
-    mockFetchJson({ "/api/participants/search": { participants } });
+    mockFetchJson({ "/api/people/search": { people: participants } });
     renderWithProviders(<PrintBadgesPage />);
     await screen.findByText("Kim Keyholder");
 

--- a/checkin-app/src/app/facility-ops/print-badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/page.tsx
@@ -39,13 +39,13 @@ export default function PrintBadgesPage() {
   const fetchParticipants = useCallback(async () => {
     setLoading(true);
     try {
-      const url = new URL('/api/participants/search', window.location.origin);
+      const url = new URL('/api/people/search', window.location.origin);
       if (searchTerm) url.searchParams.set('q', searchTerm);
 
       const res = await fetch(url.toString());
       const data = await res.json();
-      if (data.participants) {
-        setParticipants(data.participants);
+      if (data.people) {
+        setParticipants(data.people);
       }
     } catch (e) {
       console.error(e);

--- a/checkin-app/src/app/membership-ops/participants/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/__tests__/page.test.tsx
@@ -25,7 +25,7 @@ const carol = { id: 3, name: "Carol C", email: null, phone: null, household: nul
 describe("AdminParticipantsIndex", () => {
     it("searches, sorts, and edits a participant's details", async () => {
         mockFetchJson({
-            "/api/participants/search": { participants: [alice, bob] },
+            "/api/people/search": { people: [alice, bob] },
             "/api/membership-ops/participants/1": { participant: { id: 1, name: "Alice A", email: "alice@new.com", phone: "555-2222" } },
         });
         renderWithProviders(<AdminParticipantsIndex />);
@@ -47,18 +47,18 @@ describe("AdminParticipantsIndex", () => {
         const aliceRow = screen.getByText("Alice A").closest("tr")!;
         fireEvent.click(within(aliceRow).getByRole("button", { name: "Details" }));
 
-        expect(await screen.findByText("Edit Participant")).toBeInTheDocument();
+        expect(await screen.findByText("Edit Person")).toBeInTheDocument();
         const emailInput = screen.getByLabelText("Email Address");
         fireEvent.change(emailInput, { target: { value: "alice@new.com" } });
         fireEvent.click(screen.getByRole("button", { name: "Save Details" }));
 
-        await waitFor(() => expect(screen.queryByText("Edit Participant")).not.toBeInTheDocument());
-        expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Participant updated successfully!" }));
+        await waitFor(() => expect(screen.queryByText("Edit Person")).not.toBeInTheDocument());
+        expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Person updated successfully!" }));
     });
 
     it("assigns a new household to a participant with none", async () => {
         mockFetchJson({
-            "/api/participants/search": { participants: [carol] },
+            "/api/people/search": { people: [carol] },
             "/api/membership-ops/participants/3/household": {
                 participant: { ...carol, household: { id: 50, name: "Carol Household", householdMembers: [{ id: 3, name: "Carol C", email: null }] } },
             },

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -14,7 +14,7 @@ type HouseholdRef = {
   householdMembers: { id: number; name: string | null; email: string | null }[];
 };
 
-type ParticipantRow = {
+type PersonRow = {
   id: number;
   name: string | null;
   email: string | null;
@@ -24,7 +24,7 @@ type ParticipantRow = {
 
 export default function AdminParticipantsIndex() {
   const [searchQuery, setSearchQuery] = useState("");
-  const [results, setResults] = useState<ParticipantRow[]>([]);
+  const [results, setResults] = useState<PersonRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [sortBy, setSortBy] = useState<"id" | "name" | "email" | "household">("id");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
@@ -65,10 +65,10 @@ export default function AdminParticipantsIndex() {
   const fetchParticipants = async (query = "") => {
     setLoading(true);
     try {
-      const res = await fetch(`/api/participants/search?q=${encodeURIComponent(query)}`);
+      const res = await fetch(`/api/people/search?q=${encodeURIComponent(query)}`);
       const data = await res.json();
-      if (data.participants) {
-        setResults(data.participants);
+      if (data.people) {
+        setResults(data.people);
       }
     } catch (err) {
       console.error(err);
@@ -78,7 +78,7 @@ export default function AdminParticipantsIndex() {
   };
 
   const [assignModalOpen, setAssignModalOpen] = useState(false);
-  const [selectedParticipant, setSelectedParticipant] = useState<ParticipantRow | null>(null);
+  const [selectedParticipant, setSelectedParticipant] = useState<PersonRow | null>(null);
   const [householdId, setHouseholdId] = useState("");
   const [householdSearch, setHouseholdSearch] = useState("");
   const [assigning, setAssigning] = useState(false);
@@ -86,7 +86,7 @@ export default function AdminParticipantsIndex() {
 
   // Edit Participant State
   const [editModalOpen, setEditModalOpen] = useState(false);
-  const [editingParticipant, setEditingParticipant] = useState<ParticipantRow | null>(null);
+  const [editingParticipant, setEditingParticipant] = useState<PersonRow | null>(null);
   const [editForm, setEditForm] = useState({ name: "", email: "", phone: "" });
   const [savingDetails, setSavingDetails] = useState(false);
 
@@ -157,10 +157,10 @@ export default function AdminParticipantsIndex() {
         setResults(results.map(p => p.id === editingParticipant.id ? { ...p, ...data.participant } : p));
         setEditModalOpen(false);
         setEditingParticipant(null);
-        showNotification("Participant updated successfully!");
+        showNotification("Person updated successfully!");
       } else {
         const data = await res.json().catch(() => ({}));
-        showNotification(data.error || "Failed to update participant", "error");
+        showNotification(data.error || "Failed to update person", "error");
       }
     } catch (err) {
       console.error(err);
@@ -177,11 +177,11 @@ export default function AdminParticipantsIndex() {
     <Stack maw={1000} mx="auto">
       <Group justify="space-between" align="flex-start" wrap="wrap">
         <div>
-          <Text c="dimmed">Search and manage system participants and households.</Text>
+          <Text c="dimmed">Search and manage system people and households.</Text>
         </div>
         <Group>
           <Button variant="light" onClick={() => router.push('/membership-ops/participants/import')}>Bulk Import</Button>
-          <Button color="green" onClick={() => router.push('/membership-ops/participants/new')}>+ New Participant</Button>
+          <Button color="green" onClick={() => router.push('/membership-ops/participants/new')}>+ New Person</Button>
         </Group>
       </Group>
 
@@ -253,7 +253,7 @@ export default function AdminParticipantsIndex() {
               </Table>
             </Table.ScrollContainer>
           ) : searchQuery && !loading ? (
-            <Text ta="center" c="dimmed">No participants found.</Text>
+            <Text ta="center" c="dimmed">No people found.</Text>
           ) : null}
         </Box>
       </Card>
@@ -318,7 +318,7 @@ export default function AdminParticipantsIndex() {
       </Modal>
 
       {/* Edit participant modal */}
-      <Modal opened={editModalOpen} onClose={() => { setEditModalOpen(false); setEditingParticipant(null); }} title={<Text span fw={700} fz="lg">Edit Participant</Text>} size="lg">
+      <Modal opened={editModalOpen} onClose={() => { setEditModalOpen(false); setEditingParticipant(null); }} title={<Text span fw={700} fz="lg">Edit Person</Text>} size="lg">
         <form onSubmit={handleEditParticipant}>
           <Stack>
             {/* Read e.currentTarget.value synchronously into a local before the setState

--- a/checkin-app/src/app/program-ops/new/page.tsx
+++ b/checkin-app/src/app/program-ops/new/page.tsx
@@ -128,10 +128,10 @@ export default function CreateProgramPage() {
               selectedId={leadMentorId || null}
               selectedLabel={mentorSearch}
               search={async (q) => {
-                const res = await fetch(`/api/participants/search?q=${encodeURIComponent(q)}&filter=adults`);
+                const res = await fetch(`/api/people/search?q=${encodeURIComponent(q)}&filter=adults`);
                 if (!res.ok) return [];
                 const data = await res.json();
-                return data.participants || [];
+                return data.people || [];
               }}
               getOptionLabel={(p) => p.name || 'Unnamed'}
               getOptionDescription={(p) => p.email}

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -120,10 +120,10 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
 
   // Lead-mentor picker searches adult members.
   const searchAdults = useCallback(async (query: string): Promise<ParticipantOption[]> => {
-    const res = await fetch(`/api/participants/search?q=${encodeURIComponent(query)}&filter=adults`);
+    const res = await fetch(`/api/people/search?q=${encodeURIComponent(query)}&filter=adults`);
     if (!res.ok) return [];
     const data = await res.json();
-    return data.participants || [];
+    return data.people || [];
   }, []);
 
   const handleSaveGeneral = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Phase B2 — person-umbrella terminology

`participant` is now reserved for **program enrollees only**. The search route runs an unfiltered `prisma.person.findMany` and returns every human (a mixed set), so it is a *people* search, not a participant search.

## Changes
- **Move API route dir** `api/participants/search` → `api/people/search` (`git mv`); response envelope `{ participants }` → `{ people }`; internal var renamed.
- **Consumers** updated (fetch URL + `data.participants` → `data.people`): membership-ops/participants browser page, facility-ops/print-badges, program-ops/programs/[id], program-ops/new.
- **Browser page**: `type ParticipantRow` → `PersonRow`; visible participant copy → people/person.
- **authzRegistry drift guard**: `AUTHZ_TESTED` entry `participants/search` → `people/search` (tsc-blind; caught by jest).

## Scope
UI dir `membership-ops/participants/` is **not** moved (later cosmetic slice). `merge/`, `import/`, `new/` untouched — `merge/` still fetches the old URL until B3.

## Verify
- `npx tsc --noEmit` clean.
- Full jest (`INTEGRATION_DB=1 --runInBand`, throwaway PG): **287 suites / 1916 tests pass**. Only failure is a `.flow.test.ts` needing a live dev server (pre-existing infra, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)