### PR TITLE
feat(membership-ops): audited admin edit of household "member since"

### DIFF
--- a/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
@@ -37,7 +37,27 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
         Object.assign(data, normalizeAddressInput(body));
 
         const editsContact = body.emergencyContactName !== undefined || body.emergencyContactPhone !== undefined;
-        if (Object.keys(data).length === 0 && !editsContact) {
+        const editsHousehold = Object.keys(data).length > 0 || editsContact;
+
+        // "Member since" lives on the household's Membership (1:1). Treat the date
+        // as date-only: parse at UTC midnight and only act on a real change, so an
+        // unchanged field re-sent by the form never writes a spurious audit row.
+        let memberSinceChange: { membershipId: number; oldValue: Date; newValue: Date } | null = null;
+        if (typeof body.memberSince === "string" && body.memberSince !== "") {
+            const parsed = new Date(`${body.memberSince}T00:00:00.000Z`);
+            if (isNaN(parsed.getTime())) {
+                return NextResponse.json({ error: "Invalid member-since date" }, { status: 400 });
+            }
+            const membership = await prisma.membership.findUnique({ where: { householdId: id } });
+            if (!membership) {
+                return NextResponse.json({ error: "Household has no membership record" }, { status: 400 });
+            }
+            if (membership.memberSince.toISOString().slice(0, 10) !== body.memberSince) {
+                memberSinceChange = { membershipId: membership.id, oldValue: membership.memberSince, newValue: parsed };
+            }
+        }
+
+        if (!editsHousehold && !memberSinceChange) {
             return NextResponse.json({ error: "No fields to update provided" }, { status: 400 });
         }
 
@@ -54,21 +74,43 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
             await upsertPrimaryContact(prisma, id, { name: body.emergencyContactName, phone: body.emergencyContactPhone });
         }
 
-        await prisma.auditLog.create({
-            data: {
-                actorId: auth.user.id,
-                action: "EDIT",
-                tableName: "Household",
-                affectedEntityId: id,
-                oldData: {
-                    name: existing.name,
-                    ...pickAddress(existing),
-                    emergencyContactName: priorContact?.name ?? null,
-                    emergencyContactPhone: priorContact?.phone ?? null,
-                },
-                newData: { ...data, ...(editsContact && { emergencyContactName: body.emergencyContactName, emergencyContactPhone: body.emergencyContactPhone }) },
-            }
-        });
+        if (editsHousehold) {
+            await prisma.auditLog.create({
+                data: {
+                    actorId: auth.user.id,
+                    action: "EDIT",
+                    tableName: "Household",
+                    affectedEntityId: id,
+                    oldData: {
+                        name: existing.name,
+                        ...pickAddress(existing),
+                        emergencyContactName: priorContact?.name ?? null,
+                        emergencyContactPhone: priorContact?.phone ?? null,
+                    },
+                    newData: { ...data, ...(editsContact && { emergencyContactName: body.emergencyContactName, emergencyContactPhone: body.emergencyContactPhone }) },
+                }
+            });
+        }
+
+        // Separate audit row for the membership edit — a legible before/after of the
+        // join date on its own record, rather than folded into the Household row.
+        if (memberSinceChange) {
+            await prisma.membership.update({
+                where: { id: memberSinceChange.membershipId },
+                data: { memberSince: memberSinceChange.newValue },
+            });
+            await prisma.auditLog.create({
+                data: {
+                    actorId: auth.user.id,
+                    action: "EDIT",
+                    tableName: "Membership",
+                    affectedEntityId: memberSinceChange.membershipId,
+                    secondaryAffectedEntity: id,
+                    oldData: { memberSince: memberSinceChange.oldValue },
+                    newData: { memberSince: memberSinceChange.newValue },
+                }
+            });
+        }
 
         return NextResponse.json({ household: updated });
     } catch (error) {

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -12,6 +12,7 @@ export type AdminHousehold = {
   emergencyContactPhone: string | null;
   householdMembers?: Array<{ id: number; name: string | null; email: string | null }>;
   householdLeads?: Array<{ personId: number }>;
+  membership?: { memberSince: string | null } | null;
 } & Partial<StructuredAddress>;
 
 type FormState = {
@@ -23,9 +24,10 @@ type FormState = {
   postalCode: string;
   emergencyContactName: string;
   emergencyContactPhone: string;
+  memberSince: string;
 };
 
-const EMPTY: FormState = { name: "", line1: "", line2: "", city: "", state: "", postalCode: "", emergencyContactName: "", emergencyContactPhone: "" };
+const EMPTY: FormState = { name: "", line1: "", line2: "", city: "", state: "", postalCode: "", emergencyContactName: "", emergencyContactPhone: "", memberSince: "" };
 
 /** Deep-compares flat string form state. Exported for unit test. */
 export function isFormDirty(a: FormState, b: FormState): boolean {
@@ -75,6 +77,8 @@ export function AdminEditHouseholdModal({
           line1: a.line1 ?? "", line2: a.line2 ?? "", city: a.city ?? "", state: a.state ?? "", postalCode: a.postalCode ?? "",
           emergencyContactName: h.emergencyContactName || "",
           emergencyContactPhone: h.emergencyContactPhone || "",
+          // date-only slice of the membership's join date (ISO → YYYY-MM-DD)
+          memberSince: h.membership?.memberSince ? h.membership.memberSince.slice(0, 10) : "",
         };
         setForm(loaded);
         setInitial(loaded);
@@ -214,6 +218,13 @@ export function AdminEditHouseholdModal({
                 placeholder="(555) 555-5555"
               />
             </SimpleGrid>
+            <TextInput
+              type="date"
+              label="Member since"
+              description="Household's membership start date. Editing this is recorded in the audit log."
+              value={form.memberSince}
+              onChange={(e) => update({ memberSince: e.currentTarget.value })}
+            />
             <Divider label="Household Leads" labelPosition="left" mt="sm" />
             <Stack gap="xs">
               {leadIds.length === 0 && (

--- a/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
@@ -5,7 +5,7 @@ import { notifications } from "@mantine/notifications";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
 import { AdminEditHouseholdModal, isFormDirty } from "../AdminEditHouseholdModal";
 
-const base = { name: "Smith", line1: "1 Main", line2: "", city: "Austin", state: "TX", postalCode: "78701", emergencyContactName: "Jo", emergencyContactPhone: "5550000" };
+const base = { name: "Smith", line1: "1 Main", line2: "", city: "Austin", state: "TX", postalCode: "78701", emergencyContactName: "Jo", emergencyContactPhone: "5550000", memberSince: "2020-01-15" };
 
 describe("isFormDirty", () => {
   it("is false when snapshots match", () => {
@@ -15,6 +15,7 @@ describe("isFormDirty", () => {
   it("is true when any field differs", () => {
     expect(isFormDirty(base, { ...base, name: "Jones" })).toBe(true);
     expect(isFormDirty(base, { ...base, emergencyContactPhone: "5551111" })).toBe(true);
+    expect(isFormDirty(base, { ...base, memberSince: "2021-06-01" })).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

Lets **sysadmin / board** hand-correct a household's **membership start date** ("member since") from the existing Admin Edit Household modal, with every edit recorded in the audit log.

## Why

Membership start dates occasionally need manual correction (bad intake data, grandfathered households). No surface existed for it. Because the actor isn't a member of the household they're touching, the change must be attributable.

## How

- **API** — `PATCH /api/membership-ops/households/[id]` accepts optional `memberSince` (date-only, parsed at UTC midnight).
  - Diffs against the current value → an unchanged field re-sent by the form writes **no** audit row.
  - `400`s if the household has no `Membership` record (no side-effecting auto-create).
  - Writes a **dedicated** `AuditLog` row: `tableName:"Membership"`, `EDIT`, `secondaryAffectedEntity`=householdId, `old/newData:{ memberSince }`. The existing Household audit row now only fires when household/contact fields actually change.
- **UI** — `AdminEditHouseholdModal` gains a native `<input type="date">` field (no new dependency), loaded from the `membership` the GET route already returns. Rides the modal's existing dirty-guard, "use admin powers?" confirmation, and audit messaging.

Gating unchanged: `withAuth({ roles: ['isSysadmin','isBoardMember'] })`.

## Scope notes

- Household-level (matches the `Membership` model — one per household), not per-person.
- No reason/note field (would need a schema column).

## Test plan

- [ ] Board/sysadmin edits member-since → value persists, one `Membership` audit row with correct before/after.
- [ ] Save without changing the date → no `Membership` audit row.
- [ ] Household with no membership → `400`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)