### PR TITLE
feat(admin): add success toasts to three silent admin actions

### DIFF
--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -74,6 +74,7 @@ export default function PendingParticipantsPage() {
       if (res.ok) {
         setRequests(prev => prev.filter(r => !(r.programId === programId && r.personId === participantId)));
         notifyNavRefresh();
+        notifications.show({ color: 'green', message: 'Payment plan approved.' });
       } else {
         const data = await res.json();
         if (data.error === "No pending payment-plan request") {

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -59,6 +59,7 @@ export default function AdminHouseholdsPage() {
 
       if (res.ok) {
         fetchHouseholds();
+        notifications.show({ color: 'green', message: currentActive ? 'Membership revoked.' : 'Membership granted.' });
       } else {
         notifications.show({ color: 'red', message: 'Failed to update membership.', autoClose: false });
       }
@@ -88,6 +89,7 @@ export default function AdminHouseholdsPage() {
 
       if (res.ok) {
         fetchHouseholds();
+        notifications.show({ color: 'green', message: deny ? 'Membership denied — members can no longer log in.' : 'Membership restored.' });
       } else {
         const data = await res.json().catch(() => ({}));
         notifications.show({ color: 'red', message: data.error || 'Failed to update membership.', autoClose: false });

--- a/checkin-app/src/app/settings/roles/page.tsx
+++ b/checkin-app/src/app/settings/roles/page.tsx
@@ -82,6 +82,8 @@ export default function RoleAssignmentPage() {
         setRowError({ id: userId, text: data.error || "Failed to update role." });
         // Revert optimistic update
         fetchUsers();
+      } else {
+        notifications.show({ color: 'green', message: 'Role updated.' });
       }
     } catch {
       notifications.show({ color: "red", message: "Network error updating role.", autoClose: false });


### PR DESCRIPTION
## What

Three admin actions succeeded silently (only a refetch or row removal) while the rest of the app confirms success with a green auto-dismiss toast. This adds matching success toasts.

- **membership-ops/households** — `toggleMembership` toasts "Membership granted." / "Membership revoked." (keyed off `!currentActive`); `doSetDenied` toasts "Membership denied — members can no longer log in." / "Membership restored." (keyed off `deny`). Highest priority: deny blocks login for every household member, so silent success was worst here.
- **settings/roles** — role PATCH handler had *only* an error branch; added an `else` → "Role updated."
- **finance-ops/payment-plan** — `doApprove` toasts "Payment plan approved." after `notifyNavRefresh()`.

## Why

Operators got no positive confirmation these actions landed — inconsistent with the green-toast pattern used everywhere else.

## Reviewer notes

- **Success branches only.** No `res.ok` checks or error paths changed.
- Green toasts use Mantine's ~4s default (no `autoClose` set), matching the app convention.
- `safety/trusted-adults` `override` left deliberately silent per its own code comment ("Override deliberately shows no success notice — just reload.") — out of scope.
- `npx tsc --noEmit` clean for the three edited files; pre-commit test suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)