### PR TITLE
fix(toasts): persistent toast for catch-block network errors (N21–N24)

### DIFF
--- a/checkin-app/src/app/communication/page.tsx
+++ b/checkin-app/src/app/communication/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Card, Checkbox, Stack, Text, Title, Tooltip } from '@mantine/core';
 import { PageContainer } from '@/components/ui/PageContainer';
+import { notifications } from '@mantine/notifications';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 const OPTIONS = [
@@ -48,7 +49,7 @@ export default function CommunicationPage() {
         setMessage("Failed to load settings.");
       }
     } catch {
-      setMessage("Network error loading settings.");
+      notifications.show({ color: "red", message: "Network error loading settings.", autoClose: false });
     } finally {
       setLoading(false);
     }

--- a/checkin-app/src/app/membership-audit/broken/page.tsx
+++ b/checkin-app/src/app/membership-audit/broken/page.tsx
@@ -52,7 +52,7 @@ export default function BrokenHouseholdsPage() {
         setNotice((n) => ({ ...n, [householdId]: { ok: false, text: data.error || "Failed to assign lead." } }));
       }
     } catch {
-      setNotice((n) => ({ ...n, [householdId]: { ok: false, text: "Network error." } }));
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
     } finally {
       setPromoting(null);
     }

--- a/checkin-app/src/app/membership-audit/emergency-contacts/page.tsx
+++ b/checkin-app/src/app/membership-audit/emergency-contacts/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Badge, Button, Card, Center, Group, Paper, Stack, Text, Title } from "@mantine/core";
 import { AdminEditHouseholdModal } from "@/components/admin/AdminEditHouseholdModal";
 import { formatPhone } from "@/lib/phone";
+import { notifications } from "@mantine/notifications";
 
 import { PageLoader } from "@/components/ui/PageLoader";
 type Lead = { id: number; name: string | null; phone: string | null; email: string | null };
@@ -30,7 +31,7 @@ export default function MissingEmergencyContactsPage() {
       }
     } catch (e) {
       console.error(e);
-      setError("Network error loading households.");
+      notifications.show({ color: "red", message: "Network error loading households.", autoClose: false });
     } finally {
       setLoading(false);
     }

--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -39,7 +39,7 @@ export default function ProfilePage() {
         setMessage({ text: "Failed to load profile.", tone: "error" });
       }
     } catch {
-      setMessage({ text: "Network error loading profile.", tone: "error" });
+      notifications.show({ color: "red", message: "Network error loading profile.", autoClose: false });
     } finally {
       setLoading(false);
     }
@@ -75,7 +75,7 @@ export default function ProfilePage() {
         setMessage({ text: "Failed to update profile.", tone: "error" });
       }
     } catch {
-      setMessage({ text: "Network error saving profile.", tone: "error" });
+      notifications.show({ color: "red", message: "Network error saving profile.", autoClose: false });
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## What

Route catch-block network-error writes to persistent Mantine toasts on 4 pages. Each former inline/transient network-error message becomes `notifications.show({ color: "red", message: "<existing wording>", autoClose: false })` — stays until dismissed.

| Taxonomy | File | Catch |
|---|---|---|
| N21 | `profile/page.tsx` | load + save network errors |
| N22 | `membership-audit/broken/page.tsx` | lead-assign network error |
| N23 | `membership-audit/emergency-contacts/page.tsx` | household-load network error |
| N24 | `communication/page.tsx` | settings-load network error |

## Why

A dropped request previously wrote a transient/inline message that could be missed. Persistent toast (`autoClose: false`) makes network failures visible until the user acts.

## Reviewer notes

- Exact message wording preserved verbatim.
- Only `catch`-block network writes changed. Every `else`/server-load message left inline (hardcoded or already JSON-guarded); no `else` touched.
- `console.error(e)` retained in emergency-contacts.
- `finally` blocks and per-household `setNotice` server-error write untouched.
- `notifications` import added to emergency-contacts + communication; other two already imported it.
- `programs/[id]/register/page.tsx` intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)