### PR TITLE
feat(my-programs): mirror conflict red pill on left nav

### DIFF
--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth";
 import type { OrgMembershipProcessStatus, TrustedAdultReviewStatus } from "@/generated/prisma/client";
 import { countHouseholdsMissingValidContact } from "@/lib/emergencyContacts/service";
 import { canReviewBackgroundChecks, reviewQueueCounts } from "@/lib/membership/review";
+import { getLeadConflicts } from "@/lib/attendanceConflicts";
 import { pickAddress, validateAddress } from "@/lib/address";
 import { ORG_DOMAIN } from "@/lib/config";
 import { apiError } from "@/lib/api-response";
@@ -72,7 +73,9 @@ export type TodoCounts = {
     // visibility and its green badge (sum of pending attendance to confirm).
     // `pending` mirrors the post-event email's targets (ended events not yet
     // confirmed), deep-linked to the existing confirm screen. No new capability.
-    lead?: { programs: LedProgram[] };
+    // `conflicts` = overlapping-visit conflicts across the caller's led programs;
+    // drives the red badge on the "My Programs" nav item and the Conflicts subtab.
+    lead?: { programs: LedProgram[]; conflicts?: number };
 };
 
 /** RSVP tally (Yes/Maybe/No; NO_RESPONSE omitted). */
@@ -245,7 +248,7 @@ export const GET = withAuth({}, async (_req, auth) => {
     if (ledPrograms.length > 0) {
         const ledIds = ledPrograms.map((p) => p.id);
         const now = new Date();
-        const [pendingEvents, enrolledCounts, futureEvents, volunteerRows] = await Promise.all([
+        const [pendingEvents, enrolledCounts, futureEvents, volunteerRows, conflicts] = await Promise.all([
             prisma.event.findMany({
                 where: { programId: { in: ledIds }, endAt: { lte: now }, attendanceConfirmedAt: null },
                 select: { id: true, name: true, programId: true },
@@ -268,6 +271,7 @@ export const GET = withAuth({}, async (_req, auth) => {
                 where: { programId: { in: ledIds } },
                 select: { programId: true, personId: true },
             }),
+            getLeadConflicts(user.id),
         ]);
         // (programId, personId) keys that belong to a volunteer; everyone else on a roster is a participant.
         const volunteerKeys = new Set(volunteerRows.map((v) => `${v.programId}:${v.personId}`));
@@ -332,6 +336,7 @@ export const GET = withAuth({}, async (_req, auth) => {
                     return { eventId: e.id, name: e.name, startAt: e.startAt.toISOString(), participants: t.participants, volunteers: t.volunteers };
                 }),
             })),
+            conflicts: conflicts.length,
         };
     }
 

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -338,7 +338,7 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                         // text, same as before). NavLink forces section text white on the colored
                         // sidebar, so the dark label is pinned explicitly.
                         const intent =
-                          badge.color === 'gray' ? 'info' : badge.color === 'treehouseGreen' ? 'action' : null;
+                          badge.color === 'gray' ? 'info' : badge.color === 'treehouseGreen' ? 'action' : badge.color === 'red' ? 'alert' : null;
                         return intent ? (
                           <CountBadge key={badge.color} intent={intent} aria-label={badge.label}>
                             {badge.count}

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -1,4 +1,4 @@
-import { navBadgeFor, tabBadgeFor, reviewBadges, leadsAnyProgram, leadPendingCount } from '@/components/navBadges';
+import { navBadgeFor, tabBadgeFor, reviewBadges, leadsAnyProgram, leadPendingCount, leadConflictCount } from '@/components/navBadges';
 import type { TodoCounts } from '@/app/api/nav/todo-counts/route';
 
 const base: TodoCounts = {
@@ -55,6 +55,22 @@ describe('My Programs badge count', () => {
   it('singularizes the label for a single pending item', () => {
     const counts: TodoCounts = { ...base, lead: { programs: [prog(1, 'A', [item(10)])] } };
     expect(navBadgeFor('/my-programs', counts)[0].label).toBe('1 attendance item to confirm');
+  });
+
+  it('shows a red conflict badge left of the green pending badge', () => {
+    const counts: TodoCounts = { ...base, lead: { programs: [prog(1, 'A', [item(10)])], conflicts: 2 } };
+    expect(leadConflictCount(counts)).toBe(2);
+    expect(navBadgeFor('/my-programs', counts)).toEqual([
+      { count: 2, color: 'red', label: '2 attendance conflicts to resolve' },
+      { count: 1, color: 'treehouseGreen', label: '1 attendance item to confirm' },
+    ]);
+  });
+
+  it('shows only the red badge when there are conflicts but nothing pending', () => {
+    const counts: TodoCounts = { ...base, lead: { programs: [prog(1, 'A')], conflicts: 1 } };
+    expect(navBadgeFor('/my-programs', counts)).toEqual([
+      { count: 1, color: 'red', label: '1 attendance conflict to resolve' },
+    ]);
   });
 });
 

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -15,6 +15,11 @@ export function leadPendingCount(counts: TodoCounts | null): number {
   return counts?.lead?.programs.reduce((sum, p) => sum + p.pending.length, 0) ?? 0;
 }
 
+/** Overlapping-visit conflicts across the caller's led programs (red badge count). */
+export function leadConflictCount(counts: TodoCounts | null): number {
+  return counts?.lead?.conflicts ?? 0;
+}
+
 /**
  * Background-check Review badges (0, 1, or 2), shared by the left-nav Membership
  * Ops item and the Review sub-tab so both stay in lockstep: green = applications
@@ -48,9 +53,12 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
     case '/my-household':
       return green(counts.member.household.length, `${counts.member.household.length} items need attention`);
     case '/my-programs': {
-      // Pending attendance the lead must confirm, summed across their programs.
+      // Red conflicts first (left of green), then pending attendance the lead
+      // must confirm — mirrors the Conflicts/Attendance subtab badges.
+      const c = leadConflictCount(counts);
+      const red = c > 0 ? [{ count: c, color: 'red', label: `${c} attendance ${c === 1 ? 'conflict' : 'conflicts'} to resolve` }] : [];
       const n = leadPendingCount(counts);
-      return green(n, `${n} attendance ${n === 1 ? 'item' : 'items'} to confirm`);
+      return [...red, ...green(n, `${n} attendance ${n === 1 ? 'item' : 'items'} to confirm`)];
     }
     case '/attendance': {
       const mine = counts.buildingHousehold;


### PR DESCRIPTION
## What

The **Conflicts** subtab under `/my-programs` shows a red pill counting overlapping-visit conflicts, but the **My Programs** left-nav item only showed the green pending-attendance count. This surfaces the same conflict count as a red pill on the nav item, **left of** the existing green pill — so a lead sees unresolved conflicts without opening the section.

## How

- **`todo-counts` route** — add `lead.conflicts` via the existing `getLeadConflicts()`. The nav already fetches this payload, so no new client fetch; one extra query, only for users who lead ≥1 program.
- **`navBadges`** — new `leadConflictCount()` helper; `/my-programs` now returns `[red, green]` (red first = leftmost).
- **`AppFrame`** — map badge color `red` → `alert` intent so it renders through the shared `CountBadge` (red fill, white text), matching the subtab.

## Reviewer notes

- `lead.conflicts` is optional on the type — existing `lead` mocks don't need touching; the helper defaults to 0.
- Nav red count (server `getLeadConflicts`) and the Conflicts subtab red count (client `useConflicts`) both derive from `getLeadConflicts`, so they stay consistent.

## Tests

- New `navBadges` unit cases: red-left-of-green, red-only.
- Full suite green locally: 1452 unit + 853 integration = **2305 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)