### PR TITLE
fix(ui): route success messages to corner toast, keep AlertBanner for errors

### DIFF
--- a/checkin-app/src/app/facility-ops/visits/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/visits/__tests__/page.test.tsx
@@ -2,7 +2,6 @@
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
 import { screen, fireEvent, waitFor, within } from "@testing-library/react";

--- a/checkin-app/src/app/facility-ops/visits/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/visits/__tests__/page.test.tsx
@@ -2,12 +2,15 @@
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
 import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import { notifications } from "@mantine/notifications";
 import AdminVisitsPage from "../page";
 
-beforeEach(() => resetRtl());
+beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
 
 const visits = [
   { id: 1, arrivedAt: "2026-01-01T14:00:00.000Z", departedAt: "2026-01-01T16:00:00.000Z", arrivedVia: "SCANNER", departedVia: "WEB", person: { name: "Val Volunteer" }, event: { name: "Open Gym" } },
@@ -57,6 +60,6 @@ describe("facility-ops/visits page", () => {
         expect.objectContaining({ method: "PATCH" }),
       ),
     );
-    expect(await screen.findByText("Visit updated successfully.")).toBeInTheDocument();
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Visit updated successfully." })));
   });
 });

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -6,6 +6,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp, IconDeviceLaptop, IconRobot, IconScan, IconSelector } from '@tabler/icons-react';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
+import { notifications } from '@mantine/notifications';
 import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -138,7 +139,7 @@ export default function AdminVisitsPage() {
         })
       });
       if (res.ok) {
-        setMessage({ text: "Visit updated successfully.", tone: "success" });
+        notifications.show({ color: "green", message: "Visit updated successfully." });
         setEditingVisitId(null);
         fetchVisits();
       } else {

--- a/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-require-imports -- jest.mock factories are hoisted above imports */
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import { notifications } from "@mantine/notifications";
 import AdminMembershipPage from "../page";
 
-beforeEach(() => resetRtl());
+beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
 
 function household(name: string, id: number) {
     return { name, householdMembers: [{ id: 1, name: "Lead One", email: "lead@example.com" }], leads: [{ personId: 1 }], householdId: id };
@@ -82,18 +84,18 @@ describe("AdminMembershipPage", () => {
         await screen.findByText("Awaiting Family");
 
         fireEvent.click(screen.getByRole("button", { name: "Confirm contract signed" }));
-        expect(await screen.findByText("Updated.")).toBeInTheDocument();
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Updated." })));
 
         fireEvent.click(screen.getByRole("button", { name: "Confirm BG consent" }));
-        expect(await screen.findByText("Updated.")).toBeInTheDocument();
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Updated." })));
 
         fireEvent.click(screen.getByRole("button", { name: /Certify payment plan/ }));
-        expect(await screen.findByText("Certified — membership activated.")).toBeInTheDocument();
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Certified — membership activated." })));
 
         fireEvent.click(screen.getByRole("button", { name: "Reset for re-review" }));
-        expect(await screen.findByText("Sent back for re-review.")).toBeInTheDocument();
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Sent back for re-review." })));
 
         fireEvent.click(screen.getByRole("button", { name: /Override/ }));
-        expect(await screen.findByText("Overridden to payment.")).toBeInTheDocument();
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Overridden to payment." })));
     });
 });

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Alert, Badge, Button, Card, Center, Group, Loader, Stack, Text } from "@mantine/core";
 import { AlertBanner } from "@/components/admin/AlertBanner";
+import { notifications } from "@mantine/notifications";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 
 interface Person {
@@ -88,8 +89,7 @@ export default function AdminMembershipPage() {
       });
       const data = await res.json();
       if (res.ok) {
-        setIsError(false);
-        setMessage("Updated.");
+        notifications.show({ color: "green", message: "Updated." });
         await load();
         notifyNavRefresh();
       } else {
@@ -115,8 +115,7 @@ export default function AdminMembershipPage() {
       });
       const data = await res.json();
       if (res.ok) {
-        setIsError(false);
-        setMessage(action === "reset" ? "Sent back for re-review." : "Overridden to payment.");
+        notifications.show({ color: "green", message: action === "reset" ? "Sent back for re-review." : "Overridden to payment." });
         await load();
         notifyNavRefresh();
       } else {
@@ -142,8 +141,7 @@ export default function AdminMembershipPage() {
       });
       const data = await res.json();
       if (res.ok) {
-        setIsError(false);
-        setMessage("Certified — membership activated.");
+        notifications.show({ color: "green", message: "Certified — membership activated." });
         await load();
         notifyNavRefresh();
       } else {

--- a/checkin-app/src/app/membership-ops/participants/new/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/__tests__/page.test.tsx
@@ -2,12 +2,15 @@
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, setSession, setSearchParams, resetRtl, router } from "@/test-helpers/rtl";
+import { notifications } from "@mantine/notifications";
 import NewParticipantPage from "../page";
 
-beforeEach(() => resetRtl());
+beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
 
 const household = { id: 9, name: "The Does", householdMembers: [{ id: 1, name: "Jane Doe", email: null }, { id: 2, name: null, email: "john@example.com" }] };
 const emptyHousehold = { id: 8, name: "", householdMembers: [] };
@@ -53,7 +56,7 @@ describe("membership-ops/participants/new page", () => {
         }),
       ),
     );
-    expect(await screen.findByText("Participant Jane Doe successfully!")).toBeInTheDocument();
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Participant Jane Doe successfully!" })));
   });
 
   it("requires a parent email once a student DOB is entered", async () => {
@@ -168,7 +171,7 @@ describe("membership-ops/participants/new page", () => {
         }),
       ),
     );
-    expect(await screen.findByText("Participant member@example.com successfully!")).toBeInTheDocument();
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Participant member@example.com successfully!" })));
   });
 
   it("submits a student with a parent email and no household", async () => {

--- a/checkin-app/src/app/membership-ops/participants/new/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/__tests__/page.test.tsx
@@ -2,7 +2,6 @@
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
 import { screen, fireEvent, waitFor } from "@testing-library/react";

--- a/checkin-app/src/app/membership-ops/participants/new/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/page.tsx
@@ -8,6 +8,7 @@ import { EntityPicker } from '@/components/admin/EntityPicker';
 import { isYouth } from '@/lib/time';
 import { Button, Card, Checkbox, Container, Paper, Stack, Text, TextInput } from '@mantine/core';
 import { AlertBanner } from '@/components/admin/AlertBanner';
+import { notifications } from '@mantine/notifications';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 type HouseholdOption = {
@@ -97,7 +98,7 @@ function NewParticipantForm() {
       const data = await res.json();
 
       if (res.ok) {
-        setMessage(`Participant ${name || data.participant.email || 'created'} successfully!`);
+        notifications.show({ color: "green", message: `Participant ${name || data.participant.email || 'created'} successfully!` });
         setName("");
         setEmail("");
         setParentEmail("");

--- a/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
+++ b/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Button, Card, Center, Group, Loader, Stack, Table, Text, TextInput, Title } from "@mantine/core";
 import { AlertBanner } from "@/components/admin/AlertBanner";
+import { notifications } from "@mantine/notifications";
 
 interface Designation {
   id: number;
@@ -45,7 +46,7 @@ export default function VolunteerMembershipsPage() {
       const data = await res.json();
       if (res.ok) {
         setNewEmail("");
-        flash(data.warning || "Designation added.", !!data.warning);
+        if (data.warning) { flash(data.warning, true); } else { notifications.show({ color: "green", message: "Designation added." }); }
         await load();
       } else flash(data.error || "Could not add.", true);
     } catch { flash("Network error.", true); }

--- a/checkin-app/src/app/profile/__tests__/page.test.tsx
+++ b/checkin-app/src/app/profile/__tests__/page.test.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-require-imports -- jest.mock factories are hoisted above imports */
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import { notifications } from "@mantine/notifications";
 import ProfilePage from "../page";
 
-beforeEach(() => resetRtl());
+beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
 
 describe("ProfilePage", () => {
     it("loads an adult's profile and saves an edit", async () => {
@@ -23,7 +25,7 @@ describe("ProfilePage", () => {
         fireEvent.change(nameInput, { target: { value: "Jamie Updated" } });
         fireEvent.click(screen.getByRole("button", { name: "Save Profile" }));
 
-        expect(await screen.findByText("Profile updated successfully!")).toBeInTheDocument();
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Profile updated successfully!" })));
         expect(fetchMock).toHaveBeenCalledWith("/api/profile", expect.objectContaining({ method: "PATCH" }));
     });
 

--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { Anchor, Button, Card, Stack, Text, TextInput, Title } from '@mantine/core';
 import { PageContainer } from '@/components/ui/PageContainer';
 import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
+import { notifications } from '@mantine/notifications';
 import { isYouth } from '@/lib/time';
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -69,7 +70,7 @@ export default function ProfilePage() {
       });
 
       if (res.ok) {
-        setMessage({ text: "Profile updated successfully!", tone: "success" });
+        notifications.show({ color: "green", message: "Profile updated successfully!" });
       } else {
         setMessage({ text: "Failed to update profile.", tone: "error" });
       }

--- a/checkin-app/src/app/settings/localization/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/localization/__tests__/page.test.tsx
@@ -2,11 +2,13 @@
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
-import { screen, fireEvent } from "@testing-library/react";
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import { notifications } from "@mantine/notifications";
 import LocalizationSettingsPage from "../page";
 
-beforeEach(() => resetRtl());
+beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
 
 describe("LocalizationSettingsPage", () => {
     it("loads current settings and saves an update", async () => {
@@ -19,6 +21,6 @@ describe("LocalizationSettingsPage", () => {
         const saveButton = await screen.findByRole("button", { name: /save settings/i });
         fireEvent.click(saveButton);
 
-        expect(await screen.findByText("Settings saved.")).toBeInTheDocument();
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Settings saved." })));
     });
 });

--- a/checkin-app/src/app/settings/localization/page.tsx
+++ b/checkin-app/src/app/settings/localization/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Button, Card, Center, Group, Loader, Select, Stack, Text, Title } from "@mantine/core";
 import { SettingsTabs } from "@/components/admin/SettingsTabs";
 import { AlertBanner } from "@/components/admin/AlertBanner";
+import { notifications } from "@mantine/notifications";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { useUnsavedGuard, shallowEqual } from "@/components/UnsavedChangesProvider";
 
@@ -76,7 +77,7 @@ export default function LocalizationSettingsPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ timezone, locale }),
       });
-      if (res.ok) { flash("Settings saved."); await load(); }
+      if (res.ok) { notifications.show({ color: "green", message: "Settings saved." }); await load(); }
       else flash((await res.json()).error || "Save failed.", true);
     } catch { flash("Network error.", true); }
     finally { setSaving(false); }

--- a/checkin-app/src/app/shop-ops/create/__tests__/page.test.tsx
+++ b/checkin-app/src/app/shop-ops/create/__tests__/page.test.tsx
@@ -2,11 +2,13 @@
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
-import { screen, fireEvent } from "@testing-library/react";
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import { notifications } from "@mantine/notifications";
 import CreateToolPage from "../page";
 
-beforeEach(() => resetRtl());
+beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
 
 describe("CreateToolPage", () => {
     it("lists existing tools and creates a new one", async () => {
@@ -18,6 +20,6 @@ describe("CreateToolPage", () => {
         fireEvent.change(screen.getByLabelText(/equipment name/i), { target: { value: "Band Saw" } });
         fireEvent.click(screen.getByRole("button", { name: /create tool/i }));
 
-        expect(await screen.findByText("New tool added successfully!")).toBeInTheDocument();
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "New tool added successfully!" })));
     });
 });

--- a/checkin-app/src/app/shop-ops/create/page.tsx
+++ b/checkin-app/src/app/shop-ops/create/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Button, Card, Flex, ScrollArea, Stack, Text, TextInput } from "@mantine/core";
 import { AlertBanner, type AlertTone } from "@/components/admin/AlertBanner";
+import { notifications } from "@mantine/notifications";
 
 type ToolListItem = {
   id: number;
@@ -40,7 +41,7 @@ export default function CreateToolPage() {
       });
 
       if (res.ok) {
-        setCreateMessage({ text: "New tool added successfully!", tone: "success" });
+        notifications.show({ color: "green", message: "New tool added successfully!" });
         setNewToolName("");
         setNewToolGuide("");
         loadTools();


### PR DESCRIPTION
## What

On 7 admin pages, the **success** message now fires the app's standard corner toast (`@mantine/notifications`) instead of the inline shared `AlertBanner`. Error and warning messages are unchanged — they still render through `AlertBanner`.

Pages touched:
- `shop-ops/create`
- `profile`
- `facility-ops/visits`
- `membership-ops/participants/new`
- `membership-ops/applications` (3 success paths)
- `membership-ops/volunteer-memberships`
- `settings/localization`

## Why

Success feedback via `AlertBanner` inserts a block into page flow, causing a layout shift each time it appears. Routing success to the existing corner-toast pattern (already used in `membership-ops/participants/page.tsx`) removes that shift. Errors stay inline where they're most visible next to the form.

## Reviewer notes

- **No `AlertBanner` removed.** Message state, banner mounts, and all error/warning setters are untouched. Reset-at-start clears (`setMessage("")` / `flash("")`) are left in place — they still clear stale error banners.
- `membership-ops/volunteer-memberships`: the old call combined success + warning into one `flash(...)`. Split so only the success branch toasts; the warning branch keeps using `flash` + banner.
- `membership-ops/participants/new`: task originally called for dropping a paired `setIsError(false)` on the success path — that call is actually reset-at-start (before the fetch), so it was left as-is per the reset rule.
- `@mantine/notifications` import added to each file; `<Notifications />` provider is already globally mounted in `layout.tsx`.
- `tsc --noEmit`: zero errors in the 7 touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)