### PR TITLE
feat(finance-ops): frame the finance request as "scholarship or payment plan"

### DIFF
--- a/checkin-app/src/app/api/membership/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/membership/request-payment-plan/route.ts
@@ -45,7 +45,7 @@ export const POST = withAuth({}, async (req, auth) => {
 
         // Alert the finance committee. In a real implementation this would trigger an
         // actual email via SendGrid, NodeMailer, etc.
-        logger.info(`[EMAIL DISPATCH] To: finance@innovationtreehouse.org, Subject: Membership Payment Plan Request for household ${process.orgMembership.householdId}`);
+        logger.info(`[EMAIL DISPATCH] To: finance@innovationtreehouse.org, Subject: Membership Scholarship / Payment Plan Request for household ${process.orgMembership.householdId}`);
 
         return NextResponse.json({ success: true, process: updated });
     } catch (error) {

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -72,7 +72,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
 
         // Send email to finances
         // In a real implementation this would trigger an actual email via SendGrid, NodeMailer, etc.
-        logger.info(`[EMAIL DISPATCH] To: finance@innovationtreehouse.org, Subject: Payment Plan Request for ${participant.person?.name || 'User'} in ${participant.program?.name || 'Program'}`);
+        logger.info(`[EMAIL DISPATCH] To: finance@innovationtreehouse.org, Subject: Scholarship / Payment Plan Request for ${participant.person?.name || 'User'} in ${participant.program?.name || 'Program'}`);
 
         return NextResponse.json({ success: true, participant: updatedParticipant });
     } catch (error) {

--- a/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
@@ -127,9 +127,9 @@ export default function MembershipPaymentPlansPage() {
   return (
     <Stack>
       <Text c="dimmed">
-        Review households that have asked to pay their membership dues on a plan. Approving a
-        request activates the membership without a Shopify payment (it still holds for background
-        clearance if that isn&apos;t done yet).
+        Review households that have requested a scholarship or payment plan for their membership
+        dues. Approving a request activates the membership without a Shopify payment (it still holds
+        for background clearance if that isn&apos;t done yet).
       </Text>
 
       <AlertBanner message={message} tone="error" />
@@ -138,17 +138,17 @@ export default function MembershipPaymentPlansPage() {
         columns={columns}
         rows={requests}
         getRowKey={(req) => `${req.id}`}
-        emptyMessage="No pending membership payment plan requests."
+        emptyMessage="No pending membership scholarship or payment plan requests."
       />
 
       <Modal
         opened={confirmApproveOpened}
         onClose={closeConfirmApprove}
-        title={<Text span fw={700} fz="lg">Approve Payment Plan</Text>}
+        title={<Text span fw={700} fz="lg">Approve Scholarship / Payment Plan</Text>}
         centered
       >
         <Text mb="lg">
-          Approve this payment plan? This activates the household&apos;s membership without a
+          Approve this scholarship or payment plan? This activates the household&apos;s membership without a
           Shopify payment (holding for background clearance if it isn&apos;t done yet).
         </Text>
         <Group justify="flex-end">

--- a/checkin-app/src/app/finance-ops/payment-plan/__tests__/page.test.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/__tests__/page.test.tsx
@@ -42,7 +42,7 @@ describe("finance-ops/payment-plan page", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Approve/ }));
 
-    const confirmModal = await screen.findByRole("dialog", { name: "Approve Payment Plan" });
+    const confirmModal = await screen.findByRole("dialog", { name: "Approve Scholarship / Payment Plan" });
     fireEvent.click(within(confirmModal).getByRole("button", { name: /Approve/ }));
 
     await waitFor(() =>
@@ -54,6 +54,6 @@ describe("finance-ops/payment-plan page", () => {
         }),
       ),
     );
-    expect(await screen.findByText("No pending payment plan requests.")).toBeInTheDocument();
+    expect(await screen.findByText("No pending scholarship or payment plan requests.")).toBeInTheDocument();
   });
 });

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -74,7 +74,7 @@ export default function PendingParticipantsPage() {
       if (res.ok) {
         setRequests(prev => prev.filter(r => !(r.programId === programId && r.personId === participantId)));
         notifyNavRefresh();
-        notifications.show({ color: 'green', message: 'Payment plan approved.' });
+        notifications.show({ color: 'green', message: 'Scholarship / payment plan approved.' });
       } else {
         const data = await res.json();
         if (data.error === "No pending payment-plan request") {
@@ -145,7 +145,7 @@ export default function PendingParticipantsPage() {
   return (
     <Stack>
       <Text c="dimmed">
-        Review pending participants who have clicked the &quot;Request Payment Plan&quot; button.
+        Review pending participants who have requested a scholarship or payment plan.
         Approving a request marks the user as ACTIVE and exempts them from the 7-day automated
         removal cron job.
       </Text>
@@ -156,17 +156,17 @@ export default function PendingParticipantsPage() {
         columns={columns}
         rows={requests}
         getRowKey={(req) => `${req.programId}-${req.personId}`}
-        emptyMessage="No pending payment plan requests."
+        emptyMessage="No pending scholarship or payment plan requests."
       />
 
       <Modal
         opened={confirmApproveOpened}
         onClose={closeConfirmApprove}
-        title={<Text span fw={700} fz="lg">Approve Payment Plan</Text>}
+        title={<Text span fw={700} fz="lg">Approve Scholarship / Payment Plan</Text>}
         centered
       >
         <Text mb="lg">
-          Approve this payment plan? This sets the participant&apos;s status to ACTIVE and stops
+          Approve this scholarship or payment plan? This sets the participant&apos;s status to ACTIVE and stops
           automated unpaid warning emails.
         </Text>
         <Group justify="flex-end">

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -817,11 +817,11 @@ export default function MembershipPage() {
                       </Alert>
                     )}
                     {planRequested ? (
-                      <Text c="green" mt="lg">Payment plan requested — the finance committee will follow up.</Text>
+                      <Text c="green" mt="lg">Scholarship or payment plan requested — the finance committee will follow up.</Text>
                     ) : (
                       <Text mt="lg">
                         <Anchor component="button" type="button" onClick={requestPaymentPlan}>
-                          request a payment plan from the finance committee of the board
+                          request a scholarship or payment plan from the finance committee of the board
                         </Anchor>
                       </Text>
                     )}

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -253,7 +253,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
-        fireEvent.click(screen.getByRole("button", { name: /request a payment plan/ }));
+        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/ }));
         await waitFor(() =>
             expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringMatching(/Requested! Please check your email/) })),
         );
@@ -279,7 +279,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
-        fireEvent.click(screen.getByRole("button", { name: /request a payment plan/ }));
+        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/ }));
         expect(await screen.findByText("Already pending.")).toBeInTheDocument();
     });
 
@@ -298,7 +298,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
-        fireEvent.click(screen.getByRole("button", { name: /request a payment plan/ }));
+        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/ }));
         expect(await screen.findByText(/failed to alert the finance committee/)).toBeInTheDocument();
     });
 
@@ -311,7 +311,7 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Which of your household wants to enroll?");
 
         global.fetch = jest.fn().mockRejectedValue(new Error("down"));
-        fireEvent.click(screen.getByRole("button", { name: /request a payment plan/ }));
+        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/ }));
         await waitFor(() =>
             expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "red", message: "Network error requesting payment plan.", autoClose: false })),
         );

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -510,7 +510,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
 
                 {hasPrice && !isClosed && (
                   <Anchor component="button" type="button" size="sm" onClick={handleRequestPaymentPlan}>
-                    request a payment plan from the finance committee of the board
+                    request a scholarship or payment plan from the finance committee of the board
                   </Anchor>
                 )}
               </Stack>


### PR DESCRIPTION
## What

Reframes the household-requestable finance flow from PR #906 — currently labeled purely "payment plan" — as **"scholarship or payment plan"** across every user- and finance-facing surface, for both the program and membership paths.

## Why

The same request → finance-approval loop already covers scholarships as well as payment plans. Finance settles **both** in QuickBooks, not Shopify, so the app needs no new logic, enum, amount field, or approve-flow change to grant either. The only gap was vocabulary: households requesting help, and finance reviewing the queue, only saw "payment plan."

**Copy-only. No behavior, schema, flow, or nav changes.**

## Changes

- **Request links** — program (`programs/[id]/page.tsx`) + membership (`membership/page.tsx`) → "request a scholarship or payment plan…"
- **Membership requested-state** text → "Scholarship or payment plan requested — the finance committee will follow up"
- **Finance approve modals** (both `finance-ops/payment-plan` + `finance-ops/membership-payment-plan`) → title "Approve Scholarship / Payment Plan" + reworded body
- **Finance queue** descriptions, empty messages, approval toast → scholarship/plan vocab
- **finance@ email subjects** in both `request-payment-plan` routes → mention either kind
- **Tests** — updated the 3 assertions that pinned the old copy (program page regex, finance-ops modal name + empty message)

## Flow (unchanged)

Request only flags `isPaymentPlanRequested`; status stays `PENDING_PAYMENT`. Finance approval remains the sole activation gate (`certifyPaymentPlan` → ACTIVE, no Shopify). The schema flag keeps its name — it means "household asked finance for help," and renaming it would churn 17 files for zero behavior change.

## Verified

Full CI suite green via pre-commit hook: 199 suites, 1560 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
