### PR TITLE
fix(email): correct bouncing finances@ → finance@ address in two backends

### DIFF
--- a/checkin-app/src/app/api/cron/pending-participants/route.ts
+++ b/checkin-app/src/app/api/cron/pending-participants/route.ts
@@ -28,7 +28,7 @@ export const GET = withCron(async () => {
             const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24)); // Calculate total full days
 
             // Email text for warnings
-            const warningText = `If not paid, your spot in ${record.program.name} will be freed up. If a payment plan is needed, contact the board via finances@innovationtreehouse.org`;
+            const warningText = `If not paid, your spot in ${record.program.name} will be freed up. If a payment plan is needed, contact the board via finance@innovationtreehouse.org`;
 
             if (diffDays >= 7) {
                 // Collect IDs for batch deletion

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -72,7 +72,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
 
         // Send email to finances
         // In a real implementation this would trigger an actual email via SendGrid, NodeMailer, etc.
-        logger.info(`[EMAIL DISPATCH] To: finances@innovationtreehouse.org, Subject: Payment Plan Request for ${participant.person?.name || 'User'} in ${participant.program?.name || 'Program'}`);
+        logger.info(`[EMAIL DISPATCH] To: finance@innovationtreehouse.org, Subject: Payment Plan Request for ${participant.person?.name || 'User'} in ${participant.program?.name || 'Program'}`);
 
         return NextResponse.json({ success: true, participant: updatedParticipant });
     } catch (error) {


### PR DESCRIPTION
## What changed

Fixes two backend files that emailed / logged the wrong Treehouse finance address:

- `checkin-app/src/app/api/cron/pending-participants/route.ts` — payment-plan warning text sent to households.
- `checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts` — the `[EMAIL DISPATCH]` log line.

Both changed `finances@innovationtreehouse.org` (plural) → `finance@innovationtreehouse.org` (singular).

## Why

The plural `finances@` address bounces. The canonical finance contact is `finance@innovationtreehouse.org`, matching the already-correct membership page (`checkin-app/src/app/membership/page.tsx`).

## Reviewer notes

- `grep -rn "finances@innovationtreehouse" checkin-app/src` returns zero hits post-change.
- Already-correct `finance@` uses in `membership/page.tsx` were left untouched. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)