### PR TITLE
test(notifications): swap flaky wall-clock perf assert for max-concurrency check

### DIFF
--- a/checkin-app/src/app/__tests__/notificationsCheckin.perf.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsCheckin.perf.test.ts
@@ -1,8 +1,26 @@
 import { sendCheckinNotifications } from "@/lib/notifications";
 import { sendEmail } from "@/lib/email";
 
+// Track how many sendEmail calls are in flight at once. Parallel dispatch
+// (Promise.all) lets all 11 enter before any resolves, so maxInFlight === 11.
+// A sequential `for await` loop would cap maxInFlight at 1.
+//
+// The resolve is deferred with a macrotask (setTimeout), not a microtask, so an
+// in-flight send survives the `await prisma.householdLead.findMany` that sits
+// between the participant send and the 10 household-lead sends — otherwise the
+// participant email would resolve during that await and cap the count at 10.
+let inFlight = 0;
+let maxInFlight = 0;
+
 jest.mock("@/lib/email", () => ({
-    sendEmail: jest.fn().mockImplementation(() => new Promise(resolve => setTimeout(resolve, 50))) // Simulate 50ms delay per email
+    sendEmail: jest.fn().mockImplementation(() => new Promise<void>(resolve => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        setTimeout(() => {
+            inFlight--;
+            resolve();
+        }, 0);
+    }))
 }));
 
 jest.mock("@/lib/prisma", () => ({
@@ -36,19 +54,16 @@ jest.mock("@/lib/prisma", () => ({
 describe("Performance: sendCheckinNotifications", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        inFlight = 0;
+        maxInFlight = 0;
     });
 
     it("should send notifications in parallel", async () => {
-        const start = Date.now();
         await sendCheckinNotifications(1, "checkin");
-        const end = Date.now();
-        const duration = end - start;
 
-        console.log(`Execution time: ${duration}ms`);
         expect(sendEmail).toHaveBeenCalledTimes(11);
-
-        // If emails are sent sequentially, it should take at least 50ms * 11 = 550ms.
-        // If sent in parallel (Promise.all), it should take around 50ms.
-        expect(duration).toBeLessThan(400);
+        // All 11 emails must be in flight simultaneously — proves parallel
+        // dispatch. If the code regressed to sequential sends, this drops to 1.
+        expect(maxInFlight).toBe(11);
     });
 });


### PR DESCRIPTION
## What

Replace the wall-clock timing assertion in `checkin-app/src/app/__tests__/notificationsCheckin.perf.test.ts` with a deterministic max-concurrency check.

## Why

The single test measured `Date.now()` around `sendCheckinNotifications(1, "checkin")` and asserted `duration < 400ms` to prove the 11 emails go out via `Promise.all` rather than a sequential loop. Under CI (coverage instrumentation + parallel jest workers) a genuinely-parallel run measured 764ms and failed the threshold — it flaked for everyone, and the file is unrelated to any feature work.

## How

- The `@/lib/email` mock now tracks how many `sendEmail` calls are in flight at once: increment `inFlight` on entry, record `maxInFlight`, decrement on resolve.
- After the call, keep `expect(sendEmail).toHaveBeenCalledTimes(11)` and add `expect(maxInFlight).toBe(11)`. Parallel dispatch enters all 11 before any resolves; a sequential `for await` loop would cap `maxInFlight` at 1.
- The resolve is a **macrotask** (`setTimeout(…, 0)`), not a microtask, so an in-flight send survives the `await prisma.householdLead.findMany` that sits between the participant send and the 10 household-lead sends — a microtask resolve would settle the participant email during that await and cap the count at 10.
- Counters reset in `beforeEach` alongside `jest.clearAllMocks()`. Dropped `Date.now()`, `duration`, and the `console.log`.

## Reviewer notes

- Test-only change. No production code in `@/lib/notifications` touched. A failure here now means the code genuinely regressed to sequential sends — the real signal we want.
- Prisma mock (1 participant + 10 household leads = 11 recipients) unchanged.
- Verified green and deterministic across repeated runs (~0.2s each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)