### PR TITLE
feat(intake): declarative field-profile registry (PR A)

### DIFF
--- a/checkin-app/src/lib/intake/__tests__/profiles.test.ts
+++ b/checkin-app/src/lib/intake/__tests__/profiles.test.ts
@@ -1,0 +1,53 @@
+import { INTAKE_PROFILES, missingRequiredFields } from "@/lib/intake/profiles";
+
+describe("intake profiles registry", () => {
+    it("membership-initial requires address + emergencyContact + primaryName", () => {
+        const req = INTAKE_PROFILES["membership-initial"].requiredAtSubmit;
+        expect(req).toEqual(["address", "emergencyContact", "primaryName"]);
+    });
+
+    it("program-first-time requires primaryName + emergencyContact + participantDob but NOT address", () => {
+        const req = INTAKE_PROFILES["program-first-time"].requiredAtSubmit;
+        expect(req).toEqual(expect.arrayContaining(["primaryName", "emergencyContact", "participantDob"]));
+        expect(req).not.toContain("address");
+        // Address is still shown (collected if offered), just not required.
+        expect(INTAKE_PROFILES["program-first-time"].shown).toContain("address");
+    });
+
+    it("missingRequiredFields flags empty membership-initial fields in profile order", () => {
+        const missing = missingRequiredFields(INTAKE_PROFILES["membership-initial"], {
+            addressLine1: null,
+            emergencyContacts: [],
+            primaryName: null,
+        });
+        expect(missing.map((m) => m.field)).toEqual(["address", "emergencyContact", "primaryName"]);
+    });
+
+    it("missingRequiredFields returns [] when membership-initial is satisfied", () => {
+        const missing = missingRequiredFields(INTAKE_PROFILES["membership-initial"], {
+            addressLine1: "1 Main St",
+            emergencyContacts: [{ conflictParticipantId: null, name: "Aunt May", phone: "555-2000" }],
+            primaryName: "Primary",
+        });
+        expect(missing).toEqual([]);
+    });
+
+    it("program-first-time: age-gated enrollee without DOB fails participantDob; none age-gated passes", () => {
+        const ctx = {
+            emergencyContacts: [{ conflictParticipantId: null, name: "Aunt", phone: "555-2000" }],
+            primaryName: "Parent",
+        };
+        expect(
+            missingRequiredFields(INTAKE_PROFILES["program-first-time"], {
+                ...ctx,
+                participants: [{ ageGated: true, dob: null }],
+            }).map((m) => m.field),
+        ).toEqual(["participantDob"]);
+        expect(
+            missingRequiredFields(INTAKE_PROFILES["program-first-time"], {
+                ...ctx,
+                participants: [{ ageGated: false, dob: null }],
+            }),
+        ).toEqual([]);
+    });
+});

--- a/checkin-app/src/lib/intake/profiles.ts
+++ b/checkin-app/src/lib/intake/profiles.ts
@@ -1,0 +1,92 @@
+/**
+ * Intake field profiles — one declarative source of truth for "which fields
+ * each intake context shows / requires."
+ *
+ * Four surfaces (membership intake, public program register, household add,
+ * household edit) each hand-rolled their own field list + required-ness and
+ * drifted apart (allergies present in edit paths but not create; parent phone
+ * required in one, absent in another). A profile keyed by context fixes that:
+ * adding/renaming a field is a one-line edit every surface inherits.
+ *
+ * Field keys stay aligned with the intake form keys used by IntakeError.fields
+ * ("address", "emergencyContact", "primaryName") so the client can highlight
+ * the offending inputs unchanged.
+ *
+ * See docs/designs/auth-first-registration.md §9.3.
+ */
+
+export type FieldKey = "address" | "emergencyContact" | "primaryName" | "participantDob";
+
+export interface IntakeProfile {
+    context: string;
+    /** Fields the form renders for this context. */
+    shown: FieldKey[];
+    /** Fields validated at submit; order drives the "Please complete: …" message. */
+    requiredAtSubmit: FieldKey[];
+}
+
+/**
+ * The state a submit is validated against. Built by the caller (e.g.
+ * submitIntake) from the loaded household; profile-agnostic so any surface can
+ * reuse it.
+ */
+export interface IntakeSubmitContext {
+    addressLine1?: string | null;
+    emergencyContacts: { conflictParticipantId: number | null; name: string; phone: string }[];
+    primaryName?: string | null;
+    /** Enrollees whose DOB gates an age-restricted program (program-first-time). */
+    participants?: { dob?: string | Date | null; ageGated?: boolean }[];
+}
+
+/**
+ * Per-field label + satisfied-predicate. The label reproduces the exact human
+ * text membership submit has always used, so the IntakeError message is
+ * unchanged.
+ */
+const FIELD_RULES: Record<FieldKey, { label: string; isSatisfied: (ctx: IntakeSubmitContext) => boolean }> = {
+    address: {
+        label: "home address",
+        isSatisfied: (ctx) => !!ctx.addressLine1?.trim(),
+    },
+    emergencyContact: {
+        // A household must keep >= 1 valid (non-member, complete) emergency contact.
+        label: "a valid emergency contact (someone outside the household)",
+        isSatisfied: (ctx) => ctx.emergencyContacts.some((c) => c.conflictParticipantId === null && c.name.trim() && c.phone.trim()),
+    },
+    primaryName: {
+        label: "primary parent name",
+        isSatisfied: (ctx) => !!ctx.primaryName?.trim(),
+    },
+    participantDob: {
+        label: "date of birth for each enrolled participant",
+        // Only age-gated enrollees need a DOB; no age-gated enrollees → satisfied.
+        isSatisfied: (ctx) => (ctx.participants ?? []).filter((p) => p.ageGated).every((p) => !!p.dob),
+    },
+};
+
+export const INTAKE_PROFILES = {
+    "membership-initial": {
+        context: "membership-initial",
+        shown: ["address", "emergencyContact", "primaryName"],
+        requiredAtSubmit: ["address", "emergencyContact", "primaryName"],
+    },
+    "program-first-time": {
+        context: "program-first-time",
+        // Address is shown (collected if offered) but not required — a non-member
+        // enrolling in one workshop is not a membership application.
+        shown: ["primaryName", "emergencyContact", "participantDob", "address"],
+        requiredAtSubmit: ["primaryName", "emergencyContact", "participantDob"],
+    },
+} satisfies Record<string, IntakeProfile>;
+
+export type IntakeContext = keyof typeof INTAKE_PROFILES;
+
+/**
+ * The profile's required fields not yet satisfied by `ctx`, in profile order,
+ * each with its form key + human label. Empty array = complete.
+ */
+export function missingRequiredFields(profile: IntakeProfile, ctx: IntakeSubmitContext): { field: FieldKey; label: string }[] {
+    return profile.requiredAtSubmit
+        .filter((field) => !FIELD_RULES[field].isSatisfied(ctx))
+        .map((field) => ({ field, label: FIELD_RULES[field].label }));
+}

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -6,6 +6,7 @@ import { householdBgIsFresh, nextBoundary } from "@/lib/membership/renewal";
 import { addHouseholdLead, HouseholdLeadLimitError, MAX_HOUSEHOLD_LEADS } from "@/lib/household/leads";
 import { upsertPrimaryContact, reconcileHouseholdConflicts } from "@/lib/emergencyContacts/service";
 import { normalizeAddressInput, pickAddress, type StructuredAddress } from "@/lib/address";
+import { INTAKE_PROFILES, missingRequiredFields } from "@/lib/intake/profiles";
 
 /**
  * Membership intake service — the write/read model behind the "Join the
@@ -350,17 +351,15 @@ export async function submitIntake(userId: number) {
         .sort((a, b) => b.id - a.id)[0];
     if (!process) throw new IntakeError("no_process", "No application is awaiting your information.");
 
-    // Each missing requirement carries the form field key to highlight + a label
-    // for the summary message.
-    const missing: { field: string; label: string }[] = [];
-    if (!household.line1?.trim()) missing.push({ field: "address", label: "home address" });
-    // A household must keep >= 1 valid (non-member, complete) emergency contact.
-    const hasValidContact = household.emergencyContacts.some(
-        (c) => c.conflictParticipantId === null && c.name.trim() && c.phone.trim(),
-    );
-    if (!hasValidContact) missing.push({ field: "emergencyContact", label: "a valid emergency contact (someone outside the household)" });
+    // Required-field validation is driven by the membership-initial profile (one
+    // declarative source of truth shared across intake surfaces), not inline
+    // literals. Field keys + labels + order are unchanged from the hardcoded set.
     const primary = household.householdMembers.find((p) => p.id === userId);
-    if (!primary?.name?.trim()) missing.push({ field: "primaryName", label: "primary parent name" });
+    const missing = missingRequiredFields(INTAKE_PROFILES["membership-initial"], {
+        addressLine1: household.line1,
+        emergencyContacts: household.emergencyContacts,
+        primaryName: primary?.name,
+    });
     if (missing.length) {
         throw new IntakeError(
             "incomplete",


### PR DESCRIPTION
## What

Introduces one declarative source of truth for **which fields each intake context shows / requires**, and refactors membership `submitIntake` to use it.

Foundation PR "A" from [`auth-first-registration.md` §9.3](checkin-app/docs/designs/auth-first-registration.md).

## Why

Four intake surfaces (membership intake, public program register, household add, household edit) each hand-roll their own field list + required-ness, so they diverge (allergies present in edit paths but not create; parent phone required in one, absent in another). This lifts the required-set out of inline literals into a per-context profile so adding/renaming a field is a one-line registry edit every surface inherits.

## Changes

- **New** `src/lib/intake/profiles.ts` — `FieldKey`, `IntakeProfile`, `INTAKE_PROFILES` (`membership-initial` + `program-first-time`), and `missingRequiredFields(profile, ctx)`. A per-field label+predicate map reproduces membership submit's exact labels and order.
- **Refactor** `submitIntake` — required-field check driven by `INTAKE_PROFILES["membership-initial"]` instead of inline literals. **Behavior-preserving**: same `IntakeError("incomplete")` code, same field keys in `fields`, same human labels, same order. Transaction / FOR-UPDATE locking / BG-freshness / advance logic untouched.
- **New** `src/lib/intake/__tests__/profiles.test.ts` — asserts required sets for both profiles and `participantDob` age-gate behavior.

## Scope notes

- `program-first-time` has **no consumer yet** (the program intake panel is a later PR "C"). Defined + unit-tested only; not wired into any page.
- Does **not** touch the household add-member allergies gap (separate in-flight chip), the program registration UI, the auth-first CTA, public-register removal, or dev-login tooling.
- `membership-renewal` / `household-self-service` from the doc's table are omitted — no consumer this PR; add when those surfaces migrate.

## Verify

- Membership intake tests are the oracle and pass unchanged. `intake.test.ts` (23) + `profiles.test.ts` (5) → **28 passed**. `tsc --noEmit` → **clean**.
- Tests exercising `submitIntake`: the `describe('submitIntake')` block — `no_process`, `incomplete: missing address + emergency contact`, `bgFresh=false no stamp`, `bgFresh=true stamps + advances`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)