### PR TITLE
refactor(membership): stop surfacing server `detail` to applicants

### DIFF
--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -370,10 +370,10 @@ describe("membership page", () => {
     expect(await screen.findByText("Couldn't open the signing form. Please try again.")).toBeInTheDocument();
   });
 
-  it("shows the server's error and detail when signing fails", async () => {
+  it("shows the server's error when signing fails", async () => {
     setSession({ id: 1 });
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
-      if (String(input).includes("contract/sign")) return { ok: false, json: async () => ({ error: "Signing closed", detail: "zoho maintenance" }) } as Response;
+      if (String(input).includes("contract/sign")) return { ok: false, json: async () => ({ error: "Signing closed" }) } as Response;
       return {
         ok: true,
         json: async () => state({
@@ -388,7 +388,7 @@ describe("membership page", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Sign your membership agreement/ }));
 
-    expect(await screen.findByText("Signing closed — zoho maintenance")).toBeInTheDocument();
+    expect(await screen.findByText("Signing closed")).toBeInTheDocument();
   });
 
   it("shows a network error when starting to sign throws", async () => {
@@ -442,12 +442,12 @@ describe("membership page", () => {
   });
 
   // ── save() failures + warnings branches ──────────────────────────────────
-  it("shows the server detail when saving progress fails", async () => {
+  it("shows the server error when saving progress fails", async () => {
     setSession({ id: 1 });
     const fetchMock = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/membership/intake") && init?.method === "PATCH") {
-        return { ok: false, json: async () => ({ detail: "constraint violated" }) } as Response;
+        return { ok: false, json: async () => ({ error: "constraint violated" }) } as Response;
       }
       return { ok: true, json: async () => state({ process: { id: 1, kind: "INITIAL", status: "INTAKE" } }) } as Response;
     });
@@ -562,7 +562,7 @@ describe("membership page", () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/membership/intake") && init?.method === "PATCH") {
-        return { ok: false, json: async () => ({ error: "Save failed", detail: "timeout" }) } as Response;
+        return { ok: false, json: async () => ({ error: "Save failed" }) } as Response;
       }
       if (url.includes("/api/membership/intake/submit")) return { ok: true, json: async () => ({ state: state({}) }) } as Response;
       return { ok: true, json: async () => state({ process: { id: 1, kind: "INITIAL", status: "INTAKE" } }) } as Response;
@@ -581,7 +581,7 @@ describe("membership page", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Submit & continue" }));
 
-    expect(await screen.findByText("Save failed — timeout")).toBeInTheDocument();
+    expect(await screen.findByText("Save failed")).toBeInTheDocument();
     expect(fetchMock.mock.calls.some(([u]) => String(u).includes("/api/membership/intake/submit"))).toBe(false);
   });
 

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -258,11 +258,9 @@ export default function MembershipPage() {
     if (error || msg === "") setWarnings([]);
   };
 
-  // Build an error message from an API response, appending the dev-only `detail`
-  // (the real server failure) when present so an "Internal Server Error" isn't a
-  // dead end. Falls back to a friendly default when the body carries nothing.
-  const apiError = (data: { error?: string; detail?: string } | null | undefined, fallback: string) =>
-    [data?.error, data?.detail].filter(Boolean).join(" — ") || fallback;
+  // Prefer the API's user-facing error string; fall back to a friendly default.
+  const apiError = (data: { error?: string } | null | undefined, fallback: string) =>
+    data?.error || fallback;
 
   // Clear a single field's error (called as the user edits it).
   const clearErr = (key: string) =>


### PR DESCRIPTION
## What

The local `apiError` helper in `checkin-app/src/app/membership/page.tsx` built user-facing error copy by joining the API response's `error` and `detail` fields (`error — detail`). This drops the `detail` branch: the helper now shows only the API's user-facing `error`, or a friendly fallback.

```diff
-const apiError = (data: { error?: string; detail?: string } | null | undefined, fallback: string) =>
-  [data?.error, data?.detail].filter(Boolean).join(" — ") || fallback;
+const apiError = (data: { error?: string } | null | undefined, fallback: string) =>
+  data?.error || fallback;
```

## Why

No route in `src/app/api` returns a `detail` field today (grep of `src/app/api` finds nothing), so the branch never fired in production. But it was **live and tested**, not dead — any route that later added a `detail` field would silently start leaking internal error text (exception/stack strings) straight to membership applicants. The old code comment explicitly advertised appending "the real server failure" to user copy. This closes that latent info-leak path by treating `detail` as internal-only.

> Note: the shared helper in `src/lib/api-response.ts` returns `details` (plural) — a different field this page never read. Not touched.

## Reviewer notes

- **This is a behavior change, not a pure cleanup.** If a route ever returns `detail`, it is no longer shown to the user. That is the intent.
- Three membership page tests asserted `detail` rendered in the UI; updated to assert the `error` field instead (one test that mocked `detail`-only now mocks `error`). Test names updated to match.
- The 6 call sites of `apiError` are unchanged — the signature is compatible.
- Full suite green locally: **1520/1520** (pre-commit hook runs the CI test script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
