### PR TITLE
Email deliverability: capture send failures, Resend bounce webhook, broken-address flagging

### DIFF
--- a/checkin-app/prisma/migrations/20260706060000_person_email_undeliverable/migration.sql
+++ b/checkin-app/prisma/migrations/20260706060000_person_email_undeliverable/migration.sql
@@ -1,0 +1,4 @@
+-- Additive, nullable: tracks when Resend last reported this person's address as
+-- undeliverable (bounce/complaint), cleared on a later successful delivery. No
+-- backfill needed (nullable, defaults to "deliverable").
+ALTER TABLE "Person" ADD COLUMN "emailUndeliverableAt" TIMESTAMP(3);

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -88,6 +88,11 @@ model Person {
   waiverSignedBy       Int?
   /// @sensitivity:internal
   lastBackgroundCheck  DateTime?
+  /// Set when Resend reports a bounce/complaint for this person's address
+  /// (webhooks/resend); cleared on a later `email.delivered` for the same
+  /// address (self-healing). Role/audit metadata about deliverability, not the
+  /// address itself. @sensitivity:internal
+  emailUndeliverableAt DateTime?
   /// @sensitivity:personal
   notificationSettings Json?
 

--- a/checkin-app/src/app/__tests__/webhookResend.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookResend.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for POST /api/webhooks/resend:
+ *   - unconfigured secret (500), missing/bad Svix signature (401)
+ *   - email.bounced / email.complained flag the matching Person
+ *   - email.delivered clears a previously-flagged Person (self-healing)
+ *   - a bounce for an address with no matching Person no-ops cleanly (200)
+ *   - email.delivery_delayed logs only — never sets the flag
+ *   - rate limiting precedes signature verification (mirrors webhookShopify's ordering test)
+ */
+import { Webhook } from 'svix';
+import { POST } from '@/app/api/webhooks/resend/route';
+import prisma from '@/lib/prisma';
+
+// Keep the REAL logIntegrationError (withWebhook's top-level catch writes to the
+// DB on a handler throw) but silence the console logger.
+jest.mock('@/lib/logger', () => ({
+    ...jest.requireActual('@/lib/logger'),
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const SECRET = 'whsec_' + Buffer.from('resend-webhook-test-secret').toString('base64');
+const TAG = 'resend-webhook-test';
+
+function sign(id: string, timestamp: Date, body: string): string {
+    return new Webhook(SECRET).sign(id, timestamp, body);
+}
+
+function webhookReq(
+    body: string,
+    opts: { id?: string; timestamp?: Date; signature?: string | null; omitHeaders?: boolean; ip?: string } = {},
+) {
+    const id = opts.id ?? 'msg_test';
+    const timestamp = opts.timestamp ?? new Date();
+    const signature = opts.signature === undefined ? sign(id, timestamp, body) : opts.signature;
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (!opts.omitHeaders) {
+        headers['svix-id'] = id;
+        headers['svix-timestamp'] = String(Math.floor(timestamp.getTime() / 1000));
+        if (signature !== null) headers['svix-signature'] = signature;
+    }
+    if (opts.ip) headers['x-forwarded-for'] = opts.ip;
+    return new Request('http://localhost/api/webhooks/resend', { method: 'POST', headers, body });
+}
+
+function resendEvent(type: string, to: string) {
+    return JSON.stringify({ type, data: { to: [to], subject: 'Test Subject', email_id: 'evt_test' } });
+}
+
+describe('POST /api/webhooks/resend', () => {
+    let personId: number;
+    let householdId: number;
+    const email = `bounce-${TAG}@example.com`;
+    let prevSecret: string | undefined;
+
+    beforeAll(async () => {
+        prevSecret = process.env.RESEND_WEBHOOK_SECRET;
+        const p = await prisma.person.create({
+            data: { name: `Resend Webhook Test ${TAG}`, email, household: { create: { name: 'Test HH' } } },
+        });
+        personId = p.id;
+        householdId = p.householdId;
+    });
+
+    beforeEach(() => {
+        process.env.RESEND_WEBHOOK_SECRET = SECRET;
+    });
+
+    afterAll(async () => {
+        if (prevSecret === undefined) delete process.env.RESEND_WEBHOOK_SECRET;
+        else process.env.RESEND_WEBHOOK_SECRET = prevSecret;
+        await prisma.integrationErrorLog.deleteMany({ where: { source: 'resend-webhook' } });
+        await prisma.person.deleteMany({ where: { id: personId } });
+        await prisma.household.deleteMany({ where: { id: householdId } });
+    });
+
+    it('returns 500 when RESEND_WEBHOOK_SECRET is not configured', async () => {
+        delete process.env.RESEND_WEBHOOK_SECRET;
+        const res = await POST(webhookReq(resendEvent('email.bounced', email)));
+        expect(res.status).toBe(500);
+    });
+
+    it('returns 401 when the Svix headers are missing', async () => {
+        const res = await POST(webhookReq(resendEvent('email.bounced', email), { omitHeaders: true }));
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 401 on a signature mismatch', async () => {
+        const res = await POST(webhookReq(resendEvent('email.bounced', email), { signature: 'v1,not-the-right-signature' }));
+        expect(res.status).toBe(401);
+    });
+
+    it('flags the matching Person on email.bounced', async () => {
+        const res = await POST(webhookReq(resendEvent('email.bounced', email)));
+        expect(res.status).toBe(200);
+
+        const person = await prisma.person.findUnique({ where: { id: personId } });
+        expect(person?.emailUndeliverableAt).not.toBeNull();
+    });
+
+    it('flags the matching Person on email.complained', async () => {
+        await prisma.person.update({ where: { id: personId }, data: { emailUndeliverableAt: null } });
+        const res = await POST(webhookReq(resendEvent('email.complained', email)));
+        expect(res.status).toBe(200);
+
+        const person = await prisma.person.findUnique({ where: { id: personId } });
+        expect(person?.emailUndeliverableAt).not.toBeNull();
+    });
+
+    it('clears the flag on a later email.delivered for the same address (self-healing)', async () => {
+        await prisma.person.update({ where: { id: personId }, data: { emailUndeliverableAt: new Date() } });
+        const res = await POST(webhookReq(resendEvent('email.delivered', email)));
+        expect(res.status).toBe(200);
+
+        const person = await prisma.person.findUnique({ where: { id: personId } });
+        expect(person?.emailUndeliverableAt).toBeNull();
+    });
+
+    it('acknowledges (200) but does not throw when a bounce has no matching Person', async () => {
+        const res = await POST(webhookReq(resendEvent('email.bounced', `nobody-${TAG}@example.com`)));
+        expect(res.status).toBe(200);
+    });
+
+    it('logs only on email.delivery_delayed — never sets the flag', async () => {
+        await prisma.person.update({ where: { id: personId }, data: { emailUndeliverableAt: null } });
+        const res = await POST(webhookReq(resendEvent('email.delivery_delayed', email)));
+        expect(res.status).toBe(200);
+
+        const person = await prisma.person.findUnique({ where: { id: personId } });
+        expect(person?.emailUndeliverableAt).toBeNull();
+    });
+
+    it('acknowledges (200) an unrecognized event type without acting', async () => {
+        const res = await POST(webhookReq(resendEvent('email.opened', email)));
+        expect(res.status).toBe(200);
+    });
+
+    it('rate-limits a flood (429 + Retry-After) AHEAD of the Svix check — bad sig still 401, not 429', async () => {
+        // route.ts: rateLimit(..., { limit: 60, windowMs: 60_000 }) runs BEFORE
+        // signature verification (via withWebhook). Dedicated IP so this doesn't
+        // share a bucket with the tests above.
+        const ip = '198.51.100.22';
+        const body = resendEvent('email.bounced', email);
+        for (let i = 0; i < 60; i++) {
+            const res = await POST(webhookReq(body, { signature: 'v1,wrong', ip }));
+            expect(res.status).toBe(401);
+        }
+        const limited = await POST(webhookReq(body, { signature: 'v1,wrong', ip }));
+        expect(limited.status).toBe(429);
+        expect(Number(limited.headers.get('Retry-After'))).toBeGreaterThan(0);
+    });
+});

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -64,6 +64,8 @@ export type TodoCounts = {
     // `membership` = board-actionable (BLOCKED, green). `applicationsTotal` =
     // every in-flight (non-ACTIVE) application, the gray count shown on the
     // Applications tab — mirrors what /api/admin/membership lists.
+    // `brokenEmails` = people whose email Resend has reported as undeliverable
+    // (bounce/complaint) and no later delivery has cleared — see webhooks/resend.
     // `brokenHouseholds` = households with no lead at all (red — blocking board action).
     // `memberFamilies` = total member families (gray), shown on the Manage Memberships tab:
     // households with >=1 non-org-email (or null-email) participant. Staff households hold
@@ -73,7 +75,7 @@ export type TodoCounts = {
     // the Settings nav + Membership Settings tab — checkout is broken until both are set.
     // `programsMisconfig` = how many programs have a price but no matching Shopify variant
     // (paid enrollment silently can't check out). Red pill on the Program Ops Programs tab.
-    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; membershipPaymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; memberFamilies: number; settingsMisconfig: number; programsMisconfig: number };
+    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; membershipPaymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; brokenEmails: number; memberFamilies: number; settingsMisconfig: number; programsMisconfig: number };
     // Config-health gaps (admins + board only): number of failing system-config checks
     // (e.g. Zoho e-sign unconfigured). Drives the red System Status nav badge; the full
     // list lives at /api/system-status/config-health. See lib/configHealth.ts.
@@ -361,7 +363,7 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     // ---- Admin surface (board's own queue) — only for board/isSysadmin ----
     if (user.isSysadmin || user.isBoardMember) {
-        const [membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies, programsMisconfig, boardSettings] = await Promise.all([
+        const [membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, memberFamilies, programsMisconfig, boardSettings] = await Promise.all([
             prisma.orgMembershipProcess.count({
                 where: { status: { in: BOARD_ACTIONABLE_MEMBERSHIP } },
             }),
@@ -400,6 +402,11 @@ export const GET = withAuth({}, async (_req, auth) => {
             prisma.household.count({
                 where: { leads: { none: {} } },
             }),
+            // People Resend has reported as undeliverable (bounce/complaint), not since
+            // cleared by a later delivery. See Person.emailUndeliverableAt / webhooks/resend.
+            prisma.person.count({
+                where: { emailUndeliverableAt: { not: null } },
+            }),
             // Member families: households with >=1 non-org-email participant. A null email is
             // not an org address, but Prisma's `NOT endsWith` skips null rows — list it
             // explicitly so null-email members (e.g. children) count.
@@ -428,7 +435,7 @@ export const GET = withAuth({}, async (_req, auth) => {
             (boardSettings?.volunteerDiscountCode ? 0 : 1) +
             ((boardSettings?.bgRecheckMonths ?? 0) > 0 ? 0 : 1) +
             (boardSettings?.orgMembershipYearBoundary ? 0 : 1);
-        result.admin = { membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, memberFamilies, settingsMisconfig, programsMisconfig };
+        result.admin = { membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, memberFamilies, settingsMisconfig, programsMisconfig };
         // System-config health (env-var/deploy gaps). Synchronous, no DB — just presence
         // checks. Same admin+board gate as the rest of this block.
         result.configHealth = { openIssues: openConfigIssues() };

--- a/checkin-app/src/app/api/webhooks/resend/route.ts
+++ b/checkin-app/src/app/api/webhooks/resend/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from "next/server";
+import { Webhook, WebhookVerificationError } from "svix";
+import prisma from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+import { config } from "@/lib/config";
+import { withWebhook } from "@/lib/webhookAuth";
+import { canonicalizeEmail } from "@/lib/emailNormalize";
+
+/**
+ * Verify Resend's inbound webhook — signed via Svix (svix-id/svix-timestamp/
+ * svix-signature headers) over the raw body. Config-not-set is a server error
+ * (500); a missing/invalid signature is unauthorized (401) — same shape as the
+ * Shopify HMAC / Zoho shared-secret verify fns.
+ */
+function verifyResendSignature(req: Request, rawBody: string): { ok: true } | { ok: false; status: number; error: string } {
+    const secret = config.resendWebhookSecret();
+    if (!secret) {
+        logger.error("Resend webhook received but RESEND_WEBHOOK_SECRET is not configured.");
+        return { ok: false, status: 500, error: "Configuration Error" };
+    }
+
+    const headers = {
+        "svix-id": req.headers.get("svix-id") ?? "",
+        "svix-timestamp": req.headers.get("svix-timestamp") ?? "",
+        "svix-signature": req.headers.get("svix-signature") ?? "",
+    };
+
+    try {
+        new Webhook(secret).verify(rawBody, headers);
+        return { ok: true };
+    } catch (err) {
+        if (err instanceof WebhookVerificationError) {
+            return { ok: false, status: 401, error: "Invalid signature" };
+        }
+        throw err; // unexpected — withWebhook's top-level catch logs + 500s it
+    }
+}
+
+type ResendWebhookEvent = {
+    type: string;
+    data?: { to?: string | string[]; subject?: string; email_id?: string };
+};
+
+function toAddresses(data: ResendWebhookEvent["data"]): string[] {
+    if (!data?.to) return [];
+    return Array.isArray(data.to) ? data.to : [data.to];
+}
+
+/**
+ * Find every Person whose stored email matches `address` under the shared
+ * Gmail/+tag-aware canonicalization (lib/emailNormalize) — Resend echoes back
+ * exactly the address sendEmail submitted, so this is almost always an exact
+ * hit; canonicalizing only matters for a stray case/punctuation difference.
+ *
+ * ponytail: O(n) scan over people with an email set, no indexed normalized
+ * column. Fine at this org's membership-list scale (bounce/complaint events
+ * are rare and rate-limited); add an indexed column if the Person table grows
+ * large enough for this to show up in practice.
+ */
+async function findPersonIdsByEmail(address: string): Promise<number[]> {
+    const normalized = canonicalizeEmail(address);
+    const people = await prisma.person.findMany({
+        where: { email: { not: null } },
+        select: { id: true, email: true },
+    });
+    return people.filter((p) => p.email && canonicalizeEmail(p.email) === normalized).map((p) => p.id);
+}
+
+/**
+ * POST /api/webhooks/resend — Resend email-deliverability events.
+ *
+ *   email.bounced / email.complained → stamp Person.emailUndeliverableAt (flag).
+ *   email.delivered                  → clear it (self-healing: the address works again).
+ *   email.delivery_delayed           → log only, no flag (a delay isn't a broken address).
+ *   anything else                    → acknowledged and ignored, so Resend stops retrying.
+ *
+ * An address with no matching Person no-ops cleanly (still 200s). Setting/
+ * clearing the same flag more than once is harmless — idempotent by design, no
+ * dedupe bookkeeping needed.
+ */
+export const POST = withWebhook({ provider: "resend", verify: verifyResendSignature }, async (_req, event: ResendWebhookEvent) => {
+    const addresses = toAddresses(event.data);
+
+    switch (event.type) {
+        case "email.bounced":
+        case "email.complained": {
+            for (const address of addresses) {
+                const ids = await findPersonIdsByEmail(address);
+                if (ids.length === 0) continue;
+                await prisma.person.updateMany({ where: { id: { in: ids } }, data: { emailUndeliverableAt: new Date() } });
+            }
+            return NextResponse.json({ ok: true });
+        }
+        case "email.delivered": {
+            for (const address of addresses) {
+                const ids = await findPersonIdsByEmail(address);
+                if (ids.length === 0) continue;
+                await prisma.person.updateMany({ where: { id: { in: ids } }, data: { emailUndeliverableAt: null } });
+            }
+            return NextResponse.json({ ok: true });
+        }
+        case "email.delivery_delayed":
+            logger.warn(`[RESEND WEBHOOK] Delivery delayed for ${addresses.join(", ") || "unknown address"}`);
+            return NextResponse.json({ ok: true, ignored: "delivery_delayed" });
+        default:
+            return NextResponse.json({ ok: true, ignored: event.type });
+    }
+});

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -108,6 +108,7 @@ const admin = (over: Partial<NonNullable<TodoCounts['admin']>> = {}): TodoCounts
     householdsMissingContact: 0,
     unclaimedHouseholds: 0,
     brokenHouseholds: 0,
+    brokenEmails: 0,
     memberFamilies: 0,
     settingsMisconfig: 0,
     programsMisconfig: 0,

--- a/checkin-app/src/lib/__tests__/email.test.ts
+++ b/checkin-app/src/lib/__tests__/email.test.ts
@@ -98,12 +98,14 @@ describe('sendEmail no-key logging + capture', () => {
 // can't reach: Resend returning `{ error }`, and Resend throwing. Both must → false.
 describe('sendEmail send-failure contract (Resend configured)', () => {
     const sendMock = jest.fn();
+    const logIntegrationErrorMock = jest.fn();
     let errorSpy: jest.SpyInstance;
     let logSpy: jest.SpyInstance;
 
     beforeEach(() => {
         jest.resetModules();
         sendMock.mockReset();
+        logIntegrationErrorMock.mockReset();
         // Re-mock the module's deps for the fresh module instance loaded below.
         jest.doMock('../config.ts', () => ({
             config: { resendApiKey: () => 'test-key', emailFrom: () => 'test@test.com', isDevInstance: () => false },
@@ -112,6 +114,8 @@ describe('sendEmail send-failure contract (Resend configured)', () => {
         jest.doMock('resend', () => ({
             Resend: jest.fn().mockImplementation(() => ({ emails: { send: sendMock } })),
         }));
+        // Mocked (not the real DB-writing logger) — this file is a unit test, no DB.
+        jest.doMock('../logger', () => ({ logIntegrationError: logIntegrationErrorMock }));
         // Silence the expected error logging from the failure paths.
         errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -123,6 +127,7 @@ describe('sendEmail send-failure contract (Resend configured)', () => {
         jest.dontMock('../config.ts');
         jest.dontMock('../dev/sentMail');
         jest.dontMock('resend');
+        jest.dontMock('../logger');
     });
 
     it('returns false when Resend responds with an { error }', async () => {
@@ -144,5 +149,37 @@ describe('sendEmail send-failure contract (Resend configured)', () => {
         const result = await send('test@test.com', 'Subject', '<p>hi</p>');
         expect(result).toBe(false);
         expect(sendMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('persists an IntegrationErrorLog (to+subject, no body) when Resend responds with an { error }', async () => {
+        sendMock.mockResolvedValue({ data: null, error: { name: 'validation_error', message: 'bad recipient' } });
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendEmail: send } = require('../email');
+        const html = 'Sensitive body <a href="reset">Link</a>';
+
+        await send('bounced@test.com', 'Subject', html);
+
+        expect(logIntegrationErrorMock).toHaveBeenCalledTimes(1);
+        const [source, error, context] = logIntegrationErrorMock.mock.calls[0];
+        expect(source).toBe('email');
+        expect(String(error)).toContain('bad recipient');
+        expect(context).toEqual({ to: 'bounced@test.com', subject: 'Subject' });
+        expect(JSON.stringify(context)).not.toContain(html);
+    });
+
+    it('persists an IntegrationErrorLog when the Resend call throws', async () => {
+        sendMock.mockRejectedValue(new Error('network down'));
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendEmail: send } = require('../email');
+        const html = '<p>Another sensitive body</p>';
+
+        await send('bounced@test.com', 'Subject', html);
+
+        expect(logIntegrationErrorMock).toHaveBeenCalledTimes(1);
+        const [source, error, context] = logIntegrationErrorMock.mock.calls[0];
+        expect(source).toBe('email');
+        expect((error as Error).message).toBe('network down');
+        expect(context).toEqual({ to: 'bounced@test.com', subject: 'Subject' });
+        expect(JSON.stringify(context)).not.toContain(html);
     });
 });

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -135,6 +135,11 @@ export const config = {
     // Email
     resendApiKey: (): string | null => process.env.RESEND_API_KEY || null,
     emailFrom: () => process.env.EMAIL_FROM || 'CheckMeIn <onboarding@resend.dev>',
+    // Resend's inbound bounce/complaint webhook signs with Svix under this shared
+    // secret (Resend dashboard → Webhooks → signing secret, "whsec_..."). Null when
+    // unset — the webhook route's verify fn fails closed with a 500 config error,
+    // same pattern as shopifyWebhookSecret/zohoWebhookSecret.
+    resendWebhookSecret: (): string | null => process.env.RESEND_WEBHOOK_SECRET || null,
 
     // Background check (Averity/VERITY hosted consent deep link). No API — this is a
     // static hosted URL provided out-of-band, so it lives in config, not BoardSettings.

--- a/checkin-app/src/lib/email.ts
+++ b/checkin-app/src/lib/email.ts
@@ -1,6 +1,7 @@
 import { Resend } from 'resend';
 import { config } from './config';
 import { captureSentEmail } from './dev/sentMail';
+import { logIntegrationError } from './logger';
 
 const resend = config.resendApiKey()
     ? new Resend(config.resendApiKey()!)
@@ -34,6 +35,9 @@ export async function sendEmail(to: string, subject: string, html: string): Prom
 
         if (error) {
             console.error(`[Email Error] Failed to send to ${to}:`, error);
+            // System Status > Link Status tab (see logIntegrationError). Deliberately no
+            // `html` in context — log-hygiene contract asserted in email.test.ts.
+            await logIntegrationError('email', error.message, { to, subject });
             return false;
         }
 
@@ -41,6 +45,7 @@ export async function sendEmail(to: string, subject: string, html: string): Prom
         return true;
     } catch (err) {
         console.error(`[Email Exception] Failed to send to ${to}:`, err);
+        await logIntegrationError('email', err, { to, subject });
         return false;
     }
 }

--- a/checkin-app/src/lib/emailRecipients.ts
+++ b/checkin-app/src/lib/emailRecipients.ts
@@ -9,9 +9,13 @@ import { logger } from "@/lib/logger";
  * errorLabel; these helpers only resolve recipients and swallow send/query errors.
  */
 
-/** Send one email to each recipient; per-send errors are logged and swallowed. */
-function fanOutEmails(emails: string[], subject: string, html: string, errorLabel: string): Promise<unknown[]> {
-    return Promise.all(emails.map((email) => sendEmail(email, subject, html).catch((e) => logger.error(errorLabel, e))));
+/**
+ * Send one email to each recipient. sendEmail never rejects (failures resolve to
+ * `false` and are already persisted via logIntegrationError) — this just fans out,
+ * nothing left to catch here.
+ */
+function fanOutEmails(emails: string[], subject: string, html: string): Promise<boolean[]> {
+    return Promise.all(emails.map((email) => sendEmail(email, subject, html)));
 }
 
 /** Email every lead of a household. Resolve + fan-out; all errors logged and swallowed. */
@@ -22,7 +26,7 @@ export async function emailHouseholdLeads(householdId: number, subject: string, 
             select: { person: { select: { email: true } } },
         });
         const emails = leads.map((l) => l.person?.email).filter((e): e is string => !!e);
-        await fanOutEmails(emails, subject, html, errorLabel);
+        await fanOutEmails(emails, subject, html);
     } catch (e) {
         logger.error(errorLabel, e);
     }
@@ -36,7 +40,7 @@ export async function emailBoardMembers(subject: string, html: string, errorLabe
             select: { email: true },
         });
         const emails = board.map((b) => b.email).filter((e): e is string => !!e);
-        await fanOutEmails(emails, subject, html, errorLabel);
+        await fanOutEmails(emails, subject, html);
     } catch (e) {
         logger.error(errorLabel, e);
     }

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -108,11 +108,13 @@ export async function notifyReviewers(): Promise<void> {
         await Promise.all(
             reviewers.map((r) =>
                 r.email
+                    // sendEmail never rejects (resolves false + logs via logIntegrationError
+                    // on failure) — nothing here for a .catch to ever reach.
                     ? sendEmail(
                           r.email,
                           "Membership: a background-check review is needed",
                           `<p>An application is ready for your background-check review. Please sign in to review it: <a href="${base}/membership-ops/review">${base}/membership-ops/review</a></p>`,
-                      ).catch((e) => logger.error("Reviewer ping failed:", e))
+                      )
                     : Promise.resolve(),
             ),
         );

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -15,6 +15,7 @@ export const classifications = {
         lastWaiverSign: 'internal',
         waiverSignedBy: 'internal',
         lastBackgroundCheck: 'internal',
+        emailUndeliverableAt: 'internal',
         notificationSettings: 'personal',
         householdId: 'public',
         allergies: 'personal',


### PR DESCRIPTION
## Summary

Closes three requirements for end-to-end email deliverability capture:

- **Unreachable-address detection**: a new `POST /api/webhooks/resend` route receives Resend's `email.bounced` / `email.complained` / `email.delivery_delayed` / `email.delivered` events, verified via Svix (`svix-id`/`svix-timestamp`/`svix-signature` over the raw body) — same `withWebhook` shape as the existing Shopify/Zoho routes (rate-limited, config-not-set → 500, bad/missing signature → 401).
- **Broken-email capture**: new nullable `Person.emailUndeliverableAt DateTime?` (`@sensitivity:internal`, alongside `lastBackgroundCheck`/`lastWaiverSign`). The webhook stamps it on bounce/complaint (matched by the shared `canonicalizeEmail` helper, same Gmail/+tag normalization used elsewhere in the codebase) and **clears it on a later `email.delivered`** for the same address (self-healing). `delivery_delayed` is logged only — a delay isn't a broken address. Setting/clearing the same flag twice is harmless by construction (no dedupe bookkeeping needed). Separately, `sendEmail`'s two failure branches (Resend `{ error }` response, and a thrown exception) now also call `logIntegrationError('email', ..., { to, subject })` — persisting to the existing `IntegrationErrorLog` table (previously only `console.error`'d). No `html`/body is ever included in the log context, preserving the existing log-hygiene contract (`email.test.ts`).
- **Admin visibility**: `/api/nav/todo-counts` gains an `admin.brokenEmails` count (people with `emailUndeliverableAt` set), mirroring the existing `brokenHouseholds` pattern, gated behind the same `isSysadmin || isBoardMember` check as the rest of the admin block.

Also cleaned up two dead `.catch(e => logger.error(...))` chains directly on `sendEmail(...)` calls (`emailRecipients.ts`, `membership/review.ts`) — `sendEmail` always resolves to `false` on failure, it never rejects, so those catches could never fire. Replaced with a comment explaining why.

## Ops step required

**`RESEND_WEBHOOK_SECRET` must be set per environment before this is live**: Resend dashboard → **Webhooks** → add an endpoint pointing at `/api/webhooks/resend` → copy the generated signing secret (`whsec_...`) → put it in each environment's env/Secrets Manager entry (dev + prod). Until it's set, the route fails closed with a 500 (same pattern as `SHOPIFY_WEBHOOK_SECRET`/`ZOHO_WEBHOOK_SECRET`) — no events are silently dropped or accepted unverified.

## Dependency note

The webhook signature verification uses `svix` (Resend's documented method), which is **not a new direct dependency** — it's already present transitively via `resend@6.9.3`'s own dependency on `svix@1.84.1` (`node_modules/svix`, confirmed resolvable via `require.resolve('svix')` from `checkin-app`). No `package.json` change. If the team would rather pin `svix` as an explicit direct dependency (since we now import it directly rather than through `resend`'s own internals), that's a one-line addition — flagging it here rather than making that call unilaterally.

## Deliberately out of scope (follow-ups)

- **Suppressing sends to flagged addresses.** `sendEmail` behavior is unchanged — a flagged `Person` doesn't block or alter future sends, this PR only *records* deliverability signal. Skipping/short-circuiting sends to a known-broken address is a reasonable next step but changes send semantics and deserves its own review (e.g., should a household lead re-adding a valid email clear the flag immediately, or only wait for the next `email.delivered`?).
- **A dedicated "broken emails" list/management UI.** Per the task's own steer ("the count is the deliverable"), this PR stops at the `brokenEmails` count in `todo-counts` — it is **not** wired into `navBadges.ts` or given a nav badge/list page, unlike `brokenHouseholds`'s `/membership-audit/broken` tab. Wiring a badge without a target page to link to would be misleading; a `/membership-audit/broken-emails`-style tab (or folding it into the existing Membership Audit page) is a natural follow-up once someone wants to act on the count, not just see it.

## Design notes

- Person-by-email matching (`findPersonIdsByEmail` in the new route) queries all `Person` rows with a non-null email and compares via `canonicalizeEmail` in application code, rather than a raw/indexed lookup — reuses the existing shared normalization helper (`lib/emailNormalize.ts`) instead of reinventing case/+tag handling. Marked `ponytail:` as an O(n) scan that's fine at this org's membership scale (bounce events are rare and rate-limited); an indexed normalized-email column is the upgrade path if the `Person` table grows large enough for this to matter.
- Migration hand-written (`ALTER TABLE "Person" ADD COLUMN "emailUndeliverableAt" TIMESTAMP(3);`) rather than Prisma-generated, per repo convention — additive/nullable, no backfill.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` (`eslint --max-warnings 0`) — clean.
- [x] Full unit suite (`npm run test:ci`): 199 suites / 1576 tests passing, including new/updated `email.test.ts` cases (failure-branch `IntegrationErrorLog` persistence + no-body-in-context assertions) and the `navBadges.test.ts` fixture update for the new `admin.brokenEmails` field.
- [x] Full integration suite (`INTEGRATION_DB=1 npm run test:integration`): 113 suites / 927 tests passing, including the new `webhookResend.integration.test.ts` (10 cases: 500 unconfigured secret, 401 missing/bad Svix signature, bounce/complaint flags the matching Person, delivered clears it, unknown-address bounce no-ops cleanly, delivery_delayed logs only, unrecognized event type acknowledged, rate-limit precedes signature verification) and the pre-existing `webhookShopify.integration.test.ts` + `navTodoCountsAPI.integration.test.ts` (no regressions).
- [x] Migration verified against a scratch Postgres (`localhost:5433`, agent-owned throwaway DB — never the shared `checkmein` DB): `prisma migrate deploy` applies cleanly, and `prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code` reports "No difference detected" (zero drift).
- [x] `prisma generate` regenerated `src/security/generated/classifications.ts` with exactly one new line (`emailUndeliverableAt: 'internal'`) and is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz7egoZoDp37iL9FpC8tH