### PR TITLE
feat(index): alphabetize page list, relabel My Programs links

### DIFF
--- a/checkin-app/src/app/index/page.tsx
+++ b/checkin-app/src/app/index/page.tsx
@@ -24,22 +24,13 @@ export default function IndexPage() {
 
   const matches = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return visible;
-    return visible.filter((p) =>
-      `${p.label} ${p.section} ${p.keywords ?? ''}`.toLowerCase().includes(q),
-    );
+    const filtered = !q
+      ? visible
+      : visible.filter((p) =>
+          `${p.label} ${p.section} ${p.keywords ?? ''}`.toLowerCase().includes(q),
+        );
+    return [...filtered].sort((a, b) => a.label.localeCompare(b.label));
   }, [visible, query]);
-
-  // Group by section (first-seen section order, registry page order within).
-  const grouped = useMemo(() => {
-    const bySection = new Map<string, typeof matches>();
-    for (const p of matches) {
-      const pages = bySection.get(p.section);
-      if (pages) pages.push(p);
-      else bySection.set(p.section, [p]);
-    }
-    return Array.from(bySection, ([section, pages]) => ({ section, pages }));
-  }, [matches]);
 
   return (
     <PageContainer>
@@ -53,25 +44,18 @@ export default function IndexPage() {
         autoFocus
         mb="lg"
       />
-      {grouped.length === 0 ? (
+      {matches.length === 0 ? (
         <Text c="dimmed">No pages match “{query}”.</Text>
       ) : (
-        <Stack gap="lg">
-          {grouped.map((group) => (
-            <div key={group.section}>
-              <Text fw={700} size="sm" c="dimmed" tt="uppercase" mb={4}>
-                {group.section}
-              </Text>
-              {group.pages.map((p) => (
-                <NavLink
-                  key={p.href}
-                  component={Link}
-                  href={p.href}
-                  label={p.label}
-                  description={p.href}
-                />
-              ))}
-            </div>
+        <Stack gap={0}>
+          {matches.map((p) => (
+            <NavLink
+              key={p.href}
+              component={Link}
+              href={p.href}
+              label={p.label}
+              description={p.href}
+            />
           ))}
         </Stack>
       )}

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -48,12 +48,12 @@ export const PAGES: PageEntry[] = [
   { href: '/my-household', label: 'My Household', section: 'Personal', visible: SIGNED_IN },
   { href: '/my-activities', label: 'My Activities', section: 'Personal', visible: SIGNED_IN },
   { href: '/my-activities/events', label: 'My Events', section: 'Personal', visible: SIGNED_IN },
-  { href: '/my-activities/programs', label: 'My Programs', section: 'Personal', visible: SIGNED_IN },
+  { href: '/my-activities/programs', label: 'My Programs (as Participant)', section: 'Personal', visible: SIGNED_IN },
   { href: '/profile', label: 'My Profile', section: 'Personal', visible: SIGNED_IN },
   // Staff home for program lead mentors. Lead status rides in on the todo-counts
   // payload (leadsAnyProgram), matching the nav gate. Distinct from the attendee
   // "My Programs" tab above.
-  { href: '/my-programs/attendance', label: 'My Programs (Staff)', section: 'Personal', keywords: 'lead mentor program staff attendance', visible: LEADS_PROGRAM },
+  { href: '/my-programs/attendance', label: 'My Programs (as Volunteer)', section: 'Personal', keywords: 'lead mentor program staff attendance', visible: LEADS_PROGRAM },
   { href: '/my-programs/conflicts', label: 'Attendance Conflicts', section: 'Personal', keywords: 'lead mentor duplicate overlapping visit attendance', visible: LEADS_PROGRAM },
   // Stays visible to all members: also the Join/renewal entry for new applicants
   // who aren't a household lead yet (gating it on lead would break joining).


### PR DESCRIPTION
## What

- Sort the `/index` page list **alphabetically by label**; drop section grouping and navbar-order.
- Disambiguate the two "My Programs" entries:
  - attendee link (`/my-activities/programs`) → **"My Programs (as Participant)"**
  - staff link (`/my-programs/attendance`) → **"My Programs (as Volunteer)"**

## Why

Two identical "My Programs" labels were ambiguous. Index was grouped by section and ordered to mirror the navbar, making it hard to scan for a specific page.

## Notes for reviewer

- All changes are in `checkin-app/src/components/pageRegistry.ts` (labels) and `checkin-app/src/app/index/page.tsx` (sort + flat render).
- `AppFrame.tsx` nav still shows bare "My Programs" for the attendee tab — left as-is since only the index was in scope. Say if you want nav updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)