### PR TITLE
refactor(roles): rename /api/roles response envelope participants → people (B1)

### DIFF
--- a/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
@@ -112,15 +112,15 @@ describe('Admin Roles API Integration Tests', () => {
             expect(res.status).toBe(200);
 
             const data = await res.json();
-            expect(data.participants).toBeDefined();
-            expect(Array.isArray(data.participants)).toBe(true);
+            expect(data.people).toBeDefined();
+            expect(Array.isArray(data.people)).toBe(true);
 
-            const ids = data.participants.map((p: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => p.id);
+            const ids = data.people.map((p: { id?: number; email?: string; name?: string; participantId?: number; level?: string; status?: string; role?: string; type?: string; [key: string]: unknown }) => p.id);
             expect(ids).toContain(testTargetUserId);
             // Youth are returned (client filters via "Hide Youth"), flagged isYouth; dob is not leaked.
             expect(ids).toContain(testStudentId);
-            const adult = data.participants.find((p: { id?: number }) => p.id === testTargetUserId);
-            const student = data.participants.find((p: { id?: number }) => p.id === testStudentId);
+            const adult = data.people.find((p: { id?: number }) => p.id === testTargetUserId);
+            const student = data.people.find((p: { id?: number }) => p.id === testStudentId);
             expect(adult.isYouth).toBe(false);
             expect(student.isYouth).toBe(true);
             expect(adult).not.toHaveProperty('dateOfBirth');

--- a/checkin-app/src/app/api/roles/route.ts
+++ b/checkin-app/src/app/api/roles/route.ts
@@ -23,11 +23,11 @@ export const GET = withAuth(
                 orderBy: { name: "asc" },
             });
             // Don't leak dob (PII); expose only a youth flag for filtering.
-            const participants = rows.map(({ dateOfBirth, ...p }: (typeof rows)[number]) => ({
+            const people = rows.map(({ dateOfBirth, ...p }: (typeof rows)[number]) => ({
                 ...p,
                 isYouth: dateOfBirth != null && dateOfBirth > eighteenYearsAgo,
             }));
-            return NextResponse.json({ participants });
+            return NextResponse.json({ people });
         } catch (error) {
             console.error("Error fetching roles:", error);
             return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
+++ b/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
@@ -30,7 +30,7 @@ const householdData = {
 function mockRoutes(overrides: Record<string, unknown | (() => unknown)> = {}) {
   return mockFetchJson({
     "/api/household": householdData,
-    "/api/roles": { participants: [{ id: 555, name: "Wendy West", email: "wendy@example.com", isKeyholder: false, isSysadmin: false }] },
+    "/api/roles": { people: [{ id: 555, name: "Wendy West", email: "wendy@example.com", isKeyholder: false, isSysadmin: false }] },
     "/api/attendance": attendanceData,
     ...overrides,
   });

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -162,7 +162,7 @@ function KioskDisplayInner() {
         const res = await fetch(`/api/roles`);
         if (res.ok) {
           const data = await res.json();
-          const filtered = data.participants.filter(
+          const filtered = data.people.filter(
             (p: Person) =>
               (p.name || "").toLowerCase().includes((searchQuery || "").toLowerCase()) ||
               (p.email || "").toLowerCase().includes((searchQuery || "").toLowerCase())

--- a/checkin-app/src/app/settings/roles/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/roles/__tests__/page.test.tsx
@@ -16,7 +16,7 @@ const users = [
 describe("RoleAssignmentPage", () => {
     it("loads and lists users, hiding youth by default", async () => {
         setSession({ id: 1, isSysadmin: true });
-        mockFetchJson({ "/api/roles": { participants: users } });
+        mockFetchJson({ "/api/roles": { people: users } });
         renderWithProviders(<RoleAssignmentPage />);
 
         expect(await screen.findByText("Ann Admin")).toBeInTheDocument();
@@ -26,7 +26,7 @@ describe("RoleAssignmentPage", () => {
     it("filters by search text and toggles a role checkbox", async () => {
         setSession({ id: 1, isSysadmin: true });
         const fetchSpy = mockFetchJson({
-            "/api/roles": () => ({ participants: users }),
+            "/api/roles": () => ({ people: users }),
         });
         renderWithProviders(<RoleAssignmentPage />);
 

--- a/checkin-app/src/app/settings/roles/page.tsx
+++ b/checkin-app/src/app/settings/roles/page.tsx
@@ -41,7 +41,7 @@ export default function RoleAssignmentPage() {
       const res = await fetch('/api/roles');
       if (res.ok) {
         const data = await res.json();
-        setUsers(data.participants);
+        setUsers(data.people);
       } else {
         setMessage("Failed to load user list.");
       }


### PR DESCRIPTION
## Phase B1 — person-umbrella terminology

`participant` is now reserved for program enrollees (`ProgramParticipant`) only. `/api/roles` returns **every** person (sysadmins, board, keyholders, youth) for the role-management grid — a mixed set — so its response envelope must not be called `participants`.

## Change
- `api/roles/route.ts`: GET response `{ participants }` → `{ people }`; internal variable renamed. `isYouth` flag and everything else unchanged.
- Consumers of the response `.participants` updated: `settings/roles/page.tsx`, `attendance/current/page.tsx` search, plus test mocks and the integration assertion.
- Prisma layer (`prisma.person`), route path, and DB unchanged.

No `src/security/**` envelope declares this route (verified), so no security-registry change needed.

## Verify
- `tsc --noEmit`: clean
- Unit (roles + attendance): 7/7 pass
- Integration tier incl. `adminRolesAPI` / `authzRoleRejection` / `auditLog`: 830/830 pass

Builds on Phase A2 (`Participant`→`Person`), already merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)