### PR TITLE
test(safety): raise timeout on heavy trusted-adults RTL tests

### DIFF
--- a/checkin-app/src/app/safety/trusted-adults/__tests__/page.test.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/__tests__/page.test.tsx
@@ -117,7 +117,7 @@ describe("safety/trusted-adults page", () => {
         expect.objectContaining({ body: JSON.stringify({ reviewId: 9, decision: "REQUEST_INFO", note: "Need proof of ID." }) }),
       ),
     );
-  });
+  }, 10000); // heavy: full page + modal opened twice + two decision round-trips
 
   it("leaves an empty queue when the initial load fails", async () => {
     setSession({ id: 1, isBoardMember: true, householdId: 1 });
@@ -185,7 +185,7 @@ describe("safety/trusted-adults page", () => {
     await screen.findByText("Guardian House");
     expect(screen.getByText("Renewal")).toBeInTheDocument();
     expect(screen.queryByText(/lapsed/)).not.toBeInTheDocument();
-  });
+  }, 10000); // heavy: renders the full page three times (mount/unmount ×3)
 
   it("shows the fallback failure message on a decision error, and dismisses the alert", async () => {
     setSession({ id: 1, isBoardMember: true, householdId: 1 });
@@ -273,7 +273,7 @@ describe("safety/trusted-adults page", () => {
         expect.objectContaining({ body: JSON.stringify({ reviewId: 9, action: "revoke" }) }),
       ),
     );
-  });
+  }, 10000); // heaviest test in file: full page + modal + 3 sequential override round-trips; guards the full-suite serial flake
 
   it("hides override actions for a revoked review, and shows an override failure message", async () => {
     const revoked = [{ ...trustedAdults[0], reviews: [{ ...trustedAdults[0].reviews[0], status: "REVOKED" }] }];


### PR DESCRIPTION
## What

Give three heavy RTL tests in `checkin-app/src/app/safety/trusted-adults/__tests__/page.test.tsx` an explicit `10000`ms timeout (3rd arg to `it(...)`):

- **override force-approve/deny/revoke** — full page + Mantine modal + 3 sequential override round-trips (the reported flake)
- **deny + request-info modal** — full page + modal opened twice + 2 decision round-trips
- **withdraw-and-resubmit** — renders the full page three times

## Why

On the loaded serial full-suite run (`jest --runInBand`, ~1563 tests) the override test intermittently throws `Exceeded timeout of 5000 ms for a test.`; it passes when run alone or on retry. It is the heaviest test in the file and occasionally crosses the default 5000ms threshold under CPU pressure. A config/threshold flake, not a logic bug — the test is correctly written (findBy*/waitFor, no arbitrary sleeps).

Per-test timeout rather than a global `testTimeout` bump, which would mask genuine slow-test regressions elsewhere.

## Notes for reviewer

- No assertion or structural changes — only the timeout arg + a one-line comment on each.
- Scope: this one file. Unrelated to any membership work; surfaced as a spurious failure on an unrelated PR's pre-commit full-suite run.
- Verified: `npm test -- --testPathPatterns "safety/trusted-adults"` → 13/13 pass; eslint `--max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)