### PR TITLE
fix(shopify): explicit CHECKIN_ENV=local mock gate for enroll + dues settlement

### DIFF
--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -146,12 +146,15 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         }
     });
 
-    it('accepts a mock-signed webhook when Shopify is unconfigured (dev orders/paid mock)', async () => {
-        // Off a real store (creds unset, non-prod), shopifyWebhookSecret() falls back
-        // to the fixed mock secret so the dev mock's self-signed webhook verifies for
-        // real — the symmetry /api/dev/shopify/orders-paid relies on. Bad signature
-        // still 401s; a correctly mock-signed body passes verification (200).
+    it('accepts a mock-signed webhook on local (dev orders/paid mock)', async () => {
+        // On local (CHECKIN_ENV=local), shopifyWebhookSecret() falls back to the fixed
+        // mock secret so the mock's self-signed webhook verifies for real — the symmetry
+        // /api/dev/shopify/orders-paid relies on. Bad signature still 401s; a correctly
+        // mock-signed body passes verification (200). The mock is gated on the env, not
+        // on cred presence, so run this test as local.
         delete process.env.SHOPIFY_WEBHOOK_SECRET;
+        const prevEnv = process.env.CHECKIN_ENV;
+        process.env.CHECKIN_ENV = 'local';
         // Imported so signer and verifier track the same constant — the value
         // itself is not a contract; this test asserts the fallback wiring.
         const MOCK_SECRET = DEV_MOCK_SHOPIFY_WEBHOOK_SECRET;
@@ -161,6 +164,8 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
             expect((await POST(webhookReq(body, sign(body, MOCK_SECRET)))).status).toBe(200); // signed with the mock secret
         } finally {
             process.env.SHOPIFY_WEBHOOK_SECRET = SECRET;
+            if (prevEnv === undefined) delete process.env.CHECKIN_ENV;
+            else process.env.CHECKIN_ENV = prevEnv;
         }
     });
 

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
@@ -33,6 +33,11 @@ function anonymous() {
 function jsonReq(body?: unknown) {
     return new Request('http://localhost:4000/api/dev/shopify/orders-paid', {
         method: 'POST',
+        // A real local browser always carries the session cookie; without it, the
+        // local (CHECKIN_ENV=local) kiosk fallback in authenticateRequest treats the
+        // cookieless request as a kiosk and withAuth 403s it. Send one so auth resolves
+        // to the mocked session, as it would in the app.
+        headers: { cookie: 'next-auth.session-token=test' },
         ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     });
 }
@@ -81,10 +86,15 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
     // running first nor permanently erases ambient creds for later suites.
     const SHOPIFY_ENV_KEYS = ['SHOPIFY_STORE_DOMAIN', 'SHOPIFY_CLIENT_ID', 'SHOPIFY_CLIENT_SECRET'] as const;
     let prevShopifyEnv: Record<string, string | undefined> = {};
+    // The mock is gated EXPLICITLY on CHECKIN_ENV=local (config.shopifyMockActiveEnv);
+    // the suite default is 'dev'. Run as local so shopifyMockActive() is true.
+    let prevCheckinEnv: string | undefined;
 
     beforeAll(async () => {
         // Capture before anything fallible so afterAll can't restore `undefined`.
         originalFetch = global.fetch;
+        prevCheckinEnv = process.env.CHECKIN_ENV;
+        process.env.CHECKIN_ENV = 'local';
         prevShopifyEnv = Object.fromEntries(SHOPIFY_ENV_KEYS.map((k) => [k, process.env[k]]));
         for (const k of SHOPIFY_ENV_KEYS) delete process.env[k];
 
@@ -122,6 +132,8 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
             if (prevShopifyEnv[k] === undefined) delete process.env[k];
             else process.env[k] = prevShopifyEnv[k];
         }
+        if (prevCheckinEnv === undefined) delete process.env.CHECKIN_ENV;
+        else process.env.CHECKIN_ENV = prevCheckinEnv;
         global.fetch = originalFetch;
         await prisma.$disconnect();
     });
@@ -130,18 +142,14 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
         jest.clearAllMocks();
     });
 
-    it('404s when the mock is inactive (real Shopify creds configured)', async () => {
+    it('404s when not local (dev/prod pay through the real store, not this route)', async () => {
         asSession();
-        process.env.SHOPIFY_STORE_DOMAIN = 'test.myshopify.com';
-        process.env.SHOPIFY_CLIENT_ID = 'test-client-id';
-        process.env.SHOPIFY_CLIENT_SECRET = 'test-client-secret';
+        process.env.CHECKIN_ENV = 'dev';
         try {
             const res = await POST(jsonReq({ processId: 1 }));
             expect(res.status).toBe(404);
         } finally {
-            delete process.env.SHOPIFY_STORE_DOMAIN;
-            delete process.env.SHOPIFY_CLIENT_ID;
-            delete process.env.SHOPIFY_CLIENT_SECRET;
+            process.env.CHECKIN_ENV = 'local';
         }
     });
 

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
@@ -172,12 +172,18 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
         expect(res.status).toBe(404);
     });
 
-    it('409s when no membership variant is configured on BoardSettings', async () => {
+    it('settles via the synthetic mock variant when none is configured on BoardSettings', async () => {
+        // A local seed never sets a membership variant; the mock falls back to
+        // DEV_MOCK_MEMBERSHIP_VARIANT_ID (config), which the inbound handler echoes,
+        // so dues still settle end-to-end instead of dead-ending on a 409.
         asSession();
         await setVariant(null);
         const { processId } = await makeProc();
         const res = await POST(jsonReq({ processId }));
-        expect(res.status).toBe(409);
+        expect(res.status).toBe(200);
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe('PENDING_BG_CLEARANCE');
+        expect(proc?.paidAt).not.toBeNull();
     });
 
     it('200s, fires the real inbound webhook, and advances the process (PENDING_PAYMENT -> PENDING_BG_CLEARANCE)', async () => {

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import crypto from "crypto";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
-import { config } from "@/lib/config";
+import { config, DEV_MOCK_MEMBERSHIP_VARIANT_ID } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { apiError } from "@/lib/api-response";
 
@@ -71,10 +71,9 @@ async function fireMembership(processId: number): Promise<NextResponse> {
     // the membership product (#624/H2). The mock must echo a configured variant id
     // or the webhook lands as a no-membership-item anomaly, not an activation.
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const variantId = settings?.orgMembershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId;
-    if (!variantId) {
-        return apiError("No membership variant configured. Set one in Settings → Membership first (design §2, O4a).", 409);
-    }
+    // Mock stands in for the manual BoardSettings variant a local seed never sets;
+    // the inbound handler echoes the same fallback so the order matches (config).
+    const variantId = settings?.orgMembershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId ?? DEV_MOCK_MEMBERSHIP_VARIANT_ID;
 
     // Shape mirrors the subset the inbound handler reads: note_attributes (where
     // Shopify maps cart attributes) + line_items + an order id. Stable id so two

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
@@ -21,13 +21,15 @@ export const dynamic = "force-dynamic";
  *   { processId }                     → membership activation
  *   { programId, participantIds[] }   → program-enrollment activation
  *
- * 404s whenever the mock isn't active — always in prod. Each path also fails
+ * ENV GATE: LOCAL ONLY. shopifyMockActive() is true iff CHECKIN_ENV=local, so this
+ * route 404s on BOTH dev and prod — dev and prod pay through their real Shopify
+ * store, which fires the real orders/paid webhook itself. Each path also fails
  * CLOSED when its target isn't actually awaiting payment (process not
  * PENDING_PAYMENT / participants not PENDING): the dev UI only ever lists
  * awaiting-payment rows, so the API refuses to fire a webhook for anything else.
  */
 export const POST = withAuth({}, async (req, auth) => {
-    if (!config.shopifyMockActive()) return apiError("Not available", 404);
+    if (!config.shopifyMockActive()) return apiError("Not available", 404); // local only; 404 on dev + prod
     if (auth.type !== "session") return apiError("Unauthorized", 401);
 
     if (!config.shopifyWebhookSecret()) return apiError("No webhook secret", 500);

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -4,7 +4,7 @@ import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { activateByProcessId } from "@/lib/membership/payment";
 import { withWebhook } from "@/lib/webhookAuth";
-import { config } from "@/lib/config";
+import { config, DEV_MOCK_MEMBERSHIP_VARIANT_ID } from "@/lib/config";
 
 interface ShopifyOrder {
     id?: number | string;
@@ -94,9 +94,13 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
             if (!isNaN(processId)) {
                 const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
                 const membershipVariantIds = new Set(
-                    [settings?.orgMembershipVariantId, settings?.shopifyNormalVariantId, settings?.shopifyVolunteerVariantId].filter(
-                        (v): v is string => !!v,
-                    ),
+                    [
+                        settings?.orgMembershipVariantId,
+                        settings?.shopifyNormalVariantId,
+                        settings?.shopifyVolunteerVariantId,
+                        // Local mock's self-fired order carries this synthetic id (config).
+                        config.shopifyMockActive() ? DEV_MOCK_MEMBERSHIP_VARIANT_ID : null,
+                    ].filter((v): v is string => !!v),
                 );
                 const hasMembershipItem = (order.line_items ?? []).some((li) => membershipVariantIds.has(String(li.variant_id)));
                 const proc = await activateByProcessId(processId, order.id ? String(order.id) : "", hasMembershipItem);

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -49,7 +49,13 @@ function verifyShopifyHmac(req: Request, rawBody: string): { ok: true } | { ok: 
 }
 
 // Shopify Webhook for `orders/paid` or `orders/create`
-// Verifies HMAC signature, extracts custom attributes, and marks user as ACTIVE
+// Verifies HMAC signature, extracts custom attributes, and marks user as ACTIVE.
+//
+// ENV: this handler runs in ALL environments — dev/prod receive it from the real
+// Shopify store; local receives it from the self-fired mock (/api/dev/shopify/orders-paid).
+// The HMAC secret differs per env (config.shopifyWebhookSecret). The only env-branched
+// logic is the synthetic dev-mock variant fallback, gated on config.shopifyMockActive()
+// (⇔ CHECKIN_ENV=local) below.
 export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac }, async (_req, order: ShopifyOrder) => {
         // Iterate through line items to find CheckMeIn_Account_ID and Program_ID
         // We set these custom attributes in the permalink URL:

--- a/checkin-app/src/app/dev/shopify/page.tsx
+++ b/checkin-app/src/app/dev/shopify/page.tsx
@@ -6,14 +6,15 @@ import DevShopifyClient from "./DevShopifyClient";
 export const dynamic = "force-dynamic";
 
 /**
- * Dev-only stand-in for a Shopify orders/paid webhook (see
+ * ENV GATE: LOCAL ONLY. Stand-in for a Shopify orders/paid webhook (see
  * docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md §6). Lists the membership processes
  * AND program enrollments currently awaiting payment and fires a
- * synthesized-but-real webhook for the chosen one. 404s the moment the mock
- * isn't active (always in prod).
+ * synthesized-but-real webhook for the chosen one. 404s on dev AND prod
+ * (shopifyMockActive() is true iff CHECKIN_ENV=local) — dev/prod pay through
+ * their real Shopify store.
  */
 export default async function DevShopifyPage() {
-    if (!config.shopifyMockActive()) notFound();
+    if (!config.shopifyMockActive()) notFound(); // local only; 404 on dev + prod
 
     const processes = await prisma.orgMembershipProcess.findMany({
         where: { status: "PENDING_PAYMENT" },

--- a/checkin-app/src/app/dev/shopify/page.tsx
+++ b/checkin-app/src/app/dev/shopify/page.tsx
@@ -22,7 +22,8 @@ export default async function DevShopifyPage() {
     });
 
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const hasVariant = !!(settings?.orgMembershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId);
+    // Mock synthesizes a membership variant (config), so the fire tool is always usable on local.
+    const hasVariant = config.shopifyMockActive() || !!(settings?.orgMembershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId);
 
     const pendingParticipants = await prisma.programParticipant.findMany({
         where: { status: "PENDING" },

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -19,6 +19,7 @@ import { useUnsavedGuard, useConfirmNav } from "@/components/UnsavedChangesProvi
 import AddressForm from "@/components/membership/AddressForm";
 import EmergencyContactForm from "@/components/membership/EmergencyContactForm";
 import ChildrenListForm from "@/components/membership/ChildrenListForm";
+import { useIsLocalInstance } from "@/components/EnvProvider";
 
 import { PageLoader } from "@/components/ui/PageLoader";
 const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
@@ -100,6 +101,7 @@ function ExternalTask({ done, title, doneText, children }: { done: boolean; titl
 
 export default function MembershipPage() {
   const { data: session, status: sessionStatus } = useSession();
+  const isLocalInstance = useIsLocalInstance();
 
   const [state, setState] = useState<IntakeState | null>(null);
   const [loading, setLoading] = useState(true);
@@ -263,6 +265,32 @@ export default function MembershipPage() {
   // dead end. Falls back to a friendly default when the body carries nothing.
   const apiError = (data: { error?: string; detail?: string } | null | undefined, fallback: string) =>
     [data?.error, data?.detail].filter(Boolean).join(" — ") || fallback;
+
+  // Local dev has no Shopify store, so instead of a checkout redirect we fire the
+  // mock orders/paid webhook in-app (same endpoint the Debug → Shopify tool uses),
+  // settling dues end-to-end with zero setup. Only rendered on a local instance.
+  const settleMockPayment = async () => {
+    if (!state?.process) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/dev/shopify/orders-paid", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ processId: state.process.id }),
+      });
+      if (res.ok) {
+        flash("Payment mocked (local) — updating status.");
+        notifyNavRefresh();
+        await load();
+      } else {
+        flash(apiError(await res.json().catch(() => null), "Mock payment failed."), true);
+      }
+    } catch {
+      flash("Mock payment failed.", true);
+    } finally {
+      setSaving(false);
+    }
+  };
 
   // Clear a single field's error (called as the user edits it).
   const clearErr = (key: string) =>
@@ -693,6 +721,10 @@ export default function MembershipPage() {
                     {payment.checkoutUrl ? (
                       <Button component="a" href={payment.checkoutUrl} target="_blank" rel="noopener noreferrer" color="green" mt="md">
                         Pay here with Shopify →
+                      </Button>
+                    ) : isLocalInstance ? (
+                      <Button color="green" mt="md" disabled={saving} onClick={settleMockPayment}>
+                        Pay now (local mock) →
                       </Button>
                     ) : (
                       <Text c="yellow" mt="md">The payment link isn&apos;t available yet. Please check back shortly.</Text>

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -11,6 +11,7 @@ import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { formatCents } from '@inventory/money';
 import { aggregateEnrollOutcomes, buildShopifyCheckoutUrl, type EnrollOutcome } from './enroll';
 import FirstTimeIntakePanel from './FirstTimeIntakePanel';
+import { useIsLocalInstance } from '@/components/EnvProvider';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 type ProgramDetail = {
@@ -43,6 +44,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   const { id } = use(params);
   const { data: session, status } = useSession();
   const router = useRouter();
+  const isLocalInstance = useIsLocalInstance();
 
   const [program, setProgram] = useState<ProgramDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -230,6 +232,13 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
       // instead of creating a free, unchargeable enrollment.
       let variantId: string | null = null;
       let storeDomain: string | undefined;
+      // LOCAL only: no real Shopify store, so the mock (config.shopifyMockActive)
+      // stands in. Redirecting to a nonexistent store would dead-end, so we settle the
+      // charge in-app via the Debug section's orders/paid webhook instead. Dev/prod
+      // hit their real stores (storeDomain set → redirect below). Variant is still
+      // required — the mock synthesizes dev-mock-variant ids, so a null one is a real
+      // config gap even locally.
+      let mockPay = false;
       if (isPayingOnShopify && program) {
         const householdRes = await fetch('/api/household');
         let isMember = false;
@@ -239,7 +248,8 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
         }
         variantId = isMember ? program.shopifyOrgMemberVariantId : program.shopifyNonOrgMemberVariantId;
         storeDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
-        if (!variantId || !storeDomain) {
+        mockPay = !storeDomain && isLocalInstance;
+        if (!variantId || (!storeDomain && !mockPay)) {
           notifications.show({ color: "red", autoClose: false, message: variantId
             ? "Cannot enroll: Shopify store domain not configured. Contact an admin."
             : "Cannot enroll: no pricing variant set for this program tier — set one in program-ops." });
@@ -265,7 +275,22 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
 
       if (enrolledIds.length > 0) {
         notifyNavRefresh();
-        if (isPayingOnShopify && program && variantId && storeDomain) {
+        if (isPayingOnShopify && program && variantId && mockPay) {
+          // Local mock: fire the Debug section's orders/paid webhook to activate the
+          // PENDING enrollments, exactly as the dev Shopify tool's button does — no redirect.
+          const payRes = await fetch('/api/dev/shopify/orders-paid', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ programId: program.id, participantIds: enrolledIds }),
+          });
+          if (payRes.ok) {
+            notifications.show({ color: "green", message: "Payment mocked (local) — enrollment activated." });
+          } else {
+            notifications.show({ color: "red", autoClose: false, message: "Enrolled, but the mock payment failed — fire it from the Debug → Shopify tool." });
+          }
+          setRequiresOverride(false);
+          fetchProgram();
+        } else if (isPayingOnShopify && program && variantId && storeDomain) {
           setSuccessMessage("Redirecting to Shopify for secure payment...");
           // qty=N single variant + comma-joined account ids — see buildShopifyCheckoutUrl.
           navigating = true;

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -232,12 +232,12 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
       // instead of creating a free, unchargeable enrollment.
       let variantId: string | null = null;
       let storeDomain: string | undefined;
-      // LOCAL only: no real Shopify store, so the mock (config.shopifyMockActive)
-      // stands in. Redirecting to a nonexistent store would dead-end, so we settle the
-      // charge in-app via the Debug section's orders/paid webhook instead. Dev/prod
-      // hit their real stores (storeDomain set → redirect below). Variant is still
-      // required — the mock synthesizes dev-mock-variant ids, so a null one is a real
-      // config gap even locally.
+      // ENV GATE (mirrors server config.shopifyMockActive ⇔ CHECKIN_ENV=local):
+      //   local     → mockPay: settle the charge in-app via the Debug orders/paid
+      //               webhook, no redirect (there is no local Shopify store).
+      //   dev/prod  → redirect to the real store (storeDomain required).
+      // Variant is always required — local synthesizes dev-mock-variant ids, so a null
+      // one is a real config gap in every env.
       let mockPay = false;
       if (isPayingOnShopify && program) {
         const householdRes = await fetch('/api/household');
@@ -248,8 +248,8 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
         }
         variantId = isMember ? program.shopifyOrgMemberVariantId : program.shopifyNonOrgMemberVariantId;
         storeDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
-        mockPay = !storeDomain && isLocalInstance;
-        if (!variantId || (!storeDomain && !mockPay)) {
+        mockPay = isLocalInstance;
+        if (!variantId || (!mockPay && !storeDomain)) {
           notifications.show({ color: "red", autoClose: false, message: variantId
             ? "Cannot enroll: Shopify store domain not configured. Contact an admin."
             : "Cannot enroll: no pricing variant set for this program tier — set one in program-ops." });

--- a/checkin-app/src/lib/__tests__/config.test.ts
+++ b/checkin-app/src/lib/__tests__/config.test.ts
@@ -148,18 +148,24 @@ describe("zohoMockActive / zohoAvailable / zohoWebhookSecret", () => {
 });
 
 describe("shopifyMockActive / shopifyWebhookSecret", () => {
-    it("mock active when unconfigured, non-prod, non-production NODE_ENV", () => {
+    it("mock active on local, non-production NODE_ENV", () => {
         clearShopify();
         process.env.CHECKIN_ENV = "local";
         (process.env as Record<string, string>).NODE_ENV = "test";
         expect(config.shopifyMockActive()).toBe(true);
         expect(config.shopifyWebhookSecret()).toBe(DEV_MOCK_SHOPIFY_WEBHOOK_SECRET);
     });
-    it("mock inactive when Shopify is configured (real integration wins)", () => {
+    it("mock STILL active on local even when Shopify creds are set (env gate, not cred gate)", () => {
         process.env.SHOPIFY_STORE_DOMAIN = "shop.myshopify.com";
         process.env.SHOPIFY_CLIENT_ID = "a";
         process.env.SHOPIFY_CLIENT_SECRET = "b";
         process.env.CHECKIN_ENV = "local";
+        (process.env as Record<string, string>).NODE_ENV = "test";
+        expect(config.shopifyMockActive()).toBe(true);
+    });
+    it("mock inactive on dev (real dev store, not the mock)", () => {
+        clearShopify();
+        process.env.CHECKIN_ENV = "dev";
         (process.env as Record<string, string>).NODE_ENV = "test";
         expect(config.shopifyMockActive()).toBe(false);
     });

--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -54,10 +54,11 @@ describe('createShopifyProgramVariants', () => {
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it('returns synthetic variant ids for priced tiers when the dev mock is active', async () => {
-        // Non-prod + no creds → shopifyMockActive: stand in for the real store so
-        // the seed → checkout → orders/paid dev tool works with zero env.
-        process.env.CHECKIN_ENV = 'dev';
+    it('returns synthetic variant ids for priced tiers on local (mock active)', async () => {
+        // CHECKIN_ENV=local → shopifyMockActive: stand in for the real store so the
+        // seed → checkout → orders/paid dev tool works with zero env. Gated on the
+        // env, not on cred presence.
+        process.env.CHECKIN_ENV = 'local';
         delete process.env.SHOPIFY_STORE_DOMAIN;
         delete process.env.SHOPIFY_CLIENT_ID;
         delete process.env.SHOPIFY_CLIENT_SECRET;

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -54,22 +54,31 @@ function zohoMockActiveEnv(): boolean {
  */
 export const DEV_MOCK_WEBHOOK_SECRET = 'dev-zoho-mock-webhook-secret';
 
-/** Real Shopify integration is wired only when all three credentials are present. */
-function shopifyConfiguredEnv(): boolean {
-    return !!(process.env.SHOPIFY_STORE_DOMAIN && process.env.SHOPIFY_CLIENT_ID && process.env.SHOPIFY_CLIENT_SECRET);
-}
-
 /**
- * The dev/local Shopify orders/paid MOCK is active when the real integration is
- * unconfigured AND we're on a non-prod instance (see
- * docs/designs/SHOPIFY_DEV_STORE_WEBHOOK.md §6). Same two server-only fuses as the
- * Zoho mock — CHECKIN_ENV (fails safe to prod) and NODE_ENV — so no mock path is
- * reachable in prod by construction. Wiring real Shopify creds opts back into the
- * real store.
+ * Which Shopify backend runs — gated EXPLICITLY on CHECKIN_ENV, never on whether
+ * creds happen to be set:
+ *
+ *   prod  → real PRODUCTION Shopify store   (SHOPIFY_* creds required)
+ *   dev   → real DEV Shopify store          (SHOPIFY_* creds required)
+ *   local → in-app MOCK, no store, no creds — checkout is settled by the self-fired
+ *           orders/paid webhook (Debug tool or the in-app "local mock" button),
+ *           signed with DEV_MOCK_SHOPIFY_WEBHOOK_SECRET and matched against synthetic
+ *           dev-mock variant ids.
+ *
+ * dev and prod are identical code paths; they differ only in which store SHOPIFY_*
+ * points at per-deploy. The ONLY behavioural branch is local. To hit a real store
+ * from a laptop, run as CHECKIN_ENV=dev with real creds — CHECKIN_ENV=local is always
+ * the mock, regardless of whether creds happen to be set.
+ *
+ * Gated on the explicit env, NOT on cred presence. The `NODE_ENV !== 'production'`
+ * clause is a hard security backstop, not a feature toggle: the mock hands out a
+ * FIXED webhook secret (anyone could forge orders/paid), so it must be impossible in
+ * a production build even if CHECKIN_ENV were misconfigured to 'local' there.
  */
 function shopifyMockActiveEnv(): boolean {
-    return !shopifyConfiguredEnv() && readCheckinEnv() !== 'prod' && process.env.NODE_ENV !== 'production';
+    return readCheckinEnv() === 'local' && process.env.NODE_ENV !== 'production';
 }
+
 
 /**
  * Fixed secret the Shopify mock signs its self-fired orders/paid webhook with.
@@ -176,13 +185,13 @@ export const config = {
     shopifyStoreDomain: (): string | null => process.env.SHOPIFY_STORE_DOMAIN || null,
     shopifyClientId: (): string | null => process.env.SHOPIFY_CLIENT_ID || null,
     shopifyClientSecret: (): string | null => process.env.SHOPIFY_CLIENT_SECRET || null,
-    // Real store's per-store secret, else the fixed mock secret when the mock is
-    // active (self-fired webhook verifies for real with zero env setup), else null
-    // (unconfigured on a real-but-unwired instance → webhook 500s, the intended fail).
+    // dev/prod: the real store's per-store webhook secret (null if unwired → the
+    // inbound webhook 500s, the intended fail). local: the fixed mock secret, so the
+    // self-fired webhook verifies for real with zero env setup.
     shopifyWebhookSecret: (): string | null =>
         process.env.SHOPIFY_WEBHOOK_SECRET || (shopifyMockActiveEnv() ? DEV_MOCK_SHOPIFY_WEBHOOK_SECRET : null),
-    // True when the dev/local mock stands in for a real Shopify store (creds unset,
-    // non-prod). Gates /api/dev/shopify/* + the dev tool. Always false in prod.
+    // True ONLY on CHECKIN_ENV=local (see shopifyMockActiveEnv). Gates /api/dev/shopify/*
+    // + the dev tool + the synthetic dev-mock variant fallbacks. Always false on dev and prod.
     shopifyMockActive: (): boolean => shopifyMockActiveEnv(),
 
     // True when the dev/local background-check mock stands in for Averity (consent URL

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -86,6 +86,17 @@ function shopifyMockActiveEnv(): boolean {
 export const DEV_MOCK_SHOPIFY_WEBHOOK_SECRET = 'dev-shopify-mock-webhook-secret';
 
 /**
+ * Synthetic membership variant id used when the Shopify mock is active. Programs
+ * synthesize dev-mock-variant ids at creation (shopify.ts › createShopifyProgramVariants),
+ * but the membership variant is manual BoardSettings config that a local seed never
+ * populates — so with no fallback the mock orders/paid webhook can't match a membership
+ * order (webhooks/shopify/route.ts) and the dev fire tool 409s. Both the mock firer and
+ * the inbound handler fall back to this id when shopifyMockActive(), so local membership
+ * dues settle end-to-end with zero setup. Same shape as the program dev-mock ids.
+ */
+export const DEV_MOCK_MEMBERSHIP_VARIANT_ID = 'dev-mock-variant-membership';
+
+/**
  * The dev/local background-check MOCK is active when the real Averity consent link
  * is unconfigured (AVERITY_CONSENT_URL unset) AND we're on a non-prod instance.
  * Same two server-only fuses as the Zoho/Shopify mocks — CHECKIN_ENV (fails safe to

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -94,14 +94,13 @@ export async function getAccessToken(): Promise<string | null> {
 }
 
 export async function createShopifyProgramVariants(name: string, orgMemberPriceCents: number | null, nonOrgMemberPriceCents: number | null, maxParticipants: number | null = null) {
-  // Dev/local mock: the real Shopify store is unreachable with no creds, so a
-  // locally-seeded paid program would store null variant ids and the orders/paid
-  // dev tool would then refuse to fire (route.ts: "No Shopify variant configured").
-  // Mirror the inbound webhook mock — synthesize the ids the real store would
-  // return so the create → checkout → webhook path works end-to-end with zero env.
-  // Only priced tiers get a variant, exactly like the real branch below. Ids need
-  // not be globally unique: the inbound handler resolves the program by id, then
-  // matches line-items against that program's own variant set.
+  // ENV GATE: LOCAL ONLY (shopifyMockActive() ⇔ CHECKIN_ENV=local). No real store,
+  // so synthesize the variant ids the real store would return — otherwise a paid
+  // program stores null variants and the checkout → webhook path can't match. Only
+  // priced tiers get a variant, exactly like the real (dev/prod) branch below. Ids
+  // need not be globally unique: the inbound handler resolves the program by id, then
+  // matches line-items against that program's own variant set. dev/prod fall through
+  // to the real Shopify Admin API call below.
   if (config.shopifyMockActive()) {
     const slug = name.replace(/\W+/g, "-").toLowerCase().slice(0, 24);
     return {


### PR DESCRIPTION
Cherry-picks the local-mock Shopify work from `claude/mystifying-pasteur-ecebd0` onto current `main` (three commits, `-x` provenance preserved). Files had moved since that branch was cut; verified the changes land on main's current structure.

## What changed

- **`fix(programs)`** — local enroll settles payment in-app via the Debug `orders/paid` webhook instead of redirecting to a real Shopify store (there is no local store). `mockPay = isLocalInstance`.
- **`fix(membership)`** — local dues settle via the same in-app mock; synthesize a membership variant id so the checkout to webhook path can match.
- **`refactor(shopify)`** — gate the mock **explicitly** on `CHECKIN_ENV=local` (`shopifyMockActive()`), not on credential presence. Adds a `NODE_ENV!=production` security backstop (the mock hands out a fixed webhook secret). Drops the now-unused `shopifyConfiguredEnv` cred check.

Behaviour per env is now one branch:
- `local` -> in-app mock: self-fired orders/paid webhook, synthetic `dev-mock-variant-*` ids, no real store.
- `dev`/`prod` -> real Shopify store (identical code paths; differ only in which store `SHOPIFY_*` points at).

## Why

The mock was implicitly active whenever creds were unset on a non-prod instance — hard to reason about "what fires in prod vs dev vs local", and a mis-wired dev instance could silently fall into the mock. Explicit env gate removes that ambiguity.

## Reviewer notes

- `createShopifyProgramVariants` synthesizes variant ids only for priced tiers, mirroring the real branch; ids need not be globally unique (inbound handler resolves program by id, then matches line-items to that program's own variants).
- `shopifyConfiguredEnv` fully removed (0 refs repo-wide).
- Landed onto main's post-rename field names (`shopifyOrgMemberVariantId` / `orgMembership.status`), not stale vocab.

## Testing

- Unit (`npm test`): 1517 passed / 197 suites
- Integration (`npm run test:integration`): 868 passed / 106 suites, incl. `webhookShopify.integration.test.ts` + `orders-paid/route.integration.test.ts`
- Shopify unit tests pass (`shopify.test.ts`, `register-shopify-webhook.test.ts`)
- Flow tests not run (need a running dev server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)