### PR TITLE
fix(safety): per-card confirmation notices on trusted-adults review

### DIFF
--- a/checkin-app/src/app/safety/trusted-adults/page.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/page.tsx
@@ -69,7 +69,11 @@ export default function AdminTrustedAdultsPage() {
     const [loading, setLoading] = useState(true);
     const [busyId, setBusyId] = useState<number | null>(null);
     const [shared, setShared] = useState<Record<number, string>>({});
-    const [message, setMessage] = useState<{ text: string; tone: AlertTone } | undefined>();
+    // Per-review confirmation, rendered card-local so the notice stays next to the
+    // button that triggered it (a single page-top banner scrolls off-screen on long queues).
+    const [notices, setNotices] = useState<Record<number, { text: string; tone: AlertTone }>>({});
+    const clearNotice = (id: number) =>
+        setNotices((n) => { const c = { ...n }; delete c[id]; return c; });
 
     const load = useCallback(async () => {
         setLoading(true);
@@ -90,7 +94,7 @@ export default function AdminTrustedAdultsPage() {
 
     const decide = async (reviewId: number, decision: string, extra?: Record<string, unknown>) => {
         setBusyId(reviewId);
-        setMessage(undefined);
+        clearNotice(reviewId);
         try {
             const res = await fetch("/api/safety/trusted-adults/decision", {
                 method: "POST",
@@ -99,9 +103,9 @@ export default function AdminTrustedAdultsPage() {
             });
             const body = await res.json().catch(() => ({}));
             if (!res.ok) {
-                setMessage({ text: body.error ?? "Decision failed.", tone: "error" });
+                setNotices((n) => ({ ...n, [reviewId]: { text: body.error ?? "Decision failed.", tone: "error" } }));
             } else {
-                setMessage({ text: `Recorded: ${label(body.status)}.`, tone: "success" });
+                setNotices((n) => ({ ...n, [reviewId]: { text: `Recorded: ${label(body.status)}.`, tone: "success" } }));
                 await load();
             }
         } finally {
@@ -111,6 +115,7 @@ export default function AdminTrustedAdultsPage() {
 
     const override = async (reviewId: number, action: string, extra?: Record<string, unknown>) => {
         setBusyId(reviewId);
+        clearNotice(reviewId);
         try {
             const res = await fetch("/api/safety/trusted-adults/override", {
                 method: "POST",
@@ -119,8 +124,9 @@ export default function AdminTrustedAdultsPage() {
             });
             const body = await res.json().catch(() => ({}));
             if (!res.ok) {
-                setMessage({ text: body.error ?? "Override failed.", tone: "error" });
+                setNotices((n) => ({ ...n, [reviewId]: { text: body.error ?? "Override failed.", tone: "error" } }));
             } else {
+                // Override deliberately shows no success notice — just reload.
                 await load();
             }
         } finally {
@@ -148,8 +154,6 @@ export default function AdminTrustedAdultsPage() {
                     keyholders and program leads will see.
                 </Text>
             </div>
-
-            <AlertBanner message={message?.text} tone={message?.tone} onClose={() => setMessage(undefined)} />
 
             {items.length === 0 && <Text c="dimmed">Nothing in the queue.</Text>}
 
@@ -259,6 +263,15 @@ export default function AdminTrustedAdultsPage() {
                                     Revoke
                                 </Button>
                             </Group>
+                        )}
+
+                        {latest && notices[latest.id] && (
+                            <AlertBanner
+                                message={notices[latest.id].text}
+                                tone={notices[latest.id].tone}
+                                mt="xs"
+                                onClose={() => clearNotice(latest.id)}
+                            />
                         )}
                     </Card>
                 );


### PR DESCRIPTION
## What

Move the trusted-adults board-review action confirmations from a single page-top `AlertBanner` into per-card scope.

## Why

One page-top banner (fed by `message`/`setMessage`) served every review card's **Approve / Deny / Request info** and **Force approve / deny / revoke** buttons. Cards render in an unbounded `.map()` queue. Deciding an item several cards down scrolled the banner off-screen — the action read as a no-op ("nothing happened").

Same off-screen-confirmation pattern flagged elsewhere in the frontend audit; reference fix is `my-household/page.tsx` (section-local `<Alert>` next to the triggering button).

## How

- Replace `message: {text, tone}` with `notices: Record<number, {text, tone}>`, keyed by review id like the existing `busyId`/`shared` state.
- Render a card-local `<AlertBanner>` next to each card's button group (reuses the shared component — already maps tone→color + guards empty).
- Clear the per-id notice at the start of the next `decide`/`override`, plus a close button.
- `override()` still shows **no** success notice (reload-only) — unchanged by design; only its error path now targets the per-id notice.

## Reviewer notes

- No test added: jest finds 0 tests in worktrees. `tsc --noEmit` clean for the file.
- Behavior parity otherwise: same messages, same tones, same conflict-of-interest gating.