### PR TITLE
fix(shopify): verify program's Shopify variant before activating enrollment (price-integrity)

### DIFF
--- a/checkin-app/__tests__/programLifecycle.integration.test.ts
+++ b/checkin-app/__tests__/programLifecycle.integration.test.ts
@@ -179,9 +179,12 @@ describe('Program Lifecycle Integration Tests', () => {
             create: { programId: testProgramId, personId: testParticipantId, status: 'PENDING', pendingSince: new Date() }
         });
 
-        // 2. Build Shopify webhook payload
+        // 2. Build Shopify webhook payload. line_items must contain the program's
+        // own Shopify variant (shopifyNonOrgMemberVariantId set in beforeAll) —
+        // the route now verifies this before activating (see route.ts).
         const payload = JSON.stringify({
             id: 12345,
+            line_items: [{ variant_id: "test-non-var" }],
             note_attributes: [
                 { name: "CheckMeIn_Account_ID", value: String(testParticipantId) },
                 { name: "Program_ID", value: String(testProgramId) }

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -9,6 +9,8 @@
  *   - replaying the same valid payload twice (Shopify retries at-least-once)
  *   - the membership-process activation branch
  *   - comma-separated multi-participant activation
+ *   - the program-enrollment Shopify-variant guard (fails closed when the
+ *     paid order doesn't contain the program's own variant)
  */
 import crypto from 'crypto';
 import { POST } from '@/app/api/webhooks/shopify/route';
@@ -29,6 +31,8 @@ jest.mock('@/lib/logger', () => ({
 const SECRET = 'shopify-test-secret';
 const TAG = 'shopify-webhook-test';
 const MEMBERSHIP_VARIANT_ID = '778899';
+const PROGRAM_VARIANT_ID = '445566';
+const OTHER_VARIANT_ID = '999999'; // cheapest-item-in-the-store stand-in — never matches the program
 
 function sign(body: string, secret = SECRET): string {
     return crypto.createHmac('sha256', secret).update(body, 'utf8').digest('base64');
@@ -54,8 +58,11 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
     let prevMembershipVariantId: string | null = null;
 
     beforeAll(async () => {
+        // shopifyNonOrgMemberVariantId is the variant public-register's checkout
+        // link is built from — seed it so the guard under test has something to
+        // match line_items against.
         const program = await prisma.program.create({
-            data: { name: `Webhook Test Program ${TAG}`, enrollmentStatus: 'OPEN' },
+            data: { name: `Webhook Test Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyNonOrgMemberVariantId: PROGRAM_VARIANT_ID },
         });
         programId = program.id;
 
@@ -104,9 +111,13 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         });
     }
 
-    function programPayload(accountIds: string) {
+    // Defaults to a line item matching the program's own variant, since most
+    // tests here aren't exercising the variant guard — pass variantId: null for
+    // no line items, or an explicit mismatched id, to exercise it.
+    function programPayload(accountIds: string, variantId: string | null = PROGRAM_VARIANT_ID) {
         return JSON.stringify({
             id: 555,
+            ...(variantId ? { line_items: [{ variant_id: variantId }] } : {}),
             note_attributes: [
                 { name: 'CheckMeIn_Account_ID', value: accountIds },
                 { name: 'Program_ID', value: String(programId) },
@@ -182,6 +193,8 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
     });
 
     it('activates a PENDING participant and is idempotent across a replayed delivery', async () => {
+        // Line items (via programPayload's default) contain the program's own
+        // Shopify variant — the guard under test is satisfied.
         await setPending(p1);
         const body = programPayload(String(p1));
 
@@ -217,6 +230,55 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         });
         expect(rows).toHaveLength(2);
         expect(rows.every(r => r.status === 'ACTIVE')).toBe(true);
+    });
+
+    it('does NOT activate a PENDING participant when the paid order does not contain the program\'s Shopify variant (fails closed)', async () => {
+        // The core regression test: note_attributes alone (CheckMeIn_Account_ID /
+        // Program_ID) are customer-controlled and must NOT be enough to activate —
+        // the order's line_items have to actually contain the program's variant.
+        // Here they carry an unrelated (cheaper) variant instead.
+        await setPending(p1);
+        const body = programPayload(String(p1), OTHER_VARIANT_ID);
+
+        const res = await POST(webhookReq(body, sign(body)));
+        expect(res.status).toBe(200); // still acks Shopify — only the DB state-change is gated
+
+        const row = await prisma.programParticipant.findUnique({
+            where: { programId_personId: { programId, personId: p1 } },
+        });
+        expect(row?.status).toBe('PENDING');
+        expect(row?.pendingSince).not.toBeNull();
+    });
+
+    it('fails closed when the Program has no Shopify variant configured at all', async () => {
+        // "Cannot verify" must mean "don't activate", not "trust the payload".
+        const noVariantProgram = await prisma.program.create({
+            data: { name: `Webhook Test No-Variant Program ${TAG}`, enrollmentStatus: 'OPEN' },
+        });
+        try {
+            await prisma.programParticipant.create({
+                data: { programId: noVariantProgram.id, personId: p1, status: 'PENDING', pendingSince: new Date() },
+            });
+            const body = JSON.stringify({
+                id: 654,
+                line_items: [{ variant_id: PROGRAM_VARIANT_ID }], // even a "valid-looking" variant can't match — nothing configured
+                note_attributes: [
+                    { name: 'CheckMeIn_Account_ID', value: String(p1) },
+                    { name: 'Program_ID', value: String(noVariantProgram.id) },
+                ],
+            });
+            const res = await POST(webhookReq(body, sign(body)));
+            expect(res.status).toBe(200);
+
+            const row = await prisma.programParticipant.findUnique({
+                where: { programId_personId: { programId: noVariantProgram.id, personId: p1 } },
+            });
+            expect(row?.status).toBe('PENDING');
+            expect(row?.pendingSince).not.toBeNull();
+        } finally {
+            await prisma.programParticipant.deleteMany({ where: { programId: noVariantProgram.id } });
+            await prisma.program.delete({ where: { id: noVariantProgram.id } });
+        }
     });
 
     it('rate-limits a flood (429 + Retry-After) AHEAD of the HMAC check — bad sig still 429, not 401', async () => {

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -118,6 +118,27 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
             const programId = parseInt(programIdStr, 10);
 
             if (participantIds.length > 0 && !isNaN(programId)) {
+                // Guard mirrors the membership H2 fix above: note_attributes
+                // (CheckMeIn_Account_ID / Program_ID) are entirely
+                // customer-controlled — set from the public cart permalink —
+                // so nothing in the payload itself proves the paid order was
+                // for THIS program at THIS program's price. Without this, an
+                // attacker could self-register (public-register creates a
+                // PENDING participant, no payment) then pay for the cheapest
+                // item in the store with a forged Program_ID/CheckMeIn_Account_ID
+                // attribute and activate (or activate someone else's)
+                // enrollment. Checked by variant id — stable, and the same id
+                // public-register's checkout link is built from — not order
+                // total. Fail CLOSED: no variant configured on the Program, or
+                // no line-item match, means we do NOT activate.
+                const program = await prisma.program.findUnique({ where: { id: programId } });
+                const programVariantIds = new Set(
+                    [program?.shopifyOrgMemberVariantId, program?.shopifyNonOrgMemberVariantId].filter(
+                        (v): v is string => !!v,
+                    ),
+                );
+                const hasProgramItem = (order.line_items ?? []).some((li) => programVariantIds.has(String(li.variant_id)));
+
                 for (const participantId of participantIds) {
                     // Find existing participant
                     const existing = await prisma.programParticipant.findUnique({
@@ -127,6 +148,11 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                     });
 
                     if (existing) {
+                        if (!hasProgramItem) {
+                            logger.warn(`[SHOPIFY WEBHOOK] Paid order ${order.id ?? "?"} for participant ${participantId} / program ${programId} did not contain the program's Shopify variant${programVariantIds.size === 0 ? " (program has no variant configured)" : ""} — participant left PENDING, NOT activated.`);
+                            continue;
+                        }
+
                         await prisma.programParticipant.update({
                             where: {
                                 programId_personId: { programId, personId: participantId }
@@ -136,7 +162,7 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                                 pendingSince: null, // clear out the pending timer
                             }
                         });
-                        
+
                         logger.info(`[SHOPIFY WEBHOOK] Marked participant ${participantId} as ACTIVE for program ${programId}`);
                     } else {
                         logger.warn(`[SHOPIFY WEBHOOK] Participant ${participantId} not found in Program ${programId}. Ignoring payment.`);


### PR DESCRIPTION
## Vulnerability

`checkin-app/src/app/api/webhooks/shopify/route.ts`, the `orders/paid` handler's PROGRAM-enrollment branch (`if (accountIdStr && programIdStr)`), flipped a PENDING `programParticipant` to `ACTIVE` (clearing `pendingSince`) based **only** on the customer-controlled cart-permalink `note_attributes` `CheckMeIn_Account_ID` and `Program_ID`. It never checked that the paid order's `line_items` actually contained the program's own Shopify variant.

Exploit path:
1. Unauthenticated `POST /api/programs/[id]/public-register` creates a PENDING `programParticipant` — no payment required.
2. Attacker checks out the **cheapest** variant in the store via a cart permalink carrying `attributes[Program_ID]=<expensive program>` and `attributes[CheckMeIn_Account_ID]=<their or another user's person id>`.
3. Shopify legitimately HMAC-signs the resulting `orders/paid` webhook (the signature only proves *a* valid order happened at *some* price — not *which* product), and the handler activated the enrollment for a trivial price, or activated another user's pending enrollment entirely.

## Fix

Mirrors the membership branch's existing H2 guard (`hasMembershipItem` in the same file, enforced via `lib/membership/payment.ts`): before setting a participant ACTIVE, verify the paid order's `line_items` actually contain one of the Program's own Shopify variants.

```ts
const program = await prisma.program.findUnique({ where: { id: programId } });
const programVariantIds = new Set(
    [program?.shopifyOrgMemberVariantId, program?.shopifyNonOrgMemberVariantId].filter(
        (v): v is string => !!v,
    ),
);
const hasProgramItem = (order.line_items ?? []).some((li) => programVariantIds.has(String(li.variant_id)));
```

Checked by variant id (stable, and the same id `public-register`'s checkout link is built from) rather than order total — a total-price check drifts if program prices fall out of sync with Shopify's real price, and doesn't stop paying for unrelated items that happen to add up to the right amount.

**Fail-closed semantics:**
- Line-item match found → activate as before (unchanged happy path).
- No match, **or** the Program has no Shopify variant configured at all ("cannot verify") → do **NOT** activate. The participant stays PENDING, and `logger.warn(...)` names the participant/program so ops/board can see it.
- The webhook still acks `200` to Shopify either way — only the DB state-change is gated, ack semantics are unchanged.

## Tests

Extended `checkin-app/src/app/__tests__/webhookShopify.integration.test.ts`:
- Seeded the test program's `shopifyNonOrgMemberVariantId` and updated the shared `programPayload()` helper to include a matching `line_items` entry by default (so unrelated existing tests keep passing without change), with an override to send a mismatched/absent variant.
- New: activates when `line_items` contains the program's variant (existing PENDING→ACTIVE test, now explicit about the guard).
- New (core regression): does **not** activate — participant stays PENDING — when `line_items` contains an unrelated variant.
- New: fails closed when the Program has no Shopify variant configured at all.

Also fixed `checkin-app/__tests__/programLifecycle.integration.test.ts`'s webhook payload, which asserted PENDING→ACTIVE without any `line_items` — updated to include the program's configured test variant now that it's required.

## Verification

- `npx tsc --noEmit` — clean.
- `npm run lint` (repo root) — clean, 0 warnings.
- Targeted integration run (`INTEGRATION_DB=1 npx jest --ci --testRegex "\.integration\.test\.[jt]sx?$" src/app/__tests__/webhookShopify.integration.test.ts`, which in practice runs the full integration suite): **105 suites / 843 tests passed**, including all 13 in the target file (2 new).
- Full unit suite (`npm run test:ci`): **188 suites / 1414 tests passed**, including `programSignupIntegration.test.ts` (mocked, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)