### PR TITLE
fix(enroll): mark emergency contact name + phone as required

### DIFF
--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -78,8 +78,8 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact name"), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact phone"), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Save progress" }));
@@ -101,8 +101,8 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact name"), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact phone"), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Submit & continue" }));
@@ -524,8 +524,8 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact name"), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact phone"), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
     fireEvent.change(screen.getByLabelText("Emergency contact email (optional)"), { target: { value: "not-an-email" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
@@ -563,8 +563,8 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact name"), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact phone"), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Submit & continue" }));
@@ -591,8 +591,8 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact name"), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact phone"), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Submit & continue" }));
@@ -615,8 +615,8 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact name"), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact phone"), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Submit & continue" }));
@@ -703,8 +703,8 @@ describe("membership page", () => {
     fireEvent.change(screen.getByLabelText("City"), { target: { value: "Austin" } });
     fireEvent.change(screen.getByLabelText("State"), { target: { value: "TX" } });
     fireEvent.change(screen.getByPlaceholderText("78701"), { target: { value: "78701" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact name"), { target: { value: "Aunt Jo" } });
-    fireEvent.change(screen.getByLabelText("Emergency contact phone"), { target: { value: "555-1234" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
+    fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "555-1234" } });
     fireEvent.change(screen.getByLabelText("Emergency contact email (optional)"), { target: { value: "jo@example.com" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
     fireEvent.change(screen.getByLabelText("Date of birth"), { target: { value: "1980-01-01" } });

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -131,8 +131,8 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "+ Add child" }));
         fireEvent.change(screen.getByLabelText("Full name"), { target: { value: "New Kid" } });
         fireEvent.change(screen.getByLabelText("Date of birth"), { target: { value: "2015-01-01" } });
-        fireEvent.change(screen.getByLabelText("Emergency contact name"), { target: { value: "Aunt May" } });
-        fireEvent.change(screen.getByLabelText("Emergency contact phone"), { target: { value: "5125550000" } });
+        fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt May" } });
+        fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "5125550000" } });
         fireEvent.click(screen.getByRole("button", { name: "Save & continue to enroll" }));
 
         // Back to member-select with the now-enrollable child preselected.

--- a/checkin-app/src/components/membership/EmergencyContactForm.tsx
+++ b/checkin-app/src/components/membership/EmergencyContactForm.tsx
@@ -17,8 +17,8 @@ export default function EmergencyContactForm({
 }) {
   return (
     <SimpleGrid cols={{ base: 1, sm: 2 }} mt="md">
-      <TextInput label="Emergency contact name" value={emName} error={errors.emName} onChange={(e) => { setEmName(e.currentTarget.value); clearErr("emName"); }} />
-      <TextInput label="Emergency contact phone" value={emPhone} error={errors.emPhone} onChange={(e) => { setEmPhone(e.currentTarget.value); clearErr("emPhone"); }} />
+      <TextInput withAsterisk label="Emergency contact name" value={emName} error={errors.emName} onChange={(e) => { setEmName(e.currentTarget.value); clearErr("emName"); }} />
+      <TextInput withAsterisk label="Emergency contact phone" value={emPhone} error={errors.emPhone} onChange={(e) => { setEmPhone(e.currentTarget.value); clearErr("emPhone"); }} />
       <TextInput type="email" label="Emergency contact email (optional)" value={emEmail} error={errors.emEmail} onChange={(e) => { setEmEmail(e.currentTarget.value); clearErr("emEmail"); }} />
     </SimpleGrid>
   );


### PR DESCRIPTION
## What

Add `withAsterisk` to the **Emergency contact name** and **Emergency contact phone** fields in the shared `EmergencyContactForm`, so they show the `*` required indicator. Email stays optional (no asterisk).

## Why

On the program enroll flow (`/programs/[id]` first-time intake) and the membership page, name + phone were already enforced as required in validation, but the UI gave no visual cue. This adds the standard `*` marker.

## Where

- `EmergencyContactForm.tsx` is shared by both the program enroll intake (`FirstTimeIntakePanel`) and `membership/page.tsx`, so both surfaces get the indicator from one change.

## Reviewer notes

- Used `withAsterisk` (visual marker only) rather than native `required`, keeping the existing custom validation in control.
- `withAsterisk` appends " *" to each label, which broke exact-match `getByLabelText("Emergency contact name/phone")` queries in two test suites — updated those to regex matchers.
- Full unit suite: **1496 pass**. Integration suite: **864 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)