### PR TITLE
fix(ui): corner toast for stay-on-page success confirmations

### DIFF
--- a/checkin-app/src/app/attendance/manual/__tests__/page.test.tsx
+++ b/checkin-app/src/app/attendance/manual/__tests__/page.test.tsx
@@ -1,11 +1,16 @@
 /* eslint-disable @typescript-eslint/no-require-imports -- jest.mock factories are hoisted above imports */
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+import { notifications } from "@mantine/notifications";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
 import ManualAttendance from "../page";
 
-beforeEach(() => resetRtl());
+beforeEach(() => {
+    resetRtl();
+    (notifications.show as jest.Mock).mockClear();
+});
 
 describe("ManualAttendance", () => {
     it("records a manual visit and shows a success message", async () => {
@@ -20,7 +25,9 @@ describe("ManualAttendance", () => {
         fireEvent.change(screen.getByLabelText(/Arrival Time/), { target: { value: "2026-06-01T10:00" } });
         fireEvent.click(submit);
 
-        expect(await screen.findByText("Visit recorded successfully.")).toBeInTheDocument();
+        await waitFor(() =>
+            expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Visit recorded successfully." })),
+        );
     });
 
     it("shows an error message when the API rejects the entry", async () => {

--- a/checkin-app/src/app/attendance/manual/page.tsx
+++ b/checkin-app/src/app/attendance/manual/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Alert, Button, Card, Stack, Text, TextInput, Title } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { AttendanceTabs } from "../AttendanceTabs";
@@ -13,13 +14,11 @@ export default function ManualAttendance() {
   const [departedAt, setDeparted] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState("");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setError("");
-    setSuccess("");
 
     try {
       const res = await fetch("/api/attendance/manual", {
@@ -32,7 +31,7 @@ export default function ManualAttendance() {
       if (!res.ok) {
         setError(data.error || "Failed to record manual visit.");
       } else {
-        setSuccess("Visit recorded successfully.");
+        notifications.show({ color: "green", message: "Visit recorded successfully." });
         setArrived("");
         setDeparted("");
       }
@@ -60,7 +59,6 @@ export default function ManualAttendance() {
         </Text>
 
         {error && !departureError && <Alert color="red" mb="md">{error}</Alert>}
-        {success && <Alert color="green" mb="md">{success}</Alert>}
 
         <form onSubmit={handleSubmit}>
           <Stack>

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -2,10 +2,15 @@
 import { screen, waitFor, fireEvent } from "@testing-library/react";
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+import { notifications } from "@mantine/notifications";
 import { renderWithProviders, mockFetchJson, setSession, router, resetRtl } from "@/test-helpers/rtl";
 import ProgramEnrollmentPage from "../page";
 
-beforeEach(() => resetRtl());
+beforeEach(() => {
+    resetRtl();
+    (notifications.show as jest.Mock).mockClear();
+});
 
 // `use(params)` suspends on any promise it hasn't already tracked, even one that
 // resolved microtasks ago — pre-mark it "fulfilled" (React's own thenable-caching
@@ -74,7 +79,9 @@ describe("ProgramEnrollmentPage", () => {
         expect(screen.getByText("(Too young)")).toBeInTheDocument();
 
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
-        expect(await screen.findByText("Successfully enrolled!")).toBeInTheDocument();
+        await waitFor(() =>
+            expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Successfully enrolled!" })),
+        );
     });
 
     it("priced program with no Shopify variant configured falls back to a direct enroll message", async () => {
@@ -92,7 +99,9 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Which of your household wants to enroll?");
 
         fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
-        expect(await screen.findByText("Enrolled! (Note: No pricing variant configured for this tier)")).toBeInTheDocument();
+        await waitFor(() =>
+            expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Enrolled! (Note: No pricing variant configured for this tier)" })),
+        );
     });
 
     it("shows a not-found card and navigates back to the directory", async () => {
@@ -148,7 +157,9 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Which of your household wants to enroll?");
 
         fireEvent.click(screen.getByRole("button", { name: /request a payment plan/ }));
-        expect(await screen.findByText(/Requested! Please check your email/)).toBeInTheDocument();
+        await waitFor(() =>
+            expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringMatching(/Requested! Please check your email/) })),
+        );
         expect(fetchMock).toHaveBeenCalledWith("/api/programs/10/request-payment-plan", expect.objectContaining({ method: "POST" }));
     });
 
@@ -221,7 +232,9 @@ describe("ProgramEnrollmentPage", () => {
 
         fireEvent.click(screen.getByLabelText("Too Young"));
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
-        expect(await screen.findByText("Successfully enrolled 2 members!")).toBeInTheDocument();
+        await waitFor(() =>
+            expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Successfully enrolled 2 members!" })),
+        );
     });
 
     it("treats a 409 already-enrolled response as a successful outcome without parsing a body", async () => {
@@ -240,7 +253,9 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
-        expect(await screen.findByText("Successfully enrolled!")).toBeInTheDocument();
+        await waitFor(() =>
+            expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Successfully enrolled!" })),
+        );
     });
 
     it("shows an override prompt when enrollment requires admin override, then force-enrolls", async () => {
@@ -269,7 +284,7 @@ describe("ProgramEnrollmentPage", () => {
 
         fireEvent.click(screen.getByRole("button", { name: "Force Enroll (Override)" }));
         await waitFor(() => expect(screen.queryByText("Warning: Enrollment rules not met.")).not.toBeInTheDocument());
-        expect(screen.getByText("Successfully enrolled!")).toBeInTheDocument();
+        expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Successfully enrolled!" }));
     });
 
     it("shows a network-error message when enrollment throws", async () => {

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -4,6 +4,7 @@ import { use, useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Anchor, Button, Card, Center, Checkbox, Container, Divider, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
 import { formatDate, calculateAge } from '@/lib/time';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { formatCents } from '@inventory/money';
@@ -145,7 +146,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
       }
 
       if (anyRequested) {
-        setSuccessMessage("Requested! Please check your email for communication from the finance committee of the board.");
+        notifications.show({ color: "green", message: "Requested! Please check your email for communication from the finance committee of the board." });
         fetchProgram();
         notifyNavRefresh();
       }
@@ -205,11 +206,12 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
             window.location.href = buildShopifyCheckoutUrl(storeDomain, variantId, enrolledIds, id);
             return;
           } else {
-            setSuccessMessage("Enrolled! (Note: No pricing variant configured for this tier)");
+            notifications.show({ color: "green", message: "Enrolled! (Note: No pricing variant configured for this tier)" });
+            setSuccessMessage("");
             fetchProgram();
           }
         } else {
-          setSuccessMessage(enrolledIds.length > 1 ? `Successfully enrolled ${enrolledIds.length} members!` : "Successfully enrolled!");
+          notifications.show({ color: "green", message: enrolledIds.length > 1 ? `Successfully enrolled ${enrolledIds.length} members!` : "Successfully enrolled!" });
           setRequiresOverride(false);
           fetchProgram();
         }


### PR DESCRIPTION
## What

Convert three stay-on-page **success** confirmations from hand-rolled inline `<Alert color="green">` to the app's standard corner toast (`@mantine/notifications`).

- **`attendance/manual/page.tsx`** — drop the `success` state + reset + green Alert entirely; emit `notifications.show(...)` on record. Red error `Alert` (separate `error` state) untouched.
- **`programs/[id]/page.tsx`** — convert 3 of 4 `setSuccessMessage` setters to toast:
  - "Requested! …finance committee…"
  - "Enrolled! (Note: No pricing variant configured for this tier)"
  - "Successfully enrolled …" (ternary preserved)
  - Keep `successMessage` state + Alert mount for the **"Redirecting to Shopify…"** case.

## Why

Consistency — corner toast is the app's standard success surface (already used e.g. `membership-ops/participants`). Inline green banners were one-off.

## Reviewer notes

- **Redirect-coupled messages stay inline by design** — a toast dies on full-page nav (`window.location.href`), so "Redirecting…" remains an `Alert`. `programs/[id]/register/page.tsx` left untouched for the same reason.
- The no-variant enroll path now also calls `setSuccessMessage("")` — it runs right after the "Redirecting…" banner is set, which would otherwise linger.
- `tsc --noEmit` clean on both edited pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)