### PR TITLE
fix(app-frame): unique nav badge keys

### DIFF
--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -332,7 +332,7 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                 rightSection={
                   badges.length > 0 ? (
                     <Group gap={4} wrap="nowrap">
-                      {badges.map((badge) => {
+                      {badges.map((badge, i) => {
                         // Green action + gray info badges go through the shared CountBadge
                         // (treehouseGreen/black and gray.2/gray-8 respectively). The gray solid
                         // fill is deliberate: on the dark purple sidebar a 'light' translucent
@@ -342,12 +342,12 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                         // sidebar, so the dark label is pinned explicitly.
                         const intent = badgeIntentFor(badge.color);
                         return intent ? (
-                          <CountBadge key={badge.color} intent={intent} aria-label={badge.label}>
+                          <CountBadge key={i} intent={intent} aria-label={badge.label}>
                             {badge.count}
                           </CountBadge>
                         ) : (
                           <Badge
-                            key={badge.color}
+                            key={i}
                             size="md"
                             color={badge.color}
                             variant="filled"


### PR DESCRIPTION
## What

Nav badges in `AppFrame` were keyed on `badge.color`. When a NavLink has two badges of the same color (e.g. two `gray` info badges), the keys collide and React logs:

> Encountered two children with the same key, `.$gray`.

Switched all three badge `key`s (`CountBadge` intent branch, `Badge` fallback branch, and the `.map` index binding) to the array index. The badge list is static per render, so an index key is stable and safe.

## Why

Duplicate keys are unsupported and can cause children to be duplicated/omitted. This clears the console error with no behavior change.

## Reviewer notes

- No visual/behavior change — key attribute only.
- One file: `checkin-app/src/components/AppFrame.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)