### PR TITLE
docs(membership-bg): record 18+ BG-check policy as a code comment

### DIFF
--- a/checkin-app/src/lib/membership/personBgCheck.ts
+++ b/checkin-app/src/lib/membership/personBgCheck.ts
@@ -1,6 +1,31 @@
 import { calculateAge } from "@/lib/time";
 
 /**
+ * ┌─ 18+ program-people background-check POLICY (board-decided; not inferable from code) ─┐
+ * These are the rules the feature encodes. They are policy, not implementation detail —
+ * change them only with the board.
+ *
+ *  • Subject = program-attached people ≥18: ProgramParticipant ∪ ProgramVolunteer ∪
+ *    Program.leadMentor. (Volunteers who are household leads are already checked via the
+ *    household flow — this is the non-lead / aged-up gap.)
+ *  • Age is judged AS-OF the membership-year boundary (orgMembershipYearBoundary), boundary
+ *    INCLUSIVE (an 18th birthday landing on it counts as ≥18). NOT as-of "now" or a role
+ *    change: someone who turns 18 after the boundary waits for the next one (Nov-1 birthday +
+ *    Nov-15 role → next Sept-1, not now).
+ *  • ≥18 is a HARD floor. Under-18 volunteers ("young adult mentors") are never checked — a
+ *    minor cannot be background-checked. Unknown age (no DOB, not declared-adult) is a
+ *    data-hygiene item, NEVER auto-checked and NEVER treated as cleared.
+ *  • Checks are PER-ADULT. One person's check must never satisfy another's — in particular a
+ *    household lead's check does not cover a second volunteering spouse. (The legacy household
+ *    clearBackgroundCheck still blanket-stamps all leads; PERSON_BG stamps only its subject.
+ *    Removing the household blanket-stamp is deferred work.)
+ *  • Posture is WARN-ONLY. An un-cleared obligation never blocks participation/check-in/renewal.
+ *  • Consent for the (manual) path is IMPLICIT in the self-initiated external check; the board/
+ *    lead submits "a check exists, review it". No in-app consent orchestration was shipped.
+ *  • Recheck window = BoardSettings.bgRecheckMonths (same knob as household leads). When 0 the
+ *    policy is UNSET — treat as "do not enforce", never as "everyone is stale".
+ * └──────────────────────────────────────────────────────────────────────────────────────┘
+ *
  * Per-person background-check verdict for the board compliance dashboard
  * (Phase 1 — warn-only, read-only). Generalizes householdBgIsFresh from
  * "any household lead is fresh" to "this specific person is fresh".


### PR DESCRIPTION
## What

Adds a policy comment block to `personBgCheck.ts` recording the board-decided rules for the 18+ program-people background-check feature. Comment-only — **no behavior change**.

## Why

These rules are policy, not implementation detail, and aren't inferable from the code:

- Subject = program-attached people **≥18 as-of the membership boundary (inclusive)** — judged as-of the boundary, **not** role-time
- **≥18 hard floor** — under-18 "young adult mentors" excluded; unknown-age (missing DOB) is a data-hygiene item, never auto-checked
- **Per-adult** — one person's check never covers another (a lead's check ≠ a second volunteering spouse)
- **Warn-only** posture; consent **implicit** in the self-initiated external check (manual path)
- `bgRecheckMonths = 0` = policy unset → don't enforce

Recording them where the classifier lives means they're read at the point of change and can only be altered deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)