### PR TITLE
fix(jest): stop pre-commit false-failing inside .claude/worktrees checkouts

### DIFF
--- a/checkin-app/jest.config.js
+++ b/checkin-app/jest.config.js
@@ -75,7 +75,17 @@ const customJestConfig = {
     // is <rootDir>-anchored and must reach up to the repo root.
     testPathIgnorePatterns: [
         '/node_modules/',
-        '/.claude/worktrees/',
+        // Stop the PRIMARY checkout's jest from descending into sibling worktree
+        // dirs. But when jest itself runs FROM inside a worktree, every test path
+        // contains /.claude/worktrees/ -> this ignore matches ALL of them ->
+        // "No tests found" -> exit 1 -> the pre-commit hook false-blocks every
+        // worktree commit. So only apply the ignore when our own cwd is NOT in a
+        // worktree; from within a worktree, rootDir already scopes collection to
+        // this worktree's own tests, so dropping the pattern is safe.
+        // (Detect via cwd, not an env flag: core.hooksPath points at the PRIMARY
+        // checkout's .husky, so a worktree commit runs main's pre-commit — a
+        // hook-exported flag wouldn't reach here until merged+deployed to main.)
+        ...(process.cwd().includes('/.claude/worktrees/') ? [] : ['/.claude/worktrees/']),
         '\\.integration\\.test\\.[jt]sx?$',
         // Flow tests drive a running dev server over HTTP — excluded from the
         // default/unit run; run with `npm run test:flow` (see AGENTS.md).


### PR DESCRIPTION
## What

`checkin-app/jest.config.js` now applies the `/.claude/worktrees/` `testPathIgnorePattern` **only when jest's own cwd is not inside a worktree**. One line:

```js
...(process.cwd().includes('/.claude/worktrees/') ? [] : ['/.claude/worktrees/']),
```

No hook change. `/node_modules/`, `\.integration\.test\.`, `\.flow\.test\.` exclusions unchanged.

## Why

The pre-commit hook runs `npm -w checkin-app run test:ci` (`jest --ci --runInBand`). `testPathIgnorePatterns` lists the bare substring `/.claude/worktrees/` to stop the **primary** checkout's jest from descending into sibling worktree dirs. But it matches the **absolute** test path — so when jest runs *inside* a worktree, every test path contains `/.claude/worktrees/<name>/…`, all 302 tests match the ignore → `No tests found` → exit 1 → the hook false-blocks the commit. ~28+ sessions worked around this with `git commit --no-verify`; this is the #1 repeated friction in the project's session history.

From within a worktree, `rootDir` already scopes collection to that worktree's own tests, so dropping the single pattern is safe.

## Why the fix is in jest.config.js, not the hook

The obvious first idea — have the hook detect a worktree and export a flag — does not work here. `core.hooksPath` is repo-wide and points at the **primary checkout's** `.husky/_`, and husky's runner resolves the hook script relative to `$0`, so git runs **main's** `.husky/pre-commit` for *every* worktree commit. An edited worktree hook is inert until merged and checked out on main. `jest.config.js`, by contrast, is loaded from the worktree's own cwd at test time, so the fix takes effect immediately from any worktree.

## Reviewer notes

- **Primary checkout unchanged:** its cwd is `…/checkin/checkin-app` (no `/.claude/worktrees/`), so the ignore still applies and jest won't descend into sibling worktree dirs.
- **Verified in a worktree:** before = `No tests found` exit 1; after = 195 suites / 1496 tests pass, exit 0, ~37s (no integration/flow hang). Full pre-commit hook (prisma generate + security-classification diff + tests + lint + tsc) passed end-to-end with **no `--no-verify`**.
- DB / migrations untouched — jest-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)