### PR TITLE
fix(dev): serve persona picker on cloud dev prod build

### DIFF
--- a/checkin-app/src/app/api/auth/dev-personas/route.ts
+++ b/checkin-app/src/app/api/auth/dev-personas/route.ts
@@ -17,9 +17,9 @@ export const dynamic = 'force-dynamic';
  * logged-out picker is the initial login path).
  */
 export async function GET() {
-    if (process.env.NODE_ENV === 'production') {
-        return apiError("Not available", 404);
-    }
+    // Gate on CHECKIN_ENV only (via isDevInstance) — NOT NODE_ENV. The cloud dev instance is a
+    // prod build (NODE_ENV=production, CHECKIN_ENV=dev), so a NODE_ENV check would 404 the picker
+    // there. isDevInstance() already fails safe to prod. Mirrors the shared dev fence (guard.ts).
     if (!config.isDevInstance()) {
         return apiError("Not available", 404);
     }


### PR DESCRIPTION
## What

`GET /api/auth/dev-personas` (feeds the dev persona/impersonation picker) gated on `process.env.NODE_ENV === 'production'` and 404'd there. The cloud dev instance runs a **prod build** — `NODE_ENV=production` with `CHECKIN_ENV=dev` — so the route 404'd on the very instance it's meant to serve. `DevDashboard` swallows a non-ok response into an empty list, so the picker rendered **empty** despite a populated DB and a valid board-member session.

## Why

`NODE_ENV` is not the environment switch — `CHECKIN_ENV` is (one image, fails safe to prod). The shared dev fence `lib/dev/guard.ts › assertDevActor` (used by every macro, reset, and ledger read) gates purely on `config.isProd()` / `config.checkinEnv()` and never touches `NODE_ENV` — which is exactly why those surfaces work on cloud dev but the picker didn't. This route was the odd one out.

## Change

- GET now gates on `config.isDevInstance()` only (excludes prod via `CHECKIN_ENV`), matching the shared fence. The session requirement on cloud dev is unchanged.
- POST keeps its `NODE_ENV === 'production'` backstop — it mints a login and must remain local-only.

## Reviewer notes

- No test referenced this route; nothing to update.
- The `@example.com` filter, DB, and session gate were never the cause — the request 404'd before reaching them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)