### PR TITLE
fix(membership-ops): surface Review tab in nav for BG reviewers

### DIFF
--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -54,6 +54,7 @@ type SessionUser = {
   isSysadmin?: boolean;
   isBoardMember?: boolean;
   isKeyholder?: boolean;
+  isBackgroundCheckReviewer?: boolean;
   toolStatuses?: Array<{ level: string }>;
 };
 
@@ -64,6 +65,9 @@ type NavItem = {
   // counts is passed so computed-role items (e.g. the staff "My Programs" home,
   // gated on leading ≥1 program) can decide visibility from the todo-counts payload.
   visible: (user: SessionUser | undefined, signedIn: boolean, counts: TodoCounts | null) => boolean;
+  // Per-role destination override. The hub (/membership-ops) redirects to the admin-only
+  // first tab, so a reviewer-only user must be pointed straight at their one reachable tab.
+  hrefFor?: (user: SessionUser | undefined) => string;
   // Dev-instance-only item (hidden in prod). The target route 404s off a dev instance anyway;
   // this just keeps it out of the prod nav. Gated on useIsDevInstance() at render, not `visible`.
   devOnly?: boolean;
@@ -110,7 +114,13 @@ const NAV_ITEMS: NavItem[] = [
     href: '/membership-ops',
     label: 'Membership Ops',
     icon: <IconUsers size={18} />,
-    visible: (u) => !!u?.isSysadmin || !!u?.isBoardMember,
+    // Reviewers get in for the Background-check Review tab; other tabs 403 independently.
+    visible: (u) => !!u?.isSysadmin || !!u?.isBoardMember || !!u?.isBackgroundCheckReviewer,
+    // Admins land on the hub (→ first tab); a reviewer-only user has just the Review tab.
+    hrefFor: (u) =>
+      !u?.isSysadmin && !u?.isBoardMember && u?.isBackgroundCheckReviewer
+        ? '/membership-ops/review'
+        : '/membership-ops',
   },
   {
     href: '/membership-audit',
@@ -301,16 +311,17 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
           }
         >
           {visibleItems.map((item) => {
-            const active = isActive(pathname, item.href);
+            const href = item.hrefFor?.(user) ?? item.href;
+            const active = isActive(pathname, href);
             // On the colored sidebar all text is white; the 'light' variant gives a soft
             // translucent overlay on the active item rather than a harsh solid fill.
             const sidebarText = onColoredSidebar ? 'var(--mantine-color-white)' : undefined;
-            const badges = navBadgeFor(item.href, todoCounts);
+            const badges = navBadgeFor(href, todoCounts);
             return (
               <NavLink
                 key={item.href}
                 component={Link}
-                href={item.href}
+                href={href}
                 onNavigate={guardNav}
                 label={item.label}
                 leftSection={item.icon}

--- a/checkin-app/src/components/__tests__/AppFrame.test.tsx
+++ b/checkin-app/src/components/__tests__/AppFrame.test.tsx
@@ -80,6 +80,16 @@ describe("AppFrame", () => {
     expect(screen.queryByText("Facility Ops")).not.toBeInTheDocument();
   });
 
+  it("shows Membership Ops to a reviewer-only user, linking straight to the Review tab", () => {
+    setSession({ id: 3, isBackgroundCheckReviewer: true });
+    renderFrame();
+
+    const link = screen.getByText("Membership Ops").closest("a");
+    expect(link).toHaveAttribute("href", "/membership-ops/review");
+    // Reviewer-only: the admin-gated siblings stay hidden.
+    expect(screen.queryByText("Membership Audit")).not.toBeInTheDocument();
+  });
+
   it("highlights the active nav item based on pathname", () => {
     setSession({ id: 1 });
     setPathname("/attendance");


### PR DESCRIPTION
## What

A background-check-reviewer-only user had **no `/membership-ops` nav entry**, so the Background-check Review tab was undiscoverable in-app (only reachable via a notification link).

- `AppFrame.tsx`: `/membership-ops` nav item is now visible to `isBackgroundCheckReviewer`.
- Added a per-role `hrefFor` so reviewer-only users link straight to `/membership-ops/review`; board/sysadmin still land on the hub.
- Added `isBackgroundCheckReviewer` to the local `SessionUser` type.
- Test: reviewer-only sees "Membership Ops" linking to `/review`, admin-only siblings stay hidden.

## Why

Just forcing the nav item visible would have dead-ended reviewers: the hub (`/membership-ops`) blind-redirects to the admin-only first tab (`participants`), which 403s for a reviewer. Routing reviewers directly to their one reachable tab avoids that.

The `bg.reviewer@example.com` seed persona and its login badge already existed — this was purely a nav-gating gap, not a seed problem.

## Reviewer notes

- The existing membership-ops layout already admits reviewers (`useRequireRole` includes `isBackgroundCheckReviewer`) and shows only the Review tab; each admin tab 403s independently. No auth surface widened here.
- Skipped: making the hub redirect itself role-aware (needs server-side session — new pattern + drift-guard risk). Add if a reviewer ever needs the bare hub URL.
- Jest not run locally (worktree has no `node_modules`); test logic verified against fixtures. CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)