### PR TITLE
fix(membership-ops): green BG-review count on reviewer-only left nav

### DIFF
--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -317,7 +317,10 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
             // On the colored sidebar all text is white; the 'light' variant gives a soft
             // translucent overlay on the active item rather than a harsh solid fill.
             const sidebarText = onColoredSidebar ? 'var(--mantine-color-white)' : undefined;
-            const badges = navBadgeFor(href, todoCounts);
+            // Badge keys off the canonical section href, not the per-role
+            // destination — a reviewer-only user's link points at /review, but its
+            // badges live under the /membership-ops case.
+            const badges = navBadgeFor(item.href, todoCounts);
             return (
               <NavLink
                 key={item.href}

--- a/checkin-app/src/components/__tests__/AppFrame.test.tsx
+++ b/checkin-app/src/components/__tests__/AppFrame.test.tsx
@@ -90,6 +90,22 @@ describe("AppFrame", () => {
     expect(screen.queryByText("Membership Audit")).not.toBeInTheDocument();
   });
 
+  it("badges the reviewer-only Membership Ops nav with the green can-act-on count", () => {
+    setSession({ id: 3, isBackgroundCheckReviewer: true });
+    mockedUseTodoCounts.mockReturnValue({
+      member: { household: [], programs: [] },
+      building: 0,
+      buildingHousehold: 0,
+      activePrograms: 0,
+      review: { canActOn: 4, approvedAwaitingSecond: 0 },
+    });
+    renderFrame();
+
+    // Badge keys off the section href (/membership-ops), not the per-role /review
+    // destination — the green count must reach a reviewer-only user's nav item.
+    expect(screen.getByLabelText("4 background checks you can review now")).toHaveTextContent("4");
+  });
+
   it("highlights the active nav item based on pathname", () => {
     setSession({ id: 1 });
     setPathname("/attendance");


### PR DESCRIPTION
## What

The left-nav **Membership Ops** item never showed the green "background checks you can review now" count for a background-check-reviewer-only user — the count that already renders at the top of `/membership-ops/review`.

## Why

The nav item has a per-role destination override: a reviewer-only user's link points at `/membership-ops/review` instead of the admin hub `/membership-ops`. The badge was keyed off that *destination* href:

```js
const href = item.hrefFor?.(user) ?? item.href;  // /membership-ops/review for reviewers
const badges = navBadgeFor(href, todoCounts);     // no /review case → []
```

`navBadgeFor` only has a `/membership-ops` case (which includes `reviewBadges`), so the reviewer's destination href fell through to `[]` — no badge. Board/sysadmin were unaffected because their href stays `/membership-ops`.

## Fix

Key the badge off the canonical section href (`item.href`), not the per-role link destination. One line, plus a test asserting the green count reaches a reviewer-only nav item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)