### PR TITLE
feat(my-activities): Volunteer tag on events where member volunteers

### DIFF
--- a/checkin-app/src/app/api/events/mine/route.ts
+++ b/checkin-app/src/app/api/events/mine/route.ts
@@ -36,6 +36,9 @@ export const GET = withAuth({}, async (_req, auth) => {
             set.add(personId);
         }
 
+        // (person, program) pairs where the household member volunteers, not enrolls.
+        const volunteerKeys = new Set(volunteers.map(v => `${v.personId}:${v.programId}`));
+
         const events = await prisma.event.findMany({
             where: {
                 programId: { in: [...programParticipants.keys()] },
@@ -66,7 +69,8 @@ export const GET = withAuth({}, async (_req, auth) => {
                     endAt: ev.endAt,
                     program: ev.program,
                     participant: householdMemberById.get(pid),
-                    rsvp: ev.rsvps.find((r: typeof ev.rsvps[number]) => r.personId === pid)?.status ?? null
+                    rsvp: ev.rsvps.find((r: typeof ev.rsvps[number]) => r.personId === pid)?.status ?? null,
+                    isVolunteer: volunteerKeys.has(`${pid}:${ev.programId}`)
                 }));
         });
 

--- a/checkin-app/src/app/my-activities/events/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-activities/events/__tests__/page.test.tsx
@@ -30,4 +30,19 @@ describe("ParticipantEventsDashboard", () => {
         renderWithProviders(<ParticipantEventsDashboard />);
         expect(await screen.findByText("No Upcoming Events")).toBeInTheDocument();
     });
+
+    it("tags events where the member volunteers", async () => {
+        setSession({ id: 1 });
+        mockFetchJson({
+            "/api/events/mine": [
+                { id: 10, name: "Robotics Meet", description: null, startAt: "2026-07-10T18:00:00.000Z", endAt: "2026-07-10T20:00:00.000Z", program: { name: "Robotics Club" }, participant: { id: 100, name: "Kid One" }, rsvp: null, isVolunteer: true },
+                { id: 11, name: "Chess Night", description: null, startAt: "2026-07-11T18:00:00.000Z", endAt: "2026-07-11T20:00:00.000Z", program: { name: "Chess Club" }, participant: { id: 100, name: "Kid One" }, rsvp: null, isVolunteer: false },
+            ],
+        });
+        renderWithProviders(<ParticipantEventsDashboard />);
+
+        expect(await screen.findByText("Robotics Meet")).toBeInTheDocument();
+        // One badge, on the volunteered event only.
+        expect(screen.getAllByText("Volunteer")).toHaveLength(1);
+    });
 });

--- a/checkin-app/src/app/my-activities/events/page.tsx
+++ b/checkin-app/src/app/my-activities/events/page.tsx
@@ -23,6 +23,7 @@ type EventData = {
   program: { name: string } | null;
   participant: { id: number; name: string | null };
   rsvp: RsvpStatus | null;
+  isVolunteer: boolean;
 };
 
 // Group (event, member) rows into one bucket per event, preserving first-seen order.
@@ -125,13 +126,18 @@ export default function ParticipantEventsDashboard() {
             return (
               <Card key={ev.id} withBorder radius="md" padding="lg">
                 <Stack gap="sm" h="100%">
-                  <div>
-                    {ev.program && (
-                      <Text size="xs" c="cyan" fw={600} tt="uppercase">{ev.program.name}</Text>
+                  <Group justify="space-between" wrap="nowrap" align="flex-start">
+                    <div>
+                      {ev.program && (
+                        <Text size="xs" c="cyan" fw={600} tt="uppercase">{ev.program.name}</Text>
+                      )}
+                      <Title order={4}>{ev.name}</Title>
+                      <Text size="sm" c="dimmed">📅 {startStr} – {endStr}</Text>
+                    </div>
+                    {rows.some((r) => r.isVolunteer) && (
+                      <Badge color="grape" variant="light" style={{ flexShrink: 0 }}>Volunteer</Badge>
                     )}
-                    <Title order={4}>{ev.name}</Title>
-                    <Text size="sm" c="dimmed">📅 {startStr} – {endStr}</Text>
-                  </div>
+                  </Group>
 
                   {ev.description && (
                     <Text size="sm" lineClamp={2}>{ev.description}</Text>


### PR DESCRIPTION
## What

On `/my-activities/events`, event cards now show a grape **Volunteer** badge in the upper right when the household member volunteers for that event's program (rather than being enrolled).

## Why

`/api/events/mine` fetched both `programParticipant` (enrolled) and `programVolunteer` rows but merged them into one attendee set — the volunteer distinction was lost before reaching the UI. A member volunteering for an event looked identical to one enrolled in it.

## Changes

- **`api/events/mine/route.ts`**: build a `(personId:programId)` set from the already-fetched volunteer rows; expose per-row `isVolunteer`.
- **`my-activities/events/page.tsx`**: wrap the card header in a `Group justify="space-between"`; render the badge when any member on the card is a volunteer.
- Test: asserts the badge shows only on the volunteered event.

## Reviewer notes

- Card-level badge — shows if **any** member on a multi-member household card volunteers. Per-member distinction deferred (see commit body).
- No schema/migration changes; both queries already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)