### PR TITLE
fix(trusted-adults): give prior-decision badge a solid fill

### DIFF
--- a/checkin-app/src/app/safety/trusted-adults/page.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/page.tsx
@@ -214,7 +214,7 @@ export default function AdminTrustedAdultsPage() {
                             <Text c="dimmed">→</Text>
                             <Text>{ta.trustedAdultPerson?.name || ta.trustedAdultName || "trusted adult"}</Text>
                             <Badge color={STATUS_COLORS[status] ?? "gray"}>{label(status)}</Badge>
-                            {priorMeta && <Badge variant="outline" color={priorMeta.color}>{priorMeta.text}</Badge>}
+                            {priorMeta && <Badge variant="filled" color={priorMeta.color}>{priorMeta.text}</Badge>}
                         </Group>
                         <TrustedAdultContact phone={ta.trustedAdultPhone} email={ta.trustedAdultEmail} />
                         <Text size="sm" mt={6}><b>Family context (board only):</b> {ta.familyContext}</Text>


### PR DESCRIPTION
## What

The prior-decision badge on `/safety/trusted-adults` used `variant="outline"`, which renders a transparent background over the dark page — so the **Previously denied** label read as blackish instead of red. Switched to `variant="filled"` so the badge background takes its color.

## Scope note

This is a single prop change, so it applies to all three prior-decision badges, not only DENY:
- `DENY` → **Previously denied** (red)
- `APPROVE` → **Renewal** (blue)
- `REQUEST_INFO` → **Previously: more info requested** (orange)

If only the denied badge should be filled, say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)