### PR TITLE
feat(skills): add merge-safe conflict-resolution checklist

### DIFF
--- a/.claude/skills/merge-safe/SKILL.md
+++ b/.claude/skills/merge-safe/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: merge-safe
+description: >
+  Blocking checklist run AFTER resolving any rebase/merge conflict and BEFORE
+  the first `git add`. Auto-fire this any time `<<<<<<<` appeared in a diff
+  during the session, or right after `git rebase` / `git merge` / `git
+  cherry-pick` reported conflicts. Prevents two proven blow-ups: committing
+  literal conflict markers into history, and silently keeping a pre-rename
+  symbol on a line adjacent to the other side's independent rename. Use when
+  the user says "resolve conflicts", "finish the rebase/merge", "stage the
+  resolution", or you are about to `git add` after a conflict.
+---
+
+# merge-safe
+
+Conflict resolution is NOT done until every step below passes. Run them in
+order. Do NOT `git add` anything until step 4.
+
+## 1. No unmerged paths remain
+
+```
+git diff --name-only --diff-filter=U
+```
+
+Must print NOTHING. Any path listed = still unmerged. Resolve it, rerun.
+
+## 2. No conflict markers left in touched files
+
+```
+git diff --name-only --diff-filter=M HEAD | tr '\n' '\0' | \
+  xargs -0 grep -nE '^(<{7}|={7}|>{7})( |$)' 2>/dev/null
+```
+
+Must print NOTHING. If it prints lines, those are unresolved markers — fix
+them, rerun.
+
+NEVER verify remaining markers with `tail`/`head` — they truncate the list and
+manufacture false confidence. A committed `<<<<<<<` triggered a full hard reset
+and ~1h lost, twice. Grep the WHOLE set or nothing.
+
+## 3. Silent-adjacent-rename check
+
+Read BOTH sides' commit messages for rename / "→" / "rename" / "renamed"
+language:
+
+```
+git log --format='%s%n%b' HEAD@{1}..HEAD 2>/dev/null    # or the two merged tips
+```
+
+If either side renamed a symbol, field, route, or wire-key, grep the touched
+files for the OTHER side's PRE-rename name. Auto-merge keeps a stale name on a
+line next to the other side's rename — compiles clean, wrong. Grep to zero.
+
+## 4. Stage by explicit filename ONLY
+
+```
+git add path/to/resolved-file.ts   # name each file
+```
+
+NEVER `git add -A` / `git add .` after a conflict — blindly stages markers and
+unintended changes.
+
+## Only now
+
+Steps 1–3 green + staging explicit → run tsc / targeted tests, then commit.


### PR DESCRIPTION
## What

Adds a project Claude Code skill at `.claude/skills/merge-safe/SKILL.md` — a blocking checklist that runs after resolving any rebase/merge conflict, before the first `git add`.

## Why

Derived from ~100 mined agent sessions; targets the two highest-severity merge blow-ups in that corpus:

1. **Committed conflict markers.** An agent spot-checked remaining markers with `tail -N` (which truncated the real list), then `git add -A` and committed literal `<<<<<<<`/`=======`/`>>>>>>>` into history. Triggered the sharpest user reaction in the dataset and a full hard reset (~1h lost). Happened twice.
2. **Silent adjacent-line rename.** Rebase auto-merge kept a pre-rename field name on a line next to main's independent rename of the same concept — compiles clean, stale.

## The checklist (blocking, in order)

1. `git diff --name-only --diff-filter=U` must be EMPTY — no unmerged paths.
2. Grep touched files for `<<<<<<<`/`=======`/`>>>>>>>` — must return nothing. Explicitly forbids `tail`/`head` (truncates → false confidence).
3. Read both sides' commit messages for rename/"→" language; if either renamed a symbol/field, grep touched files for the OTHER side's pre-rename name.
4. Stage by explicit filename — never `git add -A`/`git add .`.

tsc / targeted tests only proceed after 1–3 pass and staging is explicit.

## Reviewer notes

- Trigger conditions live in the frontmatter `description` (auto-fires whenever `<<<<<<<` appeared in a session diff, or after a conflicting rebase/merge/cherry-pick).
- All git commands verified in this worktree layout; the step-2 marker regex was smoke-tested against a synthetic conflicted file and catches all three marker types.
- Docs-only; no code, DB, or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)