### PR TITLE
feat(my-household): view/edit per-member allergies

### DIFF
--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -17,7 +17,7 @@ export const PATCH = withAuth(
             const userId = auth.user.id;
 
             const body = await req.json();
-            const { participantId, name, email, dob, phone, isLead, over25 } = body;
+            const { participantId, name, email, dob, phone, isLead, over25, allergies } = body;
 
             if (!participantId) {
                 return apiError("Participant ID is required", 400);
@@ -55,6 +55,7 @@ export const PATCH = withAuth(
                         phone: phone !== undefined ? (phone === "" ? null : formatPhone(phone)) : undefined,
                         // A real DoB supersedes the 25+ flag; otherwise honor the checkbox.
                         isDeclaredAdult: over25 !== undefined ? (dob ? false : !!over25) : undefined,
+                        allergies: allergies !== undefined ? (allergies === "" ? null : allergies) : undefined,
                     },
                     select: HOUSEHOLD_PEER_SELECT,
                 });

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -288,7 +288,7 @@ describe("HouseholdPage", () => {
         "/api/household/member",
         expect.objectContaining({
           method: "PATCH",
-          body: JSON.stringify({ participantId: 12, name: "Casey Smith", email: "", dob: "", phone: "5125559999", isLead: true, over25: true }),
+          body: JSON.stringify({ participantId: 12, name: "Casey Smith", email: "", dob: "", phone: "5125559999", isLead: true, over25: true, allergies: "" }),
         }),
       ),
     );

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -44,7 +44,7 @@ function ageBadge(p: HouseholdMember): { label: string; color: string; variant: 
   return { label: 'Age Unavailable', color: 'red', variant: 'filled' };
 }
 
-type HouseholdMember = { id: number; name?: string; email?: string; dateOfBirth?: string; phone?: string; isDeclaredAdult?: boolean };
+type HouseholdMember = { id: number; name?: string; email?: string; dateOfBirth?: string; phone?: string; isDeclaredAdult?: boolean; allergies?: string | null };
 type EmergencyContact = { id: number; name: string; phone: string; email?: string | null; relationship?: string | null; priority: number; invalid: boolean };
 type HouseholdData = {
   id?: number;
@@ -76,7 +76,7 @@ export default function HouseholdPage() {
   const [householdMemberErrors, setHouseholdMemberErrors] = useState<{ name?: string; email?: string; dob?: string }>({});
 
   const [editingHouseholdMemberId, setEditingHouseholdMemberId] = useState<number | null>(null);
-  const [editForm, setEditForm] = useState({ name: "", email: "", dob: "", phone: "", isLead: false, over25: false });
+  const [editForm, setEditForm] = useState({ name: "", email: "", dob: "", phone: "", isLead: false, over25: false, allergies: "" });
   // Errors for the inline edit form. phone shown only after a Save attempt, so
   // the red ring never appears mid-typing.
   const [editErrors, setEditErrors] = useState<{ name?: string; email?: string; dob?: string; phone?: string }>({});
@@ -271,7 +271,7 @@ export default function HouseholdPage() {
       const res = await fetch('/api/household/member', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantId, name: editForm.name, email: editForm.email, dob: editForm.over25 ? "" : editForm.dob, phone: editForm.phone, isLead: editForm.isLead, over25: editForm.over25 })
+        body: JSON.stringify({ participantId, name: editForm.name, email: editForm.email, dob: editForm.over25 ? "" : editForm.dob, phone: editForm.phone, isLead: editForm.isLead, over25: editForm.over25, allergies: editForm.allergies })
       });
       const data = await res.json();
       if (res.ok) {
@@ -396,6 +396,7 @@ export default function HouseholdPage() {
                               <TextInput size="xs" type="date" label="Date of Birth" value={editForm.dob} error={editErrors.dob} onChange={(e) => { setEditForm({ ...editForm, dob: e.currentTarget.value }); setEditErrors({ ...editErrors, dob: undefined }); }} />
                             )}
                             <TextInput size="xs" type="tel" label="Phone" value={editForm.phone} error={editErrors.phone} onChange={(e) => { setEditForm({ ...editForm, phone: e.currentTarget.value }); setEditErrors({ ...editErrors, phone: undefined }); }} />
+                            <TextInput size="xs" label="Allergies (optional)" value={editForm.allergies} onChange={(e) => setEditForm({ ...editForm, allergies: e.currentTarget.value })} />
                             {p.id !== userId && (editForm.over25 || (editForm.dob && calculateAge(editForm.dob) >= 18)) && (
                               <Checkbox label="Household Lead" checked={editForm.isLead} onChange={(e) => setEditForm({ ...editForm, isLead: e.currentTarget.checked })} />
                             )}
@@ -413,6 +414,7 @@ export default function HouseholdPage() {
                           </Group>
                           {p.email && <Text size="sm" c="dimmed" style={{ wordBreak: 'break-word' }}>{p.email}</Text>}
                           {p.phone && <Text size="sm" c="dimmed" style={{ wordBreak: 'break-word' }}>{formatPhone(p.phone)}</Text>}
+                          {p.allergies && <Text size="sm" c="dimmed" style={{ wordBreak: 'break-word' }}>Allergies: {p.allergies}</Text>}
                           {leadMissingPhone && <Badge color="red" variant="filled" mt="xs">TODO: Add phone number</Badge>}
                           <Group gap="xs" mt="sm">
                             {householdMemberIsLead && <Badge color="grape" variant="light">Household Lead</Badge>}
@@ -423,7 +425,7 @@ export default function HouseholdPage() {
                               <Button size="compact-xs" variant="subtle" color="gray" onClick={() => {
                                 setEditingHouseholdMemberId(p.id);
                                 setEditErrors({});
-                                setEditForm({ name: p.name || "", email: p.email || "", dob: p.dateOfBirth ? new Date(p.dateOfBirth).toISOString().split('T')[0] : "", phone: p.phone || "", isLead: householdMemberIsLead, over25: !p.dateOfBirth && !!p.isDeclaredAdult });
+                                setEditForm({ name: p.name || "", email: p.email || "", dob: p.dateOfBirth ? new Date(p.dateOfBirth).toISOString().split('T')[0] : "", phone: p.phone || "", isLead: householdMemberIsLead, over25: !p.dateOfBirth && !!p.isDeclaredAdult, allergies: p.allergies || "" });
                               }}>Edit</Button>
                             )}
                           </Group>

--- a/checkin-app/src/lib/household/participantProjection.ts
+++ b/checkin-app/src/lib/household/participantProjection.ts
@@ -18,4 +18,7 @@ export const HOUSEHOLD_PEER_SELECT = {
     // peer legitimately needs it to render each member's age badge / pre-fill the edit
     // form (my-household). It's an age-status flag, not a role/audit/security flag.
     isDeclaredAdult: true,
+    // Collected per-person at membership intake; household peers view/edit it on
+    // the my-household cards. Same @sensitivity:personal tier as name/email/phone.
+    allergies: true,
 } satisfies Prisma.PersonSelect;


### PR DESCRIPTION
## What

Surfaces the per-person "Allergies (optional)" field — collected at membership intake — on **/my-household**, where it was previously neither shown nor editable.

- **Display**: each member card now shows `Allergies: …` when set.
- **Edit**: the inline member edit form gains an "Allergies (optional)" input.
- **Persist**: `/api/household/member` PATCH accepts and writes `allergies` (`""` → `null`).
- **Projection**: `allergies` added to `HOUSEHOLD_PEER_SELECT` so the field reaches the client.

## Why

Membership intake asks for allergies on every student/parent, but households had no way to view or update it afterward. This closes that gap.

## Reviewer notes

- `allergies` is `@sensitivity:personal` — same tier as `name`/`email`/`phone`, all already in `HOUSEHOLD_PEER_SELECT`. Exposing it to household peers is consistent with existing PII handling; no PII-minimization test forbids it.
- **Out of scope**: the **+ Add Household Member** form (separate `/api/household` add path) does not yet capture allergies — edit-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)