### PR TITLE
fix(attendance): replace native alert() with persistent red toasts

### DIFF
--- a/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
+++ b/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
@@ -390,7 +390,11 @@ describe("attendance/current page", () => {
     fireEvent.click(within(modal).getAllByRole("button", { name: "Sign Out" })[0]);
     const confirmModal = await screen.findByRole("dialog", { name: "Force Checkout" });
     fireEvent.click(within(confirmModal).getByRole("button", { name: "Force Checkout" }));
-    await waitFor(() => expect(window.alert).toHaveBeenCalledWith("Failed to force checkout."));
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red", message: "Failed to force checkout.", autoClose: false }),
+      ),
+    );
 
     failMode = "network";
     fireEvent.click(within(modal).getAllByRole("button", { name: "Sign Out" })[0]);
@@ -420,7 +424,11 @@ describe("attendance/current page", () => {
     await screen.findByText("3 People Present");
 
     fireEvent.click(screen.getByRole("button", { name: "Check Me In" }));
-    await waitFor(() => expect(window.alert).toHaveBeenCalledWith("Error: Already checked in"));
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red", message: "Already checked in", autoClose: false }),
+      ),
+    );
 
     failMode = "network";
     fireEvent.click(screen.getByRole("button", { name: "Check Me In" }));
@@ -580,7 +588,11 @@ describe("attendance/current page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Out" }));
     // isSelf → no window.confirm prompt, and the "check out" (not "force checkout") wording.
     expect(window.confirm).not.toHaveBeenCalled();
-    await waitFor(() => expect(window.alert).toHaveBeenCalledWith("Failed to check out."));
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red", message: "Failed to check out.", autoClose: false }),
+      ),
+    );
   });
 
   it("shows a critical two-deep-violation banner over the last-keyholder warning", async () => {

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -219,7 +219,7 @@ function KioskDisplayInner() {
         body: JSON.stringify({ visitId }),
       });
       if (res.ok) refreshAttendance();
-      else alert(isSelf ? "Failed to check out." : "Failed to force checkout.");
+      else notifications.show({ color: "red", message: isSelf ? "Failed to check out." : "Failed to force checkout.", autoClose: false });
     } catch (e) {
       console.error(e);
       notifications.show({ color: "red", message: "Network error.", autoClose: false });
@@ -249,8 +249,8 @@ function KioskDisplayInner() {
         setSearchResults([]);
         refreshAttendance();
       } else {
-        const d = await res.json();
-        alert(`Error: ${d.error}`);
+        const d = await res.json().catch(() => ({}));
+        notifications.show({ color: "red", message: d.error || "Action failed.", autoClose: false });
       }
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
## What

Replaces the two remaining native `alert()` calls in `checkin-app/src/app/attendance/current/page.tsx` with the app's persistent red toast (`notifications.show({ color: "red", ..., autoClose: false })`), matching the network-error toasts already in these same two handlers.

Also adds the deferred JSON parse guard on the force-checkout error branch:

```
const d = await res.json().catch(() => ({}));
notifications.show({ color: "red", message: d.error || "Action failed.", autoClose: false });
```

## Why

- Native `alert()` must go regardless — blocking, unstyled, inconsistent with the rest of the app.
- Persistent toast chosen to match the sibling `catch { ... "Network error." }` toasts in the same handlers.
- Parse guard: a non-JSON 5xx now shows a clean "Action failed." fallback instead of throwing into the catch or rendering "Error: undefined".

## Notes for reviewer

- The two `catch` network-error toasts were left untouched (already persistent).
- These are T4 op-errors; T4 inline-vs-toast placement is otherwise undecided. Persistent toast picked here specifically to match the sibling network toasts, not as a general T4 ruling.
- `npx tsc --noEmit` on the edited file is clean; remaining tsc errors are pre-existing worktree Prisma-client generation noise, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)