### PR TITLE
fix(program-ops): render save/enroll errors next to their buttons

### DIFF
--- a/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
@@ -12,12 +12,12 @@ type ProgramRosterTabProps = {
   programId: string;
   program: Pick<ProgramDetail, 'volunteers' | 'participants' | 'startAt' | 'minAge' | 'maxAge'>;
   isSysAdminOrBoard: boolean;
-  setMessage: (msg: string) => void;
   fetchProgram: () => Promise<void>;
 };
 
-export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMessage, fetchProgram }: ProgramRosterTabProps) {
+export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, fetchProgram }: ProgramRosterTabProps) {
   const [saving, setSaving] = useState(false);
+  const [enrollError, setEnrollError] = useState("");
   const [newVolId, setNewVolId] = useState("");
   const [volLabel, setVolLabel] = useState("");
   const [newPartId, setNewPartId] = useState("");
@@ -96,7 +96,7 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
   const doAddParticipant = async () => {
     closeConfirmAddPart();
     setSaving(true);
-    setMessage("");
+    setEnrollError("");
     try {
       const res = await fetch(`/api/programs/${programId}/participants`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
@@ -105,7 +105,7 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
       if (res.ok) { setNewPartId(""); setPartLabel(""); fetchProgram(); }
       else {
         const data = await res.json();
-        setMessage(data.error || "Failed to enroll participant.");
+        setEnrollError(data.error || "Failed to enroll participant.");
       }
     } finally {
       setSaving(false);
@@ -208,6 +208,8 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, setMes
             )}
           </Group>
         </form>
+
+        {enrollError && <Alert color="red" variant="light" mb="lg">{enrollError}</Alert>}
 
         {activeParticipants.length === 0 ? <Text c="dimmed">No active participants yet.</Text> : (
           <Stack gap="xs">

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -78,6 +78,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState("");
   const [message, setMessage] = useState("");
   const [activeTab, setActiveTab] = useState<'general' | 'roster' | 'events'>('general');
 
@@ -127,7 +128,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
   const handleSaveGeneral = async (e: React.FormEvent) => {
     e.preventDefault();
     setSaving(true);
-    setMessage("");
+    setSaveError("");
     try {
       const res = await fetch(`/api/programs/${id}`, {
         method: 'PATCH',
@@ -149,10 +150,10 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
         fetchProgram();
       } else {
         const data = await res.json();
-        setMessage(data.error || "Failed to save settings.");
+        setSaveError(data.error || "Failed to save settings.");
       }
     } catch {
-      setMessage("Network error.");
+      setSaveError("Network error.");
     } finally {
       setSaving(false);
     }
@@ -327,6 +328,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                     ]} />
                 </SimpleGrid>
 
+                {saveError && <Alert color="red" variant="light">{saveError}</Alert>}
                 <Group gap="sm">
                   <Button type="submit" color="green" disabled={saving || !leadMentorIdInput} loading={saving}>
                     Save Settings
@@ -342,7 +344,6 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
               programId={id}
               program={program}
               isSysAdminOrBoard={!!isSysAdminOrBoard}
-              setMessage={setMessage}
               fetchProgram={fetchProgram}
             />
           </Tabs.Panel>


### PR DESCRIPTION
## What

On the program details page (`program-ops/programs/[id]`), Save-Settings failures and Roster Enroll failures were both routed into a single page-top `<AlertBanner>` shared across all tabs. On long forms these landed off-screen — reading as "nothing happened" — and worse, an Enroll error (triggered from the *Roster* tab) painted in the *General* tab panel.

Fix: render each action's error in a section-local `<Alert>` right beside the button that triggered it.

- **General tab** — new `saveError` state; red `<Alert>` above the Save button group. (Existing `✓ Saved` success indicator left as-is.)
- **Roster tab** — new local `enrollError` state; red `<Alert>` inside the Active Participants card below the enroll form. Dropped the now-unused `setMessage` prop from `ProgramRosterTab`.
- Page-top `AlertBanner` now carries only page-load errors (not-found / load-fail / network) — its correct home.
- Each notice clears on the next action.

Follows the section-local Alert pattern from `my-household/page.tsx`.

## Notes for reviewer

- Modal-scoped warning and the static Program-Lead advisory alert were already local — untouched.
- No test run: jest finds 0 tests in worktrees.