### PR TITLE
test(security): arm scope validators with assert-green CI test (GAP-2)

### DIFF
--- a/checkin-app/src/security/__tests__/scopeValidators.test.ts
+++ b/checkin-app/src/security/__tests__/scopeValidators.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Arms the security scope validators (scopes.ts §7.6). They are pure config
+ * checks with no runtime caller — this test is what makes them enforce anything.
+ * See docs/security/auth-consistency-analysis.md §9 Step 3 (final flip).
+ *
+ * Both assertions must stay `toEqual([])`. If one goes red, DO NOT pin it to the
+ * current error list — a red test naming a real gap is the point of the gate.
+ */
+import { validateBindings, validateRouteGrants } from '../scopes';
+import { SCOPE_BINDINGS, OPT_OUT_PENDING_ROUTE } from '../scopeBindings';
+import { classifications, allRoutes } from '../core';
+
+describe('security scope validators (assert green)', () => {
+    it('validateBindings: bindings field-exist + every sensitive model covered', () => {
+        expect(
+            validateBindings(SCOPE_BINDINGS, classifications, OPT_OUT_PENDING_ROUTE),
+        ).toEqual([]);
+    });
+
+    it('validateRouteGrants: every row-scoped grant is resolvable on a returned model', () => {
+        const specs = [...allRoutes()].map(([, spec]) => spec);
+        expect(validateRouteGrants(specs, SCOPE_BINDINGS)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## What

Arms the security scope validators in `scopes.ts` (§7.6). `validateBindings` and `validateRouteGrants` existed but had no caller — they enforced nothing. Adds `scopeValidators.test.ts` asserting both return `[]` against live inputs:

- `SCOPE_BINDINGS` (scopeBindings.ts)
- `classifications` (generated, re-exported via core.ts)
- `allRoutes()` → mapped to specs
- `OPT_OUT_PENDING_ROUTE` (existing pending-model set, 4 models)

## Result

Both **green today** — no config fixes required. The validators pass as-is; this test locks them so future drift (a binding referencing a nonexistent field, an uncovered sensitive model, a route granting an unresolvable scope) fails CI.

## Scope

Analysis §9 Step 3 (final flip). Assert-green test **only** — no drift-guard (getServerSession/unregistered-route ban), no route migration, no handler/stripper changes.

## Note for CI

Tests run clean on a normal checkout. In a git worktree, `testPathIgnorePatterns` matches `.claude/worktrees/` and reports "0 tests" — a worktree artifact affecting the whole suite, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)