### PR TITLE
fix(my-household): toast success confirmations instead of shifting page

### DIFF
--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -9,7 +9,14 @@ import { notifications } from "@mantine/notifications";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl, router } from "@/test-helpers/rtl";
 import HouseholdPage from "../page";
 
-beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
+// Successes toast via notifications.show (no inline banner); assert on the mock.
+const expectToast = (message: string) =>
+  expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message }));
+
+beforeEach(() => {
+  resetRtl();
+  (notifications.show as jest.Mock).mockClear();
+});
 
 // `mockFetchJson`/`mockRoutes` always answer a matched url with 200, and one value
 // per url regardless of method. Several branches below need a specific method
@@ -110,7 +117,7 @@ describe("HouseholdPage", () => {
         expect.objectContaining({ method: "PATCH" }),
       ),
     );
-    expect(await screen.findByText("Settings updated successfully!")).toBeInTheDocument();
+    expectToast("Settings updated successfully!");
   });
 
   it("adds an emergency contact", async () => {
@@ -291,7 +298,7 @@ describe("HouseholdPage", () => {
     fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
     expect(screen.queryByLabelText("Household Lead")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    expect(await screen.findByText("Household member updated successfully!")).toBeInTheDocument();
+    await waitFor(() => expectToast("Household member updated successfully!"));
   });
 
   it("promotes a household member to lead, and shows a server error on failure", async () => {
@@ -322,7 +329,7 @@ describe("HouseholdPage", () => {
         expect.objectContaining({ method: "POST", body: JSON.stringify({ participantId: 12 }) }),
       ),
     );
-    expect(await screen.findByText("Household member promoted to lead successfully!")).toBeInTheDocument();
+    await waitFor(() => expectToast("Household member promoted to lead successfully!"));
 
     fireEvent.click(screen.getByRole("button", { name: "Make Lead" }));
     expect(await screen.findByText("Already a lead.")).toBeInTheDocument();

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -65,7 +65,9 @@ export default function HouseholdPage() {
   const [message, setMessage] = useState<{ text: string; tone: AlertTone } | null>(null);
   // Explicit tone per outcome so a real error can never render green (was
   // decided by `message.includes('success')`).
-  const ok = (text: string) => setMessage({ text, tone: "success" });
+  // Successes toast in the corner (no layout shift); errors/warnings stay in
+  // the page banner where they can't be missed.
+  const ok = (text: string) => notifications.show({ color: "green", message: text });
   const err = (text: string) => setMessage({ text, tone: "error" });
   const warn = (text: string) => setMessage({ text, tone: "warning" });
   const [addingHouseholdMember, setAddingHouseholdMember] = useState(false);
@@ -145,7 +147,6 @@ export default function HouseholdPage() {
 
       if (householdRes.ok) {
         ok("Settings updated successfully!");
-        notifications.show({ color: "green", message: "Address updated." });
         fetchHousehold();
         notifyNavRefresh();
       } else {


### PR DESCRIPTION
## What

On http://localhost:3010/my-household, editing a household member (and other success actions) rendered an inline "Household member updated successfully." banner at the top of the page. The banner pushed layout down, making content jump/dance on screen.

This routes all four success paths on the page through the existing Mantine notifications toast (bottom-right corner, already mounted in `layout.tsx`), so confirmations appear without moving on-screen content:

- Member edit
- Member add
- Make-lead
- Address save

Errors and warnings still render in the inline `AlertBanner` where they can't be missed.

## Why

Toast in a fixed corner = no layout shift. The inline banner was the root cause shared by every success path, so the fix lives in the `ok()` helper rather than each call site.

## Notes for reviewer

- Removed a now-duplicate `notifications.show({ message: "Address updated." })` that would have double-fired alongside the settings-save toast.
- Tests updated: 3 assertions switched from `findByText` on the banner to asserting on the mocked `notifications.show`. `@mantine/notifications` was already mocked in the suite.
- All 17 tests in `my-household/__tests__/page.test.tsx` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)