### PR TITLE
feat(membership-bg): manual "record external check → submit for review" (Phase 3)

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -66,6 +66,8 @@ const AUTHZ_TESTED = new Set<string>([
     'facility/visits',
     'kioskdisplay/certifications',
     'membership-audit/compliance',
+    // POST deny-path (403 non-board) in personBgManualSubmit.integration.test.ts.
+    'membership-audit/person-bg',
     'membership-audit/households-missing-contact',
     'membership-audit/unclaimed-households',
     'membership-ops/applications/certify-payment',

--- a/checkin-app/src/app/__tests__/personBgManualSubmit.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgManualSubmit.integration.test.ts
@@ -1,0 +1,253 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for Phase 3 (manual review mode) of the per-person background
+ * check: the board-driven "record an external check → submit for review" action.
+ *   - submit opens a PERSON_BG (dedup-guarded) + sets bgConsentAt + is audit-logged,
+ *     is idempotent, and the route rejects a non-board/non-sysadmin caller;
+ *   - queue gating flips on submit: an unsubmitted PERSON_BG is NOT listed/counted,
+ *     a submitted one IS — with the subject identity rendered (incl. no household);
+ *   - end-to-end: submit → two distinct-household reviewers attest → only the
+ *     subject is stamped → the compliance dashboard PERSON_BG_NEEDED clears.
+ *
+ * Modeled on membershipReviewAPI / personBgComplianceAPI / personBgTriggers.
+ */
+
+import { submitPersonBgForReview } from '@/lib/membership/personBgSubmit';
+import { POST as SUBMIT_BG } from '@/app/api/membership-audit/person-bg/route';
+import { GET as REVIEW_QUEUE } from '@/app/api/membership/reviews/route';
+import { GET as COMPLIANCE } from '@/app/api/membership-audit/compliance/route';
+import { attest, eligibleReviewProcessIds } from '@/lib/membership/review';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import { sendEmail } from '@/lib/email';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+// The reviewer ping is exercised (notifyReviewers) but must not hit Resend.
+jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+const sendEmailMock = sendEmail as jest.Mock;
+
+const TAG = 'person-bg-submit-test';
+const RECHECK_MONTHS = 12;
+const BOUNDARY_SEED = new Date('2000-09-01');
+const ADULT_DOB = new Date('1990-01-01');
+
+function as(id: number, roles: { isBackgroundCheckReviewer?: boolean; isBoardMember?: boolean; isSysadmin?: boolean } = {}) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, isSysadmin: false, isBoardMember: false, isBackgroundCheckReviewer: false, ...roles } });
+}
+function jsonReq(body: unknown) {
+    return new Request('http://localhost:4000/x', { method: 'POST', body: JSON.stringify(body) }) as never;
+}
+function getReq() {
+    return new Request('http://localhost:4000/x') as never;
+}
+
+async function makeHousehold(slug: string) {
+    return prisma.household.create({ data: { name: `${TAG} ${slug}` } });
+}
+async function makePerson(slug: string, householdId: number, data: Partial<{ dateOfBirth: Date | null; lastBackgroundCheck: Date | null; isBackgroundCheckReviewer: boolean }> = {}) {
+    return prisma.person.create({
+        data: {
+            email: `${slug}-${TAG}@example.com`,
+            name: slug,
+            householdId,
+            dateOfBirth: data.dateOfBirth ?? null,
+            lastBackgroundCheck: data.lastBackgroundCheck ?? null,
+            isBackgroundCheckReviewer: data.isBackgroundCheckReviewer ?? false,
+        },
+    });
+}
+async function attachToProgram(slug: string, personId: number) {
+    const program = await prisma.program.create({ data: { name: `${TAG} ${slug} program` } });
+    await prisma.programParticipant.create({ data: { programId: program.id, personId } });
+    return program.id;
+}
+function personBgFor(personId: number) {
+    return prisma.orgMembershipProcess.findFirst({ where: { kind: 'PERSON_BG', subjectPersonId: personId }, orderBy: { id: 'desc' } });
+}
+function personBgCountFor(personId: number) {
+    return prisma.orgMembershipProcess.count({ where: { kind: 'PERSON_BG', subjectPersonId: personId } });
+}
+async function setRecheckMonths(months: number) {
+    await prisma.boardSettings.upsert({
+        where: { id: 1 },
+        create: { id: 1, bgRecheckMonths: months, orgMembershipYearBoundary: BOUNDARY_SEED },
+        update: { bgRecheckMonths: months, orgMembershipYearBoundary: BOUNDARY_SEED },
+    });
+}
+
+async function cleanup() {
+    // People created directly (no household) are tagged via email; households via name.
+    const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+    const ids = hhs.map((h) => h.id);
+    const progs = await prisma.program.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+    const progIds = progs.map((p) => p.id);
+    const taggedPeople = await prisma.person.findMany({ where: { email: { contains: TAG } }, select: { id: true, householdId: true } });
+    const peopleIds = taggedPeople.map((p) => p.id);
+    // A nameless household (the "no household context" fixture) isn't matched by name —
+    // reap it via the tagged person that lives in it.
+    const peopleHhIds = taggedPeople.map((p) => p.householdId);
+    const procs = await prisma.orgMembershipProcess.findMany({
+        where: { OR: [{ orgMembership: { householdId: { in: ids } } }, { subjectPersonId: { in: peopleIds } }] },
+        select: { id: true },
+    });
+    const pids = procs.map((p) => p.id);
+    await prisma.backgroundCheckAttestation.deleteMany({ where: { processId: { in: pids } } });
+    await prisma.programParticipant.deleteMany({ where: { programId: { in: progIds } } });
+    await prisma.programVolunteer.deleteMany({ where: { programId: { in: progIds } } });
+    await prisma.program.deleteMany({ where: { id: { in: progIds } } });
+    await prisma.orgMembershipProcess.deleteMany({ where: { id: { in: pids } } });
+    await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
+    await prisma.householdLead.deleteMany({ where: { householdId: { in: ids } } });
+    await prisma.person.deleteMany({ where: { OR: [{ householdId: { in: ids } }, { id: { in: peopleIds } }] } });
+    await prisma.household.deleteMany({ where: { id: { in: [...ids, ...peopleHhIds] } } });
+}
+
+describe('Phase 3 — manual PERSON_BG submit + queue gating + e2e', () => {
+    let savedSettings: { bgRecheckMonths: number; orgMembershipYearBoundary: Date | null } | null = null;
+    let rev1 = 0, rev2 = 0, board = 0, nonReviewer = 0;
+
+    beforeAll(async () => {
+        await cleanup();
+        const prev = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        savedSettings = prev ? { bgRecheckMonths: prev.bgRecheckMonths, orgMembershipYearBoundary: prev.orgMembershipYearBoundary } : null;
+        await setRecheckMonths(RECHECK_MONTHS);
+
+        const hhA = await makeHousehold('revA');
+        const hhB = await makeHousehold('revB');
+        const hhC = await makeHousehold('misc');
+        rev1 = (await makePerson('rev1', hhA.id, { isBackgroundCheckReviewer: true })).id;
+        rev2 = (await makePerson('rev2', hhB.id, { isBackgroundCheckReviewer: true })).id;
+        board = (await makePerson('board', hhC.id)).id;
+        nonReviewer = (await makePerson('nonreviewer', hhC.id)).id;
+    });
+
+    afterAll(async () => {
+        await cleanup();
+        if (savedSettings) await prisma.boardSettings.update({ where: { id: 1 }, data: savedSettings });
+        await prisma.$disconnect();
+    });
+
+    it('submit opens a PERSON_BG, sets bgConsentAt, audit-logs it, and is idempotent', async () => {
+        const hh = await makeHousehold('submitHh');
+        const subject = await makePerson('submit-subject', hh.id, { dateOfBirth: ADULT_DOB });
+        await attachToProgram('submit', subject.id);
+
+        sendEmailMock.mockClear();
+        await submitPersonBgForReview(subject.id, board);
+
+        const proc = await personBgFor(subject.id);
+        expect(proc).not.toBeNull();
+        expect(proc!.status).toBe('PENDING_BG_REVIEW');
+        expect(proc!.bgConsentAt).not.toBeNull(); // review-ready
+        expect(await personBgCountFor(subject.id)).toBe(1);
+        // Audit: the open (CREATE) + the consent mark (EDIT) both landed on this process.
+        const audits = await prisma.auditLog.count({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: proc!.id } });
+        expect(audits).toBeGreaterThanOrEqual(1);
+        // First submit pinged reviewers.
+        expect(sendEmailMock.mock.calls.length).toBeGreaterThan(0);
+
+        // Idempotent: a second submit does not double-open and does not re-ping.
+        sendEmailMock.mockClear();
+        await submitPersonBgForReview(subject.id, board);
+        expect(await personBgCountFor(subject.id)).toBe(1);
+        expect(sendEmailMock.mock.calls.length).toBe(0);
+    });
+
+    it('route rejects an anon (401) and a non-board / non-sysadmin caller (403), no obligation opened', async () => {
+        const hh = await makeHousehold('gateHh');
+        const subject = await makePerson('gate-subject', hh.id, { dateOfBirth: ADULT_DOB });
+
+        // Anonymous — no session.
+        (getServerSession as jest.Mock).mockResolvedValue(null);
+        expect((await SUBMIT_BG(jsonReq({ personId: subject.id }))).status).toBe(401);
+
+        // Authenticated but unprivileged.
+        as(nonReviewer, {});
+        const res = await SUBMIT_BG(jsonReq({ personId: subject.id }));
+        expect(res.status).toBe(403);
+        expect(await personBgCountFor(subject.id)).toBe(0);
+
+        // Board caller succeeds through the same route.
+        as(board, { isBoardMember: true });
+        const ok = await SUBMIT_BG(jsonReq({ personId: subject.id }));
+        expect(ok.status).toBe(200);
+        expect(await personBgCountFor(subject.id)).toBe(1);
+    });
+
+    it('queue gating flips on submit — excluded until submitted, then listed with subject identity (incl. no household)', async () => {
+        // Subject WITH a household, distinct from the reviewers.
+        const subjHh = await makeHousehold('queueSubjHh');
+        const subject = await makePerson('queue-subject', subjHh.id, { dateOfBirth: ADULT_DOB });
+        const personBg = await prisma.orgMembershipProcess.create({
+            data: { kind: 'PERSON_BG', subjectPersonId: subject.id, orgMembershipId: null, status: 'PENDING_BG_REVIEW' },
+        });
+        // Subject whose household carries no name — the render must fall back to
+        // "No household on file" rather than blank (Person.householdId is required,
+        // so a nameless household is the real "no household context" case).
+        const namelessHh = await prisma.household.create({ data: { name: null } });
+        const orphan = await makePerson('queue-orphan', namelessHh.id, { dateOfBirth: ADULT_DOB });
+        const orphanBg = await prisma.orgMembershipProcess.create({
+            data: { kind: 'PERSON_BG', subjectPersonId: orphan.id, orgMembershipId: null, status: 'PENDING_BG_REVIEW' },
+        });
+
+        // Before submit: neither is listed/counted.
+        let ids = await eligibleReviewProcessIds(rev1);
+        expect(ids).not.toContain(personBg.id);
+        expect(ids).not.toContain(orphanBg.id);
+
+        // Submit both (idempotent open already exists → just marks bgConsentAt).
+        await submitPersonBgForReview(subject.id, board);
+        await submitPersonBgForReview(orphan.id, board);
+
+        ids = await eligibleReviewProcessIds(rev1);
+        expect(ids).toContain(personBg.id);
+        expect(ids).toContain(orphanBg.id);
+
+        // The GET renders the subject identity + household context, and never blanks.
+        as(rev1, { isBackgroundCheckReviewer: true });
+        const data = await (await REVIEW_QUEUE(getReq())).json();
+        const rows: Array<{ id: number; subjectPerson: { name: string; household: { name: string | null } | null } | null }> = data.queue;
+        const withHh = rows.find((r) => r.id === personBg.id);
+        const noHh = rows.find((r) => r.id === orphanBg.id);
+        expect(withHh?.subjectPerson?.name).toBe('queue-subject');
+        expect(withHh?.subjectPerson?.household?.name).toBe(`${TAG} queueSubjHh`);
+        expect(noHh?.subjectPerson?.name).toBe('queue-orphan');
+        expect(noHh?.subjectPerson?.household?.name).toBeNull(); // nameless household → "No household on file"
+    });
+
+    it('end-to-end: submit → two distinct reviewers attest → only the subject is stamped → dashboard clears', async () => {
+        const hh = await makeHousehold('e2eHh');
+        const subject = await makePerson('e2e-subject', hh.id, { dateOfBirth: ADULT_DOB });
+        await attachToProgram('e2e', subject.id);
+        // A household-mate with no check — the subject-scoped clear must not touch them.
+        const mate = await makePerson('e2e-mate', hh.id, { dateOfBirth: ADULT_DOB });
+        await prisma.householdLead.create({ data: { householdId: hh.id, personId: mate.id } });
+
+        // Before: the subject is on the dashboard's PERSON_BG_NEEDED list.
+        as(board, { isBoardMember: true });
+        let compliance = await (await COMPLIANCE(getReq())).json();
+        expect(compliance.peopleNeedingBgCheck.some((p: { personId: number }) => p.personId === subject.id)).toBe(true);
+
+        // Submit, then two distinct-household reviewers attest.
+        await submitPersonBgForReview(subject.id, board);
+        const proc = await personBgFor(subject.id);
+        await attest(rev1, proc!.id, { result: 'APPROVE' });
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: proc!.id } }))?.status).toBe('PENDING_BG_REVIEW');
+        await attest(rev2, proc!.id, { result: 'APPROVE' });
+
+        const after = await prisma.orgMembershipProcess.findUnique({ where: { id: proc!.id } });
+        expect(after?.bgClearedAt).not.toBeNull();
+        expect(after?.status).toBe('ACTIVE');
+
+        // Only the subject is stamped; the household-mate is untouched.
+        expect((await prisma.person.findUnique({ where: { id: subject.id } }))?.lastBackgroundCheck).not.toBeNull();
+        expect((await prisma.person.findUnique({ where: { id: mate.id } }))?.lastBackgroundCheck).toBeNull();
+
+        // After: the subject has dropped off the dashboard PERSON_BG_NEEDED list.
+        as(board, { isBoardMember: true });
+        compliance = await (await COMPLIANCE(getReq())).json();
+        expect(compliance.peopleNeedingBgCheck.some((p: { personId: number }) => p.personId === subject.id)).toBe(false);
+    });
+});

--- a/checkin-app/src/app/api/membership-audit/person-bg/route.ts
+++ b/checkin-app/src/app/api/membership-audit/person-bg/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { submitPersonBgForReview, PersonBgSubmitError } from "@/lib/membership/personBgSubmit";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/membership-audit/person-bg — board/sysadmin records that an external
+ * background check exists for a program person and submits it for two-reviewer
+ * approval (Phase 3, manual path). Body: { personId }.
+ *
+ * Opens the PERSON_BG obligation if one isn't already open and marks it
+ * review-ready (bgConsentAt) so the reviewer queue surfaces it. Idempotent. The
+ * subject may have no login, so this is board/lead-initiated, not subject-initiated.
+ */
+export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
+    let body: { personId?: number };
+    try {
+        body = await req.json();
+    } catch {
+        return apiError("Invalid JSON", 400);
+    }
+    if (!body.personId) return apiError("personId is required", 400);
+    try {
+        const process = await submitPersonBgForReview(body.personId, auth.user.id);
+        return NextResponse.json({ process });
+    } catch (error) {
+        if (error instanceof PersonBgSubmitError) return apiError(error.message, 409);
+        logger.error("submitPersonBgForReview error:", error);
+        return apiError("Internal Server Error", 500);
+    }
+});

--- a/checkin-app/src/app/api/membership/reviews/route.ts
+++ b/checkin-app/src/app/api/membership/reviews/route.ts
@@ -25,9 +25,13 @@ const STATUS_FOR: Record<ReviewError["code"], number> = {
  * pii + public only — applicant parents' names/emails, nothing internal). The
  * attestation _count doubles as the approval count for queue rows.
  *
- * The query selects ONLY the household leads' (parents') person rows — the
- * reviewer never needs the children, so their PII never leaves the DB. The
- * stripper is defense-in-depth on top of this narrowing, not the primary filter.
+ * For a household review the query selects ONLY the household leads' (parents')
+ * person rows — the reviewer never needs the children, so their PII never leaves
+ * the DB. For a PERSON_BG it selects the SUBJECT person instead (name + household
+ * context, subject may have no household), so the reviewer sees who they're
+ * approving rather than a blank row. Both name/household fields are public-band, so
+ * the stripper passes them for the reviewer grant; it stays defense-in-depth on top
+ * of this narrowing, not the primary filter.
  */
 export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
     if (auth.type !== "session") throw unauthorized();
@@ -37,6 +41,16 @@ export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
         orderBy: { stageEnteredAt: "asc" },
         select: {
             id: true,
+            // The BG subject (set only on a PERSON_BG row): identity + household
+            // context so the reviewer knows who the check is for. Household may be null.
+            subjectPerson: {
+                select: {
+                    id: true,
+                    name: true,
+                    householdId: true,
+                    household: { select: { name: true } },
+                },
+            },
             orgMembership: {
                 select: {
                     household: {

--- a/checkin-app/src/app/membership-audit/compliance/page.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Badge, Card, Center, Group, Paper, Stack, Text, Title } from "@mantine/core";
+import { useState, useEffect, type ReactNode } from "react";
+import { Badge, Button, Card, Center, Group, Paper, Stack, Text, Title } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
 import { formatPhone } from "@/lib/phone";
 import { PageLoader } from "@/components/ui/PageLoader";
 
@@ -37,11 +38,13 @@ function PersonSection({
   description,
   color,
   people,
+  renderAction,
 }: {
   title: string;
   description: string;
   color: string;
   people: PersonRow[];
+  renderAction?: (p: PersonRow) => ReactNode;
 }) {
   if (people.length === 0) return null;
   return (
@@ -58,7 +61,10 @@ function PersonSection({
                 {" · "}Household #{p.householdId}
               </Text>
             </div>
-            <Badge color={color} variant="light">{title}</Badge>
+            <Group gap="sm">
+              <Badge color={color} variant="light">{title}</Badge>
+              {renderAction?.(p)}
+            </Group>
           </Group>
         </Card>
       ))}
@@ -76,6 +82,32 @@ export default function CompliancePage() {
   const [peopleMissingDob, setPeopleMissingDob] = useState<PersonRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [submittedIds, setSubmittedIds] = useState<Set<number>>(new Set());
+
+  // Record that an external background check exists for a program person and submit
+  // it for two-reviewer approval. Board/lead-initiated — the subject may have no login.
+  const submitBg = async (personId: number) => {
+    setBusyId(personId);
+    try {
+      const res = await fetch("/api/membership-audit/person-bg", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ personId }),
+      });
+      if (res.ok) {
+        setSubmittedIds((s) => new Set(s).add(personId));
+        notifications.show({ color: "green", message: "Submitted for background-check review." });
+      } else {
+        const data = await res.json().catch(() => ({}));
+        notifications.show({ color: "red", message: data.error || "Could not submit for review." });
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error." });
+    } finally {
+      setBusyId(null);
+    }
+  };
 
   useEffect(() => {
     (async () => {
@@ -168,9 +200,18 @@ export default function CompliancePage() {
 
       <PersonSection
         title="Background check needed"
-        description="Program-attached people 18 or older with no current background check. Warn-only — nothing is blocked."
+        description="Program-attached people 18 or older with no current background check. Warn-only — nothing is blocked. Once an external check exists, submit it below for two-reviewer approval."
         color="orange"
         people={peopleNeedingBgCheck}
+        renderAction={(p) =>
+          submittedIds.has(p.personId) ? (
+            <Badge color="green" variant="light">Submitted for review</Badge>
+          ) : (
+            <Button size="xs" variant="light" loading={busyId === p.personId} disabled={busyId === p.personId} onClick={() => submitBg(p.personId)}>
+              Record external check &amp; submit
+            </Button>
+          )
+        }
       />
 
       <PersonSection

--- a/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
@@ -69,4 +69,24 @@ describe("membership-ops/review page", () => {
 
     expect(await screen.findByText("Nothing awaiting your review right now.")).toBeInTheDocument();
   });
+
+  it("renders a PERSON_BG row by its subject identity (falls back when the household has no name)", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({
+      "/api/membership/reviews": {
+        queue: [{
+          id: 200,
+          subjectPerson: { id: 9, name: "Dana Vol", householdId: 5, household: { name: null } },
+          orgMembership: null,
+          _count: { attestations: 0 },
+        }],
+      },
+    });
+    renderWithProviders(<MembershipReviewPage />);
+
+    expect(await screen.findByText("Dana Vol")).toBeInTheDocument();
+    expect(screen.getByText("No household on file", { exact: false })).toBeInTheDocument();
+    // The volunteer-only checkbox is a household-application concept — hidden for PERSON_BG.
+    expect(screen.queryByText("This is a volunteer only family (no students)")).not.toBeInTheDocument();
+  });
 });

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -14,9 +14,11 @@ interface Person {
     email: string | null;
 }
 // Shape returned by GET /api/membership/reviews (security-stripped model rows).
-// Only the household leads (parents) are returned — children are never sent.
+// A household review returns the leads (parents); a PERSON_BG review returns the
+// subject person (name + household context) instead. Children are never sent.
 interface QueueItem {
   id: number;
+  subjectPerson: { id: number; name: string | null; householdId: number | null; household: { name: string | null } | null } | null;
   orgMembership: { household: { name: string | null; intakeNotes: string | null; leads: { person: Person }[] } | null } | null;
   _count: { attestations: number };
 }
@@ -112,37 +114,50 @@ export default function MembershipReviewPage() {
       ) : (
         <Stack mt="md">
           {queue.map((item) => {
+            const subject = item.subjectPerson;
             const parents = (item.orgMembership?.household?.leads ?? []).map((l) => l.person);
             const notes = item.orgMembership?.household?.intakeNotes?.trim();
             return (
             <Card key={item.id} withBorder radius="md" padding="lg">
-              <Text fw={700} fz="lg">
-                {item.orgMembership?.household?.name || `Household (application #${item.id})`}
-              </Text>
-              <Text size="sm" c="dimmed" mt={4}>
-                {parents.length > 0
-                  ? parents.map((p) => `${p.name || "—"}${p.email ? ` <${p.email}>` : ""}`).join(", ")
-                  : "No parent contact on file."}
-              </Text>
+              {subject ? (
+                <>
+                  <Text fw={700} fz="lg">{subject.name || `Person #${subject.id}`}</Text>
+                  <Text size="sm" c="dimmed" mt={4}>
+                    Background check for an individual · {subject.household?.name ? `Household: ${subject.household.name}` : "No household on file"}
+                  </Text>
+                </>
+              ) : (
+                <>
+                  <Text fw={700} fz="lg">
+                    {item.orgMembership?.household?.name || `Household (application #${item.id})`}
+                  </Text>
+                  <Text size="sm" c="dimmed" mt={4}>
+                    {parents.length > 0
+                      ? parents.map((p) => `${p.name || "—"}${p.email ? ` <${p.email}>` : ""}`).join(", ")
+                      : "No parent contact on file."}
+                  </Text>
+                </>
+              )}
               <Text size="xs" c="dimmed" mt={4}>{item._count.attestations}/2 approvals so far.</Text>
 
-              {/* The applicant's "anything else?" note — surfaced up front (not
-                  behind a click) because it's where a volunteer-only household asks
-                  to be marked volunteer, which drives the checkbox below. */}
-              {notes && (
+              {/* Household-application concepts (intake note + volunteer-only mark)
+                  don't apply to a per-person BG check. */}
+              {!subject && notes && (
                 <Alert color="yellow" variant="light" mt="md" title="From the applicant — “Anything else we should know?”">
                   <Text style={{ whiteSpace: "pre-wrap" }}>{notes}</Text>
                 </Alert>
               )}
 
-              <Checkbox
-                my="md"
-                checked={!!volunteer[item.id]}
-                onChange={(e) => { const checked = e.currentTarget.checked; setVolunteer((v) => ({ ...v, [item.id]: checked })); }}
-                label="This is a volunteer only family (no students)"
-              />
+              {!subject && (
+                <Checkbox
+                  my="md"
+                  checked={!!volunteer[item.id]}
+                  onChange={(e) => { const checked = e.currentTarget.checked; setVolunteer((v) => ({ ...v, [item.id]: checked })); }}
+                  label="This is a volunteer only family (no students)"
+                />
+              )}
 
-              <Group gap="sm" wrap="wrap">
+              <Group gap="sm" wrap="wrap" mt={subject ? "md" : undefined}>
                 <Button color="green" disabled={busyId === item.id} loading={busyId === item.id} onClick={() => submit(item.id, "APPROVE")}>
                   Attest — check is clean
                 </Button>

--- a/checkin-app/src/lib/membership/personBgSubmit.ts
+++ b/checkin-app/src/lib/membership/personBgSubmit.ts
@@ -1,0 +1,53 @@
+import prisma from "@/lib/prisma";
+import { markBgConsent } from "@/lib/membership/external";
+import { notifyReviewers } from "@/lib/membership/review";
+import { bgFreshThreshold } from "@/lib/membership/personBgCheck";
+import { openPersonBg } from "@/lib/membership/personBgTriggers";
+
+/**
+ * Manual "record an external background check → submit for review" — the Phase 3
+ * board-driven path. Mirrors the household BG flow: an external check exists and
+ * the board asserts it; the system never sees the check itself.
+ *
+ * Opens a PERSON_BG obligation for `personId` if one isn't already open (reuses
+ * openPersonBg's dedup + Person-row lock, so it can't double-open), then marks it
+ * review-ready by setting bgConsentAt via markBgConsent — consent is IMPLICIT in a
+ * self-initiated external check (there is NO in-app consent link/email). Once
+ * bgConsentAt is set the obligation surfaces in the reviewer queue; two
+ * distinct-household reviewers then attest to clear it.
+ *
+ * Idempotent: a second submit re-uses the open process, markBgConsent no-ops, and
+ * reviewers are pinged only on the FIRST submit (the transition into the queue).
+ */
+export class PersonBgSubmitError extends Error {
+    constructor(public readonly code: "no_obligation", message: string) {
+        super(message);
+        this.name = "PersonBgSubmitError";
+    }
+}
+
+export async function submitPersonBgForReview(personId: number, actorId: number) {
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const months = settings?.bgRecheckMonths ?? 0;
+    // Open one if the person genuinely needs a check and none is open (dedup-guarded
+    // inside openPersonBg). When the policy is unset we can only submit against an
+    // obligation a trigger already opened.
+    if (months > 0) {
+        const now = new Date();
+        await openPersonBg(personId, now, bgFreshThreshold(now, months));
+    }
+
+    const process = await prisma.orgMembershipProcess.findFirst({
+        where: { kind: "PERSON_BG", subjectPersonId: personId, status: "PENDING_BG_REVIEW" },
+        orderBy: { id: "desc" },
+        select: { id: true, bgConsentAt: true },
+    });
+    if (!process) {
+        throw new PersonBgSubmitError("no_obligation", "No open background-check obligation for this person.");
+    }
+
+    const firstSubmit = !process.bgConsentAt;
+    await markBgConsent(process.id, actorId); // sets bgConsentAt (+ audit row), idempotent
+    if (firstSubmit) await notifyReviewers(); // ping only on the transition into the queue
+    return process;
+}

--- a/checkin-app/src/lib/membership/personBgTriggers.ts
+++ b/checkin-app/src/lib/membership/personBgTriggers.ts
@@ -37,7 +37,7 @@ const PROGRAM_ATTACHED_WHERE = {
  * person (BLOCKED is a manual-followup item, not something to auto-reopen nightly).
  * Returns the created process, or null when skipped.
  */
-async function openPersonBg(personId: number, asOf: Date, threshold: Date) {
+export async function openPersonBg(personId: number, asOf: Date, threshold: Date) {
     return prisma.$transaction(async (tx) => {
         await tx.$queryRaw`SELECT id FROM "Person" WHERE id = ${personId} FOR UPDATE`;
         const person = await tx.person.findUnique({

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -75,14 +75,18 @@ function isAwaitingBgReview(p: { status: OrgMembershipProcessStatus; bgConsentAt
 }
 
 /**
- * PERSON_BG is attestable at the SERVICE level (attest() still accepts it, so the
- * two-reviewer gate is exercised + tested) but must NOT surface as an actionable
- * row in the reviewer QUEUE until Phase 3 renders the subject + consent. The queue
- * GET only shows a household's leads; a PERSON_BG row would render blank yet stay
- * attestable — a reviewer could blind-approve an unidentified person. So the queue
- * listing + badge counts exclude it (warn-only Phase 2); the gate machinery stays.
+ * A PERSON_BG surfaces in the reviewer queue only once it's been SUBMITTED — i.e.
+ * bgConsentAt is set (the board recorded that an external check exists via
+ * submitPersonBgForReview). This mirrors how the household parallel track gates on
+ * bgConsentAt in AWAITING_BG_WHERE. An unsubmitted PERSON_BG (bgConsentAt == null)
+ * stays out: not listed, not counted, no reviewer ping — its subject isn't ready to
+ * approve yet, and the queue GET now renders the subject once it is. A single `NOT`
+ * key so it spreads cleanly alongside AWAITING_BG_WHERE's own `OR` (two spread
+ * objects sharing an `OR` key would clobber it).
  */
-const QUEUE_EXCLUDES_PERSON_BG: Prisma.OrgMembershipProcessWhereInput = { kind: { not: "PERSON_BG" } };
+const QUEUE_EXCLUDES_UNSUBMITTED_PERSON_BG: Prisma.OrgMembershipProcessWhereInput = {
+    NOT: { kind: "PERSON_BG", bgConsentAt: null },
+};
 
 /** Prisma `where` matching the same predicate as isAwaitingBgReview, for queue queries. */
 export const AWAITING_BG_WHERE: Prisma.OrgMembershipProcessWhereInput = {
@@ -153,7 +157,7 @@ export async function eligibleReviewProcessIds(reviewerId: number): Promise<numb
     if (!reviewer || !canReviewBackgroundChecks(reviewer)) return [];
 
     const processes = await prisma.orgMembershipProcess.findMany({
-        where: { ...AWAITING_BG_WHERE, ...QUEUE_EXCLUDES_PERSON_BG },
+        where: { ...AWAITING_BG_WHERE, ...QUEUE_EXCLUDES_UNSUBMITTED_PERSON_BG },
         orderBy: { stageEnteredAt: "asc" },
         select: {
             id: true,
@@ -188,7 +192,7 @@ export async function reviewQueueCounts(reviewerId: number): Promise<{ canActOn:
     if (!reviewer || !canReviewBackgroundChecks(reviewer)) return { canActOn: 0, approvedAwaitingSecond: 0 };
     const [canActOnIds, approvedAwaitingSecond] = await Promise.all([
         eligibleReviewProcessIds(reviewerId),
-        prisma.orgMembershipProcess.count({ where: { ...AWAITING_BG_WHERE, ...QUEUE_EXCLUDES_PERSON_BG, attestations: { some: { reviewerId } } } }),
+        prisma.orgMembershipProcess.count({ where: { ...AWAITING_BG_WHERE, ...QUEUE_EXCLUDES_UNSUBMITTED_PERSON_BG, attestations: { some: { reviewerId } } } }),
     ]);
     return { canActOn: canActOnIds.length, approvedAwaitingSecond };
 }


### PR DESCRIPTION
Stacked on Phase 2 (#910). Ships the compliance substance of per-person background checks — record + two-reviewer approval + per-person `lastBackgroundCheck` stamp + full audit — driven by a **manual board action**, no cron/consent/migration machinery. Mirrors the household BG flow: an external check exists, the board asserts it, the system never sees the check itself.

## What changed

**Manual submit** — `submitPersonBgForReview(personId, actorId)` (`personBgSubmit.ts`): opens a `PERSON_BG` obligation if none is open (reuses Phase 2's `openPersonBg` — now exported — with its dedup + Person-row lock), then marks it review-ready via `markBgConsent` (sets `bgConsentAt`). Idempotent; reviewers pinged only on the first submit. Exposed at `POST /api/membership-audit/person-bg`, gated `withAuth({ roles: ["isSysadmin","isBoardMember"] })`.

**Queue gating flip** (`review.ts`) — `QUEUE_EXCLUDES_PERSON_BG` ("hide all PERSON_BG") → `QUEUE_EXCLUDES_UNSUBMITTED_PERSON_BG` = `{ NOT: { kind: "PERSON_BG", bgConsentAt: null } }`. A single `NOT` key so it spreads cleanly beside `AWAITING_BG_WHERE`'s own `OR` (two `OR`-bearing spreads would clobber). Unsubmitted → not listed/counted/notified; submitted → in the queue and reviewers notified.

**Subject rendering** — the review-queue GET (`membership/reviews`) selects `subjectPerson` (name + household context) so a `PERSON_BG` renders who the reviewer is approving instead of a blank row (closes the Phase 2 gap). Handles a subject whose household has no name. Both fields are `public`-band and both models already in the route's `returns` bag, so **no security-registry / edge-allowlist change**. Review page + compliance dashboard updated (submit button per `PERSON_BG_NEEDED` person).

**Resolution** (unchanged from Phase 2): two distinct-household reviewers attest → `clearBackgroundCheck` stamps only the subject → `personBgVerdict` → `FRESH` → person drops off the dashboard.

## Reviewer notes / scope calls

- **No program context in the queue** — traversing `ProgramParticipant`/`ProgramVolunteer` there trips `routeAuthDrift`'s edge-sensitive rule (would force an EDGE_INCLUDE_ALLOWLIST entry). Name + household is enough to identify the subject; add program context + allowlist entry if a reviewer needs it.
- **"No household" = nameless household** — `Person.householdId` is a required FK, so a household-less subject can't exist; the real fallback case is a null household *name*. Render + test cover that.
- Board/sysadmin gate only; skipped the optional household-lead grant.
- **Deferred (untouched):** consent link/email, supplier affirmation, cron reliance, blanket-stamp/per-adult migration, enforcement/grace. Warn-only stands.

## Tests

New `personBgManualSubmit.integration.test.ts`: submit opens+consents+audits, idempotent; route 401 anon / 403 non-board; queue excluded-until-submitted then listed with subject identity (incl. nameless-household subject); e2e submit → two distinct reviewers attest → only subject stamped (household-mate untouched) → dashboard clears. Added a subject-render case to the review page unit test; registered the new route in `authzRegistry`.

**Full suite green:** unit 1571 pass, integration 917 pass, tsc + eslint clean. Safe-refactor sweep (predicate + response-shape change) verified: `routeAuthDrift` / `scopeValidators` / `policy.contract` green, only frontend consumer of the queue shape updated, `classifications.ts` unchanged (schema untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)