### PR TITLE
fix(toasts): persist red error notifications until dismissed

### DIFF
--- a/checkin-app/src/app/facility-ops/print-badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/page.tsx
@@ -117,7 +117,7 @@ export default function PrintBadgesPage() {
       URL.revokeObjectURL(url);
     } catch (e) {
       console.error(`Failed to generate ${kind} PDF`, e);
-      notifications.show({ color: 'red', message: `Failed to generate ${kind} PDF. Please try again.` });
+      notifications.show({ color: 'red', message: `Failed to generate ${kind} PDF. Please try again.`, autoClose: false });
     } finally {
       setIsGenerating(false);
     }

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -76,10 +76,10 @@ export default function PendingParticipantsPage() {
         notifyNavRefresh();
       } else {
         const data = await res.json();
-        notifications.show({ color: 'red', message: data.error || "Failed to approve." });
+        notifications.show({ color: 'red', message: data.error || "Failed to approve.", autoClose: false });
       }
     } catch {
-      notifications.show({ color: 'red', message: "Network error processing approval." });
+      notifications.show({ color: 'red', message: "Network error processing approval.", autoClose: false });
     }
   };
 

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -60,10 +60,10 @@ export default function AdminHouseholdsPage() {
       if (res.ok) {
         fetchHouseholds();
       } else {
-        notifications.show({ color: 'red', message: 'Failed to update membership.' });
+        notifications.show({ color: 'red', message: 'Failed to update membership.', autoClose: false });
       }
     } catch {
-      notifications.show({ color: 'red', message: 'Network error.' });
+      notifications.show({ color: 'red', message: 'Network error.', autoClose: false });
     }
   };
 
@@ -90,10 +90,10 @@ export default function AdminHouseholdsPage() {
         fetchHouseholds();
       } else {
         const data = await res.json().catch(() => ({}));
-        notifications.show({ color: 'red', message: data.error || 'Failed to update membership.' });
+        notifications.show({ color: 'red', message: data.error || 'Failed to update membership.', autoClose: false });
       }
     } catch {
-      notifications.show({ color: 'red', message: 'Network error.' });
+      notifications.show({ color: 'red', message: 'Network error.', autoClose: false });
     }
   };
 

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -94,7 +94,7 @@ export default function AdminParticipantsIndex() {
   const [editHouseholdId, setEditHouseholdId] = useState<number | null>(null);
 
   const showNotification = (message: string, type: 'success' | 'error' = 'success') => {
-    notifications.show({ message, color: type === 'error' ? 'red' : 'green' });
+    notifications.show({ message, color: type === 'error' ? 'red' : 'green', autoClose: type === 'error' ? false : 4000 });
   };
 
   const closeAssign = () => {

--- a/checkin-app/src/app/my-programs/conflicts/page.tsx
+++ b/checkin-app/src/app/my-programs/conflicts/page.tsx
@@ -36,10 +36,10 @@ export default function ConflictsPage() {
         refresh();
         notifyNavRefresh();
       } else {
-        notifications.show({ color: "red", message: data.error || "Failed to delete visit." });
+        notifications.show({ color: "red", message: data.error || "Failed to delete visit.", autoClose: false });
       }
     } catch {
-      notifications.show({ color: "red", message: "Network error." });
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
     } finally {
       setDeleting(null);
     }

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -87,7 +87,7 @@ export function AdminEditHouseholdModal({
         setLeadIds((h.householdLeads ?? []).map((l) => l.personId));
       }
     } catch {
-      notifications.show({ color: "red", message: "Failed to load household." });
+      notifications.show({ color: "red", message: "Failed to load household.", autoClose: false });
     }
   }, [householdId]);
 
@@ -118,10 +118,10 @@ export function AdminEditHouseholdModal({
         await loadHousehold();
       } else {
         const data = await res.json().catch(() => ({}));
-        notifications.show({ color: "red", message: data.error || "Failed to remove lead." });
+        notifications.show({ color: "red", message: data.error || "Failed to remove lead.", autoClose: false });
       }
     } catch {
-      notifications.show({ color: "red", message: "Network error." });
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
     } finally {
       setRemovingLead(null);
     }
@@ -154,10 +154,10 @@ export function AdminEditHouseholdModal({
         onClose();
       } else {
         const data = await res.json().catch(() => ({}));
-        notifications.show({ color: "red", message: data.error || "Failed to update household." });
+        notifications.show({ color: "red", message: data.error || "Failed to update household.", autoClose: false });
       }
     } catch {
-      notifications.show({ color: "red", message: "Network error." });
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## What

Add `autoClose: false` to every **red** `notifications.show(...)` call across six ops surfaces so error toasts stay until the user clicks the close button, instead of vanishing after Mantine's 4s default.

Files:
- `my-programs/conflicts/page.tsx` — delete-visit failure, network error
- `membership-ops/participants/page.tsx` — via the `showNotification` wrapper: `autoClose: type === 'error' ? false : 4000` (covers all four error callers)
- `membership-ops/households/page.tsx` — 4 red sites
- `facility-ops/print-badges/page.tsx` — PDF-failure toast
- `finance-ops/payment-plan/page.tsx` — approve failure, network error
- `components/admin/AdminEditHouseholdModal.tsx` — 5 red sites

## Why

Errors that auto-dismiss after 4s can be missed. Persisting them until dismissed makes failures actionable.

## Notes for reviewer

- **Green/success toasts untouched** — they keep the 4s auto-dismiss (conflicts:35, AdminEditHouseholdModal:117/151, and the success branch of the participants wrapper).
- Mantine shows the close button by default, so no other change needed.
- `<Notifications />` provider unchanged.
- `tsc --noEmit` clean on all edited files (pre-existing repo errors from un-generated prisma client / test `any` params are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)