### PR TITLE
feat(membership-audit): read-only board compliance dashboard

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -63,6 +63,7 @@ const AUTHZ_TESTED = new Set<string>([
     'facility/trends',
     'facility/visits',
     'kioskdisplay/certifications',
+    'membership-audit/compliance',
     'membership-audit/households-missing-contact',
     'membership-audit/unclaimed-households',
     'membership-ops/applications/certify-payment',

--- a/checkin-app/src/app/__tests__/membershipComplianceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipComplianceAPI.integration.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the read-only Membership Compliance dashboard
+ * (GET /api/membership-audit/compliance). Asserts each out-of-compliance
+ * bucket surfaces with the right reason tag, a fresh ACTIVE household does not,
+ * and a non-board user is forbidden.
+ */
+
+import { GET } from '@/app/api/membership-audit/compliance/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+const TAG = 'compliance-api-test';
+const RECHECK_MONTHS = 12;
+
+function get() {
+    return GET(new Request('http://localhost:4000/api/membership-audit/compliance', {
+        method: 'GET',
+    }) as unknown as import('next/server').NextRequest);
+}
+
+/** Household with one lead person; optional lastBackgroundCheck on the lead. */
+async function makeHousehold(slug: string, lastBackgroundCheck: Date | null) {
+    const household = await prisma.household.create({ data: { name: `${TAG} ${slug}` } });
+    const person = await prisma.person.create({
+        data: {
+            email: `${slug}-${TAG}@example.com`,
+            name: `${slug} lead`,
+            phone: '5551234567',
+            householdId: household.id,
+            lastBackgroundCheck,
+        },
+    });
+    await prisma.householdLead.create({ data: { householdId: household.id, personId: person.id } });
+    return household.id;
+}
+
+describe('GET /api/membership-audit/compliance', () => {
+    let boardId: number;
+    let staleId: number;
+    let freshId: number;
+    let revokedId: number;
+    let stuckId: number;
+    let savedSettings: { bgRecheckMonths: number; orgMembershipYearBoundary: Date | null } | null = null;
+
+    const cleanup = async () => {
+        const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+        const hhIds = hhs.map(h => h.id);
+        const ms = await prisma.orgMembership.findMany({ where: { householdId: { in: hhIds } }, select: { id: true } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembershipId: { in: ms.map(m => m.id) } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: hhIds } } });
+        await prisma.householdLead.deleteMany({ where: { householdId: { in: hhIds } } });
+        await prisma.person.deleteMany({ where: { OR: [{ email: { contains: TAG } }, { householdId: { in: hhIds } }] } });
+        await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
+    };
+
+    beforeAll(async () => {
+        await cleanup();
+
+        // Configure a real recheck window + boundary so the STALE_BG bucket is active.
+        const prev = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        savedSettings = prev ? { bgRecheckMonths: prev.bgRecheckMonths, orgMembershipYearBoundary: prev.orgMembershipYearBoundary } : null;
+        await prisma.boardSettings.upsert({
+            where: { id: 1 },
+            create: { id: 1, bgRecheckMonths: RECHECK_MONTHS, orgMembershipYearBoundary: new Date('2000-06-01') },
+            update: { bgRecheckMonths: RECHECK_MONTHS, orgMembershipYearBoundary: new Date('2000-06-01') },
+        });
+
+        const board = await prisma.person.create({
+            data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, household: { create: { name: `${TAG} board` } } },
+        });
+        boardId = board.id;
+
+        // ACTIVE + lead check 5 years old → STALE_BG.
+        staleId = await makeHousehold('stale', new Date('2021-01-01'));
+        await prisma.orgMembership.create({ data: { householdId: staleId, status: 'ACTIVE' } });
+
+        // ACTIVE + lead check today → fresh, must NOT appear.
+        freshId = await makeHousehold('fresh', new Date());
+        await prisma.orgMembership.create({ data: { householdId: freshId, status: 'ACTIVE' } });
+
+        // REVOKED membership.
+        revokedId = await makeHousehold('revoked', new Date());
+        await prisma.orgMembership.create({ data: { householdId: revokedId, status: 'REVOKED' } });
+
+        // Process parked at PENDING_BG_CLEARANCE.
+        stuckId = await makeHousehold('stuck', new Date());
+        const stuckMembership = await prisma.orgMembership.create({ data: { householdId: stuckId, status: 'NONE' } });
+        await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: stuckMembership.id, kind: 'INITIAL', status: 'PENDING_BG_CLEARANCE' },
+        });
+    });
+
+    afterAll(async () => {
+        await cleanup();
+        if (savedSettings) {
+            await prisma.boardSettings.update({ where: { id: 1 }, data: savedSettings });
+        }
+    });
+
+    it('lists each out-of-compliance household with correct reason tags and excludes a fresh one', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+        const res = await get();
+        expect(res.status).toBe(200);
+        const { households } = await res.json();
+        const byId = new Map<number, { reasons: string[]; lastBackgroundCheck: string | null }>(
+            households.map((h: { id: number; reasons: string[]; lastBackgroundCheck: string | null }) => [h.id, h]),
+        );
+
+        expect(byId.get(staleId)?.reasons).toContain('STALE_BG');
+        expect(byId.get(staleId)?.lastBackgroundCheck).not.toBeNull();
+        expect(byId.get(revokedId)?.reasons).toContain('REVOKED');
+        expect(byId.get(stuckId)?.reasons).toContain('STUCK_BG_CLEARANCE');
+        expect(byId.has(freshId)).toBe(false);
+    });
+
+    it('forbids a non-board user', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: false } });
+        const res = await get();
+        expect(res.status).toBe(403);
+    });
+
+    it('rejects an anonymous caller', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue(null);
+        const res = await get();
+        expect(res.status).toBe(401);
+    });
+});

--- a/checkin-app/src/app/api/membership-audit/compliance/route.ts
+++ b/checkin-app/src/app/api/membership-audit/compliance/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { householdBgIsFresh, nextBoundary } from "@/lib/membership/renewal";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Board-only, PULL-ONLY membership compliance dashboard: households that have
+ * fallen out of compliance but were NOT auto-terminated (the system deliberately
+ * never auto-revokes — a human must follow up). Surfaces only what's knowable
+ * from real data; there is no GRACE status modeled, so no grace bucket. Reasons:
+ *   STALE_BG  — ACTIVE household whose background check aged past bgRecheckMonths
+ *               (predicate owned by householdBgIsFresh; skipped when the board
+ *               hasn't set the policy, i.e. bgRecheckMonths = 0).
+ *   REVOKED / DENIED — OrgMembership status.
+ *   STUCK_BG_CLEARANCE — a process parked at PENDING_BG_CLEARANCE (paid, never cleared).
+ * A household with multiple problems gets all its reason tags.
+ */
+export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async () => {
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const bgRecheckMonths = settings?.bgRecheckMonths ?? 0;
+    const boundary = settings?.orgMembershipYearBoundary
+        ? nextBoundary(settings.orgMembershipYearBoundary, new Date())
+        : new Date();
+
+    // householdId -> Set<reason>
+    const reasons = new Map<number, Set<string>>();
+    const add = (householdId: number, reason: string) => {
+        const set = reasons.get(householdId) ?? new Set<string>();
+        set.add(reason);
+        reasons.set(householdId, set);
+    };
+
+    // 1. Stale background check — only when the board has configured a window.
+    //    Reuse householdBgIsFresh per household (stale = returns false); when
+    //    bgRecheckMonths = 0 it always returns false, so skip the whole bucket.
+    if (bgRecheckMonths > 0) {
+        const active = await prisma.orgMembership.findMany({
+            where: { status: "ACTIVE" },
+            select: { householdId: true },
+        });
+        for (const m of active) {
+            const fresh = await householdBgIsFresh(m.householdId, boundary, bgRecheckMonths);
+            if (!fresh) add(m.householdId, "STALE_BG");
+        }
+    }
+
+    // 2. REVOKED / DENIED memberships — tag which.
+    const revokedDenied = await prisma.orgMembership.findMany({
+        where: { status: { in: ["REVOKED", "DENIED"] } },
+        select: { householdId: true, status: true },
+    });
+    for (const m of revokedDenied) add(m.householdId, m.status);
+
+    // 3. Stuck at BG clearance — paid but never cleared.
+    const stuck = await prisma.orgMembershipProcess.findMany({
+        where: { status: "PENDING_BG_CLEARANCE" },
+        select: { orgMembership: { select: { householdId: true } } },
+    });
+    for (const p of stuck) add(p.orgMembership.householdId, "STUCK_BG_CLEARANCE");
+
+    if (reasons.size === 0) return NextResponse.json({ households: [] });
+
+    const households = await prisma.household.findMany({
+        where: { id: { in: [...reasons.keys()] } },
+        include: {
+            leads: {
+                include: {
+                    person: { select: { id: true, name: true, phone: true, email: true, lastBackgroundCheck: true } },
+                },
+            },
+        },
+        orderBy: { name: "asc" },
+    });
+
+    const result = households.map((h) => {
+        const checks = h.leads
+            .map((l) => l.person.lastBackgroundCheck)
+            .filter((d): d is Date => d !== null);
+        // Most recent lead check — the date the board is chasing on a STALE_BG row.
+        const lastBackgroundCheck = checks.length
+            ? checks.reduce((a, b) => (a > b ? a : b)).toISOString()
+            : null;
+        return {
+            id: h.id,
+            name: h.name || `Household #${h.id}`,
+            reasons: [...(reasons.get(h.id) ?? [])],
+            lastBackgroundCheck,
+            leads: h.leads.map((l) => ({
+                id: l.person.id,
+                name: l.person.name,
+                phone: l.person.phone,
+                email: l.person.email,
+            })),
+        };
+    });
+
+    return NextResponse.json({ households: result });
+});

--- a/checkin-app/src/app/membership-audit/compliance/page.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Badge, Card, Center, Group, Paper, Stack, Text, Title } from "@mantine/core";
+import { formatPhone } from "@/lib/phone";
+import { PageLoader } from "@/components/ui/PageLoader";
+
+type Lead = { id: number; name: string | null; phone: string | null; email: string | null };
+type Household = {
+  id: number;
+  name: string | null;
+  reasons: string[];
+  lastBackgroundCheck: string | null;
+  leads: Lead[];
+};
+
+// Reason tag -> human label + badge color. Keys mirror the endpoint's tags.
+const REASON: Record<string, { label: string; color: string }> = {
+  STALE_BG: { label: "Background check expired", color: "orange" },
+  REVOKED: { label: "Revoked", color: "red" },
+  DENIED: { label: "Denied", color: "red" },
+  STUCK_BG_CLEARANCE: { label: "Stuck at BG clearance", color: "yellow" },
+};
+
+/**
+ * Membership Audit view: households out of compliance that the system did NOT
+ * auto-terminate. Read-only — the board follows up manually; no action buttons.
+ */
+export default function CompliancePage() {
+  const [households, setHouseholds] = useState<Household[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/membership-audit/compliance");
+        if (res.ok) {
+          const data = await res.json();
+          setHouseholds(data.households ?? []);
+        } else {
+          setError("Failed to load compliance data. Ensure you have the proper authorizations.");
+        }
+      } catch (e) {
+        console.error(e);
+        setError("Network error loading compliance data.");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  if (loading) return <PageLoader />;
+
+  if (error) {
+    return (
+      <Center mih="60vh">
+        <Title order={3} c="red">{error}</Title>
+      </Center>
+    );
+  }
+
+  return (
+    <Stack>
+      <Card withBorder radius="md" padding="lg">
+        <Text c="dimmed">
+          Households out of compliance that the system did not auto-terminate. This is
+          a standing list for manual board follow-up — no emails or actions are sent
+          from here.
+        </Text>
+      </Card>
+
+      {households.length === 0 ? (
+        <Card withBorder radius="md" padding="xl" ta="center">
+          <Text c="dimmed">Every household is in compliance. 🎉</Text>
+        </Card>
+      ) : (
+        <Stack gap="sm">
+          {households.map((h) => (
+            <Card key={h.id} withBorder radius="md" padding="lg">
+              <Group justify="space-between" wrap="wrap" mb="xs">
+                <Text fw={600} fz="lg">{h.name || `Household #${h.id}`}</Text>
+                <Group gap="xs">
+                  {h.reasons.map((r) => {
+                    const meta = REASON[r] ?? { label: r, color: "gray" };
+                    return (
+                      <Badge key={r} color={meta.color} variant="light">{meta.label}</Badge>
+                    );
+                  })}
+                </Group>
+              </Group>
+              {h.reasons.includes("STALE_BG") && (
+                <Text size="sm" c="dimmed" mb="xs">
+                  Last background check:{" "}
+                  {h.lastBackgroundCheck
+                    ? new Date(h.lastBackgroundCheck).toLocaleDateString()
+                    : "Never"}
+                </Text>
+              )}
+              <Text size="sm" c="dimmed" mb="xs">Household Leads:</Text>
+              {h.leads.length > 0 ? (
+                <Stack gap="xs">
+                  {h.leads.map((l) => (
+                    <Paper key={l.id} withBorder radius="sm" p="xs">
+                      <Text fw={500}>{l.name || l.email || `Member #${l.id}`}</Text>
+                      <Text size="sm" c="dimmed">Phone: {l.phone ? formatPhone(l.phone) : "Not provided"}</Text>
+                      {l.email && <Text size="sm" c="dimmed">Email: {l.email}</Text>}
+                    </Paper>
+                  ))}
+                </Stack>
+              ) : (
+                <Text size="sm" c="red">No designated leads found.</Text>
+              )}
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/checkin-app/src/app/membership-audit/layout.tsx
+++ b/checkin-app/src/app/membership-audit/layout.tsx
@@ -14,6 +14,7 @@ const NAV_LINKS = [
   { name: "Emergency Contacts", href: "/membership-audit/emergency-contacts", icon: "🚑" },
   { name: "Unclaimed Accounts", href: "/membership-audit/unclaimed", icon: "📨" },
   { name: "Broken Households", href: "/membership-audit/broken", icon: "⚠️" },
+  { name: "Compliance", href: "/membership-audit/compliance", icon: "🚩" },
 ];
 
 export default function MembershipAuditLayout({ children }: { children: React.ReactNode }) {

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -108,6 +108,7 @@ export const PAGES: PageEntry[] = [
   { href: '/membership-audit/emergency-contacts', label: 'Missing Emergency Contacts', section: 'Membership Audit', visible: BOARD },
   { href: '/membership-audit/unclaimed', label: 'Unclaimed Accounts', section: 'Membership Audit', visible: BOARD },
   { href: '/membership-audit/broken', label: 'Broken Households', section: 'Membership Audit', keywords: 'lead leadless no lead unclaimed', visible: BOARD },
+  { href: '/membership-audit/compliance', label: 'Membership Compliance', section: 'Membership Audit', keywords: 'violations background check revoked denied stale follow-up', visible: BOARD },
 
   // Program Ops — board
   { href: '/program-ops', label: 'Program Ops', section: 'Program Ops', visible: BOARD },


### PR DESCRIPTION
## What

New read-only board view of households **out of compliance that the system did not auto-terminate**. The system deliberately never auto-revokes members who lapse, so today violations are invisible until a human happens to look. This is the standing board list of who needs manual follow-up.

**Pull-only** — no emails, notifications, or cascade. The push/notification half is tracked separately and intentionally not built here.

## Changes
- **Page** `/membership-audit/compliance` — card list, colored reason badges, last-BG date on stale rows. No mutate/terminate buttons (system must not auto-terminate).
- **API** `GET /api/membership-audit/compliance` — `withAuth({ roles: ["isSysadmin", "isBoardMember"] })`, `force-dynamic`, returns `{ households: [...] }` hydrated with leads (id/name/phone/email) + reason tags, matching the sibling audit routes.
- New "Compliance" tab in the Membership Audit layout; registered in `pageRegistry` and the authz drift guard.

## Reason buckets (a household hitting multiple gets all tags)
- **STALE_BG** — ACTIVE household whose background check aged past `BoardSettings.bgRecheckMonths`. Reuses the existing `householdBgIsFresh()` predicate (stale = returns false); the whole bucket is **skipped when `bgRecheckMonths=0`** (policy unset) so nothing false-positives.
- **REVOKED / DENIED** — `OrgMembership.status`, tagged which.
- **STUCK_BG_CLEARANCE** — an `OrgMembershipProcess` parked at `PENDING_BG_CLEARANCE` (paid, never cleared).

No GRACE bucket — that status isn't modeled; only surfaces what's knowable from real data.

## Reviewer notes
- Stale-BG loops `householdBgIsFresh` once per ACTIVE household (N+1) to honor "reuse the predicate, don't re-derive". Fine at board-household scale; can batch into one query if it grows.
- `membershipOpsNav.ts` untouched — audit tabs live inline in the section layout, not that nav.
- Scope held: no notification/cron/GRACE/auto-termination work.

## Checks
- Integration (`membershipComplianceAPI.integration.test.ts`): each bucket surfaces with the right tag, a fresh ACTIVE household is excluded, non-board gets 403, anon gets 401.
- pageRegistry + authzRegistry drift guards updated and green.
- Full CI suite green via pre-commit hook; full integration suite (107 suites / 871 checks) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)