### PR TITLE
fix(my-household): capture allergies when adding a household member

### DIFF
--- a/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
@@ -199,7 +199,7 @@ describe('Household API Integration Tests', () => {
 
             const req = new Request('http://localhost:4000/api/household', {
                 method: 'PATCH',
-                body: JSON.stringify({ memberName: 'New Child', memberEmail: 'new-child-household-api-test@example.com', memberDob: '2015-01-01' })
+                body: JSON.stringify({ memberName: 'New Child', memberEmail: 'new-child-household-api-test@example.com', memberDob: '2015-01-01', memberAllergies: 'Peanuts' })
             });
 
             const res = await PATCH(req as unknown as import("next/server").NextRequest);
@@ -213,6 +213,24 @@ describe('Household API Integration Tests', () => {
             // PII minimization) — verify the attachment directly against the DB instead.
             const created = await prisma.person.findUnique({ where: { id: data.member.id } });
             expect(created?.householdId).toBe(householdId);
+            // Allergies (safety data) must persist on the ADD path, no second edit.
+            expect(created?.allergies).toBe('Peanuts');
+        });
+
+        it('should default allergies to null when omitted on add', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: testUserId } });
+
+            const req = new Request('http://localhost:4000/api/household', {
+                method: 'PATCH',
+                body: JSON.stringify({ memberName: 'No Allergies Child', memberDob: '2016-01-01' })
+            });
+
+            const res = await PATCH(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            const created = await prisma.person.findUnique({ where: { id: data.member.id } });
+            expect(created?.allergies).toBeNull();
         });
 
         it('should reject a new member with neither a DoB nor a 25+ declaration (400)', async () => {

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -54,7 +54,7 @@ export const PATCH = withAuth(
             }
 
             const body = await req.json();
-            const { memberName, memberEmail, memberDob, memberOver25 } = body;
+            const { memberName, memberEmail, memberDob, memberOver25, memberAllergies } = body;
 
             const hh = await householdLeadship(userId);
 
@@ -101,6 +101,7 @@ export const PATCH = withAuth(
                             ...(memberEmail && { email: memberEmail.toLowerCase() }),
                             dateOfBirth: memberDob ? new Date(memberDob) : null,
                             isDeclaredAdult: !memberDob && !!memberOver25,
+                            allergies: memberAllergies || null,
                             householdId,
                         },
                         select: HOUSEHOLD_PEER_SELECT,

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -90,6 +90,8 @@ describe("HouseholdPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "+ Add Household Member" }));
     fireEvent.change(screen.getByLabelText("Full Name"), { target: { value: "Robin Smith" } });
     fireEvent.click(screen.getByLabelText("Individual is over 25"));
+    // Allergies (safety data) must be capturable on ADD, not only on a later edit.
+    fireEvent.change(screen.getByLabelText("Allergies (optional)"), { target: { value: "Bees" } });
     fireEvent.click(screen.getByRole("button", { name: "Save / Invite Household Member" }));
 
     await waitFor(() =>
@@ -97,7 +99,7 @@ describe("HouseholdPage", () => {
         "/api/household",
         expect.objectContaining({
           method: "PATCH",
-          body: JSON.stringify({ memberName: "Robin Smith", memberEmail: "", memberDob: "", memberOver25: true }),
+          body: JSON.stringify({ memberName: "Robin Smith", memberEmail: "", memberDob: "", memberOver25: true, memberAllergies: "Bees" }),
         }),
       ),
     );

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -72,7 +72,7 @@ export default function HouseholdPage() {
   const warn = (text: string) => setMessage({ text, tone: "warning" });
   const [addingHouseholdMember, setAddingHouseholdMember] = useState(false);
 
-  const [householdMemberForm, setHouseholdMemberForm] = useState({ name: "", email: "", dob: "", over25: false });
+  const [householdMemberForm, setHouseholdMemberForm] = useState({ name: "", email: "", dob: "", over25: false, allergies: "" });
   const [householdMemberErrors, setHouseholdMemberErrors] = useState<{ name?: string; email?: string; dob?: string }>({});
 
   const [editingHouseholdMemberId, setEditingHouseholdMemberId] = useState<number | null>(null);
@@ -243,11 +243,11 @@ export default function HouseholdPage() {
       const res = await fetch('/api/household', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ memberName: householdMemberForm.name, memberEmail: householdMemberForm.email, memberDob: householdMemberForm.over25 ? "" : householdMemberForm.dob, memberOver25: householdMemberForm.over25 })
+        body: JSON.stringify({ memberName: householdMemberForm.name, memberEmail: householdMemberForm.email, memberDob: householdMemberForm.over25 ? "" : householdMemberForm.dob, memberOver25: householdMemberForm.over25, memberAllergies: householdMemberForm.allergies })
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        setHouseholdMemberForm({ name: "", email: "", dob: "", over25: false });
+        setHouseholdMemberForm({ name: "", email: "", dob: "", over25: false, allergies: "" });
         setHouseholdMemberErrors({});
         setAddingHouseholdMember(false);
         fetchHousehold();
@@ -454,6 +454,7 @@ export default function HouseholdPage() {
                       {!householdMemberForm.over25 && (
                         <TextInput type="date" label="Date of Birth" value={householdMemberForm.dob} error={householdMemberErrors.dob} onChange={(e) => { setHouseholdMemberForm({ ...householdMemberForm, dob: e.currentTarget.value }); setHouseholdMemberErrors({ ...householdMemberErrors, dob: undefined }); }} />
                       )}
+                      <TextInput label="Allergies (optional)" value={householdMemberForm.allergies} onChange={(e) => setHouseholdMemberForm({ ...householdMemberForm, allergies: e.currentTarget.value })} />
                       <Group grow>
                         <Button type="submit" color="green">Save / Invite Household Member</Button>
                         <Button type="button" variant="default" onClick={() => { setAddingHouseholdMember(false); setHouseholdMemberErrors({}); }}>Cancel</Button>


### PR DESCRIPTION
## What

The **Add Household Member** form collected name / email / age but had no allergies field. A lead had to save the member first, then re-open the member's Edit form to record allergies. Allergies is safety data — forcing a second save is an easy way to lose it.

This adds an optional **Allergies (optional)** input to the add form and persists it on the create path.

## Changes

- **`api/household` PATCH (add path)**: read `memberAllergies` from the body, write `allergies: memberAllergies || null` into `person.create`. Matches the naming/normalization already used by the edit route (`member/route.ts`) — empty → `null`.
- **`my-household/page.tsx`**: add `allergies` to `householdMemberForm` state, an Allergies input in the add form, and `memberAllergies` in the PATCH body + form reset.
- **Tests**: integration cases asserting allergies persists on ADD and defaults to `null` when omitted; unit test asserts the value flows from the form into the request body.

## Notes for reviewer

- Scope is only the add/edit parity gap. No changes to auth-first program registration or the membership intake service.
- Not touched: the existing-person join path (`targetMember` update — re-parenting an already-registered account) still ignores allergies, since the add form only creates new people. Can extend if desired.
- Verified locally: `my-household/__tests__/page.test.tsx` (17/17), `householdAPI.integration` (11/11, incl. 2 new allergies cases), `householdMemberAPI.integration` (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)