### PR TITLE
feat(dev): in-process Shopify orders/paid webhook mock

### DIFF
--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -114,11 +114,40 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         });
     }
 
-    it('returns 500 when the webhook secret is not configured', async () => {
+    it('returns 500 when the webhook secret is not configured on a real (non-mock) instance', async () => {
+        // The dev orders/paid mock supplies a fixed fallback secret when Shopify is
+        // unconfigured on a non-prod instance, so "no secret → 500" only holds off
+        // the mock. Wire store creds so shopifyMockActive() is false, then a missing
+        // webhook secret is a real misconfiguration → 500.
         delete process.env.SHOPIFY_WEBHOOK_SECRET;
-        const body = programPayload(String(p1));
-        const res = await POST(webhookReq(body, sign(body)));
-        expect(res.status).toBe(500);
+        process.env.SHOPIFY_STORE_DOMAIN = 'test.myshopify.com';
+        process.env.SHOPIFY_CLIENT_ID = 'test-client-id';
+        process.env.SHOPIFY_CLIENT_SECRET = 'test-client-secret';
+        try {
+            const body = programPayload(String(p1));
+            const res = await POST(webhookReq(body, sign(body)));
+            expect(res.status).toBe(500);
+        } finally {
+            delete process.env.SHOPIFY_STORE_DOMAIN;
+            delete process.env.SHOPIFY_CLIENT_ID;
+            delete process.env.SHOPIFY_CLIENT_SECRET;
+        }
+    });
+
+    it('accepts a mock-signed webhook when Shopify is unconfigured (dev orders/paid mock)', async () => {
+        // Off a real store (creds unset, non-prod), shopifyWebhookSecret() falls back
+        // to the fixed mock secret so the dev mock's self-signed webhook verifies for
+        // real — the symmetry /api/dev/shopify/orders-paid relies on. Bad signature
+        // still 401s; a correctly mock-signed body passes verification (200).
+        delete process.env.SHOPIFY_WEBHOOK_SECRET;
+        const MOCK_SECRET = 'dev-shopify-mock-webhook-secret';
+        try {
+            const body = programPayload(String(p1));
+            expect((await POST(webhookReq(body, sign(body)))).status).toBe(401); // signed with the wrong secret
+            expect((await POST(webhookReq(body, sign(body, MOCK_SECRET)))).status).toBe(200); // signed with the mock secret
+        } finally {
+            process.env.SHOPIFY_WEBHOOK_SECRET = SECRET;
+        }
     });
 
     it('returns 401 when the signature header is missing', async () => {

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { config } from "@/lib/config";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/dev/shopify/orders-paid — dev-only stand-in for a real Shopify
+ * orders/paid webhook (see docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md §6). Reached
+ * from the dev tool's "Fire orders/paid" button. Rather than shortcut to
+ * activate(), it synthesizes the order payload Shopify would send for a paid
+ * membership checkout, signs it with the mock webhook secret, and fires the REAL
+ * inbound webhook — so it exercises the same HMAC-verify → match-by-cart-attribute
+ * → activate() path prod runs (mirrors the Zoho mock, ZOHO_SIGN_DEV_MOCK.md §4a).
+ *
+ * 404s whenever the mock isn't active — always in prod.
+ */
+export const POST = withAuth({}, async (req, auth) => {
+    if (!config.shopifyMockActive()) return NextResponse.json({ error: "Not available" }, { status: 404 });
+    if (auth.type !== "session") return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { processId } = await req.json().catch(() => ({ processId: undefined }));
+    if (typeof processId !== "number" || !Number.isInteger(processId)) {
+        return NextResponse.json({ error: "Missing or invalid processId" }, { status: 400 });
+    }
+
+    const secret = config.shopifyWebhookSecret();
+    if (!secret) return NextResponse.json({ error: "No webhook secret" }, { status: 500 });
+
+    // A real paid order carries the membership variant id in its line_items; the
+    // inbound handler matches it against BoardSettings to confirm the order is for
+    // the membership product (#624/H2). The mock must echo a configured variant id
+    // or the webhook lands as a no-membership-item anomaly, not an activation.
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const variantId = settings?.membershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId;
+    if (!variantId) {
+        return NextResponse.json(
+            { error: "No membership variant configured. Set one in Settings → Membership first (design §2, O4a)." },
+            { status: 409 },
+        );
+    }
+
+    // Shape mirrors the subset the inbound handler reads: note_attributes (where
+    // Shopify maps cart attributes) + line_items + an order id. Stable id so a
+    // re-fire is an idempotent webhook retry, exactly like Shopify's own retries.
+    const payload = {
+        id: `dev-mock-order-${processId}`,
+        note_attributes: [{ name: "Membership_Process_ID", value: String(processId) }],
+        line_items: [{ variant_id: variantId }],
+    };
+    const rawBody = JSON.stringify(payload);
+    const signature = crypto.createHmac("sha256", secret).update(rawBody, "utf8").digest("base64");
+
+    const res = await fetch(`${config.baseUrl()}/api/webhooks/shopify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-shopify-hmac-sha256": signature },
+        body: rawBody,
+    });
+    if (!res.ok) {
+        logger.error(`Dev shopify orders-paid: webhook returned ${res.status} for process ${processId}`);
+        return NextResponse.json({ error: "Webhook failed", status: res.status }, { status: 502 });
+    }
+
+    // Report the resulting status so the tool can show whether it activated, held
+    // for background clearance, etc. (the webhook itself always 200s to Shopify).
+    const proc = await prisma.membershipProcess.findUnique({ where: { id: processId }, select: { status: true } });
+    return NextResponse.json({ ok: true, status: proc?.status ?? null });
+});

--- a/checkin-app/src/app/dev/shopify/DevShopifyClient.tsx
+++ b/checkin-app/src/app/dev/shopify/DevShopifyClient.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+
+interface PendingProcess {
+    id: number;
+    household: string;
+    isVolunteer: boolean;
+}
+
+/**
+ * Dev Shopify orders/paid mock UI. Picks a PENDING_PAYMENT process and fires a
+ * synthesized-but-real orders/paid webhook at it (via /api/dev/shopify/orders-paid),
+ * driving PENDING_PAYMENT → ACTIVE (or → PENDING_BG_CLEARANCE) the same way a real
+ * Shopify payment would. Inline styles match the sibling dev tools (dev/zoho-sign).
+ * Page 404s off a dev instance.
+ */
+export default function DevShopifyClient({ hasVariant, processes }: { hasVariant: boolean; processes: PendingProcess[] }) {
+    const [busy, setBusy] = useState<number | null>(null);
+    const [result, setResult] = useState<{ id: number; status: string | null } | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    async function fire(processId: number) {
+        setBusy(processId);
+        setError(null);
+        setResult(null);
+        try {
+            const res = await fetch("/api/dev/shopify/orders-paid", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ processId }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                setError(data.error ? `${data.error} (${res.status})` : `Webhook failed (${res.status}). Check server logs.`);
+                return;
+            }
+            setResult({ id: processId, status: data.status ?? null });
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e));
+        } finally {
+            setBusy(null);
+        }
+    }
+
+    const btn: React.CSSProperties = {
+        padding: "0.4rem 0.9rem",
+        borderRadius: 6,
+        border: "none",
+        background: "#059669",
+        color: "#fff",
+        fontWeight: 600,
+        cursor: "pointer",
+    };
+
+    return (
+        <div style={{ maxWidth: 640 }}>
+            <h1 style={{ fontSize: "1.5rem", fontWeight: 600, margin: 0 }}>Shopify orders/paid (mock)</h1>
+            <p style={{ opacity: 0.7, fontSize: "0.85rem", marginTop: "0.5rem" }}>
+                Shopify is mocked on this instance (no store credentials). Firing a payment sends a
+                real signed <code>orders/paid</code> webhook — <strong>DEV, NO REAL MONEY</strong>.
+            </p>
+
+            {!hasVariant && (
+                <p style={{ color: "#b45309", marginTop: "1rem", fontSize: "0.85rem" }}>
+                    No membership variant configured. Set one in <strong>Settings → Membership</strong> first,
+                    or the webhook lands as a no-membership-item anomaly instead of activating.
+                </p>
+            )}
+
+            {error && <p style={{ color: "#b91c1c", marginTop: "1rem" }}>{error}</p>}
+            {result && (
+                <p style={{ color: "#059669", marginTop: "1rem" }}>
+                    Fired for process {result.id} → status <strong>{result.status ?? "unknown"}</strong>
+                </p>
+            )}
+
+            <div style={{ marginTop: "1.5rem" }}>
+                {processes.length === 0 ? (
+                    <p style={{ fontSize: "0.9rem", opacity: 0.7 }}>No applications awaiting payment.</p>
+                ) : (
+                    <table style={{ borderCollapse: "collapse", width: "100%" }}>
+                        <thead>
+                            <tr style={{ textAlign: "left", fontSize: "0.8rem", opacity: 0.6 }}>
+                                <th style={{ padding: "0.4rem" }}>Process</th>
+                                <th style={{ padding: "0.4rem" }}>Household</th>
+                                <th style={{ padding: "0.4rem" }}>Tier</th>
+                                <th />
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {processes.map((p) => (
+                                <tr key={p.id} style={{ borderTop: "1px solid #e5e7eb" }}>
+                                    <td style={{ padding: "0.4rem" }}>#{p.id}</td>
+                                    <td style={{ padding: "0.4rem" }}>{p.household}</td>
+                                    <td style={{ padding: "0.4rem" }}>{p.isVolunteer ? "Volunteer" : "Normal"}</td>
+                                    <td style={{ padding: "0.4rem", textAlign: "right" }}>
+                                        <button
+                                            onClick={() => fire(p.id)}
+                                            disabled={busy !== null}
+                                            style={{ ...btn, opacity: busy !== null ? 0.5 : 1 }}
+                                        >
+                                            {busy === p.id ? "Firing…" : "Fire orders/paid"}
+                                        </button>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/checkin-app/src/app/dev/shopify/page.tsx
+++ b/checkin-app/src/app/dev/shopify/page.tsx
@@ -1,0 +1,36 @@
+import { notFound } from "next/navigation";
+import prisma from "@/lib/prisma";
+import { config } from "@/lib/config";
+import DevShopifyClient from "./DevShopifyClient";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Dev-only stand-in for a Shopify orders/paid webhook (see
+ * docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md §6). Lists the processes currently
+ * awaiting payment and fires a synthesized-but-real webhook for the chosen one.
+ * 404s the moment the mock isn't active (always in prod).
+ */
+export default async function DevShopifyPage() {
+    if (!config.shopifyMockActive()) notFound();
+
+    const processes = await prisma.membershipProcess.findMany({
+        where: { status: "PENDING_PAYMENT" },
+        orderBy: { id: "desc" },
+        select: { id: true, membership: { select: { household: { select: { name: true } }, isVolunteer: true } } },
+    });
+
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const hasVariant = !!(settings?.membershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId);
+
+    return (
+        <DevShopifyClient
+            hasVariant={hasVariant}
+            processes={processes.map((p) => ({
+                id: p.id,
+                household: p.membership.household?.name ?? "(unnamed household)",
+                isVolunteer: p.membership.isVolunteer,
+            }))}
+        />
+    );
+}

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -147,4 +147,5 @@ export const REGISTRY_EXCLUDED: string[] = [
   '/dev',                    // dev-tools hub, redirects to /dev/sent-mail
   '/dev/sent-mail',          // dev-only captured-email inbox (EMAIL_DEV_MOCK.md); 404s off dev
   '/dev/zoho-sign',          // dev-only Zoho Sign mock interstitial (404 in prod)
+  '/dev/shopify',            // dev-only Shopify orders/paid mock (SHOPIFY_DEV_STORE_WEBHOOK.md); 404s off dev
 ];

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -53,6 +53,32 @@ function zohoMockActiveEnv(): boolean {
  */
 const DEV_MOCK_WEBHOOK_SECRET = 'dev-zoho-mock-webhook-secret';
 
+/** Real Shopify integration is wired only when all three credentials are present. */
+function shopifyConfiguredEnv(): boolean {
+    return !!(process.env.SHOPIFY_STORE_DOMAIN && process.env.SHOPIFY_CLIENT_ID && process.env.SHOPIFY_CLIENT_SECRET);
+}
+
+/**
+ * The dev/local Shopify orders/paid MOCK is active when the real integration is
+ * unconfigured AND we're on a non-prod instance (see
+ * docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md §6). Same two server-only fuses as the
+ * Zoho mock — CHECKIN_ENV (fails safe to prod) and NODE_ENV — so no mock path is
+ * reachable in prod by construction. Wiring real Shopify creds opts back into the
+ * real store.
+ */
+function shopifyMockActiveEnv(): boolean {
+    return !shopifyConfiguredEnv() && readCheckinEnv() !== 'prod' && process.env.NODE_ENV !== 'production';
+}
+
+/**
+ * Fixed secret the Shopify mock signs its self-fired orders/paid webhook with.
+ * Unlike a real dev store (which signs with Shopify's own per-store secret we
+ * don't choose), the mock generates the payload locally, so a fixed constant is
+ * enough for verifyShopifyHmac's real timing-safe compare — same rationale as
+ * DEV_MOCK_WEBHOOK_SECRET. See §4 of the design: fixed ⇔ self-fired mock.
+ */
+const DEV_MOCK_SHOPIFY_WEBHOOK_SECRET = 'dev-shopify-mock-webhook-secret';
+
 export const config = {
     // Database
     databaseUrl: () => requireEnv('DATABASE_URL'),
@@ -119,7 +145,14 @@ export const config = {
     shopifyStoreDomain: (): string | null => process.env.SHOPIFY_STORE_DOMAIN || null,
     shopifyClientId: (): string | null => process.env.SHOPIFY_CLIENT_ID || null,
     shopifyClientSecret: (): string | null => process.env.SHOPIFY_CLIENT_SECRET || null,
-    shopifyWebhookSecret: (): string | null => process.env.SHOPIFY_WEBHOOK_SECRET || null,
+    // Real store's per-store secret, else the fixed mock secret when the mock is
+    // active (self-fired webhook verifies for real with zero env setup), else null
+    // (unconfigured on a real-but-unwired instance → webhook 500s, the intended fail).
+    shopifyWebhookSecret: (): string | null =>
+        process.env.SHOPIFY_WEBHOOK_SECRET || (shopifyMockActiveEnv() ? DEV_MOCK_SHOPIFY_WEBHOOK_SECRET : null),
+    // True when the dev/local mock stands in for a real Shopify store (creds unset,
+    // non-prod). Gates /api/dev/shopify/* + the dev tool. Always false in prod.
+    shopifyMockActive: (): boolean => shopifyMockActiveEnv(),
 
     // App
     checkinEnv: (): CheckinEnv => readCheckinEnv(),

--- a/checkin-app/src/lib/devToolsNav.ts
+++ b/checkin-app/src/lib/devToolsNav.ts
@@ -11,4 +11,5 @@ export interface DevToolsNavLink {
 export const DEV_TOOLS_NAV_LINKS: DevToolsNavLink[] = [
   { name: "Email", href: "/dev/sent-mail" },
   { name: "Sign", href: "/dev/zoho-sign" },
+  { name: "Shopify", href: "/dev/shopify" },
 ];


### PR DESCRIPTION
## What

Dev/local stand-in for a real Shopify `orders/paid` webhook, mirroring the Zoho Sign mock (#669) and email inbox (#665). Unblocks testing the membership payment leg (`PENDING_PAYMENT → ACTIVE`) locally with zero infra — no Shopify store, no tunnel.

A gated `POST /api/dev/shopify/orders-paid` synthesizes the order payload Shopify would send for a paid membership checkout, HMAC-signs it with a fixed dev secret, and fires the **REAL** inbound webhook (`/api/webhooks/shopify`). So it runs the same `verifyShopifyHmac → match-by-cart-attribute → activate()` path prod does — not a shortcut to `activate()`.

## How

- `config.ts`: `shopifyMockActive()` (real creds unset **and** non-prod, same two-fuse guard as `zohoMockActive`) + fixed `DEV_MOCK_SHOPIFY_WEBHOOK_SECRET` fallback in `shopifyWebhookSecret()`. Setting real Shopify creds opts the instance back into the real store.
- Route echoes a configured `BoardSettings` membership variant id into `line_items` so the #624/H2 membership-item check passes; 409s with a pointer to Settings → Membership when none is configured.
- "Shopify" dev-tools tab lists `PENDING_PAYMENT` processes, one fire button each; reports the resulting status.

## Prod safety

Everything gates on `shopifyMockActive()` — false in prod by construction (`CHECKIN_ENV` fails safe to prod, `NODE_ENV`). No dev store domain hardcoded. The prod webhook path (real store, real per-store secret, real HMAC) is untouched. The fixed mock secret is only ever returned when the mock is active.

## Notes

- Fixed dev secret is correct **only** because the mock self-signs its own payload (same rationale as the Zoho mock). A real dev store must use its own per-store secret — see the design doc.
- No jest test added: signing is stdlib crypto symmetric with the verifier, and end-to-end activation is already covered by `webhookShopify.integration.test.ts`. Manual dev-tool flow is the intended check.

Design doc (`docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md`) intentionally **not** committed. Real-dev-store setup (§2–5) is the follow-up; this is "mock first" per §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)