### PR TITLE
fix(household-edit): only show Member-since for org-member households

### DIFF
--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -63,6 +63,7 @@ export function AdminEditHouseholdModal({
   const [leadIds, setLeadIds] = useState<number[]>([]);
   const [removingLead, setRemovingLead] = useState<number | null>(null);
   const [fieldErrors, setFieldErrors] = useState<{ memberSince?: string }>({});
+  const [hasMembership, setHasMembership] = useState(false);
   // Modal-local notice for save-error / lead-remove results, so feedback lands
   // next to the form instead of a global corner toast behind the modal.
   const [notice, setNotice] = useState<{ color: string; message: string } | null>(null);
@@ -86,6 +87,7 @@ export function AdminEditHouseholdModal({
         };
         setForm(loaded);
         setInitial(loaded);
+        setHasMembership(!!h.orgMembership);
         setDisplayName(h.name || `Household #${h.id}`);
         setMembers(h.householdMembers ?? []);
         setLeadIds((h.householdLeads ?? []).map((l) => l.personId));
@@ -246,14 +248,18 @@ export function AdminEditHouseholdModal({
                 error={phoneInvalid ? PHONE_ERROR : undefined}
               />
             </SimpleGrid>
-            <TextInput
-              type="date"
-              label="Member since"
-              description="Household's membership start date. Editing this is recorded in the audit log."
-              value={form.memberSince}
-              onChange={(e) => { update({ memberSince: e.currentTarget.value }); setFieldErrors({}); }}
-              error={fieldErrors.memberSince}
-            />
+            {hasMembership ? (
+              <TextInput
+                type="date"
+                label="Member since"
+                description="Household's membership start date. Editing this is recorded in the audit log."
+                value={form.memberSince}
+                onChange={(e) => { update({ memberSince: e.currentTarget.value }); setFieldErrors({}); }}
+                error={fieldErrors.memberSince}
+              />
+            ) : (
+              <Text size="sm" c="dimmed">This household isn&apos;t an org member — no membership date.</Text>
+            )}
             <Divider label="Household Leads" labelPosition="left" mt="sm" />
             <Stack gap="xs">
               {leadIds.length === 0 && (


### PR DESCRIPTION
## What

Gate the **Member since** date input in `AdminEditHouseholdModal` on whether the household actually has an `orgMembership` record. Non-member households now see a dimmed note ("This household isn't an org member — no membership date") instead of an editable date field.

## Why

The input was always rendered. An admin editing a household with **no** membership record could type a date and, on save, hit the server's `Household has no membership record` (400) rejection — a dead-end field with no way to succeed. Presence of `h.orgMembership` = the household is an org member, so only members should see it.

## How

- New `hasMembership` state, set from `!!h.orgMembership` inside `loadHousehold`.
- The `<TextInput type="date" label="Member since" …>` is wrapped in `{hasMembership ? (…) : (<Text c="dimmed">…</Text>)}`.

## Reviewer notes

- **Based on `claude/interesting-yonath-eb831c`** (this PR targets it, not `main`) — that branch adds the client-side member-since validation. This change **preserves** the `error={fieldErrors.memberSince}` prop and the onChange clear on the input; it only gates rendering.
- Server route (`/api/membership-ops/households/[id]`) untouched — its rejection stays as defense-in-depth.
- Single-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)