### PR TITLE
refactor(household): rename Household.participants relation → householdMembers (B3)

### DIFF
--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -166,7 +166,7 @@ model Household {
   /// @sensitivity:personal
   postalCode String?
 
-  participants      Person[]
+  householdMembers  Person[]
   leads             HouseholdLead[]
   membership        Membership?
   trustedAdults     TrustedAdult[]

--- a/checkin-app/src/app/__tests__/adminBulkImportMalformedRow.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportMalformedRow.integration.test.ts
@@ -27,7 +27,7 @@ describe('Bulk import: malformed row among valid rows', () => {
             await prisma.householdLead.deleteMany({});
             await prisma.person.deleteMany({ where: { email: { contains: 'malrow-import-test' } } });
             await prisma.person.deleteMany({ where: { name: { contains: 'Malrow Import Test' } } });
-            await prisma.household.deleteMany({ where: { participants: { none: {} } } });
+            await prisma.household.deleteMany({ where: { householdMembers: { none: {} } } });
         } catch {}
     };
 

--- a/checkin-app/src/app/__tests__/adminBulkImportMergeRollback.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportMergeRollback.integration.test.ts
@@ -36,7 +36,7 @@ describe('Bulk import merge rollback', () => {
             await prisma.membership.deleteMany({});
             await prisma.householdLead.deleteMany({});
             await prisma.person.deleteMany({ where: { email: { contains: 'mergeroll-test' } } });
-            await prisma.household.deleteMany({ where: { participants: { none: {} } } });
+            await prisma.household.deleteMany({ where: { householdMembers: { none: {} } } });
         } catch {}
     };
 

--- a/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
@@ -49,7 +49,7 @@ describe('Bulk import: preview vs commit consistency', () => {
             await prisma.householdLead.deleteMany({});
             await prisma.person.deleteMany({ where: { email: { contains: 'consist-import-test' } } });
             await prisma.person.deleteMany({ where: { name: { contains: 'Consist Import Test' } } });
-            await prisma.household.deleteMany({ where: { participants: { none: {} } } });
+            await prisma.household.deleteMany({ where: { householdMembers: { none: {} } } });
         } catch {}
     };
 

--- a/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
@@ -54,7 +54,7 @@ describe('Admin Participants API Integration Tests', () => {
         // doesn't own could share a similar name (e.g. "Test Household"), and the
         // Participant->Household FK is RESTRICT.
         if (householdIds.length) {
-            await prisma.household.deleteMany({ where: { id: { in: householdIds }, participants: { none: {} } } });
+            await prisma.household.deleteMany({ where: { id: { in: householdIds }, householdMembers: { none: {} } } });
         }
     }
 

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -19,10 +19,10 @@ describe("GET /api/cron/post-event", () => {
         await prisma.person.deleteMany({ where: { email: { contains: 'example.com' } } });
         // Global participant-less household delete: clear the membership chain for those
         // households first or Membership_householdId_fkey (RESTRICT) blocks the delete.
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { participants: { none: {} } } } } } });
-        await prisma.membershipProcess.deleteMany({ where: { membership: { household: { participants: { none: {} } } } } });
-        await prisma.membership.deleteMany({ where: { household: { participants: { none: {} } } } });
-        await prisma.household.deleteMany({ where: { participants: { none: {} } } });
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { householdMembers: { none: {} } } } } } });
+        await prisma.membershipProcess.deleteMany({ where: { membership: { household: { householdMembers: { none: {} } } } } });
+        await prisma.membership.deleteMany({ where: { household: { householdMembers: { none: {} } } } });
+        await prisma.household.deleteMany({ where: { householdMembers: { none: {} } } });
         jest.clearAllMocks();
     });
 

--- a/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
@@ -149,7 +149,7 @@ describe('Household API Integration Tests', () => {
             const data = await res.json();
             expect(data.household).toBeDefined();
             expect(data.household.id).toBe(householdId);
-            expect(data.household.participants.length).toBeGreaterThanOrEqual(2);
+            expect(data.household.householdMembers.length).toBeGreaterThanOrEqual(2);
         });
     });
 

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -73,7 +73,7 @@ const membershipStatusOf = async (id: number) => (await prisma.membership.findUn
 
 async function wipe() {
     const hhs = await prisma.household.findMany({
-        where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] },
+        where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] },
         select: { id: true },
     });
     const ids = hhs.map((h) => h.id);

--- a/checkin-app/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
@@ -40,7 +40,7 @@ describe('Bulk renewal migration', () => {
     }
 
     async function wipe() {
-        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
+        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
             await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -40,7 +40,7 @@ describe('Membership renewal', () => {
     }
 
     async function wipe() {
-        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
+        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
             await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: ids } } } } });

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -50,7 +50,7 @@ describe('Membership BG review API', () => {
     }
 
     async function wipe() {
-        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
+        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
             await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: ids } } } } });

--- a/checkin-app/src/app/__tests__/membershipReviewConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewConcurrency.integration.test.ts
@@ -42,7 +42,7 @@ async function makePendingProcess(): Promise<number> {
 
 async function wipe() {
     const hhs = await prisma.household.findMany({
-        where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] },
+        where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] },
         select: { id: true },
     });
     const ids = hhs.map((h) => h.id);

--- a/checkin-app/src/app/__tests__/notificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsAPI.integration.test.ts
@@ -23,7 +23,7 @@ describe('Membership notifications API', () => {
     let reviewerId: number, boardId: number, plainId: number;
 
     async function wipe() {
-        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { participants: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
+        const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
             await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });

--- a/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
@@ -21,11 +21,11 @@ describe("sendCheckinNotifications()", () => {
         await prisma.person.deleteMany({
             where: { email: { contains: "notify-test" } }
         });
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { participants: { none: {} } } } } } });
-        await prisma.membershipProcess.deleteMany({ where: { membership: { household: { participants: { none: {} } } } } });
-        await prisma.membership.deleteMany({ where: { household: { participants: { none: {} } } } });
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { householdMembers: { none: {} } } } } } });
+        await prisma.membershipProcess.deleteMany({ where: { membership: { household: { householdMembers: { none: {} } } } } });
+        await prisma.membership.deleteMany({ where: { household: { householdMembers: { none: {} } } } });
         await prisma.household.deleteMany({
-            where: { participants: { none: {} } }
+            where: { householdMembers: { none: {} } }
         });
         jest.clearAllMocks();
 
@@ -72,11 +72,11 @@ describe("sendCheckinNotifications()", () => {
         await prisma.person.deleteMany({
             where: { email: { contains: "notify-test" } }
         });
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { participants: { none: {} } } } } } });
-        await prisma.membershipProcess.deleteMany({ where: { membership: { household: { participants: { none: {} } } } } });
-        await prisma.membership.deleteMany({ where: { household: { participants: { none: {} } } } });
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { householdMembers: { none: {} } } } } } });
+        await prisma.membershipProcess.deleteMany({ where: { membership: { household: { householdMembers: { none: {} } } } } });
+        await prisma.membership.deleteMany({ where: { household: { householdMembers: { none: {} } } } });
         await prisma.household.deleteMany({
-            where: { participants: { none: {} } }
+            where: { householdMembers: { none: {} } }
         });
     });
 

--- a/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
@@ -53,7 +53,7 @@ describe('Eligible Participants API Integration Tests', () => {
         });
 
         await prisma.household.deleteMany({
-             where: { participants: { some: { id: { in: existingUserIds } } } }
+             where: { householdMembers: { some: { id: { in: existingUserIds } } } }
         });
 
         await prisma.program.deleteMany({

--- a/checkin-app/src/app/api/admin/broken-households/route.ts
+++ b/checkin-app/src/app/api/admin/broken-households/route.ts
@@ -16,7 +16,7 @@ export const GET = withAuth(
             const households = await prisma.household.findMany({
                 where: { leads: { none: {} } },
                 include: {
-                    participants: {
+                    householdMembers: {
                         select: { id: true, name: true, dateOfBirth: true },
                         orderBy: { id: "asc" },
                     },
@@ -27,7 +27,7 @@ export const GET = withAuth(
             const result = households.map(h => ({
                 id: h.id,
                 name: h.name || `Household #${h.id}`,
-                members: h.participants.map(p => ({ id: p.id, name: p.name, dateOfBirth: p.dateOfBirth })),
+                members: h.householdMembers.map(p => ({ id: p.id, name: p.name, dateOfBirth: p.dateOfBirth })),
             }));
 
             return NextResponse.json({ households: result });

--- a/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
+++ b/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
@@ -50,7 +50,7 @@ describe("Participant PII minimization (M1, M2)", () => {
         // Full raw row as it exists in the DB, including everything a household
         // peer must never see (M2). The mock applies whatever `select` the route
         // actually requests — same as Prisma would — so this fails if the route
-        // ever regresses back to `participants: true`.
+        // ever regresses back to `householdMembers: true`.
         const rawPeer = {
             id: 2,
             name: "Kid Two",
@@ -71,7 +71,7 @@ describe("Participant PII minimization (M1, M2)", () => {
         } as Record<string, unknown>;
 
         (prisma.person.findUnique as jest.Mock).mockImplementation((args) => {
-            const peerSelect = args.include.household.include.participants.select as Record<string, boolean>;
+            const peerSelect = args.include.household.include.householdMembers.select as Record<string, boolean>;
             const projected = Object.fromEntries(
                 Object.keys(peerSelect).filter((k) => peerSelect[k]).map((k) => [k, rawPeer[k]])
             );
@@ -83,7 +83,7 @@ describe("Participant PII minimization (M1, M2)", () => {
                     name: "Test Household",
                     leads: [{ householdId: 10, participantId: 1 }],
                     membership: { id: 1, status: "ACTIVE", memberSince: new Date(), isVolunteer: false, householdId: 10 },
-                    participants: [projected],
+                    householdMembers: [projected],
                 },
             });
         });
@@ -93,7 +93,7 @@ describe("Participant PII minimization (M1, M2)", () => {
         expect(res.status).toBe(200);
 
         const data = await res.json();
-        const peer = data.household.participants[0];
+        const peer = data.household.householdMembers[0];
 
         // Safe fields survive.
         expect(peer.name).toBe("Kid Two");
@@ -112,7 +112,7 @@ describe("Participant PII minimization (M1, M2)", () => {
 
         // Pin the actual query shape, not just this test's mock.
         const callArgs = (prisma.person.findUnique as jest.Mock).mock.calls[0][0];
-        expect(callArgs.include.household.include.participants).toEqual({ select: HOUSEHOLD_PEER_SELECT });
+        expect(callArgs.include.household.include.householdMembers).toEqual({ select: HOUSEHOLD_PEER_SELECT });
     });
 
     it("GET /api/attendance (full access) does not leak email/googleId", async () => {

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -18,7 +18,7 @@ export const GET = withAuth(
                 include: {
                     household: {
                         include: {
-                            participants: { select: HOUSEHOLD_PEER_SELECT },
+                            householdMembers: { select: HOUSEHOLD_PEER_SELECT },
                             leads: true,
                             membership: true,
                         }

--- a/checkin-app/src/app/api/membership-ops/applications/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/route.ts
@@ -34,7 +34,7 @@ export const GET = handler("GET /api/membership-ops/applications", async () => {
                     household: {
                         select: {
                             name: true,
-                            participants: { select: { id: true, name: true, email: true } },
+                            householdMembers: { select: { id: true, name: true, email: true } },
                             leads: { select: { personId: true } },
                         },
                     },

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -28,7 +28,7 @@ export const GET = withAuth(
                 const household = await prisma.household.findUnique({
                     where: { id: parseInt(id) },
                     include: {
-                        participants: {
+                        householdMembers: {
                             select: { id: true, name: true, email: true }
                         },
                         householdLeads: { select: { personId: true } },
@@ -47,15 +47,15 @@ export const GET = withAuth(
             const whereClause = q ? {
                 OR: [
                     { name: { contains: q, mode: 'insensitive' as const } },
-                    { participants: { some: { name: { contains: q, mode: 'insensitive' as const } } } },
-                    { participants: { some: { email: { contains: q, mode: 'insensitive' as const } } } },
+                    { householdMembers: { some: { name: { contains: q, mode: 'insensitive' as const } } } },
+                    { householdMembers: { some: { email: { contains: q, mode: 'insensitive' as const } } } },
                 ]
             } : {};
 
             const households = await prisma.household.findMany({
                 where: whereClause,
                 include: {
-                    participants: {
+                    householdMembers: {
                         select: { id: true, name: true, email: true, isBoardMember: true }
                     },
                     membership: true,

--- a/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
@@ -22,7 +22,7 @@ export const GET = withAuth(
                     include: {
                         household: {
                             include: {
-                                participants: true,
+                                householdMembers: true,
                                 leads: true
                             }
                         },

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -38,7 +38,7 @@ export const POST = withAuth(
                     householdLeads: true,
                     household: {
                         include: {
-                            participants: true
+                            householdMembers: true
                         }
                     }
                 }
@@ -49,7 +49,7 @@ export const POST = withAuth(
             }
 
             const isLead = mergeParticipant.householdLeads.length > 0;
-            const householdOthersCount = mergeParticipant.household?.participants.filter(p => p.id !== mergeId).length || 0;
+            const householdOthersCount = mergeParticipant.household?.householdMembers.filter(p => p.id !== mergeId).length || 0;
 
             if (isLead && householdOthersCount > 0) {
                 return NextResponse.json({ error: "Cannot merge: the to-be-deleted participant is the lead of a household with other members." }, { status: 400 });

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -355,7 +355,7 @@ export const GET = withAuth({}, async (_req, auth) => {
             // explicitly so null-email members (e.g. children) count.
             prisma.household.count({
                 where: {
-                    participants: {
+                    householdMembers: {
                         some: { OR: [{ email: null }, { NOT: { email: { endsWith: `@${ORG_DOMAIN}` } } }] },
                     },
                 },

--- a/checkin-app/src/app/api/participants/search/route.ts
+++ b/checkin-app/src/app/api/participants/search/route.ts
@@ -27,7 +27,7 @@ export const GET = withAuth(
                 include: {
                     household: {
                         include: {
-                            participants: true,
+                            householdMembers: true,
                             membership: true,
                         }
                     }

--- a/checkin-app/src/app/api/safety/emergency-contacts/route.ts
+++ b/checkin-app/src/app/api/safety/emergency-contacts/route.ts
@@ -9,7 +9,7 @@ export const GET = withAuth(
         try {
             const households = await prisma.household.findMany({
                 include: {
-                    participants: {
+                    householdMembers: {
                         select: {
                             id: true,
                             name: true,
@@ -39,7 +39,7 @@ export const GET = withAuth(
             });
 
             const formattedHouseholds = households.map(h => {
-                const isPresent = h.participants.some(p => p.visits.length > 0);
+                const isPresent = h.householdMembers.some(p => p.visits.length > 0);
                 const contacts = h.emergencyContacts.map(c => ({
                     id: c.id,
                     name: c.name,
@@ -59,7 +59,7 @@ export const GET = withAuth(
                     emergencyContactPhone: primaryValid?.phone ?? null,
                     emergencyContacts: contacts,
                     isPresent,
-                    participants: h.participants.map(p => ({
+                    householdMembers: h.householdMembers.map(p => ({
                         id: p.id,
                         name: p.name,
                         isPresent: p.visits.length > 0

--- a/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
+++ b/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
@@ -23,7 +23,7 @@ const attendanceData = {
 const householdData = {
   household: {
     leads: [{ participantId: 1 }],
-    participants: [{ id: 90, name: "Jamie Kid", email: "jamie@example.com" }],
+    householdMembers: [{ id: 90, name: "Jamie Kid", email: "jamie@example.com" }],
   },
 };
 

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -48,7 +48,7 @@ function KioskDisplayInner() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [checkingOut, setCheckingOut] = useState<number | null>(null);
-  const [household, setHousehold] = useState<{ leads: { participantId: number }[], participants: Person[] } | null>(null);
+  const [household, setHousehold] = useState<{ leads: { participantId: number }[], householdMembers: Person[] } | null>(null);
   const [showSignOutModal, setShowSignOutModal] = useState(false);
   const [searchSignOutQuery, setSearchSignOutQuery] = useState("");
   const [selectedParticipant, setSelectedParticipant] = useState<Person | null>(null);
@@ -371,12 +371,12 @@ function KioskDisplayInner() {
           <Box mb="lg">
             <Title order={4} c="blue" mb="sm">Check In Household Members</Title>
             <Group gap="xs" wrap="wrap">
-              {household.participants?.filter((p) => !checkedInIds.includes(p.id)).map((p) => (
+              {household.householdMembers?.filter((p) => !checkedInIds.includes(p.id)).map((p) => (
                 <Button key={p.id} variant="default" onClick={() => handleManualCheckIn(p.id)} disabled={checkingInId === p.id}>
                   {checkingInId === p.id ? "..." : (p.name || p.email)}
                 </Button>
               ))}
-              {household.participants?.filter((p) => !checkedInIds.includes(p.id)).length === 0 && (
+              {household.householdMembers?.filter((p) => !checkedInIds.includes(p.id)).length === 0 && (
                 <Text c="dimmed" fs="italic" size="sm">All household members are currently checked in!</Text>
               )}
             </Group>

--- a/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
@@ -8,7 +8,7 @@ import AdminMembershipPage from "../page";
 beforeEach(() => resetRtl());
 
 function household(name: string, id: number) {
-    return { name, participants: [{ id: 1, name: "Lead One", email: "lead@example.com" }], leads: [{ personId: 1 }], householdId: id };
+    return { name, householdMembers: [{ id: 1, name: "Lead One", email: "lead@example.com" }], leads: [{ personId: 1 }], householdId: id };
 }
 
 const rows = [

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -29,7 +29,7 @@ interface ProcessRow {
   membership: {
     householdId: number;
     isVolunteer: boolean;
-    household: { name: string | null; participants: Person[]; leads: { personId: number }[] } | null;
+    household: { name: string | null; householdMembers: Person[]; leads: { personId: number }[] } | null;
   } | null;
 }
 
@@ -162,7 +162,7 @@ export default function AdminMembershipPage() {
     const hh = r.membership?.household;
     if (!hh) return `Household #${r.membership?.householdId ?? "?"}`;
     const leadIds = new Set((hh.leads || []).map((l) => l.personId));
-    const parents = (hh.participants || []).filter((p) => leadIds.has(p.id)).map((p) => p.name || p.email).filter(Boolean);
+    const parents = (hh.householdMembers || []).filter((p) => leadIds.has(p.id)).map((p) => p.name || p.email).filter(Boolean);
     return hh.name || parents.join(" & ") || `Household #${r.membership?.householdId}`;
   };
 

--- a/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
@@ -15,13 +15,13 @@ const households = {
       id: 1,
       name: "The Smiths",
       membership: { status: "ACTIVE" },
-      participants: [{ id: 10, name: "Pat Smith", email: "pat@example.com", isBoardMember: false }],
+      householdMembers: [{ id: 10, name: "Pat Smith", email: "pat@example.com", isBoardMember: false }],
     },
     {
       id: 2,
       name: "The Joneses",
       membership: null,
-      participants: [{ id: 20, name: "Jo Jones", email: "jo@example.com", isBoardMember: false }],
+      householdMembers: [{ id: 20, name: "Jo Jones", email: "jo@example.com", isBoardMember: false }],
     },
   ],
 };

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -13,7 +13,7 @@ type Household = {
   id: number;
   name?: string | null;
   membership?: { status: string } | null;
-  participants?: { id: number; name?: string | null; email?: string | null; isBoardMember?: boolean }[] | null;
+  householdMembers?: { id: number; name?: string | null; email?: string | null; isBoardMember?: boolean }[] | null;
 };
 
 export default function AdminHouseholdsPage() {
@@ -116,7 +116,7 @@ export default function AdminHouseholdsPage() {
   const filtered = q
     ? households.filter((h) =>
         (h.name || `Household #${h.id}`).toLowerCase().includes(q) ||
-        (h.participants?.some((p) =>
+        (h.householdMembers?.some((p) =>
           (p.name || '').toLowerCase().includes(q) ||
           (p.email || '').toLowerCase().includes(q)
         ) ?? false)
@@ -155,7 +155,7 @@ export default function AdminHouseholdsPage() {
               const status = household.membership?.status;
               const hasActiveMembership = status === "ACTIVE";
               const isDenied = status === "DENIED";
-              const hasBoardMember = household.participants?.some((p) => p.isBoardMember) ?? false;
+              const hasBoardMember = household.householdMembers?.some((p) => p.isBoardMember) ?? false;
 
               return (
                 <Table.Tr key={household.id}>
@@ -163,9 +163,9 @@ export default function AdminHouseholdsPage() {
                     <Text fw={600}>{household.name || `Household #${household.id}`}</Text>
                   </Table.Td>
                   <Table.Td>
-                    {household.participants && household.participants.length > 0 ? (
+                    {household.householdMembers && household.householdMembers.length > 0 ? (
                       <List size="sm">
-                        {household.participants.map((p) => (
+                        {household.householdMembers.map((p) => (
                           <List.Item key={p.id}>{p.name || p.email}</List.Item>
                         ))}
                       </List>

--- a/checkin-app/src/app/membership-ops/participants/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/__tests__/page.test.tsx
@@ -18,7 +18,7 @@ const bob = {
     name: "Bob B",
     email: null,
     phone: null,
-    household: { id: 20, name: "The B Family", participants: [{ id: 2, name: "Bob B", email: null }, { id: 3, name: "Sis B", email: "sis@example.com" }] },
+    household: { id: 20, name: "The B Family", householdMembers: [{ id: 2, name: "Bob B", email: null }, { id: 3, name: "Sis B", email: "sis@example.com" }] },
 };
 const carol = { id: 3, name: "Carol C", email: null, phone: null, household: null };
 
@@ -60,7 +60,7 @@ describe("AdminParticipantsIndex", () => {
         mockFetchJson({
             "/api/participants/search": { participants: [carol] },
             "/api/membership-ops/participants/3/household": {
-                participant: { ...carol, household: { id: 50, name: "Carol Household", participants: [{ id: 3, name: "Carol C", email: null }] } },
+                participant: { ...carol, household: { id: 50, name: "Carol Household", householdMembers: [{ id: 3, name: "Carol C", email: null }] } },
             },
         });
         renderWithProviders(<AdminParticipantsIndex />);

--- a/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
@@ -12,7 +12,7 @@ beforeEach(() => resetRtl());
 const participantA = {
   id: 1, name: "Alice Adams", email: "alice@example.com", phone: null, googleId: "g1",
   _count: { visits: 5, rawBadgeLogs: 0, programParticipants: 0, programVolunteers: 0 },
-  household: { id: 10, name: "Adams House", leads: [], participants: [{ id: 1 }] },
+  household: { id: 10, name: "Adams House", leads: [], householdMembers: [{ id: 1 }] },
 };
 const participantB = {
   id: 2, name: "Bob Adams", email: "bob@example.com", phone: null, googleId: null,

--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -13,7 +13,7 @@ interface ParticipantMergeView {
   phone?: string;
   googleId?: string;
   _count: { visits: number, rawBadgeLogs: number, programParticipants: number, programVolunteers: number };
-  household?: { id: number, name: string, leads: { participant: { name: string, email: string } }[], _count?: { participants: number }, participants: Record<string, unknown>[] } | null;
+  household?: { id: number, name: string, leads: { participant: { name: string, email: string } }[], _count?: { householdMembers: number }, householdMembers: Record<string, unknown>[] } | null;
   [key: string]: unknown;
 }
 
@@ -180,9 +180,9 @@ export default function MergeParticipants() {
         <Text size="sm" c="dimmed" mt="md">
           Household: {p.household ? p.household.name || `Household #${p.household.id}` : "None"}
         </Text>
-        {p.household && p.household.participants && (
+        {p.household && p.household.householdMembers && (
           <List size="sm">
-            {(p.household.participants as { id: number, name: string | null }[]).map((hp) => (
+            {(p.household.householdMembers as { id: number, name: string | null }[]).map((hp) => (
               <List.Item key={hp.id}>
                 {hp.name} {hp.id === p.id && "(This)"} {((p.household!.leads as unknown) as { personId: number }[]).find((l) => l.personId === hp.id) && "[Lead]"}
               </List.Item>
@@ -198,7 +198,7 @@ export default function MergeParticipants() {
         </Alert>
       )}
 
-      {!isKept && p.household && p.household.participants && !isLeadWithOthers && p.household.participants.length > 1 && (
+      {!isKept && p.household && p.household.householdMembers && !isLeadWithOthers && p.household.householdMembers.length > 1 && (
         <Alert color="yellow" variant="light" mt="md" fw={700}>
           Warning: This participant is in a household with others. They will be removed from that
           household during deletion.
@@ -230,7 +230,7 @@ export default function MergeParticipants() {
   let isLeadWithOthers = false;
   if (mergeParticipant && !previewMode) {
     const isLead = mergeParticipant.household?.leads.find((l: { personId?: number;[key: string]: unknown }) => l.personId === mergeParticipant.id);
-    const othersCount = (mergeParticipant.household?.participants as { id: number }[] | undefined)?.filter((p) => p.id !== mergeParticipant.id).length || 0;
+    const othersCount = (mergeParticipant.household?.householdMembers as { id: number }[] | undefined)?.filter((p) => p.id !== mergeParticipant.id).length || 0;
     isLeadWithOthers = !!isLead && othersCount > 0;
   }
 

--- a/checkin-app/src/app/membership-ops/participants/new/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/page.tsx
@@ -12,7 +12,7 @@ import { AlertBanner } from '@/components/admin/AlertBanner';
 type HouseholdOption = {
   id: number;
   name: string;
-  participants: { id: number; name: string | null; email: string | null }[];
+  householdMembers: { id: number; name: string | null; email: string | null }[];
 };
 
 export default function NewParticipantPage() {
@@ -187,7 +187,7 @@ function NewParticipantForm() {
                   return data.households || [];
                 }}
                 getOptionLabel={(h) => h.name || `Household #${h.id}`}
-                getOptionDescription={(h) => h.participants.map((p) => p.name || p.email || 'Unnamed').join(', ') || 'Empty'}
+                getOptionDescription={(h) => h.householdMembers.map((p) => p.name || p.email || 'Unnamed').join(', ') || 'Empty'}
                 onSelect={(h) => { setHouseholdId(h.id.toString()); setHouseholdSearch(h.name || `Household #${h.id}`); }}
                 onClear={() => { setHouseholdId(""); setHouseholdSearch(""); }}
               />

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -11,7 +11,7 @@ import { AdminEditHouseholdModal } from "@/components/admin/AdminEditHouseholdMo
 type HouseholdRef = {
   id: number;
   name: string | null;
-  participants: { id: number; name: string | null; email: string | null }[];
+  householdMembers: { id: number; name: string | null; email: string | null }[];
 };
 
 type ParticipantRow = {
@@ -170,8 +170,8 @@ export default function AdminParticipantsIndex() {
     }
   };
 
-  const canSubmitAssign = !selectedParticipant?.household || (selectedParticipant.household.participants.length > 1);
-  const canChangeHousehold = selectedParticipant?.household && selectedParticipant.household.participants.length === 1 && householdId;
+  const canSubmitAssign = !selectedParticipant?.household || (selectedParticipant.household.householdMembers.length > 1);
+  const canChangeHousehold = selectedParticipant?.household && selectedParticipant.household.householdMembers.length === 1 && householdId;
 
   return (
     <Stack maw={1000} mx="auto">
@@ -264,7 +264,7 @@ export default function AdminParticipantsIndex() {
           <Paper withBorder radius="md" p="md" mb="md">
             <Text size="sm" fw={600} c="dimmed" mb="xs">Current Household: {selectedParticipant.household.name}</Text>
             <Text size="sm">
-              Members: {selectedParticipant.household.participants
+              Members: {selectedParticipant.household.householdMembers
                 .filter((p) => p.id !== selectedParticipant.id)
                 .map((p) => p.name || p.email)
                 .join(', ') || 'No other members'}
@@ -298,7 +298,7 @@ export default function AdminParticipantsIndex() {
                 return data.households || [];
               }}
               getOptionLabel={(h) => h.name || `Household #${h.id}`}
-              getOptionDescription={(h) => h.participants.map((p) => p.name || p.email || 'Unnamed').join(', ') || 'Empty'}
+              getOptionDescription={(h) => h.householdMembers.map((p) => p.name || p.email || 'Unnamed').join(', ') || 'Empty'}
               onSelect={(h) => { setHouseholdId(h.id.toString()); setHouseholdSearch(h.name || `Household #${h.id}`); }}
               onClear={() => { setHouseholdId(""); setHouseholdSearch(""); }}
             />

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -13,7 +13,7 @@ const householdData = {
   id: 55,
   name: "Smith Household",
   leads: [{ participantId: 10 }],
-  participants: [
+  householdMembers: [
     { id: 10, name: "Sam Smith", email: "sam@example.com", phone: "5125551234", dateOfBirth: "1980-01-01" },
     { id: 11, name: "Jamie Smith", email: "", dateOfBirth: "2012-05-01" },
   ],

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -49,7 +49,7 @@ type HouseholdData = {
   id?: number;
   name?: string;
   leads?: Array<{ participantId: number }>;
-  participants?: HouseholdMember[];
+  householdMembers?: HouseholdMember[];
   membership?: { status?: string; memberSince?: string; isVolunteer?: boolean } | null;
 } & Partial<StructuredAddress> | null;
 
@@ -331,7 +331,7 @@ export default function HouseholdPage() {
   const isLead = (pid: number) => household?.leads?.some((l) => l.participantId === pid) ?? false;
   const viewerIsLead = isLead(userId);
 
-  const sortedHouseholdMembers = (household?.participants || []).slice().sort((a, b) => {
+  const sortedHouseholdMembers = (household?.householdMembers || []).slice().sort((a, b) => {
     const isLeadA = isLead(a.id) ? 1 : 0;
     const isLeadB = isLead(b.id) ? 1 : 0;
     if (isLeadA !== isLeadB) return isLeadB - isLeadA;

--- a/checkin-app/src/app/safety/emergency-contacts/__tests__/page.test.tsx
+++ b/checkin-app/src/app/safety/emergency-contacts/__tests__/page.test.tsx
@@ -17,7 +17,7 @@ const households = [
     emergencyContactPhone: null,
     emergencyContacts: [{ id: 11, name: "Gary Guardian", phone: "5551234567", email: "gary@example.com", relationship: "Uncle", invalid: false }],
     isPresent: true,
-    participants: [{ id: 101, name: "Kid Keyholder", isPresent: true }],
+    householdMembers: [{ id: 101, name: "Kid Keyholder", isPresent: true }],
     leads: [{ id: 201, name: "Lea Lead", phone: "5559876543", email: "lea@example.com" }],
   },
   {
@@ -27,7 +27,7 @@ const households = [
     emergencyContactPhone: null,
     emergencyContacts: [],
     isPresent: false,
-    participants: [],
+    householdMembers: [],
     leads: [],
   },
 ];

--- a/checkin-app/src/app/safety/emergency-contacts/page.tsx
+++ b/checkin-app/src/app/safety/emergency-contacts/page.tsx
@@ -25,7 +25,7 @@ type Household = {
   emergencyContactPhone: string | null;
   emergencyContacts: EmergencyContactInfo[];
   isPresent: boolean;
-  participants: ParticipantInfo[];
+  householdMembers: ParticipantInfo[];
   leads: LeadInfo[];
 };
 
@@ -80,7 +80,7 @@ export default function EmergencyContactsPage() {
     const query = searchQuery.toLowerCase();
     if (h.name && h.name.toLowerCase().includes(query)) return true;
     if (h.leads.some(l => l.name && l.name.toLowerCase().includes(query))) return true;
-    if (h.participants.some(p => p.name && p.name.toLowerCase().includes(query))) return true;
+    if (h.householdMembers.some(p => p.name && p.name.toLowerCase().includes(query))) return true;
     return false;
   });
 
@@ -131,9 +131,9 @@ export default function EmergencyContactsPage() {
                   {h.isPresent && <Badge color="cyan" variant="light">Present Now</Badge>}
                 </Group>
                 <Text size="sm" c="dimmed">Household members:</Text>
-                {h.participants.length > 0 ? (
+                {h.householdMembers.length > 0 ? (
                   <List size="sm">
-                    {h.participants.map((p) => (
+                    {h.householdMembers.map((p) => (
                       <List.Item key={p.id}>
                         {p.name || `Member #${p.id}`}
                         {p.isPresent && <Text component="span" c="green" size="sm"> ● (Checked In)</Text>}

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -10,7 +10,7 @@ export type AdminHousehold = {
   name: string | null;
   emergencyContactName: string | null;
   emergencyContactPhone: string | null;
-  participants?: Array<{ id: number; name: string | null; email: string | null }>;
+  householdMembers?: Array<{ id: number; name: string | null; email: string | null }>;
   householdLeads?: Array<{ participantId: number }>;
 } & Partial<StructuredAddress>;
 
@@ -57,7 +57,7 @@ export function AdminEditHouseholdModal({
   const [form, setForm] = useState<FormState>(EMPTY);
   const [initial, setInitial] = useState<FormState>(EMPTY);
   const [displayName, setDisplayName] = useState("");
-  const [members, setMembers] = useState<NonNullable<AdminHousehold["participants"]>>([]);
+  const [members, setMembers] = useState<NonNullable<AdminHousehold["householdMembers"]>>([]);
   const [leadIds, setLeadIds] = useState<number[]>([]);
   const [removingLead, setRemovingLead] = useState<number | null>(null);
 
@@ -79,7 +79,7 @@ export function AdminEditHouseholdModal({
         setForm(loaded);
         setInitial(loaded);
         setDisplayName(h.name || `Household #${h.id}`);
-        setMembers(h.participants ?? []);
+        setMembers(h.householdMembers ?? []);
         setLeadIds((h.householdLeads ?? []).map((l) => l.participantId));
       }
     } catch {

--- a/checkin-app/src/lib/dev/__tests__/seed-helpers.integration.test.ts
+++ b/checkin-app/src/lib/dev/__tests__/seed-helpers.integration.test.ts
@@ -51,11 +51,11 @@ describe("dev seed-helpers (integration)", () => {
         // The created household has exactly one lead.
         const household = await prisma.household.findFirst({
             where: { name: { startsWith: "Test Family" } },
-            include: { leads: true, participants: true },
+            include: { leads: true, householdMembers: true },
             orderBy: { id: "desc" },
         });
         expect(household?.leads.length).toBe(1);
-        expect(household?.participants.length).toBe(3);
+        expect(household?.householdMembers.length).toBe(3);
     });
 
     it("+ Program adds a program with a fee and two participants", async () => {

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -63,7 +63,7 @@ async function loadUserWithHousehold(userId: number) {
             householdLeads: true,
             household: {
                 include: {
-                    participants: { orderBy: { id: "asc" } },
+                    householdMembers: { orderBy: { id: "asc" } },
                     leads: true,
                     membership: { include: { processes: true } },
                     emergencyContacts: { orderBy: [{ priority: "asc" }, { id: "asc" }] },
@@ -94,8 +94,8 @@ export async function getIntakeState(userId: number) {
 
     // Parents/guardians are the household leads; children are non-lead members.
     const leadIds = new Set((household?.leads ?? []).map((l) => l.personId));
-    const parents = (household?.participants ?? []).filter((p) => leadIds.has(p.id));
-    const children = (household?.participants ?? []).filter((p) => !leadIds.has(p.id));
+    const parents = (household?.householdMembers ?? []).filter((p) => leadIds.has(p.id));
+    const children = (household?.householdMembers ?? []).filter((p) => !leadIds.has(p.id));
     const primary = parents.find((p) => p.id === userId) ?? null;
     const secondary = parents.find((p) => p.id !== userId) ?? null;
 
@@ -211,7 +211,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
     if (!user) throw new IntakeError("no_household", "User not found.");
     assertLead(user);
     const householdId = user.householdId!;
-    const householdMemberIds = new Set((user.household?.participants ?? []).map((p) => p.id));
+    const householdMemberIds = new Set((user.household?.householdMembers ?? []).map((p) => p.id));
 
     const toDate = (d?: string | null) => (d ? new Date(d) : null);
 
@@ -355,7 +355,7 @@ export async function submitIntake(userId: number) {
         (c) => c.conflictParticipantId === null && c.name.trim() && c.phone.trim(),
     );
     if (!hasValidContact) missing.push({ field: "emergencyContact", label: "a valid emergency contact (someone outside the household)" });
-    const primary = household.participants.find((p) => p.id === userId);
+    const primary = household.householdMembers.find((p) => p.id === userId);
     if (!primary?.name?.trim()) missing.push({ field: "primaryName", label: "primary parent name" });
     if (missing.length) {
         throw new IntakeError(

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -351,7 +351,7 @@ export const relations = {
         tool: { model: 'Tool', isList: false },
     },
     Household: {
-        participants: { model: 'Person', isList: true },
+        householdMembers: { model: 'Person', isList: true },
         leads: { model: 'HouseholdLead', isList: true },
         membership: { model: 'Membership', isList: false },
         trustedAdults: { model: 'TrustedAdult', isList: true },

--- a/checkin-app/tests/security/routeAuthDrift.test.ts
+++ b/checkin-app/tests/security/routeAuthDrift.test.ts
@@ -129,8 +129,9 @@ function findUnwrappedPrismaHandlers(code: string): string[] {
 const EDGE_MODELS = new Set(['ProgramParticipant', 'ProgramVolunteer', 'RSVP', 'Visit']);
 
 /** The generated relations map, typed: ParentModel → relationKey → target. This
- * is what makes the scan parent-AWARE: the same key (`participants`) resolves to
- * ProgramParticipant under Program (edge) but Person under Household (not),
+ * is what makes the scan parent-AWARE: a relation key resolves by enclosing
+ * model — `participants` is ProgramParticipant under Program (edge), while the
+ * household member set (`householdMembers`) is Person under Household (not),
  * so we must know the enclosing model — a flat key match can't, and would either
  * miss the Program case (the #575 leak class) or false-flag the Household case. */
 const REL = relations as Record<string, Record<string, { model: string }>>;
@@ -361,11 +362,11 @@ describe('route auth drift-guard — every app/api/**/route.ts', () => {
     });
 
     describe('rule 3 — edge-sensitive reads in GET/HEAD must be allowlisted', () => {
-        it('resolves the shared `participants` key parent-aware via the map', () => {
-            // The whole point: same key, different model by parent. If this map
+        it('resolves relation keys parent-aware via the map', () => {
+            // The whole point: resolve each key by enclosing model. If this map
             // shape changes, the parent-aware walk's assumptions broke.
             expect(REL.Program?.participants?.model).toBe('ProgramParticipant'); // edge
-            expect(REL.Household?.participants?.model).toBe('Person'); // not edge
+            expect(REL.Household?.householdMembers?.model).toBe('Person'); // not edge
         });
 
         for (const { rel, code } of routeFiles) {
@@ -469,8 +470,8 @@ describe('route auth drift-guard — detectors catch violations', () => {
         expect(findEdgeReadsInReads(stripComments(synthetic))).toEqual([]);
     });
 
-    it('does NOT flag Household.participants (same key, resolves to Person — not edge)', () => {
-        const synthetic = `export const GET = withAuth({}, async () => prisma.household.findUnique({ include: { participants: true } }));`;
+    it('does NOT flag Household.householdMembers (resolves to Person — not edge)', () => {
+        const synthetic = `export const GET = withAuth({}, async () => prisma.household.findUnique({ include: { householdMembers: true } }));`;
         expect(findEdgeReadsInReads(stripComments(synthetic))).toEqual([]);
     });
 


### PR DESCRIPTION
## Phase B3 — person-umbrella terminology

`participant` is reserved for **program enrollees**. A household's people set (leads + dependents, any role) is a **member** set, not enrollees. This renames the Prisma relation field and its `household.participants` API wire key to the canonical **`householdMembers`** (sense-B).

### Scope
- **Schema:** `Household.participants Person[]` → `householdMembers Person[]`. Prisma relation-field rename only — no column/table change (reverse `Person.household` + `householdId` FK untouched), so the migration is a no-op and raw SQL is unaffected. Security classifications regenerated.
- **Server:** household, emergency-contacts, merge (+analyze), households, applications, broken-households, nav/todo-counts routes, and `lib/membership/intake.ts` — include/select/where keys, `.householdMembers` access, and response wire keys.
- **Clients (tsc-blind loose types):** attendance/current, my-household, membership-ops households/applications/participants/new/merge, safety/emergency-contacts, AdminEditHouseholdModal.
- **Tests:** teardown where-filters + household mocks across all three test roots.

### Out of scope (kept)
`ProgramParticipant`, `Program.participants`, `prisma.person`, `personId` — all enrollee concepts. `/api/participants/*` dir paths untouched.

### Verify
- `tsc --noEmit` clean.
- jest green: component/PII suites + household/membership/notifications/cron/emergency/nav integration suites (`--runInBand`), incl. the security PII-minimization oracle and the security scope oracles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)