### PR TITLE
fix(membership-audit): card-local lead-assign notice on broken-households page

### DIFF
--- a/checkin-app/src/app/membership-audit/broken/page.tsx
+++ b/checkin-app/src/app/membership-audit/broken/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Badge, Box, Button, Card, Group, Loader, Stack, Text } from "@mantine/core";
-import { notifications } from "@mantine/notifications";
+import { Alert, Badge, Box, Button, Card, Group, Loader, Stack, Text } from "@mantine/core";
 import { formatDate, isYouth } from "@/lib/time";
 
 type Member = { id: number; name: string | null; dateOfBirth: string | null };
@@ -12,6 +11,10 @@ export default function BrokenHouseholdsPage() {
   const [households, setHouseholds] = useState<BrokenHousehold[]>([]);
   const [loading, setLoading] = useState(true);
   const [promoting, setPromoting] = useState<number | null>(null);
+  // Per-household lead-assign result, shown in a card-local Alert. A page-corner
+  // toast reads as "nothing happened" for a card far down; the card also doesn't
+  // reliably vanish on success. Keyed by household id, cleared on the next click.
+  const [notice, setNotice] = useState<Record<number, { ok: boolean; text: string }>>({});
 
   const fetchHouseholds = useCallback(async () => {
     try {
@@ -29,8 +32,9 @@ export default function BrokenHouseholdsPage() {
     fetchHouseholds();
   }, [fetchHouseholds]);
 
-  const makeLead = async (participantId: number) => {
+  const makeLead = async (householdId: number, participantId: number) => {
     setPromoting(participantId);
+    setNotice(({ [householdId]: _, ...rest }) => rest);
     try {
       const res = await fetch("/api/household/lead", {
         method: "POST",
@@ -38,14 +42,14 @@ export default function BrokenHouseholdsPage() {
         body: JSON.stringify({ participantId }),
       });
       if (res.ok) {
-        notifications.show({ color: "green", message: "Lead assigned." });
+        setNotice((n) => ({ ...n, [householdId]: { ok: true, text: "Lead assigned." } }));
         fetchHouseholds();
       } else {
         const data = await res.json().catch(() => ({}));
-        notifications.show({ color: "red", message: data.error || "Failed to assign lead." });
+        setNotice((n) => ({ ...n, [householdId]: { ok: false, text: data.error || "Failed to assign lead." } }));
       }
     } catch {
-      notifications.show({ color: "red", message: "Network error." });
+      setNotice((n) => ({ ...n, [householdId]: { ok: false, text: "Network error." } }));
     } finally {
       setPromoting(null);
     }
@@ -67,6 +71,12 @@ export default function BrokenHouseholdsPage() {
             {households.map((h) => (
               <Card key={h.id} withBorder radius="md" padding="md">
                 <Text fw={600} mb="xs">{h.name}</Text>
+                {notice[h.id] && (
+                  <Alert color={notice[h.id].ok ? "green" : "red"} variant="light" mb="xs" withCloseButton
+                    onClose={() => setNotice(({ [h.id]: _, ...rest }) => rest)}>
+                    {notice[h.id].text}
+                  </Alert>
+                )}
                 {h.members.length > 0 ? (
                   <Stack gap={6}>
                     {h.members.map((m) => (
@@ -83,7 +93,7 @@ export default function BrokenHouseholdsPage() {
                             size="compact-xs"
                             variant="light"
                             loading={promoting === m.id}
-                            onClick={() => makeLead(m.id)}
+                            onClick={() => makeLead(h.id, m.id)}
                           >
                             Make Lead
                           </Button>

--- a/checkin-app/src/app/membership-audit/broken/page.tsx
+++ b/checkin-app/src/app/membership-audit/broken/page.tsx
@@ -34,7 +34,7 @@ export default function BrokenHouseholdsPage() {
 
   const makeLead = async (householdId: number, participantId: number) => {
     setPromoting(participantId);
-    setNotice(({ [householdId]: _, ...rest }) => rest);
+    setNotice((n) => { const next = { ...n }; delete next[householdId]; return next; });
     try {
       const res = await fetch("/api/household/lead", {
         method: "POST",
@@ -73,7 +73,7 @@ export default function BrokenHouseholdsPage() {
                 <Text fw={600} mb="xs">{h.name}</Text>
                 {notice[h.id] && (
                   <Alert color={notice[h.id].ok ? "green" : "red"} variant="light" mb="xs" withCloseButton
-                    onClose={() => setNotice(({ [h.id]: _, ...rest }) => rest)}>
+                    onClose={() => setNotice((n) => { const next = { ...n }; delete next[h.id]; return next; })}>
                     {notice[h.id].text}
                   </Alert>
                 )}


### PR DESCRIPTION
## What

Replace the global Mantine corner toast on the broken-households page with a per-household, card-local `<Alert>` for the **Make Lead** result.

## Why

The **Make Lead** button sits deep inside a per-household `<Card>` in a long `<Stack>` of cards. Success/failure fired a `notifications.show()` toast at the viewport corner — for a card far down the page that reads as "nothing happened." Unlike the delete flows, the card does **not** reliably disappear on success, so there was no other signal the action landed.

## Change

- Drop `notifications` import, add `Alert`.
- Add `notice` state — `Record<householdId, { ok, text }>`.
- `makeLead(householdId, participantId)` clears any prior notice for that card, then writes success/error into `notice[householdId]`.
- Render a dismissible card-local `<Alert>` under the household name (green/red by outcome), right next to the button that triggered it.

Mirrors the existing local-`<Alert>` pattern in `my-household/page.tsx`.

## Notes for reviewer

- Confirmation now appears at the card the user clicked, not the viewport corner.
- Notice is cleared on the next assign click and via the Alert's close button.
- No test added — jest finds 0 tests in worktrees.