### PR TITLE
feat(household): make Household.name NOT NULL

### DIFF
--- a/checkin-app/__tests__/programLifecycle.integration.test.ts
+++ b/checkin-app/__tests__/programLifecycle.integration.test.ts
@@ -34,7 +34,7 @@ describe('Program Lifecycle Integration Tests', () => {
                 isSysadmin: false,
                 isBoardMember: true,
                 dateOfBirth: new Date('1990-01-01'),
-                household: { create: {} }
+                household: { create: { name: "Test HH" } }
             }
         });
         boardAdminId = adminUser.id;
@@ -46,7 +46,7 @@ describe('Program Lifecycle Integration Tests', () => {
                 email: "mentor@test.com",
                 googleId: "test-auth-mentor",
                 dateOfBirth: new Date('1985-01-01'),
-                household: { create: {} }
+                household: { create: { name: "Test HH" } }
             }
         });
         leadMentorId = mentorUser.id;
@@ -58,7 +58,7 @@ describe('Program Lifecycle Integration Tests', () => {
                 email: "participant@test.com",
                 googleId: "test-auth-std",
                 dateOfBirth: new Date('2000-01-01'),
-                household: { create: {} }
+                household: { create: { name: "Test HH" } }
             }
         });
         testParticipantId = standardUser.id;

--- a/checkin-app/prisma/migrations/20260705160000_household_name_not_null/migration.sql
+++ b/checkin-app/prisma/migrations/20260705160000_household_name_not_null/migration.sql
@@ -1,0 +1,18 @@
+-- Make Household.name NOT NULL. Every live create path already writes a name
+-- (OAuth: email fallback; membership-ops: 'User' fallback; Zoho: 'Household'
+-- literal), so no live row is expected to be null. Backfill defensively anyway:
+-- copy a household member's name, else the literal 'Household', before the
+-- NOT NULL constraint so the migration can never fail on the real DB.
+UPDATE "Household" h
+SET "name" = COALESCE(
+    (SELECT p."name"
+       FROM "Person" p
+      WHERE p."householdId" = h."id"
+        AND p."name" IS NOT NULL
+      ORDER BY p."id"
+      LIMIT 1),
+    'Household'
+)
+WHERE h."name" IS NULL;
+
+ALTER TABLE "Household" ALTER COLUMN "name" SET NOT NULL;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -155,7 +155,7 @@ model Household {
   /// @sensitivity:public
   id      Int     @id @default(autoincrement())
   /// @sensitivity:public
-  name    String?
+  name    String
   /// @sensitivity:personal
   line1      String?
   /// @sensitivity:personal

--- a/checkin-app/src/app/__tests__/adminAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminAuditAPI.integration.test.ts
@@ -37,13 +37,13 @@ describe('Admin Audit API Integration Tests', () => {
 
         // Create Admin
         const admin = await prisma.person.create({
-            data: { email: 'admin-audit-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-audit-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         adminId = admin.id;
 
         // Create Common User
         const commonUser = await prisma.person.create({
-            data: { email: 'common-audit-api-test@example.com', name: 'Common', household: { create: {} } }
+            data: { email: 'common-audit-api-test@example.com', name: 'Common', household: { create: { name: "Test HH" } } }
         });
         commonId = commonUser.id;
 

--- a/checkin-app/src/app/__tests__/adminBadgesAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBadgesAPI.integration.test.ts
@@ -33,12 +33,12 @@ describe('Admin Badges API Integration Tests', () => {
 
         // Setup mock database records
         const admin = await prisma.person.create({
-            data: { email: 'admin-badges-api-test@example.com', name: 'Admin Badges Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-badges-api-test@example.com', name: 'Admin Badges Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 
         const user = await prisma.person.create({
-            data: { email: 'user-badges-api-test@example.com', name: 'User Badges Test', household: { create: {} } }
+            data: { email: 'user-badges-api-test@example.com', name: 'User Badges Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
 

--- a/checkin-app/src/app/__tests__/adminBulkImport.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImport.integration.test.ts
@@ -41,12 +41,12 @@ describe('Admin Bulk Import API Integration Tests', () => {
 
         // Setup mock database records
         const admin = await prisma.person.create({
-            data: { email: 'admin-import-test@example.com', name: 'Admin Import Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-import-test@example.com', name: 'Admin Import Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 
         const user = await prisma.person.create({
-            data: { email: 'user-import-test@example.com', name: 'User Import Test', household: { create: {} } }
+            data: { email: 'user-import-test@example.com', name: 'User Import Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
     });

--- a/checkin-app/src/app/__tests__/adminBulkImportMalformedRow.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportMalformedRow.integration.test.ts
@@ -34,7 +34,7 @@ describe('Bulk import: malformed row among valid rows', () => {
     beforeAll(async () => {
         await cleanup();
         const admin = await prisma.person.create({
-            data: { email: 'admin-malrow-import-test@example.com', name: 'Admin Malrow Import Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-malrow-import-test@example.com', name: 'Admin Malrow Import Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
         (getServerSession as jest.Mock).mockResolvedValue({

--- a/checkin-app/src/app/__tests__/adminBulkImportMergeRollback.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportMergeRollback.integration.test.ts
@@ -44,18 +44,18 @@ describe('Bulk import merge rollback', () => {
         await cleanup();
 
         const admin = await prisma.person.create({
-            data: { email: 'admin-mergeroll-test@example.com', name: 'Admin Mergeroll Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-mergeroll-test@example.com', name: 'Admin Mergeroll Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 
         const target = await prisma.person.create({
-            data: { email: TARGET_EMAIL, name: 'Target Anchor Mergeroll Test', household: { create: {} } },
+            data: { email: TARGET_EMAIL, name: 'Target Anchor Mergeroll Test', household: { create: { name: "Test HH" } } },
             select: { householdId: true }
         });
         targetHouseholdId = target.householdId;
 
         const source = await prisma.person.create({
-            data: { email: SOURCE_EMAIL, name: 'Source Member Mergeroll Test', household: { create: {} } },
+            data: { email: SOURCE_EMAIL, name: 'Source Member Mergeroll Test', household: { create: { name: "Test HH" } } },
             select: { id: true, householdId: true }
         });
         sourceMemberId = source.id;

--- a/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImportPreviewConsistency.integration.test.ts
@@ -56,7 +56,7 @@ describe('Bulk import: preview vs commit consistency', () => {
     beforeAll(async () => {
         await cleanup();
         const admin = await prisma.person.create({
-            data: { email: 'admin-consist-import-test@example.com', name: 'Admin Consist Import Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-consist-import-test@example.com', name: 'Admin Consist Import Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
         (getServerSession as jest.Mock).mockResolvedValue({

--- a/checkin-app/src/app/__tests__/adminHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminHouseholdsAPI.integration.test.ts
@@ -40,7 +40,7 @@ describe('Admin Households API Integration Tests', () => {
 
         // Setup mock database records
         const admin = await prisma.person.create({
-            data: { email: 'admin-households-api-test@example.com', name: 'Admin Households Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-households-api-test@example.com', name: 'Admin Households Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 

--- a/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
@@ -28,12 +28,12 @@ describe('Admin Participant Household API Integration Tests', () => {
         });
 
         const admin = await prisma.person.create({
-            data: { email: 'admin-household-api-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-household-api-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 
         const user = await prisma.person.create({
-            data: { email: 'user-household-api-test@example.com', name: 'User Test', household: { create: {} } }
+            data: { email: 'user-household-api-test@example.com', name: 'User Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
 
@@ -56,7 +56,7 @@ describe('Admin Participant Household API Integration Tests', () => {
 
     beforeEach(async () => {
         const participant = await prisma.person.create({
-            data: { email: 'subject-household-api-test@example.com', name: 'Subject Test', household: { create: {} } }
+            data: { email: 'subject-household-api-test@example.com', name: 'Subject Test', household: { create: { name: "Test HH" } } }
         });
         testParticipantId = participant.id;
     });

--- a/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
@@ -64,12 +64,12 @@ describe('Admin Participants API Integration Tests', () => {
 
         // Setup mock database records
         const admin = await prisma.person.create({
-            data: { email: 'admin-participants-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-participants-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 
         const user = await prisma.person.create({
-            data: { email: 'user-participants-test@example.com', name: 'User Test', household: { create: {} } }
+            data: { email: 'user-participants-test@example.com', name: 'User Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
     });
@@ -261,7 +261,7 @@ describe('Admin Participants API Integration Tests', () => {
 
             // Create a disposable user just for this edit test
             const editUser = await prisma.person.create({
-                data: { email: 'edit-test-user@example.com', name: 'Original Name', household: { create: {} } }
+                data: { email: 'edit-test-user@example.com', name: 'Original Name', household: { create: { name: "Test HH" } } }
             });
 
             const req = new Request(`http://localhost:4000/api/membership-ops/participants/${editUser.id}`, {

--- a/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
@@ -37,22 +37,22 @@ describe('Admin Roles API Integration Tests', () => {
 
         // Setup mock database records
         const isSysadmin = await prisma.person.create({
-            data: { email: 'sysadmin-roles-api-test@example.com', name: 'Admin Roles Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'sysadmin-roles-api-test@example.com', name: 'Admin Roles Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testSysAdminId = isSysadmin.id;
 
         const isBoardMember = await prisma.person.create({
-            data: { email: 'board-roles-api-test@example.com', name: 'Board Roles Test', isBoardMember: true, household: { create: {} } }
+            data: { email: 'board-roles-api-test@example.com', name: 'Board Roles Test', isBoardMember: true, household: { create: { name: "Test HH" } } }
         });
         testBoardMemberId = isBoardMember.id;
 
         const user = await prisma.person.create({
-            data: { email: 'user-roles-api-test@example.com', name: 'User Roles Test', household: { create: {} } }
+            data: { email: 'user-roles-api-test@example.com', name: 'User Roles Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
 
         const targetUser = await prisma.person.create({
-            data: { email: 'target-roles-api-test@example.com', name: 'Target Roles Test', dateOfBirth: new Date('1990-01-01'), household: { create: {} } }
+            data: { email: 'target-roles-api-test@example.com', name: 'Target Roles Test', dateOfBirth: new Date('1990-01-01'), household: { create: { name: "Test HH" } } }
         });
         testTargetUserId = targetUser.id;
 
@@ -60,7 +60,7 @@ describe('Admin Roles API Integration Tests', () => {
         const tenYearsAgo = new Date(now.getFullYear() - 10, now.getMonth(), now.getDate());
         
         const student = await prisma.person.create({
-            data: { email: 'student-roles-api-test@example.com', name: 'Student Roles Test', dateOfBirth: tenYearsAgo, household: { create: {} } }
+            data: { email: 'student-roles-api-test@example.com', name: 'Student Roles Test', dateOfBirth: tenYearsAgo, household: { create: { name: "Test HH" } } }
         });
         testStudentId = student.id;
     });

--- a/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
@@ -41,12 +41,12 @@ describe('Admin Unclaimed Households API Integration Tests', () => {
         await cleanup();
 
         const admin = await prisma.person.create({
-            data: { email: 'admin-unclaimed-api-test@example.com', name: 'Admin Unclaimed Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-unclaimed-api-test@example.com', name: 'Admin Unclaimed Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 
         const user = await prisma.person.create({
-            data: { email: 'user-unclaimed-api-test@example.com', name: 'User Unclaimed Test', isSysadmin: false, household: { create: {} } }
+            data: { email: 'user-unclaimed-api-test@example.com', name: 'User Unclaimed Test', isSysadmin: false, household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
 

--- a/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
@@ -43,14 +43,14 @@ describe('Admin Visits API Integration Tests', () => {
 
         // Setup mock database records
         const admin = await prisma.person.create({
-            data: { email: 'admin-visits-api-test@example.com', name: 'Admin Visits Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-visits-api-test@example.com', name: 'Admin Visits Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
         const checkAdmin = await prisma.person.findUnique({ where: { id: testAdminId } });
         console.log("Check Admin:", checkAdmin);
 
         const user = await prisma.person.create({
-            data: { email: 'user-visits-api-test@example.com', name: 'User Visits Test', household: { create: {} } }
+            data: { email: 'user-visits-api-test@example.com', name: 'User Visits Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
 

--- a/checkin-app/src/app/__tests__/attendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendance.integration.test.ts
@@ -46,7 +46,7 @@ describe('Attendance API Integration Tests', () => {
         testHouseholdId = household.id;
 
         const admin = await prisma.person.create({
-            data: { email: 'admin-attendance-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-attendance-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
         testAdminHouseholdId = admin.householdId;
@@ -77,7 +77,7 @@ describe('Attendance API Integration Tests', () => {
         // Keyholder present + checked in: the facility-open guard requires an
         // active keyholder before any non-keyholder MANUAL_CHECKIN succeeds.
         const keyholder = await prisma.person.create({
-            data: { email: 'keyholder-attendance-test@example.com', name: 'Keyholder Test', isKeyholder: true, household: { create: {} } }
+            data: { email: 'keyholder-attendance-test@example.com', name: 'Keyholder Test', isKeyholder: true, household: { create: { name: "Test HH" } } }
         });
         testKeyholderId = keyholder.id;
         testKeyholderHouseholdId = keyholder.householdId;

--- a/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
@@ -72,19 +72,19 @@ describe('General Attendance API Integration Tests', () => {
 
         // Create Admin
         const admin = await prisma.person.create({
-            data: { email: 'admin-attend-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-attend-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         adminId = admin.id;
 
         // Create Board Member
         const isBoardMember = await prisma.person.create({
-            data: { email: 'board-attend-api-test@example.com', name: 'Board Member', isBoardMember: true, household: { create: {} } }
+            data: { email: 'board-attend-api-test@example.com', name: 'Board Member', isBoardMember: true, household: { create: { name: "Test HH" } } }
         });
         boardMemberId = isBoardMember.id;
 
         // Create Common User
         const commonUser = await prisma.person.create({
-            data: { email: 'common-attend-api-test@example.com', name: 'Common', household: { create: {} } }
+            data: { email: 'common-attend-api-test@example.com', name: 'Common', household: { create: { name: "Test HH" } } }
         });
         commonId = commonUser.id;
 
@@ -115,7 +115,7 @@ describe('General Attendance API Integration Tests', () => {
         // Keyholder present + checked in: the facility-open guard requires an
         // active keyholder before any non-keyholder MANUAL_CHECKIN succeeds.
         const keyholder = await prisma.person.create({
-            data: { email: 'keyholder-attend-api-test@example.com', name: 'Keyholder', isKeyholder: true, household: { create: {} } }
+            data: { email: 'keyholder-attend-api-test@example.com', name: 'Keyholder', isKeyholder: true, household: { create: { name: "Test HH" } } }
         });
         keyholderId = keyholder.id;
         await prisma.visit.create({

--- a/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualAPI.integration.test.ts
@@ -41,7 +41,7 @@ describe('Manual Attendance API Integration Tests', () => {
 
         // Setup mock database records
         const user = await prisma.person.create({
-            data: { email: 'user-manual-attendance-test@example.com', name: 'User Manual Attendance Test', household: { create: {} } }
+            data: { email: 'user-manual-attendance-test@example.com', name: 'User Manual Attendance Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
         testHouseholdId = user.householdId;
@@ -265,9 +265,9 @@ describe('Manual Attendance API keyholder-first guard (open backfills)', () => {
         await prisma.person.deleteMany({ where: { id: { in: ids } } });
         await prisma.household.deleteMany({ where: { id: { in: leaked.map(p => p.householdId) } } });
 
-        const nk = await prisma.person.create({ data: { email: `nk-${TAG}@example.com`, name: 'Guard NK', household: { create: {} } } });
+        const nk = await prisma.person.create({ data: { email: `nk-${TAG}@example.com`, name: 'Guard NK', household: { create: { name: "Test HH" } } } });
         nkId = nk.id;
-        const kh = await prisma.person.create({ data: { email: `kh-${TAG}@example.com`, name: 'Guard KH', isKeyholder: true, household: { create: {} } } });
+        const kh = await prisma.person.create({ data: { email: `kh-${TAG}@example.com`, name: 'Guard KH', isKeyholder: true, household: { create: { name: "Test HH" } } } });
         khId = kh.id;
         householdIds = [nk.householdId, kh.householdId];
     });

--- a/checkin-app/src/app/__tests__/attendanceManualCheckinConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualCheckinConcurrency.integration.test.ts
@@ -62,7 +62,7 @@ describe('POST /api/attendance MANUAL_CHECKIN concurrency (advisory lock)', () =
         // Keyholder so the facility-open guard passes: this suite exercises the
         // advisory lock, not the keyholder-first rule (covered separately below).
         const subject = await prisma.person.create({
-            data: { email: `subject-${EMAIL_TAG}@example.com`, name: 'Manual Checkin Concurrency Subject', isKeyholder: true, household: { create: {} } },
+            data: { email: `subject-${EMAIL_TAG}@example.com`, name: 'Manual Checkin Concurrency Subject', isKeyholder: true, household: { create: { name: "Test HH" } } },
         });
         subjectId = subject.id;
         householdId = subject.householdId;
@@ -120,11 +120,11 @@ describe('POST /api/attendance MANUAL_CHECKIN keyholder-first guard', () => {
         await prisma.household.deleteMany({ where: { id: { in: leaked.map(p => p.householdId) } } });
 
         const nk = await prisma.person.create({
-            data: { email: `nk-${GUARD_TAG}@example.com`, name: 'Guard NonKeyholder', household: { create: {} } },
+            data: { email: `nk-${GUARD_TAG}@example.com`, name: 'Guard NonKeyholder', household: { create: { name: "Test HH" } } },
         });
         nonKeyholderId = nk.id;
         const kh = await prisma.person.create({
-            data: { email: `kh-${GUARD_TAG}@example.com`, name: 'Guard Keyholder', isKeyholder: true, household: { create: {} } },
+            data: { email: `kh-${GUARD_TAG}@example.com`, name: 'Guard Keyholder', isKeyholder: true, household: { create: { name: "Test HH" } } },
         });
         keyholderId = kh.id;
         householdIds = [nk.householdId, kh.householdId];

--- a/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceManualConcurrency.integration.test.ts
@@ -64,7 +64,7 @@ describe('POST /api/attendance/manual concurrency (advisory lock)', () => {
         await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
 
         const subject = await prisma.person.create({
-            data: { email: `subject-${EMAIL_TAG}@example.com`, name: 'Manual Concurrency Subject', household: { create: {} } },
+            data: { email: `subject-${EMAIL_TAG}@example.com`, name: 'Manual Concurrency Subject', household: { create: { name: "Test HH" } } },
         });
         subjectId = subject.id;
         householdId = subject.householdId;

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -43,7 +43,7 @@ describe('AuditLog Integration Tests', () => {
     async function makeParticipant(suffix: string) {
         const p = await prisma.person.create({
             // 'audit-test' substring also matches the beforeAll backstop sweep.
-            data: { email: `${TAG}-${suffix}-audit-test@example.com`, name: `${TAG} ${suffix}`, household: { create: {} } },
+            data: { email: `${TAG}-${suffix}-audit-test@example.com`, name: `${TAG} ${suffix}`, household: { create: { name: "Test HH" } } },
             select: { id: true, householdId: true },
         });
         createdParticipantIds.push(p.id);
@@ -66,12 +66,12 @@ describe('AuditLog Integration Tests', () => {
 
         // Setup mock database records
         const admin = await prisma.person.create({
-            data: { email: 'admin-audit-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-audit-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 
         const participant = await prisma.person.create({
-            data: { email: 'participant-audit-test@example.com', name: 'Participant Test', household: { create: {} } }
+            data: { email: 'participant-audit-test@example.com', name: 'Participant Test', household: { create: { name: "Test HH" } } }
         });
         testParticipantId = participant.id;
     });

--- a/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
@@ -36,19 +36,19 @@ describe('Sensitive route authorization', () => {
 
     beforeAll(async () => {
         const plain = await prisma.person.create({
-            data: { name: 'Authz Plain', email: `plain-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Authz Plain', email: `plain-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         plainId = plain.id;
         householdIds.push(plain.householdId);
 
         const target = await prisma.person.create({
-            data: { name: `ZZTarget ${TAG}`, email: `target-${TAG}@example.com`, phone: '555-0101', household: { create: {} } },
+            data: { name: `ZZTarget ${TAG}`, email: `target-${TAG}@example.com`, phone: '555-0101', household: { create: { name: "Test HH" } } },
         });
         searchTargetId = target.id;
         householdIds.push(target.householdId);
 
         const persona = await prisma.person.create({
-            data: { name: 'Persona One', email: `persona-${TAG}@example.com`, isSysadmin: true, household: { create: {} } },
+            data: { name: 'Persona One', email: `persona-${TAG}@example.com`, isSysadmin: true, household: { create: { name: "Test HH" } } },
         });
         personaId = persona.id;
         householdIds.push(persona.householdId);

--- a/checkin-app/src/app/__tests__/autoAssociation.integration.test.ts
+++ b/checkin-app/src/app/__tests__/autoAssociation.integration.test.ts
@@ -31,7 +31,7 @@ describe('Auto-Association and Checkout Chunking Logic', () => {
 
         // Setup User
         const user = await prisma.person.create({
-            data: { email: 'auto-assoc-test@example.com', name: 'Auto Assoc Tester', household: { create: {} } }
+            data: { email: 'auto-assoc-test@example.com', name: 'Auto Assoc Tester', household: { create: { name: "Test HH" } } }
         });
         participantId = user.id;
         householdId = user.householdId;

--- a/checkin-app/src/app/__tests__/brokenHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/brokenHouseholdsAPI.integration.test.ts
@@ -42,7 +42,7 @@ describe('Broken Households API Integration Tests', () => {
 
         // Acting board member (not a member of any test household below).
         const board = await prisma.person.create({
-            data: { email: 'board-broken-api-test@example.com', name: 'Board Broken Test', isBoardMember: true, household: { create: {} } }
+            data: { email: 'board-broken-api-test@example.com', name: 'Board Broken Test', isBoardMember: true, household: { create: { name: "Test HH" } } }
         });
         boardId = board.id;
 

--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -42,17 +42,17 @@ describe('Cron Nightly API Integration Tests', () => {
 
         // Setup Users
         const board = await prisma.person.create({
-            data: { email: 'board-nightly@example.com', name: 'Board Member', isBoardMember: true, household: { create: {} } }
+            data: { email: 'board-nightly@example.com', name: 'Board Member', isBoardMember: true, household: { create: { name: "Test HH" } } }
         });
         boardMemberId = board.id;
 
         const isKeyholder = await prisma.person.create({
-            data: { email: 'keyholder-nightly@example.com', name: 'Forgetful Keyholder', isKeyholder: true, household: { create: {} } }
+            data: { email: 'keyholder-nightly@example.com', name: 'Forgetful Keyholder', isKeyholder: true, household: { create: { name: "Test HH" } } }
         });
         keyholderId = isKeyholder.id;
 
         const normalUser = await prisma.person.create({
-            data: { email: 'user-nightly@example.com', name: 'Normal User', household: { create: {} } }
+            data: { email: 'user-nightly@example.com', name: 'Normal User', household: { create: { name: "Test HH" } } }
         });
         normalUserId = normalUser.id;
 
@@ -194,7 +194,7 @@ describe('Cron Nightly API Integration Tests', () => {
             // An extra plain participant (no program enrollment -> simple close path)
             // so we have two GOOD visits whose `departedAt` we can assert by id.
             const extra = await prisma.person.create({
-                data: { email: 'extra-nightly@example.com', name: 'Extra User', household: { create: {} } }
+                data: { email: 'extra-nightly@example.com', name: 'Extra User', household: { create: { name: "Test HH" } } }
             });
 
             const badVisit = await prisma.visit.create({

--- a/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
@@ -27,7 +27,7 @@ describe('Cron Pending-Participants API Integration Tests', () => {
 
     const mkParticipant = async (key: string) => {
         const p = await prisma.person.create({
-            data: { email: `${key}-pending-cron-test@example.com`, name: `${key} Pending Cron`, household: { create: {} } }
+            data: { email: `${key}-pending-cron-test@example.com`, name: `${key} Pending Cron`, household: { create: { name: "Test HH" } } }
         });
         ids[key] = p.id;
         return p.id;

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -29,7 +29,7 @@ describe("GET /api/cron/post-event", () => {
     it("should send emails for finished events and mark them as sent", async () => {
         // Setup data
         const lead = await prisma.person.create({
-            data: { email: "lead@example.com", name: "Lead Mentor", household: { create: {} } }
+            data: { email: "lead@example.com", name: "Lead Mentor", household: { create: { name: "Test HH" } } }
         });
 
         const program = await prisma.program.create({
@@ -52,7 +52,7 @@ describe("GET /api/cron/post-event", () => {
 
         // Add some RSVPs and Visits
         const user = await prisma.person.create({
-            data: { email: "user@example.com", name: "User", household: { create: {} } }
+            data: { email: "user@example.com", name: "User", household: { create: { name: "Test HH" } } }
         });
         
         await prisma.rSVP.create({

--- a/checkin-app/src/app/__tests__/cronRemindersAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronRemindersAPI.integration.test.ts
@@ -46,7 +46,7 @@ describe('Cron Reminders API Integration Tests', () => {
 
         // Setup mock database records
         const user = await prisma.person.create({
-            data: { email: 'user-cron-reminders-test@example.com', name: 'User Cron Reminders Test', household: { create: {} } }
+            data: { email: 'user-cron-reminders-test@example.com', name: 'User Cron Reminders Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
         testHouseholdId = user.householdId;

--- a/checkin-app/src/app/__tests__/cronRemindersEdge.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronRemindersEdge.integration.test.ts
@@ -40,7 +40,7 @@ describe('GET /api/cron/reminders — auth & window edges', () => {
 
     beforeAll(async () => {
         const p = await prisma.person.create({
-            data: { name: 'Reminders Edge', email: `p-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Reminders Edge', email: `p-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         participantId = p.id;
         householdId = p.householdId;

--- a/checkin-app/src/app/__tests__/directoryBoardAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/directoryBoardAPI.integration.test.ts
@@ -42,7 +42,7 @@ describe('GET /api/directory/board', () => {
                 dateOfBirth: new Date('1980-01-01'),
                 googleId: `google-${TAG}`,
                 isBoardMember: true,
-                household: { create: {} },
+                household: { create: { name: "Test HH" } },
             },
         });
         boardId = board.id;
@@ -53,7 +53,7 @@ describe('GET /api/directory/board', () => {
                 name: `Keyholder ${TAG}`,
                 email: `isKeyholder-${TAG}@example.com`,
                 isKeyholder: true,
-                household: { create: {} },
+                household: { create: { name: "Test HH" } },
             },
         });
         keyholderId = isKeyholder.id;

--- a/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
@@ -43,27 +43,27 @@ describe('Event Attendance API Integration Tests', () => {
 
         // Setup mock database records
         const admin = await prisma.person.create({
-            data: { email: 'admin-event-attendance-test@example.com', name: 'Admin Att Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-event-attendance-test@example.com', name: 'Admin Att Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 
         const user = await prisma.person.create({
-            data: { email: 'user-event-attendance-test@example.com', name: 'User Att Test', household: { create: {} } }
+            data: { email: 'user-event-attendance-test@example.com', name: 'User Att Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
 
         const mentor = await prisma.person.create({
-            data: { email: 'mentor-event-attendance-test@example.com', name: 'Mentor Att Test', household: { create: {} } }
+            data: { email: 'mentor-event-attendance-test@example.com', name: 'Mentor Att Test', household: { create: { name: "Test HH" } } }
         });
         testLeadMentorId = mentor.id;
 
         const participant1 = await prisma.person.create({
-            data: { email: 'p1-event-attendance-test@example.com', name: 'P1 Att Test', household: { create: {} } }
+            data: { email: 'p1-event-attendance-test@example.com', name: 'P1 Att Test', household: { create: { name: "Test HH" } } }
         });
         testParticipant1Id = participant1.id;
 
         const participant2 = await prisma.person.create({
-            data: { email: 'p2-event-attendance-test@example.com', name: 'P2 Att Test', household: { create: {} } }
+            data: { email: 'p2-event-attendance-test@example.com', name: 'P2 Att Test', household: { create: { name: "Test HH" } } }
         });
         testParticipant2Id = participant2.id;
 
@@ -81,7 +81,7 @@ describe('Event Attendance API Integration Tests', () => {
         // A lead of an UNRELATED program — the cross-tenant attacker for the IDOR
         // tests. Privileged in their own program, but not lead/staff of testEvent's.
         const foreignLead = await prisma.person.create({
-            data: { email: 'foreignlead-event-attendance-test@example.com', name: 'Foreign Lead Att Test', household: { create: {} } }
+            data: { email: 'foreignlead-event-attendance-test@example.com', name: 'Foreign Lead Att Test', household: { create: { name: "Test HH" } } }
         });
         foreignLeadId = foreignLead.id;
         const foreignProgram = await prisma.program.create({

--- a/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
@@ -58,13 +58,13 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
 
     beforeAll(async () => {
         const admin = await prisma.person.create({
-            data: { name: 'Cancel Admin', email: `admin-${TAG}@example.com`, isSysadmin: true, household: { create: {} } },
+            data: { name: 'Cancel Admin', email: `admin-${TAG}@example.com`, isSysadmin: true, household: { create: { name: "Test HH" } } },
         });
         adminId = admin.id;
         adminHouseholdId = admin.householdId;
 
         const p = await prisma.person.create({
-            data: { name: 'Cancel Attendee', email: `attendee-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Cancel Attendee', email: `attendee-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         participantId = p.id;
         householdId = p.householdId;

--- a/checkin-app/src/app/__tests__/eventCancelNotification.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelNotification.integration.test.ts
@@ -39,13 +39,13 @@ describe("PATCH /api/events/[id] cancel — attendee notification (characterizat
 
     beforeAll(async () => {
         const a = await prisma.person.create({
-            data: { name: 'Notify Attendee', email: `attendee-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Notify Attendee', email: `attendee-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         attendeeId = a.id;
         attendeeHouseholdId = a.householdId;
 
         const admin = await prisma.person.create({
-            data: { name: 'Notify Admin', email: `admin-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Notify Admin', email: `admin-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         adminId = admin.id;
         adminHouseholdId = admin.householdId;

--- a/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelRollback.integration.test.ts
@@ -43,13 +43,13 @@ describe('PATCH /api/events/[id] cancel — transaction rollback on partial fail
 
     beforeAll(async () => {
         const p = await prisma.person.create({
-            data: { name: 'Cancel Attendee', email: `attendee-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Cancel Attendee', email: `attendee-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         participantId = p.id;
         householdId = p.householdId;
 
         const admin = await prisma.person.create({
-            data: { name: 'Cancel Admin', email: `admin-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Cancel Admin', email: `admin-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         adminId = admin.id;
         adminHouseholdId = admin.householdId;

--- a/checkin-app/src/app/__tests__/eventMineAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventMineAPI.integration.test.ts
@@ -45,12 +45,12 @@ describe('My Events API Integration Tests', () => {
 
         // Setup mock database records
         const user = await prisma.person.create({
-            data: { email: 'user-mine-events-test@example.com', name: 'User Mine Test', household: { create: {} } }
+            data: { email: 'user-mine-events-test@example.com', name: 'User Mine Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
 
         const volunteer = await prisma.person.create({
-            data: { email: 'volunteer-mine-events-test@example.com', name: 'Volunteer Mine Test', household: { create: {} } }
+            data: { email: 'volunteer-mine-events-test@example.com', name: 'Volunteer Mine Test', household: { create: { name: "Test HH" } } }
         });
         testVolunteerId = volunteer.id;
 

--- a/checkin-app/src/app/__tests__/eventRSVPAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventRSVPAPI.integration.test.ts
@@ -42,12 +42,12 @@ describe('Event RSVP API Integration Tests', () => {
 
         // Setup mock database records
         const user = await prisma.person.create({
-            data: { email: 'enrolled-user-rsvp-test@example.com', name: 'Enrolled RSVP Test', household: { create: {} } }
+            data: { email: 'enrolled-user-rsvp-test@example.com', name: 'Enrolled RSVP Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
 
         const unenrolledUser = await prisma.person.create({
-            data: { email: 'unenrolled-user-rsvp-test@example.com', name: 'Unenrolled RSVP Test', household: { create: {} } }
+            data: { email: 'unenrolled-user-rsvp-test@example.com', name: 'Unenrolled RSVP Test', household: { create: { name: "Test HH" } } }
         });
         testUnenrolledUserId = unenrolledUser.id;
 
@@ -73,7 +73,7 @@ describe('Event RSVP API Integration Tests', () => {
         // A lead of an UNRELATED program — the cross-tenant attacker. Privileged in
         // their own program but not enrolled/volunteering in testEvent's program.
         const foreignLead = await prisma.person.create({
-            data: { email: 'foreignlead-rsvp-test@example.com', name: 'Foreign Lead RSVP Test', household: { create: {} } }
+            data: { email: 'foreignlead-rsvp-test@example.com', name: 'Foreign Lead RSVP Test', household: { create: { name: "Test HH" } } }
         });
         foreignLeadId = foreignLead.id;
         const foreignProgram = await prisma.program.create({

--- a/checkin-app/src/app/__tests__/eventRescheduleClearsReminder.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventRescheduleClearsReminder.integration.test.ts
@@ -62,13 +62,13 @@ describe('PATCH /api/events/[id] editTime — clears reminderSentAt on reschedul
 
     beforeAll(async () => {
         const p = await prisma.person.create({
-            data: { name: 'Reschedule Attendee', email: `attendee-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Reschedule Attendee', email: `attendee-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         participantId = p.id;
         householdId = p.householdId;
 
         const admin = await prisma.person.create({
-            data: { name: 'Reschedule Admin', email: `admin-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Reschedule Admin', email: `admin-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         adminId = admin.id;
         adminHouseholdId = admin.householdId;

--- a/checkin-app/src/app/__tests__/eventsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventsAPI.integration.test.ts
@@ -36,17 +36,17 @@ describe('Events API Integration Tests', () => {
 
         // Setup mock database records
         const admin = await prisma.person.create({
-            data: { email: 'admin-events-api-test@example.com', name: 'Admin Events Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-events-api-test@example.com', name: 'Admin Events Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 
         const user = await prisma.person.create({
-            data: { email: 'user-events-api-test@example.com', name: 'User Events Test', household: { create: {} } }
+            data: { email: 'user-events-api-test@example.com', name: 'User Events Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
 
         const mentor = await prisma.person.create({
-            data: { email: 'mentor-events-api-test@example.com', name: 'Mentor Events Test', household: { create: {} } }
+            data: { email: 'mentor-events-api-test@example.com', name: 'Mentor Events Test', household: { create: { name: "Test HH" } } }
         });
         testLeadMentorId = mentor.id;
 

--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -37,7 +37,7 @@ describe('Facility trends API', () => {
 
     beforeAll(async () => {
         const admin = await prisma.person.create({
-            data: { email: `admin-${TAG}@example.com`, name: 'Admin', isSysadmin: true, household: { create: {} } },
+            data: { email: `admin-${TAG}@example.com`, name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } },
         });
         adminId = admin.id;
         householdId = admin.householdId;

--- a/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdVisitsAPI.integration.test.ts
@@ -85,7 +85,7 @@ describe('Household Visits API Integration Tests', () => {
 
         // Every participant now belongs to a household; this user's own household simply has no visits.
         const noHouseUser = await prisma.person.create({
-            data: { email: 'nohouse-visits-api-test@example.com', name: 'No House User', household: { create: {} } }
+            data: { email: 'nohouse-visits-api-test@example.com', name: 'No House User', household: { create: { name: "Test HH" } } }
         });
         testNoHouseId = noHouseUser.id;
 

--- a/checkin-app/src/app/__tests__/householdsDenyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsDenyAPI.integration.test.ts
@@ -41,20 +41,20 @@ describe('POST /api/membership-ops/households — Deny Membership', () => {
 
         // Acting board member (in their own household).
         const board = await prisma.person.create({
-            data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, household: { create: {} } },
+            data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, household: { create: { name: "Test HH" } } },
         });
         boardId = board.id;
 
         // A plain household to deny.
         const member = await prisma.person.create({
-            data: { email: `member-${TAG}@example.com`, name: 'Plain Member', household: { create: {} } },
+            data: { email: `member-${TAG}@example.com`, name: 'Plain Member', household: { create: { name: "Test HH" } } },
         });
         plainMemberId = member.id;
         plainHouseholdId = member.householdId;
 
         // A household that contains a board member — must be undeniable.
         const protectedBoard = await prisma.person.create({
-            data: { email: `protected-${TAG}@example.com`, name: 'Protected Board', isBoardMember: true, household: { create: {} } },
+            data: { email: `protected-${TAG}@example.com`, name: 'Protected Board', isBoardMember: true, household: { create: { name: "Test HH" } } },
         });
         boardHouseholdId = protectedBoard.householdId;
     });

--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -39,19 +39,19 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
 
         // Acting board member (in their own household).
         const board = await prisma.person.create({
-            data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, household: { create: {} } },
+            data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, household: { create: { name: "Test HH" } } },
         });
         boardId = board.id;
 
         // A household with no membership row → will be granted (ACTIVE).
         const inactive = await prisma.person.create({
-            data: { email: `inactive-${TAG}@example.com`, name: 'Inactive Member', household: { create: {} } },
+            data: { email: `inactive-${TAG}@example.com`, name: 'Inactive Member', household: { create: { name: "Test HH" } } },
         });
         inactiveHouseholdId = inactive.householdId;
 
         // A household that is already ACTIVE → will be revoked (REVOKED).
         const active = await prisma.person.create({
-            data: { email: `active-${TAG}@example.com`, name: 'Active Member', household: { create: {} } },
+            data: { email: `active-${TAG}@example.com`, name: 'Active Member', household: { create: { name: "Test HH" } } },
         });
         activeHouseholdId = active.householdId;
         await prisma.orgMembership.create({ data: { householdId: activeHouseholdId, status: 'ACTIVE' } });

--- a/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/kioskCertificationsAPI.integration.test.ts
@@ -60,7 +60,7 @@ describe('Kiosk Certifications API Integration Tests', () => {
 
         // Setup mock database records
         const user = await prisma.person.create({
-            data: { email: 'user-certifications-api-test@example.com', name: 'User Kiosk Test', household: { create: {} } }
+            data: { email: 'user-certifications-api-test@example.com', name: 'User Kiosk Test', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
         testHouseholdId = user.householdId;

--- a/checkin-app/src/app/__tests__/localizationSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/localizationSettingsAPI.integration.test.ts
@@ -36,10 +36,10 @@ describe('Localization settings API', () => {
         prevSettings = existing ? { timezone: existing.timezone, locale: existing.locale } : null;
 
         adminId = (await prisma.person.create({
-            data: { email: 'admin-loc-test@example.com', name: 'Loc Admin', isSysadmin: true, household: { create: {} } },
+            data: { email: 'admin-loc-test@example.com', name: 'Loc Admin', isSysadmin: true, household: { create: { name: "Test HH" } } },
         })).id;
         plainId = (await prisma.person.create({
-            data: { email: 'plain-loc-test@example.com', name: 'Loc Plain', household: { create: {} } },
+            data: { email: 'plain-loc-test@example.com', name: 'Loc Plain', household: { create: { name: "Test HH" } } },
         })).id;
     });
 

--- a/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -79,9 +79,9 @@ describe('Membership EXTERNAL phase API', () => {
         process.env.ZOHO_WEBHOOK_SECRET = SECRET;
         await wipe();
 
-        const board = await prisma.person.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: {} } } });
+        const board = await prisma.person.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: "Test HH" } } } });
         boardId = board.id;
-        const user = await prisma.person.create({ data: { email: `user-${TAG}@example.com`, name: 'User', household: { create: {} } } });
+        const user = await prisma.person.create({ data: { email: `user-${TAG}@example.com`, name: 'User', household: { create: { name: "Test HH" } } } });
         plainUserId = user.id;
 
         const a = await makeProcess(`A ${TAG}`, 'zoho-A');
@@ -275,7 +275,7 @@ describe('Membership EXTERNAL phase — background-check step', () => {
         process.env.AVERITY_CONSENT_URL = AVERITY_URL;
         await wipe2();
 
-        const board = await prisma.person.create({ data: { email: `board-${TAG2}@example.com`, name: 'Board', isBoardMember: true, household: { create: {} } } });
+        const board = await prisma.person.create({ data: { email: `board-${TAG2}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: "Test HH" } } } });
         boardId2 = board.id;
 
         // Applicant household with an in-flight process already past the contract:

--- a/checkin-app/src/app/__tests__/myProgramsConflictsResolveAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/myProgramsConflictsResolveAPI.integration.test.ts
@@ -35,7 +35,7 @@ describe('My-programs conflicts resolve API', () => {
 
     beforeAll(async () => {
         const lead = await prisma.person.create({
-            data: { email: `lead-${TAG}@example.com`, name: 'Lead', household: { create: {} } },
+            data: { email: `lead-${TAG}@example.com`, name: 'Lead', household: { create: { name: "Test HH" } } },
         });
         leadId = lead.id;
         householdId = lead.householdId;

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -48,7 +48,7 @@ describe('Nav todo-counts API', () => {
         // Household A: a lead with a full slate of *member-actionable* todos, plus
         // one reviewer-owned membership state that must NOT count for the member.
         const lead = await prisma.person.create({
-            data: { email: `lead-${TAG}@example.com`, name: 'Lead A', dateOfBirth: new Date('1985-01-01'), phone: '555-0001', household: { create: {} } },
+            data: { email: `lead-${TAG}@example.com`, name: 'Lead A', dateOfBirth: new Date('1985-01-01'), phone: '555-0001', household: { create: { name: "Test HH" } } },
         });
         leadId = lead.id;
         householdAId = lead.householdId;
@@ -135,7 +135,7 @@ describe('Nav todo-counts API', () => {
 
         // Household B: a board member with no household todos of their own.
         const board = await prisma.person.create({
-            data: { email: `board-${TAG}@example.com`, name: 'Board B', dateOfBirth: new Date('1980-01-01'), phone: '555-0000', isBoardMember: true, household: { create: {} } },
+            data: { email: `board-${TAG}@example.com`, name: 'Board B', dateOfBirth: new Date('1980-01-01'), phone: '555-0000', isBoardMember: true, household: { create: { name: "Test HH" } } },
         });
         boardId = board.id;
         householdBId = board.householdId;
@@ -302,13 +302,13 @@ describe('Nav todo-counts API', () => {
 
         // Staff household: only an org-email participant → must NOT count.
         const staff = await prisma.person.create({
-            data: { email: `staff-${TAG}@${ORG_DOMAIN}`, name: 'Staff', household: { create: {} } },
+            data: { email: `staff-${TAG}@${ORG_DOMAIN}`, name: 'Staff', household: { create: { name: "Test HH" } } },
         });
         expect(await memberFamilies()).toBe(before);
 
         // Member family: a non-org email → +1.
         const member = await prisma.person.create({
-            data: { email: `family-${TAG}@example.com`, name: 'Family', household: { create: {} } },
+            data: { email: `family-${TAG}@example.com`, name: 'Family', household: { create: { name: "Test HH" } } },
         });
         expect(await memberFamilies()).toBe(before + 1);
 

--- a/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
@@ -30,7 +30,7 @@ describe("sendCheckinNotifications()", () => {
         jest.clearAllMocks();
 
         // Create household
-        const hh = await prisma.household.create({ data: {} });
+        const hh = await prisma.household.create({ data: { name: "Test HH" } });
         householdId = hh.id;
 
         // Create Lead

--- a/checkin-app/src/app/__tests__/onboardingStatusAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/onboardingStatusAPI.integration.test.ts
@@ -46,7 +46,7 @@ describe('Onboarding Status API Integration Tests', () => {
                 email: 'adult-onboarding-status-test@example.com',
                 name: 'Adult No Phone',
                 dateOfBirth: new Date('1990-01-01'),
-                household: { create: {} }
+                household: { create: { name: "Test HH" } }
             }
         });
         adultId = adult.id;
@@ -57,7 +57,7 @@ describe('Onboarding Status API Integration Tests', () => {
                 email: 'youth-onboarding-status-test@example.com',
                 name: 'Youth No Phone',
                 dateOfBirth: youthDob(),
-                household: { create: {} }
+                household: { create: { name: "Test HH" } }
             }
         });
         youthId = youth.id;
@@ -67,7 +67,7 @@ describe('Onboarding Status API Integration Tests', () => {
             data: {
                 email: 'nodob-onboarding-status-test@example.com',
                 name: 'No DOB No Phone',
-                household: { create: {} }
+                household: { create: { name: "Test HH" } }
             }
         });
         noDobId = noDob.id;

--- a/checkin-app/src/app/__tests__/personBgManualSubmit.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgManualSubmit.integration.test.ts
@@ -185,8 +185,10 @@ describe('Phase 3 — manual PERSON_BG submit + queue gating + e2e', () => {
         });
         // Subject whose household carries no name — the render must fall back to
         // "No household on file" rather than blank (Person.householdId is required,
-        // so a nameless household is the real "no household context" case).
-        const namelessHh = await prisma.household.create({ data: { name: null } });
+        // so an empty-name household is the real "no household context" case).
+        // name is NOT NULL; "" is the empty sentinel and the render's falsy check
+        // (`household?.name ? … : "No household on file"`) treats it like the old null.
+        const namelessHh = await prisma.household.create({ data: { name: "" } });
         const orphan = await makePerson('queue-orphan', namelessHh.id, { dateOfBirth: ADULT_DOB });
         const orphanBg = await prisma.orgMembershipProcess.create({
             data: { kind: 'PERSON_BG', subjectPersonId: orphan.id, orgMembershipId: null, status: 'PENDING_BG_REVIEW' },
@@ -214,7 +216,7 @@ describe('Phase 3 — manual PERSON_BG submit + queue gating + e2e', () => {
         expect(withHh?.subjectPerson?.name).toBe('queue-subject');
         expect(withHh?.subjectPerson?.household?.name).toBe(`${TAG} queueSubjHh`);
         expect(noHh?.subjectPerson?.name).toBe('queue-orphan');
-        expect(noHh?.subjectPerson?.household?.name).toBeNull(); // nameless household → "No household on file"
+        expect(noHh?.subjectPerson?.household?.name).toBe(""); // empty-name household → "No household on file"
     });
 
     it('end-to-end: submit → two distinct reviewers attest → only the subject is stamped → dashboard clears', async () => {

--- a/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
@@ -51,7 +51,7 @@ describe('Profile API Integration Tests', () => {
                 email: 'user-profile-api-test@example.com',
                 name: 'Profile Tester',
                 dateOfBirth: new Date('1990-01-01'),
-                household: { create: {} }
+                household: { create: { name: "Test HH" } }
             }
         });
         testUserId = user.id;

--- a/checkin-app/src/app/__tests__/profileVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileVisitsAPI.integration.test.ts
@@ -43,7 +43,7 @@ describe('Profile Visits API Integration Tests', () => {
 
         // Setup mock database records
         const user = await prisma.person.create({
-            data: { email: 'user-profile-visits-test@example.com', name: 'Profile Visits Tester', household: { create: {} } }
+            data: { email: 'user-profile-visits-test@example.com', name: 'Profile Visits Tester', household: { create: { name: "Test HH" } } }
         });
         testUserId = user.id;
         testHouseholdId = user.householdId;

--- a/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
@@ -58,47 +58,47 @@ describe('Program Age Bounds Integration Tests', () => {
 
         // Setup mock database records
         const admin = await prisma.person.create({
-            data: { email: 'admin-age-test@example.com', name: 'Admin Age Test', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-age-test@example.com', name: 'Admin Age Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 
         const pValid = await prisma.person.create({
-            data: { email: 'valid-age-test@example.com', name: 'Valid Age Test', dateOfBirth: dob16, household: { create: {} } }
+            data: { email: 'valid-age-test@example.com', name: 'Valid Age Test', dateOfBirth: dob16, household: { create: { name: "Test HH" } } }
         });
         validUserId = pValid.id;
 
         const pUnder = await prisma.person.create({
-            data: { email: 'underage-test@example.com', name: 'Underage Test', dateOfBirth: dob12, household: { create: {} } }
+            data: { email: 'underage-test@example.com', name: 'Underage Test', dateOfBirth: dob12, household: { create: { name: "Test HH" } } }
         });
         underageUserId = pUnder.id;
 
         const pOver = await prisma.person.create({
-            data: { email: 'overage-test@example.com', name: 'Overage Test', dateOfBirth: dob20, household: { create: {} } }
+            data: { email: 'overage-test@example.com', name: 'Overage Test', dateOfBirth: dob20, household: { create: { name: "Test HH" } } }
         });
         overageUserId = pOver.id;
 
         const pNoDob = await prisma.person.create({
-            data: { email: 'no-dob-test@example.com', name: 'No DOB Test', household: { create: {} } }
+            data: { email: 'no-dob-test@example.com', name: 'No DOB Test', household: { create: { name: "Test HH" } } }
         });
         noDobUserId = pNoDob.id;
 
         const pExactlyMin = await prisma.person.create({
-            data: { email: 'exactly-min-age-test@example.com', name: 'Exactly Min Age Test', dateOfBirth: dobExactly14, household: { create: {} } }
+            data: { email: 'exactly-min-age-test@example.com', name: 'Exactly Min Age Test', dateOfBirth: dobExactly14, household: { create: { name: "Test HH" } } }
         });
         exactlyMinUserId = pExactlyMin.id;
 
         const pExactlyMax = await prisma.person.create({
-            data: { email: 'exactly-max-age-test@example.com', name: 'Exactly Max Age Test', dateOfBirth: dobExactly18, household: { create: {} } }
+            data: { email: 'exactly-max-age-test@example.com', name: 'Exactly Max Age Test', dateOfBirth: dobExactly18, household: { create: { name: "Test HH" } } }
         });
         exactlyMaxUserId = pExactlyMax.id;
 
         const pTurns14Tomorrow = await prisma.person.create({
-            data: { email: 'turns-14-tomorrow-age-test@example.com', name: 'Turns 14 Tomorrow Test', dateOfBirth: dobTurns14Tomorrow, household: { create: {} } }
+            data: { email: 'turns-14-tomorrow-age-test@example.com', name: 'Turns 14 Tomorrow Test', dateOfBirth: dobTurns14Tomorrow, household: { create: { name: "Test HH" } } }
         });
         turns14TomorrowUserId = pTurns14Tomorrow.id;
 
         const pTurned19Yesterday = await prisma.person.create({
-            data: { email: 'turned-19-yesterday-age-test@example.com', name: 'Turned 19 Yesterday Test', dateOfBirth: dobTurned19Yesterday, household: { create: {} } }
+            data: { email: 'turned-19-yesterday-age-test@example.com', name: 'Turned 19 Yesterday Test', dateOfBirth: dobTurned19Yesterday, household: { create: { name: "Test HH" } } }
         });
         turned19YesterdayUserId = pTurned19Yesterday.id;
 

--- a/checkin-app/src/app/__tests__/programAgeStartDate.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeStartDate.integration.test.ts
@@ -56,7 +56,7 @@ describe('Program Age Start-Date Basis (authenticated route)', () => {
         // Born 2012-04-01: age 13 as of 2026-01-01 (frozen now), turns 14 on
         // 2026-04-01 — BEFORE the 2026-09-01 start. Eligible as of startAt only.
         const user = await prisma.person.create({
-            data: { email: 'turns14-age-startdate-test@example.com', name: 'Turns 14 Before Start', dateOfBirth: new Date('2012-04-01T00:00:00.000Z'), household: { create: {} } }
+            data: { email: 'turns14-age-startdate-test@example.com', name: 'Turns 14 Before Start', dateOfBirth: new Date('2012-04-01T00:00:00.000Z'), household: { create: { name: "Test HH" } } }
         });
         userId = user.id;
     });

--- a/checkin-app/src/app/__tests__/programAnnounceNotification.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAnnounceNotification.integration.test.ts
@@ -49,11 +49,11 @@ describe('New-program announce notification trigger', () => {
         await prisma.person.deleteMany({ where: { id: { in: existingUserIds } } });
 
         const admin = await prisma.person.create({
-            data: { email: 'admin-announce-notify-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } },
+            data: { email: 'admin-announce-notify-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } },
         });
         adminId = admin.id;
         const lead = await prisma.person.create({
-            data: { email: 'lead-announce-notify-test@example.com', name: 'Lead', household: { create: {} } },
+            data: { email: 'lead-announce-notify-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } },
         });
         leadId = lead.id;
     });

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -41,7 +41,7 @@ describe('Program payment-plan routes', () => {
 
     beforeAll(async () => {
         const mentor = await prisma.person.create({
-            data: { name: 'PP Mentor', email: `mentor-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'PP Mentor', email: `mentor-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         mentorId = mentor.id;
         householdIds.push(mentor.householdId);
@@ -52,25 +52,25 @@ describe('Program payment-plan routes', () => {
         programId = program.id;
 
         const board = await prisma.person.create({
-            data: { name: 'PP Board', email: `board-${TAG}@example.com`, isBoardMember: true, household: { create: {} } },
+            data: { name: 'PP Board', email: `board-${TAG}@example.com`, isBoardMember: true, household: { create: { name: "Test HH" } } },
         });
         boardId = board.id;
         householdIds.push(board.householdId);
 
         const self = await prisma.person.create({
-            data: { name: 'PP Self', email: `self-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'PP Self', email: `self-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         selfId = self.id;
         householdIds.push(self.householdId);
 
         const other = await prisma.person.create({
-            data: { name: 'PP Other', email: `other-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'PP Other', email: `other-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         otherId = other.id;
         householdIds.push(other.householdId);
 
         const noise = await prisma.person.create({
-            data: { name: 'PP Noise', email: `noise-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'PP Noise', email: `noise-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         noiseId = noise.id;
         householdIds.push(noise.householdId);

--- a/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
@@ -46,12 +46,12 @@ describe('Program price round-trip (dollars -> cents) Integration Tests', () => 
         await prisma.person.deleteMany({ where: { id: { in: existingUserIds } } });
 
         const admin = await prisma.person.create({
-            data: { email: 'admin-price-roundtrip-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } },
+            data: { email: 'admin-price-roundtrip-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } },
         });
         adminId = admin.id;
 
         const lead = await prisma.person.create({
-            data: { email: 'lead-price-roundtrip-test@example.com', name: 'Lead', household: { create: {} } },
+            data: { email: 'lead-price-roundtrip-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } },
         });
         leadId = lead.id;
     });

--- a/checkin-app/src/app/__tests__/programSyncShopifyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programSyncShopifyAPI.integration.test.ts
@@ -49,15 +49,15 @@ describe('POST /api/programs/[id]/sync-shopify', () => {
         process.env.CHECKIN_ENV = 'local';
 
         const admin = await prisma.person.create({
-            data: { email: `admin-${TAG}@example.com`, name: 'Admin', isSysadmin: true, household: { create: {} } },
+            data: { email: `admin-${TAG}@example.com`, name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } },
         });
         adminId = admin.id;
         const board = await prisma.person.create({
-            data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: {} } },
+            data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: "Test HH" } } },
         });
         boardId = board.id;
         const common = await prisma.person.create({
-            data: { email: `common-${TAG}@example.com`, name: 'Common', household: { create: {} } },
+            data: { email: `common-${TAG}@example.com`, name: 'Common', household: { create: { name: "Test HH" } } },
         });
         commonId = common.id;
     });

--- a/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
@@ -45,19 +45,19 @@ describe('Programs API Integration Tests', () => {
 
         // Create Admin
         const admin = await prisma.person.create({
-            data: { email: 'admin-programs-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-programs-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         adminId = admin.id;
 
         // Create Lead
         const lead = await prisma.person.create({
-            data: { email: 'lead-programs-api-test@example.com', name: 'Lead', household: { create: {} } }
+            data: { email: 'lead-programs-api-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } }
         });
         leadId = lead.id;
 
         // Create Common User
         const commonUser = await prisma.person.create({
-            data: { email: 'common-programs-api-test@example.com', name: 'Common', household: { create: {} } }
+            data: { email: 'common-programs-api-test@example.com', name: 'Common', household: { create: { name: "Test HH" } } }
         });
         commonId = commonUser.id;
 

--- a/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsEligibleParticipantsAPI.integration.test.ts
@@ -66,19 +66,19 @@ describe('Eligible Participants API Integration Tests', () => {
 
         // Create Admin
         const admin = await prisma.person.create({
-            data: { email: 'admin-elig-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-elig-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         adminId = admin.id;
 
         // Create Lead
         const lead = await prisma.person.create({
-            data: { email: 'lead-elig-api-test@example.com', name: 'Lead', household: { create: {} } }
+            data: { email: 'lead-elig-api-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } }
         });
         leadId = lead.id;
 
         // Create Common User
         const commonUser = await prisma.person.create({
-            data: { email: 'common-elig-api-test@example.com', name: 'Common', household: { create: {} } }
+            data: { email: 'common-elig-api-test@example.com', name: 'Common', household: { create: { name: "Test HH" } } }
         });
         commonId = commonUser.id;
 
@@ -89,6 +89,7 @@ describe('Eligible Participants API Integration Tests', () => {
                 name: 'Active Member Candidate',
                 household: {
                     create: {
+                        name: "Test HH",
                         orgMembership: {
                             create: {
                                 status: 'ACTIVE',
@@ -129,7 +130,7 @@ describe('Eligible Participants API Integration Tests', () => {
             data: {
                 email: 'non-member-elig-api-test@example.com',
                 name: 'Non Member Candidate',
-                household: { create: {} }
+                household: { create: { name: "Test HH" } }
             }
         });
         nonMemberId = nonMember.id;
@@ -150,7 +151,7 @@ describe('Eligible Participants API Integration Tests', () => {
             data: {
                 email: 'enrolled-elig-api-test@example.com',
                 name: 'Already Enrolled Candidate',
-                household: { create: {} },
+                household: { create: { name: "Test HH" } },
                 programParticipants: {
                     create: {
                         programId: publicProgramId

--- a/checkin-app/src/app/__tests__/programsEnrollClosed.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsEnrollClosed.integration.test.ts
@@ -36,7 +36,7 @@ describe('Enroll into a CLOSED program is rejected', () => {
 
     beforeAll(async () => {
         await cleanup();
-        const user = await prisma.person.create({ data: { email: `user-${TAG}@example.com`, name: 'Self Enroller', household: { create: {} } } });
+        const user = await prisma.person.create({ data: { email: `user-${TAG}@example.com`, name: 'Self Enroller', household: { create: { name: "Test HH" } } } });
         userId = user.id;
         const program = await prisma.program.create({
             data: { name: `Closed ${TAG}`, phase: 'RUNNING', enrollmentStatus: 'CLOSED', orgMemberPriceCents: null, nonOrgMemberPriceCents: null },

--- a/checkin-app/src/app/__tests__/programsHouseholdEnrollment.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsHouseholdEnrollment.integration.test.ts
@@ -60,7 +60,7 @@ describe('Multi-select household enrollment (integration)', () => {
         await cleanup();
 
         // One household: a lead + three adult dependents (no age limits in play).
-        const household = await prisma.household.create({ data: {} });
+        const household = await prisma.household.create({ data: { name: "Test HH" } });
         const lead = await prisma.person.create({
             data: { email: `lead-${TAG}@example.com`, name: 'HH Lead', householdId: household.id }
         });

--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -54,19 +54,19 @@ describe('Individual Program API Integration Tests', () => {
 
         // Create Admin
         const admin = await prisma.person.create({
-            data: { email: 'admin-prog-id-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-prog-id-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         adminId = admin.id;
 
         // Create Lead
         const lead = await prisma.person.create({
-            data: { email: 'lead-prog-id-api-test@example.com', name: 'Lead', household: { create: {} } }
+            data: { email: 'lead-prog-id-api-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } }
         });
         leadId = lead.id;
 
         // Create Common User (no membership)
         const commonUser = await prisma.person.create({
-            data: { email: 'common-prog-id-api-test@example.com', name: 'Common', household: { create: {} } }
+            data: { email: 'common-prog-id-api-test@example.com', name: 'Common', household: { create: { name: "Test HH" } } }
         });
         commonId = commonUser.id;
 
@@ -77,6 +77,7 @@ describe('Individual Program API Integration Tests', () => {
                 name: 'Member',
                 household: {
                     create: {
+                        name: "Test HH",
                         orgMembership: {
                             create: {
                                 status: 'ACTIVE',
@@ -105,7 +106,7 @@ describe('Individual Program API Integration Tests', () => {
         // Enroll a participant with a recognizable name into the public program so
         // the leak tests have a roster identity to look for.
         const enrolled = await prisma.person.create({
-            data: { email: 'enrolled-prog-id-api-test@example.com', name: ENROLLED_NAME, household: { create: {} } }
+            data: { email: 'enrolled-prog-id-api-test@example.com', name: ENROLLED_NAME, household: { create: { name: "Test HH" } } }
         });
         enrolledId = enrolled.id;
         await prisma.programParticipant.create({

--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -61,13 +61,13 @@ describe('Program Participants API Integration Tests', () => {
 
         // Create Admin
         const admin = await prisma.person.create({
-            data: { email: 'admin-partic-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-partic-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         adminId = admin.id;
 
         // Create Lead
         const lead = await prisma.person.create({
-            data: { email: 'lead-partic-api-test@example.com', name: 'Lead', household: { create: {} } }
+            data: { email: 'lead-partic-api-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } }
         });
         leadId = lead.id;
 
@@ -77,7 +77,7 @@ describe('Program Participants API Integration Tests', () => {
                 email: 'common-partic-api-test@example.com',
                 name: 'Common',
                 dateOfBirth: new Date(Date.now() - (25 * 31556952000)),
-                household: { create: {} }
+                household: { create: { name: "Test HH" } }
             }
         });
         commonId = commonUser.id;
@@ -88,14 +88,14 @@ describe('Program Participants API Integration Tests', () => {
                 email: 'other-partic-api-test@example.com',
                 name: 'Other Underage',
                 dateOfBirth: new Date(Date.now() - (10 * 31556952000)),
-                household: { create: {} }
+                household: { create: { name: "Test HH" } }
             }
         });
         otherId = otherUser.id;
 
         // Board member who leads a household containing a 25yo dependent. The
         // board flag lives on the session, not the DB row — see the mocks below.
-        const boardHousehold = await prisma.household.create({ data: {} });
+        const boardHousehold = await prisma.household.create({ data: { name: "Test HH" } });
         const board = await prisma.person.create({
             data: { email: 'board-partic-api-test@example.com', name: 'Board Parent', householdId: boardHousehold.id }
         });

--- a/checkin-app/src/app/__tests__/programsPublishAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsPublishAPI.integration.test.ts
@@ -49,19 +49,19 @@ describe('Program Publish API Integration Tests', () => {
 
         // Create Admin
         const admin = await prisma.person.create({
-            data: { email: 'admin-publish-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-publish-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         adminId = admin.id;
 
         // Create Lead
         const lead = await prisma.person.create({
-            data: { email: 'lead-publish-api-test@example.com', name: 'Lead', household: { create: {} } }
+            data: { email: 'lead-publish-api-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } }
         });
         leadId = lead.id;
 
         // Create Common User
         const commonUser = await prisma.person.create({
-            data: { email: 'common-publish-api-test@example.com', name: 'Common', household: { create: {} } }
+            data: { email: 'common-publish-api-test@example.com', name: 'Common', household: { create: { name: "Test HH" } } }
         });
         commonId = commonUser.id;
 

--- a/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
@@ -43,25 +43,25 @@ describe('Program Settings API Integration Tests', () => {
 
         // Create Admin
         const admin = await prisma.person.create({
-            data: { email: 'admin-settings-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-settings-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         adminId = admin.id;
 
         // Create Lead
         const lead = await prisma.person.create({
-            data: { email: 'lead-settings-api-test@example.com', name: 'Lead', household: { create: {} } }
+            data: { email: 'lead-settings-api-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } }
         });
         leadId = lead.id;
 
         // Create New Lead Candidate
         const newLead = await prisma.person.create({
-            data: { email: 'newlead-settings-api-test@example.com', name: 'New Lead', household: { create: {} } }
+            data: { email: 'newlead-settings-api-test@example.com', name: 'New Lead', household: { create: { name: "Test HH" } } }
         });
         newLeadId = newLead.id;
 
         // Create Common User
         const commonUser = await prisma.person.create({
-            data: { email: 'common-settings-api-test@example.com', name: 'Common', household: { create: {} } }
+            data: { email: 'common-settings-api-test@example.com', name: 'Common', household: { create: { name: "Test HH" } } }
         });
         commonId = commonUser.id;
 

--- a/checkin-app/src/app/__tests__/programsVolunteersAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsVolunteersAPI.integration.test.ts
@@ -49,27 +49,27 @@ describe('Program Volunteers API Integration Tests', () => {
 
         // Create Roles
         const admin = await prisma.person.create({
-            data: { email: 'admin-volun-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-volun-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         adminId = admin.id;
 
         const lead = await prisma.person.create({
-            data: { email: 'lead-volun-api-test@example.com', name: 'Lead', household: { create: {} } }
+            data: { email: 'lead-volun-api-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } }
         });
         leadId = lead.id;
 
         const commonUser = await prisma.person.create({
-            data: { email: 'common-volun-api-test@example.com', name: 'Common', household: { create: {} } }
+            data: { email: 'common-volun-api-test@example.com', name: 'Common', household: { create: { name: "Test HH" } } }
         });
         commonId = commonUser.id;
 
         const candidate = await prisma.person.create({
-            data: { email: 'candidate-volun-api-test@example.com', name: 'Candidate', household: { create: {} } }
+            data: { email: 'candidate-volun-api-test@example.com', name: 'Candidate', household: { create: { name: "Test HH" } } }
         });
         candidateId = candidate.id;
 
         const existingVol = await prisma.person.create({
-            data: { email: 'existing-volun-api-test@example.com', name: 'Existing Volunteer', household: { create: {} } }
+            data: { email: 'existing-volun-api-test@example.com', name: 'Existing Volunteer', household: { create: { name: "Test HH" } } }
         });
         existingVolunteerId = existingVol.id;
 

--- a/checkin-app/src/app/__tests__/scanAuth.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanAuth.integration.test.ts
@@ -103,7 +103,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
                     name: 'Kiosk Keyholder',
                     email: `kiosk-${TAG}@example.com`,
                     isKeyholder: true,
-                    household: { create: {} },
+                    household: { create: { name: "Test HH" } },
                 },
             });
             kioskId = k.id;
@@ -249,7 +249,7 @@ describe('POST /api/scan — REAL auth wiring (no @/lib/auth mock)', () => {
                     data: {
                         name,
                         email: `${name.replace(/\s+/g, '-').toLowerCase()}-${TAG}@example.com`,
-                        household: { create: {} },
+                        household: { create: { name: "Test HH" } },
                         ...extra,
                     },
                 });

--- a/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
@@ -45,11 +45,11 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
     beforeAll(async () => {
         (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'kiosk' });
         isKeyholder = await prisma.person.create({
-            data: { name: 'Causal Key', email: `key-${TAG}@example.com`, isKeyholder: true, household: { create: {} } },
+            data: { name: 'Causal Key', email: `key-${TAG}@example.com`, isKeyholder: true, household: { create: { name: "Test HH" } } },
         });
         householdIds.push(isKeyholder.householdId);
         normal = await prisma.person.create({
-            data: { name: 'Causal Normal', email: `normal-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Causal Normal', email: `normal-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         householdIds.push(normal.householdId);
     });

--- a/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCheckin.integration.test.ts
@@ -52,7 +52,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
                 name: 'Keyholder Scan',
                 email: `isKeyholder-${TAG}@example.com`,
                 isKeyholder: true,
-                household: { create: {} },
+                household: { create: { name: "Test HH" } },
             },
         });
         keyholderId = isKeyholder.id;
@@ -62,7 +62,7 @@ describe('POST /api/scan — real check-in/out logic', () => {
             data: {
                 name: 'Normal Scan',
                 email: `normal-${TAG}@example.com`,
-                household: { create: {} },
+                household: { create: { name: "Test HH" } },
             },
         });
         normalId = normal.id;

--- a/checkin-app/src/app/__tests__/scanConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanConcurrency.integration.test.ts
@@ -79,7 +79,7 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         await prisma.household.deleteMany({ where: { id: { in: leakedHouseholdIds } } });
 
         const keeper = await prisma.person.create({
-            data: { email: `keeper-${EMAIL_TAG}@example.com`, name: 'Keeper', isKeyholder: true, household: { create: {} } },
+            data: { email: `keeper-${EMAIL_TAG}@example.com`, name: 'Keeper', isKeyholder: true, household: { create: { name: "Test HH" } } },
         });
         keeperId = keeper.id;
         // Keep the isKeyholder checked in so non-isKeyholder check-ins are allowed
@@ -87,12 +87,12 @@ describe('POST /api/scan concurrency (advisory lock)', () => {
         await prisma.visit.create({ data: { personId: keeperId, arrivedAt: new Date() } });
 
         const checkinSubject = await prisma.person.create({
-            data: { email: `checkin-${EMAIL_TAG}@example.com`, name: 'Checkin Subject', household: { create: {} } },
+            data: { email: `checkin-${EMAIL_TAG}@example.com`, name: 'Checkin Subject', household: { create: { name: "Test HH" } } },
         });
         checkinSubjectId = checkinSubject.id;
 
         const checkoutSubject = await prisma.person.create({
-            data: { email: `checkout-${EMAIL_TAG}@example.com`, name: 'Checkout Subject', household: { create: {} } },
+            data: { email: `checkout-${EMAIL_TAG}@example.com`, name: 'Checkout Subject', household: { create: { name: "Test HH" } } },
         });
         checkoutSubjectId = checkoutSubject.id;
     });

--- a/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/shopAPI.integration.test.ts
@@ -63,13 +63,13 @@ describe('Shop API Integration Tests', () => {
 
         // Create Admin
         const admin = await prisma.person.create({
-            data: { email: 'admin-shop-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: {} } }
+            data: { email: 'admin-shop-api-test@example.com', name: 'Admin', isSysadmin: true, household: { create: { name: "Test HH" } } }
         });
         adminId = admin.id;
 
         // Create Board Member
         const board = await prisma.person.create({
-            data: { email: 'board-shop-api-test@example.com', name: 'Board', isBoardMember: true, household: { create: {} } }
+            data: { email: 'board-shop-api-test@example.com', name: 'Board', isBoardMember: true, household: { create: { name: "Test HH" } } }
         });
         boardId = board.id;
 
@@ -79,7 +79,7 @@ describe('Shop API Integration Tests', () => {
                 email: 'common-shop-api-test@example.com',
                 name: 'Common',
                 // Volunteer member: the household holds an ACTIVE, isVolunteer membership.
-                household: { create: { orgMembership: { create: { status: 'ACTIVE', isVolunteer: true } } } }
+                household: { create: { name: 'Test HH', orgMembership: { create: { status: 'ACTIVE', isVolunteer: true } } } }
             }
         });
         commonId = commonUser.id;
@@ -94,7 +94,7 @@ describe('Shop API Integration Tests', () => {
             data: {
                 email: 'certifier-shop-api-test@example.com',
                 name: 'Certifier',
-                household: { create: {} },
+                household: { create: { name: "Test HH" } },
                 toolStatuses: {
                     create: { toolId: mockToolId, level: 'MAY_CERTIFY_OTHERS' }
                 }
@@ -339,12 +339,12 @@ describe('Shop API Integration Tests', () => {
                 data: {
                     email: 'recert-certifier-shop-api-test@example.com',
                     name: 'Recert Certifier',
-                    household: { create: {} },
+                    household: { create: { name: "Test HH" } },
                     toolStatuses: { create: { toolId: tool.id, level: 'MAY_CERTIFY_OTHERS' } },
                 },
             });
             const target = await prisma.person.create({
-                data: { email: 'recert-target-shop-api-test@example.com', name: 'Recert Target', household: { create: {} } },
+                data: { email: 'recert-target-shop-api-test@example.com', name: 'Recert Target', household: { create: { name: "Test HH" } } },
             });
 
             try {

--- a/checkin-app/src/app/__tests__/systemStatusHealthAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/systemStatusHealthAPI.integration.test.ts
@@ -30,7 +30,7 @@ describe('System status health API', () => {
 
     beforeAll(async () => {
         const keyholder = await prisma.person.create({
-            data: { email: `keyholder-${TAG}@example.com`, name: 'Keyholder', isKeyholder: true, household: { create: {} } },
+            data: { email: `keyholder-${TAG}@example.com`, name: 'Keyholder', isKeyholder: true, household: { create: { name: "Test HH" } } },
         });
         keyholderId = keyholder.id;
         householdId = keyholder.householdId;

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -68,12 +68,12 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         programId = program.id;
 
         const a = await prisma.person.create({
-            data: { name: 'Hook P1', email: `p1-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Hook P1', email: `p1-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         p1 = a.id;
         h1 = a.householdId;
         const b = await prisma.person.create({
-            data: { name: 'Hook P2', email: `p2-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'Hook P2', email: `p2-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         p2 = b.id;
         h2 = b.householdId;

--- a/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
@@ -34,8 +34,13 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
         }
 
         const body = await request.json();
-        const data: { name?: string | null } & Partial<StructuredAddress> = {};
-        if (body.name !== undefined) data.name = body.name;
+        const data: { name?: string } & Partial<StructuredAddress> = {};
+        if (body.name !== undefined) {
+            if (typeof body.name !== "string" || !body.name.trim()) {
+                return apiError("Household name cannot be empty", 400);
+            }
+            data.name = body.name.trim();
+        }
         Object.assign(data, normalizeAddressInput(body));
 
         const editsContact = body.emergencyContactName !== undefined || body.emergencyContactPhone !== undefined;

--- a/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
@@ -27,7 +27,7 @@ describe('attendanceTransitions', () => {
         programId = program.id;
 
         const p = await prisma.person.create({
-            data: { name: 'AT Enrolled', email: `enrolled-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'AT Enrolled', email: `enrolled-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         participantId = p.id;
         householdIds.push(p.householdId);
@@ -36,7 +36,7 @@ describe('attendanceTransitions', () => {
         });
 
         const u = await prisma.person.create({
-            data: { name: 'AT Unenrolled', email: `unenrolled-${TAG}@example.com`, household: { create: {} } },
+            data: { name: 'AT Unenrolled', email: `unenrolled-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
         });
         unenrolledId = u.id;
         householdIds.push(u.householdId);

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -62,7 +62,7 @@ export async function createParticipantWithHousehold(data: {
 }) {
     return prisma.$transaction(async (tx) => {
         const household = await tx.household.create({
-            data: { name: data.name ?? data.email ?? null },
+            data: { name: data.name ?? data.email ?? "Household" },
         });
         const participant = await tx.person.create({
             data: { ...data, householdId: household.id },


### PR DESCRIPTION
## What

Tighten `Household.name` from nullable (`String?`) to `String`.

## Why

No live create path ever writes null: OAuth signup falls back to email, membership-ops to `'User'`, Zoho import to the literal `'Household'`. The nullable was schema slack no production row exercised.

## Changes

- **schema**: `name String?` → `name String`
- **migration `20260705160000`**: backfill any null from a household member's `Person.name` (itself nullable, so `COALESCE` → `'Household'`), then `SET NOT NULL`. Cannot fail on the live DB.
- **auth-options**: OAuth create's now-illegal `?? null` tail → `?? "Household"`.
- **membership-ops `households/[id]` route**: admin edit accepted raw `body.name` (could be null/empty) → rejects empty with `400`, trims.
- **~70 test fixtures**: spun throwaway households via `household: { create: {} }`, relying on the nullable default — all pass a name now.

## Reconciliation with #920

[#920](https://github.com/innovationtreehouse/checkin/pull/920) (PERSON_BG manual review) merged **after** this branch started. Its reviewer queue renders `"No household on file"` when a subject's household has no name — a **falsy check** (`household?.name ? … : "No household on file"`), not null-specific. That state is prod-unreachable (PERSON_BG subjects reuse their named signup household), but #920's integration test manufactured it with `name: null`.

Switched that one fixture to the empty-string sentinel `""` (+ its `.toBeNull()` → `.toBe("")`). The render's falsy check treats `""` identically, so #920's feature and its `"No household on file"` assertion are **fully preserved** under NOT NULL. No change to #920's shipped code — two lines in its test.

This is what ejected the PR from the merge queue 3× earlier: the queue merges with newer main, surfacing #920's null insert against the new constraint.

## Verification

- `tsc --noEmit`: clean
- Unit: 1560 pass
- Integration: 917 pass (fresh PG, all 5 migrations applied in order)
- Flow: passed in CI

## Reviewer notes

- Migration safe to deploy but **not yet applied to any real DB** — deploy step.
- Backfill source is a household member's name per request; `'Household'` literal only if zero named members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)