### PR TITLE
fix(roles): surface role-toggle error at the affected row

### DIFF
--- a/checkin-app/src/app/settings/roles/page.tsx
+++ b/checkin-app/src/app/settings/roles/page.tsx
@@ -32,6 +32,7 @@ export default function RoleAssignmentPage() {
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState("");
   const [savingId, setSavingId] = useState<number | null>(null);
+  const [rowError, setRowError] = useState<{ id: number; text: string } | null>(null);
   const [userSearchText, setUserSearchText] = useState("");
   const [hideYouth, setHideYouth] = useState(true);
 
@@ -60,6 +61,7 @@ export default function RoleAssignmentPage() {
   const handleRoleChange = async (userId: number, field: keyof UserRole, value: boolean) => {
     setSavingId(userId);
     setMessage("");
+    setRowError(null);
 
     // Optimistic update
     setUsers(users.map(u => u.id === userId ? { ...u, [field]: value } : u));
@@ -76,12 +78,12 @@ export default function RoleAssignmentPage() {
 
       if (!res.ok) {
         const data = await res.json();
-        setMessage(data.error || "Failed to update role.");
+        setRowError({ id: userId, text: data.error || "Failed to update role." });
         // Revert optimistic update
         fetchUsers();
       }
     } catch {
-      setMessage("Network error updating role.");
+      setRowError({ id: userId, text: "Network error updating role." });
       fetchUsers();
     } finally {
       setSavingId(null);
@@ -142,6 +144,9 @@ export default function RoleAssignmentPage() {
                 <Table.Td>
                   <Text fw={500}>{user.name || 'Unnamed'}</Text>
                   <Text size="sm" c="dimmed">{user.email}</Text>
+                  {rowError?.id === user.id && (
+                    <Text size="xs" c="red">{rowError.text}</Text>
+                  )}
                 </Table.Td>
                 {ROLE_COLUMNS.map((col) => (
                   <Table.Td key={col.field} ta="center">


### PR DESCRIPTION
## What

Role-toggle failures on the Role Assignment screen (`settings/roles`) were routed to a page-top `<AlertBanner>`. On a long user table, a checkbox toggled far down the list reverts optimistically and its error lands off-screen — reads as "nothing happened."

Route the role-change error to a **row-local indicator** keyed to the affected user id, rendered in that row's User cell (`<Text size="xs" c="red">`) and cleared on the next change. Page-top banner retained for list-load errors.

## Why it matters

Realistic failure paths that now surface at the row:
- **500** — target person deleted since the list loaded (Prisma P2025), or DB error.
- **401** — session expired while the tab sat open.
- **403** — board member toggling Sysadmin (UI disables that box, so race/direct-API only).

Before: optimistic toggle reverts silently with feedback scrolled out of view.

## Reviewer notes

- The client literal `"Failed to update role."` is a near-dead fallback: `apiError` always returns `{ error }`, so the real server message (e.g. "Internal server error", "Only Sysadmins can modify...") is what renders. Left as-is.
- No test added — jest finds 0 tests in worktrees. Change is a small render/state wiring in `checkin-app/src/app/settings/roles/page.tsx` (+7/-2).
