### PR TITLE
fix(attendance): refresh nav/sub-tab counts after self check-in

### DIFF
--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -11,6 +11,7 @@ import {
 import { formatTime, isYouth } from "@/lib/time";
 import { formatPhone } from "@/lib/phone";
 import { getKioskDisplayNames } from "@/lib/kiosk-names";
+import { notifyNavRefresh } from "@/lib/nav-refresh";
 import { AttendanceTabs } from "../AttendanceTabs";
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -194,6 +195,8 @@ function KioskDisplayInner() {
       setData(json);
       if (json.signedRequest) setIsKioskMode(true);
     }
+    // Refresh nav/sub-tab building counts too — they read a separate cached fetch.
+    notifyNavRefresh();
   };
 
   const handleForceCheckout = async (visitId: number, isSelf: boolean = false) => {


### PR DESCRIPTION
## What

On `/attendance/current`, clicking **Check Me In** updated the page's own count columns but left the top sub-tab badge and left-nav badge stale until a full reload.

## Why

Those badges don't read the page's local state — they read a separate, cached `/api/nav/todo-counts` fetch ([`useTodoCounts`](checkin-app/src/hooks/useTodoCounts.ts)) that only refetches when `NAV_COUNTS_EVENT` fires. The check-in flow never fired it.

## Fix

One line: call `notifyNavRefresh()` from `refreshAttendance()`. That's the shared choke point for every mutation on the page — self check-in, household check-in buttons, admin manual search, and all checkouts — so the badges now update for others too, not just yourself.

## Reviewer notes

- No test added — matches the existing untested nav-refresh callers (emergency contact, membership phase). Say the word if you want one.