### PR TITLE
feat(programs): fire new-program email on UPCOMING+OPEN transition

### DIFF
--- a/checkin-app/src/app/__tests__/programAnnounceNotification.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAnnounceNotification.integration.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the "new program announced" notification trigger.
+ *
+ * The PATCH route fires notifyNewProgramAnnounced ONLY on the transition INTO
+ * (phase=UPCOMING && enrollmentStatus=OPEN) — see src/app/api/programs/[id]/route.ts.
+ * These guard: it fires on the edge, does NOT re-fire while already announced,
+ * and does NOT fire when only one of the two conditions flips.
+ */
+
+import { PATCH } from '@/app/api/programs/[id]/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import { notifyNewProgramAnnounced } from '@/lib/notifications';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+jest.mock('@/lib/notifications', () => ({
+    notifyNewProgramAnnounced: jest.fn(),
+}));
+
+const PROGRAM_NAME_TAG = 'Announce Notify Test Program';
+const mockNotify = notifyNewProgramAnnounced as jest.Mock;
+
+const patch = (id: number, body: Record<string, unknown>) =>
+    PATCH(
+        new Request(`http://localhost:4000/api/programs/${id}`, {
+            method: 'PATCH',
+            body: JSON.stringify(body),
+        }) as unknown as Request,
+        { params: Promise.resolve({ id: String(id) }) },
+    );
+
+describe('New-program announce notification trigger', () => {
+    let adminId: number;
+    let leadId: number;
+
+    beforeAll(async () => {
+        const existingUsers = await prisma.person.findMany({
+            where: { email: { contains: 'announce-notify-test' } },
+            select: { id: true },
+        });
+        const existingUserIds = existingUsers.map(u => u.id);
+        await prisma.program.deleteMany({ where: { name: { contains: PROGRAM_NAME_TAG } } });
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: existingUserIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: existingUserIds } } });
+
+        const admin = await prisma.person.create({
+            data: { email: 'admin-announce-notify-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } },
+        });
+        adminId = admin.id;
+        const lead = await prisma.person.create({
+            data: { email: 'lead-announce-notify-test@example.com', name: 'Lead', household: { create: {} } },
+        });
+        leadId = lead.id;
+    });
+
+    afterAll(async () => {
+        const ids = [adminId, leadId];
+        await prisma.program.deleteMany({ where: { name: { contains: PROGRAM_NAME_TAG } } });
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { id: { in: ids } } });
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+    });
+
+    it('fires once when a program crosses INTO UPCOMING + OPEN', async () => {
+        const name = `${PROGRAM_NAME_TAG} cross`;
+        const program = await prisma.program.create({
+            data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' },
+        });
+
+        const res = await patch(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' });
+        expect(res.status).toBe(200);
+        expect(mockNotify).toHaveBeenCalledTimes(1);
+        expect(mockNotify).toHaveBeenCalledWith(name);
+    });
+
+    it('does NOT re-fire on a later edit while already UPCOMING + OPEN', async () => {
+        const name = `${PROGRAM_NAME_TAG} already`;
+        const program = await prisma.program.create({
+            data: { name, leadMentorId: leadId, phase: 'UPCOMING', enrollmentStatus: 'OPEN' },
+        });
+
+        const res = await patch(program.id, { name: `${name} renamed` });
+        expect(res.status).toBe(200);
+        expect(mockNotify).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire when only phase flips to UPCOMING (enrollment still CLOSED)', async () => {
+        const name = `${PROGRAM_NAME_TAG} phaseonly`;
+        const program = await prisma.program.create({
+            data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' },
+        });
+
+        const res = await patch(program.id, { phase: 'UPCOMING' });
+        expect(res.status).toBe(200);
+        expect(mockNotify).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire when only enrollment flips to OPEN (phase still PLANNING)', async () => {
+        const name = `${PROGRAM_NAME_TAG} enrollonly`;
+        const program = await prisma.program.create({
+            data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' },
+        });
+
+        const res = await patch(program.id, { enrollmentStatus: 'OPEN' });
+        expect(res.status).toBe(200);
+        expect(mockNotify).not.toHaveBeenCalled();
+    });
+});

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { handler, notFound, forbidden, badRequest } from "@/security/handler";
 import { isActiveOrgMember } from "@/lib/orgMembership";
+import { notifyNewProgramAnnounced } from "@/lib/notifications";
 import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
 import { validateProgramAgeBounds } from "@/lib/programAge";
@@ -166,6 +167,14 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
                 newData: updatedProgram
             }
         });
+
+        // Announce only on the transition INTO (UPCOMING && OPEN) — not on every
+        // save while already there, and not when only one of the two is set.
+        const wasAnnounced = currentProgram.phase === 'UPCOMING' && currentProgram.enrollmentStatus === 'OPEN';
+        const nowAnnounced = updatedProgram.phase === 'UPCOMING' && updatedProgram.enrollmentStatus === 'OPEN';
+        if (!wasAnnounced && nowAnnounced) {
+            await notifyNewProgramAnnounced(updatedProgram.name);
+        }
 
         return NextResponse.json({ success: true, program: updatedProgram });
     } catch (error) {

--- a/checkin-app/src/lib/__tests__/notifications.test.ts
+++ b/checkin-app/src/lib/__tests__/notifications.test.ts
@@ -1,15 +1,16 @@
-import { sendNotification } from '../notifications';
+import { sendNotification, notifyNewProgramAnnounced } from '../notifications';
 import { sendEmail } from '../email';
 import prisma from '../prisma';
 
 jest.mock('../email', () => ({ sendEmail: jest.fn() }));
 jest.mock('../prisma', () => ({
     __esModule: true,
-    default: { person: { findUnique: jest.fn() } },
+    default: { person: { findUnique: jest.fn(), findMany: jest.fn() } },
 }));
 
 const mockSendEmail = sendEmail as jest.Mock;
 const mockFindUnique = (prisma as unknown as { person: { findUnique: jest.Mock } }).person.findUnique;
+const mockFindMany = (prisma as unknown as { person: { findMany: jest.Mock } }).person.findMany;
 
 describe('sendNotification return contract', () => {
     beforeEach(() => jest.clearAllMocks());
@@ -40,5 +41,25 @@ describe('sendNotification return contract', () => {
         mockFindUnique.mockResolvedValue(null);
         await expect(sendNotification(1, 'EVENT_STARTING_SOON', {})).resolves.toBe(true);
         expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+});
+
+describe('notifyNewProgramAnnounced opt-in filtering', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('emails only users not opted out, defaulting ON', async () => {
+        mockFindMany.mockResolvedValue([
+            { email: 'in@b.com', name: 'In', notificationSettings: { notifyNewPrograms: true } },
+            { email: 'def@b.com', name: 'Def', notificationSettings: {} },            // default ON
+            { email: 'null@b.com', name: 'Null', notificationSettings: null },        // default ON
+            { email: 'out@b.com', name: 'Out', notificationSettings: { notifyNewPrograms: false } },
+            { email: 'noemail@b.com', name: 'NoE', notificationSettings: { email: false } },
+            { email: '', name: 'Empty', notificationSettings: {} },                   // empty address
+        ]);
+        await notifyNewProgramAnnounced('Robotics');
+
+        expect(mockSendEmail).toHaveBeenCalledTimes(3);
+        const recipients = mockSendEmail.mock.calls.map(c => c[0]);
+        expect(recipients).toEqual(['in@b.com', 'def@b.com', 'null@b.com']);
     });
 });

--- a/checkin-app/src/lib/notifications.ts
+++ b/checkin-app/src/lib/notifications.ts
@@ -79,6 +79,36 @@ export async function sendNotification(userId: number, eventType: NotificationEv
 }
 
 /**
+ * Broadcast a "new program announced" email to every user opted into
+ * notifyNewPrograms. Fired when a program first becomes BOTH phase=UPCOMING and
+ * enrollmentStatus=OPEN. Respects the global `email` opt-out too. Both prefs
+ * default ON — only an explicit `false` opts out.
+ */
+export async function notifyNewProgramAnnounced(programName: string): Promise<void> {
+    try {
+        // ponytail: full scan of users-with-email, filtered in JS. This fires at
+        // most once per program (the UPCOMING+OPEN edge), so a table scan is fine;
+        // switch to a JSON-path where-filter if the person table grows large.
+        const users = await prisma.person.findMany({
+            where: { email: { not: null } },
+            select: { email: true, name: true, notificationSettings: true },
+        });
+
+        const subject = `New program: ${programName}`;
+        await Promise.all(users.map(u => {
+            if (!u.email) return;
+            const s = u.notificationSettings as unknown as Record<string, boolean> | null;
+            if (s?.notifyNewPrograms === false) return; // opted out of this notice
+            if (s?.email === false) return;             // opted out of all email
+            const message = `Hi ${u.name}, a new program "${programName}" is now open for enrollment.`;
+            return sendEmail(u.email, subject, `<p>${escapeHtml(message)}</p>`);
+        }));
+    } catch (error) {
+        console.error("Failed to send new-program notifications:", error);
+    }
+}
+
+/**
  * Send check-in/out notifications based on user & household preferences.
  * 
  * Handles two notification settings:


### PR DESCRIPTION
## What

Wires up the `notifyNewPrograms` notification, which was a dead UI toggle — the preference existed in the communication settings page (default ON, saved to `notificationSettings`) but nothing ever read it: no event type, no sender, no trigger. So the email log stayed empty.

- **`notifyNewProgramAnnounced(programName)`** (`src/lib/notifications.ts`): broadcasts a "new program" email to every user opted into `notifyNewPrograms`. Both `notifyNewPrograms` and the global `email` pref default ON — only an explicit `false` opts out.
- **PATCH `/api/programs/[id]`**: fires the broadcast inline, only on the transition **into** (`phase=UPCOMING && enrollmentStatus=OPEN`) — the edge, when *both* conditions hold. No re-fire on later edits while already announced; no fire when only one of the two flips.

## Why

Per product intent, "a new program is announced" = the program becomes both upcoming and open for enrollment. The notification was never implemented on the send side; this closes that gap.

## Reviewer notes

- **Recipient scan is a JS filter over users-with-email**, marked with a `ponytail:` comment. Fires at most once per program (the UPCOMING+OPEN edge), so a table scan is fine; swap to a JSON-path where-filter if the person table grows large.
- **Transition-only**: a program *created* already UPCOMING+OPEN via POST will not notify — only edits through PATCH do. Can extend to the create path if desired.
- Send is awaited inline in the request; acceptable given the once-per-program rarity. Move to a queue if recipient counts risk request timeouts.

## Tests

- Unit: `notifyNewProgramAnnounced` opt-in filtering (default ON, respects both opt-outs, skips empty addresses).
- Integration (`programAnnounceNotification.integration.test.ts`): fires once on cross-in; silent on re-edit while already announced; silent on single-field flips (phase-only, enrollment-only). Full integration suite green (868 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)