### PR TITLE
fix(membership): home banner reflects in-flight application state

### DIFF
--- a/checkin-app/src/app/page.tsx
+++ b/checkin-app/src/app/page.tsx
@@ -39,7 +39,8 @@ export default function Home() {
 
   const [isLastKeyholder, setIsLastKeyholder] = useState(false);
   const [isTwoDeepViolation, setIsTwoDeepViolation] = useState(false);
-  const [isMember, setIsMember] = useState<boolean | null>(null);
+  // null = not loaded yet; once loaded, status/processStatus drive the join banner.
+  const [membership, setMembership] = useState<{ status: string | null; processStatus: string | null } | null>(null);
 
   const checkAttendanceStatus = useCallback(async () => {
     if (!session?.user) return;
@@ -84,14 +85,16 @@ export default function Home() {
   useEffect(() => {
     if (!session?.user) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIsMember(null);
+      setMembership(null);
       return;
     }
     let cancelled = false;
     fetch('/api/membership')
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
-        if (!cancelled && data) setIsMember(data.membershipStatus === 'ACTIVE');
+        if (!cancelled && data) {
+          setMembership({ status: data.membershipStatus ?? null, processStatus: data.process?.status ?? null });
+        }
       })
       .catch(() => { /* non-blocking: leave banner hidden on error */ });
     return () => { cancelled = true; };
@@ -151,8 +154,10 @@ export default function Home() {
                 )}
               </Paper>
 
-              {/* Visitor call-to-action — only for non-members */}
-              {isMember === false && <JoinTreehouseBanner />}
+              {/* Visitor call-to-action — only for non-members; copy reflects in-flight state */}
+              {membership && membership.status !== 'ACTIVE' && (
+                <JoinTreehouseBanner processStatus={membership.processStatus} />
+              )}
 
               {/* In-app red-dot indicators (membership reviewer queue / blocked apps, …) */}
               <Notifications />

--- a/checkin-app/src/components/JoinTreehouseBanner.tsx
+++ b/checkin-app/src/components/JoinTreehouseBanner.tsx
@@ -2,23 +2,59 @@ import Link from "next/link";
 import { Button, Card, Group, Text } from "@mantine/core";
 
 /**
- * Visitor call-to-action — shown to logged-in non–Treehouse Members to start a
- * membership application. Render only when the viewer is not an active Treehouse Member.
+ * Visitor call-to-action — shown to logged-in non–Treehouse Members. Copy adapts
+ * to the household's in-flight application state so a returning applicant sees
+ * "Continue" (or a background-check status) instead of a stale "Get started".
+ *
+ * `processStatus` is the current OrgMembershipProcess status (null = no
+ * application started yet). Render only when the viewer is not an active member.
  */
-export default function JoinTreehouseBanner() {
+export default function JoinTreehouseBanner({
+  processStatus = null,
+}: {
+  processStatus?: string | null;
+}) {
+  const { title, sub, cta } = bannerCopy(processStatus);
   return (
     <Card withBorder radius="md" padding="md" bg="var(--mantine-color-blue-light)">
       <Group justify="space-between" wrap="wrap" gap="md">
         <div>
-          <Text fw={700} fz="lg">Join the Treehouse — become a Treehouse Member today!</Text>
-          <Text size="sm" c="dimmed">
-            Tell us about your family to start your membership application.
-          </Text>
+          <Text fw={700} fz="lg">{title}</Text>
+          <Text size="sm" c="dimmed">{sub}</Text>
         </div>
-        <Button component={Link} href="/membership" style={{ whiteSpace: "nowrap" }}>
-          Get started →
-        </Button>
+        {cta && (
+          <Button component={Link} href="/membership" style={{ whiteSpace: "nowrap" }}>
+            {cta}
+          </Button>
+        )}
       </Group>
     </Card>
   );
+}
+
+function bannerCopy(status: string | null): { title: string; sub: string; cta: string | null } {
+  switch (status) {
+    case "INTAKE":
+    case "PENDING_EXTERNAL_ACTION":
+    case "PENDING_PAYMENT":
+      return {
+        title: "Finish your Treehouse membership application",
+        sub: "Pick up where you left off — we saved your progress.",
+        cta: "Continue →",
+      };
+    case "PENDING_BG_CLEARANCE":
+    case "PENDING_BG_REVIEW":
+      return {
+        title: "Membership application — background check in progress",
+        sub: "We're reviewing your background check and will email you when it clears.",
+        cta: "View status →",
+      };
+    default:
+      // No application started yet.
+      return {
+        title: "Join the Treehouse — become a Treehouse Member today!",
+        sub: "Tell us about your family to start your membership application.",
+        cta: "Get started →",
+      };
+  }
 }


### PR DESCRIPTION
## What

The "Join the Treehouse" banner on the home page always showed **"Get started"**, even for a household that had already begun (or partway completed) a membership application. Returning applicants had no way to tell the banner would resume vs. restart.

The banner copy + CTA now reflect the household's current `OrgMembershipProcess` status:

| State | Title | CTA |
|-------|-------|-----|
| No application | Join the Treehouse… | **Get started →** |
| `INTAKE` / `PENDING_EXTERNAL_ACTION` / `PENDING_PAYMENT` | Finish your membership application | **Continue →** |
| `PENDING_BG_CLEARANCE` / `PENDING_BG_REVIEW` | Background check in progress | **View status →** |

## Why

`/api/membership` already returns `process.status`; the home page was discarding it and only reading `membershipStatus`. No new data, endpoint, or query — just threading the existing status through.

## Changes

- `src/app/page.tsx` — replace the `isMember` boolean with membership state that retains `process.status`; pass it to the banner.
- `src/components/JoinTreehouseBanner.tsx` — accept optional `processStatus`; branch title/subtext/CTA. Off-track `BLOCKED` falls to the default "Get started" (not yet a user-facing flow).

## Reviewer notes

- Banner still renders only for non-active members; loading state unchanged (hidden until `/api/membership` resolves).
- Tests: full unit suite **1496 passed**, integration suite **864 passed** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)