### PR TITLE
refactor(db): unify root-or-tx Prisma client convention

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/import/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { Prisma } from "@/generated/prisma/client";
 import { withAuth } from "@/lib/auth";
 import * as xlsx from "xlsx";
 import { logBackendError } from "@/lib/logger";
 import { addHouseholdLead, HouseholdLeadLimitError, MAX_HOUSEHOLD_LEADS } from "@/lib/household/leads";
 import { parseImportDob } from "@/lib/importDob";
 import { calculateAge } from "@/lib/time";
+import type { DbClient } from "@/lib/db-client";
 
 export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (req: NextRequest, auth) => {
     try {
@@ -53,7 +53,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
 
         // Helper: look up a participant's household. Every participant has one
         // (householdId is a required FK).
-        const ensureHousehold = async (participantId: number, db: Prisma.TransactionClient = prisma): Promise<number> => {
+        const ensureHousehold = async (participantId: number, db: DbClient = prisma): Promise<number> => {
             const participant = await db.person.findUnique({ where: { id: participantId } });
             if (!participant) throw new Error(`Participant ${participantId} not found`);
             return participant.householdId;
@@ -66,7 +66,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
             name: string;
             dob?: Date;
             address?: string;
-        }, db: Prisma.TransactionClient = prisma) => {
+        }, db: DbClient = prisma) => {
             const isAdult = !data.dob || calculateAge(data.dob) >= 18;
             const participant = await db.person.create({
                 data: {
@@ -91,7 +91,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         // A CSV address overwrites the row's household address when provided.
         // ponytail: legacy CSV has one free-text address column → goes to line1
         // verbatim. Bulk import is being redone; structured columns land then.
-        const applyAddressToHousehold = async (householdId: number, address: string, db: Prisma.TransactionClient = prisma) => {
+        const applyAddressToHousehold = async (householdId: number, address: string, db: DbClient = prisma) => {
             if (!address) return;
             await db.household.update({
                 where: { id: householdId },
@@ -102,7 +102,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         // Helper: ensure an active household membership exists for a household
         const ensureHouseholdMembership = async (
             householdId: number,
-            db: Prisma.TransactionClient = prisma,
+            db: DbClient = prisma,
         ) => {
             await db.membership.upsert({
                 where: { householdId },

--- a/checkin-app/src/lib/attendanceTransitions.ts
+++ b/checkin-app/src/lib/attendanceTransitions.ts
@@ -1,14 +1,5 @@
 import prisma from "@/lib/prisma";
-import type { PrismaClient, Prisma } from "@/generated/prisma/client";
-
-/**
- * A Prisma client that can run queries: either the global singleton or a
- * transaction-scoped client passed in by a caller that has already opened a
- * `$transaction` (e.g. the scan route's per-participant lock). Threading this
- * through lets the same reads/writes run under the caller's transaction and
- * lock instead of on independent connections.
- */
-type DbClient = PrismaClient | Prisma.TransactionClient;
+import { type DbClient, type TxClient, withTx } from "@/lib/db-client";
 
 /**
  * Finds all program IDs that a participant is associated with
@@ -130,7 +121,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
 
     // We have at least one event. We need to chunk the visit by deleting the
     // original open visit and recreating the chunks atomically.
-    const chunk = async (tx: Prisma.TransactionClient) => {
+    const chunk = async (tx: TxClient) => {
         // First, delete the original open visit
         await tx.visit.delete({
             where: { id: visitId }
@@ -213,8 +204,5 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
     // the scan route's per-participant lock), run the chunking on it directly:
     // Postgres has no nested transactions and the tx client has no `$transaction`.
     // Otherwise open our own transaction so the delete + recreates stay atomic.
-    if ("$transaction" in db) {
-        return await db.$transaction(chunk);
-    }
-    return await chunk(db);
+    return withTx(db, chunk);
 }

--- a/checkin-app/src/lib/db-client.ts
+++ b/checkin-app/src/lib/db-client.ts
@@ -1,0 +1,24 @@
+import { Prisma, type PrismaClient } from "@/generated/prisma/client";
+
+/**
+ * Shared root-or-tx client types. The prisma singleton has `$transaction`; a
+ * transaction client does not (it's in the ITX deny list) — that's how
+ * {@link isRootClient} tells them apart at runtime.
+ */
+export type TxClient = Prisma.TransactionClient;
+export type DbClient = PrismaClient | TxClient;
+
+export function isRootClient(db: DbClient): db is PrismaClient {
+    return "$transaction" in db;
+}
+
+/**
+ * Run `fn` under `db`: opens a new transaction if `db` is the root client, or
+ * joins the caller's transaction (just calls `fn` directly) if `db` is
+ * already a tx client. Lets a function be called standalone (owns its own
+ * atomicity) or nested inside a caller's `$transaction` (joins it) without
+ * double-wrapping.
+ */
+export function withTx<T>(db: DbClient, fn: (tx: TxClient) => Promise<T>): Promise<T> {
+    return isRootClient(db) ? db.$transaction(fn) : fn(db);
+}

--- a/checkin-app/src/lib/emergencyContacts/service.ts
+++ b/checkin-app/src/lib/emergencyContacts/service.ts
@@ -1,7 +1,8 @@
 import prisma from "@/lib/prisma";
-import type { Prisma, EmergencyContact } from "@/generated/prisma/client";
+import type { EmergencyContact } from "@/generated/prisma/client";
 import { identityKeys, sameIdentity, identityMatchReason, cleanEmail, normalizePhone } from "./identity";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
+import type { DbClient } from "@/lib/db-client";
 
 /**
  * Emergency-contact write/read model. Enforces the not-a-household-member rule
@@ -27,7 +28,7 @@ export class EmergencyContactError extends Error {
 }
 
 /** Accepts either the base client or a transaction client. */
-type Db = Prisma.TransactionClient | typeof prisma;
+type Db = DbClient;
 
 export interface ContactInput {
     name: string;

--- a/checkin-app/src/lib/household/leads.ts
+++ b/checkin-app/src/lib/household/leads.ts
@@ -1,5 +1,4 @@
-import { Prisma } from "@/generated/prisma/client";
-import type { PrismaClient } from "@/generated/prisma/client";
+import { type DbClient, type TxClient, withTx } from "@/lib/db-client";
 
 /**
  * Maximum number of leads a single household may have (issue #269).
@@ -13,16 +12,6 @@ export class HouseholdLeadLimitError extends Error {
         super(`A household can have at most ${MAX_HOUSEHOLD_LEADS} leads.`);
         this.name = "HouseholdLeadLimitError";
     }
-}
-
-// Accepts either the prisma singleton or a $transaction client. The singleton
-// has `$transaction`; a transaction client does not (it's in the ITX deny list),
-// which is how we tell them apart at runtime.
-type TxClient = Prisma.TransactionClient;
-type DbClient = PrismaClient | TxClient;
-
-function isRootClient(db: DbClient): db is PrismaClient {
-    return "$transaction" in db;
 }
 
 /**
@@ -78,9 +67,5 @@ export async function addHouseholdLead(
     householdId: number,
     participantId: number,
 ): Promise<{ created: boolean }> {
-    if (isRootClient(db)) {
-        return db.$transaction((tx) => addHouseholdLeadTx(tx, householdId, participantId));
-    }
-    // Already inside a transaction — the caller owns atomicity; just join it.
-    return addHouseholdLeadTx(db, householdId, participantId);
+    return withTx(db, (tx) => addHouseholdLeadTx(tx, householdId, participantId));
 }

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -6,8 +6,7 @@ import { sendCongrats } from "@/lib/membership/payment";
 import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
 import { config } from "@/lib/config";
 import { canonicalizeEmail } from "@/lib/emailNormalize";
-
-type TxClient = Prisma.TransactionClient;
+import { type DbClient, type TxClient } from "@/lib/db-client";
 
 /**
  * Background-check review — now a PARALLEL track, not a blocking phase.
@@ -257,7 +256,7 @@ export function matchesVolunteerDesignation(parentEmails: string[], designationE
  * reviewer marked the family volunteer-only OR a household parent's email is pre-
  * designated. Never clears it here.
  */
-export async function applyVolunteerStatus(db: TxClient | typeof prisma, membershipId: number, householdId: number, markedByReviewer: boolean) {
+export async function applyVolunteerStatus(db: DbClient, membershipId: number, householdId: number, markedByReviewer: boolean) {
     let isVolunteer = markedByReviewer;
     if (!isVolunteer) {
         const parents = await db.person.findMany({ where: { householdId, householdLeads: { some: { householdId } }, email: { not: null } }, select: { email: true } });
@@ -300,7 +299,7 @@ export async function overrideBlocked(processId: number, actorId: number, action
     return { status };
 }
 
-function audit(db: TxClient | typeof prisma, actorId: number, processId: number, oldData: object, newData: object) {
+function audit(db: DbClient, actorId: number, processId: number, oldData: object, newData: object) {
     return db.auditLog.create({
         data: {
             actorId: actorId || SYSTEM_ACTOR,

--- a/checkin-app/src/lib/program/capacity.ts
+++ b/checkin-app/src/lib/program/capacity.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@/generated/prisma/client";
+import type { TxClient } from "@/lib/db-client";
 
 /** Thrown by {@link lockProgramAndCheckCapacity} when a program is full. */
 export class ProgramCapacityError extends Error {
@@ -22,7 +22,7 @@ export class ProgramCapacityError extends Error {
  * auto-releases on commit/rollback.
  */
 export async function lockProgramAndCheckCapacity(
-    tx: Prisma.TransactionClient,
+    tx: TxClient,
     programId: number,
     seats: number,
     maxParticipants: number | null,

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -2,10 +2,8 @@ import prisma from "@/lib/prisma";
 import { findAssociatedEventAt, processVisitCheckout } from "@/lib/attendanceTransitions";
 import { sendCheckinNotifications } from "@/lib/notifications";
 import { apiError, apiJson } from "@/lib/api-response";
-import type { Person, PrismaClient, Prisma } from "@/generated/prisma/client";
-
-/** Global client or a caller-supplied transaction-scoped client. */
-type DbClient = PrismaClient | Prisma.TransactionClient;
+import type { Person } from "@/generated/prisma/client";
+import { type DbClient, isRootClient } from "@/lib/db-client";
 
 /**
  * Process a check-in for a participant who has no active visit.
@@ -124,7 +122,7 @@ export async function processCheckout(
             // client — e.g. tests) we own the whole operation, so run them here;
             // under the route's tx client the route runs both AFTER it commits
             // (see finalizeFacilityClose / route.ts).
-            if ("$transaction" in db) {
+            if (isRootClient(db)) {
                 await closeAllOpenVisits(db);
                 kickPostEventEmails();
             }

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -1,12 +1,10 @@
-import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { escapeHtml } from "@/lib/email-templates/base";
 import { emailBoardMembers, emailHouseholdLeads } from "@/lib/emailRecipients";
 import { isTrustedAdultConflict } from "@/lib/trusted-adult/conflict";
 import { config } from "@/lib/config";
 import { validateContact } from "@/lib/trusted-adult/contact";
-
-type TxClient = Prisma.TransactionClient;
+import type { TxClient } from "@/lib/db-client";
 
 /**
  * Serialize all mutations of one TrustedAdult by taking a row lock on the parent.


### PR DESCRIPTION
## Summary

An audit found the "accepts either the root prisma client or an open `$transaction` client" pattern spelled 3+ different ways across `src/lib`:

- **leads.ts**: root/tx union + runtime `isRootClient()` check, auto-wraps in its own transaction when called with root.
- **attendanceTransitions.ts** / **scan-service.ts**: the same auto-wrap logic duplicated inline (`"$transaction" in db`) instead of sharing a helper.
- **emergencyContacts/service.ts**, **trusted-adult/service.ts**, **membership/review.ts**: a plain `TransactionClient | typeof prisma` union with no runtime branching — each declared its own local type alias.
- **membership-ops/participants/import/route.ts**: 4 inline helpers typed their `db` param as `Prisma.TransactionClient` but defaulted it to the root `prisma` client — only compiled because `PrismaClient` is structurally assignable to `TransactionClient`.

No double-wrap or atomicity bugs were found in the existing code (traced real call sites for each pattern), but the duplication and the mistyped default were worth consolidating.

- Added `src/lib/db-client.ts`: `DbClient`, `TxClient`, `isRootClient()`, and `withTx()` (opens a transaction if handed the root client, joins the caller's transaction otherwise).
- Repointed all 8 files at the shared types/helper; replaced the two duplicated inline auto-wrap branches with `withTx(...)`.
- Fixed the mistyped `db: Prisma.TransactionClient = prisma` defaults in the import route to `db: DbClient = prisma`.

Pure refactor — no behavior change, no call-site signature changes.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] Unit tests for all touched files pass (45/45)
- [x] Integration + concurrency tests pass against a throwaway Postgres (356/356), including the household-lead cap lock, attendance chunking, scan facility-close, trusted-adult review, membership background-check review, and program capacity lock suites that exercise these exact root-vs-tx paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)