### PR TITLE
fix(ui): replace inline save indicators with corner toast

### DIFF
--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -8,6 +8,7 @@ import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
 import { PageContainer } from '@/components/ui/PageContainer';
 import { formatDate, calculateAge } from '@/lib/time';
 import TrustedAdultPanel from '@/components/TrustedAdultPanel';
+import { notifications } from '@mantine/notifications';
 import TodoCard from '@/components/TodoCard';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { isOrgAccount } from '@/lib/orgAccount';
@@ -85,7 +86,6 @@ export default function HouseholdPage() {
   const [addressErrors, setAddressErrors] = useState<Partial<Record<AddressField, string>>>({});
   const [savingSettings, setSavingSettings] = useState(false);
   // Transient "Updated" confirmation shown in the Address card header for 5s.
-  const [addressSaved, setAddressSaved] = useState(false);
 
   const [contacts, setContacts] = useState<EmergencyContact[]>([]);
   const [contactForm, setContactForm] = useState(blankContactForm);
@@ -148,8 +148,7 @@ export default function HouseholdPage() {
 
       if (householdRes.ok) {
         ok("Settings updated successfully!");
-        setAddressSaved(true);
-        setTimeout(() => setAddressSaved(false), 5000);
+        notifications.show({ color: "green", message: "Address updated." });
         fetchHousehold();
         notifyNavRefresh();
       } else {
@@ -475,7 +474,6 @@ export default function HouseholdPage() {
           <Card withBorder radius="md" padding="lg">
             <Group justify="space-between" align="center" mb="md">
               <Title order={3} c="blue">Household Address</Title>
-              {addressSaved && <Badge color="green" variant="light">✓ Updated</Badge>}
             </Group>
             <Text size="sm" c="dimmed" mb="sm">The main address associated with this household.</Text>
             <Stack gap="xs">

--- a/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
@@ -2,8 +2,10 @@
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
 import { screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { notifications } from "@mantine/notifications";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl, router } from "@/test-helpers/rtl";
 import ProgramDetailsPage from "../page";
 
@@ -204,7 +206,9 @@ describe("ProgramDetailsPage", () => {
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith("/api/programs/1", expect.objectContaining({ method: "PATCH" })),
     );
-    expect(await screen.findByText("✓ Saved")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Saved." })),
+    );
   });
 
   it("shows the server error message when saving general settings fails", async () => {

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -8,6 +8,7 @@ import { AlertBanner } from '@/components/admin/AlertBanner';
 import { EntityPicker } from '@/components/admin/EntityPicker';
 import { ScrollableTabsList } from '@/components/ui/ScrollableTabsList';
 import { ProgramRosterTab } from './ProgramRosterTab';
+import { notifications } from '@mantine/notifications';
 import { ProgramEventsTab } from './ProgramEventsTab';
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -77,7 +78,6 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [justSaved, setJustSaved] = useState(false);
   const [message, setMessage] = useState("");
   const [activeTab, setActiveTab] = useState<'general' | 'roster' | 'events'>('general');
 
@@ -145,8 +145,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
         })
       });
       if (res.ok) {
-        setJustSaved(true);
-        setTimeout(() => setJustSaved(false), 3000);
+        notifications.show({ color: "green", message: "Saved." });
         fetchProgram();
       } else {
         const data = await res.json();
@@ -332,7 +331,6 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                   <Button type="submit" color="green" disabled={saving || !leadMentorIdInput} loading={saving}>
                     Save Settings
                   </Button>
-                  {justSaved && <Text c="green" fw={500}>✓ Saved</Text>}
                 </Group>
               </Stack>
             </form>


### PR DESCRIPTION
## What

Convert two inline transient success indicators to the app's standard corner toast (`@mantine/notifications`), matching how existing green success flows work.

- **`my-household/page.tsx`**: `✓ Updated` Badge → `notifications.show({ color: "green", message: "Address updated." })`. Removed `addressSaved` state + `setTimeout` reset.
- **`program-ops/programs/[id]/page.tsx`**: `✓ Saved` Text → `notifications.show({ color: "green", message: "Saved." })`. Removed `justSaved` state + `setTimeout` reset.

## Why

Both indicators rendered in-flow and shifted layout on show/hide. The corner toast is the app-wide pattern (`<Notifications />` already mounted globally in `layout.tsx`) and doesn't move surrounding content.

## Notes for reviewer

- `Badge` (my-household) and `Text` (programs) imports kept — still used elsewhere in each file.
- No new state or setup; provider already mounted.
- Grepped both files: zero remaining refs to removed state vars, no leftover unused imports.