### PR TITLE
feat(membership-ops): surface applications gray count in left nav

### DIFF
--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -64,14 +64,17 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
     }
     case '/programs':
       return gray(counts.activePrograms, `${counts.activePrograms} active programs`);
-    case '/membership-ops':
+    case '/membership-ops': {
       // Board's BLOCKED queue (green) plus the viewer's own background-check
       // review counts — the Review tab lives under this nav item, so its badges
-      // surface here too.
+      // surface here too. Gray mirrors the Applications tab's total in-flight count.
+      const apps = counts.admin ? counts.admin.applicationsTotal : 0;
       return [
         ...green(counts.admin ? counts.admin.membership : 0, 'Pending membership reviews'),
+        ...gray(apps, `${apps} application${plural(apps, '', 's')}`),
         ...reviewBadges(counts),
       ];
+    }
     case '/membership-audit': {
       // Green: leadless households the board must fix (assign a lead). Gray: gaps
       // the household must close — missing emergency contacts plus accounts created


### PR DESCRIPTION
## What

The Applications sub-tab under Membership Ops shows a **gray pill** with the total in-flight applications (`admin.applicationsTotal`, status != ACTIVE). The left-nav **Membership Ops** item only showed the green pending-review badge — so that count wasn't visible without opening the section.

This adds the same gray badge to the `/membership-ops` case in `navBadgeFor`, so the left nav mirrors the tab.

## How

One case in `navBadgeFor` (`checkin-app/src/components/navBadges.ts`):
- reuse `counts.admin.applicationsTotal` and the shared `plural` helper
- count + label match the Applications tab exactly (single source of truth stays in this file)
- renders alongside the existing green pending-review badge and the reviewer gray badge — all through the shared `CountBadge`, colors consistent everywhere

## Reviewer notes

- Two grays can coexist on this nav item for a reviewer (this new `applicationsTotal` + `reviewBadges`' `approvedAwaitingSecond`); both are informational, both gray by design.
- No API/type change — `applicationsTotal` already exists on `admin` (used by `tabBadgeFor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)