### PR TITLE
feat(email): board-configurable sender From + Reply-To (own Settings section)

### DIFF
--- a/checkin-app/prisma/migrations/20260705150000_add_email_sender_settings/migration.sql
+++ b/checkin-app/prisma/migrations/20260705150000_add_email_sender_settings/migration.sql
@@ -1,0 +1,5 @@
+-- Board-configurable email sender identity (overrides the EMAIL_FROM env default;
+-- adds an optional Reply-To). Both nullable, no default — a safe additive change
+-- on a populated table.
+ALTER TABLE "BoardSettings" ADD COLUMN "emailFromAddress" TEXT;
+ALTER TABLE "BoardSettings" ADD COLUMN "emailReplyToAddress" TEXT;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -443,6 +443,16 @@ model BoardSettings {
   /// (the board must set the real Treehouse policy value before renewals re-check).
   /// @sensitivity:public
   bgRecheckMonths            Int       @default(0)
+  /// Overrides the EMAIL_FROM env default as the Resend sender on every outbound
+  /// email when set. Must be on a Resend-verified domain or all mail bounces —
+  /// hence the confirm-to-edit guard in the settings UI. Null = use the env default.
+  /// @sensitivity:public
+  emailFromAddress           String?
+  /// Reply-To header set on every outbound email when set (the From address is a
+  /// no-reply, so this routes replies to a real inbox). Null = no Reply-To (replies
+  /// go to From). Need not be on the sending domain.
+  /// @sensitivity:public
+  emailReplyToAddress        String?
   /// @sensitivity:internal
   shopifyOrgMembershipProductId String?
   /// @sensitivity:internal

--- a/checkin-app/src/app/__tests__/emailSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/emailSettingsAPI.integration.test.ts
@@ -78,6 +78,23 @@ describe('Email sender-identity settings API', () => {
         expect(after.emailFromAddress).toBe('Good <ok@example.org>');
     });
 
+    it('accepts a comma-separated Reply-To list', async () => {
+        asBoard(boardId);
+        const put = await EMAIL_PUT(jsonReq('PUT', { emailReplyToAddress: 'info@example.org, ops@example.org' }));
+        expect(put.status).toBe(200);
+        const saved = (await put.json()).settings;
+        expect(saved.emailReplyToAddress).toBe('info@example.org, ops@example.org');
+    });
+
+    it('rejects a Reply-To list with one malformed entry and keeps the previous value', async () => {
+        asBoard(boardId);
+        await EMAIL_PUT(jsonReq('PUT', { emailReplyToAddress: 'info@example.org, ops@example.org' }));
+        const bad = await EMAIL_PUT(jsonReq('PUT', { emailReplyToAddress: 'info@example.org, not-an-email' }));
+        expect(bad.status).toBe(400);
+        const after = (await (await EMAIL_GET(jsonReq('GET'))).json()).settings;
+        expect(after.emailReplyToAddress).toBe('info@example.org, ops@example.org');
+    });
+
     it('empty strings clear back to null (env default From, no Reply-To)', async () => {
         asBoard(boardId);
         const cleared = await EMAIL_PUT(jsonReq('PUT', { emailFromAddress: '', emailReplyToAddress: '' }));

--- a/checkin-app/src/app/__tests__/emailSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/emailSettingsAPI.integration.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the email sender-identity settings API.
+ */
+
+import { GET as EMAIL_GET, PUT as EMAIL_PUT } from '@/app/api/settings/email/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+function asBoard(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, isSysadmin: false, isBoardMember: true } });
+}
+function asUser(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, isSysadmin: false, isBoardMember: false } });
+}
+function jsonReq(method: string, body?: unknown) {
+    return new Request('http://localhost:4000/x', { method, ...(body ? { body: JSON.stringify(body) } : {}) }) as never;
+}
+
+const TAG = 'email-settings-test';
+
+describe('Email sender-identity settings API', () => {
+    let boardId: number, plainId: number;
+    let prevSettings: { emailFromAddress: string | null; emailReplyToAddress: string | null } | null = null;
+
+    async function wipe() {
+        const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+        const ids = hhs.map((h) => h.id);
+        if (ids.length) {
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.household.deleteMany({ where: { id: { in: ids } } });
+        }
+    }
+
+    beforeAll(async () => {
+        await wipe();
+        boardId = (await prisma.person.create({ data: { name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
+        plainId = (await prisma.person.create({ data: { name: 'Plain', household: { create: { name: `Plain HH ${TAG}` } } } })).id;
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevSettings = existing ? { emailFromAddress: existing.emailFromAddress, emailReplyToAddress: existing.emailReplyToAddress } : null;
+    });
+
+    afterAll(async () => {
+        if (prevSettings) await prisma.boardSettings.update({ where: { id: 1 }, data: prevSettings });
+        await wipe();
+        await prisma.$disconnect();
+    });
+
+    it('non-board cannot read', async () => {
+        asUser(plainId);
+        expect((await EMAIL_GET(jsonReq('GET'))).status).toBe(403);
+    });
+
+    it('board reads, sets a valid identity (both header shapes), and reads it back', async () => {
+        asBoard(boardId);
+        expect((await EMAIL_GET(jsonReq('GET'))).status).toBe(200);
+
+        const put = await EMAIL_PUT(jsonReq('PUT', {
+            emailFromAddress: 'Treehouse <noreply@updates.example.org>',
+            emailReplyToAddress: 'board@example.org',
+        }));
+        expect(put.status).toBe(200);
+        const saved = (await put.json()).settings;
+        expect(saved.emailFromAddress).toBe('Treehouse <noreply@updates.example.org>');
+        expect(saved.emailReplyToAddress).toBe('board@example.org');
+    });
+
+    it('rejects a malformed From and keeps the previous value', async () => {
+        asBoard(boardId);
+        await EMAIL_PUT(jsonReq('PUT', { emailFromAddress: 'Good <ok@example.org>' }));
+        const bad = await EMAIL_PUT(jsonReq('PUT', { emailFromAddress: 'not-an-email' }));
+        expect(bad.status).toBe(400);
+        const after = (await (await EMAIL_GET(jsonReq('GET'))).json()).settings;
+        expect(after.emailFromAddress).toBe('Good <ok@example.org>');
+    });
+
+    it('empty strings clear back to null (env default From, no Reply-To)', async () => {
+        asBoard(boardId);
+        const cleared = await EMAIL_PUT(jsonReq('PUT', { emailFromAddress: '', emailReplyToAddress: '' }));
+        expect(cleared.status).toBe(200);
+        const s = (await cleared.json()).settings;
+        expect(s.emailFromAddress).toBeNull();
+        expect(s.emailReplyToAddress).toBeNull();
+    });
+});

--- a/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
@@ -26,7 +26,7 @@ function jsonReq(method: string, body?: unknown, url = 'http://localhost:4000/x'
 
 describe('Membership settings + volunteer designations API', () => {
     let boardId: number, plainId: number;
-    let prevSettings: { normalDuesCents: number; volunteerDuesCents: number } | null = null;
+    let prevSettings: { normalDuesCents: number; volunteerDuesCents: number; emailFromAddress: string | null; emailReplyToAddress: string | null } | null = null;
 
     async function wipe() {
         await prisma.volunteerDesignation.deleteMany({ where: { email: { contains: TAG } } });
@@ -43,7 +43,7 @@ describe('Membership settings + volunteer designations API', () => {
 
     beforeAll(async () => {
         const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-        prevSettings = existing ? { normalDuesCents: existing.normalDuesCents, volunteerDuesCents: existing.volunteerDuesCents } : null;
+        prevSettings = existing ? { normalDuesCents: existing.normalDuesCents, volunteerDuesCents: existing.volunteerDuesCents, emailFromAddress: existing.emailFromAddress, emailReplyToAddress: existing.emailReplyToAddress } : null;
         await wipe();
 
         boardId = (await prisma.person.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
@@ -93,6 +93,32 @@ describe('Membership settings + volunteer designations API', () => {
         const getRes = await SETTINGS_GET(jsonReq('GET'));
         const { settings } = await getRes.json();
         expect(settings.normalDuesCents).toBe(12000);
+    });
+
+    it('accepts a valid email sender identity and rejects a malformed one (keeping the prior value)', async () => {
+        asBoard(boardId);
+        // Both header shapes are accepted.
+        const ok = await SETTINGS_PUT(jsonReq('PUT', {
+            emailFromAddress: 'Treehouse <noreply@updates.example.org>',
+            emailReplyToAddress: 'board@example.org',
+        }));
+        expect(ok.status).toBe(200);
+        const saved = (await ok.json()).settings;
+        expect(saved.emailFromAddress).toBe('Treehouse <noreply@updates.example.org>');
+        expect(saved.emailReplyToAddress).toBe('board@example.org');
+
+        // A malformed From is rejected and must not clobber the saved value.
+        const bad = await SETTINGS_PUT(jsonReq('PUT', { emailFromAddress: 'not-an-email' }));
+        expect(bad.status).toBe(400);
+        const after = (await (await SETTINGS_GET(jsonReq('GET'))).json()).settings;
+        expect(after.emailFromAddress).toBe('Treehouse <noreply@updates.example.org>');
+
+        // Empty string clears back to the env default (null).
+        const cleared = await SETTINGS_PUT(jsonReq('PUT', { emailFromAddress: '', emailReplyToAddress: '' }));
+        expect(cleared.status).toBe(200);
+        const clearedSettings = (await cleared.json()).settings;
+        expect(clearedSettings.emailFromAddress).toBeNull();
+        expect(clearedSettings.emailReplyToAddress).toBeNull();
     });
 
     it('adds, lists, and removes a volunteer designation', async () => {

--- a/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
@@ -26,7 +26,7 @@ function jsonReq(method: string, body?: unknown, url = 'http://localhost:4000/x'
 
 describe('Membership settings + volunteer designations API', () => {
     let boardId: number, plainId: number;
-    let prevSettings: { normalDuesCents: number; volunteerDuesCents: number; emailFromAddress: string | null; emailReplyToAddress: string | null } | null = null;
+    let prevSettings: { normalDuesCents: number; volunteerDuesCents: number } | null = null;
 
     async function wipe() {
         await prisma.volunteerDesignation.deleteMany({ where: { email: { contains: TAG } } });
@@ -43,7 +43,7 @@ describe('Membership settings + volunteer designations API', () => {
 
     beforeAll(async () => {
         const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-        prevSettings = existing ? { normalDuesCents: existing.normalDuesCents, volunteerDuesCents: existing.volunteerDuesCents, emailFromAddress: existing.emailFromAddress, emailReplyToAddress: existing.emailReplyToAddress } : null;
+        prevSettings = existing ? { normalDuesCents: existing.normalDuesCents, volunteerDuesCents: existing.volunteerDuesCents } : null;
         await wipe();
 
         boardId = (await prisma.person.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
@@ -93,32 +93,6 @@ describe('Membership settings + volunteer designations API', () => {
         const getRes = await SETTINGS_GET(jsonReq('GET'));
         const { settings } = await getRes.json();
         expect(settings.normalDuesCents).toBe(12000);
-    });
-
-    it('accepts a valid email sender identity and rejects a malformed one (keeping the prior value)', async () => {
-        asBoard(boardId);
-        // Both header shapes are accepted.
-        const ok = await SETTINGS_PUT(jsonReq('PUT', {
-            emailFromAddress: 'Treehouse <noreply@updates.example.org>',
-            emailReplyToAddress: 'board@example.org',
-        }));
-        expect(ok.status).toBe(200);
-        const saved = (await ok.json()).settings;
-        expect(saved.emailFromAddress).toBe('Treehouse <noreply@updates.example.org>');
-        expect(saved.emailReplyToAddress).toBe('board@example.org');
-
-        // A malformed From is rejected and must not clobber the saved value.
-        const bad = await SETTINGS_PUT(jsonReq('PUT', { emailFromAddress: 'not-an-email' }));
-        expect(bad.status).toBe(400);
-        const after = (await (await SETTINGS_GET(jsonReq('GET'))).json()).settings;
-        expect(after.emailFromAddress).toBe('Treehouse <noreply@updates.example.org>');
-
-        // Empty string clears back to the env default (null).
-        const cleared = await SETTINGS_PUT(jsonReq('PUT', { emailFromAddress: '', emailReplyToAddress: '' }));
-        expect(cleared.status).toBe(200);
-        const clearedSettings = (await cleared.json()).settings;
-        expect(clearedSettings.emailFromAddress).toBeNull();
-        expect(clearedSettings.emailReplyToAddress).toBeNull();
     });
 
     it('adds, lists, and removes a volunteer designation', async () => {

--- a/checkin-app/src/app/api/settings/email/route.ts
+++ b/checkin-app/src/app/api/settings/email/route.ts
@@ -2,21 +2,11 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
+import { isValidEmailHeader } from "@/lib/emailHeader";
 
 export const dynamic = "force-dynamic";
 
 const SELECT = { emailFromAddress: true, emailReplyToAddress: true } as const;
-
-/**
- * Accept a bare address (`a@b.co`) or a display-name form (`Name <a@b.co>`) — the
- * two shapes Resend allows for From/Reply-To. Rejects anything without a plausible
- * address so a typo can't silently break (From) or misroute (Reply-To) all mail.
- */
-function isValidEmailHeader(value: string): boolean {
-    const angle = value.match(/<([^>]*)>\s*$/);
-    const addr = (angle ? angle[1] : value).trim();
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(addr);
-}
 
 /** GET /api/settings/email — outbound-email sender identity (BoardSettings singleton). */
 export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async () => {

--- a/checkin-app/src/app/api/settings/email/route.ts
+++ b/checkin-app/src/app/api/settings/email/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
-import { isValidEmailHeader } from "@/lib/emailHeader";
+import { isValidEmailHeader, parseEmailHeaderList } from "@/lib/emailHeader";
 
 export const dynamic = "force-dynamic";
 
@@ -16,10 +16,13 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
 
 /**
  * PUT /api/settings/email — set the Resend From override and Reply-To.
- * Body may include emailFromAddress and emailReplyToAddress (string|null). Each must be a
- * valid address shape (bare or `Name <addr@domain>`); a malformed value rejects the whole
- * update (400) so the previous value survives. Blank/empty clears back to null (env default
- * From; no Reply-To). The From must be on a Resend-verified domain to actually deliver.
+ * Body may include emailFromAddress and emailReplyToAddress (string|null). emailFromAddress
+ * is a single address shape (bare or `Name <addr@domain>`). emailReplyToAddress may be a
+ * comma-separated list of one or more addresses, each in that same shape (e.g.
+ * "info@x.org, ops@x.org") — replies can fan out to more than one inbox. A malformed value
+ * rejects the whole update (400) so the previous value survives. Blank/empty clears back to
+ * null (env default From; no Reply-To). The From must be on a Resend-verified domain to
+ * actually deliver.
  */
 export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
     if (auth.type !== "session") return apiError("Unauthorized", 401);
@@ -38,7 +41,9 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
     }
     if (body.emailReplyToAddress !== undefined) {
         const replyTo = body.emailReplyToAddress?.trim();
-        if (replyTo && !isValidEmailHeader(replyTo)) return apiError("emailReplyToAddress must be an email address or \"Name <addr@domain>\"", 400);
+        if (replyTo && !parseEmailHeaderList(replyTo)) {
+            return apiError("emailReplyToAddress must be a comma-separated list of email addresses (each an address or \"Name <addr@domain>\")", 400);
+        }
         data.emailReplyToAddress = replyTo || null;
     }
 

--- a/checkin-app/src/app/api/settings/email/route.ts
+++ b/checkin-app/src/app/api/settings/email/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { apiError } from "@/lib/api-response";
+
+export const dynamic = "force-dynamic";
+
+const SELECT = { emailFromAddress: true, emailReplyToAddress: true } as const;
+
+/**
+ * Accept a bare address (`a@b.co`) or a display-name form (`Name <a@b.co>`) — the
+ * two shapes Resend allows for From/Reply-To. Rejects anything without a plausible
+ * address so a typo can't silently break (From) or misroute (Reply-To) all mail.
+ */
+function isValidEmailHeader(value: string): boolean {
+    const angle = value.match(/<([^>]*)>\s*$/);
+    const addr = (angle ? angle[1] : value).trim();
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(addr);
+}
+
+/** GET /api/settings/email — outbound-email sender identity (BoardSettings singleton). */
+export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async () => {
+    const settings = await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1 }, update: {}, select: SELECT });
+    return NextResponse.json({ settings });
+});
+
+/**
+ * PUT /api/settings/email — set the Resend From override and Reply-To.
+ * Body may include emailFromAddress and emailReplyToAddress (string|null). Each must be a
+ * valid address shape (bare or `Name <addr@domain>`); a malformed value rejects the whole
+ * update (400) so the previous value survives. Blank/empty clears back to null (env default
+ * From; no Reply-To). The From must be on a Resend-verified domain to actually deliver.
+ */
+export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
+    let body: { emailFromAddress?: string | null; emailReplyToAddress?: string | null };
+    try {
+        body = await req.json();
+    } catch {
+        return apiError("Invalid JSON", 400);
+    }
+
+    const data: Record<string, string | null> = {};
+    if (body.emailFromAddress !== undefined) {
+        const from = body.emailFromAddress?.trim();
+        if (from && !isValidEmailHeader(from)) return apiError("emailFromAddress must be an email address or \"Name <addr@domain>\"", 400);
+        data.emailFromAddress = from || null;
+    }
+    if (body.emailReplyToAddress !== undefined) {
+        const replyTo = body.emailReplyToAddress?.trim();
+        if (replyTo && !isValidEmailHeader(replyTo)) return apiError("emailReplyToAddress must be an email address or \"Name <addr@domain>\"", 400);
+        data.emailReplyToAddress = replyTo || null;
+    }
+
+    const settings = await prisma.boardSettings.upsert({
+        where: { id: 1 },
+        create: { id: 1, ...data },
+        update: data,
+        select: SELECT,
+    });
+
+    await prisma.auditLog.create({
+        data: {
+            actorId: auth.user.id,
+            action: "EDIT",
+            tableName: "BoardSettings",
+            affectedEntityId: 1,
+            newData: data,
+        },
+    });
+
+    return NextResponse.json({ settings });
+});

--- a/checkin-app/src/app/api/settings/membership/route.ts
+++ b/checkin-app/src/app/api/settings/membership/route.ts
@@ -7,17 +7,6 @@ export const dynamic = "force-dynamic";
 
 const DEFAULTS = { id: 1, normalDuesCents: 0, volunteerDuesCents: 0 };
 
-/**
- * Accept a bare address (`a@b.co`) or a display-name form (`Name <a@b.co>`) — the
- * two shapes Resend allows for From/Reply-To. Rejects anything without a plausible
- * address so a typo can't silently break (From) or misroute (Reply-To) all mail.
- */
-function isValidEmailHeader(value: string): boolean {
-    const angle = value.match(/<([^>]*)>\s*$/);
-    const addr = (angle ? angle[1] : value).trim();
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(addr);
-}
-
 /** GET /api/settings/membership — board settings singleton (created on first read). */
 export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async () => {
     const settings = await prisma.boardSettings.upsert({ where: { id: 1 }, create: DEFAULTS, update: {} });
@@ -27,11 +16,10 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
 /**
  * PUT /api/settings/membership — update board settings.
  * Body may include: normalDuesCents, volunteerDuesCents, orgMembershipYearBoundary (ISO|null),
- * orgMembershipVariantId (string|null), volunteerDiscountCode (string|null),
- * emailFromAddress (string|null), emailReplyToAddress (string|null).
- * Dues must be finite and >= 0, and email headers must be a valid address shape; an invalid
- * value rejects the whole update (400) so the previous value survives rather than silently
- * collapsing to zero. (The Averity consent link is an env var, not a board setting.)
+ * orgMembershipVariantId (string|null), volunteerDiscountCode (string|null).
+ * Dues must be finite and >= 0; an invalid value rejects the whole update (400) so the
+ * previous value survives rather than silently collapsing to zero. (The Averity consent
+ * link is an env var, not a board setting. Email sender identity lives in /api/settings/email.)
  */
 export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
     if (auth.type !== "session") return apiError("Unauthorized", 401);
@@ -42,8 +30,6 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
         orgMembershipVariantId?: string | null;
         volunteerDiscountCode?: string | null;
         bgRecheckMonths?: number;
-        emailFromAddress?: string | null;
-        emailReplyToAddress?: string | null;
     };
     try {
         body = await req.json();
@@ -73,16 +59,6 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
         data.volunteerDiscountCode = body.volunteerDiscountCode?.trim() || null;
     }
     if (body.bgRecheckMonths !== undefined) data.bgRecheckMonths = Math.max(0, Math.round(body.bgRecheckMonths));
-    if (body.emailFromAddress !== undefined) {
-        const from = body.emailFromAddress?.trim();
-        if (from && !isValidEmailHeader(from)) return apiError("emailFromAddress must be an email address or \"Name <addr@domain>\"", 400);
-        data.emailFromAddress = from || null;
-    }
-    if (body.emailReplyToAddress !== undefined) {
-        const replyTo = body.emailReplyToAddress?.trim();
-        if (replyTo && !isValidEmailHeader(replyTo)) return apiError("emailReplyToAddress must be an email address or \"Name <addr@domain>\"", 400);
-        data.emailReplyToAddress = replyTo || null;
-    }
 
     const settings = await prisma.boardSettings.upsert({
         where: { id: 1 },

--- a/checkin-app/src/app/api/settings/membership/route.ts
+++ b/checkin-app/src/app/api/settings/membership/route.ts
@@ -7,6 +7,17 @@ export const dynamic = "force-dynamic";
 
 const DEFAULTS = { id: 1, normalDuesCents: 0, volunteerDuesCents: 0 };
 
+/**
+ * Accept a bare address (`a@b.co`) or a display-name form (`Name <a@b.co>`) — the
+ * two shapes Resend allows for From/Reply-To. Rejects anything without a plausible
+ * address so a typo can't silently break (From) or misroute (Reply-To) all mail.
+ */
+function isValidEmailHeader(value: string): boolean {
+    const angle = value.match(/<([^>]*)>\s*$/);
+    const addr = (angle ? angle[1] : value).trim();
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(addr);
+}
+
 /** GET /api/settings/membership — board settings singleton (created on first read). */
 export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async () => {
     const settings = await prisma.boardSettings.upsert({ where: { id: 1 }, create: DEFAULTS, update: {} });
@@ -16,10 +27,11 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
 /**
  * PUT /api/settings/membership — update board settings.
  * Body may include: normalDuesCents, volunteerDuesCents, orgMembershipYearBoundary (ISO|null),
- * orgMembershipVariantId (string|null), volunteerDiscountCode (string|null).
- * Dues must be finite and >= 0; an invalid value rejects the whole update (400) so the
- * previous value survives rather than silently collapsing to zero. (The Averity consent
- * link is an env var, not a board setting.)
+ * orgMembershipVariantId (string|null), volunteerDiscountCode (string|null),
+ * emailFromAddress (string|null), emailReplyToAddress (string|null).
+ * Dues must be finite and >= 0, and email headers must be a valid address shape; an invalid
+ * value rejects the whole update (400) so the previous value survives rather than silently
+ * collapsing to zero. (The Averity consent link is an env var, not a board setting.)
  */
 export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
     if (auth.type !== "session") return apiError("Unauthorized", 401);
@@ -30,6 +42,8 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
         orgMembershipVariantId?: string | null;
         volunteerDiscountCode?: string | null;
         bgRecheckMonths?: number;
+        emailFromAddress?: string | null;
+        emailReplyToAddress?: string | null;
     };
     try {
         body = await req.json();
@@ -59,6 +73,16 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
         data.volunteerDiscountCode = body.volunteerDiscountCode?.trim() || null;
     }
     if (body.bgRecheckMonths !== undefined) data.bgRecheckMonths = Math.max(0, Math.round(body.bgRecheckMonths));
+    if (body.emailFromAddress !== undefined) {
+        const from = body.emailFromAddress?.trim();
+        if (from && !isValidEmailHeader(from)) return apiError("emailFromAddress must be an email address or \"Name <addr@domain>\"", 400);
+        data.emailFromAddress = from || null;
+    }
+    if (body.emailReplyToAddress !== undefined) {
+        const replyTo = body.emailReplyToAddress?.trim();
+        if (replyTo && !isValidEmailHeader(replyTo)) return apiError("emailReplyToAddress must be an email address or \"Name <addr@domain>\"", 400);
+        data.emailReplyToAddress = replyTo || null;
+    }
 
     const settings = await prisma.boardSettings.upsert({
         where: { id: 1 },

--- a/checkin-app/src/app/settings/email/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/email/__tests__/page.test.tsx
@@ -5,7 +5,7 @@ jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
 import { screen, fireEvent, waitFor } from "@testing-library/react";
-import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import { renderWithProviders, mockFetchJson, setSession, resetRtl, router } from "@/test-helpers/rtl";
 import EmailSettingsPage from "../page";
 
 beforeEach(() => resetRtl());
@@ -41,5 +41,28 @@ describe("EmailSettingsPage", () => {
     fireEvent.click(screen.getByLabelText(/let me edit the sender addresses/i));
     expect(from).not.toBeDisabled();
     expect(screen.getByRole("button", { name: "Save settings" })).not.toBeDisabled();
+  });
+
+  it("validates client-side: a malformed From shows an inline error and never PUTs", async () => {
+    setSession({ id: 1, isBoardMember: true });
+    const fetchMock = mockFetchJson({ "/api/settings/email": { settings: { emailFromAddress: null, emailReplyToAddress: null } } });
+    renderWithProviders(<EmailSettingsPage />);
+
+    const from = await screen.findByLabelText(/From address/i);
+    fireEvent.change(from, { target: { value: "not-an-email" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    expect(await screen.findByText(/Enter an email address/i)).toBeInTheDocument();
+    // Only the initial GET happened — no PUT was attempted.
+    expect(fetchMock.mock.calls.some(([, opts]) => opts?.method === "PUT")).toBe(false);
+  });
+
+  it("redirects a user without board/sysadmin and never renders the form", async () => {
+    setSession({ id: 9 }); // authenticated but no roles
+    mockFetchJson({ "/api/settings/email": { settings: { emailFromAddress: null, emailReplyToAddress: null } } });
+    renderWithProviders(<EmailSettingsPage />);
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/"));
+    expect(screen.queryByLabelText(/From address/i)).not.toBeInTheDocument();
   });
 });

--- a/checkin-app/src/app/settings/email/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/email/__tests__/page.test.tsx
@@ -43,6 +43,21 @@ describe("EmailSettingsPage", () => {
     expect(screen.getByRole("button", { name: "Save settings" })).not.toBeDisabled();
   });
 
+  it("accepts a comma-separated Reply-To list: no inline error, PUT fires", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({ "/api/settings/email": { settings: { emailFromAddress: null, emailReplyToAddress: null } } });
+    renderWithProviders(<EmailSettingsPage />);
+
+    await screen.findByLabelText(/From address/i);
+    fireEvent.change(screen.getByLabelText(/Reply-To address/i), { target: { value: "info@org.test, ops@org.test" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/settings/email", expect.objectContaining({ method: "PUT" })));
+    expect(screen.queryByText(/Enter one or more comma-separated addresses/i)).not.toBeInTheDocument();
+    const [, putOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PUT")!;
+    expect(JSON.parse(putOpts!.body as string)).toEqual({ emailFromAddress: null, emailReplyToAddress: "info@org.test, ops@org.test" });
+  });
+
   it("validates client-side: a malformed From shows an inline error and never PUTs", async () => {
     setSession({ id: 1, isBoardMember: true });
     const fetchMock = mockFetchJson({ "/api/settings/email": { settings: { emailFromAddress: null, emailReplyToAddress: null } } });

--- a/checkin-app/src/app/settings/email/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/email/__tests__/page.test.tsx
@@ -1,0 +1,45 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import EmailSettingsPage from "../page";
+
+beforeEach(() => resetRtl());
+
+describe("EmailSettingsPage", () => {
+  it("first-time set: fields editable, no unlock checkbox, saves the entered identity", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({ "/api/settings/email": { settings: { emailFromAddress: null, emailReplyToAddress: null } } });
+    renderWithProviders(<EmailSettingsPage />);
+
+    const from = await screen.findByLabelText(/From address/i);
+    expect(from).not.toBeDisabled();
+    expect(screen.queryByText(/let me edit the sender addresses/i)).not.toBeInTheDocument();
+
+    fireEvent.change(from, { target: { value: "Org <no-reply@org.test>" } });
+    fireEvent.change(screen.getByLabelText(/Reply-To address/i), { target: { value: "board@org.test" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/settings/email", expect.objectContaining({ method: "PUT" })));
+    const [, putOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PUT")!;
+    expect(JSON.parse(putOpts!.body as string)).toEqual({ emailFromAddress: "Org <no-reply@org.test>", emailReplyToAddress: "board@org.test" });
+  });
+
+  it("already set: fields locked until the confirm checkbox unlocks them", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/settings/email": { settings: { emailFromAddress: "Org <no-reply@org.test>", emailReplyToAddress: null } } });
+    renderWithProviders(<EmailSettingsPage />);
+
+    const from = await screen.findByLabelText(/From address/i);
+    expect(from).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save settings" })).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText(/let me edit the sender addresses/i));
+    expect(from).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save settings" })).not.toBeDisabled();
+  });
+});

--- a/checkin-app/src/app/settings/email/page.tsx
+++ b/checkin-app/src/app/settings/email/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Alert, Button, Card, Center, Checkbox, Loader, Stack, Text, TextInput, Title } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { SettingsTabs } from "@/components/admin/SettingsTabs";
+import { useUnsavedGuard, shallowEqual } from "@/components/UnsavedChangesProvider";
+
+interface Settings {
+  emailFromAddress: string | null;
+  emailReplyToAddress: string | null;
+}
+
+export default function EmailSettingsPage() {
+  const [emailFrom, setEmailFrom] = useState("");
+  const [emailReplyTo, setEmailReplyTo] = useState("");
+  // Once an identity exists, editing is high-stakes (a wrong From on an unverified
+  // domain bounces all mail; a wrong Reply-To misroutes replies) — lock behind an
+  // explicit unlock, mirroring the membership-year boundary. First-time set is free.
+  const [unlocked, setUnlocked] = useState(false);
+
+  const [initial, setInitial] = useState<Record<string, string> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveNotice, setSaveNotice] = useState<{ text: string; err: boolean } | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/settings/email");
+      if (res.ok) {
+        const { settings } = (await res.json()) as { settings: Settings };
+        const snap = { emailFrom: settings.emailFromAddress ?? "", emailReplyTo: settings.emailReplyToAddress ?? "" };
+        setEmailFrom(snap.emailFrom);
+        setEmailReplyTo(snap.emailReplyTo);
+        setInitial(snap);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const wasSet = !!(initial?.emailFrom || initial?.emailReplyTo);
+  const locked = wasSet && !unlocked;
+
+  const save = async () => {
+    setSaveNotice(null);
+    setSaving(true);
+    try {
+      const res = await fetch("/api/settings/email", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ emailFromAddress: emailFrom.trim() || null, emailReplyToAddress: emailReplyTo.trim() || null }),
+      });
+      if (res.ok) { notifications.show({ color: "green", message: "Email settings saved." }); setUnlocked(false); await load(); }
+      else { const d = await res.json().catch(() => ({})); setSaveNotice({ text: d.error || "Save failed.", err: true }); }
+    } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }
+    finally { setSaving(false); }
+  };
+
+  const isDirty = !!initial && !shallowEqual(initial, { emailFrom, emailReplyTo });
+  useUnsavedGuard(isDirty);
+
+  return (
+    <Stack>
+      <SettingsTabs active="email" />
+
+      {loading ? (
+        <Center py="xl"><Loader /></Center>
+      ) : (
+        <Card withBorder radius="md" padding="lg">
+          <Title order={3} mb="xs">Email sender identity</Title>
+          <Text size="sm" c="dimmed" mb="md">
+            Controls the sender on <strong>every</strong> outbound email (check-in receipts, membership
+            notices, board alerts). Leave blank to use the environment default sender.
+          </Text>
+
+          <Alert color={wasSet ? "yellow" : "blue"} variant="light" mb="md">
+            {wasSet ? (
+              <Text size="sm">
+                ⚠️ The <strong>From</strong> address must be on a domain verified in Resend or all mail
+                bounces. Changing these affects every outbound email — only edit if you are sure.
+              </Text>
+            ) : (
+              <Text size="sm">
+                The <strong>From</strong> address must be on a domain verified in Resend.{" "}
+                <strong>Reply-To</strong> can be any address (e.g. a real board inbox) so replies to a
+                no-reply sender reach someone.
+              </Text>
+            )}
+          </Alert>
+
+          {wasSet && (
+            <Checkbox
+              mb="md"
+              checked={unlocked}
+              onChange={(e) => setUnlocked(e.currentTarget.checked)}
+              label="I understand — let me edit the sender addresses"
+            />
+          )}
+
+          <Stack gap="md">
+            <TextInput
+              label="From address"
+              description={'Bare address or "Name <addr@domain>". Blank = environment default.'}
+              placeholder="Innovation Treehouse <noreply@updates.innovationtreehouse.org>"
+              w={440}
+              value={emailFrom}
+              onChange={(e) => setEmailFrom(e.currentTarget.value)}
+              disabled={locked}
+            />
+            <TextInput
+              label="Reply-To address"
+              description="Where replies go. Blank = replies go to the From address."
+              placeholder="board@innovationtreehouse.org"
+              w={440}
+              value={emailReplyTo}
+              onChange={(e) => setEmailReplyTo(e.currentTarget.value)}
+              disabled={locked}
+            />
+          </Stack>
+
+          {saveNotice && (
+            <Alert mt="lg" color={saveNotice.err ? "red" : "green"} variant="light">
+              {saveNotice.text}
+            </Alert>
+          )}
+
+          <Button mt="lg" disabled={saving || locked} loading={saving} onClick={save} style={{ alignSelf: "flex-start" }}>
+            Save settings
+          </Button>
+        </Card>
+      )}
+    </Stack>
+  );
+}

--- a/checkin-app/src/app/settings/email/page.tsx
+++ b/checkin-app/src/app/settings/email/page.tsx
@@ -6,7 +6,7 @@ import { notifications } from "@mantine/notifications";
 import { SettingsTabs } from "@/components/admin/SettingsTabs";
 import { useUnsavedGuard, shallowEqual } from "@/components/UnsavedChangesProvider";
 import { useRequireRole } from "@/hooks/useRequireRole";
-import { isValidEmailHeader } from "@/lib/emailHeader";
+import { isValidEmailHeader, parseEmailHeaderList } from "@/lib/emailHeader";
 
 interface Settings {
   emailFromAddress: string | null;
@@ -14,6 +14,7 @@ interface Settings {
 }
 
 const HEADER_ERROR = 'Enter an email address or "Name <addr@domain>".';
+const REPLY_TO_ERROR = 'Enter one or more comma-separated addresses, each an email address or "Name <addr@domain>".';
 
 export default function EmailSettingsPage() {
   // The sender identity is editable by board + sysadmin (same as the /settings layout
@@ -66,7 +67,7 @@ export default function EmailSettingsPage() {
     const replyTo = emailReplyTo.trim();
     const fe: { from?: string; replyTo?: string } = {};
     if (from && !isValidEmailHeader(from)) fe.from = HEADER_ERROR;
-    if (replyTo && !isValidEmailHeader(replyTo)) fe.replyTo = HEADER_ERROR;
+    if (replyTo && !parseEmailHeaderList(replyTo)) fe.replyTo = REPLY_TO_ERROR;
     if (fe.from || fe.replyTo) { setFieldErrors(fe); return; }
     setFieldErrors({});
     setSaving(true);
@@ -111,8 +112,8 @@ export default function EmailSettingsPage() {
             ) : (
               <Text size="sm">
                 The <strong>From</strong> address must be on a domain verified in Resend.{" "}
-                <strong>Reply-To</strong> can be any address (e.g. a real board inbox) so replies to a
-                no-reply sender reach someone.
+                <strong>Reply-To</strong> can be one or more addresses, comma-separated (e.g. real board
+                inboxes) so replies to a no-reply sender reach someone.
               </Text>
             )}
           </Alert>
@@ -139,8 +140,8 @@ export default function EmailSettingsPage() {
             />
             <TextInput
               label="Reply-To address"
-              description="Where replies go. Blank = replies go to the From address."
-              placeholder="board@innovationtreehouse.org"
+              description="Where replies go. Comma-separated for multiple addresses. Blank = replies go to the From address."
+              placeholder="info@innovationtreehouse.org, ops@innovationtreehouse.org"
               w={440}
               value={emailReplyTo}
               error={fieldErrors.replyTo}

--- a/checkin-app/src/app/settings/email/page.tsx
+++ b/checkin-app/src/app/settings/email/page.tsx
@@ -5,13 +5,22 @@ import { Alert, Button, Card, Center, Checkbox, Loader, Stack, Text, TextInput, 
 import { notifications } from "@mantine/notifications";
 import { SettingsTabs } from "@/components/admin/SettingsTabs";
 import { useUnsavedGuard, shallowEqual } from "@/components/UnsavedChangesProvider";
+import { useRequireRole } from "@/hooks/useRequireRole";
+import { isValidEmailHeader } from "@/lib/emailHeader";
 
 interface Settings {
   emailFromAddress: string | null;
   emailReplyToAddress: string | null;
 }
 
+const HEADER_ERROR = 'Enter an email address or "Name <addr@domain>".';
+
 export default function EmailSettingsPage() {
+  // The sender identity is editable by board + sysadmin (same as the /settings layout
+  // admits). Gate the page client-side and redirect anyone else, rather than letting them
+  // load the form and only discover the 403 on save.
+  const { authorized, ready, loading: authLoading } = useRequireRole(["isSysadmin", "isBoardMember"]);
+
   const [emailFrom, setEmailFrom] = useState("");
   const [emailReplyTo, setEmailReplyTo] = useState("");
   // Once an identity exists, editing is high-stakes (a wrong From on an unverified
@@ -23,6 +32,7 @@ export default function EmailSettingsPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saveNotice, setSaveNotice] = useState<{ text: string; err: boolean } | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<{ from?: string; replyTo?: string }>({});
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -40,13 +50,25 @@ export default function EmailSettingsPage() {
     }
   }, []);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => { if (ready) load(); }, [ready, load]);
 
   const wasSet = !!(initial?.emailFrom || initial?.emailReplyTo);
   const locked = wasSet && !unlocked;
 
   const save = async () => {
     setSaveNotice(null);
+    // Belt-and-suspenders: the page is role-gated and the route re-checks, but never fire
+    // a mutation the user isn't allowed to make.
+    if (!authorized) { setSaveNotice({ text: "You do not have permission to change these settings.", err: true }); return; }
+    // Validate client-side with the same rule the route enforces (imported, not
+    // duplicated) so a typo is caught inline instead of surfacing as a raw API error.
+    const from = emailFrom.trim();
+    const replyTo = emailReplyTo.trim();
+    const fe: { from?: string; replyTo?: string } = {};
+    if (from && !isValidEmailHeader(from)) fe.from = HEADER_ERROR;
+    if (replyTo && !isValidEmailHeader(replyTo)) fe.replyTo = HEADER_ERROR;
+    if (fe.from || fe.replyTo) { setFieldErrors(fe); return; }
+    setFieldErrors({});
     setSaving(true);
     try {
       const res = await fetch("/api/settings/email", {
@@ -62,6 +84,9 @@ export default function EmailSettingsPage() {
 
   const isDirty = !!initial && !shallowEqual(initial, { emailFrom, emailReplyTo });
   useUnsavedGuard(isDirty);
+
+  if (authLoading) return <Center mih="60vh"><Loader /></Center>;
+  if (!ready) return null; // redirect to / is in flight
 
   return (
     <Stack>
@@ -108,7 +133,8 @@ export default function EmailSettingsPage() {
               placeholder="Innovation Treehouse <noreply@updates.innovationtreehouse.org>"
               w={440}
               value={emailFrom}
-              onChange={(e) => setEmailFrom(e.currentTarget.value)}
+              error={fieldErrors.from}
+              onChange={(e) => { setEmailFrom(e.currentTarget.value); setFieldErrors((f) => ({ ...f, from: undefined })); }}
               disabled={locked}
             />
             <TextInput
@@ -117,7 +143,8 @@ export default function EmailSettingsPage() {
               placeholder="board@innovationtreehouse.org"
               w={440}
               value={emailReplyTo}
-              onChange={(e) => setEmailReplyTo(e.currentTarget.value)}
+              error={fieldErrors.replyTo}
+              onChange={(e) => { setEmailReplyTo(e.currentTarget.value); setFieldErrors((f) => ({ ...f, replyTo: undefined })); }}
               disabled={locked}
             />
           </Stack>

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -15,8 +15,6 @@ interface Settings {
   orgMembershipVariantId: string | null;
   volunteerDiscountCode: string | null;
   bgRecheckMonths: number;
-  emailFromAddress: string | null;
-  emailReplyToAddress: string | null;
 }
 
 const dollars = (cents: number) => (cents / 100).toFixed(2);
@@ -40,9 +38,6 @@ export default function MembershipSettingsPage() {
   const [boundaryUnlocked, setBoundaryUnlocked] = useState(false);
   const [variantId, setVariantId] = useState("");
   const [discountCode, setDiscountCode] = useState("");
-  const [emailFrom, setEmailFrom] = useState("");
-  const [emailReplyTo, setEmailReplyTo] = useState("");
-  const [emailUnlocked, setEmailUnlocked] = useState(false);
 
   // Snapshot of the dues-form values as last loaded/saved; isDirty compares it to
   // current state to drive the unsaved-changes guard.
@@ -72,8 +67,6 @@ export default function MembershipSettingsPage() {
           boundary: settings.orgMembershipYearBoundary ? settings.orgMembershipYearBoundary.slice(0, 10) : "",
           variantId: settings.orgMembershipVariantId ?? "",
           discountCode: settings.volunteerDiscountCode ?? "",
-          emailFrom: settings.emailFromAddress ?? "",
-          emailReplyTo: settings.emailReplyToAddress ?? "",
         };
         setNormalDues(snap.normalDues);
         setVolunteerDues(snap.volunteerDues);
@@ -81,8 +74,6 @@ export default function MembershipSettingsPage() {
         setBoundary(snap.boundary);
         setVariantId(snap.variantId);
         setDiscountCode(snap.discountCode);
-        setEmailFrom(snap.emailFrom);
-        setEmailReplyTo(snap.emailReplyTo);
         setInitial(snap);
       }
     } finally {
@@ -95,11 +86,6 @@ export default function MembershipSettingsPage() {
   // Confirm-checkbox gate only matters when a boundary already exists — changing
   // it shifts every household's cycle. First-time set has nothing to shift.
   const boundaryWasSet = !!initial?.boundary;
-
-  // Same confirm-to-edit guard as the boundary: once a sender identity exists,
-  // changing From (wrong domain → all mail bounces) or Reply-To (misrouted replies)
-  // is high-stakes, so lock both behind an explicit unlock. First-time set is free.
-  const emailWasSet = !!(initial?.emailFrom || initial?.emailReplyTo);
 
   const saveSettings = async () => {
     setSaveNotice(null);
@@ -123,11 +109,9 @@ export default function MembershipSettingsPage() {
           // Send the boundary when the unlock is checked, or when it was never set (no
           // unlock shown then — nothing to protect from an accidental shift).
           ...(boundaryUnlocked || !boundaryWasSet ? { orgMembershipYearBoundary: boundary || null } : {}),
-          // Same rule for the sender identity: only send when unlocked or never set.
-          ...(emailUnlocked || !emailWasSet ? { emailFromAddress: emailFrom.trim() || null, emailReplyToAddress: emailReplyTo.trim() || null } : {}),
         }),
       });
-      if (res.ok) { notifications.show({ color: "green", message: "Settings saved." }); setBoundaryUnlocked(false); setEmailUnlocked(false); notifyNavRefresh(); await load(); }
+      if (res.ok) { notifications.show({ color: "green", message: "Settings saved." }); setBoundaryUnlocked(false); notifyNavRefresh(); await load(); }
       else { const d = await res.json().catch(() => ({})); setSaveNotice({ text: d.error || "Save failed.", err: true }); }
     } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }
     finally { setSaving(false); }
@@ -152,7 +136,7 @@ export default function MembershipSettingsPage() {
 
   const isDirty =
     !!initial &&
-    !shallowEqual(initial, { normalDues, volunteerDues, bgRecheckMonths, boundary, variantId, discountCode, emailFrom, emailReplyTo });
+    !shallowEqual(initial, { normalDues, volunteerDues, bgRecheckMonths, boundary, variantId, discountCode });
   useUnsavedGuard(isDirty);
 
   return (
@@ -264,51 +248,6 @@ export default function MembershipSettingsPage() {
                 onChange={(e) => setBoundary(e.currentTarget.value)}
                 disabled={boundaryWasSet && !boundaryUnlocked}
               />
-            </Alert>
-
-            <Title order={4} mt="lg" mb="sm">Email sender identity</Title>
-            <Alert color={emailWasSet ? "yellow" : "blue"} variant="light">
-              {emailWasSet ? (
-                <Text size="sm" mb="sm">
-                  ⚠️ These control the sender on <strong>every</strong> outbound email. The
-                  <strong> From</strong> address must be on a domain verified in Resend or all mail
-                  bounces. Only change if you are sure.
-                </Text>
-              ) : (
-                <Text size="sm" mb="sm">
-                  Optional. Leave blank to use the environment default sender. The <strong>From</strong>{" "}
-                  address must be on a domain verified in Resend; <strong>Reply-To</strong> can be any
-                  address (e.g. a real board inbox) so replies to a no-reply sender reach someone.
-                </Text>
-              )}
-              {emailWasSet && (
-                <Checkbox
-                  mb="sm"
-                  checked={emailUnlocked}
-                  onChange={(e) => setEmailUnlocked(e.currentTarget.checked)}
-                  label="I understand — let me edit the sender addresses"
-                />
-              )}
-              <Stack gap="md">
-                <TextInput
-                  label="From address"
-                  description={'Bare address or "Name <addr@domain>". Blank = environment default.'}
-                  placeholder="Innovation Treehouse <noreply@updates.innovationtreehouse.org>"
-                  w={420}
-                  value={emailFrom}
-                  onChange={(e) => setEmailFrom(e.currentTarget.value)}
-                  disabled={emailWasSet && !emailUnlocked}
-                />
-                <TextInput
-                  label="Reply-To address"
-                  description="Where replies go. Blank = replies go to the From address."
-                  placeholder="board@innovationtreehouse.org"
-                  w={420}
-                  value={emailReplyTo}
-                  onChange={(e) => setEmailReplyTo(e.currentTarget.value)}
-                  disabled={emailWasSet && !emailUnlocked}
-                />
-              </Stack>
             </Alert>
 
             {saveNotice && (

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -15,6 +15,8 @@ interface Settings {
   orgMembershipVariantId: string | null;
   volunteerDiscountCode: string | null;
   bgRecheckMonths: number;
+  emailFromAddress: string | null;
+  emailReplyToAddress: string | null;
 }
 
 const dollars = (cents: number) => (cents / 100).toFixed(2);
@@ -38,6 +40,9 @@ export default function MembershipSettingsPage() {
   const [boundaryUnlocked, setBoundaryUnlocked] = useState(false);
   const [variantId, setVariantId] = useState("");
   const [discountCode, setDiscountCode] = useState("");
+  const [emailFrom, setEmailFrom] = useState("");
+  const [emailReplyTo, setEmailReplyTo] = useState("");
+  const [emailUnlocked, setEmailUnlocked] = useState(false);
 
   // Snapshot of the dues-form values as last loaded/saved; isDirty compares it to
   // current state to drive the unsaved-changes guard.
@@ -67,6 +72,8 @@ export default function MembershipSettingsPage() {
           boundary: settings.orgMembershipYearBoundary ? settings.orgMembershipYearBoundary.slice(0, 10) : "",
           variantId: settings.orgMembershipVariantId ?? "",
           discountCode: settings.volunteerDiscountCode ?? "",
+          emailFrom: settings.emailFromAddress ?? "",
+          emailReplyTo: settings.emailReplyToAddress ?? "",
         };
         setNormalDues(snap.normalDues);
         setVolunteerDues(snap.volunteerDues);
@@ -74,6 +81,8 @@ export default function MembershipSettingsPage() {
         setBoundary(snap.boundary);
         setVariantId(snap.variantId);
         setDiscountCode(snap.discountCode);
+        setEmailFrom(snap.emailFrom);
+        setEmailReplyTo(snap.emailReplyTo);
         setInitial(snap);
       }
     } finally {
@@ -86,6 +95,11 @@ export default function MembershipSettingsPage() {
   // Confirm-checkbox gate only matters when a boundary already exists — changing
   // it shifts every household's cycle. First-time set has nothing to shift.
   const boundaryWasSet = !!initial?.boundary;
+
+  // Same confirm-to-edit guard as the boundary: once a sender identity exists,
+  // changing From (wrong domain → all mail bounces) or Reply-To (misrouted replies)
+  // is high-stakes, so lock both behind an explicit unlock. First-time set is free.
+  const emailWasSet = !!(initial?.emailFrom || initial?.emailReplyTo);
 
   const saveSettings = async () => {
     setSaveNotice(null);
@@ -109,9 +123,11 @@ export default function MembershipSettingsPage() {
           // Send the boundary when the unlock is checked, or when it was never set (no
           // unlock shown then — nothing to protect from an accidental shift).
           ...(boundaryUnlocked || !boundaryWasSet ? { orgMembershipYearBoundary: boundary || null } : {}),
+          // Same rule for the sender identity: only send when unlocked or never set.
+          ...(emailUnlocked || !emailWasSet ? { emailFromAddress: emailFrom.trim() || null, emailReplyToAddress: emailReplyTo.trim() || null } : {}),
         }),
       });
-      if (res.ok) { notifications.show({ color: "green", message: "Settings saved." }); setBoundaryUnlocked(false); notifyNavRefresh(); await load(); }
+      if (res.ok) { notifications.show({ color: "green", message: "Settings saved." }); setBoundaryUnlocked(false); setEmailUnlocked(false); notifyNavRefresh(); await load(); }
       else { const d = await res.json().catch(() => ({})); setSaveNotice({ text: d.error || "Save failed.", err: true }); }
     } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }
     finally { setSaving(false); }
@@ -136,7 +152,7 @@ export default function MembershipSettingsPage() {
 
   const isDirty =
     !!initial &&
-    !shallowEqual(initial, { normalDues, volunteerDues, bgRecheckMonths, boundary, variantId, discountCode });
+    !shallowEqual(initial, { normalDues, volunteerDues, bgRecheckMonths, boundary, variantId, discountCode, emailFrom, emailReplyTo });
   useUnsavedGuard(isDirty);
 
   return (
@@ -248,6 +264,51 @@ export default function MembershipSettingsPage() {
                 onChange={(e) => setBoundary(e.currentTarget.value)}
                 disabled={boundaryWasSet && !boundaryUnlocked}
               />
+            </Alert>
+
+            <Title order={4} mt="lg" mb="sm">Email sender identity</Title>
+            <Alert color={emailWasSet ? "yellow" : "blue"} variant="light">
+              {emailWasSet ? (
+                <Text size="sm" mb="sm">
+                  ⚠️ These control the sender on <strong>every</strong> outbound email. The
+                  <strong> From</strong> address must be on a domain verified in Resend or all mail
+                  bounces. Only change if you are sure.
+                </Text>
+              ) : (
+                <Text size="sm" mb="sm">
+                  Optional. Leave blank to use the environment default sender. The <strong>From</strong>{" "}
+                  address must be on a domain verified in Resend; <strong>Reply-To</strong> can be any
+                  address (e.g. a real board inbox) so replies to a no-reply sender reach someone.
+                </Text>
+              )}
+              {emailWasSet && (
+                <Checkbox
+                  mb="sm"
+                  checked={emailUnlocked}
+                  onChange={(e) => setEmailUnlocked(e.currentTarget.checked)}
+                  label="I understand — let me edit the sender addresses"
+                />
+              )}
+              <Stack gap="md">
+                <TextInput
+                  label="From address"
+                  description={'Bare address or "Name <addr@domain>". Blank = environment default.'}
+                  placeholder="Innovation Treehouse <noreply@updates.innovationtreehouse.org>"
+                  w={420}
+                  value={emailFrom}
+                  onChange={(e) => setEmailFrom(e.currentTarget.value)}
+                  disabled={emailWasSet && !emailUnlocked}
+                />
+                <TextInput
+                  label="Reply-To address"
+                  description="Where replies go. Blank = replies go to the From address."
+                  placeholder="board@innovationtreehouse.org"
+                  w={420}
+                  value={emailReplyTo}
+                  onChange={(e) => setEmailReplyTo(e.currentTarget.value)}
+                  disabled={emailWasSet && !emailUnlocked}
+                />
+              </Stack>
             </Alert>
 
             {saveNotice && (

--- a/checkin-app/src/components/admin/SettingsTabs.tsx
+++ b/checkin-app/src/components/admin/SettingsTabs.tsx
@@ -9,12 +9,13 @@ import { useTodoCounts } from "@/hooks/useTodoCounts";
 import { settingsMisconfigBadge } from "@/components/navBadges";
 import { CountBadge } from "@/components/ui/CountBadge";
 
-export type SettingsTab = "membership" | "roles" | "localization";
+export type SettingsTab = "membership" | "roles" | "localization" | "email";
 
 // sysadminOnly tabs are hidden from board members (the /settings layout admits both).
 const TABS: { value: SettingsTab; label: string; href: string; sysadminOnly?: boolean }[] = [
   { value: "membership", label: "Membership Settings", href: "/settings/membership" },
   { value: "roles", label: "Role Assignment", href: "/settings/roles" },
+  { value: "email", label: "Email", href: "/settings/email" },
   { value: "localization", label: "Localization", href: "/settings/localization", sysadminOnly: true },
 ];
 

--- a/checkin-app/src/lib/__tests__/email.test.ts
+++ b/checkin-app/src/lib/__tests__/email.test.ts
@@ -1,5 +1,6 @@
 let mockIsDevInstance = false;
 const mockCapture = jest.fn();
+let mockIdentity: { from: string; replyTo?: string } = { from: 'test@test.com' };
 
 jest.mock('resend');
 jest.mock('../config.ts', () => ({
@@ -11,6 +12,9 @@ jest.mock('../config.ts', () => ({
 }));
 jest.mock('../dev/sentMail', () => ({
     captureSentEmail: (...args: unknown[]) => mockCapture(...args),
+}));
+jest.mock('../emailIdentity', () => ({
+    getEmailSenderIdentity: () => Promise.resolve(mockIdentity),
 }));
 
 import { sendEmail } from '../email';
@@ -30,6 +34,7 @@ describe('sendEmail no-key logging + capture', () => {
         originalEnv = process.env.NODE_ENV;
         mockIsDevInstance = false;
         mockCapture.mockReset();
+        mockIdentity = { from: 'test@test.com' };
     });
 
     afterEach(() => {
@@ -98,17 +103,20 @@ describe('sendEmail no-key logging + capture', () => {
 // can't reach: Resend returning `{ error }`, and Resend throwing. Both must → false.
 describe('sendEmail send-failure contract (Resend configured)', () => {
     const sendMock = jest.fn();
+    let doMockIdentity: { from: string; replyTo?: string } = { from: 'test@test.com' };
     let errorSpy: jest.SpyInstance;
     let logSpy: jest.SpyInstance;
 
     beforeEach(() => {
         jest.resetModules();
         sendMock.mockReset();
+        doMockIdentity = { from: 'test@test.com' };
         // Re-mock the module's deps for the fresh module instance loaded below.
         jest.doMock('../config.ts', () => ({
             config: { resendApiKey: () => 'test-key', emailFrom: () => 'test@test.com', isDevInstance: () => false },
         }));
         jest.doMock('../dev/sentMail', () => ({ captureSentEmail: jest.fn() }));
+        jest.doMock('../emailIdentity', () => ({ getEmailSenderIdentity: () => Promise.resolve(doMockIdentity) }));
         jest.doMock('resend', () => ({
             Resend: jest.fn().mockImplementation(() => ({ emails: { send: sendMock } })),
         }));
@@ -122,6 +130,7 @@ describe('sendEmail send-failure contract (Resend configured)', () => {
         logSpy.mockRestore();
         jest.dontMock('../config.ts');
         jest.dontMock('../dev/sentMail');
+        jest.dontMock('../emailIdentity');
         jest.dontMock('resend');
     });
 
@@ -144,5 +153,30 @@ describe('sendEmail send-failure contract (Resend configured)', () => {
         const result = await send('test@test.com', 'Subject', '<p>hi</p>');
         expect(result).toBe(false);
         expect(sendMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the resolved From and, when set, Reply-To through to Resend', async () => {
+        doMockIdentity = { from: 'Org <no-reply@org.test>', replyTo: 'board@org.test' };
+        sendMock.mockResolvedValue({ data: { id: '1' }, error: null });
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendEmail: send } = require('../email');
+
+        const result = await send('to@org.test', 'Subject', '<p>hi</p>');
+        expect(result).toBe(true);
+        expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({
+            from: 'Org <no-reply@org.test>',
+            replyTo: 'board@org.test',
+        }));
+    });
+
+    it('omits Reply-To entirely when the identity has none', async () => {
+        doMockIdentity = { from: 'test@test.com' };
+        sendMock.mockResolvedValue({ data: { id: '1' }, error: null });
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendEmail: send } = require('../email');
+
+        await send('to@test.com', 'Subject', '<p>hi</p>');
+        expect(sendMock).toHaveBeenCalledTimes(1);
+        expect(sendMock.mock.calls[0][0]).not.toHaveProperty('replyTo');
     });
 });

--- a/checkin-app/src/lib/__tests__/email.test.ts
+++ b/checkin-app/src/lib/__tests__/email.test.ts
@@ -1,6 +1,6 @@
 let mockIsDevInstance = false;
 const mockCapture = jest.fn();
-let mockIdentity: { from: string; replyTo?: string } = { from: 'test@test.com' };
+let mockIdentity: { from: string; replyTo?: string[] } = { from: 'test@test.com' };
 
 jest.mock('resend');
 jest.mock('../config.ts', () => ({
@@ -103,7 +103,7 @@ describe('sendEmail no-key logging + capture', () => {
 // can't reach: Resend returning `{ error }`, and Resend throwing. Both must → false.
 describe('sendEmail send-failure contract (Resend configured)', () => {
     const sendMock = jest.fn();
-    let doMockIdentity: { from: string; replyTo?: string } = { from: 'test@test.com' };
+    let doMockIdentity: { from: string; replyTo?: string[] } = { from: 'test@test.com' };
     let errorSpy: jest.SpyInstance;
     let logSpy: jest.SpyInstance;
 
@@ -155,8 +155,8 @@ describe('sendEmail send-failure contract (Resend configured)', () => {
         expect(sendMock).toHaveBeenCalledTimes(1);
     });
 
-    it('passes the resolved From and, when set, Reply-To through to Resend', async () => {
-        doMockIdentity = { from: 'Org <no-reply@org.test>', replyTo: 'board@org.test' };
+    it('passes the resolved From and, when set, a single Reply-To through to Resend', async () => {
+        doMockIdentity = { from: 'Org <no-reply@org.test>', replyTo: ['board@org.test'] };
         sendMock.mockResolvedValue({ data: { id: '1' }, error: null });
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { sendEmail: send } = require('../email');
@@ -165,7 +165,20 @@ describe('sendEmail send-failure contract (Resend configured)', () => {
         expect(result).toBe(true);
         expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({
             from: 'Org <no-reply@org.test>',
-            replyTo: 'board@org.test',
+            replyTo: ['board@org.test'],
+        }));
+    });
+
+    it('passes multiple Reply-To addresses through to Resend as an array, verbatim', async () => {
+        doMockIdentity = { from: 'Org <no-reply@org.test>', replyTo: ['info@org.test', 'ops@org.test'] };
+        sendMock.mockResolvedValue({ data: { id: '1' }, error: null });
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendEmail: send } = require('../email');
+
+        const result = await send('to@org.test', 'Subject', '<p>hi</p>');
+        expect(result).toBe(true);
+        expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({
+            replyTo: ['info@org.test', 'ops@org.test'],
         }));
     });
 

--- a/checkin-app/src/lib/__tests__/emailHeader.test.ts
+++ b/checkin-app/src/lib/__tests__/emailHeader.test.ts
@@ -1,0 +1,19 @@
+import { isValidEmailHeader } from '../emailHeader';
+
+describe('isValidEmailHeader', () => {
+    it.each([
+        'a@b.co',
+        'first.last@sub.example.org',
+        'Innovation Treehouse <noreply@updates.example.org>',
+        'Name <a@b.co>',
+    ])('accepts %s', (v) => expect(isValidEmailHeader(v)).toBe(true));
+
+    it.each([
+        'not-an-email',
+        'missing-at.example.org',
+        'no-domain@',
+        '@no-local.org',
+        'spaces in@addr.org',
+        'Name <not-an-email>',
+    ])('rejects %s', (v) => expect(isValidEmailHeader(v)).toBe(false));
+});

--- a/checkin-app/src/lib/__tests__/emailHeader.test.ts
+++ b/checkin-app/src/lib/__tests__/emailHeader.test.ts
@@ -1,4 +1,4 @@
-import { isValidEmailHeader } from '../emailHeader';
+import { isValidEmailHeader, parseEmailHeaderList } from '../emailHeader';
 
 describe('isValidEmailHeader', () => {
     it.each([
@@ -16,4 +16,30 @@ describe('isValidEmailHeader', () => {
         'spaces in@addr.org',
         'Name <not-an-email>',
     ])('rejects %s', (v) => expect(isValidEmailHeader(v)).toBe(false));
+});
+
+describe('parseEmailHeaderList', () => {
+    it('accepts a single address as a one-element array', () => {
+        expect(parseEmailHeaderList('a@b.co')).toEqual(['a@b.co']);
+    });
+
+    it('accepts a comma-separated list, trimming spaces around entries', () => {
+        expect(parseEmailHeaderList('a@b.co,  c@d.co')).toEqual(['a@b.co', 'c@d.co']);
+    });
+
+    it('accepts display-name entries within a list', () => {
+        expect(parseEmailHeaderList('Info <info@x.org>, Ops <ops@x.org>')).toEqual(['Info <info@x.org>', 'Ops <ops@x.org>']);
+    });
+
+    it('dedupes exact-duplicate entries', () => {
+        expect(parseEmailHeaderList('a@b.co, a@b.co')).toEqual(['a@b.co']);
+    });
+
+    it('rejects the whole list when any one entry is malformed', () => {
+        expect(parseEmailHeaderList('a@b.co, not-an-email')).toBeNull();
+    });
+
+    it.each(['', '   ', ','])('rejects a blank value %j', (v) => {
+        expect(parseEmailHeaderList(v)).toBeNull();
+    });
 });

--- a/checkin-app/src/lib/__tests__/emailIdentity.test.ts
+++ b/checkin-app/src/lib/__tests__/emailIdentity.test.ts
@@ -12,9 +12,19 @@ describe('getEmailSenderIdentity', () => {
         expect(await getEmailSenderIdentity()).toEqual({ from: 'env-default@example.com', replyTo: undefined });
     });
 
-    it('lets BoardSettings override the From and set a Reply-To', async () => {
+    it('lets BoardSettings override the From and set a single Reply-To (one-element array)', async () => {
         mockFindUnique.mockResolvedValue({ emailFromAddress: 'Org <no-reply@org.test>', emailReplyToAddress: 'board@org.test' });
-        expect(await getEmailSenderIdentity()).toEqual({ from: 'Org <no-reply@org.test>', replyTo: 'board@org.test' });
+        expect(await getEmailSenderIdentity()).toEqual({ from: 'Org <no-reply@org.test>', replyTo: ['board@org.test'] });
+    });
+
+    it('parses a comma-separated Reply-To into an array', async () => {
+        mockFindUnique.mockResolvedValue({ emailFromAddress: null, emailReplyToAddress: 'info@org.test, ops@org.test' });
+        expect(await getEmailSenderIdentity()).toEqual({ from: 'env-default@example.com', replyTo: ['info@org.test', 'ops@org.test'] });
+    });
+
+    it('trims whitespace and dedupes Reply-To entries', async () => {
+        mockFindUnique.mockResolvedValue({ emailFromAddress: null, emailReplyToAddress: '  info@org.test ,info@org.test,  ops@org.test' });
+        expect(await getEmailSenderIdentity()).toEqual({ from: 'env-default@example.com', replyTo: ['info@org.test', 'ops@org.test'] });
     });
 
     it('treats blank/whitespace values as unset (env From, no Reply-To)', async () => {

--- a/checkin-app/src/lib/__tests__/emailIdentity.test.ts
+++ b/checkin-app/src/lib/__tests__/emailIdentity.test.ts
@@ -1,0 +1,29 @@
+const mockFindUnique = jest.fn();
+jest.mock('../prisma', () => ({ __esModule: true, default: { boardSettings: { findUnique: (...a: unknown[]) => mockFindUnique(...a) } } }));
+jest.mock('../config', () => ({ config: { emailFrom: () => 'env-default@example.com' } }));
+
+import { getEmailSenderIdentity } from '../emailIdentity';
+
+describe('getEmailSenderIdentity', () => {
+    beforeEach(() => mockFindUnique.mockReset());
+
+    it('falls back to the env From with no Reply-To when nothing is configured', async () => {
+        mockFindUnique.mockResolvedValue(null);
+        expect(await getEmailSenderIdentity()).toEqual({ from: 'env-default@example.com', replyTo: undefined });
+    });
+
+    it('lets BoardSettings override the From and set a Reply-To', async () => {
+        mockFindUnique.mockResolvedValue({ emailFromAddress: 'Org <no-reply@org.test>', emailReplyToAddress: 'board@org.test' });
+        expect(await getEmailSenderIdentity()).toEqual({ from: 'Org <no-reply@org.test>', replyTo: 'board@org.test' });
+    });
+
+    it('treats blank/whitespace values as unset (env From, no Reply-To)', async () => {
+        mockFindUnique.mockResolvedValue({ emailFromAddress: '   ', emailReplyToAddress: '' });
+        expect(await getEmailSenderIdentity()).toEqual({ from: 'env-default@example.com', replyTo: undefined });
+    });
+
+    it('never blocks mail: falls back to the env From if the settings read throws', async () => {
+        mockFindUnique.mockRejectedValue(new Error('db down'));
+        expect(await getEmailSenderIdentity()).toEqual({ from: 'env-default@example.com' });
+    });
+});

--- a/checkin-app/src/lib/email.ts
+++ b/checkin-app/src/lib/email.ts
@@ -1,17 +1,21 @@
 import { Resend } from 'resend';
 import { config } from './config';
 import { captureSentEmail } from './dev/sentMail';
+import { getEmailSenderIdentity } from './emailIdentity';
 
 const resend = config.resendApiKey()
     ? new Resend(config.resendApiKey()!)
     : null;
 
-const FROM_ADDRESS = config.emailFrom();
-
 /**
  * Send an email via Resend. Falls back to console.log if no API key is configured.
+ *
+ * The From (and optional Reply-To) come from getEmailSenderIdentity(): the board
+ * can override the EMAIL_FROM env default and set a Reply-To in Settings → Membership.
  */
 export async function sendEmail(to: string, subject: string, html: string): Promise<boolean> {
+    const { from, replyTo } = await getEmailSenderIdentity();
+
     if (!resend) {
         console.log(`[Email (no RESEND_API_KEY)] To: ${to} | Subject: ${subject}`);
         // Dev/local: capture the email so link/token flows are retrievable at /dev/sent-mail,
@@ -19,17 +23,18 @@ export async function sendEmail(to: string, subject: string, html: string): Prom
         // persona-mint idiom (see auth-options.ts) so it is impossible in prod: a prod box that
         // somehow lost its key still falls through to `return false` (fail loud, not fake success).
         if (config.isDevInstance() && process.env.NODE_ENV !== 'production') {
-            return captureSentEmail(FROM_ADDRESS, to, subject, html);
+            return captureSentEmail(from, to, subject, html);
         }
         return false;
     }
 
     try {
         const { error } = await resend.emails.send({
-            from: FROM_ADDRESS,
+            from,
             to,
             subject,
             html,
+            ...(replyTo ? { replyTo } : {}),
         });
 
         if (error) {

--- a/checkin-app/src/lib/emailHeader.ts
+++ b/checkin-app/src/lib/emailHeader.ts
@@ -13,3 +13,19 @@ export function isValidEmailHeader(value: string): boolean {
     const angle = value.match(/<([^>]*)>\s*$/);
     return isValidEmail(angle ? angle[1] : value);
 }
+
+/**
+ * Parse a comma-separated list of email headers (Reply-To can have more than one
+ * recipient, e.g. "info@x.org, ops@x.org"). Each entry is validated with
+ * isValidEmailHeader; returns the trimmed, deduplicated list, or null if the value
+ * is blank or any entry is malformed (reject-the-whole-list, same as a single header).
+ *
+ * ponytail: splits on a bare ',' — a quoted display name containing a comma
+ * (`"Smith, Jane" <jane@x.org>`) isn't supported. Add a quoted-string-aware split
+ * if that ever comes up.
+ */
+export function parseEmailHeaderList(value: string): string[] | null {
+    const parts = value.split(',').map((p) => p.trim()).filter(Boolean);
+    if (parts.length === 0 || !parts.every(isValidEmailHeader)) return null;
+    return Array.from(new Set(parts));
+}

--- a/checkin-app/src/lib/emailHeader.ts
+++ b/checkin-app/src/lib/emailHeader.ts
@@ -1,0 +1,14 @@
+/**
+ * Validate an email From/Reply-To header value: a bare address (`a@b.co`) or a
+ * display-name form (`Name <a@b.co>`) — the two shapes Resend accepts. Rejects
+ * anything without a plausible address so a typo can't silently break (From) or
+ * misroute (Reply-To) all mail.
+ *
+ * Zero imports on purpose: shared by the server route (authoritative) and the
+ * client settings form (UX), so the two validations can never drift.
+ */
+export function isValidEmailHeader(value: string): boolean {
+    const angle = value.match(/<([^>]*)>\s*$/);
+    const addr = (angle ? angle[1] : value).trim();
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(addr);
+}

--- a/checkin-app/src/lib/emailHeader.ts
+++ b/checkin-app/src/lib/emailHeader.ts
@@ -1,14 +1,15 @@
+import { isValidEmail } from "./emergencyContacts/identity";
+
 /**
  * Validate an email From/Reply-To header value: a bare address (`a@b.co`) or a
- * display-name form (`Name <a@b.co>`) — the two shapes Resend accepts. Rejects
- * anything without a plausible address so a typo can't silently break (From) or
- * misroute (Reply-To) all mail.
+ * display-name form (`Name <a@b.co>`) — the two shapes Resend accepts. Extracts the
+ * address from the angle-bracket form (the only thing a header adds over a plain
+ * address) and defers to the shared `isValidEmail` so the address rule stays single-sourced.
  *
- * Zero imports on purpose: shared by the server route (authoritative) and the
- * client settings form (UX), so the two validations can never drift.
+ * Shared by the server route (authoritative) and the client settings form (UX),
+ * so the two validations can never drift.
  */
 export function isValidEmailHeader(value: string): boolean {
     const angle = value.match(/<([^>]*)>\s*$/);
-    const addr = (angle ? angle[1] : value).trim();
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(addr);
+    return isValidEmail(angle ? angle[1] : value);
 }

--- a/checkin-app/src/lib/emailIdentity.ts
+++ b/checkin-app/src/lib/emailIdentity.ts
@@ -1,0 +1,36 @@
+import prisma from "./prisma";
+import { config } from "./config";
+
+export interface EmailSenderIdentity {
+    /** The Resend `from`. BoardSettings.emailFromAddress overrides the EMAIL_FROM env default. */
+    from: string;
+    /** The Resend `replyTo`, or undefined when the board hasn't configured one. */
+    replyTo?: string;
+}
+
+/**
+ * Resolve the effective sender identity for outbound mail: the board can override
+ * the EMAIL_FROM env default and add a Reply-To via Settings → Membership. Falls
+ * back to the env-only identity on any DB error so a settings-table hiccup never
+ * blocks mail delivery.
+ *
+ * ponytail: one findUnique on the single-row BoardSettings PK per send. Fan-outs
+ * (e.g. notifyNewProgramAnnounced) pay it per recipient; the lookup is a cached
+ * PK hit and those volumes are small. If a large fan-out ever dominates, resolve
+ * once and pass the identity down.
+ */
+export async function getEmailSenderIdentity(): Promise<EmailSenderIdentity> {
+    const envFrom = config.emailFrom();
+    try {
+        const settings = await prisma.boardSettings.findUnique({
+            where: { id: 1 },
+            select: { emailFromAddress: true, emailReplyToAddress: true },
+        });
+        return {
+            from: settings?.emailFromAddress?.trim() || envFrom,
+            replyTo: settings?.emailReplyToAddress?.trim() || undefined,
+        };
+    } catch {
+        return { from: envFrom };
+    }
+}

--- a/checkin-app/src/lib/emailIdentity.ts
+++ b/checkin-app/src/lib/emailIdentity.ts
@@ -1,11 +1,12 @@
 import prisma from "./prisma";
 import { config } from "./config";
+import { parseEmailHeaderList } from "./emailHeader";
 
 export interface EmailSenderIdentity {
     /** The Resend `from`. BoardSettings.emailFromAddress overrides the EMAIL_FROM env default. */
     from: string;
-    /** The Resend `replyTo`, or undefined when the board hasn't configured one. */
-    replyTo?: string;
+    /** The Resend `replyTo` addresses (one or more), or undefined when the board hasn't configured any. */
+    replyTo?: string[];
 }
 
 /**
@@ -26,9 +27,10 @@ export async function getEmailSenderIdentity(): Promise<EmailSenderIdentity> {
             where: { id: 1 },
             select: { emailFromAddress: true, emailReplyToAddress: true },
         });
+        const replyToRaw = settings?.emailReplyToAddress?.trim();
         return {
             from: settings?.emailFromAddress?.trim() || envFrom,
-            replyTo: settings?.emailReplyToAddress?.trim() || undefined,
+            replyTo: (replyToRaw ? parseEmailHeaderList(replyToRaw) : null) ?? undefined,
         };
     } catch {
         return { from: envFrom };

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -112,6 +112,8 @@ export const classifications = {
         orgMembershipVariantId: 'internal',
         volunteerDiscountCode: 'internal',
         bgRecheckMonths: 'public',
+        emailFromAddress: 'public',
+        emailReplyToAddress: 'public',
         shopifyOrgMembershipProductId: 'internal',
         shopifyNormalVariantId: 'internal',
         shopifyVolunteerVariantId: 'internal',


### PR DESCRIPTION
## What

Adds a dedicated **Email** section under Settings (`/settings/email`) where board/sysadmin configure the outbound-email sender identity, and adds **Reply-To** support the codebase didn't have.

- **Reply-To (new capability).** Every email currently sends with no `Reply-To`, so replies go to the no-reply From address. A configured Reply-To (e.g. `board@…`) routes replies to a real inbox. Passed through to Resend's `replyTo`; omitted entirely when unset; need not be on the sending domain.
- **From override.** `BoardSettings.emailFromAddress` overrides the `EMAIL_FROM` env default when set; blank falls back to env. The env default (per-environment in the ECS task-def) stays the bootstrap value — **no infra change needed**.

Both fields sit behind the **same confirm-to-edit lock the membership-year boundary uses**: once a value exists the fields lock behind an "I understand — let me edit" checkbox. High-stakes — a From on a non-Resend-verified domain bounces *all* mail; a wrong Reply-To silently misroutes replies. First-time set is unguarded, like the boundary.

## Layout

New **Email** tab in `SettingsTabs` (board + sysadmin, matching what the `/settings` layout admits — membership's existing access level is preserved), its own page `src/app/settings/email/page.tsx`, and its own API route `/api/settings/email` (GET + PUT) scoped to the two fields. It reads/writes the same `BoardSettings` singleton — the storage and the `getEmailSenderIdentity()` resolution are unchanged; only the edit surface is its own section.

## How

- Resolution is centralized in `getEmailSenderIdentity()` (`src/lib/emailIdentity.ts`), called by the single `sendEmail` chokepoint — **all ~15 callers unchanged**. On any settings-read error it falls back to the env-only identity, so a `BoardSettings` hiccup never blocks delivery.
- `/api/settings/email` PUT validates the From/Reply-To header shape (bare address or `Name <addr@domain>`) and rejects the whole update on a bad value so the previous value survives; blank clears back to null. Writes an audit-log row.
- Both fields are `/// @sensitivity:public` (endpoint role-gated to board/sysadmin; a From header ships in every email — not secret). Generated classifications regenerated + committed.
- Migration `20260705150000_add_email_sender_settings` is two nullable `ADD COLUMN`s — a safe additive change on a populated table.

## Verification

- **Migration:** fresh `migrate deploy` clean; `prisma migrate diff --exit-code` → no drift.
- **Tests:** `emailIdentity` unit (override / blank-is-unset / never-blocks-on-error); `email.test` reply-to pass-through + omission; new `emailSettingsAPI` integration (read gate / accept-valid / reject-malformed-keeps-prior / clear-to-null); new email **page** test (first-time-set editable vs already-set lock/unlock guard). Unit + page suites and the two settings integration suites green; `tsc`, `eslint`, security-classification suite, and `check-route-coverage` (0 errors) all clean.

## Multiple Reply-To addresses

Reply-To now accepts a **comma-separated list** (e.g. `info@innovationtreehouse.org, ops@innovationtreehouse.org`) so replies can fan out to more than one inbox. Design keeps the existing single `TEXT` column (`BoardSettings.emailReplyToAddress`) — **no migration**:

- `parseEmailHeaderList()` (`src/lib/emailHeader.ts`) splits the value on `,`, trims each entry, validates each one with the existing `isValidEmailHeader` (same bare-address / `Name <addr@domain>` shapes), and dedupes exact repeats. Any one malformed entry rejects the *whole* list (400) — same reject-and-keep-prior-value contract the single-address From/Reply-To validation already had.
- `getEmailSenderIdentity()` now returns `replyTo?: string[]` (parsed, trimmed, deduped; `undefined` when unset) instead of `replyTo?: string`.
- Resend's SDK already accepts `replyTo?: string | string[]` (`node_modules/resend/dist/index.d.cts`), so `email.ts` passes the array straight through to `resend.emails.send()` — **no changes needed there**; a single configured address just becomes a one-element array.
- From stays single-address, unchanged — multiple Froms aren't a real use case and weren't in scope.
- Route (`/api/settings/email` PUT) and the client settings page both switch their Reply-To validation to the new list parser; From validation is untouched.
- **Known limitation (documented with a `ponytail:` comment):** the split is on a bare `,`. A quoted display name that itself contains a comma (e.g. `"Smith, Jane" <jane@x.org>`) is not supported — it would be mis-split into two bogus entries and rejected. Not a real-world case for board/ops addresses; upgrade to a quoted-string-aware splitter if it ever comes up.

Tests added/updated: `emailHeader.test.ts` (list parsing: single, multi with spaces, display-name entries, dedupe, reject-whole-list-on-one-bad-entry, blank), `emailIdentity.test.ts` (comma value → array, whitespace/dedupe, single address stays a one-element array), `email.test.ts` (array Reply-To passed through to Resend verbatim, single and multi), `emailSettingsAPI.integration.test.ts` (PUT accepts a valid comma list, rejects a list with one bad entry and keeps the prior value), and the settings page test (a comma list produces no inline error and fires the PUT). The Reply-To field's description and placeholder were updated to show the comma-separated form.

## Follow-up note

For prod first-launch this pairs with the earlier readiness note: the prod From domain (`updates.innovationtreehouse.org`) must be Resend-verified. This section lets the board point From/Reply-To at the right addresses without a redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz7egoZoDp37iL9FpC8tH
