### PR TITLE
fix(program-ops): move create-program error next to submit button

### DIFF
--- a/checkin-app/src/app/program-ops/new/page.tsx
+++ b/checkin-app/src/app/program-ops/new/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Alert, Box, Button, Card, Checkbox, Group, NumberInput, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
-import { AlertBanner } from '@/components/admin/AlertBanner';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { EntityPicker } from '@/components/admin/EntityPicker';
@@ -33,7 +32,6 @@ export default function CreateProgramPage() {
   const [saving, setSaving] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [message, setMessage] = useState("");
-  const [messageType, setMessageType] = useState<"success" | "error">("success");
 
   // Lead Mentor selection state (the EntityPicker owns the transient query/results)
   const [leadMentorId, setLeadMentorId] = useState("");
@@ -74,12 +72,10 @@ export default function CreateProgramPage() {
       } else {
         const data = await res.json();
         setMessage(data.error || "Failed to create program.");
-        setMessageType("error");
         setSaving(false);
       }
     } catch {
       setMessage("Network error creating program.");
-      setMessageType("error");
       setSaving(false);
     }
   };
@@ -107,8 +103,6 @@ export default function CreateProgramPage() {
         <Text c="dimmed" mb="lg">
           Create a new program. You can configure the roster and schedule events later.
         </Text>
-
-        <AlertBanner message={message} tone={messageType === 'success' ? 'success' : 'error'} mb="md" />
 
         <form onSubmit={handleCreate}>
           <Stack>
@@ -213,6 +207,10 @@ export default function CreateProgramPage() {
               label="Treehouse Members-Only Program"
               description="If checked, this program will only be visible to logged-in users with active memberships."
             />
+
+            {message && (
+              <Alert color="red" variant="light" title="Couldn't create program">{message}</Alert>
+            )}
 
             <Group justify="flex-end">
               <Button type="submit" color="green" disabled={saving || !name.trim() || !leadMentorId || datesInvalid} loading={saving}>


### PR DESCRIPTION
## What

On the Create Program form (`program-ops/new`), a creation failure fed a page-top `AlertBanner`. The form is long (name, mentor picker, age/date grids, pricing card, checkboxes) and the **Create Program** submit button is the last element — so on a filled-out form the error banner rendered off-screen and read as "nothing happened."

Replaced it with a section-local `<Alert>` rendered just above the submit `<Group>`, right next to the button that triggers it (matches the `my-household` page pattern).

## Why

Action-confirmation messages that render far from their trigger are effectively invisible on long forms. This is part of an audit sweep for that anti-pattern in the checkin-app frontend.

## Reviewer notes

- Success redirects away (`router.push`), so error is the only message that needs a local surface — dropped the now-dead `messageType` state and the unused `AlertBanner` import.
- Cleared on next submit via the existing `setMessage("")` at the top of the handler.
- Inline field validation (dates, price/participant warnings) was already section-local — left untouched.
- Net −2 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)