### PR TITLE
feat(membership-ops): household detail page showing program enrollments

### DIFF
--- a/checkin-app/src/app/__tests__/adminHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminHouseholdsAPI.integration.test.ts
@@ -20,9 +20,16 @@ describe('Admin Households API Integration Tests', () => {
     let testUserId: number;
     let testHousehold1Id: number;
     let testHousehold2Id: number;
+    let testProgramId: number;
 
     beforeAll(async () => {
         // Clean up any leaked state
+        await prisma.programParticipant.deleteMany({
+            where: { program: { name: { contains: 'Households API Test' } } }
+        });
+        await prisma.program.deleteMany({
+            where: { name: { contains: 'Households API Test' } }
+        });
         await prisma.orgMembership.deleteMany({});
         await prisma.person.deleteMany({
             where: { email: { contains: 'households-api-test' } }
@@ -60,10 +67,26 @@ describe('Admin Households API Integration Tests', () => {
                 status: 'ACTIVE'
             }
         });
+
+        // Enroll the household-2 member in a program so the single-household
+        // (?id=) branch has an enrollment to surface for the detail view.
+        const program = await prisma.program.create({
+            data: { name: 'Households API Test Program' }
+        });
+        testProgramId = program.id;
+        await prisma.programParticipant.create({
+            data: { programId: testProgramId, personId: testUserId, status: 'ACTIVE' }
+        });
     });
 
     afterAll(async () => {
         // Clean up — scope membership deletes to this test's households
+        await prisma.programParticipant.deleteMany({
+            where: { programId: testProgramId }
+        });
+        await prisma.program.deleteMany({
+            where: { id: testProgramId }
+        });
         await prisma.orgMembership.deleteMany({
             where: { householdId: { in: [testHousehold1Id, testHousehold2Id] } }
         });
@@ -124,6 +147,51 @@ describe('Admin Households API Integration Tests', () => {
             
             expect(h2).toBeDefined();
             expect(h1).toBeUndefined(); // Should be filtered out
+        });
+    });
+
+    describe('GET /api/membership-ops/households?id= (single household detail)', () => {
+        it('returns each member with their program enrollments (name + status)', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true }
+            });
+
+            const req = new Request(`http://localhost:4000/api/membership-ops/households?id=${testHousehold2Id}`, { method: 'GET' });
+
+            const res = await GET(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.household).toBeDefined();
+            expect(data.household.id).toBe(testHousehold2Id);
+
+            const member = data.household.householdMembers.find((m: { id: number }) => m.id === testUserId);
+            expect(member).toBeDefined();
+            expect(member.programParticipants).toHaveLength(1);
+            expect(member.programParticipants[0].status).toBe('ACTIVE');
+            expect(member.programParticipants[0].program.name).toBe('Households API Test Program');
+        });
+
+        it('returns an empty enrollment list for a member in no programs', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true }
+            });
+
+            // Household 1 has no members; add a bare person to assert the empty case.
+            const loner = await prisma.person.create({
+                data: { email: 'loner-households-api-test@example.com', name: 'Loner Households Test', householdId: testHousehold1Id }
+            });
+
+            const req = new Request(`http://localhost:4000/api/membership-ops/households?id=${testHousehold1Id}`, { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            const member = data.household.householdMembers.find((m: { id: number }) => m.id === loner.id);
+            expect(member).toBeDefined();
+            expect(member.programParticipants).toEqual([]);
+
+            await prisma.person.deleteMany({ where: { id: loner.id } });
         });
     });
 

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -31,7 +31,15 @@ export const GET = withAuth(
                     where: { id: parseInt(id) },
                     include: {
                         householdMembers: {
-                            select: { id: true, name: true, email: true }
+                            select: {
+                                id: true, name: true, email: true,
+                                // Program enrollments for the household detail view. Extra field the
+                                // Edit Info modal (same endpoint) simply ignores.
+                                programParticipants: {
+                                    select: { status: true, program: { select: { id: true, name: true } } },
+                                    orderBy: { program: { name: "asc" } },
+                                },
+                            }
                         },
                         leads: { select: { personId: true } },
                         orgMembership: true,

--- a/checkin-app/src/app/membership-ops/households/[id]/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/[id]/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useEffect, useCallback, use } from "react";
+import { useRouter } from "next/navigation";
+import { Badge, Button, Card, Group, Stack, Text, Title } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { useRequireRole } from "@/hooks/useRequireRole";
+import { PageLoader } from "@/components/ui/PageLoader";
+
+type Enrollment = {
+  status: "PENDING" | "ACTIVE";
+  program: { id: number; name: string };
+};
+type Member = {
+  id: number;
+  name?: string | null;
+  email?: string | null;
+  programParticipants?: Enrollment[] | null;
+};
+type Household = {
+  id: number;
+  name?: string | null;
+  orgMembership?: { status: string } | null;
+  householdMembers?: Member[] | null;
+};
+
+// A household detail view for the board — its members and each member's program
+// enrollments in one focused screen, off the noisy households list.
+export default function HouseholdDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { ready, loading: authLoading } = useRequireRole(["isSysadmin", "isBoardMember"]);
+  const router = useRouter();
+
+  const [household, setHousehold] = useState<Household | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchHousehold = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/membership-ops/households?id=${id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setHousehold(data.household);
+      } else {
+        notifications.show({ color: "red", message: "Failed to load household.", autoClose: false });
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (ready) fetchHousehold();
+  }, [ready, fetchHousehold]);
+
+  if (authLoading || loading) return <PageLoader />;
+  if (!ready) return null;
+
+  if (!household) {
+    return (
+      <Stack>
+        <Button variant="subtle" onClick={() => router.push("/membership-ops/households")} w="fit-content">
+          ← Back to Households
+        </Button>
+        <Text c="dimmed">Household not found.</Text>
+      </Stack>
+    );
+  }
+
+  const status = household.orgMembership?.status;
+  const members = household.householdMembers ?? [];
+
+  return (
+    <Stack>
+      <Button variant="subtle" onClick={() => router.push("/membership-ops/households")} w="fit-content">
+        ← Back to Households
+      </Button>
+
+      <Group justify="space-between" align="center">
+        <Title order={3}>{household.name || `Household #${household.id}`}</Title>
+        {status === "DENIED" ? (
+          <Badge color="red">Denied</Badge>
+        ) : status === "ACTIVE" ? (
+          <Badge color="green">Member</Badge>
+        ) : (
+          <Badge color="gray">Not a member</Badge>
+        )}
+      </Group>
+
+      {members.length === 0 ? (
+        <Text c="dimmed" fs="italic">No people in this household.</Text>
+      ) : (
+        <Stack gap="sm">
+          {members.map((m) => {
+            const enrollments = m.programParticipants ?? [];
+            return (
+              <Card key={m.id} withBorder padding="md">
+                <Text fw={600}>{m.name || m.email}</Text>
+                {enrollments.length === 0 ? (
+                  <Text size="sm" c="dimmed" fs="italic" mt={4}>Not enrolled in any program.</Text>
+                ) : (
+                  <Group gap="xs" mt="xs">
+                    {enrollments.map((e) => (
+                      <Badge
+                        key={e.program.id}
+                        variant="light"
+                        color={e.status === "ACTIVE" ? "green" : "yellow"}
+                        style={{ cursor: "pointer" }}
+                        onClick={() => router.push(`/program-ops/programs/${e.program.id}`)}
+                      >
+                        {e.program.name}{e.status === "PENDING" ? " (pending)" : ""}
+                      </Badge>
+                    ))}
+                  </Group>
+                )}
+              </Card>
+            );
+          })}
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -163,7 +163,14 @@ export default function AdminHouseholdsPage() {
               return (
                 <Table.Tr key={household.id}>
                   <Table.Td>
-                    <Text fw={600}>{household.name || `Household #${household.id}`}</Text>
+                    <Text
+                      fw={600}
+                      c="blue"
+                      style={{ cursor: "pointer" }}
+                      onClick={() => router.push(`/membership-ops/households/${household.id}`)}
+                    >
+                      {household.name || `Household #${household.id}`}
+                    </Text>
                   </Table.Td>
                   <Table.Td>
                     {household.householdMembers && household.householdMembers.length > 0 ? (

--- a/checkin-app/tests/security/routeAuthDrift.test.ts
+++ b/checkin-app/tests/security/routeAuthDrift.test.ts
@@ -313,6 +313,7 @@ const EDGE_INCLUDE_ALLOWLIST: Record<string, string> = {
     'household/visits': "query-shaped — own household only (where householdId = caller's)",
     'kioskdisplay/certifications': 'admin-role-gated — sysadmin/board/keyholder (+ kiosk)',
     'membership-audit/compliance': 'admin-role-gated — withAuth roles [sysadmin, board]; reads ProgramParticipant/Volunteer to flag people needing a background check',
+    'membership-ops/households': 'admin-role-gated — withAuth roles [sysadmin, board]; ?id= branch includes each member ProgramParticipant for the household detail view',
     'membership-ops/participants/merge/analyze': 'admin-role-gated — sysadmin/board',
     'nav/todo-counts': 'query-shaped — counts scoped to caller (own household + programs the caller leads)',
     'profile': "query-shaped — authorize 'self'; visits are the caller's own",


### PR DESCRIPTION
## What

Gives the board a way to see **all program enrollments of a household** in one place. Previously there was no per-household drill-down — the households list is a flat management table, and program rosters are per-program only.

- **New route** `/membership-ops/households/[id]` — click a household name in the list to reach it. Shows the household header + membership badge, then one card per member listing their program enrollments (green = active, yellow = pending; each badge links to the program roster).
- **API**: extended the existing `GET /api/membership-ops/households?id=` branch to include each member's `programParticipants` (program name + status). The Edit Info modal shares this endpoint and simply ignores the extra field.
- **List**: household name is now a link to the detail page.

Read-only view — no enrollment editing from here.

## Why

Board asked to see a household's program enrollments without opening each program roster and eyeballing. Data relation (Household to members to programParticipants to program) already existed; this just surfaces it.

## Reviewer notes

- The GET handler is admin-role-gated (withAuth roles [sysadmin, board]). Adding ProgramParticipant (an all-public-tier edge model) to the include tripped the routeAuthDrift rule-3 guard; added a justified entry to EDGE_INCLUDE_ALLOWLIST.
- The [id] route needs no pageRegistry entry (dynamic routes are excluded by the registry test).

## Tests

Two new cases on the ?id= branch in adminHouseholdsAPI.integration.test.ts: enrollments returned with name + status, and empty list for a member in no programs. Full integration file green; full CI suite passes via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)