### PR TITLE
fix(debug-loader): repair certifications load + add dependency-ordered wrapper

### DIFF
--- a/checkin-app/scripts/debug_loader/load_all.sh
+++ b/checkin-app/scripts/debug_loader/load_all.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Load every data/*.json fixture through load_debug_data.py in dependency order.
+# Stops on the first failure (set -e) so a broken tool load doesn't cascade into
+# certs that reference missing tools.
+#
+# Order matters:
+#   tools          first  — certifications reference tools by name
+#   programs       before enrollments — enrollments reference programs by name
+#   past_programs  before enrollments — the enrolled program names live here
+#   certifications after tools
+#   enrollments    after both program files
+#   visits         last (persona-only, no fixture deps)
+#
+# Extra args pass through to the loader, applied to EVERY file, e.g.:
+#   ./load_all.sh
+#   ./load_all.sh --base-url http://localhost:3010
+#
+# Personas are seeded (npx tsx prisma/seed.ts); the loader logs in as a sysadmin
+# by default, which can create programs/tools/certs and comp-enroll.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+FILES=(
+  data/tools.json
+  data/programs.json
+  data/past_programs.json
+  data/certifications.json
+  data/enrollments.json
+  data/attendance_visits.json
+  data/visits_history.json
+)
+
+# Drift guard: warn about any data/*.json we don't list, so a newly-added fixture
+# isn't silently skipped by a wrapper whose whole job is "load them all".
+for f in data/*.json; do
+  case " ${FILES[*]} " in
+    *" $f "*) ;;
+    *) echo "WARN: $f is not in the load order — add it to FILES in $0" >&2 ;;
+  esac
+done
+
+for f in "${FILES[@]}"; do
+  echo "==> $f"
+  python3 load_debug_data.py "$f" "$@"
+done
+
+echo "All fixtures loaded."

--- a/checkin-app/scripts/debug_loader/load_debug_data.py
+++ b/checkin-app/scripts/debug_loader/load_debug_data.py
@@ -217,7 +217,8 @@ def load_certifications(api, doc, actor):
     cache = {"tools": None}
     for c in doc["certifications"]:
         body = {
-            "participantId": _resolve_participant_id(api, c),
+            # API renamed the field participant->person; enrollments still take participantId.
+            "personId": _resolve_participant_id(api, c),
             "toolId": _resolve_tool_id(api, c, cache),
             "level": c["level"],
         }


### PR DESCRIPTION
## What

Two fixes to `checkin-app/scripts/debug_loader`, the local dev-data loader that POSTs JSON fixtures to the running app's public API.

1. **Fix the certifications loader.** `POST /api/shop/certifications` was migrated to require `personId` (Participant→Person rename), but the loader still sent `participantId` — producing a `400 Missing required fields` and a hard exit. Changed the request body key. Enrollments API still takes `participantId`, so only the cert body changed.

2. **Add `load_all.sh`** — a wrapper that runs every `data/*.json` fixture through `load_debug_data.py` in dependency order:
   - tools → certifications (cert rows reference tools by name)
   - both program files → enrollments (enrollments reference programs by name)
   - visits last (persona-only, no fixture deps)

   `set -e` halts on first failure so a broken load doesn't cascade. Extra args (`--base-url`, `--persona-email`) pass through to every call. A drift guard warns if a new `data/*.json` isn't in the load order.

## Why

Validated all seven fixtures against the current API route handlers field-by-field. Every path matched except certifications, which broke on the person rename. The wrapper removes the need to remember the manual load order.

## Reviewer notes

- Validation was static (read every handler, matched request/response shapes) — not run end-to-end against a live seeded DB.
- The API is intentionally left inconsistent: certs want `personId`, enrollments want `participantId`. The loader now matches each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)