### PR TITLE
feat(prisma): central write-time lowercasing of Person.email

### DIFF
--- a/checkin-app/src/lib/__tests__/prismaEmailNormalize.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/prismaEmailNormalize.integration.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the Person.email write-time normalization extension
+ * (src/lib/prismaEmailNormalize.ts). Uses the real extended client against the
+ * test DB — this is what actually proves the $extends wiring intercepts writes.
+ */
+
+import prisma from '@/lib/prisma';
+
+// All fixtures carry this marker so cleanup is scoped (this file shares one DB
+// with ~285 other integration files per jest worker — an unscoped wipe corrupts
+// their fixtures).
+const MARK = 'email-normalize-test';
+
+describe('Person.email write-time normalization', () => {
+    let householdId: number;
+
+    beforeAll(async () => {
+        const hh = await prisma.household.create({ data: { name: `${MARK}-hh` } });
+        householdId = hh.id;
+    });
+
+    afterEach(async () => {
+        await prisma.person.deleteMany({ where: { householdId } });
+    });
+
+    afterAll(async () => {
+        await prisma.person.deleteMany({ where: { householdId } });
+        await prisma.household.delete({ where: { id: householdId } });
+    });
+
+    it('create lowercases a mixed-case email', async () => {
+        const p = await prisma.person.create({
+            data: { householdId, name: 'A', email: `Foo.${MARK}@X.com` },
+        });
+        expect(p.email).toBe(`foo.${MARK}@x.com`);
+    });
+
+    it('update lowercases a mixed-case email (plain form)', async () => {
+        const p = await prisma.person.create({
+            data: { householdId, name: 'B', email: `b.${MARK}@x.com` },
+        });
+        const u = await prisma.person.update({
+            where: { id: p.id },
+            data: { email: `B.${MARK}@Y.COM` },
+        });
+        expect(u.email).toBe(`b.${MARK}@y.com`);
+    });
+
+    it('update lowercases the wrapped { set } form', async () => {
+        const p = await prisma.person.create({
+            data: { householdId, name: 'C', email: `c.${MARK}@x.com` },
+        });
+        const u = await prisma.person.update({
+            where: { id: p.id },
+            data: { email: { set: `C.${MARK}@Y.COM` } },
+        });
+        expect(u.email).toBe(`c.${MARK}@y.com`);
+    });
+
+    it('upsert lowercases on the create branch', async () => {
+        const email = `Up.${MARK}@X.com`;
+        const p = await prisma.person.upsert({
+            where: { email: email.toLowerCase() },
+            create: { householdId, name: 'D', email },
+            update: { name: 'D2' },
+        });
+        expect(p.email).toBe(`up.${MARK}@x.com`);
+    });
+
+    it('upsert lowercases on the update branch', async () => {
+        const lower = `up2.${MARK}@x.com`;
+        await prisma.person.create({ data: { householdId, name: 'E', email: lower } });
+        const p = await prisma.person.upsert({
+            where: { email: lower },
+            create: { householdId, name: 'E', email: lower },
+            update: { email: `UP2.${MARK}@X.com` },
+        });
+        expect(p.email).toBe(lower);
+    });
+
+    it('createMany lowercases each row', async () => {
+        await prisma.person.createMany({
+            data: [
+                { householdId, name: 'F', email: `F1.${MARK}@X.com` },
+                { householdId, name: 'G', email: `G1.${MARK}@X.com` },
+            ],
+        });
+        const rows = await prisma.person.findMany({
+            where: { householdId },
+            select: { email: true },
+            orderBy: { email: 'asc' },
+        });
+        expect(rows.map((r) => r.email)).toEqual([`f1.${MARK}@x.com`, `g1.${MARK}@x.com`]);
+    });
+
+    it('leaves a create with no email / null email untouched', async () => {
+        const none = await prisma.person.create({ data: { householdId, name: 'H' } });
+        expect(none.email).toBeNull();
+        const nul = await prisma.person.create({ data: { householdId, name: 'I', email: null } });
+        expect(nul.email).toBeNull();
+    });
+
+    it('leaves an already-lowercase email unchanged', async () => {
+        const email = `already.${MARK}@x.com`;
+        const p = await prisma.person.create({ data: { householdId, name: 'J', email } });
+        expect(p.email).toBe(email);
+    });
+});

--- a/checkin-app/src/lib/prisma.ts
+++ b/checkin-app/src/lib/prisma.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@/generated/prisma/client'
 import { Pool } from 'pg'
 import { PrismaPg } from '@prisma/adapter-pg'
+import { emailNormalizeExtension } from '@/lib/prismaEmailNormalize'
 
 const connectionString = `${process.env.DATABASE_URL}`
 // Tests default to a single connection so suites don't exhaust a small CI
@@ -38,8 +39,19 @@ const pool = new Pool({
 // keeps its single long-lived pool untouched.
 const adapter = new PrismaPg(pool, process.env.NODE_ENV === 'test' ? { disposeExternalPool: true } : undefined)
 
-const prismaClientSingleton = () => {
-    return new PrismaClient({ adapter })
+// The email-normalize extension lowercases Person.email at write time — the one
+// choke point so no route can drift into storing a case-variant on the @unique
+// column. The extension runs at runtime for every top-level person.* write
+// (incl. $transaction and tx.person.* inside interactive transactions).
+//
+// We cast the extended client back to PrismaClient for the exported type. A
+// $extends() result is a runtime superset but a DIFFERENT static type (it drops
+// $on and re-parameterizes $transaction/TransactionClient), so leaking it into
+// `ReturnType<typeof prismaClientSingleton>` would break every consumer typed
+// against PrismaClient / Prisma.TransactionClient / DbClient. The person.* API
+// is identical either way, so the cast hides nothing consumers use.
+const prismaClientSingleton = (): PrismaClient => {
+    return new PrismaClient({ adapter }).$extends(emailNormalizeExtension) as unknown as PrismaClient
 }
 
 declare const globalThis: {

--- a/checkin-app/src/lib/prismaEmailNormalize.ts
+++ b/checkin-app/src/lib/prismaEmailNormalize.ts
@@ -1,0 +1,75 @@
+import { Prisma } from '@/generated/prisma/client'
+
+/**
+ * Central write-time normalization for Person.email.
+ *
+ * Person.email is `@unique`. Lowercasing at the individual-route level is
+ * drift-prone: any future write path that forgets it can store a case-variant
+ * ("Foo@x.com" vs "foo@x.com") — two distinct rows on the unique column (a
+ * duplicate account) and case-mismatched lookups that miss. This extension is
+ * the single choke point: every top-level `person` write is lowercased here so
+ * no route can drift. Enforcement only — it does NOT migrate existing rows.
+ *
+ * KNOWN LIMITATION: Prisma query extensions intercept top-level `person.*`
+ * operations and operations inside `$transaction`, but do NOT reliably
+ * intercept NESTED writes that create a Person through another model's relation
+ * (e.g. `household.create({ data: { householdMembers: { create: { email } } } })`).
+ * Every known write site in this codebase uses direct `tx.person.create/update`
+ * (createParticipantWithHousehold creates the household then the person
+ * separately; routes call `person.*` directly), so those are covered. Any
+ * future nested-write path must lowercase email itself.
+ */
+
+/** Lowercase `data.email`, handling the plain (`email: "X"`) and wrapped
+ * (`email: { set: "X" }`) forms. Null/undefined/non-string emails are left
+ * untouched. Idempotent. Mutates `data` in place. */
+function lowerEmailOnData(data: unknown): void {
+    if (data == null || typeof data !== 'object') return
+    const d = data as { email?: unknown }
+    const email = d.email
+    if (typeof email === 'string' && email.length > 0) {
+        d.email = email.toLowerCase()
+        return
+    }
+    // Wrapped update form: { email: { set: "X" } }
+    if (email != null && typeof email === 'object' && 'set' in email) {
+        const wrapped = email as { set?: unknown }
+        if (typeof wrapped.set === 'string' && wrapped.set.length > 0) {
+            wrapped.set = wrapped.set.toLowerCase()
+        }
+    }
+}
+
+export const emailNormalizeExtension = Prisma.defineExtension({
+    name: 'personEmailNormalize',
+    query: {
+        person: {
+            create({ args, query }) {
+                lowerEmailOnData(args.data)
+                return query(args)
+            },
+            update({ args, query }) {
+                lowerEmailOnData(args.data)
+                return query(args)
+            },
+            updateMany({ args, query }) {
+                lowerEmailOnData(args.data)
+                return query(args)
+            },
+            upsert({ args, query }) {
+                lowerEmailOnData(args.create)
+                lowerEmailOnData(args.update)
+                return query(args)
+            },
+            createMany({ args, query }) {
+                const data = args.data
+                if (Array.isArray(data)) {
+                    for (const row of data) lowerEmailOnData(row)
+                } else {
+                    lowerEmailOnData(data)
+                }
+                return query(args)
+            },
+        },
+    },
+})


### PR DESCRIPTION
## What

Add a Prisma **client query extension** that lowercases `Person.email` on every top-level `person` write, wired at the client singleton in `checkin-app/src/lib/prisma.ts`.

- New: `checkin-app/src/lib/prismaEmailNormalize.ts` — the extension.
- New: `checkin-app/src/lib/__tests__/prismaEmailNormalize.integration.test.ts` — 8-case integration test.
- Changed: `checkin-app/src/lib/prisma.ts` — `$extends` at the singleton.

Covers `create`, `update`, `updateMany`, `upsert` (both `create` and `update` branches), and `createMany` (each row). Handles the plain form (`data.email = "X"`) and the wrapped update form (`data.email = { set: "X" }`). Null/undefined-safe and idempotent. Because it's applied at the singleton, it also covers `$transaction` and `tx.person.*` inside interactive transactions.

## Why

`Person.email` is `@unique`, but lowercasing was done ad-hoc in individual routes (household add/edit, membership `saveIntake`, etc.). Any future write path that forgets to lowercase can store a case-variant (`Foo@x.com` vs `foo@x.com`) — two distinct rows on the unique column (a duplicate account) and case-mismatched lookups that miss. This closes it at **one choke point** so no route can drift.

## Scope / deliberate non-changes

- **Enforcement only.** No data migration or backfill of existing rows — lowercasing in place can collide on the unique constraint and needs a separate dedup plan. Deferred by design.
- **Existing per-route `.toLowerCase()` calls left in place** — now redundant but harmless; keeps the diff tight and belt-and-suspenders.
- No route/schema/data changes.

## Reviewer notes

- **The spec assumed the extended client is a drop-in superset of `PrismaClient` at the type level — it is not.** A `$extends()` result is a runtime superset but a *different static type*: it drops `$on` and re-parameterizes `$transaction`/`TransactionClient`. Leaking it into `ReturnType<typeof prismaClientSingleton>` broke every consumer typed against `PrismaClient` / `Prisma.TransactionClient` / `DbClient`. Fixed by casting the exported type back to `PrismaClient` (`as unknown as PrismaClient`); the runtime extension still fires, and the `person.*` API is identical either way, so the cast hides nothing consumers use.
- **Known limitation (documented in a code comment):** query extensions intercept top-level `person.*` and `$transaction` operations but do **not** reliably intercept NESTED writes that create a Person through another model's relation (e.g. `household.create({ data: { householdMembers: { create: { email } } } })`). All known write sites use direct `tx.person.create/update`, so they're covered. Future nested-write code must lowercase email itself.

## Verification

- `tsc` clean (no new errors; remaining are pre-existing implicit-`any` in older test files).
- New integration test: all 8 cases pass (create/update/wrapped-set/upsert-both-branches/createMany/null-email/already-lowercase) against the real extended client on a test DB.
- Full integration suite (107 suites, 874 tests) passes — nothing that creates Persons regressed.
- Pre-commit unit suite (`test:ci`) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)