### PR TITLE
test(programs): cover program->Shopify category sync route

### DIFF
--- a/checkin-app/src/app/__tests__/programSyncShopifyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programSyncShopifyAPI.integration.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for POST /api/programs/[id]/sync-shopify — the checkout
+ * repair path that mints Shopify variants for a program that was priced AFTER
+ * creation (PATCH never mints variants, so it sits checkout-broken). This was
+ * the one fully-built-but-untested route in the program domain; webhookShopify
+ * covers inbound MEMBERSHIP webhooks, not this outbound program-category sync.
+ *
+ * Runs against the CHECKIN_ENV=local Shopify mock (config.shopifyMockActive) so
+ * createShopifyProgramVariants returns synthetic dev-mock ids instead of hitting
+ * the real Admin API — same explicit env gate PR #888 established.
+ *
+ * NOTE (Q13): this route has NO empty/mis-categorized-category detection. An
+ * IntegrationErrorLog row is written only inside createShopifyProgramVariants'
+ * catch on a REAL Shopify API failure, which the mock branch never reaches; the
+ * route's own catch writes a BackendErrorLog (logBackendError), not an
+ * IntegrationErrorLog. So the "empty-category warning surface" is a separate,
+ * unbuilt feature — the success-path assertion below pins that no
+ * IntegrationErrorLog is emitted here today.
+ */
+import { POST } from '@/app/api/programs/[id]/sync-shopify/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+const TAG = 'sync-shopify-api-test';
+const params = (id: number) => ({ params: Promise.resolve({ id: id.toString() }) }) as unknown as never;
+// A cookie header is required: CHECKIN_ENV=local (needed for the Shopify mock)
+// also arms the keyless-kiosk fallback in authenticateRequest, which hijacks any
+// cookie-less request as `kiosk` → 403 before the session/role gate runs.
+const req = () => new Request('http://localhost/api/programs/x/sync-shopify', { method: 'POST', headers: { cookie: 'session=test' } }) as unknown as import('next/server').NextRequest;
+
+describe('POST /api/programs/[id]/sync-shopify', () => {
+    let adminId: number;
+    let boardId: number;
+    let commonId: number;
+    let prevCheckinEnv: string | undefined;
+
+    beforeAll(async () => {
+        // Route reaches the Shopify MOCK only when CHECKIN_ENV=local (jest.setup
+        // sets 'dev'). config reads process.env live per call, so flip it here and
+        // restore in afterAll — --runInBand shares the process with sibling suites.
+        prevCheckinEnv = process.env.CHECKIN_ENV;
+        process.env.CHECKIN_ENV = 'local';
+
+        const admin = await prisma.person.create({
+            data: { email: `admin-${TAG}@example.com`, name: 'Admin', isSysadmin: true, household: { create: {} } },
+        });
+        adminId = admin.id;
+        const board = await prisma.person.create({
+            data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: {} } },
+        });
+        boardId = board.id;
+        const common = await prisma.person.create({
+            data: { email: `common-${TAG}@example.com`, name: 'Common', household: { create: {} } },
+        });
+        commonId = common.id;
+    });
+
+    afterAll(async () => {
+        const ids = [adminId, boardId, commonId];
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: ids } } });
+        await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { id: { in: ids } } });
+        process.env.CHECKIN_ENV = prevCheckinEnv;
+    });
+
+    // A priced program with no variants — the exact checkout-broken state the
+    // route repairs (isProgramCheckoutBroken: price>0 tier, variant null).
+    const makeBrokenProgram = () =>
+        prisma.program.create({
+            data: {
+                name: `Broken Prog ${TAG} ${Math.round(performance.now())}`,
+                phase: 'RUNNING',
+                orgMemberPriceCents: 5000,
+                nonOrgMemberPriceCents: 7500,
+            },
+        });
+
+    it('rejects a caller without isSysadmin/isBoardMember (403)', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
+        const program = await makeBrokenProgram();
+
+        const res = await POST(req(), params(program.id));
+        expect(res.status).toBe(403);
+
+        // Gate held: no variants minted.
+        const after = await prisma.program.findUnique({ where: { id: program.id } });
+        expect(after?.shopifyProductId).toBeNull();
+    });
+
+    it('upserts Shopify product + variants and persists the ids on the program', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+        const program = await makeBrokenProgram();
+        const errLogsBefore = await prisma.integrationErrorLog.count({ where: { source: 'shopify' } });
+
+        const res = await POST(req(), params(program.id));
+        expect(res.status).toBe(200);
+
+        const data = await res.json();
+        expect(data.success).toBe(true);
+        // Success contract: a product id + a variant id per priced tier, echoed back...
+        expect(data.program.shopifyProductId).toMatch(/^dev-mock-product-/);
+        expect(data.program.shopifyOrgMemberVariantId).toMatch(/^dev-mock-variant-member-/);
+        expect(data.program.shopifyNonOrgMemberVariantId).toMatch(/^dev-mock-variant-nonmember-/);
+
+        // ...and PERSISTED — this is what fails if the route stops upserting.
+        const persisted = await prisma.program.findUnique({ where: { id: program.id } });
+        expect(persisted?.shopifyProductId).toBe(data.program.shopifyProductId);
+        expect(persisted?.shopifyOrgMemberVariantId).toBe(data.program.shopifyOrgMemberVariantId);
+
+        // Audit trail written.
+        const audit = await prisma.auditLog.findFirst({
+            where: { actorId: boardId, tableName: 'Program', affectedEntityId: program.id, action: 'EDIT' },
+        });
+        expect(audit).not.toBeNull();
+
+        // Q13: no empty-category detection here — the mock never errors, so no
+        // IntegrationErrorLog is emitted. Pins current behavior (see file header).
+        const errLogsAfter = await prisma.integrationErrorLog.count({ where: { source: 'shopify' } });
+        expect(errLogsAfter).toBe(errLogsBefore);
+    });
+
+    it('refuses a program whose checkout is already configured (400)', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+        // Priced AND has both variants -> not broken.
+        const program = await prisma.program.create({
+            data: {
+                name: `Configured Prog ${TAG}`,
+                phase: 'RUNNING',
+                orgMemberPriceCents: 5000,
+                nonOrgMemberPriceCents: 7500,
+                shopifyProductId: 'dev-mock-product-existing',
+                shopifyOrgMemberVariantId: 'dev-mock-variant-member-existing',
+                shopifyNonOrgMemberVariantId: 'dev-mock-variant-nonmember-existing',
+            },
+        });
+
+        const res = await POST(req(), params(program.id));
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for a missing program', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+        const res = await POST(req(), params(999_999_999));
+        expect(res.status).toBe(404);
+    });
+});


### PR DESCRIPTION
## What

First integration test for `POST /api/programs/[id]/sync-shopify` — the checkout-repair route that mints Shopify variants for a program priced *after* creation (PATCH never mints variants, so the program sits checkout-broken). It was the one fully-built-but-untested route in the program domain; `webhookShopify.integration.test.ts` covers inbound *membership* webhooks, not this outbound program-category sync.

Test only — no production code changes.

## How

Runs against the `CHECKIN_ENV=local` Shopify mock (`config.shopifyMockActive`), so `createShopifyProgramVariants` returns synthetic `dev-mock-*` ids instead of hitting the real Admin API — the same explicit env gate #888 established. Fixtures are self-created (sysadmin/board/common person + a priced-but-variant-less program), matching the sibling `programsAPI` pattern.

Asserts:
- **Upsert** — board member syncs a checkout-broken program -> 200, `dev-mock-product-*` + one variant per priced tier, and the ids are **persisted on the Program** (fails if the route stops upserting) + `AuditLog` written.
- **Auth** — a caller without `isSysadmin`/`isBoardMember` -> 403.
- **Guards** — 400 for an already-configured program, 404 for a missing one.
- **No `IntegrationErrorLog`** on the mock success path (pins current behavior — see below).

## Reviewer notes

- **Empty-category / Q13:** this route has **no** empty/mis-categorized-category detection. `IntegrationErrorLog` is written only inside `createShopifyProgramVariants`' catch on a *real* Shopify API failure, unreachable on the mock branch; the route's own catch writes a `BackendErrorLog` (`logBackendError`), a different model. So the empty-category warning surface (Q13) remains a separate, unbuilt feature.
- **Two auth traps** the test works around: (1) `CHECKIN_ENV=local` (needed for the mock) also arms the keyless-kiosk fallback in `authenticateRequest`, so a cookie-less request resolves as `kiosk` -> 403 before the role gate — the test adds a `cookie` header to force the session path. (2) `withAuth` returns a 2-arg `(req, ctx)` wrapper; there is no `auth` middle arg (that lives on the inner handler).

Green locally: 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)