### PR TITLE
fix(terminology): repair tsc-blind consumers of B2/B3 renames

### DIFF
--- a/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
@@ -91,8 +91,8 @@ describe("membership-ops/participants/merge page", () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({
       "/api/membership-ops/participants/merge/analyze": { participants: [zack, belle] },
-      "/api/participants/search?q=Zack": { participants: [zack] },
-      "/api/participants/search?q=Belle": { participants: [belle] },
+      "/api/people/search?q=Zack": { people: [zack] },
+      "/api/people/search?q=Belle": { people: [belle] },
     });
     renderWithProviders(<MergeParticipants />);
 
@@ -139,8 +139,8 @@ describe("membership-ops/participants/merge page", () => {
     setSession({ id: 1, isSysadmin: true });
     global.fetch = jest.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("q=Alice")) return { ok: true, json: async () => ({ participants: [participantA] }) } as Response;
-      if (url.includes("q=Bob")) return { ok: true, json: async () => ({ participants: [participantB] }) } as Response;
+      if (url.includes("q=Alice")) return { ok: true, json: async () => ({ people: [participantA] }) } as Response;
+      if (url.includes("q=Bob")) return { ok: true, json: async () => ({ people: [participantB] }) } as Response;
       if (url.includes("merge/analyze")) throw new Error("boom");
       return { ok: false, json: async () => ({}) } as Response;
     }) as unknown as typeof fetch;
@@ -164,8 +164,8 @@ describe("membership-ops/participants/merge page", () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({
       "/api/membership-ops/participants/merge/analyze": { participants: [leo, otto] },
-      "/api/participants/search?q=Leo": { participants: [leo] },
-      "/api/participants/search?q=Otto": { participants: [otto] },
+      "/api/people/search?q=Leo": { people: [leo] },
+      "/api/people/search?q=Otto": { people: [otto] },
     });
     renderWithProviders(<MergeParticipants />);
 
@@ -193,8 +193,8 @@ describe("membership-ops/participants/merge page", () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({
       "/api/membership-ops/participants/merge/analyze": { participants: [mia, hank] },
-      "/api/participants/search?q=Mia": { participants: [mia] },
-      "/api/participants/search?q=Hank": { participants: [hank] },
+      "/api/people/search?q=Mia": { people: [mia] },
+      "/api/people/search?q=Hank": { people: [hank] },
     });
     renderWithProviders(<MergeParticipants />);
 

--- a/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
@@ -24,8 +24,8 @@ function mockRoutes() {
   return mockFetchJson({
     "/api/membership-ops/participants/merge/analyze": { participants: [participantA, participantB] },
     "/api/membership-ops/participants/merge": { success: true },
-    "/api/participants/search?q=Alice": { participants: [participantA] },
-    "/api/participants/search?q=Bob": { participants: [participantB] },
+    "/api/people/search?q=Alice": { people: [participantA] },
+    "/api/people/search?q=Bob": { people: [participantB] },
   });
 }
 

--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -42,9 +42,9 @@ export default function MergeParticipants() {
 
   useEffect(() => {
     if (searchA.length > 2 && !pA) {
-      fetch(`/api/participants/search?q=${encodeURIComponent(searchA)}`)
+      fetch(`/api/people/search?q=${encodeURIComponent(searchA)}`)
         .then(r => r.json())
-        .then(d => setResultsA(d.participants || []));
+        .then(d => setResultsA(d.people || []));
     } else {
       setResultsA([]);
     }
@@ -52,9 +52,9 @@ export default function MergeParticipants() {
 
   useEffect(() => {
     if (searchB.length > 2 && !pB) {
-      fetch(`/api/participants/search?q=${encodeURIComponent(searchB)}`)
+      fetch(`/api/people/search?q=${encodeURIComponent(searchB)}`)
         .then(r => r.json())
-        .then(d => setResultsB(d.participants || []));
+        .then(d => setResultsB(d.people || []));
     } else {
       setResultsB([]);
     }

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -26,7 +26,7 @@ function renderPage() {
 
 const household = {
     household: {
-        participants: [
+        householdMembers: [
             { id: 100, name: "Jamie Guardian", dateOfBirth: "1990-01-01" },
             { id: 101, name: "Kid One", dateOfBirth: "2015-01-01" },
             { id: 102, name: "Too Young", dateOfBirth: "2023-01-01" },

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -87,10 +87,10 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
       const res = await fetch(`/api/household`);
       if (res.ok) {
         const data = await res.json();
-        if (data.household && data.household.participants) {
-          setHouseholdMembers(data.household.participants);
-          const me = data.household.participants.find((p: { id: number }) => p.id === currentUserId);
-          setSelectedParticipantIds([me ? me.id : (data.household.participants[0]?.id || currentUserId)]);
+        if (data.household && data.household.householdMembers) {
+          setHouseholdMembers(data.household.householdMembers);
+          const me = data.household.householdMembers.find((p: { id: number }) => p.id === currentUserId);
+          setSelectedParticipantIds([me ? me.id : (data.household.householdMembers[0]?.id || currentUserId)]);
         } else {
           setHouseholdMembers([{ id: currentUserId, name: "Myself", dateOfBirth: null }]);
           setSelectedParticipantIds([currentUserId]);


### PR DESCRIPTION
## What

Two runtime regressions on `main` left by prior terminology renames (B2: people-search route + envelope; B3: household wire key). Both slipped past `tsc` because the consumers read loosely-typed `fetch(...).json()` results, and stale test mocks kept CI green.

**REG-1 — merge tool** (`membership-ops/participants/merge/page.tsx`)
- Both search fetches: `/api/participants/search` → `/api/people/search` (renamed in B2)
- Both handlers: `d.participants` → `d.people` (B2 envelope rename)
- Left untouched: the `merge/analyze` fetch and its `d.participants` — different endpoint, still returns `participants`.

**REG-2 — program enrollment picker** (`programs/[id]/page.tsx`)
- All four reads: `data.household.participants` → `data.household.householdMembers` (B3 key rename). Restores real household members in the picker instead of only "Myself".

**Test mocks** updated to the new wire shapes:
- merge page test: mock keys `/api/participants/search` → `/api/people/search`, bodies `{ participants }` → `{ people }`
- programs/[id] page test: household mock key `participants` → `householdMembers` (same mock-rot class — its fixture still emitted the old key)

## Why

Symptom: merge search returned no results; program enrollment picker showed only "Myself". Root cause: consumers on the old URL/keys. Renames were type-invisible because the responses are untyped JSON.

## Verify
- `grep -rn "/api/participants/search" src` → 0
- `grep -rnE "household[A-Za-z]*\.participants\b" src` → 0
- `tsc --noEmit` clean
- jest: 3 suites / 10 tests pass (merge + programs/[id])

## Reviewer notes
- Deliberately **not** touched (verified NOT regressions): `attendance/certifications/page.tsx` `data.participants` (certs API still emits `participants` server-side) and `programs/[id]/register/page.tsx` `data.participants` (`ProgramParticipant` enrollee count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)