### PR TITLE
fix(deploy-prod): target the real treehouse-prod cluster

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -39,8 +39,12 @@ env:
   AWS_REGION: us-east-2
   ECR_REGISTRY: 639595353568.dkr.ecr.us-east-2.amazonaws.com
   ECR_REPOSITORY: checkin-prod
-  ECS_CLUSTER: checkin-prod
+  # Prod runs on the shared Managed-Instances cluster, not a dedicated
+  # checkin-prod cluster (infra #104 destroyed that one). Names below come from
+  # the infra repo — see the "prod infra" note in the PR description.
+  ECS_CLUSTER: treehouse-prod
   ECS_SERVICE: checkin-prod
+  ECS_CAPACITY_PROVIDER: treehouse-prod-c6g
   APP_TASK_FAMILY: checkin-prod
   MIGRATE_TASK_FAMILY: checkin-migrate-prod
   DEPLOY_ROLE: arn:aws:iam::639595353568:role/checkin-deploy-prod
@@ -131,12 +135,6 @@ jobs:
             --query 'taskDefinition.taskDefinitionArn' --output text)
           echo "Registered migrate task def: $MIGRATE_ARN"
 
-          # Reuse the service's own network config (subnets / SG / public IP) so
-          # the one-off task lands exactly where the service runs.
-          NETWORK_CONFIG=$(aws ecs describe-services \
-            --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
-            --query 'services[0].networkConfiguration' --output json)
-
           # The shared Aurora cluster is Serverless v2 with min capacity 0 and
           # auto-pause: if it's idle at deploy time, the first connection races
           # the ~30s resume and Prisma fails fast with P1001. Override the
@@ -151,11 +149,17 @@ jobs:
           }
           EOF
 
+          # treehouse-prod is ECS Managed Instances: the app + migrate task defs
+          # are host-networked/EC2-compatible here (modules/checkin/compute.tf),
+          # and the service itself has no networkConfiguration (its dynamic
+          # block is empty on Managed Instances) — unlike dev's Fargate/awsvpc
+          # path, there is no network config to copy and no FARGATE launch type
+          # to use. Launch via the cluster's capacity provider instead, with no
+          # --network-configuration at all.
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \
             --task-definition "$MIGRATE_ARN" \
-            --launch-type FARGATE \
-            --network-configuration "$NETWORK_CONFIG" \
+            --capacity-provider-strategy capacityProvider=$ECS_CAPACITY_PROVIDER,weight=1 \
             --overrides "file://$RUNNER_TEMP/migrate-overrides.json" \
             --query 'tasks[0].taskArn' --output text)
           echo "Migration task: $TASK_ARN"
@@ -166,8 +170,22 @@ jobs:
             --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN" \
             --query 'tasks[0].containers[0].exitCode' --output text)
           echo "Migration exit code: $EXIT_CODE"
+
+          # Surface the container's own output either way — without this, a failure
+          # only shows the exit code here and the real Prisma error (P3009 etc.)
+          # hides in CloudWatch, which is how the 2026-07-02 P3009 wedge went
+          # undiagnosed for a day (mirrors deploy-dev.yml).
+          TASK_ID="${TASK_ARN##*/}"
+          echo "--- migrate container logs (/ecs/checkin-migrate-prod) ---"
+          aws logs get-log-events \
+            --log-group-name /ecs/checkin-migrate-prod \
+            --log-stream-name "ecs/checkin-migrate/$TASK_ID" \
+            --start-from-head --limit 200 \
+            --query 'events[].message' --output text | tr '\t' '\n' || echo "(could not fetch logs)"
+          echo "--- end migrate container logs ---"
+
           if [ "$EXIT_CODE" != "0" ]; then
-            echo "::error::Database migration failed (exit $EXIT_CODE)"
+            echo "::error::Database migration failed (exit $EXIT_CODE) — see migrate container logs above"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Prep for the first real prod deployment: `deploy-prod.yml` still targets the
standalone `checkin-prod` ECS cluster, which infra destroyed when it
consolidated prod onto the shared `treehouse-prod` cluster (infra repo #104,
confirmed INACTIVE in AWS). Left as-is, the first prod deploy fails at the
migrate step with `ClusterNotFoundException`.

**This PR is prep only — do not merge until:**
1. The paired infra PR (branch `infra/checkin-prod-launch-prep`) lands, and
2. An authed verification pass (real AWS credentials) confirms the live
   cluster/service/task-family names below against the actual account —
   this PR was written and statically verified with **no AWS calls**
   (intentionally; no credentials available in this session).

## Derived names (quoted from the local infra repo, ground truth)

- **Cluster**: `treehouse-prod` — `modules/prod-cluster/main.tf`:
  ```hcl
  resource "aws_ecs_cluster" "this" {
    name = "treehouse-prod"
  ```
- **Capacity provider**: `treehouse-prod-c6g` — same file:
  ```hcl
  resource "aws_ecs_capacity_provider" "c6g" {
    name    = "treehouse-prod-c6g"
  ```
  (output as `module.prod_cluster.c6g_provider`, `modules/prod-cluster/outputs.tf`)
- **Service / app task family**: `checkin-prod` — `modules/checkin/overview.tf`:
  ```hcl
  name  = "checkin-${var.environment}" # cluster / service / family / repo / role base
  ```
  and `modules/checkin/compute.tf`: `aws_ecs_service.checkin` `name = local.checkin.name`,
  `aws_ecs_task_definition.checkin_app` `family = local.checkin.name`.
- **Migrate task family**: `checkin-migrate-prod` — `modules/checkin/compute.tf`:
  ```hcl
  resource "aws_ecs_task_definition" "checkin_migrate" {
    family = "checkin-migrate-${var.environment}"
  ```
- **Prod actually runs on the shared cluster**: `live/mgmt/main.tf`, the
  `checkin_prod` module call:
  ```hcl
  cluster_arn       = module.prod_cluster.cluster_arn
  capacity_provider = module.prod_cluster.c6g_provider
  ```
  No ambiguity found — every name above is a literal in the HCL, not
  interpolated from something environment-specific I couldn't resolve.

## networkConfiguration / launch-type finding (bigger than expected — flagging prominently)

The task description assumed `--launch-type FARGATE` on the migrate one-off
task would keep working on an EC2-capacity cluster and that only the
network-configuration *source* might need to change. That assumption doesn't
hold — the infra code shows prod is **host-networked**, not awsvpc, and the
task definition itself is EC2-only there, so both the launch type and the
network-config source were broken:

- `modules/checkin/compute.tf`, the service's `network_configuration` block:
  ```hcl
  # awsvpc (Fargate) only — host networking uses the instance's ENI/default SG, so
  # there is no task network_configuration (see the network module's
  # checkin_prod_alb_from_alb_host rule + database_from_default).
  dynamic "network_configuration" {
    for_each = local.on_mi ? [] : [1]
  ```
  `on_mi = var.capacity_provider != ""`, and prod sets `capacity_provider`
  (above) → `on_mi = true` → **the prod service has no `networkConfiguration`
  at all.** `describe-services --query networkConfiguration` on prod would
  return `null`, so the old "copy from service" approach had nothing to copy.

- The migrate task definition, same file:
  ```hcl
  network_mode             = local.on_mi ? "host" : "awsvpc"
  requires_compatibilities = local.on_mi ? ["EC2"] : ["FARGATE"]
  ```
  with the infra author's own comment directly above it:
  ```hcl
  # Match the app task's launch path so a one-off run-task can run on this env's
  # cluster (host/EC2 on the shared cluster, else awsvpc/Fargate). The prod deploy
  # workflow that invokes it doesn't exist yet — when built it runs via the capacity
  # provider (not --launch-type FARGATE) on Managed Instances.
  ```
  So for prod the migrate task def is registered `network_mode = "host"`,
  `requiresCompatibilities = ["EC2"]` — **`--launch-type FARGATE` would be
  rejected outright** (a host-networked, EC2-only task definition isn't
  Fargate-compatible), independent of the network-config question.

**Fix applied** (not the "explicit SUBNETS/SECURITY_GROUP vars" fallback
suggested as a fallback, since there's no networking to configure — host
mode has none, matching the service):
- Drop `--network-configuration` from the migrate `run-task` call entirely.
- Replace `--launch-type FARGATE` with
  `--capacity-provider-strategy capacityProvider=treehouse-prod-c6g,weight=1`,
  matching the infra comment's stated intent.

## Other change: mirror deploy-dev.yml's log dump

Per deploy-dev.yml (added this week), the migrate step now dumps
`/ecs/checkin-migrate-prod` CloudWatch logs after the task stops, with the
same `|| echo "(could not fetch logs)"` degradation — so a failed prod
migration doesn't hide its Prisma error in CloudWatch alone.

⚠ Per repo memory, deploy-dev's log dump needs `logs:GetLogEvents` granted
to `checkin-deploy-dev` to actually work, and that grant is still open. The
same gap applies here: `checkin-deploy-prod`'s policy
(`modules/checkin/iam.tf`, `aws_iam_role_policy.checkin_deploy`) does not
currently include `logs:GetLogEvents` — confirm/add it in the infra PR, or
this block will just print "(could not fetch logs)" every time.

## Final env block

```yaml
env:
  AWS_REGION: us-east-2
  ECR_REGISTRY: 639595353568.dkr.ecr.us-east-2.amazonaws.com
  ECR_REPOSITORY: checkin-prod
  ECS_CLUSTER: treehouse-prod
  ECS_SERVICE: checkin-prod
  ECS_CAPACITY_PROVIDER: treehouse-prod-c6g
  APP_TASK_FAMILY: checkin-prod
  MIGRATE_TASK_FAMILY: checkin-migrate-prod
  DEPLOY_ROLE: arn:aws:iam::639595353568:role/checkin-deploy-prod
  APP_URL: https://ops.innovationtreehouse.org
```

`ECS_SERVICE` / `APP_TASK_FAMILY` / `MIGRATE_TASK_FAMILY` were already
correct — only `ECS_CLUSTER` (was the destroyed `checkin-prod`) and the new
`ECS_CAPACITY_PROVIDER` changed.

The "Deploy to ECS" step (`update-service` + `wait services-stable`) needed
no changes — it doesn't touch launch type or network config, only the task
definition ARN on an already-existing service.

## Validation (no AWS calls made — none available/intended this session)

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-prod.yml'))"` → parses clean.
- `actionlint` not available in this environment; did a careful manual diff review instead (see diff above).
- `git status --porcelain` checked before commit — only the one workflow file changed, no symlinks.
- Cross-checked every changed name against the local infra repo HCL (quoted above), not guessed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz7egoZoDp37iL9FpC8tH
