### PR TITLE
fix(notifications): send check-in/out receipts on all paths, not just kiosk

### DIFF
--- a/checkin-app/src/app/api/attendance/manual/route.ts
+++ b/checkin-app/src/app/api/attendance/manual/route.ts
@@ -3,7 +3,8 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import type { Prisma } from "@/generated/prisma/client";
 import { findAssociatedEventAt, processVisitCheckout } from "@/lib/attendanceTransitions";
-import { logBackendError } from "@/lib/logger";
+import { sendCheckinNotifications } from "@/lib/notifications";
+import { logBackendError, logger } from "@/lib/logger";
 import { apiError } from "@/lib/api-response";
 
 // Self-service manual visit entry. INTENTIONAL by design: a member records a
@@ -72,7 +73,7 @@ export const POST = withAuth({}, async (req, auth) => {
         // visit before creating, so two concurrent manual submits — or a manual
         // submit racing a kiosk scan — can't leave two open visits for one
         // participant (checkout closes only one, the other lingers forever).
-        const visit = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        const { visit, freshCheckin } = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
             await tx.$executeRaw`SELECT pg_advisory_xact_lock(${Number(userId)})`;
 
             // Only an open visit carries dedup-able state; a closed one (departure
@@ -81,10 +82,10 @@ export const POST = withAuth({}, async (req, auth) => {
                 const openVisit = await tx.visit.findFirst({
                     where: { personId: userId, departedAt: null }
                 });
-                if (openVisit) return openVisit;
+                if (openVisit) return { visit: openVisit, freshCheckin: false };
             }
 
-            return await tx.visit.create({
+            const created = await tx.visit.create({
                 data: {
                     personId: userId,
                     arrivedAt: arrivalTime,
@@ -94,15 +95,26 @@ export const POST = withAuth({}, async (req, auth) => {
                     associatedEventId: eventId
                 }
             });
+            // freshCheckin only when a NEW open visit was created — not a backfilled
+            // closed visit (has departure) and not the dedup return above.
+            return { visit: created, freshCheckin: !departureTime };
         }, {
             maxWait: 5000,
             timeout: 15000,
         });
 
-        // If a departure time was provided, we process the checkout logic directly 
+        // If a departure time was provided, we process the checkout logic directly
         // to handle any back-to-back event transitions.
         if (departureTime) {
              await processVisitCheckout(visit.id, departureTime, undefined, "WEB");
+        }
+
+        // Fire-and-forget: notify only on a fresh active check-in (mirrors /api/scan).
+        // A backfilled closed visit is a historical record, not a live arrival.
+        if (freshCheckin) {
+            sendCheckinNotifications(Number(userId), 'checkin').catch(err =>
+                logger.error('Checkin notification error:', err)
+            );
         }
 
         await prisma.auditLog.create({

--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { getKioskPublicKeys, verifyKioskSignature } from "@/lib/verify-kiosk";
 import { getFullAttendance } from "@/lib/getFullAttendance";
 import { findAssociatedEventAt, processVisitCheckout } from "@/lib/attendanceTransitions";
+import { sendCheckinNotifications } from "@/lib/notifications";
 import { logBackendError, logger } from "@/lib/logger";
 import { config } from "@/lib/config";
 import { apiError } from "@/lib/api-response";
@@ -122,6 +123,11 @@ export const DELETE = withAuth({}, async (req, auth) => {
         const finalVisits = await processVisitCheckout(visitId, new Date(), undefined, "WEB");
         const updatedVisit = finalVisits.length > 0 ? finalVisits[finalVisits.length - 1] : visit;
 
+        // Fire-and-forget: send check-out notifications (mirrors /api/scan)
+        sendCheckinNotifications(visit.personId, 'checkout').catch(err =>
+            logger.error('Checkout notification error:', err)
+        );
+
         return NextResponse.json({ success: true, visit: updatedVisit });
     } catch (error) {
         await logBackendError(error, "DELETE /api/attendance");
@@ -203,6 +209,11 @@ export const POST = withAuth({}, async (req, auth) => {
             if (result.alreadyCheckedIn) {
                 return apiError("User is already checked in", 400);
             }
+
+            // Fire-and-forget: send check-in notifications (mirrors /api/scan)
+            sendCheckinNotifications(participant.id, 'checkin').catch(err =>
+                logger.error('Checkin notification error:', err)
+            );
 
             return NextResponse.json({ success: true, visit: result.visit });
         }

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -132,6 +132,11 @@ export async function processCheckout(
     const finalVisits = await processVisitCheckout(activeVisitId, new Date(), db, "SCANNER");
     const updatedVisit = finalVisits.length > 0 ? finalVisits[finalVisits.length - 1] : null;
 
+    // Fire-and-forget: send check-out notifications (mirrors processCheckin)
+    sendCheckinNotifications(participant.id, 'checkout').catch(err =>
+        console.error('Checkout notification error:', err)
+    );
+
     return apiJson({
         message: facilityClosed ? "Checked out and Facility closed" : "Checked out successfully",
         type: "checkout" as const,


### PR DESCRIPTION
## Problem

`sendCheckinNotifications` was only wired into the kiosk scanner (`scan-service.processCheckin`). Every other check-in/out path created the visit but never fired the receipt — so a user with **"Email me when I check in or out"** enabled saw nothing when checking in/out via the web app or self-service manual entry.

## Fix

Fire the notifier (fire-and-forget, mirroring `/api/scan`) on the paths that were missing it:

| Path | check-in | check-out |
|------|----------|-----------|
| `/api/scan` (kiosk) | already worked | **fixed** (checkout was missing) |
| `/api/attendance` (web) | **fixed** (`MANUAL_CHECKIN`) | **fixed** (DELETE) |
| `/api/attendance/manual` | **fixed** — active check-in only | n/a |

`/api/attendance/manual` notifies **only on a fresh active check-in** — a `freshCheckin` flag threaded out of the transaction skips:
- backfilled **closed** visits (has a departure → historical record, not a live arrival)
- **dedup hits** that return an already-open visit (no new check-in happened)

The `sendCheckinNotifications` function itself was always correct (respects `emailCheckinReceipts` / `emailDependentCheckins` prefs + household leads); it was just never invoked on these paths.

## Tests

- Unit: 195 suites, 1496 passed
- Integration: 106 suites, 864 passed (incl. `notificationsCheckin` + `attendanceManualCheckinConcurrency`)

No new test asserts these routes *invoke* the notifier — existing tests cover the notifier and visit creation separately. Can add call-site assertions if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)