### PR TITLE
fix(membership): gate Start application button on household lead status

### DIFF
--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -17,6 +17,7 @@ const emptyPrefill = { household: null, primaryParent: null, secondaryParent: nu
 function state(overrides: Record<string, unknown>) {
   return {
     hasHousehold: false,
+    isLead: true,
     membershipStatus: null,
     process: null,
     external: null,
@@ -56,6 +57,15 @@ describe("membership page", () => {
       expect(fetchMock).toHaveBeenCalledWith("/api/membership", expect.objectContaining({ method: "POST" })),
     );
     expect(await screen.findByText("Your household")).toBeInTheDocument();
+  });
+
+  it("hides the Start button and shows a note for a non-lead member", async () => {
+    setSession({ id: 2 });
+    mockFetchJson({ "/api/membership": state({ isLead: false }) });
+    renderWithProviders(<MembershipPage />);
+
+    expect(await screen.findByText("Only a household lead can start the membership application.", { exact: false })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Start application" })).not.toBeInTheDocument();
   });
 
   it("fills the intake form and saves progress", async () => {

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -41,6 +41,7 @@ interface ExternalStatus {
 
 interface IntakeState {
   hasHousehold: boolean;
+  isLead: boolean;
   membershipStatus: OrgMembershipStatus | null;
   process: { id: number; kind: string; status: OrgMembershipProcessStatus } | null;
   external: ExternalStatus | null;
@@ -495,7 +496,11 @@ export default function MembershipPage() {
               family, then walk you through signing a contract, a background check, and payment. You
               can stop and resume anytime.
             </Text>
-            <Button disabled={saving} loading={saving} onClick={startApplication}>Start application</Button>
+            {state?.isLead ? (
+              <Button disabled={saving} loading={saving} onClick={startApplication}>Start application</Button>
+            ) : (
+              <Text c="dimmed">Only a household lead can start the membership application. Ask your household&apos;s lead to begin.</Text>
+            )}
           </Card>
         )
       ) : isRenewal && inStatus === "PENDING_RENEWAL" ? (

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -112,6 +112,7 @@ export async function getIntakeState(userId: number) {
 
     return {
         hasHousehold: !!household,
+        isLead: leadIds.has(userId),
         membershipStatus: membership?.status ?? null,
         process: process ? { id: process.id, kind: process.kind, status: process.status } : null,
         external,


### PR DESCRIPTION
## What

A non-lead household member (e.g. a child) saw the **Start application** button on the membership page. Clicking it hit `assertLead`'s `not_lead` error — "Only a household lead can manage the membership application." The intake state never told the client whether the viewer was a lead, so the button rendered for everyone with no in-flight process and no active membership.

- `getIntakeState` now returns `isLead` — whether the caller's `personId` is in the household's lead set (already computed as `leadIds`).
- The membership page gates the Start button on `state.isLead`. Non-leads see a short explanatory note instead of the button.

## Why

Reachability bug: the button led to a guaranteed error for non-lead members. Gating it client-side keeps the action visible only to those who can actually perform it.

## Notes for reviewer

- `assertLead` also permits sysadmins. A non-lead sysadmin now sees the note rather than the button — accepted tradeoff (they have admin tools elsewhere). The client stays `isLead`-only rather than mirroring the sysadmin allowance.
- Two files, both under `checkin-app/`. No other intake logic touched.
- Type-checked: the local `IntakeState` interface (hand-declared on the client) gained `isLead`; no new tsc errors from the change. Remaining tsc noise is pre-existing worktree state (generated Prisma client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)