### PR TITLE
refactor(nav): single-source admin sub-tab badge derivation (P1-7)

### DIFF
--- a/checkin-app/src/app/membership-audit/layout.tsx
+++ b/checkin-app/src/app/membership-audit/layout.tsx
@@ -5,6 +5,7 @@ import { useSession } from "next-auth/react";
 import { Badge, Box, Center, Loader, Stack, Tabs, Text } from "@mantine/core";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { useTodoCounts } from "@/hooks/useTodoCounts";
+import { tabBadgeFor } from "@/components/navBadges";
 import { ScrollableTabsList } from "@/components/ui/ScrollableTabsList";
 import { PageContainer } from "@/components/ui/PageContainer";
 
@@ -40,35 +41,23 @@ export default function MembershipAuditLayout({ children }: { children: React.Re
       .sort((a, b) => b.href.length - a.href.length)
       .find((l) => pathname === l.href || pathname.startsWith(l.href + "/"))?.href ?? null;
 
-  const missingContact = todoCounts?.admin?.householdsMissingContact ?? 0;
-  const unclaimed = todoCounts?.admin?.unclaimedHouseholds ?? 0;
-  const broken = todoCounts?.admin?.brokenHouseholds ?? 0;
-
-  // Emergency/Unclaimed are gray: gaps on the household, not something the board can fix.
-  // Broken is green: the board must assign a lead. Returns [count, label].
-  const badgeFor = (href: string): [number, string] => {
-    if (href === "/membership-audit/emergency-contacts")
-      return [missingContact, `${missingContact} household${missingContact === 1 ? "" : "s"} missing an emergency contact`];
-    if (href === "/membership-audit/broken")
-      return [broken, `${broken} household${broken === 1 ? "" : "s"} without a lead`];
-    return [unclaimed, `${unclaimed} unclaimed account household${unclaimed === 1 ? "" : "s"}`];
-  };
-
+  // Emergency/Unclaimed are gray (gaps on the household), Broken is green (board must
+  // assign a lead) — derived in navBadges.tabBadgeFor so nav and tab agree.
   return (
     <PageContainer>
       <Stack>
       <Tabs value={activeTab} onChange={(value) => value && router.push(value)}>
         <ScrollableTabsList>
           {NAV_LINKS.map((link) => {
-            const [count, label] = badgeFor(link.href);
-            const isBroken = link.href === "/membership-audit/broken";
+            const badge = tabBadgeFor(link.href, todoCounts);
+            const isBroken = badge?.color === "treehouseGreen";
             return (
               <Tabs.Tab
                 key={link.href}
                 value={link.href}
                 leftSection={<span>{link.icon}</span>}
                 rightSection={
-                  count > 0 ? (
+                  badge ? (
                     <Badge
                       size="md"
                       color={isBroken ? "treehouseGreen" : "gray"}
@@ -76,9 +65,9 @@ export default function MembershipAuditLayout({ children }: { children: React.Re
                       // Pinned label color so the active tab's green recolor doesn't render the
                       // count green-on-green (gray informational fill, or black on the green fill).
                       c={isBroken ? "var(--mantine-color-black)" : "var(--mantine-color-gray-7)"}
-                      aria-label={label}
+                      aria-label={badge.label}
                     >
-                      {count}
+                      {badge.count}
                     </Badge>
                   ) : undefined
                 }

--- a/checkin-app/src/app/membership-ops/layout.tsx
+++ b/checkin-app/src/app/membership-ops/layout.tsx
@@ -5,16 +5,9 @@ import { Badge, Box, Center, Loader, Stack, Text } from "@mantine/core";
 import { MEMBERSHIP_OPS_NAV_LINKS } from "@/lib/membershipOpsNav";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { useTodoCounts } from "@/hooks/useTodoCounts";
-import type { TodoCounts } from "@/app/api/nav/todo-counts/route";
+import { tabBadgeFor } from "@/components/navBadges";
 import { SectionTabs } from "@/components/ui/SectionTabs";
 import { PageContainer } from "@/components/ui/PageContainer";
-
-/** Informational count for a Membership Ops nav link, or 0 when none / unknown. */
-function membershipTodoCountFor(href: string, counts: TodoCounts | null): number {
-  if (!counts?.admin) return 0;
-  if (href === "/membership-ops/applications") return counts.admin.applicationsTotal;
-  return 0;
-}
 
 export default function MembershipOpsLayout({ children }: { children: React.ReactNode }) {
   const { data: session } = useSession();
@@ -50,8 +43,8 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
 
   // Right-aligned count badge for a tab: pending applications, or the member-family total.
   const badgeFor = (href: string): React.ReactNode => {
-    const todoCount = membershipTodoCountFor(href, todoCounts);
-    if (todoCount > 0) {
+    const badge = tabBadgeFor(href, todoCounts);
+    if (badge) {
       return (
         <Badge
           size="md"
@@ -60,9 +53,9 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
           // Active tab recolors its content to the tabs color (green); pin a readable
           // label color so the count isn't rendered green-on-green on the active tab.
           c="var(--mantine-color-gray-7)"
-          aria-label={`${todoCount} application${todoCount === 1 ? "" : "s"}`}
+          aria-label={badge.label}
         >
-          {todoCount}
+          {badge.count}
         </Badge>
       );
     }

--- a/checkin-app/src/app/safety/layout.tsx
+++ b/checkin-app/src/app/safety/layout.tsx
@@ -5,6 +5,7 @@ import { useSession } from "next-auth/react";
 import { Badge, Box, Center, Loader, Stack, Tabs, Text } from "@mantine/core";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { useTodoCounts } from "@/hooks/useTodoCounts";
+import { tabBadgeFor } from "@/components/navBadges";
 import { ScrollableTabsList } from "@/components/ui/ScrollableTabsList";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { useConfirmNav } from "@/components/UnsavedChangesProvider";
@@ -17,9 +18,10 @@ export default function SafetyLayout({ children }: { children: React.ReactNode }
   const sessionUser = session?.user as { isSysadmin?: boolean; isBoardMember?: boolean } | undefined;
   const isBoard = !!(sessionUser?.isSysadmin || sessionUser?.isBoardMember);
   const { loading, ready } = useRequireRole(["isSysadmin", "isBoardMember", "isKeyholder"]);
-  // Trusted-adult disclosures awaiting board review — same count as the Safety nav badge.
+  // Trusted-adult disclosures awaiting board review — same count as the Safety nav badge
+  // (derived in navBadges.tabBadgeFor so nav and tab can't diverge).
   const counts = useTodoCounts(isBoard);
-  const taCount = counts?.admin?.trustedAdults ?? 0;
+  const taCount = tabBadgeFor("/safety/trusted-adults", counts)?.count ?? 0;
 
   if (loading) {
     return (

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -1,4 +1,4 @@
-import { navBadgeFor, leadsAnyProgram, leadPendingCount } from '@/components/navBadges';
+import { navBadgeFor, tabBadgeFor, leadsAnyProgram, leadPendingCount } from '@/components/navBadges';
 import type { TodoCounts } from '@/app/api/nav/todo-counts/route';
 
 const base: TodoCounts = {
@@ -55,5 +55,69 @@ describe('My Programs badge count', () => {
   it('singularizes the label for a single pending item', () => {
     const counts: TodoCounts = { ...base, lead: { programs: [prog(1, 'A', [item(10)])] } };
     expect(navBadgeFor('/my-programs', counts)[0].label).toBe('1 attendance item to confirm');
+  });
+});
+
+const admin = (over: Partial<NonNullable<TodoCounts['admin']>> = {}): TodoCounts => ({
+  ...base,
+  admin: {
+    membership: 0,
+    applicationsTotal: 0,
+    paymentPlanPending: 0,
+    trustedAdults: 0,
+    householdsMissingContact: 0,
+    unclaimedHouseholds: 0,
+    brokenHouseholds: 0,
+    memberFamilies: 0,
+    ...over,
+  },
+});
+
+describe('tabBadgeFor', () => {
+  it('returns null without an admin block (non-board viewer)', () => {
+    expect(tabBadgeFor('/membership-ops/applications', base)).toBeNull();
+    expect(tabBadgeFor('/safety/trusted-adults', null)).toBeNull();
+  });
+
+  it('applications tab shows every in-flight application (gray)', () => {
+    expect(tabBadgeFor('/membership-ops/applications', admin({ applicationsTotal: 40 })))
+      .toEqual({ count: 40, color: 'gray', label: '40 applications' });
+  });
+
+  it('broken-households tab is green (board action), the other audit tabs gray', () => {
+    expect(tabBadgeFor('/membership-audit/broken', admin({ brokenHouseholds: 2 })))
+      .toEqual({ count: 2, color: 'treehouseGreen', label: '2 households without a lead' });
+    expect(tabBadgeFor('/membership-audit/emergency-contacts', admin({ householdsMissingContact: 1 })))
+      .toEqual({ count: 1, color: 'gray', label: '1 household missing an emergency contact' });
+    expect(tabBadgeFor('/membership-audit/unclaimed', admin({ unclaimedHouseholds: 3 })))
+      .toEqual({ count: 3, color: 'gray', label: '3 unclaimed account households' });
+  });
+
+  it('trusted-adults tab matches the safety count (green)', () => {
+    expect(tabBadgeFor('/safety/trusted-adults', admin({ trustedAdults: 5 })))
+      .toEqual({ count: 5, color: 'treehouseGreen', label: '5 trusted-adult disclosures to review' });
+  });
+
+  it('hides action/gap tabs at zero', () => {
+    expect(tabBadgeFor('/membership-ops/applications', admin())).toBeNull();
+    expect(tabBadgeFor('/membership-audit/broken', admin())).toBeNull();
+  });
+});
+
+// The /membership-audit section badge is a roll-up of its tabs; keep them in lockstep.
+// Green section total == broken tab; gray section total == emergency + unclaimed tabs.
+describe('membership-audit nav ↔ tab agreement', () => {
+  it('section badges equal the sum of their tab badges', () => {
+    const counts = admin({ brokenHouseholds: 2, householdsMissingContact: 3, unclaimedHouseholds: 4 });
+    const nav = navBadgeFor('/membership-audit', counts);
+    const navGreen = nav.find((b) => b.color === 'treehouseGreen')?.count ?? 0;
+    const navGray = nav.find((b) => b.color === 'gray')?.count ?? 0;
+
+    const broken = tabBadgeFor('/membership-audit/broken', counts)?.count ?? 0;
+    const emergency = tabBadgeFor('/membership-audit/emergency-contacts', counts)?.count ?? 0;
+    const unclaimed = tabBadgeFor('/membership-audit/unclaimed', counts)?.count ?? 0;
+
+    expect(navGreen).toBe(broken);
+    expect(navGray).toBe(emergency + unclaimed);
   });
 });

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -74,3 +74,46 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
       return [];
   }
 }
+
+const plural = (n: number, one: string, many: string) => (n === 1 ? one : many);
+
+/**
+ * Badge for a section *sub-tab*, off the same shared counts. Lives here beside
+ * navBadgeFor so the tab number and the section-nav number are derived from one
+ * file — a new admin badge is one edit, and nav vs tab can't silently slice
+ * different fields for the same thing (they used to). Returns null when the tab
+ * has nothing to show. Layouts own the <Badge> JSX (variant, active-tab color
+ * pins); this owns only count + intent-color + label.
+ *
+ * NOT covered here: informational *total* counters that show even at 0 (e.g. the
+ * Manage Memberships member-family total) — those have no section-nav twin to
+ * diverge from, so they stay local to their layout.
+ */
+export function tabBadgeFor(href: string, counts: TodoCounts | null): NavBadge | null {
+  const admin = counts?.admin;
+  if (!admin) return null;
+  const green = (n: number, label: string): NavBadge | null =>
+    n > 0 ? { count: n, color: 'treehouseGreen', label } : null;
+  const gray = (n: number, label: string): NavBadge | null =>
+    n > 0 ? { count: n, color: 'gray', label } : null;
+  switch (href) {
+    // Membership Ops. Gray, informational: every in-flight application the
+    // Applications page lists (status != ACTIVE). Distinct from the /membership-ops
+    // section badge, which is green board-actionable (BLOCKED) only.
+    case '/membership-ops/applications':
+      return gray(admin.applicationsTotal, `${admin.applicationsTotal} application${plural(admin.applicationsTotal, '', 's')}`);
+    // Membership Audit — mirrors the /membership-audit section badge: broken is
+    // green (board must assign a lead), the other two gray (household's own gaps).
+    case '/membership-audit/emergency-contacts':
+      return gray(admin.householdsMissingContact, `${admin.householdsMissingContact} household${plural(admin.householdsMissingContact, '', 's')} missing an emergency contact`);
+    case '/membership-audit/broken':
+      return green(admin.brokenHouseholds, `${admin.brokenHouseholds} household${plural(admin.brokenHouseholds, '', 's')} without a lead`);
+    case '/membership-audit/unclaimed':
+      return gray(admin.unclaimedHouseholds, `${admin.unclaimedHouseholds} unclaimed account household${plural(admin.unclaimedHouseholds, '', 's')}`);
+    // Safety — same count as the /safety section badge.
+    case '/safety/trusted-adults':
+      return green(admin.trustedAdults, `${admin.trustedAdults} trusted-adult disclosure${plural(admin.trustedAdults, '', 's')} to review`);
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## What

Audit item **P1-7**: badge derivation off the shared `TodoCounts` object was duplicated and could diverge. The counting was already centralized (`todo-counts/route.ts` + `useTodoCounts`); the problem was **badge derivation**, hand-rolled separately in the top nav and in each section layout with no shared mapping.

Adds `tabBadgeFor(href, counts)` to `navBadges.ts`, beside the existing `navBadgeFor`, so both the section-nav badge and the per-tab badges derive from **one file**. Rewires the three section layouts to call it.

## Why

- New admin badge = edit multiple files, no single mapping keeping nav and tab aligned.
- Nav vs tab could silently slice **different fields for the same section**. `membership-ops` did exactly that:
  - Section nav badge → `admin.membership` = BLOCKED-only count (green, "board must act").
  - Applications tab badge → `admin.applicationsTotal` = all in-flight (gray, pipeline depth).
  - `membership` ⊆ `applicationsTotal`, so nav could show `2` while the tab showed `40`.

## Changed

- **`navBadges.ts`** — new `tabBadgeFor`: owns count + intent-color + label for membership-ops applications, membership-audit (×3), safety trusted-adults.
- **membership-ops / membership-audit / safety layouts** — deleted inline derivations, call `tabBadgeFor`. Layouts keep only their own `<Badge>` JSX (variant, active-tab color pins) — presentation stays local.
- **navBadges.test.ts** — `tabBadgeFor` cases + a nav↔tab agreement invariant asserting the membership-audit section badge is the roll-up of its three tab badges.

## Notes for reviewer

- **Values preserved, not unified.** The `membership-ops` nav-vs-tab split (BLOCKED-only green nav vs all-in-flight gray tab) is **intentionally kept** — it's a product call, not this refactor. The split is now single-sourced and documented rather than accidental. If you want them unified, that's a one-line change in `navBadgeFor` case `/membership-ops`.
- **`my-programs` untouched** — it already shared `leadPendingCount` across nav and tab (the target pattern).
- **membership-ops member-family total stays local** — it's an always-shown counter (shows at 0) with no section-nav twin, so no divergence risk; a `ponytail:`-style comment marks why.

## Testing

- `navBadges` suite: 12/12 pass (incl. new tabBadgeFor + roll-up invariant).
- All `layout.test` suites: 43/43 pass.
- Edited files typecheck clean (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)