### PR TITLE
fix(membership-audit): make tab count badges legible

### DIFF
--- a/checkin-app/src/app/membership-audit/layout.tsx
+++ b/checkin-app/src/app/membership-audit/layout.tsx
@@ -60,11 +60,11 @@ export default function MembershipAuditLayout({ children }: { children: React.Re
                   badge ? (
                     <Badge
                       size="md"
-                      color={isBroken ? "treehouseGreen" : "gray"}
-                      variant={isBroken ? "filled" : "light"}
+                      color={isBroken ? "treehouseGreen" : "gray.2"}
+                      variant="filled"
                       // Pinned label color so the active tab's green recolor doesn't render the
-                      // count green-on-green (gray informational fill, or black on the green fill).
-                      c={isBroken ? "var(--mantine-color-black)" : "var(--mantine-color-gray-7)"}
+                      // count green-on-green (dark gray on the light-gray fill, or black on the green fill).
+                      c={isBroken ? "var(--mantine-color-black)" : "var(--mantine-color-gray-8)"}
                       aria-label={badge.label}
                     >
                       {badge.count}


### PR DESCRIPTION
## What

Fix the count badges on the Membership Audit tabs (Emergency Contacts, Unclaimed Accounts) rendering dark-gray-on-gray and hard to read.

## Why

The non-broken badges used the gray `light` variant with `gray-7` text. On the light-gray fill that's a low-contrast dark-gray-on-gray — the count at the top of `/membership-audit/unclaimed` was nearly illegible.

## Change

- Non-broken badges: fixed light-gray fill (`gray.2` filled) + `gray-8` text.
- Using `filled` with an explicit shade (not `light`) so the active tab's green recolor can't override the background and re-introduce a low-contrast state.
- Broken badge unchanged (green fill, black text).

One file: `checkin-app/src/app/membership-audit/layout.tsx`.