### PR TITLE
Self-enroll for single-person households + unified program-age logic

### DIFF
--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -4,7 +4,7 @@ import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
 import { lockProgramAndCheckCapacity, ProgramCapacityError } from "@/lib/program/capacity";
-import { calculateAge } from "@/lib/time";
+import { checkProgramAge } from "@/lib/programAge";
 import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
@@ -39,7 +39,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
 
         const participantData = await prisma.person.findUnique({
             where: { id: participantId },
-            select: { dateOfBirth: true, householdId: true }
+            select: { dateOfBirth: true, isDeclaredAdult: true, householdId: true }
         });
 
         let isHouseholdLead = false;
@@ -91,19 +91,22 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
                 return NextResponse.json({ error: "Program enrollment is currently closed.", requiresOverride: true }, { status: 400 });
             }
 
-            // Check Age
-            if (currentProgram.minAge !== null || currentProgram.maxAge !== null) {
-                if (!participantData?.dateOfBirth) {
-                    return NextResponse.json({ error: "Participant Date of Birth is missing.", requiresOverride: true }, { status: 400 });
-                }
-                // Age as of program start; now for dateless programs.
-                const age = calculateAge(participantData.dateOfBirth, currentProgram.startAt ?? undefined);
-                if (currentProgram.minAge !== null && age < currentProgram.minAge) {
-                    return NextResponse.json({ error: `Participant must be at least ${currentProgram.minAge} years old.`, requiresOverride: true }, { status: 400 });
-                }
-                if (currentProgram.maxAge !== null && age > currentProgram.maxAge) {
-                    return NextResponse.json({ error: `Participant maximum age is ${currentProgram.maxAge} years old.`, requiresOverride: true }, { status: 400 });
-                }
+            // Check Age (as of program start; now for dateless programs). A declared
+            // adult with no DOB is handled inside checkProgramAge — over-25 satisfies
+            // a youth minimum like "16 and up".
+            const ageCheck = checkProgramAge(
+                { dateOfBirth: participantData?.dateOfBirth ?? null, isDeclaredAdult: participantData?.isDeclaredAdult },
+                { minAge: currentProgram.minAge, maxAge: currentProgram.maxAge, asOf: currentProgram.startAt ?? undefined },
+            );
+            if (!ageCheck.ok) {
+                const error = ageCheck.reason === "dob"
+                    ? "Participant Date of Birth is missing."
+                    : ageCheck.label === "Too young"
+                        ? `Participant must be at least ${currentProgram.minAge} years old.`
+                        : ageCheck.label === "Too old"
+                            ? `Participant maximum age is ${currentProgram.maxAge} years old.`
+                            : "Participant is outside this program's age range.";
+                return NextResponse.json({ error, requiresOverride: true }, { status: 400 });
             }
         }
 

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -6,6 +6,7 @@ import { handler, notFound, forbidden, badRequest } from "@/security/handler";
 import { isActiveOrgMember } from "@/lib/orgMembership";
 import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
+import { validateProgramAgeBounds } from "@/lib/programAge";
 
 export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ auth, params }) => {
     const programId = parseInt(params.id, 10);
@@ -127,6 +128,11 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
             if (isNaN(leadMentorId)) {
                 return apiError("Invalid lead mentor", 400);
             }
+        }
+
+        const ageErr = validateProgramAgeBounds(minAge, maxAge);
+        if (ageErr) {
+            return apiError(ageErr, 400);
         }
 
         const updateData: Record<string, unknown> = {

--- a/checkin-app/src/app/api/programs/[id]/settings/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/settings/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
+import { validateProgramAgeBounds } from "@/lib/programAge";
 
 export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
     if (auth.type !== 'session') return apiError("Unauthorized", 401);
@@ -46,17 +47,12 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         } = body;
 
         // Age range sanity. Use effective values (body overrides current) so a
-        // one-sided edit can't leave minAge > maxAge.
+        // one-sided edit can't leave minAge > maxAge or exceed the 25+ ceiling.
         const effMinAge = minAge !== undefined ? minAge : currentProgram.minAge;
         const effMaxAge = maxAge !== undefined ? maxAge : currentProgram.maxAge;
-        if (minAge != null && minAge < 0) {
-            return apiError("minAge cannot be negative", 400);
-        }
-        if (maxAge != null && maxAge < 0) {
-            return apiError("maxAge cannot be negative", 400);
-        }
-        if (effMinAge != null && effMaxAge != null && effMinAge > effMaxAge) {
-            return apiError("minAge cannot exceed maxAge", 400);
+        const ageErr = validateProgramAgeBounds(effMinAge, effMaxAge);
+        if (ageErr) {
+            return apiError(ageErr, 400);
         }
 
         // maxParticipants: null = uncapped (allowed). Otherwise must be a

--- a/checkin-app/src/app/api/programs/route.ts
+++ b/checkin-app/src/app/api/programs/route.ts
@@ -7,6 +7,7 @@ import { logBackendError, logger } from "@/lib/logger";
 import { isActiveOrgMember } from "@/lib/orgMembership";
 import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
+import { validateProgramAgeBounds } from "@/lib/programAge";
 
 // GET is the PUBLIC program catalog — anonymous callers legitimately get the
 // non-draft, non-orgMemberOnly list (asserted by programsAPI.integration.test.ts),
@@ -107,6 +108,11 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
 
         if (!leadMentorId) {
             return apiError("Lead Mentor is required", 400);
+        }
+
+        const ageErr = validateProgramAgeBounds(minAge, maxAge);
+        if (ageErr) {
+            return apiError(ageErr, 400);
         }
 
         // Client sends a raw dollar string; tolerate a number too. Convert to cents here.

--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -79,7 +79,7 @@ describe("membership page", () => {
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Save progress" }));
@@ -102,7 +102,7 @@ describe("membership page", () => {
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Submit & continue" }));
@@ -525,7 +525,7 @@ describe("membership page", () => {
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Emergency contact email (optional)"), { target: { value: "not-an-email" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
@@ -564,7 +564,7 @@ describe("membership page", () => {
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Submit & continue" }));
@@ -592,7 +592,7 @@ describe("membership page", () => {
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Submit & continue" }));
@@ -616,7 +616,7 @@ describe("membership page", () => {
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Submit & continue" }));
@@ -662,7 +662,7 @@ describe("membership page", () => {
       "/api/membership": state({
         process: { id: 1, kind: "INITIAL", status: "INTAKE" },
         prefill: {
-          household: { name: null, emergencyContactName: "Aunt Jo", emergencyContactPhone: "555-1234", emergencyContactEmail: null, line1: "1 Treehouse Ln", line2: null, city: "Austin", state: "TX", postalCode: "78701" },
+          household: { name: null, emergencyContactName: "Aunt Jo", emergencyContactPhone: "512-555-1234", emergencyContactEmail: null, line1: "1 Treehouse Ln", line2: null, city: "Austin", state: "TX", postalCode: "78701" },
           primaryParent: { id: 1, name: "Pat Parent", email: "pat@example.com", dob: "1980-01-01", allergies: null },
           // Sam has every field null except name/id — exercises the `sec.x ?? ""`
           // fallback side of hydrate() (the "fills every intake field" test below
@@ -704,7 +704,7 @@ describe("membership page", () => {
     fireEvent.change(screen.getByLabelText("State"), { target: { value: "TX" } });
     fireEvent.change(screen.getByPlaceholderText("78701"), { target: { value: "78701" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Emergency contact email (optional)"), { target: { value: "jo@example.com" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
     fireEvent.change(screen.getByLabelText("Date of birth"), { target: { value: "1980-01-01" } });

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -14,6 +14,7 @@ import MembershipFlowStepper from "@/components/MembershipFlowStepper";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
 import { isValidEmail } from "@/lib/emergencyContacts/identity";
+import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 import { useUnsavedGuard, useConfirmNav } from "@/components/UnsavedChangesProvider";
 import AddressForm from "@/components/membership/AddressForm";
 import EmergencyContactForm from "@/components/membership/EmergencyContactForm";
@@ -274,6 +275,7 @@ export default function MembershipPage() {
     if (!address.line1?.trim()) errs.address = "Home address is required.";
     if (!emName.trim()) errs.emName = "Emergency contact name is required.";
     if (!emPhone.trim()) errs.emPhone = "Emergency contact phone is required.";
+    else if (!isValidPhone(emPhone)) errs.emPhone = PHONE_ERROR;
     if (emEmail.trim() && !isValidEmail(emEmail)) errs.emEmail = "That email address doesn't look right.";
     if (!primaryName.trim()) errs.primaryName = "Your name is required.";
     return errs;

--- a/checkin-app/src/app/program-ops/new/page.tsx
+++ b/checkin-app/src/app/program-ops/new/page.tsx
@@ -136,8 +136,8 @@ export default function CreateProgramPage() {
             />
 
             <SimpleGrid cols={{ base: 1, sm: 2 }}>
-              <NumberInput label="Min Age (Optional)" value={minAge} onChange={(v) => setMinAge(String(v))} min={0} />
-              <NumberInput label="Max Age (Optional)" value={maxAge} onChange={(v) => setMaxAge(String(v))} min={0} />
+              <NumberInput label="Min Age (Optional)" value={minAge} onChange={(v) => setMinAge(String(v))} min={0} max={25} />
+              <NumberInput label="Max Age (Optional)" value={maxAge} onChange={(v) => setMaxAge(String(v))} min={0} max={25} />
             </SimpleGrid>
 
             <SimpleGrid cols={{ base: 1, sm: 2 }}>

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -291,8 +291,8 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                 <SimpleGrid cols={{ base: 1, sm: 2 }}>
                   <TextInput type="date" label="Start Date" value={startAt} onChange={e => setStartAt(e.currentTarget.value)} />
                   <TextInput type="date" label="End Date" value={endAt} onChange={e => setEndAt(e.currentTarget.value)} />
-                  <NumberInput label="Minimum Age (Optional)" value={minAge} onChange={v => setMinAge(String(v))} min={0} placeholder="e.g. 14" />
-                  <NumberInput label="Maximum Age (Optional)" value={maxAge} onChange={v => setMaxAge(String(v))} min={0} placeholder="e.g. 18" />
+                  <NumberInput label="Minimum Age (Optional)" value={minAge} onChange={v => setMinAge(String(v))} min={0} max={25} placeholder="e.g. 14" />
+                  <NumberInput label="Maximum Age (Optional)" value={maxAge} onChange={v => setMaxAge(String(v))} min={0} max={25} placeholder="e.g. 18" />
                 </SimpleGrid>
 
                 <div>

--- a/checkin-app/src/app/programs/[id]/FirstTimeIntakePanel.tsx
+++ b/checkin-app/src/app/programs/[id]/FirstTimeIntakePanel.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Alert, Button, Center, Loader, Stack, Text, TextInput, Title } from "@mantine/core";
+import { Alert, Button, Center, Checkbox, Loader, Stack, Text, TextInput, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
+import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 import { INTAKE_PROFILES, missingRequiredFields, type IntakeSubmitContext } from "@/lib/intake/profiles";
 import AddressForm from "@/components/membership/AddressForm";
 import EmergencyContactForm from "@/components/membership/EmergencyContactForm";
@@ -43,6 +44,8 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
   const [emPhone, setEmPhone] = useState("");
   const [emEmail, setEmEmail] = useState("");
   const [primaryName, setPrimaryName] = useState("");
+  const [primaryDob, setPrimaryDob] = useState("");
+  const [primaryOver25, setPrimaryOver25] = useState(false);
   const [primaryAllergies, setPrimaryAllergies] = useState("");
   const [children, setChildren] = useState<ChildForm[]>([]);
 
@@ -65,6 +68,8 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
         setEmPhone(h?.emergencyContactPhone ?? "");
         setEmEmail(h?.emergencyContactEmail ?? "");
         setPrimaryName(s.prefill?.primaryParent?.name ?? "");
+        setPrimaryDob(s.prefill?.primaryParent?.dob ?? "");
+        setPrimaryOver25(!!s.prefill?.primaryParent?.over25);
         setPrimaryAllergies(s.prefill?.primaryParent?.allergies ?? "");
         setChildren(
           (s.prefill?.children ?? []).map((c: { id: number; name: string | null; dob: string | null; allergies: string | null }) => ({
@@ -93,12 +98,21 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
 
   // Required-ness comes from the program-first-time profile (single source of
   // truth), mapped onto the form's inputs for red-box feedback.
+  // The primary adult can be the enrollee themselves (single-person household):
+  // an entered DOB or the over-25 declaration counts as their age being set.
+  const primarySelfEnrolling = !!primaryDob || primaryOver25;
+
   const validate = (): Record<string, string> => {
     const errs: Record<string, string> = {};
     const ctx: IntakeSubmitContext = {
       emergencyContacts: emName.trim() && emPhone.trim() ? [{ conflictParticipantId: null, name: emName, phone: emPhone }] : [],
       primaryName,
-      participants: namedChildren.map((c) => ({ dob: c.dob || null, ageGated })),
+      // Self is an age-gated enrollee only when giving an exact DOB; over-25 is a
+      // declared-adult flag (no DOB expected), same as the my-household form.
+      participants: [
+        ...namedChildren.map((c) => ({ dob: c.dob || null, ageGated })),
+        ...(primaryDob ? [{ dob: primaryDob, ageGated }] : []),
+      ],
     };
     for (const m of missingRequiredFields(INTAKE_PROFILES["program-first-time"], ctx)) {
       if (m.field === "primaryName") errs.primaryName = "Your name is required.";
@@ -107,9 +121,13 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
         errs.emPhone = "Add an emergency contact who isn't in your household.";
       } else if (m.field === "participantDob") errs.childDob = "Enter each participant's date of birth.";
     }
-    // An age-gated program needs someone to actually enroll — nudge them to add
-    // the child (participantDob is trivially satisfied when there are no children).
-    if (ageGated && namedChildren.length === 0) errs.child = "Add the child you want to enroll.";
+    // Format check mirrors the server guard so a filled-but-invalid number gets
+    // inline feedback instead of a 500 from the intake save.
+    if (emPhone.trim() && !isValidPhone(emPhone)) errs.emPhone = PHONE_ERROR;
+    // An age-gated program needs someone to actually enroll — a household member,
+    // or the adult themselves once they've set their own age.
+    if (ageGated && namedChildren.length === 0 && !primarySelfEnrolling)
+      errs.child = "Add the household member you want to enroll, or set your date of birth below to enroll yourself.";
     return errs;
   };
 
@@ -128,9 +146,9 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           household: { ...address, emergencyContactName: emName, emergencyContactPhone: emPhone, emergencyContactEmail: emEmail },
-          // No dob/over25 for the adult — leave their age untouched; they aren't
-          // the age-gated enrollee.
-          primaryParent: { name: primaryName, allergies: primaryAllergies || null },
+          // Adult's age is captured so a single-person household can enroll itself.
+          // over25 wins when checked (declared adult, DOB cleared), matching my-household.
+          primaryParent: { name: primaryName, dob: primaryOver25 ? null : primaryDob || null, over25: primaryOver25, allergies: primaryAllergies || null },
           children: namedChildren.map((c) => ({ id: c.id, name: c.name, dob: c.dob || null, allergies: c.allergies || null })),
         }),
       });
@@ -157,8 +175,18 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
       </div>
 
       <section>
-        <Title order={5} mb="sm">{ageGated ? "Who are you enrolling?" : "Participants"}</Title>
-        <ChildrenListForm items={children} onAdd={addChild} onUpdate={updateChild} onRemove={removeChild} hideEmail />
+        <Title order={5} mb="sm">Enrolling someone else in your household? Enter their info now</Title>
+        <ChildrenListForm
+          items={children}
+          onAdd={addChild}
+          onUpdate={updateChild}
+          onRemove={removeChild}
+          hideEmail
+          titleText="Household members"
+          addText="+ Add household member"
+          emptyText="No other household members added yet."
+          itemLabel="Household member"
+        />
         {fieldErrors.child && <Text c="red" size="sm" mt="xs">{fieldErrors.child}</Text>}
         {fieldErrors.childDob && <Text c="red" size="sm" mt="xs">{fieldErrors.childDob}</Text>}
       </section>
@@ -171,6 +199,22 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
           error={fieldErrors.primaryName}
           onChange={(e) => { setPrimaryName(e.currentTarget.value); clearErr("primaryName"); }}
         />
+        <Checkbox
+          mt="sm"
+          label="I am over 25"
+          checked={primaryOver25}
+          onChange={(e) => { setPrimaryOver25(e.currentTarget.checked); if (e.currentTarget.checked) setPrimaryDob(""); clearErr("child"); }}
+        />
+        {!primaryOver25 && (
+          <TextInput
+            type="date"
+            mt="sm"
+            label="Your date of birth"
+            description="Fill this in if you're the one enrolling."
+            value={primaryDob}
+            onChange={(e) => { setPrimaryDob(e.currentTarget.value); clearErr("child"); }}
+          />
+        )}
         <TextInput mt="sm" label="Allergies (optional)" value={primaryAllergies} onChange={(e) => setPrimaryAllergies(e.currentTarget.value)} />
       </section>
 

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -128,7 +128,7 @@ describe("ProgramEnrollmentPage", () => {
 
         // Panel mounts, prefilled with the adult's name; add the child + emergency contact.
         await screen.findByText("Finish setting up your household");
-        fireEvent.click(screen.getByRole("button", { name: "+ Add child" }));
+        fireEvent.click(screen.getByRole("button", { name: "+ Add household member" }));
         fireEvent.change(screen.getByLabelText("Full name"), { target: { value: "New Kid" } });
         fireEvent.change(screen.getByLabelText("Date of birth"), { target: { value: "2015-01-01" } });
         fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt May" } });

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -5,7 +5,8 @@ import { signIn, useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Anchor, Button, Card, Center, Checkbox, Container, Divider, Group, Loader, Stack, Text, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { formatDate, calculateAge } from '@/lib/time';
+import { formatDate } from '@/lib/time';
+import { checkProgramAge } from '@/lib/programAge';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { formatCents } from '@inventory/money';
 import { aggregateEnrollOutcomes, buildShopifyCheckoutUrl, type EnrollOutcome } from './enroll';
@@ -86,17 +87,11 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   // returned a confusing "Date of Birth is missing" for over-25 adults).
   const enrollBlock = (member: { id: number; dateOfBirth: string | null; isDeclaredAdult?: boolean }): { reason: 'enrolled' | 'age' | 'dob' | null; label: string } => {
     if ((program?.participants ?? []).some(p => p.personId === member.id)) return { reason: 'enrolled', label: 'Already Enrolled' };
-    if (program && (program.minAge !== null || program.maxAge !== null)) {
-      if (!member.dateOfBirth) {
-        // A declared over-25 adult is simply outside a child age range — not a
-        // missing-data problem the household needs to fix.
-        return member.isDeclaredAdult ? { reason: 'age', label: 'Adult' } : { reason: 'dob', label: 'DOB missing' };
-      }
-      const age = calculateAge(member.dateOfBirth, program.startAt ?? undefined);
-      if (program.minAge !== null && age < program.minAge) return { reason: 'age', label: 'Too young' };
-      if (program.maxAge !== null && age > program.maxAge) return { reason: 'age', label: 'Too old' };
-    }
-    return { reason: null, label: '' };
+    if (!program) return { reason: null, label: '' };
+    // Same eligibility rule as the enroll route: a declared over-25 adult clears
+    // a youth minimum like "16 and up" without a DOB on file.
+    const check = checkProgramAge(member, { minAge: program.minAge, maxAge: program.maxAge, asOf: program.startAt ?? undefined });
+    return check.ok ? { reason: null, label: '' } : { reason: check.reason, label: check.label };
   };
 
   // Load the caller's household into the member-select, and decide whether they

--- a/checkin-app/src/components/membership/ChildrenListForm.tsx
+++ b/checkin-app/src/components/membership/ChildrenListForm.tsx
@@ -16,6 +16,12 @@ export default function ChildrenListForm({
   onUpdate,
   onRemove,
   hideEmail = false,
+  // Copy overrides — membership intake lists a family's children, but program
+  // intake lists any household member (a spouse, an adult enrolling themselves).
+  titleText = "Children",
+  addText = "+ Add child",
+  emptyText = "No children added yet.",
+  itemLabel = "Child",
 }: {
   items: ChildForm[];
   onAdd: () => void;
@@ -24,19 +30,23 @@ export default function ChildrenListForm({
   // Program-first-time intake collects a child's email later (on the household
   // screen), so it hides the email input here; membership intake keeps it.
   hideEmail?: boolean;
+  titleText?: string;
+  addText?: string;
+  emptyText?: string;
+  itemLabel?: string;
 }) {
   return (
     <section>
       <Group justify="space-between" align="center" mb="sm">
-        <Title order={2}>Children</Title>
-        <Button variant="light" size="xs" fz={15} onClick={onAdd}>+ Add child</Button>
+        <Title order={2}>{titleText}</Title>
+        <Button variant="light" size="xs" fz={15} onClick={onAdd}>{addText}</Button>
       </Group>
-      {items.length === 0 && <Text c="dimmed">No children added yet.</Text>}
+      {items.length === 0 && <Text c="dimmed">{emptyText}</Text>}
       <Stack>
         {items.map((child, i) => (
           <Card key={child.id ?? `new-${i}`} withBorder radius="md" padding="md">
             <Group justify="space-between" align="center" mb="xs">
-              <Text fw={600}>Child {i + 1}</Text>
+              <Text fw={600}>{itemLabel} {i + 1}</Text>
               <Button variant="subtle" color="red" size="compact-sm" onClick={() => onRemove(i)}>Remove</Button>
             </Group>
             <TextInput label="Full name" value={child.name} onChange={(e) => onUpdate(i, "name", e.currentTarget.value)} />

--- a/checkin-app/src/lib/__tests__/programAge.test.ts
+++ b/checkin-app/src/lib/__tests__/programAge.test.ts
@@ -1,0 +1,68 @@
+import { checkProgramAge, validateProgramAgeBounds, MAX_PROGRAM_AGE } from "@/lib/programAge";
+
+// as-of date pins calculateAge so the DOB cases don't drift with wall-clock time.
+const asOf = "2026-01-01";
+
+describe("checkProgramAge", () => {
+  it("passes anyone when the program has no age bounds", () => {
+    expect(checkProgramAge({ dateOfBirth: null }, { minAge: null, maxAge: null }).ok).toBe(true);
+  });
+
+  it("lets a declared over-25 adult into a '16 and up' program without a DOB", () => {
+    expect(
+      checkProgramAge({ dateOfBirth: null, isDeclaredAdult: true }, { minAge: 16, maxAge: null }).ok,
+    ).toBe(true);
+  });
+
+  it("blocks a declared adult from a youth program with a maximum age", () => {
+    const r = checkProgramAge({ dateOfBirth: null, isDeclaredAdult: true }, { minAge: 8, maxAge: 16 });
+    expect(r).toEqual({ ok: false, reason: "age", label: "Adult" });
+  });
+
+  it("blocks a declared adult when the minimum is above 25 (over-25 can't guarantee it)", () => {
+    const r = checkProgramAge({ dateOfBirth: null, isDeclaredAdult: true }, { minAge: 30, maxAge: null });
+    expect(r).toEqual({ ok: false, reason: "age", label: "Adult" });
+  });
+
+  it("treats a missing DOB with no adult flag as missing data", () => {
+    const r = checkProgramAge({ dateOfBirth: null }, { minAge: 16, maxAge: null });
+    expect(r).toEqual({ ok: false, reason: "dob", label: "DOB missing" });
+  });
+
+  it("enforces min/max against a real DOB", () => {
+    expect(checkProgramAge({ dateOfBirth: "2015-01-01" }, { minAge: 16, maxAge: null, asOf })).toEqual({
+      ok: false,
+      reason: "age",
+      label: "Too young",
+    });
+    expect(checkProgramAge({ dateOfBirth: "1990-01-01" }, { minAge: null, maxAge: 16, asOf })).toEqual({
+      ok: false,
+      reason: "age",
+      label: "Too old",
+    });
+    expect(checkProgramAge({ dateOfBirth: "2000-01-01" }, { minAge: 16, maxAge: 40, asOf }).ok).toBe(true);
+  });
+});
+
+describe("validateProgramAgeBounds", () => {
+  it("accepts null/undefined (optional bounds)", () => {
+    expect(validateProgramAgeBounds()).toBeNull();
+    expect(validateProgramAgeBounds(null, null)).toBeNull();
+  });
+
+  it("accepts a valid range within the 25 ceiling", () => {
+    expect(validateProgramAgeBounds(14, 18)).toBeNull();
+    expect(validateProgramAgeBounds(0, MAX_PROGRAM_AGE)).toBeNull();
+  });
+
+  it("rejects ages over 25 (the 'over 25' bucket, not a real age)", () => {
+    expect(validateProgramAgeBounds(26, null)).toBe("minAge cannot exceed 25");
+    expect(validateProgramAgeBounds(null, 26)).toBe("maxAge cannot exceed 25");
+  });
+
+  it("rejects negatives and inverted ranges", () => {
+    expect(validateProgramAgeBounds(-1, null)).toBe("minAge cannot be negative");
+    expect(validateProgramAgeBounds(null, -1)).toBe("maxAge cannot be negative");
+    expect(validateProgramAgeBounds(18, 14)).toBe("minAge cannot exceed maxAge");
+  });
+});

--- a/checkin-app/src/lib/programAge.ts
+++ b/checkin-app/src/lib/programAge.ts
@@ -1,0 +1,63 @@
+import { calculateAge } from "@/lib/time";
+
+/**
+ * Single source of truth for "can this person enroll in this age-gated program".
+ * Shared by the client member-select (enrollBlock) and the server enroll route
+ * so a declared adult ("I am over 25") is treated the same in both places.
+ *
+ * A declared adult has no DOB on file but is known to be over 25. That's enough
+ * to satisfy a youth minimum (e.g. "16 and up") and there's no youth maximum
+ * they'd fall under — so they're eligible unless the program sets a finite
+ * maxAge (a youth cap an over-25 adult can't be inside) or a minimum above 25
+ * (which "over 25" alone can't guarantee).
+ */
+
+export type AgeReason = "dob" | "age";
+
+export type ProgramAgeResult =
+  | { ok: true }
+  | { ok: false; reason: AgeReason; label: "DOB missing" | "Too young" | "Too old" | "Adult" };
+
+export function checkProgramAge(
+  person: { dateOfBirth: Date | string | null; isDeclaredAdult?: boolean },
+  program: { minAge: number | null; maxAge: number | null; asOf?: Date | string },
+): ProgramAgeResult {
+  const { minAge, maxAge } = program;
+  if (minAge === null && maxAge === null) return { ok: true };
+
+  if (!person.dateOfBirth) {
+    if (person.isDeclaredAdult) {
+      const minOk = minAge === null || minAge <= 25;
+      const maxOk = maxAge === null;
+      return minOk && maxOk ? { ok: true } : { ok: false, reason: "age", label: "Adult" };
+    }
+    return { ok: false, reason: "dob", label: "DOB missing" };
+  }
+
+  const age = calculateAge(person.dateOfBirth, program.asOf);
+  if (minAge !== null && age < minAge) return { ok: false, reason: "age", label: "Too young" };
+  if (maxAge !== null && age > maxAge) return { ok: false, reason: "age", label: "Too old" };
+  return { ok: true };
+}
+
+/**
+ * Highest age a program may target. Anyone older falls into the "over 25"
+ * bucket (a single radio, no exact age recorded — see Person.isDeclaredAdult),
+ * so 26+ is not a real age to gate on. minAge/maxAge must stay <= this. This is
+ * exactly why a declared adult clears any youth minimum in checkProgramAge.
+ */
+export const MAX_PROGRAM_AGE = 25;
+
+/**
+ * Validate a program's age bounds. Returns an error message for the caller to
+ * pass to apiError(400), or null when valid. Shared by every write path
+ * (create, PATCH, settings) so the 25+ ceiling can't be bypassed via one route.
+ */
+export function validateProgramAgeBounds(minAge?: number | null, maxAge?: number | null): string | null {
+  if (minAge != null && minAge < 0) return "minAge cannot be negative";
+  if (maxAge != null && maxAge < 0) return "maxAge cannot be negative";
+  if (minAge != null && minAge > MAX_PROGRAM_AGE) return `minAge cannot exceed ${MAX_PROGRAM_AGE}`;
+  if (maxAge != null && maxAge > MAX_PROGRAM_AGE) return `maxAge cannot exceed ${MAX_PROGRAM_AGE}`;
+  if (minAge != null && maxAge != null && minAge > maxAge) return "minAge cannot exceed maxAge";
+  return null;
+}


### PR DESCRIPTION
## What

Adults in a single-person household can now enroll **themselves** in a program. Previously the program-registration intake assumed a child was always the enrollee, and the enrollment age check ignored the "over 25" declaration — so a declared adult couldn't join even an age-open program like "16 and up".

## Why

Reported: on `/programs/[id]` the first-time intake only let you add children, and a declared over-25 adult showed as "Adult" and was blocked from a "16 and up" program. The DOB/`isDeclaredAdult` age logic was duplicated across the client member-select and the server enroll route, and they disagreed.

## Changes

**Intake panel (`FirstTimeIntakePanel`)**
- Adult age capture — DOB + "I am over 25" checkbox in "About you" — so the adult can be the enrollee. Wired to `primaryParent.dob`/`over25` (already persisted by `saveIntake`).
- Shared `ChildrenListForm` copy is now configurable: program context reads "Household member" / "+ Add household member" (spouse, or the adult); membership intake keeps "Children" via defaults.
- Clearer heading: "Enrolling someone else in your household? Enter their info now" (was the misleading "Who are you enrolling?").
- Client-validate emergency-contact phone format.

**Age eligibility — new `lib/programAge.ts`, single source of truth**
- `checkProgramAge`: a declared over-25 adult (no DOB) clears any youth minimum and is blocked only by a finite `maxAge`. Both the client `enrollBlock` and `POST /participants` route through it (the server used to hard-block on missing DOB and ignore `isDeclaredAdult`).
- `validateProgramAgeBounds` + `MAX_PROGRAM_AGE` (0–25 write cap) consolidated here beside the eligibility check that relies on that ceiling; the three program write routes import from `@/lib/programAge`.

## Testing

- New `programAge` unit suite (eligibility + bounds).
- Updated a renamed button label and stale membership phone fixtures.
- Full unit suite green (196 suites / 1506 tests) and integration suite green (106 suites / 864 tests, incl. `programsEnrollClosed`, `programAgeStartDate`, `programAgeBounds`).

## Reviewer notes

- `MAX_PROGRAM_AGE = 25` is exactly why `checkProgramAge` lets a declared adult clear any youth minimum — programs can't gate above 25, so "over 25" always satisfies the min; only a finite max excludes them.
- A declared adult is still correctly "Adult"-blocked from a youth program that sets a max (e.g. ages 8–16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)