### PR TITLE
feat(settings): red pill for unset checkout settings in nav + subtabs

### DIFF
--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -63,7 +63,10 @@ export type TodoCounts = {
     // `memberFamilies` = total member families (gray), shown on the Manage Memberships tab:
     // households with >=1 non-org-email (or null-email) participant. Staff households hold
     // only the org-email lead, so they fall out.
-    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; memberFamilies: number };
+    // `settingsMisconfig` = how many required Shopify-checkout board settings are still
+    // unset (0–2): the membership variant ID and the volunteer discount code. Red pill on
+    // the Settings nav + Membership Settings tab — checkout is broken until both are set.
+    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; memberFamilies: number; settingsMisconfig: number };
     // Background-check reviewer surface (reviewers + board, per-viewer). `canActOn`
     // = applications this reviewer may attest now (green). `approvedAwaitingSecond`
     // = ones they approved that still need a second reviewer (gray).
@@ -342,7 +345,7 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     // ---- Admin surface (board's own queue) — only for board/isSysadmin ----
     if (user.isSysadmin || user.isBoardMember) {
-        const [membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies] = await Promise.all([
+        const [membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies, boardSettings] = await Promise.all([
             prisma.orgMembershipProcess.count({
                 where: { status: { in: BOARD_ACTIONABLE_MEMBERSHIP } },
             }),
@@ -387,8 +390,16 @@ export const GET = withAuth({}, async (_req, auth) => {
                     },
                 },
             }),
+            // Required Shopify-checkout settings — count how many are still unset so the
+            // board sees a red pill until both are configured. Empty string counts as unset.
+            prisma.boardSettings.findUnique({
+                where: { id: 1 },
+                select: { orgMembershipVariantId: true, volunteerDiscountCode: true },
+            }),
         ]);
-        result.admin = { membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies };
+        const settingsMisconfig =
+            (boardSettings?.orgMembershipVariantId ? 0 : 1) + (boardSettings?.volunteerDiscountCode ? 0 : 1);
+        result.admin = { membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies, settingsMisconfig };
     }
 
     // ---- Reviewer surface (per-viewer background-check queue) ----

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -1,4 +1,4 @@
-import { navBadgeFor, tabBadgeFor, reviewBadges, leadsAnyProgram, leadPendingCount, leadConflictCount } from '@/components/navBadges';
+import { navBadgeFor, tabBadgeFor, reviewBadges, settingsMisconfigBadge, leadsAnyProgram, leadPendingCount, leadConflictCount } from '@/components/navBadges';
 import type { TodoCounts } from '@/app/api/nav/todo-counts/route';
 
 const base: TodoCounts = {
@@ -85,6 +85,7 @@ const admin = (over: Partial<NonNullable<TodoCounts['admin']>> = {}): TodoCounts
     unclaimedHouseholds: 0,
     brokenHouseholds: 0,
     memberFamilies: 0,
+    settingsMisconfig: 0,
     ...over,
   },
 });
@@ -119,6 +120,26 @@ describe('reviewBadges (Review tab + Membership Ops nav)', () => {
       { count: 2, color: 'treehouseGreen', label: 'Pending membership reviews' },
       { count: 1, color: 'treehouseGreen', label: '1 background check you can review now' },
     ]);
+  });
+});
+
+describe('settings misconfig red pill', () => {
+  it('is null off the admin surface (non-board viewer)', () => {
+    expect(settingsMisconfigBadge(base)).toBeNull();
+    expect(settingsMisconfigBadge(null)).toBeNull();
+    expect(navBadgeFor('/settings', base)).toEqual([]);
+  });
+
+  it('hidden when both settings are configured', () => {
+    expect(settingsMisconfigBadge(admin({ settingsMisconfig: 0 }))).toBeNull();
+    expect(navBadgeFor('/settings', admin({ settingsMisconfig: 0 }))).toEqual([]);
+  });
+
+  it('red pill with the unset count, singular label at 1', () => {
+    expect(settingsMisconfigBadge(admin({ settingsMisconfig: 1 })))
+      .toEqual({ count: 1, color: 'red', label: '1 required checkout setting not configured' });
+    expect(navBadgeFor('/settings', admin({ settingsMisconfig: 2 })))
+      .toEqual([{ count: 2, color: 'red', label: '2 required checkout settings not configured' }]);
   });
 });
 

--- a/checkin-app/src/components/admin/SettingsTabs.tsx
+++ b/checkin-app/src/components/admin/SettingsTabs.tsx
@@ -5,6 +5,9 @@ import { useSession } from "next-auth/react";
 import { Tabs } from "@mantine/core";
 import { ScrollableTabsList } from "@/components/ui/ScrollableTabsList";
 import { useConfirmNav } from "@/components/UnsavedChangesProvider";
+import { useTodoCounts } from "@/hooks/useTodoCounts";
+import { settingsMisconfigBadge } from "@/components/navBadges";
+import { CountBadge } from "@/components/ui/CountBadge";
 
 export type SettingsTab = "membership" | "roles" | "localization";
 
@@ -26,6 +29,9 @@ export function SettingsTabs({ active }: { active: SettingsTab }) {
   const { data: session } = useSession();
   const isSysadmin = !!session?.user?.isSysadmin;
   const tabs = TABS.filter((t) => !t.sysadminOnly || isSysadmin);
+  // Red pill on Membership Settings when a required checkout setting is unset. Same
+  // shared counts as the nav badge, so tab and nav can't diverge.
+  const misconfig = settingsMisconfigBadge(useTodoCounts(!!session));
   return (
     <Tabs
       value={active}
@@ -40,7 +46,17 @@ export function SettingsTabs({ active }: { active: SettingsTab }) {
     >
       <ScrollableTabsList>
         {tabs.map((t) => (
-          <Tabs.Tab key={t.value} value={t.value}>
+          <Tabs.Tab
+            key={t.value}
+            value={t.value}
+            rightSection={
+              t.value === "membership" && misconfig ? (
+                <CountBadge intent="alert" size="sm" aria-label={misconfig.label}>
+                  {misconfig.count}
+                </CountBadge>
+              ) : undefined
+            }
+          >
             {t.label}
           </Tabs.Tab>
         ))}

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -21,6 +21,21 @@ export function leadConflictCount(counts: TodoCounts | null): number {
 }
 
 /**
+ * Red pill for unconfigured required Shopify-checkout board settings (the
+ * membership variant ID and the volunteer discount code). Count is 1 or 2, or
+ * null when both are set. Red (alert) — not green/gray — because until it's
+ * fixed membership checkout is broken. Shown on the Settings nav item and the
+ * Membership Settings sub-tab, both board/sysadmin-only (the people who can fix
+ * it). Returns null off the admin surface (non-board viewers never see it).
+ */
+export function settingsMisconfigBadge(counts: TodoCounts | null): NavBadge | null {
+  const n = counts?.admin?.settingsMisconfig ?? 0;
+  return n > 0
+    ? { count: n, color: 'red', label: `${n} required checkout setting${n === 1 ? '' : 's'} not configured` }
+    : null;
+}
+
+/**
  * Background-check Review badges (0, 1, or 2), shared by the left-nav Membership
  * Ops item and the Review sub-tab so both stay in lockstep: green = applications
  * this reviewer can act on now; gray = ones they approved awaiting a second
@@ -99,6 +114,11 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
     case '/safety':
       // Trusted-adult disclosures awaiting board review.
       return green(counts.admin ? counts.admin.trustedAdults : 0, 'Trusted-adult disclosures to review');
+    case '/settings': {
+      // Red: required Shopify-checkout settings still unset (variant ID, volunteer code).
+      const b = settingsMisconfigBadge(counts);
+      return b ? [b] : [];
+    }
     // System Status has no badge: every count it could show (membership,
     // payment-plan, trusted-adult) belongs to another nav item that already
     // badges it. A roll-up here just duplicates those numbers under an


### PR DESCRIPTION
## What

Surfaces a red **alert** count pill when either required Shopify-checkout board setting is unset:

- `orgMembershipVariantId` (membership product variant)
- `volunteerDiscountCode` (volunteer coupon)

The pill shows how many of the two (**1 or 2**) are still unconfigured, in two places:

- **Left nav** — on the *Settings* item
- **Top subtabs** — on the *Membership Settings* tab

## Why

Both fields are optional `BoardSettings` with no surfacing when empty. When unset, membership checkout silently returns a null pay link (`ensurePaymentLink` in `lib/membership/payment.ts`) — nothing tells the board they need to configure it. This makes the gap visible to exactly the people who can fix it.

## How

- Count the unset settings in the **board-only** `admin` block of `/api/nav/todo-counts` (`settingsMisconfig: 0–2`), via one extra `boardSettings.findUnique` in the existing `Promise.all`. Empty string counts as unset.
- New `settingsMisconfigBadge()` in `navBadges.ts` (color `red`) + a `/settings` case in `navBadgeFor`. Red flows through the existing `badgeIntentFor → CountBadge` `alert` path (red fill, white text) — no AppFrame change needed.
- `SettingsTabs` renders `<CountBadge intent="alert">` on the Membership Settings tab, off the same shared `useTodoCounts` store, so nav and subtab counts can't diverge.

## Reviewer notes

- **Visibility**: the count only exists in the board/sysadmin `admin` payload, so non-board users never see it.
- **Live refresh**: re-fetches on the existing `NAV_COUNTS_EVENT`, which already fires after a settings save — the pill clears without a reload.
- Full unit suite green (189 suites / 1453 tests), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)