### PR TITLE
docs: intake-profile registry guide + local-login invariant

### DIFF
--- a/checkin-app/src/lib/intake/README.md
+++ b/checkin-app/src/lib/intake/README.md
@@ -1,0 +1,56 @@
+# Intake field profiles — the single source of truth for "what does each intake ask"
+
+`profiles.ts` is the **authoritative registry** of which fields each intake
+surface shows and requires. It exists to stop a bug we already lived through:
+four different intake forms each hand-rolled their own field list + validation,
+and they drifted apart (allergies present in edit forms but not create forms;
+parent phone required in one surface, absent in another, optional in a third).
+
+**The rule:** an intake surface declares its context and reads its shown/required
+fields from a profile here. It does **not** hard-code a field list or re-derive
+"required at submit" inline. Add or rename an intake field in **one place** — a
+profile — and every surface inherits it.
+
+## The surfaces and their contexts
+
+| Surface | Context profile | Writes via |
+|---|---|---|
+| Membership "Join the Treehouse" (initial) | `membership-initial` | `saveIntake` + `submitIntake` (advances the OrgMembershipProcess) |
+| Membership renewal | `membership-renewal` | same service |
+| Household self-service (my-household add/edit member) | `household-self-service` | `/api/household/*` |
+| First-time program registration (auth-first) | `program-first-time` | `saveIntake` only — **no** membership process |
+
+New surface? Add a context + profile here first; don't invent a parallel form.
+
+## How the pieces fit
+
+- **`profiles.ts`** — declares, per context: which fields are *shown* and which
+  are *required at submit*. This is the only place required-ness lives.
+- **`saveIntake` / `getIntakeState`** (`src/lib/membership/intake.ts`) — the one
+  write/prefill service for household + person + emergency-contact rows.
+  Resumable, never-deletes, lead-scoped, honors the household-lead cap, runs the
+  emergency-contact not-a-member reconcile. It is **context-free**: it does *not*
+  create or advance an `OrgMembershipProcess` (that's `startIntake`/`submitIntake`).
+  A non-membership surface (e.g. program registration) calls `saveIntake`
+  directly and never touches a membership process.
+- **Shared form components** (`src/components/membership/AddressForm`,
+  `ChildrenListForm`, `EmergencyContactForm`) — reuse these; don't rebuild inputs.
+
+## Do / don't
+
+- **Do** validate a submit against `profile.requiredAtSubmit`, and render
+  `profile.shown`. Membership's `submitIntake` already works this way — follow it.
+- **Do** enforce context-specific rules the registry can't express at the right
+  layer (e.g. program registration requires a participant's DOB only when the
+  target program is age-gated — that's enforced by the enroll step's
+  `enrollBlock` + the participants route, not by the profile).
+- **Don't** add a field to one form's JSX + one route's body without adding it to
+  the profile — that's exactly how the surfaces diverged before.
+- **Don't** call `startIntake`/`submitIntake` from a non-membership surface.
+
+## History
+
+This registry was extracted from the auth-first program-registration work
+(the old anonymous `public-register` form was the poorest of the four intakes and
+was removed). If you're tempted to hand-roll a new intake form, that's the smell
+this file exists to prevent.

--- a/docs/designs/DEV_INSTANCE_DESIGN.md
+++ b/docs/designs/DEV_INSTANCE_DESIGN.md
@@ -217,3 +217,34 @@ A slide-up panel, rendered **only** when `CHECKIN_ENV` is `dev`/`local`, for the
   `sysadmin` persona desired for testing admin flows? (Likely yes — it's fake data.)
 - **Infra note (for the deploy side, not this repo):** the dev task definition sets
   `CHECKIN_ENV=dev` and `DATABASE_URL`→`checkin_dev`; prod sets neither. Same image both places.
+
+---
+
+## 12. Local login: never call Google on a local-reachable path
+
+**Invariant.** On `CHECKIN_ENV=local` there is no Google identity (creds are
+dummy). Any UI control that calls `signIn("google", …)` on a path a *local*
+user can reach is a bug — it redirects to real Google OAuth and dead-ends. Local
+authenticates **only** through the offline persona-mint dev picker
+(`DevLoginPicker` → `signIn("persona-mint", …)`, incl. its "New registrant (fresh
+household)" button for a brand-new empty user). `dev` and `prod` use Google, only.
+
+**The pattern for a logged-out CTA** (any "sign in to do X" button):
+
+- Do **not** call `signIn("google")` directly from the feature page. Route to the
+  sign-in screen with a return URL: `router.push("/signin?callbackUrl=<target>")`.
+- `/signin` is the *one* place that branches by env: it renders `DevLoginPicker`
+  (carrying the `callbackUrl`) when `useIsLocalInstance()`, and the Google button
+  otherwise. Feature pages stay env-agnostic.
+- `DevLoginPicker` takes a `callbackUrl` prop (default `"/"`) so the offline mint
+  returns the user to where they started.
+
+**Why this section exists.** Auth-first program registration shipped a CTA that
+called `signIn("google")` unconditionally; it worked on dev/prod but broke every
+local test of the new-user flow (no Google on a laptop). Fixed in
+`fix(programs): route enroll CTA through /signin so LOCAL uses dev picker` (#863).
+The single remaining sanctioned `signIn("google")` call site is the `/signin`
+Google button itself (the dev/prod path). Adding another on a local-reachable
+surface re-introduces this bug — grep for `signIn("google"` and keep that the
+only hit.
+


### PR DESCRIPTION
## What

Two small, durable docs extracted from the (now-deleted) auth-first program-registration plan:

- **`checkin-app/src/lib/intake/README.md`** — documents the intake field-profile registry (`src/lib/intake/profiles.ts`, shipped in #836) as the single source of truth for what each intake surface shows/requires. States the discipline: new intake fields/surfaces go through a profile + `saveIntake`, not a hand-rolled form; non-membership surfaces call `saveIntake` (never `startIntake`/`submitIntake`).
- **`docs/designs/DEV_INSTANCE_DESIGN.md` §12** — the local-login invariant: never call `signIn("google")` on a path a local user can reach; local authenticates only through the offline persona-mint dev picker; logged-out CTAs route through `/signin`, which branches by env.

## Why

The auth-first registration work spanned several PRs (#834 allergies, #835 local dev-login, #836 intake registry, #845 auth-first build, #863 local-login CTA fix) plus in-flight follow-ups (public-register removal, household-add attach fix, email-normalization choke point). Most of the plan doc was a one-time build plan and was intentionally dropped. These two pieces are standing guidance that prevent regressions:

- The registry discipline stops the four-way intake-field divergence that motivated #836 from re-accreting.
- The local-login invariant codifies the fix in #863 so the next logged-out CTA doesn't re-break local testing by calling Google directly.

## Reviewer notes

- Docs only — no code, no behavior change.
- §12 is appended to `DEV_INSTANCE_DESIGN.md`; it adds a new section and does not renumber existing §§1–11 (code comments reference specific section numbers).
- The referenced code (`profiles.ts`, `DevLoginPicker`, `/signin` routing) is already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)