### PR TITLE
fix(admin-household): inline admin-save notice + standard phone error

### DIFF
--- a/checkin-app/src/app/membership-ops/participants/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/__tests__/page.test.tsx
@@ -267,11 +267,9 @@ describe("AdminParticipantsIndex", () => {
         fireEvent.click(within(bobRow).getByRole("button", { name: "Household" }));
         expect(await screen.findByText(/Edit Household Info/)).toBeInTheDocument();
 
-        fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
-        expect(await screen.findByText("Use admin powers?")).toBeInTheDocument();
-        fireEvent.click(screen.getByRole("button", { name: "Yes, save changes" }));
+        fireEvent.click(screen.getByRole("button", { name: "Save Changes — As Admin" }));
 
-        await waitFor(() => expect(screen.queryByText("Use admin powers?")).not.toBeInTheDocument());
+        await waitFor(() => expect(screen.queryByText(/Edit Household Info/)).not.toBeInTheDocument());
         expect(await screen.findByText("The B Family Updated")).toBeInTheDocument();
     });
 

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Alert, Button, Divider, Group, Loader, Modal, SimpleGrid, Stack, Text, TextInput } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
+import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 
 export type AdminHousehold = {
   id: number;
@@ -55,7 +56,6 @@ export function AdminEditHouseholdModal({
 }) {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [confirming, setConfirming] = useState(false);
   const [form, setForm] = useState<FormState>(EMPTY);
   const [initial, setInitial] = useState<FormState>(EMPTY);
   const [displayName, setDisplayName] = useState("");
@@ -95,7 +95,6 @@ export function AdminEditHouseholdModal({
     if (!opened || householdId == null) return;
     const signal = { cancelled: false };
     setLoading(true);
-    setConfirming(false);
     loadHousehold(signal).finally(() => {
       if (!signal.cancelled) setLoading(false);
     });
@@ -137,8 +136,11 @@ export function AdminEditHouseholdModal({
     onClose();
   };
 
+  // Phone is optional here, so only a non-empty malformed value is an error.
+  const phoneInvalid = form.emergencyContactPhone.trim() !== "" && !isValidPhone(form.emergencyContactPhone);
+
   const handleSave = async () => {
-    if (householdId == null) return;
+    if (householdId == null || phoneInvalid) return;
     setSaving(true);
     try {
       const res = await fetch(`/api/membership-ops/households/${householdId}`, {
@@ -150,7 +152,6 @@ export function AdminEditHouseholdModal({
         const data = await res.json();
         notifications.show({ color: "green", message: "Household updated." });
         onSaved?.(data.household);
-        setConfirming(false);
         onClose();
       } else {
         const data = await res.json().catch(() => ({}));
@@ -216,6 +217,7 @@ export function AdminEditHouseholdModal({
                 value={form.emergencyContactPhone}
                 onChange={(e) => update({ emergencyContactPhone: e.currentTarget.value })}
                 placeholder="(555) 555-5555"
+                error={phoneInvalid ? PHONE_ERROR : undefined}
               />
             </SimpleGrid>
             <TextInput
@@ -256,37 +258,20 @@ export function AdminEditHouseholdModal({
               )}
             </Stack>
 
-            <Group justify="flex-end" mt="md">
-              <Button variant="default" onClick={requestClose}>
+            <Alert color="orange" mt="md">
+              You&apos;re editing <strong>{displayName}</strong>, a household you&apos;re not a member of. This
+              uses your administrative privileges and is recorded in the audit log.
+            </Alert>
+            <Group justify="flex-end">
+              <Button variant="default" onClick={requestClose} disabled={saving}>
                 Cancel
               </Button>
-              <Button color="green" onClick={() => setConfirming(true)}>
-                Save Changes
+              <Button color="orange" onClick={handleSave} loading={saving} disabled={phoneInvalid}>
+                Save Changes — As Admin
               </Button>
             </Group>
           </Stack>
         )}
-      </Modal>
-
-      <Modal
-        opened={confirming}
-        onClose={() => setConfirming(false)}
-        size="sm"
-        zIndex={1100}
-        title={<Text fw={600}>Use admin powers?</Text>}
-      >
-        <Alert color="orange" mb="md">
-          You&apos;re editing <strong>{displayName}</strong>, a household you&apos;re not a member of. This
-          uses your administrative privileges and is recorded in the audit log.
-        </Alert>
-        <Group justify="flex-end">
-          <Button variant="default" onClick={() => setConfirming(false)} disabled={saving}>
-            Cancel
-          </Button>
-          <Button color="orange" onClick={handleSave} loading={saving}>
-            Yes, save changes
-          </Button>
-        </Group>
       </Modal>
     </>
   );

--- a/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
@@ -28,7 +28,7 @@ const household = {
   state: "TX",
   postalCode: "78701",
   emergencyContactName: "Jo Smith",
-  emergencyContactPhone: "5551234",
+  emergencyContactPhone: "555-123-4567",
   householdMembers: [
     { id: 1, name: "Kid A", email: "kid@example.com" },
     { id: 2, name: null, email: null },
@@ -63,7 +63,7 @@ describe("AdminEditHouseholdModal", () => {
     expect(await screen.findByDisplayValue("Smith Family")).toBeInTheDocument();
   });
 
-  it("loads and lets every field be edited, then saves via the confirm dialog", async () => {
+  it("loads and lets every field be edited, then saves as admin", async () => {
     const onSaved = jest.fn();
     const onClose = jest.fn();
     const fetchMock = mockFetchJson({
@@ -85,14 +85,11 @@ describe("AdminEditHouseholdModal", () => {
     fireEvent.change(screen.getByLabelText("State"), { target: { value: "TX" } });
     fireEvent.change(screen.getByLabelText("ZIP"), { target: { value: "78664" } });
     fireEvent.change(screen.getByLabelText("Emergency Contact Name"), { target: { value: "Jo S." } });
-    fireEvent.change(screen.getByLabelText("Emergency Contact Phone"), { target: { value: "5559999" } });
+    fireEvent.change(screen.getByLabelText("Emergency Contact Phone"), { target: { value: "5559999999" } });
 
-    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
-    // Mantine's Modal mounts its content on a transition tick, not synchronously.
-    expect(await screen.findByText("Use admin powers?")).toBeInTheDocument();
+    // Admin-power notice is inline; save is a single orange button.
     expect(screen.getByText(/editing/)).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Yes, save changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes — As Admin" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith("/api/membership-ops/households/55", expect.objectContaining({ method: "PATCH" })),
@@ -105,6 +102,21 @@ describe("AdminEditHouseholdModal", () => {
     await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green" })));
     expect(onSaved).toHaveBeenCalledWith(expect.objectContaining({ name: "Smith Fam" }));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows an inline phone error and blocks save until fixed", async () => {
+    const fetchMock = mockFetchJson({ "/api/membership-ops/households?id=55": { household } });
+    renderWithProviders(<AdminEditHouseholdModal householdId={55} opened={true} onClose={jest.fn()} />);
+    await screen.findByDisplayValue("Smith Family");
+
+    fetchMock.mockClear();
+    fireEvent.change(screen.getByLabelText("Emergency Contact Phone"), { target: { value: "555" } });
+    expect(screen.getByText("Enter a valid 10-digit US phone number.")).toBeInTheDocument();
+
+    const save = screen.getByRole("button", { name: "Save Changes — As Admin" });
+    expect(save).toBeDisabled();
+    fireEvent.click(save);
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/membership-ops/households/55", expect.anything());
   });
 
   it("prompts before discarding unsaved edits, and closes directly when nothing changed", async () => {
@@ -146,17 +158,16 @@ describe("AdminEditHouseholdModal", () => {
     await screen.findByDisplayValue("Smith Family");
 
     global.fetch = jest.fn(async () => ({ ok: false, status: 400, json: async () => ({ error: "Name taken." }) })) as unknown as typeof fetch;
-    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Yes, save changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes — As Admin" }));
     await waitFor(() =>
       expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "red", message: "Name taken." })),
     );
-    // The confirm dialog stays open on failure (only success calls onClose/setConfirming(false)).
-    expect(screen.getByText("Use admin powers?")).toBeInTheDocument();
+    // The modal stays open on failure (only success calls onClose).
+    expect(screen.getByText(/Edit Household Info/)).toBeInTheDocument();
 
     (notifications.show as jest.Mock).mockClear();
     global.fetch = jest.fn(() => Promise.reject(new Error("boom"))) as unknown as typeof fetch;
-    fireEvent.click(screen.getByRole("button", { name: "Yes, save changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes — As Admin" }));
     await waitFor(() =>
       expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "red", message: "Network error." })),
     );


### PR DESCRIPTION
## What

On the admin household editor (`/membership-ops/households`), Save was gated behind a **second confirmation modal stacked on top of the edit modal**. Any save-failure notification rendered *behind* that top modal, so an admin never saw why a save failed.

- Removed the modal-on-modal confirm. The orange admin-power notice ("You're editing X, a household you're not a member of…") is now **inline, above the buttons**.
- The single Save button is orange and reads **"Save Changes — As Admin"** — it saves directly. Errors surface in the still-open editor.
- Emergency-contact **phone validation** now follows the app's error standard: red field with the message beneath it (Mantine `error` prop via `isValidPhone` / `PHONE_ERROR`), replacing the notification popup. Save is disabled while the phone is malformed.

## Why

Errors behind a stacked modal were invisible, and the phone popup diverged from the codebase's inline field-error convention.

## Notes for reviewer

- Client phone gate is UX only — the API (`upsertPrimaryContact`) still rejects invalid phones with a 400, so it remains the real guard.
- The gate keys off `isValidPhone`; real data is stored dashed-valid via `formatPhone`. A legacy household with a malformed stored phone would be blocked from saving until the phone is fixed — add a bypass only if such data surfaces.
- Updated both affected test files for the single-step flow and added an inline-phone-error test. `AdminEditHouseholdModal` (12) and `membership-ops/participants` page (13) tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)