### PR TITLE
feat(membership-audit): surface program people needing a background check

### DIFF
--- a/checkin-app/src/app/__tests__/personBgComplianceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgComplianceAPI.integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the person-scoped PERSON_BG_NEEDED / DOB_MISSING buckets
+ * of GET /api/membership-audit/compliance (Phase 1, warn-only). Asserts a ≥18
+ * non-fresh program participant / volunteer / lead surfaces, under-18 and fresh
+ * people are omitted, a program volunteer with no membership still appears in the
+ * person-level list, and a missing-DOB person lands in the data-hygiene bucket.
+ */
+
+import { GET } from '@/app/api/membership-audit/compliance/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+const TAG = 'person-bg-test';
+const RECHECK_MONTHS = 12;
+
+function get() {
+    return GET(new Request('http://localhost:4000/api/membership-audit/compliance', {
+        method: 'GET',
+    }) as unknown as import('next/server').NextRequest);
+}
+
+/** A person in their own household (no OrgMembership = not a member household). */
+async function makePerson(slug: string, data: {
+    dateOfBirth?: Date | null;
+    isDeclaredAdult?: boolean;
+    lastBackgroundCheck?: Date | null;
+}) {
+    const household = await prisma.household.create({ data: { name: `${TAG} ${slug}` } });
+    return prisma.person.create({
+        data: {
+            email: `${slug}-${TAG}@example.com`,
+            name: `${slug} person`,
+            householdId: household.id,
+            dateOfBirth: data.dateOfBirth ?? null,
+            isDeclaredAdult: data.isDeclaredAdult ?? false,
+            lastBackgroundCheck: data.lastBackgroundCheck ?? null,
+        },
+    });
+}
+
+describe('GET /api/membership-audit/compliance — person BG buckets', () => {
+    let boardId: number;
+    let programId: number;
+    let participantId: number;
+    let volunteerId: number;
+    let leadId: number;
+    let minorId: number;
+    let freshId: number;
+    let missingDobId: number;
+    let savedSettings: { bgRecheckMonths: number; orgMembershipYearBoundary: Date | null } | null = null;
+
+    const cleanup = async () => {
+        const progs = await prisma.program.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+        const progIds = progs.map(p => p.id);
+        await prisma.programParticipant.deleteMany({ where: { programId: { in: progIds } } });
+        await prisma.programVolunteer.deleteMany({ where: { programId: { in: progIds } } });
+        // Drop the leadMentor FK before deleting the lead person.
+        await prisma.program.deleteMany({ where: { id: { in: progIds } } });
+        const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+        const hhIds = hhs.map(h => h.id);
+        await prisma.person.deleteMany({ where: { OR: [{ email: { contains: TAG } }, { householdId: { in: hhIds } }] } });
+        await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
+    };
+
+    beforeAll(async () => {
+        await cleanup();
+
+        const prev = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        savedSettings = prev ? { bgRecheckMonths: prev.bgRecheckMonths, orgMembershipYearBoundary: prev.orgMembershipYearBoundary } : null;
+        await prisma.boardSettings.upsert({
+            where: { id: 1 },
+            create: { id: 1, bgRecheckMonths: RECHECK_MONTHS, orgMembershipYearBoundary: new Date('2000-06-01') },
+            update: { bgRecheckMonths: RECHECK_MONTHS, orgMembershipYearBoundary: new Date('2000-06-01') },
+        });
+
+        const board = await prisma.person.create({
+            data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, household: { create: { name: `${TAG} board` } } },
+        });
+        boardId = board.id;
+
+        // Adult (37), no check → NEEDED. Enrolled as a participant.
+        participantId = (await makePerson('participant', { dateOfBirth: new Date('1990-01-01') })).id;
+        // Adult, no check, in a non-member household → NEEDED, must appear in the person list.
+        volunteerId = (await makePerson('volunteer', { dateOfBirth: new Date('1988-01-01') })).id;
+        // Adult, no check → NEEDED. Program lead.
+        leadId = (await makePerson('lead', { dateOfBirth: new Date('1985-01-01') })).id;
+        // Under 18 → excluded even though attached as a volunteer.
+        minorId = (await makePerson('minor', { dateOfBirth: new Date('2015-01-01') })).id;
+        // Adult with a current check → FRESH, excluded.
+        freshId = (await makePerson('fresh', { dateOfBirth: new Date('1980-01-01'), lastBackgroundCheck: new Date() })).id;
+        // No DOB, not declared adult → DOB_MISSING, not NEEDED.
+        missingDobId = (await makePerson('nodob', { dateOfBirth: null })).id;
+
+        const program = await prisma.program.create({ data: { name: `${TAG} program`, leadMentorId: leadId } });
+        programId = program.id;
+        await prisma.programParticipant.create({ data: { programId, personId: participantId } });
+        await prisma.programParticipant.create({ data: { programId, personId: freshId } });
+        await prisma.programParticipant.create({ data: { programId, personId: missingDobId } });
+        await prisma.programVolunteer.create({ data: { programId, personId: volunteerId } });
+        await prisma.programVolunteer.create({ data: { programId, personId: minorId } });
+    });
+
+    afterAll(async () => {
+        await cleanup();
+        if (savedSettings) {
+            await prisma.boardSettings.update({ where: { id: 1 }, data: savedSettings });
+        }
+    });
+
+    it('flags ≥18 non-fresh participant/volunteer/lead and omits minor + fresh', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+        const res = await get();
+        expect(res.status).toBe(200);
+        const { peopleNeedingBgCheck, peopleMissingDob } = await res.json();
+
+        const needIds = new Set(peopleNeedingBgCheck.map((p: { personId: number }) => p.personId));
+        expect(needIds.has(participantId)).toBe(true);
+        expect(needIds.has(volunteerId)).toBe(true);
+        expect(needIds.has(leadId)).toBe(true);
+        expect(needIds.has(minorId)).toBe(false);
+        expect(needIds.has(freshId)).toBe(false);
+        expect(needIds.has(missingDobId)).toBe(false);
+
+        // Every needed row carries the tag + program context; the volunteer has no membership.
+        for (const p of peopleNeedingBgCheck) {
+            if (needIds.has(p.personId)) expect(p.reason).toBe('PERSON_BG_NEEDED');
+        }
+        const vol = peopleNeedingBgCheck.find((p: { personId: number }) => p.personId === volunteerId);
+        expect(vol.programId).toBe(programId);
+
+        // Missing-DOB person is data-hygiene, not bg-needed.
+        const dobIds = new Set(peopleMissingDob.map((p: { personId: number }) => p.personId));
+        expect(dobIds.has(missingDobId)).toBe(true);
+        expect(needIds.has(missingDobId)).toBe(false);
+        const miss = peopleMissingDob.find((p: { personId: number }) => p.personId === missingDobId);
+        expect(miss.reason).toBe('DOB_MISSING');
+    });
+});

--- a/checkin-app/src/app/api/membership-audit/compliance/route.ts
+++ b/checkin-app/src/app/api/membership-audit/compliance/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { householdBgIsFresh, nextBoundary } from "@/lib/membership/renewal";
+import { bgFreshThreshold, personBgVerdict } from "@/lib/membership/personBgCheck";
 
 export const dynamic = "force-dynamic";
 
@@ -16,6 +17,13 @@ export const dynamic = "force-dynamic";
  *   REVOKED / DENIED — OrgMembership status.
  *   STUCK_BG_CLEARANCE — a process parked at PENDING_BG_CLEARANCE (paid, never cleared).
  * A household with multiple problems gets all its reason tags.
+ *
+ * Also returns two PERSON-scoped lists (program people may not sit in a member
+ * household, so they can't key on householdId):
+ *   peopleNeedingBgCheck — program-attached people ≥18 (as of the boundary) with
+ *                          no fresh check. Skipped when bgRecheckMonths = 0.
+ *   peopleMissingDob     — program-attached people whose age is unknown (no DOB,
+ *                          not declared 25+): data hygiene, NOT bg-needed.
  */
 export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async () => {
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
@@ -60,7 +68,69 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
     });
     for (const p of stuck) add(p.orgMembership.householdId, "STUCK_BG_CLEARANCE");
 
-    if (reasons.size === 0) return NextResponse.json({ households: [] });
+    // 4. Program-attached people ≥18 without a fresh background check (warn-only).
+    //    Subject = union of ProgramParticipant / ProgramVolunteer / Program.leadMentor.
+    //    A program lead/volunteer may sit in a household that isn't a member household,
+    //    so these are person-scoped, NOT folded into the householdId reason map above.
+    //    Skip the whole bucket when the board hasn't set a recheck window, exactly
+    //    like STALE_BG — bgRecheckMonths = 0 means "no policy", nothing is stale.
+    type PersonRow = {
+        personId: number;
+        name: string;
+        householdId: number;
+        programId: number | null;
+        programName: string | null;
+        reason: string;
+    };
+    const peopleNeedingBgCheck: PersonRow[] = [];
+    const peopleMissingDob: PersonRow[] = [];
+    if (bgRecheckMonths > 0) {
+        const threshold = bgFreshThreshold(boundary, bgRecheckMonths);
+        const people = await prisma.person.findMany({
+            where: {
+                OR: [
+                    { programParticipants: { some: {} } },
+                    { programVolunteers: { some: {} } },
+                    { programsLed: { some: {} } },
+                ],
+            },
+            select: {
+                id: true,
+                name: true,
+                householdId: true,
+                dateOfBirth: true,
+                isDeclaredAdult: true,
+                lastBackgroundCheck: true,
+                programParticipants: { select: { program: { select: { id: true, name: true } } } },
+                programVolunteers: { select: { program: { select: { id: true, name: true } } } },
+                programsLed: { select: { id: true, name: true } },
+            },
+            orderBy: { name: "asc" },
+        });
+        for (const p of people) {
+            const verdict = personBgVerdict(p, boundary, threshold);
+            if (verdict === "FRESH" || verdict === "MINOR") continue;
+            // One program for context — first attachment found across the three roles.
+            const prog =
+                p.programParticipants[0]?.program ??
+                p.programVolunteers[0]?.program ??
+                p.programsLed[0] ??
+                null;
+            const row: PersonRow = {
+                personId: p.id,
+                name: p.name || `Person #${p.id}`,
+                householdId: p.householdId,
+                programId: prog?.id ?? null,
+                programName: prog?.name ?? null,
+                reason: verdict === "DOB_MISSING" ? "DOB_MISSING" : "PERSON_BG_NEEDED",
+            };
+            (verdict === "DOB_MISSING" ? peopleMissingDob : peopleNeedingBgCheck).push(row);
+        }
+    }
+
+    if (reasons.size === 0) {
+        return NextResponse.json({ households: [], peopleNeedingBgCheck, peopleMissingDob });
+    }
 
     const households = await prisma.household.findMany({
         where: { id: { in: [...reasons.keys()] } },
@@ -96,5 +166,5 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
         };
     });
 
-    return NextResponse.json({ households: result });
+    return NextResponse.json({ households: result, peopleNeedingBgCheck, peopleMissingDob });
 });

--- a/checkin-app/src/app/membership-audit/compliance/page.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/page.tsx
@@ -13,6 +13,14 @@ type Household = {
   lastBackgroundCheck: string | null;
   leads: Lead[];
 };
+type PersonRow = {
+  personId: number;
+  name: string;
+  householdId: number;
+  programId: number | null;
+  programName: string | null;
+  reason: string;
+};
 
 // Reason tag -> human label + badge color. Keys mirror the endpoint's tags.
 const REASON: Record<string, { label: string; color: string }> = {
@@ -22,12 +30,50 @@ const REASON: Record<string, { label: string; color: string }> = {
   STUCK_BG_CLEARANCE: { label: "Stuck at BG clearance", color: "yellow" },
 };
 
+/** Person-scoped section (bg-needed / DOB-missing). Program people may not be in a
+ *  member household, so these render on their own, keyed on the person. */
+function PersonSection({
+  title,
+  description,
+  color,
+  people,
+}: {
+  title: string;
+  description: string;
+  color: string;
+  people: PersonRow[];
+}) {
+  if (people.length === 0) return null;
+  return (
+    <Stack gap="sm">
+      <Title order={4}>{title}</Title>
+      <Text c="dimmed" size="sm">{description}</Text>
+      {people.map((p) => (
+        <Card key={p.personId} withBorder radius="md" padding="lg">
+          <Group justify="space-between" wrap="wrap">
+            <div>
+              <Text fw={600} fz="lg">{p.name}</Text>
+              <Text size="sm" c="dimmed">
+                {p.programName ? `Program: ${p.programName}` : "No program on file"}
+                {" · "}Household #{p.householdId}
+              </Text>
+            </div>
+            <Badge color={color} variant="light">{title}</Badge>
+          </Group>
+        </Card>
+      ))}
+    </Stack>
+  );
+}
+
 /**
  * Membership Audit view: households out of compliance that the system did NOT
  * auto-terminate. Read-only — the board follows up manually; no action buttons.
  */
 export default function CompliancePage() {
   const [households, setHouseholds] = useState<Household[]>([]);
+  const [peopleNeedingBgCheck, setPeopleNeedingBgCheck] = useState<PersonRow[]>([]);
+  const [peopleMissingDob, setPeopleMissingDob] = useState<PersonRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -38,6 +84,8 @@ export default function CompliancePage() {
         if (res.ok) {
           const data = await res.json();
           setHouseholds(data.households ?? []);
+          setPeopleNeedingBgCheck(data.peopleNeedingBgCheck ?? []);
+          setPeopleMissingDob(data.peopleMissingDob ?? []);
         } else {
           setError("Failed to load compliance data. Ensure you have the proper authorizations.");
         }
@@ -70,11 +118,13 @@ export default function CompliancePage() {
         </Text>
       </Card>
 
-      {households.length === 0 ? (
+      {households.length === 0 && peopleNeedingBgCheck.length === 0 && peopleMissingDob.length === 0 && (
         <Card withBorder radius="md" padding="xl" ta="center">
-          <Text c="dimmed">Every household is in compliance. 🎉</Text>
+          <Text c="dimmed">Everyone is in compliance. 🎉</Text>
         </Card>
-      ) : (
+      )}
+
+      {households.length > 0 && (
         <Stack gap="sm">
           {households.map((h) => (
             <Card key={h.id} withBorder radius="md" padding="lg">
@@ -115,6 +165,20 @@ export default function CompliancePage() {
           ))}
         </Stack>
       )}
+
+      <PersonSection
+        title="Background check needed"
+        description="Program-attached people 18 or older with no current background check. Warn-only — nothing is blocked."
+        color="orange"
+        people={peopleNeedingBgCheck}
+      />
+
+      <PersonSection
+        title="Missing date of birth"
+        description="Program-attached people with no recorded age. Confirm their date of birth before a background check can be assessed."
+        color="grape"
+        people={peopleMissingDob}
+      />
     </Stack>
   );
 }

--- a/checkin-app/src/lib/membership/__tests__/personBgCheck.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/personBgCheck.test.ts
@@ -1,0 +1,55 @@
+import { bgFreshThreshold, personBgVerdict } from "@/lib/membership/personBgCheck";
+
+// Boundary = Sept 1 2026. 12-month recheck → fresh cutoff Sept 1 2025.
+const BOUNDARY = new Date(Date.UTC(2026, 8, 1));
+const THRESHOLD = bgFreshThreshold(BOUNDARY, 12);
+
+function verdict(person: Partial<{ dateOfBirth: Date | null; isDeclaredAdult: boolean; lastBackgroundCheck: Date | null }>) {
+    return personBgVerdict(
+        { dateOfBirth: null, isDeclaredAdult: false, lastBackgroundCheck: null, ...person },
+        BOUNDARY,
+        THRESHOLD,
+    );
+}
+
+describe("bgFreshThreshold", () => {
+    it("subtracts recheckMonths from the boundary", () => {
+        expect(bgFreshThreshold(BOUNDARY, 12).toISOString()).toBe("2025-09-01T00:00:00.000Z");
+    });
+});
+
+describe("personBgVerdict age gate (inclusive boundary)", () => {
+    // Turns 18 the day before the boundary → ≥18 → NEEDED.
+    it("Aug 31 birthday is in scope", () => {
+        expect(verdict({ dateOfBirth: new Date(Date.UTC(2008, 7, 31)) })).toBe("NEEDED");
+    });
+    // Turns 18 exactly on the boundary → inclusive → in scope.
+    it("Sept 1 birthday (exactly 18 on the boundary) is in scope", () => {
+        expect(verdict({ dateOfBirth: new Date(Date.UTC(2008, 8, 1)) })).toBe("NEEDED");
+    });
+    // Turns 18 the day after the boundary → 17 as of boundary → out.
+    it("Sept 2 birthday is out of scope (still 17 at the boundary)", () => {
+        expect(verdict({ dateOfBirth: new Date(Date.UTC(2008, 8, 2)) })).toBe("MINOR");
+    });
+    it("a young child is a MINOR", () => {
+        expect(verdict({ dateOfBirth: new Date(Date.UTC(2015, 0, 1)) })).toBe("MINOR");
+    });
+});
+
+describe("personBgVerdict adult/freshness/data-hygiene", () => {
+    it("isDeclaredAdult with no DOB is in scope (≥18)", () => {
+        expect(verdict({ isDeclaredAdult: true })).toBe("NEEDED");
+    });
+    it("missing DOB and not declared adult → DOB_MISSING, never cleared or needed", () => {
+        expect(verdict({})).toBe("DOB_MISSING");
+    });
+    it("adult with a check newer than the cutoff is FRESH", () => {
+        expect(verdict({ isDeclaredAdult: true, lastBackgroundCheck: new Date(Date.UTC(2025, 9, 1)) })).toBe("FRESH");
+    });
+    it("adult with a check older than the cutoff is NEEDED", () => {
+        expect(verdict({ isDeclaredAdult: true, lastBackgroundCheck: new Date(Date.UTC(2025, 7, 1)) })).toBe("NEEDED");
+    });
+    it("a fresh check does not rescue a MINOR (age gate wins)", () => {
+        expect(verdict({ dateOfBirth: new Date(Date.UTC(2015, 0, 1)), lastBackgroundCheck: new Date(Date.UTC(2026, 0, 1)) })).toBe("MINOR");
+    });
+});

--- a/checkin-app/src/lib/membership/personBgCheck.ts
+++ b/checkin-app/src/lib/membership/personBgCheck.ts
@@ -1,0 +1,46 @@
+import { calculateAge } from "@/lib/time";
+
+/**
+ * Per-person background-check verdict for the board compliance dashboard
+ * (Phase 1 — warn-only, read-only). Generalizes householdBgIsFresh from
+ * "any household lead is fresh" to "this specific person is fresh".
+ *
+ *   NEEDED      — ≥18 (as of the boundary) and NOT background-checked recently.
+ *   FRESH       — check still valid at the boundary; already covered.
+ *   MINOR       — under 18 as of the boundary; a minor cannot be checked.
+ *   DOB_MISSING — no DOB and not declared 25+; age unknown, so we can neither
+ *                 confirm ≥18 nor treat them as cleared. A data-hygiene item,
+ *                 NOT a bg-needed item (never auto-check a possible minor).
+ */
+export type PersonBgVerdict = "NEEDED" | "FRESH" | "MINOR" | "DOB_MISSING";
+
+/**
+ * Freshness cutoff: boundary minus recheckMonths. Mirrors monthsBefore() in
+ * renewal.ts (UTC month math) so per-person freshness matches householdBgIsFresh.
+ */
+export function bgFreshThreshold(boundary: Date, recheckMonths: number): Date {
+    const d = new Date(boundary);
+    d.setUTCMonth(d.getUTCMonth() - recheckMonths);
+    return d;
+}
+
+/**
+ * Classify one program-attached person. `boundary` is the annual membership
+ * boundary — age is judged as-of it (inclusive: an 18th birthday landing exactly
+ * on the boundary counts as ≥18). `threshold` is bgFreshThreshold(boundary, months).
+ */
+export function personBgVerdict(
+    person: { dateOfBirth: Date | null; isDeclaredAdult: boolean; lastBackgroundCheck: Date | null },
+    boundary: Date,
+    threshold: Date,
+): PersonBgVerdict {
+    // Unknown age — cannot confirm ≥18, must not be treated as cleared.
+    if (!person.dateOfBirth && !person.isDeclaredAdult) return "DOB_MISSING";
+
+    // isDeclaredAdult = "25+, no DOB recorded" → definitely ≥18.
+    const isAdult = person.isDeclaredAdult || calculateAge(person.dateOfBirth!, boundary) >= 18;
+    if (!isAdult) return "MINOR";
+
+    if (person.lastBackgroundCheck && person.lastBackgroundCheck >= threshold) return "FRESH";
+    return "NEEDED";
+}

--- a/checkin-app/tests/security/routeAuthDrift.test.ts
+++ b/checkin-app/tests/security/routeAuthDrift.test.ts
@@ -312,6 +312,7 @@ const EDGE_INCLUDE_ALLOWLIST: Record<string, string> = {
     'finance-ops/payment-plans': 'admin-role-gated — registry authorize anyRole [sysadmin, board]',
     'household/visits': "query-shaped — own household only (where householdId = caller's)",
     'kioskdisplay/certifications': 'admin-role-gated — sysadmin/board/keyholder (+ kiosk)',
+    'membership-audit/compliance': 'admin-role-gated — withAuth roles [sysadmin, board]; reads ProgramParticipant/Volunteer to flag people needing a background check',
     'membership-ops/participants/merge/analyze': 'admin-role-gated — sysadmin/board',
     'nav/todo-counts': 'query-shaped — counts scoped to caller (own household + programs the caller leads)',
     'profile': "query-shaped — authorize 'self'; visits are the caller's own",


### PR DESCRIPTION
## What

Phase 1 (read-only, **warn-only**) of "background checks for 18+ program people". Extends the board compliance dashboard ([#898]) with two new **person-scoped** buckets. No schema changes, no obligation records, no blocking.

- **`PERSON_BG_NEEDED`** — every program-attached person (`ProgramParticipant` ∪ `ProgramVolunteer` ∪ `Program.leadMentor`) who is **≥18 as of the annual boundary** and lacks a fresh background check.
- **`DOB_MISSING`** — program person with no DOB and not declared 25+: age unknown → data-hygiene tag, **not** treated as cleared and **not** put in `PERSON_BG_NEEDED` (must never auto-check a possible minor).

## Why

Program leads/volunteers/participants over 18 need background checks, but the existing dashboard only keys on `householdId` — and a program volunteer or lead may not sit in a member household at all. This surfaces *who* needs a check as a warning, so the board can chase it manually. Later phases handle consent flow, actual checks, and any blocking.

## Design notes for reviewers

- **Age judged as-of the boundary**, not "now" — via `calculateAge(dob, boundary)`. Boundary is **inclusive**: an 18th birthday landing exactly on the boundary counts as ≥18. Someone who turns 18 after the boundary is out of scope until next year.
- **Freshness** mirrors `householdBgIsFresh` (threshold = `boundary − bgRecheckMonths`), generalized per-person. When `bgRecheckMonths <= 0` the whole bucket is skipped, exactly like the existing `STALE_BG` block.
- **Under-18 excluded** (e.g. young-adult mentors); `isDeclaredAdult` (25+, no DOB) → in scope.
- Rows are **person-scoped**, not folded into the household reason map. Each carries `personId`, `name`, `householdId` (context), and program context. Response gains `peopleNeedingBgCheck` + `peopleMissingDob` alongside `households`; the `reasons.size === 0` early-return was fixed so these still return when no household is flagged.
- Cohort/age predicate extracted to `lib/membership/personBgCheck.ts` — pure, no DB, unit-tested.

## Scope guardrails (deliberately out — later phases)

No Prisma schema changes, no new `OrgMembershipProcess.kind` / `subjectPersonId`, no triggering of checks, no consent flow, no cron, no blocking of anything. `clearBackgroundCheck` untouched. Program-lead-scoped view stays board-gated for now.

## Tests

- **Unit** (`personBgCheck.test.ts`, 10 cases): Aug 31 / Sep 1 / Sep 2 vs a Sep-1 boundary → in / in / out (inclusive); under-18 excluded; `isDeclaredAdult` included; missing-DOB → data-hygiene, not cleared/needed; freshness cutoff; age gate beats a fresh check on a minor.
- **Integration** (`personBgComplianceAPI.integration.test.ts`): route returns `PERSON_BG_NEEDED` for a ≥18 non-fresh participant/volunteer/lead, omits under-18 and fresh, lists a **non-household** program volunteer in the person-level list, and routes a missing-DOB person to `DOB_MISSING`.

Verified: `tsc --noEmit` clean and full integration suite **876/876** on the rebased base (includes #898 + #900).

🤖 Generated with [Claude Code](https://claude.com/claude-code)