### PR TITLE
fix(system-status): sort unresolved integration errors first

### DIFF
--- a/checkin-app/src/app/api/system-status/links/route.ts
+++ b/checkin-app/src/app/api/system-status/links/route.ts
@@ -17,7 +17,8 @@ export const GET = withAuth(
                 .catch((err: unknown) => logger.error("Failed to purge old integration errors:", err));
 
             const errors = await prisma.integrationErrorLog.findMany({
-                orderBy: [{ resolvedAt: "asc" }, { timestamp: "desc" }],
+                // nulls:"first" — unresolved (resolvedAt null) sort first; PG default is NULLS LAST.
+                orderBy: [{ resolvedAt: { sort: "asc", nulls: "first" } }, { timestamp: "desc" }],
                 take: 200,
             });
 


### PR DESCRIPTION
## What

The **Link Status** tab (`/system-status/links`) is the surface for `IntegrationErrorLog` rows (Shopify/Zoho/webhook failures) with a resolve/reopen action — already built and shipped.

Its GET route ordered by `resolvedAt: "asc"` with no `nulls` clause. Postgres defaults to **NULLS LAST**, so unresolved rows (`resolvedAt = null`) sorted *below* resolved ones — the opposite of what an errors triage tab wants.

## Fix

One line — `orderBy: { resolvedAt: { sort: "asc", nulls: "first" } }` so open integration failures surface at the top. Exploits the existing `@@index([resolvedAt, timestamp])`.

## Note

Started as a request to build a new "Integration Errors" panel + resolve action. On inspection that whole feature already exists as **Link Status** (panel, GET + PATCH routes, nav tab, pageRegistry entry, tests). Scoped down to the one real gap: the nulls-last ordering bug. No duplicate panel built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)