### PR TITLE
fix(membership-ops/review): render attest/reject result in the acted card

### DIFF
--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -3,8 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { Button, Card, Checkbox, Container, Group, Stack, Text, Title } from "@mantine/core";
-import { AlertBanner, type AlertTone } from "@/components/admin/AlertBanner";
+import { Alert, Button, Card, Checkbox, Container, Group, Stack, Text, Title } from "@mantine/core";
+import { type AlertTone } from "@/components/admin/AlertBanner";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -30,7 +30,8 @@ export default function MembershipReviewPage() {
   const [forbidden, setForbidden] = useState(false);
   const [busyId, setBusyId] = useState<number | null>(null);
   const [volunteer, setVolunteer] = useState<Record<number, boolean>>({});
-  const [message, setMessage] = useState<{ text: string; tone: AlertTone } | undefined>();
+  // Tagged with the acting row's processId so the result renders in that card, not off-screen at page top.
+  const [message, setMessage] = useState<{ processId: number; text: string; tone: AlertTone } | undefined>();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -65,14 +66,14 @@ export default function MembershipReviewPage() {
       });
       const data = await res.json();
       if (res.ok) {
-        setMessage({ text: result === "APPROVE" ? "Attestation recorded — thank you." : "Recorded. The board has been notified.", tone: "success" });
+        setMessage({ processId, text: result === "APPROVE" ? "Attestation recorded — thank you." : "Recorded. The board has been notified.", tone: "success" });
         await load();
         notifyNavRefresh();
       } else {
-        setMessage({ text: data.error || "Could not record your attestation.", tone: "error" });
+        setMessage({ processId, text: data.error || "Could not record your attestation.", tone: "error" });
       }
     } catch {
-      setMessage({ text: "Network error.", tone: "error" });
+      setMessage({ processId, text: "Network error.", tone: "error" });
     } finally {
       setBusyId(null);
     }
@@ -105,8 +106,6 @@ export default function MembershipReviewPage() {
         reviewers are required. If anything is concerning, choose <strong>Reject</strong> — the
         board is notified and the applicant is not told the reason.
       </Text>
-
-      <AlertBanner message={message?.text} tone={message?.tone} mt="md" />
 
       {queue.length === 0 ? (
         <Card withBorder radius="md" padding="xl" ta="center" mt="md">
@@ -143,6 +142,12 @@ export default function MembershipReviewPage() {
                   Reject
                 </Button>
               </Group>
+
+              {message?.processId === item.id && (
+                <Alert color={message.tone === "success" ? "green" : "red"} variant="light" mt="md">
+                  {message.text}
+                </Alert>
+              )}
             </Card>
             );
           })}


### PR DESCRIPTION
## What

The background-check review queue rendered a single page-top `<AlertBanner>` fed by one `setMessage` state. Every queue card repeats **Attest** / **Reject** buttons, so acting on a card far down the list posted the success/error result at the very top — off-screen — and read as "nothing happened."

This tags the message with the acting row's `processId` (`{ processId, text, tone }`) and renders a section-local Mantine `<Alert>` **inside the acted card**, right below its button `<Group>`, only in the card whose id matches. Mirrors the existing per-row `busyId` handling. The page-top banner is removed.

## Why

On long queues the confirmation was invisible without scrolling back up, so reviewers couldn't tell whether their attestation landed.

## Reviewer notes

- Follows the section-local `<Alert>` pattern already used in `my-household/page.tsx`.
- `tone` → color: `success` = green, `error` = red.
- Message clears at the start of each action, so an old card's alert disappears when acting elsewhere.
- On APPROVE, `load()` refetches the queue; the card survives until 2/2 approvals, so the success alert shows on the first attestation and always on reject/error.
- Dropped the now-unused `AlertBanner` import; kept the `AlertTone` type.
- No test added — jest finds 0 tests in worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)