### PR TITLE
feat(membership): require city/state/ZIP on intake address

### DIFF
--- a/checkin-app/flow-tests/membership-bg-nonblocking.flow.test.ts
+++ b/checkin-app/flow-tests/membership-bg-nonblocking.flow.test.ts
@@ -34,7 +34,7 @@ describe("flow: membership background check is non-blocking (PR #428)", () => {
         const save = await api(applicant, "/api/membership/intake", {
             method: "PATCH",
             body: JSON.stringify({
-                household: { address: "456 Workshop Drive", emergencyContactName: "Pat Outside", emergencyContactPhone: "555-987-6543" },
+                household: { line1: "456 Workshop Drive", city: "Austin", state: "TX", postalCode: "78701", emergencyContactName: "Pat Outside", emergencyContactPhone: "555-987-6543" },
                 primaryParent: { name: "Parent Family2" },
             }),
         });

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -192,7 +192,7 @@ describe('background check is non-blocking', () => {
         const { processId, orgMembershipId, householdId } = await makeApplicant('PENDING_EXTERNAL_ACTION', { lastBackgroundCheck: new Date() });
         // Reset the process to INTAKE with the household fully filled so submitIntake passes validation.
         await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
-        await prisma.household.update({ where: { id: householdId }, data: { line1: '123 Test St' } });
+        await prisma.household.update({ where: { id: householdId }, data: { line1: '123 Test St', city: 'Austin', state: 'TX', postalCode: '78701' } });
         await prisma.emergencyContact.create({ data: { householdId, name: 'Out Of House', phone: '555-555-1212', phoneDigits: '5555551212', priority: 0 } });
         const lead = await prisma.person.findFirst({ where: { householdId, householdLeads: { some: { householdId } } } });
 

--- a/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
@@ -130,7 +130,7 @@ describe('Membership Intake API', () => {
         const patchReq = new Request('http://localhost:4000/api/membership/intake', {
             method: 'PATCH',
             body: JSON.stringify({
-                household: { line1: '1 Treehouse Way', emergencyContactName: 'Aunt May', emergencyContactPhone: '555-555-0100' },
+                household: { line1: '1 Treehouse Way', city: 'Austin', state: 'TX', postalCode: '78701', emergencyContactName: 'Aunt May', emergencyContactPhone: '555-555-0100' },
                 primaryParent: { name: 'Lead Parent', dob: '1985-04-01', allergies: 'peanuts' },
                 children: [{ name: 'Kid One', dob: '2015-06-01' }],
             }),
@@ -199,7 +199,7 @@ describe('Membership Intake API', () => {
         const patch = new Request('http://localhost:4000/api/membership/intake', {
             method: 'PATCH',
             body: JSON.stringify({
-                household: { line1: '9 Audit Way', emergencyContactName: 'Aunt Audit', emergencyContactPhone: '555-555-9001' },
+                household: { line1: '9 Audit Way', city: 'Austin', state: 'TX', postalCode: '78701', emergencyContactName: 'Aunt Audit', emergencyContactPhone: '555-555-9001' },
                 primaryParent: { name: 'Audit Lead' },
             }),
         });

--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -78,6 +78,9 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
+    fireEvent.change(screen.getByLabelText("City", { exact: false }), { target: { value: "Austin" } });
+    fireEvent.change(screen.getByLabelText("State", { exact: false }), { target: { value: "TX" } });
+    fireEvent.change(screen.getByLabelText("ZIP", { exact: false }), { target: { value: "78701" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
@@ -101,6 +104,9 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
+    fireEvent.change(screen.getByLabelText("City", { exact: false }), { target: { value: "Austin" } });
+    fireEvent.change(screen.getByLabelText("State", { exact: false }), { target: { value: "TX" } });
+    fireEvent.change(screen.getByLabelText("ZIP", { exact: false }), { target: { value: "78701" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
@@ -511,6 +517,9 @@ describe("membership page", () => {
 
     expect(await screen.findByText("Please complete the highlighted fields.")).toBeInTheDocument();
     expect(screen.getByText("Home address is required.")).toBeInTheDocument();
+    expect(screen.getByText("City is required.")).toBeInTheDocument();
+    expect(screen.getByText("State is required.")).toBeInTheDocument();
+    expect(screen.getByText("ZIP is required.")).toBeInTheDocument();
     expect(screen.getByText("Emergency contact name is required.")).toBeInTheDocument();
     expect(screen.getByText("Emergency contact phone is required.")).toBeInTheDocument();
     expect(screen.getByText("Your name is required.")).toBeInTheDocument();
@@ -563,6 +572,9 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
+    fireEvent.change(screen.getByLabelText("City", { exact: false }), { target: { value: "Austin" } });
+    fireEvent.change(screen.getByLabelText("State", { exact: false }), { target: { value: "TX" } });
+    fireEvent.change(screen.getByLabelText("ZIP", { exact: false }), { target: { value: "78701" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
@@ -591,6 +603,9 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
+    fireEvent.change(screen.getByLabelText("City", { exact: false }), { target: { value: "Austin" } });
+    fireEvent.change(screen.getByLabelText("State", { exact: false }), { target: { value: "TX" } });
+    fireEvent.change(screen.getByLabelText("ZIP", { exact: false }), { target: { value: "78701" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
@@ -615,6 +630,9 @@ describe("membership page", () => {
     await screen.findByText("Your household");
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
+    fireEvent.change(screen.getByLabelText("City", { exact: false }), { target: { value: "Austin" } });
+    fireEvent.change(screen.getByLabelText("State", { exact: false }), { target: { value: "TX" } });
+    fireEvent.change(screen.getByLabelText("ZIP", { exact: false }), { target: { value: "78701" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });
     fireEvent.change(screen.getByLabelText("Full name", { exact: false }), { target: { value: "Pat Parent" } });
@@ -700,8 +718,8 @@ describe("membership page", () => {
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
     fireEvent.change(screen.getByPlaceholderText("Apt 4B"), { target: { value: "Unit 2" } });
-    fireEvent.change(screen.getByLabelText("City"), { target: { value: "Austin" } });
-    fireEvent.change(screen.getByLabelText("State"), { target: { value: "TX" } });
+    fireEvent.change(screen.getByLabelText("City", { exact: false }), { target: { value: "Austin" } });
+    fireEvent.change(screen.getByLabelText("State", { exact: false }), { target: { value: "TX" } });
     fireEvent.change(screen.getByPlaceholderText("78701"), { target: { value: "78701" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact name/), { target: { value: "Aunt Jo" } });
     fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "512-555-1234" } });

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -273,6 +273,9 @@ export default function MembershipPage() {
   const validateIntake = (): Record<string, string> => {
     const errs: Record<string, string> = {};
     if (!address.line1?.trim()) errs.address = "Home address is required.";
+    if (!address.city?.trim()) errs.addrCity = "City is required.";
+    if (!address.state?.trim()) errs.addrState = "State is required.";
+    if (!address.postalCode?.trim()) errs.addrZip = "ZIP is required.";
     if (!emName.trim()) errs.emName = "Emergency contact name is required.";
     if (!emPhone.trim()) errs.emPhone = "Emergency contact phone is required.";
     else if (!isValidPhone(emPhone)) errs.emPhone = PHONE_ERROR;
@@ -555,7 +558,12 @@ export default function MembershipPage() {
                 <Stack gap="lg">
                   <section>
                     <Title order={2} mb="sm">Your household</Title>
-                    <AddressForm address={address} onChange={setAddress} error={fieldErrors.address} onErrorClear={() => clearErr("address")} />
+                    <AddressForm
+                      address={address}
+                      onChange={setAddress}
+                      errors={{ line1: fieldErrors.address, city: fieldErrors.addrCity, state: fieldErrors.addrState, postalCode: fieldErrors.addrZip }}
+                      onErrorClear={(f) => clearErr(f === "line1" ? "address" : f === "city" ? "addrCity" : f === "state" ? "addrState" : "addrZip")}
+                    />
                     <EmergencyContactForm
                       emName={emName} setEmName={setEmName}
                       emPhone={emPhone} setEmPhone={setEmPhone}

--- a/checkin-app/src/app/programs/[id]/FirstTimeIntakePanel.tsx
+++ b/checkin-app/src/app/programs/[id]/FirstTimeIntakePanel.tsx
@@ -231,7 +231,7 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
 
       <section>
         <Title order={5} mb="sm">Home address (optional)</Title>
-        <AddressForm address={address} onChange={setAddress} onErrorClear={() => {}} />
+        <AddressForm address={address} onChange={setAddress} onErrorClear={() => {}} required={false} />
       </section>
 
       {error && <Alert color="red" variant="light">{error}</Alert>}

--- a/checkin-app/src/components/membership/AddressForm.tsx
+++ b/checkin-app/src/components/membership/AddressForm.tsx
@@ -3,31 +3,43 @@
 import { SimpleGrid, Stack, TextInput } from "@mantine/core";
 import type { StructuredAddress } from "@/lib/address";
 
+type Field = "line1" | "city" | "state" | "postalCode";
+
 export default function AddressForm({
   address,
   onChange,
-  error,
+  errors,
   onErrorClear,
+  required = true,
 }: {
   address: StructuredAddress;
   onChange: (address: StructuredAddress) => void;
-  error?: string;
-  onErrorClear: () => void;
+  errors?: Partial<Record<Field, string>>;
+  onErrorClear: (field: Field) => void;
+  // Membership intake requires a full address; program register collects it as
+  // optional (program-first-time profile) — pass required={false} there so the
+  // asterisks don't contradict the "optional" heading.
+  required?: boolean;
 }) {
+  const set = (field: Field, value: string) => {
+    onChange({ ...address, [field]: value });
+    onErrorClear(field);
+  };
   return (
     <Stack gap="xs">
       <TextInput
         label="Street address"
+        withAsterisk={required}
         value={address.line1 ?? ""}
-        error={error}
-        onChange={(e) => { onChange({ ...address, line1: e.currentTarget.value }); onErrorClear(); }}
+        error={errors?.line1}
+        onChange={(e) => set("line1", e.currentTarget.value)}
         placeholder="123 Main St"
       />
       <TextInput label="Apt / Suite (optional)" value={address.line2 ?? ""} onChange={(e) => onChange({ ...address, line2: e.currentTarget.value })} placeholder="Apt 4B" />
       <SimpleGrid cols={{ base: 1, sm: 3 }}>
-        <TextInput label="City" value={address.city ?? ""} onChange={(e) => onChange({ ...address, city: e.currentTarget.value })} />
-        <TextInput label="State" maxLength={2} value={address.state ?? ""} onChange={(e) => onChange({ ...address, state: e.currentTarget.value })} placeholder="TX" />
-        <TextInput label="ZIP" value={address.postalCode ?? ""} onChange={(e) => onChange({ ...address, postalCode: e.currentTarget.value })} placeholder="78701" />
+        <TextInput label="City" withAsterisk={required} value={address.city ?? ""} error={errors?.city} onChange={(e) => set("city", e.currentTarget.value)} />
+        <TextInput label="State" withAsterisk={required} maxLength={2} value={address.state ?? ""} error={errors?.state} onChange={(e) => set("state", e.currentTarget.value)} placeholder="TX" />
+        <TextInput label="ZIP" withAsterisk={required} value={address.postalCode ?? ""} error={errors?.postalCode} onChange={(e) => set("postalCode", e.currentTarget.value)} placeholder="78701" />
       </SimpleGrid>
     </Stack>
   );

--- a/checkin-app/src/lib/intake/__tests__/profiles.test.ts
+++ b/checkin-app/src/lib/intake/__tests__/profiles.test.ts
@@ -26,10 +26,22 @@ describe("intake profiles registry", () => {
     it("missingRequiredFields returns [] when membership-initial is satisfied", () => {
         const missing = missingRequiredFields(INTAKE_PROFILES["membership-initial"], {
             addressLine1: "1 Main St",
+            addressCity: "Austin",
+            addressState: "TX",
+            addressPostalCode: "78701",
             emergencyContacts: [{ conflictParticipantId: null, name: "Aunt May", phone: "555-2000" }],
             primaryName: "Primary",
         });
         expect(missing).toEqual([]);
+    });
+
+    it("membership-initial address requires city/state/ZIP, not just street", () => {
+        const missing = missingRequiredFields(INTAKE_PROFILES["membership-initial"], {
+            addressLine1: "1 Main St",
+            emergencyContacts: [{ conflictParticipantId: null, name: "Aunt May", phone: "555-2000" }],
+            primaryName: "Primary",
+        });
+        expect(missing.map((m) => m.field)).toEqual(["address"]);
     });
 
     it("program-first-time: age-gated enrollee without DOB fails participantDob; none age-gated passes", () => {

--- a/checkin-app/src/lib/intake/profiles.ts
+++ b/checkin-app/src/lib/intake/profiles.ts
@@ -32,6 +32,9 @@ export interface IntakeProfile {
  */
 export interface IntakeSubmitContext {
     addressLine1?: string | null;
+    addressCity?: string | null;
+    addressState?: string | null;
+    addressPostalCode?: string | null;
     emergencyContacts: { conflictParticipantId: number | null; name: string; phone: string }[];
     primaryName?: string | null;
     /** Enrollees whose DOB gates an age-restricted program (program-first-time). */
@@ -45,8 +48,12 @@ export interface IntakeSubmitContext {
  */
 const FIELD_RULES: Record<FieldKey, { label: string; isSatisfied: (ctx: IntakeSubmitContext) => boolean }> = {
     address: {
-        label: "home address",
-        isSatisfied: (ctx) => !!ctx.addressLine1?.trim(),
+        label: "home address (street, city, state, ZIP)",
+        isSatisfied: (ctx) =>
+            !!ctx.addressLine1?.trim() &&
+            !!ctx.addressCity?.trim() &&
+            !!ctx.addressState?.trim() &&
+            !!ctx.addressPostalCode?.trim(),
     },
     emergencyContact: {
         // A household must keep >= 1 valid (non-member, complete) emergency contact.

--- a/checkin-app/src/lib/membership/__tests__/intake.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/intake.test.ts
@@ -343,6 +343,9 @@ describe('submitIntake', () => {
         household: {
             id: 7,
             line1: '1 Main St',
+            city: 'Austin',
+            state: 'TX',
+            postalCode: '78701',
             emergencyContacts: [{ conflictParticipantId: null, name: 'Aunt May', phone: '555-555-2000' }],
             householdMembers: [{ id: 1, name: 'Primary' }],
             orgMembership: { processes: [{ id: 11, kind: 'INITIAL', status: 'INTAKE' }] },

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -358,6 +358,9 @@ export async function submitIntake(userId: number) {
     const primary = household.householdMembers.find((p) => p.id === userId);
     const missing = missingRequiredFields(INTAKE_PROFILES["membership-initial"], {
         addressLine1: household.line1,
+        addressCity: household.city,
+        addressState: household.state,
+        addressPostalCode: household.postalCode,
         emergencyContacts: household.emergencyContacts,
         primaryName: primary?.name,
     });


### PR DESCRIPTION
## What

Membership intake (`/membership`) now requires **City, State, and ZIP** in addition to Street address. Previously street (`line1`) was the only enforced address field.

- **UI**: `AddressForm` marks Street/City/State/ZIP with `*` and shows per-field inline errors. Apt/Suite stays optional.
- **Client**: `validateIntake` blocks submit until city/state/zip are filled.
- **Server**: the shared `membership-initial` profile's `address` rule now requires all four sub-fields — the real trust boundary, not just a cosmetic asterisk.

## Why

A membership home address without city/state/ZIP is unusable for mailings/records. The asterisks are backed by real validation on both client and server so the marker isn't a lie.

## Reviewer notes

- **Program registration is intentionally unaffected.** `/programs/[id]` uses the `program-first-time` profile where address stays **optional**. `AddressForm` gained a `required` prop (default `true`); `FirstTimeIntakePanel` passes `required={false}` so no asterisks appear under its "Home address (optional)" heading.
- The server sends a single `address` field key on an incomplete submit, so a server-side rejection highlights the street box (backstop only — the client blocks first with per-field errors). Future work if you want the server to name which sub-field is missing.
- Tests updated: unit (profiles, intake, page) + 3 integration fixtures that previously seeded street-only addresses.

## Testing

- Unit: 1513 passed
- Integration: 864 passed (throwaway Postgres)