### PR TITLE
fix(membership-settings): complete the config-health pill — 4 fields, live refresh, inline highlighting

### DIFF
--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -395,15 +395,20 @@ export const GET = withAuth({}, async (_req, auth) => {
                     },
                 },
             }),
-            // Required Shopify-checkout settings — count how many are still unset so the
-            // board sees a red pill until both are configured. Empty string counts as unset.
+            // Required membership settings — count how many are still unset so the board
+            // sees a red pill until all are configured. Empty string counts as unset for
+            // the Shopify fields; bgRecheckMonths <= 0 means the re-check interval is unset;
+            // a null orgMembershipYearBoundary means the renewal cycle has no anchor date.
             prisma.boardSettings.findUnique({
                 where: { id: 1 },
-                select: { orgMembershipVariantId: true, volunteerDiscountCode: true },
+                select: { orgMembershipVariantId: true, volunteerDiscountCode: true, bgRecheckMonths: true, orgMembershipYearBoundary: true },
             }),
         ]);
         const settingsMisconfig =
-            (boardSettings?.orgMembershipVariantId ? 0 : 1) + (boardSettings?.volunteerDiscountCode ? 0 : 1);
+            (boardSettings?.orgMembershipVariantId ? 0 : 1) +
+            (boardSettings?.volunteerDiscountCode ? 0 : 1) +
+            ((boardSettings?.bgRecheckMonths ?? 0) > 0 ? 0 : 1) +
+            (boardSettings?.orgMembershipYearBoundary ? 0 : 1);
         result.admin = { membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies, settingsMisconfig };
         // System-config health (env-var/deploy gaps). Synchronous, no DB — just presence
         // checks. Same admin+board gate as the rest of this block.

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -6,6 +6,7 @@ import { useDisclosure } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
 import { SettingsTabs } from "@/components/admin/SettingsTabs";
 import { useUnsavedGuard, shallowEqual } from "@/components/UnsavedChangesProvider";
+import { notifyNavRefresh } from "@/lib/nav-refresh";
 
 interface Settings {
   normalDuesCents: number;
@@ -82,6 +83,10 @@ export default function MembershipSettingsPage() {
 
   useEffect(() => { load(); }, [load]);
 
+  // Confirm-checkbox gate only matters when a boundary already exists — changing
+  // it shifts every household's cycle. First-time set has nothing to shift.
+  const boundaryWasSet = !!initial?.boundary;
+
   const saveSettings = async () => {
     setSaveNotice(null);
     setFieldErrors({});
@@ -101,10 +106,12 @@ export default function MembershipSettingsPage() {
           orgMembershipVariantId: variantId.trim() || null,
           volunteerDiscountCode: discountCode.trim() || null,
           bgRecheckMonths: Math.round(parseInt(bgRecheckMonths || "0", 10)),
-          ...(boundaryUnlocked ? { orgMembershipYearBoundary: boundary || null } : {}),
+          // Send the boundary when the unlock is checked, or when it was never set (no
+          // unlock shown then — nothing to protect from an accidental shift).
+          ...(boundaryUnlocked || !boundaryWasSet ? { orgMembershipYearBoundary: boundary || null } : {}),
         }),
       });
-      if (res.ok) { notifications.show({ color: "green", message: "Settings saved." }); setBoundaryUnlocked(false); await load(); }
+      if (res.ok) { notifications.show({ color: "green", message: "Settings saved." }); setBoundaryUnlocked(false); notifyNavRefresh(); await load(); }
       else { const d = await res.json().catch(() => ({})); setSaveNotice({ text: d.error || "Save failed.", err: true }); }
     } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }
     finally { setSaving(false); }
@@ -168,14 +175,15 @@ export default function MembershipSettingsPage() {
                 rightSectionWidth={36}
                 inputMode="numeric"
                 w={200}
+                error={(!bgRecheckMonths || parseInt(bgRecheckMonths, 10) <= 0) ? "Required — not configured." : undefined}
                 value={bgRecheckMonths}
                 onChange={(e) => setBgRecheckMonths(e.currentTarget.value)}
               />
             </Group>
 
             {(!bgRecheckMonths || parseInt(bgRecheckMonths, 10) <= 0) && (
-              <Alert color="yellow" variant="light" mt="md">
-                ⚠️ Background-check interval is <strong>not set</strong>. Until the board enters the
+              <Alert color="red" variant="light" mt="md">
+                ⛔ Background-check interval is <strong>not set</strong>. Until the board enters the
                 policy value (in months), every renewal will be sent back for a fresh background
                 review. Enter the real Treehouse re-check interval above.
               </Alert>
@@ -194,7 +202,7 @@ export default function MembershipSettingsPage() {
                 description="The Shopify variant ID of the membership product. We build the “Pay with Shopify” link from it as https://<store>/cart/<variantId>:1."
                 placeholder="1234567890"
                 w={260}
-                error={fieldErrors.variantId}
+                error={fieldErrors.variantId ?? (variantId.trim() === "" ? "Required for checkout — not configured." : undefined)}
                 value={variantId}
                 onChange={(e) => { setVariantId(e.currentTarget.value); setFieldErrors((f) => ({ ...f, variantId: undefined })); }}
               />
@@ -203,32 +211,42 @@ export default function MembershipSettingsPage() {
                 description="Create this discount in Shopify, then paste the code here. It is appended to the checkout link for volunteer households only."
                 placeholder="VOLUNTEER"
                 w={260}
+                error={discountCode.trim() === "" ? "Required for checkout — not configured." : undefined}
                 value={discountCode}
                 onChange={(e) => setDiscountCode(e.currentTarget.value)}
               />
             </Stack>
 
-            <Alert color="yellow" variant="light" mt="md" title="Membership-year boundary">
-              <Text size="sm" mb="sm">
-                ⚠️ Changing this date shifts the renewal cycle for <strong>every household</strong>.
-                Only change it if you are sure.
-              </Text>
+            <Alert color={boundary ? "yellow" : "red"} variant="light" mt="md" title="Membership-year boundary">
+              {boundary ? (
+                <Text size="sm" mb="sm">
+                  ⚠️ Changing this date shifts the renewal cycle for <strong>every household</strong>.
+                  Only change it if you are sure.
+                </Text>
+              ) : (
+                <Text size="sm" mb="sm">
+                  ⛔ The membership-year boundary is <strong>not configured</strong>. Renewal cycles
+                  have no anchor date until you enter it below.
+                </Text>
+              )}
               <Text size="sm" mb="sm">
                 Current boundary:{" "}
-                <strong>{boundary ? (currentBoundaryLabel(boundary) ?? "—") : "not set"}</strong>
+                <strong>{initial?.boundary ? (currentBoundaryLabel(initial.boundary) ?? "—") : "not set"}</strong>
               </Text>
-              <Checkbox
-                mb="sm"
-                checked={boundaryUnlocked}
-                onChange={(e) => setBoundaryUnlocked(e.currentTarget.checked)}
-                label="I understand — let me edit the boundary date"
-              />
+              {boundaryWasSet && (
+                <Checkbox
+                  mb="sm"
+                  checked={boundaryUnlocked}
+                  onChange={(e) => setBoundaryUnlocked(e.currentTarget.checked)}
+                  label="I understand — let me edit the boundary date"
+                />
+              )}
               <TextInput
                 type="date"
                 w={220}
                 value={boundary}
                 onChange={(e) => setBoundary(e.currentTarget.value)}
-                disabled={!boundaryUnlocked}
+                disabled={boundaryWasSet && !boundaryUnlocked}
               />
             </Alert>
 

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -137,9 +137,9 @@ describe('settings misconfig red pill', () => {
 
   it('red pill with the unset count, singular label at 1', () => {
     expect(settingsMisconfigBadge(admin({ settingsMisconfig: 1 })))
-      .toEqual({ count: 1, color: 'red', label: '1 required checkout setting not configured' });
-    expect(navBadgeFor('/settings', admin({ settingsMisconfig: 2 })))
-      .toEqual([{ count: 2, color: 'red', label: '2 required checkout settings not configured' }]);
+      .toEqual({ count: 1, color: 'red', label: '1 required membership setting not configured' });
+    expect(navBadgeFor('/settings', admin({ settingsMisconfig: 4 })))
+      .toEqual([{ count: 4, color: 'red', label: '4 required membership settings not configured' }]);
   });
 });
 

--- a/checkin-app/src/components/admin/SettingsTabs.tsx
+++ b/checkin-app/src/components/admin/SettingsTabs.tsx
@@ -29,7 +29,7 @@ export function SettingsTabs({ active }: { active: SettingsTab }) {
   const { data: session } = useSession();
   const isSysadmin = !!session?.user?.isSysadmin;
   const tabs = TABS.filter((t) => !t.sysadminOnly || isSysadmin);
-  // Red pill on Membership Settings when a required checkout setting is unset. Same
+  // Red pill on Membership Settings when a required membership setting is unset. Same
   // shared counts as the nav badge, so tab and nav can't diverge.
   const misconfig = settingsMisconfigBadge(useTodoCounts(!!session));
   return (

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -21,17 +21,19 @@ export function leadConflictCount(counts: TodoCounts | null): number {
 }
 
 /**
- * Red pill for unconfigured required Shopify-checkout board settings (the
- * membership variant ID and the volunteer discount code). Count is 1 or 2, or
- * null when both are set. Red (alert) — not green/gray — because until it's
- * fixed membership checkout is broken. Shown on the Settings nav item and the
- * Membership Settings sub-tab, both board/sysadmin-only (the people who can fix
- * it). Returns null off the admin surface (non-board viewers never see it).
+ * Red pill for unconfigured required membership board settings (the Shopify
+ * membership variant ID, the volunteer discount code, the background-check
+ * re-check interval, and the membership-year boundary). Count is 1–4, or null
+ * when all are set. Red (alert) — not green/gray — because until it's fixed
+ * membership checkout / renewals are broken. Shown on the Settings nav item and
+ * the Membership Settings sub-tab,
+ * both board/sysadmin-only (the people who can fix it). Returns null off the
+ * admin surface (non-board viewers never see it).
  */
 export function settingsMisconfigBadge(counts: TodoCounts | null): NavBadge | null {
   const n = counts?.admin?.settingsMisconfig ?? 0;
   return n > 0
-    ? { count: n, color: 'red', label: `${n} required checkout setting${n === 1 ? '' : 's'} not configured` }
+    ? { count: n, color: 'red', label: `${n} required membership setting${n === 1 ? '' : 's'} not configured` }
     : null;
 }
 


### PR DESCRIPTION
## What

Finishes the Membership Settings config-health indicator (the red pill on the Settings nav item + Membership Settings sub-tab). Before this, the pill counted only the two Shopify-checkout fields, never highlighted *which* fields were broken, and never refreshed after a save.

- **Pill now covers all 4 required membership settings** (`settingsMisconfig`, `todo-counts` route): Shopify variant ID, volunteer discount code, background-check re-check interval (`bgRecheckMonths <= 0`), and membership-year boundary (`null`). Count range 1–4.
- **Broken fields highlight inline on load**: variant ID, discount code, and re-check interval show a red "not configured" error when unset (previously only after a failed save).
- **Warnings escalate yellow → red** for the bg-recheck interval and the membership-year boundary when unset — they're errors, not advisories.
- **Boundary first-time set is frictionless**: when no boundary was ever saved, the "I understand" unlock is skipped and the date input is directly editable (nothing to protect from an accidental cycle shift); the save sends the new value in that case. The unlock still gates *changing* an existing boundary.
- **Pill refreshes on save**: `notifyNavRefresh()` fires after a successful save so the nav item and sub-tab recompute immediately instead of showing a stale count until a full reload.
- Badge label/doc updated to "required membership setting(s)".

Includes merged boundary fixes from `claude/clever-jackson-4d9b1a` (label reads saved value not live input; edit-gate keyed off saved state).

## Why

The pill claimed "N broken" but gave the board no way to see which settings, and the number went stale after fixing them — so the fix looked like it didn't work.

## Reviewer notes

- The edit-gate / red-error logic keys off the **saved** state (`boundaryWasSet = !!initial?.boundary`), not the live input, so typing a new date doesn't flip the gate mid-edit.
- Full unit suite: **1496 pass**. Integration suite: **864 pass** (throwaway PG). No integration-covered API touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)