### PR TITLE
fix(dev): make cloud-dev impersonation work end to end — persona-mint registration + searchable picker

### DIFF
--- a/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
@@ -140,19 +140,23 @@ describe('Sensitive route authorization', () => {
         it('404 in production (impersonation surface must be off)', async () => {
             process.env.CHECKIN_ENV = 'prod';
             mockSession.mockResolvedValue({ user: { id: personaId, isSysadmin: true } });
-            expect((await DevPersonasGet()).status).toBe(404);
+            expect((await DevPersonasGet(req('http://localhost/api/auth/dev-personas'))).status).toBe(404);
         });
 
         it('404 on the cloud dev instance when unauthenticated', async () => {
             process.env.CHECKIN_ENV = 'dev';
             mockSession.mockResolvedValue(null);
-            expect((await DevPersonasGet()).status).toBe(404);
+            expect((await DevPersonasGet(req('http://localhost/api/auth/dev-personas'))).status).toBe(404);
         });
 
         it('200 with the persona list when authenticated on dev', async () => {
             process.env.CHECKIN_ENV = 'dev';
             mockSession.mockResolvedValue({ user: { id: personaId } });
-            const res = await DevPersonasGet();
+            // Search by the unique seed tag so the assertion is independent of the 50-row cap /
+            // name ordering (the list now spans every participant, not just a handful).
+            const res = await DevPersonasGet(
+                req(`http://localhost/api/auth/dev-personas?q=persona-${TAG}`),
+            );
             expect(res.status).toBe(200);
             const json = await res.json();
             expect(json.personas.some((p: { id: number }) => p.id === personaId)).toBe(true);

--- a/checkin-app/src/app/api/auth/dev-personas/route.ts
+++ b/checkin-app/src/app/api/auth/dev-personas/route.ts
@@ -7,16 +7,27 @@ import { apiError } from "@/lib/api-response";
 
 export const dynamic = 'force-dynamic';
 
+// Cap the result set so the picker never has to render every seeded row — the
+// search box narrows to what the developer actually wants.
+const PERSONA_LIMIT = 50;
+
 /**
- * GET /api/auth/dev-personas
+ * GET /api/auth/dev-personas[?q=…]
  *
- * Returns @example.com personas (with role flags) that feed the persona picker. Available on
- * the dev instance and local laptops only. Middleware exempts /api, so on the cloud dev instance
- * we additionally require a session here — otherwise an anonymous visitor could enumerate the
- * persona list, violating the "not world-readable" rule. On local no session is required (the
- * logged-out picker is the initial login path).
+ * Returns the seeded @example.com personas (with role flags) that feed the persona picker.
+ * The impersonation surface is deliberately limited to these disposable test users — a caller
+ * can never mint a real participant, even one that exists in the dev DB (mirrored by the same
+ * suffix filter in persona-mint's authorize()). An optional `q` filters those personas by
+ * name/email (case-insensitive substring) so the caller can search rather than scroll a
+ * cramped list — note personas render by NAME, so searching by email is the reliable way to
+ * find one (e.g. "bg.reviewer" surfaces "BG Reviewer"). Results are capped at PERSONA_LIMIT.
+ *
+ * Available on the dev instance and local laptops only. Middleware exempts /api, so on the
+ * cloud dev instance we additionally require a session here — otherwise an anonymous visitor
+ * could enumerate the persona list, violating the "not world-readable" rule. On local no
+ * session is required (the logged-out picker is the initial login path).
  */
-export async function GET() {
+export async function GET(request: Request) {
     // Gate on CHECKIN_ENV only (via isDevInstance) — NOT NODE_ENV. The cloud dev instance is a
     // prod build (NODE_ENV=production, CHECKIN_ENV=dev), so a NODE_ENV check would 404 the picker
     // there. isDevInstance() already fails safe to prod. Mirrors the shared dev fence (guard.ts).
@@ -38,10 +49,26 @@ export async function GET() {
         }
     }
 
+    const q = new URL(request.url).searchParams.get("q")?.trim();
+
+    // The persona picker only ever exposes seeded @example.com test users; `q` searches WITHIN
+    // that set (name or email), never widening it to real participants.
+    const exampleOnly = { email: { endsWith: "@example.com" } };
+
     const personas = await prisma.person.findMany({
-        where: {
-            email: { endsWith: "@example.com" },
-        },
+        where: q
+            ? {
+                  AND: [
+                      exampleOnly,
+                      {
+                          OR: [
+                              { name: { contains: q, mode: "insensitive" } },
+                              { email: { contains: q, mode: "insensitive" } },
+                          ],
+                      },
+                  ],
+              }
+            : exampleOnly,
         select: {
             id: true,
             email: true,
@@ -59,7 +86,8 @@ export async function GET() {
                 },
             },
         },
-        orderBy: { id: "asc" },
+        orderBy: [{ name: "asc" }, { id: "asc" }],
+        take: PERSONA_LIMIT,
     });
 
     return NextResponse.json({ personas });

--- a/checkin-app/src/components/DevDashboard.tsx
+++ b/checkin-app/src/components/DevDashboard.tsx
@@ -269,7 +269,7 @@ export default function DevDashboard() {
                                 🔓 Logged out
                             </button>
                         </div>
-                        <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", maxHeight: "9.5rem", overflowY: "auto" }}>
+                        <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", maxHeight: "15rem", overflowY: "auto" }}>
                             {personas.length === 0 && (
                                 <span style={{ fontSize: "0.78rem", color: "#9ca3af" }}>
                                     No personas yet — run the + Family macro or the seed.
@@ -282,14 +282,23 @@ export default function DevDashboard() {
                                     disabled={switching}
                                     style={{
                                         ...macroBtn(switching),
+                                        display: "flex",
+                                        flexDirection: "column",
+                                        alignItems: "flex-start",
+                                        gap: "0.1rem",
                                         textAlign: "left",
-                                        whiteSpace: "nowrap",
                                         overflow: "hidden",
-                                        textOverflow: "ellipsis",
                                     }}
                                     title={p.email}
                                 >
-                                    🎭 {p.name || p.email}
+                                    <span style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", maxWidth: "100%" }}>
+                                        🎭 {p.name || p.email}
+                                    </span>
+                                    {p.name && p.email && (
+                                        <span style={{ fontSize: "0.68rem", color: "#9ca3af", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", maxWidth: "100%" }}>
+                                            {p.email}
+                                        </span>
+                                    )}
                                 </button>
                             ))}
                         </div>

--- a/checkin-app/src/components/DevDashboard.tsx
+++ b/checkin-app/src/components/DevDashboard.tsx
@@ -73,6 +73,7 @@ export default function DevDashboard() {
     const [toast, setToast] = useState<string | null>(null);
     const [activity, setActivity] = useState<Entry[]>([]);
     const [personas, setPersonas] = useState<PersonaOption[]>([]);
+    const [query, setQuery] = useState("");
     const [switching, setSwitching] = useState(false);
     const [pending, startTransition] = useTransition();
 
@@ -87,11 +88,23 @@ export default function DevDashboard() {
     useEffect(() => {
         if (!isDevInstance || !signedIn || !open) return;
         loadActivity();
-        fetch("/api/auth/dev-personas", { cache: "no-store" })
-            .then((res) => (res.ok ? res.json() : { personas: [] }))
-            .then((data) => setPersonas(data.personas || []))
-            .catch(() => setPersonas([]));
     }, [isDevInstance, signedIn, open, loadActivity]);
+
+    // Search the seeded @example.com personas (debounced). The server applies the suffix filter +
+    // cap and narrows by `q`; we just re-fetch as the query changes. Personas render by name, so
+    // searching by email is the reliable way to reach one (e.g. "bg.reviewer" → "BG Reviewer").
+    useEffect(() => {
+        if (!isDevInstance || !signedIn || !open) return;
+        const handle = setTimeout(() => {
+            const q = query.trim();
+            const url = q ? `/api/auth/dev-personas?q=${encodeURIComponent(q)}` : "/api/auth/dev-personas";
+            fetch(url, { cache: "no-store" })
+                .then((res) => (res.ok ? res.json() : { personas: [] }))
+                .then((data) => setPersonas(data.personas || []))
+                .catch(() => setPersonas([]));
+        }, 200);
+        return () => clearTimeout(handle);
+    }, [isDevInstance, signedIn, open, query]);
 
     if (!isDevInstance || !signedIn) return null;
 
@@ -269,10 +282,30 @@ export default function DevDashboard() {
                                 🔓 Logged out
                             </button>
                         </div>
+                        <input
+                            type="text"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            placeholder="Search personas by name or email…"
+                            aria-label="Search test personas to impersonate"
+                            style={{
+                                width: "100%",
+                                boxSizing: "border-box",
+                                padding: "0.45rem 0.6rem",
+                                marginBottom: "0.5rem",
+                                borderRadius: 8,
+                                background: "rgba(255,255,255,0.06)",
+                                border: "1px solid rgba(255,255,255,0.18)",
+                                color: "white",
+                                fontSize: "0.8rem",
+                            }}
+                        />
                         <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", maxHeight: "15rem", overflowY: "auto" }}>
                             {personas.length === 0 && (
                                 <span style={{ fontSize: "0.78rem", color: "#9ca3af" }}>
-                                    No personas yet — run the + Family macro or the seed.
+                                    {query.trim()
+                                        ? `No personas match “${query.trim()}”.`
+                                        : "No personas yet — run the + Family macro or the seed."}
                                 </span>
                             )}
                             {personas.map((p) => (

--- a/checkin-app/src/lib/__tests__/auth-options-authorize.test.ts
+++ b/checkin-app/src/lib/__tests__/auth-options-authorize.test.ts
@@ -113,6 +113,30 @@ describe('persona-mint authorize() glue', () => {
         expect(() => getAuthorize()).not.toThrow();
     });
 
+    it('stays registered on a prod BUILD (NODE_ENV=production) when CHECKIN_ENV is dev — the cloud dev instance', () => {
+        // The cloud dev instance runs the prod image: NODE_ENV=production + CHECKIN_ENV=dev
+        // (Dockerfile pins NODE_ENV; deploy-dev.yml ships that image). Registration must key on
+        // CHECKIN_ENV alone — a NODE_ENV clause here (#280) unregistered the provider on cloud
+        // dev and every mint failed. Prod SAFETY is the policy's job: see the "prod env →
+        // returns null even if the provider runs" test below.
+        const env = process.env as Record<string, string | undefined>;
+        const before = env.NODE_ENV;
+        env.NODE_ENV = 'production';
+        try {
+            jest.isolateModules(() => {
+                // Re-evaluate the module under NODE_ENV=production (providers are built at eval).
+                // eslint-disable-next-line @typescript-eslint/no-require-imports
+                const fresh = require('@/lib/auth-options') as typeof import('@/lib/auth-options');
+                const provider = fresh.authOptions.providers.find(
+                    (p) => (p as { options?: { id?: string } }).options?.id === fresh.PERSONA_MINT_PROVIDER_ID,
+                );
+                expect(provider).toBeDefined();
+            });
+        } finally {
+            env.NODE_ENV = before;
+        }
+    });
+
     it('prod env → returns null even if the provider runs (defense in depth)', async () => {
         mockCheckinEnv.mockReturnValue('prod');
         mockGetToken.mockResolvedValue(ORG_CALLER);

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -177,7 +177,15 @@ export const authOptions: NextAuthOptions = {
         // lives in evaluateMint(); this provider just supplies the caller's claims and the target.
         // (Replaces the old local-only "Offline Login" provider — local mints are the
         // unauthenticated-caller case in evaluateMint.)
-        ...(config.isDevInstance() && process.env.NODE_ENV !== 'production' ? [
+        //
+        // Registration gates on CHECKIN_ENV only (via isDevInstance) — NOT NODE_ENV. The cloud dev
+        // instance runs the prod image (NODE_ENV=production, CHECKIN_ENV=dev; see Dockerfile +
+        // deploy-dev.yml), so a NODE_ENV clause here (added by #280) unregistered the provider on
+        // the very instance impersonation is designed for, and every mint failed. isDevInstance()
+        // fails safe to prod (unset CHECKIN_ENV → 'prod'), matching the shared dev fence
+        // (lib/dev/guard.ts), and evaluateMint independently denies prod even if the provider
+        // somehow runs — both covered in auth-options-authorize.test.ts.
+        ...(config.isDevInstance() ? [
             CredentialsProvider({
                 id: PERSONA_MINT_PROVIDER_ID,
                 name: "Persona",


### PR DESCRIPTION
## What

Companion to #903 (now merged & deployed). With #903 the persona list finally loads on cloud dev — this PR makes it usable end to end. Two commits:

### 1. `fix`: register persona-mint on the prod build

The same `NODE_ENV !== 'production'` clause #903 removed from the list route also exists on the **persona-mint provider registration** in `auth-options.ts` (added by #280). On the cloud dev prod image the provider is never registered, so clicking any persona fails at `signIn("persona-mint")` — confirmed on the live dev instance after #903 deployed: the list populates, switching still breaks.

- Registration now gates on `config.isDevInstance()` alone, matching the shared dev fence (`lib/dev/guard.ts`) and #903's rationale (`CHECKIN_ENV` fails safe to `'prod'` when unset).
- Regression test: re-evaluates the module under `NODE_ENV=production` + `CHECKIN_ENV=dev` (the exact broken configuration) and asserts the provider is registered.
- Prod stays dead by construction at the policy layer too: `evaluateMint` denies `checkinEnv === 'prod'` even if the provider runs (existing test).

### 2. `feat`: searchable persona picker

Now that the list actually renders, it's a cramped, hard-to-read scroll box. This makes personas findable:

- `GET /api/auth/dev-personas?q=…` — case-insensitive name/email substring search **within** the `@example.com` set; ordered by name, capped at 50.
- `DevDashboard` — debounced search input; each row shows **name + email** (a persona seeded as "BG Reviewer" was unfindable when scanning for `bg.reviewer@example.com`); taller list (15rem).

## Impersonation surface: unchanged

The `@example.com` filters on both the persona list and the mint target are untouched. `q` narrows within that set; it never widens it to real participants.

## Tests

- `auth-options-authorize`: 10/10 including the new prod-build registration regression test.
- `authzRoutes.integration.test.ts`: updated for the `GET(request)` signature; the 200-path searches by the unique seed tag so it's independent of the cap/ordering. Needs the throwaway Postgres — please confirm in CI.
- Full unit suite green via pre-commit `test:ci` (1541/1541).

🤖 Generated with [Claude Code](https://claude.com/claude-code)