### PR TITLE
fix(participant-merge): show merge failure next to Confirm button

### DIFF
--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -243,7 +243,7 @@ export default function MergeParticipants() {
         </Text>
       </div>
 
-      <AlertBanner message={error} tone="error" />
+      {!previewMode && <AlertBanner message={error} tone="error" />}
 
       {!previewMode ? (
         <>
@@ -288,6 +288,12 @@ export default function MergeParticipants() {
             <List.Item>Missing personal info on the kept participant will be filled in from the merged participant.</List.Item>
             <List.Item>Raw badge scans will remain on the tombstoned record for audit purposes.</List.Item>
           </List>
+
+          {error && (
+            <Alert color="red" variant="light" mb="md" fw={700}>
+              {error}
+            </Alert>
+          )}
 
           <Group justify="flex-end">
             <Button variant="default" onClick={() => setPreviewMode(false)} disabled={merging}>Cancel</Button>


### PR DESCRIPTION
## What

On the participant merge page, the page-top `<AlertBanner>` carried the `handleMerge` error. That banner sits far above the **Confirm Merge & Delete** button, which lives at the bottom of the yellow preview `<Card>`. On a filled preview the button is well below the banner, so a merge failure rendered off-screen above the fold — the user clicked, nothing visibly happened.

## Changes

- Added a section-local `<Alert>` (fed by `error`) inside the preview card, just above the Cancel / Confirm buttons — a failed merge now shows right next to the button that triggered it.
- Gated the page-top `<AlertBanner>` to `!previewMode` so per-analyze errors still surface at the top, without duplicating the merge error in preview mode.

## Notes for reviewer

- Reuses the existing `error` state rather than a new local var: the analyze error (`Failed to analyze participants`) only fires in non-preview mode, and `handleMerge` errors only in preview mode, so they never coexist once the top banner is mode-gated.
- Clear-on-retry already handled — `handleMerge` calls `setError(null)` at start.
- Untouched (already correct): per-card validation `<Alert>`s and the success full-page swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)