### PR TITLE
fix(attendance): validate visit times in manualEditAttendance

### DIFF
--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -5,6 +5,7 @@ import { Prisma } from "@/generated/prisma/client";
 import { withAuth } from "@/lib/auth";
 import { handler, notFound, forbidden, badRequest } from "@/security/handler";
 import { apiError } from "@/lib/api-response";
+import { parseVisitTime, departureAfterArrival } from "@/lib/visitTimes";
 
 // FAIL-CLOSED, staff-only. This payload is fundamentally a roster — who is
 // enrolled / RSVP'd / attended — and a participant's name, id, and the very
@@ -250,6 +251,20 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                     return apiError("Arrival time is required for Present status", 400);
                 }
 
+                const now = new Date();
+                const ar = parseVisitTime(arrivedAt, "arrival", now);
+                if (!ar.ok) return apiError(ar.error, 400);
+
+                let dep: Date | null = null;
+                if (departedAt) {
+                    const dr = parseVisitTime(departedAt, "departure", now);
+                    if (!dr.ok) return apiError(dr.error, 400);
+                    if (!departureAfterArrival(ar.value, dr.value)) {
+                        return apiError("Departure time must be after arrival time", 400);
+                    }
+                    dep = dr.value;
+                }
+
                 // Check if there is an existing visit
                 const existingVisit = await prisma.visit.findFirst({
                     where: {
@@ -262,8 +277,8 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                     await prisma.visit.update({
                         where: { id: existingVisit.id },
                         data: {
-                            arrivedAt: new Date(arrivedAt),
-                            departedAt: departedAt ? new Date(departedAt) : null,
+                            arrivedAt: ar.value,
+                            departedAt: dep,
                             arrivedVia: "WEB",
                             departedVia: departedAt ? "WEB" : null
                         }
@@ -273,8 +288,8 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                         data: {
                             personId: Number(participantId),
                             associatedEventId: eventId,
-                            arrivedAt: new Date(arrivedAt),
-                            departedAt: departedAt ? new Date(departedAt) : null,
+                            arrivedAt: ar.value,
+                            departedAt: dep,
                             arrivedVia: "WEB",
                             departedVia: departedAt ? "WEB" : null
                         }


### PR DESCRIPTION
## What

Adds server-side time validation to the `manualEditAttendance` action (`PATCH` handler) in `checkin-app/src/app/api/events/[id]/route.ts`. The `status === 'Present'` branch previously wrote Visit `arrivedAt`/`departedAt` straight from user input via `new Date(...)` with no validation.

Reuses the already-shipped shared helper `checkin-app/src/lib/visitTimes.ts` so this and the admin visit-edit path stay in lock-step.

Rules enforced (right after the existing `!arrivedAt` guard):
- Invalid provided `arrivedAt`/`departedAt` → `400`
- Future provided date → `400` (reject, no clamp)
- Departure strictly-after arrival, **only when a departure is provided** → `400 "Departure time must be after arrival time"`

Both the `update` and `create` data objects now use the parsed `ar.value` / `dep` instead of `new Date(...)`.

## Why

Same corruption/500 risk as the admin visit-edit path — unvalidated `new Date(...)` on user input. This is the sibling fix to #839; sharing the helper keeps both paths consistent.

## Reviewer notes

- **Blank departure stays allowed** — a Present attendee with no departure is still on-site during the session; the nightly cron closes it. So no "must be closed" rule here (unlike the facility path).
- **M7 recent-arrival open-visit guard deliberately NOT ported** — a session's open visit is bounded by the nightly auto-checkout, unlike self-entry.
- Enrollment/authz checks and everything else untouched. Other actions (confirmAttendance / editTime / cancel) not modified.

## Testing

- `npx tsc --noEmit` → clean.
- No unit route-test harness exists for this PATCH (only integration-DB coverage in `eventsAPI.integration.test.ts`); the helper is already unit-tested. No test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)