### PR TITLE
fix(attendance): refresh nav badges after manual time entry

### DIFF
--- a/checkin-app/src/app/attendance/manual/page.tsx
+++ b/checkin-app/src/app/attendance/manual/page.tsx
@@ -5,6 +5,7 @@ import { Alert, Button, Card, Stack, Text, TextInput, Title } from "@mantine/cor
 import { notifications } from "@mantine/notifications";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { useRequireRole } from "@/hooks/useRequireRole";
+import { notifyNavRefresh } from "@/lib/nav-refresh";
 import { AttendanceTabs } from "../AttendanceTabs";
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -34,6 +35,8 @@ export default function ManualAttendance() {
         notifications.show({ color: "green", message: "Visit recorded successfully." });
         setArrived("");
         setDeparted("");
+        // Building occupancy badges (attendance nav) count this new visit — refresh them.
+        notifyNavRefresh();
       }
     } catch {
       setError("Network error occurred.");


### PR DESCRIPTION
## What

Manual time entry (`/attendance/manual`) now refreshes the nav building-occupancy badges after a successful write.

## Why

The page POSTs to `/api/attendance/manual` via AJAX and stays put. The Attendance nav badges (`building` / `buildingHousehold`) only refetch on mount or on the `NAV_COUNTS_EVENT`. Recording a visit while checked into the building never fired that event, so the left-nav counts stayed stale until a remount.

## Fix

Call `notifyNavRefresh()` on success — the same pattern the other 10 mutation sites already use (my-household, membership review, trusted-adults, etc.).

One import + one call, no behavior change beyond the badge refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)