### PR TITLE
feat(shopify): productionize the dev orders/paid mock + webhook-registration script

### DIFF
--- a/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md
+++ b/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md
@@ -1,0 +1,207 @@
+# Shopify Development Store + Webhooks in Dev/Local
+
+**Status:** Proposal — for review. No code written.
+**Author:** design pass, 2026-07-02 (revised 2026-07-02 after grepping prod deploy + `src/`)
+**Related:** [`ZOHO_SIGN_DEV_MOCK.md`](./ZOHO_SIGN_DEV_MOCK.md) (#669, in-process sign mock), #665 (email dev inbox), #278 (checkout-token honor-system TODO), #624/#625 (order-amount / price-alignment safety), #683 (Shopify env routed through `config.ts`)
+**Implementation plan:** [`SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md`](./SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md) (concrete steps + two prod-grounded corrections folded back into §2/§4 below).
+
+## 0. Scope check — what already exists
+
+Confirmed by `git log` + grep before writing this: **no Shopify dev-store or webhook-mock work has landed or is in flight.** The only recent Shopify commits are #683 (route env through `config.ts`), #624 (validate order amount before activating), and #466 (fetch timeouts). The two sibling dev-integration features — Zoho Sign mock (#669) and email inbox (#665) — do **not** touch Shopify. So this is greenfield; nothing to redesign.
+
+Unlike Zoho (which got a fully in-process mock), the ask here is to connect to a **real Shopify development store** so genuine `orders/paid` webhooks fire against the dev instance and drive `PENDING_PAYMENT → ACTIVE` end-to-end. An in-process mock is also proposed as the zero-infra fallback (§6). **Prod behavior is unchanged** — every dev-only path is env-gated the same way Zoho's is.
+
+---
+
+## 1. Current flow (as wired today)
+
+Trace from checkout link to activation:
+
+1. **Build the checkout link** — [`payment.ts › ensurePaymentLink`](../../src/lib/membership/payment.ts) reads `BoardSettings.membershipVariantId` + `config.shopifyStoreDomain()` and calls `buildMembershipCheckoutUrl`, producing a Shopify **cart permalink**:
+   ```
+   https://{SHOPIFY_STORE_DOMAIN}/cart/{variantId}:1?discount={code}&attributes[Membership_Process_ID]={processId}
+   ```
+   Volunteer households get `discount=<BoardSettings.volunteerDiscountCode>` appended. The process id rides along as a **cart attribute** so the webhook can match the payment back. If domain or variant is unset, the link is `null`.
+
+2. **Applicant pays on Shopify** — hosted checkout on the store. Shopify maps cart-attribute `attributes[Membership_Process_ID]` onto the Order's `note_attributes`.
+
+3. **`orders/paid` webhook fires** → [`api/webhooks/shopify/route.ts`](../../src/app/api/webhooks/shopify/route.ts), wrapped by `withWebhook({ provider: "shopify", verify: verifyShopifyHmac })` ([`webhookAuth.ts`](../../src/lib/webhookAuth.ts)): per-IP rate-limit → HMAC verify → JSON parse → handler.
+
+4. **HMAC verify** — `verifyShopifyHmac` computes `HMAC-SHA256(rawBody, config.shopifyWebhookSecret())` in base64 and `timingSafeEqual`s it against `x-shopify-hmac-sha256`. Unset secret → **500** (config error); missing/wrong sig → **401**. Verified over the exact raw bytes before parse.
+
+5. **Match by cart attribute** — handler scans `note_attributes` for `Membership_Process_ID`, then checks the order's `line_items` actually contain a known membership variant (`membershipVariantId` / `shopifyNormalVariantId` / `shopifyVolunteerVariantId` from `BoardSettings`) — the #624/H2 guard against paying for an unrelated item that totals the same.
+
+6. **`activate()`** ([`payment.ts`](../../src/lib/membership/payment.ts), via `activateByProcessId`) — `FOR UPDATE` row lock, idempotent on webhook retry. Flips `ACTIVE` if the background check already cleared (else holds `PENDING_BG_CLEARANCE`); handles paid-while-`BLOCKED` and no-membership-item as board-alerted anomalies rather than silent no-ops. On `ACTIVE`, sends the one congrats email.
+
+### What's missing in dev today
+
+Everything upstream of the handler. Concretely:
+
+| Gap | Symptom in dev |
+|-----|----------------|
+| No `SHOPIFY_STORE_DOMAIN/CLIENT_ID/CLIENT_SECRET` set | `shopify.ts` logs "integration disabled"; no Admin API; product/variant creation is a no-op |
+| No `BoardSettings.membershipVariantId` (seed does **not** set it — grep of `prisma/seed.ts` is empty) | `ensurePaymentLink` returns `checkoutUrl: null`; nothing to click |
+| No `SHOPIFY_WEBHOOK_SECRET` | inbound webhook 500s (`verifyShopifyHmac` config-error branch) |
+| No public URL | even a real store can't reach `localhost:4000` |
+
+So the payment leg of membership is **untestable locally** end-to-end right now. This proposal closes those four gaps.
+
+---
+
+## 2. Dev store setup
+
+Per [Shopify's development-stores docs](https://shopify.dev/docs/apps/build/dev-dashboard/stores/development-stores):
+
+**Create the store**
+1. Shopify [Dev Dashboard](https://dev.shopify.com/dashboard/) → **Stores** → **Create store**.
+2. Name it (e.g. `treehouse-checkin-dev`), pick a plan tier, confirm, log in.
+3. Requires a **Shopify Partner account** (or a merchant store with developer permissions). → *see open question O1.*
+
+**Dev-store limitations that matter to us** (from the docs):
+- **Cannot process real transactions.** Payment testing uses the **Bogus Gateway** / test mode — fine for us: a Bogus-Gateway checkout still fires a real `orders/paid` webhook. This is the whole point (real webhook, fake money).
+- Only free / partner-friendly apps are installable — irrelevant, our app is a custom app.
+- The store **password page can't be removed** — the checkout link works, but testers need the storefront password. Document it in the runbook.
+- Dev stores are **non-transferable** — a throwaway, not a future prod store.
+
+**Install a custom app + Admin API access**
+Our client uses the **Client Credentials Grant** (`shopify.ts › getAccessToken`, API version `2026-01`), so we need a custom app with client id/secret, not a legacy private-app token:
+1. In the dev store admin: **Settings → Apps and sales channels → Develop apps → Create an app** (or create it in the Dev Dashboard and install to this store).
+2. **Admin API scopes:** `write_products`, `read_products` (product/variant creation in `shopify.ts`), `read_orders` / `write_orders` (order data on the webhook), `read_inventory` / `write_inventory` (the `inventory_levels/set` call for capped programs), `write_discounts` / `read_discounts` (volunteer discount code). Storefront scopes not needed — checkout is the hosted cart permalink.
+3. Grab **Client ID** and **Client secret** → env `SHOPIFY_CLIENT_ID` / `SHOPIFY_CLIENT_SECRET`; the `*.myshopify.com` domain → `SHOPIFY_STORE_DOMAIN`.
+
+**Webhook subscription(s)**
+Subscribe **`orders/paid`** (primary; the handler also tolerates `orders/create`) pointed at `{instance}/api/webhooks/shopify`. Two ways:
+- Admin **Settings → Notifications → Webhooks** (manual, per-store) — **recommended, mirrors prod**, or
+- Admin API `POST /admin/api/2026-01/webhooks.json` (scriptable — only worth building if the callback URL rotates, §3/O2).
+
+> **Prod precedent (verified by grep):** there is **no webhook-registration code anywhere in `src/`** — `grep webhooks.json` returns zero hits, and `shopify.ts` only creates product variants. So prod's `orders/paid` subscription was **registered by hand in the store admin**, meaning prod uses the **store webhook signing secret** path. Mirror it for the dev store: register manually, paste the store's signing secret into `SHOPIFY_WEBHOOK_SECRET`. Build the Admin-API script (§3) **only** if O2 shows cloud-dev's URL rotates and needs unattended re-registration.
+
+Shopify shows the **webhook signing secret** once per store → env `SHOPIFY_WEBHOOK_SECRET` (§4). Note: an app-level `webhookSubscriptions` uses the **app's** API secret to sign; a store-admin-created webhook uses the store's **webhook signing secret**. Pick one path and keep the matching secret — mismatched secret is the #1 cause of 401s here. (We pick the store-admin path, per the prod precedent above.)
+
+**Membership product + variant + discount**
+- Create one **product** ("Treehouse Membership") with a variant per tier (normal / volunteer), or a single variant if the discount code covers volunteers.
+- Create the **volunteer discount code** in the store; set its code string.
+
+**Where each value lives** (mirrors prod, don't hardcode):
+
+| Value | Home | Why |
+|-------|------|-----|
+| `SHOPIFY_CLIENT_ID`, `_CLIENT_SECRET`, `_WEBHOOK_SECRET` (+ server-side `SHOPIFY_STORE_DOMAIN`) | **AWS Secrets Manager → ECS task-def `secrets:`** (see §4) | prod/dev run on ECS; `config.ts` reads them from `process.env` at runtime — this app repo stores nothing |
+| `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN` (client bundle only) | **GitHub repo `vars` → build-arg** | public, baked into the client bundle at build time (non-secret); how prod already sets it ([`deploy-dev.yml`](/.github/workflows/deploy-dev.yml)) |
+| `membershipVariantId`, `shopifyNormalVariantId`, `shopifyVolunteerVariantId`, `volunteerDiscountCode`, `normalDuesCents`, `volunteerDuesCents` | **`BoardSettings`** (row id 1) | admin-editable via [`settings/membership`](../../src/app/settings/membership/page.tsx) |
+| dev defaults for those `BoardSettings` | **seed** (`prisma/seed.ts`) — *new* | seed currently sets none; a dev store's variant/discount ids should be seeded (or set once via the settings UI) so a fresh local DB has a clickable link |
+
+> **No OAuth redirect/callback URL to configure.** The client uses the Client Credentials Grant (server-to-server, `shopify.ts › getAccessToken`), so custom-app setup needs no redirect URI. The only URL Shopify calls into is the webhook callback `{host}/api/webhooks/shopify`; checkout is an async cart permalink with no return-to-app URL.
+
+> Seed can't know a real store's variant ids ahead of time. Options: (a) seed leaves them null and the dev runbook says "set them once in `settings/membership` after creating the store," or (b) seed reads them from env (`SHOPIFY_DEV_MEMBERSHIP_VARIANT_ID` etc.) if present. **(a) is lazier and matches how prod is configured** — recommend (a).
+
+---
+
+## 3. Webhook routing / reachability (the hard part)
+
+Shopify must POST to a **publicly reachable** URL. Two environments, two answers:
+
+### Cloud-dev instance — easy
+Already public. Subscribe `{cloud-dev-host}/api/webhooks/shopify` in the dev store (or via Admin API). Nothing else. The URL is stable as long as the host is (→ open question O2).
+
+### Local laptop — needs a tunnel
+`localhost:4000` isn't reachable. Put a tunnel in front:
+- **Cloudflare Tunnel** (`cloudflared tunnel --url http://localhost:4000`) or **ngrok** (`ngrok http 4000`). Either yields an `https://<random>.trycloudflare.com` / `.ngrok-free.app` URL.
+- Register that URL as the store's `orders/paid` subscription. **The URL changes each tunnel restart** (unless you pay for a reserved subdomain / named Cloudflare tunnel) → re-register the subscription each session. A tiny `npm run shopify:webhook -- <url>` helper that upserts the subscription via Admin API keeps it a one-liner (not built here — noted for impl).
+- **Worktree note:** local dev binds `4000`; per the worktree-port convention throwaway services get a suffix, but the app port itself is fixed at 4000 — point the tunnel there.
+
+### Recommended split
+**Cloud-dev = real dev store** (stable public URL, shared team store, real webhooks). **Local laptop = in-process mock by default** (§6), with the tunnel as an opt-in for anyone who needs to exercise the *actual* Shopify checkout UI. Rationale: tunnels are fiddly and the URL churns; most local work only needs "a paid webhook lands and activates the process," which the mock delivers with zero infra. Reserve the real-store-over-tunnel path for checkout-fidelity work.
+
+---
+
+## 4. HMAC / secret handling
+
+**Verification stays real and unchanged** — `verifyShopifyHmac` already does a timing-safe HMAC over raw bytes. We do **not** weaken it in dev. The only per-env variable is the *value* of `SHOPIFY_WEBHOOK_SECRET`:
+
+- **Prod:** prod store's real webhook signing secret (already wired).
+- **Cloud-dev / local-with-tunnel:** the **dev store's own real signing secret**. Because a real Shopify store signs each webhook with a real secret, verification is genuinely end-to-end — the same code path prod runs, exercised for real.
+
+### Why NOT copy the Zoho fixed-dev-secret trick here
+Zoho's mock uses a **fixed** `DEV_MOCK_WEBHOOK_SECRET = 'dev-zoho-mock-webhook-secret'` ([`config.ts:54`](../../src/lib/config.ts)) because the mock **generates and self-fires its own payload** — the secret "guards nothing real; it exists only so the timing-safe compare has a value." That's correct *for a self-fired mock*.
+
+A **real dev store is different**: Shopify signs with a secret **we don't choose**, so verification only passes if `SHOPIFY_WEBHOOK_SECRET` holds the store's *actual* secret. Substituting a fixed constant would make every real webhook 401. So:
+- **Real dev store → real per-store secret in env** (no fallback in `config.ts` — `shopifyWebhookSecret()` already returns `null` when unset, which the handler surfaces as 500. Good; leave it).
+- **In-process mock (§6) → fixed dev secret**, exactly like Zoho, since the mock self-signs. This is the one place the Zoho pattern transfers.
+
+This gives a clean rule: *fixed secret ⇔ self-fired mock; real secret ⇔ real store.*
+
+### Where the real secret is actually stored (AWS, not this repo)
+`config.ts` only ever reads `process.env.SHOPIFY_WEBHOOK_SECRET` — it neither knows nor cares where that came from. In prod/dev the value is **injected at runtime by the ECS task definition's `secrets:` block from AWS Secrets Manager / SSM**, defined in Terraform at `~/projects/treehouse/aws/infra/modules/checkin/` (external infra repo; the deploy workflows assume the `checkin-deploy-{dev,prod}` roles there). It is **not** in `.env`, `docker-compose*.yml`, or the GitHub workflow — only `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN` appears there, as a public build-arg.
+
+So wiring the dev store's secrets = **an infra-repo change** (add the dev-store values to Secrets Manager + map them in the task-def `secrets:`), then redeploy cloud-dev so `shopifyConfiguredEnv()` flips true. **This app repo needs no change for secret wiring** — the getters already read `process.env`. (Exact Secrets Manager keys / task-def entry names live in that external repo, not visible from this checkout.)
+
+---
+
+## 5. Shared vs. per-developer store
+
+**Recommend: one shared team dev store.**
+
+| | Shared team store | Per-developer store |
+|--|--|--|
+| Setup cost | once | every dev repeats §2 |
+| Credentials | one set in AWS Secrets Manager → cloud-dev task-def (§4) | each dev manages their own Partner org |
+| Webhook URL contention | **real** — a store has *one* `orders/paid` subscription URL; two devs tunnelling at once fight over it | none (each store independent) |
+| Test-order pollution | shared order history gets noisy | isolated |
+
+The contention point cuts the decision: a single store can only point `orders/paid` at **one** URL at a time, so two developers each running a tunnel would clobber each other's subscription. But the §3 recommendation already sends **local dev to the in-process mock**, not the tunnel — so local devs never contend for the store's subscription. The shared store's single subscription is owned by **cloud-dev** (stable URL, set once). Order pollution on a throwaway dev store is a non-issue.
+
+Net: **one shared dev store, its webhook subscription owned by cloud-dev; locals use the mock.** Per-dev stores only if someone genuinely needs isolated real-checkout testing — rare.
+
+---
+
+## 6. Mock alternative (zero-infra fallback)
+
+Mirror Zoho #669 exactly. Add a dev-only route — `POST /api/dev/shopify/orders-paid` — that:
+1. 404s unless a `config.shopifyMockActive()` gate is true (non-prod + Shopify real creds unset), same shape as `zohoMockActive`.
+2. Takes a `processId`, synthesizes a realistic `orders/paid` payload (`note_attributes[Membership_Process_ID]`, `line_items` with the seeded membership variant id, an `id`), signs it with a **fixed dev webhook secret** (§4), and **fires the REAL inbound webhook** `POST /api/webhooks/shopify` — so it drives the exact verify → match → `activate()` path prod runs.
+3. Surfaced from a dev UI ("Simulate membership payment" button) alongside the existing `/dev` tools ([`src/app/dev`](../../src/app/dev)).
+
+`config.ts` gains a `shopifyMockActive()` + a `SHOPIFY_MOCK_WEBHOOK_SECRET` fallback in `shopifyWebhookSecret()`, both structured identically to the Zoho ones (`config.ts:45–54, 80–81`).
+
+### Real dev store vs in-process mock
+
+| | Real dev store | In-process mock |
+|--|--|--|
+| Fidelity | **high** — real checkout UI, real Shopify payload shape, real discount application, real HMAC from Shopify | medium — we author the payload; drift from Shopify's real schema is possible |
+| Setup cost | Partner account, store, app, scopes, tunnel-or-public-URL, secret provisioning | **~zero** — a route + a gate, no external anything |
+| Exercises checkout-link build (`ensurePaymentLink`) | yes | only if the mock UI reuses the real link build |
+| Catches Shopify-side surprises (attribute mapping, discount edge cases) | yes | no |
+
+**Build order: mock first, real store second. They coexist.** The mock unblocks every local dev immediately (matches the Zoho precedent, zero infra, deterministic tests) and is the default local experience. The real dev store on cloud-dev then adds true end-to-end fidelity for the checkout UI and Shopify's real payload — valuable but not blocking. The `shopifyMockActive()` gate means setting real Shopify creds automatically opts an instance *out* of the mock and *into* the real store, so cloud-dev runs real while locals run mock, no code branch beyond the gate.
+
+---
+
+## 7. Prod safety
+
+Same posture as Zoho:
+- **Every dev-only surface is env-gated.** `/api/dev/shopify/*` 404s unless `config.shopifyMockActive()` (which is `false` in prod by construction: `readCheckinEnv() !== 'prod' && NODE_ENV !== 'production'`, both fail-safe to prod).
+- **No dev store domain hardcoded.** `SHOPIFY_STORE_DOMAIN` stays env-only; the dev store's `*.myshopify.com` never appears in source or seed defaults.
+- **Fixed dev webhook secret is unreachable in prod** — only returned by `shopifyWebhookSecret()` when the mock is active, never in prod (same guard as `DEV_MOCK_WEBHOOK_SECRET`).
+- **Prod webhook path is byte-for-byte unchanged** — real secret, real HMAC, real store. This proposal adds env values and a gated dev route; it touches no prod branch.
+
+---
+
+## 8. Open questions / decisions before implementation
+
+- **O1.** Do we already own a **Shopify Partner org**? Creating a dev store needs one (or merchant dev-permissions). If not, someone must create it — blocks §2. *(decision + owner needed)*
+- **O2.** Is **cloud-dev's URL stable** enough to hold a standing `orders/paid` subscription, or does it rotate on redeploy? If it rotates, cloud-dev also needs the Admin-API re-register helper from §3. *(needs infra answer)*
+- **O3.** **Build the mock (§6) first and defer the real store** — confirm this ordering. Recommendation: yes.
+- **O4.** Seed `BoardSettings` variant/discount: leave null + document manual one-time setup (recommended), or read from env? *(§2 note)*
+- **O5.** Volunteer discount / per-process checkout token (#278) is still honor-system. A dev store lets us *test* the flow but doesn't fix the token gap — confirm that's out of scope here (it is; #278 tracks it).
+- **O6.** Bogus Gateway acceptable for all dev payment testing, or do we need a real (test-mode) gateway for any card-level fidelity? Bogus is almost certainly enough.
+
+---
+
+## Recommendation summary
+
+1. **Build the in-process `orders/paid` mock first** (§6) — mirror Zoho #669: a gated `/api/dev/shopify/orders-paid` that self-signs and fires the *real* inbound webhook. Zero infra, unblocks all local dev, becomes the default local experience.
+2. **Stand up one shared dev store** (§5) and subscribe **cloud-dev's** stable public URL to `orders/paid` (§3). Real end-to-end fidelity where it's cheap (already public).
+3. **Locals default to the mock**, tunnel is opt-in only for real-checkout-UI work — avoids webhook-subscription contention entirely.
+4. **Keep HMAC verification real** (§4): fixed dev secret *only* for the self-fired mock; the real dev store uses its own real per-store secret. `fixed ⇔ mock, real ⇔ store`.
+5. **Prod untouched** — everything gated on `shopifyMockActive()` / `CHECKIN_ENV`, no hardcoded dev domain, no prod branch modified.

--- a/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md
+++ b/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md
@@ -192,7 +192,7 @@ Same posture as Zoho:
 - **O1.** Do we already own a **Shopify Partner org**? Creating a dev store needs one (or merchant dev-permissions). If not, someone must create it — blocks §2. *(decision + owner needed)*
 - **O2.** Is **cloud-dev's URL stable** enough to hold a standing `orders/paid` subscription, or does it rotate on redeploy? If it rotates, cloud-dev also needs the Admin-API re-register helper from §3. *(needs infra answer)*
 - **O3.** **Build the mock (§6) first and defer the real store** — confirm this ordering. Recommendation: yes.
-- **O4.** Seed `BoardSettings` variant/discount: leave null + document manual one-time setup (recommended), or read from env? *(§2 note)* **Resolved otherwise:** implementation seeds obviously-fake placeholder ids (`dev-mock-variant-normal` / `-volunteer`, a placeholder discount code, non-zero dues) in `seedBaseline` (`src/lib/dev/seed-helpers.ts`) via an idempotent `upsert(..., update: {})`, so a fresh local DB has the in-process mock (§6) immediately clickable with zero manual setup. Deliberate deviation from the "leave null" recommendation above — real dev-store ids (once one exists) overwrite these via the Settings → Membership UI, same as prod.
+- **O4.** Seed `BoardSettings` variant/discount: leave null + document manual one-time setup (recommended), or read from env? *(§2 note)*
 - **O5.** Volunteer discount / per-process checkout token (#278) is still honor-system. A dev store lets us *test* the flow but doesn't fix the token gap — confirm that's out of scope here (it is; #278 tracks it).
 - **O6.** Bogus Gateway acceptable for all dev payment testing, or do we need a real (test-mode) gateway for any card-level fidelity? Bogus is almost certainly enough.
 

--- a/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md
+++ b/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md
@@ -1,6 +1,6 @@
 # Shopify Development Store + Webhooks in Dev/Local
 
-**Status:** Proposal — for review. No code written.
+**Status:** Implemented in part — the in-process mock (§6) landed via #730; mock hardening + the §3 registration script via #740. The real dev store (§2–§5) remains ops work, blocked on O1/O2.
 **Author:** design pass, 2026-07-02 (revised 2026-07-02 after grepping prod deploy + `src/`)
 **Related:** [`ZOHO_SIGN_DEV_MOCK.md`](./ZOHO_SIGN_DEV_MOCK.md) (#669, in-process sign mock), #665 (email dev inbox), #278 (checkout-token honor-system TODO), #624/#625 (order-amount / price-alignment safety), #683 (Shopify env routed through `config.ts`)
 **Implementation plan:** [`SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md`](./SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md) (concrete steps + two prod-grounded corrections folded back into §2/§4 below).
@@ -17,7 +17,7 @@ Unlike Zoho (which got a fully in-process mock), the ask here is to connect to a
 
 Trace from checkout link to activation:
 
-1. **Build the checkout link** — [`payment.ts › ensurePaymentLink`](../../src/lib/membership/payment.ts) reads `BoardSettings.membershipVariantId` + `config.shopifyStoreDomain()` and calls `buildMembershipCheckoutUrl`, producing a Shopify **cart permalink**:
+1. **Build the checkout link** — [`payment.ts › ensurePaymentLink`](../../src/lib/membership/payment.ts) reads `BoardSettings.orgMembershipVariantId` + `config.shopifyStoreDomain()` and calls `buildMembershipCheckoutUrl`, producing a Shopify **cart permalink**:
    ```
    https://{SHOPIFY_STORE_DOMAIN}/cart/{variantId}:1?discount={code}&attributes[Membership_Process_ID]={processId}
    ```
@@ -29,7 +29,7 @@ Trace from checkout link to activation:
 
 4. **HMAC verify** — `verifyShopifyHmac` computes `HMAC-SHA256(rawBody, config.shopifyWebhookSecret())` in base64 and `timingSafeEqual`s it against `x-shopify-hmac-sha256`. Unset secret → **500** (config error); missing/wrong sig → **401**. Verified over the exact raw bytes before parse.
 
-5. **Match by cart attribute** — handler scans `note_attributes` for `Membership_Process_ID`, then checks the order's `line_items` actually contain a known membership variant (`membershipVariantId` / `shopifyNormalVariantId` / `shopifyVolunteerVariantId` from `BoardSettings`) — the #624/H2 guard against paying for an unrelated item that totals the same.
+5. **Match by cart attribute** — handler scans `note_attributes` for `Membership_Process_ID`, then checks the order's `line_items` actually contain a known membership variant (`orgMembershipVariantId` / `shopifyNormalVariantId` / `shopifyVolunteerVariantId` from `BoardSettings`) — the #624/H2 guard against paying for an unrelated item that totals the same.
 
 6. **`activate()`** ([`payment.ts`](../../src/lib/membership/payment.ts), via `activateByProcessId`) — `FOR UPDATE` row lock, idempotent on webhook retry. Flips `ACTIVE` if the background check already cleared (else holds `PENDING_BG_CLEARANCE`); handles paid-while-`BLOCKED` and no-membership-item as board-alerted anomalies rather than silent no-ops. On `ACTIVE`, sends the one congrats email.
 
@@ -40,7 +40,7 @@ Everything upstream of the handler. Concretely:
 | Gap | Symptom in dev |
 |-----|----------------|
 | No `SHOPIFY_STORE_DOMAIN/CLIENT_ID/CLIENT_SECRET` set | `shopify.ts` logs "integration disabled"; no Admin API; product/variant creation is a no-op |
-| No `BoardSettings.membershipVariantId` (seed does **not** set it — grep of `prisma/seed.ts` is empty) | `ensurePaymentLink` returns `checkoutUrl: null`; nothing to click |
+| No `BoardSettings.orgMembershipVariantId` (seed does **not** set it — grep of `prisma/seed.ts` is empty) | `ensurePaymentLink` returns `checkoutUrl: null`; nothing to click |
 | No `SHOPIFY_WEBHOOK_SECRET` | inbound webhook 500s (`verifyShopifyHmac` config-error branch) |
 | No public URL | even a real store can't reach `localhost:4000` |
 
@@ -72,7 +72,7 @@ Our client uses the **Client Credentials Grant** (`shopify.ts › getAccessToken
 **Webhook subscription(s)**
 Subscribe **`orders/paid`** (primary; the handler also tolerates `orders/create`) pointed at `{instance}/api/webhooks/shopify`. Two ways:
 - Admin **Settings → Notifications → Webhooks** (manual, per-store) — **recommended, mirrors prod**, or
-- Admin API `POST /admin/api/2026-01/webhooks.json` (scriptable — only worth building if the callback URL rotates, §3/O2).
+- Admin API via `npm run shopify:webhook -- --url <callback> [--commit]` (shipped in #740, primarily for the §3 local-tunnel churn; dry-run by default). **Caveat:** Shopify signs deliveries to an API-created subscription with the **app client secret**, so pairing it with the store signing secret in `SHOPIFY_WEBHOOK_SECRET` 401s every delivery — pick one path and keep the matching secret.
 
 > **Prod precedent (verified by grep):** there is **no webhook-registration code anywhere in `src/`** — `grep webhooks.json` returns zero hits, and `shopify.ts` only creates product variants. So prod's `orders/paid` subscription was **registered by hand in the store admin**, meaning prod uses the **store webhook signing secret** path. Mirror it for the dev store: register manually, paste the store's signing secret into `SHOPIFY_WEBHOOK_SECRET`. Build the Admin-API script (§3) **only** if O2 shows cloud-dev's URL rotates and needs unattended re-registration.
 
@@ -88,8 +88,8 @@ Shopify shows the **webhook signing secret** once per store → env `SHOPIFY_WEB
 |-------|------|-----|
 | `SHOPIFY_CLIENT_ID`, `_CLIENT_SECRET`, `_WEBHOOK_SECRET` (+ server-side `SHOPIFY_STORE_DOMAIN`) | **AWS Secrets Manager → ECS task-def `secrets:`** (see §4) | prod/dev run on ECS; `config.ts` reads them from `process.env` at runtime — this app repo stores nothing |
 | `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN` (client bundle only) | **GitHub repo `vars` → build-arg** | public, baked into the client bundle at build time (non-secret); how prod already sets it ([`deploy-dev.yml`](/.github/workflows/deploy-dev.yml)) |
-| `membershipVariantId`, `shopifyNormalVariantId`, `shopifyVolunteerVariantId`, `volunteerDiscountCode`, `normalDuesCents`, `volunteerDuesCents` | **`BoardSettings`** (row id 1) | admin-editable via [`settings/membership`](../../src/app/settings/membership/page.tsx) |
-| dev defaults for those `BoardSettings` | **seed** (`prisma/seed.ts`) — *new* | seed currently sets none; a dev store's variant/discount ids should be seeded (or set once via the settings UI) so a fresh local DB has a clickable link |
+| `orgMembershipVariantId`, `volunteerDiscountCode`, `normalDuesCents`, `volunteerDuesCents` | **`BoardSettings`** (row id 1) | admin-editable via [`settings/membership`](../../src/app/settings/membership/page.tsx). (`shopifyNormalVariantId` / `shopifyVolunteerVariantId` are also matched by the webhook's H2 check but have **no UI writer** — DB-only legacy fields) |
+| dev defaults for those `BoardSettings` | **none — deliberately not seeded** (O4, §6) | a placeholder id seeded into the shared `BoardSettings` would land on cloud-dev via the dev-dashboard reset and silently fail the real store's H2 variant check; set once per environment via `settings/membership` |
 
 > **No OAuth redirect/callback URL to configure.** The client uses the Client Credentials Grant (server-to-server, `shopify.ts › getAccessToken`), so custom-app setup needs no redirect URI. The only URL Shopify calls into is the webhook callback `{host}/api/webhooks/shopify`; checkout is an async cart permalink with no return-to-app URL.
 
@@ -107,7 +107,7 @@ Already public. Subscribe `{cloud-dev-host}/api/webhooks/shopify` in the dev sto
 ### Local laptop — needs a tunnel
 `localhost:4000` isn't reachable. Put a tunnel in front:
 - **Cloudflare Tunnel** (`cloudflared tunnel --url http://localhost:4000`) or **ngrok** (`ngrok http 4000`). Either yields an `https://<random>.trycloudflare.com` / `.ngrok-free.app` URL.
-- Register that URL as the store's `orders/paid` subscription. **The URL changes each tunnel restart** (unless you pay for a reserved subdomain / named Cloudflare tunnel) → re-register the subscription each session. A tiny `npm run shopify:webhook -- <url>` helper that upserts the subscription via Admin API keeps it a one-liner (not built here — noted for impl).
+- Register that URL as the store's `orders/paid` subscription. **The URL changes each tunnel restart** (unless you pay for a reserved subdomain / named Cloudflare tunnel) → re-register the subscription each session. The `npm run shopify:webhook -- --url <url> [--commit]` helper (shipped in #740) upserts the subscription via the Admin API and keeps it a one-liner — mind the app-client-secret caveat in §2.
 - **Worktree note:** local dev binds `4000`; per the worktree-port convention throwaway services get a suffix, but the app port itself is fixed at 4000 — point the tunnel there.
 
 ### Recommended split
@@ -162,7 +162,7 @@ Mirror Zoho #669 exactly. Add a dev-only route — `POST /api/dev/shopify/orders
 2. Takes a `processId`, synthesizes a realistic `orders/paid` payload (`note_attributes[Membership_Process_ID]`, `line_items` with the configured membership variant id, an `id`), signs it with a **fixed dev webhook secret** (§4), and **fires the REAL inbound webhook** `POST /api/webhooks/shopify` — so it drives the exact verify → match → `activate()` path prod runs.
 3. Surfaced from a dev UI ("Simulate membership payment" button) alongside the existing `/dev` tools ([`src/app/dev`](../../src/app/dev)).
 
-`config.ts` gains a `shopifyMockActive()` + a `SHOPIFY_MOCK_WEBHOOK_SECRET` fallback in `shopifyWebhookSecret()`, both structured identically to the Zoho ones (`config.ts:45–54, 80–81`).
+`config.ts` gains a `shopifyMockActive()` gate + a fixed `DEV_MOCK_SHOPIFY_WEBHOOK_SECRET` fallback in `shopifyWebhookSecret()` (a constant, not an env var), both structured identically to the Zoho ones ([`config.ts`](../../src/lib/config.ts)).
 
 ### The variant id is configuration, never hardcoded
 

--- a/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md
+++ b/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md
@@ -159,10 +159,19 @@ Net: **one shared dev store, its webhook subscription owned by cloud-dev; locals
 
 Mirror Zoho #669 exactly. Add a dev-only route — `POST /api/dev/shopify/orders-paid` — that:
 1. 404s unless a `config.shopifyMockActive()` gate is true (non-prod + Shopify real creds unset), same shape as `zohoMockActive`.
-2. Takes a `processId`, synthesizes a realistic `orders/paid` payload (`note_attributes[Membership_Process_ID]`, `line_items` with the seeded membership variant id, an `id`), signs it with a **fixed dev webhook secret** (§4), and **fires the REAL inbound webhook** `POST /api/webhooks/shopify` — so it drives the exact verify → match → `activate()` path prod runs.
+2. Takes a `processId`, synthesizes a realistic `orders/paid` payload (`note_attributes[Membership_Process_ID]`, `line_items` with the configured membership variant id, an `id`), signs it with a **fixed dev webhook secret** (§4), and **fires the REAL inbound webhook** `POST /api/webhooks/shopify` — so it drives the exact verify → match → `activate()` path prod runs.
 3. Surfaced from a dev UI ("Simulate membership payment" button) alongside the existing `/dev` tools ([`src/app/dev`](../../src/app/dev)).
 
 `config.ts` gains a `shopifyMockActive()` + a `SHOPIFY_MOCK_WEBHOOK_SECRET` fallback in `shopifyWebhookSecret()`, both structured identically to the Zoho ones (`config.ts:45–54, 80–81`).
+
+### The variant id is configuration, never hardcoded
+
+A recurring confusion (raised in review): *"how can variant ids in our code align with a real Shopify dev store's variant ids?"* They can't — and they never need to, because **the membership variant id is never in code. It lives in `BoardSettings.orgMembershipVariantId`** (admin-editable via Settings → Membership), set once per environment to whatever that environment needs:
+
+- **In-process mock (local, no Shopify creds):** the value is just a **correlation token**. The mock reads it, echoes it in the synthesized `line_items`, and the inbound handler matches it against the *same* `BoardSettings` — a closed loop. Any string works; it never touches Shopify. Set it once locally (the dev tool's empty-state points you to Settings → Membership).
+- **Real dev store (cloud-dev, real creds):** the value must be the **store's actual variant id**, set once by a human after creating the membership product. A real `orders/paid` then carries that id and the inbound H2 check matches it.
+
+Because both environments read the id from `BoardSettings` (not from code), there is nothing to "align." We deliberately do **not** seed a placeholder id (see O4): a fake id seeded into the shared `BoardSettings` would land on cloud-dev via the dev-dashboard reset and then silently fail the real store's H2 variant check. The one-time "set the variant id" step is identical in shape for both paths — only the *value* differs.
 
 ### Real dev store vs in-process mock
 

--- a/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md
+++ b/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md
@@ -192,7 +192,7 @@ Same posture as Zoho:
 - **O1.** Do we already own a **Shopify Partner org**? Creating a dev store needs one (or merchant dev-permissions). If not, someone must create it — blocks §2. *(decision + owner needed)*
 - **O2.** Is **cloud-dev's URL stable** enough to hold a standing `orders/paid` subscription, or does it rotate on redeploy? If it rotates, cloud-dev also needs the Admin-API re-register helper from §3. *(needs infra answer)*
 - **O3.** **Build the mock (§6) first and defer the real store** — confirm this ordering. Recommendation: yes.
-- **O4.** Seed `BoardSettings` variant/discount: leave null + document manual one-time setup (recommended), or read from env? *(§2 note)*
+- **O4.** Seed `BoardSettings` variant/discount: leave null + document manual one-time setup (recommended), or read from env? *(§2 note)* **Resolved otherwise:** implementation seeds obviously-fake placeholder ids (`dev-mock-variant-normal` / `-volunteer`, a placeholder discount code, non-zero dues) in `seedBaseline` (`src/lib/dev/seed-helpers.ts`) via an idempotent `upsert(..., update: {})`, so a fresh local DB has the in-process mock (§6) immediately clickable with zero manual setup. Deliberate deviation from the "leave null" recommendation above — real dev-store ids (once one exists) overwrite these via the Settings → Membership UI, same as prod.
 - **O5.** Volunteer discount / per-process checkout token (#278) is still honor-system. A dev store lets us *test* the flow but doesn't fix the token gap — confirm that's out of scope here (it is; #278 tracks it).
 - **O6.** Bogus Gateway acceptable for all dev payment testing, or do we need a real (test-mode) gateway for any card-level fidelity? Bogus is almost certainly enough.
 

--- a/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md
+++ b/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md
@@ -69,7 +69,7 @@ So "env wiring" = an **infra-repo change**, not an edit here:
 **This repo needs zero change for secret wiring** — getters already read `process.env`.
 > Exact Secrets Manager keys / task-def `secrets:` names live in the external infra repo — not visible from this checkout.
 
-`BoardSettings` variant/discount ids (O4): ~~leave null in seed; set once via [`settings/membership`](../../src/app/settings/membership/page.tsx) after the store exists. Matches how prod is configured. No seed change.~~ **Superseded:** `seedBaseline` now upserts placeholder ids (`dev-mock-variant-normal`/`-volunteer`, a placeholder discount code, non-zero dues) so the in-process mock is clickable with zero setup on a fresh DB — a deliberate deviation, called out inline in `seed-helpers.ts`. Real dev-store ids still overwrite these via `settings/membership` once a store exists.
+`BoardSettings` variant/discount ids (O4): leave null in seed; set once via [`settings/membership`](../../src/app/settings/membership/page.tsx) after the store exists. Matches how prod is configured. No seed change.
 
 ## Phase 5 — local = mock by default
 Locals keep the in-process mock (Phase 0). Tunnel (`cloudflared`/`ngrok` → callback `https://<random>.trycloudflare.com/api/webhooks/shopify`) is **opt-in only** for checkout-UI-fidelity work. A store has **one** `orders/paid` URL — cloud-dev owns it; sending locals to the mock removes subscription contention.

--- a/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md
+++ b/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md
@@ -69,7 +69,7 @@ So "env wiring" = an **infra-repo change**, not an edit here:
 **This repo needs zero change for secret wiring** — getters already read `process.env`.
 > Exact Secrets Manager keys / task-def `secrets:` names live in the external infra repo — not visible from this checkout.
 
-`BoardSettings` variant/discount ids (O4): leave null in seed; set once via [`settings/membership`](../../src/app/settings/membership/page.tsx) after the store exists. Matches how prod is configured. No seed change.
+`BoardSettings` variant/discount ids (O4): ~~leave null in seed; set once via [`settings/membership`](../../src/app/settings/membership/page.tsx) after the store exists. Matches how prod is configured. No seed change.~~ **Superseded:** `seedBaseline` now upserts placeholder ids (`dev-mock-variant-normal`/`-volunteer`, a placeholder discount code, non-zero dues) so the in-process mock is clickable with zero setup on a fresh DB — a deliberate deviation, called out inline in `seed-helpers.ts`. Real dev-store ids still overwrite these via `settings/membership` once a store exists.
 
 ## Phase 5 — local = mock by default
 Locals keep the in-process mock (Phase 0). Tunnel (`cloudflared`/`ngrok` → callback `https://<random>.trycloudflare.com/api/webhooks/shopify`) is **opt-in only** for checkout-UI-fidelity work. A store has **one** `orders/paid` URL — cloud-dev owns it; sending locals to the mock removes subscription contention.

--- a/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md
+++ b/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md
@@ -1,0 +1,95 @@
+# Shopify Dev-Store Webhook — Implementation Plan
+
+**Status:** Plan — no code written.
+**Companion:** [`SHOPIFY_DEV_STORE_WEBHOOK.md`](./SHOPIFY_DEV_STORE_WEBHOOK.md) (design/rationale).
+**Fallback mock:** `origin/claude/wonderful-tesla-621492` @ `455362c2` (in-process orders/paid mock).
+
+---
+
+## TL;DR — most of the "real" code already exists
+
+The prod path is **already built and correct**. Verified in `src/`:
+
+| Piece | Location | State |
+|-------|----------|-------|
+| Inbound route | [`api/webhooks/shopify/route.ts`](../../src/app/api/webhooks/shopify/route.ts) | done, prod-correct |
+| HMAC verify (timing-safe, raw bytes) | `verifyShopifyHmac` in same file | done — **path-agnostic** |
+| Rate-limit → verify → parse → handler wrapper | [`webhookAuth.ts`](../../src/lib/webhookAuth.ts) `withWebhook` | done |
+| Env getters (`shopifyStoreDomain/ClientId/ClientSecret/WebhookSecret`) | [`config.ts`](../../src/lib/config.ts) | done |
+| Mock-vs-real switch (`shopifyMockActive()`) | `config.ts` (mock commit) | done — auto-off when real creds set |
+
+**No new prod route. No touching verify. No new config getters.** Making it "real" = store setup + secret wiring + (maybe) one small registration script.
+
+There is **no webhook-registration code anywhere in `src/`** (`grep webhooks.json` → 0 hits). Prod's `orders/paid` subscription was **registered by hand** in the store admin → so prod uses the **store webhook signing secret** path, pasted into `SHOPIFY_WEBHOOK_SECRET`. Mirror that.
+
+---
+
+## Phase 0 — land the mock (prereq)
+Merge `origin/claude/wonderful-tesla-621492` (455362c2). Its `shopifyMockActive()` gate is the entire mock↔real switch. Setting real creds opts an instance out of the mock automatically — no branch. Nothing to build.
+
+## Phase 1 — stand up ONE shared dev store (ops)
+**Hard blocker: O1 — do we own a Shopify Partner org?** Needs an owner before anything below.
+1. Partner Dashboard → create dev store `treehouse-checkin-dev`.
+2. **Develop apps → create custom app.** Admin API scopes: `read/write_products`, `read/write_orders`, `read/write_inventory`, `read/write_discounts`. (No Storefront scopes — checkout is a hosted cart permalink. **No OAuth redirect URL** — Client Credentials Grant is server-to-server.)
+3. **Install app** to the store (install is what makes the token grant work).
+4. Create product "Treehouse Membership" + variant(s) + volunteer discount code. Record variant ids.
+
+## Phase 2 — get the four values
+| Env var | Where in Shopify | Notes |
+|---------|------------------|-------|
+| `SHOPIFY_STORE_DOMAIN` | Settings → Domains (the `*.myshopify.com`) | raw myshopify domain, not a pretty domain |
+| `SHOPIFY_CLIENT_ID` | app → API credentials | shown directly |
+| `SHOPIFY_CLIENT_SECRET` | app → API credentials | reveal-once, copy now |
+| `SHOPIFY_WEBHOOK_SECRET` | Settings → Notifications → Webhooks (bottom of page: "signed with…") | store-admin path, matches prod |
+
+Verify token before trusting creds:
+```
+curl -X POST https://{STORE_DOMAIN}/admin/oauth/access_token \
+  -d grant_type=client_credentials -d client_id={ID} -d client_secret={SECRET}
+```
+200 + `access_token` = good. 401 = wrong creds or app not installed.
+
+## Phase 3 — register the `orders/paid` subscription
+Mirror prod = **manual**, store admin → Settings → Notifications → Webhooks → `orders/paid` → callback:
+```
+https://{cloud-dev-host}/api/webhooks/shopify
+```
+That callback is the **only** URL Shopify calls into. Checkout is async (cart permalink → webhook), no return/redirect URL to app.
+
+**Optional script (build ONLY if O2 says cloud-dev URL rotates on redeploy):** `npm run shopify:webhook -- <url>` — idempotent upsert via Admin API `POST/PUT /admin/api/2026-01/webhooks.json`, reusing `shopify.ts`'s `getAccessToken` + `shopifyFetch`. Prod proves manual is enough; don't build this unless the URL churns.
+
+## Phase 4 — secret wiring (AWS, NOT this repo)
+Prod/dev run on **AWS ECS** (`us-east-2`), deployed via GitHub OIDC ([`deploy-dev.yml`](/.github/workflows/deploy-dev.yml)). Secrets are **not** in `.env`, compose, or the workflow — they're injected at runtime by the **ECS task-def `secrets:` block → AWS Secrets Manager / SSM**, defined in Terraform at `~/projects/treehouse/aws/infra/modules/checkin/` (external repo).
+
+So "env wiring" = an **infra-repo change**, not an edit here:
+- The three server-side secrets (`SHOPIFY_CLIENT_ID/SECRET`, `SHOPIFY_WEBHOOK_SECRET`) + server-side `SHOPIFY_STORE_DOMAIN` → **AWS Secrets Manager** (dev env secret) → mapped in the task-def `secrets:` block.
+- Client-bundle `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN` → GitHub repo `vars` build-arg (public, like prod).
+- Redeploy cloud-dev → ECS pulls new values → `shopifyConfiguredEnv()` true → real store on, mock off.
+
+**This repo needs zero change for secret wiring** — getters already read `process.env`.
+> Exact Secrets Manager keys / task-def `secrets:` names live in the external infra repo — not visible from this checkout.
+
+`BoardSettings` variant/discount ids (O4): leave null in seed; set once via [`settings/membership`](../../src/app/settings/membership/page.tsx) after the store exists. Matches how prod is configured. No seed change.
+
+## Phase 5 — local = mock by default
+Locals keep the in-process mock (Phase 0). Tunnel (`cloudflared`/`ngrok` → callback `https://<random>.trycloudflare.com/api/webhooks/shopify`) is **opt-in only** for checkout-UI-fidelity work. A store has **one** `orders/paid` URL — cloud-dev owns it; sending locals to the mock removes subscription contention.
+
+## Phase 6 — verify + runbook
+1. Cloud-dev: create a `PENDING_PAYMENT` process → click real permalink → pay via **Bogus Gateway** (real webhook, fake money) → confirm HMAC passes → `activate()` → `ACTIVE` + congrats email.
+2. Runbook: dev-store password page can't be removed (testers need storefront password); dev store is non-transferable/throwaway.
+
+---
+
+## Blockers before Phase 1
+| | Question | Recommend |
+|--|--|--|
+| **O1** | Own a Shopify Partner org? | needs owner — hard blocker |
+| **O2** | Cloud-dev URL stable across redeploy? | if not, build the Phase-3 script + run on deploy |
+| **O6** | Bogus Gateway enough for payment testing? | yes |
+
+## Net new work
+- **This repo:** ~0 lines (optionally: one idempotent registration script, only if O2 fails).
+- **Infra repo:** add dev-store secrets to Secrets Manager + task-def `secrets:` mapping.
+- **Ops:** Partner org → dev store → app → product/variant/discount → manual `orders/paid` subscription.
+
+Mock stays as the local default via the gate that already ships. Prod byte-for-byte unchanged.

--- a/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md
+++ b/checkin-app/docs/designs/SHOPIFY_DEV_STORE_WEBHOOK_PLAN.md
@@ -1,8 +1,8 @@
 # Shopify Dev-Store Webhook — Implementation Plan
 
-**Status:** Plan — no code written.
+**Status:** Partially executed — Phase 0 (mock) landed via #730; the Phase-3 registration script shipped in #740 (built ahead of O2, see Phase 3). Store setup (Phases 1–2), registration (Phase 3), and secret wiring (Phase 4) remain ops work.
 **Companion:** [`SHOPIFY_DEV_STORE_WEBHOOK.md`](./SHOPIFY_DEV_STORE_WEBHOOK.md) (design/rationale).
-**Fallback mock:** `origin/claude/wonderful-tesla-621492` @ `455362c2` (in-process orders/paid mock).
+**Fallback mock:** landed on `main` via #730 (in-process orders/paid mock).
 
 ---
 
@@ -24,8 +24,8 @@ There is **no webhook-registration code anywhere in `src/`** (`grep webhooks.jso
 
 ---
 
-## Phase 0 — land the mock (prereq)
-Merge `origin/claude/wonderful-tesla-621492` (455362c2). Its `shopifyMockActive()` gate is the entire mock↔real switch. Setting real creds opts an instance out of the mock automatically — no branch. Nothing to build.
+## Phase 0 — land the mock (prereq) — ✅ done
+Landed on `main` via #730 (with follow-up fixes; the original `claude/wonderful-tesla-621492` branch is superseded — don't merge it). Its `shopifyMockActive()` gate is the entire mock↔real switch. Setting real creds opts an instance out of the mock automatically — no branch. Nothing left to build.
 
 ## Phase 1 — stand up ONE shared dev store (ops)
 **Hard blocker: O1 — do we own a Shopify Partner org?** Needs an owner before anything below.
@@ -40,7 +40,7 @@ Merge `origin/claude/wonderful-tesla-621492` (455362c2). Its `shopifyMockActive(
 | `SHOPIFY_STORE_DOMAIN` | Settings → Domains (the `*.myshopify.com`) | raw myshopify domain, not a pretty domain |
 | `SHOPIFY_CLIENT_ID` | app → API credentials | shown directly |
 | `SHOPIFY_CLIENT_SECRET` | app → API credentials | reveal-once, copy now |
-| `SHOPIFY_WEBHOOK_SECRET` | Settings → Notifications → Webhooks (bottom of page: "signed with…") | store-admin path, matches prod |
+| `SHOPIFY_WEBHOOK_SECRET` | Settings → Notifications → Webhooks (bottom of page: "signed with…") | store-admin path, matches prod. **If the subscription was created via the Phase-3 script instead, use the app client secret** — Shopify signs API-created subscriptions with it, not the store signing secret |
 
 Verify token before trusting creds:
 ```
@@ -56,7 +56,7 @@ https://{cloud-dev-host}/api/webhooks/shopify
 ```
 That callback is the **only** URL Shopify calls into. Checkout is async (cart permalink → webhook), no return/redirect URL to app.
 
-**Optional script (build ONLY if O2 says cloud-dev URL rotates on redeploy):** `npm run shopify:webhook -- <url>` — idempotent upsert via Admin API `POST/PUT /admin/api/2026-01/webhooks.json`, reusing `shopify.ts`'s `getAccessToken` + `shopifyFetch`. Prod proves manual is enough; don't build this unless the URL churns.
+**Script (shipped in #740, ahead of O2 — its immediate use is local-tunnel churn, design §3):** `npm run shopify:webhook -- --url <url> [--commit]` — idempotent upsert via the Admin API, reusing `shopify.ts`'s `getAccessToken` + `shopifyFetch`; dry-run by default. Manual admin registration stays the recommended cloud-dev path. **Secret caveat:** Shopify signs deliveries to an API-created subscription with the **app client secret**, so an instance relying on a script-registered webhook needs `SHOPIFY_WEBHOOK_SECRET` set to that value, not the store signing secret (design §2/§4). The Admin API also only lists subscriptions created by this app — a manually registered webhook is invisible to the script and keeps firing on its own.
 
 ## Phase 4 — secret wiring (AWS, NOT this repo)
 Prod/dev run on **AWS ECS** (`us-east-2`), deployed via GitHub OIDC ([`deploy-dev.yml`](/.github/workflows/deploy-dev.yml)). Secrets are **not** in `.env`, compose, or the workflow — they're injected at runtime by the **ECS task-def `secrets:` block → AWS Secrets Manager / SSM**, defined in Terraform at `~/projects/treehouse/aws/infra/modules/checkin/` (external repo).
@@ -88,7 +88,7 @@ Locals keep the in-process mock (Phase 0). Tunnel (`cloudflared`/`ngrok` → cal
 | **O6** | Bogus Gateway enough for payment testing? | yes |
 
 ## Net new work
-- **This repo:** ~0 lines (optionally: one idempotent registration script, only if O2 fails).
+- **This repo:** shipped in #740 — the registration script + unit tests, dev orders/paid route hardening + integration suite, and the Shopify config-fuse tests.
 - **Infra repo:** add dev-store secrets to Secrets Manager + task-def `secrets:` mapping.
 - **Ops:** Partner org → dev store → app → product/variant/discount → manual `orders/paid` subscription.
 

--- a/checkin-app/package.json
+++ b/checkin-app/package.json
@@ -14,7 +14,8 @@
     "test:integration": "INTEGRATION_DB=1 jest --ci --testPathIgnorePatterns=/node_modules/ --testRegex \"\\.integration\\.test\\.[jt]sx?$\"",
     "test:coverage": "INTEGRATION_DB=1 jest --ci --coverage --testPathIgnorePatterns \"/node_modules/|/\\.next/|/\\.claude/worktrees/|\\.flow\\.test\\.\"",
     "check-route-coverage": "ts-node --project scripts/tsconfig.json scripts/check-route-coverage.ts",
-    "import:zoho": "tsx scripts/import-zoho.ts"
+    "import:zoho": "tsx scripts/import-zoho.ts",
+    "shopify:webhook": "tsx scripts/register-shopify-webhook.ts"
   },
   "engines": {
     "node": ">=24"

--- a/checkin-app/scripts/__tests__/register-shopify-webhook.test.ts
+++ b/checkin-app/scripts/__tests__/register-shopify-webhook.test.ts
@@ -18,13 +18,21 @@ describe("decideWebhookAction", () => {
         const existing: ShopifyWebhookSubscription[] = [
             { id: 42, topic: "orders/paid", address: "https://old-host/api/webhooks/shopify" },
         ];
-        expect(decideWebhookAction(existing, desired)).toEqual({ action: "update", id: 42 });
+        expect(decideWebhookAction(existing, desired)).toEqual({ action: "update", id: 42, staleDuplicates: [] });
     });
 
     it("noops when orders/paid already points at the desired address", () => {
         const existing: ShopifyWebhookSubscription[] = [
             { id: 42, topic: "orders/paid", address: desired },
         ];
-        expect(decideWebhookAction(existing, desired)).toEqual({ action: "noop", id: 42 });
+        expect(decideWebhookAction(existing, desired)).toEqual({ action: "noop", id: 42, staleDuplicates: [] });
+    });
+
+    it("targets the subscription already at the desired address and surfaces others as stale duplicates", () => {
+        const existing: ShopifyWebhookSubscription[] = [
+            { id: 7, topic: "orders/paid", address: "https://dead-tunnel/api/webhooks/shopify" },
+            { id: 42, topic: "orders/paid", address: desired },
+        ];
+        expect(decideWebhookAction(existing, desired)).toEqual({ action: "noop", id: 42, staleDuplicates: [7] });
     });
 });

--- a/checkin-app/scripts/__tests__/register-shopify-webhook.test.ts
+++ b/checkin-app/scripts/__tests__/register-shopify-webhook.test.ts
@@ -1,0 +1,30 @@
+import { decideWebhookAction, type ShopifyWebhookSubscription } from "../register-shopify-webhook";
+
+describe("decideWebhookAction", () => {
+    const desired = "https://ops-dev.innovationtreehouse.org/api/webhooks/shopify";
+
+    it("creates when the subscription list is empty", () => {
+        expect(decideWebhookAction([], desired)).toEqual({ action: "create" });
+    });
+
+    it("creates when no subscription has the orders/paid topic", () => {
+        const existing: ShopifyWebhookSubscription[] = [
+            { id: 1, topic: "orders/create", address: desired },
+        ];
+        expect(decideWebhookAction(existing, desired)).toEqual({ action: "create" });
+    });
+
+    it("updates when orders/paid exists with a different address", () => {
+        const existing: ShopifyWebhookSubscription[] = [
+            { id: 42, topic: "orders/paid", address: "https://old-host/api/webhooks/shopify" },
+        ];
+        expect(decideWebhookAction(existing, desired)).toEqual({ action: "update", id: 42 });
+    });
+
+    it("noops when orders/paid already points at the desired address", () => {
+        const existing: ShopifyWebhookSubscription[] = [
+            { id: 42, topic: "orders/paid", address: desired },
+        ];
+        expect(decideWebhookAction(existing, desired)).toEqual({ action: "noop", id: 42 });
+    });
+});

--- a/checkin-app/scripts/register-shopify-webhook.ts
+++ b/checkin-app/scripts/register-shopify-webhook.ts
@@ -1,0 +1,133 @@
+import * as dotenv from "dotenv";
+import { getAccessToken, shopifyFetch } from "../src/lib/shopify";
+import { config } from "../src/lib/config";
+
+/**
+ * Idempotently upserts the `orders/paid` webhook subscription against the
+ * Shopify Admin API, pointed at a caller-supplied callback URL.
+ *
+ *   npx tsx scripts/register-shopify-webhook.ts --url <https://host/api/webhooks/shopify> [--commit]
+ *
+ * Defaults to a DRY RUN (prints the create/update/noop decision, writes nothing).
+ * Pass --commit to apply it. Reuses shopify.ts's token exchange and fetch wrapper —
+ * no Prisma needed here, there's no DB write.
+ */
+
+dotenv.config();
+
+const EXPECTED_PATH = "/api/webhooks/shopify";
+const API_VERSION = "2026-01";
+
+function arg(flag: string): string | undefined {
+    const i = process.argv.indexOf(flag);
+    return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const hasFlag = (flag: string) => process.argv.includes(flag);
+
+export interface ShopifyWebhookSubscription {
+    id: number | string;
+    topic: string;
+    address: string;
+}
+
+export type WebhookAction =
+    | { action: "create" }
+    | { action: "update"; id: number | string }
+    | { action: "noop"; id: number | string };
+
+/** Pure decision: does the orders/paid subscription need creating, updating, or nothing? */
+export function decideWebhookAction(existing: ShopifyWebhookSubscription[], desiredAddress: string): WebhookAction {
+    const match = existing.find((w) => w.topic === "orders/paid");
+    if (!match) return { action: "create" };
+    if (match.address === desiredAddress) return { action: "noop", id: match.id };
+    return { action: "update", id: match.id };
+}
+
+async function main() {
+    const url = arg("--url");
+    const commit = hasFlag("--commit");
+
+    if (!url) {
+        throw new Error("--url <https://host/api/webhooks/shopify> is required.");
+    }
+
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new Error(`--url is not a valid URL: ${url}`);
+    }
+    if (parsed.protocol !== "https:") {
+        throw new Error(`--url must be https — got "${parsed.protocol}//..." (${url})`);
+    }
+    if (!parsed.pathname.endsWith(EXPECTED_PATH)) {
+        console.warn(`Warning: --url path is "${parsed.pathname}", expected it to end with "${EXPECTED_PATH}". Continuing anyway.`);
+    }
+
+    const accessToken = await getAccessToken();
+    if (!accessToken) {
+        console.error("Shopify not configured (missing SHOPIFY_STORE_DOMAIN, SHOPIFY_CLIENT_ID, or SHOPIFY_CLIENT_SECRET) — nothing to register.");
+        process.exit(1);
+    }
+
+    // getAccessToken() only succeeds once storeDomain is confirmed non-null.
+    const storeDomain = config.shopifyStoreDomain()!;
+
+    const listRes = await shopifyFetch(`https://${storeDomain}/admin/api/${API_VERSION}/webhooks.json`, {
+        headers: { "X-Shopify-Access-Token": accessToken },
+    }, "Shopify list webhooks");
+
+    if (!listRes.ok) {
+        console.error(`Shopify API error listing webhooks: ${listRes.status} ${await listRes.text()}`);
+        process.exit(1);
+    }
+
+    const listData = await listRes.json();
+    const webhooks: ShopifyWebhookSubscription[] = listData.webhooks ?? [];
+    const decision = decideWebhookAction(webhooks, url);
+
+    if (decision.action === "noop") {
+        console.log(`No change needed: orders/paid webhook ${decision.id} already points at ${url}`);
+        return;
+    }
+    if (decision.action === "create") {
+        console.log(`Will CREATE an orders/paid webhook subscription pointing at ${url}`);
+    } else {
+        console.log(`Will UPDATE orders/paid webhook ${decision.id} address to ${url}`);
+    }
+
+    if (!commit) {
+        console.log("\nDRY RUN — no changes written. Re-run with --commit to apply.");
+        return;
+    }
+
+    const body = JSON.stringify({ webhook: { topic: "orders/paid", address: url, format: "json" } });
+    const mutateRes = decision.action === "create"
+        ? await shopifyFetch(`https://${storeDomain}/admin/api/${API_VERSION}/webhooks.json`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "X-Shopify-Access-Token": accessToken },
+            body,
+        }, "Shopify create webhook")
+        : await shopifyFetch(`https://${storeDomain}/admin/api/${API_VERSION}/webhooks/${decision.id}.json`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json", "X-Shopify-Access-Token": accessToken },
+            body,
+        }, "Shopify update webhook");
+
+    if (!mutateRes.ok) {
+        console.error(`Shopify API error ${decision.action === "create" ? "creating" : "updating"} webhook: ${mutateRes.status} ${await mutateRes.text()}`);
+        process.exit(1);
+    }
+
+    const result = await mutateRes.json();
+    console.log(`✅ ${decision.action === "create" ? "Created" : "Updated"} webhook: id=${result.webhook.id} address=${result.webhook.address}`);
+}
+
+// Guarded so importing decideWebhookAction (e.g. from the unit test) doesn't
+// also run the CLI's main().
+if (require.main === module) {
+    main().catch((e) => {
+        console.error(e);
+        process.exit(1);
+    });
+}

--- a/checkin-app/scripts/register-shopify-webhook.ts
+++ b/checkin-app/scripts/register-shopify-webhook.ts
@@ -1,5 +1,5 @@
 import * as dotenv from "dotenv";
-import { getAccessToken, shopifyFetch } from "../src/lib/shopify";
+import { getAccessToken, shopifyFetch, SHOPIFY_API_VERSION } from "../src/lib/shopify";
 import { config } from "../src/lib/config";
 
 /**
@@ -11,12 +11,19 @@ import { config } from "../src/lib/config";
  * Defaults to a DRY RUN (prints the create/update/noop decision, writes nothing).
  * Pass --commit to apply it. Reuses shopify.ts's token exchange and fetch wrapper —
  * no Prisma needed here, there's no DB write.
+ *
+ * Two Admin-API facts that matter (design §2/§3):
+ * - Shopify signs deliveries to an API-created subscription with the APP's client
+ *   secret, NOT the store's Settings → Notifications signing secret. An instance
+ *   relying on a script-registered webhook needs SHOPIFY_WEBHOOK_SECRET set to the
+ *   client secret's value.
+ * - The API only sees subscriptions created by this app. A webhook registered
+ *   manually in the store admin is invisible here and keeps firing on its own.
  */
 
 dotenv.config();
 
 const EXPECTED_PATH = "/api/webhooks/shopify";
-const API_VERSION = "2026-01";
 
 function arg(flag: string): string | undefined {
     const i = process.argv.indexOf(flag);
@@ -25,22 +32,30 @@ function arg(flag: string): string | undefined {
 const hasFlag = (flag: string) => process.argv.includes(flag);
 
 export interface ShopifyWebhookSubscription {
-    id: number | string;
+    id: number;
     topic: string;
     address: string;
 }
 
 export type WebhookAction =
     | { action: "create" }
-    | { action: "update"; id: number | string }
-    | { action: "noop"; id: number | string };
+    | { action: "update"; id: number; staleDuplicates: number[] }
+    | { action: "noop"; id: number; staleDuplicates: number[] };
 
-/** Pure decision: does the orders/paid subscription need creating, updating, or nothing? */
+/**
+ * Pure decision: does the orders/paid subscription need creating, updating, or
+ * nothing? Prefers a subscription already at the desired address; any other
+ * orders/paid subscriptions are surfaced as staleDuplicates so the caller can
+ * warn — Shopify allows several subscriptions on one topic, and a stale one
+ * keeps firing at a dead URL until removed.
+ */
 export function decideWebhookAction(existing: ShopifyWebhookSubscription[], desiredAddress: string): WebhookAction {
-    const match = existing.find((w) => w.topic === "orders/paid");
-    if (!match) return { action: "create" };
-    if (match.address === desiredAddress) return { action: "noop", id: match.id };
-    return { action: "update", id: match.id };
+    const matches = existing.filter((w) => w.topic === "orders/paid");
+    if (matches.length === 0) return { action: "create" };
+    const target = matches.find((w) => w.address === desiredAddress) ?? matches[0];
+    const staleDuplicates = matches.filter((w) => w.id !== target.id).map((w) => w.id);
+    if (target.address === desiredAddress) return { action: "noop", id: target.id, staleDuplicates };
+    return { action: "update", id: target.id, staleDuplicates };
 }
 
 async function main() {
@@ -72,8 +87,12 @@ async function main() {
 
     // getAccessToken() only succeeds once storeDomain is confirmed non-null.
     const storeDomain = config.shopifyStoreDomain()!;
+    const apiBase = `https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}`;
 
-    const listRes = await shopifyFetch(`https://${storeDomain}/admin/api/${API_VERSION}/webhooks.json`, {
+    // topic filter + max page size keep the read aligned with what
+    // decideWebhookAction assumes it saw (an unfiltered list is capped at 50
+    // entries, so the orders/paid subscription could fall off the first page).
+    const listRes = await shopifyFetch(`${apiBase}/webhooks.json?topic=orders%2Fpaid&limit=250`, {
         headers: { "X-Shopify-Access-Token": accessToken },
     }, "Shopify list webhooks");
 
@@ -86,11 +105,23 @@ async function main() {
     const webhooks: ShopifyWebhookSubscription[] = listData.webhooks ?? [];
     const decision = decideWebhookAction(webhooks, url);
 
+    console.log(
+        "NOTE: Shopify signs deliveries to an API-created subscription with the app's client secret\n" +
+        "(SHOPIFY_CLIENT_SECRET), NOT the store's Settings → Notifications signing secret — set\n" +
+        "SHOPIFY_WEBHOOK_SECRET to match, or every delivery will 401 (design §2/§4). Subscriptions\n" +
+        "registered manually in the store admin are invisible to this script and fire independently.\n",
+    );
+    if (decision.action !== "create" && decision.staleDuplicates.length > 0) {
+        console.warn(`Warning: ${decision.staleDuplicates.length} other orders/paid subscription(s) (id(s) ${decision.staleDuplicates.join(", ")}) point elsewhere and keep firing until removed in the store admin.`);
+    }
+
     if (decision.action === "noop") {
         console.log(`No change needed: orders/paid webhook ${decision.id} already points at ${url}`);
         return;
     }
-    if (decision.action === "create") {
+
+    const creating = decision.action === "create";
+    if (creating) {
         console.log(`Will CREATE an orders/paid webhook subscription pointing at ${url}`);
     } else {
         console.log(`Will UPDATE orders/paid webhook ${decision.id} address to ${url}`);
@@ -102,25 +133,26 @@ async function main() {
     }
 
     const body = JSON.stringify({ webhook: { topic: "orders/paid", address: url, format: "json" } });
-    const mutateRes = decision.action === "create"
-        ? await shopifyFetch(`https://${storeDomain}/admin/api/${API_VERSION}/webhooks.json`, {
-            method: "POST",
+    const mutateRes = await shopifyFetch(
+        creating ? `${apiBase}/webhooks.json` : `${apiBase}/webhooks/${decision.id}.json`,
+        {
+            method: creating ? "POST" : "PUT",
             headers: { "Content-Type": "application/json", "X-Shopify-Access-Token": accessToken },
             body,
-        }, "Shopify create webhook")
-        : await shopifyFetch(`https://${storeDomain}/admin/api/${API_VERSION}/webhooks/${decision.id}.json`, {
-            method: "PUT",
-            headers: { "Content-Type": "application/json", "X-Shopify-Access-Token": accessToken },
-            body,
-        }, "Shopify update webhook");
+        },
+        `Shopify ${creating ? "create" : "update"} webhook`,
+    );
 
     if (!mutateRes.ok) {
-        console.error(`Shopify API error ${decision.action === "create" ? "creating" : "updating"} webhook: ${mutateRes.status} ${await mutateRes.text()}`);
+        console.error(`Shopify API error ${creating ? "creating" : "updating"} webhook: ${mutateRes.status} ${await mutateRes.text()}`);
         process.exit(1);
     }
 
-    const result = await mutateRes.json();
-    console.log(`✅ ${decision.action === "create" ? "Created" : "Updated"} webhook: id=${result.webhook.id} address=${result.webhook.address}`);
+    // The 2xx contract is {webhook:{...}} — don't crash the success report on an
+    // unexpected body; the mutation has already applied at this point.
+    const result = await mutateRes.json().catch(() => null);
+    const w = result?.webhook;
+    console.log(`✅ ${creating ? "Created" : "Updated"} orders/paid webhook${w ? `: id=${w.id} address=${w.address}` : ` (HTTP ${mutateRes.status}, unexpected response body)`}`);
 }
 
 // Guarded so importing decideWebhookAction (e.g. from the unit test) doesn't

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -14,6 +14,7 @@ import crypto from 'crypto';
 import { POST } from '@/app/api/webhooks/shopify/route';
 import prisma from '@/lib/prisma';
 import { activateByProcessId } from '@/lib/membership/payment';
+import { DEV_MOCK_SHOPIFY_WEBHOOK_SECRET } from '@/lib/config';
 
 jest.mock('@/lib/membership/payment', () => ({
     activateByProcessId: jest.fn().mockResolvedValue(undefined),
@@ -140,7 +141,8 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         // real — the symmetry /api/dev/shopify/orders-paid relies on. Bad signature
         // still 401s; a correctly mock-signed body passes verification (200).
         delete process.env.SHOPIFY_WEBHOOK_SECRET;
-        const MOCK_SECRET = 'dev-shopify-mock-webhook-secret';
+        // Imported (not hardcoded) so this test fails fast if the mock secret ever changes.
+        const MOCK_SECRET = DEV_MOCK_SHOPIFY_WEBHOOK_SECRET;
         try {
             const body = programPayload(String(p1));
             expect((await POST(webhookReq(body, sign(body)))).status).toBe(401); // signed with the wrong secret

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -152,7 +152,8 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         // real — the symmetry /api/dev/shopify/orders-paid relies on. Bad signature
         // still 401s; a correctly mock-signed body passes verification (200).
         delete process.env.SHOPIFY_WEBHOOK_SECRET;
-        // Imported (not hardcoded) so this test fails fast if the mock secret ever changes.
+        // Imported so signer and verifier track the same constant — the value
+        // itself is not a contract; this test asserts the fallback wiring.
         const MOCK_SECRET = DEV_MOCK_SHOPIFY_WEBHOOK_SECRET;
         try {
             const body = programPayload(String(p1));

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
@@ -75,7 +75,19 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
         });
     }
 
+    // The mock gate needs the three real-store creds ABSENT for every test but the
+    // first — and a dev following the runbook has them in .env. Snapshot + clear up
+    // front (restored in afterAll) so the suite neither depends on the wiping test
+    // running first nor permanently erases ambient creds for later suites.
+    const SHOPIFY_ENV_KEYS = ['SHOPIFY_STORE_DOMAIN', 'SHOPIFY_CLIENT_ID', 'SHOPIFY_CLIENT_SECRET'] as const;
+    let prevShopifyEnv: Record<string, string | undefined> = {};
+
     beforeAll(async () => {
+        // Capture before anything fallible so afterAll can't restore `undefined`.
+        originalFetch = global.fetch;
+        prevShopifyEnv = Object.fromEntries(SHOPIFY_ENV_KEYS.map((k) => [k, process.env[k]]));
+        for (const k of SHOPIFY_ENV_KEYS) delete process.env[k];
+
         const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
         prevSettings = existing
             ? {
@@ -86,16 +98,30 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
             : null;
         await wipe();
 
-        originalFetch = global.fetch;
         global.fetch = jest.fn(async (input, init) => {
-            const req = new Request(String(input), init as RequestInit);
+            const url = String(input);
+            // Only the self-fired inbound webhook may pass; anything else reaching
+            // global fetch in this suite is a bug — fail it loudly, not by feeding
+            // it the webhook handler's response.
+            if (!url.endsWith('/api/webhooks/shopify')) throw new Error(`Unexpected fetch in dev-shopify suite: ${url}`);
+            const req = new Request(url, init as RequestInit);
             return WEBHOOK_POST(req as never) as unknown as Response;
         }) as unknown as typeof fetch;
     });
 
     afterAll(async () => {
         await wipe();
-        if (prevSettings) await prisma.boardSettings.update({ where: { id: 1 }, data: prevSettings });
+        if (prevSettings) {
+            await prisma.boardSettings.update({ where: { id: 1 }, data: prevSettings });
+        } else {
+            // Row didn't exist before this suite — remove what setVariant created
+            // so the worker DB is left as found (AGENTS.md: suites self-clean).
+            await prisma.boardSettings.deleteMany({ where: { id: 1 } });
+        }
+        for (const k of SHOPIFY_ENV_KEYS) {
+            if (prevShopifyEnv[k] === undefined) delete process.env[k];
+            else process.env[k] = prevShopifyEnv[k];
+        }
         global.fetch = originalFetch;
         await prisma.$disconnect();
     });

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for POST /api/dev/shopify/orders-paid — the dev-only mock
+ * that synthesizes an orders/paid payload and self-fires it at the REAL inbound
+ * webhook (see docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md §6). Covers the gate
+ * fuses (mock-active, session, validation) plus an end-to-end happy path that
+ * proves the mock actually drives activate() via the real webhook handler —
+ * not just a mocked 200.
+ *
+ * The route calls `fetch(config.baseUrl() + '/api/webhooks/shopify')`. There is
+ * no live HTTP server bound to that URL in the test process, so `global.fetch`
+ * is replaced here with an implementation that routes the exact request the
+ * route built (same headers, same raw body) straight into the real inbound
+ * `POST` handler — same DB, same HMAC verify, same activate() call prod runs.
+ */
+import { POST } from '@/app/api/dev/shopify/orders-paid/route';
+import { POST as WEBHOOK_POST } from '@/app/api/webhooks/shopify/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+const TAG = 'dev-shopify-route-test';
+
+function asSession(id = 1) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, isSysadmin: false, isBoardMember: false } });
+}
+function anonymous() {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+}
+function jsonReq(body?: unknown) {
+    return new Request('http://localhost:4000/api/dev/shopify/orders-paid', {
+        method: 'POST',
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+}
+
+describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
+    let originalFetch: typeof global.fetch;
+    let prevSettings: {
+        orgMembershipVariantId: string | null;
+        shopifyNormalVariantId: string | null;
+        shopifyVolunteerVariantId: string | null;
+    } | null;
+
+    async function wipe() {
+        const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+        const ids = hhs.map((h) => h.id);
+        if (ids.length) {
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.household.deleteMany({ where: { id: { in: ids } } });
+        }
+    }
+
+    /** A fresh household + membership + PENDING_PAYMENT process, matching what the dev UI lists. */
+    async function makeProc() {
+        const hh = await prisma.household.create({ data: { name: `Dev Mock HH ${TAG}` } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE', isVolunteer: false } });
+        // No bgClearedAt: activate() deterministically lands PENDING_BG_CLEARANCE
+        // (not ACTIVE) when it advances — see payment.ts `activating = !!process.bgClearedAt`.
+        const p = await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: m.id, kind: 'INITIAL', status: 'PENDING_PAYMENT' },
+        });
+        return { householdId: hh.id, orgMembershipId: m.id, processId: p.id };
+    }
+
+    async function setVariant(variantId: string | null) {
+        await prisma.boardSettings.upsert({
+            where: { id: 1 },
+            create: { id: 1, orgMembershipVariantId: variantId },
+            update: { orgMembershipVariantId: variantId, shopifyNormalVariantId: null, shopifyVolunteerVariantId: null },
+        });
+    }
+
+    beforeAll(async () => {
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevSettings = existing
+            ? {
+                  orgMembershipVariantId: existing.orgMembershipVariantId,
+                  shopifyNormalVariantId: existing.shopifyNormalVariantId,
+                  shopifyVolunteerVariantId: existing.shopifyVolunteerVariantId,
+              }
+            : null;
+        await wipe();
+
+        originalFetch = global.fetch;
+        global.fetch = jest.fn(async (input, init) => {
+            const req = new Request(String(input), init as RequestInit);
+            return WEBHOOK_POST(req as never) as unknown as Response;
+        }) as unknown as typeof fetch;
+    });
+
+    afterAll(async () => {
+        await wipe();
+        if (prevSettings) await prisma.boardSettings.update({ where: { id: 1 }, data: prevSettings });
+        global.fetch = originalFetch;
+        await prisma.$disconnect();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('404s when the mock is inactive (real Shopify creds configured)', async () => {
+        asSession();
+        process.env.SHOPIFY_STORE_DOMAIN = 'test.myshopify.com';
+        process.env.SHOPIFY_CLIENT_ID = 'test-client-id';
+        process.env.SHOPIFY_CLIENT_SECRET = 'test-client-secret';
+        try {
+            const res = await POST(jsonReq({ processId: 1 }));
+            expect(res.status).toBe(404);
+        } finally {
+            delete process.env.SHOPIFY_STORE_DOMAIN;
+            delete process.env.SHOPIFY_CLIENT_ID;
+            delete process.env.SHOPIFY_CLIENT_SECRET;
+        }
+    });
+
+    it('401s when there is no session', async () => {
+        anonymous();
+        const res = await POST(jsonReq({ processId: 1 }));
+        expect(res.status).toBe(401);
+    });
+
+    it('400s when processId is missing or not an integer', async () => {
+        asSession();
+        expect((await POST(jsonReq({}))).status).toBe(400);
+        expect((await POST(jsonReq({ processId: 'not-a-number' }))).status).toBe(400);
+        expect((await POST(jsonReq({ processId: 1.5 }))).status).toBe(400);
+    });
+
+    it('404s when the process does not exist', async () => {
+        asSession();
+        const res = await POST(jsonReq({ processId: 999999999 }));
+        expect(res.status).toBe(404);
+    });
+
+    it('404s when the process exists but is not PENDING_PAYMENT', async () => {
+        asSession();
+        const { processId } = await makeProc();
+        await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: 'PENDING_BG_REVIEW' } });
+        const res = await POST(jsonReq({ processId }));
+        expect(res.status).toBe(404);
+    });
+
+    it('409s when no membership variant is configured on BoardSettings', async () => {
+        asSession();
+        await setVariant(null);
+        const { processId } = await makeProc();
+        const res = await POST(jsonReq({ processId }));
+        expect(res.status).toBe(409);
+    });
+
+    it('200s, fires the real inbound webhook, and advances the process (PENDING_PAYMENT -> PENDING_BG_CLEARANCE)', async () => {
+        asSession();
+        await setVariant('dev-mock-variant-route-test');
+        const { processId } = await makeProc();
+
+        const res = await POST(jsonReq({ processId }));
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body).toEqual({ ok: true, status: 'PENDING_BG_CLEARANCE' });
+
+        // The real proof: the webhook actually ran end-to-end and mutated the DB,
+        // not just that the route returned 200.
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe('PENDING_BG_CLEARANCE');
+        expect(proc?.paidAt).not.toBeNull();
+    });
+});

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
@@ -26,7 +26,9 @@ export const POST = withAuth({}, async (req, auth) => {
     if (!config.shopifyMockActive()) return apiError("Not available", 404);
     if (auth.type !== "session") return apiError("Unauthorized", 401);
 
-    const { processId } = await req.json().catch(() => ({ processId: undefined }));
+    // .catch covers unparseable bodies; ?. covers parseable non-objects (`null`, `42`).
+    const body = await req.json().catch(() => null);
+    const processId = body?.processId;
     if (typeof processId !== "number" || !Number.isInteger(processId)) {
         return apiError("Missing or invalid processId", 400);
     }
@@ -50,8 +52,10 @@ export const POST = withAuth({}, async (req, auth) => {
     }
 
     // Shape mirrors the subset the inbound handler reads: note_attributes (where
-    // Shopify maps cart attributes) + line_items + an order id. Stable id so a
-    // re-fire is an idempotent webhook retry, exactly like Shopify's own retries.
+    // Shopify maps cart attributes) + line_items + an order id. Stable id so two
+    // overlapping fires for the same process (both inside the pre-check window
+    // above) collapse into one idempotent webhook retry on the handler side;
+    // sequential re-fires are blocked by the PENDING_PAYMENT gate.
     const payload = {
         id: `dev-mock-order-${processId}`,
         note_attributes: [{ name: "Membership_Process_ID", value: String(processId) }],

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
@@ -17,7 +17,10 @@ export const dynamic = "force-dynamic";
  * inbound webhook — so it exercises the same HMAC-verify → match-by-cart-attribute
  * → activate() path prod runs (mirrors the Zoho mock, ZOHO_SIGN_DEV_MOCK.md §4a).
  *
- * 404s whenever the mock isn't active — always in prod.
+ * 404s whenever the mock isn't active — always in prod. Also 404s a processId
+ * that doesn't exist or isn't PENDING_PAYMENT: the dev UI only ever lists
+ * PENDING_PAYMENT processes, so the API fails closed on anything else rather
+ * than firing a webhook for a process that was never awaiting payment.
  */
 export const POST = withAuth({}, async (req, auth) => {
     if (!config.shopifyMockActive()) return apiError("Not available", 404);
@@ -26,6 +29,11 @@ export const POST = withAuth({}, async (req, auth) => {
     const { processId } = await req.json().catch(() => ({ processId: undefined }));
     if (typeof processId !== "number" || !Number.isInteger(processId)) {
         return apiError("Missing or invalid processId", 400);
+    }
+
+    const existing = await prisma.orgMembershipProcess.findUnique({ where: { id: processId }, select: { status: true } });
+    if (!existing || existing.status !== "PENDING_PAYMENT") {
+        return apiError("Process not found or not awaiting payment", 404);
     }
 
     const secret = config.shopifyWebhookSecret();

--- a/checkin-app/src/app/dev/shopify/DevShopifyClient.tsx
+++ b/checkin-app/src/app/dev/shopify/DevShopifyClient.tsx
@@ -63,8 +63,11 @@ export default function DevShopifyClient({ hasVariant, processes }: { hasVariant
 
             {!hasVariant && (
                 <p style={{ color: "#b45309", marginTop: "1rem", fontSize: "0.85rem" }}>
-                    No membership variant configured. Set one in <strong>Settings → Membership</strong> first,
-                    or the webhook lands as a no-membership-item anomaly instead of activating.
+                    No membership variant configured. Set one in <strong>Settings → Membership</strong> first —
+                    the mock only needs <em>a</em> value here (any string): it signs a payload carrying that id and
+                    the inbound webhook matches it against this same setting, so it&apos;s a closed loop.
+                    On a real dev store, set this to the store&apos;s actual variant id instead. Without it the
+                    webhook lands as a no-membership-item anomaly instead of activating.
                 </p>
             )}
 

--- a/checkin-app/src/app/dev/shopify/DevShopifyClient.tsx
+++ b/checkin-app/src/app/dev/shopify/DevShopifyClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 interface PendingProcess {
     id: number;
@@ -16,6 +17,7 @@ interface PendingProcess {
  * Page 404s off a dev instance.
  */
 export default function DevShopifyClient({ hasVariant, processes }: { hasVariant: boolean; processes: PendingProcess[] }) {
+    const router = useRouter();
     const [busy, setBusy] = useState<number | null>(null);
     const [result, setResult] = useState<{ id: number; status: string | null } | null>(null);
     const [error, setError] = useState<string | null>(null);
@@ -36,6 +38,9 @@ export default function DevShopifyClient({ hasVariant, processes }: { hasVariant
                 return;
             }
             setResult({ id: processId, status: data.status ?? null });
+            // The fired process is no longer PENDING_PAYMENT — refresh the
+            // server-rendered list so its row (and 404-on-re-click) disappears.
+            router.refresh();
         } catch (e) {
             setError(e instanceof Error ? e.message : String(e));
         } finally {

--- a/checkin-app/src/lib/__tests__/config.test.ts
+++ b/checkin-app/src/lib/__tests__/config.test.ts
@@ -1,10 +1,11 @@
-import { config, ORG_DOMAIN } from "@/lib/config";
+import { config, ORG_DOMAIN, DEV_MOCK_SHOPIFY_WEBHOOK_SECRET } from "@/lib/config";
 
 const ENV_KEYS = [
     "DATABASE_URL", "NEXTAUTH_URL", "NEXTAUTH_SECRET", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET",
     "KIOSK_PUBLIC_KEY", "RESEND_API_KEY", "EMAIL_FROM", "AVERITY_CONSENT_URL", "ZOHO_WEBHOOK_SECRET",
     "AWS_REGION", "AGREEMENT_PDF_S3_BUCKET", "AGREEMENT_PDF_S3_KEY", "ZOHO_CLIENT_ID", "ZOHO_CLIENT_SECRET",
     "ZOHO_REFRESH_TOKEN", "ZOHO_ACCOUNTS_URL", "ZOHO_SIGN_API", "CHECKIN_ENV", "VERCEL_URL", "NODE_ENV",
+    "SHOPIFY_STORE_DOMAIN", "SHOPIFY_CLIENT_ID", "SHOPIFY_CLIENT_SECRET", "SHOPIFY_WEBHOOK_SECRET",
 ];
 
 let saved: Record<string, string | undefined>;
@@ -26,6 +27,13 @@ function clearZoho() {
     delete process.env.ZOHO_CLIENT_SECRET;
     delete process.env.ZOHO_REFRESH_TOKEN;
     delete process.env.ZOHO_WEBHOOK_SECRET;
+}
+
+function clearShopify() {
+    delete process.env.SHOPIFY_STORE_DOMAIN;
+    delete process.env.SHOPIFY_CLIENT_ID;
+    delete process.env.SHOPIFY_CLIENT_SECRET;
+    delete process.env.SHOPIFY_WEBHOOK_SECRET;
 }
 
 describe("requireEnv-backed getters", () => {
@@ -136,6 +144,49 @@ describe("zohoMockActive / zohoAvailable / zohoWebhookSecret", () => {
         clearZoho();
         process.env.CHECKIN_ENV = "prod";
         expect(config.zohoWebhookSecret()).toBeNull();
+    });
+});
+
+describe("shopifyMockActive / shopifyWebhookSecret", () => {
+    it("mock active when unconfigured, non-prod, non-production NODE_ENV", () => {
+        clearShopify();
+        process.env.CHECKIN_ENV = "local";
+        (process.env as Record<string, string>).NODE_ENV = "test";
+        expect(config.shopifyMockActive()).toBe(true);
+        expect(config.shopifyWebhookSecret()).toBe(DEV_MOCK_SHOPIFY_WEBHOOK_SECRET);
+    });
+    it("mock inactive when Shopify is configured (real integration wins)", () => {
+        process.env.SHOPIFY_STORE_DOMAIN = "shop.myshopify.com";
+        process.env.SHOPIFY_CLIENT_ID = "a";
+        process.env.SHOPIFY_CLIENT_SECRET = "b";
+        process.env.CHECKIN_ENV = "local";
+        (process.env as Record<string, string>).NODE_ENV = "test";
+        expect(config.shopifyMockActive()).toBe(false);
+    });
+    it("mock inactive on prod checkinEnv", () => {
+        clearShopify();
+        process.env.CHECKIN_ENV = "prod";
+        (process.env as Record<string, string>).NODE_ENV = "test";
+        expect(config.shopifyMockActive()).toBe(false);
+        expect(config.shopifyWebhookSecret()).toBeNull();
+    });
+    it("mock inactive when NODE_ENV is production", () => {
+        clearShopify();
+        process.env.CHECKIN_ENV = "local";
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        expect(config.shopifyMockActive()).toBe(false);
+        expect(config.shopifyWebhookSecret()).toBeNull();
+    });
+    it("SHOPIFY_WEBHOOK_SECRET env wins regardless of mock state", () => {
+        clearShopify();
+        process.env.SHOPIFY_WEBHOOK_SECRET = "explicit-shopify-secret";
+        process.env.CHECKIN_ENV = "prod";
+        expect(config.shopifyWebhookSecret()).toBe("explicit-shopify-secret");
+    });
+    it("null when unset and mock inactive", () => {
+        clearShopify();
+        process.env.CHECKIN_ENV = "prod";
+        expect(config.shopifyWebhookSecret()).toBeNull();
     });
 });
 

--- a/checkin-app/src/lib/__tests__/config.test.ts
+++ b/checkin-app/src/lib/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { config, ORG_DOMAIN, DEV_MOCK_SHOPIFY_WEBHOOK_SECRET } from "@/lib/config";
+import { config, ORG_DOMAIN, DEV_MOCK_SHOPIFY_WEBHOOK_SECRET, DEV_MOCK_WEBHOOK_SECRET } from "@/lib/config";
 
 const ENV_KEYS = [
     "DATABASE_URL", "NEXTAUTH_URL", "NEXTAUTH_SECRET", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET",
@@ -110,7 +110,7 @@ describe("zohoMockActive / zohoAvailable / zohoWebhookSecret", () => {
         (process.env as Record<string, string>).NODE_ENV = "test";
         expect(config.zohoMockActive()).toBe(true);
         expect(config.zohoAvailable()).toBe(true);
-        expect(config.zohoWebhookSecret()).toBe("dev-zoho-mock-webhook-secret");
+        expect(config.zohoWebhookSecret()).toBe(DEV_MOCK_WEBHOOK_SECRET);
     });
     it("mock inactive when Zoho is configured (real integration wins)", () => {
         process.env.ZOHO_CLIENT_ID = "a";
@@ -182,11 +182,6 @@ describe("shopifyMockActive / shopifyWebhookSecret", () => {
         process.env.SHOPIFY_WEBHOOK_SECRET = "explicit-shopify-secret";
         process.env.CHECKIN_ENV = "prod";
         expect(config.shopifyWebhookSecret()).toBe("explicit-shopify-secret");
-    });
-    it("null when unset and mock inactive", () => {
-        clearShopify();
-        process.env.CHECKIN_ENV = "prod";
-        expect(config.shopifyWebhookSecret()).toBeNull();
     });
 });
 

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -50,8 +50,9 @@ function zohoMockActiveEnv(): boolean {
  * Fixed shared secret the dev mock signs its self-fired webhook with (§4a of the
  * design). It guards nothing real — the payload is generated locally — it exists
  * only so verifyZohoToken's real timing-safe compare has a value in dev.
+ * Exported for the same reason as DEV_MOCK_SHOPIFY_WEBHOOK_SECRET below.
  */
-const DEV_MOCK_WEBHOOK_SECRET = 'dev-zoho-mock-webhook-secret';
+export const DEV_MOCK_WEBHOOK_SECRET = 'dev-zoho-mock-webhook-secret';
 
 /** Real Shopify integration is wired only when all three credentials are present. */
 function shopifyConfiguredEnv(): boolean {
@@ -77,10 +78,10 @@ function shopifyMockActiveEnv(): boolean {
  * enough for verifyShopifyHmac's real timing-safe compare — same rationale as
  * DEV_MOCK_WEBHOOK_SECRET. See §4 of the design: fixed ⇔ self-fired mock.
  *
- * Exported (unlike DEV_MOCK_WEBHOOK_SECRET) so tests that assert the mock's
- * self-signed webhook verifies can import the real value instead of duplicating
- * the literal — a copy-pasted string would silently stop testing anything if
- * this constant ever changed.
+ * Exported so tests that assert the mock's self-signed webhook verifies can
+ * import it instead of duplicating the literal: the tests exercise the fallback
+ * wiring, and the exact value is not a contract anything external signs with,
+ * so signer and verifier should track one source of truth.
  */
 export const DEV_MOCK_SHOPIFY_WEBHOOK_SECRET = 'dev-shopify-mock-webhook-secret';
 

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -76,8 +76,13 @@ function shopifyMockActiveEnv(): boolean {
  * don't choose), the mock generates the payload locally, so a fixed constant is
  * enough for verifyShopifyHmac's real timing-safe compare — same rationale as
  * DEV_MOCK_WEBHOOK_SECRET. See §4 of the design: fixed ⇔ self-fired mock.
+ *
+ * Exported (unlike DEV_MOCK_WEBHOOK_SECRET) so tests that assert the mock's
+ * self-signed webhook verifies can import the real value instead of duplicating
+ * the literal — a copy-pasted string would silently stop testing anything if
+ * this constant ever changed.
  */
-const DEV_MOCK_SHOPIFY_WEBHOOK_SECRET = 'dev-shopify-mock-webhook-secret';
+export const DEV_MOCK_SHOPIFY_WEBHOOK_SECRET = 'dev-shopify-mock-webhook-secret';
 
 export const config = {
     // Database

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -223,25 +223,6 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         });
     }
 
-    // ponytail: deliberate deviation from SHOPIFY_DEV_STORE_WEBHOOK.md's O4 recommendation
-    // ("leave null, document manual setup") — a placeholder membership variant makes the
-    // dev Shopify orders/paid mock immediately clickable on a fresh DB, no settings-page
-    // detour first. Obviously-fake ids; upgrade path: once a real dev store exists, set
-    // real ids via Settings → Membership (update: {} leaves a hand-set value alone).
-    await prisma.boardSettings.upsert({
-        where: { id: 1 },
-        create: {
-            id: 1,
-            orgMembershipVariantId: "dev-mock-variant-normal",
-            shopifyNormalVariantId: "dev-mock-variant-normal",
-            shopifyVolunteerVariantId: "dev-mock-variant-volunteer",
-            volunteerDiscountCode: "DEV-VOLUNTEER",
-            normalDuesCents: 10000,
-            volunteerDuesCents: 2500,
-        },
-        update: {},
-    });
-
     console.log("🎉 Seed complete — 9 debug personas, tools, and a sample program are ready.");
 }
 

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -223,6 +223,25 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         });
     }
 
+    // ponytail: deliberate deviation from SHOPIFY_DEV_STORE_WEBHOOK.md's O4 recommendation
+    // ("leave null, document manual setup") — a placeholder membership variant makes the
+    // dev Shopify orders/paid mock immediately clickable on a fresh DB, no settings-page
+    // detour first. Obviously-fake ids; upgrade path: once a real dev store exists, set
+    // real ids via Settings → Membership (update: {} leaves a hand-set value alone).
+    await prisma.boardSettings.upsert({
+        where: { id: 1 },
+        create: {
+            id: 1,
+            orgMembershipVariantId: "dev-mock-variant-normal",
+            shopifyNormalVariantId: "dev-mock-variant-normal",
+            shopifyVolunteerVariantId: "dev-mock-variant-volunteer",
+            volunteerDiscountCode: "DEV-VOLUNTEER",
+            normalDuesCents: 10000,
+            volunteerDuesCents: 2500,
+        },
+        update: {},
+    });
+
     console.log("🎉 Seed complete — 9 debug personas, tools, and a sample program are ready.");
 }
 

--- a/checkin-app/src/lib/membership/contract/__tests__/zohoProvider.test.ts
+++ b/checkin-app/src/lib/membership/contract/__tests__/zohoProvider.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { config } from "@/lib/config";
+import { config, DEV_MOCK_WEBHOOK_SECRET } from "@/lib/config";
 import { zohoSign } from "@/lib/membership/contract/zohoProvider";
 
 const ORIGINAL_ENV = { ...process.env };
@@ -29,7 +29,7 @@ describe("zoho mock fuse (config)", () => {
             expect(config.zohoAvailable()).toBe(true);
             expect(config.zohoConfigured()).toBe(false);
             // Dev default webhook secret so the self-fired webhook verifies with zero setup.
-            expect(config.zohoWebhookSecret()).toBe("dev-zoho-mock-webhook-secret");
+            expect(config.zohoWebhookSecret()).toBe(DEV_MOCK_WEBHOOK_SECRET);
         }
     });
 

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -19,7 +19,7 @@ let tokenExpiresAt: number = 0;
 const SHOPIFY_FETCH_TIMEOUT_MS = 20_000;
 
 /** fetch with a hard timeout that surfaces as a clear error instead of hanging. */
-async function shopifyFetch(input: string, init: RequestInit, label: string): Promise<Response> {
+export async function shopifyFetch(input: string, init: RequestInit, label: string): Promise<Response> {
   try {
     return await fetch(input, { ...init, signal: AbortSignal.timeout(SHOPIFY_FETCH_TIMEOUT_MS) });
   } catch (err) {
@@ -40,7 +40,7 @@ export function resetTokenCache() {
  * Fetches a fresh Admin API access token using the client credentials grant.
  * Caches the token and refreshes ~5 minutes before expiry.
  */
-async function getAccessToken(): Promise<string | null> {
+export async function getAccessToken(): Promise<string | null> {
   const storeDomain = config.shopifyStoreDomain();
   const clientId = config.shopifyClientId();
   const clientSecret = config.shopifyClientSecret();

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -18,6 +18,9 @@ let tokenExpiresAt: number = 0;
  */
 const SHOPIFY_FETCH_TIMEOUT_MS = 20_000;
 
+/** Admin API version for every REST call here and in scripts/register-shopify-webhook.ts — bump it in one place. */
+export const SHOPIFY_API_VERSION = "2026-01";
+
 /** fetch with a hard timeout that surfaces as a clear error instead of hanging. */
 export async function shopifyFetch(input: string, init: RequestInit, label: string): Promise<Response> {
   try {
@@ -107,7 +110,7 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
     const productTitle = `Program Enrollment: ${name}`;
 
     // 1. Create Product
-    const productRes = await shopifyFetch(`https://${storeDomain}/admin/api/2026-01/products.json`, {
+    const productRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/products.json`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -162,7 +165,7 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
 
     if (variants.length > 0) {
         for (const variant of variants) {
-            const variantRes = await shopifyFetch(`https://${storeDomain}/admin/api/2026-01/products/${productId}/variants.json`, {
+            const variantRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/products/${productId}/variants.json`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -183,14 +186,14 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
                 if (maxParticipants && variantData.variant.inventory_item_id) {
                     try {
                         // Get the store's primary location
-                        const locRes = await shopifyFetch(`https://${storeDomain}/admin/api/2026-01/locations.json`, {
+                        const locRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/locations.json`, {
                             headers: { 'X-Shopify-Access-Token': accessToken },
                         }, "Shopify get locations");
                         if (locRes.ok) {
                             const locData = await locRes.json();
                             const locationId = locData.locations?.[0]?.id;
                             if (locationId) {
-                                const invRes = await shopifyFetch(`https://${storeDomain}/admin/api/2026-01/inventory_levels/set.json`, {
+                                const invRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/set.json`, {
                                     method: 'POST',
                                     headers: {
                                         'Content-Type': 'application/json',


### PR DESCRIPTION
## What

Finishes the Shopify dev-store webhook work planned in #738, on top of the in-process `orders/paid` mock that already landed in #730.

- **Mock hardening** — export `DEV_MOCK_SHOPIFY_WEBHOOK_SECRET` (dedupes the literal the webhook test hardcoded); the dev route now `404`s a `processId` that doesn't exist or isn't `PENDING_PAYMENT` (fail-closed, matches what the dev UI already offers).
- **Tests** — new dedicated integration suite for `POST /api/dev/shopify/orders-paid` (404 mock-inactive, 401 no-session, 400 bad processId, 404 unknown/wrong-phase process, 409 no variant configured, and a genuinely end-to-end 200 happy path that hands the mock's signed payload to the real inbound `/api/webhooks/shopify` handler and asserts the `OrgMembershipProcess` actually advanced). Plus a Shopify fuse-matrix block in `config.test.ts` mirroring the Zoho one.
- **Admin-API registration script** — new `scripts/register-shopify-webhook.ts` (`npm run shopify:webhook -- --url <callback> [--commit]`): idempotent create/update/noop of the `orders/paid` subscription via the Admin API, reusing `getAccessToken`/`shopifyFetch` (now exported from `shopify.ts`). Dry-run by default; the decision is a pure, unit-tested function.
- **Docs** — brings in #738's `SHOPIFY_DEV_STORE_WEBHOOK.md` + `_PLAN.md` (resolves the mock's dangling doc citations).

## How the membership variant id works (addressing review feedback)

**The variant id is never hardcoded in our code** — it lives in `BoardSettings.orgMembershipVariantId` (admin-editable via Settings → Membership), set once per environment:

- **Local mock** (no Shopify creds): the value is just a **correlation token**. The mock reads it, echoes it in the synthesized `line_items`, and the inbound handler matches it against the *same* `BoardSettings` — a closed loop that never touches Shopify, so any string works. Set it once locally; the dev tool's empty-state points you there.
- **Real dev store** (cloud-dev, real creds): the value must be the **store's actual variant id**, set once by a human after creating the product. A real `orders/paid` carries that id and the inbound H2 check matches it.

Because both read the id from `BoardSettings` (not code), there is nothing to "align."

> **Correction since first push:** the initial version *seeded* a fake placeholder variant id so the local mock was clickable with zero setup. That was wrong for a design with a real-store path — `seedBaseline` is reachable on cloud-dev (via the dev-dashboard reset), where a fake id would silently fail the real store's H2 variant check. **Reverted** (`revert(shopify-dev-mock)`): we now follow #738's O4 — `BoardSettings` variant stays null until configured once via Settings → Membership, and the dev UI + design §6 explain the model explicitly.

## Safety

- **Prod path byte-for-byte unchanged** — `verifyShopifyHmac`, `withWebhook`, `activate()`, and the four `config` Shopify getters are untouched. Every dev surface stays gated on `shopifyMockActive()` (false in prod by construction).
- **No infra change** — the AWS Secrets Manager / ECS task-def wiring for dev + prod is already committed on the infra repo's `feat/enable-shopify-dev` branch; only the human `put-secret-value` of the dev values remains (out of scope here).

## Verification

Node 24, live Postgres: full `npm run test:coverage` green — **295 suites / 2276 tests**, coverage above the 85/75/75 floors; `tsc --noEmit`, `lint`, and `check-route-coverage` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)