### PR TITLE
refactor(shop): rename shop-members API path + envelope to org-members (P4c)

### DIFF
--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -6,7 +6,7 @@
  * Tests members, tools, and certifications sub-routes
  */
 
-import { GET as getMembers } from '@/app/api/shop/members/route';
+import { GET as getMembers } from '@/app/api/shop/org-members/route';
 import { normalizeAuditData } from '@/lib/auditPayload';
 import { GET as getTools, POST as postTools } from '@/app/api/shop/tools/route';
 import { GET as getCerts, POST as postCerts } from '@/app/api/shop/certifications/route';
@@ -158,7 +158,7 @@ describe('Shop API Integration Tests', () => {
         } as unknown as never;
     };
 
-    describe('/api/shop/members', () => {
+    describe('/api/shop/org-members', () => {
         it('should return 403 for common users', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
 
@@ -174,7 +174,7 @@ describe('Shop API Integration Tests', () => {
              const data = await res.json();
              
              // Our common user has an active membership so they should appear
-             const memberEmails = data.members.map((m: { email: string }) => m.email);
+             const memberEmails = data.orgMembers.map((m: { email: string }) => m.email);
              expect(memberEmails).toContain('common-shop-api-test@example.com');
         });
 
@@ -189,9 +189,9 @@ describe('Shop API Integration Tests', () => {
              const res = await getMembers(createReq('GET')) as Response;
              expect(res.status).toBe(200);
              const data = await res.json();
-             expect(data.members.length).toBeGreaterThan(0);
-             expect(data.members.every((m: { name?: string }) => typeof m.name === 'string')).toBe(true);
-             expect(data.members.every((m: { email?: string }) => m.email === undefined)).toBe(true);
+             expect(data.orgMembers.length).toBeGreaterThan(0);
+             expect(data.orgMembers.every((m: { name?: string }) => typeof m.name === 'string')).toBe(true);
+             expect(data.orgMembers.every((m: { email?: string }) => m.email === undefined)).toBe(true);
         });
     });
 

--- a/checkin-app/src/app/api/shop/org-members/route.ts
+++ b/checkin-app/src/app/api/shop/org-members/route.ts
@@ -4,7 +4,7 @@ import { ACTIVE_ORG_MEMBER_PERSON_WHERE } from "@/lib/orgMembership";
 
 export const dynamic = 'force-dynamic';
 
-export const GET = handler('GET /api/shop/members', async () => {
+export const GET = handler('GET /api/shop/org-members', async () => {
     // Select email too: admins/board are granted everyones:pii and see it. For a
     // certifier the view holds only member+public, so the stripper drops email
     // and keeps name. Field-stripping — not the query — decides who sees what.

--- a/checkin-app/src/app/shop-ops/manage/ToolManagementPanel.tsx
+++ b/checkin-app/src/app/shop-ops/manage/ToolManagementPanel.tsx
@@ -503,10 +503,10 @@ export function ToolManagementPanel() {
       hasFetched.current = true;
       Promise.all([
         fetch('/api/shop/tools').then(r => r.ok ? r.json() : []),
-        fetch('/api/shop/members').then(r => r.ok ? r.json() : { members: [] }),
+        fetch('/api/shop/org-members').then(r => r.ok ? r.json() : { orgMembers: [] }),
       ]).then(([toolData, memberData]) => {
         setTools(toolData);
-        setMembers(memberData.members ?? []);
+        setMembers(memberData.orgMembers ?? []);
       }).finally(() => setLoading(false));
     }
   }, [ready]);

--- a/checkin-app/src/app/shop-ops/manage/__tests__/ToolManagementPanel.test.tsx
+++ b/checkin-app/src/app/shop-ops/manage/__tests__/ToolManagementPanel.test.tsx
@@ -41,7 +41,7 @@ describe("ToolManagementPanel", () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({
       "/api/shop/tools": [TABLE_SAW, LASER],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -57,7 +57,7 @@ describe("ToolManagementPanel", () => {
         { participantId: 10, toolId: 1, level: "CERTIFIED", participant: { id: 10, name: "Alice" } },
       ],
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -74,7 +74,7 @@ describe("ToolManagementPanel", () => {
     const fetchMock = mockFetchJson({
       "/api/shop/tools/1": { success: true, tool: { ...TABLE_SAW, safetyGuide: "https://new.example.com" } },
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -97,7 +97,7 @@ describe("ToolManagementPanel", () => {
         { participantId: 10, toolId: 1, level: "CERTIFIED", tool: { id: 1, name: "Table Saw" } },
       ],
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: [MEMBERS[0]] },
+      "/api/shop/org-members": { orgMembers: [MEMBERS[0]] },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -120,7 +120,7 @@ describe("ToolManagementPanel", () => {
         },
       ],
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -133,7 +133,7 @@ describe("ToolManagementPanel", () => {
     setSession({ id: 1 });
     mockFetchJson({
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -147,7 +147,7 @@ describe("ToolManagementPanel", () => {
       "/api/shop/certifications?toolId=1": [],
       "/api/shop/certifications": { success: true },
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -175,7 +175,7 @@ describe("ToolManagementPanel", () => {
     const fetchMock = mockFetchJson({
       "/api/shop/certifications?toolId=1": [],
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -195,7 +195,7 @@ describe("ToolManagementPanel", () => {
     mockFetchJson({
       "/api/shop/certifications?toolId=1": [],
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -217,7 +217,7 @@ describe("ToolManagementPanel", () => {
       }
       if (url.includes("/api/shop/certifications?toolId=1")) return { ok: true, json: async () => [] } as Response;
       if (url.includes("/api/shop/tools")) return { ok: true, json: async () => [TABLE_SAW] } as Response;
-      if (url.includes("/api/shop/members")) return { ok: true, json: async () => ({ members: MEMBERS }) } as Response;
+      if (url.includes("/api/shop/org-members")) return { ok: true, json: async () => ({ orgMembers: MEMBERS }) } as Response;
       return { ok: false, status: 404, json: async () => ({}) } as Response;
     });
     global.fetch = fetchMock as unknown as typeof fetch;
@@ -241,7 +241,7 @@ describe("ToolManagementPanel", () => {
         { participantId: 10, toolId: 1, level: "CERTIFIED", participant: { id: 10, name: "Alice" } },
       ],
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -255,7 +255,7 @@ describe("ToolManagementPanel", () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({
       "/api/shop/tools": [TABLE_SAW, LASER],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -273,7 +273,7 @@ describe("ToolManagementPanel", () => {
       const url = typeof input === "string" ? input : input.toString();
       if (init?.method === "PATCH") return { ok: false, status: 500, json: async () => ({}) } as Response;
       if (url.includes("/api/shop/tools")) return { ok: true, json: async () => [TABLE_SAW] } as Response;
-      if (url.includes("/api/shop/members")) return { ok: true, json: async () => ({ members: MEMBERS }) } as Response;
+      if (url.includes("/api/shop/org-members")) return { ok: true, json: async () => ({ orgMembers: MEMBERS }) } as Response;
       return { ok: false, status: 404, json: async () => ({}) } as Response;
     });
     global.fetch = fetchMock as unknown as typeof fetch;
@@ -291,7 +291,7 @@ describe("ToolManagementPanel", () => {
       "/api/shop/certifications?toolId=1": [],
       "/api/shop/tools/1": { success: true, tool: { ...TABLE_SAW, safetyGuide: "https://new.example.com" } },
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -313,7 +313,7 @@ describe("ToolManagementPanel", () => {
         { participantId: 10, toolId: 1, level: "CERTIFIED", tool: { id: 1, name: "Table Saw" } },
       ],
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: [MEMBERS[0]] },
+      "/api/shop/org-members": { orgMembers: [MEMBERS[0]] },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -333,7 +333,7 @@ describe("ToolManagementPanel", () => {
       "/api/shop/certifications?participantId=10": [],
       "/api/shop/certifications": { success: true },
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: [MEMBERS[0]] },
+      "/api/shop/org-members": { orgMembers: [MEMBERS[0]] },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -354,7 +354,7 @@ describe("ToolManagementPanel", () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({
       "/api/shop/tools": [TABLE_SAW],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 
@@ -373,7 +373,7 @@ describe("ToolManagementPanel", () => {
         },
       ],
       "/api/shop/tools": [TABLE_SAW, LASER],
-      "/api/shop/members": { members: MEMBERS },
+      "/api/shop/org-members": { orgMembers: MEMBERS },
     });
     renderWithProviders(<ToolManagementPanel />);
 

--- a/checkin-app/src/app/shop-ops/manage/__tests__/page.test.tsx
+++ b/checkin-app/src/app/shop-ops/manage/__tests__/page.test.tsx
@@ -13,7 +13,7 @@ describe("ManageToolsPage", () => {
         setSession({ id: 1, isSysadmin: true });
         mockFetchJson({
             "/api/shop/tools": [],
-            "/api/shop/members": { members: [] },
+            "/api/shop/org-members": { orgMembers: [] },
         });
         renderWithProviders(<ManageToolsPage />);
 

--- a/checkin-app/src/security/__tests__/shop-org-members-strip.test.ts
+++ b/checkin-app/src/security/__tests__/shop-org-members-strip.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 /**
- * Strip-assertion for GET /api/shop/members. The route returns every active
+ * Strip-assertion for GET /api/shop/org-members. The route returns every active
  * member's {id, name, email}. The view decides who sees email (pii):
  *
  *   - board/sysadmin (everyones:pii) → name + email.
@@ -40,11 +40,11 @@ function tokensFor(endpoint: string, role: Role): readonly Token[] {
     return entry[1];
 }
 
-const ENDPOINT = 'GET /api/shop/members';
+const ENDPOINT = 'GET /api/shop/org-members';
 // Another member (not the caller) — id !== selfId, so only the 'everyones' scope applies.
 const member = { id: 99, name: 'Other Member', email: 'other@x.test' };
 
-describe('shop/members field-stripping', () => {
+describe('shop/org-members field-stripping', () => {
     it('board sees name + email (pii)', () => {
         const tokens = tokensFor(ENDPOINT, 'isBoardMember');
         const out = stripValue('Person', member, tokens, ctx()) as Record<string, unknown>;

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -225,9 +225,10 @@ defineRoute({
 // name (public) + member-tier — NOT everyones:pii. This deliberately TIGHTENS the
 // pre-migration behavior, which leaked every member's email to any certifier.
 defineRoute({
-    endpoint: 'GET /api/shop/members',
+    endpoint: 'GET /api/shop/org-members',
     authorize: 'certifier',
-    envelope: 'members',
+    // bag-key `Person` (model driving field-strip) vs envelope `orgMembers` (camelCase JSON key) vs path `org-members` (kebab URL) — divergence intentional.
+    envelope: 'orgMembers',
     returns: ['Person'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],


### PR DESCRIPTION
Phase 4c of the OrgMembership terminology migration. Wire-contract change — route path + JSON envelope key renamed, with all consumers + tests moved in the same commit.

## Changes
- **Route path** `/api/shop/members` → `/api/shop/org-members` (`git mv`).
- **Response envelope key** `members` → `orgMembers` (camelCase). Path is kebab (URL convention) but the JSON key is camelCase, so consumers read `.orgMembers`. The divergence is intentional and noted in `registry.ts`.
- **Bag key `Person` unchanged** — it drives field-stripping, unrelated to the "member" word.
- Consumer `ToolManagementPanel.tsx`: fetch URL + `.orgMembers` read/fallback.
- Tests moved with the change: strip test (renamed file), `shopAPI.integration`, and the panel fetch-mocks.

## Out of scope (untouched)
Price fields (`orgMemberPriceCents`), read-model symbols, `model Membership`/enums (P4d), the `'member'` security tier, `membership-ops`/`membership-audit` paths, board/corporation/household member.

## Verify
- `npx tsc --noEmit` clean.
- `grep -rn "shop/members\b\|api/shop/members" src` → zero.
- Integration (`shopAPI.integration.test.ts`, real Postgres, serial): 14/14 pass — exercises the new `.orgMembers` envelope.
- Strip + panel unit tests: 22/22 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)