### PR TITLE
fix(auth): repair Google sign-in — PrismaAdapter shim missed the Person rename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,16 @@ routes, auth, and DB together.
   reseeds every run). Don't rely on re-running against the same DB locally.
 - `*.flow.test.ts` is excluded from the unit/integration runs (it needs a live
   server) — keep it that way; run it only via `npm run test:flow`.
+- **No test tier exercises real Google OAuth.** Flow tests authenticate via
+  persona-mint (a credentials sign-in), which — with JWT sessions — never
+  touches the NextAuth **PrismaAdapter**; the adapter's user methods run only
+  inside the live Google OAuth callback. The adapter↔model mapping in
+  `checkin-app/src/lib/auth-options.ts` is guarded by tsc (keep the
+  `user: prisma.person` reference cast-free) and by
+  `src/lib/__tests__/auth-options-adapter.test.ts`. Regression to learn from:
+  the Participant→Person rename (#708) left `.participant` in that mapping
+  behind an `as` cast — CI stayed fully green while every Google sign-in on
+  the dev instance 500'd in the OAuth callback.
 
 To add a journey: drop a `flow-tests/<name>.flow.test.ts` using `loginAs`/`api`,
 keep it to real HTTP calls + response assertions. Prefer routes that don't need

--- a/checkin-app/src/lib/__tests__/auth-options-adapter.test.ts
+++ b/checkin-app/src/lib/__tests__/auth-options-adapter.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Regression guard for the NextAuth PrismaAdapter ↔ Person-model mapping in
+ * auth-options.ts (the `user: prisma.person` shim).
+ *
+ * Why this exists: the Participant→Person rename (#708) missed that mapping —
+ * it was hidden behind an `as` cast, so tsc stayed green — and every Google
+ * sign-in on the dev instance crashed in the OAuth callback with
+ * `Cannot read properties of undefined (reading 'findUnique')` in
+ * getUserByEmail. No test tier caught it, because the adapter's user methods
+ * run ONLY inside the real Google OAuth callback: persona-mint/credentials
+ * sign-in (what flow tests use via loginAs) never touches the adapter, and
+ * the global prisma mock in jest.setup.js is a permissive proxy that resolves
+ * ANY model name, so even importing auth-options can't surface a stale name.
+ *
+ * This suite therefore (a) mocks prisma with ONLY the real model names and
+ * (b) actually CALLS the adapter methods — PrismaAdapter's closures are lazy,
+ * so a stale mapping only explodes on invocation, exactly as in production.
+ */
+
+import prisma from '@/lib/prisma';
+import { addHouseholdLead } from '@/lib/household/leads';
+
+// Same env scaffolding as auth-options-jwt.test.ts: real ORG_DOMAIN, settable
+// predicates so auth-options constructs cleanly at import time.
+jest.mock('@/lib/config', () => {
+    const actual = jest.requireActual('@/lib/config');
+    return {
+        __esModule: true,
+        ...actual,
+        config: {
+            ...actual.config,
+            checkinEnv: jest.fn(() => 'dev'),
+            isDevInstance: jest.fn(() => true),
+            isProd: jest.fn(() => false),
+            nextAuthSecret: jest.fn(() => 'test-secret'),
+            googleClientId: jest.fn(() => 'gid'),
+            googleClientSecret: jest.fn(() => 'gsecret'),
+        },
+    };
+});
+
+// ONLY the real model names — a shim pointing at a renamed/stale model finds
+// `undefined` here and throws, exactly like production. Do NOT add a fallback
+// proxy; the whole point is that unknown model names must fail.
+jest.mock('@/lib/prisma', () => ({
+    __esModule: true,
+    default: {
+        person: { findUnique: jest.fn(), update: jest.fn(), create: jest.fn() },
+        household: { create: jest.fn() },
+        $transaction: jest.fn((cb: (tx: unknown) => unknown) => cb(prismaMockTx)),
+    },
+}));
+
+jest.mock('@/lib/household/leads', () => ({ addHouseholdLead: jest.fn() }));
+
+// jest.setup.js globally mocks @/lib/auth-options to `{}`; unmock to get the real adapter.
+jest.unmock('@/lib/auth-options');
+
+import { authOptions } from '@/lib/auth-options';
+
+const prismaMockTx = {
+    household: { create: jest.fn() },
+    person: { create: jest.fn() },
+};
+
+const mockPersonFindUnique = (prisma as unknown as { person: { findUnique: jest.Mock } })
+    .person.findUnique;
+
+// Adapter methods are typed optional on Adapter; the shim always provides these.
+const adapter = authOptions.adapter as unknown as {
+    getUserByEmail: (email: string) => Promise<unknown>;
+    getUser: (id: string) => Promise<unknown>;
+    createUser: (user: Record<string, unknown>) => Promise<{ id: string; email: string }>;
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('PrismaAdapter user-model shim (auth-options.ts)', () => {
+    test('adapter is wired with the user→person mapping', () => {
+        // If the shim referenced a stale model, `user` would be undefined and
+        // PrismaAdapter would still construct — the breakage is lazy. Assert the
+        // methods exist up front so a gutted adapter fails loudly here too.
+        expect(typeof adapter.getUserByEmail).toBe('function');
+        expect(typeof adapter.getUser).toBe('function');
+        expect(typeof adapter.createUser).toBe('function');
+    });
+
+    test('getUserByEmail (the OAuth-callback path that broke in #708) queries prisma.person', async () => {
+        mockPersonFindUnique.mockResolvedValue(null);
+        // With a stale shim this throws `Cannot read properties of undefined
+        // (reading 'findUnique')` — the exact production failure.
+        await expect(adapter.getUserByEmail('who@example.com')).resolves.toBeNull();
+        expect(mockPersonFindUnique).toHaveBeenCalledWith(
+            expect.objectContaining({ where: expect.objectContaining({ email: 'who@example.com' }) }),
+        );
+    });
+
+    test('getUser resolves numeric ids against prisma.person', async () => {
+        mockPersonFindUnique.mockResolvedValue({ id: 42, email: 'p@example.com' });
+        const user = await adapter.getUser('42');
+        expect(mockPersonFindUnique).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { id: 42 } }),
+        );
+        expect(user).toEqual(expect.objectContaining({ id: '42', email: 'p@example.com' }));
+    });
+
+    test('createUser creates a Person inside a household transaction', async () => {
+        prismaMockTx.household.create.mockResolvedValue({ id: 9 });
+        prismaMockTx.person.create.mockResolvedValue({ id: 7, email: 'new@example.com' });
+        const created = await adapter.createUser({ email: 'new@example.com', name: 'New Person' });
+        expect(prismaMockTx.person.create).toHaveBeenCalledWith(
+            expect.objectContaining({ data: expect.objectContaining({ householdId: 9 }) }),
+        );
+        expect(addHouseholdLead).toHaveBeenCalled();
+        expect(created).toEqual(expect.objectContaining({ id: '7', email: 'new@example.com' }));
+    });
+});

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -16,12 +16,19 @@ import { withAuroraResumeRetry } from "@/lib/auroraResumeRetry";
 // Stable id for the dev/local persona-mint credential flow.
 export const PERSONA_MINT_PROVIDER_ID = "persona-mint";
 
-// NextAuth PrismaAdapter hardcodes `prisma.user` for its user operations.
-// We map `.user` to `.participant` so the adapter can find our custom model.
-const prismaAdapterCore = prisma as unknown as Record<string, unknown> & { participant: unknown };
+// NextAuth PrismaAdapter hardcodes `prisma.user` for its user operations, so
+// alias `.user` to our Person model. `prisma.person` below MUST stay a plain,
+// type-checked property access — never hide the model name behind an `as`
+// cast. The Participant→Person rename (#708) missed this mapping precisely
+// because a cast (`as ... & { participant: unknown }`) kept tsc green with a
+// stale name, and no test tier can reach it: the adapter's user methods run
+// ONLY inside the real Google OAuth callback (persona-mint/credentials
+// sign-in bypasses the adapter entirely), so every Google sign-in crashed on
+// the dev instance while CI passed. The compiler plus
+// auth-options-adapter.test.ts are the guards — keep both intact.
 const prismaAdapterClient = {
-    ...prismaAdapterCore,
-    user: prismaAdapterCore.participant,
+    ...(prisma as unknown as Record<string, unknown>),
+    user: prisma.person,
 };
 
 // Every participant must belong to a household (Participant.householdId is


### PR DESCRIPTION
## What broke

Every **Google sign-in on ops-dev fails**: the OAuth callback 500s and the user is bounced back to `/signin` unauthenticated. CloudWatch (`/ecs/checkin-dev`) shows:

```
[next-auth][error][adapter_error_getUserByEmail]
Cannot read properties of undefined (reading 'findUnique')
→ OAUTH_CALLBACK_HANDLER_ERROR
```

## Root cause

The Participant→Person rename (#708) swept every `prisma.participant.<method>()` call site, but missed the NextAuth PrismaAdapter shim in `auth-options.ts`:

```ts
const prismaAdapterCore = prisma as unknown as Record<string, unknown> & { participant: unknown };
user: prismaAdapterCore.participant,   // ← no `prisma.` prefix, no `.method()` suffix — invisible to the sweep
```

The `as … & { participant: unknown }` cast **manufactured the stale property, so `tsc --noEmit` stayed green** (it's even in #708's commit message). At runtime `user` is `undefined`, and the adapter's `getUserByEmail` crashes.

**Why no test tier caught it:** the adapter's user methods run *only* inside the real Google OAuth callback. Persona-mint (what flow tests use via `loginAs`) is a credentials sign-in that never touches the adapter under JWT sessions; the global jest prisma mock is a permissive proxy that resolves *any* model name; integration tests never drive the NextAuth handshake. The one untestable sign-in path was exactly the one that broke.

## Fix + three backslide guards

1. **`auth-options.ts`** — map `user:` to a plain, **compiler-checked** `prisma.person` reference (cast removed from the model name). The next rename that misses this line fails the build instead of breaking sign-in at runtime. Comment documents the incident.
2. **New `auth-options-adapter.test.ts`** — drives `getUserByEmail` / `getUser` / `createUser` against a prisma mock defining **only** real model names (the adapter closures are lazy — invocation is what makes a stale mapping bite). **Verified red against the pre-fix shim** with the exact production error, green after.
3. **`AGENTS.md`** — documents the Google-OAuth coverage hole under the flow-test gotchas: no tier exercises real Google OAuth; tsc + the adapter test are the guards; keep the mapping cast-free.

## Verification

- New test: red on broken shim (`TypeError: Cannot read properties of undefined (reading 'findUnique')`), green on fix
- `tsc --noEmit`: clean
- Full unit suite (pre-commit hook): 198 suites / 1516 tests green
- After merge, `deploy-dev.yml` rolls this to ops-dev — will confirm live Google sign-in there

🤖 Generated with [Claude Code](https://claude.com/claude-code)