### PR TITLE
fix(safety): stale participant→person ref crashes trusted-adults board

### DIFF
--- a/checkin-app/src/app/safety/trusted-adults/__tests__/page.test.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/__tests__/page.test.tsx
@@ -139,7 +139,7 @@ describe("safety/trusted-adults page", () => {
     const conflicted = [
       {
         ...trustedAdults[0],
-        household: { id: 1, name: "Guardian House", leads: [{ participant: { name: "Lead Lucy", email: "lucy@example.com" } }] },
+        household: { id: 1, name: "Guardian House", leads: [{ person: { name: "Lead Lucy", email: "lucy@example.com" } }] },
         reviews: [{ ...trustedAdults[0].reviews[0], sharedNote: "Already shared.", reviewBy: "2026-02-01T00:00:00.000Z" }],
       },
     ];

--- a/checkin-app/src/app/safety/trusted-adults/page.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/page.tsx
@@ -38,7 +38,7 @@ interface PersonRef {
 interface HouseholdRef {
     id: number;
     name: string | null;
-    leads: { participant: PersonRef }[];
+    leads: { person: PersonRef }[];
 }
 interface TrustedAdult {
     id: number;
@@ -182,7 +182,7 @@ export default function AdminTrustedAdultsPage() {
                         )}
                         {ta.household?.leads?.length ? (
                             <Text size="xs" c="dimmed" mt={2}>
-                                Leads: {ta.household.leads.map((l) => l.participant.name || l.participant.email).join(", ")}
+                                Leads: {ta.household.leads.map((l) => l.person.name || l.person.email).join(", ")}
                             </Text>
                         ) : null}
                         {latest?.reviewBy && (


### PR DESCRIPTION
## What

The safety trusted-adults board page crashed at runtime:

```
Cannot read properties of undefined (reading 'name')
src/app/safety/trusted-adults/page.tsx (185:85)
```

Two stale references from the `Participant→Person` model rename, both `participant`→`person`:
- **Type decl** (`page.tsx:41`): `leads: { participant: PersonRef }[]` → `{ person: PersonRef }[]`
- **Usage** (`page.tsx:185`): `l.participant.name || l.participant.email` → `l.person.name || l.person.email`

## Why it wasn't caught

The API route already returns `l.person` ([`api/safety/trusted-adults/route.ts:28`](https://github.com/innovationtreehouse/checkin/blob/main/checkin-app/src/app/api/safety/trusted-adults/route.ts#L28)). The page's local type and its usage both still said `participant`, so they agreed with each other and stayed tsc-green — while disagreeing with the actual API shape. Classic rename escape: loosely-typed response boundary hides the mismatch until runtime.

## Reviewer notes

- No other `participant` refs remain in this file.
- Rest of the page already uses `trustedAdultPerson` (post-rename), so this was the last straggler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)