### PR TITLE
refactor(api): standardize error responses on apiError() + lint guard (P3-1)

### DIFF
--- a/checkin-app/src/app/api/admin/broken-households/route.ts
+++ b/checkin-app/src/app/api/admin/broken-households/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -34,7 +35,7 @@ export const GET = withAuth(
             return NextResponse.json({ households: result });
         } catch (error) {
             logger.error("Failed to fetch broken households:", error);
-            return NextResponse.json({ error: "Failed to fetch broken households" }, { status: 500 });
+            return apiError("Failed to fetch broken households", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/admin/settings/localization/route.ts
+++ b/checkin-app/src/app/api/admin/settings/localization/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { APP_TIMEZONE } from "@/lib/time";
 import { APP_LOCALE } from "@/lib/appSettings";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -21,19 +22,19 @@ export const GET = withAuth({ roles: ["isSysadmin"] }, async () => {
  * previous value survives rather than being overwritten with garbage.
  */
 export const PUT = withAuth({ roles: ["isSysadmin"] }, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     let body: { timezone?: string; locale?: string };
     try {
         body = await req.json();
     } catch {
-        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+        return apiError("Invalid JSON", 400);
     }
 
     const data: Record<string, string> = {};
     if (body.timezone !== undefined) {
         const tz = body.timezone.trim();
         if (!Intl.supportedValuesOf("timeZone").includes(tz)) {
-            return NextResponse.json({ error: "timezone must be a valid IANA timezone" }, { status: 400 });
+            return apiError("timezone must be a valid IANA timezone", 400);
         }
         data.timezone = tz;
     }
@@ -42,7 +43,7 @@ export const PUT = withAuth({ roles: ["isSysadmin"] }, async (req, auth) => {
         try {
             if (Intl.getCanonicalLocales(loc)[0] !== loc) throw new Error();
         } catch {
-            return NextResponse.json({ error: "locale must be a valid BCP-47 locale" }, { status: 400 });
+            return apiError("locale must be a valid BCP-47 locale", 400);
         }
         data.locale = loc;
     }

--- a/checkin-app/src/app/api/attendance/manual/route.ts
+++ b/checkin-app/src/app/api/attendance/manual/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import type { Prisma } from "@/generated/prisma/client";
 import { findAssociatedEventAt, processVisitCheckout } from "@/lib/attendanceTransitions";
 import { logBackendError } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
 
 // Self-service manual visit entry. INTENTIONAL by design: a member records a
 // visit for THEMSELVES only (participantId is forced to auth.user.id, never taken
@@ -15,28 +16,28 @@ import { logBackendError } from "@/lib/logger";
 // a security or integrity boundary. Recurring-audit note: this is not an IDOR and
 // not a fabrication vuln; do not re-flag the arbitrary backdate.
 export const POST = withAuth({}, async (req, auth) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     try {
         const userId = auth.user.id;
         const body = await req.json();
         const { arrivedAt, departedAt } = body;
 
         if (!arrivedAt) {
-            return NextResponse.json({ error: "Arrival time is required" }, { status: 400 });
+            return apiError("Arrival time is required", 400);
         }
 
         const arrivalTime = new Date(arrivedAt);
         const departureTime = departedAt ? new Date(departedAt) : null;
 
         if (isNaN(arrivalTime.getTime())) {
-            return NextResponse.json({ error: "Invalid arrival time" }, { status: 400 });
+            return apiError("Invalid arrival time", 400);
         }
         if (departureTime && isNaN(departureTime.getTime())) {
-            return NextResponse.json({ error: "Invalid departure time" }, { status: 400 });
+            return apiError("Invalid departure time", 400);
         }
 
         if (departureTime && departureTime <= arrivalTime) {
-            return NextResponse.json({ error: "Departure time must be after arrival time" }, { status: 400 });
+            return apiError("Departure time must be after arrival time", 400);
         }
 
         // Blank departure means "still in the building" → an open visit. Only allow
@@ -49,7 +50,7 @@ export const POST = withAuth({}, async (req, auth) => {
             const withinSixHours = now.getTime() - arrivalTime.getTime() <= 6 * 60 * 60 * 1000;
             const sameDay = arrivalTime.toDateString() === now.toDateString();
             if (!withinSixHours && !sameDay) {
-                return NextResponse.json({ error: "Departure time is required for past arrivals." }, { status: 400 });
+                return apiError("Departure time is required for past arrivals.", 400);
             }
         }
 
@@ -107,6 +108,6 @@ export const POST = withAuth({}, async (req, auth) => {
         return NextResponse.json({ message: "Manual visit recorded successfully.", visit }, { status: 201 });
     } catch (error: unknown) {
         await logBackendError(error, "POST /api/attendance/manual");
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -6,6 +6,7 @@ import { getFullAttendance } from "@/lib/getFullAttendance";
 import { findAssociatedEventAt, processVisitCheckout } from "@/lib/attendanceTransitions";
 import { logBackendError, logger } from "@/lib/logger";
 import { config } from "@/lib/config";
+import { apiError } from "@/lib/api-response";
 
 // GET is kiosk-first with distinct signature-failure semantics (403 on bad signature,
 // not 401), so it keeps its own kiosk plumbing rather than moving to withAuth. The one
@@ -33,12 +34,12 @@ export async function GET(req: NextRequest) {
                 pubKeys
             );
             if (!result.ok) {
-                return NextResponse.json({ error: result.error }, { status: result.status });
+                return apiError(result.error, result.status);
             }
             isKiosk = true;
         } else if (!user && pubKeys.length > 0) {
             // No session and no kiosk headers — reject
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            return apiError("Unauthorized", 401);
         } else if (!user && pubKeys.length === 0 && config.isLocal()) {
             // Local dev only (CHECKIN_ENV=local): no pubKey configured, treat as kiosk.
             // Deliberately gated on isLocal() — on the cloud dev instance or prod an
@@ -46,7 +47,7 @@ export async function GET(req: NextRequest) {
             // anonymous callers. Mirrors the keyless-kiosk gating in src/lib/auth.ts.
             isKiosk = true;
         } else if (!user) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            return apiError("Unauthorized", 401);
         }
 
         const { attendance, counts, safety } = await getFullAttendance();
@@ -81,15 +82,12 @@ export async function GET(req: NextRequest) {
         });
     } catch (error) {
         await logBackendError(error, "GET /api/attendance");
-        return NextResponse.json(
-            { error: "Internal Server Error while fetching attendance." },
-            { status: 500 }
-        );
+        return apiError("Internal Server Error while fetching attendance.", 500);
     }
 }
 
 export const DELETE = withAuth({}, async (req, auth) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const user = auth.user;
 
     try {
@@ -97,7 +95,7 @@ export const DELETE = withAuth({}, async (req, auth) => {
         const { visitId } = body;
 
         if (!visitId) {
-            return NextResponse.json({ error: "visitId is required" }, { status: 400 });
+            return apiError("visitId is required", 400);
         }
 
         const visit = await prisma.visit.findUnique({
@@ -106,7 +104,7 @@ export const DELETE = withAuth({}, async (req, auth) => {
         });
 
         if (!visit) {
-            return NextResponse.json({ error: "Visit not found" }, { status: 404 });
+            return apiError("Visit not found", 404);
         }
 
         // Check permissions:
@@ -118,7 +116,7 @@ export const DELETE = withAuth({}, async (req, auth) => {
         const isAdmin = user.isSysadmin || user.isKeyholder || user.isBoardMember;
 
         if (!isSelf && !isHouseholdCheckOut && !isAdmin) {
-            return NextResponse.json({ error: "Forbidden: You are not authorized to check out this user." }, { status: 403 });
+            return apiError("Forbidden: You are not authorized to check out this user.", 403);
         }
 
         const finalVisits = await processVisitCheckout(visitId, new Date(), undefined, "WEB");
@@ -127,12 +125,12 @@ export const DELETE = withAuth({}, async (req, auth) => {
         return NextResponse.json({ success: true, visit: updatedVisit });
     } catch (error) {
         await logBackendError(error, "DELETE /api/attendance");
-        return NextResponse.json({ error: "Failed to force checkout" }, { status: 500 });
+        return apiError("Failed to force checkout", 500);
     }
 });
 
 export const POST = withAuth({}, async (req, auth) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const user = auth.user;
     const isAdmin = user.isSysadmin || user.isKeyholder || user.isBoardMember;
 
@@ -143,7 +141,7 @@ export const POST = withAuth({}, async (req, auth) => {
         // Manual Check-in explicitly via the Dashboard
         if (type === 'MANUAL_CHECKIN') {
             if (!participantId) {
-                return NextResponse.json({ error: "participantId is required" }, { status: 400 });
+                return apiError("participantId is required", 400);
             }
 
             // Verify participant exists
@@ -152,14 +150,14 @@ export const POST = withAuth({}, async (req, auth) => {
             });
 
             if (!participant) {
-                return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+                return apiError("Participant not found", 404);
             }
 
             // Check Permissions
             const isSelf = participant.id === Number(user.id);
             const isHouseholdCheckIn = Boolean(user.householdId && participant.householdId === user.householdId && user.householdLead);
             if (!isSelf && !isHouseholdCheckIn && !isAdmin) {
-                return NextResponse.json({ error: "Forbidden: You are not authorized to check in this user." }, { status: 403 });
+                return apiError("Forbidden: You are not authorized to check in this user.", 403);
             }
 
             const arrivalTime = new Date();
@@ -203,7 +201,7 @@ export const POST = withAuth({}, async (req, auth) => {
             });
 
             if (result.alreadyCheckedIn) {
-                return NextResponse.json({ error: "User is already checked in" }, { status: 400 });
+                return apiError("User is already checked in", 400);
             }
 
             return NextResponse.json({ success: true, visit: result.visit });
@@ -248,9 +246,9 @@ export const POST = withAuth({}, async (req, auth) => {
             return NextResponse.json({ success: true, notified: boardMembers.length });
         }
 
-        return NextResponse.json({ error: "Unknown notification type" }, { status: 400 });
+        return apiError("Unknown notification type", 400);
     } catch (error) {
         await logBackendError(error, "POST /api/attendance");
-        return NextResponse.json({ error: "Failed to process notification" }, { status: 500 });
+        return apiError("Failed to process notification", 500);
     }
 });

--- a/checkin-app/src/app/api/auth/dev-personas/route.ts
+++ b/checkin-app/src/app/api/auth/dev-personas/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next";
 import prisma from "@/lib/prisma";
 import { config } from "@/lib/config";
 import { authOptions } from "@/lib/auth-options";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = 'force-dynamic';
 
@@ -17,10 +18,10 @@ export const dynamic = 'force-dynamic';
  */
 export async function GET() {
     if (process.env.NODE_ENV === 'production') {
-        return NextResponse.json({ error: "Not available" }, { status: 404 });
+        return apiError("Not available", 404);
     }
     if (!config.isDevInstance()) {
-        return NextResponse.json({ error: "Not available" }, { status: 404 });
+        return apiError("Not available", 404);
     }
     if (config.checkinEnv() === 'dev') {
         // DRIFT-GUARD ALLOWLIST (Step 7): this is the single sanctioned raw
@@ -33,7 +34,7 @@ export async function GET() {
         // breaking persona-switch) fits; this route stays on getServerSession.
         const session = await getServerSession(authOptions);
         if (!session?.user) {
-            return NextResponse.json({ error: "Not available" }, { status: 404 });
+            return apiError("Not available", 404);
         }
     }
 

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { config } from "@/lib/config";
 import { logger } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -19,16 +20,16 @@ export const dynamic = "force-dynamic";
  * 404s whenever the mock isn't active — always in prod.
  */
 export const POST = withAuth({}, async (req, auth) => {
-    if (!config.shopifyMockActive()) return NextResponse.json({ error: "Not available" }, { status: 404 });
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!config.shopifyMockActive()) return apiError("Not available", 404);
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
 
     const { processId } = await req.json().catch(() => ({ processId: undefined }));
     if (typeof processId !== "number" || !Number.isInteger(processId)) {
-        return NextResponse.json({ error: "Missing or invalid processId" }, { status: 400 });
+        return apiError("Missing or invalid processId", 400);
     }
 
     const secret = config.shopifyWebhookSecret();
-    if (!secret) return NextResponse.json({ error: "No webhook secret" }, { status: 500 });
+    if (!secret) return apiError("No webhook secret", 500);
 
     // A real paid order carries the membership variant id in its line_items; the
     // inbound handler matches it against BoardSettings to confirm the order is for
@@ -37,10 +38,7 @@ export const POST = withAuth({}, async (req, auth) => {
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
     const variantId = settings?.membershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId;
     if (!variantId) {
-        return NextResponse.json(
-            { error: "No membership variant configured. Set one in Settings → Membership first (design §2, O4a)." },
-            { status: 409 },
-        );
+        return apiError("No membership variant configured. Set one in Settings → Membership first (design §2, O4a).", 409);
     }
 
     // Shape mirrors the subset the inbound handler reads: note_attributes (where

--- a/checkin-app/src/app/api/dev/zoho-sign/complete/route.ts
+++ b/checkin-app/src/app/api/dev/zoho-sign/complete/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from "@/lib/auth";
 import { config } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { ZOHO_WEBHOOK_HEADER } from "@/lib/membership/contract/zoho";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -17,14 +18,14 @@ export const dynamic = "force-dynamic";
  * 404s whenever the mock isn't active — always in prod.
  */
 export const POST = withAuth({}, async (req, auth) => {
-    if (!config.zohoMockActive()) return NextResponse.json({ error: "Not available" }, { status: 404 });
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!config.zohoMockActive()) return apiError("Not available", 404);
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
 
     const { rid } = await req.json().catch(() => ({ rid: undefined }));
-    if (!rid || typeof rid !== "string") return NextResponse.json({ error: "Missing rid" }, { status: 400 });
+    if (!rid || typeof rid !== "string") return apiError("Missing rid", 400);
 
     const secret = config.zohoWebhookSecret();
-    if (!secret) return NextResponse.json({ error: "No webhook secret" }, { status: 500 });
+    if (!secret) return apiError("No webhook secret", 500);
 
     const res = await fetch(`${config.baseUrl()}/api/webhooks/zoho`, {
         method: "POST",

--- a/checkin-app/src/app/api/events/[id]/attendance/route.ts
+++ b/checkin-app/src/app/api/events/[id]/attendance/route.ts
@@ -2,15 +2,16 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await params;
 
     try {
         const eventId = parseInt(id, 10);
         if (isNaN(eventId)) {
-            return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+            return apiError("Invalid event ID", 400);
         }
 
         const event = await prisma.event.findUnique({
@@ -19,7 +20,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         });
 
         if (!event) {
-            return NextResponse.json({ error: "Event not found" }, { status: 404 });
+            return apiError("Event not found", 404);
         }
 
         const currentUserId = auth.user.id;
@@ -27,14 +28,14 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         const isSysAdminOrBoardOrKeyholder = auth.user.isSysadmin || auth.user.isBoardMember || auth.user.isKeyholder;
 
         if (!isLeadMentor && !isSysAdminOrBoardOrKeyholder) {
-            return NextResponse.json({ error: "Forbidden: Not authorized to validate attendance" }, { status: 403 });
+            return apiError("Forbidden: Not authorized to validate attendance", 403);
         }
 
         const body = await req.json();
         const { participantIds } = body; // Array of participant IDs who actually attended
 
         if (!Array.isArray(participantIds)) {
-            return NextResponse.json({ error: "participantIds array is required" }, { status: 400 });
+            return apiError("participantIds array is required", 400);
         }
 
         // Authz on the TARGETS: only participants enrolled or volunteering in
@@ -55,7 +56,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             const allowedIds = new Set<number>([...enrolled, ...volunteering].map(r => r.personId));
             const unknownIds = participantIds.filter(pId => !allowedIds.has(pId));
             if (unknownIds.length > 0) {
-                return NextResponse.json({ error: `Participants not enrolled or volunteering in this program: ${unknownIds.join(", ")}` }, { status: 400 });
+                return apiError(`Participants not enrolled or volunteering in this program: ${unknownIds.join(", ")}`, 400);
             }
         }
 
@@ -159,6 +160,6 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         return NextResponse.json({ success: true, processed: results.length });
     } catch (error) {
         logger.error("Attendance validation error:", error);
-        return NextResponse.json({ error: "Failed to validate attendance" }, { status: 500 });
+        return apiError("Failed to validate attendance", 500);
     }
 });

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { Prisma } from "@/generated/prisma/client";
 import { withAuth } from "@/lib/auth";
 import { handler, notFound, forbidden, badRequest } from "@/security/handler";
+import { apiError } from "@/lib/api-response";
 
 // FAIL-CLOSED, staff-only. This payload is fundamentally a roster — who is
 // enrolled / RSVP'd / attended — and a participant's name, id, and the very
@@ -63,11 +64,11 @@ export const GET = handler<{ id: string }>('GET /api/events/[id]', async ({ auth
 });
 
 export const PATCH = withAuth({}, async (req: Request, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
 
     const resolvedParams = await params;
     const eventId = parseInt(resolvedParams.id, 10);
-    if (isNaN(eventId)) return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+    if (isNaN(eventId)) return apiError("Invalid event ID", 400);
     const body = await req.json();
 
     try {
@@ -76,7 +77,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
             include: { program: { include: { volunteers: true } } }
         });
 
-        if (!event) return NextResponse.json({ error: "Event not found" }, { status: 404 });
+        if (!event) return apiError("Event not found", 404);
 
         const userId = auth.user.id;
         const isSysAdminOrBoard = auth.user.isSysadmin || auth.user.isBoardMember;
@@ -86,7 +87,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
         // Action: Confirm Attendance
         if (body.action === 'confirmAttendance') {
             if (!isSysAdminOrBoard && !isLeadMentor && !isCoreVolunteer) {
-                return NextResponse.json({ error: "Forbidden: Not authorized to confirm attendance" }, { status: 403 });
+                return apiError("Forbidden: Not authorized to confirm attendance", 403);
             }
 
             const updatedEvent = await prisma.event.update({
@@ -104,7 +105,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
         if (body.action === 'editTime' || body.action === 'cancel') {
             // Core volunteers can't edit or cancel events. Only lead mentors, isSysadmin, board.
             if (!isSysAdminOrBoard && !isLeadMentor) {
-                return NextResponse.json({ error: "Forbidden: Only Lead Mentors or Admins can edit/cancel events" }, { status: 403 });
+                return apiError("Forbidden: Only Lead Mentors or Admins can edit/cancel events", 403);
             }
 
             // Block edits to an event that has already finished. Re-clearing
@@ -112,7 +113,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
             // stale reminder; today only the cron's future-only window stops it
             // from firing. Use endAt (not startAt) so an in-progress event still edits.
             if (body.action === 'editTime' && event.endAt.getTime() < Date.now()) {
-                return NextResponse.json({ error: "Cannot edit a past event" }, { status: 400 });
+                return apiError("Cannot edit a past event", 400);
             }
 
             const { startAt, endAt, applyToFuture } = body;
@@ -198,13 +199,13 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
         // Action: Manual Edit Attendance
         if (body.action === 'manualEditAttendance') {
             if (!isSysAdminOrBoard && !isLeadMentor && !isCoreVolunteer) {
-                return NextResponse.json({ error: "Forbidden: Not authorized to edit attendance" }, { status: 403 });
+                return apiError("Forbidden: Not authorized to edit attendance", 403);
             }
 
             const { participantId, status, arrivedAt, departedAt } = body;
 
             if (!participantId || !status) {
-                return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+                return apiError("Missing required fields", 400);
             }
 
             // Authz on the TARGET: the participant must be enrolled or volunteering
@@ -219,7 +220,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                     prisma.programVolunteer.findFirst({ where: { programId: event.programId, personId: targetId }, select: { personId: true } }),
                 ]);
                 if (!enrolled && !volunteering) {
-                    return NextResponse.json({ error: "Participant is not enrolled or volunteering in this program" }, { status: 400 });
+                    return apiError("Participant is not enrolled or volunteering in this program", 400);
                 }
             }
 
@@ -235,7 +236,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                     }
                 });
                 if (openVisit) {
-                    return NextResponse.json({ error: "Participant is currently checked in — check them out before marking Absent" }, { status: 400 });
+                    return apiError("Participant is currently checked in — check them out before marking Absent", 400);
                 }
                 // Only closed visits remain; safe to remove on an Absent correction.
                 await prisma.visit.deleteMany({
@@ -246,7 +247,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                 });
             } else if (status === 'Present') {
                 if (!arrivedAt) {
-                    return NextResponse.json({ error: "Arrival time is required for Present status" }, { status: 400 });
+                    return apiError("Arrival time is required for Present status", 400);
                 }
 
                 // Check if there is an existing visit
@@ -284,10 +285,10 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
             return NextResponse.json({ success: true });
         }
 
-        return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+        return apiError("Invalid action", 400);
 
     } catch (error: unknown) {
         logger.error("Failed to update event:", error);
-        return NextResponse.json({ error: "Failed to update event" }, { status: 500 });
+        return apiError("Failed to update event", 500);
     }
 });

--- a/checkin-app/src/app/api/events/[id]/rsvp/route.ts
+++ b/checkin-app/src/app/api/events/[id]/rsvp/route.ts
@@ -5,9 +5,10 @@ import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { canActFor } from "@/lib/household/activityMembers";
 import { RSVP_STATUSES, type RSVPStatus } from "@/types/rsvp";
+import { apiError } from "@/lib/api-response";
 
 export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await params;
     // canActFor only reads session.user; reconstruct the minimal shape from auth.user.
     const session = { user: auth.user } as unknown as Session;
@@ -15,21 +16,21 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
     try {
         const eventId = parseInt(id, 10);
         if (isNaN(eventId)) {
-            return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+            return apiError("Invalid event ID", 400);
         }
 
         const body = await req.json();
         const { status } = body;
 
         if (!status || !RSVP_STATUSES.includes(status)) {
-            return NextResponse.json({ error: "Invalid RSVP status" }, { status: 400 });
+            return apiError("Invalid RSVP status", 400);
         }
 
         // Target defaults to self; a household lead may RSVP for a member of
         // their household. Authorize the target before trusting it.
         const targetId = typeof body.participantId === "number" ? body.participantId : session.user.id;
         if (!(await canActFor(session, targetId))) {
-            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+            return apiError("Forbidden", 403);
         }
         const currentUserId = targetId;
 
@@ -40,13 +41,13 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         });
 
         if (!event) {
-            return NextResponse.json({ error: "Event not found" }, { status: 404 });
+            return apiError("Event not found", 404);
         }
 
         // Can't RSVP to an event that already finished. Use endAt (not startAt) so an
         // in-progress event still accepts RSVPs.
         if (event.endAt.getTime() < Date.now()) {
-            return NextResponse.json({ error: "Cannot RSVP to a past event" }, { status: 400 });
+            return apiError("Cannot RSVP to a past event", 400);
         }
 
         if (event.programId) {
@@ -68,7 +69,7 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
             });
 
             if (!isEnrolled && !isVolunteer) {
-                return NextResponse.json({ error: "Forbidden: You are not a participant of this program" }, { status: 403 });
+                return apiError("Forbidden: You are not a participant of this program", 403);
             }
         }
 
@@ -92,6 +93,6 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         return NextResponse.json({ success: true, rsvp });
     } catch (error) {
         logger.error("RSVP update error:", error);
-        return NextResponse.json({ error: "Failed to update RSVP" }, { status: 500 });
+        return apiError("Failed to update RSVP", 500);
     }
 });

--- a/checkin-app/src/app/api/events/mine/route.ts
+++ b/checkin-app/src/app/api/events/mine/route.ts
@@ -4,9 +4,10 @@ import type { Session } from "next-auth";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { activityMembers } from "@/lib/household/activityMembers";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth({}, async (_req, auth) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     // activityMembers only reads session.user; reconstruct the minimal shape from auth.user.
     const session = { user: auth.user } as unknown as Session;
 
@@ -72,6 +73,6 @@ export const GET = withAuth({}, async (_req, auth) => {
         return NextResponse.json(rows);
     } catch (error) {
         logger.error("Failed to fetch user events:", error);
-        return NextResponse.json({ error: "Failed to fetch events" }, { status: 500 });
+        return apiError("Failed to fetch events", 500);
     }
 });

--- a/checkin-app/src/app/api/events/route.ts
+++ b/checkin-app/src/app/api/events/route.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { addDays, parseISO, isBefore, isEqual, getDay, setHours, setMinutes } from 'date-fns';
 import { fromZonedTime } from 'date-fns-tz';
 import { getAppSettings } from "@/lib/appSettings";
+import { apiError } from "@/lib/api-response";
 
 // List standalone (one-time) events — those with no associated program.
 export const GET = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async () => {
@@ -17,14 +18,14 @@ export const GET = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async ()
 });
 
 export const POST = withAuth({}, async (req, auth) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
 
     try {
         const body = await req.json();
         const { name, description, programId, startDate, startTime, endTime, recurrence } = body;
 
         if (!name || !startDate || !startTime || !endTime) {
-            return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+            return apiError("Missing required fields", 400);
         }
 
         const user = auth.user;
@@ -39,7 +40,7 @@ export const POST = withAuth({}, async (req, auth) => {
         }
 
         if (!isSysAdminOrBoard && !isLeadMentor) {
-            return NextResponse.json({ error: "Forbidden: Not authorized to create events" }, { status: 403 });
+            return apiError("Forbidden: Not authorized to create events", 403);
         }
 
         // Wall-clock times are entered in the org's local timezone; convert to UTC against it.
@@ -57,7 +58,7 @@ export const POST = withAuth({}, async (req, auth) => {
         // Each event (single or recurring) spans one day's wall-clock window, so
         // compare time-of-day once here rather than per-iteration. End must be after start.
         if (endHr * 60 + endMin <= startHr * 60 + startMin) {
-            return NextResponse.json({ error: "Event end time must be after start time" }, { status: 400 });
+            return apiError("Event end time must be after start time", 400);
         }
 
         const eventsToCreate = [];
@@ -111,7 +112,7 @@ export const POST = withAuth({}, async (req, auth) => {
         }
 
         if (eventsToCreate.length === 0) {
-            return NextResponse.json({ error: "No events generated from constraints." }, { status: 400 });
+            return apiError("No events generated from constraints.", 400);
         }
 
         const insertedEvents = await prisma.event.createMany({
@@ -133,6 +134,6 @@ export const POST = withAuth({}, async (req, auth) => {
         return NextResponse.json({ success: true, count: insertedEvents.count });
     } catch (error: unknown) {
         logger.error("Event creation error:", error);
-        return NextResponse.json({ error: "Failed to create event(s)" }, { status: 500 });
+        return apiError("Failed to create event(s)", 500);
     }
 });

--- a/checkin-app/src/app/api/facility/badges/route.ts
+++ b/checkin-app/src/app/api/facility/badges/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     { roles: ['isSysadmin', 'isBoardMember'] },
@@ -20,7 +21,7 @@ export const GET = withAuth(
             return NextResponse.json({ badges });
         } catch (error) {
             logger.error("Fetch badges error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/facility/trends/route.ts
+++ b/checkin-app/src/app/api/facility/trends/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { getAppSettings } from "@/lib/appSettings";
+import { apiError } from "@/lib/api-response";
 
 type PeriodType = "week" | "month" | "quarter" | "year";
 
@@ -76,7 +77,7 @@ export const GET = withAuth(
             const programId = programIdParam ? parseInt(programIdParam, 10) : null;
 
             if (!["week", "month", "quarter", "year"].includes(period)) {
-                return NextResponse.json({ error: "Invalid period. Use week, month, quarter, or year." }, { status: 400 });
+                return apiError("Invalid period. Use week, month, quarter, or year.", 400);
             }
 
             const { locale } = await getAppSettings();
@@ -190,7 +191,7 @@ export const GET = withAuth(
             return NextResponse.json({ buckets, totals, period });
         } catch (error) {
             logger.error("Trends API error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/facility/visits/route.ts
+++ b/checkin-app/src/app/api/facility/visits/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     { roles: ['isSysadmin', 'isBoardMember'] },
@@ -20,7 +21,7 @@ export const GET = withAuth(
             return NextResponse.json({ visits });
         } catch (error) {
             logger.error("Fetch visits error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );
@@ -32,7 +33,7 @@ export const PATCH = withAuth(
             const { visitId, arrivedAt, departedAt } = await req.json();
 
             if (!visitId) {
-                return NextResponse.json({ error: "visitId is required." }, { status: 400 });
+                return apiError("visitId is required.", 400);
             }
 
             const updatedVisit = await prisma.visit.update({
@@ -59,7 +60,7 @@ export const PATCH = withAuth(
             return NextResponse.json({ visit: updatedVisit });
         } catch (error) {
             logger.error("Update visit error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { handler } from "@/security/handler";
+import { apiError } from "@/lib/api-response";
 
 export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
     const requests = await prisma.programParticipant.findMany({
@@ -31,7 +32,7 @@ export const POST = withAuth(
             const participantId = parseInt(body.participantId, 10);
 
             if (Number.isNaN(programId) || Number.isNaN(participantId)) {
-                return NextResponse.json({ error: "programId and participantId are required" }, { status: 400 });
+                return apiError("programId and participantId are required", 400);
             }
 
             const data = {
@@ -48,7 +49,7 @@ export const POST = withAuth(
             });
 
             if (count === 0) {
-                return NextResponse.json({ error: "No pending payment-plan request" }, { status: 409 });
+                return apiError("No pending payment-plan request", 409);
             }
 
             if (auth.type === 'session') {
@@ -67,7 +68,7 @@ export const POST = withAuth(
             return NextResponse.json({ success: true });
         } catch (error) {
             logger.error("Failed to approve payment plan:", error);
-            return NextResponse.json({ error: "Failed to approve payment plan" }, { status: 500 });
+            return apiError("Failed to approve payment plan", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/household/emergency-contacts/[contactId]/route.ts
+++ b/checkin-app/src/app/api/household/emergency-contacts/[contactId]/route.ts
@@ -4,13 +4,14 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { updateContact, deleteContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
 import { leadHousehold } from "@/lib/household/leads";
+import { apiError } from "@/lib/api-response";
 
 export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promise<{ contactId: string }> }) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     const hh = await leadHousehold(auth.user.id);
-    if (typeof hh !== "number") return NextResponse.json({ error: hh.error }, { status: hh.status });
+    if (typeof hh !== "number") return apiError(hh.error, hh.status);
     const contactId = parseInt((await params).contactId, 10);
-    if (isNaN(contactId)) return NextResponse.json({ error: "Invalid contact id" }, { status: 400 });
+    if (isNaN(contactId)) return apiError("Invalid contact id", 400);
 
     try {
         const { name, phone, email, relationship, priority } = await req.json();
@@ -28,19 +29,19 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         return NextResponse.json({ contact });
     } catch (error) {
         if (error instanceof EmergencyContactError) {
-            return NextResponse.json({ error: error.message }, { status: error.code === "not_found" ? 404 : 400 });
+            return apiError(error.message, error.code === "not_found" ? 404 : 400);
         }
         logger.error("Emergency contact PATCH error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });
 
 export const DELETE = withAuth({}, async (_req, auth, { params }: { params: Promise<{ contactId: string }> }) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     const hh = await leadHousehold(auth.user.id);
-    if (typeof hh !== "number") return NextResponse.json({ error: hh.error }, { status: hh.status });
+    if (typeof hh !== "number") return apiError(hh.error, hh.status);
     const contactId = parseInt((await params).contactId, 10);
-    if (isNaN(contactId)) return NextResponse.json({ error: "Invalid contact id" }, { status: 400 });
+    if (isNaN(contactId)) return apiError("Invalid contact id", 400);
 
     try {
         // A household must never be left without a valid emergency contact: block
@@ -48,17 +49,14 @@ export const DELETE = withAuth({}, async (_req, auth, { params }: { params: Prom
         // (Removing an already-invalid contact is always allowed — it doesn't drop
         // the valid count, and lets a household clean up a flagged row.)
         const target = await prisma.emergencyContact.findFirst({ where: { id: contactId, householdId: hh } });
-        if (!target) return NextResponse.json({ error: "Emergency contact not found." }, { status: 404 });
+        if (!target) return apiError("Emergency contact not found.", 404);
         const targetIsValid = target.conflictParticipantId === null && !!target.name.trim() && !!target.phone.trim();
         if (targetIsValid) {
             const otherValid = await prisma.emergencyContact.count({
                 where: { householdId: hh, id: { not: contactId }, conflictParticipantId: null, name: { not: "" }, phone: { not: "" } },
             });
             if (otherValid === 0) {
-                return NextResponse.json(
-                    { error: "Add a second emergency contact before removing this one — your household must always have at least one valid emergency contact." },
-                    { status: 400 },
-                );
+                return apiError("Add a second emergency contact before removing this one — your household must always have at least one valid emergency contact.", 400);
             }
         }
 
@@ -75,9 +73,9 @@ export const DELETE = withAuth({}, async (_req, auth, { params }: { params: Prom
         return NextResponse.json({ success: true });
     } catch (error) {
         if (error instanceof EmergencyContactError) {
-            return NextResponse.json({ error: error.message }, { status: error.code === "not_found" ? 404 : 400 });
+            return apiError(error.message, error.code === "not_found" ? 404 : 400);
         }
         logger.error("Emergency contact DELETE error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/household/emergency-contacts/route.ts
+++ b/checkin-app/src/app/api/household/emergency-contacts/route.ts
@@ -5,6 +5,7 @@ import { withAuth } from "@/lib/auth";
 import { createContact, listContacts, EmergencyContactError } from "@/lib/emergencyContacts/service";
 import { isValidEmail } from "@/lib/emergencyContacts/identity";
 import { leadHousehold } from "@/lib/household/leads";
+import { apiError } from "@/lib/api-response";
 
 /** Shape a contact for the client, exposing the validity flag. */
 function present(c: { id: number; name: string; phone: string; email: string | null; relationship: string | null; priority: number; conflictParticipantId: number | null }) {
@@ -20,22 +21,22 @@ function present(c: { id: number; name: string; phone: string; email: string | n
 }
 
 export const GET = withAuth({}, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     const hh = await leadHousehold(auth.user.id);
-    if (typeof hh !== "number") return NextResponse.json({ error: hh.error }, { status: hh.status });
+    if (typeof hh !== "number") return apiError(hh.error, hh.status);
     const contacts = await listContacts(prisma, hh);
     return NextResponse.json({ contacts: contacts.map(present) });
 });
 
 export const POST = withAuth({}, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     const hh = await leadHousehold(auth.user.id);
-    if (typeof hh !== "number") return NextResponse.json({ error: hh.error }, { status: hh.status });
+    if (typeof hh !== "number") return apiError(hh.error, hh.status);
 
     try {
         const { name, phone, email, relationship, priority } = await req.json();
         if (email && !isValidEmail(email)) {
-            return NextResponse.json({ error: "Invalid email format" }, { status: 400 });
+            return apiError("Invalid email format", 400);
         }
         const contact = await createContact(prisma, hh, { name, phone, email, relationship, priority });
         await prisma.auditLog.create({
@@ -50,8 +51,8 @@ export const POST = withAuth({}, async (req, auth) => {
         });
         return NextResponse.json({ contact: present(contact) }, { status: 201 });
     } catch (error) {
-        if (error instanceof EmergencyContactError) return NextResponse.json({ error: error.message }, { status: 400 });
+        if (error instanceof EmergencyContactError) return apiError(error.message, 400);
         logger.error("Emergency contact POST error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/household/lead/route.ts
+++ b/checkin-app/src/app/api/household/lead/route.ts
@@ -3,19 +3,20 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { addHouseholdLead, HouseholdLeadLimitError } from "@/lib/household/leads";
+import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth(
     {},
     async (req, auth) => {
         try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            if (auth.type !== 'session') return apiError("Unauthorized", 401);
             const userId = auth.user.id;
 
             const body = await req.json();
             const { participantId } = body;
 
             if (!participantId) {
-                return NextResponse.json({ error: "Participant ID is required" }, { status: 400 });
+                return apiError("Participant ID is required", 400);
             }
 
             const user = await prisma.person.findUnique({
@@ -25,7 +26,7 @@ export const POST = withAuth(
 
             const targetMember = await prisma.person.findUnique({ where: { id: participantId } });
             if (!targetMember) {
-                return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+                return apiError("Participant not found", 404);
             }
             const targetHouseholdId = targetMember.householdId;
 
@@ -35,7 +36,7 @@ export const POST = withAuth(
             const isPrivileged = !!user?.isSysadmin || !!user?.isBoardMember;
             const isLeadOfTarget = !!user?.householdLeads.some(lead => lead.householdId === targetHouseholdId);
             if (!isPrivileged && !isLeadOfTarget) {
-                return NextResponse.json({ error: "Only household leads, board members, or sysadmins can promote members" }, { status: 403 });
+                return apiError("Only household leads, board members, or sysadmins can promote members", 403);
             }
 
             const { created } = await addHouseholdLead(prisma, targetHouseholdId, participantId);
@@ -60,10 +61,10 @@ export const POST = withAuth(
 
         } catch (error: unknown) {
             if (error instanceof HouseholdLeadLimitError) {
-                return NextResponse.json({ error: error.message }, { status: 400 });
+                return apiError(error.message, 400);
             }
             logger.error("Household Lead POST Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );
@@ -72,14 +73,14 @@ export const DELETE = withAuth(
     {},
     async (req, auth) => {
         try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            if (auth.type !== 'session') return apiError("Unauthorized", 401);
             const userId = auth.user.id;
 
             const body = await req.json();
             const { participantId } = body;
 
             if (!participantId) {
-                return NextResponse.json({ error: "Participant ID is required" }, { status: 400 });
+                return apiError("Participant ID is required", 400);
             }
 
             const user = await prisma.person.findUnique({
@@ -89,11 +90,11 @@ export const DELETE = withAuth(
 
             const targetMember = await prisma.person.findUnique({ where: { id: participantId } });
             if (!targetMember) {
-                return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+                return apiError("Participant not found", 404);
             }
             const targetHouseholdId = targetMember.householdId;
             if (!targetHouseholdId) {
-                return NextResponse.json({ error: "Member has no household" }, { status: 400 });
+                return apiError("Member has no household", 400);
             }
 
             // Board members and sysadmins can remove a lead from ANY household — the
@@ -102,7 +103,7 @@ export const DELETE = withAuth(
             const isPrivileged = !!user?.isSysadmin || !!user?.isBoardMember;
             const isLeadOfTarget = !!user?.householdLeads.some(lead => lead.householdId === targetHouseholdId);
             if (!isPrivileged && !isLeadOfTarget) {
-                return NextResponse.json({ error: "Only household leads, board members, or sysadmins can remove leads" }, { status: 403 });
+                return apiError("Only household leads, board members, or sysadmins can remove leads", 403);
             }
 
             const allLeads = await prisma.householdLead.findMany({
@@ -110,7 +111,7 @@ export const DELETE = withAuth(
             });
 
             if (allLeads.length <= 1 && allLeads.some(l => l.personId === participantId)) {
-                return NextResponse.json({ error: "Cannot remove the last lead of a household." }, { status: 400 });
+                return apiError("Cannot remove the last lead of a household.", 400);
             }
 
             const existingLead = await prisma.householdLead.findUnique({
@@ -123,7 +124,7 @@ export const DELETE = withAuth(
             });
 
             if (!existingLead) {
-                 return NextResponse.json({ error: "Member is not a lead" }, { status: 400 });
+                 return apiError("Member is not a lead", 400);
             }
 
             await prisma.householdLead.delete({
@@ -150,7 +151,7 @@ export const DELETE = withAuth(
 
         } catch (error: unknown) {
             logger.error("Household Lead DELETE Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -7,41 +7,42 @@ import { reconcileAndWarn } from "@/lib/emergencyContacts/service";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
 import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
 import { householdLeadship } from "@/lib/household/leads";
+import { apiError } from "@/lib/api-response";
 
 export const PATCH = withAuth(
     {},
     async (req, auth) => {
         try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            if (auth.type !== 'session') return apiError("Unauthorized", 401);
             const userId = auth.user.id;
 
             const body = await req.json();
             const { participantId, name, email, dob, phone, isLead, over25 } = body;
 
             if (!participantId) {
-                return NextResponse.json({ error: "Participant ID is required" }, { status: 400 });
+                return apiError("Participant ID is required", 400);
             }
 
             // Phone is optional for a member, but if supplied it must be valid.
             if (phone !== undefined && phone !== "" && !isValidPhone(phone)) {
-                return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
+                return apiError(PHONE_ERROR, 400);
             }
 
             const hh = await householdLeadship(userId);
 
             if (!hh) {
-                return NextResponse.json({ error: "You must create a household first" }, { status: 400 });
+                return apiError("You must create a household first", 400);
             }
             const householdId = hh.householdId;
 
             // Leads/sysadmins edit anyone; anyone may edit their own record.
             if (!hh.canManage && participantId !== userId) {
-                return NextResponse.json({ error: "Only household leads can edit household members" }, { status: 403 });
+                return apiError("Only household leads can edit household members", 403);
             }
 
             const targetHouseholdMember = await prisma.person.findUnique({ where: { id: participantId } });
             if (!targetHouseholdMember || targetHouseholdMember.householdId !== householdId) {
-                return NextResponse.json({ error: "That household member was not found" }, { status: 404 });
+                return apiError("That household member was not found", 404);
             }
 
             const { updatedHouseholdMember, leadRejection, warning } = await prisma.$transaction(async (tx) => {
@@ -138,10 +139,10 @@ export const PATCH = withAuth(
 
         } catch (error: unknown) {
             if (error instanceof HouseholdLeadLimitError) {
-                return NextResponse.json({ error: error.message }, { status: 400 });
+                return apiError(error.message, 400);
             }
             logger.error("Household Member PATCH Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -7,12 +7,13 @@ import { isValidEmail } from "@/lib/emergencyContacts/identity";
 import { isOrgAccount } from "@/lib/orgAccount";
 import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
 import { householdLeadship } from "@/lib/household/leads";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     {},
     async (_req, auth) => {
         try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            if (auth.type !== 'session') return apiError("Unauthorized", 401);
             const userId = auth.user.id;
 
             const user = await prisma.person.findUnique({
@@ -28,12 +29,12 @@ export const GET = withAuth(
                 }
             });
 
-            if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
+            if (!user) return apiError("User not found", 404);
 
             return NextResponse.json({ household: user.household }, { status: 200 });
         } catch (error: unknown) {
             logger.error("Household GET Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );
@@ -42,17 +43,14 @@ export const PATCH = withAuth(
     {},
     async (req, auth) => {
         try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            if (auth.type !== 'session') return apiError("Unauthorized", 401);
             const userId = auth.user.id;
 
             // Internal staff (@innovationtreehouse.org) accounts are not real member families,
             // so they may not build out a household with extra members via self-service. The
             // admin participant-add flow (isSysadmin/isBoardMember) is separate and stays open.
             if (isOrgAccount(auth.user)) {
-                return NextResponse.json(
-                    { error: "Staff accounts cannot add household members. Use the membership-ops participant tools instead." },
-                    { status: 403 }
-                );
+                return apiError("Staff accounts cannot add household members. Use the membership-ops participant tools instead.", 403);
             }
 
             const body = await req.json();
@@ -61,15 +59,15 @@ export const PATCH = withAuth(
             const hh = await householdLeadship(userId);
 
             if (!hh) {
-                return NextResponse.json({ error: "You must create a household first" }, { status: 400 });
+                return apiError("You must create a household first", 400);
             }
 
             if (!hh.canManage) {
-                return NextResponse.json({ error: "Only household leads can add members" }, { status: 403 });
+                return apiError("Only household leads can add members", 403);
             }
 
             if (memberEmail && !isValidEmail(memberEmail)) {
-                return NextResponse.json({ error: "Invalid email format" }, { status: 400 });
+                return apiError("Invalid email format", 400);
             }
 
             let targetMember: Awaited<ReturnType<typeof prisma.person.findUnique>> = null;
@@ -78,14 +76,14 @@ export const PATCH = withAuth(
                 targetMember = await prisma.person.findUnique({ where: { email: memberEmail.toLowerCase() } });
 
                 if (targetMember && targetMember.householdId) {
-                    return NextResponse.json({ error: "A user with this email already belongs to a household." }, { status: 400 });
+                    return apiError("A user with this email already belongs to a household.", 400);
                 }
             }
 
             if (!targetMember && !memberDob && !memberOver25) {
                 // A new member's age must be known: either a DoB, or an explicit
                 // "25+" declaration (mirrors the client form's requirement).
-                return NextResponse.json({ error: "Date of birth is required for anyone under 25." }, { status: 400 });
+                return apiError("Date of birth is required for anyone under 25.", 400);
             }
 
             const householdId = hh.householdId;
@@ -128,7 +126,7 @@ export const PATCH = withAuth(
             return NextResponse.json({ member, warning }, { status: 200 });
         } catch (error: unknown) {
             logger.error("Household PATCH Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/household/settings/route.ts
+++ b/checkin-app/src/app/api/household/settings/route.ts
@@ -4,12 +4,13 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { upsertPrimaryContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
 import { normalizeAddressInput, pickAddress, assertValidAddress, AddressValidationError } from "@/lib/address";
+import { apiError } from "@/lib/api-response";
 
 export const PATCH = withAuth(
     {},
     async (req, auth) => {
         try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            if (auth.type !== 'session') return apiError("Unauthorized", 401);
             const userId = auth.user.id;
 
             const body = await req.json();
@@ -26,12 +27,12 @@ export const PATCH = withAuth(
             });
 
             if (!user || !user.householdId) {
-                return NextResponse.json({ error: "Household not found" }, { status: 404 });
+                return apiError("Household not found", 404);
             }
 
             const isLead = user.householdLeads.some(lead => lead.householdId === user.householdId);
             if (!isLead && !user.isSysadmin) {
-                return NextResponse.json({ error: "Only household leads can edit household settings" }, { status: 403 });
+                return apiError("Only household leads can edit household settings", 403);
             }
 
             const updatedHousehold = await prisma.household.update({
@@ -62,10 +63,10 @@ export const PATCH = withAuth(
 
         } catch (error: unknown) {
             if (error instanceof EmergencyContactError || error instanceof AddressValidationError) {
-                return NextResponse.json({ error: error.message }, { status: 400 });
+                return apiError(error.message, 400);
             }
             logger.error("Household Settings PATCH Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/household/visits/route.ts
+++ b/checkin-app/src/app/api/household/visits/route.ts
@@ -2,12 +2,13 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     {},
     async (req, auth) => {
         try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            if (auth.type !== 'session') return apiError("Unauthorized", 401);
             const userId = auth.user.id;
 
             const { searchParams } = new URL(req.url);
@@ -57,7 +58,7 @@ export const GET = withAuth(
             return NextResponse.json({ visits }, { status: 200 });
         } catch (error) {
             logger.error("Household Visits GET Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/kioskdisplay/certifications/route.ts
+++ b/checkin-app/src/app/api/kioskdisplay/certifications/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 // Serves the participant roster for the tool-certification grid: id, a display name, and
 // tool certs. The raw email is read only to resolve the name fallback and never leaves the
@@ -69,9 +70,6 @@ export const GET = withAuth(
         return NextResponse.json({ participants, tools });
     } catch (error) {
         logger.error("Certifications fetch error:", error);
-        return NextResponse.json(
-            { error: "Internal Server Error while fetching certifications." },
-            { status: 500 }
-        );
+        return apiError("Internal Server Error while fetching certifications.", 500);
     }
 });

--- a/checkin-app/src/app/api/membership-audit/unclaimed-households/route.ts
+++ b/checkin-app/src/app/api/membership-audit/unclaimed-households/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = 'force-dynamic';
 
@@ -43,7 +44,7 @@ export const GET = withAuth(
             return NextResponse.json({ households: result });
         } catch (error) {
             logger.error("Failed to fetch unclaimed households:", error);
-            return NextResponse.json({ error: "Failed to fetch unclaimed households" }, { status: 500 });
+            return apiError("Failed to fetch unclaimed households", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/membership-ops/applications/certify-payment/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/certify-payment/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { certifyPaymentPlan, PaymentError } from "@/lib/membership/payment";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -11,14 +12,14 @@ export const dynamic = "force-dynamic";
  * Body: { processId }
  */
 export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     let body: { processId?: number };
     try {
         body = await req.json();
     } catch {
-        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+        return apiError("Invalid JSON", 400);
     }
-    if (!body.processId) return NextResponse.json({ error: "processId is required" }, { status: 400 });
+    if (!body.processId) return apiError("processId is required", 400);
     try {
         const process = await certifyPaymentPlan(body.processId, auth.user.id);
         return NextResponse.json({ process });
@@ -27,6 +28,6 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
             return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 409 });
         }
         logger.error("Certify payment error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/membership-ops/applications/external/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/external/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { markContractSigned, markBgConsent, setZohoEnvelope, ExternalError } from "@/lib/membership/external";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -17,19 +18,19 @@ export const dynamic = "force-dynamic";
  * PENDING_PAYMENT; the background check then reviews in parallel with payment.
  */
 export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     const actorId = auth.user.id;
 
     let body: { processId?: number; action?: string; envelopeId?: string };
     try {
         body = await req.json();
     } catch {
-        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+        return apiError("Invalid JSON", 400);
     }
 
     const { processId, action, envelopeId } = body;
     if (!processId || !action) {
-        return NextResponse.json({ error: "processId and action are required" }, { status: 400 });
+        return apiError("processId and action are required", 400);
     }
 
     try {
@@ -39,16 +40,16 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
             case "mark-bg-consent":
                 return NextResponse.json({ process: await markBgConsent(processId, actorId) });
             case "set-envelope":
-                if (!envelopeId) return NextResponse.json({ error: "envelopeId is required" }, { status: 400 });
+                if (!envelopeId) return apiError("envelopeId is required", 400);
                 return NextResponse.json({ process: await setZohoEnvelope(processId, envelopeId, actorId) });
             default:
-                return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });
+                return apiError(`Unknown action: ${action}`, 400);
         }
     } catch (error) {
         if (error instanceof ExternalError) {
             return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 400 });
         }
         logger.error("Membership external action error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/membership-ops/applications/review-override/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/review-override/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { overrideBlocked, ReviewError } from "@/lib/membership/review";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -13,15 +14,15 @@ export const dynamic = "force-dynamic";
  *             leaving it at PENDING_PAYMENT
  */
 export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     let body: { processId?: number; action?: "reset" | "approve" };
     try {
         body = await req.json();
     } catch {
-        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+        return apiError("Invalid JSON", 400);
     }
     if (!body.processId || (body.action !== "reset" && body.action !== "approve")) {
-        return NextResponse.json({ error: "processId and action (reset|approve) are required" }, { status: 400 });
+        return apiError("processId and action (reset|approve) are required", 400);
     }
     try {
         const outcome = await overrideBlocked(body.processId, auth.user.id, body.action);
@@ -31,6 +32,6 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
             return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 409 });
         }
         logger.error("Review override error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { upsertPrimaryContact, getPrimaryValidContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
 import { normalizeAddressInput, pickAddress, type StructuredAddress } from "@/lib/address";
+import { apiError } from "@/lib/api-response";
 
 /**
  * Admin edit of a household's own info (name, address, emergency contact).
@@ -17,19 +18,19 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
     { roles: ['isSysadmin', 'isBoardMember'] },
     async (request: NextRequest, auth, { params }) => {
     if (auth.type !== 'session') {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        return apiError("Unauthorized", 401);
     }
 
     try {
         const { id: idParam } = await params;
         const id = parseInt(idParam, 10);
         if (isNaN(id)) {
-            return NextResponse.json({ error: "Invalid household ID" }, { status: 400 });
+            return apiError("Invalid household ID", 400);
         }
 
         const existing = await prisma.household.findUnique({ where: { id } });
         if (!existing) {
-            return NextResponse.json({ error: "Household not found" }, { status: 404 });
+            return apiError("Household not found", 404);
         }
 
         const body = await request.json();
@@ -47,11 +48,11 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
         if (typeof body.memberSince === "string" && body.memberSince !== "") {
             const parsed = new Date(`${body.memberSince}T00:00:00.000Z`);
             if (isNaN(parsed.getTime())) {
-                return NextResponse.json({ error: "Invalid member-since date" }, { status: 400 });
+                return apiError("Invalid member-since date", 400);
             }
             const membership = await prisma.membership.findUnique({ where: { householdId: id } });
             if (!membership) {
-                return NextResponse.json({ error: "Household has no membership record" }, { status: 400 });
+                return apiError("Household has no membership record", 400);
             }
             if (membership.memberSince.toISOString().slice(0, 10) !== body.memberSince) {
                 memberSinceChange = { membershipId: membership.id, oldValue: membership.memberSince, newValue: parsed };
@@ -59,7 +60,7 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
         }
 
         if (!editsHousehold && !memberSinceChange) {
-            return NextResponse.json({ error: "No fields to update provided" }, { status: 400 });
+            return apiError("No fields to update provided", 400);
         }
 
         // Emergency contact is its own entity; the admin editor maps onto the
@@ -116,9 +117,9 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
         return NextResponse.json({ household: updated });
     } catch (error) {
         if (error instanceof EmergencyContactError) {
-            return NextResponse.json({ error: error.message }, { status: 400 });
+            return apiError(error.message, 400);
         }
         logger.error("Failed to update household:", error);
-        return NextResponse.json({ error: "Failed to update household" }, { status: 500 });
+        return apiError("Failed to update household", 500);
     }
 });

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = 'force-dynamic';
 
@@ -78,7 +79,7 @@ export const GET = withAuth(
             return NextResponse.json({ households: households.map(withFlatContact) });
         } catch (error) {
             logger.error("Failed to fetch households:", error);
-            return NextResponse.json({ error: "Failed to fetch households" }, { status: 500 });
+            return apiError("Failed to fetch households", 500);
         }
     }
 );
@@ -91,7 +92,7 @@ export const POST = withAuth(
             const { householdId, active, deny } = body;
 
             if (!householdId) {
-                return NextResponse.json({ error: "Household ID is required" }, { status: 400 });
+                return apiError("Household ID is required", 400);
             }
 
             const existingMembership = await prisma.membership.findUnique({
@@ -110,10 +111,7 @@ export const POST = withAuth(
                         select: { id: true }
                     });
                     if (boardMemberInHousehold) {
-                        return NextResponse.json(
-                            { error: "This household includes a board member. Remove the board role before denying membership." },
-                            { status: 409 }
-                        );
+                        return apiError("This household includes a board member. Remove the board role before denying membership.", 409);
                     }
                 }
 
@@ -185,7 +183,7 @@ export const POST = withAuth(
             return NextResponse.json({ success: true, message: "No change needed" });
         } catch (error) {
             logger.error("Failed to update household membership:", error);
-            return NextResponse.json({ error: "Failed to update membership" }, { status: 500 });
+            return apiError("Failed to update membership", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/household/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/household/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { logBackendError, logger } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth<{ params: Promise<{ id: string }> }>(
     { roles: ['isSysadmin', 'isBoardMember'] },
@@ -9,24 +10,24 @@ export const POST = withAuth<{ params: Promise<{ id: string }> }>(
     try {
         const { id } = await params;
         if (auth.type !== 'session') {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            return apiError("Unauthorized", 401);
         }
 
         const participantId = parseInt(id);
         if (isNaN(participantId)) {
             logger.error(`Invalid participant ID from params: ${id}`);
-            return NextResponse.json({ error: `Invalid participant ID: ${id}` }, { status: 400 });
+            return apiError(`Invalid participant ID: ${id}`, 400);
         }
 
         const { householdId, createNew } = await req.json();
 
         if (!householdId && !createNew) {
-            return NextResponse.json({ error: "Must provide either householdId or createNew boolean" }, { status: 400 });
+            return apiError("Must provide either householdId or createNew boolean", 400);
         }
 
         const participant = await prisma.person.findUnique({ where: { id: participantId } });
         if (!participant) {
-            return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+            return apiError("Participant not found", 404);
         }
 
         let targetHouseholdId: number;
@@ -48,12 +49,12 @@ export const POST = withAuth<{ params: Promise<{ id: string }> }>(
         } else {
             targetHouseholdId = parseInt(householdId);
             if (isNaN(targetHouseholdId)) {
-                return NextResponse.json({ error: "Invalid household ID" }, { status: 400 });
+                return apiError("Invalid household ID", 400);
             }
 
             const household = await prisma.household.findUnique({ where: { id: targetHouseholdId } });
             if (!household) {
-                return NextResponse.json({ error: "Household not found" }, { status: 404 });
+                return apiError("Household not found", 404);
             }
         }
 
@@ -86,6 +87,6 @@ export const POST = withAuth<{ params: Promise<{ id: string }> }>(
         return NextResponse.json({ success: true, participant: updatedParticipant });
     } catch (error) {
         await logBackendError(error, "POST /api/membership-ops/participants/[id]/household");
-        return NextResponse.json({ error: `Internal server error` }, { status: 500 });
+        return apiError(`Internal server error`, 500);
     }
 });

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
@@ -3,19 +3,20 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
+import { apiError } from "@/lib/api-response";
 
 export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
     { roles: ['isSysadmin', 'isBoardMember'] },
     async (request: NextRequest, auth, { params }) => {
     if (auth.type !== 'session') {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        return apiError("Unauthorized", 401);
     }
 
     try {
         const resolvedParams = await params;
         const id = parseInt(resolvedParams.id, 10);
         if (isNaN(id)) {
-            return NextResponse.json({ error: "Invalid participant ID" }, { status: 400 });
+            return apiError("Invalid participant ID", 400);
         }
 
         const body = await request.json();
@@ -25,13 +26,13 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
         if (body.email !== undefined) updateData.email = body.email;
         if (body.phone !== undefined) {
             if (body.phone !== "" && body.phone !== null && !isValidPhone(body.phone)) {
-                return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
+                return apiError(PHONE_ERROR, 400);
             }
             updateData.phone = body.phone === "" || body.phone === null ? null : formatPhone(body.phone);
         }
 
         if (Object.keys(updateData).length === 0) {
-            return NextResponse.json({ error: "No fields to update provided" }, { status: 400 });
+            return apiError("No fields to update provided", 400);
         }
 
         const prior = await prisma.person.findUnique({
@@ -71,6 +72,6 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
         return NextResponse.json({ participant: formatted });
     } catch (error) {
         logger.error("Failed to update participant:", error);
-        return NextResponse.json({ error: "Failed to update participant" }, { status: 500 });
+        return apiError("Failed to update participant", 500);
     }
 });

--- a/checkin-app/src/app/api/membership-ops/participants/import/preview/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/preview/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import * as xlsx from "xlsx";
 import { parseImportDob } from "@/lib/importDob";
+import { apiError } from "@/lib/api-response";
 
 type RowStatus = "ready" | "update" | "warning" | "error";
 
@@ -27,14 +28,14 @@ interface RowPreview {
 export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (req: NextRequest, auth) => {
     try {
         if (auth.type !== 'session') {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            return apiError("Unauthorized", 401);
         }
 
         const formData = await req.formData();
         const file = formData.get("file") as File;
 
         if (!file) {
-            return NextResponse.json({ error: "No file provided" }, { status: 400 });
+            return apiError("No file provided", 400);
         }
 
         const buffer = await file.arrayBuffer();
@@ -46,7 +47,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         const rawData = xlsx.utils.sheet_to_json(worksheet, { header: 1 }) as unknown[][];
 
         if (rawData.length < 2) {
-            return NextResponse.json({ error: "Empty spreadsheet or no data rows found" }, { status: 400 });
+            return apiError("Empty spreadsheet or no data rows found", 400);
         }
 
         const headers = rawData[0].map((h: unknown) => String(h).trim().toLowerCase());
@@ -61,7 +62,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         const sameHouseholdIndex = headers.findIndex(h => h.includes("same household as"));
 
         if (firstNameIndex === -1 || lastNameIndex === -1) {
-            return NextResponse.json({ error: "Missing required 'First Name' or 'Last Name' columns." }, { status: 400 });
+            return apiError("Missing required 'First Name' or 'Last Name' columns.", 400);
         }
 
         // Parse all rows first so we can check cross-references
@@ -299,6 +300,6 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
 
     } catch (error) {
         logger.error("Error in participant import preview:", error);
-        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+        return apiError("Internal server error", 500);
     }
 });

--- a/checkin-app/src/app/api/membership-ops/participants/import/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/route.ts
@@ -7,18 +7,19 @@ import { addHouseholdLead, HouseholdLeadLimitError, MAX_HOUSEHOLD_LEADS } from "
 import { parseImportDob } from "@/lib/importDob";
 import { calculateAge } from "@/lib/time";
 import type { DbClient } from "@/lib/db-client";
+import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (req: NextRequest, auth) => {
     try {
         if (auth.type !== 'session') {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            return apiError("Unauthorized", 401);
         }
 
         const formData = await req.formData();
         const file = formData.get("file") as File;
 
         if (!file) {
-            return NextResponse.json({ error: "No file provided" }, { status: 400 });
+            return apiError("No file provided", 400);
         }
 
         const buffer = await file.arrayBuffer();
@@ -30,7 +31,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         const rawData = xlsx.utils.sheet_to_json(worksheet, { header: 1 }) as unknown[][];
 
         if (rawData.length < 2) {
-            return NextResponse.json({ error: "Empty spreadsheet or no data rows found" }, { status: 400 });
+            return apiError("Empty spreadsheet or no data rows found", 400);
         }
 
         const headers = rawData[0].map((h: unknown) => String(h).trim().toLowerCase());
@@ -45,7 +46,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         const sameHouseholdIndex = headers.findIndex(h => h.includes("same household as"));
 
         if (firstNameIndex === -1 || lastNameIndex === -1) {
-            return NextResponse.json({ error: "Missing required 'First Name' or 'Last Name' columns." }, { status: 400 });
+            return apiError("Missing required 'First Name' or 'Last Name' columns.", 400);
         }
 
         let insertedOrUpdatedCount = 0;
@@ -409,9 +410,9 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
 
     } catch (error: unknown) {
         if (error instanceof HouseholdLeadLimitError) {
-            return NextResponse.json({ error: error.message }, { status: 400 });
+            return apiError(error.message, 400);
         }
         await logBackendError(error, "POST /api/membership-ops/participants/import");
-        return NextResponse.json({ error: `Internal server error` }, { status: 500 });
+        return apiError(`Internal server error`, 500);
     }
 });

--- a/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = 'force-dynamic';
 
@@ -14,7 +15,7 @@ export const GET = withAuth(
             const bId = parseInt(url.searchParams.get('b') || '0');
 
             if (!aId || !bId) {
-                return NextResponse.json({ error: "Missing IDs" }, { status: 400 });
+                return apiError("Missing IDs", 400);
             }
 
             const getParticipant = async (id: number) => {
@@ -43,13 +44,13 @@ export const GET = withAuth(
             const [pA, pB] = await Promise.all([getParticipant(aId), getParticipant(bId)]);
 
             if (!pA || !pB) {
-                return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+                return apiError("Participant not found", 404);
             }
 
             return NextResponse.json({ participants: [pA, pB] });
         } catch (error) {
             logger.error("Failed to analyze participants:", error);
-            return NextResponse.json({ error: "Server error" }, { status: 500 });
+            return apiError("Server error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { logBackendError } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = 'force-dynamic';
 
@@ -13,7 +14,7 @@ export const POST = withAuth(
             const { keepId, mergeId } = body;
 
             if (!keepId || !mergeId || keepId === mergeId) {
-                return NextResponse.json({ error: "Invalid participant IDs provided." }, { status: 400 });
+                return apiError("Invalid participant IDs provided.", 400);
             }
 
             const keepParticipant = await prisma.person.findUnique({
@@ -45,14 +46,14 @@ export const POST = withAuth(
             });
 
             if (!keepParticipant || !mergeParticipant) {
-                return NextResponse.json({ error: "Participant(s) not found." }, { status: 404 });
+                return apiError("Participant(s) not found.", 404);
             }
 
             const isLead = mergeParticipant.householdLeads.length > 0;
             const householdOthersCount = mergeParticipant.household?.householdMembers.filter(p => p.id !== mergeId).length || 0;
 
             if (isLead && householdOthersCount > 0) {
-                return NextResponse.json({ error: "Cannot merge: the to-be-deleted participant is the lead of a household with other members." }, { status: 400 });
+                return apiError("Cannot merge: the to-be-deleted participant is the lead of a household with other members.", 400);
             }
 
             await prisma.$transaction(async (tx) => {
@@ -203,7 +204,7 @@ export const POST = withAuth(
             return NextResponse.json({ success: true });
         } catch (error: unknown) {
             await logBackendError(error, "POST /api/membership-ops/participants/merge");
-            return NextResponse.json({ error: "Failed to merge participants" }, { status: 500 });
+            return apiError("Failed to merge participants", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/membership-ops/participants/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/route.ts
@@ -4,10 +4,11 @@ import { withAuth } from "@/lib/auth";
 import { logBackendError } from "@/lib/logger";
 import { addHouseholdLead, HouseholdLeadLimitError } from "@/lib/household/leads";
 import { isValidEmail } from "@/lib/emergencyContacts/identity";
+import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (req, auth) => {
     if (auth.type !== 'session') {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        return apiError("Unauthorized", 401);
     }
 
     try {
@@ -17,15 +18,15 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         const { name, email, parentEmail, dob, householdId, alreadyMember = false } = body;
 
         if (!email && !parentEmail && !householdId) {
-            return NextResponse.json({ error: "Email, Parent Email, or Household assignment is required" }, { status: 400 });
+            return apiError("Email, Parent Email, or Household assignment is required", 400);
         }
 
         if (email && !isValidEmail(email)) {
-             return NextResponse.json({ error: "Invalid email format" }, { status: 400 });
+             return apiError("Invalid email format", 400);
         }
 
         if (parentEmail && !isValidEmail(parentEmail)) {
-             return NextResponse.json({ error: "Invalid parent email format" }, { status: 400 });
+             return apiError("Invalid parent email format", 400);
         }
 
         if (email) {
@@ -34,7 +35,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
             });
 
             if (existingUser) {
-                return NextResponse.json({ error: "A participant with this email already exists" }, { status: 409 });
+                return apiError("A participant with this email already exists", 409);
             }
         }
 
@@ -111,9 +112,9 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         return NextResponse.json({ success: true, participant: newParticipant });
     } catch (error: unknown) {
         if (error instanceof HouseholdLeadLimitError) {
-            return NextResponse.json({ error: error.message }, { status: 400 });
+            return apiError(error.message, 400);
         }
         await logBackendError(error, "POST /api/membership-ops/participants");
-        return NextResponse.json({ error: `Failed to create participant` }, { status: 500 });
+        return apiError(`Failed to create participant`, 500);
     }
 });

--- a/checkin-app/src/app/api/membership/contract/sign/route.ts
+++ b/checkin-app/src/app/api/membership/contract/sign/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import { logger } from "@/lib/logger";
 import { getOrCreateContractSigningUrl, ExternalError, type ExternalErrorCode } from "@/lib/membership/external";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -22,7 +23,7 @@ const STATUS_BY_CODE: Record<ExternalErrorCode, number> = {
  * process) and returns a fresh embedded sign URL to redirect the applicant into.
  */
 export const POST = withAuth({}, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     try {
         const url = await getOrCreateContractSigningUrl(auth.user.id);
         return NextResponse.json({ url });
@@ -31,6 +32,6 @@ export const POST = withAuth({}, async (_req, auth) => {
             return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_BY_CODE[error.code] });
         }
         logger.error(`Membership contract sign error: ${error instanceof Error ? error.message : String(error)}`);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/membership/contract/sync/route.ts
+++ b/checkin-app/src/app/api/membership/contract/sync/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import { logger } from "@/lib/logger";
 import { syncContractStatus } from "@/lib/membership/external";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -13,12 +14,12 @@ export const dynamic = "force-dynamic";
  * Zoho webhook. Returns the current external status.
  */
 export const POST = withAuth({}, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     try {
         const status = await syncContractStatus(auth.user.id);
         return NextResponse.json({ status });
     } catch (error) {
         logger.error(`Contract status sync error: ${error instanceof Error ? error.message : String(error)}`);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/membership/intake/route.ts
+++ b/checkin-app/src/app/api/membership/intake/route.ts
@@ -2,12 +2,13 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import { saveIntake } from "@/lib/membership/intake";
 import { intakeErrorResponse } from "@/lib/membership/intakeResponse";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
 // PATCH /api/membership/intake — save (partial) intake form data. Resumable.
 export const PATCH = withAuth({}, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     try {
         const body = await req.json();
         const { state, rejections } = await saveIntake(auth.user.id, body);

--- a/checkin-app/src/app/api/membership/intake/submit/route.ts
+++ b/checkin-app/src/app/api/membership/intake/submit/route.ts
@@ -2,12 +2,13 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import { submitIntake, getIntakeState } from "@/lib/membership/intake";
 import { intakeErrorResponse } from "@/lib/membership/intakeResponse";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
 // POST /api/membership/intake/submit — validate + advance INTAKE -> EXTERNAL.
 export const POST = withAuth({}, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     try {
         await submitIntake(auth.user.id);
         const state = await getIntakeState(auth.user.id);

--- a/checkin-app/src/app/api/membership/payment/route.ts
+++ b/checkin-app/src/app/api/membership/payment/route.ts
@@ -2,12 +2,13 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { ensurePaymentLinkForUser, PaymentError } from "@/lib/membership/payment";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
 // GET /api/membership/payment — the caller's dues amount + Shopify checkout link.
 export const GET = withAuth({}, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     try {
         return NextResponse.json(await ensurePaymentLinkForUser(auth.user.id));
     } catch (error) {
@@ -15,6 +16,6 @@ export const GET = withAuth({}, async (_req, auth) => {
             return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 409 });
         }
         logger.error("Payment link error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/membership/renew/route.ts
+++ b/checkin-app/src/app/api/membership/renew/route.ts
@@ -2,12 +2,13 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { beginRenewalForUser, RenewalError } from "@/lib/membership/renewal";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
 // POST /api/membership/renew — member confirms renewal; advances PENDING_RENEWAL.
 export const POST = withAuth({}, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     try {
         const process = await beginRenewalForUser(auth.user.id);
         return NextResponse.json({ process });
@@ -16,6 +17,6 @@ export const POST = withAuth({}, async (_req, auth) => {
             return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 409 });
         }
         logger.error("Renewal begin error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/membership/renewal-status/route.ts
+++ b/checkin-app/src/app/api/membership/renewal-status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { nextBoundary } from "@/lib/membership/renewal";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -11,7 +12,7 @@ export const dynamic = "force-dynamic";
  * Renewal is lead-driven, so only leads see the nudge.
  */
 export const GET = withAuth({}, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
 
     const user = await prisma.person.findUnique({
         where: { id: auth.user.id },

--- a/checkin-app/src/app/api/membership/reviews/route.ts
+++ b/checkin-app/src/app/api/membership/reviews/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { handler, unauthorized } from "@/security/handler";
 import { eligibleReviewProcessIds, attest, ReviewError } from "@/lib/membership/review";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -55,15 +56,15 @@ export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
 // POST /api/membership/reviews — submit an attestation { processId, result, isMarkedVolunteer }.
 // Board members are implicit reviewers (see canReviewBackgroundChecks); attest() re-checks.
 export const POST = withAuth({ roles: ["isBackgroundCheckReviewer", "isBoardMember"] }, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     let body: { processId?: number; result?: "APPROVE" | "REJECT"; isMarkedVolunteer?: boolean };
     try {
         body = await req.json();
     } catch {
-        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+        return apiError("Invalid JSON", 400);
     }
     if (!body.processId || (body.result !== "APPROVE" && body.result !== "REJECT")) {
-        return NextResponse.json({ error: "processId and result (APPROVE|REJECT) are required" }, { status: 400 });
+        return apiError("processId and result (APPROVE|REJECT) are required", 400);
     }
     try {
         const outcome = await attest(auth.user.id, body.processId, { result: body.result, isMarkedVolunteer: body.isMarkedVolunteer });
@@ -73,6 +74,6 @@ export const POST = withAuth({ roles: ["isBackgroundCheckReviewer", "isBoardMemb
             return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
         }
         logger.error("Attestation error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/membership/route.ts
+++ b/checkin-app/src/app/api/membership/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import { getIntakeState, startIntake } from "@/lib/membership/intake";
 import { intakeErrorResponse } from "@/lib/membership/intakeResponse";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -9,7 +10,7 @@ const handleError = (error: unknown) => intakeErrorResponse(error, "Membership r
 
 // GET /api/membership — the caller's current application state, prefilled.
 export const GET = withAuth({}, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     try {
         return NextResponse.json(await getIntakeState(auth.user.id));
     } catch (error) {
@@ -19,7 +20,7 @@ export const GET = withAuth({}, async (_req, auth) => {
 
 // POST /api/membership — begin (or resume) an application.
 export const POST = withAuth({}, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     try {
         const process = await startIntake(auth.user.id);
         const state = await getIntakeState(auth.user.id);

--- a/checkin-app/src/app/api/my-programs/conflicts/resolve/route.ts
+++ b/checkin-app/src/app/api/my-programs/conflicts/resolve/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { intervalsOverlap } from "@/lib/attendanceConflicts";
+import { apiError } from "@/lib/api-response";
 
 /**
  * Resolve an attendance conflict by deleting one of the duplicate Visit rows.
@@ -22,14 +23,14 @@ import { intervalsOverlap } from "@/lib/attendanceConflicts";
  */
 export const POST = withAuth({}, async (req, auth) => {
   if (auth.type !== "session") {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
   const user = auth.user;
 
   const body = await req.json().catch(() => null);
   const visitId = body?.visitId;
   if (!Number.isInteger(visitId)) {
-    return NextResponse.json({ error: "visitId (integer) is required" }, { status: 400 });
+    return apiError("visitId (integer) is required", 400);
   }
 
   const visit = await prisma.visit.findUnique({
@@ -37,13 +38,13 @@ export const POST = withAuth({}, async (req, auth) => {
     include: { event: { include: { program: { select: { leadMentorId: true } } } } },
   });
   if (!visit) {
-    return NextResponse.json({ error: "Visit not found" }, { status: 404 });
+    return apiError("Visit not found", 404);
   }
 
   const isGlobalAdmin = !!(user.isSysadmin || user.isBoardMember || user.isKeyholder);
   const leadsOwningProgram = visit.event?.program?.leadMentorId === user.id;
   if (!isGlobalAdmin && !leadsOwningProgram) {
-    return NextResponse.json({ error: "Forbidden: not authorized to resolve this visit" }, { status: 403 });
+    return apiError("Forbidden: not authorized to resolve this visit", 403);
   }
 
   // Guard: only delete a visit that genuinely overlaps another of the same
@@ -54,7 +55,7 @@ export const POST = withAuth({}, async (req, auth) => {
   });
   const isConflicting = siblings.some((s) => intervalsOverlap(visit, s));
   if (!isConflicting) {
-    return NextResponse.json({ error: "Visit is not part of an attendance conflict" }, { status: 409 });
+    return apiError("Visit is not part of an attendance conflict", 409);
   }
 
   await prisma.$transaction(async (tx) => {

--- a/checkin-app/src/app/api/my-programs/conflicts/route.ts
+++ b/checkin-app/src/app/api/my-programs/conflicts/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import { getLeadConflicts, type AttendanceConflict } from "@/lib/attendanceConflicts";
+import { apiError } from "@/lib/api-response";
 
 export type ConflictsResponse = { conflicts: AttendanceConflict[] };
 
@@ -9,7 +10,7 @@ export type ConflictsResponse = { conflicts: AttendanceConflict[] };
 // events and returns [] for non-leads, so there's nothing to leak.
 export const GET = withAuth({}, async (_req, auth) => {
   if (auth.type !== "session") {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
   const conflicts = await getLeadConflicts(auth.user.id);
   return NextResponse.json({ conflicts } satisfies ConflictsResponse);

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth";
 import type { MembershipProcessStatus, TrustedAdultReviewStatus } from "@/generated/prisma/client";
 import { countHouseholdsMissingValidContact } from "@/lib/emergencyContacts/service";
 import { ORG_DOMAIN } from "@/lib/config";
+import { apiError } from "@/lib/api-response";
 
 /**
  * Aggregate "things to do" counts for the left-nav badges. Every count is scoped
@@ -92,7 +93,7 @@ const MEMBERSHIP_TODO_LABEL: Record<string, string> = {
 
 export const GET = withAuth({}, async (_req, auth) => {
     if (auth.type !== "session") {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        return apiError("Unauthorized", 401);
     }
     const user = auth.user;
 

--- a/checkin-app/src/app/api/notifications/route.ts
+++ b/checkin-app/src/app/api/notifications/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import { getMembershipNotifications } from "@/lib/membership/notifications";
 import { getEmergencyContactNotifications } from "@/lib/emergencyContacts/notifications";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -12,7 +13,7 @@ export const dynamic = "force-dynamic";
  *   { membership: { pendingReviews, blocked }, emergencyContacts: { householdsMissingValidContact } }
  */
 export const GET = withAuth({}, async (_req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
 
     const [membership, emergencyContacts] = await Promise.all([
         getMembershipNotifications(auth.user),

--- a/checkin-app/src/app/api/people/search/route.ts
+++ b/checkin-app/src/app/api/people/search/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { personRecordIsActiveOrgMember } from "@/lib/orgMembership";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = 'force-dynamic';
 
@@ -49,7 +50,7 @@ export const GET = withAuth(
             return NextResponse.json({ people: formatted });
         } catch (error) {
             logger.error("Failed to fetch people:", error);
-            return NextResponse.json({ error: "Failed to fetch people" }, { status: 500 });
+            return apiError("Failed to fetch people", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/profile/onboarding-status/route.ts
+++ b/checkin-app/src/app/api/profile/onboarding-status/route.ts
@@ -3,11 +3,12 @@ import { logger } from "@/lib/logger";
 import prisma from '@/lib/prisma';
 import { withAuth } from "@/lib/auth";
 import { isYouth } from "@/lib/time";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     {},
     async (_req, auth) => {
-        if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        if (auth.type !== 'session') return apiError("Unauthorized", 401);
         const userId = auth.user.id;
 
         try {
@@ -22,7 +23,7 @@ export const GET = withAuth(
             });
 
             if (!user) {
-                return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+                return apiError("Participant not found", 404);
             }
 
             // Youth are never required to provide a phone number (issue #169)
@@ -46,7 +47,7 @@ export const GET = withAuth(
             });
         } catch (error) {
             logger.error("Error checking onboarding status:", error);
-            return NextResponse.json({ error: "Failed to check status" }, { status: 500 });
+            return apiError("Failed to check status", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/profile/onboarding/route.ts
+++ b/checkin-app/src/app/api/profile/onboarding/route.ts
@@ -4,11 +4,12 @@ import prisma from '@/lib/prisma';
 import { withAuth } from "@/lib/auth";
 import { upsertPrimaryContact, EmergencyContactError } from "@/lib/emergencyContacts/service";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
+import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth(
     {},
     async (req, auth) => {
-        if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        if (auth.type !== 'session') return apiError("Unauthorized", 401);
         const userId = auth.user.id;
 
         try {
@@ -21,12 +22,12 @@ export const POST = withAuth(
             });
 
             if (!user) {
-                return NextResponse.json({ error: "User not found" }, { status: 404 });
+                return apiError("User not found", 404);
             }
 
             if (phone !== undefined) {
                 if (phone !== "" && !isValidPhone(phone)) {
-                    return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
+                    return apiError(PHONE_ERROR, 400);
                 }
                 await prisma.person.update({
                     where: { id: userId },
@@ -48,10 +49,10 @@ export const POST = withAuth(
             return NextResponse.json({ success: true });
         } catch (error) {
             if (error instanceof EmergencyContactError) {
-                return NextResponse.json({ error: error.message }, { status: 400 });
+                return apiError(error.message, 400);
             }
             logger.error("Error saving onboarding details:", error);
-            return NextResponse.json({ error: "Failed to save data" }, { status: 500 });
+            return apiError("Failed to save data", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -5,6 +5,7 @@ import { withAuth } from "@/lib/auth";
 import { handler, notFound, unauthorized } from "@/security/handler";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
 import { isYouth } from "@/lib/time";
+import { apiError } from "@/lib/api-response";
 
 export const GET = handler('GET /api/profile', async ({ auth }) => {
     if (auth.type !== 'session') throw unauthorized();
@@ -26,7 +27,7 @@ export const PATCH = withAuth(
     {},
     async (req, auth) => {
         try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            if (auth.type !== 'session') return apiError("Unauthorized", 401);
             const userId = auth.user.id;
 
             const me = await prisma.person.findUnique({
@@ -34,14 +35,14 @@ export const PATCH = withAuth(
                 select: { dateOfBirth: true },
             });
             if (isYouth(me?.dateOfBirth)) {
-                return NextResponse.json({ error: "Youth profiles are read-only." }, { status: 403 });
+                return apiError("Youth profiles are read-only.", 403);
             }
 
             const body = await req.json();
             const { name, phone, dob, notificationSettings } = body;
 
             if (phone !== undefined && phone !== "" && !isValidPhone(phone)) {
-                return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
+                return apiError(PHONE_ERROR, 400);
             }
 
             const updatedProfile = await prisma.person.update({
@@ -75,7 +76,7 @@ export const PATCH = withAuth(
 
         } catch (error) {
             logger.error("Profile PATCH Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/profile/visits/route.ts
+++ b/checkin-app/src/app/api/profile/visits/route.ts
@@ -2,12 +2,13 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     {},
     async (req, auth) => {
         try {
-            if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            if (auth.type !== 'session') return apiError("Unauthorized", 401);
             const userId = auth.user.id;
 
             const { searchParams } = new URL(req.url);
@@ -48,7 +49,7 @@ export const GET = withAuth(
             return NextResponse.json({ visits }, { status: 200 });
         } catch (error) {
             logger.error("Profile Visits GET Error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -5,22 +5,23 @@ import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
 import { lockProgramAndCheckCapacity, ProgramCapacityError } from "@/lib/program/capacity";
 import { calculateAge } from "@/lib/time";
+import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await params;
 
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {
-            return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
+            return apiError("Invalid program ID", 400);
         }
 
         const body = await req.json();
         const { participantId } = body;
 
         if (!participantId) {
-            return NextResponse.json({ error: "participantId is required" }, { status: 400 });
+            return apiError("participantId is required", 400);
         }
 
         // Capacity is counted under a row lock inside the enroll transaction
@@ -29,7 +30,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             where: { id: programId }
         });
         if (!currentProgram) {
-            return NextResponse.json({ error: "Program not found" }, { status: 404 });
+            return apiError("Program not found", 404);
         }
 
         const currentUserId = auth.user.id;
@@ -55,7 +56,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         }
 
         if (!isSelfEnrollment && !isSysAdminOrBoard && !isHouseholdLead) {
-            return NextResponse.json({ error: "Forbidden: Not authorized to enroll this participant. Program leads cannot manually add participants." }, { status: 403 });
+            return apiError("Forbidden: Not authorized to enroll this participant. Program leads cannot manually add participants.", 403);
         }
 
         const override = body.override === true;
@@ -151,10 +152,10 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         // Benign double-submit (UI double-click) re-enrolls the same participant;
         // return 409 instead of a 500.
         if (isPrismaError(error, 'P2002')) {
-            return NextResponse.json({ error: "Participant is already enrolled in this program." }, { status: 409 });
+            return apiError("Participant is already enrolled in this program.", 409);
         }
         logger.error("Enrollment creation error:", error);
-        return NextResponse.json({ error: "Failed to enroll participant" }, { status: 500 });
+        return apiError("Failed to enroll participant", 500);
     }
 });
 
@@ -166,20 +167,20 @@ function isPrismaError(error: unknown, code: string): boolean {
 }
 
 export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await params;
 
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {
-            return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
+            return apiError("Invalid program ID", 400);
         }
 
         const body = await req.json();
         const { participantId } = body;
 
         if (!participantId) {
-            return NextResponse.json({ error: "participantId is required" }, { status: 400 });
+            return apiError("participantId is required", 400);
         }
 
         const currentProgram = await prisma.program.findUnique({
@@ -187,7 +188,7 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
         });
 
         if (!currentProgram) {
-            return NextResponse.json({ error: "Program not found" }, { status: 404 });
+            return apiError("Program not found", 404);
         }
 
         const currentUserId = auth.user.id;
@@ -196,7 +197,7 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
         const isSysAdminOrBoard = auth.user.isSysadmin || auth.user.isBoardMember;
 
         if (!isSelfRemoval && !isLeadMentor && !isSysAdminOrBoard) {
-            return NextResponse.json({ error: "Forbidden: Not authorized to remove this participant" }, { status: 403 });
+            return apiError("Forbidden: Not authorized to remove this participant", 403);
         }
 
         const enrollment = await prisma.programParticipant.delete({
@@ -227,6 +228,6 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
             return NextResponse.json({ success: true, idempotent: true });
         }
         logger.error("Enrollment deletion error:", error);
-        return NextResponse.json({ error: "Failed to remove participant" }, { status: 500 });
+        return apiError("Failed to remove participant", 500);
     }
 });

--- a/checkin-app/src/app/api/programs/[id]/public-register/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/public-register/route.ts
@@ -8,6 +8,7 @@ import { createContact, EmergencyContactError } from "@/lib/emergencyContacts/se
 import { rateLimit, rateLimitEmail } from "@/lib/rate-limit";
 import { calculateAge } from "@/lib/time";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
+import { apiError } from "@/lib/api-response";
 
 interface ParentInput {
     name: string;
@@ -31,7 +32,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {
-            return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
+            return apiError("Invalid program ID", 400);
         }
 
         // Capacity is counted under a row lock inside the registration
@@ -41,24 +42,24 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         });
 
         if (!currentProgram) {
-            return NextResponse.json({ error: "Program not found" }, { status: 404 });
+            return apiError("Program not found", 404);
         }
 
         const body = await req.json();
         const { parents, emergencyContact, participants } = body;
 
         if (!parents || parents.length === 0 || !parents[0].name || !parents[0].email || !parents[0].phone) {
-            return NextResponse.json({ error: "Primary parent/guardian information is required." }, { status: 400 });
+            return apiError("Primary parent/guardian information is required.", 400);
         }
         if (!isValidPhone(parents[0].phone)) {
-            return NextResponse.json({ error: PHONE_ERROR }, { status: 400 });
+            return apiError(PHONE_ERROR, 400);
         }
         if (!emergencyContact || !emergencyContact.name || !emergencyContact.phone) {
-            return NextResponse.json({ error: "Emergency contact is required." }, { status: 400 });
+            return apiError("Emergency contact is required.", 400);
         }
         // Emergency-contact phone format is enforced in createContact below.
         if (!participants || participants.length === 0) {
-            return NextResponse.json({ error: "At least one participant is required." }, { status: 400 });
+            return apiError("At least one participant is required.", 400);
         }
 
         // Second limit keyed on the normalized primary email so an attacker can't
@@ -77,7 +78,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                 where: { email: { in: emailsToCheck } }
             });
             if (existingUsers.length > 0) {
-                return NextResponse.json({ error: "An account with that email already exists. Please log in to enroll." }, { status: 400 });
+                return apiError("An account with that email already exists. Please log in to enroll.", 400);
             }
         }
 
@@ -87,7 +88,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
         // Check Enrollment Status
         if (currentProgram.enrollmentStatus === 'CLOSED') {
-            return NextResponse.json({ error: "Program enrollment is currently closed." }, { status: 400 });
+            return apiError("Program enrollment is currently closed.", 400);
         }
 
         // Check Age constraints
@@ -98,23 +99,23 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
                     // It's an adult parent. Assume they are over 18.
                     const age = 30; 
                     if (currentProgram.minAge !== null && age < currentProgram.minAge) {
-                        return NextResponse.json({ error: `Participant ${p.name} does not meet minimum age restriction.` }, { status: 400 });
+                        return apiError(`Participant ${p.name} does not meet minimum age restriction.`, 400);
                     }
                     if (currentProgram.maxAge !== null && age > currentProgram.maxAge) {
-                        return NextResponse.json({ error: `Participant ${p.name} exceeds maximum age restriction.` }, { status: 400 });
+                        return apiError(`Participant ${p.name} exceeds maximum age restriction.`, 400);
                     }
                 } else {
                     if (!p.dob) {
-                        return NextResponse.json({ error: `Date of Birth is required for participant ${p.name} to verify age constraints.` }, { status: 400 });
+                        return apiError(`Date of Birth is required for participant ${p.name} to verify age constraints.`, 400);
                     }
                     // Judge age as of the program's start date; fall back to now
                     // for dateless ("TBD") programs.
                     const age = calculateAge(p.dob, currentProgram.startAt ?? undefined);
                     if (currentProgram.minAge !== null && age < currentProgram.minAge) {
-                        return NextResponse.json({ error: `Participant ${p.name} must be at least ${currentProgram.minAge} years old.` }, { status: 400 });
+                        return apiError(`Participant ${p.name} must be at least ${currentProgram.minAge} years old.`, 400);
                     }
                     if (currentProgram.maxAge !== null && age > currentProgram.maxAge) {
-                        return NextResponse.json({ error: `Participant maximum age is ${currentProgram.maxAge} years old for ${p.name}.` }, { status: 400 });
+                        return apiError(`Participant maximum age is ${currentProgram.maxAge} years old for ${p.name}.`, 400);
                     }
                 }
             }
@@ -231,12 +232,12 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
     } catch (error) {
         if (error instanceof ProgramCapacityError) {
-            return NextResponse.json({ error: `Not enough open spots. Only ${error.spotsLeft} spots left.` }, { status: 400 });
+            return apiError(`Not enough open spots. Only ${error.spotsLeft} spots left.`, 400);
         }
         if (error instanceof HouseholdLeadLimitError || error instanceof EmergencyContactError) {
-            return NextResponse.json({ error: error.message }, { status: 400 });
+            return apiError(error.message, 400);
         }
         await logBackendError(error, "POST /api/programs/[id]/public-register");
-        return NextResponse.json({ error: "An error occurred during registration." }, { status: 500 });
+        return apiError("An error occurred during registration.", 500);
     }
 }

--- a/checkin-app/src/app/api/programs/[id]/publish/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/publish/route.ts
@@ -2,22 +2,23 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await params;
 
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {
-            return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
+            return apiError("Invalid program ID", 400);
         }
 
         const body = await req.json();
         const { publish } = body;
 
         if (publish !== true) {
-            return NextResponse.json({ error: "publish must be true" }, { status: 400 });
+            return apiError("publish must be true", 400);
         }
 
         const currentProgram = await prisma.program.findUnique({
@@ -26,7 +27,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         });
 
         if (!currentProgram) {
-            return NextResponse.json({ error: "Program not found" }, { status: 404 });
+            return apiError("Program not found", 404);
         }
 
         const currentUserId = auth.user.id;
@@ -34,7 +35,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         const isLeadMentor = currentProgram.leadMentorId === currentUserId;
 
         if (!isSysAdminOrBoard && !isLeadMentor) {
-            return NextResponse.json({ error: "Forbidden: Not authorized to publish this program" }, { status: 403 });
+            return apiError("Forbidden: Not authorized to publish this program", 403);
         }
 
         if (publish) {
@@ -42,14 +43,14 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             // pre-launch phase (PLANNING/UPCOMING). Re-publishing a RUNNING or FINISHED
             // program would silently resurrect it — reject terminal/active phases.
             if (currentProgram.phase === 'RUNNING' || currentProgram.phase === 'FINISHED') {
-                return NextResponse.json({ error: `Cannot publish a program that is already ${currentProgram.phase.toLowerCase()}.` }, { status: 409 });
+                return apiError(`Cannot publish a program that is already ${currentProgram.phase.toLowerCase()}.`, 409);
             }
             // Validation rules for publishing
             if (!currentProgram.leadMentorId) {
-                return NextResponse.json({ error: "Cannot publish a program without a Lead Mentor assigned" }, { status: 400 });
+                return apiError("Cannot publish a program without a Lead Mentor assigned", 400);
             }
             if (currentProgram.events.length === 0) {
-                return NextResponse.json({ error: "Cannot publish a program without any scheduled events" }, { status: 400 });
+                return apiError("Cannot publish a program without any scheduled events", 400);
             }
         }
 
@@ -71,6 +72,6 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         return NextResponse.json({ success: true, program: updatedProgram });
     } catch (error) {
         logger.error("Program publish error:", error);
-        return NextResponse.json({ error: "Failed to set publish state" }, { status: 500 });
+        return apiError("Failed to set publish state", 500);
     }
 });

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -2,23 +2,23 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
-
+import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await params;
 
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {
-            return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
+            return apiError("Invalid program ID", 400);
         }
 
         const body = await req.json();
         const { participantId } = body;
 
         if (!participantId) {
-            return NextResponse.json({ error: "participantId is required" }, { status: 400 });
+            return apiError("participantId is required", 400);
         }
 
         const participant = await prisma.programParticipant.findUnique({
@@ -32,7 +32,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         });
 
         if (!participant) {
-            return NextResponse.json({ error: "Participant not found in program" }, { status: 404 });
+            return apiError("Participant not found in program", 404);
         }
 
         // Authorization: only the participant themselves, a lead of their household,
@@ -58,7 +58,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         }
 
         if (!isSelf && !isSysAdminOrBoard && !isLeadMentor && !isHouseholdLead) {
-            return NextResponse.json({ error: "Forbidden: Not authorized to request a payment plan for this participant" }, { status: 403 });
+            return apiError("Forbidden: Not authorized to request a payment plan for this participant", 403);
         }
 
         const updatedParticipant = await prisma.programParticipant.update({
@@ -77,6 +77,6 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         return NextResponse.json({ success: true, participant: updatedParticipant });
     } catch (error) {
         logger.error("Payment plan request error:", error);
-        return NextResponse.json({ error: "Failed to request payment plan" }, { status: 500 });
+        return apiError("Failed to request payment plan", 500);
     }
 });

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { handler, notFound, forbidden, badRequest } from "@/security/handler";
 import { isActiveOrgMember } from "@/lib/orgMembership";
 import { dollarsToCentsOrNull } from "@inventory/money";
+import { apiError } from "@/lib/api-response";
 
 export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ auth, params }) => {
     const programId = parseInt(params.id, 10);
@@ -92,18 +93,18 @@ export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
 // GAP-1: this PATCH previously had no denied check), so a denied lead mentor can
 // no longer edit their program.
 export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await ctx.params;
 
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {
-            return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
+            return apiError("Invalid program ID", 400);
         }
 
         const currentProgram = await prisma.program.findUnique({ where: { id: programId } });
         if (!currentProgram) {
-            return NextResponse.json({ error: "Program not found" }, { status: 404 });
+            return apiError("Program not found", 404);
         }
 
         const user = auth.user;
@@ -111,7 +112,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
         const isSysAdminOrBoard = user.isSysadmin || user.isBoardMember;
 
         if (!isLeadMentor && !isSysAdminOrBoard) {
-            return NextResponse.json({ error: "Forbidden: Only Admin, Board Members, or Lead Mentors can edit" }, { status: 403 });
+            return apiError("Forbidden: Only Admin, Board Members, or Lead Mentors can edit", 403);
         }
 
         const body = await req.json();
@@ -120,11 +121,11 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
 
         if (body.hasOwnProperty('leadMentorId')) {
             if (!leadMentorId) {
-                return NextResponse.json({ error: "Lead Mentor is required" }, { status: 400 });
+                return apiError("Lead Mentor is required", 400);
             }
             leadMentorId = parseInt(leadMentorId);
             if (isNaN(leadMentorId)) {
-                return NextResponse.json({ error: "Invalid lead mentor" }, { status: 400 });
+                return apiError("Invalid lead mentor", 400);
             }
         }
 
@@ -163,6 +164,6 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
         return NextResponse.json({ success: true, program: updatedProgram });
     } catch (error) {
         logger.error("Program update error:", error);
-        return NextResponse.json({ error: "Failed to update program" }, { status: 500 });
+        return apiError("Failed to update program", 500);
     }
 });

--- a/checkin-app/src/app/api/programs/[id]/settings/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/settings/route.ts
@@ -2,15 +2,16 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+import { apiError } from "@/lib/api-response";
 
 export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await params;
 
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {
-            return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
+            return apiError("Invalid program ID", 400);
         }
 
         const currentProgram = await prisma.program.findUnique({
@@ -18,7 +19,7 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         });
 
         if (!currentProgram) {
-            return NextResponse.json({ error: "Program not found" }, { status: 404 });
+            return apiError("Program not found", 404);
         }
 
         const currentUserId = auth.user.id;
@@ -26,7 +27,7 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         const isLeadMentor = currentProgram.leadMentorId === currentUserId;
 
         if (!isSysAdminOrBoard && !isLeadMentor) {
-            return NextResponse.json({ error: "Forbidden: Not authorized to update program settings" }, { status: 403 });
+            return apiError("Forbidden: Not authorized to update program settings", 403);
         }
 
         const body = await req.json();
@@ -49,13 +50,13 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         const effMinAge = minAge !== undefined ? minAge : currentProgram.minAge;
         const effMaxAge = maxAge !== undefined ? maxAge : currentProgram.maxAge;
         if (minAge != null && minAge < 0) {
-            return NextResponse.json({ error: "minAge cannot be negative" }, { status: 400 });
+            return apiError("minAge cannot be negative", 400);
         }
         if (maxAge != null && maxAge < 0) {
-            return NextResponse.json({ error: "maxAge cannot be negative" }, { status: 400 });
+            return apiError("maxAge cannot be negative", 400);
         }
         if (effMinAge != null && effMaxAge != null && effMinAge > effMaxAge) {
-            return NextResponse.json({ error: "minAge cannot exceed maxAge" }, { status: 400 });
+            return apiError("minAge cannot exceed maxAge", 400);
         }
 
         // maxParticipants: null = uncapped (allowed). Otherwise must be a
@@ -63,11 +64,11 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         // perma-rejects everyone. Mirrors the all-rows count in capacity.ts.
         if (maxParticipants !== undefined && maxParticipants !== null) {
             if (typeof maxParticipants !== "number" || !Number.isInteger(maxParticipants) || maxParticipants <= 0) {
-                return NextResponse.json({ error: "maxParticipants must be a positive integer" }, { status: 400 });
+                return apiError("maxParticipants must be a positive integer", 400);
             }
             const enrolled = await prisma.programParticipant.count({ where: { programId } });
             if (maxParticipants < enrolled) {
-                return NextResponse.json({ error: `maxParticipants cannot be set below the current enrollment of ${enrolled}` }, { status: 400 });
+                return apiError(`maxParticipants cannot be set below the current enrollment of ${enrolled}`, 400);
             }
         }
 
@@ -87,12 +88,12 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         // leadMentorId can only be changed by SysAdmin or Board
         if (leadMentorId !== undefined) {
             if (!leadMentorId) {
-                return NextResponse.json({ error: "Lead Mentor is required" }, { status: 400 });
+                return apiError("Lead Mentor is required", 400);
             }
             if (isSysAdminOrBoard) {
                 updateData.leadMentorId = parseInt(leadMentorId, 10);
             } else if (parseInt(leadMentorId, 10) !== currentProgram.leadMentorId) {
-                return NextResponse.json({ error: "Forbidden: Only administrators can reassign lead mentors" }, { status: 403 });
+                return apiError("Forbidden: Only administrators can reassign lead mentors", 403);
             }
         }
 
@@ -114,6 +115,6 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         return NextResponse.json({ success: true, program: updatedProgram });
     } catch (error) {
         logger.error("Program settings update error:", error);
-        return NextResponse.json({ error: "Failed to update program settings" }, { status: 500 });
+        return apiError("Failed to update program settings", 500);
     }
 });

--- a/checkin-app/src/app/api/programs/[id]/volunteers/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/volunteers/route.ts
@@ -2,27 +2,28 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await params;
 
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {
-            return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
+            return apiError("Invalid program ID", 400);
         }
 
         const body = await req.json();
         const { participantId } = body;
 
         if (!participantId || typeof participantId !== 'number') {
-            return NextResponse.json({ error: "participantId is required" }, { status: 400 });
+            return apiError("participantId is required", 400);
         }
 
         const currentProgram = await prisma.program.findUnique({ where: { id: programId } });
         if (!currentProgram) {
-            return NextResponse.json({ error: "Program not found" }, { status: 404 });
+            return apiError("Program not found", 404);
         }
 
         const currentUserId = auth.user.id;
@@ -30,7 +31,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         const isSysAdminOrBoard = auth.user.isSysadmin || auth.user.isBoardMember;
 
         if (!isLeadMentor && !isSysAdminOrBoard) {
-            return NextResponse.json({ error: "Forbidden: Not authorized to assign volunteers" }, { status: 403 });
+            return apiError("Forbidden: Not authorized to assign volunteers", 403);
         }
 
         // ponytail: no eligibility gate (age/membership) on volunteers — they're
@@ -60,15 +61,15 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         // P2002 = unique violation on @@id([programId, participantId]). Benign
         // double-submit re-assigns the same volunteer; 409 instead of 500.
         if (isPrismaError(error, 'P2002')) {
-            return NextResponse.json({ error: "Participant is already a volunteer for this program." }, { status: 409 });
+            return apiError("Participant is already a volunteer for this program.", 409);
         }
         // P2003 = FK violation: participantId points at no Participant row. Bad
         // input, not a server fault; 400 instead of 500.
         if (isPrismaError(error, 'P2003')) {
-            return NextResponse.json({ error: "Participant not found" }, { status: 400 });
+            return apiError("Participant not found", 400);
         }
         logger.error("Volunteer assignment error:", error);
-        return NextResponse.json({ error: "Failed to assign volunteer" }, { status: 500 });
+        return apiError("Failed to assign volunteer", 500);
     }
 });
 
@@ -80,25 +81,25 @@ function isPrismaError(error: unknown, code: string): boolean {
 }
 
 export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await params;
 
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {
-            return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
+            return apiError("Invalid program ID", 400);
         }
 
         const body = await req.json();
         const { participantId } = body;
 
         if (!participantId) {
-            return NextResponse.json({ error: "participantId is required" }, { status: 400 });
+            return apiError("participantId is required", 400);
         }
 
         const currentProgram = await prisma.program.findUnique({ where: { id: programId } });
         if (!currentProgram) {
-            return NextResponse.json({ error: "Program not found" }, { status: 404 });
+            return apiError("Program not found", 404);
         }
 
         const currentUserId = auth.user.id;
@@ -106,7 +107,7 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
         const isSysAdminOrBoard = auth.user.isSysadmin || auth.user.isBoardMember;
 
         if (!isLeadMentor && !isSysAdminOrBoard) {
-            return NextResponse.json({ error: "Forbidden: Not authorized to remove volunteers" }, { status: 403 });
+            return apiError("Forbidden: Not authorized to remove volunteers", 403);
         }
 
         const assignment = await prisma.programVolunteer.delete({
@@ -132,30 +133,30 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
         return NextResponse.json({ success: true, assignment });
     } catch (error) {
         logger.error("Volunteer removal error:", error);
-        return NextResponse.json({ error: "Failed to remove volunteer" }, { status: 500 });
+        return apiError("Failed to remove volunteer", 500);
     }
 });
 
 export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await params;
 
     try {
         const programId = parseInt(id, 10);
         if (isNaN(programId)) {
-            return NextResponse.json({ error: "Invalid program ID" }, { status: 400 });
+            return apiError("Invalid program ID", 400);
         }
 
         const body = await req.json();
         const { participantId, isCore } = body;
 
         if (!participantId || isCore === undefined) {
-            return NextResponse.json({ error: "participantId and isCore are required" }, { status: 400 });
+            return apiError("participantId and isCore are required", 400);
         }
 
         const currentProgram = await prisma.program.findUnique({ where: { id: programId } });
         if (!currentProgram) {
-            return NextResponse.json({ error: "Program not found" }, { status: 404 });
+            return apiError("Program not found", 404);
         }
 
         const currentUserId = auth.user.id;
@@ -163,7 +164,7 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         const isSysAdminOrBoard = auth.user.isSysadmin || auth.user.isBoardMember;
 
         if (!isLeadMentor && !isSysAdminOrBoard) {
-            return NextResponse.json({ error: "Forbidden: Not authorized to modify volunteers" }, { status: 403 });
+            return apiError("Forbidden: Not authorized to modify volunteers", 403);
         }
 
         const assignment = await prisma.programVolunteer.update({
@@ -192,6 +193,6 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         return NextResponse.json({ success: true, assignment });
     } catch (error) {
         logger.error("Volunteer toggle error:", error);
-        return NextResponse.json({ error: "Failed to toggle volunteer" }, { status: 500 });
+        return apiError("Failed to toggle volunteer", 500);
     }
 });

--- a/checkin-app/src/app/api/programs/mine/route.ts
+++ b/checkin-app/src/app/api/programs/mine/route.ts
@@ -4,9 +4,10 @@ import type { Session } from "next-auth";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { activityMembers } from "@/lib/household/activityMembers";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth({}, async (_req, auth) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
     // activityMembers only reads session.user; reconstruct the minimal shape from auth.user.
     const session = { user: auth.user } as unknown as Session;
 
@@ -31,6 +32,6 @@ export const GET = withAuth({}, async (_req, auth) => {
         return NextResponse.json(enrollments);
     } catch (error) {
         logger.error("Failed to fetch user programs:", error);
-        return NextResponse.json({ error: "Failed to fetch programs" }, { status: 500 });
+        return apiError("Failed to fetch programs", 500);
     }
 });

--- a/checkin-app/src/app/api/programs/route.ts
+++ b/checkin-app/src/app/api/programs/route.ts
@@ -6,6 +6,7 @@ import { createShopifyProgramVariants } from "@/lib/shopify";
 import { logBackendError, logger } from "@/lib/logger";
 import { isActiveOrgMember } from "@/lib/orgMembership";
 import { dollarsToCentsOrNull } from "@inventory/money";
+import { apiError } from "@/lib/api-response";
 
 // GET is the PUBLIC program catalog — anonymous callers legitimately get the
 // non-draft, non-memberOnly list (asserted by programsAPI.integration.test.ts),
@@ -86,12 +87,12 @@ export async function GET(req: Request) {
         return NextResponse.json(programs);
     } catch (error) {
         await logBackendError(error, "GET /api/programs");
-        return NextResponse.json({ error: "Failed to fetch programs" }, { status: 500 });
+        return apiError("Failed to fetch programs", 500);
     }
 }
 
 export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (req, auth) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
 
     // Hoisted so the catch can name an orphaned Shopify product (created, but DB write failed) for manual cleanup.
     let shopifyData: { shopifyProductId: string, shopifyMemberVariantId: string | null, shopifyNonMemberVariantId: string | null } | null = null;
@@ -101,11 +102,11 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         const { name, leadMentorId, startAt, endAt, memberOnly, minAge, maxAge, memberPrice, nonMemberPrice, maxParticipants } = body;
 
         if (!name) {
-            return NextResponse.json({ error: "Program name is required" }, { status: 400 });
+            return apiError("Program name is required", 400);
         }
 
         if (!leadMentorId) {
-            return NextResponse.json({ error: "Lead Mentor is required" }, { status: 400 });
+            return apiError("Lead Mentor is required", 400);
         }
 
         // Client sends a raw dollar string; tolerate a number too. Convert to cents here.
@@ -162,6 +163,6 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
             logger.error("[Shopify] Orphaned product after program DB write failed, manual cleanup needed:", shopifyData.shopifyProductId);
         }
         await logBackendError(error, "POST /api/programs");
-        return NextResponse.json({ error: "Failed to create program" }, { status: 500 });
+        return apiError("Failed to create program", 500);
     }
 });

--- a/checkin-app/src/app/api/roles/route.ts
+++ b/checkin-app/src/app/api/roles/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     { roles: ['isSysadmin', 'isBoardMember'] },
@@ -31,7 +32,7 @@ export const GET = withAuth(
             return NextResponse.json({ people });
         } catch (error) {
             logger.error("Error fetching roles:", error);
-            return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+            return apiError("Internal server error", 500);
         }
     }
 );
@@ -44,15 +45,12 @@ export const PATCH = withAuth(
             const { targetUserId, ...roleUpdates } = body;
 
             if (!targetUserId) {
-                return NextResponse.json({ error: "Missing 'targetUserId'" }, { status: 400 });
+                return apiError("Missing 'targetUserId'", 400);
             }
 
             // Board Members cannot modify isSysadmin privileges
             if (auth.type === 'session' && !auth.user.isSysadmin && roleUpdates.isSysadmin !== undefined) {
-                return NextResponse.json(
-                    { error: "Only Sysadmins can modify isSysadmin privileges" },
-                    { status: 403 }
-                );
+                return apiError("Only Sysadmins can modify isSysadmin privileges", 403);
             }
 
             const allowedFields = ["isSysadmin", "isBoardMember", "isKeyholder", "isBackgroundCheckReviewer"];
@@ -64,7 +62,7 @@ export const PATCH = withAuth(
             }
 
             if (Object.keys(updateData).length === 0) {
-                return NextResponse.json({ error: "No valid role fields provided" }, { status: 400 });
+                return apiError("No valid role fields provided", 400);
             }
 
             const updated = await prisma.person.update({
@@ -97,7 +95,7 @@ export const PATCH = withAuth(
             return NextResponse.json({ message: "Roles updated successfully", user: updated });
         } catch (error) {
             logger.error("Error updating role:", error);
-            return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+            return apiError("Internal server error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/safety/board-contacts/route.ts
+++ b/checkin-app/src/app/api/safety/board-contacts/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { logBackendError } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     { roles: ['isSysadmin', 'isBoardMember', 'isKeyholder'] },
@@ -15,10 +16,7 @@ export const GET = withAuth(
             return NextResponse.json({ members });
         } catch (error) {
             await logBackendError(error, "GET /api/safety/board-contacts");
-            return NextResponse.json(
-                { error: "Internal Server Error fetching board contacts." },
-                { status: 500 }
-            );
+            return apiError("Internal Server Error fetching board contacts.", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/safety/emergency-contacts/route.ts
+++ b/checkin-app/src/app/api/safety/emergency-contacts/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { logBackendError } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     { roles: ['isSysadmin', 'isBoardMember', 'isKeyholder'] },
@@ -76,10 +77,7 @@ export const GET = withAuth(
             return NextResponse.json({ households: formattedHouseholds });
         } catch (error) {
             await logBackendError(error, "GET /api/safety/emergency-contacts");
-            return NextResponse.json(
-                { error: "Internal Server Error fetching emergency contacts." },
-                { status: 500 }
-            );
+            return apiError("Internal Server Error fetching emergency contacts.", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/safety/trusted-adults/decision/route.ts
+++ b/checkin-app/src/app/api/safety/trusted-adults/decision/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { decideReview, TrustedAdultError } from "@/lib/trusted-adult/service";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -21,15 +22,15 @@ const DECISIONS = new Set(["APPROVE", "DENY", "REQUEST_INFO"]);
  * (the outward note keyholders & program leads see). Single entry, no quorum.
  */
 export const POST = withAuth({ roles: ["isBoardMember", "isSysadmin"] }, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     let body: { reviewId?: number; decision?: string; sharedNote?: string; note?: string };
     try {
         body = await req.json();
     } catch {
-        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+        return apiError("Invalid JSON", 400);
     }
     if (!body.reviewId || !body.decision || !DECISIONS.has(body.decision)) {
-        return NextResponse.json({ error: "reviewId and a valid decision are required" }, { status: 400 });
+        return apiError("reviewId and a valid decision are required", 400);
     }
     try {
         const outcome = await decideReview(body.reviewId, auth.user.id, {
@@ -43,6 +44,6 @@ export const POST = withAuth({ roles: ["isBoardMember", "isSysadmin"] }, async (
             return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
         }
         logger.error("Trusted adult decision error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/safety/trusted-adults/override/route.ts
+++ b/checkin-app/src/app/api/safety/trusted-adults/override/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { overrideReview, TrustedAdultError } from "@/lib/trusted-adult/service";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -18,15 +19,15 @@ const STATUS_FOR: Record<TrustedAdultError["code"], number> = {
  * terminal state regardless of phase. Body: { reviewId, action: approve|deny|revoke }.
  */
 export const POST = withAuth({ roles: ["isBoardMember", "isSysadmin"] }, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     let body: { reviewId?: number; action?: "approve" | "deny" | "revoke"; sharedNote?: string };
     try {
         body = await req.json();
     } catch {
-        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+        return apiError("Invalid JSON", 400);
     }
     if (!body.reviewId || !["approve", "deny", "revoke"].includes(body.action ?? "")) {
-        return NextResponse.json({ error: "reviewId and action (approve|deny|revoke) are required" }, { status: 400 });
+        return apiError("reviewId and action (approve|deny|revoke) are required", 400);
     }
     try {
         const outcome = await overrideReview(body.reviewId, auth.user.id, body.action!, body.sharedNote, {
@@ -38,6 +39,6 @@ export const POST = withAuth({ roles: ["isBoardMember", "isSysadmin"] }, async (
             return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
         }
         logger.error("Trusted adult override error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/settings/membership/bulk-open-renewals/route.ts
+++ b/checkin-app/src/app/api/settings/membership/bulk-open-renewals/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import { openRenewalsForAllActive } from "@/lib/membership/renewal";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -12,7 +13,7 @@ export const dynamic = "force-dynamic";
  * Body: { sendReminders?: boolean } (default false — avoids a mass email blast).
  */
 export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     let body: { sendReminders?: boolean } = {};
     try {
         body = await req.json();

--- a/checkin-app/src/app/api/settings/membership/route.ts
+++ b/checkin-app/src/app/api/settings/membership/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -21,7 +22,7 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
  * link is an env var, not a board setting.)
  */
 export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     let body: {
         normalDuesCents?: number;
         volunteerDuesCents?: number;
@@ -33,17 +34,17 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
     try {
         body = await req.json();
     } catch {
-        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+        return apiError("Invalid JSON", 400);
     }
 
     const data: Record<string, unknown> = {};
     const invalidDues = (v: number) => !Number.isFinite(v) || v < 0;
     if (body.normalDuesCents !== undefined) {
-        if (invalidDues(body.normalDuesCents)) return NextResponse.json({ error: "normalDuesCents must be a number >= 0" }, { status: 400 });
+        if (invalidDues(body.normalDuesCents)) return apiError("normalDuesCents must be a number >= 0", 400);
         data.normalDuesCents = Math.round(body.normalDuesCents);
     }
     if (body.volunteerDuesCents !== undefined) {
-        if (invalidDues(body.volunteerDuesCents)) return NextResponse.json({ error: "volunteerDuesCents must be a number >= 0" }, { status: 400 });
+        if (invalidDues(body.volunteerDuesCents)) return apiError("volunteerDuesCents must be a number >= 0", 400);
         data.volunteerDuesCents = Math.round(body.volunteerDuesCents);
     }
     if (body.membershipYearBoundary !== undefined) {
@@ -51,7 +52,7 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
     }
     if (body.membershipVariantId !== undefined) {
         const variantId = body.membershipVariantId?.trim();
-        if (variantId && !/^\d+$/.test(variantId)) return NextResponse.json({ error: "membershipVariantId must be a numeric Shopify variant ID" }, { status: 400 });
+        if (variantId && !/^\d+$/.test(variantId)) return apiError("membershipVariantId must be a numeric Shopify variant ID", 400);
         data.membershipVariantId = variantId || null;
     }
     if (body.volunteerDiscountCode !== undefined) {

--- a/checkin-app/src/app/api/settings/membership/volunteer-designations/route.ts
+++ b/checkin-app/src/app/api/settings/membership/volunteer-designations/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -17,16 +18,16 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
  * Non-blocking warning if that email already has an ACTIVE, full-price membership.
  */
 export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     let body: { email?: string };
     try {
         body = await req.json();
     } catch {
-        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+        return apiError("Invalid JSON", 400);
     }
     const email = body.email?.trim().toLowerCase();
     if (!email || !emailRegex.test(email)) {
-        return NextResponse.json({ error: "A valid email is required" }, { status: 400 });
+        return apiError("A valid email is required", 400);
     }
 
     const existing = await prisma.volunteerDesignation.findUnique({ where: { email } });
@@ -50,7 +51,7 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
 /** DELETE — remove a designation. Query: ?id=<n>. */
 export const DELETE = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req) => {
     const id = parseInt(new URL(req.url).searchParams.get("id") || "", 10);
-    if (isNaN(id)) return NextResponse.json({ error: "id is required" }, { status: 400 });
+    if (isNaN(id)) return apiError("id is required", 400);
     await prisma.volunteerDesignation.delete({ where: { id } }).catch(() => null);
     return NextResponse.json({ success: true });
 });

--- a/checkin-app/src/app/api/shop/certifications/route.ts
+++ b/checkin-app/src/app/api/shop/certifications/route.ts
@@ -4,6 +4,7 @@ import { handler, forbidden, unauthorized } from "@/security/handler";
 import { Prisma } from '@/generated/prisma/client';
 import prisma from "@/lib/prisma";
 import { logBackendError } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
 
 // Cert status is PUBLIC BY DESIGN — certifications are physically posted in the
 // shop. This route runs on the @/security handler() runtime so that intent is
@@ -63,7 +64,7 @@ export const GET = handler('GET /api/shop/certifications', async ({ req, auth })
 // certifier (MAY_CERTIFY_OTHERS) authorization runs as before.
 export const POST = withAuth({}, async (req, auth) => {
     if (auth.type !== 'session') {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        return apiError("Unauthorized", 401);
     }
     const session = { user: auth.user };
 
@@ -72,12 +73,12 @@ export const POST = withAuth({}, async (req, auth) => {
         const { participantId, toolId, level } = body;
 
         if (!participantId || !toolId || !level) {
-            return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+            return apiError("Missing required fields", 400);
         }
 
         const validLevels = ["BASIC", "DOF", "CERTIFIED", "INSTRUCTOR", "MAY_CERTIFY_OTHERS"];
         if (!validLevels.includes(level)) {
-            return NextResponse.json({ error: "Invalid certification level" }, { status: 400 });
+            return apiError("Invalid certification level", 400);
         }
 
         const currentUserId = session.user.id;
@@ -102,14 +103,14 @@ export const POST = withAuth({}, async (req, auth) => {
         }
 
         if (!hasCertifierPermission) {
-            return NextResponse.json({ error: "Forbidden: You are not authorized to certify users on this tool" }, { status: 403 });
+            return apiError("Forbidden: You are not authorized to certify users on this tool", 403);
         }
 
         // Only sysadmins/board may promote a user to MAY_CERTIFY_OTHERS. A tool
         // certifier can change certification status up to (but not including)
         // MAY_CERTIFY_OTHERS — they cannot mint new certifiers.
         if (level === "MAY_CERTIFY_OTHERS" && !isSysAdminOrBoard) {
-            return NextResponse.json({ error: "Forbidden: Only admins and board members can grant the Certifier level" }, { status: 403 });
+            return apiError("Forbidden: Only admins and board members can grant the Certifier level", 403);
         }
 
         const tId = parseInt(toolId, 10);
@@ -151,6 +152,6 @@ export const POST = withAuth({}, async (req, auth) => {
         return NextResponse.json({ success: true, certification: upsertedCert });
     } catch (error: unknown) {
         await logBackendError(error, "POST /api/shop/certifications");
-        return NextResponse.json({ error: "Failed to upsert certification" }, { status: 500 });
+        return apiError("Failed to upsert certification", 500);
     }
 });

--- a/checkin-app/src/app/api/shop/tools/[id]/route.ts
+++ b/checkin-app/src/app/api/shop/tools/[id]/route.ts
@@ -2,16 +2,17 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { logBackendError } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
 
 export const PATCH = withAuth(
     { roles: ['isSysadmin', 'isBoardMember'] },
     async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
 
     const { id } = await params;
     const toolId = parseInt(id, 10);
     if (isNaN(toolId)) {
-        return NextResponse.json({ error: "Invalid tool ID" }, { status: 400 });
+        return apiError("Invalid tool ID", 400);
     }
 
     try {
@@ -40,6 +41,6 @@ export const PATCH = withAuth(
         return NextResponse.json({ success: true, tool });
     } catch (error) {
         await logBackendError(error, "PATCH /api/shop/tools/[id]");
-        return NextResponse.json({ error: "Failed to update tool" }, { status: 500 });
+        return apiError("Failed to update tool", 500);
     }
 });

--- a/checkin-app/src/app/api/shop/tools/route.ts
+++ b/checkin-app/src/app/api/shop/tools/route.ts
@@ -2,12 +2,13 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { logBackendError } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth({}, async (_req, auth) => {
     // withAuth funnels the denied-household check (auth.ts) and rejects kiosk —
     // a raw getServerSession would let a board-denied member keep reading shop data.
     if (auth.type !== 'session') {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        return apiError("Unauthorized", 401);
     }
 
     try {
@@ -23,20 +24,20 @@ export const GET = withAuth({}, async (_req, auth) => {
         return NextResponse.json(tools);
     } catch (error) {
         await logBackendError(error, "GET /api/shop/tools");
-        return NextResponse.json({ error: "Failed to fetch tools" }, { status: 500 });
+        return apiError("Failed to fetch tools", 500);
     }
 });
 
 export const POST = withAuth({}, async (req, auth) => {
     if (auth.type !== 'session') {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        return apiError("Unauthorized", 401);
     }
     const session = { user: auth.user };
 
     const isAuthorized = session.user?.isSysadmin || session.user?.isBoardMember;
 
     if (!isAuthorized) {
-        return NextResponse.json({ error: "Forbidden: Only admins and board members can create tools" }, { status: 403 });
+        return apiError("Forbidden: Only admins and board members can create tools", 403);
     }
 
     try {
@@ -44,7 +45,7 @@ export const POST = withAuth({}, async (req, auth) => {
         const { name, safetyGuide } = body;
 
         if (!name) {
-            return NextResponse.json({ error: "Tool name is required" }, { status: 400 });
+            return apiError("Tool name is required", 400);
         }
 
         const newTool = await prisma.tool.create({
@@ -67,6 +68,6 @@ export const POST = withAuth({}, async (req, auth) => {
         return NextResponse.json({ success: true, tool: newTool });
     } catch (error: unknown) {
         await logBackendError(error, "POST /api/shop/tools");
-        return NextResponse.json({ error: "Failed to create tool" }, { status: 500 });
+        return apiError("Failed to create tool", 500);
     }
 });

--- a/checkin-app/src/app/api/system-status/audit-log/route.ts
+++ b/checkin-app/src/app/api/system-status/audit-log/route.ts
@@ -7,6 +7,7 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import type { Prisma } from "@/generated/prisma/client";
+import { apiError } from "@/lib/api-response";
 
 const PAGE_SIZE = 50;
 const ACTIONS = ["CREATE", "EDIT", "DELETE", "BECOME_ADMIN"] as const;
@@ -77,7 +78,7 @@ export const GET = withAuth(
             });
         } catch (error) {
             logger.error("Failed to fetch audit logs:", error);
-            return NextResponse.json({ error: "Failed to fetch audit logs" }, { status: 500 });
+            return apiError("Failed to fetch audit logs", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/system-status/errors/route.ts
+++ b/checkin-app/src/app/api/system-status/errors/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     { roles: ['isSysadmin', 'isBoardMember'] },
@@ -14,7 +15,7 @@ export const GET = withAuth(
             return NextResponse.json({ errors });
         } catch (error) {
             logger.error("Failed to fetch error logs:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/system-status/health/route.ts
+++ b/checkin-app/src/app/api/system-status/health/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
     { roles: ['isSysadmin', 'isBoardMember', 'isKeyholder'] },
@@ -81,7 +82,7 @@ export const GET = withAuth(
             });
         } catch (error) {
             logger.error("Failed to fetch system health metrics:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/system-status/links/[id]/route.ts
+++ b/checkin-app/src/app/api/system-status/links/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 // Mark an integration error resolved / unresolved.
 export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
@@ -10,7 +11,7 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
         const { id } = await params;
         const errorId = parseInt(id, 10);
         if (isNaN(errorId)) {
-            return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+            return apiError("Invalid id", 400);
         }
 
         try {
@@ -22,10 +23,11 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
                 data: { resolvedAt: resolved ? new Date() : null },
             });
 
+            // eslint-disable-next-line no-restricted-syntax -- not an error response: `error` is the updated IntegrationErrorLog record (200). ponytail: rename key to `data` when a client touch is in scope.
             return NextResponse.json({ error: updated });
         } catch (error) {
             logger.error("Failed to update integration error:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/system-status/links/route.ts
+++ b/checkin-app/src/app/api/system-status/links/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
 
 // Link Status data source: recent external-integration failures.
 export const GET = withAuth(
@@ -23,7 +24,7 @@ export const GET = withAuth(
             return NextResponse.json({ errors });
         } catch (error) {
             logger.error("Failed to fetch integration errors:", error);
-            return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+            return apiError("Internal Server Error", 500);
         }
     }
 );

--- a/checkin-app/src/app/api/trusted-adults/[id]/renew/route.ts
+++ b/checkin-app/src/app/api/trusted-adults/[id]/renew/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { renewTrustedAdult, TrustedAdultError } from "@/lib/trusted-adult/service";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -18,9 +19,9 @@ const STATUS_FOR: Record<TrustedAdultError["code"], number> = {
  * fact on the link and opens a fresh board review. Subject or household lead only.
  */
 export const POST = withAuth({}, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     const id = parseInt(req.nextUrl.pathname.split("/").at(-2) ?? "", 10);
-    if (isNaN(id)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    if (isNaN(id)) return apiError("Invalid id", 400);
     try {
         const review = await renewTrustedAdult(id, auth.user.id);
         return NextResponse.json({ reviewId: review.id });
@@ -29,6 +30,6 @@ export const POST = withAuth({}, async (req, auth) => {
             return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
         }
         logger.error("Trusted adult renew error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/trusted-adults/[id]/withdraw/route.ts
+++ b/checkin-app/src/app/api/trusted-adults/[id]/withdraw/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { withdrawTrustedAdult, TrustedAdultError } from "@/lib/trusted-adult/service";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -18,9 +19,9 @@ const STATUS_FOR: Record<TrustedAdultError["code"], number> = {
  * withdraws a disclosed relationship; the latest review is marked REVOKED.
  */
 export const POST = withAuth({}, async (req, auth) => {
-    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
     const id = parseInt(req.nextUrl.pathname.split("/").at(-2) ?? "", 10);
-    if (isNaN(id)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    if (isNaN(id)) return apiError("Invalid id", 400);
     try {
         await withdrawTrustedAdult(id, auth.user.id);
         return NextResponse.json({ ok: true });
@@ -29,6 +30,6 @@ export const POST = withAuth({}, async (req, auth) => {
             return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
         }
         logger.error("Trusted adult withdraw error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/trusted-adults/route.ts
+++ b/checkin-app/src/app/api/trusted-adults/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { createTrustedAdult, TrustedAdultError } from "@/lib/trusted-adult/service";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -34,10 +35,10 @@ export const POST = withAuth({ allowKiosk: true }, async (req, auth) => {
     try {
         body = await req.json();
     } catch {
-        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+        return apiError("Invalid JSON", 400);
     }
     if (!body.counterpartyName || !body.familyContext) {
-        return NextResponse.json({ error: "counterpartyName and familyContext are required" }, { status: 400 });
+        return apiError("counterpartyName and familyContext are required", 400);
     }
 
     let householdId: number | undefined;
@@ -49,7 +50,7 @@ export const POST = withAuth({ allowKiosk: true }, async (req, auth) => {
         const isStaff = auth.user.isBoardMember || auth.user.isSysadmin;
         if (body.householdId && body.householdId !== auth.user.householdId) {
             if (!isStaff) {
-                return NextResponse.json({ error: "You may only add trusted adults for your own household." }, { status: 403 });
+                return apiError("You may only add trusted adults for your own household.", 403);
             }
             householdId = body.householdId;
             origin = "STAFF_ENTERED";
@@ -59,7 +60,7 @@ export const POST = withAuth({ allowKiosk: true }, async (req, auth) => {
     } else {
         // kiosk
         if (!body.householdId) {
-            return NextResponse.json({ error: "householdId is required" }, { status: 400 });
+            return apiError("householdId is required", 400);
         }
         householdId = body.householdId;
     }
@@ -81,6 +82,6 @@ export const POST = withAuth({ allowKiosk: true }, async (req, auth) => {
             return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
         }
         logger.error("Trusted adult create error:", error);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+        return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/api/webhooks/zoho/route.ts
+++ b/checkin-app/src/app/api/webhooks/zoho/route.ts
@@ -4,6 +4,7 @@ import { config } from "@/lib/config";
 import { verifyZohoToken, parseZohoWebhook, ZOHO_WEBHOOK_HEADER } from "@/lib/membership/contract/zoho";
 import { findProcessByEnvelope, markContractSigned } from "@/lib/membership/external";
 import { withWebhook } from "@/lib/webhookAuth";
+import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -34,7 +35,7 @@ export const POST = withWebhook({ provider: "zoho", verify: verifyZoho }, async 
     const { requestId, completed } = parseZohoWebhook(body);
     if (!requestId) {
         logger.error("Zoho webhook missing request id.");
-        return NextResponse.json({ error: "Missing request id" }, { status: 400 });
+        return apiError("Missing request id", 400);
     }
 
     // Only act on completed signings; acknowledge other events so Zoho stops retrying.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,25 @@ const eslintConfig = defineConfig([
     files: ["**/src/app/api/**/*.ts"],
     rules: { "no-console": "warn" },
   },
+  {
+    // P3-1: error responses must go through apiError() (@/lib/api-response) so the
+    // { error, details? } shape stays uniform. Bans re-growing a raw
+    // NextResponse.json({ error }) / ({ error, details }) in the route surface.
+    // Multi-key error bodies (e.g. { error, code }, { error, requiresOverride })
+    // are intentional richer contracts and are NOT flagged.
+    files: ["**/src/app/api/**/*.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression[callee.object.name='NextResponse'][callee.property.name='json'] > ObjectExpression:has(Property[key.name='error']):not(:has(Property[key.name!='error'][key.name!='details']))",
+          message:
+            "Return errors via apiError(message, status[, details]) from @/lib/api-response, not a raw NextResponse.json({ error }).",
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;


### PR DESCRIPTION
## What & why

Audit item **P3-1**: ~547 raw `NextResponse.json(...)` calls across the route surface with inconsistent shapes, while the shared `src/lib/api-response.ts` helper was used by only 4 files. Error responses were already uniform in intent (`{ error: string }` + non-2xx status), which makes them the **safe, non-breaking subset** to standardize now — without touching success bodies.

## Changes

- **390 error sites → `apiError(message, status)`** across **83 route files** (`src/app/api/**`). Done with an **AST codemod (ts-morph)**, not regex: only bodies whose sole keys were `error` (+ optional `details`) *with* a status arg were converted. Response bytes are **identical** — `apiError` emits `{ error, ...details }` with the same status. Bubbled-status cases became `apiError(result.error, result.status)`.
- **Lint guard** in `eslint.config.mjs`: a `no-restricted-syntax` rule on `src/app/api/**` bans re-growing raw `NextResponse.json({ error })` / `({ error, details })`. The selector excludes multi-key error bodies, so intentional richer contracts aren't flagged.

## Deliberately left untouched

- **19 multi-key error bodies** (`{ error, code }`, `{ error, requiresOverride }`, `{ error, status }`) — carry client-read keys; flattening would drop data.
- **1 misnamed 200 body** (`system-status/links/[id]`) that returns a record under key `error` — suppressed with an `eslint-disable` + reason, `ponytail:` note to rename `error`→`data` on a future client touch.
- **All ~130 ad-hoc success bodies** — deferred to the **`handler()` migration**, which already owns the success envelope (see `docs/security/auth-consistency-analysis.md §4`). A parallel success rewrite would collide with it. This PR is scoped to errors only.

## Verification

- `tsc --noEmit`: 0 errors in touched routes.
- `eslint --max-warnings 0 src/app/api`: clean.
- Unit suite: **1086 tests pass** (182 suites). Shapes are byte-identical, so mocked `{error}` assertions still hold.
- Integration tests **not run** (need a DB); risk is near-zero given byte-identical responses.

## Reviewer notes

- Because responses are byte-identical by construction, no client changes are needed.
- `apiError`'s 3-arg `details` path is unused (no error body carried `details`); `apiSuccess`/`apiJson` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)