### PR TITLE
fix(participants): highlight email field on duplicate-email conflict (T3)

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/route.ts
@@ -35,7 +35,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
             });
 
             if (existingUser) {
-                return apiError("A participant with this email already exists", 409);
+                return NextResponse.json({ error: "A participant with this email already exists", fields: ["email"] }, { status: 409 });
             }
         }
 

--- a/checkin-app/src/app/membership-ops/participants/new/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/page.tsx
@@ -44,6 +44,7 @@ function NewParticipantForm() {
   const [alreadyMember, setAlreadyMember] = useState(false);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({});
 
   // Handle deep linked household
   useEffect(() => {
@@ -78,6 +79,7 @@ function NewParticipantForm() {
     e.preventDefault();
     setSaving(true);
     setMessage("");
+    setFieldErrors({});
 
     try {
       const res = await fetch('/api/membership-ops/participants', {
@@ -104,6 +106,8 @@ function NewParticipantForm() {
         setHouseholdId("");
         setHouseholdSearch("");
         setAlreadyMember(false);
+      } else if (data.fields?.includes("email")) {
+        setFieldErrors({ email: "This email is already registered." });
       } else {
         setMessage(data.error || "Failed to create participant");
       }
@@ -152,7 +156,8 @@ function NewParticipantForm() {
               label={`Participant Google Email ${isYouthSelected ? '(Optional for Students)' : ''}`}
               required={!isYouthSelected && !householdId}
               value={email}
-              onChange={(e) => setEmail(e.currentTarget.value)}
+              error={fieldErrors.email}
+              onChange={(e) => { setEmail(e.currentTarget.value); setFieldErrors((fe) => ({ ...fe, email: undefined })); }}
               placeholder="jane.doe@example.com"
             />
 


### PR DESCRIPTION
The "email already exists" 409 on participant creation showed a flat page banner. This routes it to the Email field instead, following the existing `mapServerFields` convention (`app/membership/page.tsx`): the server returns a `fields` string-array and the client owns the message.

## What changed
- **Server** (`api/membership-ops/participants/route.ts`): the email-uniqueness 409 now returns `{ error, fields: ["email"] }` via `NextResponse.json`. Every other `apiError(...)` path unchanged.
- **Client** (`membership-ops/participants/new/page.tsx`): new `fieldErrors` state; the email conflict sets a field-level error on the Email `TextInput`, all other errors still fall through to the `AlertBanner`. Field error clears on change and resets on submit.

## Reviewer notes
- The `catch` now shows a persistent red notification for network errors — that came from origin/main (separate N13 chip), merged cleanly on rebase; not part of this change.
- `npx tsc --noEmit` shows no new errors in either file (pre-existing errors are unrelated generated-Prisma cascade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)