### PR TITLE
ci: verify Prisma migrations against a populated DB, not just fresh ones

### DIFF
--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -1,0 +1,156 @@
+name: Migration safety (populated DB)
+
+# Mimics how deploy-dev.yml actually applies migrations: `prisma migrate
+# deploy` against a database that already has real rows in it — NOT the
+# always-empty DB that CI's own drift check (ci.yml "Check migrations match
+# schema") and every local dev setup use.
+#
+# Motivating incident: on 2026-07-02 Prisma generated three "rename"
+# migrations as DROP+ADD / DROP TABLE+CREATE TABLE instead of RENAMEs. They
+# passed CI and every local run because those DBs are always freshly created
+# (empty tables) — then migration 20260702054206 failed on dev's populated
+# RSVP with `23502: column "personId" of relation "RSVP" contains null
+# values`, and because `prisma migrate deploy` does not wrap a migration in a
+# transaction, it PARTIALLY applied (FeePayment's ALTER committed, RSVP's
+# rolled back), wedging every deploy behind a P3009 for over a day until
+# manual surgery + PR #791 (rewriting them as RENAMEs). No CI job had ever
+# applied a NEW migration on top of a POPULATED database. This job closes
+# that gap.
+#
+# Only runs when migrations (or this file) change — most PRs don't touch
+# migrations/prisma/schema.prisma, so there's nothing new to verify.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'checkin-app/prisma/migrations/**'
+      - '.github/workflows/migration-safety.yml'
+
+jobs:
+  migrate-populated:
+    name: Migrations apply to populated DB
+    runs-on: ubuntu-latest
+
+    # Version matches deploy/docker-compose.yml's `db` service (postgres:15) —
+    # same major version dev/prod run migrations against.
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpassword
+          POSTGRES_DB: checkmein_migtest
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://testuser:testpassword@localhost:5432/checkmein_migtest
+
+    steps:
+      # fetch-depth: 0 so origin/main's full history is available locally —
+      # needed to compute the merge-base below.
+      - name: Checkout PR
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Determine base + check for migration changes
+        id: base
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          BASE=$(git merge-base origin/main HEAD)
+          echo "Merge base with origin/main: $BASE"
+          echo "sha=$BASE" >> "$GITHUB_OUTPUT"
+          if git diff --quiet "$BASE" HEAD -- checkin-app/prisma/migrations; then
+            echo "No migration changes vs $BASE — nothing to verify, exiting early."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "New/changed migrations vs $BASE — running the populated-DB check."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js
+        if: steps.base.outputs.skip == 'false'
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - name: Install PR dependencies
+        if: steps.base.outputs.skip == 'false'
+        run: npm ci
+
+      - name: Generate Prisma Client (PR)
+        if: steps.base.outputs.skip == 'false'
+        run: npm -w checkin-app exec -- prisma generate
+
+      # Materialize the BASE commit as a full sibling checkout (its own
+      # worktree) — the base migrations must be applied/seeded with BASE's
+      # OWN prisma dir (schema.prisma, seed.ts) in case those changed too,
+      # not the PR's.
+      - name: Materialize base checkout
+        if: steps.base.outputs.skip == 'false'
+        run: git worktree add "${{ runner.temp }}/base" "${{ steps.base.outputs.sha }}"
+
+      - name: Apply base migrations + seed (populates the DB)
+        if: steps.base.outputs.skip == 'false'
+        working-directory: ${{ runner.temp }}/base
+        run: |
+          npm ci
+          npm -w checkin-app exec -- prisma generate
+          npm -w checkin-app exec -- prisma migrate deploy
+          npm -w checkin-app exec -- prisma db seed
+
+      # `prisma db seed` (seedBaseline) only populates Household/Person/Tool/
+      # ToolStatus/Program — it never creates Event/Fee/FeePayment/RSVP rows.
+      # Those are exactly the tables the 2026-07-02 incident hit (RSVP,
+      # FeePayment), so top them up here with a handful of rows referencing
+      # the seed's own baseline data (the "Woodworking 101" program + its
+      # personas) — this is what makes a destructive/non-applying migration
+      # on those tables fail here instead of on dev.
+      - name: Top up seed-empty tables the incident hit (Event/Fee/FeePayment/RSVP)
+        if: steps.base.outputs.skip == 'false'
+        env:
+          PGPASSWORD: testpassword
+        run: |
+          psql -h localhost -U testuser -d checkmein_migtest <<'SQL'
+          INSERT INTO "Event" (name, "programId", "startAt", "endAt", description)
+          SELECT 'CI Fixture Event', p.id, now(), now() + interval '2 hours', 'migration-safety CI fixture'
+          FROM "Program" p WHERE p.name = 'Woodworking 101';
+
+          INSERT INTO "Fee" (name, "programId", "nonOrgMemberPriceCents", "orgMemberPriceCents")
+          SELECT 'CI Fixture Fee', p.id, 4000, 2500
+          FROM "Program" p WHERE p.name = 'Woodworking 101';
+
+          INSERT INTO "RSVP" ("eventId", "personId", status)
+          SELECT e.id, pe.id, 'ATTENDING'::"RSVPStatus"
+          FROM "Event" e, "Person" pe
+          WHERE e.name = 'CI Fixture Event'
+            AND pe.email IN ('parent.family@example.com', 'parent2.family@example.com');
+
+          INSERT INTO "FeePayment" ("feeId", "personId")
+          SELECT f.id, pe.id
+          FROM "Fee" f, "Person" pe
+          WHERE f.name = 'CI Fixture Fee'
+            AND pe.email IN ('parent.family@example.com', 'parent2.family@example.com');
+          SQL
+
+      # The actual regression test: apply ONLY the PR's new migrations on top
+      # of a database that already has real rows in the tables they touch.
+      # Failing here means the migration doesn't apply to a real database —
+      # exactly what wedged dev on 2026-07-02.
+      - name: Apply PR's new migrations on top of the populated DB
+        if: steps.base.outputs.skip == 'false'
+        run: npm -w checkin-app exec -- prisma migrate deploy
+
+      # Proves the migrations land exactly on schema.prisma (Prisma 7:
+      # --from-url was removed, use --from-config-datasource).
+      - name: Drift check — migrations match schema.prisma
+        if: steps.base.outputs.skip == 'false'
+        run: npm -w checkin-app exec -- prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code


### PR DESCRIPTION
## Why

Dev deploys were wedged for **>1 day** starting 2026-07-02: Prisma generated three "rename" migrations as DROP+ADD / DROP TABLE+CREATE instead of in-place RENAMEs. They passed CI and every local run because those databases are always **freshly created** (empty tables) — then migration `20260702054206` failed on dev's **populated** RSVP table with:

```
23502: column "personId" of relation "RSVP" contains null values
```

and because `prisma migrate deploy` does **not** wrap a migration file in a transaction, it partially applied — FeePayment's `ALTER` committed, RSVP's rolled back — leaving `_prisma_migrations` in a failed state (P3009) that wedged every subsequent deploy until manual surgery. Fixed in #791 by rewriting the three migrations as RENAMEs.

**The CI gap this closes:** no test ever applied a *new* migration on top of a *populated* database. CI's own drift check (`ci.yml` → "Check migrations match schema") and every local dev setup only ever exercise migrations against an empty DB, which is exactly why this landmine was invisible until it hit dev's real data.

## What

New workflow `.github/workflows/migration-safety.yml`, gated on changes to `checkin-app/prisma/migrations/**` (and on itself, so it exercises its own early-exit path on this very PR). One job, `postgres:15` service (matches `deploy/docker-compose.yml`):

1. Checkout the PR (`fetch-depth: 0`), compute `BASE=$(git merge-base origin/main HEAD)`. If migrations are unchanged vs `BASE`, exit early — most PRs don't touch migrations.
2. Materialize `BASE` as a full sibling checkout (`git worktree add`) — so the base migrations are applied/seeded using BASE's *own* `schema.prisma`/`seed.ts`, not the PR's.
3. From the BASE checkout: `prisma migrate deploy` then `prisma db seed` — populates the DB with BASE's schema and data.
4. `prisma db seed` (`seedBaseline`) only populates **Household, Person, Tool, ToolStatus, and one Program** ("Woodworking 101") — it never touches Event/Fee/FeePayment/RSVP. Those are exactly the tables the incident hit, so a small top-up (`psql` heredoc, a handful of `INSERT`s referencing the seed's own persona emails and program name) adds a couple of rows to each.
5. From the PR checkout: `prisma migrate deploy` — applies **only** the PR's new migrations on top of that now-populated DB. Failing here means the migration doesn't apply to a real database, exactly what wedged dev.
6. `prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code` — proves the migrations land exactly on `schema.prisma` (Prisma 7 flag; `--from-url` was removed).

**Known limitation (out of scope):** this does not simulate a mid-migration crash / partial-transaction application — it only proves whether the migration *fully* applies to a populated DB. The partial-apply nuance from the incident (FeePayment committed, RSVP rolled back) is a Postgres/`migrate deploy` behavior, not something achievable to test generically without faking a crash.

## Local verification

Ran on a scratch Postgres (localhost:5433), node 24, outside CI, in two parts:

**(a) Regression proof — reconstructs the actual incident:**
1. Checked out `77c5118c` (pre-incident main), `npm ci`, `prisma generate`, `prisma migrate deploy` (44 migrations) into scratch DB `migmimic_a`, ran the real `prisma db seed`, then added 2 RSVP rows (left FeePayment empty, matching the incident's actual row distribution) referencing the seed's own persona/event data.
2. Checked out `4ea7cb1b` (main with the **original, destructive** versions of the three rename migrations) and ran `prisma migrate deploy` against that same populated DB.
   → **Failed exactly as it did on dev**: `Error P3018` / `23502: column "personId" of relation "RSVP" contains null values`, on migration `20260702054206_rsvp_feepayment_participantid_to_personid`. Inspecting the DB afterward even reproduced the exact partial-apply: `FeePayment` had already been renamed to `personId` (0 rows, no violation) while `RSVP` was left mid-migration with the old `participantId` column — the identical partial-apply the incident report describes.
3. Restored the same populated snapshot into a fresh DB and ran `prisma migrate deploy` from **current `origin/main`** (with #791's RENAME-based fix) instead.
   → **Succeeded** — all 10 new migrations applied, the RSVP rows survived with their data intact (`personId` populated, not null), and `prisma migrate diff --exit-code` reported **"No difference detected."** (no drift).

**(b) Sanity — no-new-migrations early exit:**
Ran the workflow's exact `git merge-base` / `git diff --quiet` logic against this real branch (which only adds the workflow file, no migration changes) → correctly computed `skip=true`. This same path also runs for real as this PR's own check (the paths filter includes the workflow file itself), since this PR doesn't touch `checkin-app/prisma/migrations/**`.

Also independently verified the exact `psql` fixture SQL shipped in the workflow against a fresh DB seeded from current `main`'s full migration set: 1 Event, 1 Fee, 2 RSVP, 2 FeePayment rows inserted cleanly, and both `migrate deploy` (no-op) and the drift check passed afterward.

## Seed coverage

`prisma db seed` → `seedBaseline` populates: **Household, Person (9 debug personas), Tool, ToolStatus, Program** (one, "Woodworking 101"). It does **not** populate Event, Fee, FeePayment, or ProgramParticipant/RSVP — those only come from the dev-dashboard's additive macros (`createFamily`/`createProgram`/`createEvent`/`createCheckins`), which the CLI seed never calls. Hence the small SQL top-up for Event/Fee/FeePayment/RSVP in the new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz7egoZoDp37iL9FpC8tH