### PR TITLE
fix(membership): self-serve recovery from a dead Zoho signing request

### DIFF
--- a/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSignAPI.integration.test.ts
@@ -25,7 +25,7 @@ jest.mock('@/lib/membership/contract/zohoClient', () => ({
     createRequest: jest.fn().mockResolvedValue({ requestId: 'REQ-1', actionId: 'ACT-1', documentId: 'DOC-1' }),
     submitRequest: jest.fn().mockResolvedValue(undefined),
     getEmbeddedSignUrl: jest.fn().mockResolvedValue('https://sign.zoho.com/embed/xyz'),
-    getRequestStatus: jest.fn().mockResolvedValue(false),
+    getRequestStatus: jest.fn().mockResolvedValue('in_progress'),
 }));
 
 // Imported AFTER the mocks so the route picks up the mocked client.
@@ -173,6 +173,34 @@ describe('POST /api/membership/contract/sign', () => {
         const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(p?.zohoEnvelopeId).toBe('REQ-1'); // overwritten with the embeddable request
         expect(p?.zohoActionId).toBe('ACT-1');
+    });
+
+    it('recreates a fresh request when the stored one is dead — declined or expired (#876)', async () => {
+        await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { zohoEnvelopeId: 'DEAD-REQ', zohoActionId: 'DEAD-ACT' } });
+        (zoho.getRequestStatus as jest.Mock).mockResolvedValueOnce('terminal');
+
+        asUser(leadId);
+        const res = await SIGN(signReq());
+        expect(res.status).toBe(200);
+        expect((await res.json()).url).toBe('https://sign.zoho.com/embed/xyz');
+        // The dead ids were forgotten and a fresh request created + stored.
+        expect(zoho.createRequest).toHaveBeenCalledTimes(1);
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(p?.zohoEnvelopeId).toBe('REQ-1');
+        expect(p?.zohoActionId).toBe('ACT-1');
+    });
+
+    it('falls back to the stored request when the status check fails (best-effort)', async () => {
+        (zoho.getRequestStatus as jest.Mock).mockRejectedValueOnce(new Error('Zoho 503'));
+
+        asUser(leadId);
+        const res = await SIGN(signReq());
+        expect(res.status).toBe(200);
+        // No re-create: the stored request is reused exactly as before the check existed.
+        expect(zoho.createRequest).not.toHaveBeenCalled();
+        expect((zoho.getEmbeddedSignUrl as jest.Mock).mock.calls[0][0].requestId).toBe('REQ-1');
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(p?.zohoEnvelopeId).toBe('REQ-1');
     });
 
     it('lets a isSysadmin who is NOT a household lead sign (isSysadmin bypass)', async () => {

--- a/checkin-app/src/app/__tests__/membershipContractSync.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSync.integration.test.ts
@@ -108,7 +108,7 @@ describe('syncContractStatus', () => {
 
     it('HAPPY: Zoho signed=true records contractSignedAt and (with bgConsent present) advances to PENDING_PAYMENT', async () => {
         const { userId, processId } = await makeApplicant({ bgConsentAt: new Date() });
-        mockGetRequestStatus.mockResolvedValue(true);
+        mockGetRequestStatus.mockResolvedValue('completed');
 
         const status = await syncContractStatus(userId);
 
@@ -126,7 +126,7 @@ describe('syncContractStatus', () => {
 
     it('HAPPY (no bg consent): records contractSignedAt but stays EXTERNAL', async () => {
         const { userId, processId } = await makeApplicant();
-        mockGetRequestStatus.mockResolvedValue(true);
+        mockGetRequestStatus.mockResolvedValue('completed');
 
         await syncContractStatus(userId);
 
@@ -137,7 +137,7 @@ describe('syncContractStatus', () => {
 
     it('NOT-YET-SIGNED: Zoho false leaves the process untouched', async () => {
         const { userId, processId } = await makeApplicant({ bgConsentAt: new Date() });
-        mockGetRequestStatus.mockResolvedValue(false);
+        mockGetRequestStatus.mockResolvedValue('in_progress');
 
         const status = await syncContractStatus(userId);
 
@@ -151,7 +151,7 @@ describe('syncContractStatus', () => {
 
     it('IDEMPOTENT: a second sync after signing is a safe no-op (no double advance, no duplicate audit)', async () => {
         const { userId, processId } = await makeApplicant({ bgConsentAt: new Date() });
-        mockGetRequestStatus.mockResolvedValue(true);
+        mockGetRequestStatus.mockResolvedValue('completed');
 
         await syncContractStatus(userId);
         // Second call: Zoho would still say "signed", but the contract is already recorded.
@@ -162,6 +162,24 @@ describe('syncContractStatus', () => {
         const a = await audits(processId);
         expect(a.signed).toHaveLength(1);
         expect(a.advanced).toHaveLength(1);
+    });
+
+    it('TERMINAL: a declined/expired request clears the stored Zoho ids so the next click starts fresh (#876)', async () => {
+        const { userId, processId } = await makeApplicant({ zohoActionId: `act-${TAG}` });
+        mockGetRequestStatus.mockResolvedValue('terminal');
+
+        const status = await syncContractStatus(userId);
+
+        // contractStarted resets — the UI offers a fresh "Sign" instead of a dead "Resume".
+        expect(status?.contractSigned).toBe(false);
+        expect(status?.contractStarted).toBe(false);
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(p?.zohoEnvelopeId).toBeNull();
+        expect(p?.zohoActionId).toBeNull();
+        expect(p?.contractSignedAt).toBeNull();
+        expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
+        const a = await audits(processId);
+        expect(a.signed).toHaveLength(0);
     });
 
     it('ZOHO ERROR SWALLOWED: getRequestStatus throwing returns current status without throwing; process unchanged', async () => {
@@ -179,7 +197,7 @@ describe('syncContractStatus', () => {
 
     it('returns null when the user has no in-flight EXTERNAL process', async () => {
         const { userId, processId } = await makeApplicant({ status: 'ACTIVE' });
-        mockGetRequestStatus.mockResolvedValue(true);
+        mockGetRequestStatus.mockResolvedValue('completed');
 
         expect(await syncContractStatus(userId)).toBeNull();
         // Zoho never consulted, nothing signed.

--- a/checkin-app/src/lib/membership/__tests__/external.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/external.test.ts
@@ -215,12 +215,53 @@ describe('getOrCreateContractSigningUrl', () => {
             household: { orgMembership: { processes: [{ ...pendingProcess, zohoEnvelopeId: 'req-existing', zohoActionId: 'act-existing' }] } },
         });
         zohoSign.getAccessToken.mockResolvedValue('token-1');
+        zohoSign.getRequestStatus.mockResolvedValue('in_progress');
         zohoSign.getEmbeddedSignUrl.mockResolvedValue('https://sign.example/embed-existing');
 
         const url = await getOrCreateContractSigningUrl(1);
 
         expect(zohoSign.createRequest).not.toHaveBeenCalled();
         expect(zohoSign.submitRequest).not.toHaveBeenCalled();
+        expect(url).toBe('https://sign.example/embed-existing');
+    });
+
+    it('dead stored request (declined/expired) → clears the ids and creates a fresh one (#876)', async () => {
+        prisma.person.findUnique.mockResolvedValue({
+            ...leadUser,
+            household: { orgMembership: { processes: [{ ...pendingProcess, zohoEnvelopeId: 'req-dead', zohoActionId: 'act-dead' }] } },
+        });
+        zohoSign.getAccessToken.mockResolvedValue('token-1');
+        zohoSign.getRequestStatus.mockResolvedValue('terminal');
+        zohoSign.createRequest.mockResolvedValue({ requestId: 'req-fresh', actionId: 'act-fresh', documentId: 'doc-fresh' });
+        zohoSign.getEmbeddedSignUrl.mockResolvedValue('https://sign.example/embed-fresh');
+        prisma.$transaction.mockImplementation(async (fn: (tx: typeof prisma) => Promise<unknown>) => fn(prisma));
+        prisma.orgMembershipProcess.updateMany.mockResolvedValue({ count: 1 });
+
+        const url = await getOrCreateContractSigningUrl(1);
+
+        // The dead pair is forgotten (conditional on still pointing at it)…
+        expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith({
+            where: { id: 20, zohoEnvelopeId: 'req-dead', contractSignedAt: null },
+            data: { zohoEnvelopeId: null, zohoActionId: null },
+        });
+        // …and a fresh request is created and embedded.
+        expect(zohoSign.createRequest).toHaveBeenCalledTimes(1);
+        expect(zohoSign.getEmbeddedSignUrl).toHaveBeenCalledWith(expect.objectContaining({ requestId: 'req-fresh', actionId: 'act-fresh' }));
+        expect(url).toBe('https://sign.example/embed-fresh');
+    });
+
+    it('status check failure → falls back to embedding the stored request (best-effort)', async () => {
+        prisma.person.findUnique.mockResolvedValue({
+            ...leadUser,
+            household: { orgMembership: { processes: [{ ...pendingProcess, zohoEnvelopeId: 'req-existing', zohoActionId: 'act-existing' }] } },
+        });
+        zohoSign.getAccessToken.mockResolvedValue('token-1');
+        zohoSign.getRequestStatus.mockRejectedValue(new Error('Zoho 503'));
+        zohoSign.getEmbeddedSignUrl.mockResolvedValue('https://sign.example/embed-existing');
+
+        const url = await getOrCreateContractSigningUrl(1);
+
+        expect(zohoSign.createRequest).not.toHaveBeenCalled();
         expect(url).toBe('https://sign.example/embed-existing');
     });
 

--- a/checkin-app/src/lib/membership/contract/__tests__/zohoClient.test.ts
+++ b/checkin-app/src/lib/membership/contract/__tests__/zohoClient.test.ts
@@ -113,12 +113,19 @@ describe("zohoClient", () => {
         expect(calledUrl.searchParams.get("host")).toBe("https://app.example.com");
     });
 
-    it("getRequestStatus is true only when the request is completed", async () => {
+    it("getRequestStatus normalizes completed / in-flight / dead request states", async () => {
         mockFetchOnce({ requests: { request_status: "completed" } });
-        await expect(getRequestStatus("t", "req-1")).resolves.toBe(true);
+        await expect(getRequestStatus("t", "req-1")).resolves.toBe("completed");
 
         mockFetchOnce({ requests: { request_status: "inprogress" } });
-        await expect(getRequestStatus("t", "req-1")).resolves.toBe(false);
+        await expect(getRequestStatus("t", "req-1")).resolves.toBe("in_progress");
+
+        // Declined and expired requests can never be signed — they must surface as
+        // terminal so the caller creates a fresh request (#876).
+        for (const dead of ["declined", "expired", "recalled"]) {
+            mockFetchOnce({ requests: { request_status: dead } });
+            await expect(getRequestStatus("t", "req-1")).resolves.toBe("terminal");
+        }
     });
 
     it("rejects with a ZohoError timeout when the connection hangs (never resolves)", async () => {

--- a/checkin-app/src/lib/membership/contract/__tests__/zohoProvider.test.ts
+++ b/checkin-app/src/lib/membership/contract/__tests__/zohoProvider.test.ts
@@ -74,6 +74,6 @@ describe("mock provider behavior", () => {
         });
         expect(url).toBe(`http://localhost:4000/dev/zoho-sign?rid=${created.requestId}`);
 
-        expect(await zohoSign.getRequestStatus("t", created.requestId)).toBe(true);
+        expect(await zohoSign.getRequestStatus("t", created.requestId)).toBe("completed");
     });
 });

--- a/checkin-app/src/lib/membership/contract/zohoClient.ts
+++ b/checkin-app/src/lib/membership/contract/zohoClient.ts
@@ -248,18 +248,28 @@ export async function getEmbeddedSignUrl(params: {
     return signUrl;
 }
 
+/** Request states Zoho can never collect a signature from — a fresh request is required (#876). */
+const TERMINAL_REQUEST_STATUSES = new Set(["declined", "expired", "recalled", "deleted"]);
+
+export type ZohoRequestState = "completed" | "in_progress" | "terminal";
+
 /**
- * Read a signing request's current status. Returns true once the request is fully
- * completed. Used to sync state on the applicant's return from embedded signing,
- * so completion doesn't depend on the inbound webhook (which is unreliable against
- * a scale-to-zero dev instance).
+ * Read a signing request's current state, normalized to the three cases checkin
+ * acts on: "completed" (record the contract signed), "terminal" (declined,
+ * expired, recalled or deleted — the request is dead, a fresh one must be
+ * created), and "in_progress" (anything else — still signable). Used to sync
+ * state on the applicant's return from embedded signing (the inbound webhook is
+ * unreliable against a scale-to-zero dev instance) and to detect dead requests
+ * on the resume path.
  */
-export async function getRequestStatus(token: string, requestId: string): Promise<boolean> {
+export async function getRequestStatus(token: string, requestId: string): Promise<ZohoRequestState> {
     const resp = await zohoFetch(`${config.zohoSignApi()}/requests/${requestId}`, {
         method: "GET",
         headers: authHeader(token),
     }, "Zoho getRequestStatus");
     if (!resp.ok) throw new ZohoError(`Failed to get request status (${resp.status}): ${await resp.text()}`);
     const result = (await resp.json()) as { requests?: { request_status?: string } };
-    return result.requests?.request_status?.toLowerCase() === "completed";
+    const status = result.requests?.request_status?.toLowerCase() ?? "";
+    if (status === "completed") return "completed";
+    return TERMINAL_REQUEST_STATUSES.has(status) ? "terminal" : "in_progress";
 }

--- a/checkin-app/src/lib/membership/contract/zohoProvider.ts
+++ b/checkin-app/src/lib/membership/contract/zohoProvider.ts
@@ -51,9 +51,11 @@ const mockProvider: ZohoSignProvider = {
         return `${host}/dev/zoho-sign?rid=${encodeURIComponent(requestId)}`;
     },
     // The webhook records signing in the mock; this backs the ?signed=1 sync path,
-    // which then no-ops idempotently. Report completed so a sync-only race still lands.
+    // which then no-ops idempotently. Report completed so a sync-only race still
+    // lands. Never "terminal": mock requests don't expire, so the dead-request
+    // recovery path (#876) stays dormant in mock mode.
     async getRequestStatus() {
-        return true;
+        return "completed" as const;
     },
 };
 

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -205,6 +205,35 @@ export async function findProcessByEnvelope(requestId: string) {
 }
 
 /**
+ * Forget a dead Zoho signing request (declined/expired/recalled) so the next
+ * "sign" click creates a fresh one — the applicant's self-serve recovery (#876).
+ * Conditional on the process still pointing at THAT request and being unsigned,
+ * so a concurrent re-create's fresh ids are never clobbered and the audit row is
+ * written only by the caller that actually cleared.
+ */
+async function clearDeadSigningRequest(processId: number, requestId: string, actorId: number) {
+    const cleared = await prisma.$transaction(async (tx) => {
+        const { count } = await tx.orgMembershipProcess.updateMany({
+            where: { id: processId, zohoEnvelopeId: requestId, contractSignedAt: null },
+            data: { zohoEnvelopeId: null, zohoActionId: null },
+        });
+        if (count !== 1) return false;
+        await tx.auditLog.create({
+            data: {
+                actorId,
+                action: "EDIT",
+                tableName: "OrgMembershipProcess",
+                affectedEntityId: processId,
+                oldData: { zohoEnvelopeId: requestId },
+                newData: { zohoEnvelopeId: null, zohoActionId: null },
+            },
+        });
+        return true;
+    });
+    if (cleared) logger.info(`Cleared dead Zoho signing request ${requestId} for membership process ${processId}.`);
+}
+
+/**
  * Pull the contract status from Zoho for the applicant's in-flight process and
  * record it signed if Zoho says so. Called when the signer returns from embedded
  * signing (?signed=1) so completion doesn't hinge on the inbound webhook — which
@@ -225,8 +254,13 @@ export async function syncContractStatus(userId: number): Promise<ExternalStatus
     if (!process.contractSignedAt && process.zohoEnvelopeId && config.zohoAvailable()) {
         try {
             const token = await zohoSign.getAccessToken();
-            if (await zohoSign.getRequestStatus(token, process.zohoEnvelopeId)) {
+            const state = await zohoSign.getRequestStatus(token, process.zohoEnvelopeId);
+            if (state === "completed") {
                 await markContractSigned(process.id, userId);
+            } else if (state === "terminal") {
+                // Declined or expired — forget the dead request so contractStarted
+                // resets and the next click creates a fresh one (#876).
+                await clearDeadSigningRequest(process.id, process.zohoEnvelopeId, userId);
             }
         } catch (e) {
             logger.error(`Zoho status sync failed for process ${process.id}: ${e instanceof Error ? e.message : String(e)}`);
@@ -285,6 +319,25 @@ export async function getOrCreateContractSigningUrl(userId: number): Promise<str
     // document is never re-generated (only the embed session below is ephemeral).
     let requestId = process.zohoEnvelopeId;
     let actionId = process.zohoActionId;
+
+    // A stored request may be dead — declined by the signer, or expired after
+    // CONTRACT_EXPIRATION_DAYS — and Zoho can neither embed nor revive it. Check
+    // before reusing (#876): forget dead ids and fall through to the create path
+    // below, so the same button self-recovers. Best-effort — if the status read
+    // fails, proceed with the stored ids rather than blocking the click (worst
+    // case the embed call fails, as it did before this check existed).
+    if (requestId && actionId && !process.contractSignedAt) {
+        try {
+            if ((await zohoSign.getRequestStatus(token, requestId)) === "terminal") {
+                await clearDeadSigningRequest(process.id, requestId, userId);
+                requestId = null;
+                actionId = null;
+            }
+        } catch (e) {
+            logger.warn(`Zoho request-status check failed for membership process ${process.id}: ${e instanceof Error ? e.message : String(e)}`);
+        }
+    }
+
     if (!requestId || !actionId) {
         // Mock mode never uploads the PDF (its createRequest ignores the bytes), so
         // skip the S3 load that also 503s in dev — an empty placeholder keeps the


### PR DESCRIPTION
## Problem

Fixes #876. A declined or expired (`CONTRACT_EXPIRATION_DAYS`) Zoho signing request left the stored `zohoEnvelopeId`/`zohoActionId` in place forever. `getOrCreateContractSigningUrl` only created a new request when either id was null, so once a request was dead every "Resume signing" click minted an embed URL for a request Zoho can neither embed nor revive — and the decline redirect told the applicant to restart, which reused the same declined request. An applicant coming back after expiry was stuck until a board member ran `mark-contract`.

## Fix

- **`zohoClient.getRequestStatus`** now returns a normalized state — `completed` / `in_progress` / `terminal` — instead of a completed boolean. Declined, expired, recalled, and deleted map to `terminal`.
- **`external.ts`** adds an audited `clearDeadSigningRequest` helper, conditional on the process still pointing at that exact request (and unsigned), so a concurrent re-create's fresh ids are never clobbered and the audit row is written once. Both applicant paths act on `terminal`:
  - `getOrCreateContractSigningUrl` checks the stored request before reusing it and falls through to the existing create path — the same button self-recovers for both the decline and the come-back-after-expiry cases. Best-effort: a failed status read reuses the stored ids exactly as before.
  - `syncContractStatus` clears the ids on a terminal state so `contractStarted` resets and the UI offers a fresh "Sign" instead of a dead "Resume".
- **Dev mock** keeps reporting `completed`, so the recovery path stays dormant in mock mode and the dev decline-interstitial flow is unchanged. No UI changes needed — the declined banner's "restart when you're ready" message is now actually true.

Deliberately out of scope: the inbound webhook still ignores non-completed events; eager clearing on a decline webhook would only reset the button label sooner and can be a follow-up.

## Testing

- Full unit suite (1,562 tests) and full integration suite (899 tests, live Postgres) pass, plus tsc and eslint.
- New coverage: terminal-state normalization (`zohoClient.test.ts`), dead-request re-create + status-check-failure fallback (`external.test.ts`, `membershipContractSignAPI.integration.test.ts`), and sync clearing ids without touching `contractSignedAt` (`membershipContractSync.integration.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)