### PR TITLE
test(shopify): close variant round-trip, inventory-branch, and fireProgram coverage gaps

### DIFF
--- a/checkin-app/src/app/__tests__/programVariantRoundtripShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programVariantRoundtripShopify.integration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration test: the FULL round-trip connecting program creation, Shopify
+ * variant persistence, and inbound webhook activation as ONE flow.
+ *
+ * Every existing Shopify test exercises one half in isolation:
+ *   - webhookShopify.integration.test.ts seeds a HAND-WRITTEN literal variant id
+ *     directly on the Program row, then proves the webhook matches it.
+ *   - programSyncShopifyAPI.integration.test.ts (and shopify.test.ts) prove
+ *     createShopifyProgramVariants mints + persists synthetic mock ids.
+ * Neither proves the id MINTED by POST /api/programs is the SAME id the
+ * webhook later matches against — this test drives both halves back-to-back:
+ * create (mock active) -> assert persisted ids -> sign a webhook payload
+ * carrying THOSE EXACT ids -> assert the real inbound handler flips the
+ * PENDING participant ACTIVE.
+ *
+ * Also covers the sibling branch: mock inactive + creds absent ->
+ * createShopifyProgramVariants returns null -> the route falls back to its
+ * `warning` response instead of persisting variants.
+ */
+import crypto from 'crypto';
+import { POST as programsPOST } from '@/app/api/programs/route';
+import { POST as webhookPOST } from '@/app/api/webhooks/shopify/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import { DEV_MOCK_SHOPIFY_WEBHOOK_SECRET } from '@/lib/config';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/notifications', () => ({ sendNotification: jest.fn() }));
+
+const TAG = 'shopify-roundtrip-test';
+
+function programsReq(body: unknown) {
+    // CHECKIN_ENV=local also arms the keyless-kiosk fallback in authenticateRequest,
+    // which hijacks any cookie-less request as `kiosk` before the role gate runs —
+    // send a cookie so auth resolves through the mocked session instead.
+    return new Request('http://localhost:4000/api/programs', {
+        method: 'POST',
+        headers: { cookie: 'session=test' },
+        body: JSON.stringify(body),
+    }) as unknown as import('next/server').NextRequest;
+}
+
+function webhookReq(body: string, secret: string) {
+    const signature = crypto.createHmac('sha256', secret).update(body, 'utf8').digest('base64');
+    return new Request('http://localhost/api/webhooks/shopify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-shopify-hmac-sha256': signature },
+        body,
+    });
+}
+
+describe('Shopify variant round-trip: create -> persist -> webhook match', () => {
+    let boardId: number;
+    let leadId: number;
+    let participantId: number;
+    const programIds: number[] = [];
+
+    let prevCheckinEnv: string | undefined;
+    const SHOPIFY_ENV_KEYS = ['SHOPIFY_WEBHOOK_SECRET', 'SHOPIFY_STORE_DOMAIN', 'SHOPIFY_CLIENT_ID', 'SHOPIFY_CLIENT_SECRET'] as const;
+    let prevShopifyEnv: Record<string, string | undefined> = {};
+
+    beforeAll(async () => {
+        prevCheckinEnv = process.env.CHECKIN_ENV;
+        prevShopifyEnv = Object.fromEntries(SHOPIFY_ENV_KEYS.map((k) => [k, process.env[k]]));
+        for (const k of SHOPIFY_ENV_KEYS) delete process.env[k];
+        // Mock active requires CHECKIN_ENV=local (config.shopifyMockActiveEnv); the
+        // suite default set by jest.setup.js is 'dev' — flip it here, restore in afterAll.
+        process.env.CHECKIN_ENV = 'local';
+
+        const board = await prisma.person.create({
+            data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } },
+        });
+        boardId = board.id;
+        const lead = await prisma.person.create({
+            data: { email: `lead-${TAG}@example.com`, name: 'Lead', household: { create: { name: `Lead HH ${TAG}` } } },
+        });
+        leadId = lead.id;
+        const participant = await prisma.person.create({
+            data: { email: `participant-${TAG}@example.com`, name: 'Participant', household: { create: { name: `Participant HH ${TAG}` } } },
+        });
+        participantId = participant.id;
+    });
+
+    afterAll(async () => {
+        await prisma.programParticipant.deleteMany({ where: { programId: { in: programIds } } });
+        await prisma.auditLog.deleteMany({ where: { actorId: boardId } });
+        await prisma.program.deleteMany({ where: { id: { in: programIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: [boardId, leadId, participantId] } } });
+        await prisma.household.deleteMany({ where: { name: { contains: TAG } } });
+        for (const k of SHOPIFY_ENV_KEYS) {
+            if (prevShopifyEnv[k] === undefined) delete process.env[k];
+            else process.env[k] = prevShopifyEnv[k];
+        }
+        if (prevCheckinEnv === undefined) delete process.env.CHECKIN_ENV;
+        else process.env.CHECKIN_ENV = prevCheckinEnv;
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+    });
+
+    it('mints + persists synthetic variant ids on create, then a webhook carrying those exact ids activates the PENDING participant', async () => {
+        const res = await programsPOST(programsReq({
+            name: `Roundtrip Program ${TAG}`,
+            leadMentorId: leadId,
+            memberPrice: '25.00',
+            nonMemberPrice: '35.00',
+        }));
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.success).toBe(true);
+        expect(data.warning).toBeUndefined();
+        programIds.push(data.program.id);
+
+        // Synthetic mock ids, not a real Shopify product/variant.
+        expect(data.program.shopifyOrgMemberVariantId).toMatch(/^dev-mock-variant-member-/);
+        expect(data.program.shopifyNonOrgMemberVariantId).toMatch(/^dev-mock-variant-nonmember-/);
+
+        // Actually PERSISTED, not just echoed in the response.
+        const persisted = await prisma.program.findUnique({ where: { id: data.program.id } });
+        expect(persisted?.shopifyOrgMemberVariantId).toBe(data.program.shopifyOrgMemberVariantId);
+        expect(persisted?.shopifyNonOrgMemberVariantId).toBe(data.program.shopifyNonOrgMemberVariantId);
+
+        // Enroll the participant the normal PENDING-awaiting-payment way (what the
+        // real enroll flow does before checkout; not the part under test here).
+        await prisma.programParticipant.create({
+            data: { programId: data.program.id, personId: participantId, status: 'PENDING', pendingSince: new Date() },
+        });
+
+        // A real paid order carries the variant id its checkout link was built
+        // from — here, THE EXACT id createShopifyProgramVariants minted above, not
+        // a hand-seeded literal (the gap every other Shopify test leaves open).
+        const orderBody = JSON.stringify({
+            id: `roundtrip-order-${data.program.id}`,
+            line_items: [{ variant_id: data.program.shopifyOrgMemberVariantId }],
+            note_attributes: [
+                { name: 'CheckMeIn_Account_ID', value: String(participantId) },
+                { name: 'Program_ID', value: String(data.program.id) },
+            ],
+        });
+        const hookRes = await webhookPOST(webhookReq(orderBody, DEV_MOCK_SHOPIFY_WEBHOOK_SECRET));
+        expect(hookRes.status).toBe(200);
+
+        const participantRow = await prisma.programParticipant.findUnique({
+            where: { programId_personId: { programId: data.program.id, personId: participantId } },
+        });
+        expect(participantRow?.status).toBe('ACTIVE');
+        expect(participantRow?.pendingSince).toBeNull();
+    });
+
+    it('falls back to the `warning` response when Shopify is unconfigured and the mock is inactive (no variants persisted)', async () => {
+        const prevEnv = process.env.CHECKIN_ENV;
+        process.env.CHECKIN_ENV = 'dev'; // mock inactive; SHOPIFY_* creds already absent for the whole suite
+        try {
+            const res = await programsPOST(programsReq({
+                name: `Warning Path Program ${TAG}`,
+                leadMentorId: leadId,
+                memberPrice: '25.00',
+                nonMemberPrice: '35.00',
+            }));
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            expect(data.success).toBe(true);
+            programIds.push(data.program.id);
+            expect(data.warning).toMatch(/Shopify integration failed or is not configured/);
+            expect(data.program.shopifyProductId).toBeNull();
+            expect(data.program.shopifyOrgMemberVariantId).toBeNull();
+            expect(data.program.shopifyNonOrgMemberVariantId).toBeNull();
+
+            const persisted = await prisma.program.findUnique({ where: { id: data.program.id } });
+            expect(persisted?.shopifyOrgMemberVariantId).toBeNull();
+        } finally {
+            process.env.CHECKIN_ENV = prevEnv;
+        }
+    });
+});

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
@@ -210,4 +210,82 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
         expect(proc?.status).toBe('PENDING_BG_CLEARANCE');
         expect(proc?.paidAt).not.toBeNull();
     });
+
+    // fireProgram — the { programId, participantIds } branch was previously
+    // untested at the route level (only fireMembership had coverage here).
+    // Mirrors the fireMembership suite's structure: same global.fetch stand-in
+    // and CHECKIN_ENV/creds wiring from the outer beforeAll, own Program/Person
+    // fixtures, self-cleaning in this block's own afterAll.
+    describe('fireProgram (program branch)', () => {
+        let programId: number;
+        let personId: number;
+        let householdId: number;
+
+        beforeAll(async () => {
+            const hh = await prisma.household.create({ data: { name: `Dev Mock Program HH ${TAG}` } });
+            householdId = hh.id;
+            const person = await prisma.person.create({ data: { name: 'Dev Mock Participant', household: { connect: { id: hh.id } } } });
+            personId = person.id;
+            const program = await prisma.program.create({ data: { name: `Dev Mock Program ${TAG}` } });
+            programId = program.id;
+        });
+
+        afterAll(async () => {
+            await prisma.programParticipant.deleteMany({ where: { programId } });
+            await prisma.program.delete({ where: { id: programId } });
+            await prisma.person.delete({ where: { id: personId } });
+            await prisma.household.delete({ where: { id: householdId } });
+        });
+
+        afterEach(async () => {
+            // Each test below manages its own participant status; leave no
+            // PENDING/ACTIVE row behind for the next test in this block.
+            await prisma.programParticipant.deleteMany({ where: { programId } });
+        });
+
+        it('400s when participantIds is empty', async () => {
+            asSession();
+            const res = await POST(jsonReq({ programId, participantIds: [] }));
+            expect(res.status).toBe(400);
+        });
+
+        it('404s when no PENDING participants match', async () => {
+            asSession();
+            // No ProgramParticipant row exists for personId yet -> nothing PENDING.
+            const res = await POST(jsonReq({ programId, participantIds: [personId] }));
+            expect(res.status).toBe(404);
+        });
+
+        it('409s when the program has no Shopify variant configured', async () => {
+            asSession();
+            await prisma.programParticipant.create({
+                data: { programId, personId, status: 'PENDING', pendingSince: new Date() },
+            });
+
+            const res = await POST(jsonReq({ programId, participantIds: [personId] }));
+            expect(res.status).toBe(409);
+
+            // Gate held: participant left PENDING, no webhook fired.
+            const row = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId } } });
+            expect(row?.status).toBe('PENDING');
+        });
+
+        it('200s, fires the real inbound webhook, and activates the PENDING participant', async () => {
+            asSession();
+            await prisma.program.update({ where: { id: programId }, data: { shopifyOrgMemberVariantId: 'dev-mock-variant-route-program-test' } });
+            await prisma.programParticipant.create({
+                data: { programId, personId, status: 'PENDING', pendingSince: new Date() },
+            });
+
+            const res = await POST(jsonReq({ programId, participantIds: [personId] }));
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body).toEqual({ ok: true, participants: [{ personId, status: 'ACTIVE' }] });
+
+            // The real proof: the webhook actually ran end-to-end and mutated the DB.
+            const row = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId } } });
+            expect(row?.status).toBe('ACTIVE');
+            expect(row?.pendingSince).toBeNull();
+        });
+    });
 });

--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -188,6 +188,75 @@ describe('createShopifyProgramVariants', () => {
         expect(fetchMock).toHaveBeenCalledTimes(1); // only token request
     });
 
+    describe('inventory branch (maxParticipants configured, real Shopify path)', () => {
+        // Single priced tier (member only) keeps the fetch sequence to one variant:
+        // token, product, variant, locations, [inventory_levels/set] — see shopify.ts:157-238.
+        it('sets inventory at the store location when maxParticipants is configured', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 500 } }) }); // product
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { id: 600, inventory_item_id: 700 } }) }); // member variant
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 900 }] }) }); // locations
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/set
+
+            const result = await createShopifyProgramVariants('Inventory Program', 10, null, 5);
+
+            expect(result).toEqual({
+                shopifyProductId: '500',
+                shopifyOrgMemberVariantId: '600',
+                shopifyNonOrgMemberVariantId: null,
+            });
+            expect(fetchMock).toHaveBeenCalledTimes(5);
+            expect(String(fetchMock.mock.calls[3][0])).toContain('/locations.json');
+            const invCall = fetchMock.mock.calls[4];
+            expect(String(invCall[0])).toContain('/inventory_levels/set.json');
+            expect(JSON.parse((invCall[1] as RequestInit).body as string)).toEqual({
+                location_id: 900,
+                inventory_item_id: 700,
+                available: 5,
+            });
+        });
+
+        it('logs and does not fail the whole call when inventory_levels/set itself fails (non-fatal)', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 501 } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { id: 601, inventory_item_id: 701 } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 901 }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'inventory boom' });
+
+            const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const result = await createShopifyProgramVariants('Inventory Fail Program', 10, null, 3);
+
+            // Non-fatal: the variant itself was created fine; only the inventory
+            // step failed, and it's logged rather than surfaced as an error email.
+            expect(result).toEqual({
+                shopifyProductId: '501',
+                shopifyOrgMemberVariantId: '601',
+                shopifyNonOrgMemberVariantId: null,
+            });
+            expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to set inventory: 500'), 'inventory boom');
+            expect(sendEmail).not.toHaveBeenCalled();
+            // afterEach's jest.restoreAllMocks() cleans up errSpy — mockRestore()
+            // here would also wipe the calls we just asserted on.
+        });
+
+        it('skips inventory_levels/set when the store has no locations configured', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 502 } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { id: 602, inventory_item_id: 702 } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [] }) });
+
+            const result = await createShopifyProgramVariants('No Location Program', 10, null, 2);
+
+            expect(result).toEqual({
+                shopifyProductId: '502',
+                shopifyOrgMemberVariantId: '602',
+                shopifyNonOrgMemberVariantId: null,
+            });
+            // No 5th call: locations returned empty, so inventory_levels/set is never reached.
+            expect(fetchMock).toHaveBeenCalledTimes(4);
+        });
+    });
+
     it('times out a hung product request and emails admins (does not hang)', async () => {
         mockTokenResponse(fetchMock); // token succeeds (its own AbortSignal.timeout is untouched)...
         // ...then the product create hangs: a fetch that only settles on abort stands in for a


### PR DESCRIPTION
## Summary

Test-only PR. No production code changes. Closes three verified Shopify coverage gaps:

- **Round-trip variant test** (`programVariantRoundtripShopify.integration.test.ts`): connects create -> persist -> webhook-match as ONE flow. `POST /api/programs` with the Shopify mock active mints synthetic `dev-mock-variant-*` ids and persists `shopifyOrgMemberVariantId`/`shopifyNonOrgMemberVariantId`; a webhook signed with `DEV_MOCK_SHOPIFY_WEBHOOK_SECRET` carrying THOSE exact ids is POSTed to the real inbound handler, which flips the PENDING `ProgramParticipant` to ACTIVE. Previously this was only verified in two disconnected halves, each seeded with a hand-written literal variant id — nothing proved the id minted at creation is the id the webhook later matches. Also covers the sibling `warning`-response path when the mock is inactive and Shopify creds are absent.
- **Inventory branch** (`shopify.test.ts`): `createShopifyProgramVariants`'s real-Shopify-API inventory logic (locations lookup + `inventory_levels/set`, shopify.ts:157-238) was 0% covered — every existing unit test omits `maxParticipants`, so the branch never ran. Adds: locations + inventory-set success, inventory-set failure (logged, non-fatal), and no-location-found skip.
- **fireProgram route coverage** (`route.integration.test.ts`): the dev orders-paid mock's `{ programId, participantIds }` branch was untested at the route level (only `fireMembership` had coverage). Adds 400 (empty participantIds), 404 (no PENDING match), 409 (no program variant configured), and an end-to-end happy path through the real inbound webhook handler asserting `ProgramParticipant` ACTIVE — mirrors the existing `fireMembership` tests' structure (global.fetch stand-in, env snapshot/restore, self-cleaning fixtures).

## Test plan

- [x] `npx jest --testPathPatterns "shopify.test.ts"` — 10/10 passed
- [x] `INTEGRATION_DB=1 npx jest --testPathIgnorePatterns=/node_modules/ --testRegex "\.integration\.test\.[jt]sx?$" --testPathPatterns "shopify|programsAPI"` — 36/36 passed (all 5 Shopify-adjacent integration suites run together, confirming no env leakage across files)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all three changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz7egoZoDp37iL9FpC8tH