### PR TITLE
fix(attendance): enforce keyholder-first on web + manual check-in paths

### DIFF
--- a/checkin-app/src/app/__tests__/attendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendance.integration.test.ts
@@ -24,6 +24,8 @@ describe('Attendance API Integration Tests', () => {
     let testHouseholdMemberId: number;
     let testHouseholdId: number;
     let testAdminHouseholdId: number;
+    let testKeyholderId: number;
+    let testKeyholderHouseholdId: number;
     let activeVisitId: number;
 
     beforeAll(async () => {
@@ -72,6 +74,17 @@ describe('Attendance API Integration Tests', () => {
         });
         testHouseholdMemberId = householdMember.id;
 
+        // Keyholder present + checked in: the facility-open guard requires an
+        // active keyholder before any non-keyholder MANUAL_CHECKIN succeeds.
+        const keyholder = await prisma.person.create({
+            data: { email: 'keyholder-attendance-test@example.com', name: 'Keyholder Test', isKeyholder: true, household: { create: {} } }
+        });
+        testKeyholderId = keyholder.id;
+        testKeyholderHouseholdId = keyholder.householdId;
+        await prisma.visit.create({
+            data: { personId: testKeyholderId, arrivedAt: new Date() }
+        });
+
         const visit = await prisma.visit.create({
             data: { personId: testParticipantId, arrivedAt: new Date() }
         });
@@ -85,10 +98,10 @@ describe('Attendance API Integration Tests', () => {
             where: { householdId: testHouseholdId }
         });
         await prisma.person.deleteMany({
-            where: { id: { in: [testAdminId, testParticipantId, testHouseholdMemberId] } }
+            where: { id: { in: [testAdminId, testParticipantId, testHouseholdMemberId, testKeyholderId] } }
         });
         await prisma.household.deleteMany({
-            where: { id: { in: [testHouseholdId, testAdminHouseholdId] } }
+            where: { id: { in: [testHouseholdId, testAdminHouseholdId, testKeyholderHouseholdId] } }
         });
     });
 

--- a/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
@@ -27,7 +27,8 @@ describe('General Attendance API Integration Tests', () => {
     let householdLeadId: number;
     let householdChildId: number;
     let boardMemberId: number;
-    
+    let keyholderId: number;
+
     let activeVisitId: number;
     let childActiveVisitId: number;
 
@@ -111,6 +112,16 @@ describe('General Attendance API Integration Tests', () => {
         });
         householdChildId = householdChild.id;
 
+        // Keyholder present + checked in: the facility-open guard requires an
+        // active keyholder before any non-keyholder MANUAL_CHECKIN succeeds.
+        const keyholder = await prisma.person.create({
+            data: { email: 'keyholder-attend-api-test@example.com', name: 'Keyholder', isKeyholder: true, household: { create: {} } }
+        });
+        keyholderId = keyholder.id;
+        await prisma.visit.create({
+            data: { personId: keyholderId, arrivedAt: new Date() }
+        });
+
         // Create initial active visits
         const commonVisit = await prisma.visit.create({
             data: { personId: commonId, arrivedAt: new Date() }
@@ -124,7 +135,7 @@ describe('General Attendance API Integration Tests', () => {
     });
 
     afterAll(async () => {
-        const existingUserIds = [adminId, commonId, householdLeadId, householdChildId, boardMemberId].filter(id => id !== undefined);
+        const existingUserIds = [adminId, commonId, householdLeadId, householdChildId, boardMemberId, keyholderId].filter(id => id !== undefined);
 
         if (existingUserIds.length > 0) {
             await prisma.householdLead.deleteMany({

--- a/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
@@ -181,8 +181,9 @@ describe('Manual Attendance API Integration Tests', () => {
         });
 
         it('should successfully record a manual visit with arrivedAt only', async () => {
+            // Keyholder: an open backfill must clear the facility-open guard.
             (getServerSession as jest.Mock).mockResolvedValue({
-                user: { id: testUserId }
+                user: { id: testUserId, isKeyholder: true }
             });
 
             const arrivedAt = new Date(Date.now() - 1800000); // 30 minutes ago
@@ -203,8 +204,9 @@ describe('Manual Attendance API Integration Tests', () => {
         });
 
         it('dedups a SERIAL double-submit: second POST returns the same open visit, only one in DB', async () => {
+            // Keyholder: an open backfill must clear the facility-open guard.
             (getServerSession as jest.Mock).mockResolvedValue({
-                user: { id: testUserId }
+                user: { id: testUserId, isKeyholder: true }
             });
 
             // Isolate: drop any open visit left by earlier tests so the count is unambiguous.
@@ -235,5 +237,73 @@ describe('Manual Attendance API Integration Tests', () => {
             expect(openVisits.length).toBe(1);
             expect(openVisits[0].id).toBe(first.id);
         });
+    });
+});
+
+// An OPEN manual backfill (no departure) claims the actor is in the building now,
+// so it must obey the same keyholder-first rule as /api/scan and MANUAL_CHECKIN.
+// A CLOSED backfill is historical and never gated.
+describe('Manual Attendance API keyholder-first guard (open backfills)', () => {
+    const TAG = 'manual-guard-test';
+    let nkId: number;
+    let khId: number;
+    let householdIds: number[];
+
+    function openReq(userId: number) {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: userId, isKeyholder: false } });
+        return new Request('http://localhost:4000/api/attendance/manual', {
+            method: 'POST',
+            body: JSON.stringify({ arrivedAt: new Date(Date.now() - 600000).toISOString() }), // 10 min ago, open
+        }) as unknown as import('next/server').NextRequest;
+    }
+
+    beforeAll(async () => {
+        const leaked = await prisma.person.findMany({ where: { email: { contains: TAG } }, select: { id: true, householdId: true } });
+        const ids = leaked.map(p => p.id);
+        await prisma.visit.deleteMany({ where: { personId: { in: ids } } });
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { id: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: leaked.map(p => p.householdId) } } });
+
+        const nk = await prisma.person.create({ data: { email: `nk-${TAG}@example.com`, name: 'Guard NK', household: { create: {} } } });
+        nkId = nk.id;
+        const kh = await prisma.person.create({ data: { email: `kh-${TAG}@example.com`, name: 'Guard KH', isKeyholder: true, household: { create: {} } } });
+        khId = kh.id;
+        householdIds = [nk.householdId, kh.householdId];
+    });
+
+    afterAll(async () => {
+        await prisma.visit.deleteMany({ where: { personId: { in: [nkId, khId] } } });
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: [nkId, khId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [nkId, khId] } } });
+        await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
+    });
+
+    it('non-keyholder open backfill into an empty building → 403, no visit', async () => {
+        await prisma.visit.deleteMany({ where: { personId: { in: [nkId, khId] } } });
+        const res = await (POST(openReq(nkId)) as Promise<Response>);
+        expect(res.status).toBe(403);
+        expect(await prisma.visit.count({ where: { personId: nkId, departedAt: null } })).toBe(0);
+    });
+
+    it('non-keyholder open backfill with a keyholder present → 201', async () => {
+        await prisma.visit.deleteMany({ where: { personId: { in: [nkId, khId] } } });
+        await prisma.visit.create({ data: { personId: khId, arrivedAt: new Date(), arrivedVia: 'WEB' } });
+        const res = await (POST(openReq(nkId)) as Promise<Response>);
+        expect(res.status).toBe(201);
+        expect(await prisma.visit.count({ where: { personId: nkId, departedAt: null } })).toBe(1);
+    });
+
+    it('non-keyholder CLOSED backfill into an empty building → 201 (historical, ungated)', async () => {
+        await prisma.visit.deleteMany({ where: { personId: { in: [nkId, khId] } } });
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: nkId, isKeyholder: false } });
+        const arrivedAt = new Date(Date.now() - 7200000).toISOString(); // 2h ago
+        const departedAt = new Date(Date.now() - 3600000).toISOString(); // 1h ago
+        const req = new Request('http://localhost:4000/api/attendance/manual', {
+            method: 'POST',
+            body: JSON.stringify({ arrivedAt, departedAt }),
+        }) as unknown as import('next/server').NextRequest;
+        const res = await (POST(req) as Promise<Response>);
+        expect(res.status).toBe(201);
     });
 });

--- a/checkin-app/src/app/__tests__/attendanceManualCheckinConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualCheckinConcurrency.integration.test.ts
@@ -59,8 +59,10 @@ describe('POST /api/attendance MANUAL_CHECKIN concurrency (advisory lock)', () =
         await prisma.person.deleteMany({ where: { id: { in: leakedIds } } });
         await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
 
+        // Keyholder so the facility-open guard passes: this suite exercises the
+        // advisory lock, not the keyholder-first rule (covered separately below).
         const subject = await prisma.person.create({
-            data: { email: `subject-${EMAIL_TAG}@example.com`, name: 'Manual Checkin Concurrency Subject', household: { create: {} } },
+            data: { email: `subject-${EMAIL_TAG}@example.com`, name: 'Manual Checkin Concurrency Subject', isKeyholder: true, household: { create: {} } },
         });
         subjectId = subject.id;
         householdId = subject.householdId;
@@ -94,5 +96,62 @@ describe('POST /api/attendance MANUAL_CHECKIN concurrency (advisory lock)', () =
 
         // The core invariant: the race did not open two visits.
         expect(await openVisitCount(subjectId)).toBe(1);
+    });
+});
+
+const GUARD_TAG = 'manual-checkin-keyholder-guard-test';
+
+// Regression: /attendance/current (MANUAL_CHECKIN) let a non-keyholder be the
+// first into an empty building, while / (/api/scan → processCheckin) blocked it.
+// The MANUAL_CHECKIN path now enforces the same facility-open guard.
+describe('POST /api/attendance MANUAL_CHECKIN keyholder-first guard', () => {
+    let nonKeyholderId: number;
+    let keyholderId: number;
+    let householdIds: number[];
+
+    beforeAll(async () => {
+        const leaked = await prisma.person.findMany({
+            where: { email: { contains: GUARD_TAG } },
+            select: { id: true, householdId: true },
+        });
+        const leakedIds = leaked.map(p => p.id);
+        await prisma.visit.deleteMany({ where: { personId: { in: leakedIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: leakedIds } } });
+        await prisma.household.deleteMany({ where: { id: { in: leaked.map(p => p.householdId) } } });
+
+        const nk = await prisma.person.create({
+            data: { email: `nk-${GUARD_TAG}@example.com`, name: 'Guard NonKeyholder', household: { create: {} } },
+        });
+        nonKeyholderId = nk.id;
+        const kh = await prisma.person.create({
+            data: { email: `kh-${GUARD_TAG}@example.com`, name: 'Guard Keyholder', isKeyholder: true, household: { create: {} } },
+        });
+        keyholderId = kh.id;
+        householdIds = [nk.householdId, kh.householdId];
+    });
+
+    afterAll(async () => {
+        await prisma.visit.deleteMany({ where: { personId: { in: [nonKeyholderId, keyholderId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [nonKeyholderId, keyholderId] } } });
+        await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
+    });
+
+    it('non-keyholder into an empty building → 403, no visit', async () => {
+        await prisma.visit.deleteMany({ where: { personId: { in: [nonKeyholderId, keyholderId] } } });
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: nonKeyholderId } });
+
+        const res = await (POST(checkinRequest(nonKeyholderId)) as Promise<Response>);
+        expect(res.status).toBe(403);
+        expect(await openVisitCount(nonKeyholderId)).toBe(0);
+    });
+
+    it('non-keyholder with a keyholder present → 200', async () => {
+        await prisma.visit.deleteMany({ where: { personId: { in: [nonKeyholderId, keyholderId] } } });
+        await prisma.visit.create({ data: { personId: keyholderId, arrivedAt: new Date(), arrivedVia: 'WEB' } });
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: nonKeyholderId } });
+
+        const res = await (POST(checkinRequest(nonKeyholderId)) as Promise<Response>);
+        expect(res.status).toBe(200);
+        expect(await openVisitCount(nonKeyholderId)).toBe(1);
     });
 });

--- a/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
@@ -82,7 +82,9 @@ describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
         await prisma.visit.deleteMany({ where: { personId: subjectId } });
         expect(await openVisitCount(subjectId)).toBe(0);
 
-        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: subjectId } });
+        // Keyholder: an open backfill must clear the facility-open guard; this
+        // suite exercises the advisory lock, not the keyholder-first rule.
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: subjectId, isKeyholder: true } });
 
         const arrivedAt = new Date(Date.now() - 1800000).toISOString(); // 30 min ago
 

--- a/checkin-app/src/app/api/attendance/manual/route.ts
+++ b/checkin-app/src/app/api/attendance/manual/route.ts
@@ -73,7 +73,7 @@ export const POST = withAuth({}, async (req, auth) => {
         // visit before creating, so two concurrent manual submits — or a manual
         // submit racing a kiosk scan — can't leave two open visits for one
         // participant (checkout closes only one, the other lingers forever).
-        const { visit, freshCheckin } = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        const result = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
             await tx.$executeRaw`SELECT pg_advisory_xact_lock(${Number(userId)})`;
 
             // Only an open visit carries dedup-able state; a closed one (departure
@@ -83,6 +83,18 @@ export const POST = withAuth({}, async (req, auth) => {
                     where: { personId: userId, departedAt: null }
                 });
                 if (openVisit) return { visit: openVisit, freshCheckin: false };
+
+                // An open backfill claims the actor is in the building NOW, so the
+                // same facility-open guard as /api/scan applies: a non-keyholder
+                // cannot be the first (only) person present. A closed backfill is
+                // historical and never gates. Checked under the lock so a racing
+                // keyholder check-in is either committed-and-seen or not yet.
+                if (!auth.user.isKeyholder) {
+                    const activeKeyholders = await tx.visit.count({
+                        where: { departedAt: null, person: { isKeyholder: true } }
+                    });
+                    if (activeKeyholders === 0) return { facilityClosed: true as const };
+                }
             }
 
             const created = await tx.visit.create({
@@ -102,6 +114,11 @@ export const POST = withAuth({}, async (req, auth) => {
             maxWait: 5000,
             timeout: 15000,
         });
+
+        if ('facilityClosed' in result) {
+            return apiError("Facility is closed. A Keyholder must check in first.", 403);
+        }
+        const { visit, freshCheckin } = result;
 
         // If a departure time was provided, we process the checkout logic directly
         // to handle any back-to-back event transitions.

--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -191,6 +191,18 @@ export const POST = withAuth({}, async (req, auth) => {
                     return { alreadyCheckedIn: true as const };
                 }
 
+                // Same facility-open guard as /api/scan's processCheckin: a
+                // non-keyholder cannot be the first in. Checked under the lock so a
+                // racing keyholder check-in is either fully committed or not yet seen.
+                if (!participant.isKeyholder) {
+                    const activeKeyholders = await tx.visit.count({
+                        where: { departedAt: null, person: { isKeyholder: true } }
+                    });
+                    if (activeKeyholders === 0) {
+                        return { facilityClosed: true as const };
+                    }
+                }
+
                 const visit = await tx.visit.create({
                     data: {
                         personId: participant.id,
@@ -206,6 +218,9 @@ export const POST = withAuth({}, async (req, auth) => {
                 timeout: 15000,
             });
 
+            if ('facilityClosed' in result) {
+                return apiError("Facility is closed. A Keyholder must check in first.", 403);
+            }
             if (result.alreadyCheckedIn) {
                 return apiError("User is already checked in", 400);
             }


### PR DESCRIPTION
## What

Two attendance write paths that create a **live open visit** skipped the facility-open guard that `/api/scan` (`processCheckin`) enforces, letting a non-keyholder become the first/only person "in the building":

- `POST /api/attendance` `MANUAL_CHECKIN` — used by `/attendance/current`
- `POST /api/attendance/manual` open backfill (no `departedAt`)

Both now reject a non-keyholder when 0 keyholders are present, checked under the existing per-participant advisory lock (no new lock, no race window). Manual **closed** backfills (departure set) stay ungated — they're historical records, not current presence.

## Why

Reported: `/attendance/current` allowed a non-keyholder to check into the building, while `/` correctly blocked a non-keyholder from being first in. Root cause: `/` posts to `/api/scan` → `processCheckin`, which enforces keyholder-first; the two other write paths hand-roll their own `visit.create` and never called that guard. Fixed at each path that opens a live visit rather than at the one route the ticket named.

## Reviewer notes

- **Guard source differs by route (intentional).** The manual route reads `auth.user.isKeyholder` (session); scan/MANUAL_CHECKIN read `participant.isKeyholder` (DB). Consistent because the manual route is self-only (`personId` forced to the session user), so it's the same person either way. In prod the session token carries `isKeyholder` reliably (authClaims → auth-options).
- **Closed backfills stay ungated** — verified by an explicit test (non-keyholder closed backfill into empty building → 201).
- Three routes now hand-roll the identical facility-open guard (scan-service, MANUAL_CHECKIN, manual). Left un-extracted (4 lines each, three different tx/count shapes); worth a shared helper if a 4th path appears.

## Tests

15 integration tests pass across `attendanceManualAPI`, `attendanceManualConcurrency`, `attendanceManualCheckinConcurrency`: empty-building 403, keyholder-present 201, ungated closed backfill. Pre-existing open-visit/concurrency tests updated to authenticate as keyholders (they relied on the missing guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)