### PR TITLE
feat(membership): dev mock for background-check consent

### DIFF
--- a/checkin-app/docs/designs/BG_CHECK_DEV_MOCK.md
+++ b/checkin-app/docs/designs/BG_CHECK_DEV_MOCK.md
@@ -1,0 +1,38 @@
+# Background-check dev mock
+
+Averity/VERITY (the background-check vendor) exposes **no API and no dev sandbox** —
+only a hosted consent page (a static deep link) and email to a human. So on a
+developer laptop or cloud dev instance there is no way to *start* a check, which means
+an application can never reach the board's review queue and the two-reviewer sign-off
+can't be exercised end-to-end. This mock fills that gap. Mirrors the Zoho Sign
+(`ZOHO_SIGN_DEV_MOCK.md`) and Shopify (`SHOPIFY_DEV_STORE_WEBHOOK.md`) mocks.
+
+## Fuse
+
+`config.bgMockActive()` is true iff **all** hold (see `bgMockActiveEnv` in `lib/config.ts`):
+
+- `AVERITY_CONSENT_URL` unset — setting the real link opts back into it,
+- `CHECKIN_ENV !== 'prod'` (fails safe to prod when unset),
+- `NODE_ENV !== 'production'`.
+
+Two server-only fuses ⇒ no mock path is reachable in prod by construction.
+
+## Flow
+
+1. **Provider seam** — `backgroundCheckProvider.getConsentDeepLink()`
+   (`background-check/manual-adapter.ts`) selects per-call: the real `ManualBackgroundCheckProvider`
+   (returns `AVERITY_CONSENT_URL`) normally, `MockBackgroundCheckProvider` (returns
+   `${baseUrl}/dev/bg-consent`) when the mock is active. The applicant's "Consent on
+   Averity →" button on `/membership` points at whichever it returns.
+2. **Interstitial** — `/dev/bg-consent` (404s unless `bgMockActive`) stands in for Averity's
+   hosted consent page. Its "Consent (DEV)" button POSTs `/api/dev/bg-consent/complete`.
+3. **Complete route** — resolves the caller's own in-flight `PENDING_EXTERNAL_ACTION` process
+   (`latestPendingExternal`) and calls the real `markBgConsent`, driving the same
+   advance → `PENDING_PAYMENT` → parallel-review → `notifyReviewers` path prod does.
+   Everything below `markBgConsent` is real and identical to prod.
+4. **Board sign-off** — unchanged: two eligible reviewers (`isBackgroundCheckReviewer`
+   or `isBoardMember`) attest at `/membership-ops/review` (`review.ts › attest`). Two
+   APPROVE clears the check; any REJECT blocks. The mock touches nothing here.
+
+The system never sees a real check — only the consent flag and the attestations, same
+as prod.

--- a/checkin-app/src/app/api/dev/bg-consent/complete/route.ts
+++ b/checkin-app/src/app/api/dev/bg-consent/complete/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { config } from "@/lib/config";
+import prisma from "@/lib/prisma";
+import { markBgConsent, ExternalError } from "@/lib/membership/external";
+import { latestPendingExternal } from "@/lib/membership/phases";
+import { apiError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/dev/bg-consent/complete — dev-only consent trigger for the background-check
+ * mock (see docs/designs/BG_CHECK_DEV_MOCK.md). Reached from the dev interstitial's
+ * "Consent" button, standing in for the applicant consenting on Averity. Records real
+ * consent (markBgConsent) on the caller's own in-flight application, driving the same
+ * advance → parallel board review path prod does.
+ *
+ * 404s whenever the mock isn't active — always in prod.
+ */
+export const POST = withAuth({}, async (_req, auth) => {
+    if (!config.bgMockActive()) return apiError("Not available", 404);
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
+    const userId = auth.user.id;
+
+    const user = await prisma.person.findUnique({
+        where: { id: userId },
+        include: { household: { include: { orgMembership: { include: { processes: true } } } } },
+    });
+    const process = latestPendingExternal(user?.household?.orgMembership?.processes);
+    if (!process) return apiError("No application is awaiting background-check consent.", 404);
+
+    try {
+        return NextResponse.json({ process: await markBgConsent(process.id, userId) });
+    } catch (error) {
+        if (error instanceof ExternalError) {
+            return NextResponse.json({ error: error.message, code: error.code }, { status: 400 });
+        }
+        logger.error("Dev bg-consent complete error:", error);
+        return apiError("Internal Server Error", 500);
+    }
+});

--- a/checkin-app/src/app/dev/bg-consent/DevBgConsentClient.tsx
+++ b/checkin-app/src/app/dev/bg-consent/DevBgConsentClient.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Dev background-check consent mock UI (the page 404s off a dev instance). Stands in
+ * for Averity's hosted consent page: "Consent (DEV)" records real consent via the dev
+ * endpoint then lands back on /membership. Inline styles match the sibling dev tool
+ * (dev/zoho-sign).
+ */
+export default function DevBgConsentClient() {
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function consent() {
+        setBusy(true);
+        setError(null);
+        try {
+            const res = await fetch("/api/dev/bg-consent/complete", { method: "POST" });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                setError(data.error ? `${data.error} (${res.status})` : `Consent failed (${res.status}). Check server logs.`);
+                setBusy(false);
+                return;
+            }
+            window.location.href = "/membership";
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e));
+            setBusy(false);
+        }
+    }
+
+    const btn: React.CSSProperties = {
+        padding: "0.5rem 1rem",
+        borderRadius: 6,
+        border: "none",
+        background: "#059669",
+        color: "#fff",
+        fontWeight: 600,
+        cursor: busy ? "default" : "pointer",
+        opacity: busy ? 0.5 : 1,
+    };
+
+    return (
+        <div style={{ maxWidth: 640 }}>
+            <h1 style={{ fontSize: "1.5rem", fontWeight: 600, margin: 0 }}>Background check (mock)</h1>
+            <p style={{ opacity: 0.7, fontSize: "0.85rem", marginTop: "0.5rem" }}>
+                Averity is mocked on this instance (no consent URL). This stands in for the hosted
+                consent page — <strong>DEV, NOT A REAL BACKGROUND CHECK</strong>. Confirming records
+                your consent and sends the application to the board for sign-off.
+            </p>
+
+            {error && <p style={{ color: "#b91c1c", marginTop: "1rem" }}>{error}</p>}
+
+            <div style={{ marginTop: "1.5rem" }}>
+                <button onClick={consent} disabled={busy} style={btn}>
+                    {busy ? "Recording…" : "Consent to background check (DEV)"}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/checkin-app/src/app/dev/bg-consent/page.tsx
+++ b/checkin-app/src/app/dev/bg-consent/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from "next/navigation";
+import { config } from "@/lib/config";
+import DevBgConsentClient from "./DevBgConsentClient";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Dev-only stand-in for Averity's hosted background-check consent page (see
+ * docs/designs/BG_CHECK_DEV_MOCK.md). The mock provider's getConsentDeepLink points
+ * the applicant here (Averity has no dev sandbox). Confirming records real consent
+ * (markBgConsent) so the application advances and enters the board review queue,
+ * where board members sign off through the normal two-reviewer attestation.
+ * 404s the moment the mock isn't active (always in prod) so it can never surface.
+ */
+export default function DevBgConsentPage() {
+    if (!config.bgMockActive()) notFound();
+    return <DevBgConsentClient />;
+}

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -148,4 +148,5 @@ export const REGISTRY_EXCLUDED: string[] = [
   '/dev/sent-mail',          // dev-only captured-email inbox (EMAIL_DEV_MOCK.md); 404s off dev
   '/dev/zoho-sign',          // dev-only Zoho Sign mock interstitial (404 in prod)
   '/dev/shopify',            // dev-only Shopify orders/paid mock (SHOPIFY_DEV_STORE_WEBHOOK.md); 404s off dev
+  '/dev/bg-consent',         // dev-only background-check consent mock (BG_CHECK_DEV_MOCK.md); 404s off dev
 ];

--- a/checkin-app/src/lib/__tests__/config.test.ts
+++ b/checkin-app/src/lib/__tests__/config.test.ts
@@ -185,6 +185,33 @@ describe("shopifyMockActive / shopifyWebhookSecret", () => {
     });
 });
 
+describe("bgMockActive", () => {
+    it("mock active when Averity unset, non-prod, non-production NODE_ENV", () => {
+        delete process.env.AVERITY_CONSENT_URL;
+        process.env.CHECKIN_ENV = "local";
+        (process.env as Record<string, string>).NODE_ENV = "test";
+        expect(config.bgMockActive()).toBe(true);
+    });
+    it("mock inactive when AVERITY_CONSENT_URL is set (real link wins)", () => {
+        process.env.AVERITY_CONSENT_URL = "https://averity.example/consent";
+        process.env.CHECKIN_ENV = "local";
+        (process.env as Record<string, string>).NODE_ENV = "test";
+        expect(config.bgMockActive()).toBe(false);
+    });
+    it("mock inactive on prod checkinEnv", () => {
+        delete process.env.AVERITY_CONSENT_URL;
+        process.env.CHECKIN_ENV = "prod";
+        (process.env as Record<string, string>).NODE_ENV = "test";
+        expect(config.bgMockActive()).toBe(false);
+    });
+    it("mock inactive when NODE_ENV is production", () => {
+        delete process.env.AVERITY_CONSENT_URL;
+        process.env.CHECKIN_ENV = "local";
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        expect(config.bgMockActive()).toBe(false);
+    });
+});
+
 describe("simple optional getters (env-set vs default)", () => {
     it("kioskPublicKey", () => {
         delete process.env.KIOSK_PUBLIC_KEY;

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -85,6 +85,20 @@ function shopifyMockActiveEnv(): boolean {
  */
 export const DEV_MOCK_SHOPIFY_WEBHOOK_SECRET = 'dev-shopify-mock-webhook-secret';
 
+/**
+ * The dev/local background-check MOCK is active when the real Averity consent link
+ * is unconfigured (AVERITY_CONSENT_URL unset) AND we're on a non-prod instance.
+ * Same two server-only fuses as the Zoho/Shopify mocks — CHECKIN_ENV (fails safe to
+ * prod) and NODE_ENV — so no mock path is reachable in prod by construction. It hands
+ * the applicant an in-app consent link (/dev/bg-consent) instead of Averity's hosted
+ * page, so the check can be started in debug mode; board members then sign off through
+ * the normal two-reviewer attestation. Setting AVERITY_CONSENT_URL opts back into the
+ * real link. See docs/designs/BG_CHECK_DEV_MOCK.md.
+ */
+function bgMockActiveEnv(): boolean {
+    return !process.env.AVERITY_CONSENT_URL && readCheckinEnv() !== 'prod' && process.env.NODE_ENV !== 'production';
+}
+
 export const config = {
     // Database
     databaseUrl: () => requireEnv('DATABASE_URL'),
@@ -159,6 +173,11 @@ export const config = {
     // True when the dev/local mock stands in for a real Shopify store (creds unset,
     // non-prod). Gates /api/dev/shopify/* + the dev tool. Always false in prod.
     shopifyMockActive: (): boolean => shopifyMockActiveEnv(),
+
+    // True when the dev/local background-check mock stands in for Averity (consent URL
+    // unset, non-prod). Selects the mock provider (in-app consent link) and gates
+    // /dev/bg-consent + its complete route. Always false in prod. See bgMockActiveEnv.
+    bgMockActive: (): boolean => bgMockActiveEnv(),
 
     // App
     checkinEnv: (): CheckinEnv => readCheckinEnv(),

--- a/checkin-app/src/lib/devToolsNav.ts
+++ b/checkin-app/src/lib/devToolsNav.ts
@@ -12,4 +12,5 @@ export const DEV_TOOLS_NAV_LINKS: DevToolsNavLink[] = [
   { name: "Email", href: "/dev/sent-mail" },
   { name: "Sign", href: "/dev/zoho-sign" },
   { name: "Shopify", href: "/dev/shopify" },
+  { name: "BG Check", href: "/dev/bg-consent" },
 ];

--- a/checkin-app/src/lib/membership/background-check/manual-adapter.ts
+++ b/checkin-app/src/lib/membership/background-check/manual-adapter.ts
@@ -15,5 +15,26 @@ export class ManualBackgroundCheckProvider implements BackgroundCheckProvider {
     }
 }
 
-/** The active provider. Swap here if a real-API provider is ever introduced. */
-export const backgroundCheckProvider: BackgroundCheckProvider = new ManualBackgroundCheckProvider();
+/**
+ * Dev/local mock provider (see BG_CHECK_DEV_MOCK.md). Averity has no dev sandbox, so
+ * when its consent URL is unset on a non-prod instance the mock hands the applicant an
+ * in-app consent page (/dev/bg-consent) that records consent for real — driving the
+ * same markBgConsent → parallel review path prod does. Board members then sign off
+ * through the normal two-reviewer attestation. 404s off a dev instance by construction.
+ */
+export class MockBackgroundCheckProvider implements BackgroundCheckProvider {
+    async getConsentDeepLink(): Promise<string | null> {
+        return `${config.baseUrl()}/dev/bg-consent`;
+    }
+}
+
+const realProvider = new ManualBackgroundCheckProvider();
+const mockProvider = new MockBackgroundCheckProvider();
+
+/**
+ * The active provider: real (manual Averity) normally, the mock on an unconfigured dev
+ * instance. Per-call selection (mirrors zohoSign) so tests toggling env pick up the change.
+ */
+export const backgroundCheckProvider: BackgroundCheckProvider = {
+    getConsentDeepLink: () => (config.bgMockActive() ? mockProvider : realProvider).getConsentDeepLink(),
+};


### PR DESCRIPTION
## What

Adds a dev/local **mock** for the background-check consent step so the full flow — start a check, then have board members sign off — can be exercised end to end without the real vendor.

Averity/VERITY exposes no API and no dev sandbox (only a hosted consent deep link + email to a human). On a dev instance `getConsentDeepLink()` returned null, so an application could never record consent, never reach the board review queue, and the two-reviewer sign-off couldn't be tested. This fills that gap.

Mirrors the existing Zoho Sign (`ZOHO_SIGN_DEV_MOCK.md`) and Shopify (`SHOPIFY_DEV_STORE_WEBHOOK.md`) dev mocks.

## How

- **`config.bgMockActive()`** — new fuse, active iff `AVERITY_CONSENT_URL` unset **and** `CHECKIN_ENV != prod` **and** `NODE_ENV != production`. Two server-only fuses ⇒ no mock path reachable in prod by construction. Setting the real consent URL opts back into the real link.
- **`MockBackgroundCheckProvider`** returns an in-app consent link (`/dev/bg-consent`) instead of Averity's page. Per-call provider selection (mirrors `zohoSign`) so tests toggling env pick up the change.
- **`/dev/bg-consent`** interstitial (404s off a dev instance) + **`/api/dev/bg-consent/complete`** resolve the caller's own in-flight `PENDING_EXTERNAL_ACTION` process (`latestPendingExternal`) and call the **real** `markBgConsent` → same advance → `PENDING_PAYMENT` → parallel-review → `notifyReviewers` path as prod. Everything below `markBgConsent` is unchanged.
- **Board sign-off is untouched** — two eligible reviewers (`isBackgroundCheckReviewer` or `isBoardMember`) still attest at `/membership-ops/review`; two APPROVE clears, any REJECT blocks.
- Registers the dev page (`pageRegistry`, `devToolsNav` "BG Check" tab) and adds `BG_CHECK_DEV_MOCK.md`.

## Reviewer notes

- No schema/migration — reuses the existing `bgConsentAt` field and attestation flow.
- Prod safety: the fuse fails safe to prod (unset `CHECKIN_ENV` → prod), and both the page and the complete route hard-404 unless `bgMockActive()`.
- The complete route only marks consent on the **caller's own** household process (session-scoped), never an arbitrary `processId`.
- Skipped: faking Averity's board-notification email. Add if wanted.

## Testing

- `config.test.ts`: 4 new fuse cases (active / real-URL-wins / prod / production) — 33 pass.
- `pageRegistry` + `external` tests pass (14).
- tsc clean, eslint clean on changed files.

To exercise: run local, take a membership application to `PENDING_EXTERNAL_ACTION`, click Consent, then sign off as two board members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)