### PR TITLE
feat(dev-login): local-only fresh-registrant mint (auth-first PR B)

### DIFF
--- a/checkin-app/src/app/api/auth/dev-personas/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/auth/dev-personas/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Gate test for POST /api/auth/dev-personas — the local-only fresh-registrant mint.
+ *
+ * This route FORGES a brand-new login, so the single security invariant worth proving is:
+ * it only works on a local laptop. On cloud 'dev' and on 'prod' it MUST 404 (stricter than
+ * the sibling GET, which also serves cloud 'dev'). On 'local' it creates one empty registrant
+ * via the real signup helper and returns its id — and never accepts a caller-supplied identity.
+ */
+
+import { config } from "@/lib/config";
+import { createParticipantWithHousehold } from "@/lib/auth-options";
+
+// checkinEnv is the gate input — make it settable per test.
+jest.mock("@/lib/config", () => {
+    const actual = jest.requireActual("@/lib/config");
+    return {
+        __esModule: true,
+        ...actual,
+        config: { ...actual.config, checkinEnv: jest.fn(() => "local") },
+    };
+});
+
+// jest.setup globally mocks @/lib/auth-options to `{ authOptions: {} }` (no signup helper).
+// Add the helper so the local-success path can create without a DB.
+jest.mock("@/lib/auth-options", () => ({
+    authOptions: {},
+    createParticipantWithHousehold: jest.fn(async () => ({ id: 42 })),
+}));
+
+import { POST } from "../route";
+
+const mockCheckinEnv = config.checkinEnv as jest.Mock;
+const mockCreate = createParticipantWithHousehold as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/auth/dev-personas gate", () => {
+    it("404s on cloud 'dev'", async () => {
+        mockCheckinEnv.mockReturnValue("dev");
+        const res = await POST();
+        expect(res.status).toBe(404);
+        expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("404s on 'prod'", async () => {
+        mockCheckinEnv.mockReturnValue("prod");
+        const res = await POST();
+        expect(res.status).toBe(404);
+        expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("mints a server-generated @example.com registrant on 'local'", async () => {
+        mockCheckinEnv.mockReturnValue("local");
+        const res = await POST();
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ personaId: 42 });
+
+        // Identity is server-generated: newfamily+<n>@example.com, never caller-supplied.
+        expect(mockCreate).toHaveBeenCalledTimes(1);
+        const arg = mockCreate.mock.calls[0][0];
+        expect(arg.email).toMatch(/^newfamily\+\d+@example\.com$/);
+        expect(arg.name).toMatch(/^New Family \d+$/);
+    });
+});

--- a/checkin-app/src/app/api/auth/dev-personas/route.ts
+++ b/checkin-app/src/app/api/auth/dev-personas/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
 import prisma from "@/lib/prisma";
 import { config } from "@/lib/config";
-import { authOptions } from "@/lib/auth-options";
+import { authOptions, createParticipantWithHousehold } from "@/lib/auth-options";
 import { apiError } from "@/lib/api-response";
 
 export const dynamic = 'force-dynamic';
@@ -63,4 +63,30 @@ export async function GET() {
     });
 
     return NextResponse.json({ personas });
+}
+
+/**
+ * POST /api/auth/dev-personas
+ *
+ * Mints a BRAND-NEW empty registrant (single-person household, no children / emergency
+ * contact / membership) so the auth-first first-time intake path can be tested on a laptop
+ * that has no Google identity. This CREATES a login, so it is gated STRICTER than GET: it
+ * must be reachable ONLY on a local laptop — never on cloud 'dev' or prod, where forging a
+ * fresh session is out of the question. The server generates the identity; it NEVER accepts
+ * a caller-supplied email, so it cannot target or collide with a real person.
+ */
+export async function POST() {
+    if (process.env.NODE_ENV === 'production' || config.checkinEnv() !== 'local') {
+        return apiError("Not available", 404);
+    }
+
+    // Date.now() is a fine per-mint uniquifier for local dev; @example.com passes authorize()'s
+    // filter and the fresh row is impersonated via the existing persona-mint (evaluateMint
+    // already relaxes the caller gate on local) — no authorize/evaluateMint change needed.
+    const n = Date.now();
+    const person = await createParticipantWithHousehold({
+        name: `New Family ${n}`,
+        email: `newfamily+${n}@example.com`,
+    });
+    return NextResponse.json({ personaId: person.id });
 }

--- a/checkin-app/src/components/DevLoginPicker.tsx
+++ b/checkin-app/src/components/DevLoginPicker.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { signIn } from "next-auth/react";
 import { Badge, Card, Center, Divider, Group, SimpleGrid, Stack, Text } from "@mantine/core";
+import { useCheckinEnv } from "@/components/EnvProvider";
 
 interface Persona {
   id: number;
@@ -26,6 +27,7 @@ export default function DevLoginPicker() {
   const [loading, setLoading] = useState(true);
   const [signingIn, setSigningIn] = useState<string | null>(null);
   const [now, setNow] = useState<number | null>(null);
+  const checkinEnv = useCheckinEnv();
 
   useEffect(() => {
     fetch("/api/auth/dev-personas", { cache: "no-store" })
@@ -46,6 +48,16 @@ export default function DevLoginPicker() {
     // Initial local login: no current session, so the mint is a plain login as this persona
     // (impersonatedBy stays null). The same flow handles impersonation once signed in.
     signIn("persona-mint", { personaId: String(persona.id), mode: "impersonate", callbackUrl: "/" });
+  };
+
+  // Local only: mint a brand-new empty registrant (server generates the identity), then log in
+  // as it via the same persona-mint. Exercises the auth-first first-time intake path on a laptop.
+  const handleNewRegistrant = async () => {
+    setSigningIn("__new__");
+    const res = await fetch("/api/auth/dev-personas", { method: "POST" });
+    if (!res.ok) { setSigningIn(null); return; }
+    const { personaId } = await res.json();
+    signIn("persona-mint", { personaId: String(personaId), mode: "impersonate", callbackUrl: "/" });
   };
 
   const getRoleBadges = (p: Persona): { label: string; color: string }[] => {
@@ -107,6 +119,25 @@ export default function DevLoginPicker() {
             )}
           </Card>
         ))}
+        {checkinEnv === "local" && (
+          <Card
+            id="dev-login-new-registrant"
+            withBorder
+            radius="md"
+            padding="sm"
+            onClick={() => { if (!signingIn) handleNewRegistrant(); }}
+            style={{
+              cursor: signingIn ? "wait" : "pointer",
+              opacity: signingIn && signingIn !== "__new__" ? 0.5 : 1,
+              borderStyle: "dashed",
+            }}
+          >
+            <Text fw={600} size="sm">
+              {signingIn === "__new__" ? "⏳ " : "＋ "}New registrant (fresh household)
+            </Text>
+            <Text size="xs" c="dimmed">Brand-new empty user — tests the first-time intake path</Text>
+          </Card>
+        )}
       </SimpleGrid>
     </Stack>
   );

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -26,7 +26,7 @@ const prismaAdapterClient = {
 
 // Every participant must belong to a household (Participant.householdId is
 // required), so new sign-ups get a single-person household they lead.
-async function createParticipantWithHousehold(data: {
+export async function createParticipantWithHousehold(data: {
     name?: string | null;
     email?: string | null;
     image?: string | null;


### PR DESCRIPTION
## What

Adds a **laptop-only** dev-login path that mints a **brand-new empty user** (single-person household, no children, no emergency contact, non-member) so the upcoming auth-first program-registration flow can be tested without a Google identity.

Implements PR "B" from `checkin-app/docs/designs/auth-first-registration.md` §10.3.

## Why

We're moving program registration to be auth-first (Google OAuth *before* the intake form). On a laptop there is no Google identity, and we must **never** bypass OAuth on any server — not even dev. The existing dev persona-mint only logs in as *existing, seeded* personas (already-populated households); testing the **new-user** intake path needs a genuinely empty registrant. This restores repeatable local testing of that path.

## Changes

- **`POST /api/auth/dev-personas`** — mints one empty registrant by reusing the *exact* Google first-sign-in helper `createParticipantWithHousehold` (exported from `auth-options.ts`), so it stays faithful to the real signup path rather than reimplementing household+lead creation. Returns `{ personaId }`.
- **`createParticipantWithHousehold`** is now exported (was module-private). No behavior change; the Google adapter still uses it unchanged.
- **`DevLoginPicker`** — a dashed "＋ New registrant (fresh household)" card, rendered **only** when `useCheckinEnv() === "local"`. Click → POST → mint via the **unchanged** existing `signIn("persona-mint", …)`.
- **Test** — proves the gate.

## Security (the important part)

Creating arbitrary logins forges sessions, so the creation path is gated **stricter** than the sibling `GET`:

- Reachable only when `process.env.NODE_ENV !== 'production'` **AND** `config.checkinEnv() === 'local'`.
- **404s on cloud `dev` and on `prod`** (GET, by contrast, also serves cloud `dev`).
- The **server generates** the identity (`newfamily+<n>@example.com`); it **never** accepts a caller-supplied email/identity, so it can't target or collide with a real person.
- **No change** to `authorize()` or `evaluateMint` — the fresh `@example.com` row already passes authorize's `@example.com` filter, and `evaluateMint` already relaxes the caller gate on local.

## Scope / out of scope

- Out: the program-registration UI, the auth-first CTA, and removing `public-register` — all separate PRs.

## Verify

- **Test**: `dev-personas/__tests__/route.test.ts` — POST 404s on `dev` and `prod`, succeeds only on `local`, and asserts the created identity is server-generated. 3/3 pass.
- **tsc**: touched files clean. (`auth-options.ts` shows 8 pre-existing errors that reproduce *without* this change — worktree missing generated prisma types — not introduced here.)
- **Fresh-household shape**: `createParticipantWithHousehold` = 1 household + 1 person + 1 lead link. No children, no emergency contact, no OrgMembership → single-member non-member household, identical to the Google `createUser` first-sign-in path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)