### PR TITLE
feat(membership-ops): reviewer-scoped count badges on Review tab + nav

### DIFF
--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import type { OrgMembershipProcessStatus, TrustedAdultReviewStatus } from "@/generated/prisma/client";
 import { countHouseholdsMissingValidContact } from "@/lib/emergencyContacts/service";
+import { canReviewBackgroundChecks, reviewQueueCounts } from "@/lib/membership/review";
 import { pickAddress, validateAddress } from "@/lib/address";
 import { ORG_DOMAIN } from "@/lib/config";
 import { apiError } from "@/lib/api-response";
@@ -62,6 +63,10 @@ export type TodoCounts = {
     // households with >=1 non-org-email (or null-email) participant. Staff households hold
     // only the org-email lead, so they fall out.
     admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; memberFamilies: number };
+    // Background-check reviewer surface (reviewers + board, per-viewer). `canActOn`
+    // = applications this reviewer may attest now (green). `approvedAwaitingSecond`
+    // = ones they approved that still need a second reviewer (gray).
+    review?: { canActOn: number; approvedAwaitingSecond: number };
     // Lead surface: programs the caller runs (program.leadMentorId). Present only
     // when they lead ≥1 program — drives the staff "My Programs" nav item's
     // visibility and its green badge (sum of pending attendance to confirm).
@@ -379,6 +384,13 @@ export const GET = withAuth({}, async (_req, auth) => {
             }),
         ]);
         result.admin = { membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies };
+    }
+
+    // ---- Reviewer surface (per-viewer background-check queue) ----
+    // canReviewBackgroundChecks: explicit reviewers + board (implicit). Returns
+    // zeros for non-reviewers, so gate on the role to avoid the query entirely.
+    if (canReviewBackgroundChecks(user)) {
+        result.review = await reviewQueueCounts(user.id);
     }
 
     return NextResponse.json(result);

--- a/checkin-app/src/app/membership-ops/layout.tsx
+++ b/checkin-app/src/app/membership-ops/layout.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { Badge, Box, Center, Loader, Stack, Text } from "@mantine/core";
+import { Badge, Box, Center, Group, Loader, Stack, Text } from "@mantine/core";
 import { MEMBERSHIP_OPS_NAV_LINKS } from "@/lib/membershipOpsNav";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { useTodoCounts } from "@/hooks/useTodoCounts";
-import { tabBadgeFor } from "@/components/navBadges";
+import { tabBadgeFor, reviewBadges } from "@/components/navBadges";
 import { SectionTabs } from "@/components/ui/SectionTabs";
 import { PageContainer } from "@/components/ui/PageContainer";
 
@@ -16,11 +16,13 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
   // Reviewers are let in so they can reach the Review tab (linked from their notifications);
   // the admin tools below stay scoped to sysadmin/board and each page 403s independently.
   const { loading, ready } = useRequireRole(["isSysadmin", "isBoardMember", "isBackgroundCheckReviewer"]);
-  const todoCounts = useTodoCounts(isAdmin);
 
   // Review tab is for reviewers + board members (implicit reviewers); all other tabs
   // are admin-only. A reviewer-only user therefore sees just the Review tab.
   const canReview = !!(sessionUser?.isBackgroundCheckReviewer || sessionUser?.isBoardMember);
+  // Fetch counts for reviewers too (not just admins), so the Review tab badges
+  // work for a reviewer-only user.
+  const todoCounts = useTodoCounts(isAdmin || canReview);
   const navLinks = MEMBERSHIP_OPS_NAV_LINKS.filter((l) =>
     l.href === "/membership-ops/review" ? canReview : isAdmin,
   );
@@ -43,6 +45,34 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
 
   // Right-aligned count badge for a tab: pending applications, or the member-family total.
   const badgeFor = (href: string): React.ReactNode => {
+    // Review tab shows two viewer-scoped badges: green (can act on now), gray
+    // (approved, awaiting a second reviewer). Colors match the left-nav badges.
+    if (href === "/membership-ops/review") {
+      const badges = reviewBadges(todoCounts);
+      if (badges.length === 0) return undefined;
+      return (
+        <Group gap={4} wrap="nowrap">
+          {badges.map((b) => {
+            const isGray = b.color === "gray";
+            return (
+              <Badge
+                key={b.color}
+                size="md"
+                color={isGray ? "gray" : b.color}
+                variant={isGray ? "light" : "filled"}
+                // Dark text: black on the green fill (matches other green count
+                // circles), gray-7 on the light-gray bubble. Also survives the
+                // active tab's green recolor.
+                c={isGray ? "var(--mantine-color-gray-7)" : "var(--mantine-color-black)"}
+                aria-label={b.label}
+              >
+                {b.count}
+              </Badge>
+            );
+          })}
+        </Group>
+      );
+    }
     const badge = tabBadgeFor(href, todoCounts);
     if (badge) {
       return (

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -1,4 +1,4 @@
-import { navBadgeFor, tabBadgeFor, leadsAnyProgram, leadPendingCount } from '@/components/navBadges';
+import { navBadgeFor, tabBadgeFor, reviewBadges, leadsAnyProgram, leadPendingCount } from '@/components/navBadges';
 import type { TodoCounts } from '@/app/api/nav/todo-counts/route';
 
 const base: TodoCounts = {
@@ -71,6 +71,39 @@ const admin = (over: Partial<NonNullable<TodoCounts['admin']>> = {}): TodoCounts
     memberFamilies: 0,
     ...over,
   },
+});
+
+describe('reviewBadges (Review tab + Membership Ops nav)', () => {
+  it('no badges without a review block, or when both are zero', () => {
+    expect(reviewBadges(base)).toEqual([]);
+    expect(reviewBadges(null)).toEqual([]);
+    expect(reviewBadges({ ...base, review: { canActOn: 0, approvedAwaitingSecond: 0 } })).toEqual([]);
+  });
+
+  it('green for can-act-on, gray for approved-awaiting-second', () => {
+    const counts: TodoCounts = { ...base, review: { canActOn: 3, approvedAwaitingSecond: 2 } };
+    expect(reviewBadges(counts)).toEqual([
+      { count: 3, color: 'treehouseGreen', label: '3 background checks you can review now' },
+      { count: 2, color: 'gray', label: '2 you approved, awaiting a second reviewer' },
+    ]);
+  });
+
+  it('singularizes the green label; hides each half independently at 0', () => {
+    expect(reviewBadges({ ...base, review: { canActOn: 1, approvedAwaitingSecond: 0 } })).toEqual([
+      { count: 1, color: 'treehouseGreen', label: '1 background check you can review now' },
+    ]);
+    expect(reviewBadges({ ...base, review: { canActOn: 0, approvedAwaitingSecond: 4 } })).toEqual([
+      { count: 4, color: 'gray', label: '4 you approved, awaiting a second reviewer' },
+    ]);
+  });
+
+  it('surfaces on the Membership Ops nav item alongside the board BLOCKED count', () => {
+    const counts: TodoCounts = { ...admin({ membership: 2 }), review: { canActOn: 1, approvedAwaitingSecond: 0 } };
+    expect(navBadgeFor('/membership-ops', counts)).toEqual([
+      { count: 2, color: 'treehouseGreen', label: 'Pending membership reviews' },
+      { count: 1, color: 'treehouseGreen', label: '1 background check you can review now' },
+    ]);
+  });
 });
 
 describe('tabBadgeFor', () => {

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -16,6 +16,23 @@ export function leadPendingCount(counts: TodoCounts | null): number {
 }
 
 /**
+ * Background-check Review badges (0, 1, or 2), shared by the left-nav Membership
+ * Ops item and the Review sub-tab so both stay in lockstep: green = applications
+ * this reviewer can act on now; gray = ones they approved awaiting a second
+ * reviewer. Each hides at 0.
+ */
+export function reviewBadges(counts: TodoCounts | null): NavBadge[] {
+  const r = counts?.review;
+  if (!r) return [];
+  const out: NavBadge[] = [];
+  if (r.canActOn > 0)
+    out.push({ count: r.canActOn, color: 'treehouseGreen', label: `${r.canActOn} background check${r.canActOn === 1 ? '' : 's'} you can review now` });
+  if (r.approvedAwaitingSecond > 0)
+    out.push({ count: r.approvedAwaitingSecond, color: 'gray', label: `${r.approvedAwaitingSecond} you approved, awaiting a second reviewer` });
+  return out;
+}
+
+/**
  * Badges for a nav item (0, 1, or 2). Green = action the viewer must take, or
  * the viewer's own household; gray = live informational count (others'
  * occupancy, running programs). Attendance shows two: my household vs everyone
@@ -48,8 +65,13 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
     case '/programs':
       return gray(counts.activePrograms, `${counts.activePrograms} active programs`);
     case '/membership-ops':
-      // Pending membership applications awaiting board review.
-      return green(counts.admin ? counts.admin.membership : 0, 'Pending membership reviews');
+      // Board's BLOCKED queue (green) plus the viewer's own background-check
+      // review counts — the Review tab lives under this nav item, so its badges
+      // surface here too.
+      return [
+        ...green(counts.admin ? counts.admin.membership : 0, 'Pending membership reviews'),
+        ...reviewBadges(counts),
+      ];
     case '/membership-audit': {
       // Green: leadless households the board must fix (assign a lead). Gray: gaps
       // the household must close — missing emergency contacts plus accounts created

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -143,6 +143,24 @@ export async function eligibleReviewProcessIds(reviewerId: number): Promise<numb
 }
 
 /**
+ * Reviewer-scoped badge counts for the Review tab / nav:
+ *   - canActOn: applications this reviewer may attest right now (green).
+ *   - approvedAwaitingSecond: applications this reviewer already approved that
+ *     still await a second reviewer (gray). An awaiting process only ever holds
+ *     APPROVE attestations and needs 2 to clear, so "this reviewer has an
+ *     attestation on it" == "approved by me, not yet done".
+ */
+export async function reviewQueueCounts(reviewerId: number): Promise<{ canActOn: number; approvedAwaitingSecond: number }> {
+    const reviewer = await loadReviewer(reviewerId);
+    if (!reviewer || !canReviewBackgroundChecks(reviewer)) return { canActOn: 0, approvedAwaitingSecond: 0 };
+    const [canActOnIds, approvedAwaitingSecond] = await Promise.all([
+        eligibleReviewProcessIds(reviewerId),
+        prisma.orgMembershipProcess.count({ where: { ...AWAITING_BG_WHERE, attestations: { some: { reviewerId } } } }),
+    ]);
+    return { canActOn: canActOnIds.length, approvedAwaitingSecond };
+}
+
+/**
  * Record a reviewer's attestation. Validates eligibility, then on REJECT blocks
  * the application and on the 2nd APPROVE clears the check — activating the
  * membership if dues are already paid, else leaving it at PENDING_PAYMENT.


### PR DESCRIPTION
## What

Adds two per-viewer count badges for background-check reviewers, shown in **both** the left-nav **Membership Ops** item and the **Review** subtab (`/membership-ops/review`):

- **Green** (black text on green fill): applications this reviewer can act on now.
- **Gray** (dark-gray text on light-gray bubble): applications they've approved that still await a second reviewer.

## Why

The Review tab and nav showed no count of what a reviewer still had to do, so reviewers/board had to open the page to know if anything was waiting.

## How

- New `reviewQueueCounts(reviewerId)` service in `lib/membership/review.ts` — `canActOn` (reuses `eligibleReviewProcessIds`) + `approvedAwaitingSecond` (awaiting processes the reviewer already attested).
- New `review` block on `/api/nav/todo-counts`, gated to `canReviewBackgroundChecks` (reviewers + board), so reviewer-only users get counts too.
- Badge derivation lives in `navBadges.reviewBadges` — nav and tab share it so the two locations can't diverge. Layout owns only the `<Badge>` JSX (colors match existing green/gray conventions).
- `membership-ops/layout.tsx` now fetches counts for reviewers (was admin-only) and renders the two badges on the Review tab.

## Reviewer notes

- Colors follow the existing convention: green = action-required (black text, matches other green count circles), gray = informational.
- Left-nav green still routes through AppFrame's shared badge map (pins `dark-9` for all nav badges) — deliberately not touched to avoid restyling every other nav count.
- Unit tests added in `navBadges.test.ts` (16 pass). Pre-commit `test:ci` finds 0 tests inside git worktrees (ignore-pattern quirk) — tests themselves pass; full suite green minus one pre-existing flaky timeout in `safety/trusted-adults`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)