### PR TITLE
fix(admin): Mantine confirm modal for household edit discard guard

### DIFF
--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Alert, Button, Divider, Group, Loader, Modal, SimpleGrid, Stack, Text, TextInput } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
+import { modals } from "@mantine/modals";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
 import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 
@@ -139,8 +140,17 @@ export function AdminEditHouseholdModal({
   // prompt when the form has unsaved edits. handleSave calls onClose directly
   // so a successful save never prompts.
   const requestClose = () => {
-    if (isFormDirty(form, initial) && !window.confirm("Discard unsaved changes?")) return;
-    onClose();
+    if (!isFormDirty(form, initial)) {
+      onClose();
+      return;
+    }
+    modals.openConfirmModal({
+      title: 'Discard unsaved changes?',
+      children: <Text size="sm">You have unsaved changes. Close without saving?</Text>,
+      labels: { confirm: 'Discard', cancel: 'Keep editing' },
+      confirmProps: { color: 'red' },
+      onConfirm: onClose,
+    });
   };
 
   // Phone is optional here, so only a non-empty malformed value is an error.

--- a/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
@@ -1,7 +1,9 @@
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+jest.mock("@mantine/modals", () => ({ modals: { openConfirmModal: jest.fn() } }));
 
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { notifications } from "@mantine/notifications";
+import { modals } from "@mantine/modals";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
 import { AdminEditHouseholdModal, isFormDirty } from "../AdminEditHouseholdModal";
 
@@ -125,20 +127,23 @@ describe("AdminEditHouseholdModal", () => {
     renderWithProviders(<AdminEditHouseholdModal householdId={55} opened={true} onClose={onClose} />);
     await screen.findByDisplayValue("Smith Family");
 
+    const openConfirmModal = modals.openConfirmModal as jest.Mock;
+
     // Not dirty -> closes without prompting.
-    window.confirm = jest.fn();
+    openConfirmModal.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(window.confirm).not.toHaveBeenCalled();
+    expect(openConfirmModal).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
 
     fireEvent.change(screen.getByLabelText("Household Name"), { target: { value: "Changed" } });
 
-    window.confirm = jest.fn(() => false);
+    // Dirty -> confirm modal opens; cancelling ("Keep editing") never fires onConfirm.
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(onClose).toHaveBeenCalledTimes(1); // still just the earlier call — cancelled this time
+    expect(openConfirmModal).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1); // still just the earlier call — no confirm yet
 
-    window.confirm = jest.fn(() => true);
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    // Confirming ("Discard") invokes the modal's onConfirm, which calls onClose.
+    openConfirmModal.mock.calls[0][0].onConfirm();
     expect(onClose).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## What

Replace the native `window.confirm` in `AdminEditHouseholdModal.requestClose` with `modals.openConfirmModal` from `@mantine/modals`, matching the app's standard confirm-dialog pattern (see `my-programs/conflicts/page.tsx`, `TrustedAdultPanel.tsx`). `ModalsProvider` is already mounted in the root layout.

## Why

The X / backdrop / escape / Cancel discard guard used a native browser prompt, inconsistent with the rest of the app's Mantine dialogs. The new confirm modal renders via portal and stacks over the still-open edit modal, so choosing **Keep editing** returns the user to the form — matching the old cancel behavior.

## Behavior

- Clean form → `onClose()` directly, no prompt.
- Dirty form → confirm modal ("Discard" / "Keep editing", red confirm).
- `handleSave` still calls `onClose` directly, so a successful save never prompts.

## Notes for reviewer

- **Scope: one component + its test.** `UnsavedChangesProvider`'s `window.confirm` in `confirmNav()` is intentionally left native — it's a synchronous navigation guard whose callers (`AppFrame.tsx`, `membership/page.tsx`) call `e.preventDefault()` on the result and can't await an async modal.
- Unit test updated to mock `@mantine/modals` and drive `onConfirm` instead of `window.confirm`.
- Full suite green locally (1520 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)