### PR TITLE
feat(intake): capture "Anything else we should know?" note, surface it to the BG reviewer

### DIFF
--- a/checkin-app/flow-tests/membership-intake-notes.flow.test.ts
+++ b/checkin-app/flow-tests/membership-intake-notes.flow.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Flow test: the intake "Anything else we should know?" note reaches the
+ * background-check reviewer's queue.
+ *
+ * This is the whole point of the field — a would-be volunteer-only household
+ * types the note during intake, and the reviewer (who also sets the volunteer
+ * bit) must actually see it. Drives the real journey over HTTP against a running
+ * seeded dev server: applicant fills intake WITH the note, board records the two
+ * external actions (which puts the application into the parallel BG-review
+ * track), then GET /api/membership/reviews returns the note on that row.
+ *
+ * Assumes a freshly-seeded DB. Uses parent.family (household1) as the applicant
+ * — disjoint from the bg-nonblocking flow test, which drives parent.family2
+ * (household2) — so the two suites don't collide on the shared seeded DB.
+ * boardmember is a sysadmin+board account: it both records the external actions
+ * and, as an implicit reviewer of another household, reads the queue.
+ */
+
+import { loginAs, api } from "./helpers";
+
+const NOTE = "MAGIC: we're a volunteer-only household, no students enrolled — please mark us volunteer.";
+
+type State = { process: { id: number; status: string } | null };
+type QueueRow = { id: number; orgMembership: { household: { name: string | null; intakeNotes: string | null } | null } | null };
+type Reviews = { queue: QueueRow[] };
+
+describe("flow: intake notes surface to the BG-review queue", () => {
+    it("applicant's intake note comes back in GET /api/membership/reviews", async () => {
+        const applicant = await loginAs("parent.family@example.com"); // non-member household1 lead
+        const reviewer = await loginAs("boardmember@example.com");     // sysadmin + board = implicit reviewer
+
+        const start = await api(applicant, "/api/membership", { method: "POST" });
+        expect([200, 201]).toContain(start.status);
+
+        // Fill the minimum required intake PLUS the freeform note, then submit.
+        const save = await api(applicant, "/api/membership/intake", {
+            method: "PATCH",
+            body: JSON.stringify({
+                household: { line1: "123 Maker Lane", city: "Austin", state: "TX", postalCode: "78701", emergencyContactName: "Pat Outside", emergencyContactPhone: "555-987-6543", notes: NOTE },
+                primaryParent: { name: "Parent Family" },
+            }),
+        });
+        expect(save.status).toBe(200);
+
+        const submit = await api(applicant, "/api/membership/intake/submit", { method: "POST" });
+        expect(submit.status).toBe(200);
+
+        const afterSubmit = await api<State>(applicant, "/api/membership");
+        const processId = afterSubmit.json.process!.id;
+
+        // Board records contract + BG consent → application enters the BG-review track.
+        await api(reviewer, "/api/membership-ops/applications/external", { method: "POST", body: JSON.stringify({ processId, action: "mark-contract" }) });
+        await api(reviewer, "/api/membership-ops/applications/external", { method: "POST", body: JSON.stringify({ processId, action: "mark-bg-consent" }) });
+
+        // The reviewer's queue must carry the applicant's note, unhidden.
+        const reviews = await api<Reviews>(reviewer, "/api/membership/reviews");
+        expect(reviews.status).toBe(200);
+        const row = reviews.json.queue.find((r) => r.id === processId);
+        expect(row).toBeDefined();
+        expect(row!.orgMembership?.household?.intakeNotes).toBe(NOTE);
+    });
+});

--- a/checkin-app/flow-tests/membership-intake-notes.flow.test.ts
+++ b/checkin-app/flow-tests/membership-intake-notes.flow.test.ts
@@ -12,11 +12,12 @@
  * external actions (which puts the application into the parallel BG-review
  * track), then GET /api/membership/reviews returns the note on that row.
  *
- * Assumes a freshly-seeded DB. Uses parent.family (household1) as the applicant
- * — disjoint from the bg-nonblocking flow test, which drives parent.family2
- * (household2) — so the two suites don't collide on the shared seeded DB.
- * boardmember is a sysadmin+board account: it both records the external actions
- * and, as an implicit reviewer of another household, reads the queue.
+ * Assumes a freshly-seeded DB. Uses parent.family3 (household3), a non-member
+ * household seeded specifically so this suite's applicant is disjoint from the
+ * other membership flow tests (parent.family / parent.family2) on the shared
+ * serial DB. boardmember is a sysadmin+board account: it both records the
+ * external actions and, as an implicit reviewer of another household, reads the
+ * queue.
  */
 
 import { loginAs, api } from "./helpers";
@@ -29,8 +30,8 @@ type Reviews = { queue: QueueRow[] };
 
 describe("flow: intake notes surface to the BG-review queue", () => {
     it("applicant's intake note comes back in GET /api/membership/reviews", async () => {
-        const applicant = await loginAs("parent.family@example.com"); // non-member household1 lead
-        const reviewer = await loginAs("boardmember@example.com");     // sysadmin + board = implicit reviewer
+        const applicant = await loginAs("parent.family3@example.com"); // dedicated non-member household3 lead
+        const reviewer = await loginAs("boardmember@example.com");      // sysadmin + board = implicit reviewer
 
         const start = await api(applicant, "/api/membership", { method: "POST" });
         expect([200, 201]).toContain(start.status);
@@ -39,8 +40,8 @@ describe("flow: intake notes surface to the BG-review queue", () => {
         const save = await api(applicant, "/api/membership/intake", {
             method: "PATCH",
             body: JSON.stringify({
-                household: { line1: "123 Maker Lane", city: "Austin", state: "TX", postalCode: "78701", emergencyContactName: "Pat Outside", emergencyContactPhone: "555-987-6543", notes: NOTE },
-                primaryParent: { name: "Parent Family" },
+                household: { line1: "789 Volunteer Way", city: "Austin", state: "TX", postalCode: "78701", emergencyContactName: "Pat Outside", emergencyContactPhone: "555-987-6543", notes: NOTE },
+                primaryParent: { name: "Parent Family3" },
             }),
         });
         expect(save.status).toBe(200);

--- a/checkin-app/prisma/migrations/20260705120000_household_intake_notes/migration.sql
+++ b/checkin-app/prisma/migrations/20260705120000_household_intake_notes/migration.sql
@@ -1,0 +1,3 @@
+-- Additive, nullable: the "Anything else we should know?" intake note.
+-- Optional freeform text, never a submit gate; no backfill needed (nullable).
+ALTER TABLE "Household" ADD COLUMN "intakeNotes" TEXT;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -166,6 +166,12 @@ model Household {
   /// @sensitivity:personal
   postalCode String?
 
+  /// Freeform "Anything else we should know?" captured at intake. Where a
+  /// volunteer-only household types the note that tells a background-check
+  /// reviewer to mark them volunteer. pii (not personal): reviewers must read it.
+  /// @sensitivity:pii
+  intakeNotes String?
+
   householdMembers  Person[]
   leads             HouseholdLead[]
   orgMembership     OrgMembership?

--- a/checkin-app/src/app/api/household/settings/route.ts
+++ b/checkin-app/src/app/api/household/settings/route.ts
@@ -14,12 +14,19 @@ export const PATCH = withAuth(
             const userId = auth.user.id;
 
             const body = await req.json();
-            const { emergencyContactName, emergencyContactPhone } = body;
+            const { emergencyContactName, emergencyContactPhone, notes } = body;
             const addressData = normalizeAddressInput(body);
             // Address is optional on this route (emergency-contact-only PATCHes
             // send no address keys); when any address field is supplied, the
             // whole address must be complete + valid.
             if (Object.keys(addressData).length > 0) assertValidAddress(addressData);
+            // Optional "anything else we should know?" note rides along on the same
+            // household.update. Trimmed to null so an emptied box clears it; only
+            // touched when the key is present.
+            const householdData = {
+                ...addressData,
+                ...(notes !== undefined && { intakeNotes: typeof notes === "string" && notes.trim() ? notes.trim() : null }),
+            };
 
             const user = await prisma.person.findUnique({
                 where: { id: userId },
@@ -37,7 +44,7 @@ export const PATCH = withAuth(
 
             const updatedHousehold = await prisma.household.update({
                 where: { id: user.householdId },
-                data: addressData,
+                data: householdData,
             });
 
             // Emergency contact is a separate entity; the settings form edits the

--- a/checkin-app/src/app/api/membership/reviews/route.ts
+++ b/checkin-app/src/app/api/membership/reviews/route.ts
@@ -42,6 +42,10 @@ export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
                     household: {
                         select: {
                             name: true,
+                            // The applicant's "anything else we should know?" note — the
+                            // signal a volunteer-only household uses to ask the reviewer to
+                            // mark them volunteer. Classified pii; reviewers hold that band.
+                            intakeNotes: true,
                             leads: { select: { person: { select: { id: true, name: true, email: true } } } },
                         },
                     },

--- a/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
@@ -15,7 +15,7 @@ const queue = {
   queue: [
     {
       id: 100,
-      orgMembership: { household: { name: "The Smiths", leads: [{ person: { id: 1, name: "Pat Smith", email: "pat@example.com" } }] } },
+      orgMembership: { household: { name: "The Smiths", intakeNotes: "We're volunteer only — no students.", leads: [{ person: { id: 1, name: "Pat Smith", email: "pat@example.com" } }] } },
       _count: { attestations: 1 },
     },
   ],
@@ -30,6 +30,8 @@ describe("membership-ops/review page", () => {
     expect(await screen.findByText("The Smiths")).toBeInTheDocument();
     expect(screen.getByText("Pat Smith <pat@example.com>", { exact: false })).toBeInTheDocument();
     expect(screen.getByText("1/2 approvals so far.")).toBeInTheDocument();
+    // The applicant's freeform note is surfaced on the card (the volunteer signal).
+    expect(screen.getByText("We're volunteer only — no students.")).toBeInTheDocument();
   });
 
   it("approves an attestation", async () => {

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -17,7 +17,7 @@ interface Person {
 // Only the household leads (parents) are returned — children are never sent.
 interface QueueItem {
   id: number;
-  orgMembership: { household: { name: string | null; leads: { person: Person }[] } | null } | null;
+  orgMembership: { household: { name: string | null; intakeNotes: string | null; leads: { person: Person }[] } | null } | null;
   _count: { attestations: number };
 }
 
@@ -113,6 +113,7 @@ export default function MembershipReviewPage() {
         <Stack mt="md">
           {queue.map((item) => {
             const parents = (item.orgMembership?.household?.leads ?? []).map((l) => l.person);
+            const notes = item.orgMembership?.household?.intakeNotes?.trim();
             return (
             <Card key={item.id} withBorder radius="md" padding="lg">
               <Text fw={700} fz="lg">
@@ -124,6 +125,15 @@ export default function MembershipReviewPage() {
                   : "No parent contact on file."}
               </Text>
               <Text size="xs" c="dimmed" mt={4}>{item._count.attestations}/2 approvals so far.</Text>
+
+              {/* The applicant's "anything else?" note — surfaced up front (not
+                  behind a click) because it's where a volunteer-only household asks
+                  to be marked volunteer, which drives the checkbox below. */}
+              {notes && (
+                <Alert color="yellow" variant="light" mt="md" title="From the applicant — “Anything else we should know?”">
+                  <Text style={{ whiteSpace: "pre-wrap" }}>{notes}</Text>
+                </Alert>
+              )}
 
               <Checkbox
                 my="md"

--- a/checkin-app/src/app/membership/__tests__/dirty.test.ts
+++ b/checkin-app/src/app/membership/__tests__/dirty.test.ts
@@ -7,6 +7,7 @@ const base = {
   hasSecondary: false, secondaryId: undefined,
   secondaryName: "", secondaryEmail: "", secondaryDob: "", secondaryOver25: false, secondaryAllergies: "",
   children: [{ id: 1, name: "Kid", email: "", dob: "2015-02-02", allergies: "peanuts" }],
+  notes: "",
 };
 
 describe("serializeMembershipForm (unsaved-changes dirty compare)", () => {
@@ -26,5 +27,9 @@ describe("serializeMembershipForm (unsaved-changes dirty compare)", () => {
   it("a nested child change → different key", () => {
     const next = { ...base, children: [{ ...base.children[0], allergies: "none" }] };
     expect(serializeMembershipForm(base)).not.toBe(serializeMembershipForm(next));
+  });
+
+  it("editing the freeform notes → different key (dirty)", () => {
+    expect(serializeMembershipForm(base)).not.toBe(serializeMembershipForm({ ...base, notes: "volunteer only" }));
   });
 });

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -6,7 +6,7 @@ import { useSession } from "next-auth/react";
 import type { OrgMembershipProcessStatus, OrgMembershipStatus } from "@/generated/prisma/client";
 import {
   Alert, Anchor, Box, Button, Card, Checkbox, Container, Group,
-  SimpleGrid, Stack, Text, TextInput, ThemeIcon, Title,
+  SimpleGrid, Stack, Text, Textarea, TextInput, ThemeIcon, Title,
 } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { AlertBanner, type AlertTone } from "@/components/admin/AlertBanner";
@@ -47,7 +47,7 @@ interface IntakeState {
   process: { id: number; kind: string; status: OrgMembershipProcessStatus } | null;
   external: ExternalStatus | null;
   prefill: {
-    household: ({ name: string | null; emergencyContactName: string | null; emergencyContactPhone: string | null; emergencyContactEmail: string | null } & Partial<StructuredAddress>) | null;
+    household: ({ name: string | null; notes: string | null; emergencyContactName: string | null; emergencyContactPhone: string | null; emergencyContactEmail: string | null } & Partial<StructuredAddress>) | null;
     primaryParent: PersonPrefill | null;
     secondaryParent: PersonPrefill | null;
     children: PersonPrefill[];
@@ -69,6 +69,7 @@ interface FormValues {
   hasSecondary: boolean; secondaryId?: number;
   secondaryName: string; secondaryEmail: string; secondaryDob: string; secondaryOver25: boolean; secondaryAllergies: string;
   children: ChildForm[];
+  notes: string;
 }
 
 // Stable key for the unsaved-changes dirty compare. Array (not object) so order
@@ -80,6 +81,7 @@ export const serializeMembershipForm = (v: FormValues) =>
     v.primaryName, v.primaryDob, v.primaryOver25, v.primaryAllergies,
     v.hasSecondary, v.secondaryId, v.secondaryName, v.secondaryEmail, v.secondaryDob, v.secondaryOver25, v.secondaryAllergies,
     v.children.map((c) => [c.id, c.name, c.email, c.dob, c.allergies]),
+    v.notes,
   ]);
 
 function ExternalTask({ done, title, doneText, children }: { done: boolean; title: string; doneText: string; children: React.ReactNode }) {
@@ -129,6 +131,7 @@ export default function MembershipPage() {
   const [secondaryOver25, setSecondaryOver25] = useState(false);
   const [secondaryAllergies, setSecondaryAllergies] = useState("");
   const [children, setChildren] = useState<ChildForm[]>([]);
+  const [notes, setNotes] = useState("");
   const [payment, setPayment] = useState<{ amountCents: number; checkoutUrl: string | null } | null>(null);
   // Serialized form as last loaded/saved; isDirty compares it to current state.
   const [savedForm, setSavedForm] = useState<string | null>(null);
@@ -142,6 +145,7 @@ export default function MembershipPage() {
     setEmName(h?.emergencyContactName ?? "");
     setEmPhone(h?.emergencyContactPhone ?? "");
     setEmEmail(h?.emergencyContactEmail ?? "");
+    setNotes(h?.notes ?? "");
     const p = s.prefill.primaryParent;
     setPrimaryName(p?.name ?? "");
     setPrimaryDob(p?.dob ?? "");
@@ -184,6 +188,7 @@ export default function MembershipPage() {
       secondaryOver25: !!sec?.over25,
       secondaryAllergies: sec?.allergies ?? "",
       children: nextChildren,
+      notes: h?.notes ?? "",
     }));
   }, []);
 
@@ -316,7 +321,7 @@ export default function MembershipPage() {
   };
 
   const buildPayload = () => ({
-    household: { ...address, emergencyContactName: emName, emergencyContactPhone: emPhone, emergencyContactEmail: emEmail },
+    household: { ...address, emergencyContactName: emName, emergencyContactPhone: emPhone, emergencyContactEmail: emEmail, notes: notes || null },
     primaryParent: { name: primaryName, dob: primaryOver25 ? null : (primaryDob || null), over25: primaryOver25, allergies: primaryAllergies || null },
     secondaryParent: hasSecondary
       ? { id: secondaryId, name: secondaryName, email: secondaryEmail || undefined, dob: secondaryOver25 ? null : (secondaryDob || null), over25: secondaryOver25, allergies: secondaryAllergies || null }
@@ -453,6 +458,7 @@ export default function MembershipPage() {
     primaryName, primaryDob, primaryOver25, primaryAllergies,
     hasSecondary, secondaryId, secondaryName, secondaryEmail, secondaryDob, secondaryOver25, secondaryAllergies,
     children,
+    notes,
   });
   // Dirty once the user edits past the loaded snapshot. Re-hydrate after a
   // save/submit re-snapshots, so this flips back to false then.
@@ -616,6 +622,17 @@ export default function MembershipPage() {
                   </section>
 
                   <ChildrenListForm items={children} onAdd={addChild} onUpdate={updateChild} onRemove={removeChild} />
+
+                  <section>
+                    <Textarea
+                      label="Anything else we should know?"
+                      description="Optional. Tell us anything that would help us review your application — for example, if your household is applying to volunteer only, with no students enrolled."
+                      autosize
+                      minRows={3}
+                      value={notes}
+                      onChange={(e) => setNotes(e.currentTarget.value)}
+                    />
+                  </section>
 
                   {/* Local echo of the page-top banner: intake is a long card, so
                       the top AlertBanner posts off-screen next to these buttons. */}

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -111,7 +111,7 @@ describe("HouseholdPage", () => {
     renderWithProviders(<HouseholdPage />);
     await screen.findByRole("heading", { name: "Smith Household", level: 1 });
 
-    fireEvent.click(screen.getByRole("button", { name: "Update Address" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save household details" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
@@ -469,12 +469,12 @@ describe("HouseholdPage", () => {
 
     // Address settings: client validation error, then server failure, then network error.
     fireEvent.change(screen.getByLabelText(/Street Address/), { target: { value: "" } });
-    fireEvent.click(screen.getByRole("button", { name: "Update Address" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save household details" }));
     expect(await screen.findByText("Street address is required.")).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/Street Address/), { target: { value: "123 Main St" } });
-    fireEvent.click(screen.getByRole("button", { name: "Update Address" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save household details" }));
     expect(await screen.findByText("Failed to update some settings.")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Update Address" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save household details" }));
     await waitFor(() => expectToast("Network error saving settings."));
 
     // Emergency contact add: network error.

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { Alert, Badge, Button, Card, Checkbox, Group, Paper, SimpleGrid, Stack, Text, TextInput, Title, Tooltip } from '@mantine/core';
+import { Alert, Badge, Button, Card, Checkbox, Group, Paper, SimpleGrid, Stack, Text, Textarea, TextInput, Title, Tooltip } from '@mantine/core';
 import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
 import { PageContainer } from '@/components/ui/PageContainer';
 import { formatDate, calculateAge } from '@/lib/time';
@@ -85,6 +85,9 @@ export default function HouseholdPage() {
   // Snapshot of the address as last loaded/saved; isDirty compares it to current
   // state to drive the unsaved-changes guard.
   const [initialAddress, setInitialAddress] = useState<StructuredAddress>(blankAddress);
+  // "Anything else we should know?" — saved alongside the address on this card.
+  const [notes, setNotes] = useState("");
+  const [initialNotes, setInitialNotes] = useState("");
   const [addressErrors, setAddressErrors] = useState<Partial<Record<AddressField, string>>>({});
   const [savingSettings, setSavingSettings] = useState(false);
   // Transient "Updated" confirmation shown in the Address card header for 5s.
@@ -118,6 +121,8 @@ export default function HouseholdPage() {
         const loaded = { line1: a.line1 ?? "", line2: a.line2 ?? "", city: a.city ?? "", state: a.state ?? "", postalCode: a.postalCode ?? "" };
         setAddress(loaded);
         setInitialAddress(loaded);
+        setNotes(data.household?.intakeNotes ?? "");
+        setInitialNotes(data.household?.intakeNotes ?? "");
       }
     } catch {
       notifications.show({ color: "red", message: "Network error loading household.", autoClose: false });
@@ -142,11 +147,12 @@ export default function HouseholdPage() {
       const householdRes = await fetch('/api/household/settings', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(address)
+        body: JSON.stringify({ ...address, notes: notes || null })
       });
 
       if (householdRes.ok) {
         ok("Settings updated successfully!");
+        setInitialNotes(notes);
         fetchHousehold();
         notifyNavRefresh();
       } else {
@@ -315,7 +321,7 @@ export default function HouseholdPage() {
   // Address" button). The member add/edit forms, emergency-contact form, and the
   // receipts toggle all submit instantly with no pending state — intentionally
   // excluded so they never raise a spurious unsaved-changes prompt.
-  const isDirty = !shallowEqual({ ...initialAddress }, { ...address });
+  const isDirty = !shallowEqual({ ...initialAddress }, { ...address }) || notes !== initialNotes;
   useUnsavedGuard(isDirty);
 
   if (loading || authLoading) {
@@ -481,9 +487,17 @@ export default function HouseholdPage() {
                 <TextInput label="State" required maxLength={2} value={address.state ?? ""} error={addressErrors.state} onChange={(e) => { setAddress({ ...address, state: e.currentTarget.value }); setAddressErrors({ ...addressErrors, state: undefined }); }} placeholder="TX" />
                 <TextInput label="ZIP" required value={address.postalCode ?? ""} error={addressErrors.postalCode} onChange={(e) => { setAddress({ ...address, postalCode: e.currentTarget.value }); setAddressErrors({ ...addressErrors, postalCode: undefined }); }} placeholder="78701" />
               </SimpleGrid>
+              <Textarea
+                label="Anything else we should know?"
+                description="Optional — e.g. if your household is here to volunteer only, with no students enrolled."
+                autosize
+                minRows={2}
+                value={notes}
+                onChange={(e) => setNotes(e.currentTarget.value)}
+              />
             </Stack>
             <Button onClick={handleSaveSettings} disabled={savingSettings} loading={savingSettings} color="green" fullWidth mt="md">
-              Update Address
+              Save household details
             </Button>
           </Card>
         )}

--- a/checkin-app/src/app/programs/[id]/FirstTimeIntakePanel.tsx
+++ b/checkin-app/src/app/programs/[id]/FirstTimeIntakePanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Alert, Button, Center, Checkbox, Loader, Stack, Text, TextInput, Title } from "@mantine/core";
+import { Alert, Button, Center, Checkbox, Loader, Stack, Text, Textarea, TextInput, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
 import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
@@ -47,6 +47,7 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
   const [primaryDob, setPrimaryDob] = useState("");
   const [primaryOver25, setPrimaryOver25] = useState(false);
   const [primaryAllergies, setPrimaryAllergies] = useState("");
+  const [notes, setNotes] = useState("");
   const [children, setChildren] = useState<ChildForm[]>([]);
 
   const clearErr = (key: string) =>
@@ -71,6 +72,7 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
         setPrimaryDob(s.prefill?.primaryParent?.dob ?? "");
         setPrimaryOver25(!!s.prefill?.primaryParent?.over25);
         setPrimaryAllergies(s.prefill?.primaryParent?.allergies ?? "");
+        setNotes(h?.notes ?? "");
         setChildren(
           (s.prefill?.children ?? []).map((c: { id: number; name: string | null; dob: string | null; allergies: string | null }) => ({
             id: c.id,
@@ -145,7 +147,7 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          household: { ...address, emergencyContactName: emName, emergencyContactPhone: emPhone, emergencyContactEmail: emEmail },
+          household: { ...address, emergencyContactName: emName, emergencyContactPhone: emPhone, emergencyContactEmail: emEmail, notes: notes || null },
           // Adult's age is captured so a single-person household can enroll itself.
           // over25 wins when checked (declared adult, DOB cleared), matching my-household.
           primaryParent: { name: primaryName, dob: primaryOver25 ? null : primaryDob || null, over25: primaryOver25, allergies: primaryAllergies || null },
@@ -232,6 +234,17 @@ export default function FirstTimeIntakePanel({ ageGated, onSaved }: { ageGated: 
       <section>
         <Title order={5} mb="sm">Home address (optional)</Title>
         <AddressForm address={address} onChange={setAddress} onErrorClear={() => {}} required={false} />
+      </section>
+
+      <section>
+        <Textarea
+          label="Anything else we should know?"
+          description="Optional — for example, if your household is here to volunteer only."
+          autosize
+          minRows={2}
+          value={notes}
+          onChange={(e) => setNotes(e.currentTarget.value)}
+        />
       </section>
 
       {error && <Alert color="red" variant="light">{error}</Alert>}

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -49,6 +49,16 @@ export async function seedBaseline(prisma: Db): Promise<void> {
         });
     }
 
+    // A third non-member household. Family and Family2 are each already claimed by
+    // a membership flow test as their applicant; this one keeps the intake-notes
+    // flow test's applicant disjoint on the shared serial DB.
+    let household3 = await prisma.household.findFirst({ where: { name: "Family3" } });
+    if (!household3) {
+        household3 = await prisma.household.create({
+            data: { name: "Family3", line1: "789 Volunteer Way" },
+        });
+    }
+
     // 2. The 9 debug personas (solo personas get a single-person household of their own)
     const isBoardMember = await prisma.person.upsert({
         where: { email: "boardmember@example.com" },
@@ -104,6 +114,17 @@ export async function seedBaseline(prisma: Db): Promise<void> {
             name: "Parent Family2",
             phone: "555-555-0004",
             householdId: household2.id,
+        },
+    });
+
+    const parentFamily3 = await prisma.person.upsert({
+        where: { email: "parent.family3@example.com" },
+        update: { name: "Parent Family3", phone: "555-555-0010" },
+        create: {
+            email: "parent.family3@example.com",
+            name: "Parent Family3",
+            phone: "555-555-0010",
+            householdId: household3.id,
         },
     });
 
@@ -177,6 +198,9 @@ export async function seedBaseline(prisma: Db): Promise<void> {
 
     await prisma.person.update({ where: { id: parentFamily2.id }, data: { householdId: household2.id } });
     await addHouseholdLead(prisma, household2.id, parentFamily2.id);
+
+    await prisma.person.update({ where: { id: parentFamily3.id }, data: { householdId: household3.id } });
+    await addHouseholdLead(prisma, household3.id, parentFamily3.id);
 
     // 4. Tools & certifications
     const tableSaw = await prisma.tool.upsert({

--- a/checkin-app/src/lib/dev/zoho-import.ts
+++ b/checkin-app/src/lib/dev/zoho-import.ts
@@ -318,6 +318,10 @@ export function buildImport(files: ZohoFiles, now: Date): BuiltImport {
         ).length;
 
         const rawAddress = (family?.Address || "").trim() || null;
+        // ponytail: no Household.intakeNotes mapped — legacy Zoho has no free-text
+        // "anything else?" column, and it's the volunteer-magic-text a NEW applicant
+        // types for the reviewer, not something imported members ever supplied. Add a
+        // source→intakeNotes map here only if Zoho gains such a column.
         households.push({
             groupKey: key,
             name: ln ? `${ln} Household` : "Household",

--- a/checkin-app/src/lib/intake/profiles.ts
+++ b/checkin-app/src/lib/intake/profiles.ts
@@ -15,7 +15,7 @@
  * See docs/designs/auth-first-registration.md §9.3.
  */
 
-export type FieldKey = "address" | "emergencyContact" | "primaryName" | "participantDob";
+export type FieldKey = "address" | "emergencyContact" | "primaryName" | "participantDob" | "notes";
 
 export interface IntakeProfile {
     context: string;
@@ -69,19 +69,25 @@ const FIELD_RULES: Record<FieldKey, { label: string; isSatisfied: (ctx: IntakeSu
         // Only age-gated enrollees need a DOB; no age-gated enrollees → satisfied.
         isSatisfied: (ctx) => (ctx.participants ?? []).filter((p) => p.ageGated).every((p) => !!p.dob),
     },
+    // "Anything else we should know?" — always optional, never gates a submit, so
+    // it lives only in `shown`. Rule present to satisfy the FieldKey map.
+    notes: {
+        label: "anything else we should know",
+        isSatisfied: () => true,
+    },
 };
 
 export const INTAKE_PROFILES = {
     "membership-initial": {
         context: "membership-initial",
-        shown: ["address", "emergencyContact", "primaryName"],
+        shown: ["address", "emergencyContact", "primaryName", "notes"],
         requiredAtSubmit: ["address", "emergencyContact", "primaryName"],
     },
     "program-first-time": {
         context: "program-first-time",
         // Address is shown (collected if offered) but not required — a non-member
         // enrolling in one workshop is not a membership application.
-        shown: ["primaryName", "emergencyContact", "participantDob", "address"],
+        shown: ["primaryName", "emergencyContact", "participantDob", "address", "notes"],
         requiredAtSubmit: ["primaryName", "emergencyContact", "participantDob"],
     },
 } satisfies Record<string, IntakeProfile>;

--- a/checkin-app/src/lib/membership/__tests__/intake.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/intake.test.ts
@@ -164,6 +164,7 @@ describe('getIntakeState', () => {
             householdId: 7,
             household: {
                 name: 'Test Household',
+                intakeNotes: 'volunteer only, no students',
                 line1: '1 Main St', line2: null, city: 'Austin', state: 'TX', postalCode: '78701',
                 leads: [{ personId: 1 }, { personId: 2 }],
                 householdMembers: [
@@ -196,6 +197,7 @@ describe('getIntakeState', () => {
         expect(state.prefill.children).toHaveLength(1);
         expect(state.prefill.children[0].id).toBe(3);
         expect(state.prefill.household?.emergencyContactName).toBe('Aunt');
+        expect(state.prefill.household?.notes).toBe('volunteer only, no students');
     });
 
     it('every process ACTIVE → process is null, no external lookup', async () => {
@@ -261,6 +263,15 @@ describe('saveIntake', () => {
             email: undefined,
         });
         expect(reconcileHouseholdConflicts).toHaveBeenCalledWith(prisma, 7);
+    });
+
+    it('household notes persist as intakeNotes (trimmed; empty → null)', async () => {
+        await saveIntake(1, { household: { notes: '  we volunteer only, no students  ' } });
+        expect(prisma.household.update).toHaveBeenCalledWith({ where: { id: 7 }, data: { intakeNotes: 'we volunteer only, no students' } });
+
+        prisma.household.update.mockClear();
+        await saveIntake(1, { household: { notes: '' } });
+        expect(prisma.household.update).toHaveBeenCalledWith({ where: { id: 7 }, data: { intakeNotes: null } });
     });
 
     it('no address keys and no emergency-contact keys → neither household.update nor upsertPrimaryContact is called', async () => {

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -51,7 +51,7 @@ type ParentInput = { id?: number; name?: string; email?: string; dob?: string | 
 type ChildInput = { id?: number; name?: string; email?: string | null; dob?: string | null; allergies?: string | null };
 
 export interface IntakeSaveInput {
-    household?: Partial<StructuredAddress> & { emergencyContactName?: string; emergencyContactPhone?: string; emergencyContactEmail?: string };
+    household?: Partial<StructuredAddress> & { emergencyContactName?: string; emergencyContactPhone?: string; emergencyContactEmail?: string; notes?: string | null };
     primaryParent?: ParentInput;
     secondaryParent?: ParentInput | null;
     children?: ChildInput[];
@@ -121,6 +121,7 @@ export async function getIntakeState(userId: number) {
             household: household
                 ? {
                       name: household.name,
+                      notes: household.intakeNotes,
                       ...pickAddress(household),
                       // The primary (lowest-priority) contact backs the single-field
                       // form. Shown even when flagged invalid so the lead can fix it.
@@ -241,9 +242,14 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
     };
 
     if (input.household) {
-        const addressData = normalizeAddressInput(input.household);
-        if (Object.keys(addressData).length > 0) {
-            await prisma.household.update({ where: { id: householdId }, data: addressData });
+        // Address + the optional "anything else we should know?" note share one
+        // household.update. Note is trimmed to null so an empty box clears it.
+        const householdData = {
+            ...normalizeAddressInput(input.household),
+            ...(input.household.notes !== undefined && { intakeNotes: input.household.notes?.trim() || null }),
+        };
+        if (Object.keys(householdData).length > 0) {
+            await prisma.household.update({ where: { id: householdId }, data: householdData });
         }
         // Emergency contact lives in its own table now; the single-field intake
         // form maps onto the household's primary contact. Tolerant of partial

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -41,6 +41,7 @@ export const classifications = {
         city: 'personal',
         state: 'personal',
         postalCode: 'personal',
+        intakeNotes: 'pii',
     },
     EmergencyContact: {
         id: 'public',


### PR DESCRIPTION
## What & why

Adds an optional freeform intake field — **"Anything else we should know?"** — captured on every intake path and surfaced prominently to the background-check reviewer.

This is where a would-be **volunteer-only household** types the note that tells the reviewer (who also sets the `isMarkedVolunteer` bit) to treat them as a volunteer household. The field is worthless unless the reviewer actually sees it, so entry + reviewer surface ship together.

## Storage

- One **additive nullable** column `Household.intakeNotes`, `@sensitivity:pii` — the reviewer's view grants `pii + member + public`; `personal` would hide it (like the address). RENAME-free additive migration, nullable, no backfill.
- `prisma generate` regenerated the client (gitignored) and the tracked security classifications mirror (`intakeNotes: 'pii'`).

## Capture on every intake path (single-source per `src/lib/intake/README.md`)

| Surface | Path |
|---|---|
| `membership-initial` | `saveIntake` via `/api/membership/intake` |
| `program-first-time` | `saveIntake` via `/api/household/intake` (FirstTimeIntakePanel) |
| `household-self-service` + `membership-renewal` | `/api/household/settings` PATCH (my-household) |

- `profiles.ts` gains a `"notes"` FieldKey in `shown` (never `requiredAtSubmit` — optional, never a submit gate).
- `saveIntake` writes/reads `intakeNotes` (trimmed, empty→null); `getIntakeState` returns it for prefill.
- UI inputs reuse the shared membership form components + a Mantine `Textarea` on `membership/page`, `FirstTimeIntakePanel`, and `my-household`.

## Reviewer surface (the payoff)

- `GET /api/membership/reviews` selects `intakeNotes`.
- The review card renders it up front in a highlighted `Alert` above the volunteer checkbox — **not** behind a click.

## Deliberately skipped

- **Zoho bulk import** — legacy Zoho has no free-text column, and it's a new-applicant signal, not imported member data (`ponytail:` comment left in `zoho-import.ts`).
- **Board manual-entry tools** (`membership-ops/households`, `membership-ops/participants`) — status/person admin, not applicant intake text.

## Tests (all green)

- **Flow** (`flow-tests/membership-intake-notes.flow.test.ts`): applicant sets the note during intake → asserts it comes back in the reviewer's `GET /api/membership/reviews` payload. Uses `parent.family`/household1 to stay disjoint from the bg-nonblocking suite's `parent.family2`.
- **Intake unit**: note persists through `saveIntake` (trim/empty→null) and prefills via `getIntakeState`.
- Review-page render assert + membership dirty-tracking.
- `tsc --noEmit` + eslint clean.

## Reviewer notes

- Verified end-to-end against a fresh seeded DB in the docker flow harness (migration applied, note saved, surfaced to reviewer).
- The `pii` classification is the key call — it's the band the reviewer holds; double-check that's the intended visibility.
