### PR TITLE
fix(security): household-scope every self-approval guard

### DIFF
--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -27,6 +27,7 @@ function post(body: unknown) {
 
 describe('POST /api/membership-ops/households — grant/revoke audit logging', () => {
     let boardId: number;
+    let boardHouseholdId: number;
     let inactiveHouseholdId: number;
     let activeHouseholdId: number;
 
@@ -42,6 +43,7 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
             data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, household: { create: {} } },
         });
         boardId = board.id;
+        boardHouseholdId = board.householdId;
 
         // A household with no membership row → will be granted (ACTIVE).
         const inactive = await prisma.person.create({
@@ -83,6 +85,21 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         expect(audit).not.toBeNull();
         expect(audit!.actorId).toBe(boardId);
         expect((audit!.newData as { status: string }).status).toBe('ACTIVE');
+    });
+
+    it("refuses to grant the actor's OWN household (conflict of interest); sysadmin overrides", async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+        const res = await post({ householdId: boardHouseholdId, active: true });
+        expect(res.status).toBe(403);
+        const before = await prisma.orgMembership.findUnique({ where: { householdId: boardHouseholdId } });
+        expect(before?.status ?? 'NONE').not.toBe('ACTIVE'); // not granted
+
+        // Sysadmin is the deliberate remedy.
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isSysadmin: true } });
+        const ok = await post({ householdId: boardHouseholdId, active: true });
+        expect(ok.status).toBe(200);
+        const after = await prisma.orgMembership.findUnique({ where: { householdId: boardHouseholdId } });
+        expect(after?.status).toBe('ACTIVE');
     });
 
     it('revokes an active household, sets REVOKED, and writes an audit row', async () => {

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -13,7 +13,7 @@
 
 import { markContractSigned, markBgConsent } from '@/lib/membership/external';
 import { normalizeAuditData } from '@/lib/auditPayload';
-import { attest } from '@/lib/membership/review';
+import { attest, overrideBlocked } from '@/lib/membership/review';
 import { certifyPaymentPlan, activate } from '@/lib/membership/payment';
 import { submitIntake } from '@/lib/membership/intake';
 import { beginRenewal } from '@/lib/membership/renewal';
@@ -204,9 +204,40 @@ describe('background check is non-blocking', () => {
         // Contract alone advances (no BG consent needed), and paying activates immediately.
         await markContractSigned(processId);
         expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
-        await certifyPaymentPlan(processId, lead!.id);
+        await certifyPaymentPlan(processId, revA); // certifier must be outside the applicant household (conflict-of-interest guard)
         expect(await statusOf(processId)).toBe('ACTIVE');
         expect(await membershipStatusOf(orgMembershipId)).toBe('ACTIVE');
+    });
+
+    it('conflict of interest: a certifier in the applicant household is blocked; sysadmin overrides', async () => {
+        const { processId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        await markContractSigned(processId);
+        await markBgConsent(processId, revA);
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
+
+        // A household lead certifying their OWN membership = self-approval → forbidden.
+        await expect(certifyPaymentPlan(processId, leadId)).rejects.toMatchObject({ code: 'forbidden' });
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT'); // unchanged — nothing certified
+
+        // Sysadmin is the deliberate remedy and bypasses the guard.
+        await certifyPaymentPlan(processId, leadId, { isSysadmin: true });
+        expect(await statusOf(processId)).toBe('PENDING_BG_CLEARANCE'); // paid; still needs the check
+    });
+
+    it('conflict of interest: overrideBlocked by the applicant household is blocked; sysadmin overrides', async () => {
+        const { processId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        await markContractSigned(processId);
+        await markBgConsent(processId, revA);
+        await attest(revA, processId, { result: 'REJECT' }); // one reject → BLOCKED
+        expect(await statusOf(processId)).toBe('BLOCKED');
+
+        // A household lead force-clearing their OWN blocked check = self-approval → forbidden.
+        await expect(overrideBlocked(processId, leadId, 'approve')).rejects.toMatchObject({ code: 'same_household_applicant' });
+        expect(await statusOf(processId)).toBe('BLOCKED'); // unchanged
+
+        // Sysadmin bypasses; the force-clear lands the process back on the payment track.
+        await overrideBlocked(processId, leadId, 'approve', { isSysadmin: true });
+        expect(await statusOf(processId)).not.toBe('BLOCKED');
     });
 
     it('renewal with a still-valid check → PENDING_PAYMENT + bgClearedAt, then paying activates (not stuck)', async () => {

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -34,6 +34,7 @@ describe('Program payment-plan routes', () => {
     let programId: number;
     let mentorId: number;
     let boardId: number;
+    let boardKinId: number;
     let selfId: number;
     let otherId: number;
     let noiseId: number;
@@ -56,6 +57,12 @@ describe('Program payment-plan routes', () => {
         });
         boardId = board.id;
         householdIds.push(board.householdId);
+
+        // A household-mate of the board member — the conflict-of-interest target.
+        const boardKin = await prisma.person.create({
+            data: { name: 'PP Board Kin', email: `boardkin-${TAG}@example.com`, householdId: board.householdId },
+        });
+        boardKinId = boardKin.id;
 
         const self = await prisma.person.create({
             data: { name: 'PP Self', email: `self-${TAG}@example.com`, household: { create: {} } },
@@ -84,7 +91,7 @@ describe('Program payment-plan routes', () => {
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.program.delete({ where: { id: programId } });
         await prisma.person.deleteMany({
-            where: { id: { in: [mentorId, boardId, selfId, otherId, noiseId] } },
+            where: { id: { in: [mentorId, boardId, boardKinId, selfId, otherId, noiseId] } },
         });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
     });
@@ -160,6 +167,32 @@ describe('Program payment-plan routes', () => {
             expect(row?.status).toBe('ACTIVE');
             expect(row?.isPaymentPlanRequested).toBe(false);
             expect(row?.pendingSince).toBeNull();
+        });
+
+        it("refuses to approve a plan for the board member's OWN household (conflict of interest); sysadmin overrides", async () => {
+            await enroll(boardKinId, { requested: true });
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            const res = await PlansPost(nextReq('http://localhost', {
+                method: 'POST',
+                body: JSON.stringify({ programId, participantId: boardKinId }),
+            }));
+            expect(res.status).toBe(403);
+            let row = await prisma.programParticipant.findUnique({
+                where: { programId_personId: { programId, personId: boardKinId } },
+            });
+            expect(row?.status).toBe('PENDING'); // unchanged — nothing approved
+
+            // Sysadmin is the deliberate remedy.
+            mockSession.mockResolvedValue({ user: { id: boardId, isSysadmin: true } });
+            const ok = await PlansPost(nextReq('http://localhost', {
+                method: 'POST',
+                body: JSON.stringify({ programId, participantId: boardKinId }),
+            }));
+            expect(ok.status).toBe(200);
+            row = await prisma.programParticipant.findUnique({
+                where: { programId_personId: { programId, personId: boardKinId } },
+            });
+            expect(row?.status).toBe('ACTIVE');
         });
     });
 

--- a/checkin-app/src/app/api/finance-ops/membership-payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/membership-payment-plans/route.ts
@@ -51,7 +51,7 @@ export const POST = withAuth(
             // Reuse the membership activation path: certifies the plan and activates
             // without a Shopify payment (holding for background clearance if not yet
             // cleared). Then clear the request flag so it drops off the queue.
-            await certifyPaymentPlan(processId, auth.user.id);
+            await certifyPaymentPlan(processId, auth.user.id, { isSysadmin: auth.user.isSysadmin === true });
             await prisma.orgMembershipProcess.update({
                 where: { id: processId },
                 data: { isPaymentPlanRequested: false },
@@ -70,7 +70,7 @@ export const POST = withAuth(
             return NextResponse.json({ success: true });
         } catch (error) {
             if (error instanceof PaymentError) {
-                return apiError(error.message, error.code === "not_found" ? 404 : 409);
+                return apiError(error.message, error.code === "not_found" ? 404 : error.code === "forbidden" ? 403 : 409);
             }
             logger.error("Failed to approve membership payment plan:", error);
             return apiError("Failed to approve payment plan", 500);

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { handler } from "@/security/handler";
 import { apiError } from "@/lib/api-response";
+import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 
 export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
     const requests = await prisma.programParticipant.findMany({
@@ -33,6 +34,16 @@ export const POST = withAuth(
 
             if (Number.isNaN(programId) || Number.isNaN(participantId)) {
                 return apiError("programId and participantId are required", 400);
+            }
+
+            // Conflict of interest: a board member may not approve their OWN household's
+            // program payment plan (activate an enrollment without payment for their own
+            // family). Sysadmin bypasses.
+            if (auth.type === 'session') {
+                const target = await prisma.person.findUnique({ where: { id: participantId }, select: { householdId: true } });
+                if (await hasHouseholdConflict(prisma, auth.user.id, target?.householdId, { isSysadmin: auth.user.isSysadmin === true })) {
+                    return apiError("You cannot approve your own household's payment plan — a sysadmin must.", 403);
+                }
             }
 
             const data = {

--- a/checkin-app/src/app/api/membership-ops/applications/certify-payment/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/certify-payment/route.ts
@@ -21,11 +21,12 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
     }
     if (!body.processId) return apiError("processId is required", 400);
     try {
-        const process = await certifyPaymentPlan(body.processId, auth.user.id);
+        const process = await certifyPaymentPlan(body.processId, auth.user.id, { isSysadmin: auth.user.isSysadmin === true });
         return NextResponse.json({ process });
     } catch (error) {
         if (error instanceof PaymentError) {
-            return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 409 });
+            const status = error.code === "not_found" ? 404 : error.code === "forbidden" ? 403 : 409;
+            return NextResponse.json({ error: error.message, code: error.code }, { status });
         }
         logger.error("Certify payment error:", error);
         return apiError("Internal Server Error", 500);

--- a/checkin-app/src/app/api/membership-ops/applications/review-override/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/review-override/route.ts
@@ -25,11 +25,14 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
         return apiError("processId and action (reset|approve) are required", 400);
     }
     try {
-        const outcome = await overrideBlocked(body.processId, auth.user.id, body.action);
+        const outcome = await overrideBlocked(body.processId, auth.user.id, body.action, {
+            isSysadmin: auth.user.isSysadmin === true,
+        });
         return NextResponse.json({ outcome });
     } catch (error) {
         if (error instanceof ReviewError) {
-            return NextResponse.json({ error: error.message, code: error.code }, { status: error.code === "not_found" ? 404 : 409 });
+            const status = error.code === "not_found" ? 404 : error.code === "same_household_applicant" ? 403 : 409;
+            return NextResponse.json({ error: error.message, code: error.code }, { status });
         }
         logger.error("Review override error:", error);
         return apiError("Internal Server Error", 500);

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
+import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 
 export const dynamic = 'force-dynamic';
 
@@ -148,6 +149,13 @@ export const POST = withAuth(
             }
 
             if (active) {
+                // Conflict of interest: a board member may not grant their OWN household
+                // ACTIVE membership — that bypasses payment AND the background check for
+                // their own family. Sysadmin bypasses. (Mirrors the deny branch's
+                // board-member protection, and certifyPaymentPlan's guard.)
+                if (auth.type === 'session' && await hasHouseholdConflict(prisma, auth.user.id, householdId, { isSysadmin: auth.user.isSysadmin === true })) {
+                    return apiError("You cannot activate your own household's membership — a sysadmin must.", 403);
+                }
                 const membership = await prisma.orgMembership.upsert({
                     where: { householdId },
                     create: { householdId, status: "ACTIVE" },

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -9,6 +9,7 @@ import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { formatDateTime } from '@/lib/time';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
+import { sharesHousehold } from '@/lib/conflictOfInterest';
 import { formatCents } from '@inventory/money';
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -20,6 +21,7 @@ type PaymentPlanRequest = {
     id: number;
     name: string | null;
     email: string;
+    householdId: number | null;
   };
   program: {
     id: number;
@@ -30,7 +32,11 @@ type PaymentPlanRequest = {
 };
 
 export default function PendingParticipantsPage() {
-  const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
+  const { user: me, ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
+  // Conflict of interest: a board member may not approve their OWN household member's
+  // plan (mirrors the server guard). Sysadmin keeps the button. UX only — server enforces.
+  const ownHousehold = (req: PaymentPlanRequest) =>
+    me?.isSysadmin !== true && sharesHousehold(me?.householdId, req.person.householdId);
 
   const [requests, setRequests] = useState<PaymentPlanRequest[]>([]);
   const [loading, setLoading] = useState(true);
@@ -135,7 +141,12 @@ export default function PendingParticipantsPage() {
       header: 'Actions',
       align: 'right',
       render: (req) => (
-        <Button size="xs" fz={15} color="green" variant="light" onClick={() => handleApprove(req.programId, req.personId)}>
+        <Button
+          size="xs" fz={15} color="green" variant="light"
+          disabled={ownHousehold(req)}
+          title={ownHousehold(req) ? "You can't approve your own household's plan — a sysadmin must." : undefined}
+          onClick={() => handleApprove(req.programId, req.personId)}
+        >
           Approve &amp; Mark Active
         </Button>
       ),

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -4,7 +4,9 @@ import { useState, useEffect, useCallback } from "react";
 import { Alert, Badge, Button, Card, Center, Group, Loader, Stack, Text } from "@mantine/core";
 import { AlertBanner } from "@/components/admin/AlertBanner";
 import { notifications } from "@mantine/notifications";
+import { useSession } from "next-auth/react";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
+import { sharesHousehold } from "@/lib/conflictOfInterest";
 
 interface Person {
   id: number;
@@ -57,6 +59,14 @@ const awaitingBg = (r: ProcessRow) =>
     ((r.status === "PENDING_PAYMENT" || r.status === "PENDING_BG_CLEARANCE") && !!r.bgConsentAt));
 
 export default function AdminMembershipPage() {
+  const { data: session } = useSession();
+  const me = session?.user;
+  // Conflict of interest: a board member may not certify/override their OWN household's
+  // application (mirrors the server guards in certifyPaymentPlan/overrideBlocked). Sysadmin
+  // is the deliberate remedy and keeps the buttons. The disabled state is UX only — the
+  // server is the real enforcement.
+  const ownHousehold = (r: ProcessRow) =>
+    me?.isSysadmin !== true && sharesHousehold(me?.householdId, r.orgMembership?.householdId);
   const [rows, setRows] = useState<ProcessRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<number | null>(null);
@@ -250,9 +260,12 @@ export default function AdminMembershipPage() {
               {r.status === "PENDING_PAYMENT" && (
                 <Group mt="md" gap="md" wrap="wrap" align="center">
                   <Text size="sm" c="dimmed">Awaiting payment.</Text>
-                  <Button size="xs" fz={15} color="green" disabled={busyId === r.id} onClick={() => certify(r.id)}>
+                  <Button size="xs" fz={15} color="green" disabled={busyId === r.id || ownHousehold(r)} onClick={() => certify(r.id)}>
                     Certify payment plan → {r.bgClearedAt ? "activate" : "(holds for background check)"}
                   </Button>
+                  {ownHousehold(r) && (
+                    <Text size="xs" c="dimmed">You can&apos;t certify your own household&apos;s application — another board member (or a sysadmin) must.</Text>
+                  )}
                 </Group>
               )}
 
@@ -270,13 +283,16 @@ export default function AdminMembershipPage() {
                     </Text>
                   )}
                   <Group gap="sm" wrap="wrap">
-                    <Button size="xs" fz={15} variant="default" disabled={busyId === r.id} onClick={() => override(r.id, "reset")}>
+                    <Button size="xs" fz={15} variant="default" disabled={busyId === r.id || ownHousehold(r)} onClick={() => override(r.id, "reset")}>
                       Reset for re-review
                     </Button>
-                    <Button size="xs" fz={15} color="green" disabled={busyId === r.id} onClick={() => override(r.id, "approve")}>
+                    <Button size="xs" fz={15} color="green" disabled={busyId === r.id || ownHousehold(r)} onClick={() => override(r.id, "approve")}>
                       Override → {r.paidAt ? "activate" : "payment"}
                     </Button>
                   </Group>
+                  {ownHousehold(r) && (
+                    <Text size="xs" c="dimmed" mt="sm">You can&apos;t override your own household&apos;s application — another board member (or a sysadmin) must.</Text>
+                  )}
                 </Alert>
               )}
 

--- a/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
@@ -73,6 +73,24 @@ describe("membership-ops/households page", () => {
     );
   });
 
+  it("disables Grant for a board member's OWN household (conflict of interest)", async () => {
+    setSession({ id: 99, isBoardMember: true, householdId: 2 }); // same household as The Joneses (id 2)
+    mockFetchJson({ "/api/membership-ops/households": households });
+    renderWithProviders(<AdminHouseholdsPage />);
+    await screen.findByText("The Joneses");
+
+    expect(screen.getByRole("button", { name: "Grant Membership" })).toBeDisabled();
+  });
+
+  it("keeps Grant enabled for a board member in a different household", async () => {
+    setSession({ id: 99, isBoardMember: true, householdId: 500 });
+    mockFetchJson({ "/api/membership-ops/households": households });
+    renderWithProviders(<AdminHouseholdsPage />);
+    await screen.findByText("The Joneses");
+
+    expect(screen.getByRole("button", { name: "Grant Membership" })).toBeEnabled();
+  });
+
   it("navigates to the add-participant page for a household", async () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({ "/api/membership-ops/households": households });

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -8,6 +8,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { AdminEditHouseholdModal } from '@/components/admin/AdminEditHouseholdModal';
+import { sharesHousehold } from '@/lib/conflictOfInterest';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 type Household = {
@@ -18,7 +19,7 @@ type Household = {
 };
 
 export default function AdminHouseholdsPage() {
-  const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
+  const { user: me, ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
   const router = useRouter();
 
   const [households, setHouseholds] = useState<Household[]>([]);
@@ -159,6 +160,11 @@ export default function AdminHouseholdsPage() {
               const hasActiveMembership = status === "ACTIVE";
               const isDenied = status === "DENIED";
               const hasBoardMember = household.householdMembers?.some((p) => p.isBoardMember) ?? false;
+              // Conflict of interest: a board member may not GRANT their own household
+              // membership (bypasses payment + background check). Sysadmin keeps the button.
+              // Mirrors the server guard; disabled state is UX only. Revoke stays allowed.
+              const ownGrantBlocked =
+                !hasActiveMembership && me?.isSysadmin !== true && sharesHousehold(me?.householdId, household.id);
 
               return (
                 <Table.Tr key={household.id}>
@@ -223,6 +229,8 @@ export default function AdminHouseholdsPage() {
                             size="xs" fz={15}
                             variant="light"
                             color={hasActiveMembership ? 'red' : 'green'}
+                            disabled={ownGrantBlocked}
+                            title={ownGrantBlocked ? "You can't grant your own household's membership — a sysadmin must." : undefined}
                             onClick={() => toggleMembership(household.id, hasActiveMembership)}
                           >
                             {hasActiveMembership ? "Revoke Membership" : "Grant Membership"}

--- a/checkin-app/src/lib/__tests__/conflictOfInterest.test.ts
+++ b/checkin-app/src/lib/__tests__/conflictOfInterest.test.ts
@@ -1,0 +1,38 @@
+import { sharesHousehold, hasHouseholdConflict } from "@/lib/conflictOfInterest";
+import type { DbClient } from "@/lib/db-client";
+
+describe("sharesHousehold", () => {
+    it("true only when both ids are present and equal", () => {
+        expect(sharesHousehold(5, 5)).toBe(true);
+        expect(sharesHousehold(5, 6)).toBe(false);
+    });
+
+    it("false when either side is null/undefined (no household ≠ shared household)", () => {
+        expect(sharesHousehold(null, null)).toBe(false); // two people with no household don't conflict
+        expect(sharesHousehold(undefined, 5)).toBe(false);
+        expect(sharesHousehold(5, null)).toBe(false);
+    });
+});
+
+describe("hasHouseholdConflict", () => {
+    const db = (actorHouseholdId: number | null) =>
+        ({ person: { findUnique: jest.fn().mockResolvedValue(actorHouseholdId == null ? null : { householdId: actorHouseholdId }) } }) as unknown as DbClient;
+
+    it("conflict when the actor shares the subject's household", async () => {
+        expect(await hasHouseholdConflict(db(3), 1, 3)).toBe(true);
+    });
+
+    it("no conflict when the actor is in a different household", async () => {
+        expect(await hasHouseholdConflict(db(4), 1, 3)).toBe(false);
+    });
+
+    it("sysadmin always bypasses — no conflict, and no DB read", async () => {
+        const client = db(3); // same household as subject → would conflict without the bypass
+        expect(await hasHouseholdConflict(client, 1, 3, { isSysadmin: true })).toBe(false);
+        expect((client.person.findUnique as jest.Mock)).not.toHaveBeenCalled();
+    });
+
+    it("no conflict when the subject has no household to conflict with", async () => {
+        expect(await hasHouseholdConflict(db(3), 1, null)).toBe(false);
+    });
+});

--- a/checkin-app/src/lib/conflictOfInterest.ts
+++ b/checkin-app/src/lib/conflictOfInterest.ts
@@ -1,0 +1,51 @@
+import type { DbClient } from "@/lib/db-client";
+
+/**
+ * Conflict-of-interest primitives, shared by every self-approval gate.
+ *
+ * The policy is uniform across the app: an actor may not approve, certify, clear,
+ * or grant something for their OWN household — approving your own family is the
+ * same abuse whether it's a background-check review, membership dues, a program
+ * payment plan, or a direct membership grant. A sysadmin is the deliberate remedy
+ * everywhere and bypasses the gate.
+ *
+ * Two entry points, because callers differ in what they already hold:
+ *   - sharesHousehold(a, b): pure predicate for callers that already have both
+ *     household ids loaded (attest's already-loaded reviewer, isTrustedAdultConflict,
+ *     the UI gating its buttons off the same rule so client and server can't drift).
+ *   - hasHouseholdConflict(db, actorId, subjectHouseholdId, opts): resolves the
+ *     actor's household itself + applies the sysadmin bypass, for callers that only
+ *     hold an actor id (the service/route guards).
+ *
+ * What is deliberately NOT here: resolving the SUBJECT's household. That varies per
+ * caller (a person, an OrgMembership, an OrgMembershipProcess, or a raw householdId
+ * param) and folding it in would be a bigger discriminated-union resolver than the
+ * duplication it removes. Each caller resolves its own subject household — it already
+ * has the row loaded — and passes the scalar in.
+ */
+
+/** The core rule: an actor conflicts with a subject when they share a (non-null) household. */
+export function sharesHousehold(
+    actorHouseholdId: number | null | undefined,
+    subjectHouseholdId: number | null | undefined,
+): boolean {
+    return actorHouseholdId != null && actorHouseholdId === subjectHouseholdId;
+}
+
+/**
+ * Whether `actorId` has a household conflict with a subject in `subjectHouseholdId`.
+ * Resolves the actor's household so callers don't re-roll the same findUnique.
+ * Returns false (no conflict) when opts.isSysadmin — the escape hatch every gate
+ * grants a sysadmin — or when the subject has no household to conflict with.
+ */
+export async function hasHouseholdConflict(
+    db: DbClient,
+    actorId: number,
+    subjectHouseholdId: number | null | undefined,
+    opts?: { isSysadmin?: boolean },
+): Promise<boolean> {
+    if (opts?.isSysadmin) return false;
+    if (subjectHouseholdId == null) return false;
+    const actor = await db.person.findUnique({ where: { id: actorId }, select: { householdId: true } });
+    return sharesHousehold(actor?.householdId, subjectHouseholdId);
+}

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prisma";
+import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 import { logger } from "@/lib/logger";
 import { emailHouseholdLeads } from "@/lib/emailRecipients";
 import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
@@ -21,7 +22,7 @@ import { config } from "@/lib/config";
 const SYSTEM_ACTOR = 0;
 
 export class PaymentError extends Error {
-    constructor(public readonly code: "not_found" | "wrong_phase", message: string) {
+    constructor(public readonly code: "not_found" | "wrong_phase" | "forbidden", message: string) {
         super(message);
         this.name = "PaymentError";
     }
@@ -236,15 +237,22 @@ export async function activate(
 }
 
 /** Board override: certify a payment plan and activate without a Shopify payment. */
-export async function certifyPaymentPlan(processId: number, actorId: number) {
+export async function certifyPaymentPlan(processId: number, actorId: number, opts?: { isSysadmin?: boolean }) {
     // Unlike the webhook path, a board certify is a deliberate action — reject
     // (not silently no-op) when the process isn't actually awaiting payment, so
     // certifying an already-ACTIVE or still-in-review grant surfaces a 409
     // instead of a misleading success. activate()'s own conditional flip stays
     // idempotent for the webhook/self-serve callers.
-    const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+    const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId }, include: { orgMembership: { select: { householdId: true } } } });
     if (!process) throw new PaymentError("not_found", "Application not found.");
     if (process.status !== "PENDING_PAYMENT") throw new PaymentError("wrong_phase", "This application is not awaiting payment.");
+
+    // Conflict of interest: a board member may not certify (mark paid + activate) their
+    // OWN household's membership — else they could activate their family without paying
+    // dues. Sysadmin bypasses.
+    if (await hasHouseholdConflict(prisma, actorId, process.orgMembership?.householdId, { isSysadmin: opts?.isSysadmin })) {
+        throw new PaymentError("forbidden", "You cannot certify your own household's membership — a sysadmin must.");
+    }
     return activate(processId, { via: "certified", actorId });
 }
 

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -7,6 +7,7 @@ import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
 import { config } from "@/lib/config";
 import { canonicalizeEmail } from "@/lib/emailNormalize";
 import { openPersonBgForNewMember } from "@/lib/membership/personBgTriggers";
+import { hasHouseholdConflict, sharesHousehold } from "@/lib/conflictOfInterest";
 import { type DbClient, type TxClient } from "@/lib/db-client";
 
 /**
@@ -167,9 +168,9 @@ export async function eligibleReviewProcessIds(reviewerId: number): Promise<numb
         .filter((p) => {
             // Applicant household = subject's for a PERSON_BG, else the membership's.
             const applicantHouseholdId = p.subjectPerson?.householdId ?? p.orgMembership?.householdId ?? null;
-            if (applicantHouseholdId !== null && applicantHouseholdId === reviewer.householdId) return false; // own household
+            if (sharesHousehold(reviewer.householdId, applicantHouseholdId)) return false; // own household
             if (p.attestations.some((a) => a.reviewerId === reviewer.id)) return false; // already attested
-            if (p.attestations.some((a) => a.reviewer.householdId === reviewer.householdId)) return false; // shares household with other reviewer
+            if (p.attestations.some((a) => sharesHousehold(reviewer.householdId, a.reviewer.householdId))) return false; // shares household with other reviewer
             return true;
         })
         .map((p) => p.id);
@@ -221,9 +222,9 @@ export async function attest(
         if (!process) throw new ReviewError("not_found", "Application not found.");
         if (!isAwaitingBgReview(process)) throw new ReviewError("wrong_phase", "This application is not awaiting background-check review.");
         const applicantHouseholdId = await applicantHousehold(tx, process);
-        if (applicantHouseholdId !== null && applicantHouseholdId === reviewer.householdId) throw new ReviewError("same_household_applicant", "You cannot review an applicant in your own household.");
+        if (sharesHousehold(reviewer.householdId, applicantHouseholdId)) throw new ReviewError("same_household_applicant", "You cannot review an applicant in your own household.");
         if (process.attestations.some((a) => a.reviewerId === reviewerId)) throw new ReviewError("already_attested", "You have already reviewed this application.");
-        if (process.attestations.some((a) => a.reviewer.householdId === reviewer.householdId)) throw new ReviewError("same_household_reviewer", "Another reviewer from your household has already reviewed this application.");
+        if (process.attestations.some((a) => sharesHousehold(reviewer.householdId, a.reviewer.householdId))) throw new ReviewError("same_household_reviewer", "Another reviewer from your household has already reviewed this application.");
 
         await tx.backgroundCheckAttestation.create({
             data: { processId, reviewerId, result: input.result, isMarkedVolunteer: !!input.isMarkedVolunteer },
@@ -341,10 +342,18 @@ export async function applyVolunteerStatus(db: DbClient, orgMembershipId: number
 }
 
 /** Board override on a BLOCKED application: reset for re-review, or force-clear the check. */
-export async function overrideBlocked(processId: number, actorId: number, action: "reset" | "approve") {
+export async function overrideBlocked(processId: number, actorId: number, action: "reset" | "approve", opts?: { isSysadmin?: boolean }) {
     const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new ReviewError("not_found", "Application not found.");
     if (process.status !== "BLOCKED") throw new ReviewError("wrong_phase", "This application is not blocked.");
+
+    // Conflict of interest: a board member may not override their OWN household's blocked
+    // application — else they could force-clear their family's failed background check, the
+    // very thing attest()'s same-household gate forbids. Sysadmin bypasses (opts.isSysadmin).
+    const applicantHouseholdId = await applicantHousehold(prisma, process);
+    if (await hasHouseholdConflict(prisma, actorId, applicantHouseholdId, { isSysadmin: opts?.isSysadmin })) {
+        throw new ReviewError("same_household_applicant", "You cannot override your own household's application — a sysadmin must.");
+    }
 
     if (action === "reset") {
         // Restore the review state that matches the cycle. The check runs in parallel,

--- a/checkin-app/src/lib/trusted-adult/conflict.ts
+++ b/checkin-app/src/lib/trusted-adult/conflict.ts
@@ -1,11 +1,15 @@
+import { sharesHousehold } from "@/lib/conflictOfInterest";
+
 /**
  * Conflict-of-interest rule for trusted-adult reviews. A board member may not decide
  * (or appear able to decide) a review tied to their own household, nor one where they
  * are the counterparty (the trusted adult themselves). Another board member must.
  *
- * Pure + dependency-free on purpose: the server (decideReview) enforces it and the
- * client (the board review page) gates the buttons off the SAME rule, so the two can't
- * drift. Callers pass scalars they already have; ids are participant ids.
+ * The same-household leg is the shared {@link sharesHousehold} rule; the counterparty
+ * leg (actor IS the trusted adult) is trusted-adult-specific and stays here. Pure +
+ * dependency-free on purpose: the server (decideReview) enforces it and the client (the
+ * board review page) gates the buttons off the SAME rule, so the two can't drift.
+ * Callers pass scalars they already have; ids are participant ids.
  */
 export function isTrustedAdultConflict(args: {
     actorParticipantId: number | null | undefined;
@@ -15,7 +19,7 @@ export function isTrustedAdultConflict(args: {
 }): boolean {
     const { actorParticipantId, actorHouseholdId, taHouseholdId, taTrustedAdultPersonId } = args;
     return (
-        (actorHouseholdId != null && actorHouseholdId === taHouseholdId) ||
+        sharesHousehold(actorHouseholdId, taHouseholdId) ||
         (actorParticipantId != null && actorParticipantId === taTrustedAdultPersonId)
     );
 }


### PR DESCRIPTION
## Problem

Self-approval guards across the app blocked an actor from acting on their **own** record, but not on **anyone else in their household**. A board member could approve, certify, or grant for their own family. An audit of every self-approval / conflict-of-interest guard found four unguarded self-dealing surfaces.

## Enforcement (server — the real control)

| Site | Vector closed |
|------|---------------|
| `overrideBlocked` | board force-clearing own household's failed background check |
| `certifyPaymentPlan` | board certifying own household's membership dues as paid |
| `finance-ops/payment-plans` | board approving own household member's program payment plan |
| `membership-ops/households` (`active:true`) | board granting own household ACTIVE membership — bypassed **payment AND background check**, the worst of the four |

Each mirrors the existing trusted-adult `overrideReview`: block when actor shares the subject's household; **sysadmin bypass** is the deliberate remedy.

Chained, gaps 1 + 4 let a board member fully self-activate their household (force-clear the check, grant membership) with no independent review and no payment.

## Shared library

`src/lib/conflictOfInterest.ts` — one home for the rule, instead of re-rolling it everywhere:
- `sharesHousehold(a, b)` — the rule, previously open-coded as `a != null && a === b` in 8 places
- `hasHouseholdConflict(db, actorId, subjectHouseholdId, {isSysadmin})` — the actor-resolve + sysadmin-bypass boilerplate, previously copy-pasted in 4 guards

`isTrustedAdultConflict` and `attest` now build on the shared predicate. **Subject-household resolution stays per-caller** (a Person vs OrgMembership vs Process vs raw id — folding it in would be a bigger resolver than the duplication it removes).

## Client UX (not a security control)

Mirrors the trusted-adult page: disables Certify / Override / Grant / Approve and explains when the actor conflicts; sysadmin keeps the button. The server guards are the enforcement — a direct POST ignores button state.

## Tests

- New `conflictOfInterest` unit test (predicate edge cases, sysadmin short-circuits the DB read)
- COI cases (forbidden + sysadmin-bypass) added to: membership bg-nonblocking, program-payment-plans, households-audit integration suites, and the households page component test
- `tsc` clean; unit + integration + page tests green

## Reviewer notes

- Override **"reset"** is also blocked for own household — the guard sits at `overrideBlocked`'s entry, so both actions gate; the UI matches.
- Finance GET needed no change — `person: true` already ships `householdId`; only the client type was widened.
- Membership-payment-plans and program-payment-plans are two distinct routes (dues vs program fee); both are covered.
- `membership-ops/participants` was checked and left alone — its ACTIVE grant only touches freshly-created households, never an existing own-household.

🤖 Generated with [Claude Code](https://claude.com/claude-code)