### PR TITLE
feat(programs): surface + repair broken paid-enrollment checkout

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -80,6 +80,8 @@ const AUTHZ_TESTED = new Set<string>([
     'membership/reviews',
     'people/search',
     'programs',
+    // POST deny-path (401 anon / 403 non-board) in authzRoleRejection.integration.test.ts.
+    'programs/[id]/sync-shopify',
     'roles',
     'safety/board-contacts',
     'safety/emergency-contacts',

--- a/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
@@ -34,6 +34,7 @@ import { PATCH as SHOP_TOOL_PATCH } from '@/app/api/shop/tools/[id]/route';
 import { GET as EVENT_GET, PATCH as EVENT_PATCH } from '@/app/api/events/[id]/route';
 import { GET as EVENTS_LIST_GET } from '@/app/api/events/route';
 import { POST as PROGRAMS_POST } from '@/app/api/programs/route';
+import { POST as PROGRAM_SYNC_SHOPIFY_POST } from '@/app/api/programs/[id]/sync-shopify/route';
 import { GET as NOTIFICATIONS_GET } from '@/app/api/notifications/route';
 import { POST as CONTRACT_SYNC_POST } from '@/app/api/membership/contract/sync/route';
 import { POST as ONBOARDING_POST } from '@/app/api/profile/onboarding/route';
@@ -165,6 +166,7 @@ describe('Protected-route role rejection', () => {
         // (finance-ops/payment-plans POST is covered in programPaymentPlansAPI; its GET is now a handler().)
         { name: 'GET /api/events (standalone list)', invoke: () => EVENTS_LIST_GET(nreq('http://localhost/api/events')) },
         { name: 'POST /api/programs', invoke: () => PROGRAMS_POST(nreq('http://localhost/api/programs', 'POST', {})) },
+        { name: 'POST /api/programs/[id]/sync-shopify', invoke: () => PROGRAM_SYNC_SHOPIFY_POST(nreq('http://localhost/api/programs/1/sync-shopify', 'POST', {}), idCtx(1)) },
 
         // ---- drift-guard sweep: one row per method of each role-gated route ----
         // The withAuth roles gate fires before any body/param work, so dummy

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -8,6 +8,7 @@ import { getLeadConflicts } from "@/lib/attendanceConflicts";
 import { pickAddress, validateAddress } from "@/lib/address";
 import { ORG_DOMAIN } from "@/lib/config";
 import { openConfigIssues } from "@/lib/configHealth";
+import { PROGRAM_CHECKOUT_BROKEN_WHERE } from "@/lib/programCheckout";
 import { apiError } from "@/lib/api-response";
 
 /**
@@ -67,7 +68,9 @@ export type TodoCounts = {
     // `settingsMisconfig` = how many required Shopify-checkout board settings are still
     // unset (0–2): the membership variant ID and the volunteer discount code. Red pill on
     // the Settings nav + Membership Settings tab — checkout is broken until both are set.
-    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; memberFamilies: number; settingsMisconfig: number };
+    // `programsMisconfig` = how many programs have a price but no matching Shopify variant
+    // (paid enrollment silently can't check out). Red pill on the Program Ops Programs tab.
+    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; memberFamilies: number; settingsMisconfig: number; programsMisconfig: number };
     // Config-health gaps (admins + board only): number of failing system-config checks
     // (e.g. Zoho e-sign unconfigured). Drives the red System Status nav badge; the full
     // list lives at /api/system-status/config-health. See lib/configHealth.ts.
@@ -350,7 +353,7 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     // ---- Admin surface (board's own queue) — only for board/isSysadmin ----
     if (user.isSysadmin || user.isBoardMember) {
-        const [membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies, boardSettings] = await Promise.all([
+        const [membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies, programsMisconfig, boardSettings] = await Promise.all([
             prisma.orgMembershipProcess.count({
                 where: { status: { in: BOARD_ACTIONABLE_MEMBERSHIP } },
             }),
@@ -395,6 +398,10 @@ export const GET = withAuth({}, async (_req, auth) => {
                     },
                 },
             }),
+            // Programs priced on a tier with no matching Shopify variant — paid enrollment
+            // silently can't check out. Same condition as the list/detail UI, shared via
+            // PROGRAM_CHECKOUT_BROKEN_WHERE (see lib/programCheckout.ts).
+            prisma.program.count({ where: PROGRAM_CHECKOUT_BROKEN_WHERE }),
             // Required membership settings — count how many are still unset so the board
             // sees a red pill until all are configured. Empty string counts as unset for
             // the Shopify fields; bgRecheckMonths <= 0 means the re-check interval is unset;
@@ -409,7 +416,7 @@ export const GET = withAuth({}, async (_req, auth) => {
             (boardSettings?.volunteerDiscountCode ? 0 : 1) +
             ((boardSettings?.bgRecheckMonths ?? 0) > 0 ? 0 : 1) +
             (boardSettings?.orgMembershipYearBoundary ? 0 : 1);
-        result.admin = { membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies, settingsMisconfig };
+        result.admin = { membership, applicationsTotal, paymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies, settingsMisconfig, programsMisconfig };
         // System-config health (env-var/deploy gaps). Synchronous, no DB — just presence
         // checks. Same admin+board gate as the rest of this block.
         result.configHealth = { openIssues: openConfigIssues() };

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -118,7 +118,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
 
         const body = await req.json();
         let { leadMentorId } = body;
-        const { name, startAt, endAt, orgMemberOnly, phase, enrollmentStatus, minAge, maxAge, maxParticipants, leadMentorNotificationSettings, memberPrice, nonMemberPrice } = body;
+        const { name, startAt, endAt, orgMemberOnly, phase, enrollmentStatus, minAge, maxAge, maxParticipants, leadMentorNotificationSettings, memberPrice, nonMemberPrice, shopifyProductId, shopifyOrgMemberVariantId, shopifyNonOrgMemberVariantId } = body;
 
         if (body.hasOwnProperty('leadMentorId')) {
             if (!leadMentorId) {
@@ -149,6 +149,13 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
             ...(leadMentorNotificationSettings !== undefined && { leadMentorNotificationSettings }),
             ...(memberPrice !== undefined && { orgMemberPriceCents: dollarsToCentsOrNull(memberPrice != null ? String(memberPrice) : undefined) }),
             ...(nonMemberPrice !== undefined && { nonOrgMemberPriceCents: dollarsToCentsOrNull(nonMemberPrice != null ? String(nonMemberPrice) : undefined) }),
+            // Shopify identifiers are sysadmin/board-only — a lead mentor's PATCH can't
+            // touch them (they can break checkout, so they stay off the lead surface).
+            // Empty string clears the field. This is the manual repair path when there's
+            // no live Shopify to sync against (local/testing).
+            ...(isSysAdminOrBoard && shopifyProductId !== undefined && { shopifyProductId: shopifyProductId || null }),
+            ...(isSysAdminOrBoard && shopifyOrgMemberVariantId !== undefined && { shopifyOrgMemberVariantId: shopifyOrgMemberVariantId || null }),
+            ...(isSysAdminOrBoard && shopifyNonOrgMemberVariantId !== undefined && { shopifyNonOrgMemberVariantId: shopifyNonOrgMemberVariantId || null }),
         };
 
         const updatedProgram = await prisma.program.update({

--- a/checkin-app/src/app/api/programs/[id]/sync-shopify/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/sync-shopify/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { createShopifyProgramVariants } from "@/lib/shopify";
+import { isProgramCheckoutBroken } from "@/lib/programCheckout";
+import { logBackendError } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
+
+// Repair path for a program that has a price but no Shopify variant — a state
+// program-create (api/programs POST) can't reach but a later price edit
+// (api/programs/[id] PATCH) can, since PATCH never mints variants. Mirrors the
+// creation call so the dev/local mock branch (config.shopifyMockActive) works too.
+//
+// ponytail: recreates the whole product+variants and overwrites all three IDs.
+// For the common prod case (made free, then priced → no product at all) that's
+// exactly right. For the rarer partial case (one variant exists, the other tier
+// was added later) it orphans the old product. Upgrade to patching only the
+// missing variant onto the existing product if partial repair ever matters.
+export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (_req, auth, ctx: { params: Promise<{ id: string }> }) => {
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
+    const { id } = await ctx.params;
+    const programId = parseInt(id, 10);
+    if (isNaN(programId)) return apiError("Invalid program ID", 400);
+
+    const program = await prisma.program.findUnique({ where: { id: programId } });
+    if (!program) return apiError("Program not found", 404);
+    if (!isProgramCheckoutBroken(program)) {
+        return apiError("Program checkout is already configured (or the program is free).", 400);
+    }
+
+    try {
+        const shopifyData = await createShopifyProgramVariants(
+            program.name,
+            program.orgMemberPriceCents,
+            program.nonOrgMemberPriceCents,
+            program.maxParticipants,
+        );
+        if (!shopifyData) {
+            return apiError("Shopify sync failed or is not configured. Check Shopify credentials.", 502);
+        }
+
+        const updated = await prisma.program.update({
+            where: { id: programId },
+            data: {
+                shopifyProductId: shopifyData.shopifyProductId,
+                shopifyOrgMemberVariantId: shopifyData.shopifyOrgMemberVariantId,
+                shopifyNonOrgMemberVariantId: shopifyData.shopifyNonOrgMemberVariantId,
+            },
+        });
+
+        await prisma.auditLog.create({
+            data: {
+                actorId: auth.user.id,
+                action: 'EDIT',
+                tableName: 'Program',
+                affectedEntityId: updated.id,
+                oldData: program,
+                newData: updated,
+            },
+        });
+
+        return NextResponse.json({ success: true, program: updated });
+    } catch (error) {
+        await logBackendError(error, "POST /api/programs/[id]/sync-shopify");
+        return apiError("Failed to sync program to Shopify", 500);
+    }
+});

--- a/checkin-app/src/app/program-ops/layout.tsx
+++ b/checkin-app/src/app/program-ops/layout.tsx
@@ -5,8 +5,11 @@ import { useSession } from "next-auth/react";
 import { useEffect } from "react";
 import { Box, Center, Loader, Stack, Text } from "@mantine/core";
 import { SectionTabs } from "@/components/ui/SectionTabs";
+import { CountBadge } from "@/components/ui/CountBadge";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PROGRAM_NAV_LINKS } from "@/lib/programNav";
+import { useTodoCounts } from "@/hooks/useTodoCounts";
+import { programsMisconfigBadge } from "@/components/navBadges";
 
 // A program-edit URL (/program-ops/programs/[id]) carries a PROGRAM id, so the
 // layout can gate it precisely against the caller's led-program set. Session URLs
@@ -27,6 +30,17 @@ export default function ProgramOpsLayout({ children }: { children: React.ReactNo
 
   const user = session?.user;
   const isGlobalAdmin = !!(user?.isSysadmin || user?.isBoardMember);
+
+  // Red pill on the Programs tab for priced programs missing their Shopify variant.
+  // The count is only in the payload for admin/board, so gate the fetch on that.
+  const todoCounts = useTodoCounts(isGlobalAdmin);
+  const badgeFor = (href: string): React.ReactNode => {
+    if (href !== "/program-ops/programs") return undefined;
+    const badge = programsMisconfigBadge(todoCounts);
+    return badge ? (
+      <CountBadge intent="alert" aria-label={badge.label}>{badge.count}</CountBadge>
+    ) : undefined;
+  };
 
   // Row-aware: a lead mentor reaches program-edit only for the programs they lead.
   const editProgramId = programEditId(pathname);
@@ -64,7 +78,7 @@ export default function ProgramOpsLayout({ children }: { children: React.ReactNo
 
   return (
     <PageContainer>
-      <SectionTabs links={PROGRAM_NAV_LINKS} prefixMatch mb="md" />
+      <SectionTabs links={PROGRAM_NAV_LINKS} prefixMatch badgeFor={badgeFor} mb="md" />
       <Box style={{ minWidth: 0 }}>{children}</Box>
     </PageContainer>
   );

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -11,6 +11,7 @@ import { ProgramRosterTab } from './ProgramRosterTab';
 import { notifications } from '@mantine/notifications';
 import { ProgramEventsTab } from './ProgramEventsTab';
 import { isProgramCheckoutBroken } from '@/lib/programCheckout';
+import { notifyNavRefresh } from '@/lib/nav-refresh';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 export type ProgramDetail = {
@@ -160,6 +161,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
       });
       if (res.ok) {
         notifications.show({ color: "green", message: "Saved." });
+        notifyNavRefresh();
         fetchProgram();
       } else {
         const data = await res.json().catch(() => ({}));
@@ -187,6 +189,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
         notifications.show({ color: "green", message: "Shopify identifiers saved." });
+        notifyNavRefresh();
         fetchProgram();
       } else {
         notifications.show({ color: "red", message: data.error || "Failed to save.", autoClose: false });
@@ -205,6 +208,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
         notifications.show({ color: "green", message: "Shopify checkout configured." });
+        notifyNavRefresh();
         fetchProgram();
       } else {
         notifications.show({ color: "red", message: data.error || "Failed to sync to Shopify.", autoClose: false });

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -10,6 +10,7 @@ import { ScrollableTabsList } from '@/components/ui/ScrollableTabsList';
 import { ProgramRosterTab } from './ProgramRosterTab';
 import { notifications } from '@mantine/notifications';
 import { ProgramEventsTab } from './ProgramEventsTab';
+import { isProgramCheckoutBroken } from '@/lib/programCheckout';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 export type ProgramDetail = {
@@ -41,6 +42,8 @@ export type ProgramDetail = {
   orgMemberPriceCents: number | null;
   nonOrgMemberPriceCents: number | null;
   shopifyProductId: string | null;
+  shopifyOrgMemberVariantId: string | null;
+  shopifyNonOrgMemberVariantId: string | null;
 };
 
 export type ParticipantOption = { id: number; name: string | null; email: string; dateOfBirth?: string | null };
@@ -72,12 +75,19 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
   const [memberPrice, setMemberPrice] = useState("");
   const [nonMemberPrice, setNonMemberPrice] = useState("");
 
+  // Shopify identifiers, editable by sysadmin/board only (manual repair when
+  // there's no live Shopify to sync against).
+  const [shopifyProductIdInput, setShopifyProductIdInput] = useState("");
+  const [orgVariantInput, setOrgVariantInput] = useState("");
+  const [nonOrgVariantInput, setNonOrgVariantInput] = useState("");
+
   // EntityPicker owns the transient query/results/loading; we keep only the selected id + its display label.
   const [mentorSearch, setMentorSearch] = useState("");
   const [isEditingMentor, setIsEditingMentor] = useState(false);
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [syncing, setSyncing] = useState(false);
   const [saveError, setSaveError] = useState("");
   const [message, setMessage] = useState("");
   const [activeTab, setActiveTab] = useState<'general' | 'roster' | 'events'>('general');
@@ -100,6 +110,9 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
         setMemberPrice(data.orgMemberPriceCents !== null ? String(data.orgMemberPriceCents / 100) : "");
         setNonMemberPrice(data.nonOrgMemberPriceCents !== null ? String(data.nonOrgMemberPriceCents / 100) : "");
         setMentorSearch(data.leadMentor ? `${data.leadMentor.name || 'Unnamed'} (${data.leadMentor.email})` : "");
+        setShopifyProductIdInput(data.shopifyProductId ?? "");
+        setOrgVariantInput(data.shopifyOrgMemberVariantId ?? "");
+        setNonOrgVariantInput(data.shopifyNonOrgMemberVariantId ?? "");
         setIsEditingMentor(false);
       } else if (res.status === 404) {
         setMessage("Program not found.");
@@ -156,6 +169,50 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
       notifications.show({ color: "red", message: "Network error.", autoClose: false });
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleSaveShopifyIds = async () => {
+    setSyncing(true);
+    try {
+      const res = await fetch(`/api/programs/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          shopifyProductId: shopifyProductIdInput || null,
+          shopifyOrgMemberVariantId: orgVariantInput || null,
+          shopifyNonOrgMemberVariantId: nonOrgVariantInput || null,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        notifications.show({ color: "green", message: "Shopify identifiers saved." });
+        fetchProgram();
+      } else {
+        notifications.show({ color: "red", message: data.error || "Failed to save.", autoClose: false });
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleSyncShopify = async () => {
+    setSyncing(true);
+    try {
+      const res = await fetch(`/api/programs/${id}/sync-shopify`, { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        notifications.show({ color: "green", message: "Shopify checkout configured." });
+        fetchProgram();
+      } else {
+        notifications.show({ color: "red", message: data.error || "Failed to sync to Shopify.", autoClose: false });
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
+    } finally {
+      setSyncing(false);
     }
   };
 
@@ -247,8 +304,43 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                   </Group>
                 </Card>
 
-                {program.shopifyProductId && (
+                {isProgramCheckoutBroken(program) ? (
+                  <Alert color="red" variant="light" title="⚠️ Broken checkout">
+                    <Stack gap="xs" align="flex-start">
+                      <Text size="sm">
+                        This program has a price but no Shopify checkout variant — paid enrollment will not work
+                        (parents can&apos;t pay and enrollments stay pending). This happens when a program is priced
+                        after it was first created.
+                      </Text>
+                      {isSysAdminOrBoard && (
+                        <Button color="red" variant="filled" size="xs" loading={syncing} onClick={handleSyncShopify}>
+                          Sync to Shopify
+                        </Button>
+                      )}
+                    </Stack>
+                  </Alert>
+                ) : program.shopifyProductId && (
                   <Alert color="green" variant="light">✓ Pre-configured for Shopify Checkout (Product ID: {program.shopifyProductId})</Alert>
+                )}
+
+                {isSysAdminOrBoard && (
+                  <Card withBorder radius="md" padding="md">
+                    <Text fw={500} mb={4}>Shopify Checkout Identifiers</Text>
+                    <Text size="xs" c="dimmed" mb="sm">
+                      Admin/Board only. A priced tier needs its variant ID or paid enrollment can&apos;t check out.
+                      Set these manually here (e.g. local/testing where there is no live Shopify), or use “Sync to Shopify” above to create them.
+                    </Text>
+                    <SimpleGrid cols={{ base: 1, sm: 2 }}>
+                      <TextInput label="Member Variant ID" value={orgVariantInput} onChange={e => setOrgVariantInput(e.currentTarget.value)} placeholder="e.g. 40123456789" />
+                      <TextInput label="Non-Member Variant ID" value={nonOrgVariantInput} onChange={e => setNonOrgVariantInput(e.currentTarget.value)} placeholder="e.g. 40123456790" />
+                    </SimpleGrid>
+                    <TextInput mt="sm" label="Product ID (optional)" value={shopifyProductIdInput} onChange={e => setShopifyProductIdInput(e.currentTarget.value)} placeholder="e.g. 80123456789" />
+                    <Group mt="sm">
+                      <Button type="button" variant="light" size="xs" loading={syncing} onClick={handleSaveShopifyIds}>
+                        Save Shopify IDs
+                      </Button>
+                    </Group>
+                  </Card>
                 )}
               </Stack>
 

--- a/checkin-app/src/app/program-ops/programs/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/page.tsx
@@ -144,9 +144,6 @@ export default function AdminProgramsIndex() {
     },
   ];
 
-  // Count over all programs (not just the visible filter) so it matches the nav pill.
-  const brokenCheckoutCount = programs.filter(isProgramCheckoutBroken).length;
-
   return (
     <Stack>
       <Group justify="space-between" align="flex-start" wrap="wrap">
@@ -155,12 +152,6 @@ export default function AdminProgramsIndex() {
           + New Program
         </Button>
       </Group>
-
-      {brokenCheckoutCount > 0 && (
-        <Badge color="red" variant="filled" size="lg">
-          ⚠️ {brokenCheckoutCount} program{brokenCheckoutCount === 1 ? '' : 's'} with broken checkout
-        </Badge>
-      )}
 
       <Group gap="lg">
         <Checkbox

--- a/checkin-app/src/app/program-ops/programs/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Anchor, Badge, Button, Checkbox, Group, Stack, Text } from "@mantine/core";
+import { Anchor, Badge, Button, Checkbox, Group, Stack, Text, Tooltip } from "@mantine/core";
 import { DataTable, type DataTableColumn } from "@/components/admin/DataTable";
+import { isProgramCheckoutBroken } from "@/lib/programCheckout";
 
 type Program = {
   id: number;
@@ -14,6 +15,10 @@ type Program = {
   orgMemberOnly?: boolean;
   startAt?: string | null;
   endAt?: string | null;
+  orgMemberPriceCents?: number | null;
+  nonOrgMemberPriceCents?: number | null;
+  shopifyOrgMemberVariantId?: string | null;
+  shopifyNonOrgMemberVariantId?: string | null;
   _count?: { participants?: number; events?: number };
 };
 
@@ -72,7 +77,16 @@ export default function AdminProgramsIndex() {
   const columns: DataTableColumn<Program>[] = [
     {
       header: "Program",
-      render: (p) => <Text fw={600}>{p.name}</Text>,
+      render: (p) => (
+        <Group gap="xs" wrap="nowrap">
+          <Text fw={600}>{p.name}</Text>
+          {isProgramCheckoutBroken(p) && (
+            <Tooltip label="Priced but no Shopify checkout variant — paid enrollment will not work. Open the program to sync.">
+              <Badge color="red" variant="filled">⚠️ Broken checkout</Badge>
+            </Tooltip>
+          )}
+        </Group>
+      ),
       sortBy: (p) => p.name,
     },
     {
@@ -130,6 +144,9 @@ export default function AdminProgramsIndex() {
     },
   ];
 
+  // Count over all programs (not just the visible filter) so it matches the nav pill.
+  const brokenCheckoutCount = programs.filter(isProgramCheckoutBroken).length;
+
   return (
     <Stack>
       <Group justify="space-between" align="flex-start" wrap="wrap">
@@ -138,6 +155,12 @@ export default function AdminProgramsIndex() {
           + New Program
         </Button>
       </Group>
+
+      {brokenCheckoutCount > 0 && (
+        <Badge color="red" variant="filled" size="lg">
+          ⚠️ {brokenCheckoutCount} program{brokenCheckoutCount === 1 ? '' : 's'} with broken checkout
+        </Badge>
+      )}
 
       <Group gap="lg">
         <Checkbox

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -160,6 +160,13 @@ describe('programs misconfig red pill', () => {
     expect(programsMisconfigBadge(admin({ programsMisconfig: 3 })))
       .toEqual({ count: 3, color: 'red', label: '3 programs with broken checkout' });
   });
+
+  it('surfaces on the /program-ops left-nav item, empty off the admin surface', () => {
+    expect(navBadgeFor('/program-ops', base)).toEqual([]);
+    expect(navBadgeFor('/program-ops', admin({ programsMisconfig: 0 }))).toEqual([]);
+    expect(navBadgeFor('/program-ops', admin({ programsMisconfig: 2 })))
+      .toEqual([{ count: 2, color: 'red', label: '2 programs with broken checkout' }]);
+  });
 });
 
 describe('tabBadgeFor', () => {

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -1,4 +1,4 @@
-import { navBadgeFor, tabBadgeFor, reviewBadges, settingsMisconfigBadge, leadsAnyProgram, leadPendingCount, leadConflictCount } from '@/components/navBadges';
+import { navBadgeFor, tabBadgeFor, reviewBadges, settingsMisconfigBadge, programsMisconfigBadge, leadsAnyProgram, leadPendingCount, leadConflictCount } from '@/components/navBadges';
 import type { TodoCounts } from '@/app/api/nav/todo-counts/route';
 
 const base: TodoCounts = {
@@ -86,6 +86,7 @@ const admin = (over: Partial<NonNullable<TodoCounts['admin']>> = {}): TodoCounts
     brokenHouseholds: 0,
     memberFamilies: 0,
     settingsMisconfig: 0,
+    programsMisconfig: 0,
     ...over,
   },
 });
@@ -140,6 +141,24 @@ describe('settings misconfig red pill', () => {
       .toEqual({ count: 1, color: 'red', label: '1 required membership setting not configured' });
     expect(navBadgeFor('/settings', admin({ settingsMisconfig: 4 })))
       .toEqual([{ count: 4, color: 'red', label: '4 required membership settings not configured' }]);
+  });
+});
+
+describe('programs misconfig red pill', () => {
+  it('is null off the admin surface (non-board viewer)', () => {
+    expect(programsMisconfigBadge(base)).toBeNull();
+    expect(programsMisconfigBadge(null)).toBeNull();
+  });
+
+  it('hidden when no program is broken', () => {
+    expect(programsMisconfigBadge(admin({ programsMisconfig: 0 }))).toBeNull();
+  });
+
+  it('red pill with the broken count, singular label at 1', () => {
+    expect(programsMisconfigBadge(admin({ programsMisconfig: 1 })))
+      .toEqual({ count: 1, color: 'red', label: '1 program with broken checkout' });
+    expect(programsMisconfigBadge(admin({ programsMisconfig: 3 })))
+      .toEqual({ count: 3, color: 'red', label: '3 programs with broken checkout' });
   });
 });
 

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -38,6 +38,20 @@ export function settingsMisconfigBadge(counts: TodoCounts | null): NavBadge | nu
 }
 
 /**
+ * Red pill for programs that have a price but no matching Shopify variant — paid
+ * enrollment silently can't check out (parent can't pay; the participant stays
+ * PENDING). Red (alert) — checkout is broken until synced. Shown on the Program
+ * Ops "All Programs" tab, admin/board-gated (the count is absent from the payload
+ * for everyone else). Returns null at 0 or off the admin surface.
+ */
+export function programsMisconfigBadge(counts: TodoCounts | null): NavBadge | null {
+  const n = counts?.admin?.programsMisconfig ?? 0;
+  return n > 0
+    ? { count: n, color: 'red', label: `${n} program${n === 1 ? '' : 's'} with broken checkout` }
+    : null;
+}
+
+/**
  * Background-check Review badges (0, 1, or 2), shared by the left-nav Membership
  * Ops item and the Review sub-tab so both stay in lockstep: green = applications
  * this reviewer can act on now; gray = ones they approved awaiting a second

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -103,6 +103,12 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
     }
     case '/programs':
       return gray(counts.activePrograms, `${counts.activePrograms} active programs`);
+    case '/program-ops': {
+      // Red: priced programs missing their Shopify variant (broken paid checkout).
+      // Mirrors the Programs section-tab pill; admin/board-gated (count absent otherwise).
+      const b = programsMisconfigBadge(counts);
+      return b ? [b] : [];
+    }
     case '/membership-ops': {
       // Board's BLOCKED queue (green) plus the viewer's own background-check
       // review counts — the Review tab lives under this nav item, so its badges

--- a/checkin-app/src/lib/__tests__/programCheckout.test.ts
+++ b/checkin-app/src/lib/__tests__/programCheckout.test.ts
@@ -1,0 +1,53 @@
+import { isProgramCheckoutBroken } from "@/lib/programCheckout";
+
+describe("isProgramCheckoutBroken", () => {
+  it("free program (no prices) is never broken", () => {
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: null, nonOrgMemberPriceCents: null,
+      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+    })).toBe(false);
+  });
+
+  it("both tiers priced with both variants is not broken", () => {
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 8000,
+      shopifyOrgMemberVariantId: "gid-1", shopifyNonOrgMemberVariantId: "gid-2",
+    })).toBe(false);
+  });
+
+  it("priced org tier with a null org variant is broken", () => {
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: null,
+      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+    })).toBe(true);
+  });
+
+  it("priced non-org tier with a null non-org variant is broken", () => {
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: null, nonOrgMemberPriceCents: 8000,
+      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+    })).toBe(true);
+  });
+
+  it("partial: org configured, non-org priced but missing its variant is broken", () => {
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 8000,
+      shopifyOrgMemberVariantId: "gid-1", shopifyNonOrgMemberVariantId: null,
+    })).toBe(true);
+  });
+
+  it("a missing variant on a FREE tier does not flag (gate on price > 0)", () => {
+    // Org tier free (null price) with no org variant, non-org fully configured.
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: null, nonOrgMemberPriceCents: 8000,
+      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: "gid-2",
+    })).toBe(false);
+  });
+
+  it("zero price is treated as free, not broken", () => {
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: 0, nonOrgMemberPriceCents: 0,
+      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+    })).toBe(false);
+  });
+});

--- a/checkin-app/src/lib/programCheckout.ts
+++ b/checkin-app/src/lib/programCheckout.ts
@@ -1,0 +1,38 @@
+import type { Prisma } from "@/generated/prisma/client";
+
+/**
+ * A program is "checkout-broken" when it has a price on a tier but no matching
+ * Shopify variant to sell it — paid enrollment silently can't complete (the
+ * parent can't pay; the orders/paid webhook never fires, so the participant sits
+ * PENDING forever). This state exists because variant IDs are minted only at
+ * program-create time (api/programs POST); a program made free, then priced via
+ * edit (api/programs/[id] PATCH), never gets variants.
+ *
+ * FREE tiers legitimately have no variant, so gate on the tier's price being > 0
+ * — never flag on a missing variant alone.
+ *
+ * The JS predicate and the Prisma WHERE below MUST stay in lockstep: the count
+ * query (nav/todo-counts) and the per-row/detail UI are the same condition on two
+ * sides of the wire. Change one, change the other. programCheckout.test.ts guards
+ * the predicate.
+ */
+type CheckoutFields = {
+  orgMemberPriceCents?: number | null;
+  nonOrgMemberPriceCents?: number | null;
+  shopifyOrgMemberVariantId?: string | null;
+  shopifyNonOrgMemberVariantId?: string | null;
+};
+
+export function isProgramCheckoutBroken(p: CheckoutFields): boolean {
+  return (
+    ((p.orgMemberPriceCents ?? 0) > 0 && !p.shopifyOrgMemberVariantId) ||
+    ((p.nonOrgMemberPriceCents ?? 0) > 0 && !p.shopifyNonOrgMemberVariantId)
+  );
+}
+
+export const PROGRAM_CHECKOUT_BROKEN_WHERE: Prisma.ProgramWhereInput = {
+  OR: [
+    { orgMemberPriceCents: { gt: 0 }, shopifyOrgMemberVariantId: null },
+    { nonOrgMemberPriceCents: { gt: 0 }, shopifyNonOrgMemberVariantId: null },
+  ],
+};


### PR DESCRIPTION
## What

Defense-in-depth surfacing (and a repair path) for programs that have a price set but **no Shopify variant** — a silent state that breaks paid-enrollment checkout: the parent can't pay, and the orders/paid webhook leaves the participant `PENDING` forever.

**Broken** = `(orgMemberPriceCents > 0 && !shopifyOrgMemberVariantId) || (nonOrgMemberPriceCents > 0 && !shopifyNonOrgMemberVariantId)`. FREE tiers legitimately have no variant and are never flagged.

## Why it happens (root cause)

Variant IDs are minted **only at program-create time** (`POST /api/programs`). The PATCH route updates prices but never creates variants — so a program made free, then priced via edit, is permanently broken with no UI to repair it. This PR both surfaces the state and adds a fix path.

## Changes

- **Shared predicate** — `lib/programCheckout.ts`: `isProgramCheckoutBroken()` + `PROGRAM_CHECKOUT_BROKEN_WHERE` Prisma twin, kept in lockstep (one source for the count query and the UI).
- **Count** — `nav/todo-counts`: `programsMisconfig` admin count (admin/board only, same gate as `settingsMisconfig`).
- **Badges** — `navBadges.ts`: `programsMisconfigBadge` red pill on both the Program Ops **left-nav** item and the **Programs section tab**.
- **List** — per-row "⚠️ Broken checkout" warning tag.
- **Detail** — red Alert (replaces the green "pre-configured" one when broken); **Sync to Shopify** button (sysadmin/board) that recreates variants via `createShopifyProgramVariants` (works locally via the existing mock branch).
- **Manual edit** — sysadmin/board-only editor for the Shopify product/variant IDs on the detail page + PATCH support (gated, **not** lead mentors), for local/testing where there is no live Shopify.
- **Repair route** — `POST /api/programs/[id]/sync-shopify` (sysadmin/board), with a negative-authz deny-path test + drift-guard registration.
- Live-refresh: fix handlers call `notifyNavRefresh()` so both pills decrement immediately.

## Reviewer notes

- The repair path recreates the whole product+variants and overwrites all three IDs — correct for the common "made free, then priced" case; orphans the old product in the rarer partial-variant case (documented `ponytail:` comment names the upgrade path).
- Manual variant editing is gated **server-side** in PATCH (`isSysAdminOrBoard`), not just in the UI — a lead mentor can't set variants even by crafting the request.

## Tests

- Unit: `programCheckout` predicate + `navBadges` pill (incl. `/program-ops` left-nav case).
- Full unit suite: **196 suites / 1510 tests** pass.
- Integration suite: **106 suites / 866 tests** pass (includes the new `sync-shopify` 401/403 deny-path case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)