### PR TITLE
fix(admin): render failure banners red instead of a non-error tone

### DIFF
--- a/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
+++ b/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
@@ -17,10 +17,11 @@ export default function VolunteerMembershipsPage() {
   const [newEmail, setNewEmail] = useState("");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState<{ text: string; tone: "warning" | "error" } | undefined>();
   const [emailError, setEmailError] = useState<string | undefined>(undefined);
 
-  const flash = (m: string) => setMessage(m);
+  const flash = (text: string, tone: "warning" | "error" = "error") =>
+    setMessage(text ? { text, tone } : undefined);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -49,7 +50,7 @@ export default function VolunteerMembershipsPage() {
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
         setNewEmail("");
-        if (data.warning) { flash(data.warning); } else { notifications.show({ color: "green", message: "Designation added." }); }
+        if (data.warning) { flash(data.warning, "warning"); } else { notifications.show({ color: "green", message: "Designation added." }); }
         await load();
       } else flash(data.error || "Could not add.");
     } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }
@@ -66,7 +67,7 @@ export default function VolunteerMembershipsPage() {
 
   return (
     <Stack>
-      <AlertBanner message={message} tone="warning" />
+      <AlertBanner message={message?.text} tone={message?.tone} />
 
       <Card withBorder radius="md" padding="lg">
         <Title order={3} mb="xs">Volunteer-only designated emails</Title>

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -420,7 +420,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
           </Button>
         </Group>
 
-        <AlertBanner message={message} tone="info" mb="lg" />
+        <AlertBanner message={message} tone="error" mb="lg" />
 
         {/* PAST EVENT: ATTENDANCE CONFIRMATION */}
         {isPastEvent && canManageAttendance && (

--- a/checkin-app/src/app/settings/localization/page.tsx
+++ b/checkin-app/src/app/settings/localization/page.tsx
@@ -92,7 +92,7 @@ export default function LocalizationSettingsPage() {
     <Stack>
       <SettingsTabs active="localization" />
 
-      <AlertBanner message={message} tone="warning" />
+      <AlertBanner message={message} tone="error" />
 
       {loading ? (
         <Center py="xl"><Loader /></Center>


### PR DESCRIPTION
## What

Three admin pages reused one `message` state that only ever holds a failure, but fed it to an `AlertBanner` with a hardcoded non-error tone — so genuine failures rendered yellow or blue instead of red. `AlertBanner` maps tone→color: error=red, warning=yellow, info=cyan/blue, success=green.

- **settings/localization** — banner `tone="warning"` → `"error"`. `message` is error-only (`d.error || "Save failed."`); success uses a green toast.
- **program-ops/sessions/[id]** — banner `tone="info"` → `"error"`. The load-failure message is consumed by the not-found gate (`<Title>{message || "Not Found"}</Title>`) which returns *before* this banner renders, so when it does render `message` can only be the cancel error. Aligns with the page's other red errors.
- **membership-ops/volunteer-memberships** — `message` legitimately carries **both** a soft warning (`data.warning`) and a hard error (`data.error || "Could not add."`). Refactored the state to `{ text, tone }` so warnings stay yellow and errors go red, instead of both being yellow.

## Why

Failures were visually indistinguishable from warnings/info — users couldn't tell a save/cancel/add actually failed.

## Reviewer notes

- Behavior change is **color-only** for files 1 & 2. File 3 keeps warnings yellow and makes errors red.
- File 3 is the only type change: `message` state goes from `string` to `{ text: string; tone: "warning" | "error" } | undefined`; `flash` gains a `tone` param defaulting to `"error"`. Grepped the file — those are all the `message`/`setMessage`/`flash` references.
- `npx tsc --noEmit` clean; pre-commit test suite passed.