### PR TITLE
fix(programs): fail enroll when Shopify variant/domain missing

### DIFF
--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -173,9 +173,9 @@ describe("ProgramEnrollmentPage", () => {
         expect(screen.queryByRole("button", { name: "Complete Enrollment" })).not.toBeInTheDocument();
     });
 
-    it("priced program with no Shopify variant configured falls back to a direct enroll message", async () => {
+    it("priced program with no Shopify variant configured aborts before enrolling", async () => {
         setSession({ id: 101 });
-        mockFetchJson({
+        const fetchMock = mockFetchJson({
             "/api/programs/10/participants": { ok: true },
             "/api/household": household,
             "/api/programs/10": baseProgram({ orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 7000, minAge: null, maxAge: null }),
@@ -188,9 +188,15 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Which of your household wants to enroll?");
 
         fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
+        // No chargeable variant → persistent error, and NO enrollment is created.
         await waitFor(() =>
-            expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Enrolled! (Note: No pricing variant configured for this tier)" })),
+            expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({
+                color: "red",
+                autoClose: false,
+                message: "Cannot enroll: no pricing variant set for this program tier — set one in program-ops.",
+            })),
         );
+        expect(fetchMock).not.toHaveBeenCalledWith("/api/programs/10/participants", expect.anything());
     });
 
     it("shows a not-found card and navigates back to the directory", async () => {
@@ -396,19 +402,25 @@ describe("ProgramEnrollmentPage", () => {
 
     it("redirects to Shopify checkout for a priced enrollment with a configured member variant", async () => {
         setSession({ id: 101 });
-        const memberHousehold = { household: { ...household.household, orgMembership: { status: "ACTIVE" } } };
-        mockFetchJson({
-            "/api/household": memberHousehold,
-            "/api/programs/10": baseProgram({ orgMemberPriceCents: 5000, minAge: null, maxAge: null, shopifyOrgMemberVariantId: "gid://member", shopifyNonOrgMemberVariantId: "gid://nonmember" }),
-            "/api/programs/10/participants": { ok: true },
-        });
-        renderPage();
-        await screen.findByText("Robotics Club");
-        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
-        await screen.findByText("Which of your household wants to enroll?");
-        fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
+        const prevDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
+        process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN = "shop.example.com"; // redirect requires a store domain
+        try {
+            const memberHousehold = { household: { ...household.household, orgMembership: { status: "ACTIVE" } } };
+            mockFetchJson({
+                "/api/household": memberHousehold,
+                "/api/programs/10": baseProgram({ orgMemberPriceCents: 5000, minAge: null, maxAge: null, shopifyOrgMemberVariantId: "gid://member", shopifyNonOrgMemberVariantId: "gid://nonmember" }),
+                "/api/programs/10/participants": { ok: true },
+            });
+            renderPage();
+            await screen.findByText("Robotics Club");
+            fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+            await screen.findByText("Which of your household wants to enroll?");
+            fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
 
-        expect(await screen.findByText("Redirecting to Shopify for secure payment...")).toBeInTheDocument();
+            expect(await screen.findByText("Redirecting to Shopify for secure payment...")).toBeInTheDocument();
+        } finally {
+            process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN = prevDomain;
+        }
     });
 
     it("shows different closed-enrollment reasons depending on fullness, phase, and count source", async () => {

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -219,7 +219,30 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
     setEnrolling(true);
     setMessage("");
 
+    let navigating = false; // only the Shopify redirect keeps the spinner past finally
     try {
+      // Resolve the Shopify checkout details BEFORE enrolling. A paid program with
+      // no variant (or no store domain) can never be charged, so it must fail here
+      // instead of creating a free, unchargeable enrollment.
+      let variantId: string | null = null;
+      let storeDomain: string | undefined;
+      if (isPayingOnShopify && program) {
+        const householdRes = await fetch('/api/household');
+        let isMember = false;
+        if (householdRes.ok) {
+          const householdData = await householdRes.json();
+          isMember = householdData.household?.orgMembership?.status === "ACTIVE" || false;
+        }
+        variantId = isMember ? program.shopifyOrgMemberVariantId : program.shopifyNonOrgMemberVariantId;
+        storeDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
+        if (!variantId || !storeDomain) {
+          notifications.show({ color: "red", autoClose: false, message: variantId
+            ? "Cannot enroll: Shopify store domain not configured. Contact an admin."
+            : "Cannot enroll: no pricing variant set for this program tier — set one in program-ops." });
+          return; // no enrollment created — payment path is broken
+        }
+      }
+
       const outcomes: EnrollOutcome[] = [];
       for (const participantId of selectedParticipantIds) {
         const res = await fetch(`/api/programs/${id}/participants`, {
@@ -238,28 +261,12 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
 
       if (enrolledIds.length > 0) {
         notifyNavRefresh();
-        if (isPayingOnShopify && program) {
+        if (isPayingOnShopify && program && variantId && storeDomain) {
           setSuccessMessage("Redirecting to Shopify for secure payment...");
-
-          const householdRes = await fetch('/api/household');
-          let isMember = false;
-          if (householdRes.ok) {
-            const householdData = await householdRes.json();
-            isMember = householdData.household?.orgMembership?.status === "ACTIVE" || false;
-          }
-
-          const variantId = isMember ? program.shopifyOrgMemberVariantId : program.shopifyNonOrgMemberVariantId;
-
-          if (variantId) {
-            const storeDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
-            // qty=N single variant + comma-joined account ids — see buildShopifyCheckoutUrl.
-            window.location.href = buildShopifyCheckoutUrl(storeDomain, variantId, enrolledIds, id);
-            return;
-          } else {
-            notifications.show({ color: "green", message: "Enrolled! (Note: No pricing variant configured for this tier)" });
-            setSuccessMessage("");
-            fetchProgram();
-          }
+          // qty=N single variant + comma-joined account ids — see buildShopifyCheckoutUrl.
+          navigating = true;
+          window.location.href = buildShopifyCheckoutUrl(storeDomain, variantId, enrolledIds, id);
+          return; // spinner stays; page unloads on redirect
         } else {
           notifications.show({ color: "green", message: enrolledIds.length > 1 ? `Successfully enrolled ${enrolledIds.length} members!` : "Successfully enrolled!" });
           setRequiresOverride(false);
@@ -272,7 +279,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
     } catch {
       notifications.show({ color: "red", message: "Network error during enrollment.", autoClose: false });
     } finally {
-      if (!isPayingOnShopify) setEnrolling(false);
+      if (!navigating) setEnrolling(false);
     }
   };
 


### PR DESCRIPTION
## What

On a priced program, clicking **Pay on Shopify** could leave the button spinning forever and create an orphaned `PENDING` enrollment that can never be charged.

Two root causes in `programs/[id]/page.tsx`:
- The Shopify variant was resolved **after** the enrollment POST, so a tier with no configured variant (or unset `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN`) still created the enrollment, then flashed an auto-closing notice.
- The spinner (`enrolling`) was only cleared when `!isPayingOnShopify`, so any paid path that didn't actually redirect hung forever.

## Fix

- Resolve variant + store domain **before** the enrollment POSTs. If either is missing, abort with a persistent red error (`no pricing variant set for this program tier — set one in program-ops`) and create **no** enrollment.
- Gate the spinner on an explicit `navigating` flag so every non-redirect path clears it.

## Why it matters

No variant = unchargeable. The server already creates paid enrollments as `PENDING` (only `ACTIVE` after payment), so this never granted free access — but it left dead `PENDING` rows and a stuck UI. This closes that path client-side.

## Reviewer notes

- Server-side `POST /api/programs/[id]/participants` still creates the enrollment on its own; a direct API call with no variant would still make a `PENDING` row. A server-side reject is the fully airtight follow-up — out of scope here.
- Tests updated in `page.test.tsx`: the no-variant case now asserts the abort (no participants POST); the redirect happy-path sets `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN` since the redirect now requires it.
- Full unit suite green (1496 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)