### PR TITLE
fix(trusted-adults): native modal for info/force-approve prompts

### DIFF
--- a/checkin-app/src/app/safety/trusted-adults/__tests__/page.test.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/__tests__/page.test.tsx
@@ -4,7 +4,7 @@ jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { notifications } from "@mantine/notifications";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl, router } from "@/test-helpers/rtl";
 import AdminTrustedAdultsPage from "../page";
@@ -79,7 +79,7 @@ describe("safety/trusted-adults page", () => {
     expect(router.push).toHaveBeenCalledWith("/");
   });
 
-  it("denies a review, and requests info via a prompt (skipping when the prompt is cancelled)", async () => {
+  it("denies a review, and requests info via a modal (skipping when the modal is cancelled)", async () => {
     setSession({ id: 1, isBoardMember: true, householdId: 1 });
     const fetchMock = mockFetchJson({
       "/api/safety/trusted-adults/decision": { status: "DENIED" },
@@ -97,17 +97,20 @@ describe("safety/trusted-adults page", () => {
     );
     await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Recorded: DENIED." })));
 
-    window.prompt = jest.fn(() => null);
+    // Cancelling the modal must NOT fire a decision (the old window.prompt returned null,
+    // which `?? ""` swallowed into an empty-note REQUEST_INFO).
     fireEvent.click(screen.getByRole("button", { name: "Request info" }));
-    await waitFor(() =>
-      expect(fetchMock).toHaveBeenCalledWith(
-        "/api/safety/trusted-adults/decision",
-        expect.objectContaining({ body: JSON.stringify({ reviewId: 9, decision: "REQUEST_INFO", note: "" }) }),
-      ),
+    fireEvent.click(within(await screen.findByRole("dialog")).getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/safety/trusted-adults/decision",
+      expect.objectContaining({ body: expect.stringContaining("REQUEST_INFO") }),
     );
 
-    window.prompt = jest.fn(() => "Need proof of ID.");
     fireEvent.click(screen.getByRole("button", { name: "Request info" }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.change(within(dialog).getByRole("textbox"), { target: { value: "Need proof of ID." } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Submit" }));
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
         "/api/safety/trusted-adults/decision",
@@ -237,13 +240,14 @@ describe("safety/trusted-adults page", () => {
     expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
     expect(screen.getByText("Override:")).toBeInTheDocument();
 
-    window.prompt = jest.fn(() => "");
+    // Empty note: Submit stays disabled, so force-approve can't fire.
     fireEvent.click(screen.getByRole("button", { name: "Force approve" }));
-    await waitFor(() => expect(window.prompt).toHaveBeenCalled());
+    const forceDialog = await screen.findByRole("dialog");
+    expect(within(forceDialog).getByRole("button", { name: "Submit" })).toBeDisabled();
     expect(fetchMock).not.toHaveBeenCalledWith("/api/safety/trusted-adults/override", expect.anything());
 
-    window.prompt = jest.fn(() => "Confirmed with family.");
-    fireEvent.click(screen.getByRole("button", { name: "Force approve" }));
+    fireEvent.change(within(forceDialog).getByRole("textbox"), { target: { value: "Confirmed with family." } });
+    fireEvent.click(within(forceDialog).getByRole("button", { name: "Submit" }));
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
         "/api/safety/trusted-adults/override",

--- a/checkin-app/src/app/safety/trusted-adults/page.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/page.tsx
@@ -8,6 +8,7 @@ import {
     Center,
     Group,
     Loader,
+    Modal,
     Radio,
     Stack,
     Text,
@@ -105,6 +106,14 @@ export default function AdminTrustedAdultsPage() {
     const [notices, setNotices] = useState<Record<number, { text: string; tone: AlertTone }>>({});
     const clearNotice = (id: number) =>
         setNotices((n) => { const c = { ...n }; delete c[id]; return c; });
+    // Native in-app prompt (replaces window.prompt): cancel closes without acting,
+    // so no decision fires unless the board submits a note.
+    const [prompt, setPrompt] = useState<{ title: string; onSubmit: (note: string) => void } | null>(null);
+    const [promptVal, setPromptVal] = useState("");
+    const openPrompt = (cfg: { title: string; onSubmit: (note: string) => void }) => {
+        setPromptVal("");
+        setPrompt(cfg);
+    };
 
     const load = useCallback(async () => {
         setLoading(true);
@@ -179,6 +188,24 @@ export default function AdminTrustedAdultsPage() {
 
     return (
         <Stack p="md">
+            <Modal opened={!!prompt} onClose={() => setPrompt(null)} title={prompt?.title} centered>
+                <Textarea
+                    data-autofocus
+                    autosize
+                    minRows={3}
+                    value={promptVal}
+                    onChange={(e) => setPromptVal(e.currentTarget.value)}
+                />
+                <Group justify="flex-end" mt="md">
+                    <Button variant="default" onClick={() => setPrompt(null)}>Cancel</Button>
+                    <Button
+                        disabled={!promptVal.trim()}
+                        onClick={() => { prompt?.onSubmit(promptVal); setPrompt(null); }}
+                    >
+                        Submit
+                    </Button>
+                </Group>
+            </Modal>
             <div>
                 <Title order={2}>Trusted Adults — Board Review</Title>
                 <Text c="dimmed" size="sm">
@@ -311,10 +338,10 @@ export default function AdminTrustedAdultsPage() {
                                             variant="light"
                                             loading={busyId === latest.id}
                                             disabled={isSelf}
-                                            onClick={() => {
-                                                const note = window.prompt("What information do you need from the family?") ?? "";
-                                                decide(latest.id, "REQUEST_INFO", { note });
-                                            }}
+                                            onClick={() => openPrompt({
+                                                title: "What information do you need from the family?",
+                                                onSubmit: (note) => decide(latest.id, "REQUEST_INFO", { note }),
+                                            })}
                                         >
                                             Request info
                                         </Button>
@@ -331,10 +358,10 @@ export default function AdminTrustedAdultsPage() {
                                     variant="subtle"
                                     color="green"
                                     loading={busyId === latest.id}
-                                    onClick={() => {
-                                        const note = window.prompt("Shared note (required to force-approve):") ?? "";
-                                        if (note.trim()) override(latest.id, "approve", { sharedNote: note });
-                                    }}
+                                    onClick={() => openPrompt({
+                                        title: "Shared note (required to force-approve)",
+                                        onSubmit: (note) => override(latest.id, "approve", { sharedNote: note }),
+                                    })}
                                 >
                                     Force approve
                                 </Button>


### PR DESCRIPTION
## Summary
Replace `window.prompt` with an in-app Mantine modal for the Trusted Adults info/force-approve flow.

Browser `prompt` returned `null` on cancel, which `?? ""` swallowed into an empty note — so cancelling **Request info** still fired the decision. Cancel now closes without acting; Submit is gated on a non-empty note.

## Test plan
- Open a Trusted Adults review, click **Request info**, cancel → no decision fires
- Submit with empty note → blocked
- Submit with note → decision recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)