### PR TITLE
fix(membership-audit): make broken-households badge red, not green

### DIFF
--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -59,7 +59,7 @@ export type TodoCounts = {
     // `membership` = board-actionable (BLOCKED, green). `applicationsTotal` =
     // every in-flight (non-ACTIVE) application, the gray count shown on the
     // Applications tab — mirrors what /api/admin/membership lists.
-    // `brokenHouseholds` = households with no lead at all (green).
+    // `brokenHouseholds` = households with no lead at all (red — blocking board action).
     // `memberFamilies` = total member families (gray), shown on the Manage Memberships tab:
     // households with >=1 non-org-email (or null-email) participant. Staff households hold
     // only the org-email lead, so they fall out.

--- a/checkin-app/src/app/membership-audit/layout.tsx
+++ b/checkin-app/src/app/membership-audit/layout.tsx
@@ -6,7 +6,7 @@ import { Box, Center, Loader, Stack, Tabs, Text } from "@mantine/core";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { useTodoCounts } from "@/hooks/useTodoCounts";
 import { tabBadgeFor } from "@/components/navBadges";
-import { CountBadge } from "@/components/ui/CountBadge";
+import { CountBadge, badgeIntentFor } from "@/components/ui/CountBadge";
 import { ScrollableTabsList } from "@/components/ui/ScrollableTabsList";
 import { PageContainer } from "@/components/ui/PageContainer";
 
@@ -42,8 +42,8 @@ export default function MembershipAuditLayout({ children }: { children: React.Re
       .sort((a, b) => b.href.length - a.href.length)
       .find((l) => pathname === l.href || pathname.startsWith(l.href + "/"))?.href ?? null;
 
-  // Emergency/Unclaimed are gray (gaps on the household), Broken is green (board must
-  // assign a lead) — derived in navBadges.tabBadgeFor so nav and tab agree.
+  // Emergency/Unclaimed are gray (gaps on the household), Broken is red (board must
+  // assign a lead — blocking) — derived in navBadges.tabBadgeFor so nav and tab agree.
   return (
     <PageContainer>
       <Stack>
@@ -51,15 +51,15 @@ export default function MembershipAuditLayout({ children }: { children: React.Re
         <ScrollableTabsList>
           {NAV_LINKS.map((link) => {
             const badge = tabBadgeFor(link.href, todoCounts);
-            const isBroken = badge?.color === "treehouseGreen";
+            const intent = badge ? badgeIntentFor(badge.color) : null;
             return (
               <Tabs.Tab
                 key={link.href}
                 value={link.href}
                 leftSection={<span>{link.icon}</span>}
                 rightSection={
-                  badge ? (
-                    <CountBadge intent={isBroken ? "action" : "info"} aria-label={badge.label}>
+                  badge && intent ? (
+                    <CountBadge intent={intent} aria-label={badge.label}>
                       {badge.count}
                     </CountBadge>
                   ) : undefined

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -49,7 +49,7 @@ import { useTodoCounts } from '@/hooks/useTodoCounts';
 import { useConfirmNav } from '@/components/UnsavedChangesProvider';
 import type { TodoCounts } from '@/app/api/nav/todo-counts/route';
 import { navBadgeFor, leadsAnyProgram } from '@/components/navBadges';
-import { CountBadge } from '@/components/ui/CountBadge';
+import { CountBadge, badgeIntentFor } from '@/components/ui/CountBadge';
 
 type SessionUser = {
   isSysadmin?: boolean;
@@ -337,8 +337,7 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                         // info color CountBadge doesn't model, so it stays inline (filled + black
                         // text, same as before). NavLink forces section text white on the colored
                         // sidebar, so the dark label is pinned explicitly.
-                        const intent =
-                          badge.color === 'gray' ? 'info' : badge.color === 'treehouseGreen' ? 'action' : badge.color === 'red' ? 'alert' : null;
+                        const intent = badgeIntentFor(badge.color);
                         return intent ? (
                           <CountBadge key={badge.color} intent={intent} aria-label={badge.label}>
                             {badge.count}

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -133,9 +133,9 @@ describe('tabBadgeFor', () => {
       .toEqual({ count: 40, color: 'gray', label: '40 applications' });
   });
 
-  it('broken-households tab is green (board action), the other audit tabs gray', () => {
+  it('broken-households tab is red (board action, blocking), the other audit tabs gray', () => {
     expect(tabBadgeFor('/membership-audit/broken', admin({ brokenHouseholds: 2 })))
-      .toEqual({ count: 2, color: 'treehouseGreen', label: '2 households without a lead' });
+      .toEqual({ count: 2, color: 'red', label: '2 households without a lead' });
     expect(tabBadgeFor('/membership-audit/emergency-contacts', admin({ householdsMissingContact: 1 })))
       .toEqual({ count: 1, color: 'gray', label: '1 household missing an emergency contact' });
     expect(tabBadgeFor('/membership-audit/unclaimed', admin({ unclaimedHouseholds: 3 })))
@@ -154,19 +154,19 @@ describe('tabBadgeFor', () => {
 });
 
 // The /membership-audit section badge is a roll-up of its tabs; keep them in lockstep.
-// Green section total == broken tab; gray section total == emergency + unclaimed tabs.
+// Red section total == broken tab; gray section total == emergency + unclaimed tabs.
 describe('membership-audit nav ↔ tab agreement', () => {
   it('section badges equal the sum of their tab badges', () => {
     const counts = admin({ brokenHouseholds: 2, householdsMissingContact: 3, unclaimedHouseholds: 4 });
     const nav = navBadgeFor('/membership-audit', counts);
-    const navGreen = nav.find((b) => b.color === 'treehouseGreen')?.count ?? 0;
+    const navRed = nav.find((b) => b.color === 'red')?.count ?? 0;
     const navGray = nav.find((b) => b.color === 'gray')?.count ?? 0;
 
     const broken = tabBadgeFor('/membership-audit/broken', counts)?.count ?? 0;
     const emergency = tabBadgeFor('/membership-audit/emergency-contacts', counts)?.count ?? 0;
     const unclaimed = tabBadgeFor('/membership-audit/unclaimed', counts)?.count ?? 0;
 
-    expect(navGreen).toBe(broken);
+    expect(navRed).toBe(broken);
     expect(navGray).toBe(emergency + unclaimed);
   });
 });

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -84,12 +84,15 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
       ];
     }
     case '/membership-audit': {
-      // Green: leadless households the board must fix (assign a lead). Gray: gaps
-      // the household must close — missing emergency contacts plus accounts created
-      // at registration but never claimed.
+      // Red: leadless households the board must fix (assign a lead) — blocking, so
+      // it's an alert not a routine action. Gray: gaps the household must close —
+      // missing emergency contacts plus accounts created at registration but never
+      // claimed.
+      const red = (n: number, label: string): NavBadge[] =>
+        n > 0 ? [{ count: n, color: 'red', label }] : [];
       const grayTotal = counts.admin ? counts.admin.householdsMissingContact + counts.admin.unclaimedHouseholds : 0;
       return [
-        ...green(counts.admin ? counts.admin.brokenHouseholds : 0, 'Leadless households needing a lead assigned'),
+        ...red(counts.admin ? counts.admin.brokenHouseholds : 0, 'Leadless households needing a lead assigned'),
         ...gray(grayTotal, 'Households missing an emergency contact or with an unclaimed account'),
       ];
     }
@@ -136,11 +139,13 @@ export function tabBadgeFor(href: string, counts: TodoCounts | null): NavBadge |
     case '/membership-ops/applications':
       return gray(admin.applicationsTotal, `${admin.applicationsTotal} application${plural(admin.applicationsTotal, '', 's')}`);
     // Membership Audit — mirrors the /membership-audit section badge: broken is
-    // green (board must assign a lead), the other two gray (household's own gaps).
+    // red (board must assign a lead — blocking), the other two gray (household's own gaps).
     case '/membership-audit/emergency-contacts':
       return gray(admin.householdsMissingContact, `${admin.householdsMissingContact} household${plural(admin.householdsMissingContact, '', 's')} missing an emergency contact`);
     case '/membership-audit/broken':
-      return green(admin.brokenHouseholds, `${admin.brokenHouseholds} household${plural(admin.brokenHouseholds, '', 's')} without a lead`);
+      return admin.brokenHouseholds > 0
+        ? { count: admin.brokenHouseholds, color: 'red', label: `${admin.brokenHouseholds} household${plural(admin.brokenHouseholds, '', 's')} without a lead` }
+        : null;
     case '/membership-audit/unclaimed':
       return gray(admin.unclaimedHouseholds, `${admin.unclaimedHouseholds} unclaimed account household${plural(admin.unclaimedHouseholds, '', 's')}`);
     // Safety — same count as the /safety section badge.

--- a/checkin-app/src/components/ui/CountBadge.tsx
+++ b/checkin-app/src/components/ui/CountBadge.tsx
@@ -21,6 +21,25 @@ const INTENT: Record<'action' | 'info' | 'alert', { color: string; c: string }> 
   alert: { color: 'red', c: 'var(--mantine-color-white)' },
 };
 
+/**
+ * Maps a NavBadge.color (from navBadges.ts) to a CountBadge intent, so the
+ * left-nav and section-tab consumers can't drift on the color→look mapping.
+ * Returns null for colors CountBadge doesn't model (e.g. 'blue'), which the
+ * caller renders inline.
+ */
+export function badgeIntentFor(color: string): 'action' | 'info' | 'alert' | null {
+  switch (color) {
+    case 'treehouseGreen':
+      return 'action';
+    case 'gray':
+      return 'info';
+    case 'red':
+      return 'alert';
+    default:
+      return null;
+  }
+}
+
 export function CountBadge({
   intent,
   size = 'md',


### PR DESCRIPTION
## What

Leadless ("broken") households show a count badge on the **Membership Audit** left-nav item and its **Broken Households** sub-tab. Both were green; this makes both **red**.

## Why

Green reads as a routine action. A leadless household *blocks* the family from being claimed until the board assigns a lead — a blocking condition, which the design system already models as `alert` (red fill / white text). Emergency-contact and unclaimed counts stay gray (the household's own gaps, not board-blocking).

## How

- `navBadges.ts` — broken-households badge color set once at the source: `treehouseGreen` → `red`, in both `navBadgeFor('/membership-audit')` (nav section) and `tabBadgeFor('/membership-audit/broken')` (sub-tab). Nav and tab derive from this one file, so they stay in lockstep.
- `CountBadge.tsx` — new shared `badgeIntentFor(color)` helper maps a `NavBadge.color` to a CountBadge intent (`red`→`alert`, `treehouseGreen`→`action`, `gray`→`info`; `null` for colors rendered inline like `blue`). The `alert` red intent already existed.
- `AppFrame.tsx` (left nav) + `membership-audit/layout.tsx` (sub-tabs) — both now call `badgeIntentFor` instead of duplicating an inline `color === 'treehouseGreen' ? 'action' : ...` ternary, so the color→intent mapping can't drift between the two renderers.
- Tests + comments updated (`navBadges.test.ts`, `todo-counts/route.ts` comment).

## Reviewer notes

- Behavior change is color only — counts, labels, hide-at-zero, and roll-up (`section total == sum of tabs`) are unchanged.
- Full suite green locally: **295 suites / 2303 tests** (1450 unit + 853 integration, serial). Flow tests not run (need a live server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)