### PR TITLE
fix(attendance-manual): reject future arrivals, clamp 5-min skew

### DIFF
--- a/checkin-app/src/app/api/attendance/manual/route.ts
+++ b/checkin-app/src/app/api/attendance/manual/route.ts
@@ -32,6 +32,17 @@ export const POST = withAuth({}, async (req, auth) => {
         if (isNaN(arrivalTime.getTime())) {
             return apiError("Invalid arrival time", 400);
         }
+
+        // No future arrivals. Allow a 5-min skew (clock drift, the minute it takes
+        // to fill the form) and clamp anything inside that window back to now, so a
+        // slightly-future time records as-of-now instead of being rejected.
+        const now = new Date();
+        if (arrivalTime.getTime() > now.getTime() + 5 * 60 * 1000) {
+            return apiError("Arrival time cannot be in the future.", 400);
+        }
+        if (arrivalTime.getTime() > now.getTime()) {
+            arrivalTime.setTime(now.getTime());
+        }
         if (departureTime && isNaN(departureTime.getTime())) {
             return apiError("Invalid departure time", 400);
         }
@@ -46,7 +57,6 @@ export const POST = withAuth({}, async (req, auth) => {
         // arrival with no departure would create a permanent open visit nobody
         // scanned out of, so require a departure for it.
         if (!departureTime) {
-            const now = new Date();
             const withinSixHours = now.getTime() - arrivalTime.getTime() <= 6 * 60 * 60 * 1000;
             const sameDay = arrivalTime.toDateString() === now.toDateString();
             if (!withinSixHours && !sameDay) {

--- a/checkin-app/src/app/attendance/manual/page.tsx
+++ b/checkin-app/src/app/attendance/manual/page.tsx
@@ -46,6 +46,8 @@ export default function ManualAttendance() {
   if (!ready) return null;
 
   const departureError = error === "Departure time is required for past arrivals.";
+  const arrivalError = error === "Arrival time cannot be in the future.";
+  const fieldError = departureError || arrivalError;
 
   return (
     <PageContainer>
@@ -58,7 +60,7 @@ export default function ManualAttendance() {
           currently in the building, leave the departure time blank.
         </Text>
 
-        {error && !departureError && <Alert color="red" mb="md">{error}</Alert>}
+        {error && !fieldError && <Alert color="red" mb="md">{error}</Alert>}
 
         <form onSubmit={handleSubmit}>
           <Stack>
@@ -67,6 +69,7 @@ export default function ManualAttendance() {
               label="Arrival Time (Required)"
               value={arrivedAt}
               onChange={(e) => setArrived(e.currentTarget.value)}
+              error={arrivalError ? error : undefined}
               required
             />
             <TextInput


### PR DESCRIPTION
## What

Manual visit entry (`/attendance/manual`) accepted arrival times in the future. Now:

- **API** (`/api/attendance/manual`): reject arrivals more than 5 minutes ahead of now (400). Arrivals inside that skew window `(now, now+5min]` are clamped back to now, so a slightly-future time records as-of-now instead of erroring.
- **Client**: the specific "Arrival time cannot be in the future." error highlights the arrival field in red with the message below it (same pattern as the existing departure-required error), instead of a generic top-of-form alert.

## Why

A future arrival is a self-fixable user mistake, not a generic failure. The 5-min window absorbs clock drift and the minute it takes to fill the form. The field-level error tells the user exactly what to fix and where.

## Reviewer notes

- The intentional arbitrary-backdate behavior (documented in the route header) is unchanged — this only bounds the *upper* end.
- Clamp reuses the single `now` in the handler; the open-visit block's duplicate `const now` was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)