### PR TITLE
fix(save-errors): surface server data.error on profile/visit save failure

### DIFF
--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -159,7 +159,8 @@ export default function AdminVisitsPage() {
         setEditingVisitId(null);
         fetchVisits();
       } else {
-        setRowNotice({ id, text: "Failed to update visit.", tone: "error" });
+        const data = await res.json().catch(() => ({}));
+        setRowNotice({ id, text: data.error || "Failed to update visit.", tone: "error" });
       }
     } catch {
       notifications.show({ color: "red", message: "Network error saving visit.", autoClose: false });

--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -72,7 +72,8 @@ export default function ProfilePage() {
       if (res.ok) {
         notifications.show({ color: "green", message: "Profile updated successfully!" });
       } else {
-        setMessage({ text: "Failed to update profile.", tone: "error" });
+        const data = await res.json().catch(() => ({}));
+        setMessage({ text: data.error || "Failed to update profile.", tone: "error" });
       }
     } catch {
       notifications.show({ color: "red", message: "Network error saving profile.", autoClose: false });


### PR DESCRIPTION
## What

Save-failure `else` branch on two pages now reads the server response body and prefers `data.error` over the hardcoded generic string.

- `checkin-app/src/app/profile/page.tsx` — profile save handler
- `checkin-app/src/app/facility-ops/visits/page.tsx` — visit save handler

```
} else {
  const data = await res.json().catch(() => ({}));
  setMessage({ text: data.error || "Failed to update profile.", tone: "error" });
}
```

## Why

The `else` hardcoded a flat "Failed to update…" and threw away the server's `{ error }` body. Both PATCH routes return real messages via `apiError` — e.g. phone-format validation (400), "Youth profiles are read-only." (403), "visitId is required." (400). Those now reach the user.

## Reviewer notes

- Only the `else` (non-ok) branch changed. The `if (res.ok)` success branch and the `catch` (network) branch are untouched.
- `res.json().catch(() => ({}))` guards a non-JSON error body so it can't throw into the `catch`.
- `apiError` response shape is `{ error }` (`src/lib/api-response.ts`), so `data.error` is populated; falls back to the generic string otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)