### PR TITLE
feat(trusted-adults): point "needs more info" badge at the email

### DIFF
--- a/checkin-app/src/components/TrustedAdultPanel.tsx
+++ b/checkin-app/src/components/TrustedAdultPanel.tsx
@@ -21,7 +21,7 @@ import { TrustedAdultContact } from "@/components/TrustedAdultContact";
 
 const STATUS_META: Record<string, { label: string; color: string }> = {
     PENDING_BOARD_REVIEW: { label: "Awaiting board review", color: "yellow" },
-    PENDING_SUBJECT_ACTION: { label: "Board needs more info", color: "orange" },
+    PENDING_SUBJECT_ACTION: { label: "Board needs more info — see email", color: "orange" },
     APPROVED: { label: "Approved", color: "green" },
     DENIED: { label: "Denied", color: "red" },
     EXPIRED: { label: "Expired", color: "gray" },


### PR DESCRIPTION
## What

The trusted-adult status badge for `PENDING_SUBJECT_ACTION` now reads **"Board needs more info — see email"** (was "Board needs more info").

## Why

When a board member reviews a trusted adult and picks `REQUEST_INFO`, `decideReview` flips the review to `PENDING_SUBJECT_ACTION` and `notifyHouseholdFamily` emails the household leads with the board's note (subject: "The board needs more information about a trusted adult", link to `/trusted-adults`). The badge gave no hint that the actual request — the board's note — lives in that email. Family saw the orange badge on `/my-household` / `/trusted-adults` with no idea where to look.

## Change

One line in `TrustedAdultPanel.tsx` `STATUS_META`. No logic change.

## Reviewer notes

- Kept lowercase "see email" to match existing "Board needs more info" sentence casing.
- No test asserted on the old label string, so nothing to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)