### PR TITLE
feat(membership-bg): per-person background-check obligations (Phase 2)

### DIFF
--- a/checkin-app/prisma/migrations/20260705140000_person_bg_process/migration.sql
+++ b/checkin-app/prisma/migrations/20260705140000_person_bg_process/migration.sql
@@ -1,0 +1,17 @@
+-- Phase 2: per-person background-check obligation (PERSON_BG). Additive only —
+-- no backfill, no data loss on the live table.
+
+-- New process kind. Not referenced elsewhere in this migration, so ADD VALUE is safe.
+ALTER TYPE "OrgMembershipProcessKind" ADD VALUE 'PERSON_BG';
+
+-- A PERSON_BG process is not tied to a household membership; existing INITIAL/
+-- RENEWAL rows keep their (non-null) orgMembershipId, so dropping NOT NULL loses
+-- nothing.
+ALTER TABLE "OrgMembershipProcess" ALTER COLUMN "orgMembershipId" DROP NOT NULL;
+
+-- The person being checked (null for household INITIAL/RENEWAL).
+ALTER TABLE "OrgMembershipProcess" ADD COLUMN "subjectPersonId" INTEGER;
+
+ALTER TABLE "OrgMembershipProcess"
+    ADD CONSTRAINT "OrgMembershipProcess_subjectPersonId_fkey"
+    FOREIGN KEY ("subjectPersonId") REFERENCES "Person"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -109,6 +109,7 @@ model Person {
 
   toolStatuses        ToolStatus[]
   bgAttestations      BackgroundCheckAttestation[] @relation("BgAttestations")
+  personBgProcesses   OrgMembershipProcess[]       @relation("PersonBgSubject")
   householdLeads      HouseholdLead[]
   corporationLeads    CorporationLead[]
   corporationMembers  CorporationMember[]
@@ -251,6 +252,10 @@ enum OrgMembershipStatus {
 enum OrgMembershipProcessKind {
   INITIAL
   RENEWAL
+  // Per-person background-check obligation (Phase 2). Not tied to a household
+  // membership: orgMembershipId is null and subjectPersonId points at the person
+  // being checked. Runs through the same two-reviewer gate as household checks.
+  PERSON_BG
 }
 
 enum OrgMembershipProcessStatus {
@@ -328,9 +333,18 @@ model OrgMembership {
 model OrgMembershipProcess {
   /// @sensitivity:public
   id                    Int                        @id @default(autoincrement())
+  // Nullable since Phase 2: a PERSON_BG process is not tied to a household
+  // membership (subjectPersonId is set instead). INITIAL/RENEWAL always set it.
   /// @sensitivity:public
-  orgMembershipId       Int
-  orgMembership         OrgMembership              @relation(fields: [orgMembershipId], references: [id])
+  orgMembershipId       Int?
+  // onDelete pinned to Restrict to keep the existing constraint (Prisma's default
+  // for an optional relation is SetNull; the live FK is RESTRICT). Avoids drift.
+  orgMembership         OrgMembership?             @relation(fields: [orgMembershipId], references: [id], onDelete: Restrict)
+  // Set only for PERSON_BG processes — the person being background-checked
+  // (participant, volunteer, or lead). Null for household INITIAL/RENEWAL.
+  /// @sensitivity:public
+  subjectPersonId       Int?
+  subjectPerson         Person?                    @relation("PersonBgSubject", fields: [subjectPersonId], references: [id])
   /// @sensitivity:public
   kind                  OrgMembershipProcessKind
   /// @sensitivity:internal

--- a/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { runPersonBgAnnualSweep } from '@/lib/membership/personBgTriggers';
-import { attest, ReviewError } from '@/lib/membership/review';
+import { attest, eligibleReviewProcessIds, ReviewError } from '@/lib/membership/review';
 import { activate } from '@/lib/membership/payment';
 import prisma from '@/lib/prisma';
 
@@ -210,6 +210,27 @@ describe('PERSON_BG triggers + subject-scoped clear + gate', () => {
         await expect(attest(insider.id, proc.id, { result: 'APPROVE' })).rejects.toMatchObject({
             code: 'same_household_applicant',
         } as Partial<ReviewError>);
+    });
+
+    it('PERSON_BG is non-actionable in the reviewer queue (excluded from the listing) though attest() still gates it', async () => {
+        // Subject in a household distinct from the reviewers → would otherwise be eligible.
+        const subjHh = await makeHousehold('queueSubjHh');
+        const subject = await makePerson('queue-subject', subjHh.id, { dateOfBirth: ADULT_DOB });
+        const personBg = await prisma.orgMembershipProcess.create({
+            data: { kind: 'PERSON_BG', subjectPersonId: subject.id, orgMembershipId: null, status: 'PENDING_BG_REVIEW' },
+        });
+        // Control: a household INITIAL at the same review status DOES surface.
+        const appHh = await makeHousehold('queueAppHh');
+        const appLead = await makePerson('queue-app-lead', appHh.id);
+        await prisma.householdLead.create({ data: { householdId: appHh.id, personId: appLead.id } });
+        const appMembership = await prisma.orgMembership.create({ data: { householdId: appHh.id, status: 'NONE' } });
+        const household = await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: appMembership.id, kind: 'INITIAL', status: 'PENDING_BG_REVIEW' },
+        });
+
+        const ids = await eligibleReviewProcessIds(rev1);
+        expect(ids).not.toContain(personBg.id); // never offered as an actionable queue row
+        expect(ids).toContain(household.id); // household review is unaffected
     });
 
     it('gate: a REJECT moves the PERSON_BG to BLOCKED', async () => {

--- a/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
@@ -1,0 +1,224 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for Phase 2 PERSON_BG obligations: the two triggers that OPEN
+ * the obligation (annual cohort + new-member activation), the subject-scoped
+ * clear (stamps ONLY the subject person), and the two-reviewer gate keyed off the
+ * SUBJECT's household. Warn-only — nothing blocks participation here.
+ *
+ * Modeled on renewalConcurrency / membershipReviewAPI / personBgComplianceAPI.
+ */
+
+import { runPersonBgAnnualSweep } from '@/lib/membership/personBgTriggers';
+import { attest, ReviewError } from '@/lib/membership/review';
+import { activate } from '@/lib/membership/payment';
+import prisma from '@/lib/prisma';
+
+// Congrats/reviewer pings must not hit Resend.
+jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+
+const TAG = 'person-bg-trigger-test';
+const RECHECK_MONTHS = 12;
+// Boundary anchored to Sept 1; nextBoundary() rolls it to the current/next year.
+const BOUNDARY_SEED = new Date('2000-09-01');
+
+/** Adult born long ago → ≥18 at any as-of date. */
+const ADULT_DOB = new Date('1990-01-01');
+
+async function makeHousehold(slug: string) {
+    return prisma.household.create({ data: { name: `${TAG} ${slug}` } });
+}
+
+async function makePerson(slug: string, householdId: number, data: Partial<{ dateOfBirth: Date | null; lastBackgroundCheck: Date | null; isBackgroundCheckReviewer: boolean }> = {}) {
+    return prisma.person.create({
+        data: {
+            email: `${slug}-${TAG}@example.com`,
+            name: slug,
+            householdId,
+            dateOfBirth: data.dateOfBirth ?? null,
+            lastBackgroundCheck: data.lastBackgroundCheck ?? null,
+            isBackgroundCheckReviewer: data.isBackgroundCheckReviewer ?? false,
+        },
+    });
+}
+
+/** Attach a person to a fresh program as a participant so they count as program-attached. */
+async function attachToProgram(slug: string, personId: number) {
+    const program = await prisma.program.create({ data: { name: `${TAG} ${slug} program` } });
+    await prisma.programParticipant.create({ data: { programId: program.id, personId } });
+    return program.id;
+}
+
+function personBgCountFor(personId: number) {
+    return prisma.orgMembershipProcess.count({ where: { kind: 'PERSON_BG', subjectPersonId: personId } });
+}
+
+async function cleanup() {
+    const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+    const ids = hhs.map((h) => h.id);
+    const progs = await prisma.program.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+    const progIds = progs.map((p) => p.id);
+    if (ids.length || progIds.length) {
+        const procs = await prisma.orgMembershipProcess.findMany({
+            where: { OR: [{ orgMembership: { householdId: { in: ids } } }, { subjectPerson: { householdId: { in: ids } } }] },
+            select: { id: true },
+        });
+        const pids = procs.map((p) => p.id);
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { processId: { in: pids } } });
+        await prisma.programParticipant.deleteMany({ where: { programId: { in: progIds } } });
+        await prisma.programVolunteer.deleteMany({ where: { programId: { in: progIds } } });
+        await prisma.program.deleteMany({ where: { id: { in: progIds } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { id: { in: pids } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: ids } } });
+    }
+}
+
+async function setRecheckMonths(months: number) {
+    await prisma.boardSettings.upsert({
+        where: { id: 1 },
+        create: { id: 1, bgRecheckMonths: months, orgMembershipYearBoundary: BOUNDARY_SEED },
+        update: { bgRecheckMonths: months, orgMembershipYearBoundary: BOUNDARY_SEED },
+    });
+}
+
+describe('PERSON_BG triggers + subject-scoped clear + gate', () => {
+    let savedSettings: { bgRecheckMonths: number; orgMembershipYearBoundary: Date | null } | null = null;
+    // Two distinct-household reviewers, both eligible (different households from any subject).
+    let rev1 = 0, rev2 = 0;
+
+    beforeAll(async () => {
+        await cleanup();
+        const prev = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        savedSettings = prev ? { bgRecheckMonths: prev.bgRecheckMonths, orgMembershipYearBoundary: prev.orgMembershipYearBoundary } : null;
+        await setRecheckMonths(RECHECK_MONTHS);
+
+        const hhA = await makeHousehold('revA');
+        const hhB = await makeHousehold('revB');
+        rev1 = (await makePerson('rev1', hhA.id, { isBackgroundCheckReviewer: true })).id;
+        rev2 = (await makePerson('rev2', hhB.id, { isBackgroundCheckReviewer: true })).id;
+    });
+
+    afterAll(async () => {
+        await cleanup();
+        if (savedSettings) await prisma.boardSettings.update({ where: { id: 1 }, data: savedSettings });
+        await prisma.$disconnect();
+    });
+
+    it('Trigger A opens PERSON_BG only for ≥18-not-fresh program people, and re-running is idempotent', async () => {
+        await setRecheckMonths(RECHECK_MONTHS);
+        const hh = await makeHousehold('cohortA');
+        const adult = await makePerson('cohort-adult', hh.id, { dateOfBirth: ADULT_DOB });
+        // Turns 18 AFTER the Sept-1 boundary → 17 as of the boundary → MINOR, not opened.
+        const notYet18 = await makePerson('cohort-notyet', hh.id, { dateOfBirth: new Date('2008-10-01') });
+        const fresh = await makePerson('cohort-fresh', hh.id, { dateOfBirth: ADULT_DOB, lastBackgroundCheck: new Date() });
+        for (const p of [adult, notYet18, fresh]) await attachToProgram(`cohort-${p.id}`, p.id);
+        // Not program-attached → out of scope even though ≥18.
+        const unattached = await makePerson('cohort-unattached', hh.id, { dateOfBirth: ADULT_DOB });
+
+        await runPersonBgAnnualSweep(new Date());
+        expect(await personBgCountFor(adult.id)).toBe(1);
+        expect(await personBgCountFor(notYet18.id)).toBe(0);
+        expect(await personBgCountFor(fresh.id)).toBe(0);
+        expect(await personBgCountFor(unattached.id)).toBe(0);
+
+        // Idempotent: after one full sweep, every NEEDED person already has one, so a
+        // second sweep opens nothing new (globally, not just for our fixture).
+        const rerun = await runPersonBgAnnualSweep(new Date());
+        expect(rerun.opened).toBe(0);
+        expect(await personBgCountFor(adult.id)).toBe(1);
+    });
+
+    it('Trigger A opens nothing when bgRecheckMonths <= 0 (policy unset)', async () => {
+        const hh = await makeHousehold('nopolicy');
+        const adult = await makePerson('nopolicy-adult', hh.id, { dateOfBirth: ADULT_DOB });
+        await attachToProgram('nopolicy', adult.id);
+
+        await setRecheckMonths(0);
+        const res = await runPersonBgAnnualSweep(new Date());
+        expect(res.opened).toBe(0);
+        expect(await personBgCountFor(adult.id)).toBe(0);
+        await setRecheckMonths(RECHECK_MONTHS); // restore for later tests
+    });
+
+    it('Trigger C opens on new-member activation for an already-18 joiner; an existing member taking a role mid-year opens nothing', async () => {
+        // New member: household activates (INITIAL, bg already cleared, now paying) with
+        // a program-attached adult member → Trigger C opens a PERSON_BG for that adult.
+        const hh = await makeHousehold('joinerHh');
+        const lead = await makePerson('joiner-lead', hh.id, { dateOfBirth: ADULT_DOB });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: lead.id } });
+        const joiner = await makePerson('joiner-adult', hh.id, { dateOfBirth: ADULT_DOB });
+        await attachToProgram('joiner', joiner.id);
+        const membership = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        const proc = await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: membership.id, kind: 'INITIAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() },
+        });
+
+        await activate(proc.id, { via: 'certified', actorId: lead.id });
+
+        expect((await prisma.orgMembership.findUnique({ where: { id: membership.id } }))?.status).toBe('ACTIVE');
+        expect(await personBgCountFor(joiner.id)).toBe(1); // Trigger C fired for the program adult
+
+        // Negative: an EXISTING program member who turned 18 after the boundary. There is
+        // no role-assignment trigger, and the annual run judges age as-of the boundary —
+        // so nothing opens until the next annual run.
+        const existingHh = await makeHousehold('existingHh');
+        const roleTaker = await makePerson('role-taker', existingHh.id, { dateOfBirth: new Date('2008-10-01') });
+        await attachToProgram('role-taker', roleTaker.id);
+        await runPersonBgAnnualSweep(new Date());
+        expect(await personBgCountFor(roleTaker.id)).toBe(0);
+    });
+
+    it('clearBackgroundCheck stamps ONLY the subject person — a household-mate is untouched', async () => {
+        const hh = await makeHousehold('subjectHh');
+        const subject = await makePerson('subject', hh.id, { dateOfBirth: ADULT_DOB });
+        // A household-mate (also a lead) with no check — the old blanket-stamp would have
+        // hit them; the subject-scoped clear must NOT.
+        const mate = await makePerson('mate', hh.id, { dateOfBirth: ADULT_DOB });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: mate.id } });
+        // The subject's household has NO OrgMembership (a program lead in a non-member
+        // household) — the gate must still work off the subject's household.
+        const proc = await prisma.orgMembershipProcess.create({
+            data: { kind: 'PERSON_BG', subjectPersonId: subject.id, orgMembershipId: null, status: 'PENDING_BG_REVIEW' },
+        });
+
+        // First distinct reviewer: not enough (2 required) → still awaiting.
+        await attest(rev1, proc.id, { result: 'APPROVE' });
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: proc.id } }))?.status).toBe('PENDING_BG_REVIEW');
+
+        // Second distinct reviewer clears it.
+        await attest(rev2, proc.id, { result: 'APPROVE' });
+        const after = await prisma.orgMembershipProcess.findUnique({ where: { id: proc.id } });
+        expect(after?.bgClearedAt).not.toBeNull();
+
+        const s = await prisma.person.findUnique({ where: { id: subject.id } });
+        const m = await prisma.person.findUnique({ where: { id: mate.id } });
+        expect(s?.lastBackgroundCheck).not.toBeNull(); // subject stamped
+        expect(m?.lastBackgroundCheck).toBeNull(); // household-mate untouched (the safety assertion)
+    });
+
+    it('gate: a reviewer in the SUBJECT household is rejected (same_household_applicant)', async () => {
+        const hh = await makeHousehold('subjRevHh');
+        const subject = await makePerson('subj-rev-subject', hh.id, { dateOfBirth: ADULT_DOB });
+        const insider = await makePerson('subj-rev-insider', hh.id, { isBackgroundCheckReviewer: true });
+        const proc = await prisma.orgMembershipProcess.create({
+            data: { kind: 'PERSON_BG', subjectPersonId: subject.id, orgMembershipId: null, status: 'PENDING_BG_REVIEW' },
+        });
+        await expect(attest(insider.id, proc.id, { result: 'APPROVE' })).rejects.toMatchObject({
+            code: 'same_household_applicant',
+        } as Partial<ReviewError>);
+    });
+
+    it('gate: a REJECT moves the PERSON_BG to BLOCKED', async () => {
+        const hh = await makeHousehold('rejectHh');
+        const subject = await makePerson('reject-subject', hh.id, { dateOfBirth: ADULT_DOB });
+        const proc = await prisma.orgMembershipProcess.create({
+            data: { kind: 'PERSON_BG', subjectPersonId: subject.id, orgMembershipId: null, status: 'PENDING_BG_REVIEW' },
+        });
+        await attest(rev1, proc.id, { result: 'REJECT' });
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: proc.id } }))?.status).toBe('BLOCKED');
+    });
+});

--- a/checkin-app/src/app/api/cron/person-bg-annual/route.ts
+++ b/checkin-app/src/app/api/cron/person-bg-annual/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { withCron } from "@/lib/cronAuth";
+import { logger } from "@/lib/logger";
+import { runPersonBgAnnualSweep } from "@/lib/membership/personBgTriggers";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/cron/person-bg-annual — open PERSON_BG obligations for program-attached
+ * people ≥18 (as of the membership-year boundary) with no fresh check. Idempotent,
+ * so safe to run daily. Authorized by `Authorization: Bearer $CRON_SECRET`.
+ */
+export const GET = withCron(async () => {
+    const result = await runPersonBgAnnualSweep(new Date());
+    logger.info("[CRON] person-bg annual sweep:", result);
+    return NextResponse.json({ success: true, ...result });
+});

--- a/checkin-app/src/app/api/membership-audit/compliance/route.ts
+++ b/checkin-app/src/app/api/membership-audit/compliance/route.ts
@@ -66,7 +66,8 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
         where: { status: "PENDING_BG_CLEARANCE" },
         select: { orgMembership: { select: { householdId: true } } },
     });
-    for (const p of stuck) add(p.orgMembership.householdId, "STUCK_BG_CLEARANCE");
+    // PENDING_BG_CLEARANCE is a household-process status; orgMembership is always set.
+    for (const p of stuck) if (p.orgMembership) add(p.orgMembership.householdId, "STUCK_BG_CLEARANCE");
 
     // 4. Program-attached people ≥18 without a fresh background check (warn-only).
     //    Subject = union of ProgramParticipant / ProgramVolunteer / Program.leadMentor.

--- a/checkin-app/src/app/api/membership/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/membership/request-payment-plan/route.ts
@@ -19,7 +19,9 @@ export const POST = withAuth({}, async (req, auth) => {
             include: { orgMembership: { include: { household: { include: { leads: true } } } } },
         });
 
-        if (!process) {
+        if (!process || !process.orgMembership) {
+            // orgMembership is null only for a PERSON_BG process, which has no dues to
+            // plan — treat as not-found for this household-membership-only endpoint.
             return apiError("Membership application not found", 404);
         }
 

--- a/checkin-app/src/app/dev/shopify/page.tsx
+++ b/checkin-app/src/app/dev/shopify/page.tsx
@@ -43,8 +43,8 @@ export default async function DevShopifyPage() {
             hasVariant={hasVariant}
             processes={processes.map((p) => ({
                 id: p.id,
-                household: p.orgMembership.household?.name ?? "(unnamed household)",
-                isVolunteer: p.orgMembership.isVolunteer,
+                household: p.orgMembership?.household?.name ?? "(unnamed household)",
+                isVolunteer: p.orgMembership?.isVolunteer ?? false,
             }))}
             enrollments={pendingParticipants.map((pp) => ({
                 programId: pp.program.id,

--- a/checkin-app/src/lib/membership/__tests__/personBgCheck.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/personBgCheck.test.ts
@@ -53,3 +53,20 @@ describe("personBgVerdict adult/freshness/data-hygiene", () => {
         expect(verdict({ dateOfBirth: new Date(Date.UTC(2015, 0, 1)), lastBackgroundCheck: new Date(Date.UTC(2026, 0, 1)) })).toBe("MINOR");
     });
 });
+
+describe("as-of date drives the trigger (Trigger A boundary vs Trigger C activation)", () => {
+    // Worked example: turns 18 on Nov 1 2026, takes a role Nov 15. The Sept-1-2026
+    // annual boundary run (Trigger A) still sees a 17-year-old → MINOR, opens
+    // nothing. A later new-member activation as-of Nov 20 (Trigger C) sees ≥18 →
+    // NEEDED. Same person, opposite verdict, decided purely by the as-of date —
+    // which is why role-assignment is NOT a trigger.
+    const turns18Nov1 = { dateOfBirth: new Date(Date.UTC(2008, 10, 1)), isDeclaredAdult: false, lastBackgroundCheck: null };
+    it("MINOR as of the annual boundary (Trigger A)", () => {
+        const boundary = new Date(Date.UTC(2026, 8, 1));
+        expect(personBgVerdict(turns18Nov1, boundary, bgFreshThreshold(boundary, 12))).toBe("MINOR");
+    });
+    it("NEEDED as of a later activation date (Trigger C)", () => {
+        const activation = new Date(Date.UTC(2026, 10, 20));
+        expect(personBgVerdict(turns18Nov1, activation, bgFreshThreshold(activation, 12))).toBe("NEEDED");
+    });
+});

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -2,6 +2,7 @@ import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { emailHouseholdLeads } from "@/lib/emailRecipients";
 import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
+import { openPersonBgForNewMember } from "@/lib/membership/personBgTriggers";
 import { config } from "@/lib/config";
 
 /**
@@ -57,7 +58,9 @@ export async function ensurePaymentLink(processId: number): Promise<{ amountCent
     if (!proc) throw new PaymentError("not_found", "Application not found.");
     if (proc.status !== "PENDING_PAYMENT") throw new PaymentError("wrong_phase", "This application is not awaiting payment.");
 
-    const membership = await prisma.orgMembership.findUnique({ where: { id: proc.orgMembershipId }, select: { isVolunteer: true } });
+    // orgMembershipId is non-null for any process in PENDING_PAYMENT (a PERSON_BG
+    // never enters payment); the guard above ensures we only reach here for those.
+    const membership = await prisma.orgMembership.findUnique({ where: { id: proc.orgMembershipId! }, select: { isVolunteer: true } });
     if (!membership) throw new PaymentError("not_found", "Membership not found.");
 
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
@@ -124,7 +127,9 @@ export async function activate(
         if (process.paidAt || process.status === "ACTIVE") {
             return { kind: "noop" as const };
         }
-        const membership = await tx.orgMembership.findUnique({ where: { id: process.orgMembershipId }, select: { householdId: true, isVolunteer: true } });
+        // orgMembershipId is non-null for a payable process (PERSON_BG never reaches
+        // activate — it has no checkout — and is filtered out by the status guards above).
+        const membership = await tx.orgMembership.findUnique({ where: { id: process.orgMembershipId! }, select: { householdId: true, isVolunteer: true } });
         if (!membership) throw new PaymentError("not_found", "Membership not found.");
 
         const now = new Date();
@@ -201,7 +206,7 @@ export async function activate(
             data: { paidAt: now, stageEnteredAt: now, ...payMeta, status: activating ? "ACTIVE" : "PENDING_BG_CLEARANCE" },
         });
         if (activating) {
-            await tx.orgMembership.update({ where: { id: process.orgMembershipId }, data: { status: "ACTIVE" } });
+            await tx.orgMembership.update({ where: { id: process.orgMembershipId! }, data: { status: "ACTIVE" } });
         }
         await tx.auditLog.create({
             data: {
@@ -213,12 +218,19 @@ export async function activate(
                 newData: activating ? { status: "ACTIVE", via: opts.via } : { status: "PENDING_BG_CLEARANCE", via: opts.via, paid: true },
             },
         });
-        return activating ? { kind: "active" as const, householdId: membership.householdId } : { kind: "held" as const };
+        return activating
+            ? { kind: "active" as const, householdId: membership.householdId, isInitial: process.kind === "INITIAL" }
+            : { kind: "held" as const };
     });
 
     // Side effects outside the transaction: a slow/failed send must not roll back
     // the write, and only the call that actually recorded the change emits one.
-    if (result.kind === "active") await sendCongrats(result.householdId);
+    if (result.kind === "active") {
+        await sendCongrats(result.householdId);
+        // Trigger C: a brand-new (INITIAL) member just activated (bg cleared before
+        // payment landed) — open PERSON_BG for the household's program-attached adults.
+        if (result.isInitial) await openPersonBgForNewMember(result.householdId, new Date());
+    }
     if (result.kind === "paid_while_blocked" || result.kind === "underpaid") await notifyBoardPaidReject(processId);
     return prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
 }

--- a/checkin-app/src/lib/membership/personBgTriggers.ts
+++ b/checkin-app/src/lib/membership/personBgTriggers.ts
@@ -1,0 +1,114 @@
+import prisma from "@/lib/prisma";
+import { bgFreshThreshold, personBgVerdict } from "@/lib/membership/personBgCheck";
+import { nextBoundary } from "@/lib/membership/renewal";
+
+/**
+ * Triggers that OPEN a per-person background-check obligation (PERSON_BG process,
+ * Phase 2 — warn-only). Two triggers, both keyed on the SAME "who needs a check"
+ * rule as the compliance dashboard: personBgVerdict === "NEEDED" over the
+ * program-attached population (ProgramParticipant ∪ ProgramVolunteer ∪
+ * Program.leadMentor). Deliberately NOT triggered by role-assignment: age is
+ * judged as-of a boundary, so someone who turns 18 mid-year is caught at the next
+ * annual run, not when they take a role.
+ */
+
+const SYSTEM_ACTOR = 0;
+
+/** Person is attached to at least one program in any of the three roles. */
+const PROGRAM_ATTACHED_WHERE = {
+    OR: [
+        { programParticipants: { some: {} } },
+        { programVolunteers: { some: {} } },
+        { programsLed: { some: {} } },
+    ],
+};
+
+/**
+ * Open one PERSON_BG obligation for `personId`, evaluated as of `asOf` (the annual
+ * boundary for the cron, activation time for a new join; `threshold` is
+ * bgFreshThreshold(asOf, bgRecheckMonths)). Idempotent + concurrency-safe: a FOR
+ * UPDATE lock on the Person row serializes the check-then-insert (mirrors
+ * createRenewalProcess in renewal.ts), so the daily cron and a near-cutoff
+ * activation can't both open one.
+ *
+ * Dedup guards: (b) opens nothing unless personBgVerdict === "NEEDED" — which
+ * already encodes "≥18 as of asOf AND not fresh" (FRESH/MINOR/DOB_MISSING all
+ * skip); (a) opens nothing if a PERSON_BG is already in flight or blocked for this
+ * person (BLOCKED is a manual-followup item, not something to auto-reopen nightly).
+ * Returns the created process, or null when skipped.
+ */
+async function openPersonBg(personId: number, asOf: Date, threshold: Date) {
+    return prisma.$transaction(async (tx) => {
+        await tx.$queryRaw`SELECT id FROM "Person" WHERE id = ${personId} FOR UPDATE`;
+        const person = await tx.person.findUnique({
+            where: { id: personId },
+            select: { dateOfBirth: true, isDeclaredAdult: true, lastBackgroundCheck: true },
+        });
+        if (!person) return null;
+        if (personBgVerdict(person, asOf, threshold) !== "NEEDED") return null; // (b)
+        const existing = await tx.orgMembershipProcess.findFirst({
+            where: { kind: "PERSON_BG", subjectPersonId: personId, status: { in: ["PENDING_BG_REVIEW", "BLOCKED"] } },
+            select: { id: true },
+        });
+        if (existing) return null; // (a)
+        const created = await tx.orgMembershipProcess.create({
+            data: { kind: "PERSON_BG", subjectPersonId: personId, orgMembershipId: null, status: "PENDING_BG_REVIEW" },
+        });
+        await tx.auditLog.create({
+            data: {
+                actorId: SYSTEM_ACTOR,
+                action: "CREATE",
+                tableName: "OrgMembershipProcess",
+                affectedEntityId: created.id,
+                newData: { kind: "PERSON_BG", status: "PENDING_BG_REVIEW", subjectPersonId: personId },
+            },
+        });
+        return created;
+    });
+}
+
+/**
+ * Trigger A — annual cohort. For every program-attached person NEEDED as of the
+ * membership-year boundary, open a PERSON_BG. Idempotent: re-running opens none
+ * (dedup guard), so the cron is safe to run daily. Skips entirely when the board
+ * hasn't set bgRecheckMonths (policy unset) or has no membership-year boundary.
+ */
+export async function runPersonBgAnnualSweep(now: Date) {
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const months = settings?.bgRecheckMonths ?? 0;
+    if (months <= 0) return { opened: 0, reason: "bgRecheckMonths not configured" };
+    if (!settings?.orgMembershipYearBoundary) return { opened: 0, reason: "no membership-year boundary configured" };
+
+    const boundary = nextBoundary(settings.orgMembershipYearBoundary, now);
+    const threshold = bgFreshThreshold(boundary, months);
+    const people = await prisma.person.findMany({ where: PROGRAM_ATTACHED_WHERE, select: { id: true } });
+
+    let opened = 0;
+    for (const p of people) {
+        const created = await openPersonBg(p.id, boundary, threshold);
+        if (created) opened++;
+    }
+    return { opened, boundary: boundary.toISOString() };
+}
+
+/**
+ * Trigger C — new-member activation. When a brand-new membership (INITIAL) first
+ * goes ACTIVE, open a PERSON_BG for each program-attached person in that household
+ * who is ≥18 as of activation and not fresh. Age is judged as-of `asOf` (join),
+ * NOT the annual boundary — this is what catches a just-turned-18 joiner the
+ * boundary run would still classify as a minor. Household leads freshly stamped by
+ * the INITIAL check are skipped by the dedup guard. Population is program-attached
+ * only — the same set as Trigger A / the dashboard (one source of "who needs a
+ * check"). No-op when bgRecheckMonths is unset.
+ */
+export async function openPersonBgForNewMember(householdId: number, asOf: Date) {
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const months = settings?.bgRecheckMonths ?? 0;
+    if (months <= 0) return;
+    const threshold = bgFreshThreshold(asOf, months);
+    const people = await prisma.person.findMany({
+        where: { householdId, ...PROGRAM_ATTACHED_WHERE },
+        select: { id: true },
+    });
+    for (const p of people) await openPersonBg(p.id, asOf, threshold);
+}

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -84,7 +84,8 @@ export async function beginRenewal(processId: number) {
     if (!process) throw new RenewalError("not_found", "Renewal not found.");
     if (process.status !== "PENDING_RENEWAL") throw new RenewalError("wrong_phase", "This renewal is not awaiting your confirmation.");
 
-    const membership = await prisma.orgMembership.findUnique({ where: { id: process.orgMembershipId }, select: { householdId: true } });
+    // A RENEWAL always has a membership (orgMembershipId is only null for PERSON_BG).
+    const membership = await prisma.orgMembership.findUnique({ where: { id: process.orgMembershipId! }, select: { householdId: true } });
     if (!membership) throw new RenewalError("not_found", "Membership not found.");
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
     const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, new Date()) : new Date();

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -6,6 +6,7 @@ import { sendCongrats } from "@/lib/membership/payment";
 import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
 import { config } from "@/lib/config";
 import { canonicalizeEmail } from "@/lib/emailNormalize";
+import { openPersonBgForNewMember } from "@/lib/membership/personBgTriggers";
 import { type DbClient, type TxClient } from "@/lib/db-client";
 
 /**
@@ -111,6 +112,25 @@ async function loadReviewer(reviewerId: number) {
 }
 
 /**
+ * The household the review's "applicant" belongs to, used for the same-household
+ * reviewer-exclusion. For a PERSON_BG the applicant is the SUBJECT person; for a
+ * household INITIAL/RENEWAL it's the membership's household. Null when neither is
+ * resolvable (e.g. a PERSON_BG whose subject has no household to exclude) — the
+ * caller then applies no exclusion.
+ */
+async function applicantHousehold(db: DbClient, process: { orgMembershipId: number | null; subjectPersonId: number | null }): Promise<number | null> {
+    if (process.subjectPersonId) {
+        const p = await db.person.findUnique({ where: { id: process.subjectPersonId }, select: { householdId: true } });
+        return p?.householdId ?? null;
+    }
+    if (process.orgMembershipId) {
+        const m = await db.orgMembership.findUnique({ where: { id: process.orgMembershipId }, select: { householdId: true } });
+        return m?.householdId ?? null;
+    }
+    return null;
+}
+
+/**
  * IDs of the applications this reviewer may currently attest (eligibility
  * filtered: not their own household, not already attested, no household-mate
  * already on it). The route turns these into model rows for the stripper; the
@@ -128,13 +148,16 @@ export async function eligibleReviewProcessIds(reviewerId: number): Promise<numb
         select: {
             id: true,
             orgMembership: { select: { householdId: true } },
+            subjectPerson: { select: { householdId: true } },
             attestations: { select: { reviewerId: true, reviewer: { select: { householdId: true } } } },
         },
     });
 
     return processes
         .filter((p) => {
-            if (p.orgMembership.householdId === reviewer.householdId) return false; // own household
+            // Applicant household = subject's for a PERSON_BG, else the membership's.
+            const applicantHouseholdId = p.subjectPerson?.householdId ?? p.orgMembership?.householdId ?? null;
+            if (applicantHouseholdId !== null && applicantHouseholdId === reviewer.householdId) return false; // own household
             if (p.attestations.some((a) => a.reviewerId === reviewer.id)) return false; // already attested
             if (p.attestations.some((a) => a.reviewer.householdId === reviewer.householdId)) return false; // shares household with other reviewer
             return true;
@@ -187,8 +210,8 @@ export async function attest(
         });
         if (!process) throw new ReviewError("not_found", "Application not found.");
         if (!isAwaitingBgReview(process)) throw new ReviewError("wrong_phase", "This application is not awaiting background-check review.");
-        const membership = await tx.orgMembership.findUnique({ where: { id: process.orgMembershipId }, select: { householdId: true } });
-        if (membership?.householdId === reviewer.householdId) throw new ReviewError("same_household_applicant", "You cannot review an applicant in your own household.");
+        const applicantHouseholdId = await applicantHousehold(tx, process);
+        if (applicantHouseholdId !== null && applicantHouseholdId === reviewer.householdId) throw new ReviewError("same_household_applicant", "You cannot review an applicant in your own household.");
         if (process.attestations.some((a) => a.reviewerId === reviewerId)) throw new ReviewError("already_attested", "You have already reviewed this application.");
         if (process.attestations.some((a) => a.reviewer.householdId === reviewer.householdId)) throw new ReviewError("same_household_reviewer", "Another reviewer from your household has already reviewed this application.");
 
@@ -205,15 +228,22 @@ export async function attest(
 
         const approvals = process.attestations.filter((a) => a.result === "APPROVE").length + 1;
         if (approvals >= REQUIRED_APPROVALS) {
-            const { activated, householdId } = await clearBackgroundCheck(tx, processId, reviewerId);
-            const status: OrgMembershipProcessStatus = activated ? "ACTIVE" : "PENDING_PAYMENT";
-            return { status, activated, householdId };
+            const { activated, householdId, isInitial } = await clearBackgroundCheck(tx, processId, reviewerId);
+            // A cleared PERSON_BG resolves to ACTIVE too; only a household process
+            // gates on the PENDING_PAYMENT convergence.
+            const status: OrgMembershipProcessStatus = activated ? "ACTIVE" : process.subjectPersonId ? "ACTIVE" : "PENDING_PAYMENT";
+            return { status, activated, householdId, isInitial };
         }
         return { status: process.status, approvals };
     });
 
     // Side effects outside the transaction (a slow/failed send must not roll it back).
-    if ("activated" in result && result.activated) await sendCongrats(result.householdId);
+    if ("activated" in result && result.activated) {
+        await sendCongrats(result.householdId!);
+        // Trigger C: a brand-new (INITIAL) member just activated — open PERSON_BG
+        // for any program-attached ≥18 person in the household (as-of activation).
+        if (result.isInitial) await openPersonBgForNewMember(result.householdId!, new Date());
+    }
     if ("notifyPaidReject" in result && result.notifyPaidReject) await notifyBoardPaidReject(processId);
 
     if ("approvals" in result) return { status: result.status, approvals: result.approvals };
@@ -229,13 +259,27 @@ export async function attest(
  * Returns whether it activated + householdId so the caller can send congrats.
  * Must run inside a tx holding a FOR UPDATE lock on the process row.
  */
-async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: number): Promise<{ activated: boolean; householdId: number }> {
+async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: number): Promise<{ activated: boolean; householdId: number | null; isInitial: boolean }> {
     const process = await tx.orgMembershipProcess.findUnique({
         where: { id: processId },
         include: { attestations: true },
     });
     if (!process) throw new ReviewError("not_found", "Application not found.");
-    const membership = await tx.orgMembership.findUnique({ where: { id: process.orgMembershipId }, select: { householdId: true } });
+
+    // PERSON_BG: subject-scoped. Stamp ONLY the subject person and resolve — there is
+    // no household membership to activate/pay, so skip the payment/activation
+    // convergence entirely, and do NOT touch the household-lead blanket stamp (that's
+    // the household path below, whose lead-stamp change is Phase 5).
+    if (process.subjectPersonId) {
+        const now = new Date();
+        await tx.person.update({ where: { id: process.subjectPersonId }, data: { lastBackgroundCheck: now } });
+        await tx.orgMembershipProcess.update({ where: { id: processId }, data: { bgClearedAt: now, status: "ACTIVE", stageEnteredAt: now } });
+        await audit(tx, actorId, processId, { status: process.status }, { status: "ACTIVE", bgCleared: true, subjectPersonId: process.subjectPersonId });
+        return { activated: false, householdId: null, isInitial: false };
+    }
+
+    // Household INITIAL/RENEWAL path (unchanged): orgMembershipId is always set here.
+    const membership = await tx.orgMembership.findUnique({ where: { id: process.orgMembershipId! }, select: { householdId: true } });
     if (!membership) throw new ReviewError("not_found", "Membership not found.");
     const householdId = membership.householdId;
     const now = new Date();
@@ -244,18 +288,18 @@ async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: nu
     // Stamp the guardians' (household leads') lastBackgroundCheck. Expiry is derived from this
     // plus BoardSettings.bgRecheckMonths at read time (see householdBgIsFresh) — not stored.
     await tx.person.updateMany({ where: { householdId, householdLeads: { some: { householdId } } }, data: { lastBackgroundCheck: now } });
-    await applyVolunteerStatus(tx, process.orgMembershipId, householdId, process.attestations.some((a) => a.isMarkedVolunteer));
+    await applyVolunteerStatus(tx, process.orgMembershipId!, householdId, process.attestations.some((a) => a.isMarkedVolunteer));
 
     await tx.orgMembershipProcess.update({
         where: { id: processId },
         data: { bgClearedAt: now, status: paid ? "ACTIVE" : "PENDING_PAYMENT", stageEnteredAt: now },
     });
     if (paid) {
-        await tx.orgMembership.update({ where: { id: process.orgMembershipId }, data: { status: "ACTIVE" } });
+        await tx.orgMembership.update({ where: { id: process.orgMembershipId! }, data: { status: "ACTIVE" } });
     }
 
     await audit(tx, actorId, processId, { status: process.status }, { status: paid ? "ACTIVE" : "PENDING_PAYMENT", bgCleared: true });
-    return { activated: paid, householdId };
+    return { activated: paid, householdId, isInitial: process.kind === "INITIAL" };
 }
 
 /**
@@ -297,7 +341,9 @@ export async function overrideBlocked(processId: number, actorId: number, action
         // so an initial application returns to PENDING_BG_CLEARANCE if it had already
         // paid, else PENDING_PAYMENT; renewals go back to RENEWAL_PENDING_BG.
         const reviewStatus: OrgMembershipProcessStatus =
-            process.kind === "RENEWAL" ? "RENEWAL_PENDING_BG" : process.paidAt ? "PENDING_BG_CLEARANCE" : "PENDING_PAYMENT";
+            process.kind === "PERSON_BG" ? "PENDING_BG_REVIEW"
+            : process.kind === "RENEWAL" ? "RENEWAL_PENDING_BG"
+            : process.paidAt ? "PENDING_BG_CLEARANCE" : "PENDING_PAYMENT";
         await prisma.backgroundCheckAttestation.deleteMany({ where: { processId } });
         await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: reviewStatus, bgClearedAt: null, stageEnteredAt: new Date() } });
         await audit(prisma, actorId, processId, { status: "BLOCKED" }, { status: reviewStatus, action: "board reset" });
@@ -308,12 +354,18 @@ export async function overrideBlocked(processId: number, actorId: number, action
     // FOR UPDATE per clearBackgroundCheck's contract: serializes a board approve
     // against a late payment webhook (activate also locks), so the override reads
     // a fresh paidAt and converges to ACTIVE rather than parking it at PENDING_PAYMENT.
-    const { activated, householdId } = await prisma.$transaction(async (tx) => {
+    const { activated, householdId, isInitial } = await prisma.$transaction(async (tx) => {
         await tx.$queryRaw`SELECT id FROM "OrgMembershipProcess" WHERE id = ${processId} FOR UPDATE`;
         return clearBackgroundCheck(tx, processId, actorId);
     });
-    if (activated) await sendCongrats(householdId);
-    const status: OrgMembershipProcessStatus = activated ? "ACTIVE" : "PENDING_PAYMENT";
+    if (activated) {
+        await sendCongrats(householdId!);
+        // Trigger C: a board force-clear can be the first activation of a brand-new
+        // (INITIAL) member — open PERSON_BG for the household's program-attached adults.
+        if (isInitial) await openPersonBgForNewMember(householdId!, new Date());
+    }
+    // A cleared PERSON_BG resolves to ACTIVE; a household process gates on PENDING_PAYMENT.
+    const status: OrgMembershipProcessStatus = activated ? "ACTIVE" : process.subjectPersonId ? "ACTIVE" : "PENDING_PAYMENT";
     return { status };
 }
 

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -74,6 +74,16 @@ function isAwaitingBgReview(p: { status: OrgMembershipProcessStatus; bgConsentAt
     return false;
 }
 
+/**
+ * PERSON_BG is attestable at the SERVICE level (attest() still accepts it, so the
+ * two-reviewer gate is exercised + tested) but must NOT surface as an actionable
+ * row in the reviewer QUEUE until Phase 3 renders the subject + consent. The queue
+ * GET only shows a household's leads; a PERSON_BG row would render blank yet stay
+ * attestable — a reviewer could blind-approve an unidentified person. So the queue
+ * listing + badge counts exclude it (warn-only Phase 2); the gate machinery stays.
+ */
+const QUEUE_EXCLUDES_PERSON_BG: Prisma.OrgMembershipProcessWhereInput = { kind: { not: "PERSON_BG" } };
+
 /** Prisma `where` matching the same predicate as isAwaitingBgReview, for queue queries. */
 export const AWAITING_BG_WHERE: Prisma.OrgMembershipProcessWhereInput = {
     bgClearedAt: null,
@@ -143,7 +153,7 @@ export async function eligibleReviewProcessIds(reviewerId: number): Promise<numb
     if (!reviewer || !canReviewBackgroundChecks(reviewer)) return [];
 
     const processes = await prisma.orgMembershipProcess.findMany({
-        where: AWAITING_BG_WHERE,
+        where: { ...AWAITING_BG_WHERE, ...QUEUE_EXCLUDES_PERSON_BG },
         orderBy: { stageEnteredAt: "asc" },
         select: {
             id: true,
@@ -178,7 +188,7 @@ export async function reviewQueueCounts(reviewerId: number): Promise<{ canActOn:
     if (!reviewer || !canReviewBackgroundChecks(reviewer)) return { canActOn: 0, approvedAwaitingSecond: 0 };
     const [canActOnIds, approvedAwaitingSecond] = await Promise.all([
         eligibleReviewProcessIds(reviewerId),
-        prisma.orgMembershipProcess.count({ where: { ...AWAITING_BG_WHERE, attestations: { some: { reviewerId } } } }),
+        prisma.orgMembershipProcess.count({ where: { ...AWAITING_BG_WHERE, ...QUEUE_EXCLUDES_PERSON_BG, attestations: { some: { reviewerId } } } }),
     ]);
     return { canActOn: canActOnIds.length, approvedAwaitingSecond };
 }

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -72,6 +72,7 @@ export const classifications = {
     OrgMembershipProcess: {
         id: 'public',
         orgMembershipId: 'public',
+        subjectPersonId: 'public',
         kind: 'public',
         status: 'internal',
         stageEnteredAt: 'internal',
@@ -335,6 +336,7 @@ export const relations = {
         household: { model: 'Household', isList: false },
         toolStatuses: { model: 'ToolStatus', isList: true },
         bgAttestations: { model: 'BackgroundCheckAttestation', isList: true },
+        personBgProcesses: { model: 'OrgMembershipProcess', isList: true },
         householdLeads: { model: 'HouseholdLead', isList: true },
         corporationLeads: { model: 'CorporationLead', isList: true },
         corporationMembers: { model: 'CorporationMember', isList: true },
@@ -377,6 +379,7 @@ export const relations = {
     },
     OrgMembershipProcess: {
         orgMembership: { model: 'OrgMembership', isList: false },
+        subjectPerson: { model: 'Person', isList: false },
         attestations: { model: 'BackgroundCheckAttestation', isList: true },
     },
     BackgroundCheckAttestation: {


### PR DESCRIPTION
## Phase 2 — per-person background-check obligations (warn-only)

Builds on Phase 1 (#904, `personBgCheck.ts` + compliance-dashboard tags). Adds the obligation RECORD, the triggers that open it, and wires it into the existing two-reviewer gate. Still **warn-only** — no blocking, no consent flow, no household-lead blanket-stamp change (later phases).

### Schema (additive — no destructive migration)
- `OrgMembershipProcessKind` gains `PERSON_BG`.
- `OrgMembershipProcess.subjectPersonId Int?` + `Person` relation (the person being checked).
- `orgMembershipId` made **nullable** — a PERSON_BG has no household membership, and a subject may live in a non-member household. Relation `onDelete` pinned to `Restrict` to match the live FK (Prisma's optional-relation default is `SetNull` → would drift). Migration = `ADD VALUE` + `DROP NOT NULL` + `ADD COLUMN`/FK; no reset, no backfill.

### Gate + clear (`review.ts`)
- PERSON_BG reuses the existing `PENDING_BG_REVIEW` status, so it flows into `AWAITING_BG_WHERE` and shows in the review queue. No new status enum.
- Same-household reviewer exclusion keys off the **subject's** household (not the membership's), null-safe for a subject with no member household.
- `clearBackgroundCheck` branches on `subjectPersonId`: stamps **only** the subject person, skips the payment/activation convergence, and leaves the household-lead blanket-stamp untouched (that's Phase 5). `REJECT → BLOCKED`; board reset routes a PERSON_BG back to `PENDING_BG_REVIEW`.

### Triggers (`personBgTriggers.ts` + `/api/cron/person-bg-annual`)
- **Trigger A** — idempotent annual cohort sweep over program-attached people (`ProgramParticipant ∪ ProgramVolunteer ∪ Program.leadMentor`) `NEEDED` as of the membership-year boundary. New `withCron` endpoint, safe to run daily. Skips when `bgRecheckMonths <= 0`.
- **Trigger C** — new-member activation: age judged as-of activation, hooked post-tx in `payment.activate` + `review.attest` + `overrideBlocked` (all three activation paths), gated on `isInitial`. Program-gated (same population as A / the dashboard — one source of "who needs a check").
- **Not a trigger:** an existing member taking a role mid-year. Row-lock on `Person` + verdict/in-flight dedup guards make both triggers idempotent.

### Reviewer notes
- The one meaningful design fork: `orgMembershipId` is now nullable. All existing INITIAL/RENEWAL callers keep non-null values and use guarded `!` asserts; null-guards added to compliance, request-payment-plan, and dev/shopify. This is tsc-blind in Prisma's recursive `WhereInput`, so it was validated against the full integration + security suites, not just `tsc`.
- Trigger C being program-gated is a judgment call — if product wants every new adult member checked (not just program people), widen `openPersonBgForNewMember`'s `where`.
- Known gap (Phase 3 UI): the review-queue GET renders household leads; a PERSON_BG row appears and the gate works, but the subject identity isn't rendered yet.

### Tests
- `tsc --noEmit` clean.
- New: `personBgTriggers.integration` (trigger A + idempotency, `bgRecheckMonths<=0` skip, trigger C activation + negative role-mid-year, **subject-only stamp**, subject-household gate, `REJECT→BLOCKED`) + `personBgCheck` unit (as-of boundary vs activation).
- Safe-refactor net: membership/renewal/payment/intake/security integration **244/244**, security oracles (routeAuthDrift, scope validators, strippers, policy.contract) **478/478**, membership unit **224/224**. Pre-commit full unit suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
