### PR TITLE
fix(membership): echo intake save/submit result next to buttons

### DIFF
--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -564,6 +564,14 @@ export default function MembershipPage() {
 
                   <ChildrenListForm items={children} onAdd={addChild} onUpdate={updateChild} onRemove={removeChild} />
 
+                  {/* Local echo of the page-top banner: intake is a long card, so
+                      the top AlertBanner posts off-screen next to these buttons. */}
+                  {message && (
+                    <Alert color={message.tone === "error" ? "red" : "green"} variant="light">
+                      {message.text}
+                    </Alert>
+                  )}
+
                   <Group gap="md" wrap="wrap">
                     <Button variant="default" disabled={saving} loading={saving} onClick={save}>Save progress</Button>
                     <Button color="green" disabled={saving} loading={saving} onClick={submit}>Submit &amp; continue</Button>

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -461,7 +461,9 @@ export default function MembershipPage() {
         <Button component={Link} href="/" variant="default" onNavigate={(e) => { if (!confirmNav()) e.preventDefault(); }}>← Home</Button>
       </Group>
 
-      <AlertBanner message={message?.text} tone={message?.tone} mb="lg" />
+      {/* Intake echoes `message` in a section-local Alert next to its buttons
+          (long card), so suppress the top banner there to avoid a duplicate. */}
+      <AlertBanner message={isIntake ? undefined : message?.text} tone={message?.tone} mb="lg" />
 
       {warnings.length > 0 && (
         <Alert color="yellow" mb="lg" title="Saved — with a couple of things to know">


### PR DESCRIPTION
## What

Adds a section-local `<Alert>` inside the intake `<Card>`, rendered just above the **Save progress** / **Submit & continue** button group. It echoes the same `message` state that drives the page-top `<AlertBanner>`.

## Why

The intake card is long — address + emergency contact + two parents + children list. The page-top banner that reports "Progress saved." (and submit errors) lands off-screen next to the buttons that trigger it, so the action reads as a no-op. Mirrors the section-local pattern already used in `my-household/page.tsx`.

## Notes for reviewers

- Scope is **intake only**. Other flows left alone:
  - Per-field required errors already inline via `fieldErrors`.
  - Short single-card states (Start / Renew / Sign agreement / Refresh status) keep button and banner close enough.
- Tone → color: `error` → red, else green (intake only emits success/error via `flash`).
- Cleared on the next intake action via the existing `flash("")` reset (sets `message` undefined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)