### PR TITLE
docs(agents): batch-read files before multi-file edit sweeps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,16 @@
 Orientation for agents working in this repo. The app is a Next.js + Prisma +
 PostgreSQL membership/check-in system under `checkin-app/`.
 
+## Editing files
+
+Before a multi-file edit sweep, Read every target file first — batch all the
+Reads in one round — then Edit. Don't interleave read/edit/read/edit; the
+harness rejects any Edit/Write on a file you haven't Read this session ("File
+has not been read yet"), so front-loading the Reads avoids a stall per file.
+After a `git merge`/`rebase`/`cherry-pick` (or any external write) touches a
+file you're about to edit, re-Read it first — it counts as modified since your
+last Read.
+
 ## Test classes
 
 There are **three** classes of tests. Run all commands from `checkin-app/`.


### PR DESCRIPTION
## What

Add an **Editing files** section to `AGENTS.md`: before a multi-file edit sweep, Read every target file first (batch the Reads in one round), then Edit — don't interleave read/edit/read/edit. Re-Read a file after any `git merge`/`rebase`/`cherry-pick` touches it.

## Why

The most frequent purely-mechanical time-waster in this project's agent sessions is the "File has not been read yet" error — it fired in ~29 of 57 mined tooling-problem blocks, sometimes 5–10× in a row during a single multi-file edit sweep.

## Why a doc note, not a hook

That error IS the harness's built-in read-before-edit guard working correctly. A PreToolUse hook on Edit/Write can only allow/deny/ask or inject `additionalContext` — it **cannot run a Read on the agent's behalf**, so it would only re-emit the same error and add a failure surface. The waste is behavioral (editing one-at-a-time instead of batch-Reading), so the fix is an instruction, placed where this repo already keeps agent guidance.

## Reviewer notes

- Docs-only. No code, DB, migration, or test changes.
- Left `GEMINI.md` / `.jules/sentinel.md` untouched: the "File has not been read yet" wording is Claude-Code-harness-specific and doesn't apply verbatim to those agents' guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)