### PR TITLE
fix(nav-badges): collapse duplicate same-color pills on /membership-ops

### DIFF
--- a/checkin-app/src/components/__tests__/AppFrame.test.tsx
+++ b/checkin-app/src/components/__tests__/AppFrame.test.tsx
@@ -103,7 +103,9 @@ describe("AppFrame", () => {
 
     // Badge keys off the section href (/membership-ops), not the per-role /review
     // destination — the green count must reach a reviewer-only user's nav item.
-    expect(screen.getByLabelText("4 background checks you can review now")).toHaveTextContent("4");
+    // The green pill merges the board queue (0 here) and can-act-on (4) into one,
+    // so its aria-label names both parts and the count is their sum.
+    expect(screen.getByLabelText("0 pending membership reviews; 4 background checks you can review now")).toHaveTextContent("4");
   });
 
   it("highlights the active nav item based on pathname", () => {

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -115,12 +115,30 @@ describe('reviewBadges (Review tab + Membership Ops nav)', () => {
     ]);
   });
 
-  it('surfaces on the Membership Ops nav item alongside the board BLOCKED count', () => {
+  it('folds board queue + can-act-on into ONE green pill on the Membership Ops nav item', () => {
     const counts: TodoCounts = { ...admin({ membership: 2 }), review: { canActOn: 1, approvedAwaitingSecond: 0 } };
     expect(navBadgeFor('/membership-ops', counts)).toEqual([
-      { count: 2, color: 'treehouseGreen', label: 'Pending membership reviews' },
-      { count: 1, color: 'treehouseGreen', label: '1 background check you can review now' },
+      { count: 3, color: 'treehouseGreen', label: '2 pending membership reviews; 1 background check you can review now' },
     ]);
+  });
+
+  it('collapses to exactly one green + one gray, each summing its two parts', () => {
+    const counts: TodoCounts = {
+      ...admin({ membership: 2, applicationsTotal: 40 }),
+      review: { canActOn: 1, approvedAwaitingSecond: 3 },
+    };
+    expect(navBadgeFor('/membership-ops', counts)).toEqual([
+      { count: 3, color: 'treehouseGreen', label: '2 pending membership reviews; 1 background check you can review now' },
+      { count: 43, color: 'gray', label: '40 in-flight applications; 3 you approved awaiting a second reviewer' },
+    ]);
+  });
+
+  it('hides each pill independently when its parts sum to zero', () => {
+    // Only info counts present → green hidden, gray shown.
+    expect(navBadgeFor('/membership-ops', { ...admin({ applicationsTotal: 40 }), review: { canActOn: 0, approvedAwaitingSecond: 3 } }))
+      .toEqual([{ count: 43, color: 'gray', label: '40 in-flight applications; 3 you approved awaiting a second reviewer' }]);
+    // Nothing anywhere → no badges.
+    expect(navBadgeFor('/membership-ops', { ...admin(), review: { canActOn: 0, approvedAwaitingSecond: 0 } })).toEqual([]);
   });
 });
 

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -110,14 +110,26 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
       return b ? [b] : [];
     }
     case '/membership-ops': {
-      // Board's BLOCKED queue (green) plus the viewer's own background-check
-      // review counts — the Review tab lives under this nav item, so its badges
-      // surface here too. Gray mirrors the Applications tab's total in-flight count.
+      // The Review tab lives under this nav item, so its counts surface here
+      // too. Everything collapses into at most ONE green + ONE gray so the nav
+      // item never shows two same-color pills side by side. Green (actions you
+      // can take): board's BLOCKED membership queue + background checks you can
+      // review now. Gray (passive info): in-flight applications + reviews you
+      // approved awaiting a second reviewer. reviewBadges is NOT spread here —
+      // both its halves are folded in inline (its other caller, the Review tab,
+      // still wants them separate).
+      const membership = counts.admin ? counts.admin.membership : 0;
+      const canActOn = counts.review?.canActOn ?? 0;
+      const action = membership + canActOn;
+      const actionLabel = `${membership} pending membership review${plural(membership, '', 's')}; ${canActOn} background check${plural(canActOn, '', 's')} you can review now`;
+
       const apps = counts.admin ? counts.admin.applicationsTotal : 0;
+      const awaiting = counts.review?.approvedAwaitingSecond ?? 0;
+      const info = apps + awaiting;
+      const infoLabel = `${apps} in-flight application${plural(apps, '', 's')}; ${awaiting} you approved awaiting a second reviewer`;
       return [
-        ...green(counts.admin ? counts.admin.membership : 0, 'Pending membership reviews'),
-        ...gray(apps, `${apps} application${plural(apps, '', 's')}`),
-        ...reviewBadges(counts),
+        ...green(action, actionLabel),
+        ...gray(info, infoLabel),
       ];
     }
     case '/membership-audit': {


### PR DESCRIPTION
## What

The `/membership-ops` left-nav item rendered **two green pills and two gray pills** side by side. This collapses each color into a single pill.

- **Two grays → one gray** = `applicationsTotal` (in-flight applications, PR #821) + `review.approvedAwaitingSecond` (you approved, awaiting a second reviewer, PR #797).
- **Two greens → one green** = `admin.membership` (board BLOCKED queue) + `review.canActOn` (background checks you can review now).

Each merged pill's count is the sum of its parts; its `aria-label` names both parts (e.g. *"40 in-flight applications; 3 you approved awaiting a second reviewer"*). A pill hides when its parts sum to 0.

## Why

Both duplicates were pre-existing on `main` — two independently-merged PRs (#797, #821) each added a pill to the same nav item without noticing the other. Two pills of the same intent-color read as one number split in two, and `AppFrame` keys nav badges by `badge.color`, so two same-color badges also produced a duplicate-React-key collision. Merging fixes both.

Audited all 10 `navBadgeFor` cases — `/membership-ops` was the only one with same-color duplicates. Every other case is single-color or uses distinct colors (red+green, blue+gray).

## Reviewer notes

- `reviewBadges()` is **unchanged** — its other caller, the Review sub-tab in `membership-ops/layout.tsx`, still wants its two pills (green + gray) rendered separately. In the `/membership-ops` nav case it's no longer spread; both halves are folded in inline instead.
- Pill order preserved: green (action) before gray (info).
- `navBadges.test.ts` updated to the new single-green / single-gray shape, incl. the sum + combined-label assertions and the hide-at-zero cases. All 30 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)