### PR TITLE
fix(membership): distinguish e-sign unavailable (503) from transient failure

### DIFF
--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -398,6 +398,10 @@ export default function MembershipPage() {
       const data = await res.json().catch(() => ({}));
       if (res.ok && data.url) {
         window.location.href = data.url;
+      } else if (data.code === "not_configured" || data.code === "agreement_unavailable") {
+        // Zoho e-sign isn't set up yet (503) — retrying won't help.
+        flash("Signing is temporarily unavailable — please check back soon.", true);
+        setSaving(false);
       } else {
         flash(apiError(data, "Couldn't open the signing form. Please try again."), true);
         setSaving(false);


### PR DESCRIPTION
## What

On the membership contract-sign step, `startSigning` showed the same message —
*"Couldn't open the signing form. Please try again."* — for **every** failure,
including the environmental case where the Zoho e-sign integration isn't set up.
"Please try again" is wrong there: retrying won't help.

## Why

The sign API (`api/membership/contract/sign/route.ts`) catches `ExternalError`
and returns `{ error, code }`. Two codes — `not_configured` and
`agreement_unavailable` — map to **HTTP 503** ("integration not ready yet",
issue #289). Those should read as *temporarily unavailable*, not *retry*.

## Change

`startSigning` now branches on `data.code`:

- `not_configured` / `agreement_unavailable` → `flash("Signing is temporarily unavailable — please check back soon.", true)` (no "try again")
- everything else → unchanged `flash(apiError(data, "Couldn't open the signing form. Please try again."), true)`

Single file, client only. Server, other `flash` calls, and other files untouched.

## Reviewer notes

- Branched on `code` (always present on these 503s) rather than status. A
  `res.status === 503` fallback isn't needed unless a future path returns 503
  without a `code`.
- `npx tsc --noEmit` surfaces only pre-existing repo-wide errors (missing
  generated Prisma client, untyped test params) — none from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)