### PR TITLE
feat(trusted-adults): flag required shared note on Approve

### DIFF
--- a/checkin-app/src/app/safety/trusted-adults/page.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/page.tsx
@@ -195,6 +195,7 @@ export default function AdminTrustedAdultsPage() {
                         {pending && latest && (
                             <Stack mt="md" gap="xs">
                                 <Textarea
+                                    withAsterisk
                                     label="Shared note — what keyholders & program leads should know (required to approve)"
                                     placeholder="e.g. Grandma (Jane Doe) may pick up Bobby and Sue."
                                     autosize
@@ -208,15 +209,22 @@ export default function AdminTrustedAdultsPage() {
                                     disabled={!isSelf}
                                 >
                                     <Group gap="xs">
-                                        <Button
-                                            size="xs" fz={15}
-                                            color="green"
-                                            loading={busyId === latest.id}
-                                            disabled={isSelf || !sharedVal.trim()}
-                                            onClick={() => decide(latest.id, "APPROVE", { sharedNote: sharedVal })}
+                                        <Tooltip
+                                            label="Needs Shared Note to Approve"
+                                            disabled={isSelf || !!sharedVal.trim()}
                                         >
-                                            Approve
-                                        </Button>
+                                            <span>
+                                                <Button
+                                                    size="xs" fz={15}
+                                                    color="green"
+                                                    loading={busyId === latest.id}
+                                                    disabled={isSelf || !sharedVal.trim()}
+                                                    onClick={() => decide(latest.id, "APPROVE", { sharedNote: sharedVal })}
+                                                >
+                                                    Approve
+                                                </Button>
+                                            </span>
+                                        </Tooltip>
                                         <Button size="xs" fz={15} color="red" loading={busyId === latest.id} disabled={isSelf} onClick={() => decide(latest.id, "DENY")}>
                                             Deny
                                         </Button>


### PR DESCRIPTION
## What

On the **Trusted Adults — Board Review** page (`/safety/trusted-adults`), the Approve button is disabled until a shared note is entered, but nothing signalled *why*.

- Red asterisk on the **Shared note** field (Mantine `withAsterisk`).
- **"Needs Shared Note to Approve"** tooltip on the disabled Approve button. Span-wrapped so hover fires while the button is disabled (browsers suppress hover events on disabled buttons).

## Why

Reviewers hit a dead Approve button with no explanation. These two cues make the requirement discoverable.

## Notes

- Self-conflict tooltip on the button group is unchanged; the new tooltip is suppressed when self-conflict applies (that case already has its own message) or when a note is present.
- No logic/API change — purely the review UI affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)