### PR TITLE
fix(auth): unify adapter Int↔string id boundary — repair Google sign-in

### DIFF
--- a/checkin-app/src/lib/__tests__/auth-options-adapter.test.ts
+++ b/checkin-app/src/lib/__tests__/auth-options-adapter.test.ts
@@ -2,22 +2,26 @@
  * @jest-environment node
  */
 /**
- * Regression guard for the NextAuth PrismaAdapter ↔ Person-model mapping in
- * auth-options.ts (the `user: prisma.person` shim).
+ * Regression guard for the NextAuth adapter's Int↔string id boundary in
+ * auth-options.ts.
  *
- * Why this exists: the Participant→Person rename (#708) missed that mapping —
- * it was hidden behind an `as` cast, so tsc stayed green — and every Google
- * sign-in on the dev instance crashed in the OAuth callback with
- * `Cannot read properties of undefined (reading 'findUnique')` in
- * getUserByEmail. No test tier caught it, because the adapter's user methods
- * run ONLY inside the real Google OAuth callback: persona-mint/credentials
- * sign-in (what flow tests use via loginAs) never touches the adapter, and
- * the global prisma mock in jest.setup.js is a permissive proxy that resolves
- * ANY model name, so even importing auth-options can't surface a stale name.
+ * Why this exists: the adapter's user/account methods run ONLY inside the real
+ * Google OAuth callback — persona-mint/credentials sign-in (what flow tests use
+ * via loginAs) never touches the adapter, and the global prisma mock in
+ * jest.setup.js resolves ANY model name — so no other tier reaches this code.
+ * Two bugs have shipped here as a result:
+ *   - #708 (Participant→Person rename) missed the model map behind an `as` cast;
+ *     getUserByEmail crashed with `undefined ... findUnique`.
+ *   - createUser returned a string id that then crashed linkAccount writing it
+ *     into Account.userId (Int) — `Expected Int, provided String` — on every
+ *     first Google sign-in, while CI stayed green.
  *
- * This suite therefore (a) mocks prisma with ONLY the real model names and
- * (b) actually CALLS the adapter methods — PrismaAdapter's closures are lazy,
- * so a stale mapping only explodes on invocation, exactly as in production.
+ * The boundary is now unified: every user/account method converts ids through
+ * toAdapterUser (Int→string out) / toDbId (string→Int in). This suite (a) mocks
+ * prisma with ONLY the real model names and (b) actually CALLS the adapter
+ * methods (their closures are lazy — a stale map or missed coercion only
+ * explodes on invocation, exactly as in production), asserting BOTH directions
+ * for every method that crosses the boundary.
  */
 
 import prisma from '@/lib/prisma';
@@ -48,7 +52,8 @@ jest.mock('@/lib/config', () => {
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
     default: {
-        person: { findUnique: jest.fn(), update: jest.fn(), create: jest.fn() },
+        person: { findUnique: jest.fn(), update: jest.fn(), create: jest.fn(), delete: jest.fn() },
+        account: { findUnique: jest.fn(), create: jest.fn() },
         household: { create: jest.fn() },
         $transaction: jest.fn((cb: (tx: unknown) => unknown) => cb(prismaMockTx)),
     },
@@ -71,10 +76,16 @@ const mockPersonFindUnique = (prisma as unknown as { person: { findUnique: jest.
 
 // Adapter methods are typed optional on Adapter; the shim always provides these.
 const adapter = authOptions.adapter as unknown as {
-    getUserByEmail: (email: string) => Promise<unknown>;
-    getUser: (id: string) => Promise<unknown>;
+    getUserByEmail: (email: string) => Promise<{ id: string; email: string } | null>;
+    getUserByAccount: (key: { provider: string; providerAccountId: string }) => Promise<{ id: string; email: string } | null>;
+    getUser: (id: string) => Promise<{ id: string; email: string } | null>;
     createUser: (user: Record<string, unknown>) => Promise<{ id: string; email: string }>;
+    updateUser: (user: { id: string; name?: string | null }) => Promise<{ id: string; email: string }>;
+    linkAccount: (account: Record<string, unknown>) => Promise<unknown>;
 };
+
+const mockAccount = (prisma as unknown as { account: { findUnique: jest.Mock; create: jest.Mock } }).account;
+const mockPersonUpdate = (prisma as unknown as { person: { update: jest.Mock } }).person.update;
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -118,5 +129,50 @@ describe('PrismaAdapter user-model shim (auth-options.ts)', () => {
         );
         expect(addHouseholdLead).toHaveBeenCalled();
         expect(created).toEqual(expect.objectContaining({ id: '7', email: 'new@example.com' }));
+    });
+
+    test('getUserByEmail returns a string id (Int→string on the way out)', async () => {
+        mockPersonFindUnique.mockResolvedValue({ id: 55, email: 'q@example.com' });
+        const user = await adapter.getUserByEmail('q@example.com');
+        expect(user).toEqual(expect.objectContaining({ id: '55', email: 'q@example.com' }));
+    });
+
+    test('getUserByAccount resolves the account→person and stringifies the id', async () => {
+        mockAccount.findUnique.mockResolvedValue({ user: { id: 88, email: 'acct@example.com' } });
+        const user = await adapter.getUserByAccount({ provider: 'google', providerAccountId: '114917684045724477868' });
+        expect(mockAccount.findUnique).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { provider_providerAccountId: { provider: 'google', providerAccountId: '114917684045724477868' } },
+            }),
+        );
+        expect(user).toEqual(expect.objectContaining({ id: '88', email: 'acct@example.com' }));
+    });
+
+    // The bug from the checkin-dev logs: base linkAccount wrote the string userId
+    // straight into Account.userId (Int) → `Expected Int, provided String`.
+    test('linkAccount coerces the string userId to Int before prisma.account.create', async () => {
+        mockAccount.create.mockResolvedValue({});
+        await adapter.linkAccount({
+            userId: '298',
+            type: 'oauth',
+            provider: 'google',
+            providerAccountId: '114917684045724477868',
+            access_token: 'tok',
+            scope: 'openid email',
+        });
+        expect(mockAccount.create).toHaveBeenCalledWith(
+            expect.objectContaining({ data: expect.objectContaining({ userId: 298, provider: 'google' }) }),
+        );
+        // The id landing in the Int column must be a number, not the string "298".
+        expect(typeof mockAccount.create.mock.calls[0][0].data.userId).toBe('number');
+    });
+
+    test('updateUser converts the string id to Int for the where clause', async () => {
+        mockPersonUpdate.mockResolvedValue({ id: 12, email: 'u@example.com' });
+        const user = await adapter.updateUser({ id: '12', name: 'Renamed' });
+        expect(mockPersonUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { id: 12 } }),
+        );
+        expect(user).toEqual(expect.objectContaining({ id: '12', email: 'u@example.com' }));
     });
 });

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -5,6 +5,7 @@ import CredentialsProvider from "next-auth/providers/credentials";
 import { getToken } from "next-auth/jwt";
 import { cookies as requestCookies } from "next/headers";
 import { PrismaAdapter } from "@auth/prisma-adapter";
+import type { AdapterAccount, AdapterUser } from "next-auth/adapters";
 import prisma from "@/lib/prisma";
 import { config, ORG_DOMAIN } from "@/lib/config";
 import { evaluateMint, type MintMode } from "@/lib/impersonation";
@@ -16,20 +17,39 @@ import { withAuroraResumeRetry } from "@/lib/auroraResumeRetry";
 // Stable id for the dev/local persona-mint credential flow.
 export const PERSONA_MINT_PROVIDER_ID = "persona-mint";
 
-// NextAuth PrismaAdapter hardcodes `prisma.user` for its user operations, so
-// alias `.user` to our Person model. `prisma.person` below MUST stay a plain,
-// type-checked property access — never hide the model name behind an `as`
-// cast. The Participant→Person rename (#708) missed this mapping precisely
-// because a cast (`as ... & { participant: unknown }`) kept tsc green with a
-// stale name, and no test tier can reach it: the adapter's user methods run
-// ONLY inside the real Google OAuth callback (persona-mint/credentials
-// sign-in bypasses the adapter entirely), so every Google sign-in crashed on
-// the dev instance while CI passed. The compiler plus
-// auth-options-adapter.test.ts are the guards — keep both intact.
-const prismaAdapterClient = {
+// ── NextAuth adapter: the Int ↔ string id boundary, in ONE place ─────────────
+//
+// NextAuth models every id as a string (its cuid default); our Person.id and
+// Account.userId are Int, and the stock PrismaAdapter coerces nothing. That
+// boundary has bitten twice: the Participant→Person rename (#708) fixed the
+// model map for only the methods it happened to touch, and a later change left
+// createUser returning a string id that then crashed linkAccount's Int `userId`
+// column on every first Google sign-in. Both slipped past CI because these
+// methods run ONLY inside the real Google OAuth callback — persona-mint /
+// credentials sign-in (what flow tests exercise via loginAs) never touches the
+// adapter, and the global prisma mock resolves any model name.
+//
+// The fix is structural, not another spot-patch: every user/account method the
+// OAuth flow can reach is defined together below, and every id crosses through
+// exactly one of the two converters — never an inline String()/parseInt(). A new
+// adapter method that forgets them is the failure mode to guard against;
+// auth-options-adapter.test.ts calls these directly (the only tier that reaches
+// them) to hold that line.
+
+// The stock adapter still backs the methods this flow never overrides (sessions,
+// verification tokens); those operate on the real prisma client and touch no id
+// boundary. `prisma.person` stays a plain, type-checked access on purpose — a
+// cast is exactly how #708 kept a stale model name tsc-green.
+const baseAdapter = PrismaAdapter({
     ...(prisma as unknown as Record<string, unknown>),
     user: prisma.person,
-};
+}) as unknown as Record<string, unknown>;
+
+// Int (DB) → string (NextAuth), filling the non-null email an AdapterUser needs.
+const toAdapterUser = (u: { id: number; email: string | null }): AdapterUser =>
+    ({ ...u, id: String(u.id), email: u.email ?? "" }) as AdapterUser;
+// string (NextAuth) → Int (DB). NaN-safe; callers treat NaN as "no such id".
+const toDbId = (id: string | number): number => (typeof id === "number" ? id : parseInt(id, 10));
 
 // Every participant must belong to a household (Participant.householdId is
 // required), so new sign-ups get a single-person household they lead.
@@ -52,21 +72,70 @@ export async function createParticipantWithHousehold(data: {
     });
 }
 
-// Wrap the adapter so `getUser` can handle string IDs from CredentialsProvider.
-// NextAuth always coerces IDs to strings, but our Participant.id is an Int.
-// `createUser` is overridden so first sign-in also creates the household.
-const baseAdapter = PrismaAdapter(prismaAdapterClient) as unknown as Record<string, unknown>;
+// Every Person/Account id read or written by the OAuth flow lives in this one
+// object, and every one of them goes through toAdapterUser / toDbId. Keep it that
+// way: a method that touches an id without a converter is the bug this guards.
 const patchedAdapter = {
     ...baseAdapter,
-    createUser: async (user: Parameters<typeof createParticipantWithHousehold>[0]) => {
-        const created = await createParticipantWithHousehold(user);
-        return { ...created, id: String(created.id), email: created.email || "" };
-    },
+
+    // First Google sign-in also provisions the household (base createUser would
+    // create only the Person). googleId rides along at runtime.
+    createUser: async (user: Parameters<typeof createParticipantWithHousehold>[0]) =>
+        toAdapterUser(await createParticipantWithHousehold(user)),
+
     getUser: async (id: string) => {
-        const numericId = parseInt(id, 10);
-        if (isNaN(numericId)) return null;
-        const user = await prisma.person.findUnique({ where: { id: numericId } });
-        return user ? { ...user, id: String(user.id), email: user.email || "" } : null;
+        const dbId = toDbId(id);
+        if (isNaN(dbId)) return null;
+        const user = await prisma.person.findUnique({ where: { id: dbId } });
+        return user ? toAdapterUser(user) : null;
+    },
+
+    getUserByEmail: async (email: string) => {
+        const user = await prisma.person.findUnique({ where: { email } });
+        return user ? toAdapterUser(user) : null;
+    },
+
+    getUserByAccount: async (key: { provider: string; providerAccountId: string }) => {
+        const account = await prisma.account.findUnique({
+            where: { provider_providerAccountId: key },
+            include: { user: true },
+        });
+        return account?.user ? toAdapterUser(account.user) : null;
+    },
+
+    updateUser: async ({ id, ...data }: { id: string; name?: string | null; email?: string | null; image?: string | null; emailVerified?: Date | null }) => {
+        const user = await prisma.person.update({
+            where: { id: toDbId(id) },
+            data: { name: data.name, email: data.email ?? undefined, image: data.image, emailVerified: data.emailVerified },
+        });
+        return toAdapterUser(user);
+    },
+
+    deleteUser: async (id: string) => {
+        await prisma.person.delete({ where: { id: toDbId(id) } });
+    },
+
+    // The crash this whole boundary exists to prevent: the stock linkAccount
+    // writes NextAuth's string userId straight into Account.userId (Int). Coerce
+    // it, and map only our own columns so a provider's extra token fields can't
+    // reach prisma.account.create.
+    linkAccount: async (account: AdapterAccount) => {
+        await prisma.account.create({
+            data: {
+                userId: toDbId(account.userId),
+                type: account.type,
+                provider: account.provider,
+                providerAccountId: account.providerAccountId,
+                refresh_token: account.refresh_token,
+                access_token: account.access_token,
+                expires_at: account.expires_at,
+                token_type: account.token_type,
+                scope: account.scope,
+                id_token: account.id_token,
+                session_state: (account.session_state ?? null) as string | null,
+            },
+        });
+        return account;
     },
 };
 


### PR DESCRIPTION
## Symptom

Every **first Google sign-in** on the `checkin-dev` instance crashes in the OAuth callback (from `/ecs/checkin-dev`, 2026-07-05):

```
[next-auth][error][OAUTH_CALLBACK_HANDLER_ERROR]
Invalid `prisma.account.create()` invocation:
    userId: "298"   ← Expected Int, provided String
Argument `userId`: Invalid value provided. Expected Int, provided String.
→ Error [LinkAccountError]
```

No session is created, so login fails.

## Root cause

The custom PrismaAdapter shim in `auth-options.ts` overrode only `createUser` and `getUser` to bridge NextAuth's string ids and our `Int` `Person.id` / `Account.userId`. On a first sign-in:

1. `createUser` creates Person #298, returns `id: "298"` (string).
2. NextAuth core calls the **base** `linkAccount({ ...account, userId: "298" })`.
3. Base `linkAccount` runs `prisma.account.create({ data })` — `Account.userId` is `Int` → Prisma rejects the string.

`getUserByEmail` / `getUserByAccount` / `updateUser` / `deleteUser` were un-coerced too — the same latent bug, one method over. This is the same class as #708/#871 and evaded CI for the same reason: **the adapter's user/account methods run only in the real Google OAuth callback** — persona-mint/credentials sign-in (what flow tests exercise) bypasses the adapter entirely.

## Fix

Rather than spot-patch a fifth method, the Int↔string boundary is now **unified in one place**. Every user/account method the OAuth flow can reach is defined together and routes every id through a single pair of converters:

- `toAdapterUser` — Int→string on the way out (+ the non-null email `AdapterUser` requires)
- `toDbId` — string→Int on the way in

`linkAccount` coerces `userId` and maps only our own `Account` columns (so a provider's extra token fields can't reach `prisma.account.create`). The JWT callback is untouched and unaffected — `token.id` is derived from a DB lookup **by email**, not from the adapter's return value, so normalizing adapter ids can't disturb session identity.

## Tests

`auth-options-adapter.test.ts` is the only tier that reaches the adapter (it mocks prisma with the real model names and invokes the lazy adapter closures directly). It now asserts **both directions** for `getUser`, `getUserByEmail`, `getUserByAccount`, `updateUser`, and `linkAccount` — including a test that reproduces the exact `userId: "298"` failure and asserts a numeric `userId` reaches `prisma.account.create`. Full `test:ci` green (197 suites / 1520 tests); tsc + eslint clean.

## Verification note

This can only be confirmed end-to-end once deployed to `checkin-dev` (the adapter path is unreachable from local persona-mint login). The reproduction + regression test stand in for that until the dev deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)