### PR TITLE
test(membership): cover RenewalBanner render/dismiss branches

### DIFF
--- a/checkin-app/src/components/__tests__/RenewalBanner.test.tsx
+++ b/checkin-app/src/components/__tests__/RenewalBanner.test.tsx
@@ -1,0 +1,55 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import RenewalBanner from "../RenewalBanner";
+
+const TITLE = "Membership renewal due";
+const DUE = "2027-01-01";
+
+beforeEach(() => {
+  resetRtl();
+  sessionStorage.clear();
+  setSession({ id: 1 });
+});
+
+describe("RenewalBanner", () => {
+  it("renders the yellow renewal alert with the due date when renewalDue", async () => {
+    mockFetchJson({ "/api/membership/renewal-status": { renewalDue: true, dueDate: DUE } });
+    renderWithProviders(<RenewalBanner />);
+
+    expect(await screen.findByText(TITLE)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`up for renewal by ${DUE}`))).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Renew now/i })).toBeInTheDocument();
+  });
+
+  it("renders nothing when renewalDue is false", async () => {
+    mockFetchJson({ "/api/membership/renewal-status": { renewalDue: false } });
+    renderWithProviders(<RenewalBanner />);
+
+    await waitFor(() => expect(screen.queryByText(TITLE)).not.toBeInTheDocument());
+  });
+
+  it("stays hidden when dismissed for the session, even if renewalDue", async () => {
+    sessionStorage.setItem("renewal_banner_dismissed", "true");
+    mockFetchJson({ "/api/membership/renewal-status": { renewalDue: true, dueDate: DUE } });
+    renderWithProviders(<RenewalBanner />);
+
+    await waitFor(() => expect(screen.queryByText(TITLE)).not.toBeInTheDocument());
+  });
+
+  it("dismissing records the skip in sessionStorage and hides the banner", async () => {
+    mockFetchJson({ "/api/membership/renewal-status": { renewalDue: true, dueDate: DUE } });
+    renderWithProviders(<RenewalBanner />);
+
+    const alert = await screen.findByText(TITLE);
+    // Mantine's Alert close button has no accessible name; grab it by its class.
+    fireEvent.click(alert.closest(".mantine-Alert-root")!.querySelector(".mantine-Alert-closeButton")!);
+
+    await waitFor(() => expect(screen.queryByText(TITLE)).not.toBeInTheDocument());
+    expect(sessionStorage.getItem("renewal_banner_dismissed")).toBe("true");
+  });
+});


### PR DESCRIPTION
## What

Adds an RTL component test for `RenewalBanner` — previously an unasserted UI branch.

New file: `checkin-app/src/components/__tests__/RenewalBanner.test.tsx`. **Test only, no production change.**

## Cases covered

1. `renewalDue: true` + a `dueDate` → yellow "Membership renewal due" alert renders with the due-date copy (`…up for renewal by <dueDate>…`) and the "Renew now" action.
2. `renewalDue: false` → nothing renders.
3. `sessionStorage.renewal_banner_dismissed === "true"` (with `renewalDue: true`) → stays hidden.
4. Dismiss path: clicking the Alert close button records `renewal_banner_dismissed` and hides the banner.

## Notes for reviewer

- Uses the shared `@/test-helpers/rtl` harness (fetch/session/Mantine mocks), matching sibling `OnboardingGate.test.tsx`.
- Confirmed field names (`renewalDue`, `dueDate`) against both the component and `src/app/api/membership/renewal-status/route.ts`.
- Mantine's `Alert` close button has no accessible name, so the dismiss test targets it by `.mantine-Alert-closeButton` class rather than role.
- Green locally: 4/4 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)