### PR TITLE
feat(programs): surface program limits + payment status

### DIFF
--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -173,7 +173,11 @@ describe('Nav todo-counts API', () => {
         // + PENDING_SUBJECT_ACTION (1) + expiring trusted adult (1) = 5.
         // RENEWAL_PENDING_BG is reviewer-owned → excluded.
         expect(data.member.household).toHaveLength(5);
-        expect(data.member.programs).toHaveLength(2);
+        // program1 is unpaid PENDING (household-actionable); program2's payment plan
+        // is awaiting finance approval → gray count, not a todo.
+        expect(data.member.programs).toHaveLength(1);
+        expect(data.member.programs[0]).toEqual(expect.objectContaining({ key: `program-${program1Id}` }));
+        expect(data.member.programsAwaitingFinance).toBe(1);
         // Items carry a label + a deep link so the UI can show *what* is due.
         expect(data.member.household).toEqual(
             expect.arrayContaining([

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -48,7 +48,10 @@ export type TodoItem = { key: string; label: string; href: string };
 
 export type TodoCounts = {
     // Member buckets are itemized so the UI can show *what* is due, not just a number.
-    member: { household: TodoItem[]; programs: TodoItem[] };
+    // `programs` = enrollments the household must still pay for (actionable, green).
+    // `programsAwaitingFinance` = enrollments whose payment plan was sent to finance
+    // and not yet approved — blocked on the board, so a gray informational count, not a todo.
+    member: { household: TodoItem[]; programs: TodoItem[]; programsAwaitingFinance: number };
     // Informational gray badges (not action items): live building occupancy and
     // how many programs are currently running.
     building: number;
@@ -123,6 +126,9 @@ export const GET = withAuth({}, async (_req, auth) => {
     // ---- Member surface (scoped to the caller's household) ----
     const householdTodos: TodoItem[] = [];
     const programTodos: TodoItem[] = [];
+    // PENDING enrollments whose payment plan is awaiting finance approval — not the
+    // household's action, so counted (gray) rather than listed as a todo.
+    let programsAwaitingFinance = 0;
 
     if (user.householdId) {
         const householdId = user.householdId;
@@ -193,7 +199,7 @@ export const GET = withAuth({}, async (_req, auth) => {
             }),
             prisma.programParticipant.findMany({
                 where: { personId: { in: memberIds }, status: "PENDING" },
-                select: { programId: true, program: { select: { name: true } } },
+                select: { programId: true, isPaymentPlanRequested: true, program: { select: { name: true } } },
             }),
         ]);
 
@@ -223,6 +229,8 @@ export const GET = withAuth({}, async (_req, auth) => {
             householdTodos.push({ key: `trusted-adult-expiring-${i}`, label: "Renew an expiring trusted adult", href: "/trusted-adults" });
         }
         for (const p of pendingPrograms) {
+            // Payment plan sent to finance → blocked on the board, not the household.
+            if (p.isPaymentPlanRequested) { programsAwaitingFinance++; continue; }
             programTodos.push({
                 key: `program-${p.programId}`,
                 label: `Complete enrollment for ${p.program?.name ?? "a program"}`,
@@ -241,7 +249,7 @@ export const GET = withAuth({}, async (_req, auth) => {
     ]);
 
     const result: TodoCounts = {
-        member: { household: householdTodos, programs: programTodos },
+        member: { household: householdTodos, programs: programTodos, programsAwaitingFinance },
         building,
         buildingHousehold,
         activePrograms,

--- a/checkin-app/src/app/api/programs/mine/route.ts
+++ b/checkin-app/src/app/api/programs/mine/route.ts
@@ -21,6 +21,8 @@ export const GET = withAuth({}, async (_req, auth) => {
             select: {
                 programId: true,
                 personId: true,
+                status: true,
+                isPaymentPlanRequested: true,
                 person: { select: { id: true, name: true } },
                 program: {
                     select: { id: true, name: true, startAt: true, endAt: true }

--- a/checkin-app/src/app/my-activities/programs/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-activities/programs/__tests__/page.test.tsx
@@ -12,13 +12,30 @@ describe("MyProgramsDashboard", () => {
         setSession({ id: 1, householdLead: true });
         mockFetchJson({
             "/api/programs/mine": [
-                { programId: 5, personId: 100, person: { id: 100, name: "Kid One" }, program: { id: 5, name: "Robotics Club", startAt: "2026-06-01T00:00:00.000Z", endAt: null } },
+                { programId: 5, personId: 100, status: "ACTIVE", isPaymentPlanRequested: false, person: { id: 100, name: "Kid One" }, program: { id: 5, name: "Robotics Club", startAt: "2026-06-01T00:00:00.000Z", endAt: null } },
             ],
         });
         renderWithProviders(<MyProgramsDashboard />);
 
         expect(await screen.findByText("Robotics Club")).toBeInTheDocument();
         expect(screen.getByText("Kid One")).toBeInTheDocument();
+        // ACTIVE (paid) shows no payment pill.
+        expect(screen.queryByText("Payment due")).not.toBeInTheDocument();
+        expect(screen.queryByText("Awaiting finance approval")).not.toBeInTheDocument();
+    });
+
+    it("flags unpaid enrollments green and finance-pending ones gray", async () => {
+        setSession({ id: 1, householdLead: true });
+        mockFetchJson({
+            "/api/programs/mine": [
+                { programId: 5, personId: 100, status: "PENDING", isPaymentPlanRequested: false, person: { id: 100, name: "Kid One" }, program: { id: 5, name: "Robotics Club", startAt: null, endAt: null } },
+                { programId: 6, personId: 101, status: "PENDING", isPaymentPlanRequested: true, person: { id: 101, name: "Kid Two" }, program: { id: 6, name: "Art Class", startAt: null, endAt: null } },
+            ],
+        });
+        renderWithProviders(<MyProgramsDashboard />);
+
+        expect(await screen.findByText("Payment due")).toBeInTheDocument();
+        expect(screen.getByText("Awaiting finance approval")).toBeInTheDocument();
     });
 
     it("shows an empty state with no enrollments", async () => {

--- a/checkin-app/src/app/my-activities/programs/page.tsx
+++ b/checkin-app/src/app/my-activities/programs/page.tsx
@@ -4,13 +4,15 @@ import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Alert, Badge, Button, Card, Container, SimpleGrid, Text, Title } from '@mantine/core';
+import { Alert, Badge, Button, Card, Container, Group, SimpleGrid, Text, Title } from '@mantine/core';
 import { formatDate } from '@/lib/time';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 type UserProgram = {
   programId: number;
   personId: number;
+  status: 'PENDING' | 'ACTIVE';
+  isPaymentPlanRequested: boolean;
   person: { id: number; name: string | null };
   program: {
     id: number;
@@ -19,6 +21,16 @@ type UserProgram = {
     endAt: string | null;
   };
 };
+
+// Payment pill: ACTIVE (paid/free) shows nothing; a still-owed enrollment is
+// either the household's to pay (green, actionable) or waiting on finance to
+// approve a payment plan (gray, not actionable — don't imply it's settled).
+function paymentPill(status: string, planRequested: boolean) {
+  if (status === 'ACTIVE') return null;
+  return planRequested
+    ? <Badge color="gray" variant="filled">Awaiting finance approval</Badge>
+    : <Badge color="green" variant="filled">Payment due</Badge>;
+}
 
 export default function MyProgramsDashboard() {
   const { data: session, status } = useSession();
@@ -82,11 +94,14 @@ export default function MyProgramsDashboard() {
         </Card>
       ) : (
         <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }}>
-          {enrollments.map(({ program, personId, person }) => (
+          {enrollments.map(({ program, personId, person, status: enrollStatus, isPaymentPlanRequested }) => (
             <Card key={`${program.id}-${personId}`} withBorder radius="md" padding="lg">
-              {showMembers && (
-                <Badge variant="light" mb="sm">{person.name ?? 'Member'}</Badge>
-              )}
+              <Group gap="xs" mb="sm">
+                {showMembers && (
+                  <Badge variant="light">{person.name ?? 'Member'}</Badge>
+                )}
+                {paymentPill(enrollStatus, isPaymentPlanRequested)}
+              </Group>
               <Title order={4} mb="sm">{program.name}</Title>
               <Text c="dimmed" style={{ flex: 1 }}>
                 {program.startAt ? formatDate(program.startAt) : 'Start Date TBD'}

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -49,7 +49,7 @@ function baseProgram(overrides: Record<string, unknown> = {}) {
         endAt: null,
         leadMentorId: 5,
         leadMentor: { name: "Coach K", email: "coach@example.com" },
-        participants: [{ personId: 100, status: "ENROLLED" }],
+        participants: [{ personId: 100, status: "ACTIVE" }],
         enrollmentStatus: "OPEN",
         orgMemberPriceCents: null,
         nonOrgMemberPriceCents: null,
@@ -77,7 +77,7 @@ describe("ProgramEnrollmentPage", () => {
 
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         expect(await screen.findByText("Which of your household wants to enroll?")).toBeInTheDocument();
-        expect(screen.getByText("(Already Enrolled)")).toBeInTheDocument();
+        expect(screen.getByText("(Enrolled)")).toBeInTheDocument();
         expect(screen.getByText("(Too young)")).toBeInTheDocument();
 
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
@@ -155,7 +155,7 @@ describe("ProgramEnrollmentPage", () => {
                     ],
                 },
             },
-            "/api/programs/10": baseProgram({ participants: [{ personId: 201, status: "ENROLLED" }], minAge: 5, maxAge: 16 }),
+            "/api/programs/10": baseProgram({ participants: [{ personId: 201, status: "PENDING" }], minAge: 5, maxAge: 16 }),
         });
         renderPage();
 
@@ -166,7 +166,8 @@ describe("ProgramEnrollmentPage", () => {
         // Declared adult reads as "(Adult)", never the confusing "(DOB missing)".
         expect(screen.getByText("(Adult)")).toBeInTheDocument();
         expect(screen.queryByText("(DOB missing)")).not.toBeInTheDocument();
-        expect(screen.getByText("(Already Enrolled)")).toBeInTheDocument();
+        // PENDING enrollment reads as payment-pending, not a bare "Enrolled".
+        expect(screen.getByText("(Enrolled — Payment Pending)")).toBeInTheDocument();
         // No enrollable member -> first-time setup affordance (replaces the old
         // dead-end alert), no direct enroll button.
         expect(screen.getByRole("button", { name: "Finish setting up your household to enroll" })).toBeInTheDocument();

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -23,7 +23,7 @@ type ProgramDetail = {
   // Absent for non-enrolled callers (route gates the roster); only their own
   // household's rows arrive when enrolled, which is all the "already enrolled"
   // check below needs.
-  participants?: { personId: number, status?: string }[];
+  participants?: { personId: number, status?: string, person?: { name: string | null, householdId: number } }[];
   _count?: { participants?: number };
   phase: string;
   maxParticipants: number | null;
@@ -34,9 +34,10 @@ type ProgramDetail = {
   shopifyNonOrgMemberVariantId: string | null;
   minAge: number | null;
   maxAge: number | null;
+  orgMemberOnly: boolean;
 };
 
-type SessionUser = { isSysadmin?: boolean; isBoardMember?: boolean; id: number };
+type SessionUser = { isSysadmin?: boolean; isBoardMember?: boolean; id: number; householdId?: number | null };
 
 export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -86,7 +87,10 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   // render so an ineligible member is never auto-selected and then POSTed (which
   // returned a confusing "Date of Birth is missing" for over-25 adults).
   const enrollBlock = (member: { id: number; dateOfBirth: string | null; isDeclaredAdult?: boolean }): { reason: 'enrolled' | 'age' | 'dob' | null; label: string } => {
-    if ((program?.participants ?? []).some(p => p.personId === member.id)) return { reason: 'enrolled', label: 'Already Enrolled' };
+    const enrolledRow = (program?.participants ?? []).find(p => p.personId === member.id);
+    // ACTIVE = paid/free/override (truly done). PENDING = payment still owed,
+    // including a requested-but-incomplete payment plan — don't imply completion.
+    if (enrolledRow) return { reason: 'enrolled', label: enrolledRow.status === 'ACTIVE' ? 'Enrolled' : 'Enrolled — Payment Pending' };
     if (!program) return { reason: null, label: '' };
     // Same eligibility rule as the enroll route: a declared over-25 adult clears
     // a youth minimum like "16 and up" without a DOB on file.
@@ -293,6 +297,16 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
 
   const user = session?.user as SessionUser | undefined;
   const canManage = !!(session && (user?.isSysadmin || user?.isBoardMember || user?.id === program.leadMentorId));
+
+  // My household's already-enrolled members — shown so a returning parent doesn't
+  // re-attempt an enrollment that would 409. name/householdId are public tier, so
+  // they survive the stripper; no extra household fetch needed here.
+  const myEnrolled = (program.participants ?? [])
+    .filter(p => p.person && (p.personId === user?.id || (user?.householdId != null && p.person.householdId === user.householdId)))
+    .map(p => ({
+      name: p.personId === user?.id ? (p.person?.name || 'You') : (p.person?.name || 'Household member'),
+      active: p.status === 'ACTIVE',
+    }));
   const isClosed = program.enrollmentStatus === 'CLOSED';
   const hasPrice = !!(program.orgMemberPriceCents || program.nonOrgMemberPriceCents);
 
@@ -341,6 +355,30 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                   program.enrollmentStatus === 'WHITELIST' ? <Text component="span" c="yellow">Invite Only</Text> :
                     program.enrollmentStatus}
             </Text>
+            {(ageRange || program.maxParticipants != null || program.orgMemberOnly) && (
+              <>
+                <Divider />
+                {ageRange && <Text><strong>Age:</strong> {ageRange}</Text>}
+                {program.maxParticipants != null && (
+                  <Text>
+                    <strong>Capacity:</strong> {enrolledCount}/{program.maxParticipants}
+                    {isFull && <Text component="span" c="red"> (Full)</Text>}
+                  </Text>
+                )}
+                {program.orgMemberOnly && <Text><strong>Eligibility:</strong> Treehouse Members only</Text>}
+              </>
+            )}
+            {myEnrolled.length > 0 && (
+              <>
+                <Divider />
+                <Text><strong>Already enrolled from your household:</strong></Text>
+                {myEnrolled.map((m, i) => (
+                  <Text key={i} size="sm" c={m.active ? 'green' : 'yellow'} ml="sm">
+                    {m.name} — {m.active ? 'Enrolled' : 'Enrolled, payment pending'}
+                  </Text>
+                ))}
+              </>
+            )}
             {(program.orgMemberPriceCents !== null || program.nonOrgMemberPriceCents !== null) && (
               <>
                 <Divider />
@@ -405,7 +443,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                               disabled={disabled}
                               label={member.name || 'Unnamed Participant'}
                             />
-                            {reason === 'enrolled' && <Text size="sm" c="green">({label})</Text>}
+                            {reason === 'enrolled' && <Text size="sm" c={label.includes('Pending') ? 'yellow' : 'green'}>({label})</Text>}
                             {disabled && reason !== 'enrolled' && <Text size="sm" c="red">({label})</Text>}
                           </Group>
                         </Card>

--- a/checkin-app/src/components/__tests__/AppFrame.test.tsx
+++ b/checkin-app/src/components/__tests__/AppFrame.test.tsx
@@ -67,7 +67,7 @@ describe("AppFrame", () => {
   it("shows Shop Ops for a certifier without admin flags, and My Programs when leading a program", () => {
     setSession({ id: 2, toolStatuses: [{ level: "MAY_CERTIFY_OTHERS" }] });
     mockedUseTodoCounts.mockReturnValue({
-      member: { household: [], programs: [] },
+      member: { household: [], programs: [], programsAwaitingFinance: 0 },
       building: 0,
       buildingHousehold: 0,
       activePrograms: 0,
@@ -93,7 +93,7 @@ describe("AppFrame", () => {
   it("badges the reviewer-only Membership Ops nav with the green can-act-on count", () => {
     setSession({ id: 3, isBackgroundCheckReviewer: true });
     mockedUseTodoCounts.mockReturnValue({
-      member: { household: [], programs: [] },
+      member: { household: [], programs: [], programsAwaitingFinance: 0 },
       building: 0,
       buildingHousehold: 0,
       activePrograms: 0,

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -2,7 +2,7 @@ import { navBadgeFor, tabBadgeFor, reviewBadges, settingsMisconfigBadge, program
 import type { TodoCounts } from '@/app/api/nav/todo-counts/route';
 
 const base: TodoCounts = {
-  member: { household: [], programs: [] },
+  member: { household: [], programs: [], programsAwaitingFinance: 0 },
   building: 0,
   buildingHousehold: 0,
   activePrograms: 0,
@@ -71,6 +71,29 @@ describe('My Programs badge count', () => {
     expect(navBadgeFor('/my-programs', counts)).toEqual([
       { count: 1, color: 'red', label: '1 attendance conflict to resolve' },
     ]);
+  });
+});
+
+describe('My Activities program-payment badges', () => {
+  const todo = (id: number) => ({ key: `program-${id}`, label: `Complete enrollment for P${id}`, href: `/programs/${id}` });
+
+  it('no badge when nothing is owed', () => {
+    expect(navBadgeFor('/my-activities', base)).toEqual([]);
+  });
+
+  it('green for payments due, gray for plans awaiting finance', () => {
+    const counts: TodoCounts = { ...base, member: { household: [], programs: [todo(1), todo(2)], programsAwaitingFinance: 3 } };
+    expect(navBadgeFor('/my-activities', counts)).toEqual([
+      { count: 2, color: 'treehouseGreen', label: '2 program payments due' },
+      { count: 3, color: 'gray', label: '3 program payments awaiting finance approval' },
+    ]);
+  });
+
+  it('singularizes each label and hides each half independently at 0', () => {
+    expect(navBadgeFor('/my-activities', { ...base, member: { household: [], programs: [todo(1)], programsAwaitingFinance: 0 } }))
+      .toEqual([{ count: 1, color: 'treehouseGreen', label: '1 program payment due' }]);
+    expect(navBadgeFor('/my-activities', { ...base, member: { household: [], programs: [], programsAwaitingFinance: 1 } }))
+      .toEqual([{ count: 1, color: 'gray', label: '1 program payment awaiting finance approval' }]);
   });
 });
 

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -83,6 +83,16 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
   switch (href) {
     case '/my-household':
       return green(counts.member.household.length, `${counts.member.household.length} items need attention`);
+    case '/my-activities': {
+      // Green = program payments the household can pay now (actionable); gray =
+      // payment plans sent to finance, awaiting board approval (not actionable).
+      const due = counts.member.programs.length;
+      const finance = counts.member.programsAwaitingFinance;
+      return [
+        ...green(due, `${due} program payment${due === 1 ? '' : 's'} due`),
+        ...gray(finance, `${finance} program payment${finance === 1 ? '' : 's'} awaiting finance approval`),
+      ];
+    }
     case '/my-programs': {
       // Red conflicts first (left of green), then pending attendance the lead
       // must confirm — mirrors the Conflicts/Attendance subtab badges.

--- a/checkin-app/src/hooks/__tests__/useTodoCounts.test.tsx
+++ b/checkin-app/src/hooks/__tests__/useTodoCounts.test.tsx
@@ -5,7 +5,7 @@ import type { TodoCounts } from "@/app/api/nav/todo-counts/route";
 
 const makeCounts = (building: number): TodoCounts =>
   ({
-    member: { household: [], programs: [] },
+    member: { household: [], programs: [], programsAwaitingFinance: 0 },
     building,
     buildingHousehold: 0,
     activePrograms: 0,


### PR DESCRIPTION
## Summary

Two attendee-facing gaps on the program pages:

1. **Program detail page** (`programs/[id]`) showed no limits and a flat "(Already Enrolled)" regardless of payment state.
2. **Payment status** was invisible unless you clicked into each individual program.

### Program detail page
- Details card now lists enrollment **limitations**: age range, capacity (`enrolled/max` with a **Full** flag), and Treehouse-Members-only eligibility.
- Shows **which of your own household are already enrolled**, so a returning parent doesn't re-attempt a 409 enrollment.
- Enrolled-member labels distinguish `ACTIVE` → **"Enrolled"** from `PENDING` → **"Enrolled — Payment Pending"** (no longer implies a pending payment is settled).

### Payment status surfacing
- **`my-activities/programs`**: per-card pill — green **"Payment due"** (unpaid `PENDING`, household-actionable), gray **"Awaiting finance approval"** (payment plan sent to finance, blocked on the board). `ACTIVE` (paid/free) → no pill.
- **Left navbar `/my-activities`**: matching green (due) + gray (awaiting finance) badges, via a new `member.programsAwaitingFinance` count.
- `/api/programs/mine` returns `status` + `isPaymentPlanRequested`.
- `todo-counts` stops listing finance-pending enrollments as "complete enrollment" todos (not the household's action) — counts them gray instead.

Color convention here: **green = actionable by you** (pay now), **gray = waiting on finance** (not actionable).

## Test plan
- Unit: 198 suites / 1530 tests pass
- Integration: 106 suites / 866 tests pass
- Added coverage: navBadges `/my-activities` split, my-activities pill states, detail-page ACTIVE vs PENDING labels, todo-counts finance-pending split (unit + integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)