### PR TITLE
fix(program-register): persistent toast for submit network error

### DIFF
--- a/checkin-app/src/app/programs/[id]/register/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/register/__tests__/page.test.tsx
@@ -2,12 +2,14 @@
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, resetRtl, resolvedParams, router } from "@/test-helpers/rtl";
+import { notifications } from "@mantine/notifications";
 import PublicRegistrationPage from "../page";
 
-beforeEach(() => resetRtl());
+beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
 
 const program = {
   name: "Robotics Club",
@@ -208,7 +210,11 @@ describe("PublicRegistrationPage", () => {
 
     global.fetch = jest.fn().mockRejectedValue(new Error("down"));
     fireEvent.click(screen.getByRole("button", { name: "Pay & Register via Shopify" }));
-    expect(await screen.findByText("Network error occurred.")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red", message: "Network error occurred.", autoClose: false }),
+      ),
+    );
   });
 
   it("navigates back to the program from the Cancel button", async () => {

--- a/checkin-app/src/app/programs/[id]/register/page.tsx
+++ b/checkin-app/src/app/programs/[id]/register/page.tsx
@@ -3,6 +3,7 @@
 import { use, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Alert, Button, Card, Container, Group, SimpleGrid, Stack, Text, TextInput, Title } from '@mantine/core';
+import { notifications } from "@mantine/notifications";
 import { formatCents } from '@inventory/money';
 import { useUnsavedGuard } from '@/components/UnsavedChangesProvider';
 import { isRegistrationDirty } from './dirty';
@@ -142,7 +143,7 @@ export default function PublicRegistrationPage({ params }: { params: Promise<{ i
         body: JSON.stringify({ parents, emergencyContact, participants })
       });
 
-      const data = await res.json();
+      const data = await res.json().catch(() => ({}));
       if (res.ok) {
         setSubmitted(true); // clears the unsaved-changes guard before any redirect
         if (data.checkoutUrl) {
@@ -159,7 +160,7 @@ export default function PublicRegistrationPage({ params }: { params: Promise<{ i
         setSubmitting(false);
       }
     } catch {
-      setError("Network error occurred.");
+      notifications.show({ color: "red", message: "Network error occurred.", autoClose: false });
       setSubmitting(false);
     }
   };


### PR DESCRIPTION
## What

Public program-registration submit handler (`checkin-app/src/app/programs/[id]/register/page.tsx`), submit path only:

- **Persistent toast on network failure** — the submit `catch` set an inline `setError("Network error occurred.")` banner; replaced with a persistent Mantine toast (`notifications.show({ color: "red", message: "Network error occurred.", autoClose: false })`) so the error survives re-render/navigation. Matches the recent N15–N34 network-error toast sweep.
- **Guarded response parse** — `const data = await res.json()` (parsed before the `res.ok` check) → `.catch(() => ({}))`, so a non-JSON 5xx falls through to the `else setError(data.error || "Failed to register.")` path instead of throwing into the catch.
- Added `import { notifications } from "@mantine/notifications";` (provider globally mounted in `layout.tsx`).

## Why

A non-JSON 5xx on submit previously threw at `res.json()`, dropping the caller into the generic network catch instead of surfacing the real "Failed to register." message. The inline banner also disappeared on re-render.

## Scope / reviewer notes

- **Submit handler only.** The program-load fetch, its `catch { setProgramError("Network error.") }`, and the `if (programError || !program) return <error screen>` terminal page gate are intentionally untouched — that load failure gates the whole page and is not a toast.
- `validateForm`/`fieldErrors`/`participantErrors` (recent field-validation change) and success handling unchanged.
- `npx tsc --noEmit` clean for the touched file (repo-wide errors are pre-existing: worktree missing generated Prisma client, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)