### PR TITLE
feat(finance): pill-style scholarship request buttons

### DIFF
--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -810,23 +810,27 @@ export default function MembershipPage() {
                     ) : (
                       <Text c="yellow" mt="md">The payment link isn&apos;t available yet. Please check back shortly.</Text>
                     )}
+                    {planRequested ? (
+                      <Text c="green" mt="md">Scholarship or payment plan requested — the finance committee will follow up.</Text>
+                    ) : (
+                      <Button
+                        variant="light"
+                        type="button"
+                        mt="md"
+                        onClick={requestPaymentPlan}
+                        styles={{ root: { height: 'auto', paddingBlock: 'var(--mantine-spacing-xs)' }, label: { whiteSpace: 'normal' } }}
+                      >
+                        Request a scholarship or payment plan from the Finance Committee of the Board
+                      </Button>
+                    )}
                     {!state.external?.bgCleared && (
                       <Alert color="blue" variant="light" mt="md">
                         Your background check is being reviewed in the background — you can pay now.
                         Your membership activates as soon as both the payment and the check are done.
                       </Alert>
                     )}
-                    {planRequested ? (
-                      <Text c="green" mt="lg">Scholarship or payment plan requested — the finance committee will follow up.</Text>
-                    ) : (
-                      <Text mt="lg">
-                        <Anchor component="button" type="button" onClick={requestPaymentPlan}>
-                          request a scholarship or payment plan from the finance committee of the board
-                        </Anchor>
-                      </Text>
-                    )}
                     <Text size="sm" c="dimmed" mt="md">
-                      To discuss alternative arrangements, please email{" "}
+                      For any questions, please email{" "}
                       <Anchor href="mailto:finance@innovationtreehouse.org">finance@innovationtreehouse.org</Anchor>.
                     </Text>
                   </>

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -253,7 +253,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
-        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/ }));
+        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/i }));
         await waitFor(() =>
             expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringMatching(/Requested! Please check your email/) })),
         );
@@ -279,7 +279,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
-        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/ }));
+        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/i }));
         expect(await screen.findByText("Already pending.")).toBeInTheDocument();
     });
 
@@ -298,7 +298,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
-        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/ }));
+        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/i }));
         expect(await screen.findByText(/failed to alert the finance committee/)).toBeInTheDocument();
     });
 
@@ -311,7 +311,7 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Which of your household wants to enroll?");
 
         global.fetch = jest.fn().mockRejectedValue(new Error("down"));
-        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/ }));
+        fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/i }));
         await waitFor(() =>
             expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "red", message: "Network error requesting payment plan.", autoClose: false })),
         );

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { use, useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { Alert, Anchor, Button, Card, Center, Checkbox, Container, Divider, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import { Alert, Button, Card, Center, Checkbox, Container, Divider, Group, Loader, Stack, Text, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { formatDate } from '@/lib/time';
 import { checkProgramAge } from '@/lib/programAge';
@@ -509,9 +509,16 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                 </Button>
 
                 {hasPrice && !isClosed && (
-                  <Anchor component="button" type="button" size="sm" onClick={handleRequestPaymentPlan}>
-                    request a scholarship or payment plan from the finance committee of the board
-                  </Anchor>
+                  <Button
+                    fullWidth
+                    size="md"
+                    variant="light"
+                    type="button"
+                    onClick={handleRequestPaymentPlan}
+                    styles={{ root: { height: 'auto', paddingBlock: 'var(--mantine-spacing-xs)' }, label: { whiteSpace: 'normal' } }}
+                  >
+                    Request a scholarship or payment plan from the Finance Committee of the Board
+                  </Button>
                 )}
               </Stack>
               )}


### PR DESCRIPTION
## What changed

Scholarship request buttons on the **program purchase** and **membership** pages are now pill-style `Button`s (`variant="light"`) instead of URL-style `Anchor` links — matching the "Pay on Shopify" call-to-action.

Membership page also:
- Scholarship button moved directly under the pay button (above the background-check alert).
- Contact line reworded to "For any questions, please email finance@innovationtreehouse.org".

Copy: capitalized **Request**, **Finance Committee**, **Board**. Button labels now wrap (`whiteSpace: normal` + auto height) so the longer text isn't truncated.

## Why

The old link styling read as secondary/afterthought next to the filled pay button. Consistent pill styling makes the scholarship path a clear alternative action.

## Reviewer notes

- Programs page: dropped now-unused `Anchor` import.
- Program page test regex made case-insensitive to tolerate the capitalized copy.
- Full suite green locally (199 suites, 1567 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
