### PR TITLE
fix(trusted-adults): refresh nav/tab counts after board decision

### DIFF
--- a/checkin-app/src/app/safety/trusted-adults/page.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/page.tsx
@@ -18,6 +18,7 @@ import { AlertBanner, type AlertTone } from "@/components/admin/AlertBanner";
 import { TrustedAdultContact } from "@/components/TrustedAdultContact";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { isTrustedAdultConflict } from "@/lib/trusted-adult/conflict";
+import { notifyNavRefresh } from "@/lib/nav-refresh";
 
 interface Review {
     id: number;
@@ -103,6 +104,7 @@ export default function AdminTrustedAdultsPage() {
             } else {
                 setMessage({ text: `Recorded: ${label(body.status)}.`, tone: "success" });
                 await load();
+                notifyNavRefresh();
             }
         } finally {
             setBusyId(null);
@@ -122,6 +124,7 @@ export default function AdminTrustedAdultsPage() {
                 setMessage({ text: body.error ?? "Override failed.", tone: "error" });
             } else {
                 await load();
+                notifyNavRefresh();
             }
         } finally {
             setBusyId(null);


### PR DESCRIPTION
## Problem
On `/safety/trusted-adults`, approving/denying/overriding a disclosure reloaded the local queue but left the **`/safety` nav badge** and the **`/safety/trusted-adults` tab badge** stale until a full page reload.

## Root cause
Both badges read from `useTodoCounts`, which refetches on `NAV_COUNTS_EVENT`. The page's `decide`/`override` handlers never fired it — every other admin mutation site (membership-ops, finance-ops, membership-audit) already does.

## Fix
Call `notifyNavRefresh()` after each successful decision and override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)