### PR TITLE
feat(household-edit): validate member-since (client + Nov 1 2023 floor)

### DIFF
--- a/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
@@ -50,6 +50,10 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
             if (isNaN(parsed.getTime())) {
                 return apiError("Invalid member-since date", 400);
             }
+            // Org didn't exist before this date, so no membership can predate it.
+            if (parsed.getTime() < Date.UTC(2023, 10, 1)) {
+                return apiError("Member-since cannot be before Nov 1, 2023", 400);
+            }
             const membership = await prisma.orgMembership.findUnique({ where: { householdId: id } });
             if (!membership) {
                 return apiError("Household has no membership record", 400);

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -62,6 +62,7 @@ export function AdminEditHouseholdModal({
   const [members, setMembers] = useState<NonNullable<AdminHousehold["householdMembers"]>>([]);
   const [leadIds, setLeadIds] = useState<number[]>([]);
   const [removingLead, setRemovingLead] = useState<number | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<{ memberSince?: string }>({});
   // Modal-local notice for save-error / lead-remove results, so feedback lands
   // next to the form instead of a global corner toast behind the modal.
   const [notice, setNotice] = useState<{ color: string; message: string } | null>(null);
@@ -146,6 +147,21 @@ export function AdminEditHouseholdModal({
   const handleSave = async () => {
     if (householdId == null || phoneInvalid) return;
     setNotice(null);
+    setFieldErrors({});
+    // Client-side date checks so a bad member-since highlights the field before
+    // the server round-trip (server still re-checks as defense-in-depth).
+    if (form.memberSince) {
+      const t = new Date(`${form.memberSince}T00:00:00.000Z`).getTime();
+      if (isNaN(t)) {
+        setFieldErrors({ memberSince: "Invalid member-since date" });
+        return;
+      }
+      // Org didn't exist before this date, so no membership can predate it.
+      if (t < Date.UTC(2023, 10, 1)) {
+        setFieldErrors({ memberSince: "Member-since cannot be before Nov 1, 2023" });
+        return;
+      }
+    }
     setSaving(true);
     try {
       const res = await fetch(`/api/membership-ops/households/${householdId}`, {
@@ -235,7 +251,8 @@ export function AdminEditHouseholdModal({
               label="Member since"
               description="Household's membership start date. Editing this is recorded in the audit log."
               value={form.memberSince}
-              onChange={(e) => update({ memberSince: e.currentTarget.value })}
+              onChange={(e) => { update({ memberSince: e.currentTarget.value }); setFieldErrors({}); }}
+              error={fieldErrors.memberSince}
             />
             <Divider label="Household Leads" labelPosition="left" mt="sm" />
             <Stack gap="xs">


### PR DESCRIPTION
## What

Admin household editor now validates the **member-since** date before saving.

**Client** (`AdminEditHouseholdModal.tsx`)
- New `fieldErrors` state; the member-since input renders an inline error via `error={fieldErrors.memberSince}`, cleared on change.
- The save handler blocks and highlights the field when member-since is non-empty and either an invalid date or before **Nov 1, 2023** — no server round-trip needed for the highlight.

**Server** (`api/membership-ops/households/[id]/route.ts`)
- Same `< 2023-11-01` floor added alongside the existing invalid-date check, returning `apiError(..., 400)`. Kept server-side as defense-in-depth.

## Why

Membership can't predate the org's founding (Nov 1, 2023). Client-side feedback avoids a round-trip for an obviously bad value; the server still enforces both checks so the API can't be bypassed.

## Reviewer notes

- `Date.UTC(2023, 10, 1)` — month index 10 = November; matches the input's UTC-midnight parse (`${value}T00:00:00.000Z`).
- Server catch behavior left as-is: generic 500 for unexpected exceptions, 400 for known validation errors (including the typed `EmergencyContactError` message). No raw exception text is returned to the client.
- Not added: native `min="2023-11-01"` on the date input — the explicit guards cover correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)