### PR TITLE
fix(programs): route enroll CTA through /signin so LOCAL uses dev picker

### DIFF
--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -203,7 +203,7 @@ describe("ProgramEnrollmentPage", () => {
         expect(router.push).toHaveBeenCalledWith("/programs");
     });
 
-    it("prompts a logged-out visitor to sign in with Google before enrolling (auth-first)", async () => {
+    it("routes a logged-out visitor through /signin (carrying the return URL) before enrolling (auth-first)", async () => {
         setSession(null, "unauthenticated");
         mockFetchJson({ "/api/programs/10": baseProgram() });
         renderPage();
@@ -214,7 +214,9 @@ describe("ProgramEnrollmentPage", () => {
         expect(screen.queryByRole("button", { name: "Register (New User)" })).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByRole("button", { name: "Sign in to enroll" }));
-        expect(signIn).toHaveBeenCalledWith("google", { callbackUrl: "/programs/10" });
+        // LOCAL never calls Google directly; /signin decides Google vs. the dev picker by env.
+        expect(signIn).not.toHaveBeenCalled();
+        expect(router.push).toHaveBeenCalledWith("/signin?callbackUrl=/programs/10");
     });
 
     it("navigates back and to the manage screen for authorized managers", async () => {

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use, useState, useEffect, useCallback } from 'react';
-import { signIn, useSession } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Alert, Anchor, Button, Card, Center, Checkbox, Container, Divider, Group, Loader, Stack, Text, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
@@ -363,11 +363,12 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                   {isClosed ? <>Enrollment Closed{closedSuffix}</> : "Enroll"}
                 </Button>
               ) : (
-                // Auth-first: sign in with Google BEFORE any intake, so account
-                // existence is resolved by NextAuth (googleId), never leaked by a
-                // public API response. First-time users are then filled in by the
-                // intake panel below rather than the anonymous register form.
-                <Button size="md" onClick={() => signIn("google", { callbackUrl: `/programs/${program.id}` })} disabled={isClosed}>
+                // Auth-first: route through /signin (which picks Google vs. the
+                // offline dev picker by env) BEFORE any intake, so account
+                // existence is resolved by NextAuth, never leaked by a public API
+                // response. First-time users are then filled in by the intake
+                // panel below rather than the anonymous register form.
+                <Button size="md" onClick={() => router.push(`/signin?callbackUrl=/programs/${program.id}`)} disabled={isClosed}>
                   {isClosed ? <>Enrollment Closed{closedSuffix}</> : "Sign in to enroll"}
                 </Button>
               )}

--- a/checkin-app/src/app/signin/page.tsx
+++ b/checkin-app/src/app/signin/page.tsx
@@ -4,7 +4,8 @@ import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { ORG_DOMAIN } from "@/lib/config";
-import { useCheckinEnv, useIsDevInstance } from "@/components/EnvProvider";
+import { useCheckinEnv, useIsDevInstance, useIsLocalInstance } from "@/components/EnvProvider";
+import DevLoginPicker from "@/components/DevLoginPicker";
 
 // Layout for the glass hero (this page still uses the legacy glass-* utilities, not Mantine).
 // Inlined from the former page.module.css, which the Mantine migration removed.
@@ -35,6 +36,7 @@ function SignInInner() {
     const params = useSearchParams();
     const { data: session, status } = useSession();
     const isDevInstance = useIsDevInstance();
+    const isLocalInstance = useIsLocalInstance();
     const checkinEnv = useCheckinEnv();
     const callbackUrl = params.get("callbackUrl") || "/";
     const error = params.get("error");
@@ -149,19 +151,26 @@ function SignInInner() {
                             gap: "1.25rem",
                         }}
                     >
-                        <button
-                            className="glass-button primary-button"
-                            onClick={() => signIn("google", { callbackUrl })}
-                            style={{
-                                width: "100%",
-                                padding: "1rem 2rem",
-                                fontSize: "1.2rem",
-                                background: "rgba(59, 130, 246, 0.2)",
-                                borderColor: "rgba(59, 130, 246, 0.4)",
-                            }}
-                        >
-                            Sign in with Google
-                        </button>
+                        {isLocalInstance ? (
+                            // LOCAL never calls Google (no Google identity on a laptop) — the offline
+                            // dev persona picker is the only login path. callbackUrl is honored so a
+                            // program-page "Sign in to enroll" returns to /programs/<id> after mint.
+                            <DevLoginPicker callbackUrl={callbackUrl} />
+                        ) : (
+                            <button
+                                className="glass-button primary-button"
+                                onClick={() => signIn("google", { callbackUrl })}
+                                style={{
+                                    width: "100%",
+                                    padding: "1rem 2rem",
+                                    fontSize: "1.2rem",
+                                    background: "rgba(59, 130, 246, 0.2)",
+                                    borderColor: "rgba(59, 130, 246, 0.4)",
+                                }}
+                            >
+                                Sign in with Google
+                            </button>
+                        )}
                     </div>
                 )}
             </div>

--- a/checkin-app/src/components/DevLoginPicker.tsx
+++ b/checkin-app/src/components/DevLoginPicker.tsx
@@ -22,7 +22,7 @@ interface Persona {
  * DevLoginPicker — renders a list of debug personas for quick login.
  * Only rendered in dev mode when the user is NOT signed in.
  */
-export default function DevLoginPicker() {
+export default function DevLoginPicker({ callbackUrl = "/" }: { callbackUrl?: string }) {
   const [personas, setPersonas] = useState<Persona[]>([]);
   const [loading, setLoading] = useState(true);
   const [signingIn, setSigningIn] = useState<string | null>(null);
@@ -47,7 +47,7 @@ export default function DevLoginPicker() {
     setSigningIn(persona.email);
     // Initial local login: no current session, so the mint is a plain login as this persona
     // (impersonatedBy stays null). The same flow handles impersonation once signed in.
-    signIn("persona-mint", { personaId: String(persona.id), mode: "impersonate", callbackUrl: "/" });
+    signIn("persona-mint", { personaId: String(persona.id), mode: "impersonate", callbackUrl });
   };
 
   // Local only: mint a brand-new empty registrant (server generates the identity), then log in
@@ -57,7 +57,7 @@ export default function DevLoginPicker() {
     const res = await fetch("/api/auth/dev-personas", { method: "POST" });
     if (!res.ok) { setSigningIn(null); return; }
     const { personaId } = await res.json();
-    signIn("persona-mint", { personaId: String(personaId), mode: "impersonate", callbackUrl: "/" });
+    signIn("persona-mint", { personaId: String(personaId), mode: "impersonate", callbackUrl });
   };
 
   const getRoleBadges = (p: Persona): { label: string; color: string }[] => {


### PR DESCRIPTION
## What

PR #845 (auth-first program registration) made the logged-out **"Sign in to enroll"** button on a program page call `signIn("google", …)` directly. On a LOCAL instance (`CHECKIN_ENV=local`, dummy Google creds) there is no Google identity, so the button triggers a real OAuth redirect and fails.

Route the CTA through `/signin` instead, which is the single place that decides **Google (dev/prod)** vs. the **offline dev persona picker (local)** by env.

## Changes

- **`programs/[id]/page.tsx`** — CTA now `router.push("/signin?callbackUrl=/programs/<id>")` instead of calling Google directly; dropped the now-unused `signIn` import. No env logic in the program page.
- **`DevLoginPicker.tsx`** — accepts optional `callbackUrl` prop (default `"/"`), threaded into both persona-mint paths (persona login + "New registrant" fresh household). Default preserves the existing home-page mount behavior.
- **`signin/page.tsx`** — when local + signed-out, render `<DevLoginPicker callbackUrl={callbackUrl} />`; the Google button is unchanged for dev/prod.

## Invariant preserved

**LOCAL never calls Google; DEV/PROD use Google only.** After the change, the only remaining `signIn("google"` call site is the `/signin` dev/prod button (verified by grep).

## Testing

- `tsc` clean.
- Updated the program CTA test: asserts `router.push("/signin?callbackUrl=/programs/10")` and `signIn` is **not** called.
- Full unit suite: **195 suites / 1496 tests** pass.
- Integration suite: **106 suites / 864 tests** pass.

Scope: login-routing only. No changes to public-register, the intake panel/service, or auth-options/evaluateMint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)