### PR TITLE
test(nav): cover SectionTabs unsaved-changes guard (P1-8B)

### DIFF
--- a/checkin-app/src/components/ui/__tests__/SectionTabs.test.tsx
+++ b/checkin-app/src/components/ui/__tests__/SectionTabs.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import { SectionTabs } from "@/components/ui/SectionTabs";
+
+const push = jest.fn();
+let mockPathname = "/program-ops";
+const confirmNav = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname,
+}));
+jest.mock("@/components/UnsavedChangesProvider", () => ({
+  useConfirmNav: () => confirmNav,
+}));
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ||
+    ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList);
+  globalThis.ResizeObserver =
+    globalThis.ResizeObserver ||
+    (class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver);
+});
+
+const LINKS = [
+  { name: "Programs", href: "/program-ops" },
+  { name: "Events", href: "/program-ops/events" },
+];
+
+const renderTabs = () =>
+  render(
+    <MantineProvider>
+      <SectionTabs links={LINKS} prefixMatch />
+    </MantineProvider>,
+  );
+
+beforeEach(() => {
+  push.mockClear();
+  confirmNav.mockReset();
+  mockPathname = "/program-ops";
+});
+
+describe("SectionTabs guarded onChange", () => {
+  it("navigates when confirmNav allows it", () => {
+    confirmNav.mockReturnValue(true);
+    renderTabs();
+    fireEvent.click(screen.getByRole("tab", { name: "Events" }));
+    expect(confirmNav).toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith("/program-ops/events");
+  });
+
+  it("blocks navigation when confirmNav returns false (unsaved changes)", () => {
+    confirmNav.mockReturnValue(false);
+    renderTabs();
+    fireEvent.click(screen.getByRole("tab", { name: "Events" }));
+    expect(confirmNav).toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("no-ops (no confirm prompt) when clicking the already-active tab", () => {
+    confirmNav.mockReturnValue(true);
+    renderTabs();
+    fireEvent.click(screen.getByRole("tab", { name: "Programs" }));
+    expect(confirmNav).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Adds `SectionTabs.test.tsx` covering the shared section-tab bar's guarded `onChange`. No source change.

## Why (P1-8B)

Audit item P1-8B flagged the program-ops layout as skipping the shared discard-changes (`confirmNav`) guard when switching section tabs. **That premise is stale.** #664 centralized all 7 ops layouts' tab bars into the single `SectionTabs` component, which already gates navigation:

```tsx
const confirmNav = useConfirmNav();
onChange={(value) => { if (value && value !== active && confirmNav()) router.push(value); }}
```

No layout renders its own raw `<Tabs>` anymore, so adding `useConfirmNav` to the layout would be duplicate dead code. The bug the chip describes is already fixed — the only real gap was **missing regression coverage** for the guard.

## Coverage added

`src/components/ui/__tests__/SectionTabs.test.tsx` — 3 cases:
- navigates (`router.push`) when `confirmNav()` returns true
- **blocks navigation when `confirmNav()` returns false** — the unsaved-edits scenario P1-8B is about
- no-ops (no confirm prompt, no push) when clicking the already-active tab

## Reviewer notes

- Coverage lives on `SectionTabs`, not the layout, because that component owns the guard for all 7 ops layouts — the right regression layer.
- Verified locally: new suite 3/3 pass; existing `program-ops/__tests__/layout.test.tsx` 6/6 still pass.
- P1-8A (the `programsLed` row-aware gate) already landed separately and is untouched here.
- Sibling audit chips for other ops layouts ("skips discard guard") are likely stale for the same reason — all route through the guarded `SectionTabs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)