### PR TITLE
feat(volunteer-memberships): client-side email validation on add form

### DIFF
--- a/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
+++ b/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Button, Card, Center, Group, Loader, Stack, Table, Text, TextInput, Title } from "@mantine/core";
 import { AlertBanner } from "@/components/admin/AlertBanner";
 import { notifications } from "@mantine/notifications";
+import { isValidEmail } from "@/lib/emergencyContacts/identity";
 
 interface Designation {
   id: number;
@@ -17,6 +18,7 @@ export default function VolunteerMembershipsPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
+  const [emailError, setEmailError] = useState<string | undefined>(undefined);
 
   const flash = (m: string) => setMessage(m);
 
@@ -33,7 +35,9 @@ export default function VolunteerMembershipsPage() {
   useEffect(() => { load(); }, [load]);
 
   const addDesignation = async () => {
+    setEmailError(undefined);
     if (!newEmail.trim()) return;
+    if (!isValidEmail(newEmail)) { setEmailError("A valid email is required."); return; }
     setSaving(true);
     flash("");
     try {
@@ -74,7 +78,8 @@ export default function VolunteerMembershipsPage() {
           <TextInput
             w={320}
             value={newEmail}
-            onChange={(e) => setNewEmail(e.currentTarget.value)}
+            onChange={(e) => { setNewEmail(e.currentTarget.value); setEmailError(undefined); }}
+            error={emailError}
             placeholder="volunteer@example.com"
           />
           <Button disabled={saving} onClick={addDesignation}>Add</Button>


### PR DESCRIPTION
## What

Adds client-side email-format validation to the volunteer-designation add form. An invalid email now highlights the email field before submit, instead of round-tripping to the server.

## Why

Faster, clearer feedback for the user — bad input is caught inline rather than surfacing as a server-side banner error.

## How

- Import existing `isValidEmail` from `@/lib/emergencyContacts/identity`
- New `emailError` state bound to the `TextInput`'s `error` prop
- In `addDesignation`, after the empty-trim guard and before the `fetch`: if `!isValidEmail(newEmail)`, set the field error and return
- Clear the error at the start of `addDesignation` and on every keystroke

## Scope / notes for reviewer

- Single file: `checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx`
- No server change. The API route, the `flash(...)` warning banner ("Could not add" / warnings), and the success path are untouched.
- `npx tsc --noEmit` clean on the edited file (unrelated pre-existing `@/generated/prisma/client` errors are worktree codegen noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)