### PR TITLE
ci: fail if any committed file is a symlink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,25 @@ jobs:
         with:
           ref: ${{ inputs.ref }}   # empty on push/PR = default ref; the tag when called by deploy-prod
           fetch-depth: 0
+
+      # Guards against a repeat of PR #791 (commit 5cf40d2a): .gitignore's
+      # "node_modules/" pattern is directory-only and doesn't match a symlink
+      # of that name, so `git add -A` from a worktree with a symlinked
+      # node_modules silently committed two symlinks pointing at an absolute
+      # host path. Turbopack then panicked in the flow-test docker job
+      # ("Symlink checkin-app/node_modules is invalid, it points out of the
+      # filesystem root"). Lives in this job (not `test`/`deploy-build`)
+      # because `changes` has no path-filter `if:` and always runs, checkout
+      # already happened above, and failing here is instant — no need to
+      # wait on npm ci / docker build to catch it.
+      - name: Check for committed symlinks
+        run: |
+          SYMLINKS=$(git ls-files -s | awk '$1 == "120000" {print $4}')
+          if [ -n "$SYMLINKS" ]; then
+            echo "::error::Committed symlink(s) found (mode 120000):"; echo "$SYMLINKS"
+            exit 1
+          fi
+
       - id: detect
         env:
           EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
## Why

On PR #791, two symlinks (`node_modules` and `checkin-app/node_modules`, pointing at absolute host paths) were accidentally committed in commit `5cf40d2a`. The repo's `.gitignore` used `node_modules/` (trailing slash = directories only), which does not match a symlink of that name, so `git add -A` swept them in. The flow-test docker job then crashed with:

```
TurbopackInternalError: Symlink checkin-app/node_modules is invalid, it points out of the filesystem root
```

`.gitignore` was fixed (trailing slash dropped, commit `b923023e`), but nothing structurally prevented the next committed symlink. This PR adds that structural guard.

## Historical evidence

Offending commit — two symlinks (git mode `120000`) present:

```
$ git ls-tree -r 5cf40d2a | awk '$1=="120000"'
120000 blob b8f56ddad381b3b02115f05965195a2b8b4b41c1	checkin-app/node_modules
120000 blob 4992bba17acd545a9e0854f58ce4654f75ee89e1	node_modules
```

Current `origin/main` — none (fixed by removing the symlinks + tightening `.gitignore`, but no CI enforcement):

```
$ git ls-tree -r origin/main | awk '$1=="120000"'
(no output)
```

## Implementation

One step added to the `changes` job (`.github/workflows/ci.yml`), right after checkout:

```yaml
- name: Check for committed symlinks
  run: |
    SYMLINKS=$(git ls-files -s | awk '$1 == "120000" {print $4}')
    if [ -n "$SYMLINKS" ]; then
      echo "::error::Committed symlink(s) found (mode 120000):"; echo "$SYMLINKS"
      exit 1
    fi
```

### Placement rationale

`ci.yml` has three jobs: `changes`, `test`, `deploy-build`. `test` and `deploy-build` are the required status checks, but their *steps* are individually gated by `needs.changes.outputs.app == 'true'` so that client-only PRs (`client/**`, which has no Node CI) can still report success without doing Node work. `changes` is the one job with no conditional at all — it runs unconditionally on every `push`, `pull_request`, and `merge_group` trigger, and it already does a full checkout (`fetch-depth: 0`) before computing the path filter. Putting the symlink check there, right after that checkout and before the path-filter logic, guarantees it runs for every PR regardless of what changed, and fails in seconds rather than waiting on `npm ci` / a Docker build to get there.

No new dependencies, no new workflow file, no config knobs — 19 lines added to the existing `changes` job.

## Local verification

In a scratch worktree off `origin/main`:

1. Ran the exact check command with no symlinks committed → passed (no output, exit 0).
2. Created a throwaway symlink (`ln -s /nonexistent/host/path throwaway-symlink`), `git add`ed it → the check correctly printed `::error::Committed symlink(s) found (mode 120000): throwaway-symlink` and would exit 1.
3. Cleaned up: `git restore --staged throwaway-symlink && rm -f throwaway-symlink` — confirmed via `git status --porcelain` (only the intended `ci.yml` change remains) and `find . -type l` (no symlinks left in the worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz7egoZoDp37iL9FpC8tH
