### PR TITLE
fix(shopify): mock program variant creation for local/dev

### DIFF
--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -45,11 +45,34 @@ describe('createShopifyProgramVariants', () => {
         jest.restoreAllMocks();
     });
 
-    it('should return null if credentials are missing', async () => {
+    it('should return null if credentials are missing in prod', async () => {
+        // In prod, unconfigured Shopify fails closed to null (no mock stand-in).
+        process.env.CHECKIN_ENV = 'prod';
         delete process.env.SHOPIFY_STORE_DOMAIN;
         const result = await createShopifyProgramVariants('Test Program', 10, 20);
         expect(result).toBeNull();
         expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns synthetic variant ids for priced tiers when the dev mock is active', async () => {
+        // Non-prod + no creds → shopifyMockActive: stand in for the real store so
+        // the seed → checkout → orders/paid dev tool works with zero env.
+        process.env.CHECKIN_ENV = 'dev';
+        delete process.env.SHOPIFY_STORE_DOMAIN;
+        delete process.env.SHOPIFY_CLIENT_ID;
+        delete process.env.SHOPIFY_CLIENT_SECRET;
+
+        const result = await createShopifyProgramVariants('Test Program', 10, 20);
+        expect(result).not.toBeNull();
+        expect(result?.shopifyProductId).toBeTruthy();
+        expect(result?.shopifyOrgMemberVariantId).toBeTruthy();
+        expect(result?.shopifyNonOrgMemberVariantId).toBeTruthy();
+        expect(fetchMock).not.toHaveBeenCalled(); // no real API calls in mock mode
+
+        // Free tier (price 0/null) gets no variant, matching the real branch.
+        const freeMember = await createShopifyProgramVariants('Free Prog', null, 20);
+        expect(freeMember?.shopifyOrgMemberVariantId).toBeNull();
+        expect(freeMember?.shopifyNonOrgMemberVariantId).toBeTruthy();
     });
 
     it('should successfully create product and variants', async () => {

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -94,6 +94,23 @@ export async function getAccessToken(): Promise<string | null> {
 }
 
 export async function createShopifyProgramVariants(name: string, orgMemberPriceCents: number | null, nonOrgMemberPriceCents: number | null, maxParticipants: number | null = null) {
+  // Dev/local mock: the real Shopify store is unreachable with no creds, so a
+  // locally-seeded paid program would store null variant ids and the orders/paid
+  // dev tool would then refuse to fire (route.ts: "No Shopify variant configured").
+  // Mirror the inbound webhook mock — synthesize the ids the real store would
+  // return so the create → checkout → webhook path works end-to-end with zero env.
+  // Only priced tiers get a variant, exactly like the real branch below. Ids need
+  // not be globally unique: the inbound handler resolves the program by id, then
+  // matches line-items against that program's own variant set.
+  if (config.shopifyMockActive()) {
+    const slug = name.replace(/\W+/g, "-").toLowerCase().slice(0, 24);
+    return {
+      shopifyProductId: `dev-mock-product-${slug}`,
+      shopifyOrgMemberVariantId: orgMemberPriceCents && orgMemberPriceCents > 0 ? `dev-mock-variant-member-${slug}` : null,
+      shopifyNonOrgMemberVariantId: nonOrgMemberPriceCents && nonOrgMemberPriceCents > 0 ? `dev-mock-variant-nonmember-${slug}` : null,
+    };
+  }
+
   const storeDomain = config.shopifyStoreDomain();
   const accessToken = await getAccessToken();
 


### PR DESCRIPTION
## What

Add a `config.shopifyMockActive()` branch to `createShopifyProgramVariants` (`checkin-app/src/lib/shopify.ts`) that returns synthetic product/variant ids when the real Shopify integration is unconfigured on a non-prod instance — instead of returning `null`.

## Why

The Shopify local mock was asymmetric:

- **Inbound** (orders/paid webhook) → fully mocked. The dev tool self-fires a signed webhook via `DEV_MOCK_SHOPIFY_WEBHOOK_SECRET`.
- **Outbound** (`createShopifyProgramVariants`, called at program create) → **no mock branch**. Returned `null` with no creds.

So a locally-seeded paid program stored `null` variant ids, and the `/dev/shopify` "Fire orders/paid" tool then failed closed with *"No Shopify variant configured on this program"* — making the paid-enrollment flow untestable with zero env. The two halves of the same mock contradicted each other.

This mirrors the existing Zoho / Shopify-webhook mock pattern, so **seed → checkout → orders/paid works end-to-end with no credentials**. It also makes the "Sync to Shopify" repair button from #864 functional on local/dev.

Only priced tiers get a synthetic variant (matching the real branch); free tiers stay `null`. Ids need not be globally unique — the inbound handler resolves the program by id, then matches line-items against that program's own variant set.

## Notes for reviewer

- Variant ids are written **once at create time**, so already-seeded programs must be recreated to pick up mock variants.
- Existing `"returns null if credentials missing"` unit test now asserts the **prod** contract (mock inactive in prod); added a check for the dev mock branch.
- `shopifyMockActive()` fails safe to prod (two server-only fuses: `CHECKIN_ENV` + `NODE_ENV`), so no mock path is reachable in prod by construction.

## Test

- Unit: 195 suites / 1497 tests pass (incl. the updated `shopify.test.ts`).
- Integration: 106 suites / 864 tests pass (serial, throwaway Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)