### PR TITLE
refactor(org-membership): flip Membership model/enums to OrgMembership + schema migration (Phase 4d)

### DIFF
--- a/checkin-app/prisma/migrations/20260702214259_rename_membership_to_org_membership/migration.sql
+++ b/checkin-app/prisma/migrations/20260702214259_rename_membership_to_org_membership/migration.sql
@@ -1,0 +1,41 @@
+-- Rename Membership -> OrgMembership terminology (Phase 4d). This is a pure rename:
+-- tables, enums, the membershipId column, BoardSettings.*membership* columns, and
+-- constraint/index names. Done with ALTER ... RENAME (NOT drop+create) so the two
+-- raw-SQL partial unique indexes on OrgMembershipProcess — membership_one_inflight_initial
+-- and membership_one_inflight_renewal, which are NOT declared in schema.prisma — survive.
+-- Postgres carries indexes and FK constraints through table/column RENAME automatically.
+
+-- Enums
+ALTER TYPE "MembershipStatus" RENAME TO "OrgMembershipStatus";
+ALTER TYPE "MembershipProcessKind" RENAME TO "OrgMembershipProcessKind";
+ALTER TYPE "MembershipProcessStatus" RENAME TO "OrgMembershipProcessStatus";
+
+-- Tables
+ALTER TABLE "Membership" RENAME TO "OrgMembership";
+ALTER TABLE "MembershipProcess" RENAME TO "OrgMembershipProcess";
+
+-- FK scalar column
+ALTER TABLE "OrgMembershipProcess" RENAME COLUMN "membershipId" TO "orgMembershipId";
+
+-- BoardSettings columns (data preserved via RENAME; DB is wiped on deploy anyway)
+ALTER TABLE "BoardSettings" RENAME COLUMN "membershipYearBoundary" TO "orgMembershipYearBoundary";
+ALTER TABLE "BoardSettings" RENAME COLUMN "membershipVariantId" TO "orgMembershipVariantId";
+ALTER TABLE "BoardSettings" RENAME COLUMN "shopifyMembershipProductId" TO "shopifyOrgMembershipProductId";
+
+-- Primary keys
+ALTER INDEX "Membership_pkey" RENAME TO "OrgMembership_pkey";
+ALTER INDEX "MembershipProcess_pkey" RENAME TO "OrgMembershipProcess_pkey";
+
+-- Managed indexes (schema-declared)
+ALTER INDEX "Membership_householdId_key" RENAME TO "OrgMembership_householdId_key";
+ALTER INDEX "Membership_status_idx" RENAME TO "OrgMembership_status_idx";
+ALTER INDEX "MembershipProcess_membershipId_idx" RENAME TO "OrgMembershipProcess_orgMembershipId_idx";
+ALTER INDEX "MembershipProcess_status_idx" RENAME TO "OrgMembershipProcess_status_idx";
+
+-- FK constraints (definitions auto-repoint on table rename; rename names for tidiness)
+ALTER TABLE "OrgMembership" RENAME CONSTRAINT "Membership_householdId_fkey" TO "OrgMembership_householdId_fkey";
+ALTER TABLE "OrgMembershipProcess" RENAME CONSTRAINT "MembershipProcess_membershipId_fkey" TO "OrgMembershipProcess_orgMembershipId_fkey";
+
+-- NOTE: the two partial unique indexes membership_one_inflight_initial /
+-- membership_one_inflight_renewal are intentionally NOT renamed or recreated here —
+-- they follow the table + column rename automatically and keep their descriptive names.

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -168,7 +168,7 @@ model Household {
 
   householdMembers  Person[]
   leads             HouseholdLead[]
-  membership        Membership?
+  orgMembership     OrgMembership?
   trustedAdults     TrustedAdult[]
   emergencyContacts EmergencyContact[]
 }
@@ -231,7 +231,7 @@ model HouseholdLead {
   @@id([householdId, personId])
 }
 
-enum MembershipStatus {
+enum OrgMembershipStatus {
   NONE
   ACTIVE
   REVOKED
@@ -242,12 +242,12 @@ enum MembershipStatus {
   DENIED
 }
 
-enum MembershipProcessKind {
+enum OrgMembershipProcessKind {
   INITIAL
   RENEWAL
 }
 
-enum MembershipProcessStatus {
+enum OrgMembershipProcessStatus {
   INTAKE
   PENDING_EXTERNAL_ACTION
   PENDING_BG_REVIEW
@@ -293,35 +293,35 @@ enum TrustedAdultDecisionKind {
   REQUEST_INFO
 }
 
-model Membership {
+model OrgMembership {
   /// @sensitivity:public
-  id          Int              @id @default(autoincrement())
+  id          Int                 @id @default(autoincrement())
   /// @sensitivity:public
-  memberSince DateTime         @default(now())
+  memberSince DateTime            @default(now())
   /// @sensitivity:public
-  status      MembershipStatus @default(NONE)
+  status      OrgMembershipStatus @default(NONE)
   /// @sensitivity:public
-  isVolunteer Boolean          @default(false)
+  isVolunteer Boolean             @default(false)
 
   /// @sensitivity:public
   householdId Int       @unique
   household   Household @relation(fields: [householdId], references: [id])
 
-  processes MembershipProcess[]
+  processes OrgMembershipProcess[]
 
   @@index([status])
 }
 
-model MembershipProcess {
+model OrgMembershipProcess {
   /// @sensitivity:public
-  id                    Int                     @id @default(autoincrement())
+  id                    Int                        @id @default(autoincrement())
   /// @sensitivity:public
-  membershipId          Int
-  membership            Membership              @relation(fields: [membershipId], references: [id])
+  orgMembershipId       Int
+  orgMembership         OrgMembership              @relation(fields: [orgMembershipId], references: [id])
   /// @sensitivity:public
-  kind                  MembershipProcessKind
+  kind                  OrgMembershipProcessKind
   /// @sensitivity:internal
-  status                MembershipProcessStatus
+  status                OrgMembershipProcessStatus
   /// @sensitivity:internal
   stageEnteredAt        DateTime?               @default(now())
   /// @sensitivity:public
@@ -355,7 +355,7 @@ model MembershipProcess {
 
   attestations BackgroundCheckAttestation[]
 
-  @@index([membershipId])
+  @@index([orgMembershipId])
   @@index([status])
 }
 
@@ -364,7 +364,7 @@ model BackgroundCheckAttestation {
   id              Int               @id @default(autoincrement())
   /// @sensitivity:public
   processId       Int
-  process         MembershipProcess @relation(fields: [processId], references: [id])
+  process         OrgMembershipProcess @relation(fields: [processId], references: [id])
   /// @sensitivity:public
   reviewerId      Int
   reviewer        Person       @relation("BgAttestations", fields: [reviewerId], references: [id])
@@ -397,15 +397,15 @@ model BoardSettings {
   /// @sensitivity:public
   volunteerDuesCents         Int       @default(0)
   /// @sensitivity:public
-  membershipYearBoundary     DateTime?
+  orgMembershipYearBoundary  DateTime?
   /// Shopify variant ID of the membership product everyone checks out through.
   /// The "Pay with Shopify" link is built from it SERVER-SIDE (ensurePaymentLink
   /// in lib/membership/payment.ts) as
-  /// https://<SHOPIFY_STORE_DOMAIN>/cart/<membershipVariantId>:1; the client only
+  /// https://<SHOPIFY_STORE_DOMAIN>/cart/<orgMembershipVariantId>:1; the client only
   /// receives the derived checkoutUrl, never this raw field — hence internal, not
   /// public (contrast Program.shopify*VariantId, which the browser builds from).
   /// @sensitivity:internal
-  membershipVariantId        String?
+  orgMembershipVariantId     String?
   /// Discount code (created in Shopify by the board) appended to the checkout
   /// link for volunteer households so Shopify applies their discount.
   /// @sensitivity:internal
@@ -415,7 +415,7 @@ model BoardSettings {
   /// @sensitivity:public
   bgRecheckMonths            Int       @default(0)
   /// @sensitivity:internal
-  shopifyMembershipProductId String?
+  shopifyOrgMembershipProductId String?
   /// @sensitivity:internal
   shopifyNormalVariantId     String?
   /// @sensitivity:internal
@@ -448,7 +448,7 @@ model AppSettings {
 /// relationship — familial, romantic, guardianship, financial, legal-restriction,
 /// etc. — with a counterparty who may be another Person or someone outside
 /// the org. The durable relationship facts live here, entered once; each annual
-/// review cycle is a TrustedAdultReview row (like Membership/MembershipProcess), so
+/// review cycle is a TrustedAdultReview row (like OrgMembership/OrgMembershipProcess), so
 /// a renewal reuses the facts without re-entry.
 ///
 /// NAMING GLOSSARY (one entity, several names — read before renaming; audit P2-2).

--- a/checkin-app/prisma/seed_20_users.ts
+++ b/checkin-app/prisma/seed_20_users.ts
@@ -36,7 +36,7 @@ async function main() {
         });
 
         // Create membership
-        await prisma.membership.create({
+        await prisma.orgMembership.create({
             data: {
                 status: 'ACTIVE',
                 householdId: household.id

--- a/checkin-app/src/app/__tests__/adminBulkImport.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImport.integration.test.ts
@@ -23,7 +23,7 @@ describe('Admin Bulk Import API Integration Tests', () => {
     beforeAll(async () => {
         try {
             // Clean up any leaked state
-            await prisma.membership.deleteMany({});
+            await prisma.orgMembership.deleteMany({});
             await prisma.householdLead.deleteMany({});
             await prisma.person.deleteMany({
                 where: { email: { contains: 'import-test' } }
@@ -54,7 +54,7 @@ describe('Admin Bulk Import API Integration Tests', () => {
     afterAll(async () => {
         try {
             // Clean up
-            await prisma.membership.deleteMany({});
+            await prisma.orgMembership.deleteMany({});
             await prisma.householdLead.deleteMany({});
             await prisma.person.deleteMany({
                 where: { email: { contains: 'import-test' } }
@@ -74,7 +74,7 @@ describe('Admin Bulk Import API Integration Tests', () => {
     afterEach(async () => {
         try {
             // Clean up participants created during tests
-            await prisma.membership.deleteMany({});
+            await prisma.orgMembership.deleteMany({});
             await prisma.householdLead.deleteMany({});
             await prisma.person.deleteMany({
                 where: { email: { contains: 'batch-import-test' } }

--- a/checkin-app/src/app/__tests__/adminBulkImportMalformedRow.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportMalformedRow.integration.test.ts
@@ -23,7 +23,7 @@ describe('Bulk import: malformed row among valid rows', () => {
 
     const cleanup = async () => {
         try {
-            await prisma.membership.deleteMany({});
+            await prisma.orgMembership.deleteMany({});
             await prisma.householdLead.deleteMany({});
             await prisma.person.deleteMany({ where: { email: { contains: 'malrow-import-test' } } });
             await prisma.person.deleteMany({ where: { name: { contains: 'Malrow Import Test' } } });

--- a/checkin-app/src/app/__tests__/adminBulkImportMergeRollback.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportMergeRollback.integration.test.ts
@@ -33,7 +33,7 @@ describe('Bulk import merge rollback', () => {
     const cleanup = async () => {
         try {
             await prisma.trustedAdult.deleteMany({ where: { trustedAdultName: 'Grandma Mergeroll' } });
-            await prisma.membership.deleteMany({});
+            await prisma.orgMembership.deleteMany({});
             await prisma.householdLead.deleteMany({});
             await prisma.person.deleteMany({ where: { email: { contains: 'mergeroll-test' } } });
             await prisma.household.deleteMany({ where: { householdMembers: { none: {} } } });

--- a/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
@@ -45,7 +45,7 @@ describe('Bulk import: preview vs commit consistency', () => {
 
     const cleanup = async () => {
         try {
-            await prisma.membership.deleteMany({});
+            await prisma.orgMembership.deleteMany({});
             await prisma.householdLead.deleteMany({});
             await prisma.person.deleteMany({ where: { email: { contains: 'consist-import-test' } } });
             await prisma.person.deleteMany({ where: { name: { contains: 'Consist Import Test' } } });

--- a/checkin-app/src/app/__tests__/adminHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminHouseholdsAPI.integration.test.ts
@@ -23,7 +23,7 @@ describe('Admin Households API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        await prisma.membership.deleteMany({});
+        await prisma.orgMembership.deleteMany({});
         await prisma.person.deleteMany({
             where: { email: { contains: 'households-api-test' } }
         });
@@ -54,7 +54,7 @@ describe('Admin Households API Integration Tests', () => {
         testUserId = user.id;
 
         // Create an existing active membership for household 2
-        await prisma.membership.create({
+        await prisma.orgMembership.create({
             data: {
                 householdId: testHousehold2Id,
                 status: 'ACTIVE'
@@ -64,7 +64,7 @@ describe('Admin Households API Integration Tests', () => {
 
     afterAll(async () => {
         // Clean up — scope membership deletes to this test's households
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: [testHousehold1Id, testHousehold2Id] } }
         });
         await prisma.person.deleteMany({
@@ -173,7 +173,7 @@ describe('Admin Households API Integration Tests', () => {
             expect(data.success).toBe(true);
             expect(data.membership.status).toBe('ACTIVE');
 
-            const membership = await prisma.membership.findFirst({
+            const membership = await prisma.orgMembership.findFirst({
                 where: { householdId: testHousehold1Id, status: 'ACTIVE' }
             });
             expect(membership).toBeDefined();
@@ -195,7 +195,7 @@ describe('Admin Households API Integration Tests', () => {
             const data = await res.json();
             expect(data.success).toBe(true);
 
-            const activeMembership = await prisma.membership.findFirst({
+            const activeMembership = await prisma.orgMembership.findFirst({
                 where: { householdId: testHousehold2Id, status: 'ACTIVE' }
             });
             expect(activeMembership).toBeNull(); // Should be deactivated

--- a/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
@@ -18,7 +18,7 @@ describe('Admin Participant Household API Integration Tests', () => {
 
     beforeAll(async () => {
         // Clean up any leaked state
-        await prisma.membership.deleteMany({});
+        await prisma.orgMembership.deleteMany({});
         await prisma.householdLead.deleteMany({});
         await prisma.person.deleteMany({
             where: { email: { contains: 'household-api-test' } }
@@ -44,7 +44,7 @@ describe('Admin Participant Household API Integration Tests', () => {
     });
 
     afterAll(async () => {
-        await prisma.membership.deleteMany({});
+        await prisma.orgMembership.deleteMany({});
         await prisma.householdLead.deleteMany({});
         await prisma.person.deleteMany({
             where: { email: { contains: 'household-api-test' } }
@@ -62,7 +62,7 @@ describe('Admin Participant Household API Integration Tests', () => {
     });
 
     afterEach(async () => {
-        await prisma.membership.deleteMany({});
+        await prisma.orgMembership.deleteMany({});
         await prisma.householdLead.deleteMany({});
         await prisma.person.deleteMany({
             where: { name: 'Subject Test' }

--- a/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
@@ -46,7 +46,7 @@ describe('Admin Participants API Integration Tests', () => {
         const rows = await prisma.person.findMany({ where: { OR: filters }, select: { householdId: true } });
         const householdIds = [...new Set(rows.map((r) => r.householdId).filter((id): id is number => id != null))];
         if (householdIds.length) {
-            await prisma.membership.deleteMany({ where: { householdId: { in: householdIds } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: householdIds } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: householdIds } } });
         }
         await prisma.person.deleteMany({ where: { OR: filters } });
@@ -175,7 +175,7 @@ describe('Admin Participants API Integration Tests', () => {
             expect(household?.name).toBe('Adult Household');
 
             // D4.5: admin-created participants default to visitors (no membership)
-            const membership = await prisma.membership.findUnique({
+            const membership = await prisma.orgMembership.findUnique({
                 where: { householdId: updatedParticipant!.householdId! }
             });
             expect(membership).toBeNull();
@@ -202,7 +202,7 @@ describe('Admin Participants API Integration Tests', () => {
             const created = await prisma.person.findUnique({
                 where: { id: data.participant.id }
             });
-            const membership = await prisma.membership.findUnique({
+            const membership = await prisma.orgMembership.findUnique({
                 where: { householdId: created!.householdId! }
             });
             expect(membership?.status).toBe('ACTIVE');

--- a/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
@@ -25,7 +25,7 @@ describe('Admin Unclaimed Households API Integration Tests', () => {
     let testClaimedHouseholdId: number;
 
     const cleanup = async () => {
-        await prisma.membership.deleteMany({});
+        await prisma.orgMembership.deleteMany({});
         await prisma.householdLead.deleteMany({
             where: { household: { name: { contains: 'Unclaimed API Test' } } }
         });

--- a/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
@@ -100,8 +100,8 @@ describe('Ownership-boundary authorization', () => {
             await prisma.trustedAdult.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.emergencyContact.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.auditLog.deleteMany({ where: { tableName: 'EmergencyContact', secondaryAffectedEntity: { in: ids } } });
-            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
@@ -117,8 +117,8 @@ describe('Ownership-boundary authorization', () => {
         return p.id;
     }
     async function mkPendingProcess(householdId: number, status: 'PENDING_PAYMENT' | 'PENDING_RENEWAL', kind: 'INITIAL' | 'RENEWAL') {
-        const m = await prisma.membership.create({ data: { householdId, status: 'NONE', isVolunteer: false } });
-        await prisma.membershipProcess.create({ data: { membershipId: m.id, kind, status } });
+        const m = await prisma.orgMembership.create({ data: { householdId, status: 'NONE', isVolunteer: false } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind, status } });
     }
 
     beforeAll(async () => {

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -19,9 +19,9 @@ describe("GET /api/cron/post-event", () => {
         await prisma.person.deleteMany({ where: { email: { contains: 'example.com' } } });
         // Global participant-less household delete: clear the membership chain for those
         // households first or Membership_householdId_fkey (RESTRICT) blocks the delete.
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { householdMembers: { none: {} } } } } } });
-        await prisma.membershipProcess.deleteMany({ where: { membership: { household: { householdMembers: { none: {} } } } } });
-        await prisma.membership.deleteMany({ where: { household: { householdMembers: { none: {} } } } });
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { orgMembership: { household: { householdMembers: { none: {} } } } } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { household: { householdMembers: { none: {} } } } } });
+        await prisma.orgMembership.deleteMany({ where: { household: { householdMembers: { none: {} } } } });
         await prisma.household.deleteMany({ where: { householdMembers: { none: {} } } });
         jest.clearAllMocks();
     });

--- a/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
@@ -35,7 +35,7 @@ describe('Household API Integration Tests', () => {
             where: { personId: { in: existingUserIds } }
         });
         
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: existingHouseholdIds } }
         });
         
@@ -106,7 +106,7 @@ describe('Household API Integration Tests', () => {
             where: { personId: { in: currentIds } }
         });
 
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: validHouseholdIds } }
         });
 

--- a/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
@@ -37,7 +37,7 @@ describe('Household Lead API Integration Tests', () => {
             where: { personId: { in: existingUserIds } }
         });
         
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: existingHouseholdIds } }
         });
         
@@ -107,7 +107,7 @@ describe('Household Lead API Integration Tests', () => {
             where: { personId: { in: currentIds } }
         });
         
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: validHouseholdIds } }
         });
         

--- a/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
@@ -36,7 +36,7 @@ describe('Household Member API Integration Tests', () => {
             where: { personId: { in: existingUserIds } }
         });
         
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: existingHouseholdIds } }
         });
         
@@ -97,7 +97,7 @@ describe('Household Member API Integration Tests', () => {
             where: { personId: { in: currentIds } }
         });
         
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: validHouseholdIds } }
         });
         

--- a/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
@@ -38,7 +38,7 @@ describe('Household Visits API Integration Tests', () => {
             where: { personId: { in: existingUserIds } }
         });
         
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: existingHouseholdIds } }
         });
         
@@ -126,7 +126,7 @@ describe('Household Visits API Integration Tests', () => {
             where: { personId: { in: currentIds } }
         });
         
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: validHouseholdIds } }
         });
         

--- a/checkin-app/src/app/__tests__/householdsDenyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsDenyAPI.integration.test.ts
@@ -64,7 +64,7 @@ describe('POST /api/membership-ops/households — Deny Membership', () => {
             where: { email: { contains: TAG } }, select: { id: true, householdId: true },
         });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: ids.map(u => u.id) } } });
-        await prisma.membership.deleteMany({ where: { householdId: { in: ids.map(u => u.householdId) } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids.map(u => u.householdId) } } });
         await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
         await prisma.household.deleteMany({ where: { id: { in: ids.map(u => u.householdId) } } });
     });
@@ -82,7 +82,7 @@ describe('POST /api/membership-ops/households — Deny Membership', () => {
         const res = await post({ householdId: plainHouseholdId, deny: true });
         expect(res.status).toBe(403);
 
-        const membership = await prisma.membership.findUnique({ where: { householdId: plainHouseholdId } });
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: plainHouseholdId } });
         expect(membership?.status).not.toBe('DENIED');
     });
 
@@ -94,7 +94,7 @@ describe('POST /api/membership-ops/households — Deny Membership', () => {
         const data = await res.json();
         expect(data.error).toContain('board member');
 
-        const membership = await prisma.membership.findUnique({ where: { householdId: boardHouseholdId } });
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: boardHouseholdId } });
         expect(membership?.status).not.toBe('DENIED');
     });
 
@@ -104,11 +104,11 @@ describe('POST /api/membership-ops/households — Deny Membership', () => {
         const res = await post({ householdId: plainHouseholdId, deny: true });
         expect(res.status).toBe(200);
 
-        const membership = await prisma.membership.findUnique({ where: { householdId: plainHouseholdId } });
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: plainHouseholdId } });
         expect(membership?.status).toBe('DENIED');
 
         const audit = await prisma.auditLog.findFirst({
-            where: { actorId: boardId, tableName: 'Membership', affectedEntityId: membership!.id },
+            where: { actorId: boardId, tableName: 'OrgMembership', affectedEntityId: membership!.id },
             orderBy: { id: 'desc' },
         });
         expect(audit).not.toBeNull();
@@ -130,7 +130,7 @@ describe('POST /api/membership-ops/households — Deny Membership', () => {
         const res = await post({ householdId: plainHouseholdId, deny: false });
         expect(res.status).toBe(200);
 
-        const membership = await prisma.membership.findUnique({ where: { householdId: plainHouseholdId } });
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: plainHouseholdId } });
         expect(membership?.status).toBe('NONE');
     });
 });

--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -54,7 +54,7 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
             data: { email: `active-${TAG}@example.com`, name: 'Active Member', household: { create: {} } },
         });
         activeHouseholdId = active.householdId;
-        await prisma.membership.create({ data: { householdId: activeHouseholdId, status: 'ACTIVE' } });
+        await prisma.orgMembership.create({ data: { householdId: activeHouseholdId, status: 'ACTIVE' } });
     });
 
     afterAll(async () => {
@@ -62,7 +62,7 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
             where: { email: { contains: TAG } }, select: { id: true, householdId: true },
         });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: ids.map(u => u.id) } } });
-        await prisma.membership.deleteMany({ where: { householdId: { in: ids.map(u => u.householdId) } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids.map(u => u.householdId) } } });
         await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
         await prisma.household.deleteMany({ where: { id: { in: ids.map(u => u.householdId) } } });
     });
@@ -73,11 +73,11 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         const res = await post({ householdId: inactiveHouseholdId, active: true });
         expect(res.status).toBe(200);
 
-        const membership = await prisma.membership.findUnique({ where: { householdId: inactiveHouseholdId } });
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: inactiveHouseholdId } });
         expect(membership?.status).toBe('ACTIVE');
 
         const audit = await prisma.auditLog.findFirst({
-            where: { actorId: boardId, tableName: 'Membership', affectedEntityId: membership!.id },
+            where: { actorId: boardId, tableName: 'OrgMembership', affectedEntityId: membership!.id },
             orderBy: { id: 'desc' },
         });
         expect(audit).not.toBeNull();
@@ -91,11 +91,11 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         const res = await post({ householdId: activeHouseholdId, active: false });
         expect(res.status).toBe(200);
 
-        const membership = await prisma.membership.findUnique({ where: { householdId: activeHouseholdId } });
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: activeHouseholdId } });
         expect(membership?.status).toBe('REVOKED');
 
         const audit = await prisma.auditLog.findFirst({
-            where: { actorId: boardId, tableName: 'Membership', affectedEntityId: membership!.id },
+            where: { actorId: boardId, tableName: 'OrgMembership', affectedEntityId: membership!.id },
             orderBy: { id: 'desc' },
         });
         expect(audit).not.toBeNull();

--- a/checkin-app/src/app/__tests__/intakeConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/intakeConcurrency.integration.test.ts
@@ -29,8 +29,8 @@ async function wipe() {
     const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
     const ids = hhs.map((h) => h.id);
     if (ids.length) {
-        await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-        await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
@@ -58,15 +58,15 @@ describe('intake start concurrency', () => {
         // Both return the SAME winning process — the loser re-checked under the lock.
         expect(results[0].id).toBe(results[1].id);
 
-        const inflight = await prisma.membershipProcess.findMany({
-            where: { membership: { householdId }, kind: 'INITIAL', status: { in: IN_FLIGHT_INITIAL_STATUSES } },
+        const inflight = await prisma.orgMembershipProcess.findMany({
+            where: { orgMembership: { householdId }, kind: 'INITIAL', status: { in: IN_FLIGHT_INITIAL_STATUSES } },
             select: { id: true },
         });
         expect(inflight).toHaveLength(1); // no duplicate from the loser
 
         // Exactly one CREATE audit row for the winner — no orphan from the loser.
         const created = await prisma.auditLog.count({
-            where: { tableName: 'MembershipProcess', action: 'CREATE', affectedEntityId: results[0].id },
+            where: { tableName: 'OrgMembershipProcess', action: 'CREATE', affectedEntityId: results[0].id },
         });
         expect(created).toBe(1);
     });

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -51,9 +51,9 @@ async function makeFreshRenewal() {
         data: { email: `rlead-${Math.random()}-${TAG}@example.com`, name: 'R Lead', householdId: hh.id, lastBackgroundCheck: new Date() },
     });
     await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
-    const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
-    const proc = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
-    return { membershipId: m.id, processId: proc.id };
+    const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
+    const proc = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
+    return { orgMembershipId: m.id, processId: proc.id };
 }
 
 /** Applicant household + a lead + membership + a process at the given status. */
@@ -63,13 +63,13 @@ async function makeApplicant(status: 'PENDING_EXTERNAL_ACTION', extra: { lastBac
         data: { email: `lead-${Math.random()}-${TAG}@example.com`, name: 'Lead Parent', householdId: hh.id, lastBackgroundCheck: extra.lastBackgroundCheck ?? null },
     });
     await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
-    const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-    const proc = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status } });
-    return { householdId: hh.id, membershipId: m.id, processId: proc.id, leadId: lead.id };
+    const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+    const proc = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'INITIAL', status } });
+    return { householdId: hh.id, orgMembershipId: m.id, processId: proc.id, leadId: lead.id };
 }
 
-const statusOf = async (id: number) => (await prisma.membershipProcess.findUnique({ where: { id } }))?.status;
-const membershipStatusOf = async (id: number) => (await prisma.membership.findUnique({ where: { id } }))?.status;
+const statusOf = async (id: number) => (await prisma.orgMembershipProcess.findUnique({ where: { id } }))?.status;
+const membershipStatusOf = async (id: number) => (await prisma.orgMembership.findUnique({ where: { id } }))?.status;
 
 async function wipe() {
     const hhs = await prisma.household.findMany({
@@ -78,9 +78,9 @@ async function wipe() {
     });
     const ids = hhs.map((h) => h.id);
     if (ids.length) {
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: ids } } } } });
-        await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-        await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { orgMembership: { householdId: { in: ids } } } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.emergencyContact.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
@@ -117,20 +117,20 @@ describe('background check is non-blocking', () => {
     });
 
     it('pay before the check clears → holds at PENDING_BG_CLEARANCE, then 2 approvals activate', async () => {
-        const { processId, membershipId, householdId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        const { processId, orgMembershipId, householdId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
         await markContractSigned(processId);
         await markBgConsent(processId, revA);
         // Pay first.
         await certifyPaymentPlan(processId, revA);
         expect(await statusOf(processId)).toBe('PENDING_BG_CLEARANCE');
-        expect(await membershipStatusOf(membershipId)).toBe('NONE'); // NOT active without a valid check
+        expect(await membershipStatusOf(orgMembershipId)).toBe('NONE'); // NOT active without a valid check
 
         // Review clears in parallel; the 2nd approval converges to ACTIVE.
         await attest(revA, processId, { result: 'APPROVE' });
         expect(await statusOf(processId)).toBe('PENDING_BG_CLEARANCE');
         await attest(revB, processId, { result: 'APPROVE' });
         expect(await statusOf(processId)).toBe('ACTIVE');
-        expect(await membershipStatusOf(membershipId)).toBe('ACTIVE');
+        expect(await membershipStatusOf(orgMembershipId)).toBe('ACTIVE');
         // Guardians' lastBackgroundCheck stamped.
         const lead = await prisma.person.findUnique({ where: { id: leadId } });
         expect(lead?.lastBackgroundCheck).not.toBeNull();
@@ -138,30 +138,30 @@ describe('background check is non-blocking', () => {
     });
 
     it('check clears before payment → stays PENDING_PAYMENT, then paying activates', async () => {
-        const { processId, membershipId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        const { processId, orgMembershipId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
         await markContractSigned(processId);
         await markBgConsent(processId, revA);
         await attest(revA, processId, { result: 'APPROVE' });
         await attest(revB, processId, { result: 'APPROVE' });
         expect(await statusOf(processId)).toBe('PENDING_PAYMENT'); // cleared, but unpaid → not active
-        expect(await membershipStatusOf(membershipId)).toBe('NONE');
+        expect(await membershipStatusOf(orgMembershipId)).toBe('NONE');
         await certifyPaymentPlan(processId, revA);
         expect(await statusOf(processId)).toBe('ACTIVE');
-        expect(await membershipStatusOf(membershipId)).toBe('ACTIVE');
+        expect(await membershipStatusOf(orgMembershipId)).toBe('ACTIVE');
     });
 
     it('reject after payment → BLOCKED, membership stays inactive', async () => {
-        const { processId, membershipId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        const { processId, orgMembershipId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
         await markContractSigned(processId);
         await markBgConsent(processId, revA);
         await certifyPaymentPlan(processId, revA); // paid → PENDING_BG_CLEARANCE
         await attest(revA, processId, { result: 'REJECT' });
         expect(await statusOf(processId)).toBe('BLOCKED');
-        expect(await membershipStatusOf(membershipId)).toBe('NONE');
+        expect(await membershipStatusOf(orgMembershipId)).toBe('NONE');
     });
 
     it('reject BEFORE the payment webhook → payment still recorded + board notified (no dropped money)', async () => {
-        const { processId, membershipId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        const { processId, orgMembershipId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
         await markContractSigned(processId);
         await markBgConsent(processId, revA);            // → PENDING_PAYMENT
         await attest(revA, processId, { result: 'APPROVE' });
@@ -171,33 +171,33 @@ describe('background check is non-blocking', () => {
         (sendEmail as jest.Mock).mockClear();
         await activate(processId, { via: 'payment', shopifyOrderId: 'late-pay' }); // webhook lands after the reject
 
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe('BLOCKED');                 // not resurrected
         expect(proc?.paidAt).not.toBeNull();                  // payment recorded, not dropped
         expect(proc?.shopifyOrderId).toBe('late-pay');
-        expect(await membershipStatusOf(membershipId)).toBe('NONE');
+        expect(await membershipStatusOf(orgMembershipId)).toBe('NONE');
         expect(sendEmail as jest.Mock).toHaveBeenCalled();    // board alerted for refund
 
         // Webhook retry is idempotent: paidAt unchanged, no second alert.
         const firstPaidAt = proc?.paidAt?.getTime();
         (sendEmail as jest.Mock).mockClear();
         await activate(processId, { via: 'payment', shopifyOrderId: 'late-pay' });
-        const proc2 = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const proc2 = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc2?.paidAt?.getTime()).toBe(firstPaidAt);
         expect(sendEmail as jest.Mock).not.toHaveBeenCalled();
     });
 
     it('a still-valid prior check auto-clears at submit — no consent needed, pay activates directly', async () => {
         await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
-        const { processId, membershipId, householdId } = await makeApplicant('PENDING_EXTERNAL_ACTION', { lastBackgroundCheck: new Date() });
+        const { processId, orgMembershipId, householdId } = await makeApplicant('PENDING_EXTERNAL_ACTION', { lastBackgroundCheck: new Date() });
         // Reset the process to INTAKE with the household fully filled so submitIntake passes validation.
-        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
+        await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
         await prisma.household.update({ where: { id: householdId }, data: { line1: '123 Test St' } });
         await prisma.emergencyContact.create({ data: { householdId, name: 'Out Of House', phone: '555-555-1212', phoneDigits: '5555551212', priority: 0 } });
         const lead = await prisma.person.findFirst({ where: { householdId, householdLeads: { some: { householdId } } } });
 
         await submitIntake(lead!.id);
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe('PENDING_EXTERNAL_ACTION');
         expect(proc?.bgClearedAt).not.toBeNull(); // auto-validated
 
@@ -206,19 +206,19 @@ describe('background check is non-blocking', () => {
         expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
         await certifyPaymentPlan(processId, lead!.id);
         expect(await statusOf(processId)).toBe('ACTIVE');
-        expect(await membershipStatusOf(membershipId)).toBe('ACTIVE');
+        expect(await membershipStatusOf(orgMembershipId)).toBe('ACTIVE');
     });
 
     it('renewal with a still-valid check → PENDING_PAYMENT + bgClearedAt, then paying activates (not stuck)', async () => {
         await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
-        const { membershipId, processId } = await makeFreshRenewal();
+        const { orgMembershipId, processId } = await makeFreshRenewal();
         await beginRenewal(processId);
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe('PENDING_PAYMENT');
         expect(proc?.bgClearedAt).not.toBeNull(); // the bug: was null → paid renewal stuck forever
         await activate(processId, { via: 'payment', shopifyOrderId: 'renew-pay' });
         expect(await statusOf(processId)).toBe('ACTIVE');
-        expect(await membershipStatusOf(membershipId)).toBe('ACTIVE');
+        expect(await membershipStatusOf(orgMembershipId)).toBe('ACTIVE');
     });
 
     it('paying twice is idempotent (one activation)', async () => {
@@ -232,7 +232,7 @@ describe('background check is non-blocking', () => {
         await activate(processId, { via: 'payment', shopifyOrderId: 'pay-1' }); // ACTIVE
         await activate(processId, { via: 'payment', shopifyOrderId: 'pay-2' }); // retry — no-op
         expect(await statusOf(processId)).toBe('ACTIVE');
-        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true } });
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: processId }, select: { newData: true } });
         const activations = audits.filter((a) => JSON.stringify(normalizeAuditData(a.newData)).includes('"status":"ACTIVE"')).length;
         expect(activations).toBe(1);
     });
@@ -240,7 +240,7 @@ describe('background check is non-blocking', () => {
     it('a stray payment for a process not awaiting payment is ignored (no state corruption)', async () => {
         const { processId } = await makeApplicant('PENDING_EXTERNAL_ACTION'); // no checkout link exists for this phase
         await activate(processId, { via: 'payment', shopifyOrderId: 'stray' });
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe('PENDING_EXTERNAL_ACTION');
         expect(proc?.paidAt).toBeNull();
     });

--- a/checkin-app/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
@@ -35,7 +35,7 @@ describe('Bulk renewal migration', () => {
 
     async function makeActive(label: string) {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
         return m.id;
     }
 
@@ -43,8 +43,8 @@ describe('Bulk renewal migration', () => {
         const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
-            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
@@ -52,7 +52,7 @@ describe('Bulk renewal migration', () => {
     }
 
     beforeAll(async () => {
-        const maxRow = await prisma.membershipProcess.findFirst({ orderBy: { id: 'desc' }, select: { id: true } });
+        const maxRow = await prisma.orgMembershipProcess.findFirst({ orderBy: { id: 'desc' }, select: { id: true } });
         preMaxProcessId = maxRow?.id ?? 0;
         await wipe();
         sysId = (await prisma.person.create({ data: { email: `sys-${TAG}@example.com`, name: 'Sys', isSysadmin: true, household: { create: { name: `Sys HH ${TAG}` } } } })).id;
@@ -63,7 +63,7 @@ describe('Bulk renewal migration', () => {
     });
 
     afterAll(async () => {
-        await prisma.membershipProcess.deleteMany({ where: { id: { gt: preMaxProcessId } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { id: { gt: preMaxProcessId } } });
         await wipe();
         await prisma.$disconnect();
     });
@@ -84,8 +84,8 @@ describe('Bulk renewal migration', () => {
         expect(data.success).toBe(true);
         expect(data.opened).toBeGreaterThanOrEqual(2);
 
-        const a = await prisma.membershipProcess.findFirst({ where: { membershipId: mA } });
-        const b = await prisma.membershipProcess.findFirst({ where: { membershipId: mB } });
+        const a = await prisma.orgMembershipProcess.findFirst({ where: { orgMembershipId: mA } });
+        const b = await prisma.orgMembershipProcess.findFirst({ where: { orgMembershipId: mB } });
         expect(a?.status).toBe('PENDING_RENEWAL');
         expect(b?.status).toBe('PENDING_RENEWAL');
         expect(sendEmail as jest.Mock).not.toHaveBeenCalled();
@@ -93,7 +93,7 @@ describe('Bulk renewal migration', () => {
         // Idempotent: a second press opens nothing new.
         const second = await BULK(jsonReq({ sendReminders: false }));
         expect((await second.json()).opened).toBe(0);
-        const count = await prisma.membershipProcess.count({ where: { membershipId: mA } });
+        const count = await prisma.orgMembershipProcess.count({ where: { orgMembershipId: mA } });
         expect(count).toBe(1);
     });
 

--- a/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
@@ -53,9 +53,9 @@ describe('POST /api/membership/contract/sign', () => {
         const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
-            await prisma.auditLog.deleteMany({ where: { tableName: 'MembershipProcess', affectedEntityId: { in: ids } } }).catch(() => {});
-            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.auditLog.deleteMany({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: { in: ids } } }).catch(() => {});
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
@@ -72,8 +72,8 @@ describe('POST /api/membership/contract/sign', () => {
         const lead = await prisma.person.create({ data: { email: `lead-${TAG}@example.com`, name: 'Lead Parent', householdId: hh.id } });
         const nonLead = await prisma.person.create({ data: { email: `member-${TAG}@example.com`, name: 'Member', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-        const proc = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        const proc = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
         leadId = lead.id;
         nonLeadId = nonLead.id;
         processId = proc.id;
@@ -104,7 +104,7 @@ describe('POST /api/membership/contract/sign', () => {
         expect(zoho.createRequest).toHaveBeenCalledTimes(1);
         // PrintedName is prefilled from the applicant's name.
         expect((zoho.submitRequest as jest.Mock).mock.calls[0][0].prefill).toEqual({ PrintedName: 'Lead Parent' });
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.zohoEnvelopeId).toBe('REQ-1');
         expect(p?.zohoActionId).toBe('ACT-1');
     });
@@ -115,7 +115,7 @@ describe('POST /api/membership/contract/sign', () => {
         expect(res.status).toBe(200);
         expect(zoho.createRequest).not.toHaveBeenCalled(); // already created last test
         expect(zoho.getEmbeddedSignUrl).toHaveBeenCalledTimes(1);
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.zohoEnvelopeId).toBe('REQ-1'); // unchanged
     });
 
@@ -123,8 +123,8 @@ describe('POST /api/membership/contract/sign', () => {
         const hh = await prisma.household.create({ data: { name: `HH renewal ${TAG}` } });
         const rLead = await prisma.person.create({ data: { email: `rlead-${TAG}@example.com`, name: 'Renewing Lead', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: rLead.id } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
-        await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'RENEWAL', status: 'PENDING_EXTERNAL_ACTION' } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'RENEWAL', status: 'PENDING_EXTERNAL_ACTION' } });
 
         asUser(rLead.id);
         const res = await SIGN(signReq());
@@ -139,7 +139,7 @@ describe('POST /api/membership/contract/sign', () => {
             n += 1;
             return { requestId: `REQ-C${n}`, actionId: `ACT-C${n}`, documentId: `DOC-C${n}` };
         });
-        await prisma.membershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: null, zohoActionId: null } });
+        await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: null, zohoActionId: null } });
         asUser(leadId);
 
         const [r1, r2] = await Promise.all([SIGN(signReq()), SIGN(signReq())]);
@@ -148,7 +148,7 @@ describe('POST /api/membership/contract/sign', () => {
 
         // Exactly one canonical request persisted, and every embed URL was minted
         // against THAT id — no split brain even if both calls created at Zoho.
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.zohoEnvelopeId).toBeTruthy();
         expect(p?.zohoActionId).toBeTruthy();
         for (const call of (zoho.getEmbeddedSignUrl as jest.Mock).mock.calls) {
@@ -158,19 +158,19 @@ describe('POST /api/membership/contract/sign', () => {
 
         // Restore the default create mock + a stored request for later assertions.
         (zoho.createRequest as jest.Mock).mockResolvedValue({ requestId: 'REQ-1', actionId: 'ACT-1', documentId: 'DOC-1' });
-        await prisma.membershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: 'REQ-1', zohoActionId: 'ACT-1' } });
+        await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: 'REQ-1', zohoActionId: 'ACT-1' } });
     });
 
     it('recovers when an envelope id was stored without an action id (legacy admin/email flow)', async () => {
         // setZohoEnvelope stores zohoEnvelopeId WITHOUT an action id — that pair
         // can't be embedded, so the in-app flow must re-create and overwrite it
         // rather than 409 forever on the incomplete pair.
-        await prisma.membershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: 'LEGACY-ENV', zohoActionId: null } });
+        await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: 'LEGACY-ENV', zohoActionId: null } });
         asUser(leadId);
         const res = await SIGN(signReq());
         expect(res.status).toBe(200);
         expect(zoho.createRequest).toHaveBeenCalledTimes(1);
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.zohoEnvelopeId).toBe('REQ-1'); // overwritten with the embeddable request
         expect(p?.zohoActionId).toBe('ACT-1');
     });
@@ -181,8 +181,8 @@ describe('POST /api/membership/contract/sign', () => {
         const otherLead = await prisma.person.create({ data: { email: `otherlead-${TAG}@example.com`, name: 'Other Lead', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: otherLead.id } });
         const isSysadmin = await prisma.person.create({ data: { email: `isSysadmin-${TAG}@example.com`, name: 'Sys Admin', householdId: hh.id, isSysadmin: true } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-        await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
 
         asUser(isSysadmin.id); // session isSysadmin flag is irrelevant; the service reads the DB row
         const res = await SIGN(signReq());
@@ -196,8 +196,8 @@ describe('POST /api/membership/contract/sign', () => {
         const hh = await prisma.household.create({ data: { name: `HH noagreement ${TAG}` } });
         const lead = await prisma.person.create({ data: { email: `noagr-lead-${TAG}@example.com`, name: 'NoAgr Lead', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-        await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION' } });
 
         (loadAgreementPdf as jest.Mock).mockRejectedValueOnce(new AgreementUnavailableError('not ready'));
 
@@ -210,11 +210,11 @@ describe('POST /api/membership/contract/sign', () => {
     });
 
     it('409s when the application is not in the EXTERNAL phase', async () => {
-        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
+        await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
         asUser(leadId);
         const res = await SIGN(signReq());
         expect(res.status).toBe(409);
-        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: 'PENDING_EXTERNAL_ACTION' } });
+        await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: 'PENDING_EXTERNAL_ACTION' } });
     });
 
     it('503s when Zoho is not configured (prod — the dev mock is dead here)', async () => {

--- a/checkin-app/src/app/__tests__/membershipContractSync.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSync.integration.test.ts
@@ -38,14 +38,14 @@ const TAG = 'contract-sync-test';
 /**
  * A fresh applicant: household + membership + a process in the EXTERNAL phase, and
  * a participant (the lead) wired to that household so syncContractStatus(userId)
- * resolves the process via user.household.membership.processes.
+ * resolves the process via user.household.orgMembership.processes.
  */
 async function makeApplicant(data: Record<string, unknown> = {}): Promise<{ userId: number; processId: number }> {
     const hh = await prisma.household.create({ data: { name: `Applicant ${TAG}` } });
-    const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-    const proc = await prisma.membershipProcess.create({
+    const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+    const proc = await prisma.orgMembershipProcess.create({
         data: {
-            membershipId: m.id,
+            orgMembershipId: m.id,
             kind: 'INITIAL',
             status: 'PENDING_EXTERNAL_ACTION',
             zohoEnvelopeId: `zoho-${TAG}`,
@@ -61,7 +61,7 @@ async function makeApplicant(data: Record<string, unknown> = {}): Promise<{ user
 /** Audit rows for a process, split by the field they record. */
 async function audits(processId: number) {
     const rows = await prisma.auditLog.findMany({
-        where: { tableName: 'MembershipProcess', affectedEntityId: processId },
+        where: { tableName: 'OrgMembershipProcess', affectedEntityId: processId },
         select: { actorId: true, newData: true },
     });
     return {
@@ -74,8 +74,8 @@ async function wipe() {
     const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
     const ids = hhs.map((h) => h.id);
     if (ids.length) {
-        await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-        await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
@@ -113,7 +113,7 @@ describe('syncContractStatus', () => {
         const status = await syncContractStatus(userId);
 
         expect(status?.contractSigned).toBe(true);
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.contractSignedAt).not.toBeNull();
         expect(p?.status).toBe('PENDING_PAYMENT');
 
@@ -130,7 +130,7 @@ describe('syncContractStatus', () => {
 
         await syncContractStatus(userId);
 
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.contractSignedAt).not.toBeNull();
         expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
     });
@@ -142,7 +142,7 @@ describe('syncContractStatus', () => {
         const status = await syncContractStatus(userId);
 
         expect(status?.contractSigned).toBe(false);
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.contractSignedAt).toBeNull();
         expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
         const a = await audits(processId);
@@ -157,7 +157,7 @@ describe('syncContractStatus', () => {
         // Second call: Zoho would still say "signed", but the contract is already recorded.
         await syncContractStatus(userId);
 
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.status).toBe('PENDING_PAYMENT');
         const a = await audits(processId);
         expect(a.signed).toHaveLength(1);
@@ -172,7 +172,7 @@ describe('syncContractStatus', () => {
 
         expect(status).not.toBeNull();
         expect(status?.contractSigned).toBe(false);
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.contractSignedAt).toBeNull();
         expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
     });
@@ -184,7 +184,7 @@ describe('syncContractStatus', () => {
         expect(await syncContractStatus(userId)).toBeNull();
         // Zoho never consulted, nothing signed.
         expect(mockGetRequestStatus).not.toHaveBeenCalled();
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.contractSignedAt).toBeNull();
     });
 

--- a/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -55,9 +55,9 @@ describe('Membership EXTERNAL phase API', () => {
 
     async function makeProcess(name: string, envelopeId: string) {
         const hh = await prisma.household.create({ data: { name } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-        const p = await prisma.membershipProcess.create({
-            data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION', zohoEnvelopeId: envelopeId },
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        const p = await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION', zohoEnvelopeId: envelopeId },
         });
         return { householdId: hh.id, processId: p.id };
     }
@@ -66,8 +66,8 @@ describe('Membership EXTERNAL phase API', () => {
         const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
-            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
@@ -110,7 +110,7 @@ describe('Membership EXTERNAL phase API', () => {
         asBoard(boardId);
         const res = await BOARD_EXTERNAL(boardReq({ processId: procA, action: 'mark-contract' }) as never);
         expect(res.status).toBe(200);
-        const p = await prisma.membershipProcess.findUnique({ where: { id: procA } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: procA } });
         expect(p?.contractSignedAt).not.toBeNull();
         expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
     });
@@ -119,7 +119,7 @@ describe('Membership EXTERNAL phase API', () => {
         asBoard(boardId);
         const res = await BOARD_EXTERNAL(boardReq({ processId: procA, action: 'mark-bg-consent' }) as never);
         expect(res.status).toBe(200);
-        const p = await prisma.membershipProcess.findUnique({ where: { id: procA } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: procA } });
         expect(p?.bgConsentAt).not.toBeNull();
         expect(p?.status).toBe('PENDING_PAYMENT');
     });
@@ -150,7 +150,7 @@ describe('Membership EXTERNAL phase API', () => {
     it('a valid completed Zoho webhook records the contract as signed', async () => {
         const res = await ZOHO_WEBHOOK(zohoReq({ requests: { request_id: 'zoho-B', request_status: 'completed' } }, SECRET));
         expect(res.status).toBe(200);
-        const p = await prisma.membershipProcess.findUnique({ where: { id: procB } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: procB } });
         expect(p?.contractSignedAt).not.toBeNull();
         // BG consent not yet given → still EXTERNAL.
         expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
@@ -171,7 +171,7 @@ describe('Membership EXTERNAL phase API', () => {
             process.env.ZOHO_WEBHOOK_SECRET = SECRET;
             process.env.CHECKIN_ENV = prevEnv;
         }
-        const p = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.contractSignedAt).toBeNull();
         expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
     });
@@ -181,11 +181,11 @@ describe('Membership EXTERNAL phase API', () => {
         const req = () => ZOHO_WEBHOOK(zohoReq({ requests: { request_id: 'zoho-D', request_status: 'completed' } }, SECRET));
         // Fresh process: the contract-signed webhook is the only thing that audits it.
         const auditCount = () =>
-            prisma.auditLog.count({ where: { tableName: 'MembershipProcess', affectedEntityId: processId } });
+            prisma.auditLog.count({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: processId } });
 
         const first = await req();
         expect(first.status).toBe(200);
-        const afterFirst = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const afterFirst = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(afterFirst?.contractSignedAt).not.toBeNull();
         expect(afterFirst?.status).toBe('PENDING_EXTERNAL_ACTION'); // no BG consent → stays EXTERNAL
         expect(await auditCount()).toBe(1);
@@ -193,7 +193,7 @@ describe('Membership EXTERNAL phase API', () => {
         // Zoho retries at-least-once: replay the identical signed payload.
         const second = await req();
         expect(second.status).toBe(200);
-        const afterSecond = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const afterSecond = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         // State identical: same signed timestamp, same phase, no second audit row.
         expect(afterSecond?.contractSignedAt?.getTime()).toBe(afterFirst?.contractSignedAt?.getTime());
         expect(afterSecond?.status).toBe(afterFirst?.status);
@@ -211,7 +211,7 @@ describe('Membership EXTERNAL phase API', () => {
         asBoard(boardId);
         const res = await BOARD_EXTERNAL(boardReq({ processId: procB, action: 'set-envelope', envelopeId: 'zoho-B2' }) as never);
         expect(res.status).toBe(200);
-        const p = await prisma.membershipProcess.findUnique({ where: { id: procB } });
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: procB } });
         expect(p?.zohoEnvelopeId).toBe('zoho-B2');
     });
 
@@ -233,7 +233,7 @@ describe('Membership EXTERNAL phase API', () => {
         const ids = data.processes.map((p: { id: number }) => p.id);
         expect(ids).toEqual(expect.arrayContaining([procA, procB]));
         const a = data.processes.find((p: { id: number }) => p.id === procA);
-        expect(a.membership.householdId).toBe(hhA);
+        expect(a.orgMembership.householdId).toBe(hhA);
         expect(a.status).toBe('PENDING_PAYMENT');
     });
 });

--- a/checkin-app/src/app/__tests__/membershipExternalConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalConcurrency.integration.test.ts
@@ -24,15 +24,15 @@ const TAG = 'external-concurrency-test';
 /** A fresh applicant household + membership + a process in the EXTERNAL phase. */
 async function makeExternalProcess(data: Record<string, unknown> = {}): Promise<number> {
     const hh = await prisma.household.create({ data: { name: `Applicant ${TAG}` } });
-    const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-    const proc = await prisma.membershipProcess.create({
-        data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION', ...data },
+    const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+    const proc = await prisma.orgMembershipProcess.create({
+        data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_EXTERNAL_ACTION', ...data },
     });
     return proc.id;
 }
 
 async function advanceAudits(processId: number): Promise<number> {
-    const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true } });
+    const audits = await prisma.auditLog.findMany({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: processId }, select: { newData: true } });
     return audits.filter((a) => JSON.stringify(normalizeAuditData(a.newData)).includes('"status":"PENDING_PAYMENT"')).length;
 }
 
@@ -40,8 +40,8 @@ async function wipe() {
     const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
     const ids = hhs.map((h) => h.id);
     if (ids.length) {
-        await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-        await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
     }
 }
@@ -63,7 +63,7 @@ describe('EXTERNAL advance concurrency', () => {
             markBgConsent(processId, 1),
         ]);
 
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe('PENDING_PAYMENT');
 
         // Exactly one advance audit row + exactly one reviewer ping.
@@ -72,7 +72,7 @@ describe('EXTERNAL advance concurrency', () => {
 
         // Each mutation's audit row carries its own actor: SYSTEM_ACTOR for the contract sign
         // (default), the board member's id (1) for the bg-consent mark.
-        const all = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true, actorId: true } });
+        const all = await prisma.auditLog.findMany({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: processId }, select: { newData: true, actorId: true } });
         expect(all.find((a) => JSON.stringify(normalizeAuditData(a.newData)).includes('"contractSignedAt":true'))?.actorId).toBe(0);
         expect(all.find((a) => JSON.stringify(normalizeAuditData(a.newData)).includes('"bgConsentAt":true'))?.actorId).toBe(1);
     });
@@ -82,7 +82,7 @@ describe('EXTERNAL advance concurrency', () => {
 
         await Promise.all([markContractSigned(processId), markContractSigned(processId)]);
 
-        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true, actorId: true } });
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: processId }, select: { newData: true, actorId: true } });
         const signed = audits.filter((a) => JSON.stringify(normalizeAuditData(a.newData)).includes('"contractSignedAt":true'));
         expect(signed).toHaveLength(1);
         expect(signed[0].actorId).toBe(0); // markContractSigned default actor = SYSTEM_ACTOR
@@ -99,7 +99,7 @@ describe('EXTERNAL advance concurrency', () => {
         const result = await advanceExternalIfComplete(processId);
 
         expect(result?.status).toBe('BLOCKED');
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe('BLOCKED');
         expect(await advanceAudits(processId)).toBe(0);
         expect(notifyReviewers as jest.Mock).not.toHaveBeenCalled();

--- a/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
@@ -43,9 +43,9 @@ describe('Membership Intake API', () => {
         // Include participants created mid-flow (children/second parents lack the TAG email).
         const inHh = await prisma.person.findMany({ where: { householdId: { in: hhIds } }, select: { id: true } });
         const allIds = inHh.map((p) => p.id);
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: hhIds } } } } });
-        await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: hhIds } } } });
-        await prisma.membership.deleteMany({ where: { householdId: { in: hhIds } } });
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { orgMembership: { householdId: { in: hhIds } } } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: hhIds } } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: hhIds } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: hhIds } } });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: allIds } } });
         await prisma.person.deleteMany({ where: { householdId: { in: hhIds } } });
@@ -71,7 +71,7 @@ describe('Membership Intake API', () => {
             data: {
                 email: `active-${TAG}@example.com`,
                 name: 'Active Lead',
-                household: { create: { name: 'Active Flow HH', membership: { create: { status: 'ACTIVE' } } } },
+                household: { create: { name: 'Active Flow HH', orgMembership: { create: { status: 'ACTIVE' } } } },
             },
         });
         activeLeadId = activeLead.id;
@@ -101,7 +101,7 @@ describe('Membership Intake API', () => {
         expect(data.state.process.kind).toBe('INITIAL');
         expect(data.state.membershipStatus).toBe('NONE');
 
-        const membership = await prisma.membership.findUnique({ where: { householdId: leadHouseholdId } });
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: leadHouseholdId } });
         expect(membership?.status).toBe('NONE');
     });
 
@@ -110,7 +110,7 @@ describe('Membership Intake API', () => {
         const first = await (await POST(req() as never)).json();
         const second = await (await POST(req() as never)).json();
         expect(second.state.process.id).toBe(first.state.process.id);
-        const count = await prisma.membershipProcess.count({ where: { membership: { householdId: leadHouseholdId } } });
+        const count = await prisma.orgMembershipProcess.count({ where: { orgMembership: { householdId: leadHouseholdId } } });
         expect(count).toBe(1);
     });
 
@@ -191,7 +191,7 @@ describe('Membership Intake API', () => {
         expect(startRes.status).toBe(201);
         const processId = (await startRes.json()).state.process.id;
 
-        const createLog = await expectAuditRow(prisma, { action: 'CREATE', tableName: 'MembershipProcess', affectedEntityId: processId });
+        const createLog = await expectAuditRow(prisma, { action: 'CREATE', tableName: 'OrgMembershipProcess', affectedEntityId: processId });
         expect(createLog.actorId).toBe(lead.id);
         expect(auditJson(createLog.newData).status).toBe('INTAKE');
 
@@ -207,7 +207,7 @@ describe('Membership Intake API', () => {
 
         const submitRes = await SUBMIT(req() as never);
         expect(submitRes.status).toBe(200);
-        const editLog = await expectAuditRow(prisma, { action: 'EDIT', tableName: 'MembershipProcess', affectedEntityId: processId });
+        const editLog = await expectAuditRow(prisma, { action: 'EDIT', tableName: 'OrgMembershipProcess', affectedEntityId: processId });
         expect(editLog.actorId).toBe(lead.id);
         expect(auditJson(editLog.oldData).status).toBe('INTAKE');
         expect(auditJson(editLog.newData).status).toBe('PENDING_EXTERNAL_ACTION');
@@ -217,22 +217,22 @@ describe('Membership Intake API', () => {
         const owner = await prisma.person.create({
             data: {
                 email: `renew-lead-${TAG}@example.com`, name: 'Renew Lead',
-                household: { create: { name: 'Renew HH', membership: { create: { status: 'ACTIVE' } } } },
+                household: { create: { name: 'Renew HH', orgMembership: { create: { status: 'ACTIVE' } } } },
             },
         });
         const householdId = owner.householdId!;
-        const membership = await prisma.membership.findUniqueOrThrow({ where: { householdId } });
+        const membership = await prisma.orgMembership.findUniqueOrThrow({ where: { householdId } });
 
         const proc = await createRenewalProcess(membership.id, householdId, new Date(), { remind: false, boundary: new Date() });
         expect(proc).not.toBeNull();
 
-        const createLog = await expectAuditRow(prisma, { action: 'CREATE', tableName: 'MembershipProcess', affectedEntityId: proc!.id });
+        const createLog = await expectAuditRow(prisma, { action: 'CREATE', tableName: 'OrgMembershipProcess', affectedEntityId: proc!.id });
         expect(createLog.actorId).toBe(0); // SYSTEM_ACTOR — cron, not a person
         expect(auditJson(createLog.newData).status).toBe('PENDING_RENEWAL');
 
         const begun = await beginRenewal(proc!.id);
         expect(begun.status).not.toBe('PENDING_RENEWAL');
-        const editLog = await expectAuditRow(prisma, { action: 'EDIT', tableName: 'MembershipProcess', affectedEntityId: proc!.id });
+        const editLog = await expectAuditRow(prisma, { action: 'EDIT', tableName: 'OrgMembershipProcess', affectedEntityId: proc!.id });
         expect(editLog.actorId).toBe(0); // SYSTEM_ACTOR
         expect(auditJson(editLog.oldData).status).toBe('PENDING_RENEWAL');
     });

--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -48,7 +48,7 @@ describe('Membership payment API', () => {
     let certProc: number;
     const prevWebhookSecret = process.env.SHOPIFY_WEBHOOK_SECRET;
     const prevStoreDomain = process.env.SHOPIFY_STORE_DOMAIN;
-    let prevSettings: { normalDuesCents: number; volunteerDuesCents: number; membershipVariantId: string | null; volunteerDiscountCode: string | null } | null = null;
+    let prevSettings: { normalDuesCents: number; volunteerDuesCents: number; orgMembershipVariantId: string | null; volunteerDiscountCode: string | null } | null = null;
 
     async function makeProc(label: string, isVolunteer: boolean, withLead = false) {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
@@ -57,20 +57,20 @@ describe('Membership payment API', () => {
             await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
             leadId = lead.id;
         }
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer } });
         // bgClearedAt set: the background check has already cleared, so paying
         // activates the membership (the BG-not-cleared path is covered by the
         // non-blocking flow test).
-        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() } });
-        return { householdId: hh.id, membershipId: m.id, processId: p.id };
+        const p = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() } });
+        return { householdId: hh.id, orgMembershipId: m.id, processId: p.id };
     }
 
     async function wipe() {
         const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
-            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
@@ -82,11 +82,11 @@ describe('Membership payment API', () => {
         process.env.SHOPIFY_WEBHOOK_SECRET = WEBHOOK_SECRET;
         process.env.SHOPIFY_STORE_DOMAIN = STORE_DOMAIN;
         const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-        prevSettings = existing ? { normalDuesCents: existing.normalDuesCents, volunteerDuesCents: existing.volunteerDuesCents, membershipVariantId: existing.membershipVariantId, volunteerDiscountCode: existing.volunteerDiscountCode } : null;
+        prevSettings = existing ? { normalDuesCents: existing.normalDuesCents, volunteerDuesCents: existing.volunteerDuesCents, orgMembershipVariantId: existing.orgMembershipVariantId, volunteerDiscountCode: existing.volunteerDiscountCode } : null;
         const settingsData = {
             normalDuesCents: 10000,
             volunteerDuesCents: 2500,
-            membershipVariantId: VARIANT_ID,
+            orgMembershipVariantId: VARIANT_ID,
             volunteerDiscountCode: DISCOUNT_CODE,
         };
         await prisma.boardSettings.upsert({
@@ -98,7 +98,7 @@ describe('Membership payment API', () => {
 
         const normal = await makeProc('Normal', false, true);
         normalProc = normal.processId;
-        normalMembership = normal.membershipId;
+        normalMembership = normal.orgMembershipId;
         volProc = (await makeProc('Vol', true)).processId;
         certProc = (await makeProc('Cert', false)).processId;
     });
@@ -132,16 +132,16 @@ describe('Membership payment API', () => {
     });
 
     it('orders/paid webhook activates the membership (and is idempotent)', async () => {
-        // line_items must contain the configured membershipVariantId or the H2 check rejects it (no membership item).
+        // line_items must contain the configured orgMembershipVariantId or the H2 check rejects it (no membership item).
         const payload = { id: 555, line_items: [{ variant_id: VARIANT_ID }], note_attributes: [{ name: 'Membership_Process_ID', value: String(normalProc) }] };
         const res = await SHOPIFY_WEBHOOK(shopifyReq(payload, WEBHOOK_SECRET) as never);
         expect(res.status).toBe(200);
 
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: normalProc } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: normalProc } });
         expect(proc?.status).toBe('ACTIVE');
         expect(proc?.paidAt).not.toBeNull();
         expect(proc?.shopifyOrderId).toBe('555');
-        const m = await prisma.membership.findUnique({ where: { id: normalMembership } });
+        const m = await prisma.orgMembership.findUnique({ where: { id: normalMembership } });
         expect(m?.status).toBe('ACTIVE');
 
         // Idempotent: a second identical webhook does not throw or change state.
@@ -158,12 +158,12 @@ describe('Membership payment API', () => {
         asBoard(leadId); // leadId is fine as an actor id; role mocked as board
         const res = await CERTIFY(new Request('http://localhost:4000/x', { method: 'POST', body: JSON.stringify({ processId: certProc }) }) as never);
         expect(res.status).toBe(200);
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: certProc } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: certProc } });
         expect(proc?.status).toBe('ACTIVE');
         expect(proc?.certifiedById).toBe(leadId);
 
         // The audit row records WHO certified — the acting board member, not SYSTEM_ACTOR.
-        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'MembershipProcess', affectedEntityId: certProc }, orderBy: { id: 'desc' } });
+        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: certProc }, orderBy: { id: 'desc' } });
         expect(audit?.actorId).toBe(leadId);
         expect(normalizeAuditData(audit?.newData)).toMatchObject({ status: 'ACTIVE' });
     });
@@ -171,17 +171,17 @@ describe('Membership payment API', () => {
     it('certify on a non-PENDING_PAYMENT process is rejected (409 wrong_phase, no state change)', async () => {
         asBoard(leadId);
         const bg = await makeProc('Bg', false);
-        await prisma.membershipProcess.update({ where: { id: bg.processId }, data: { status: 'PENDING_BG_REVIEW' } });
+        await prisma.orgMembershipProcess.update({ where: { id: bg.processId }, data: { status: 'PENDING_BG_REVIEW' } });
 
         const res = await CERTIFY(new Request('http://localhost:4000/x', { method: 'POST', body: JSON.stringify({ processId: bg.processId }) }) as never);
         expect(res.status).toBe(409);
         expect((await res.json()).code).toBe('wrong_phase');
 
         // No state change: status untouched and no activation audit row written.
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: bg.processId } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: bg.processId } });
         expect(proc?.status).toBe('PENDING_BG_REVIEW');
         expect(proc?.paidAt).toBeNull();
-        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'MembershipProcess', affectedEntityId: bg.processId } });
+        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: bg.processId } });
         expect(audit).toBeNull();
     });
 
@@ -203,9 +203,9 @@ describe('Membership payment API', () => {
         const hh = await prisma.household.create({ data: { name: `Concurrent ${TAG}` } });
         const lead = await prisma.person.create({ data: { email: `concurrent-${TAG}@example.com`, name: 'C Lead', householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer: false } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer: false } });
         // bgClearedAt set so paying activates (and the one congrats email fires).
-        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() } });
+        const p = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() } });
 
         (sendEmail as jest.Mock).mockClear();
 
@@ -215,18 +215,18 @@ describe('Membership payment API', () => {
             activate(p.id, { via: 'payment', shopifyOrderId: 'race-2' }),
         ]);
 
-        const auditRows = await prisma.auditLog.count({ where: { tableName: 'MembershipProcess', affectedEntityId: p.id } });
+        const auditRows = await prisma.auditLog.count({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: p.id } });
         expect(auditRows).toBe(1);
         expect(sendEmail as jest.Mock).toHaveBeenCalledTimes(1);
 
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: p.id } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: p.id } });
         expect(proc?.status).toBe('ACTIVE');
     });
 
     it('activate() is a no-op once already ACTIVE', async () => {
-        const before = await prisma.membershipProcess.findUnique({ where: { id: normalProc } });
+        const before = await prisma.orgMembershipProcess.findUnique({ where: { id: normalProc } });
         await activate(normalProc, { via: 'payment', shopifyOrderId: 'ignored' });
-        const after = await prisma.membershipProcess.findUnique({ where: { id: normalProc } });
+        const after = await prisma.orgMembershipProcess.findUnique({ where: { id: normalProc } });
         expect(after?.shopifyOrderId).toBe(before?.shopifyOrderId); // unchanged
     });
 });

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -35,17 +35,17 @@ describe('Membership renewal', () => {
         // The guardian is a household lead (drives the 3-yr BG-freshness check).
         const parent = await prisma.person.create({ data: { name: `${label} Parent`, householdId: hh.id, lastBackgroundCheck: parentBg ?? undefined } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
-        return { householdId: hh.id, membershipId: m.id };
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
+        return { householdId: hh.id, orgMembershipId: m.id };
     }
 
     async function wipe() {
         const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
-            await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: ids } } } } });
-            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { orgMembership: { householdId: { in: ids } } } } });
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
@@ -59,17 +59,17 @@ describe('Membership renewal', () => {
     async function setBoundary(date: Date | null) {
         await prisma.boardSettings.upsert({
             where: { id: 1 },
-            create: { id: 1, normalDuesCents: 0, volunteerDuesCents: 0, membershipYearBoundary: date, bgRecheckMonths: BG_RECHECK_MONTHS },
-            update: { membershipYearBoundary: date, bgRecheckMonths: BG_RECHECK_MONTHS },
+            create: { id: 1, normalDuesCents: 0, volunteerDuesCents: 0, orgMembershipYearBoundary: date, bgRecheckMonths: BG_RECHECK_MONTHS },
+            update: { orgMembershipYearBoundary: date, bgRecheckMonths: BG_RECHECK_MONTHS },
         });
     }
 
     beforeAll(async () => {
         process.env.CRON_SECRET = CRON_SECRET;
-        const maxRow = await prisma.membershipProcess.findFirst({ orderBy: { id: 'desc' }, select: { id: true } });
+        const maxRow = await prisma.orgMembershipProcess.findFirst({ orderBy: { id: 'desc' }, select: { id: true } });
         preMaxProcessId = maxRow?.id ?? 0;
         const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-        prevBoundary = existing?.membershipYearBoundary ?? null;
+        prevBoundary = existing?.orgMembershipYearBoundary ?? null;
         await wipe();
         const r1 = await prisma.person.create({ data: { email: `rev1-${TAG}@example.com`, name: 'Rev1', isBackgroundCheckReviewer: true, household: { create: { name: `Rev1 HH ${TAG}` } } } });
         rev1 = r1.id;
@@ -79,7 +79,7 @@ describe('Membership renewal', () => {
     afterAll(async () => {
         // Remove every process (and its attestations) this test's global sweeps opened.
         await prisma.backgroundCheckAttestation.deleteMany({ where: { processId: { gt: preMaxProcessId } } });
-        await prisma.membershipProcess.deleteMany({ where: { id: { gt: preMaxProcessId } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { id: { gt: preMaxProcessId } } });
         await wipe();
         await setBoundary(prevBoundary);
         if (prevSecret === undefined) delete process.env.CRON_SECRET;
@@ -109,12 +109,12 @@ describe('Membership renewal', () => {
 
         const first = await runRenewalSweep(now);
         expect(first.opened).toBeGreaterThanOrEqual(1);
-        const proc = await prisma.membershipProcess.findFirst({ where: { membershipId: m.membershipId } });
+        const proc = await prisma.orgMembershipProcess.findFirst({ where: { orgMembershipId: m.orgMembershipId } });
         expect(proc?.status).toBe('PENDING_RENEWAL');
         expect(proc?.kind).toBe('RENEWAL');
 
         const second = await runRenewalSweep(now);
-        const count = await prisma.membershipProcess.count({ where: { membershipId: m.membershipId } });
+        const count = await prisma.orgMembershipProcess.count({ where: { orgMembershipId: m.orgMembershipId } });
         expect(count).toBe(1); // not duplicated
         expect(second).toBeDefined();
     });
@@ -122,7 +122,7 @@ describe('Membership renewal', () => {
     it('beginRenewal goes straight to payment when a parent BG is fresh', async () => {
         await setBoundary(new Date(Date.UTC(2000, 7, 1)));
         const m = await makeActiveMembership('Fresh', new Date()); // recent BG
-        const proc = await prisma.membershipProcess.create({ data: { membershipId: m.membershipId, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
+        const proc = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.orgMembershipId, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
         const out = await beginRenewal(proc.id);
         expect(out.status).toBe('PENDING_PAYMENT');
     });
@@ -130,7 +130,7 @@ describe('Membership renewal', () => {
     it('beginRenewal requires re-review when BG is stale', async () => {
         await setBoundary(new Date(Date.UTC(2000, 7, 1)));
         const m = await makeActiveMembership('Stale', null); // no BG on record
-        const proc = await prisma.membershipProcess.create({ data: { membershipId: m.membershipId, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
+        const proc = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.orgMembershipId, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
         const out = await beginRenewal(proc.id);
         expect(out.status).toBe('RENEWAL_PENDING_BG');
 

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -34,9 +34,9 @@ describe('Membership BG review API', () => {
         // A parent/guardian is a household lead.
         const parent = await prisma.person.create({ data: { name: `${label} Parent`, householdId: hh.id, ...(parentEmail ? { email: parentEmail } : {}) } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
-        return { householdId: hh.id, membershipId: m.id, processId: p.id };
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        const p = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
+        return { householdId: hh.id, orgMembershipId: m.id, processId: p.id };
     }
 
     // Build a process in an arbitrary kind/status (for non-BLOCKED + renewal-branch tests).
@@ -44,18 +44,18 @@ describe('Membership BG review API', () => {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
         const parent = await prisma.person.create({ data: { name: `${label} Parent`, householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-        const p = await prisma.membershipProcess.create({ data: { membershipId: m.id, kind, status } });
-        return { householdId: hh.id, membershipId: m.id, processId: p.id };
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        const p = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind, status } });
+        return { householdId: hh.id, orgMembershipId: m.id, processId: p.id };
     }
 
     async function wipe() {
         const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
-            await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: ids } } } } });
-            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { orgMembership: { householdId: { in: ids } } } } });
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
@@ -98,7 +98,7 @@ describe('Membership BG review API', () => {
 
     it('blocks a reviewer in the applicant household', async () => {
         as(revInApplicant, { isBackgroundCheckReviewer: true });
-        const proc = await prisma.membershipProcess.findFirst({ where: { membership: { householdId: applicantHh } } });
+        const proc = await prisma.orgMembershipProcess.findFirst({ where: { orgMembership: { householdId: applicantHh } } });
         const res = await ATTEST(req({ processId: proc!.id, result: 'APPROVE' }) as never);
         const data = await res.json();
         expect(res.status).toBe(403);
@@ -125,15 +125,15 @@ describe('Membership BG review API', () => {
         const r2 = await ATTEST(req({ processId: proc.processId, result: 'APPROVE', isMarkedVolunteer: true }) as never);
         expect((await r2.json()).outcome.status).toBe('PENDING_PAYMENT');
 
-        const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
+        const updated = await prisma.orgMembershipProcess.findUnique({ where: { id: proc.processId } });
         expect(updated?.status).toBe('PENDING_PAYMENT');
-        const membership = await prisma.membership.findUnique({ where: { id: proc.membershipId } });
+        const membership = await prisma.orgMembership.findUnique({ where: { id: proc.orgMembershipId } });
         expect(membership?.isVolunteer).toBe(true);
         const parent = await prisma.person.findFirst({ where: { householdId: proc.householdId, householdLeads: { some: { householdId: proc.householdId } } } });
         expect(parent?.lastBackgroundCheck).not.toBeNull();
 
         // The advance audit records the reviewer whose attestation triggered it (rev2), not rev1/SYSTEM.
-        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
         const advance = audits.find((a) => JSON.stringify(normalizeAuditData(a.newData)).includes('"status":"PENDING_PAYMENT"'));
         expect(advance?.actorId).toBe(rev2);
     });
@@ -147,7 +147,7 @@ describe('Membership BG review API', () => {
         await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
         as(rev2, { isBackgroundCheckReviewer: true });
         await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
-        const membership = await prisma.membership.findUnique({ where: { id: proc.membershipId } });
+        const membership = await prisma.orgMembership.findUnique({ where: { id: proc.orgMembershipId } });
         expect(membership?.isVolunteer).toBe(true);
     });
 
@@ -156,11 +156,11 @@ describe('Membership BG review API', () => {
         as(rev1, { isBackgroundCheckReviewer: true });
         const res = await ATTEST(req({ processId: proc.processId, result: 'REJECT' }) as never);
         expect((await res.json()).outcome.status).toBe('BLOCKED');
-        const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
+        const updated = await prisma.orgMembershipProcess.findUnique({ where: { id: proc.processId } });
         expect(updated?.status).toBe('BLOCKED');
 
         // The BLOCKED audit records the rejecting reviewer.
-        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
+        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
         expect(audit?.actorId).toBe(rev1);
         expect(normalizeAuditData(audit?.newData)).toMatchObject({ status: 'BLOCKED' });
     });
@@ -173,13 +173,13 @@ describe('Membership BG review API', () => {
         as(board, { isBoardMember: true });
         const res = await OVERRIDE(req({ processId: proc.processId, action: 'reset' }) as never);
         expect(res.status).toBe(200);
-        const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
+        const updated = await prisma.orgMembershipProcess.findUnique({ where: { id: proc.processId } });
         expect(updated?.status).toBe('PENDING_PAYMENT');
         const count = await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } });
         expect(count).toBe(0);
 
         // The reset audit records the acting board member and the action.
-        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
+        const audit = await prisma.auditLog.findFirst({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
         expect(audit?.actorId).toBe(board);
         expect(normalizeAuditData(audit?.newData)).toMatchObject({ action: 'board reset' });
     });
@@ -192,11 +192,11 @@ describe('Membership BG review API', () => {
         as(board, { isBoardMember: true });
         const res = await OVERRIDE(req({ processId: proc.processId, action: 'approve' }) as never);
         expect(res.status).toBe(200);
-        const updated = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
+        const updated = await prisma.orgMembershipProcess.findUnique({ where: { id: proc.processId } });
         expect(updated?.status).toBe('PENDING_PAYMENT');
 
         // The advance audit records the acting board member.
-        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: proc.processId }, orderBy: { id: 'desc' } });
         const advance = audits.find((a) => JSON.stringify(normalizeAuditData(a.newData)).includes('"status":"PENDING_PAYMENT"'));
         expect(advance?.actorId).toBe(board);
     });
@@ -209,7 +209,7 @@ describe('Membership BG review API', () => {
             const res = await OVERRIDE(req({ processId: proc.processId, action }) as never);
             expect(res.status).toBe(409);
             expect((await res.json()).code).toBe('wrong_phase');
-            const after = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
+            const after = await prisma.orgMembershipProcess.findUnique({ where: { id: proc.processId } });
             expect(after?.status).toBe('PENDING_PAYMENT');
         }
     });
@@ -226,7 +226,7 @@ describe('Membership BG review API', () => {
         const res = await OVERRIDE(req({ processId: proc.processId, action: 'reset' }) as never);
         expect(res.status).toBe(200);
         // Renewal branch: must restore the RENEWAL review phase, not the INITIAL one.
-        const after = await prisma.membershipProcess.findUnique({ where: { id: proc.processId } });
+        const after = await prisma.orgMembershipProcess.findUnique({ where: { id: proc.processId } });
         expect(after?.status).toBe('RENEWAL_PENDING_BG');
         expect(await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } })).toBe(0);
     });
@@ -242,7 +242,7 @@ describe('Membership BG review API', () => {
         as(rev1, { isBackgroundCheckReviewer: true });
         await ATTEST(req({ processId: proc.processId, result: 'REJECT' }) as never); // → BLOCKED (1 attestation, 1 audit)
         const attBefore = await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } });
-        const auditBefore = await prisma.auditLog.count({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId } });
+        const auditBefore = await prisma.auditLog.count({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: proc.processId } });
 
         // A fresh eligible reviewer (different household) tries to attest the now-decided app.
         as(rev2, { isBackgroundCheckReviewer: true });
@@ -252,7 +252,7 @@ describe('Membership BG review API', () => {
 
         // The phase guard precedes the attestation create, so nothing was written.
         expect(await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } })).toBe(attBefore);
-        expect(await prisma.auditLog.count({ where: { tableName: 'MembershipProcess', affectedEntityId: proc.processId } })).toBe(auditBefore);
+        expect(await prisma.auditLog.count({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: proc.processId } })).toBe(auditBefore);
     });
 
     it('attest on a non-existent process returns 404 not_found', async () => {
@@ -287,8 +287,8 @@ describe('Membership BG review API', () => {
         const parent = await prisma.person.create({ data: { name: 'Excl Parent', email: `exclparent-${TAG}@example.com`, householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: parent.id } });
         await prisma.person.create({ data: { name: 'Excl Child', email: `exclchild-${TAG}@example.com`, householdId: hh.id } });
-        const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-        await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
 
         as(rev2, { isBackgroundCheckReviewer: true }); // different household → eligible
         const data = await (await REVIEW_QUEUE(req({}) as never)).json();

--- a/checkin-app/src/app/__tests__/membershipReviewConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewConcurrency.integration.test.ts
@@ -3,7 +3,7 @@
  */
 /**
  * Concurrency test for attest(): two reviewers attesting the same
- * MembershipProcess at the same time must serialize on the FOR UPDATE lock so
+ * OrgMembershipProcess at the same time must serialize on the FOR UPDATE lock so
  * the process advances to payment exactly once (no double advance / double
  * background-date stamp). Regression guard for the TOCTOU race fixed in
  * lib/membership/review.ts.
@@ -33,9 +33,9 @@ async function makeReviewer(label: string): Promise<number> {
 /** A fresh applicant household + membership + a process awaiting BG review. */
 async function makePendingProcess(): Promise<number> {
     const hh = await prisma.household.create({ data: { name: `Applicant ${TAG}` } });
-    const m = await prisma.membership.create({ data: { householdId: hh.id, status: 'NONE' } });
-    const proc = await prisma.membershipProcess.create({
-        data: { membershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' },
+    const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+    const proc = await prisma.orgMembershipProcess.create({
+        data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' },
     });
     return proc.id;
 }
@@ -47,9 +47,9 @@ async function wipe() {
     });
     const ids = hhs.map((h) => h.id);
     if (ids.length) {
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { householdId: { in: ids } } } } });
-        await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-        await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { orgMembership: { householdId: { in: ids } } } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
@@ -96,7 +96,7 @@ describe('attest() concurrency', () => {
         // The winner is whichever attest returned PENDING_PAYMENT — its id is what the advance audit must carry.
         const winner = b.status === 'fulfilled' && (b.value as { status: string }).status === 'PENDING_PAYMENT' ? revB : revC;
 
-        const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe('PENDING_PAYMENT');
 
         // The loser created no attestation (it threw before the create): 2 total, not 3.
@@ -104,7 +104,7 @@ describe('attest() concurrency', () => {
         expect(attestations).toBe(2);
 
         // advanceToPayment ran exactly once → exactly one PENDING_PAYMENT audit row, stamped with the winner's id.
-        const audits = await prisma.auditLog.findMany({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, select: { newData: true, actorId: true } });
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: processId }, select: { newData: true, actorId: true } });
         const advances = audits.filter((a) => JSON.stringify(normalizeAuditData(a.newData)).includes('"status":"PENDING_PAYMENT"'));
         expect(advances).toHaveLength(1);
         expect(advances[0].actorId).toBe(winner); // not revA (prior approver) nor the loser
@@ -115,7 +115,7 @@ describe('attest() concurrency', () => {
         // revB rejects; revA never touches this process.
         await attest(revB, processId, { result: 'REJECT' });
 
-        const blocked = await prisma.auditLog.findFirst({ where: { tableName: 'MembershipProcess', affectedEntityId: processId }, orderBy: { id: 'desc' } });
+        const blocked = await prisma.auditLog.findFirst({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: processId }, orderBy: { id: 'desc' } });
         expect(JSON.stringify(normalizeAuditData(blocked?.newData))).toContain('"status":"BLOCKED"');
         expect(blocked?.actorId).toBe(revB);
         expect(blocked?.actorId).not.toBe(revA);

--- a/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
@@ -33,7 +33,7 @@ describe('Membership settings + volunteer designations API', () => {
         const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
-            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
@@ -51,7 +51,7 @@ describe('Membership settings + volunteer designations API', () => {
 
         // A full-price active member, for the designation warning.
         await prisma.person.create({
-            data: { email: `fullmember-${TAG}@example.com`, name: 'Full', household: { create: { name: `Full HH ${TAG}`, membership: { create: { status: 'ACTIVE', isVolunteer: false } } } } },
+            data: { email: `fullmember-${TAG}@example.com`, name: 'Full', household: { create: { name: `Full HH ${TAG}`, orgMembership: { create: { status: 'ACTIVE', isVolunteer: false } } } } },
         });
     });
 

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -29,7 +29,7 @@ describe('Nav todo-counts API', () => {
     let boardId: number;
     let householdAId: number;
     let householdBId: number;
-    let membershipId: number;
+    let orgMembershipId: number;
     let program1Id: number;
     let program2Id: number;
     let ledProgramId: number;
@@ -61,15 +61,15 @@ describe('Nav todo-counts API', () => {
 
         // Membership with one member-actionable process (PENDING_PAYMENT) and one
         // reviewer-owned process (PENDING_BG_REVIEW).
-        const membership = await prisma.membership.create({
+        const membership = await prisma.orgMembership.create({
             data: { householdId: householdAId, status: 'ACTIVE' },
         });
-        membershipId = membership.id;
-        await prisma.membershipProcess.create({ data: { membershipId, kind: 'INITIAL', status: 'PENDING_PAYMENT' } });
+        orgMembershipId = membership.id;
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId, kind: 'INITIAL', status: 'PENDING_PAYMENT' } });
         // Reviewer-owned state, kind RENEWAL (not INITIAL) so it doesn't collide with
         // the membership_one_inflight_initial partial unique index above — a
         // membership can hold only one in-flight INITIAL process at a time.
-        await prisma.membershipProcess.create({ data: { membershipId, kind: 'RENEWAL', status: 'RENEWAL_PENDING_BG' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId, kind: 'RENEWAL', status: 'RENEWAL_PENDING_BG' } });
 
         // Trusted adults for the lead: one awaiting subject action, one approved and
         // expiring within the warn window.
@@ -147,8 +147,8 @@ describe('Nav todo-counts API', () => {
         await prisma.programParticipant.deleteMany({ where: { programId: { in: [program1Id, program2Id] } } });
         await prisma.event.deleteMany({ where: { id: { in: [pendingEventId, confirmedEventId, futureEventId] } } });
         await prisma.program.deleteMany({ where: { id: { in: [program1Id, program2Id, ledProgramId] } } });
-        await prisma.membershipProcess.deleteMany({ where: { membershipId } });
-        await prisma.membership.deleteMany({ where: { id: membershipId } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembershipId } });
+        await prisma.orgMembership.deleteMany({ where: { id: orgMembershipId } });
         await prisma.householdLead.deleteMany({ where: { householdId: householdAId } });
         await prisma.person.deleteMany({ where: { id: { in: [leadId, secondMemberId, boardId] } } });
         await prisma.household.deleteMany({ where: { id: { in: [householdAId, householdBId] } } });
@@ -248,22 +248,22 @@ describe('Nav todo-counts API', () => {
         // Reviewer (RBAC) work — surfaced by the reviewer notifications badge, not the
         // board badge. Adding these must NOT move the board count. Anchored to a fresh
         // membership (householdB's, previously membership-less) rather than the shared
-        // `membershipId` — that one already holds an in-flight INITIAL and an in-flight
+        // `orgMembershipId` — that one already holds an in-flight INITIAL and an in-flight
         // RENEWAL process from beforeAll, and membership_one_inflight_initial /
         // membership_one_inflight_renewal each allow only one per membership.
-        const reviewerMembership = await prisma.membership.create({ data: { householdId: householdBId, status: 'ACTIVE' } });
+        const reviewerMembership = await prisma.orgMembership.create({ data: { householdId: householdBId, status: 'ACTIVE' } });
         const reviewerProcs = await prisma.$transaction([
-            prisma.membershipProcess.create({ data: { membershipId: reviewerMembership.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } }),
-            prisma.membershipProcess.create({ data: { membershipId: reviewerMembership.id, kind: 'RENEWAL', status: 'RENEWAL_PENDING_BG' } }),
+            prisma.orgMembershipProcess.create({ data: { orgMembershipId: reviewerMembership.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } }),
+            prisma.orgMembershipProcess.create({ data: { orgMembershipId: reviewerMembership.id, kind: 'RENEWAL', status: 'RENEWAL_PENDING_BG' } }),
         ]);
         expect(await boardMembershipCount()).toBe(before);
 
         // BLOCKED is the board's one actionable state (override/reset) → +1.
-        const blocked = await prisma.membershipProcess.create({ data: { membershipId, kind: 'INITIAL', status: 'BLOCKED' } });
+        const blocked = await prisma.orgMembershipProcess.create({ data: { orgMembershipId, kind: 'INITIAL', status: 'BLOCKED' } });
         expect(await boardMembershipCount()).toBe(before + 1);
 
-        await prisma.membershipProcess.deleteMany({ where: { id: { in: [...reviewerProcs.map((p) => p.id), blocked.id] } } });
-        await prisma.membership.delete({ where: { id: reviewerMembership.id } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { id: { in: [...reviewerProcs.map((p) => p.id), blocked.id] } } });
+        await prisma.orgMembership.delete({ where: { id: reviewerMembership.id } });
     });
 
     it('counts member families but excludes org-email-only (staff) households', async () => {

--- a/checkin-app/src/app/__tests__/notificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsAPI.integration.test.ts
@@ -26,8 +26,8 @@ describe('Membership notifications API', () => {
         const hhs = await prisma.household.findMany({ where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] }, select: { id: true } });
         const ids = hhs.map((h) => h.id);
         if (ids.length) {
-            await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-            await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
             await prisma.household.deleteMany({ where: { id: { in: ids } } });
         }
@@ -42,13 +42,13 @@ describe('Membership notifications API', () => {
 
         // An application awaiting review (eligible for the reviewer — different household).
         const appHh = await prisma.household.create({ data: { name: `App HH ${TAG}` } });
-        const m1 = await prisma.membership.create({ data: { householdId: appHh.id, status: 'NONE' } });
-        await prisma.membershipProcess.create({ data: { membershipId: m1.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
+        const m1 = await prisma.orgMembership.create({ data: { householdId: appHh.id, status: 'NONE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m1.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' } });
 
         // A blocked application (for the board).
         const blkHh = await prisma.household.create({ data: { name: `Blk HH ${TAG}` } });
-        const m2 = await prisma.membership.create({ data: { householdId: blkHh.id, status: 'NONE' } });
-        await prisma.membershipProcess.create({ data: { membershipId: m2.id, kind: 'INITIAL', status: 'BLOCKED' } });
+        const m2 = await prisma.orgMembership.create({ data: { householdId: blkHh.id, status: 'NONE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m2.id, kind: 'INITIAL', status: 'BLOCKED' } });
     });
 
     afterAll(async () => {

--- a/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
@@ -21,9 +21,9 @@ describe("sendCheckinNotifications()", () => {
         await prisma.person.deleteMany({
             where: { email: { contains: "notify-test" } }
         });
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { householdMembers: { none: {} } } } } } });
-        await prisma.membershipProcess.deleteMany({ where: { membership: { household: { householdMembers: { none: {} } } } } });
-        await prisma.membership.deleteMany({ where: { household: { householdMembers: { none: {} } } } });
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { orgMembership: { household: { householdMembers: { none: {} } } } } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { household: { householdMembers: { none: {} } } } } });
+        await prisma.orgMembership.deleteMany({ where: { household: { householdMembers: { none: {} } } } });
         await prisma.household.deleteMany({
             where: { householdMembers: { none: {} } }
         });
@@ -72,9 +72,9 @@ describe("sendCheckinNotifications()", () => {
         await prisma.person.deleteMany({
             where: { email: { contains: "notify-test" } }
         });
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { membership: { household: { householdMembers: { none: {} } } } } } });
-        await prisma.membershipProcess.deleteMany({ where: { membership: { household: { householdMembers: { none: {} } } } } });
-        await prisma.membership.deleteMany({ where: { household: { householdMembers: { none: {} } } } });
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { process: { orgMembership: { household: { householdMembers: { none: {} } } } } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { household: { householdMembers: { none: {} } } } } });
+        await prisma.orgMembership.deleteMany({ where: { household: { householdMembers: { none: {} } } } });
         await prisma.household.deleteMany({
             where: { householdMembers: { none: {} } }
         });

--- a/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
@@ -48,7 +48,7 @@ describe('Eligible Participants API Integration Tests', () => {
         });
 
         // Memberships live on the household now; scope cleanup to this test's households.
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
              where: { householdId: { in: existingHouseholdIds } }
         });
 
@@ -89,7 +89,7 @@ describe('Eligible Participants API Integration Tests', () => {
                 name: 'Active Member Candidate',
                 household: {
                     create: {
-                        membership: {
+                        orgMembership: {
                             create: {
                                 status: 'ACTIVE',
                                 memberSince: new Date()
@@ -105,7 +105,7 @@ describe('Eligible Participants API Integration Tests', () => {
         const household = await prisma.household.create({
             data: {
                 name: 'Elig API Test Household',
-                membership: {
+                orgMembership: {
                     create: {
                         status: 'ACTIVE',
                         memberSince: new Date()
@@ -186,7 +186,7 @@ describe('Eligible Participants API Integration Tests', () => {
             ));
 
             if (testHouseholdIds.length > 0) {
-                await prisma.membership.deleteMany({
+                await prisma.orgMembership.deleteMany({
                      where: { householdId: { in: testHouseholdIds } }
                 });
             }

--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -36,7 +36,7 @@ describe('Individual Program API Integration Tests', () => {
         const existingUserIds = existingUsers.map(u => u.id);
         const existingHouseholdIds = existingUsers.map(u => u.householdId);
 
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: existingHouseholdIds } }
         });
 
@@ -77,7 +77,7 @@ describe('Individual Program API Integration Tests', () => {
                 name: 'Member',
                 household: {
                     create: {
-                        membership: {
+                        orgMembership: {
                             create: {
                                 status: 'ACTIVE',
                                 memberSince: new Date()
@@ -117,7 +117,7 @@ describe('Individual Program API Integration Tests', () => {
         const existingUserIds = [adminId, leadId, commonId, memberId, enrolledId];
 
         if (memberHouseholdId) {
-            await prisma.membership.deleteMany({
+            await prisma.orgMembership.deleteMany({
                 where: { householdId: memberHouseholdId }
             });
         }

--- a/checkin-app/src/app/__tests__/renewalConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/renewalConcurrency.integration.test.ts
@@ -27,8 +27,8 @@ async function wipe() {
     const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
     const ids = hhs.map((h) => h.id);
     if (ids.length) {
-        await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: ids } } } });
-        await prisma.membership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: ids } } });
@@ -36,7 +36,7 @@ async function wipe() {
 }
 
 describe('renewal opening concurrency', () => {
-    let membershipId = 0;
+    let orgMembershipId = 0;
     let householdId = 0;
 
     beforeAll(async () => {
@@ -45,7 +45,7 @@ describe('renewal opening concurrency', () => {
         householdId = hh.id;
         const lead = await prisma.person.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
-        membershipId = (await prisma.membership.create({ data: { householdId: hh.id, status: 'ACTIVE' } })).id;
+        orgMembershipId = (await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'ACTIVE' } })).id;
     });
 
     afterAll(wipe);
@@ -54,16 +54,16 @@ describe('renewal opening concurrency', () => {
         const now = new Date();
         const boundary = new Date();
         const results = await Promise.all([
-            createRenewalProcess(membershipId, householdId, now, { remind: true, boundary }),
-            createRenewalProcess(membershipId, householdId, now, { remind: true, boundary }),
+            createRenewalProcess(orgMembershipId, householdId, now, { remind: true, boundary }),
+            createRenewalProcess(orgMembershipId, householdId, now, { remind: true, boundary }),
         ]);
 
         // Exactly one create won; the other lost the race and no-op'd (null).
         expect(results.filter(Boolean)).toHaveLength(1);
         expect(results.filter((r) => r === null)).toHaveLength(1);
 
-        const inflight = await prisma.membershipProcess.findMany({
-            where: { membershipId, kind: 'RENEWAL', status: { in: ['PENDING_RENEWAL', 'RENEWAL_PENDING_BG', 'PENDING_PAYMENT'] } },
+        const inflight = await prisma.orgMembershipProcess.findMany({
+            where: { orgMembershipId, kind: 'RENEWAL', status: { in: ['PENDING_RENEWAL', 'RENEWAL_PENDING_BG', 'PENDING_PAYMENT'] } },
             select: { id: true },
         });
         expect(inflight).toHaveLength(1); // the loser's P2002 no-op'd, not a second process
@@ -73,7 +73,7 @@ describe('renewal opening concurrency', () => {
 
         // Exactly one CREATE audit row for the winning process — no orphan from the loser.
         const created = await prisma.auditLog.count({
-            where: { tableName: 'MembershipProcess', action: 'CREATE', affectedEntityId: inflight[0].id },
+            where: { tableName: 'OrgMembershipProcess', action: 'CREATE', affectedEntityId: inflight[0].id },
         });
         expect(created).toBe(1);
     });

--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -47,7 +47,7 @@ describe('Shop API Integration Tests', () => {
             where: { id: { in: existingUserIds } }
         });
         // Memberships belong to the household; remove them before deleting households.
-        await prisma.membership.deleteMany({
+        await prisma.orgMembership.deleteMany({
             where: { householdId: { in: existingHouseholdIds } }
         });
         await prisma.household.deleteMany({
@@ -79,7 +79,7 @@ describe('Shop API Integration Tests', () => {
                 email: 'common-shop-api-test@example.com',
                 name: 'Common',
                 // Volunteer member: the household holds an ACTIVE, isVolunteer membership.
-                household: { create: { membership: { create: { status: 'ACTIVE', isVolunteer: true } } } }
+                household: { create: { orgMembership: { create: { status: 'ACTIVE', isVolunteer: true } } } }
             }
         });
         commonId = commonUser.id;
@@ -128,7 +128,7 @@ describe('Shop API Integration Tests', () => {
             });
             if (householdIds.length > 0) {
                 // Memberships belong to the household; remove them before deleting households.
-                await prisma.membership.deleteMany({
+                await prisma.orgMembership.deleteMany({
                     where: { householdId: { in: householdIds } }
                 });
                 await prisma.household.deleteMany({

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -74,11 +74,11 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         // configured membership variant id(s) — seed one so the routing test
         // below can prove a matching order activates.
         const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-        prevMembershipVariantId = existing?.membershipVariantId ?? null;
+        prevMembershipVariantId = existing?.orgMembershipVariantId ?? null;
         await prisma.boardSettings.upsert({
             where: { id: 1 },
-            create: { id: 1, membershipVariantId: MEMBERSHIP_VARIANT_ID },
-            update: { membershipVariantId: MEMBERSHIP_VARIANT_ID },
+            create: { id: 1, orgMembershipVariantId: MEMBERSHIP_VARIANT_ID },
+            update: { orgMembershipVariantId: MEMBERSHIP_VARIANT_ID },
         });
     });
 
@@ -88,7 +88,7 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
     });
 
     afterAll(async () => {
-        await prisma.boardSettings.update({ where: { id: 1 }, data: { membershipVariantId: prevMembershipVariantId } });
+        await prisma.boardSettings.update({ where: { id: 1 }, data: { orgMembershipVariantId: prevMembershipVariantId } });
         await prisma.integrationErrorLog.deleteMany({ where: { source: 'shopify-webhook' } });
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.program.delete({ where: { id: programId } });

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
@@ -36,7 +36,7 @@ export const POST = withAuth({}, async (req, auth) => {
     // the membership product (#624/H2). The mock must echo a configured variant id
     // or the webhook lands as a no-membership-item anomaly, not an activation.
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const variantId = settings?.membershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId;
+    const variantId = settings?.orgMembershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId;
     if (!variantId) {
         return apiError("No membership variant configured. Set one in Settings → Membership first (design §2, O4a).", 409);
     }
@@ -64,6 +64,6 @@ export const POST = withAuth({}, async (req, auth) => {
 
     // Report the resulting status so the tool can show whether it activated, held
     // for background clearance, etc. (the webhook itself always 200s to Shopify).
-    const proc = await prisma.membershipProcess.findUnique({ where: { id: processId }, select: { status: true } });
+    const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId }, select: { status: true } });
     return NextResponse.json({ ok: true, status: proc?.status ?? null });
 });

--- a/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
+++ b/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
@@ -82,7 +82,7 @@ describe("Participant PII minimization (M1, M2)", () => {
                     id: 10,
                     name: "Test Household",
                     leads: [{ householdId: 10, participantId: 1 }],
-                    membership: { id: 1, status: "ACTIVE", memberSince: new Date(), isVolunteer: false, householdId: 10 },
+                    orgMembership: { id: 1, status: "ACTIVE", memberSince: new Date(), isVolunteer: false, householdId: 10 },
                     householdMembers: [projected],
                 },
             });

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -23,7 +23,7 @@ export const GET = withAuth(
                         include: {
                             householdMembers: { select: HOUSEHOLD_PEER_SELECT },
                             leads: true,
-                            membership: true,
+                            orgMembership: true,
                         }
                     }
                 }

--- a/checkin-app/src/app/api/membership-ops/applications/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/route.ts
@@ -13,7 +13,7 @@ export const dynamic = "force-dynamic";
  * envelope preserves the response shape consumers expect.
  */
 export const GET = handler("GET /api/membership-ops/applications", async () => {
-    const processes = await prisma.membershipProcess.findMany({
+    const processes = await prisma.orgMembershipProcess.findMany({
         where: { status: { not: "ACTIVE" } },
         orderBy: { createdAt: "desc" },
         select: {
@@ -27,7 +27,7 @@ export const GET = handler("GET /api/membership-ops/applications", async () => {
             bgClearedAt: true,
             paidAt: true,
             attestations: { select: { id: true, result: true, isMarkedVolunteer: true } },
-            membership: {
+            orgMembership: {
                 select: {
                     householdId: true,
                     isVolunteer: true,
@@ -43,5 +43,5 @@ export const GET = handler("GET /api/membership-ops/applications", async () => {
         },
     });
 
-    return { MembershipProcess: processes };
+    return { OrgMembershipProcess: processes };
 });

--- a/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
@@ -44,18 +44,18 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
         // "Member since" lives on the household's Membership (1:1). Treat the date
         // as date-only: parse at UTC midnight and only act on a real change, so an
         // unchanged field re-sent by the form never writes a spurious audit row.
-        let memberSinceChange: { membershipId: number; oldValue: Date; newValue: Date } | null = null;
+        let memberSinceChange: { orgMembershipId: number; oldValue: Date; newValue: Date } | null = null;
         if (typeof body.memberSince === "string" && body.memberSince !== "") {
             const parsed = new Date(`${body.memberSince}T00:00:00.000Z`);
             if (isNaN(parsed.getTime())) {
                 return apiError("Invalid member-since date", 400);
             }
-            const membership = await prisma.membership.findUnique({ where: { householdId: id } });
+            const membership = await prisma.orgMembership.findUnique({ where: { householdId: id } });
             if (!membership) {
                 return apiError("Household has no membership record", 400);
             }
             if (membership.memberSince.toISOString().slice(0, 10) !== body.memberSince) {
-                memberSinceChange = { membershipId: membership.id, oldValue: membership.memberSince, newValue: parsed };
+                memberSinceChange = { orgMembershipId: membership.id, oldValue: membership.memberSince, newValue: parsed };
             }
         }
 
@@ -97,16 +97,16 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
         // Separate audit row for the membership edit — a legible before/after of the
         // join date on its own record, rather than folded into the Household row.
         if (memberSinceChange) {
-            await prisma.membership.update({
-                where: { id: memberSinceChange.membershipId },
+            await prisma.orgMembership.update({
+                where: { id: memberSinceChange.orgMembershipId },
                 data: { memberSince: memberSinceChange.newValue },
             });
             await prisma.auditLog.create({
                 data: {
                     actorId: auth.user.id,
                     action: "EDIT",
-                    tableName: "Membership",
-                    affectedEntityId: memberSinceChange.membershipId,
+                    tableName: "OrgMembership",
+                    affectedEntityId: memberSinceChange.orgMembershipId,
                     secondaryAffectedEntity: id,
                     oldData: { memberSince: memberSinceChange.oldValue },
                     newData: { memberSince: memberSinceChange.newValue },

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -34,7 +34,7 @@ export const GET = withAuth(
                             select: { id: true, name: true, email: true }
                         },
                         leads: { select: { personId: true } },
-                        membership: true,
+                        orgMembership: true,
                         emergencyContacts: {
                             where: PRIMARY_CONTACT_WHERE,
                             orderBy: [{ priority: "asc" }, { id: "asc" }],
@@ -62,7 +62,7 @@ export const GET = withAuth(
                     householdMembers: {
                         select: { id: true, name: true, email: true, isBoardMember: true }
                     },
-                    membership: true,
+                    orgMembership: true,
                     emergencyContacts: {
                         where: PRIMARY_CONTACT_WHERE,
                         orderBy: [{ priority: "asc" }, { id: "asc" }],
@@ -95,7 +95,7 @@ export const POST = withAuth(
                 return apiError("Household ID is required", 400);
             }
 
-            const existingMembership = await prisma.membership.findUnique({
+            const existingMembership = await prisma.orgMembership.findUnique({
                 where: { householdId }
             });
 
@@ -116,7 +116,7 @@ export const POST = withAuth(
                 }
 
                 const newStatus = deny ? "DENIED" : "NONE";
-                const membership = await prisma.membership.upsert({
+                const membership = await prisma.orgMembership.upsert({
                     where: { householdId },
                     create: { householdId, status: newStatus },
                     update: { status: newStatus }
@@ -127,7 +127,7 @@ export const POST = withAuth(
                         data: {
                             actorId: auth.user.id,
                             action: "EDIT",
-                            tableName: "Membership",
+                            tableName: "OrgMembership",
                             affectedEntityId: membership.id,
                             secondaryAffectedEntity: householdId,
                             oldData: { status: existingMembership?.status ?? "NONE" },
@@ -140,7 +140,7 @@ export const POST = withAuth(
             }
 
             if (active) {
-                const membership = await prisma.membership.upsert({
+                const membership = await prisma.orgMembership.upsert({
                     where: { householdId },
                     create: { householdId, status: "ACTIVE" },
                     update: { status: "ACTIVE" }
@@ -150,7 +150,7 @@ export const POST = withAuth(
                         data: {
                             actorId: auth.user.id,
                             action: "EDIT",
-                            tableName: "Membership",
+                            tableName: "OrgMembership",
                             affectedEntityId: membership.id,
                             secondaryAffectedEntity: householdId,
                             oldData: { status: existingMembership?.status ?? "NONE" },
@@ -160,7 +160,7 @@ export const POST = withAuth(
                 }
                 return NextResponse.json({ success: true, membership });
             } else if (existingMembership && existingMembership.status === "ACTIVE") {
-                const membership = await prisma.membership.update({
+                const membership = await prisma.orgMembership.update({
                     where: { householdId },
                     data: { status: "REVOKED" }
                 });
@@ -169,7 +169,7 @@ export const POST = withAuth(
                         data: {
                             actorId: auth.user.id,
                             action: "EDIT",
-                            tableName: "Membership",
+                            tableName: "OrgMembership",
                             affectedEntityId: membership.id,
                             secondaryAffectedEntity: householdId,
                             oldData: { status: "ACTIVE" },

--- a/checkin-app/src/app/api/membership-ops/participants/import/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/route.ts
@@ -105,7 +105,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
             householdId: number,
             db: DbClient = prisma,
         ) => {
-            await db.membership.upsert({
+            await db.orgMembership.upsert({
                 where: { householdId },
                 create: { householdId, status: 'ACTIVE' },
                 update: { status: 'ACTIVE' },
@@ -369,7 +369,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                             }
 
                             // Delete memberships and leads from the old source household
-                            await tx.membership.deleteMany({ where: { householdId: sourceHouseholdId } });
+                            await tx.orgMembership.deleteMany({ where: { householdId: sourceHouseholdId } });
                             await tx.householdLead.deleteMany({ where: { householdId: sourceHouseholdId } });
 
                             // Finally delete the source household (empty now, so the

--- a/checkin-app/src/app/api/membership-ops/participants/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/route.ts
@@ -60,7 +60,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                 });
                 await addHouseholdLead(prisma, parent.householdId, parent.id);
                 if (alreadyMember) {
-                    await prisma.membership.create({
+                    await prisma.orgMembership.create({
                         data: {
                             householdId: parent.householdId,
                             status: 'ACTIVE',
@@ -100,7 +100,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
             await addHouseholdLead(prisma, newParticipant.householdId, newParticipant.id);
 
             if (alreadyMember) {
-                await prisma.membership.create({
+                await prisma.orgMembership.create({
                     data: {
                         householdId: newParticipant.householdId,
                         status: 'ACTIVE',

--- a/checkin-app/src/app/api/membership/renewal-status/route.ts
+++ b/checkin-app/src/app/api/membership/renewal-status/route.ts
@@ -23,15 +23,15 @@ export const GET = withAuth({}, async (_req, auth) => {
     const isLead = user.householdLeads.some((l) => l.householdId === user.householdId);
     if (!isLead) return NextResponse.json({ renewalDue: false });
 
-    const open = await prisma.membershipProcess.findFirst({
-        where: { kind: "RENEWAL", status: "PENDING_RENEWAL", membership: { householdId: user.householdId } },
+    const open = await prisma.orgMembershipProcess.findFirst({
+        where: { kind: "RENEWAL", status: "PENDING_RENEWAL", orgMembership: { householdId: user.householdId } },
         select: { id: true },
     });
     if (!open) return NextResponse.json({ renewalDue: false });
 
-    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 }, select: { membershipYearBoundary: true } });
-    const dueDate = settings?.membershipYearBoundary
-        ? nextBoundary(settings.membershipYearBoundary, new Date()).toISOString().slice(0, 10)
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 }, select: { orgMembershipYearBoundary: true } });
+    const dueDate = settings?.orgMembershipYearBoundary
+        ? nextBoundary(settings.orgMembershipYearBoundary, new Date()).toISOString().slice(0, 10)
         : null;
 
     return NextResponse.json({ renewalDue: true, dueDate });

--- a/checkin-app/src/app/api/membership/reviews/route.ts
+++ b/checkin-app/src/app/api/membership/reviews/route.ts
@@ -32,12 +32,12 @@ const STATUS_FOR: Record<ReviewError["code"], number> = {
 export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
     if (auth.type !== "session") throw unauthorized();
     const ids = await eligibleReviewProcessIds(auth.user.id);
-    const queue = await prisma.membershipProcess.findMany({
+    const queue = await prisma.orgMembershipProcess.findMany({
         where: { id: { in: ids } },
         orderBy: { stageEnteredAt: "asc" },
         select: {
             id: true,
-            membership: {
+            orgMembership: {
                 select: {
                     household: {
                         select: {
@@ -50,7 +50,7 @@ export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
             _count: { select: { attestations: true } },
         },
     });
-    return { MembershipProcess: queue };
+    return { OrgMembershipProcess: queue };
 });
 
 // POST /api/membership/reviews — submit an attestation { processId, result, isMarkedVolunteer }.

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
-import type { MembershipProcessStatus, TrustedAdultReviewStatus } from "@/generated/prisma/client";
+import type { OrgMembershipProcessStatus, TrustedAdultReviewStatus } from "@/generated/prisma/client";
 import { countHouseholdsMissingValidContact } from "@/lib/emergencyContacts/service";
 import { ORG_DOMAIN } from "@/lib/config";
 import { apiError } from "@/lib/api-response";
@@ -22,7 +22,7 @@ import { apiError } from "@/lib/api-response";
 // Membership process statuses the household itself must act on. Mirrors
 // IN_FLIGHT_INITIAL_STATUSES minus the reviewer/board states, plus the
 // member-driven PENDING_RENEWAL.
-const MEMBER_ACTIONABLE_MEMBERSHIP: MembershipProcessStatus[] = ["INTAKE", "PENDING_EXTERNAL_ACTION", "PENDING_PAYMENT", "PENDING_RENEWAL"];
+const MEMBER_ACTIONABLE_MEMBERSHIP: OrgMembershipProcessStatus[] = ["INTAKE", "PENDING_EXTERNAL_ACTION", "PENDING_PAYMENT", "PENDING_RENEWAL"];
 
 // Membership statuses the board itself can act on. The board's only
 // membership-queue action is overriding/resetting a BLOCKED application
@@ -31,7 +31,7 @@ const MEMBER_ACTIONABLE_MEMBERSHIP: MembershipProcessStatus[] = ["INTAKE", "PEND
 // role isBackgroundCheckReviewer) work, surfaced by the reviewer notifications
 // badge (src/lib/membership/notifications.ts) — NOT the board. The board can
 // still SEE those in the applications list, but they don't count here.
-const BOARD_ACTIONABLE_MEMBERSHIP: MembershipProcessStatus[] = ["BLOCKED"];
+const BOARD_ACTIONABLE_MEMBERSHIP: OrgMembershipProcessStatus[] = ["BLOCKED"];
 
 const APPROVED_STATUSES: TrustedAdultReviewStatus[] = ["APPROVED"];
 
@@ -150,8 +150,8 @@ export const GET = withAuth({}, async (_req, auth) => {
                       select: { id: true, name: true },
                   })
                 : Promise.resolve([]),
-            prisma.membershipProcess.findMany({
-                where: { membership: { householdId }, status: { in: MEMBER_ACTIONABLE_MEMBERSHIP } },
+            prisma.orgMembershipProcess.findMany({
+                where: { orgMembership: { householdId }, status: { in: MEMBER_ACTIONABLE_MEMBERSHIP } },
                 select: { id: true, status: true },
             }),
             prisma.trustedAdultReview.count({
@@ -322,11 +322,11 @@ export const GET = withAuth({}, async (_req, auth) => {
     // ---- Admin surface (board's own queue) — only for board/isSysadmin ----
     if (user.isSysadmin || user.isBoardMember) {
         const [membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies] = await Promise.all([
-            prisma.membershipProcess.count({
+            prisma.orgMembershipProcess.count({
                 where: { status: { in: BOARD_ACTIONABLE_MEMBERSHIP } },
             }),
             // Every in-flight application the Applications page lists (status != ACTIVE).
-            prisma.membershipProcess.count({
+            prisma.orgMembershipProcess.count({
                 where: { status: { not: "ACTIVE" } },
             }),
             prisma.programParticipant.count({

--- a/checkin-app/src/app/api/people/search/route.ts
+++ b/checkin-app/src/app/api/people/search/route.ts
@@ -30,7 +30,7 @@ export const GET = withAuth(
                     household: {
                         include: {
                             householdMembers: true,
-                            membership: true,
+                            orgMembership: true,
                         }
                     }
                 }

--- a/checkin-app/src/app/api/settings/membership/route.ts
+++ b/checkin-app/src/app/api/settings/membership/route.ts
@@ -15,8 +15,8 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
 
 /**
  * PUT /api/settings/membership — update board settings.
- * Body may include: normalDuesCents, volunteerDuesCents, membershipYearBoundary (ISO|null),
- * membershipVariantId (string|null), volunteerDiscountCode (string|null).
+ * Body may include: normalDuesCents, volunteerDuesCents, orgMembershipYearBoundary (ISO|null),
+ * orgMembershipVariantId (string|null), volunteerDiscountCode (string|null).
  * Dues must be finite and >= 0; an invalid value rejects the whole update (400) so the
  * previous value survives rather than silently collapsing to zero. (The Averity consent
  * link is an env var, not a board setting.)
@@ -26,8 +26,8 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
     let body: {
         normalDuesCents?: number;
         volunteerDuesCents?: number;
-        membershipYearBoundary?: string | null;
-        membershipVariantId?: string | null;
+        orgMembershipYearBoundary?: string | null;
+        orgMembershipVariantId?: string | null;
         volunteerDiscountCode?: string | null;
         bgRecheckMonths?: number;
     };
@@ -47,13 +47,13 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
         if (invalidDues(body.volunteerDuesCents)) return apiError("volunteerDuesCents must be a number >= 0", 400);
         data.volunteerDuesCents = Math.round(body.volunteerDuesCents);
     }
-    if (body.membershipYearBoundary !== undefined) {
-        data.membershipYearBoundary = body.membershipYearBoundary ? new Date(body.membershipYearBoundary) : null;
+    if (body.orgMembershipYearBoundary !== undefined) {
+        data.orgMembershipYearBoundary = body.orgMembershipYearBoundary ? new Date(body.orgMembershipYearBoundary) : null;
     }
-    if (body.membershipVariantId !== undefined) {
-        const variantId = body.membershipVariantId?.trim();
-        if (variantId && !/^\d+$/.test(variantId)) return apiError("membershipVariantId must be a numeric Shopify variant ID", 400);
-        data.membershipVariantId = variantId || null;
+    if (body.orgMembershipVariantId !== undefined) {
+        const variantId = body.orgMembershipVariantId?.trim();
+        if (variantId && !/^\d+$/.test(variantId)) return apiError("orgMembershipVariantId must be a numeric Shopify variant ID", 400);
+        data.orgMembershipVariantId = variantId || null;
     }
     if (body.volunteerDiscountCode !== undefined) {
         data.volunteerDiscountCode = body.volunteerDiscountCode?.trim() || null;
@@ -72,7 +72,7 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
             action: "EDIT",
             tableName: "BoardSettings",
             affectedEntityId: 1,
-            // data holds a Date (membershipYearBoundary); clone to a JSON-safe object.
+            // data holds a Date (orgMembershipYearBoundary); clone to a JSON-safe object.
             newData: JSON.parse(JSON.stringify(data)),
         },
     });

--- a/checkin-app/src/app/api/settings/membership/volunteer-designations/route.ts
+++ b/checkin-app/src/app/api/settings/membership/volunteer-designations/route.ts
@@ -37,9 +37,9 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
     let warning: string | undefined;
     const participant = await prisma.person.findFirst({
         where: { email: { equals: email, mode: "insensitive" } },
-        select: { household: { select: { membership: { select: { status: true, isVolunteer: true } } } } },
+        select: { household: { select: { orgMembership: { select: { status: true, isVolunteer: true } } } } },
     });
-    const m = participant?.household?.membership;
+    const m = participant?.household?.orgMembership;
     if (m?.status === "ACTIVE" && !m.isVolunteer) {
         warning = "Heads up: this email already has an active full-price membership. The system can't change that — this designation only applies to their next membership cycle.";
     }

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -94,7 +94,7 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
             if (!isNaN(processId)) {
                 const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
                 const membershipVariantIds = new Set(
-                    [settings?.membershipVariantId, settings?.shopifyNormalVariantId, settings?.shopifyVolunteerVariantId].filter(
+                    [settings?.orgMembershipVariantId, settings?.shopifyNormalVariantId, settings?.shopifyVolunteerVariantId].filter(
                         (v): v is string => !!v,
                     ),
                 );

--- a/checkin-app/src/app/dev/shopify/page.tsx
+++ b/checkin-app/src/app/dev/shopify/page.tsx
@@ -14,22 +14,22 @@ export const dynamic = "force-dynamic";
 export default async function DevShopifyPage() {
     if (!config.shopifyMockActive()) notFound();
 
-    const processes = await prisma.membershipProcess.findMany({
+    const processes = await prisma.orgMembershipProcess.findMany({
         where: { status: "PENDING_PAYMENT" },
         orderBy: { id: "desc" },
-        select: { id: true, membership: { select: { household: { select: { name: true } }, isVolunteer: true } } },
+        select: { id: true, orgMembership: { select: { household: { select: { name: true } }, isVolunteer: true } } },
     });
 
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const hasVariant = !!(settings?.membershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId);
+    const hasVariant = !!(settings?.orgMembershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId);
 
     return (
         <DevShopifyClient
             hasVariant={hasVariant}
             processes={processes.map((p) => ({
                 id: p.id,
-                household: p.membership.household?.name ?? "(unnamed household)",
-                isVolunteer: p.membership.isVolunteer,
+                household: p.orgMembership.household?.name ?? "(unnamed household)",
+                isVolunteer: p.orgMembership.isVolunteer,
             }))}
         />
     );

--- a/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
@@ -23,7 +23,7 @@ const rows = [
         bgClearedAt: null,
         paidAt: null,
         attestations: [],
-        membership: { householdId: 1, isVolunteer: false, household: household("Awaiting Family", 1) },
+        orgMembership: { householdId: 1, isVolunteer: false, household: household("Awaiting Family", 1) },
     },
     {
         id: 2,
@@ -36,7 +36,7 @@ const rows = [
         bgClearedAt: null,
         paidAt: null,
         attestations: [{ id: 1, result: "APPROVE", isMarkedVolunteer: false }],
-        membership: { householdId: 2, isVolunteer: true, household: household("Payment Family", 2) },
+        orgMembership: { householdId: 2, isVolunteer: true, household: household("Payment Family", 2) },
     },
     {
         id: 3,
@@ -49,7 +49,7 @@ const rows = [
         bgClearedAt: null,
         paidAt: "2026-01-03T00:00:00.000Z",
         attestations: [],
-        membership: { householdId: 3, isVolunteer: false, household: household("Blocked Family", 3) },
+        orgMembership: { householdId: 3, isVolunteer: false, household: household("Blocked Family", 3) },
     },
 ];
 

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -26,7 +26,7 @@ interface ProcessRow {
   bgClearedAt: string | null;
   paidAt: string | null;
   attestations: Attestation[];
-  membership: {
+  orgMembership: {
     householdId: number;
     isVolunteer: boolean;
     household: { name: string | null; householdMembers: Person[]; leads: { personId: number }[] } | null;
@@ -159,11 +159,11 @@ export default function AdminMembershipPage() {
   };
 
   const householdLabel = (r: ProcessRow) => {
-    const hh = r.membership?.household;
-    if (!hh) return `Household #${r.membership?.householdId ?? "?"}`;
+    const hh = r.orgMembership?.household;
+    if (!hh) return `Household #${r.orgMembership?.householdId ?? "?"}`;
     const leadIds = new Set((hh.leads || []).map((l) => l.personId));
     const parents = (hh.householdMembers || []).filter((p) => leadIds.has(p.id)).map((p) => p.name || p.email).filter(Boolean);
-    return hh.name || parents.join(" & ") || `Household #${r.membership?.householdId}`;
+    return hh.name || parents.join(" & ") || `Household #${r.orgMembership?.householdId}`;
   };
 
   const statusCounts = rows.reduce<Record<string, number>>((acc, r) => { acc[r.status] = (acc[r.status] || 0) + 1; return acc; }, {});
@@ -211,7 +211,7 @@ export default function AdminMembershipPage() {
                   <Text fw={700} fz="lg">{householdLabel(r)}</Text>
                   <Text size="xs" c="dimmed">
                     {r.kind} · application #{r.id}
-                    {r.membership?.isVolunteer && <Text component="span" c="green"> · volunteer</Text>}
+                    {r.orgMembership?.isVolunteer && <Text component="span" c="green"> · volunteer</Text>}
                   </Text>
                 </div>
                 <Badge color={statusColor(r.status)}>{statusLabel(r.status)}</Badge>

--- a/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
@@ -14,13 +14,13 @@ const households = {
     {
       id: 1,
       name: "The Smiths",
-      membership: { status: "ACTIVE" },
+      orgMembership: { status: "ACTIVE" },
       householdMembers: [{ id: 10, name: "Pat Smith", email: "pat@example.com", isBoardMember: false }],
     },
     {
       id: 2,
       name: "The Joneses",
-      membership: null,
+      orgMembership: null,
       householdMembers: [{ id: 20, name: "Jo Jones", email: "jo@example.com", isBoardMember: false }],
     },
   ],

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -13,7 +13,7 @@ import { PageLoader } from "@/components/ui/PageLoader";
 type Household = {
   id: number;
   name?: string | null;
-  membership?: { status: string } | null;
+  orgMembership?: { status: string } | null;
   householdMembers?: { id: number; name?: string | null; email?: string | null; isBoardMember?: boolean }[] | null;
 };
 
@@ -153,7 +153,7 @@ export default function AdminHouseholdsPage() {
           </Table.Thead>
           <Table.Tbody>
             {filtered.map((household) => {
-              const status = household.membership?.status;
+              const status = household.orgMembership?.status;
               const hasActiveMembership = status === "ACTIVE";
               const isDenied = status === "DENIED";
               const hasBoardMember = household.householdMembers?.some((p) => p.isBoardMember) ?? false;

--- a/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
@@ -13,7 +13,7 @@ const queue = {
   queue: [
     {
       id: 100,
-      membership: { household: { name: "The Smiths", leads: [{ participant: { id: 1, name: "Pat Smith", email: "pat@example.com" } }] } },
+      orgMembership: { household: { name: "The Smiths", leads: [{ participant: { id: 1, name: "Pat Smith", email: "pat@example.com" } }] } },
       _count: { attestations: 1 },
     },
   ],

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -17,7 +17,7 @@ interface Person {
 // Only the household leads (parents) are returned — children are never sent.
 interface QueueItem {
   id: number;
-  membership: { household: { name: string | null; leads: { participant: Person }[] } | null } | null;
+  orgMembership: { household: { name: string | null; leads: { participant: Person }[] } | null } | null;
   _count: { attestations: number };
 }
 
@@ -115,11 +115,11 @@ export default function MembershipReviewPage() {
       ) : (
         <Stack mt="md">
           {queue.map((item) => {
-            const parents = (item.membership?.household?.leads ?? []).map((l) => l.participant);
+            const parents = (item.orgMembership?.household?.leads ?? []).map((l) => l.participant);
             return (
             <Card key={item.id} withBorder radius="md" padding="lg">
               <Text fw={700} fz="lg">
-                {item.membership?.household?.name || `Household (application #${item.id})`}
+                {item.orgMembership?.household?.name || `Household (application #${item.id})`}
               </Text>
               <Text size="sm" c="dimmed" mt={4}>
                 {parents.length > 0

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import type { MembershipProcessStatus, MembershipStatus } from "@/generated/prisma/client";
+import type { OrgMembershipProcessStatus, OrgMembershipStatus } from "@/generated/prisma/client";
 import {
   Alert, Anchor, Box, Button, Card, Checkbox, Container, Group,
   SimpleGrid, Stack, Text, TextInput, ThemeIcon, Title,
@@ -39,8 +39,8 @@ interface ExternalStatus {
 
 interface IntakeState {
   hasHousehold: boolean;
-  membershipStatus: MembershipStatus | null;
-  process: { id: number; kind: string; status: MembershipProcessStatus } | null;
+  membershipStatus: OrgMembershipStatus | null;
+  process: { id: number; kind: string; status: OrgMembershipProcessStatus } | null;
   external: ExternalStatus | null;
   prefill: {
     household: ({ name: string | null; emergencyContactName: string | null; emergencyContactPhone: string | null; emergencyContactEmail: string | null } & Partial<StructuredAddress>) | null;

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -45,7 +45,7 @@ const householdData = {
     { id: 10, name: "Sam Smith", email: "sam@example.com", phone: "5125551234", dateOfBirth: "1980-01-01" },
     { id: 11, name: "Jamie Smith", email: "", dateOfBirth: "2012-05-01" },
   ],
-  membership: { status: "ACTIVE", memberSince: "2024-01-01T00:00:00.000Z", isVolunteer: false },
+  orgMembership: { status: "ACTIVE", memberSince: "2024-01-01T00:00:00.000Z", isVolunteer: false },
   line1: "123 Main St", line2: "", city: "Austin", state: "TX", postalCode: "78701",
 };
 
@@ -134,7 +134,7 @@ describe("HouseholdPage", () => {
 
   it("prompts a lead to join when the household isn't a member yet", async () => {
     setSession({ id: 10, email: "sam@example.com" });
-    mockRoutes({ "/api/household": { household: { ...householdData, membership: null } } });
+    mockRoutes({ "/api/household": { household: { ...householdData, orgMembership: null } } });
     renderWithProviders(<HouseholdPage />);
     await screen.findByRole("heading", { name: "Smith Household", level: 1 });
 
@@ -145,7 +145,7 @@ describe("HouseholdPage", () => {
 
   it("shows a volunteer-only badge when memberSince is absent", async () => {
     setSession({ id: 10, email: "sam@example.com" });
-    mockRoutes({ "/api/household": { household: { ...householdData, membership: { status: "ACTIVE", isVolunteer: true } } } });
+    mockRoutes({ "/api/household": { household: { ...householdData, orgMembership: { status: "ACTIVE", isVolunteer: true } } } });
     renderWithProviders(<HouseholdPage />);
     await screen.findByRole("heading", { name: "Smith Household", level: 1 });
 

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -51,7 +51,7 @@ type HouseholdData = {
   name?: string;
   leads?: Array<{ personId: number }>;
   householdMembers?: HouseholdMember[];
-  membership?: { status?: string; memberSince?: string; isVolunteer?: boolean } | null;
+  orgMembership?: { status?: string; memberSince?: string; isVolunteer?: boolean } | null;
 } & Partial<StructuredAddress> | null;
 
 const blankContactForm = { id: null as number | null, name: "", phone: "", email: "", relationship: "" };
@@ -350,11 +350,11 @@ export default function HouseholdPage() {
           <Title order={1} mb="md">{household?.name || 'My Household'}</Title>
 
           {household && (
-            household.membership?.status === 'ACTIVE' ? (
+            household.orgMembership?.status === 'ACTIVE' ? (
               <Alert color="green" mb="lg">
                 <Group gap="xs" wrap="wrap">
-                  <Text fw={600}>✓ Member{household.membership.memberSince ? ` since ${formatDate(household.membership.memberSince)}` : ''}</Text>
-                  {household.membership.isVolunteer && <Badge color="green" variant="light">Volunteer-only family</Badge>}
+                  <Text fw={600}>✓ Member{household.orgMembership.memberSince ? ` since ${formatDate(household.orgMembership.memberSince)}` : ''}</Text>
+                  {household.orgMembership.isVolunteer && <Badge color="green" variant="light">Volunteer-only family</Badge>}
                 </Group>
               </Alert>
             ) : (

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -287,7 +287,7 @@ describe("ProgramEnrollmentPage", () => {
 
     it("redirects to Shopify checkout for a priced enrollment with a configured member variant", async () => {
         setSession({ id: 101 });
-        const memberHousehold = { household: { ...household.household, membership: { status: "ACTIVE" } } };
+        const memberHousehold = { household: { ...household.household, orgMembership: { status: "ACTIVE" } } };
         mockFetchJson({
             "/api/household": memberHousehold,
             "/api/programs/10": baseProgram({ orgMemberPriceCents: 5000, minAge: null, maxAge: null, shopifyOrgMemberVariantId: "gid://member", shopifyNonOrgMemberVariantId: "gid://nonmember" }),

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -194,7 +194,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
           let isMember = false;
           if (householdRes.ok) {
             const householdData = await householdRes.json();
-            isMember = householdData.household?.membership?.status === "ACTIVE" || false;
+            isMember = householdData.household?.orgMembership?.status === "ACTIVE" || false;
           }
 
           const variantId = isMember ? program.shopifyOrgMemberVariantId : program.shopifyNonOrgMemberVariantId;

--- a/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
@@ -10,8 +10,8 @@ import MembershipSettingsPage from "../page";
 const SETTINGS = {
   normalDuesCents: 15000,
   volunteerDuesCents: 5000,
-  membershipYearBoundary: "2025-09-01T00:00:00.000Z",
-  membershipVariantId: "123456",
+  orgMembershipYearBoundary: "2025-09-01T00:00:00.000Z",
+  orgMembershipVariantId: "123456",
   volunteerDiscountCode: "VOLUNTEER",
   bgRecheckMonths: 24,
 };
@@ -88,7 +88,7 @@ describe("MembershipSettingsPage", () => {
       expect(fetchMock).toHaveBeenCalledWith("/api/settings/membership", expect.objectContaining({ method: "PUT" })),
     );
     const [, putOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PUT")!;
-    expect(JSON.parse(putOpts!.body as string)).toEqual(expect.objectContaining({ membershipYearBoundary: "2026-10-15" }));
+    expect(JSON.parse(putOpts!.body as string)).toEqual(expect.objectContaining({ orgMembershipYearBoundary: "2026-10-15" }));
     // A successful save re-locks the boundary field and reloads from the (unchanged)
     // mock settings; wait for that full reload so no state update leaks past the test.
     await waitFor(() => expect(screen.getByDisplayValue("2025-09-01")).toBeDisabled());
@@ -96,7 +96,7 @@ describe("MembershipSettingsPage", () => {
 
   it("shows 'not set' and rolls the boundary label to next year when the stored date has already passed", async () => {
     setSession({ id: 1, isSysadmin: true });
-    mockFetchJson({ "/api/settings/membership": { settings: { ...SETTINGS, membershipYearBoundary: null } } });
+    mockFetchJson({ "/api/settings/membership": { settings: { ...SETTINGS, orgMembershipYearBoundary: null } } });
     renderWithProviders(<MembershipSettingsPage />);
     await screen.findByDisplayValue("150.00");
     expect(screen.getByText("not set")).toBeInTheDocument();
@@ -106,7 +106,7 @@ describe("MembershipSettingsPage", () => {
     jest.useFakeTimers().setSystemTime(new Date("2026-06-30T12:00:00.000Z"));
     setSession({ id: 1, isSysadmin: true });
     // "today" is pinned to 2026-06-30; Jan 15 has already passed this year.
-    mockFetchJson({ "/api/settings/membership": { settings: { ...SETTINGS, membershipYearBoundary: "2025-01-15T00:00:00.000Z" } } });
+    mockFetchJson({ "/api/settings/membership": { settings: { ...SETTINGS, orgMembershipYearBoundary: "2025-01-15T00:00:00.000Z" } } });
     renderWithProviders(<MembershipSettingsPage />);
     await screen.findByDisplayValue("150.00");
     expect(screen.getByText("January 15, 2027")).toBeInTheDocument();

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -10,8 +10,8 @@ import { useUnsavedGuard, shallowEqual } from "@/components/UnsavedChangesProvid
 interface Settings {
   normalDuesCents: number;
   volunteerDuesCents: number;
-  membershipYearBoundary: string | null;
-  membershipVariantId: string | null;
+  orgMembershipYearBoundary: string | null;
+  orgMembershipVariantId: string | null;
   volunteerDiscountCode: string | null;
   bgRecheckMonths: number;
 }
@@ -64,8 +64,8 @@ export default function MembershipSettingsPage() {
           normalDues: dollars(settings.normalDuesCents),
           volunteerDues: dollars(settings.volunteerDuesCents),
           bgRecheckMonths: String(settings.bgRecheckMonths ?? 0),
-          boundary: settings.membershipYearBoundary ? settings.membershipYearBoundary.slice(0, 10) : "",
-          variantId: settings.membershipVariantId ?? "",
+          boundary: settings.orgMembershipYearBoundary ? settings.orgMembershipYearBoundary.slice(0, 10) : "",
+          variantId: settings.orgMembershipVariantId ?? "",
           discountCode: settings.volunteerDiscountCode ?? "",
         };
         setNormalDues(snap.normalDues);
@@ -93,10 +93,10 @@ export default function MembershipSettingsPage() {
         body: JSON.stringify({
           normalDuesCents: Math.round(parseFloat(normalDues || "0") * 100),
           volunteerDuesCents: Math.round(parseFloat(volunteerDues || "0") * 100),
-          membershipVariantId: variantId.trim() || null,
+          orgMembershipVariantId: variantId.trim() || null,
           volunteerDiscountCode: discountCode.trim() || null,
           bgRecheckMonths: Math.round(parseInt(bgRecheckMonths || "0", 10)),
-          ...(boundaryUnlocked ? { membershipYearBoundary: boundary || null } : {}),
+          ...(boundaryUnlocked ? { orgMembershipYearBoundary: boundary || null } : {}),
         }),
       });
       if (res.ok) { flash("Settings saved."); setBoundaryUnlocked(false); await load(); }

--- a/checkin-app/src/components/MembershipFlowStepper.tsx
+++ b/checkin-app/src/components/MembershipFlowStepper.tsx
@@ -1,6 +1,6 @@
 import { Alert, Card, Stepper, Text } from "@mantine/core";
 import { INITIAL_PHASES, stepperActiveIndex } from "@/lib/membership/phases";
-import type { MembershipProcessStatus } from "@/generated/prisma/client";
+import type { OrgMembershipProcessStatus } from "@/generated/prisma/client";
 
 /**
  * Left-rail flow diagram for the membership application. Shows the INITIAL
@@ -10,7 +10,7 @@ import type { MembershipProcessStatus } from "@/generated/prisma/client";
 export default function MembershipFlowStepper({
   currentStatus,
 }: {
-  currentStatus: MembershipProcessStatus | null;
+  currentStatus: OrgMembershipProcessStatus | null;
 }) {
   const blocked = currentStatus === "BLOCKED";
   // Position in the 4-step payment track. PENDING_BG_CLEARANCE (paid, awaiting

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -12,7 +12,7 @@ export type AdminHousehold = {
   emergencyContactPhone: string | null;
   householdMembers?: Array<{ id: number; name: string | null; email: string | null }>;
   householdLeads?: Array<{ personId: number }>;
-  membership?: { memberSince: string | null } | null;
+  orgMembership?: { memberSince: string | null } | null;
 } & Partial<StructuredAddress>;
 
 type FormState = {
@@ -78,7 +78,7 @@ export function AdminEditHouseholdModal({
           emergencyContactName: h.emergencyContactName || "",
           emergencyContactPhone: h.emergencyContactPhone || "",
           // date-only slice of the membership's join date (ISO → YYYY-MM-DD)
-          memberSince: h.membership?.memberSince ? h.membership.memberSince.slice(0, 10) : "",
+          memberSince: h.orgMembership?.memberSince ? h.orgMembership.memberSince.slice(0, 10) : "",
         };
         setForm(loaded);
         setInitial(loaded);

--- a/checkin-app/src/lib/__tests__/auth-options-jwt.test.ts
+++ b/checkin-app/src/lib/__tests__/auth-options-jwt.test.ts
@@ -84,7 +84,7 @@ function dbParticipant(overrides: Record<string, unknown> = {}) {
         isBackgroundCheckReviewer: true,
         householdId: 99,
         toolStatuses: [{ toolId: 1, level: 'CERTIFIED' }],
-        household: { membership: { status: 'ACTIVE' } },
+        household: { orgMembership: { status: 'ACTIVE' } },
         ...overrides,
     };
 }
@@ -113,7 +113,7 @@ describe('jwt() callback — revocation enforcement on refresh', () => {
 
     it('DENIED membership ⇒ denied=true and every role flag forced false', async () => {
         mockFindUnique.mockResolvedValue(
-            dbParticipant({ household: { membership: { status: 'DENIED' } } }),
+            dbParticipant({ household: { orgMembership: { status: 'DENIED' } } }),
         );
 
         const result = (await callRefresh({

--- a/checkin-app/src/lib/__tests__/authClaims.test.ts
+++ b/checkin-app/src/lib/__tests__/authClaims.test.ts
@@ -10,7 +10,7 @@ function participant(overrides: Partial<ClaimSourceParticipant> = {}): ClaimSour
         isBackgroundCheckReviewer: true,
         householdId: 99,
         toolStatuses: [{ toolId: 1, level: 'CERTIFIED' }],
-        household: { membership: { status: 'ACTIVE' } },
+        household: { orgMembership: { status: 'ACTIVE' } },
         ...overrides,
     };
 }
@@ -18,7 +18,7 @@ function participant(overrides: Partial<ClaimSourceParticipant> = {}): ClaimSour
 describe('assignParticipantClaims — household login gate', () => {
     it('forces denied=true and strips every authority flag for a DENIED household', () => {
         const token = {} as JWT;
-        assignParticipantClaims(token, participant({ household: { membership: { status: 'DENIED' } } }));
+        assignParticipantClaims(token, participant({ household: { orgMembership: { status: 'DENIED' } } }));
 
         expect(token.denied).toBe(true);
         expect(token.isSysadmin).toBe(false);
@@ -45,7 +45,7 @@ describe('assignParticipantClaims — household login gate', () => {
         'does not deny for non-DENIED status: %s',
         (status) => {
             const token = {} as JWT;
-            const household = status === undefined ? null : { membership: { status } };
+            const household = status === undefined ? null : { orgMembership: { status } };
             assignParticipantClaims(token, participant({ household }));
 
             expect(token.denied).toBe(false);
@@ -71,7 +71,7 @@ describe('assignParticipantClaims — householdLead claim', () => {
         const token = {} as JWT;
         assignParticipantClaims(token, participant({
             householdLeads: [{ personId: 7 }],
-            household: { membership: { status: 'DENIED' } },
+            household: { orgMembership: { status: 'DENIED' } },
         }));
         expect(token.householdLead).toBe(false);
     });

--- a/checkin-app/src/lib/__tests__/zohoImport.test.ts
+++ b/checkin-app/src/lib/__tests__/zohoImport.test.ts
@@ -365,7 +365,7 @@ describe("applyImport", () => {
                 }),
             },
             householdLead: { upsert: jest.fn(async () => ({})) },
-            membership: {
+            orgMembership: {
                 findUnique: jest.fn(async ({ where }: { where: { householdId: number } }) => membershipsByHousehold.get(where.householdId) ?? null),
                 upsert: jest.fn(async ({ where, create }: { where: { householdId: number }; create: { status: string } }) => {
                     const existing = membershipsByHousehold.get(where.householdId);

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -251,7 +251,7 @@ export const authOptions: NextAuthOptions = {
                         householdLeads: { take: 1, select: { personId: true } },
                         // Program ids led — drives the client program-ops row gate.
                         programsLed: { select: { id: true } },
-                        household: { include: { membership: true } }
+                        household: { include: { orgMembership: true } }
                     }
                 }));
 
@@ -292,7 +292,7 @@ export const authOptions: NextAuthOptions = {
                         householdLeads: { take: 1, select: { personId: true } },
                         // Program ids led — drives the client program-ops row gate.
                         programsLed: { select: { id: true } },
-                        household: { include: { membership: true } }
+                        household: { include: { orgMembership: true } }
                     }
                 }));
 

--- a/checkin-app/src/lib/authClaims.ts
+++ b/checkin-app/src/lib/authClaims.ts
@@ -1,5 +1,5 @@
 import type { JWT } from "next-auth/jwt";
-import type { MembershipStatus } from "@/generated/prisma/client";
+import type { OrgMembershipStatus } from "@/generated/prisma/client";
 import { orgMembershipStatusBlocksLogin } from "@/lib/orgMembership";
 
 /** The participant fields the JWT carries, plus the household membership the login gate reads. */
@@ -17,7 +17,7 @@ export type ClaimSourceParticipant = {
     // Programs this participant is the lead mentor of (Program.leadMentorId === id).
     // Drives the client-side program-ops row gate; mirrors access-resolvers' programsLed.
     programsLed?: { id: number }[];
-    household?: { membership?: { status: MembershipStatus } | null } | null;
+    household?: { orgMembership?: { status: OrgMembershipStatus } | null } | null;
 };
 
 /**
@@ -29,7 +29,7 @@ export type ClaimSourceParticipant = {
  * authority flag is forced false and tool statuses are cleared, so nothing downstream honors it.
  */
 export function assignParticipantClaims(token: JWT, p: ClaimSourceParticipant): void {
-    const denied = orgMembershipStatusBlocksLogin(p.household?.membership?.status);
+    const denied = orgMembershipStatusBlocksLogin(p.household?.orgMembership?.status);
 
     token.id = p.id;
     token.denied = denied;

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -236,7 +236,7 @@ export async function createFamily(prisma: Db): Promise<string> {
     const household = await prisma.household.create({
         data: { name: `Test Family ${tag}`, line1: `${tag} Maker Way` },
     });
-    await prisma.membership.create({
+    await prisma.orgMembership.create({
         data: { householdId: household.id, status: "ACTIVE" },
     });
     const lead = await prisma.person.create({

--- a/checkin-app/src/lib/dev/zoho-import.ts
+++ b/checkin-app/src/lib/dev/zoho-import.ts
@@ -504,15 +504,15 @@ export async function applyImport(
 
         // ACTIVE membership only where they paid AND signed in Zoho.
         if (h.membershipActive) {
-            const before = await tx.membership.findUnique({ where: { householdId } });
-            const membership = await tx.membership.upsert({
+            const before = await tx.orgMembership.findUnique({ where: { householdId } });
+            const membership = await tx.orgMembership.upsert({
                 where: { householdId },
                 create: { householdId, status: "ACTIVE" },
                 update: { status: "ACTIVE" },
             });
             if (!before || before.status !== "ACTIVE") {
                 res.membershipsActivated++;
-                await audit(tx, actorId, before ? "EDIT" : "CREATE", "Membership", membership.id, {
+                await audit(tx, actorId, before ? "EDIT" : "CREATE", "OrgMembership", membership.id, {
                     status: "ACTIVE",
                     source: { system: "Zoho import" },
                 });

--- a/checkin-app/src/lib/emergencyContacts/__tests__/service.integration.test.ts
+++ b/checkin-app/src/lib/emergencyContacts/__tests__/service.integration.test.ts
@@ -29,8 +29,8 @@ async function wipe() {
     const hhIds = tagged.map((h) => h.id);
     if (hhIds.length === 0) return;
     await prisma.emergencyContact.deleteMany({ where: { householdId: { in: hhIds } } });
-    await prisma.membershipProcess.deleteMany({ where: { membership: { householdId: { in: hhIds } } } });
-    await prisma.membership.deleteMany({ where: { householdId: { in: hhIds } } });
+    await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: hhIds } } } });
+    await prisma.orgMembership.deleteMany({ where: { householdId: { in: hhIds } } });
     await prisma.householdLead.deleteMany({ where: { householdId: { in: hhIds } } });
     await prisma.person.deleteMany({ where: { householdId: { in: hhIds } } });
     await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
@@ -259,8 +259,8 @@ describe("countHouseholdsMissingValidContact — admin alarm", () => {
 
         // In-intake household with a flagged (invalid) contact -> should count.
         const hh = await makeHousehold("alarm-intake");
-        const m = await prisma.membership.create({ data: { householdId: hh, status: "NONE" } });
-        await prisma.membershipProcess.create({ data: { membershipId: m.id, kind: "INITIAL", status: "INTAKE" } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh, status: "NONE" } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: "INITIAL", status: "INTAKE" } });
         await createContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000" });
         await addMember(hh, { name: "Aunt May", phone: "555-555-2000" });
         await reconcileHouseholdConflicts(prisma, hh);
@@ -278,7 +278,7 @@ describe("countHouseholdsMissingValidContact — admin alarm", () => {
     it("also scopes an ACTIVE membership with no in-flight process", async () => {
         const before = await findHouseholdsMissingValidContact(prisma);
         const hh = await makeHousehold("alarm-active");
-        await prisma.membership.create({ data: { householdId: hh, status: "ACTIVE" } });
+        await prisma.orgMembership.create({ data: { householdId: hh, status: "ACTIVE" } });
         const after = await findHouseholdsMissingValidContact(prisma);
         expect(after.length).toBe(before.length + 1);
         expect(after).toContain(hh);

--- a/checkin-app/src/lib/emergencyContacts/service.ts
+++ b/checkin-app/src/lib/emergencyContacts/service.ts
@@ -283,7 +283,7 @@ export async function reconcileAndWarn(db: Db, householdId: number): Promise<Eme
 export async function findHouseholdsMissingValidContact(db: Db = prisma): Promise<number[]> {
     const scoped = await db.household.findMany({
         where: {
-            membership: { is: { OR: [{ status: "ACTIVE" }, { processes: { some: { status: { not: "ACTIVE" } } } }] } },
+            orgMembership: { is: { OR: [{ status: "ACTIVE" }, { processes: { some: { status: { not: "ACTIVE" } } } }] } },
         },
         select: { id: true },
     });

--- a/checkin-app/src/lib/membership/__tests__/external.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/external.test.ts
@@ -14,7 +14,7 @@ jest.mock('@/lib/prisma', () => ({
     __esModule: true,
     default: {
         person: { findUnique: jest.fn() },
-        membershipProcess: { findUnique: jest.fn(), update: jest.fn(), findFirst: jest.fn(), updateMany: jest.fn() },
+        orgMembershipProcess: { findUnique: jest.fn(), update: jest.fn(), findFirst: jest.fn(), updateMany: jest.fn() },
         auditLog: { create: jest.fn() },
     },
 }));
@@ -67,17 +67,17 @@ beforeEach(() => {
 
 describe('setZohoEnvelope', () => {
     it('not_found when the process does not exist', async () => {
-        prisma.membershipProcess.findUnique.mockResolvedValue(null);
+        prisma.orgMembershipProcess.findUnique.mockResolvedValue(null);
         await expect(setZohoEnvelope(1, 'req-1', 5)).rejects.toBeInstanceOf(ExternalError);
     });
 
     it('updates the envelope id and writes an audit row', async () => {
-        prisma.membershipProcess.findUnique.mockResolvedValue({ id: 1 });
-        prisma.membershipProcess.update.mockResolvedValue({ id: 1, zohoEnvelopeId: 'req-1' });
+        prisma.orgMembershipProcess.findUnique.mockResolvedValue({ id: 1 });
+        prisma.orgMembershipProcess.update.mockResolvedValue({ id: 1, zohoEnvelopeId: 'req-1' });
 
         const result = await setZohoEnvelope(1, 'req-1', 5);
 
-        expect(prisma.membershipProcess.update).toHaveBeenCalledWith({ where: { id: 1 }, data: { zohoEnvelopeId: 'req-1' } });
+        expect(prisma.orgMembershipProcess.update).toHaveBeenCalledWith({ where: { id: 1 }, data: { zohoEnvelopeId: 'req-1' } });
         expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
         expect(result).toEqual({ id: 1, zohoEnvelopeId: 'req-1' });
     });
@@ -85,9 +85,9 @@ describe('setZohoEnvelope', () => {
 
 describe('findProcessByEnvelope', () => {
     it('looks up the process by zohoEnvelopeId', async () => {
-        prisma.membershipProcess.findFirst.mockResolvedValue({ id: 9 });
+        prisma.orgMembershipProcess.findFirst.mockResolvedValue({ id: 9 });
         const result = await findProcessByEnvelope('req-9');
-        expect(prisma.membershipProcess.findFirst).toHaveBeenCalledWith({ where: { zohoEnvelopeId: 'req-9' } });
+        expect(prisma.orgMembershipProcess.findFirst).toHaveBeenCalledWith({ where: { zohoEnvelopeId: 'req-9' } });
         expect(result).toEqual({ id: 9 });
     });
 });
@@ -101,7 +101,7 @@ describe('getOrCreateContractSigningUrl', () => {
         email: 'lead@example.com',
         name: 'Lead Person',
         householdLeads: [{ householdId: 7 }],
-        household: { membership: { processes: [pendingProcess] } },
+        household: { orgMembership: { processes: [pendingProcess] } },
     };
 
     it('not_configured when Zoho is unavailable', async () => {
@@ -126,7 +126,7 @@ describe('getOrCreateContractSigningUrl', () => {
     });
 
     it('wrong_phase when there is no process awaiting external action', async () => {
-        prisma.person.findUnique.mockResolvedValue({ ...leadUser, household: { membership: { processes: [] } } });
+        prisma.person.findUnique.mockResolvedValue({ ...leadUser, household: { orgMembership: { processes: [] } } });
         await expect(getOrCreateContractSigningUrl(1)).rejects.toMatchObject({ code: 'wrong_phase' });
     });
 
@@ -136,7 +136,7 @@ describe('getOrCreateContractSigningUrl', () => {
         zohoSign.createRequest.mockResolvedValue({ requestId: 'req-1', actionId: 'act-1', documentId: 'doc-1' });
         zohoSign.submitRequest.mockResolvedValue(undefined);
         zohoSign.getEmbeddedSignUrl.mockResolvedValue('https://sign.example/embed');
-        prisma.membershipProcess.updateMany.mockResolvedValue({ count: 1 });
+        prisma.orgMembershipProcess.updateMany.mockResolvedValue({ count: 1 });
 
         const url = await getOrCreateContractSigningUrl(1);
 
@@ -151,7 +151,7 @@ describe('getOrCreateContractSigningUrl', () => {
     it('already claimed ids → skips create/submit and goes straight to the embed URL', async () => {
         prisma.person.findUnique.mockResolvedValue({
             ...leadUser,
-            household: { membership: { processes: [{ ...pendingProcess, zohoEnvelopeId: 'req-existing', zohoActionId: 'act-existing' }] } },
+            household: { orgMembership: { processes: [{ ...pendingProcess, zohoEnvelopeId: 'req-existing', zohoActionId: 'act-existing' }] } },
         });
         zohoSign.getAccessToken.mockResolvedValue('token-1');
         zohoSign.getEmbeddedSignUrl.mockResolvedValue('https://sign.example/embed-existing');

--- a/checkin-app/src/lib/membership/__tests__/intake.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/intake.test.ts
@@ -15,15 +15,15 @@ import { Prisma } from '@/generated/prisma/client';
 const txMembershipProcess = { findFirst: jest.fn(), create: jest.fn() };
 const txAuditLog = { create: jest.fn() };
 const txQueryRaw = jest.fn();
-const tx = { $queryRaw: txQueryRaw, membershipProcess: txMembershipProcess, auditLog: txAuditLog };
+const tx = { $queryRaw: txQueryRaw, orgMembershipProcess: txMembershipProcess, auditLog: txAuditLog };
 
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
     default: {
         person: { findUnique: jest.fn(), update: jest.fn(), create: jest.fn() },
         household: { update: jest.fn() },
-        membership: { upsert: jest.fn() },
-        membershipProcess: { findFirst: jest.fn(), update: jest.fn() },
+        orgMembership: { upsert: jest.fn() },
+        orgMembershipProcess: { findFirst: jest.fn(), update: jest.fn() },
         boardSettings: { findUnique: jest.fn() },
         auditLog: { create: jest.fn() },
         $transaction: jest.fn((cb: (tx: unknown) => unknown) => cb(tx)),
@@ -60,18 +60,18 @@ const user = {
     householdId: 7,
     isSysadmin: false,
     householdLeads: [{ householdId: 7 }],
-    household: { membership: null },
+    household: { orgMembership: null },
 };
 
 beforeEach(() => {
     jest.clearAllMocks();
     prisma.person.findUnique.mockResolvedValue(user);
-    prisma.membership.upsert.mockResolvedValue({ id: 42, householdId: 7, status: 'NONE' });
+    prisma.orgMembership.upsert.mockResolvedValue({ id: 42, householdId: 7, status: 'NONE' });
 });
 
 describe('startIntake race guard', () => {
     it('a second in-flight INITIAL start (existing found under the lock) returns the existing process, no duplicate create', async () => {
-        const existingProcess = { id: 99, membershipId: 42, kind: 'INITIAL', status: 'INTAKE' };
+        const existingProcess = { id: 99, orgMembershipId: 42, kind: 'INITIAL', status: 'INTAKE' };
         txMembershipProcess.findFirst.mockResolvedValue(existingProcess);
 
         const result = await startIntake(1);
@@ -86,14 +86,14 @@ describe('startIntake race guard', () => {
 
     it('no in-flight process → creates one INTAKE process + audit row inside the same transaction', async () => {
         txMembershipProcess.findFirst.mockResolvedValue(null);
-        const created = { id: 100, membershipId: 42, kind: 'INITIAL', status: 'INTAKE' };
+        const created = { id: 100, orgMembershipId: 42, kind: 'INITIAL', status: 'INTAKE' };
         txMembershipProcess.create.mockResolvedValue(created);
 
         const result = await startIntake(1);
 
         expect(result).toBe(created);
         expect(txMembershipProcess.create).toHaveBeenCalledWith({
-            data: { membershipId: 42, kind: 'INITIAL', status: 'INTAKE' },
+            data: { orgMembershipId: 42, kind: 'INITIAL', status: 'INTAKE' },
         });
         expect(txAuditLog.create).toHaveBeenCalledTimes(1);
     });
@@ -108,7 +108,7 @@ describe('startIntake race guard', () => {
     it('already_member: household membership is already ACTIVE', async () => {
         prisma.person.findUnique.mockResolvedValue({
             ...user,
-            household: { membership: { status: 'ACTIVE' } },
+            household: { orgMembership: { status: 'ACTIVE' } },
         });
 
         await expect(startIntake(1)).rejects.toMatchObject({ code: 'already_member' });
@@ -116,10 +116,10 @@ describe('startIntake race guard', () => {
     });
 
     it('P2002 race loser: the FOR UPDATE lock lost to a pre-fix instance, winner found on re-query', async () => {
-        const winner = { id: 101, membershipId: 42, kind: 'INITIAL', status: 'INTAKE' };
+        const winner = { id: 101, orgMembershipId: 42, kind: 'INITIAL', status: 'INTAKE' };
         const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', { code: 'P2002', clientVersion: '7.8.0' });
         prisma.$transaction.mockRejectedValueOnce(p2002);
-        prisma.membershipProcess.findFirst.mockResolvedValue(winner);
+        prisma.orgMembershipProcess.findFirst.mockResolvedValue(winner);
 
         const result = await startIntake(1);
 
@@ -129,7 +129,7 @@ describe('startIntake race guard', () => {
     it('P2002 race loser: no winner found on re-query rethrows the original error', async () => {
         const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', { code: 'P2002', clientVersion: '7.8.0' });
         prisma.$transaction.mockRejectedValueOnce(p2002);
-        prisma.membershipProcess.findFirst.mockResolvedValue(null);
+        prisma.orgMembershipProcess.findFirst.mockResolvedValue(null);
 
         await expect(startIntake(1)).rejects.toBe(p2002);
     });
@@ -171,7 +171,7 @@ describe('getIntakeState', () => {
                     { id: 2, name: 'Secondary', email: 's@x.com', dateOfBirth: null, allergies: 'peanuts' },
                     { id: 3, name: 'Kid', email: null, dateOfBirth: null, allergies: null },
                 ],
-                membership: {
+                orgMembership: {
                     status: 'NONE',
                     processes: [
                         { id: 10, kind: 'INITIAL', status: 'ACTIVE' },
@@ -206,7 +206,7 @@ describe('getIntakeState', () => {
                 name: 'H', line1: null, line2: null, city: null, state: null, postalCode: null,
                 leads: [{ personId: 1 }],
                 householdMembers: [{ id: 1, name: 'P', email: null, dateOfBirth: null, allergies: null }],
-                membership: { status: 'ACTIVE', processes: [{ id: 5, kind: 'INITIAL', status: 'ACTIVE' }] },
+                orgMembership: { status: 'ACTIVE', processes: [{ id: 5, kind: 'INITIAL', status: 'ACTIVE' }] },
                 emergencyContacts: [],
             },
         });
@@ -229,7 +229,7 @@ describe('saveIntake', () => {
             line1: null, line2: null, city: null, state: null, postalCode: null,
             leads: [{ personId: 1 }],
             householdMembers: [{ id: 1 }, { id: 4 }],
-            membership: null,
+            orgMembership: null,
             emergencyContacts: [],
         },
     };
@@ -345,20 +345,20 @@ describe('submitIntake', () => {
             line1: '1 Main St',
             emergencyContacts: [{ conflictParticipantId: null, name: 'Aunt May', phone: '555-555-2000' }],
             householdMembers: [{ id: 1, name: 'Primary' }],
-            membership: { processes: [{ id: 11, kind: 'INITIAL', status: 'INTAKE' }] },
+            orgMembership: { processes: [{ id: 11, kind: 'INITIAL', status: 'INTAKE' }] },
         },
     };
 
     beforeEach(() => {
         prisma.person.findUnique.mockResolvedValue(inFlightUser);
         prisma.boardSettings.findUnique.mockResolvedValue(null);
-        prisma.membershipProcess.update.mockResolvedValue({ id: 11, status: 'PENDING_EXTERNAL_ACTION' });
+        prisma.orgMembershipProcess.update.mockResolvedValue({ id: 11, status: 'PENDING_EXTERNAL_ACTION' });
     });
 
     it('no_process when there is no INTAKE-status INITIAL process', async () => {
         prisma.person.findUnique.mockResolvedValue({
             ...inFlightUser,
-            household: { ...inFlightUser.household, membership: { processes: [] } },
+            household: { ...inFlightUser.household, orgMembership: { processes: [] } },
         });
 
         await expect(submitIntake(1)).rejects.toMatchObject({ code: 'no_process' });
@@ -381,7 +381,7 @@ describe('submitIntake', () => {
 
         await submitIntake(1);
 
-        expect(prisma.membershipProcess.update).toHaveBeenCalledWith({
+        expect(prisma.orgMembershipProcess.update).toHaveBeenCalledWith({
             where: { id: 11 },
             data: expect.not.objectContaining({ bgClearedAt: expect.anything() }),
         });
@@ -392,7 +392,7 @@ describe('submitIntake', () => {
 
         const result = await submitIntake(1);
 
-        expect(prisma.membershipProcess.update).toHaveBeenCalledWith({
+        expect(prisma.orgMembershipProcess.update).toHaveBeenCalledWith({
             where: { id: 11 },
             data: expect.objectContaining({ status: 'PENDING_EXTERNAL_ACTION', bgClearedAt: expect.any(Date) }),
         });

--- a/checkin-app/src/lib/membership/__tests__/payment.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/payment.test.ts
@@ -13,8 +13,8 @@ import { activate, activateByProcessId } from '@/lib/membership/payment';
 
 jest.mock('@/lib/prisma', () => {
     const mock = {
-        membershipProcess: { findUnique: jest.fn(), update: jest.fn() },
-        membership: { findUnique: jest.fn(), update: jest.fn() },
+        orgMembershipProcess: { findUnique: jest.fn(), update: jest.fn() },
+        orgMembership: { findUnique: jest.fn(), update: jest.fn() },
         boardSettings: { findUnique: jest.fn() },
         auditLog: { create: jest.fn() },
         householdLead: { findMany: jest.fn().mockResolvedValue([]) },
@@ -39,18 +39,18 @@ const MEMBERSHIP_ID = 9;
 beforeEach(() => {
     jest.clearAllMocks();
     prisma.boardSettings.findUnique.mockResolvedValue({ normalDuesCents: 10000, volunteerDuesCents: 2500 });
-    prisma.membership.findUnique.mockResolvedValue({ householdId: 3, isVolunteer: false });
+    prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 3, isVolunteer: false });
 });
 
 it('does NOT activate a PENDING_PAYMENT process when the order has no membership item', async () => {
-    prisma.membershipProcess.findUnique.mockResolvedValue({
-        id: PROCESS_ID, status: 'PENDING_PAYMENT', paidAt: null, bgClearedAt: null, membershipId: MEMBERSHIP_ID,
+    prisma.orgMembershipProcess.findUnique.mockResolvedValue({
+        id: PROCESS_ID, status: 'PENDING_PAYMENT', paidAt: null, bgClearedAt: null, orgMembershipId: MEMBERSHIP_ID,
     });
 
     await activateByProcessId(PROCESS_ID, 'order-1', false);
 
-    expect(prisma.membershipProcess.update).not.toHaveBeenCalled();
-    expect(prisma.membership.update).not.toHaveBeenCalled();
+    expect(prisma.orgMembershipProcess.update).not.toHaveBeenCalled();
+    expect(prisma.orgMembership.update).not.toHaveBeenCalled();
     expect(notifyBoardPaidReject).toHaveBeenCalledWith(PROCESS_ID);
     expect(prisma.auditLog.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -62,16 +62,16 @@ it('does NOT activate a PENDING_PAYMENT process when the order has no membership
 });
 
 it('activates a PENDING_PAYMENT process when the order contains the membership item', async () => {
-    prisma.membershipProcess.findUnique.mockResolvedValue({
-        id: PROCESS_ID, status: 'PENDING_PAYMENT', paidAt: null, bgClearedAt: new Date(), membershipId: MEMBERSHIP_ID,
+    prisma.orgMembershipProcess.findUnique.mockResolvedValue({
+        id: PROCESS_ID, status: 'PENDING_PAYMENT', paidAt: null, bgClearedAt: new Date(), orgMembershipId: MEMBERSHIP_ID,
     });
 
     await activateByProcessId(PROCESS_ID, 'order-2', true);
 
-    expect(prisma.membershipProcess.update).toHaveBeenCalledWith(
+    expect(prisma.orgMembershipProcess.update).toHaveBeenCalledWith(
         expect.objectContaining({ data: expect.objectContaining({ status: 'ACTIVE' }) }),
     );
-    expect(prisma.membership.update).toHaveBeenCalledWith(
+    expect(prisma.orgMembership.update).toHaveBeenCalledWith(
         expect.objectContaining({ where: { id: MEMBERSHIP_ID }, data: { status: 'ACTIVE' } }),
     );
     expect(notifyBoardPaidReject).not.toHaveBeenCalled();
@@ -80,13 +80,13 @@ it('activates a PENDING_PAYMENT process when the order contains the membership i
 it('a certified (board) activation is exempt from the membership-item check', async () => {
     // certifyPaymentPlan never has a Shopify order to check (via !== "payment"),
     // so it activates even though no hasMembershipItem is passed at all.
-    prisma.membershipProcess.findUnique.mockResolvedValue({
-        id: PROCESS_ID, status: 'PENDING_PAYMENT', paidAt: null, bgClearedAt: new Date(), membershipId: MEMBERSHIP_ID,
+    prisma.orgMembershipProcess.findUnique.mockResolvedValue({
+        id: PROCESS_ID, status: 'PENDING_PAYMENT', paidAt: null, bgClearedAt: new Date(), orgMembershipId: MEMBERSHIP_ID,
     });
 
     await activate(PROCESS_ID, { via: 'certified', actorId: 1 });
 
-    expect(prisma.membershipProcess.update).toHaveBeenCalledWith(
+    expect(prisma.orgMembershipProcess.update).toHaveBeenCalledWith(
         expect.objectContaining({ data: expect.objectContaining({ status: 'ACTIVE' }) }),
     );
     expect(notifyBoardPaidReject).not.toHaveBeenCalled();

--- a/checkin-app/src/lib/membership/__tests__/renewal.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/renewal.test.ts
@@ -13,8 +13,8 @@ jest.mock('@/lib/prisma', () => ({
     __esModule: true,
     default: {
         person: { findFirst: jest.fn() },
-        membershipProcess: { findUnique: jest.fn() },
-        membership: { findUnique: jest.fn() },
+        orgMembershipProcess: { findUnique: jest.fn() },
+        orgMembership: { findUnique: jest.fn() },
         boardSettings: { findUnique: jest.fn() },
     },
 }));
@@ -69,7 +69,7 @@ describe('householdBgIsFresh', () => {
 
 describe('beginRenewal', () => {
     it('throws RenewalError wrong_phase when the process is not PENDING_RENEWAL', async () => {
-        prisma.membershipProcess.findUnique.mockResolvedValue({ id: 5, status: 'PENDING_PAYMENT', membershipId: 9 });
+        prisma.orgMembershipProcess.findUnique.mockResolvedValue({ id: 5, status: 'PENDING_PAYMENT', orgMembershipId: 9 });
 
         await expect(beginRenewal(5)).rejects.toMatchObject({
             name: 'RenewalError',
@@ -79,7 +79,7 @@ describe('beginRenewal', () => {
     });
 
     it('throws RenewalError not_found when the process does not exist', async () => {
-        prisma.membershipProcess.findUnique.mockResolvedValue(null);
+        prisma.orgMembershipProcess.findUnique.mockResolvedValue(null);
         await expect(beginRenewal(5)).rejects.toMatchObject({ code: 'not_found' });
     });
 });

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -78,14 +78,14 @@ export async function getExternalStatus(process: {
  * regressed. Mirrors review.ts `attest`.
  */
 export async function advanceExternalIfComplete(processId: number) {
-    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) return process;
     if (process.status !== "PENDING_EXTERNAL_ACTION") return process;
     if (!process.contractSignedAt) return process;
     if (!process.bgClearedAt && !process.bgConsentAt) return process;
 
     const advanced = await prisma.$transaction(async (tx) => {
-        const { count } = await tx.membershipProcess.updateMany({
+        const { count } = await tx.orgMembershipProcess.updateMany({
             where: {
                 id: processId,
                 status: "PENDING_EXTERNAL_ACTION",
@@ -99,15 +99,15 @@ export async function advanceExternalIfComplete(processId: number) {
             data: {
                 actorId: SYSTEM_ACTOR,
                 action: "EDIT",
-                tableName: "MembershipProcess",
+                tableName: "OrgMembershipProcess",
                 affectedEntityId: processId,
                 oldData: { status: "PENDING_EXTERNAL_ACTION" },
                 newData: { status: "PENDING_PAYMENT" },
             },
         });
-        return tx.membershipProcess.findUnique({ where: { id: processId } });
+        return tx.orgMembershipProcess.findUnique({ where: { id: processId } });
     });
-    if (!advanced) return prisma.membershipProcess.findUnique({ where: { id: processId } });
+    if (!advanced) return prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
 
     // No valid prior check ⇒ a human review is still needed. Ping the reviewers;
     // the review now proceeds in parallel with payment (log-only until email is configured).
@@ -117,19 +117,19 @@ export async function advanceExternalIfComplete(processId: number) {
 
 /** Record that the membership contract was signed (idempotent), then maybe advance. */
 export async function markContractSigned(processId: number, actorId: number = SYSTEM_ACTOR) {
-    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new ExternalError("not_found", "Application not found.");
     // Conditional on contractSignedAt: null — two concurrent Zoho webhook retries
     // both see null, but only the winner's updateMany flips it (count === 1), so the
     // audit row is written once.
     await prisma.$transaction(async (tx) => {
-        const { count } = await tx.membershipProcess.updateMany({
+        const { count } = await tx.orgMembershipProcess.updateMany({
             where: { id: processId, contractSignedAt: null },
             data: { contractSignedAt: new Date() },
         });
         if (count !== 1) return;
         await tx.auditLog.create({
-            data: { actorId, action: "EDIT", tableName: "MembershipProcess", affectedEntityId: processId, newData: { contractSignedAt: true } },
+            data: { actorId, action: "EDIT", tableName: "OrgMembershipProcess", affectedEntityId: processId, newData: { contractSignedAt: true } },
         });
     });
     return advanceExternalIfComplete(processId);
@@ -137,17 +137,17 @@ export async function markContractSigned(processId: number, actorId: number = SY
 
 /** Board human-marks that the applicant submitted background-check consent, then maybe advance. */
 export async function markBgConsent(processId: number, actorId: number) {
-    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new ExternalError("not_found", "Application not found.");
     // Conditional on bgConsentAt: null so concurrent marks write the audit row once.
     await prisma.$transaction(async (tx) => {
-        const { count } = await tx.membershipProcess.updateMany({
+        const { count } = await tx.orgMembershipProcess.updateMany({
             where: { id: processId, bgConsentAt: null },
             data: { bgConsentAt: new Date() },
         });
         if (count !== 1) return;
         await tx.auditLog.create({
-            data: { actorId, action: "EDIT", tableName: "MembershipProcess", affectedEntityId: processId, newData: { bgConsentAt: true } },
+            data: { actorId, action: "EDIT", tableName: "OrgMembershipProcess", affectedEntityId: processId, newData: { bgConsentAt: true } },
         });
     });
     return advanceExternalIfComplete(processId);
@@ -155,18 +155,18 @@ export async function markBgConsent(processId: number, actorId: number) {
 
 /** Associate a Zoho signing request id with a process so its webhook can match. */
 export async function setZohoEnvelope(processId: number, requestId: string, actorId: number) {
-    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new ExternalError("not_found", "Application not found.");
-    const updated = await prisma.membershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: requestId } });
+    const updated = await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: requestId } });
     await prisma.auditLog.create({
-        data: { actorId, action: "EDIT", tableName: "MembershipProcess", affectedEntityId: processId, newData: { zohoEnvelopeId: requestId } },
+        data: { actorId, action: "EDIT", tableName: "OrgMembershipProcess", affectedEntityId: processId, newData: { zohoEnvelopeId: requestId } },
     });
     return updated;
 }
 
 /** Find the in-flight process tied to a Zoho request id (for webhook matching). */
 export async function findProcessByEnvelope(requestId: string) {
-    return prisma.membershipProcess.findFirst({ where: { zohoEnvelopeId: requestId } });
+    return prisma.orgMembershipProcess.findFirst({ where: { zohoEnvelopeId: requestId } });
 }
 
 /**
@@ -181,10 +181,10 @@ export async function findProcessByEnvelope(requestId: string) {
 export async function syncContractStatus(userId: number): Promise<ExternalStatus | null> {
     const user = await prisma.person.findUnique({
         where: { id: userId },
-        include: { household: { include: { membership: { include: { processes: true } } } } },
+        include: { household: { include: { orgMembership: { include: { processes: true } } } } },
     });
     // Same selection as the signing action: the latest process awaiting external action.
-    const process = latestPendingExternal(user?.household?.membership?.processes);
+    const process = latestPendingExternal(user?.household?.orgMembership?.processes);
     if (!process) return null;
 
     if (!process.contractSignedAt && process.zohoEnvelopeId && config.zohoAvailable()) {
@@ -199,7 +199,7 @@ export async function syncContractStatus(userId: number): Promise<ExternalStatus
     }
 
     // Re-read: markContractSigned may have flipped contractSignedAt (and advanced the phase).
-    const fresh = await prisma.membershipProcess.findUnique({ where: { id: process.id } });
+    const fresh = await prisma.orgMembershipProcess.findUnique({ where: { id: process.id } });
     return fresh ? getExternalStatus(fresh) : null;
 }
 
@@ -223,7 +223,7 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
         where: { id: userId },
         include: {
             householdLeads: true,
-            household: { include: { membership: { include: { processes: true } } } },
+            household: { include: { orgMembership: { include: { processes: true } } } },
         },
     });
     if (!user) throw new ExternalError("not_found", "Application not found.");
@@ -237,7 +237,7 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
     // re-sign the agreement fresh each cycle. Gating on status alone keeps this in
     // step with getIntakeState/getExternalStatus, which surface the button for any
     // non-ACTIVE process (a kind filter here would render the button then 409).
-    const process = latestPendingExternal(user.household?.membership?.processes);
+    const process = latestPendingExternal(user.household?.orgMembership?.processes);
     if (!process) throw new ExternalError("wrong_phase", "No application is awaiting your signature.");
 
     const recipientEmail = user.email;
@@ -322,12 +322,12 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
         // re-create on every click and a `zohoEnvelopeId: null`-only claim would
         // always lose — a permanent 409. Overwriting it points the process (and its
         // webhook match) at the embeddable in-app request.
-        const claim = await prisma.membershipProcess.updateMany({
+        const claim = await prisma.orgMembershipProcess.updateMany({
             where: { id: process.id, OR: [{ zohoEnvelopeId: null }, { zohoActionId: null }] },
             data: { zohoEnvelopeId: created.requestId, zohoActionId: created.actionId },
         });
         if (claim.count === 0) {
-            const winner = await prisma.membershipProcess.findUnique({ where: { id: process.id } });
+            const winner = await prisma.orgMembershipProcess.findUnique({ where: { id: process.id } });
             requestId = winner?.zohoEnvelopeId ?? null;
             actionId = winner?.zohoActionId ?? null;
             if (!requestId || !actionId) {
@@ -341,7 +341,7 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
                 data: {
                     actorId: userId,
                     action: "EDIT",
-                    tableName: "MembershipProcess",
+                    tableName: "OrgMembershipProcess",
                     affectedEntityId: process.id,
                     newData: { zohoEnvelopeId: requestId, zohoActionId: actionId },
                 },

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -15,7 +15,7 @@ import { normalizeAddressInput, pickAddress, type StructuredAddress } from "@/li
  * Intake data lives in the real tables (Household + Participant), so the form
  * is naturally resumable: returning applicants are re-served their saved data.
  * A long-lived Membership (status NONE until paid) anchors the per-cycle
- * MembershipProcess that tracks application progress.
+ * OrgMembershipProcess that tracks application progress.
  */
 
 export class IntakeError extends Error {
@@ -65,7 +65,7 @@ async function loadUserWithHousehold(userId: number) {
                 include: {
                     householdMembers: { orderBy: { id: "asc" } },
                     leads: true,
-                    membership: { include: { processes: true } },
+                    orgMembership: { include: { processes: true } },
                     emergencyContacts: { orderBy: [{ priority: "asc" }, { id: "asc" }] },
                 },
             },
@@ -84,7 +84,7 @@ export async function getIntakeState(userId: number) {
     if (!user) throw new IntakeError("no_household", "User not found.");
 
     const household = user.household;
-    const membership = household?.membership ?? null;
+    const membership = household?.orgMembership ?? null;
     // The current in-flight process of any kind (INITIAL or RENEWAL) — anything
     // not yet ACTIVE. During renewal the membership stays ACTIVE while its RENEWAL
     // process cycles, so we surface that here rather than the "you're a member" card.
@@ -136,9 +136,9 @@ export async function getIntakeState(userId: number) {
 /**
  * Begin (or resume) an INITIAL application for the caller's household. Ensures a
  * household exists, anchors a Membership (status NONE), and opens a
- * MembershipProcess at INTAKE. Idempotent: an in-flight process is returned as-is.
+ * OrgMembershipProcess at INTAKE. Idempotent: an in-flight process is returned as-is.
  *
- * The caller's own read of `user.household.membership.processes` (above) is stale
+ * The caller's own read of `user.household.orgMembership.processes` (above) is stale
  * the instant it's read, so a double-click or two tabs can both pass it and both
  * reach the create. Mirrors renewal's createRenewalProcess: the check+create is
  * re-run inside a transaction holding a `SELECT ... FOR UPDATE` lock on the
@@ -153,11 +153,11 @@ export async function startIntake(userId: number) {
     assertLead(user);
     const householdId = user.householdId!;
 
-    if (user.household?.membership?.status === "ACTIVE") {
+    if (user.household?.orgMembership?.status === "ACTIVE") {
         throw new IntakeError("already_member", "Your household is already an active member.");
     }
 
-    const membership = await prisma.membership.upsert({
+    const membership = await prisma.orgMembership.upsert({
         where: { householdId },
         create: { householdId, status: "NONE" },
         update: {},
@@ -166,24 +166,24 @@ export async function startIntake(userId: number) {
     try {
         return await prisma.$transaction(async (tx) => {
             // Lock the membership row so overlapping starts serialize here, not at the INSERT.
-            await tx.$queryRaw`SELECT id FROM "Membership" WHERE id = ${membership.id} FOR UPDATE`;
-            const existing = await tx.membershipProcess.findFirst({
-                where: { membershipId: membership.id, kind: "INITIAL", status: { in: IN_FLIGHT_INITIAL_STATUSES } },
+            await tx.$queryRaw`SELECT id FROM "OrgMembership" WHERE id = ${membership.id} FOR UPDATE`;
+            const existing = await tx.orgMembershipProcess.findFirst({
+                where: { orgMembershipId: membership.id, kind: "INITIAL", status: { in: IN_FLIGHT_INITIAL_STATUSES } },
                 orderBy: { id: "desc" },
             });
             if (existing) return existing;
 
-            const process = await tx.membershipProcess.create({
-                data: { membershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
+            const process = await tx.orgMembershipProcess.create({
+                data: { orgMembershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
             });
 
             await tx.auditLog.create({
                 data: {
                     actorId: userId,
                     action: "CREATE",
-                    tableName: "MembershipProcess",
+                    tableName: "OrgMembershipProcess",
                     affectedEntityId: process.id,
-                    newData: { membershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
+                    newData: { orgMembershipId: membership.id, kind: "INITIAL", status: "INTAKE" },
                 },
             });
 
@@ -195,8 +195,8 @@ export async function startIntake(userId: number) {
         // index membership_one_inflight_initial then rejects the duplicate with P2002.
         // Return the winner instead of surfacing a 500 to the applicant (mirrors renewal).
         if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
-            const winner = await prisma.membershipProcess.findFirst({
-                where: { membershipId: membership.id, kind: "INITIAL", status: { in: IN_FLIGHT_INITIAL_STATUSES } },
+            const winner = await prisma.orgMembershipProcess.findFirst({
+                where: { orgMembershipId: membership.id, kind: "INITIAL", status: { in: IN_FLIGHT_INITIAL_STATUSES } },
                 orderBy: { id: "desc" },
             });
             if (winner) return winner;
@@ -341,7 +341,7 @@ export async function submitIntake(userId: number) {
     assertLead(user);
 
     const household = user.household!;
-    const process = household.membership?.processes
+    const process = household.orgMembership?.processes
         .filter((p) => p.kind === "INITIAL" && p.status === "INTAKE")
         .sort((a, b) => b.id - a.id)[0];
     if (!process) throw new IntakeError("no_process", "No application is awaiting your information.");
@@ -369,10 +369,10 @@ export async function submitIntake(userId: number) {
     // rule as renewals), auto-clear the BG requirement now — the applicant won't
     // need to consent to or wait on a new check, just sign + pay.
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const boundary = settings?.membershipYearBoundary ? nextBoundary(settings.membershipYearBoundary, new Date()) : new Date();
+    const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, new Date()) : new Date();
     const bgFresh = await householdBgIsFresh(household.id, boundary, settings?.bgRecheckMonths ?? 0);
 
-    const advanced = await prisma.membershipProcess.update({
+    const advanced = await prisma.orgMembershipProcess.update({
         where: { id: process.id },
         data: {
             status: "PENDING_EXTERNAL_ACTION",
@@ -385,7 +385,7 @@ export async function submitIntake(userId: number) {
         data: {
             actorId: userId,
             action: "EDIT",
-            tableName: "MembershipProcess",
+            tableName: "OrgMembershipProcess",
             affectedEntityId: process.id,
             oldData: { status: "INTAKE" },
             newData: { status: "PENDING_EXTERNAL_ACTION", ...(bgFresh ? { bgClearedAt: true } : {}) },

--- a/checkin-app/src/lib/membership/notifications.ts
+++ b/checkin-app/src/lib/membership/notifications.ts
@@ -22,7 +22,7 @@ export async function getMembershipNotifications(user: {
     const pendingReviews = canReviewBackgroundChecks(user) ? (await eligibleReviewProcessIds(user.id)).length : 0;
     const blocked =
         user.isSysadmin || user.isBoardMember
-            ? await prisma.membershipProcess.count({ where: { status: "BLOCKED" } })
+            ? await prisma.orgMembershipProcess.count({ where: { status: "BLOCKED" } })
             : 0;
     return { pendingReviews, blocked };
 }

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -48,22 +48,22 @@ export function buildMembershipCheckoutUrl(
 /**
  * Resolve the dues amount and the Shopify checkout link for a process in
  * PENDING_PAYMENT. The link is built from SHOPIFY_STORE_DOMAIN +
- * BoardSettings.membershipVariantId, with the volunteer discount code appended
+ * BoardSettings.orgMembershipVariantId, with the volunteer discount code appended
  * for volunteer households. If the store domain or variant isn't configured,
  * returns the amount with a null link.
  */
 export async function ensurePaymentLink(processId: number): Promise<{ amountCents: number; checkoutUrl: string | null }> {
-    const proc = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!proc) throw new PaymentError("not_found", "Application not found.");
     if (proc.status !== "PENDING_PAYMENT") throw new PaymentError("wrong_phase", "This application is not awaiting payment.");
 
-    const membership = await prisma.membership.findUnique({ where: { id: proc.membershipId }, select: { isVolunteer: true } });
+    const membership = await prisma.orgMembership.findUnique({ where: { id: proc.orgMembershipId }, select: { isVolunteer: true } });
     if (!membership) throw new PaymentError("not_found", "Membership not found.");
 
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
     const amountCents = membership.isVolunteer ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
 
-    const variantId = settings?.membershipVariantId;
+    const variantId = settings?.orgMembershipVariantId;
     const storeDomain = config.shopifyStoreDomain();
     if (!variantId || !storeDomain) return { amountCents, checkoutUrl: null };
 
@@ -81,8 +81,8 @@ export async function ensurePaymentLink(processId: number): Promise<{ amountCent
 export async function ensurePaymentLinkForUser(userId: number) {
     const user = await prisma.person.findUnique({ where: { id: userId }, select: { householdId: true } });
     if (!user?.householdId) throw new PaymentError("not_found", "You are not in a household.");
-    const process = await prisma.membershipProcess.findFirst({
-        where: { membership: { householdId: user.householdId }, status: "PENDING_PAYMENT" },
+    const process = await prisma.orgMembershipProcess.findFirst({
+        where: { orgMembership: { householdId: user.householdId }, status: "PENDING_PAYMENT" },
         orderBy: { id: "desc" },
     });
     if (!process) throw new PaymentError("wrong_phase", "No application is awaiting payment.");
@@ -117,14 +117,14 @@ export async function activate(
     opts: { via: "payment" | "certified"; actorId?: number; shopifyOrderId?: string; hasMembershipItem?: boolean },
 ) {
     const result = await prisma.$transaction(async (tx) => {
-        await tx.$queryRaw`SELECT id FROM "MembershipProcess" WHERE id = ${processId} FOR UPDATE`;
-        const process = await tx.membershipProcess.findUnique({ where: { id: processId } });
+        await tx.$queryRaw`SELECT id FROM "OrgMembershipProcess" WHERE id = ${processId} FOR UPDATE`;
+        const process = await tx.orgMembershipProcess.findUnique({ where: { id: processId } });
         if (!process) throw new PaymentError("not_found", "Application not found.");
         // Already recorded this payment (webhook retry) or already active → nothing to do.
         if (process.paidAt || process.status === "ACTIVE") {
             return { kind: "noop" as const };
         }
-        const membership = await tx.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true, isVolunteer: true } });
+        const membership = await tx.orgMembership.findUnique({ where: { id: process.orgMembershipId }, select: { householdId: true, isVolunteer: true } });
         if (!membership) throw new PaymentError("not_found", "Membership not found.");
 
         const now = new Date();
@@ -136,12 +136,12 @@ export async function activate(
         // Reject landed before the payment: record the payment but stay BLOCKED
         // (don't resurrect / don't bump stageEnteredAt) and flag for refund.
         if (process.status === "BLOCKED") {
-            await tx.membershipProcess.update({ where: { id: processId }, data: { paidAt: now, ...payMeta } });
+            await tx.orgMembershipProcess.update({ where: { id: processId }, data: { paidAt: now, ...payMeta } });
             await tx.auditLog.create({
                 data: {
                     actorId: opts.actorId ?? SYSTEM_ACTOR,
                     action: "EDIT",
-                    tableName: "MembershipProcess",
+                    tableName: "OrgMembershipProcess",
                     affectedEntityId: processId,
                     oldData: { status: "BLOCKED" },
                     newData: { status: "BLOCKED", via: opts.via, paid: true, refundNeeded: true },
@@ -180,7 +180,7 @@ export async function activate(
                 data: {
                     actorId: SYSTEM_ACTOR,
                     action: "EDIT",
-                    tableName: "MembershipProcess",
+                    tableName: "OrgMembershipProcess",
                     affectedEntityId: processId,
                     oldData: { status: "PENDING_PAYMENT" },
                     newData: { status: "PENDING_PAYMENT", via: opts.via, noMembershipItem: true, shopifyOrderId: opts.shopifyOrderId ?? null },
@@ -196,18 +196,18 @@ export async function activate(
         }
 
         const activating = !!process.bgClearedAt;
-        await tx.membershipProcess.update({
+        await tx.orgMembershipProcess.update({
             where: { id: processId },
             data: { paidAt: now, stageEnteredAt: now, ...payMeta, status: activating ? "ACTIVE" : "PENDING_BG_CLEARANCE" },
         });
         if (activating) {
-            await tx.membership.update({ where: { id: process.membershipId }, data: { status: "ACTIVE" } });
+            await tx.orgMembership.update({ where: { id: process.orgMembershipId }, data: { status: "ACTIVE" } });
         }
         await tx.auditLog.create({
             data: {
                 actorId: opts.actorId ?? SYSTEM_ACTOR,
                 action: "EDIT",
-                tableName: "MembershipProcess",
+                tableName: "OrgMembershipProcess",
                 affectedEntityId: processId,
                 oldData: { status: process.status },
                 newData: activating ? { status: "ACTIVE", via: opts.via } : { status: "PENDING_BG_CLEARANCE", via: opts.via, paid: true },
@@ -220,7 +220,7 @@ export async function activate(
     // the write, and only the call that actually recorded the change emits one.
     if (result.kind === "active") await sendCongrats(result.householdId);
     if (result.kind === "paid_while_blocked" || result.kind === "underpaid") await notifyBoardPaidReject(processId);
-    return prisma.membershipProcess.findUnique({ where: { id: processId } });
+    return prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
 }
 
 /** Board override: certify a payment plan and activate without a Shopify payment. */
@@ -230,7 +230,7 @@ export async function certifyPaymentPlan(processId: number, actorId: number) {
     // certifying an already-ACTIVE or still-in-review grant surfaces a 409
     // instead of a misleading success. activate()'s own conditional flip stays
     // idempotent for the webhook/self-serve callers.
-    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new PaymentError("not_found", "Application not found.");
     if (process.status !== "PENDING_PAYMENT") throw new PaymentError("wrong_phase", "This application is not awaiting payment.");
     return activate(processId, { via: "certified", actorId });

--- a/checkin-app/src/lib/membership/phases.ts
+++ b/checkin-app/src/lib/membership/phases.ts
@@ -1,4 +1,4 @@
-import type { MembershipProcess, MembershipProcessStatus } from "@/generated/prisma/client";
+import type { OrgMembershipProcess, OrgMembershipProcessStatus } from "@/generated/prisma/client";
 
 /**
  * Applicant-facing phases of an INITIAL membership application, in order.
@@ -12,7 +12,7 @@ import type { MembershipProcess, MembershipProcessStatus } from "@/generated/pri
  * (never shown as their own step).
  */
 export interface IntakePhase {
-    status: MembershipProcessStatus;
+    status: OrgMembershipProcessStatus;
     label: string;
     description: string;
 }
@@ -30,7 +30,7 @@ export const INITIAL_PHASES: IntakePhase[] = [
  * Member — payment shows complete, Member is the pending current step. BLOCKED
  * and other off-track statuses return -1 (handled with an inline alert).
  */
-export function stepperActiveIndex(status: MembershipProcessStatus | null): number {
+export function stepperActiveIndex(status: OrgMembershipProcessStatus | null): number {
     switch (status) {
         case "INTAKE": return 0;
         case "PENDING_EXTERNAL_ACTION": return 1;
@@ -47,7 +47,7 @@ export function stepperActiveIndex(status: MembershipProcessStatus | null): numb
  * part of the INITIAL flow. PENDING_BG_REVIEW is retained for any legacy rows;
  * the live flow uses PENDING_BG_CLEARANCE for the paid-awaiting-check state.
  */
-export const IN_FLIGHT_INITIAL_STATUSES: MembershipProcessStatus[] = [
+export const IN_FLIGHT_INITIAL_STATUSES: OrgMembershipProcessStatus[] = [
     "INTAKE",
     "PENDING_EXTERNAL_ACTION",
     "PENDING_BG_REVIEW",
@@ -63,7 +63,7 @@ export const IN_FLIGHT_INITIAL_STATUSES: MembershipProcessStatus[] = [
  * the button then 409. Highest id == most recent (autoincrement). Returns
  * undefined when nothing is awaiting action — callers guard for that.
  */
-export function latestPendingExternal<T extends Pick<MembershipProcess, "id" | "status">>(
+export function latestPendingExternal<T extends Pick<OrgMembershipProcess, "id" | "status">>(
     processes: T[] | null | undefined,
 ): T | undefined {
     return [...(processes ?? [])]

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -46,17 +46,17 @@ function monthsBefore(date: Date, months: number): Date {
  */
 export async function runRenewalSweep(now: Date) {
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    if (!settings?.membershipYearBoundary) {
+    if (!settings?.orgMembershipYearBoundary) {
         return { opened: 0, skipped: 0, reason: "no membership-year boundary configured" };
     }
 
-    const boundary = nextBoundary(settings.membershipYearBoundary, now);
+    const boundary = nextBoundary(settings.orgMembershipYearBoundary, now);
     const windowStart = monthsBefore(boundary, RENEWAL_LEAD_MONTHS);
     if (now.getTime() < windowStart.getTime()) {
         return { opened: 0, skipped: 0, reason: "not yet within renewal window" };
     }
 
-    const memberships = await prisma.membership.findMany({
+    const memberships = await prisma.orgMembership.findMany({
         where: { status: "ACTIVE" },
         // "Already open" = an in-flight RENEWAL by status (matches the partial unique
         // index + openRenewalsForAllActive), not the leakier createdAt window.
@@ -80,14 +80,14 @@ export async function runRenewalSweep(now: Date) {
  * from PENDING_RENEWAL.
  */
 export async function beginRenewal(processId: number) {
-    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new RenewalError("not_found", "Renewal not found.");
     if (process.status !== "PENDING_RENEWAL") throw new RenewalError("wrong_phase", "This renewal is not awaiting your confirmation.");
 
-    const membership = await prisma.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
+    const membership = await prisma.orgMembership.findUnique({ where: { id: process.orgMembershipId }, select: { householdId: true } });
     if (!membership) throw new RenewalError("not_found", "Membership not found.");
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const boundary = settings?.membershipYearBoundary ? nextBoundary(settings.membershipYearBoundary, new Date()) : new Date();
+    const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, new Date()) : new Date();
     const bgFresh = await householdBgIsFresh(membership.householdId, boundary, settings?.bgRecheckMonths ?? 0);
 
     const nextStatus = bgFresh ? "PENDING_PAYMENT" : "RENEWAL_PENDING_BG";
@@ -98,17 +98,17 @@ export async function beginRenewal(processId: number) {
     // consent step / reviewer queue for a fresh renewal). Without this the renewal
     // pays and parks at PENDING_BG_CLEARANCE forever. Re-review renewals
     // (RENEWAL_PENDING_BG) get bgClearedAt from clearBackgroundCheck instead.
-    const { count } = await prisma.membershipProcess.updateMany({
+    const { count } = await prisma.orgMembershipProcess.updateMany({
         where: { id: processId, status: "PENDING_RENEWAL" },
         data: { status: nextStatus, stageEnteredAt: new Date(), ...(bgFresh ? { bgClearedAt: new Date() } : {}) },
     });
     if (count === 1) {
         await prisma.auditLog.create({
-            data: { actorId: SYSTEM_ACTOR, action: "EDIT", tableName: "MembershipProcess", affectedEntityId: processId, oldData: { status: "PENDING_RENEWAL" }, newData: { status: nextStatus, ...(bgFresh ? { bgClearedAt: true } : {}) } },
+            data: { actorId: SYSTEM_ACTOR, action: "EDIT", tableName: "OrgMembershipProcess", affectedEntityId: processId, oldData: { status: "PENDING_RENEWAL" }, newData: { status: nextStatus, ...(bgFresh ? { bgClearedAt: true } : {}) } },
         });
         if (nextStatus === "RENEWAL_PENDING_BG") await notifyReviewers();
     }
-    return prisma.membershipProcess.findUniqueOrThrow({ where: { id: processId } });
+    return prisma.orgMembershipProcess.findUniqueOrThrow({ where: { id: processId } });
 }
 
 /**
@@ -123,34 +123,34 @@ export async function beginRenewal(processId: number) {
  * integration test DBs don't have it). The index stays as defense-in-depth and the
  * P2002 catch as a backstop. Returns null when this call lost the race.
  */
-export async function createRenewalProcess(membershipId: number, householdId: number, now: Date, opts: { remind: boolean; boundary: Date }) {
+export async function createRenewalProcess(orgMembershipId: number, householdId: number, now: Date, opts: { remind: boolean; boundary: Date }) {
     let process;
     try {
         process = await prisma.$transaction(async (tx) => {
             // Lock the membership row so overlapping opens serialize here, not at the INSERT.
-            await tx.$queryRaw`SELECT id FROM "Membership" WHERE id = ${membershipId} FOR UPDATE`;
-            const existing = await tx.membershipProcess.findFirst({
-                where: { membershipId, kind: "RENEWAL", status: { in: ["PENDING_RENEWAL", "RENEWAL_PENDING_BG", "PENDING_PAYMENT"] } },
+            await tx.$queryRaw`SELECT id FROM "OrgMembership" WHERE id = ${orgMembershipId} FOR UPDATE`;
+            const existing = await tx.orgMembershipProcess.findFirst({
+                where: { orgMembershipId, kind: "RENEWAL", status: { in: ["PENDING_RENEWAL", "RENEWAL_PENDING_BG", "PENDING_PAYMENT"] } },
                 select: { id: true },
             });
             if (existing) return null; // someone else already opened the renewal
-            const created = await tx.membershipProcess.create({
-                data: { membershipId, kind: "RENEWAL", status: "PENDING_RENEWAL", renewalReminderSentAt: opts.remind ? now : null },
+            const created = await tx.orgMembershipProcess.create({
+                data: { orgMembershipId, kind: "RENEWAL", status: "PENDING_RENEWAL", renewalReminderSentAt: opts.remind ? now : null },
             });
             await tx.auditLog.create({
-                data: { actorId: SYSTEM_ACTOR, action: "CREATE", tableName: "MembershipProcess", affectedEntityId: created.id, newData: { kind: "RENEWAL", status: "PENDING_RENEWAL" } },
+                data: { actorId: SYSTEM_ACTOR, action: "CREATE", tableName: "OrgMembershipProcess", affectedEntityId: created.id, newData: { kind: "RENEWAL", status: "PENDING_RENEWAL" } },
             });
             return created;
         });
     } catch (e) {
         if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
-            logger.info("Renewal already in flight for membership %d — concurrent open, skipping", membershipId);
+            logger.info("Renewal already in flight for membership %d — concurrent open, skipping", orgMembershipId);
             return null;
         }
         throw e;
     }
     if (!process) {
-        logger.info("Renewal already in flight for membership %d — concurrent open, skipping", membershipId);
+        logger.info("Renewal already in flight for membership %d — concurrent open, skipping", orgMembershipId);
         return null;
     }
     if (opts.remind) await remindHousehold(householdId, opts.boundary);
@@ -165,9 +165,9 @@ export async function createRenewalProcess(membershipId: number, householdId: nu
  */
 export async function openRenewalsForAllActive(now: Date, opts: { sendReminders?: boolean } = {}) {
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const boundary = settings?.membershipYearBoundary ? nextBoundary(settings.membershipYearBoundary, now) : now;
+    const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, now) : now;
 
-    const memberships = await prisma.membership.findMany({
+    const memberships = await prisma.orgMembership.findMany({
         where: { status: "ACTIVE" },
         select: {
             id: true,
@@ -190,8 +190,8 @@ export async function openRenewalsForAllActive(now: Date, opts: { sendReminders?
 export async function beginRenewalForUser(userId: number) {
     const user = await prisma.person.findUnique({ where: { id: userId }, select: { householdId: true } });
     if (!user?.householdId) throw new RenewalError("not_found", "You are not in a household.");
-    const process = await prisma.membershipProcess.findFirst({
-        where: { membership: { householdId: user.householdId }, status: "PENDING_RENEWAL" },
+    const process = await prisma.orgMembershipProcess.findFirst({
+        where: { orgMembership: { householdId: user.householdId }, status: "PENDING_RENEWAL" },
         orderBy: { id: "desc" },
     });
     if (!process) throw new RenewalError("wrong_phase", "No renewal is awaiting your confirmation.");

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -1,4 +1,4 @@
-import { Prisma, type MembershipProcessStatus } from "@/generated/prisma/client";
+import { Prisma, type OrgMembershipProcessStatus } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { sendEmail } from "@/lib/email";
 import { logger } from "@/lib/logger";
@@ -66,7 +66,7 @@ export class ReviewError extends Error {
  *   - PENDING_PAYMENT / PENDING_BG_CLEARANCE: the INITIAL parallel states, once
  *     consent has been recorded (bgConsentAt set).
  */
-function isAwaitingBgReview(p: { status: MembershipProcessStatus; bgConsentAt: Date | null; bgClearedAt: Date | null }): boolean {
+function isAwaitingBgReview(p: { status: OrgMembershipProcessStatus; bgConsentAt: Date | null; bgClearedAt: Date | null }): boolean {
     if (p.bgClearedAt) return false;
     if (p.status === "PENDING_BG_REVIEW" || p.status === "RENEWAL_PENDING_BG") return true;
     if ((p.status === "PENDING_PAYMENT" || p.status === "PENDING_BG_CLEARANCE") && p.bgConsentAt) return true;
@@ -74,7 +74,7 @@ function isAwaitingBgReview(p: { status: MembershipProcessStatus; bgConsentAt: D
 }
 
 /** Prisma `where` matching the same predicate as isAwaitingBgReview, for queue queries. */
-export const AWAITING_BG_WHERE: Prisma.MembershipProcessWhereInput = {
+export const AWAITING_BG_WHERE: Prisma.OrgMembershipProcessWhereInput = {
     bgClearedAt: null,
     OR: [
         { status: { in: ["PENDING_BG_REVIEW", "RENEWAL_PENDING_BG"] } },
@@ -122,19 +122,19 @@ export async function eligibleReviewProcessIds(reviewerId: number): Promise<numb
     const reviewer = await loadReviewer(reviewerId);
     if (!reviewer || !canReviewBackgroundChecks(reviewer)) return [];
 
-    const processes = await prisma.membershipProcess.findMany({
+    const processes = await prisma.orgMembershipProcess.findMany({
         where: AWAITING_BG_WHERE,
         orderBy: { stageEnteredAt: "asc" },
         select: {
             id: true,
-            membership: { select: { householdId: true } },
+            orgMembership: { select: { householdId: true } },
             attestations: { select: { reviewerId: true, reviewer: { select: { householdId: true } } } },
         },
     });
 
     return processes
         .filter((p) => {
-            if (p.membership.householdId === reviewer.householdId) return false; // own household
+            if (p.orgMembership.householdId === reviewer.householdId) return false; // own household
             if (p.attestations.some((a) => a.reviewerId === reviewer.id)) return false; // already attested
             if (p.attestations.some((a) => a.reviewer.householdId === reviewer.householdId)) return false; // shares household with other reviewer
             return true;
@@ -156,20 +156,20 @@ export async function attest(
     if (!reviewer || !canReviewBackgroundChecks(reviewer)) throw new ReviewError("not_reviewer", "You are not a background-check reviewer.");
 
     // Re-check eligibility, create the attestation, recompute approvals, and converge
-    // all inside one transaction. FOR UPDATE on the MembershipProcess row serializes
+    // all inside one transaction. FOR UPDATE on the OrgMembershipProcess row serializes
     // concurrent attestations AND the payment path (payment.ts › activate takes the
     // same lock) — so the payment/clearance race can't lose an update: whoever commits
     // second sees the other's field set and flips ACTIVE. Mirrors leads.ts.
     const result = await prisma.$transaction(async (tx) => {
-        await tx.$queryRaw`SELECT id FROM "MembershipProcess" WHERE id = ${processId} FOR UPDATE`;
+        await tx.$queryRaw`SELECT id FROM "OrgMembershipProcess" WHERE id = ${processId} FOR UPDATE`;
 
-        const process = await tx.membershipProcess.findUnique({
+        const process = await tx.orgMembershipProcess.findUnique({
             where: { id: processId },
             include: { attestations: { include: { reviewer: { select: { householdId: true } } } } },
         });
         if (!process) throw new ReviewError("not_found", "Application not found.");
         if (!isAwaitingBgReview(process)) throw new ReviewError("wrong_phase", "This application is not awaiting background-check review.");
-        const membership = await tx.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
+        const membership = await tx.orgMembership.findUnique({ where: { id: process.orgMembershipId }, select: { householdId: true } });
         if (membership?.householdId === reviewer.householdId) throw new ReviewError("same_household_applicant", "You cannot review an applicant in your own household.");
         if (process.attestations.some((a) => a.reviewerId === reviewerId)) throw new ReviewError("already_attested", "You have already reviewed this application.");
         if (process.attestations.some((a) => a.reviewer.householdId === reviewer.householdId)) throw new ReviewError("same_household_reviewer", "Another reviewer from your household has already reviewed this application.");
@@ -179,7 +179,7 @@ export async function attest(
         });
 
         if (input.result === "REJECT") {
-            await tx.membershipProcess.update({ where: { id: processId }, data: { status: "BLOCKED", stageEnteredAt: new Date() } });
+            await tx.orgMembershipProcess.update({ where: { id: processId }, data: { status: "BLOCKED", stageEnteredAt: new Date() } });
             await audit(tx, reviewerId, processId, { status: process.status }, { status: "BLOCKED", reason: "reviewer reject" });
             // A paid household that fails review needs a manual refund — flag the board (post-tx).
             return { status: "BLOCKED" as const, notifyPaidReject: !!process.paidAt };
@@ -188,7 +188,7 @@ export async function attest(
         const approvals = process.attestations.filter((a) => a.result === "APPROVE").length + 1;
         if (approvals >= REQUIRED_APPROVALS) {
             const { activated, householdId } = await clearBackgroundCheck(tx, processId, reviewerId);
-            const status: MembershipProcessStatus = activated ? "ACTIVE" : "PENDING_PAYMENT";
+            const status: OrgMembershipProcessStatus = activated ? "ACTIVE" : "PENDING_PAYMENT";
             return { status, activated, householdId };
         }
         return { status: process.status, approvals };
@@ -212,12 +212,12 @@ export async function attest(
  * Must run inside a tx holding a FOR UPDATE lock on the process row.
  */
 async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: number): Promise<{ activated: boolean; householdId: number }> {
-    const process = await tx.membershipProcess.findUnique({
+    const process = await tx.orgMembershipProcess.findUnique({
         where: { id: processId },
         include: { attestations: true },
     });
     if (!process) throw new ReviewError("not_found", "Application not found.");
-    const membership = await tx.membership.findUnique({ where: { id: process.membershipId }, select: { householdId: true } });
+    const membership = await tx.orgMembership.findUnique({ where: { id: process.orgMembershipId }, select: { householdId: true } });
     if (!membership) throw new ReviewError("not_found", "Membership not found.");
     const householdId = membership.householdId;
     const now = new Date();
@@ -226,14 +226,14 @@ async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: nu
     // Stamp the guardians' (household leads') lastBackgroundCheck. Expiry is derived from this
     // plus BoardSettings.bgRecheckMonths at read time (see householdBgIsFresh) — not stored.
     await tx.person.updateMany({ where: { householdId, householdLeads: { some: { householdId } } }, data: { lastBackgroundCheck: now } });
-    await applyVolunteerStatus(tx, process.membershipId, householdId, process.attestations.some((a) => a.isMarkedVolunteer));
+    await applyVolunteerStatus(tx, process.orgMembershipId, householdId, process.attestations.some((a) => a.isMarkedVolunteer));
 
-    await tx.membershipProcess.update({
+    await tx.orgMembershipProcess.update({
         where: { id: processId },
         data: { bgClearedAt: now, status: paid ? "ACTIVE" : "PENDING_PAYMENT", stageEnteredAt: now },
     });
     if (paid) {
-        await tx.membership.update({ where: { id: process.membershipId }, data: { status: "ACTIVE" } });
+        await tx.orgMembership.update({ where: { id: process.orgMembershipId }, data: { status: "ACTIVE" } });
     }
 
     await audit(tx, actorId, processId, { status: process.status }, { status: paid ? "ACTIVE" : "PENDING_PAYMENT", bgCleared: true });
@@ -256,7 +256,7 @@ export function matchesVolunteerDesignation(parentEmails: string[], designationE
  * reviewer marked the family volunteer-only OR a household parent's email is pre-
  * designated. Never clears it here.
  */
-export async function applyVolunteerStatus(db: DbClient, membershipId: number, householdId: number, markedByReviewer: boolean) {
+export async function applyVolunteerStatus(db: DbClient, orgMembershipId: number, householdId: number, markedByReviewer: boolean) {
     let isVolunteer = markedByReviewer;
     if (!isVolunteer) {
         const parents = await db.person.findMany({ where: { householdId, householdLeads: { some: { householdId } }, email: { not: null } }, select: { email: true } });
@@ -264,13 +264,13 @@ export async function applyVolunteerStatus(db: DbClient, membershipId: number, h
         isVolunteer = matchesVolunteerDesignation(parents.map((p) => p.email!), designations.map((d) => d.email));
     }
     if (isVolunteer) {
-        await db.membership.update({ where: { id: membershipId }, data: { isVolunteer: true } });
+        await db.orgMembership.update({ where: { id: orgMembershipId }, data: { isVolunteer: true } });
     }
 }
 
 /** Board override on a BLOCKED application: reset for re-review, or force-clear the check. */
 export async function overrideBlocked(processId: number, actorId: number, action: "reset" | "approve") {
-    const process = await prisma.membershipProcess.findUnique({ where: { id: processId } });
+    const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new ReviewError("not_found", "Application not found.");
     if (process.status !== "BLOCKED") throw new ReviewError("wrong_phase", "This application is not blocked.");
 
@@ -278,10 +278,10 @@ export async function overrideBlocked(processId: number, actorId: number, action
         // Restore the review state that matches the cycle. The check runs in parallel,
         // so an initial application returns to PENDING_BG_CLEARANCE if it had already
         // paid, else PENDING_PAYMENT; renewals go back to RENEWAL_PENDING_BG.
-        const reviewStatus: MembershipProcessStatus =
+        const reviewStatus: OrgMembershipProcessStatus =
             process.kind === "RENEWAL" ? "RENEWAL_PENDING_BG" : process.paidAt ? "PENDING_BG_CLEARANCE" : "PENDING_PAYMENT";
         await prisma.backgroundCheckAttestation.deleteMany({ where: { processId } });
-        await prisma.membershipProcess.update({ where: { id: processId }, data: { status: reviewStatus, bgClearedAt: null, stageEnteredAt: new Date() } });
+        await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: reviewStatus, bgClearedAt: null, stageEnteredAt: new Date() } });
         await audit(prisma, actorId, processId, { status: "BLOCKED" }, { status: reviewStatus, action: "board reset" });
         await notifyReviewers();
         return { status: reviewStatus };
@@ -291,11 +291,11 @@ export async function overrideBlocked(processId: number, actorId: number, action
     // against a late payment webhook (activate also locks), so the override reads
     // a fresh paidAt and converges to ACTIVE rather than parking it at PENDING_PAYMENT.
     const { activated, householdId } = await prisma.$transaction(async (tx) => {
-        await tx.$queryRaw`SELECT id FROM "MembershipProcess" WHERE id = ${processId} FOR UPDATE`;
+        await tx.$queryRaw`SELECT id FROM "OrgMembershipProcess" WHERE id = ${processId} FOR UPDATE`;
         return clearBackgroundCheck(tx, processId, actorId);
     });
     if (activated) await sendCongrats(householdId);
-    const status: MembershipProcessStatus = activated ? "ACTIVE" : "PENDING_PAYMENT";
+    const status: OrgMembershipProcessStatus = activated ? "ACTIVE" : "PENDING_PAYMENT";
     return { status };
 }
 
@@ -304,7 +304,7 @@ function audit(db: DbClient, actorId: number, processId: number, oldData: object
         data: {
             actorId: actorId || SYSTEM_ACTOR,
             action: "EDIT",
-            tableName: "MembershipProcess",
+            tableName: "OrgMembershipProcess",
             affectedEntityId: processId,
             oldData,
             newData,

--- a/checkin-app/src/lib/orgMembership.ts
+++ b/checkin-app/src/lib/orgMembership.ts
@@ -1,4 +1,4 @@
-import type { MembershipStatus, Prisma } from "@/generated/prisma/client";
+import type { OrgMembershipStatus, Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 
 /**
@@ -10,7 +10,7 @@ import prisma from "@/lib/prisma";
  * through here so a child or second parent in an active household is honored.
  */
 export const ACTIVE_ORG_MEMBER_PERSON_WHERE: Prisma.PersonWhereInput = {
-    household: { membership: { status: "ACTIVE" } },
+    household: { orgMembership: { status: "ACTIVE" } },
 };
 
 /**
@@ -20,7 +20,7 @@ export const ACTIVE_ORG_MEMBER_PERSON_WHERE: Prisma.PersonWhereInput = {
  * without an extra round-trip.
  */
 export const ACTIVE_ORG_MEMBER_INCLUDE = {
-    household: { include: { membership: true } },
+    household: { include: { orgMembership: true } },
 } satisfies Prisma.PersonInclude;
 
 /**
@@ -43,9 +43,9 @@ export async function isActiveOrgMember(personId: number): Promise<boolean> {
  * membership; a missing household or membership reads as "not an org member".
  */
 export function personRecordIsActiveOrgMember(p: {
-    household?: { membership?: { status: MembershipStatus } | null } | null;
+    household?: { orgMembership?: { status: OrgMembershipStatus } | null } | null;
 }): boolean {
-    return p.household?.membership?.status === "ACTIVE";
+    return p.household?.orgMembership?.status === "ACTIVE";
 }
 
 /**
@@ -57,7 +57,7 @@ export function personRecordIsActiveOrgMember(p: {
  * it so a board "Deny Membership" action takes effect for every member of the household.
  */
 export function orgMembershipStatusBlocksLogin(
-    status: MembershipStatus | null | undefined,
+    status: OrgMembershipStatus | null | undefined,
 ): boolean {
     return status === "DENIED";
 }

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -61,16 +61,16 @@ export const classifications = {
         householdId: 'public',
         personId: 'public',
     },
-    Membership: {
+    OrgMembership: {
         id: 'public',
         memberSince: 'public',
         status: 'public',
         isVolunteer: 'public',
         householdId: 'public',
     },
-    MembershipProcess: {
+    OrgMembershipProcess: {
         id: 'public',
-        membershipId: 'public',
+        orgMembershipId: 'public',
         kind: 'public',
         status: 'internal',
         stageEnteredAt: 'internal',
@@ -105,11 +105,11 @@ export const classifications = {
         id: 'public',
         normalDuesCents: 'public',
         volunteerDuesCents: 'public',
-        membershipYearBoundary: 'public',
-        membershipVariantId: 'internal',
+        orgMembershipYearBoundary: 'public',
+        orgMembershipVariantId: 'internal',
         volunteerDiscountCode: 'internal',
         bgRecheckMonths: 'public',
-        shopifyMembershipProductId: 'internal',
+        shopifyOrgMembershipProductId: 'internal',
         shopifyNormalVariantId: 'internal',
         shopifyVolunteerVariantId: 'internal',
         shopifyPriceSyncedAt: 'internal',
@@ -353,7 +353,7 @@ export const relations = {
     Household: {
         householdMembers: { model: 'Person', isList: true },
         leads: { model: 'HouseholdLead', isList: true },
-        membership: { model: 'Membership', isList: false },
+        orgMembership: { model: 'OrgMembership', isList: false },
         trustedAdults: { model: 'TrustedAdult', isList: true },
         emergencyContacts: { model: 'EmergencyContact', isList: true },
     },
@@ -364,16 +364,16 @@ export const relations = {
         household: { model: 'Household', isList: false },
         person: { model: 'Person', isList: false },
     },
-    Membership: {
+    OrgMembership: {
         household: { model: 'Household', isList: false },
-        processes: { model: 'MembershipProcess', isList: true },
+        processes: { model: 'OrgMembershipProcess', isList: true },
     },
-    MembershipProcess: {
-        membership: { model: 'Membership', isList: false },
+    OrgMembershipProcess: {
+        orgMembership: { model: 'OrgMembership', isList: false },
         attestations: { model: 'BackgroundCheckAttestation', isList: true },
     },
     BackgroundCheckAttestation: {
-        process: { model: 'MembershipProcess', isList: false },
+        process: { model: 'OrgMembershipProcess', isList: false },
         reviewer: { model: 'Person', isList: false },
     },
     VolunteerDesignation: {

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -127,10 +127,10 @@ defineRoute({
     endpoint: 'GET /api/membership-ops/applications',
     authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
     envelope: 'processes',
-    // Bag: { MembershipProcess } with attestations (BackgroundCheckAttestation),
-    // membership (Membership → household Household → participants Person,
+    // Bag: { OrgMembershipProcess } with attestations (BackgroundCheckAttestation),
+    // membership (OrgMembership → household Household → participants Person,
     // leads HouseholdLead).
-    returns: ['MembershipProcess', 'BackgroundCheckAttestation', 'Membership', 'Household', 'Person', 'HouseholdLead'],
+    returns: ['OrgMembershipProcess', 'BackgroundCheckAttestation', 'OrgMembership', 'Household', 'Person', 'HouseholdLead'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
@@ -145,9 +145,9 @@ defineRoute({
     endpoint: 'GET /api/membership/reviews',
     authorize: { anyRole: ['isBackgroundCheckReviewer', 'isBoardMember'] },
     envelope: 'queue',
-    // Bag: { MembershipProcess } with membership (Membership → household Household
+    // Bag: { OrgMembershipProcess } with membership (OrgMembership → household Household
     // → leads HouseholdLead → participant Person).
-    returns: ['MembershipProcess', 'Membership', 'Household', 'HouseholdLead', 'Person'],
+    returns: ['OrgMembershipProcess', 'OrgMembership', 'Household', 'HouseholdLead', 'Person'],
     orderedView: [
         ['isBackgroundCheckReviewer', ['everyones:pii', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'member', 'public']],

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -52,7 +52,7 @@ export const SCOPE_BINDINGS = {
         their_households: { field: 'householdId', eqCtx: 'householdId' },
         their_own: { field: 'personId', eqCtx: 'selfId' },
     },
-    Membership: { their_households: { field: 'householdId', eqCtx: 'householdId' } },
+    OrgMembership: { their_households: { field: 'householdId', eqCtx: 'householdId' } },
     Program: {
         their_program_participants: { field: 'id', inCtx: ['programsLed', 'programsCoreVolIn'] },
     },
@@ -151,7 +151,7 @@ export const ROW_SCOPE_KEY: Record<string, string> = {
  * it as pending). Removed.
  */
 export const OPT_OUT_PENDING_ROUTE = new Set<string>([
-    'MembershipProcess', // board/admin today; a household-facing status route is plausible
+    'OrgMembershipProcess', // board/admin today; a household-facing status route is plausible
     'BackgroundCheckAttestation', // bind their_own at migration, keep notes `internal`
     'Corporation', // has leads→participantId; a corp-lead view is plausible
     'VolunteerDesignation', // has createdById; confirm whether a self view is warranted

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -89,7 +89,7 @@ function referenceScopesHeld(
             if (personId !== undefined && personId === ctx.selfId) scopes.add('their_own');
             break;
         }
-        case 'Membership': {
+        case 'OrgMembership': {
             const householdId = num(row.householdId);
             if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
             break;
@@ -254,7 +254,7 @@ const MODELS = [
     'Fee',
     'Tool',
     'BoardSettings',
-    'MembershipProcess',
+    'OrgMembershipProcess',
     'UnknownModelXYZ',
 ];
 


### PR DESCRIPTION
Phase 4d of the OrgMembership terminology migration — the atomic model/enum flip with a real schema migration. Stacked on Phase 4c (now in `main`), rebased onto `main`.

## Renames
- **Models**: `Membership` → `OrgMembership`, `MembershipProcess` → `OrgMembershipProcess`
- **Enums** (type names only; VALUES like `ACTIVE`/`DENIED`/`RENEWAL` unchanged): `MembershipStatus` → `OrgMembershipStatus`, `MembershipProcessKind` → `OrgMembershipProcessKind`, `MembershipProcessStatus` → `OrgMembershipProcessStatus`
- **Relations/fields**: `Household.membership` → `orgMembership`; `OrgMembershipProcess.membership` → `orgMembership`, `membershipId` → `orgMembershipId`; `BackgroundCheckAttestation.process` type follows
- **BoardSettings**: `membershipYearBoundary`/`membershipVariantId`/`shopifyMembershipProductId` → `orgMembership*` (left `shopifyNormalVariantId`/`shopifyVolunteerVariantId`)

## Migration — RENAME, not drop+create
`OrgMembershipProcess` carries two raw-SQL partial-unique indexes (`membership_one_inflight_initial`, `membership_one_inflight_renewal`) that are **not** declared in `schema.prisma`. A Prisma-default rename emits DROP+CREATE TABLE, which would drop them. The migration hand-edits to `ALTER … RENAME` for tables/enums/columns/constraints; Postgres carries the partial indexes and FK constraints through the rename automatically. Verified post-apply via `\d "OrgMembershipProcess"` (both partial indexes present, auto-repointed to `orgMembershipId`, recast to the new enum types) and by the intake/renewal/review concurrency integration tests. Raw-SQL `FROM "Membership" … FOR UPDATE` locks repointed to `"OrgMembership"`.

## Security artifacts
- `scopeBindings.ts` model key `Membership` → `OrgMembership`; `'MembershipProcess'` → `'OrgMembershipProcess'`
- `registry.ts` model-name strings in `returns`/Bag comments
- Regenerated `classifications.ts`
- Updated the `scopeBindingsEquivalence` oracle's frozen switch + unbound-model list
- Audit `tableName` labels `"Membership"` → `"OrgMembership"` (write sites + test oracles), matching the already-renamed `"OrgMembershipProcess"` convention

**Untouched per Phase 4 scope decisions**: the `'member'` field-visibility TIER, `@sensitivity:member`, and the `membership-ops`/`membership-audit` directory names, route paths, and nav labels (model/prisma refs *inside* those files are updated).

## Verification
- `tsc --noEmit` clean
- 60 integration suites / 579 tests pass (membership, household, programs, notifications, shop, authz, concurrency, trustedAdult)
- 47 security/unit suites / 680 tests pass (incl. the #733-armed scope validators, strip tests, routeAuthDrift)
- Two partial unique indexes confirmed present after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)