### PR TITLE
Shopify single-pool capacity + scholarship lifecycle inventory (supersedes two-pool mirror)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ Read these before changing the relevant area — start here, then follow links.
 **Deploy & migrations** (`checkin-app/docs/`)
 - `DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md` — infra rules + order of operations for schema migrations vs. deploys (read before writing a migration); `.claude/skills/migration-safety/` fires this as a checklist whenever a migration is being built.
 - `MIGRATION_COALESCE_FLOW.md` — the pre-release migration-coalesce policy + script (`scripts/coalesce-migrations.ts`), the release gate (at most 1 new migration per release), and the dev/prod ledger-reconcile procedure.
+- `PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md` — single-pool Shopify capacity model + the scholarship hold-ledger state machine (read before touching `Program`/`ProgramParticipant` capacity or payment-plan logic).
 
 **Subprojects** (each has its own `README.md`)
 - `client/` — the Raspberry-Pi kiosk client (Python).

--- a/checkin-app/__tests__/programSignupIntegration.test.ts
+++ b/checkin-app/__tests__/programSignupIntegration.test.ts
@@ -22,6 +22,10 @@ jest.mock('@/lib/shopify', () => ({
         shopifyOrgMemberVariantId: 'mock-member-variant-id',
         shopifyNonOrgMemberVariantId: 'mock-non-member-variant-id',
     }),
+    createShopifySingleVariantProgram: jest.fn().mockResolvedValue({
+        shopifyProductId: 'mock-product-id',
+        shopifyVariantId: 'mock-variant-id',
+    }),
 }));
 
 // Mock Prisma

--- a/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
+++ b/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
@@ -113,9 +113,9 @@ idempotent no-op by every caller.
 
 - **(a) Withdrawal** — `DELETE /api/programs/[id]/participants` (self or admin removal;
   the same route handles both) and the non-payment kick
-  (`cron/pending-participants`, which can also catch a denied-and-still-PENDING
-  participant since denial resets `isPaymentPlanRequested` to `false` too) both funnel
-  through this.
+  (`cron/pending-participants`; denied-and-still-PENDING participants are excluded
+  from the kick via `paymentPlanDeniedAt: null` — their timeline belongs to the
+  grace-expiry cron in (c)) both funnel through this.
 - **(b) Normal payment** — the `orders/paid` webhook's activation path. A denied
   applicant who pays anyway makes Shopify auto-decrement a *second* unit for the same
   seat (the application's hold already took one out); the webhook releases the hold

--- a/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
+++ b/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
@@ -1,0 +1,153 @@
+# Program Capacity & Scholarships
+
+**Status:** Shipped on branch `feat/shopify-capacity-source-of-truth` (PR #930, unmerged).
+**Product decisions:** 2026-07-06 (single-pool capacity, hold-ledger scholarship lifecycle).
+
+## 1. Shopify is the source of truth for program capacity
+
+A program's enrollment capacity is not tracked as a separate counter in the app — it lives
+in Shopify's own inventory for the program's variant. `Program.maxParticipants` sets the
+*initial* Shopify inventory at creation time and drives `PATCH /api/programs/[id]`'s
+relative delta propagation (`adjustProgramInventory`, `lib/shopify.ts`), but from then on
+Shopify's `available` count for the variant is what's authoritative — every seat-consuming
+or seat-returning event in the app fires a corresponding relative adjustment
+(`inventory_levels/adjust`, `available_adjustment: delta`) rather than an absolute set,
+because Shopify decrements `available` itself as seats sell and the app doesn't need to
+know that running total to stay in sync.
+
+## 2. Single pool, single variant
+
+Each program has **one** Shopify variant, priced at the base (non-member) rate
+(`Program.shopifyVariantId`). Inventory on that one variant IS the program's whole
+capacity — there is no second, member-priced pool to keep numerically consistent.
+
+Members pay less at the same variant via a **server-minted, single-use discount code**
+(`mintMemberDiscountCode`, `lib/shopify.ts`): a Shopify Price Rule + Discount Code, fixed
+amount off, usage limit 1, ~48h expiry, minted per checkout by
+`POST /api/programs/[id]/discount-code` after recomputing the caller's membership status
+server-side (never trusting a client flag). A failed mint degrades to an undiscounted link
+— checkout is never blocked.
+
+This is an interim mechanism. `docs/designs/SHOPIFY_MEMBER_SEGMENT_PRICING.md` is the
+planned upgrade — segment-gated automatic discounts, once checkout identity (that doc's
+§5) is solved — at which point per-checkout discount codes go away entirely.
+
+### Legacy two-variant transition
+
+Programs created before this design still carry two variants
+(`shopifyOrgMemberVariantId` / `shopifyNonOrgMemberVariantId`), each with its own
+inventory pool mirrored via a sibling-adjustment on every seat-consuming event (the
+webhook's `orders/paid` handler mirrors the purchased tier's decrement onto the other
+pool). `adjustProgramInventory` prefers `shopifyVariantId` when set and falls back to the
+legacy pair otherwise — this is additive, not a widening of what any one program accepts;
+a given program only ever populates one shape or the other.
+
+This is an **expand** step. Dropping the legacy pair (**contract**) is a later release,
+once every program has migrated onto the single-pool model — per the repo's
+migration-safety convention of expand/contract as separate steps.
+
+## 3. Scholarship lifecycle — the hold ledger
+
+A scholarship / payment-plan request takes a seat out of Shopify's pool the moment it's
+requested, not when it's approved. The invariant: **every application-time `-1` is
+returned `+1` exactly once**, by whichever of three release paths fires first, or is
+**consumed permanently** by approval. `ProgramParticipant.inventoryHeldAt` is the ledger's
+state: non-null means a hold is outstanding.
+
+```
+                          ┌──────────────┐
+                 apply    │              │  approve
+        PENDING ───────►  │  HELD        │ ───────────►  ACTIVE (comped)
+     (no hold)   -1       │ (inventoryHeldAt set)        inventoryHeldAt -> null
+                          │              │               (hold CONSUMED, no +1 ever)
+                          └──────┬───────┘
+                                 │ deny (no Shopify op)
+                                 ▼
+                          ┌──────────────┐
+                          │  HELD +      │  re-apply (same seat, no 2nd -1)
+                          │  DENIED      │ ─────────────────────────────► back to HELD
+                          │ (paymentPlanDeniedAt set)   (deniedAt cleared)
+                          └──────┬───────┘
+                                 │
+              ┌──────────────────┼───────────────────────┐
+              │ (a) withdraw     │ (b) pay anyway         │ (c) grace expires
+              ▼                 ▼                        ▼
+     +1, row removed     +1 (compensates the       +1, auto-withdrawn
+                          webhook's real sale),     (reuses path (a))
+                          row -> ACTIVE
+```
+
+### Application (`POST /api/programs/[id]/request-payment-plan`)
+
+Stamps `inventoryHeldAt = now()` and clears `paymentPlanDeniedAt`, guarded so the `-1`
+only fires the moment `inventoryHeldAt` transitions **null → set**. A denied re-applicant
+already has `inventoryHeldAt` set (denial never clears it — see below), so re-applying
+just flips `isPaymentPlanRequested` back to `true` and clears the denial stamp — it does
+**not** decrement a second time for a seat it's already holding.
+
+### Denial (`POST /api/finance-ops/payment-plans/refuse`)
+
+Performs **no Shopify operation**. The seat stays held exactly as the application left it
+— `isPaymentPlanRequested` clears and `paymentPlanDeniedAt` stamps, but `inventoryHeldAt`
+is untouched. The applicant may still pay normally; a board member did not "give away"
+their held seat by saying no to a payment plan. (This supersedes an earlier design where
+denial fired a `+1` — that let the seat resell out from under a denied-but-not-withdrawn
+applicant, silently drifting DB capacity and Shopify's count apart.)
+
+### Approval (`POST /api/finance-ops/payment-plans`)
+
+No Shopify operation either (the seat was already taken out of the pool at application
+time) — approval only stops billing the applicant. It additionally clears
+`inventoryHeldAt` to `null` **without** a `+1`: the hold is **consumed**, not released. An
+approved participant is a permanent comped enrollment; if they're later removed from the
+program, that removal must not credit a seat back that was never returned to Shopify.
+
+### Release, exactly once — three paths
+
+All three share one implementation, `withdrawAndReleaseHold`
+(`lib/program/capacity.ts`): delete the `PENDING` row, and if the deleted row's
+`inventoryHeldAt` was set, fire the compensating `+1`. `delete()` is the atomicity
+boundary — a given row can be deleted at most once, so double-release across concurrent
+callers isn't possible; a second delete attempt hits Prisma P2025 and is treated as an
+idempotent no-op by every caller.
+
+- **(a) Withdrawal** — `DELETE /api/programs/[id]/participants` (self or admin removal;
+  the same route handles both) and the non-payment kick
+  (`cron/pending-participants`, which can also catch a denied-and-still-PENDING
+  participant since denial resets `isPaymentPlanRequested` to `false` too) both funnel
+  through this.
+- **(b) Normal payment** — the `orders/paid` webhook's activation path. A denied
+  applicant who pays anyway makes Shopify auto-decrement a *second* unit for the same
+  seat (the application's hold already took one out); the webhook releases the hold
+  (+1) to compensate, guarded transactionally (`inventoryHeldAt` not-null → null) so a
+  webhook retry can't release twice. Never allowed to fail the webhook's 200 — Shopify
+  retries the whole order on a non-2xx.
+- **(c) Grace-period expiry** — `cron/scholarship-grace-expiry`. See below.
+
+## 4. Grace-period expiry
+
+`BoardSettings.scholarshipDenialGraceDays` (nullable int; **NULL = the feature is off**,
+never a guessed default) sets how many days a denied applicant keeps their held seat
+before being auto-withdrawn. The cron sweep (`GET /api/cron/scholarship-grace-expiry`,
+`Authorization: Bearer $CRON_SECRET`, same auth guard as every other cron route) finds
+`PENDING` rows with `isPaymentPlanRequested: false`, `inventoryHeldAt` set,
+`paymentPlanDeniedAt` set, and `paymentPlanDeniedAt + scholarshipDenialGraceDays days` in
+the past, then auto-withdraws each one (reusing release path (a) — semantically, expiry
+*is* auto-withdrawal + seat restore) and audit-logs with a distinct
+`reason: "scholarship_grace_expired"` context so it reads differently from a manual
+withdrawal in the audit trail. Each row is processed independently (a per-row failure
+doesn't block the rest of the sweep), and the sweep never touches non-`PENDING` rows —
+an approved (`ACTIVE`) participant's hold was already consumed, not left outstanding, so
+it can never match this query regardless of how old `paymentPlanDeniedAt` is.
+
+Configured on the membership settings surface (`/settings/membership` →
+`PUT /api/settings/membership`), alongside the other board policy knobs
+(`bgRecheckMonths`, dues) — board/sysadmin only, audit-logged, blank input clears it back
+to `null`.
+
+## 5. Related
+
+- `docs/designs/SHOPIFY_MEMBER_SEGMENT_PRICING.md` — the segment-gated pricing design
+  that per-checkout discount codes stand in for until checkout identity is solved.
+- `docs/DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md` — the expand/contract migration
+  convention this design's legacy-variant transition follows.

--- a/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
+++ b/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
@@ -111,6 +111,23 @@ boundary — a given row can be deleted at most once, so double-release across c
 callers isn't possible; a second delete attempt hits Prisma P2025 and is treated as an
 idempotent no-op by every caller.
 
+**Failure semantics (best-effort, not transactional).** The DB write and the Shopify
+call cannot share a transaction, so "every −1 comes back +1 exactly once" is guaranteed
+against *failed calls* but not against *crashes between the two steps*:
+
+- **Failed `-1` at application time**: the hold stamp is rolled back
+  (`request-payment-plan` clears `inventoryHeldAt` again), so no phantom hold is
+  recorded; re-submitting retries the decrement. Every failure also emails
+  sysadmins/board via `reportShopifyFailure`.
+- **Failed `+1` at release time**: the row is already deleted; the caller gets a
+  `warning` and the same failure email goes out. Reconciliation is manual (**Sync to
+  Shopify** / System Status → Link Status).
+- **Crash windows** (process dies between the DB commit and the Shopify call): a
+  stranded hold or a missed release can survive. These are visible in the DB
+  (`inventoryHeldAt` vs. Shopify's count) and are fixed by the same manual sync; a
+  periodic reconcile job is deliberately deferred until the drift is observed in
+  practice.
+
 - **(a) Withdrawal** — `DELETE /api/programs/[id]/participants` (self or admin removal;
   the same route handles both) and the non-payment kick
   (`cron/pending-participants`; denied-and-still-PENDING participants are excluded

--- a/checkin-app/docs/designs/SHOPIFY_MEMBER_SEGMENT_PRICING.md
+++ b/checkin-app/docs/designs/SHOPIFY_MEMBER_SEGMENT_PRICING.md
@@ -7,6 +7,14 @@
 
 > A note on naming, since the sibling doc above got called out for it: the status line above is accurate. This document proposes nothing has landed; it is not implemented in part, and no PR against `main` should claim otherwise until code exists.
 
+> **Update (PR #930, single-pool capacity):** the companion effort referenced above
+> shipped single-pool capacity + per-enrollee, server-minted single-use discount codes
+> as the **interim** member-pricing mechanism (see
+> `checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md` §2). That does not change this
+> doc's status or recommendation — segment-gated automatic discounts remain the intended
+> **end-state** for checkout identity; the interim codes are exactly the kind of narrow
+> stopgap this doc's own §5 (option (d)) names.
+
 ---
 
 ## 0. Scope check — what already exists

--- a/checkin-app/jest.flow.config.js
+++ b/checkin-app/jest.flow.config.js
@@ -15,4 +15,14 @@ module.exports = createJestConfig({
     // The standalone build nests a package.json named "checkmein" under .next/,
     // which collides with the app's own in jest's haste map.
     modulePathIgnorePatterns: ['<rootDir>/.next/'],
+    // Jest's 5000ms default is too tight here: whichever file runs FIRST pays the
+    // full first-hit Turbopack compile cost for every route the journey touches
+    // (~10+ sequential requests against a `next dev` server that hasn't compiled
+    // any of them yet), and that cold-start tax alone can exceed 5s on a loaded CI
+    // runner — timing out mid-journey, which then races the abandoned in-flight
+    // request against afterAll's cleanup (e.g. #930's CI failure: a timed-out
+    // membership-activation-fanout run left its Shopify webhook call racing
+    // resetApplicantHousehold's DELETE, surfacing as a spurious 500). Later files
+    // reuse the now-warm routes and finish in a fraction of this.
+    testTimeout: 20000,
 });

--- a/checkin-app/prisma/migrations/20260706150000_program_shopify_variant_id/migration.sql
+++ b/checkin-app/prisma/migrations/20260706150000_program_shopify_variant_id/migration.sql
@@ -1,0 +1,6 @@
+-- Additive, nullable: single-pool Shopify variant for new-model programs (one
+-- variant priced at the base/non-member rate; member pricing is a per-enrollee
+-- discount code at checkout, not a separate variant). Legacy programs keep
+-- shopifyOrgMemberVariantId/shopifyNonOrgMemberVariantId untouched — this is
+-- an expand-only step; dropping the legacy pair is a later contract release.
+ALTER TABLE "Program" ADD COLUMN "shopifyVariantId" TEXT;

--- a/checkin-app/prisma/migrations/20260706160000_scholarship_hold_ledger/migration.sql
+++ b/checkin-app/prisma/migrations/20260706160000_scholarship_hold_ledger/migration.sql
@@ -1,0 +1,9 @@
+-- Additive, nullable: the scholarship hold-ledger (product decision
+-- 2026-07-06, supersedes this PR's earlier deny-time +1). ProgramParticipant
+-- gets two timestamps tracking the -1/+1 lifecycle; BoardSettings gets the
+-- opt-in grace-period length for the expiry sweep. No existing row is
+-- touched — every column defaults to NULL, which is exactly "no hold" / "not
+-- denied" / "expiry feature off".
+ALTER TABLE "ProgramParticipant" ADD COLUMN "inventoryHeldAt" TIMESTAMP(3);
+ALTER TABLE "ProgramParticipant" ADD COLUMN "paymentPlanDeniedAt" TIMESTAMP(3);
+ALTER TABLE "BoardSettings" ADD COLUMN "scholarshipDenialGraceDays" INTEGER;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -705,6 +705,15 @@ model Program {
   shopifyOrgMemberVariantId    String?
   /// @sensitivity:public
   shopifyNonOrgMemberVariantId String?
+  /// Single-pool model (product decision 2026-07-06, supersedes the two-variant
+  /// mirror above for NEW program creation): one variant priced at the base
+  /// (non-member) rate; members get a server-minted single-use discount code
+  /// at checkout instead of a separate variant/pool (mintMemberDiscountCode in
+  /// lib/shopify.ts). Legacy programs keep the two columns above untouched —
+  /// expand-only migration; dropping the legacy pair (contract) is a later
+  /// release once every program has migrated.
+  /// @sensitivity:public
+  shopifyVariantId          String?
 
   volunteers   ProgramVolunteer[]
   participants ProgramParticipant[]

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -469,6 +469,12 @@ model BoardSettings {
   shopifyVolunteerVariantId  String?
   /// @sensitivity:internal
   shopifyPriceSyncedAt       DateTime?
+  /// Grace period (days) a denied scholarship applicant keeps their held seat
+  /// before the grace-period expiry cron auto-withdraws them and releases it.
+  /// NULL = the expiry feature is OFF (a denied hold is only ever released by
+  /// withdrawal or payment; it never auto-expires).
+  /// @sensitivity:public
+  scholarshipDenialGraceDays Int?
   /// @sensitivity:internal
   updatedAt                  DateTime  @updatedAt
 }
@@ -752,6 +758,22 @@ model ProgramParticipant {
   /// OrgMembership row — it must be stamped at approval. Null until approved.
   /// @sensitivity:internal
   wasOrgMemberAtApproval Boolean?
+  /// Hold-ledger state (product decision 2026-07-06): stamped when a
+  /// scholarship application takes a seat out of Shopify's pool (-1). Cleared
+  /// back to null exactly once, by whichever fires first: withdrawal, a
+  /// normal payment (webhook compensates the sale's auto-decrement), or
+  /// grace-period expiry (cron) — or consumed permanently by approval (no
+  /// +1). NOT NULL is the transactional guard every release path checks
+  /// before adjusting Shopify.
+  /// @sensitivity:internal
+  inventoryHeldAt      DateTime?
+  /// Hold-ledger state: stamped when a board member denies a pending
+  /// scholarship/payment-plan request (the seat stays held — see
+  /// inventoryHeldAt — so the applicant may still pay normally). Cleared on
+  /// re-application. Drives the grace-period expiry sweep alongside
+  /// BoardSettings.scholarshipDenialGraceDays.
+  /// @sensitivity:personal
+  paymentPlanDeniedAt  DateTime?
 
   program Program     @relation(fields: [programId], references: [id])
   person  Person @relation(fields: [personId], references: [id])

--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -57,6 +57,8 @@ const AUTHZ_TESTED = new Set<string>([
     'admin/broken-households',
     // POST deny-path (401 anon / 403 non-board) in programPaymentPlansAPI.integration.test.ts.
     'finance-ops/payment-plans',
+    // POST deny-path (401 anon / 403 non-board) in programPaymentPlansAPI.integration.test.ts.
+    'finance-ops/payment-plans/refuse',
     // POST deny-path (401 anon / 403 non-board) in membershipPaymentPlansAPI.integration.test.ts.
     'finance-ops/membership-payment-plans',
     'admin/settings/localization',

--- a/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
@@ -55,6 +55,7 @@ describe('Cron Pending-Participants API Integration Tests', () => {
         await mkParticipant('day6');
         await mkParticipant('day7');
         await mkParticipant('plan'); // isPaymentPlanRequested -> never swept
+        await mkParticipant('denied'); // denied applicant -> grace-expiry cron's job, never this sweep's
 
         await prisma.programParticipant.createMany({
             data: [
@@ -63,6 +64,9 @@ describe('Cron Pending-Participants API Integration Tests', () => {
                 { programId, personId: ids.day6, status: 'PENDING', pendingSince: daysAgo(now, 6) },
                 { programId, personId: ids.day7, status: 'PENDING', pendingSince: daysAgo(now, 7) },
                 { programId, personId: ids.plan, status: 'PENDING', pendingSince: daysAgo(now, 8), isPaymentPlanRequested: true },
+                // Denied 10 days after enrolling: pendingSince is way past the 7-day
+                // kick, but paymentPlanDeniedAt hands the timeline to scholarship-grace-expiry.
+                { programId, personId: ids.denied, status: 'PENDING', pendingSince: daysAgo(now, 10), isPaymentPlanRequested: false, paymentPlanDeniedAt: daysAgo(now, 0), inventoryHeldAt: daysAgo(now, 10) },
             ]
         });
     });
@@ -107,10 +111,11 @@ describe('Cron Pending-Participants API Integration Tests', () => {
             expect(data.warned).toBe(3);
             expect(data.kicked).toBe(1);
 
-            // DB reality: only day7 deleted; the warned rows and the payment-plan row survive.
+            // DB reality: only day7 deleted; the warned rows, the payment-plan row,
+            // and the denied-applicant row (grace-expiry cron's responsibility) survive.
             const survivors = await prisma.programParticipant.findMany({ where: { programId } });
             const survivorPids = survivors.map(s => s.personId).sort((a, b) => a - b);
-            expect(survivorPids).toEqual([ids.day1, ids.day3, ids.day6, ids.plan].sort((a, b) => a - b));
+            expect(survivorPids).toEqual([ids.day1, ids.day3, ids.day6, ids.plan, ids.denied].sort((a, b) => a - b));
 
             const day7 = await prisma.programParticipant.findUnique({
                 where: { programId_personId: { programId, personId: ids.day7 } }

--- a/checkin-app/src/app/__tests__/cronScholarshipGraceExpiry.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronScholarshipGraceExpiry.integration.test.ts
@@ -1,0 +1,195 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for GET /api/cron/scholarship-grace-expiry — release path
+ * (c) of the hold-ledger (product decision 2026-07-06). A denied scholarship
+ * applicant keeps their held seat (inventoryHeldAt stays set; the refuse
+ * endpoint performs no Shopify op) so they can still pay. Once
+ * BoardSettings.scholarshipDenialGraceDays has elapsed since
+ * paymentPlanDeniedAt, this sweep auto-withdraws the participant and releases
+ * the seat (+1) — reusing the same withdrawAndReleaseHold path self/admin
+ * withdrawal uses.
+ */
+import { GET } from '@/app/api/cron/scholarship-grace-expiry/route';
+import prisma from '@/lib/prisma';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (d: number) => new Date(Date.now() - d * DAY_MS - DAY_MS / 2); // half-day offset keeps boundaries stable
+
+function mkReq(auth?: string) {
+    return new Request('http://localhost:4000/api/cron/scholarship-grace-expiry', {
+        method: 'GET',
+        headers: auth ? { authorization: auth } : {},
+    }) as unknown as Request;
+}
+
+describe('Cron Scholarship-Grace-Expiry API Integration Tests', () => {
+    let programId: number;
+    const ids: Record<string, number> = {};
+    let prevGraceDays: number | null | undefined;
+
+    const mkParticipant = async (key: string) => {
+        const p = await prisma.person.create({
+            data: { email: `${key}-grace-cron-test@example.com`, name: `${key} Grace Cron`, household: { create: { name: 'Test HH' } } },
+        });
+        ids[key] = p.id;
+        return p.id;
+    };
+
+    beforeAll(async () => {
+        const leaked = await prisma.person.findMany({ where: { email: { contains: 'grace-cron-test' } }, select: { id: true } });
+        const leakedIds = leaked.map((u) => u.id);
+        await prisma.programParticipant.deleteMany({ where: { personId: { in: leakedIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: leakedIds } } });
+        await prisma.program.deleteMany({ where: { name: { contains: 'Grace Cron Test' } } });
+
+        const program = await prisma.program.create({
+            data: { name: 'Grace Cron Test Program', phase: 'UPCOMING', enrollmentStatus: 'OPEN', shopifyVariantId: 'dev-mock-variant-grace-cron' },
+        });
+        programId = program.id;
+
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevGraceDays = existing?.scholarshipDenialGraceDays ?? null;
+
+        await mkParticipant('inside'); // denied 3 days ago — inside a 7-day grace window
+        await mkParticipant('outside'); // denied 10 days ago — past a 7-day grace window
+        await mkParticipant('active'); // ACTIVE + (hypothetically) held — must never be touched
+        await mkParticipant('gone'); // pre-deleted before the sweep runs — per-row isolation
+    });
+
+    afterAll(async () => {
+        const idList = Object.values(ids);
+        await prisma.programParticipant.deleteMany({ where: { programId } });
+        await prisma.person.deleteMany({ where: { id: { in: idList } } });
+        await prisma.program.deleteMany({ where: { id: programId } });
+        await prisma.boardSettings.update({ where: { id: 1 }, data: { scholarshipDenialGraceDays: prevGraceDays } });
+    });
+
+    describe('auth', () => {
+        it('returns 401 when the Authorization header is missing', async () => {
+            process.env.CRON_SECRET = 'test-secret';
+            const res = await GET(mkReq());
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('NULL setting — feature off', () => {
+        it('no-ops entirely when scholarshipDenialGraceDays is NULL', async () => {
+            await prisma.boardSettings.upsert({
+                where: { id: 1 },
+                create: { id: 1, scholarshipDenialGraceDays: null },
+                update: { scholarshipDenialGraceDays: null },
+            });
+            await prisma.programParticipant.upsert({
+                where: { programId_personId: { programId, personId: ids.outside } },
+                update: { status: 'PENDING', isPaymentPlanRequested: false, inventoryHeldAt: daysAgo(10), paymentPlanDeniedAt: daysAgo(10) },
+                create: { programId, personId: ids.outside, status: 'PENDING', isPaymentPlanRequested: false, inventoryHeldAt: daysAgo(10), paymentPlanDeniedAt: daysAgo(10) },
+            });
+
+            process.env.CRON_SECRET = 'test-secret';
+            const res = await GET(mkReq('Bearer test-secret'));
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            expect(data.enabled).toBe(false);
+            expect(data.processed).toBe(0);
+
+            const row = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId: ids.outside } } });
+            expect(row).not.toBeNull(); // untouched
+        });
+    });
+
+    describe('sweep boundary + isolation, graceDays=7', () => {
+        beforeAll(async () => {
+            await prisma.boardSettings.upsert({
+                where: { id: 1 },
+                create: { id: 1, scholarshipDenialGraceDays: 7 },
+                update: { scholarshipDenialGraceDays: 7 },
+            });
+
+            await prisma.programParticipant.upsert({
+                where: { programId_personId: { programId, personId: ids.inside } },
+                update: { status: 'PENDING', isPaymentPlanRequested: false, inventoryHeldAt: daysAgo(3), paymentPlanDeniedAt: daysAgo(3) },
+                create: { programId, personId: ids.inside, status: 'PENDING', isPaymentPlanRequested: false, inventoryHeldAt: daysAgo(3), paymentPlanDeniedAt: daysAgo(3) },
+            });
+            await prisma.programParticipant.upsert({
+                where: { programId_personId: { programId, personId: ids.outside } },
+                update: { status: 'PENDING', isPaymentPlanRequested: false, inventoryHeldAt: daysAgo(10), paymentPlanDeniedAt: daysAgo(10) },
+                create: { programId, personId: ids.outside, status: 'PENDING', isPaymentPlanRequested: false, inventoryHeldAt: daysAgo(10), paymentPlanDeniedAt: daysAgo(10) },
+            });
+            // ACTIVE with a (hypothetical) hold set — the status filter must exclude it.
+            await prisma.programParticipant.upsert({
+                where: { programId_personId: { programId, personId: ids.active } },
+                update: { status: 'ACTIVE', isPaymentPlanRequested: false, inventoryHeldAt: daysAgo(30), paymentPlanDeniedAt: daysAgo(30) },
+                create: { programId, personId: ids.active, status: 'ACTIVE', isPaymentPlanRequested: false, inventoryHeldAt: daysAgo(30), paymentPlanDeniedAt: daysAgo(30) },
+            });
+            // Past the window too, but its removal is forced to fail below (see
+            // the delete() spy) — must not block processing the rest of the sweep.
+            await prisma.programParticipant.upsert({
+                where: { programId_personId: { programId, personId: ids.gone } },
+                update: { status: 'PENDING', isPaymentPlanRequested: false, inventoryHeldAt: daysAgo(20), paymentPlanDeniedAt: daysAgo(20) },
+                create: { programId, personId: ids.gone, status: 'PENDING', isPaymentPlanRequested: false, inventoryHeldAt: daysAgo(20), paymentPlanDeniedAt: daysAgo(20) },
+            });
+        });
+
+        it('releases + auto-withdraws only rows past the grace window, isolates a per-row failure, and never touches ACTIVE rows', async () => {
+            const prevEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local';
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            process.env.CRON_SECRET = 'test-secret';
+
+            // Force one row's removal to fail, simulating any per-row error (DB
+            // hiccup, concurrent removal, etc.) without it blocking the rest of
+            // the sweep.
+            const originalDelete = prisma.programParticipant.delete.bind(prisma.programParticipant);
+            const deleteSpy = jest.spyOn(prisma.programParticipant, 'delete').mockImplementation((args: Parameters<typeof originalDelete>[0]) => {
+                if (args?.where?.programId_personId?.personId === ids.gone) {
+                    throw new Error('simulated per-row failure');
+                }
+                return originalDelete(args);
+            });
+
+            try {
+                const res = await GET(mkReq('Bearer test-secret'));
+                expect(res.status).toBe(200);
+                const data = await res.json();
+                expect(data.enabled).toBe(true);
+                // outside + gone both matched the query (paymentPlanDeniedAt <= cutoff);
+                // "gone" throws on delete() and is isolated, not counted as released.
+                expect(data.processed).toBe(2);
+                expect(data.released).toBe(1);
+
+                // Inside the window: untouched.
+                const inside = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId: ids.inside } } });
+                expect(inside).not.toBeNull();
+                expect(inside?.status).toBe('PENDING');
+
+                // Outside the window: auto-withdrawn (row gone) + released (+1 logged).
+                const outside = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId: ids.outside } } });
+                expect(outside).toBeNull();
+                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by 1 for variants: dev-mock-variant-grace-cron'));
+
+                const audit = await prisma.auditLog.findFirst({
+                    where: { actorId: 0, tableName: 'ProgramParticipant', affectedEntityId: ids.outside, secondaryAffectedEntity: programId },
+                });
+                expect(audit).not.toBeNull();
+                expect((audit?.newData as { reason?: string })?.reason).toBe('scholarship_grace_expired');
+
+                // The row whose removal failed: untouched, isolated from the rest.
+                const gone = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId: ids.gone } } });
+                expect(gone).not.toBeNull();
+
+                // ACTIVE row: never touched by the sweep despite being way outside the window.
+                const active = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId: ids.active } } });
+                expect(active).not.toBeNull();
+                expect(active?.status).toBe('ACTIVE');
+                expect(active?.inventoryHeldAt).not.toBeNull();
+            } finally {
+                deleteSpy.mockRestore();
+                logSpy.mockRestore();
+                if (prevEnv === undefined) delete process.env.CHECKIN_ENV;
+                else process.env.CHECKIN_ENV = prevEnv;
+            }
+        });
+    });
+});

--- a/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
@@ -94,6 +94,25 @@ describe('Membership settings + volunteer designations API', () => {
         expect(settings.normalDuesCents).toBe(12000);
     });
 
+    it('accepts a positive scholarshipDenialGraceDays and clears it back to null', async () => {
+        asBoard(boardId);
+        const res = await SETTINGS_PUT(jsonReq('PUT', { scholarshipDenialGraceDays: 14 }));
+        expect(res.status).toBe(200);
+        expect((await res.json()).settings.scholarshipDenialGraceDays).toBe(14);
+
+        const cleared = await SETTINGS_PUT(jsonReq('PUT', { scholarshipDenialGraceDays: null }));
+        expect(cleared.status).toBe(200);
+        expect((await cleared.json()).settings.scholarshipDenialGraceDays).toBeNull();
+    });
+
+    it('rejects a non-positive or fractional scholarshipDenialGraceDays', async () => {
+        asBoard(boardId);
+        for (const bad of [0, -1, 1.5]) {
+            const res = await SETTINGS_PUT(jsonReq('PUT', { scholarshipDenialGraceDays: bad }));
+            expect(res.status).toBe(400);
+        }
+    });
+
     it('adds, lists, and removes a volunteer designation', async () => {
         asBoard(boardId);
         const addRes = await DESIG_POST(jsonReq('POST', { email: `vol-${TAG}@example.com` }));

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -12,6 +12,7 @@
  * and the successful state transitions.
  */
 import { GET as PlansGet, POST as PlansPost } from '@/app/api/finance-ops/payment-plans/route';
+import { POST as RefusePost } from '@/app/api/finance-ops/payment-plans/refuse/route';
 import { POST as RequestPost } from '@/app/api/programs/[id]/request-payment-plan/route';
 import { POST as ParticipantsPost } from '@/app/api/programs/[id]/participants/route';
 import prisma from '@/lib/prisma';
@@ -220,63 +221,47 @@ describe('Program payment-plan routes', () => {
             expect(data.warning).toBeUndefined();
         });
 
-        // Shopify is the source of truth for program capacity (product decision
-        // 2026-07-06, extended): an approved scholarship/payment-plan seat consumes
-        // real capacity exactly like a paid one, so approval must decrement Shopify
-        // too. Runs against the CHECKIN_ENV=local mock (config.shopifyMockActive),
-        // same pattern as programSyncShopifyAPI.integration.test.ts.
-        it('decrements both Shopify variant pools by 1 on approval when the program has variants configured', async () => {
-            const prevCheckinEnv = process.env.CHECKIN_ENV;
-            process.env.CHECKIN_ENV = 'local';
-            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        // Scholarship lifecycle drives inventory (product decision 2026-07-06):
+        // the seat is decremented at APPLICATION time (request-payment-plan), NOT
+        // at approval — approval only stops billing the applicant. This supersedes
+        // the earlier approve-time decrement (see PR history for the two-pool
+        // mirror model this replaced). Proven here by NO fetch firing even though
+        // the program has a variant configured.
+        it('does NOT touch Shopify on approval, even when the program has a variant configured', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch');
+            const shopifyProgram = await prisma.program.create({
+                data: {
+                    name: `PP Shopify Program ${TAG}`,
+                    leadMentorId: mentorId,
+                    enrollmentStatus: 'OPEN',
+                    shopifyVariantId: 'dev-mock-variant-pp',
+                },
+            });
             try {
-                const shopifyProgram = await prisma.program.create({
-                    data: {
-                        name: `PP Shopify Program ${TAG}`,
-                        leadMentorId: mentorId,
-                        enrollmentStatus: 'OPEN',
-                        shopifyOrgMemberVariantId: 'dev-mock-variant-member-pp',
-                        shopifyNonOrgMemberVariantId: 'dev-mock-variant-nonmember-pp',
-                    },
+                await prisma.programParticipant.upsert({
+                    where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
+                    update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
+                    create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
                 });
-                try {
-                    await prisma.programParticipant.upsert({
-                        where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
-                        update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
-                        create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
-                    });
-                    mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+                mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
 
-                    // A cookie header is required: CHECKIN_ENV=local (for the Shopify mock)
-                    // also arms the keyless-kiosk fallback in authenticateRequest, which
-                    // hijacks any cookie-less request as `kiosk` -> 403 before the
-                    // session/role gate runs.
-                    const res = await PlansPost(nextReq('http://localhost', {
-                        method: 'POST',
-                        headers: { cookie: 'session=test' },
-                        body: JSON.stringify({ programId: shopifyProgram.id, participantId: selfId }),
-                    }));
-                    expect(res.status).toBe(200);
-                    const data = await res.json();
-                    expect(data.warning).toBeUndefined(); // mock no-ops successfully
+                const res = await PlansPost(nextReq('http://localhost', {
+                    method: 'POST',
+                    body: JSON.stringify({ programId: shopifyProgram.id, participantId: selfId }),
+                }));
+                expect(res.status).toBe(200);
+                const data = await res.json();
+                expect(data.warning).toBeUndefined();
 
-                    const row = await prisma.programParticipant.findUnique({
-                        where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
-                    });
-                    expect(row?.status).toBe('ACTIVE');
-
-                    // Confirms BOTH pools were targeted with delta -1, not just that the
-                    // call succeeded — the mock logs the resolved variant id list.
-                    expect(logSpy).toHaveBeenCalledWith(
-                        expect.stringContaining('Would adjust inventory by -1 for variants: dev-mock-variant-member-pp, dev-mock-variant-nonmember-pp'),
-                    );
-                } finally {
-                    await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
-                    await prisma.program.delete({ where: { id: shopifyProgram.id } });
-                }
+                const row = await prisma.programParticipant.findUnique({
+                    where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
+                });
+                expect(row?.status).toBe('ACTIVE');
+                expect(fetchSpy).not.toHaveBeenCalled();
             } finally {
-                logSpy.mockRestore();
-                process.env.CHECKIN_ENV = prevCheckinEnv;
+                fetchSpy.mockRestore();
+                await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
+                await prisma.program.delete({ where: { id: shopifyProgram.id } });
             }
         });
 
@@ -406,6 +391,216 @@ describe('Program payment-plan routes', () => {
                 where: { programId_personId: { programId, personId: selfId } },
             });
             expect(row?.isPaymentPlanRequested).toBe(false);
+        });
+
+        // Scholarship lifecycle drives inventory (product decision 2026-07-06):
+        // APPLICATION decrements Shopify by 1 — only on the false->true transition.
+        describe('Shopify inventory (apply time)', () => {
+            let shopifyProgramId: number;
+
+            beforeAll(async () => {
+                const p = await prisma.program.create({
+                    data: { name: `PP Apply Shopify Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyVariantId: 'dev-mock-variant-apply-pp' },
+                });
+                shopifyProgramId = p.id;
+            });
+
+            afterAll(async () => {
+                await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgramId } });
+                await prisma.program.delete({ where: { id: shopifyProgramId } });
+            });
+
+            it('decrements the single-pool variant by 1 on the false->true transition', async () => {
+                const prevCheckinEnv = process.env.CHECKIN_ENV;
+                process.env.CHECKIN_ENV = 'local';
+                const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+                try {
+                    await prisma.programParticipant.upsert({
+                        where: { programId_personId: { programId: shopifyProgramId, personId: selfId } },
+                        update: { status: 'PENDING', isPaymentPlanRequested: false, pendingSince: new Date() },
+                        create: { programId: shopifyProgramId, personId: selfId, status: 'PENDING', isPaymentPlanRequested: false, pendingSince: new Date() },
+                    });
+                    mockSession.mockResolvedValue({ user: { id: selfId } });
+
+                    // CHECKIN_ENV=local also arms the keyless-kiosk fallback in
+                    // authenticateRequest, which hijacks any cookie-less request as
+                    // `kiosk` -> 403 before the session/role gate runs — send a cookie.
+                    const req = new Request(`http://localhost/api/programs/${shopifyProgramId}/request-payment-plan`, {
+                        method: 'POST',
+                        headers: { cookie: 'session=test' },
+                        body: JSON.stringify({ participantId: selfId }),
+                    }) as unknown as import('next/server').NextRequest;
+                    const res = await RequestPost(req, params(shopifyProgramId));
+                    expect(res.status).toBe(200);
+                    const data = await res.json();
+                    expect(data.warning).toBeUndefined();
+
+                    expect(logSpy).toHaveBeenCalledWith(
+                        expect.stringContaining('Would adjust inventory by -1 for variants: dev-mock-variant-apply-pp'),
+                    );
+                } finally {
+                    logSpy.mockRestore();
+                    process.env.CHECKIN_ENV = prevCheckinEnv;
+                }
+            });
+
+            it('does NOT fire a second -1 on an idempotent re-request (already requested)', async () => {
+                const prevCheckinEnv = process.env.CHECKIN_ENV;
+                process.env.CHECKIN_ENV = 'local';
+                const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+                try {
+                    await prisma.programParticipant.update({
+                        where: { programId_personId: { programId: shopifyProgramId, personId: selfId } },
+                        data: { isPaymentPlanRequested: true },
+                    });
+                    mockSession.mockResolvedValue({ user: { id: selfId } });
+
+                    const req = new Request(`http://localhost/api/programs/${shopifyProgramId}/request-payment-plan`, {
+                        method: 'POST',
+                        headers: { cookie: 'session=test' },
+                        body: JSON.stringify({ participantId: selfId }),
+                    }) as unknown as import('next/server').NextRequest;
+                    const res = await RequestPost(req, params(shopifyProgramId));
+                    expect(res.status).toBe(200);
+                    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory'));
+                } finally {
+                    logSpy.mockRestore();
+                    process.env.CHECKIN_ENV = prevCheckinEnv;
+                }
+            });
+        });
+    });
+
+    describe('POST /api/finance-ops/payment-plans/refuse', () => {
+        // Cookie header: harmless when CHECKIN_ENV isn't 'local', and required for
+        // the tests below that DO flip it to 'local' — see the comment on the
+        // approve-endpoint's Shopify test above for why (keyless-kiosk fallback).
+        const refuseReq = (body: unknown) => new Request('http://localhost/api/finance-ops/payment-plans/refuse', {
+            method: 'POST',
+            headers: { cookie: 'session=test' },
+            body: JSON.stringify(body),
+        }) as unknown as import('next/server').NextRequest;
+
+        it('401 without a session', async () => {
+            mockSession.mockResolvedValue(null);
+            const res = await RefusePost(refuseReq({ programId, participantId: selfId }));
+            expect(res.status).toBe(401);
+        });
+
+        it('403 for a non-board user', async () => {
+            mockSession.mockResolvedValue({ user: { id: selfId } });
+            const res = await RefusePost(refuseReq({ programId, participantId: selfId }));
+            expect(res.status).toBe(403);
+        });
+
+        it('409 when there is no pending payment-plan request', async () => {
+            await enroll(otherId, { requested: false });
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            const res = await RefusePost(refuseReq({ programId, participantId: otherId }));
+            expect(res.status).toBe(409);
+        });
+
+        it("refuses to refuse a plan for the board member's OWN household (conflict of interest)", async () => {
+            await enroll(boardKinId, { requested: true });
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            const res = await RefusePost(refuseReq({ programId, participantId: boardKinId }));
+            expect(res.status).toBe(403);
+
+            const row = await prisma.programParticipant.findUnique({
+                where: { programId_personId: { programId, personId: boardKinId } },
+            });
+            expect(row?.isPaymentPlanRequested).toBe(true); // unchanged
+        });
+
+        it('refuses a pending request: clears the flag, audit-logs, and adds the seat back (+1)', async () => {
+            const prevCheckinEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local';
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            const shopifyProgram = await prisma.program.create({
+                data: { name: `PP Refuse Shopify Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyVariantId: 'dev-mock-variant-refuse-pp' },
+            });
+            try {
+                await prisma.programParticipant.upsert({
+                    where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
+                    update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
+                    create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
+                });
+                mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+                const res = await RefusePost(refuseReq({ programId: shopifyProgram.id, participantId: selfId }));
+                expect(res.status).toBe(200);
+                const data = await res.json();
+                expect(data.warning).toBeUndefined();
+
+                const row = await prisma.programParticipant.findUnique({
+                    where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
+                });
+                expect(row?.isPaymentPlanRequested).toBe(false);
+                expect(row?.status).toBe('PENDING'); // still holds the enrollment — known open policy question
+
+                const audit = await prisma.auditLog.findFirst({
+                    where: { actorId: boardId, tableName: 'ProgramParticipant', affectedEntityId: selfId, secondaryAffectedEntity: shopifyProgram.id, action: 'EDIT' },
+                });
+                expect(audit).not.toBeNull();
+
+                expect(logSpy).toHaveBeenCalledWith(
+                    expect.stringContaining('Would adjust inventory by 1 for variants: dev-mock-variant-refuse-pp'),
+                );
+
+                // Double-refuse: the second call finds isPaymentPlanRequested already
+                // false -> 409, no second +1.
+                logSpy.mockClear();
+                const second = await RefusePost(refuseReq({ programId: shopifyProgram.id, participantId: selfId }));
+                expect(second.status).toBe(409);
+                expect(logSpy).not.toHaveBeenCalled();
+            } finally {
+                logSpy.mockRestore();
+                process.env.CHECKIN_ENV = prevCheckinEnv;
+                await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
+                await prisma.program.delete({ where: { id: shopifyProgram.id } });
+            }
+        });
+
+        it('re-application after a refusal fires -1 again', async () => {
+            const prevCheckinEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local';
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            const shopifyProgram = await prisma.program.create({
+                data: { name: `PP Reapply Shopify Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyVariantId: 'dev-mock-variant-reapply-pp' },
+            });
+            const reqParams = (id: string | number) => ({ params: Promise.resolve({ id: String(id) }) });
+            try {
+                await prisma.programParticipant.upsert({
+                    where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
+                    update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
+                    create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
+                });
+
+                // Refuse -> +1.
+                mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+                const refuseRes = await RefusePost(refuseReq({ programId: shopifyProgram.id, participantId: selfId }));
+                expect(refuseRes.status).toBe(200);
+                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by 1'));
+
+                // Re-apply -> fresh false->true transition -> -1 again.
+                logSpy.mockClear();
+                mockSession.mockResolvedValue({ user: { id: selfId } });
+                const reapplyRes = await RequestPost(
+                    new Request(`http://localhost/api/programs/${shopifyProgram.id}/request-payment-plan`, {
+                        method: 'POST',
+                        headers: { cookie: 'session=test' },
+                        body: JSON.stringify({ participantId: selfId }),
+                    }) as unknown as import('next/server').NextRequest,
+                    reqParams(shopifyProgram.id),
+                );
+                expect(reapplyRes.status).toBe(200);
+                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by -1'));
+            } finally {
+                logSpy.mockRestore();
+                process.env.CHECKIN_ENV = prevCheckinEnv;
+                await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
+                await prisma.program.delete({ where: { id: shopifyProgram.id } });
+            }
         });
     });
 

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -214,6 +214,70 @@ describe('Program payment-plan routes', () => {
             expect(row?.status).toBe('ACTIVE');
             expect(row?.isPaymentPlanRequested).toBe(false);
             expect(row?.pendingSince).toBeNull();
+
+            // No Shopify variant on this program — capacity propagation never engages.
+            const data = await res.json();
+            expect(data.warning).toBeUndefined();
+        });
+
+        // Shopify is the source of truth for program capacity (product decision
+        // 2026-07-06, extended): an approved scholarship/payment-plan seat consumes
+        // real capacity exactly like a paid one, so approval must decrement Shopify
+        // too. Runs against the CHECKIN_ENV=local mock (config.shopifyMockActive),
+        // same pattern as programSyncShopifyAPI.integration.test.ts.
+        it('decrements both Shopify variant pools by 1 on approval when the program has variants configured', async () => {
+            const prevCheckinEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local';
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            try {
+                const shopifyProgram = await prisma.program.create({
+                    data: {
+                        name: `PP Shopify Program ${TAG}`,
+                        leadMentorId: mentorId,
+                        enrollmentStatus: 'OPEN',
+                        shopifyOrgMemberVariantId: 'dev-mock-variant-member-pp',
+                        shopifyNonOrgMemberVariantId: 'dev-mock-variant-nonmember-pp',
+                    },
+                });
+                try {
+                    await prisma.programParticipant.upsert({
+                        where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
+                        update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
+                        create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
+                    });
+                    mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+                    // A cookie header is required: CHECKIN_ENV=local (for the Shopify mock)
+                    // also arms the keyless-kiosk fallback in authenticateRequest, which
+                    // hijacks any cookie-less request as `kiosk` -> 403 before the
+                    // session/role gate runs.
+                    const res = await PlansPost(nextReq('http://localhost', {
+                        method: 'POST',
+                        headers: { cookie: 'session=test' },
+                        body: JSON.stringify({ programId: shopifyProgram.id, participantId: selfId }),
+                    }));
+                    expect(res.status).toBe(200);
+                    const data = await res.json();
+                    expect(data.warning).toBeUndefined(); // mock no-ops successfully
+
+                    const row = await prisma.programParticipant.findUnique({
+                        where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
+                    });
+                    expect(row?.status).toBe('ACTIVE');
+
+                    // Confirms BOTH pools were targeted with delta -1, not just that the
+                    // call succeeded — the mock logs the resolved variant id list.
+                    expect(logSpy).toHaveBeenCalledWith(
+                        expect.stringContaining('Would adjust inventory by -1 for variants: dev-mock-variant-member-pp, dev-mock-variant-nonmember-pp'),
+                    );
+                } finally {
+                    await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
+                    await prisma.program.delete({ where: { id: shopifyProgram.id } });
+                }
+            } finally {
+                logSpy.mockRestore();
+                process.env.CHECKIN_ENV = prevCheckinEnv;
+            }
         });
 
         it('stamps wasOrgMemberAtApproval=true approving a participant from an ACTIVE-membership household', async () => {

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -14,7 +14,7 @@
 import { GET as PlansGet, POST as PlansPost } from '@/app/api/finance-ops/payment-plans/route';
 import { POST as RefusePost } from '@/app/api/finance-ops/payment-plans/refuse/route';
 import { POST as RequestPost } from '@/app/api/programs/[id]/request-payment-plan/route';
-import { POST as ParticipantsPost } from '@/app/api/programs/[id]/participants/route';
+import { POST as ParticipantsPost, DELETE as ParticipantsDelete } from '@/app/api/programs/[id]/participants/route';
 import prisma from '@/lib/prisma';
 
 jest.mock('next-auth/next', () => ({
@@ -221,13 +221,14 @@ describe('Program payment-plan routes', () => {
             expect(data.warning).toBeUndefined();
         });
 
-        // Scholarship lifecycle drives inventory (product decision 2026-07-06):
-        // the seat is decremented at APPLICATION time (request-payment-plan), NOT
-        // at approval — approval only stops billing the applicant. This supersedes
-        // the earlier approve-time decrement (see PR history for the two-pool
-        // mirror model this replaced). Proven here by NO fetch firing even though
+        // Hold-ledger (product decision 2026-07-06): the seat is decremented at
+        // APPLICATION time (request-payment-plan), NOT at approval — approval
+        // only stops billing the applicant and CONSUMES the hold (clears
+        // inventoryHeldAt with no +1), so a later removal of this now-ACTIVE
+        // comped participant must not release a seat that was never given back
+        // to Shopify. Proven here by NO fetch firing at either step even though
         // the program has a variant configured.
-        it('does NOT touch Shopify on approval, even when the program has a variant configured', async () => {
+        it('does NOT touch Shopify on approval (hold consumed, not released), and a later removal fires no +1', async () => {
             const fetchSpy = jest.spyOn(global, 'fetch');
             const shopifyProgram = await prisma.program.create({
                 data: {
@@ -240,8 +241,8 @@ describe('Program payment-plan routes', () => {
             try {
                 await prisma.programParticipant.upsert({
                     where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
-                    update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
-                    create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
+                    update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date(), inventoryHeldAt: new Date() },
+                    create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date(), inventoryHeldAt: new Date() },
                 });
                 mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
 
@@ -257,6 +258,21 @@ describe('Program payment-plan routes', () => {
                     where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
                 });
                 expect(row?.status).toBe('ACTIVE');
+                expect(row?.inventoryHeldAt).toBeNull(); // hold consumed
+                expect(fetchSpy).not.toHaveBeenCalled();
+
+                // Later removal of the now-ACTIVE comped participant: no hold left
+                // to release, so no +1 fires.
+                mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+                const delRes = await ParticipantsDelete(
+                    new Request(`http://localhost/api/programs/${shopifyProgram.id}/participants`, {
+                        method: 'DELETE',
+                        body: JSON.stringify({ participantId: selfId }),
+                    }) as unknown as import('next/server').NextRequest,
+                    { params: Promise.resolve({ id: String(shopifyProgram.id) }) },
+                );
+                expect(delRes.status).toBe(200);
+                expect((await delRes.json()).warning).toBeUndefined();
                 expect(fetchSpy).not.toHaveBeenCalled();
             } finally {
                 fetchSpy.mockRestore();
@@ -512,56 +528,52 @@ describe('Program payment-plan routes', () => {
             expect(row?.isPaymentPlanRequested).toBe(true); // unchanged
         });
 
-        it('refuses a pending request: clears the flag, audit-logs, and adds the seat back (+1)', async () => {
-            const prevCheckinEnv = process.env.CHECKIN_ENV;
-            process.env.CHECKIN_ENV = 'local';
-            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        it('denies a pending request: no Shopify op, hold persists, denial stamped', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch');
             const shopifyProgram = await prisma.program.create({
                 data: { name: `PP Refuse Shopify Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyVariantId: 'dev-mock-variant-refuse-pp' },
             });
             try {
+                // inventoryHeldAt set, as APPLICATION would have stamped it.
                 await prisma.programParticipant.upsert({
                     where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
-                    update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
-                    create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
+                    update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date(), inventoryHeldAt: new Date() },
+                    create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date(), inventoryHeldAt: new Date() },
                 });
                 mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
 
                 const res = await RefusePost(refuseReq({ programId: shopifyProgram.id, participantId: selfId }));
                 expect(res.status).toBe(200);
-                const data = await res.json();
-                expect(data.warning).toBeUndefined();
+                expect((await res.json()).warning).toBeUndefined();
 
                 const row = await prisma.programParticipant.findUnique({
                     where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
                 });
                 expect(row?.isPaymentPlanRequested).toBe(false);
-                expect(row?.status).toBe('PENDING'); // still holds the enrollment — known open policy question
+                expect(row?.status).toBe('PENDING'); // still holds the enrollment
+                expect(row?.inventoryHeldAt).not.toBeNull(); // hold persists — no +1
+                expect(row?.paymentPlanDeniedAt).not.toBeNull(); // denial stamped
 
                 const audit = await prisma.auditLog.findFirst({
                     where: { actorId: boardId, tableName: 'ProgramParticipant', affectedEntityId: selfId, secondaryAffectedEntity: shopifyProgram.id, action: 'EDIT' },
                 });
                 expect(audit).not.toBeNull();
 
-                expect(logSpy).toHaveBeenCalledWith(
-                    expect.stringContaining('Would adjust inventory by 1 for variants: dev-mock-variant-refuse-pp'),
-                );
+                expect(fetchSpy).not.toHaveBeenCalled(); // no Shopify op at all — this supersedes the earlier deny-time +1
 
-                // Double-refuse: the second call finds isPaymentPlanRequested already
-                // false -> 409, no second +1.
-                logSpy.mockClear();
+                // Double-refuse: the second call finds isPaymentPlanRequested
+                // already false -> 409, no-op.
                 const second = await RefusePost(refuseReq({ programId: shopifyProgram.id, participantId: selfId }));
                 expect(second.status).toBe(409);
-                expect(logSpy).not.toHaveBeenCalled();
+                expect(fetchSpy).not.toHaveBeenCalled();
             } finally {
-                logSpy.mockRestore();
-                process.env.CHECKIN_ENV = prevCheckinEnv;
+                fetchSpy.mockRestore();
                 await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
                 await prisma.program.delete({ where: { id: shopifyProgram.id } });
             }
         });
 
-        it('re-application after a refusal fires -1 again', async () => {
+        it('re-applies while holding after a denial: no second -1, denial stamp clears', async () => {
             const prevCheckinEnv = process.env.CHECKIN_ENV;
             process.env.CHECKIN_ENV = 'local';
             const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -572,17 +584,25 @@ describe('Program payment-plan routes', () => {
             try {
                 await prisma.programParticipant.upsert({
                     where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
-                    update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
-                    create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date() },
+                    update: { status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date(), inventoryHeldAt: new Date() },
+                    create: { programId: shopifyProgram.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: true, pendingSince: new Date(), inventoryHeldAt: new Date() },
                 });
 
-                // Refuse -> +1.
+                // Deny -> no Shopify op, hold persists, deniedAt stamped.
                 mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
                 const refuseRes = await RefusePost(refuseReq({ programId: shopifyProgram.id, participantId: selfId }));
                 expect(refuseRes.status).toBe(200);
-                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by 1'));
+                expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory'));
 
-                // Re-apply -> fresh false->true transition -> -1 again.
+                let row = await prisma.programParticipant.findUnique({
+                    where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
+                });
+                expect(row?.inventoryHeldAt).not.toBeNull();
+                expect(row?.paymentPlanDeniedAt).not.toBeNull();
+
+                // Re-apply while still holding -> flips the request flag + clears the
+                // denial stamp, but does NOT fire a second -1 (inventoryHeldAt was
+                // already set, so the apply-time guard's branch-1 never runs).
                 logSpy.mockClear();
                 mockSession.mockResolvedValue({ user: { id: selfId } });
                 const reapplyRes = await RequestPost(
@@ -594,7 +614,14 @@ describe('Program payment-plan routes', () => {
                     reqParams(shopifyProgram.id),
                 );
                 expect(reapplyRes.status).toBe(200);
-                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by -1'));
+                expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory'));
+
+                row = await prisma.programParticipant.findUnique({
+                    where: { programId_personId: { programId: shopifyProgram.id, personId: selfId } },
+                });
+                expect(row?.isPaymentPlanRequested).toBe(true);
+                expect(row?.paymentPlanDeniedAt).toBeNull(); // denial stamp cleared
+                expect(row?.inventoryHeldAt).not.toBeNull(); // still held throughout
             } finally {
                 logSpy.mockRestore();
                 process.env.CHECKIN_ENV = prevCheckinEnv;

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -701,4 +701,75 @@ describe('Program payment-plan routes', () => {
             }
         });
     });
+
+    // Scholarship state is board/finance-confidential: a program's volunteer lead
+    // mentor must neither initiate a request nor read the hardship fields
+    // (paymentPlanDeniedAt / inventoryHeldAt) off any response; and a failed
+    // Shopify -1 must not leave a phantom hold behind.
+    describe('confidentiality + failed-hold rollback', () => {
+        const params = (id: string | number) => ({ params: Promise.resolve({ id: String(id) }) });
+
+        it('403 when the program lead mentor requests a payment plan for a participant', async () => {
+            await enroll(otherId, { requested: false });
+            mockSession.mockResolvedValue({ user: { id: mentorId } });
+            const res = await RequestPost(requestReq({ participantId: otherId }), params(programId));
+            expect(res.status).toBe(403);
+        });
+
+        it('request and DELETE responses carry no raw participant row (no hardship fields)', async () => {
+            await enroll(selfId, { requested: false });
+            mockSession.mockResolvedValue({ user: { id: selfId } });
+
+            const reqRes = await RequestPost(requestReq({ participantId: selfId }), params(programId));
+            expect(reqRes.status).toBe(200);
+            const reqBody = await reqRes.json();
+            expect(reqBody.success).toBe(true);
+            expect(reqBody.participant).toBeUndefined();
+
+            const delRes = await ParticipantsDelete(
+                new Request(`http://localhost/api/programs/${programId}/participants`, {
+                    method: 'DELETE',
+                    body: JSON.stringify({ participantId: selfId }),
+                }) as unknown as import('next/server').NextRequest,
+                params(programId),
+            );
+            expect(delRes.status).toBe(200);
+            const delBody = await delRes.json();
+            expect(delBody.success).toBe(true);
+            expect(delBody.enrollment).toBeUndefined();
+        });
+
+        it('rolls the hold back when the Shopify -1 fails (no phantom hold)', async () => {
+            // Default env: shopifyMockActive() is false and no credentials are
+            // configured, so adjustProgramInventory returns false without throwing.
+            const p = await prisma.program.create({
+                data: { name: `PP Rollback Shopify Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyVariantId: 'dev-mock-variant-rollback-pp' },
+            });
+            try {
+                await prisma.programParticipant.create({
+                    data: { programId: p.id, personId: selfId, status: 'PENDING', isPaymentPlanRequested: false, pendingSince: new Date() },
+                });
+                mockSession.mockResolvedValue({ user: { id: selfId } });
+
+                const res = await RequestPost(
+                    new Request(`http://localhost/api/programs/${p.id}/request-payment-plan`, {
+                        method: 'POST',
+                        body: JSON.stringify({ participantId: selfId }),
+                    }) as unknown as import('next/server').NextRequest,
+                    params(p.id),
+                );
+                expect(res.status).toBe(200);
+                expect((await res.json()).warning).toMatch(/rolled back/);
+
+                const row = await prisma.programParticipant.findUniqueOrThrow({
+                    where: { programId_personId: { programId: p.id, personId: selfId } },
+                });
+                expect(row.inventoryHeldAt).toBeNull(); // no phantom hold
+                expect(row.isPaymentPlanRequested).toBe(true); // finance request still stands
+            } finally {
+                await prisma.programParticipant.deleteMany({ where: { programId: p.id } });
+                await prisma.program.delete({ where: { id: p.id } });
+            }
+        });
+    });
 });

--- a/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
@@ -26,6 +26,7 @@ jest.mock('@/lib/notifications', () => ({
 // Avoid hitting the real Shopify API; the route tolerates a null result.
 jest.mock('@/lib/shopify', () => ({
     createShopifyProgramVariants: jest.fn().mockResolvedValue(null),
+    createShopifySingleVariantProgram: jest.fn().mockResolvedValue(null),
 }));
 
 const PROGRAM_NAME_TAG = 'Price RoundTrip Test Program';

--- a/checkin-app/src/app/__tests__/programSyncShopifyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programSyncShopifyAPI.integration.test.ts
@@ -3,21 +3,28 @@
  */
 /**
  * Integration tests for POST /api/programs/[id]/sync-shopify — the checkout
- * repair path that mints Shopify variants for a program that was priced AFTER
+ * repair path that mints Shopify variant(s) for a program that was priced AFTER
  * creation (PATCH never mints variants, so it sits checkout-broken). This was
  * the one fully-built-but-untested route in the program domain; webhookShopify
  * covers inbound MEMBERSHIP webhooks, not this outbound program-category sync.
  *
+ * Single-pool transition (product decision 2026-07-06): a program with NO
+ * legacy variant configured repairs onto the NEW single-variant model
+ * (shopifyVariantId); a program already carrying one legacy variant repairs
+ * via the LEGACY two-variant path (createShopifyProgramVariants), keeping the
+ * matching set — see the route's own comment for why.
+ *
  * Runs against the CHECKIN_ENV=local Shopify mock (config.shopifyMockActive) so
- * createShopifyProgramVariants returns synthetic dev-mock ids instead of hitting
- * the real Admin API — same explicit env gate PR #888 established.
+ * createShopifySingleVariantProgram/createShopifyProgramVariants return
+ * synthetic dev-mock ids instead of hitting the real Admin API — same explicit
+ * env gate PR #888 established.
  *
  * NOTE (Q13): this route has NO empty/mis-categorized-category detection. An
- * IntegrationErrorLog row is written only inside createShopifyProgramVariants'
- * catch on a REAL Shopify API failure, which the mock branch never reaches; the
- * route's own catch writes a BackendErrorLog (logBackendError), not an
- * IntegrationErrorLog. So the "empty-category warning surface" is a separate,
- * unbuilt feature — the success-path assertion below pins that no
+ * IntegrationErrorLog row is written only inside the shopify.ts creation
+ * functions' catch on a REAL Shopify API failure, which the mock branch never
+ * reaches; the route's own catch writes a BackendErrorLog (logBackendError),
+ * not an IntegrationErrorLog. So the "empty-category warning surface" is a
+ * separate, unbuilt feature — the success-path assertion below pins that no
  * IntegrationErrorLog is emitted here today.
  */
 import { POST } from '@/app/api/programs/[id]/sync-shopify/route';
@@ -94,9 +101,9 @@ describe('POST /api/programs/[id]/sync-shopify', () => {
         expect(after?.shopifyProductId).toBeNull();
     });
 
-    it('upserts Shopify product + variants and persists the ids on the program', async () => {
+    it('repairs onto the single-pool model: mints ONE variant and persists shopifyVariantId', async () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
-        const program = await makeBrokenProgram();
+        const program = await makeBrokenProgram(); // no legacy variant set -> new-model repair
         const errLogsBefore = await prisma.integrationErrorLog.count({ where: { source: 'shopify' } });
 
         const res = await POST(req(), params(program.id));
@@ -104,15 +111,16 @@ describe('POST /api/programs/[id]/sync-shopify', () => {
 
         const data = await res.json();
         expect(data.success).toBe(true);
-        // Success contract: a product id + a variant id per priced tier, echoed back...
+        // Success contract: a product id + ONE variant id (single pool), echoed back...
         expect(data.program.shopifyProductId).toMatch(/^dev-mock-product-/);
-        expect(data.program.shopifyOrgMemberVariantId).toMatch(/^dev-mock-variant-member-/);
-        expect(data.program.shopifyNonOrgMemberVariantId).toMatch(/^dev-mock-variant-nonmember-/);
+        expect(data.program.shopifyVariantId).toMatch(/^dev-mock-variant-/);
+        expect(data.program.shopifyOrgMemberVariantId).toBeNull();
+        expect(data.program.shopifyNonOrgMemberVariantId).toBeNull();
 
         // ...and PERSISTED — this is what fails if the route stops upserting.
         const persisted = await prisma.program.findUnique({ where: { id: program.id } });
         expect(persisted?.shopifyProductId).toBe(data.program.shopifyProductId);
-        expect(persisted?.shopifyOrgMemberVariantId).toBe(data.program.shopifyOrgMemberVariantId);
+        expect(persisted?.shopifyVariantId).toBe(data.program.shopifyVariantId);
 
         // Audit trail written.
         const audit = await prisma.auditLog.findFirst({
@@ -124,6 +132,32 @@ describe('POST /api/programs/[id]/sync-shopify', () => {
         // IntegrationErrorLog is emitted. Pins current behavior (see file header).
         const errLogsAfter = await prisma.integrationErrorLog.count({ where: { source: 'shopify' } });
         expect(errLogsAfter).toBe(errLogsBefore);
+    });
+
+    it('repairs a program already on the LEGACY model (one variant set) via the two-variant path', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+        // Already has ONE legacy variant (partial legacy state) -> still checkout-broken
+        // (the non-org tier has no variant) -> repairs via createShopifyProgramVariants,
+        // not the single-pool path.
+        const program = await prisma.program.create({
+            data: {
+                name: `Legacy Broken Prog ${TAG} ${Math.round(performance.now())}`,
+                phase: 'RUNNING',
+                orgMemberPriceCents: 5000,
+                nonOrgMemberPriceCents: 7500,
+                shopifyProductId: 'dev-mock-product-existing-legacy',
+                shopifyOrgMemberVariantId: 'dev-mock-variant-member-existing-legacy',
+            },
+        });
+
+        const res = await POST(req(), params(program.id));
+        expect(res.status).toBe(200);
+
+        const data = await res.json();
+        expect(data.success).toBe(true);
+        expect(data.program.shopifyVariantId).toBeNull();
+        expect(data.program.shopifyOrgMemberVariantId).toMatch(/^dev-mock-variant-member-/);
+        expect(data.program.shopifyNonOrgMemberVariantId).toMatch(/^dev-mock-variant-nonmember-/);
     });
 
     it('refuses a program whose checkout is already configured (400)', async () => {

--- a/checkin-app/src/app/__tests__/programVariantRoundtripShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programVariantRoundtripShopify.integration.test.ts
@@ -9,16 +9,21 @@
  *   - webhookShopify.integration.test.ts seeds a HAND-WRITTEN literal variant id
  *     directly on the Program row, then proves the webhook matches it.
  *   - programSyncShopifyAPI.integration.test.ts (and shopify.test.ts) prove
- *     createShopifyProgramVariants mints + persists synthetic mock ids.
+ *     createShopifySingleVariantProgram mints + persists synthetic mock ids.
  * Neither proves the id MINTED by POST /api/programs is the SAME id the
  * webhook later matches against — this test drives both halves back-to-back:
  * create (mock active) -> assert persisted ids -> sign a webhook payload
  * carrying THOSE EXACT ids -> assert the real inbound handler flips the
  * PENDING participant ACTIVE.
  *
+ * Single-pool model (product decision 2026-07-06): program creation now mints
+ * ONE variant (shopifyVariantId), not the legacy org/non-org pair — this test
+ * was rewritten from the two-variant version it originally covered (see PR
+ * body for the design change) to prove the new-model round-trip instead.
+ *
  * Also covers the sibling branch: mock inactive + creds absent ->
- * createShopifyProgramVariants returns null -> the route falls back to its
- * `warning` response instead of persisting variants.
+ * createShopifySingleVariantProgram returns null -> the route falls back to
+ * its `warning` response instead of persisting a variant.
  */
 import crypto from 'crypto';
 import { POST as programsPOST } from '@/app/api/programs/route';
@@ -103,7 +108,7 @@ describe('Shopify variant round-trip: create -> persist -> webhook match', () =>
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
     });
 
-    it('mints + persists synthetic variant ids on create, then a webhook carrying those exact ids activates the PENDING participant', async () => {
+    it('mints + persists a synthetic single-pool variant id on create, then a webhook carrying that exact id activates the PENDING participant', async () => {
         const res = await programsPOST(programsReq({
             name: `Roundtrip Program ${TAG}`,
             leadMentorId: leadId,
@@ -116,14 +121,15 @@ describe('Shopify variant round-trip: create -> persist -> webhook match', () =>
         expect(data.warning).toBeUndefined();
         programIds.push(data.program.id);
 
-        // Synthetic mock ids, not a real Shopify product/variant.
-        expect(data.program.shopifyOrgMemberVariantId).toMatch(/^dev-mock-variant-member-/);
-        expect(data.program.shopifyNonOrgMemberVariantId).toMatch(/^dev-mock-variant-nonmember-/);
+        // Synthetic mock id, not a real Shopify product/variant. Single pool: no
+        // legacy org/non-org pair minted for a new program.
+        expect(data.program.shopifyVariantId).toMatch(/^dev-mock-variant-/);
+        expect(data.program.shopifyOrgMemberVariantId).toBeNull();
+        expect(data.program.shopifyNonOrgMemberVariantId).toBeNull();
 
         // Actually PERSISTED, not just echoed in the response.
         const persisted = await prisma.program.findUnique({ where: { id: data.program.id } });
-        expect(persisted?.shopifyOrgMemberVariantId).toBe(data.program.shopifyOrgMemberVariantId);
-        expect(persisted?.shopifyNonOrgMemberVariantId).toBe(data.program.shopifyNonOrgMemberVariantId);
+        expect(persisted?.shopifyVariantId).toBe(data.program.shopifyVariantId);
 
         // Enroll the participant the normal PENDING-awaiting-payment way (what the
         // real enroll flow does before checkout; not the part under test here).
@@ -132,11 +138,12 @@ describe('Shopify variant round-trip: create -> persist -> webhook match', () =>
         });
 
         // A real paid order carries the variant id its checkout link was built
-        // from — here, THE EXACT id createShopifyProgramVariants minted above, not
-        // a hand-seeded literal (the gap every other Shopify test leaves open).
+        // from — here, THE EXACT id createShopifySingleVariantProgram minted
+        // above, not a hand-seeded literal (the gap every other Shopify test
+        // leaves open).
         const orderBody = JSON.stringify({
             id: `roundtrip-order-${data.program.id}`,
-            line_items: [{ variant_id: data.program.shopifyOrgMemberVariantId }],
+            line_items: [{ variant_id: data.program.shopifyVariantId }],
             note_attributes: [
                 { name: 'CheckMeIn_Account_ID', value: String(participantId) },
                 { name: 'Program_ID', value: String(data.program.id) },
@@ -152,7 +159,7 @@ describe('Shopify variant round-trip: create -> persist -> webhook match', () =>
         expect(participantRow?.pendingSince).toBeNull();
     });
 
-    it('falls back to the `warning` response when Shopify is unconfigured and the mock is inactive (no variants persisted)', async () => {
+    it('falls back to the `warning` response when Shopify is unconfigured and the mock is inactive (no variant persisted)', async () => {
         const prevEnv = process.env.CHECKIN_ENV;
         process.env.CHECKIN_ENV = 'dev'; // mock inactive; SHOPIFY_* creds already absent for the whole suite
         try {
@@ -168,11 +175,10 @@ describe('Shopify variant round-trip: create -> persist -> webhook match', () =>
             programIds.push(data.program.id);
             expect(data.warning).toMatch(/Shopify integration failed or is not configured/);
             expect(data.program.shopifyProductId).toBeNull();
-            expect(data.program.shopifyOrgMemberVariantId).toBeNull();
-            expect(data.program.shopifyNonOrgMemberVariantId).toBeNull();
+            expect(data.program.shopifyVariantId).toBeNull();
 
             const persisted = await prisma.program.findUnique({ where: { id: data.program.id } });
-            expect(persisted?.shopifyOrgMemberVariantId).toBeNull();
+            expect(persisted?.shopifyVariantId).toBeNull();
         } finally {
             process.env.CHECKIN_ENV = prevEnv;
         }

--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -321,9 +321,11 @@ describe('Individual Program API Integration Tests', () => {
              });
              const res = await PATCH(req as unknown as import("next/server").NextRequest, createParams(publicProgramId) as unknown as never);
              expect(res.status).toBe(200);
-             
+
              const data = await res.json();
              expect(data.program.maxParticipants).toBe(50);
+             // No Shopify variant on this program — capacity propagation never engages.
+             expect(data.warning).toBeUndefined();
         });
 
         it('should allow admins to update a program', async () => {
@@ -358,6 +360,102 @@ describe('Individual Program API Integration Tests', () => {
              const after = await prisma.program.findUnique({ where: { id: publicProgramId } });
              expect(after?.name).toBe(before?.name);
              expect(after?.name).not.toBe('Denied Hack');
+        });
+    });
+
+    // Shopify is the source of truth for program capacity (product decision
+    // 2026-07-06): a maxParticipants edit on a program with a Shopify variant
+    // propagates as a relative inventory adjustment. Runs against the
+    // CHECKIN_ENV=local mock (config.shopifyMockActive), same as
+    // programSyncShopifyAPI.integration.test.ts, so no real Admin API calls happen.
+    describe('PATCH /api/programs/[id] — Shopify capacity propagation', () => {
+        let prevCheckinEnv: string | undefined;
+        let cappedProgramId: number;
+        let uncappedProgramId: number;
+
+        beforeAll(async () => {
+            prevCheckinEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local';
+
+            const capped = await prisma.program.create({
+                data: {
+                    name: 'Prog ID API Test Shopify Capacity',
+                    phase: 'RUNNING',
+                    leadMentorId: leadId,
+                    orgMemberPriceCents: 5000,
+                    maxParticipants: 20,
+                    shopifyOrgMemberVariantId: 'dev-mock-variant-member-capacity',
+                },
+            });
+            cappedProgramId = capped.id;
+
+            const uncapped = await prisma.program.create({
+                data: {
+                    name: 'Prog ID API Test Shopify Uncapped',
+                    phase: 'RUNNING',
+                    leadMentorId: leadId,
+                    orgMemberPriceCents: 5000,
+                    maxParticipants: null,
+                    shopifyOrgMemberVariantId: 'dev-mock-variant-member-uncapped',
+                },
+            });
+            uncappedProgramId = uncapped.id;
+        });
+
+        afterAll(async () => {
+            process.env.CHECKIN_ENV = prevCheckinEnv;
+            await prisma.program.deleteMany({ where: { id: { in: [cappedProgramId, uncappedProgramId] } } });
+        });
+
+        it('returns 200 with no warning when the mock adjusts inventory for a maxParticipants change', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+            // A cookie header is required: CHECKIN_ENV=local (for the Shopify mock) also
+            // arms the keyless-kiosk fallback in authenticateRequest, which hijacks any
+            // cookie-less request as `kiosk` -> 403 before the session/role gate runs.
+            const req = new Request(`http://localhost:4000/api/programs/${cappedProgramId}`, {
+                method: 'PATCH',
+                headers: { cookie: 'session=test' },
+                body: JSON.stringify({ maxParticipants: 25 }),
+            });
+            const res = await PATCH(req as unknown as import("next/server").NextRequest, createParams(cappedProgramId) as unknown as never);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.program.maxParticipants).toBe(25);
+            expect(data.warning).toBeUndefined();
+        });
+
+        it('returns 200 with a warning transitioning capped -> uncapped (inventory not auto-adjusted)', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+            const req = new Request(`http://localhost:4000/api/programs/${cappedProgramId}`, {
+                method: 'PATCH',
+                headers: { cookie: 'session=test' },
+                body: JSON.stringify({ maxParticipants: null }),
+            });
+            const res = await PATCH(req as unknown as import("next/server").NextRequest, createParams(cappedProgramId) as unknown as never);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.program.maxParticipants).toBeNull();
+            expect(data.warning).toMatch(/capped and uncapped/i);
+        });
+
+        it('returns 200 with a warning transitioning uncapped -> capped (inventory not auto-adjusted)', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+            const req = new Request(`http://localhost:4000/api/programs/${uncappedProgramId}`, {
+                method: 'PATCH',
+                headers: { cookie: 'session=test' },
+                body: JSON.stringify({ maxParticipants: 30 }),
+            });
+            const res = await PATCH(req as unknown as import("next/server").NextRequest, createParams(uncappedProgramId) as unknown as never);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.program.maxParticipants).toBe(30);
+            expect(data.warning).toMatch(/capped and uncapped/i);
         });
     });
 });

--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -402,10 +402,16 @@ describe('Program Participants API Integration Tests', () => {
              });
              const res = await DELETE(req as unknown as import("next/server").NextRequest, createParams(standardProgramId) as unknown as never);
              expect(res.status).toBe(200);
-             
+
              const data = await res.json();
              expect(data.success).toBe(true);
-             expect(data.enrollment.personId).toBe(commonId);
+             // The response must NOT echo the deleted row: it reaches the lead
+             // mentor and carries confidential hardship fields (see #930 review).
+             expect(data.enrollment).toBeUndefined();
+             const row = await prisma.programParticipant.findUnique({
+                 where: { programId_personId: { programId: standardProgramId, personId: commonId } },
+             });
+             expect(row).toBeNull();
         });
         
         it('should allow a common user to drop out of their own program', async () => {

--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -436,5 +436,73 @@ describe('Program Participants API Integration Tests', () => {
              const data = await res.json();
              expect(data.success).toBe(true);
         });
+
+        // Hold-ledger (product decision 2026-07-06): withdrawal is release path
+        // (a) — a denied applicant who withdraws instead of paying gets their
+        // held seat back, exactly once (double-withdraw is the existing
+        // idempotent no-op above, and must not fire a second +1).
+        it('releases a held scholarship seat back to Shopify (+1) on withdrawal, exactly once', async () => {
+            const prevCheckinEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local';
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            const shopifyProgram = await prisma.program.create({
+                data: { name: 'Withdraw Shopify Partic API Test', enrollmentStatus: 'OPEN', shopifyVariantId: 'dev-mock-variant-withdraw-partic' },
+            });
+            try {
+                await prisma.programParticipant.create({
+                    data: {
+                        programId: shopifyProgram.id,
+                        personId: commonId,
+                        status: 'PENDING',
+                        isPaymentPlanRequested: false,
+                        inventoryHeldAt: new Date(),
+                        paymentPlanDeniedAt: new Date(),
+                    },
+                });
+                (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } }); // self-withdraw
+
+                const res = await DELETE(
+                    // CHECKIN_ENV=local arms the keyless-kiosk fallback in
+                    // authenticateRequest, which hijacks any cookie-less request as
+                    // `kiosk` -> 403 before the session/role gate runs — send a cookie.
+                    new Request(`http://localhost:4000/api/programs/${shopifyProgram.id}/participants`, {
+                        method: 'DELETE',
+                        headers: { cookie: 'session=test' },
+                        body: JSON.stringify({ participantId: commonId }),
+                    }) as unknown as import("next/server").NextRequest,
+                    createParams(shopifyProgram.id) as unknown as never,
+                );
+                expect(res.status).toBe(200);
+                expect((await res.json()).warning).toBeUndefined();
+                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by 1 for variants: dev-mock-variant-withdraw-partic'));
+
+                const row = await prisma.programParticipant.findUnique({
+                    where: { programId_personId: { programId: shopifyProgram.id, personId: commonId } },
+                });
+                expect(row).toBeNull();
+
+                // Double-withdraw: idempotent 200 (P2025), no second +1.
+                logSpy.mockClear();
+                const second = await DELETE(
+                    // CHECKIN_ENV=local arms the keyless-kiosk fallback in
+                    // authenticateRequest, which hijacks any cookie-less request as
+                    // `kiosk` -> 403 before the session/role gate runs — send a cookie.
+                    new Request(`http://localhost:4000/api/programs/${shopifyProgram.id}/participants`, {
+                        method: 'DELETE',
+                        headers: { cookie: 'session=test' },
+                        body: JSON.stringify({ participantId: commonId }),
+                    }) as unknown as import("next/server").NextRequest,
+                    createParams(shopifyProgram.id) as unknown as never,
+                );
+                expect(second.status).toBe(200);
+                expect((await second.json()).idempotent).toBe(true);
+                expect(logSpy).not.toHaveBeenCalled();
+            } finally {
+                logSpy.mockRestore();
+                process.env.CHECKIN_ENV = prevCheckinEnv;
+                await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
+                await prisma.program.delete({ where: { id: shopifyProgram.id } });
+            }
+        });
     });
 });

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -340,11 +340,14 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         expect(rows[0].context).toEqual({ operation: 'POST /api/webhooks/shopify' });
     });
 
-    // Interim two-pool mirror model (product decision 2026-07-06, extended): the
-    // org-member/non-member variants each carry their OWN Shopify inventory pool.
-    // Shopify auto-decrements only the pool for the tier actually purchased, so the
-    // webhook mirrors the same drop onto the SIBLING pool after activation.
-    describe('sibling inventory mirror after program activation', () => {
+    // LEGACY-ONLY two-pool mirror (product decision 2026-07-06, single-pool
+    // redesign): the org-member/non-member variants each carry their OWN
+    // Shopify inventory pool. Shopify auto-decrements only the pool for the
+    // tier actually purchased, so the webhook mirrors the same drop onto the
+    // SIBLING pool after activation — but ONLY for programs still on this
+    // legacy model (no shopifyVariantId). See the 'single-pool model' describe
+    // block below for the new-model equivalent (no mirror needed).
+    describe('sibling inventory mirror after program activation (legacy two-variant programs)', () => {
         let siblingProgramId: number;
         let sp1: number;
         let sp2: number;
@@ -449,6 +452,75 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
                 where: { programId_personId: { programId: siblingProgramId, personId: sp1 } },
             });
             expect(row?.status).toBe('ACTIVE');
+        });
+    });
+
+    // Single-pool model (product decision 2026-07-06): shopifyVariantId is
+    // matched alongside the legacy pair (transition), and activation needs NO
+    // mirror call at all — there's exactly one pool, and Shopify already
+    // auto-decremented it on the sale.
+    describe('single-pool model (shopifyVariantId)', () => {
+        let singlePoolProgramId: number;
+        let sgp1: number;
+        let sgh1: number;
+        const SINGLE_VARIANT_ID = '556677';
+
+        beforeAll(async () => {
+            const program = await prisma.program.create({
+                data: { name: `Webhook Single-Pool Test Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyVariantId: SINGLE_VARIANT_ID },
+            });
+            singlePoolProgramId = program.id;
+
+            const a = await prisma.person.create({
+                data: { name: 'Single Pool P1', email: `sgp1-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
+            });
+            sgp1 = a.id;
+            sgh1 = a.householdId;
+        });
+
+        afterAll(async () => {
+            await prisma.programParticipant.deleteMany({ where: { programId: singlePoolProgramId } });
+            await prisma.program.delete({ where: { id: singlePoolProgramId } });
+            await prisma.person.deleteMany({ where: { id: sgp1 } });
+            await prisma.household.deleteMany({ where: { id: sgh1 } });
+        });
+
+        it('activates on a shopifyVariantId match with no mirror call (single pool, no sibling)', async () => {
+            const prevEnv = process.env.CHECKIN_ENV;
+            // Arms config.shopifyMockActive() so a mirror call (if any fired) would
+            // log rather than hit a real API — asserting its ABSENCE below.
+            process.env.CHECKIN_ENV = 'local';
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            try {
+                await prisma.programParticipant.upsert({
+                    where: { programId_personId: { programId: singlePoolProgramId, personId: sgp1 } },
+                    update: { status: 'PENDING', pendingSince: new Date() },
+                    create: { programId: singlePoolProgramId, personId: sgp1, status: 'PENDING', pendingSince: new Date() },
+                });
+                const body = JSON.stringify({
+                    id: 888,
+                    line_items: [{ variant_id: SINGLE_VARIANT_ID }],
+                    note_attributes: [
+                        { name: 'CheckMeIn_Account_ID', value: String(sgp1) },
+                        { name: 'Program_ID', value: String(singlePoolProgramId) },
+                    ],
+                });
+
+                const res = await POST(webhookReq(body, sign(body)));
+                expect(res.status).toBe(200);
+
+                const row = await prisma.programParticipant.findUnique({
+                    where: { programId_personId: { programId: singlePoolProgramId, personId: sgp1 } },
+                });
+                expect(row?.status).toBe('ACTIVE');
+
+                // No mirror/adjust call at all — single pool, Shopify already decremented it.
+                expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory'));
+            } finally {
+                logSpy.mockRestore();
+                if (prevEnv === undefined) delete process.env.CHECKIN_ENV;
+                else process.env.CHECKIN_ENV = prevEnv;
+            }
         });
     });
 });

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -522,5 +522,48 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
                 else process.env.CHECKIN_ENV = prevEnv;
             }
         });
+
+        // Hold-ledger (product decision 2026-07-06): release path (b) — a denied
+        // scholarship applicant who pays anyway (inventoryHeldAt still set from
+        // application time) gets that hold released (+1) to compensate Shopify's
+        // real sale, which just auto-decremented a SECOND unit for the same seat.
+        // Without this, every denied-then-paying applicant leaks a seat.
+        it('activates AND releases the scholarship hold (+1) when a denied applicant pays anyway', async () => {
+            const prevEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local';
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            try {
+                await prisma.programParticipant.upsert({
+                    where: { programId_personId: { programId: singlePoolProgramId, personId: sgp1 } },
+                    update: { status: 'PENDING', pendingSince: new Date(), isPaymentPlanRequested: false, inventoryHeldAt: new Date(), paymentPlanDeniedAt: new Date() },
+                    create: { programId: singlePoolProgramId, personId: sgp1, status: 'PENDING', pendingSince: new Date(), isPaymentPlanRequested: false, inventoryHeldAt: new Date(), paymentPlanDeniedAt: new Date() },
+                });
+                const body = JSON.stringify({
+                    id: 889,
+                    line_items: [{ variant_id: SINGLE_VARIANT_ID }],
+                    note_attributes: [
+                        { name: 'CheckMeIn_Account_ID', value: String(sgp1) },
+                        { name: 'Program_ID', value: String(singlePoolProgramId) },
+                    ],
+                });
+
+                const res = await POST(webhookReq(body, sign(body)));
+                expect(res.status).toBe(200);
+
+                const row = await prisma.programParticipant.findUnique({
+                    where: { programId_personId: { programId: singlePoolProgramId, personId: sgp1 } },
+                });
+                expect(row?.status).toBe('ACTIVE');
+                expect(row?.inventoryHeldAt).toBeNull(); // hold released
+
+                expect(logSpy).toHaveBeenCalledWith(
+                    expect.stringContaining(`Would adjust inventory by 1 for variants: ${SINGLE_VARIANT_ID}`),
+                );
+            } finally {
+                logSpy.mockRestore();
+                if (prevEnv === undefined) delete process.env.CHECKIN_ENV;
+                else process.env.CHECKIN_ENV = prevEnv;
+            }
+        });
     });
 });

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -437,6 +437,31 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
             }
         });
 
+        it('does NOT re-fire the sibling mirror when the same order is redelivered (participant already ACTIVE)', async () => {
+            const prevEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local';
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            try {
+                await setSiblingPending(sp1);
+                const body = siblingPayload(String(sp1), NONORG_VARIANT_ID);
+
+                // First delivery activates and mirrors -1.
+                expect((await POST(webhookReq(body, sign(body)))).status).toBe(200);
+                const mirrorCalls = () => logSpy.mock.calls.filter(c =>
+                    String(c[0]).includes(`Would adjust inventory by -1 for variants: ${ORG_VARIANT_ID}`)).length;
+                expect(mirrorCalls()).toBe(1);
+
+                // Shopify redelivers the identical order (timeout / non-2xx retry):
+                // the participant is already ACTIVE, so no second -1 may fire.
+                expect((await POST(webhookReq(body, sign(body)))).status).toBe(200);
+                expect(mirrorCalls()).toBe(1);
+            } finally {
+                logSpy.mockRestore();
+                if (prevEnv === undefined) delete process.env.CHECKIN_ENV;
+                else process.env.CHECKIN_ENV = prevEnv;
+            }
+        });
+
         it('activates the participant and still returns 200 even when the sibling inventory adjust fails', async () => {
             // Default env here (no CHECKIN_ENV=local, no Shopify creds configured in
             // this suite) — adjustProgramInventory's real "missing credentials" path

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -339,4 +339,116 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         expect(rows[0].message).toBe('handler boom');
         expect(rows[0].context).toEqual({ operation: 'POST /api/webhooks/shopify' });
     });
+
+    // Interim two-pool mirror model (product decision 2026-07-06, extended): the
+    // org-member/non-member variants each carry their OWN Shopify inventory pool.
+    // Shopify auto-decrements only the pool for the tier actually purchased, so the
+    // webhook mirrors the same drop onto the SIBLING pool after activation.
+    describe('sibling inventory mirror after program activation', () => {
+        let siblingProgramId: number;
+        let sp1: number;
+        let sp2: number;
+        let sh1: number;
+        let sh2: number;
+        const ORG_VARIANT_ID = '223344';
+        const NONORG_VARIANT_ID = '112233';
+
+        beforeAll(async () => {
+            const program = await prisma.program.create({
+                data: {
+                    name: `Webhook Sibling Test Program ${TAG}`,
+                    enrollmentStatus: 'OPEN',
+                    shopifyOrgMemberVariantId: ORG_VARIANT_ID,
+                    shopifyNonOrgMemberVariantId: NONORG_VARIANT_ID,
+                },
+            });
+            siblingProgramId = program.id;
+
+            const a = await prisma.person.create({
+                data: { name: 'Sib P1', email: `sib1-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
+            });
+            sp1 = a.id;
+            sh1 = a.householdId;
+            const b = await prisma.person.create({
+                data: { name: 'Sib P2', email: `sib2-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
+            });
+            sp2 = b.id;
+            sh2 = b.householdId;
+        });
+
+        afterAll(async () => {
+            await prisma.programParticipant.deleteMany({ where: { programId: siblingProgramId } });
+            await prisma.program.delete({ where: { id: siblingProgramId } });
+            await prisma.person.deleteMany({ where: { id: { in: [sp1, sp2] } } });
+            await prisma.household.deleteMany({ where: { id: { in: [sh1, sh2] } } });
+        });
+
+        async function setSiblingPending(participantId: number) {
+            await prisma.programParticipant.upsert({
+                where: { programId_personId: { programId: siblingProgramId, personId: participantId } },
+                update: { status: 'PENDING', pendingSince: new Date() },
+                create: { programId: siblingProgramId, personId: participantId, status: 'PENDING', pendingSince: new Date() },
+            });
+        }
+
+        function siblingPayload(accountIds: string, variantId: string) {
+            return JSON.stringify({
+                id: 777,
+                line_items: [{ variant_id: variantId }],
+                note_attributes: [
+                    { name: 'CheckMeIn_Account_ID', value: accountIds },
+                    { name: 'Program_ID', value: String(siblingProgramId) },
+                ],
+            });
+        }
+
+        it('mirrors the purchase onto the SIBLING pool after activating (Shopify already decremented the purchased pool)', async () => {
+            const prevEnv = process.env.CHECKIN_ENV;
+            // Arms config.shopifyMockActive() so adjustProgramInventory no-ops via a
+            // log line we can assert on, instead of a real Admin API call.
+            process.env.CHECKIN_ENV = 'local';
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            try {
+                await setSiblingPending(sp1);
+                await setSiblingPending(sp2);
+                // Buys the NON-member tier for both participants in one order.
+                const body = siblingPayload(`${sp1},${sp2}`, NONORG_VARIANT_ID);
+
+                const res = await POST(webhookReq(body, sign(body)));
+                expect(res.status).toBe(200);
+
+                const rows = await prisma.programParticipant.findMany({
+                    where: { programId: siblingProgramId, personId: { in: [sp1, sp2] } },
+                });
+                expect(rows.every(r => r.status === 'ACTIVE')).toBe(true);
+
+                // Sibling = the ORG-member pool (the tier NOT purchased); delta = -2
+                // (both participants activated by this one order).
+                expect(logSpy).toHaveBeenCalledWith(
+                    expect.stringContaining(`Would adjust inventory by -2 for variants: ${ORG_VARIANT_ID}`),
+                );
+            } finally {
+                logSpy.mockRestore();
+                if (prevEnv === undefined) delete process.env.CHECKIN_ENV;
+                else process.env.CHECKIN_ENV = prevEnv;
+            }
+        });
+
+        it('activates the participant and still returns 200 even when the sibling inventory adjust fails', async () => {
+            // Default env here (no CHECKIN_ENV=local, no Shopify creds configured in
+            // this suite) — adjustProgramInventory's real "missing credentials" path
+            // returns false without throwing. Confirms the webhook never fails over an
+            // inventory call (a non-2xx would make Shopify retry the whole order).
+            await setSiblingPending(sp1);
+            const body = siblingPayload(String(sp1), NONORG_VARIANT_ID);
+
+            const res = await POST(webhookReq(body, sign(body)));
+            expect(res.status).toBe(200);
+
+            const row = await prisma.programParticipant.findUnique({
+                where: { programId_personId: { programId: siblingProgramId, personId: sp1 } },
+            });
+            expect(row?.status).toBe('ACTIVE');
+        });
+    });
 });

--- a/checkin-app/src/app/api/cron/pending-participants/route.ts
+++ b/checkin-app/src/app/api/cron/pending-participants/route.ts
@@ -10,6 +10,11 @@ export const GET = withCron(async () => {
             where: {
                 status: 'PENDING',
                 isPaymentPlanRequested: false,
+                // Denied scholarship applicants are governed by the
+                // scholarship-grace-expiry cron (scholarshipDenialGraceDays),
+                // not this 7-day clock — a denial never resets pendingSince, so
+                // without this exclusion they'd be kicked the night after denial.
+                paymentPlanDeniedAt: null,
                 pendingSince: { not: null }
             },
             include: {
@@ -32,9 +37,10 @@ export const GET = withCron(async () => {
             const warningText = `If not paid, your spot in ${record.program.name} will be freed up. If a payment plan is needed, contact the board via finance@innovationtreehouse.org`;
 
             if (diffDays >= 7) {
-                // Collect for removal below (hold-ledger: a denied scholarship
-                // applicant is isPaymentPlanRequested:false too, so this query can
-                // also catch a still-held seat — see the per-row removal below).
+                // Collect for removal below (denied scholarship applicants are
+                // excluded by the query above; anything caught here is an
+                // ordinary non-payer, though withdrawAndReleaseHold still
+                // handles a held seat correctly if one slips through).
                 toDelete.push(record);
 
                 kickedCount++;

--- a/checkin-app/src/app/api/cron/pending-participants/route.ts
+++ b/checkin-app/src/app/api/cron/pending-participants/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withCron } from "@/lib/cronAuth";
 import prisma from "@/lib/prisma";
+import { withdrawAndReleaseHold } from "@/lib/program/capacity";
 
 export const GET = withCron(async () => {
         const now = new Date();
@@ -19,7 +20,7 @@ export const GET = withCron(async () => {
 
         let kickedCount = 0;
         let warnedCount = 0;
-        const toDelete: { programId: number; personId: number }[] = [];
+        const toDelete: typeof pendingParticipants = [];
 
         for (const record of pendingParticipants) {
             if (!record.pendingSince) continue;
@@ -31,11 +32,10 @@ export const GET = withCron(async () => {
             const warningText = `If not paid, your spot in ${record.program.name} will be freed up. If a payment plan is needed, contact the board via finance@innovationtreehouse.org`;
 
             if (diffDays >= 7) {
-                // Collect IDs for batch deletion
-                toDelete.push({
-                    programId: record.programId,
-                    personId: record.personId
-                });
+                // Collect for removal below (hold-ledger: a denied scholarship
+                // applicant is isPaymentPlanRequested:false too, so this query can
+                // also catch a still-held seat — see the per-row removal below).
+                toDelete.push(record);
 
                 kickedCount++;
 
@@ -56,13 +56,24 @@ export const GET = withCron(async () => {
             }
         }
 
-        if (toDelete.length > 0) {
-            await prisma.programParticipant.deleteMany({
-                where: {
-                    OR: toDelete
+        // Removed one row at a time (not a bulk deleteMany) so the hold-ledger
+        // release (withdrawAndReleaseHold) runs per participant, and one bad row
+        // can't block the rest of the sweep.
+        for (const record of toDelete) {
+            try {
+                await withdrawAndReleaseHold(record.programId, record.personId, record.program);
+            } catch (err) {
+                // P2025 = already removed by another path (e.g. self-withdraw)
+                // between this sweep's read and now — benign, skip.
+                if (!isPrismaP2025(err)) {
+                    logger.error(`[CRON] Failed to remove pending participant ${record.personId} from program ${record.programId}:`, err);
                 }
-            });
+            }
         }
 
         return NextResponse.json({ success: true, processed: pendingParticipants.length, kicked: kickedCount, warned: warnedCount });
 });
+
+function isPrismaP2025(err: unknown): boolean {
+    return typeof err === 'object' && err !== null && 'code' in err && (err as { code?: unknown }).code === 'P2025';
+}

--- a/checkin-app/src/app/api/cron/scholarship-grace-expiry/route.ts
+++ b/checkin-app/src/app/api/cron/scholarship-grace-expiry/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { withCron } from "@/lib/cronAuth";
+import prisma from "@/lib/prisma";
+import { withdrawAndReleaseHold } from "@/lib/program/capacity";
+
+const SYSTEM_ACTOR = 0;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * GET /api/cron/scholarship-grace-expiry — release path (c) of the
+ * scholarship hold ledger (product decision 2026-07-06). A denied applicant
+ * keeps their held seat (denial performs no Shopify op — see the refuse
+ * route) so they can still pay; this sweep is the backstop for the ones who
+ * never pay and never withdraw. Once BoardSettings.scholarshipDenialGraceDays
+ * has elapsed since the denial, the participant is auto-withdrawn and the
+ * seat released (+1) — reusing the exact withdrawal path self/admin removal
+ * uses (withdrawAndReleaseHold), so this is "auto-withdrawal + seat restore",
+ * not a bespoke release. They can re-enroll afterward if seats remain.
+ *
+ * NULL scholarshipDenialGraceDays = the feature is OFF; the sweep no-ops
+ * entirely (never guesses a default). Authorized by
+ * `Authorization: Bearer $CRON_SECRET` (see lib/cronAuth.ts).
+ */
+export const GET = withCron(async () => {
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const graceDays = settings?.scholarshipDenialGraceDays;
+    if (graceDays === null || graceDays === undefined) {
+        return NextResponse.json({ success: true, enabled: false, processed: 0, released: 0 });
+    }
+
+    const cutoff = new Date(Date.now() - graceDays * DAY_MS);
+    const expired = await prisma.programParticipant.findMany({
+        where: {
+            status: 'PENDING',
+            isPaymentPlanRequested: false,
+            inventoryHeldAt: { not: null },
+            paymentPlanDeniedAt: { not: null, lte: cutoff },
+        },
+        include: { program: true, person: true },
+    });
+
+    let released = 0;
+    for (const record of expired) {
+        try {
+            const { released: didRelease } = await withdrawAndReleaseHold(record.programId, record.personId, record.program);
+            if (didRelease) released++;
+
+            await prisma.auditLog.create({
+                data: {
+                    actorId: SYSTEM_ACTOR,
+                    action: "DELETE",
+                    tableName: "ProgramParticipant",
+                    affectedEntityId: record.personId,
+                    secondaryAffectedEntity: record.programId,
+                    // Distinct context from a manual withdrawal's audit entry — this
+                    // one is system-driven, so it's discoverable as a grace expiry.
+                    newData: { reason: "scholarship_grace_expired", graceDays, paymentPlanDeniedAt: record.paymentPlanDeniedAt },
+                },
+            });
+
+            logger.info(`[CRON] Auto-withdrew ${record.person.name} from ${record.program.name} — scholarship denial grace period (${graceDays}d) expired.`);
+        } catch (err) {
+            // Isolate one bad row from the rest of the sweep.
+            logger.error(`[CRON] Failed to process grace-expiry for participant ${record.personId} in program ${record.programId}:`, err);
+        }
+    }
+
+    return NextResponse.json({ success: true, enabled: true, processed: expired.length, released });
+});

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
@@ -270,7 +270,7 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
             expect(row?.status).toBe('PENDING');
         });
 
-        it('200s, fires the real inbound webhook, and activates the PENDING participant', async () => {
+        it('200s, fires the real inbound webhook, and activates the PENDING participant (legacy variant)', async () => {
             asSession();
             await prisma.program.update({ where: { id: programId }, data: { shopifyOrgMemberVariantId: 'dev-mock-variant-route-program-test' } });
             await prisma.programParticipant.create({
@@ -283,6 +283,29 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
             expect(body).toEqual({ ok: true, participants: [{ personId, status: 'ACTIVE' }] });
 
             // The real proof: the webhook actually ran end-to-end and mutated the DB.
+            const row = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId } } });
+            expect(row?.status).toBe('ACTIVE');
+            expect(row?.pendingSince).toBeNull();
+        });
+
+        // Single-pool model (product decision 2026-07-06): the mock tool must
+        // echo shopifyVariantId too, or every new-model program's local mock-pay
+        // flow 409s despite being fully configured.
+        it('200s, fires the real inbound webhook, and activates the PENDING participant (single-pool variant)', async () => {
+            asSession();
+            await prisma.program.update({
+                where: { id: programId },
+                data: { shopifyOrgMemberVariantId: null, shopifyVariantId: 'dev-mock-variant-single-pool-route-test' },
+            });
+            await prisma.programParticipant.create({
+                data: { programId, personId, status: 'PENDING', pendingSince: new Date() },
+            });
+
+            const res = await POST(jsonReq({ programId, participantIds: [personId] }));
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body).toEqual({ ok: true, participants: [{ personId, status: 'ACTIVE' }] });
+
             const row = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId } } });
             expect(row?.status).toBe('ACTIVE');
             expect(row?.pendingSince).toBeNull();

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
@@ -122,12 +122,13 @@ async function fireProgram(programId: number, rawParticipantIds: unknown): Promi
     // handler fails CLOSED unless the paid order's line_items contain one of the
     // program's own Shopify variant ids (webhooks/shopify/route.ts). Program has a
     // price (that's how the participant reached PENDING) but the variant may still
-    // be unset.
+    // be unset. Single-pool model (product decision 2026-07-06): shopifyVariantId
+    // takes priority — new programs never populate the legacy pair.
     const program = await prisma.program.findUnique({
         where: { id: programId },
-        select: { shopifyOrgMemberVariantId: true, shopifyNonOrgMemberVariantId: true },
+        select: { shopifyVariantId: true, shopifyOrgMemberVariantId: true, shopifyNonOrgMemberVariantId: true },
     });
-    const variantId = program?.shopifyOrgMemberVariantId ?? program?.shopifyNonOrgMemberVariantId;
+    const variantId = program?.shopifyVariantId ?? program?.shopifyOrgMemberVariantId ?? program?.shopifyNonOrgMemberVariantId;
     if (!variantId) {
         return apiError("No Shopify variant configured on this program. Set one on the program in program-ops first, or the webhook leaves the participant PENDING.", 409);
     }

--- a/checkin-app/src/app/api/finance-ops/payment-plans/refuse/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/refuse/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { adjustProgramInventory } from "@/lib/shopify";
+import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
+
+// Denies a pending scholarship / payment-plan request — the sibling of
+// POST /api/finance-ops/payment-plans (approve) this branch previously lacked.
+// The participant stays PENDING (they can still pay normally, or re-request);
+// only the isPaymentPlanRequested flag clears. Same auth/conflict-of-interest
+// posture as approve.
+export const POST = withAuth(
+    { roles: ['isSysadmin', 'isBoardMember'] },
+    async (req, auth) => {
+        try {
+            const body = await req.json();
+            const programId = parseInt(body.programId, 10);
+            const participantId = parseInt(body.participantId, 10);
+
+            if (Number.isNaN(programId) || Number.isNaN(participantId)) {
+                return apiError("programId and participantId are required", 400);
+            }
+
+            // Conflict of interest: mirrors approve — a board member may not refuse
+            // their OWN household's request either. Sysadmin bypasses.
+            if (auth.type === 'session') {
+                const target = await prisma.person.findUnique({ where: { id: participantId }, select: { householdId: true } });
+                if (await hasHouseholdConflict(prisma, auth.user.id, target?.householdId, { isSysadmin: auth.user.isSysadmin === true })) {
+                    return apiError("You cannot refuse your own household's payment plan — a sysadmin must.", 403);
+                }
+            }
+
+            const data = { isPaymentPlanRequested: false };
+
+            // Scope to the pending request so refusing a non-pending/nonexistent
+            // request is a no-op error, mirroring approve's guard. Transactional
+            // true->false guard: a double-refuse (already false) 409s instead of
+            // crediting +1 twice.
+            const { count } = await prisma.programParticipant.updateMany({
+                where: { programId, personId: participantId, isPaymentPlanRequested: true, status: 'PENDING' },
+                data,
+            });
+
+            if (count === 0) {
+                return apiError("No pending payment-plan request", 409);
+            }
+
+            if (auth.type === 'session') {
+                await prisma.auditLog.create({
+                    data: {
+                        actorId: auth.user.id,
+                        action: "EDIT",
+                        tableName: "ProgramParticipant",
+                        affectedEntityId: participantId,
+                        secondaryAffectedEntity: programId,
+                        newData: data,
+                    },
+                });
+            }
+
+            // Scholarship lifecycle drives inventory (product decision 2026-07-06):
+            // a refusal returns the seat to Shopify's pool, since the application
+            // took it out of the pool. Non-fatal: the refusal itself already
+            // committed above regardless of the Shopify result. The participant
+            // row still exists PENDING (may re-apply, pay normally, or withdraw —
+            // see the open policy question in this feature's PR body about a
+            // refused-but-never-withdrawn participant still holding DB capacity).
+            let warning: string | undefined;
+            const program = await prisma.program.findUnique({ where: { id: programId } });
+            if (program) {
+                const ok = await adjustProgramInventory(program, 1);
+                if (!ok) {
+                    warning = "Payment plan refused, but the Shopify inventory adjustment failed. Capacity may be out of sync — check System Status > Link Status.";
+                }
+            }
+
+            const responseObj: Record<string, unknown> = { success: true };
+            if (warning) responseObj.warning = warning;
+            return NextResponse.json(responseObj);
+        } catch (error) {
+            logger.error("Failed to refuse payment plan:", error);
+            return apiError("Failed to refuse payment plan", 500);
+        }
+    }
+);

--- a/checkin-app/src/app/api/finance-ops/payment-plans/refuse/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/refuse/route.ts
@@ -3,14 +3,18 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
-import { adjustProgramInventory } from "@/lib/shopify";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 
 // Denies a pending scholarship / payment-plan request — the sibling of
 // POST /api/finance-ops/payment-plans (approve) this branch previously lacked.
-// The participant stays PENDING (they can still pay normally, or re-request);
-// only the isPaymentPlanRequested flag clears. Same auth/conflict-of-interest
-// posture as approve.
+// The participant stays PENDING and keeps their held seat (product decision
+// 2026-07-06, hold-ledger): a denial performs NO Shopify operation — the seat
+// stays out of Shopify's pool exactly as the application left it, so the
+// applicant may still pay normally. This supersedes the earlier deny-time +1
+// (that let the seat re-sell out from under a denied-but-not-withdrawn
+// applicant). The hold is released, exactly once, by whichever of withdrawal /
+// normal payment / grace-period expiry fires first (see
+// docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md).
 export const POST = withAuth(
     { roles: ['isSysadmin', 'isBoardMember'] },
     async (req, auth) => {
@@ -32,12 +36,12 @@ export const POST = withAuth(
                 }
             }
 
-            const data = { isPaymentPlanRequested: false };
+            const data = { isPaymentPlanRequested: false, paymentPlanDeniedAt: new Date() };
 
             // Scope to the pending request so refusing a non-pending/nonexistent
             // request is a no-op error, mirroring approve's guard. Transactional
             // true->false guard: a double-refuse (already false) 409s instead of
-            // crediting +1 twice.
+            // re-stamping paymentPlanDeniedAt.
             const { count } = await prisma.programParticipant.updateMany({
                 where: { programId, personId: participantId, isPaymentPlanRequested: true, status: 'PENDING' },
                 data,
@@ -60,25 +64,7 @@ export const POST = withAuth(
                 });
             }
 
-            // Scholarship lifecycle drives inventory (product decision 2026-07-06):
-            // a refusal returns the seat to Shopify's pool, since the application
-            // took it out of the pool. Non-fatal: the refusal itself already
-            // committed above regardless of the Shopify result. The participant
-            // row still exists PENDING (may re-apply, pay normally, or withdraw —
-            // see the open policy question in this feature's PR body about a
-            // refused-but-never-withdrawn participant still holding DB capacity).
-            let warning: string | undefined;
-            const program = await prisma.program.findUnique({ where: { id: programId } });
-            if (program) {
-                const ok = await adjustProgramInventory(program, 1);
-                if (!ok) {
-                    warning = "Payment plan refused, but the Shopify inventory adjustment failed. Capacity may be out of sync — check System Status > Link Status.";
-                }
-            }
-
-            const responseObj: Record<string, unknown> = { success: true };
-            if (warning) responseObj.warning = warning;
-            return NextResponse.json(responseObj);
+            return NextResponse.json({ success: true });
         } catch (error) {
             logger.error("Failed to refuse payment plan:", error);
             return apiError("Failed to refuse payment plan", 500);

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -69,7 +69,14 @@ export const POST = withAuth(
                 status: 'ACTIVE' as const,
                 isPaymentPlanRequested: false, // cleared since it's approved
                 pendingSince: null, // reset
-                wasOrgMemberAtApproval
+                wasOrgMemberAtApproval,
+                // Hold-ledger (product decision 2026-07-06): approval CONSUMES the
+                // hold — the applicant keeps the seat permanently as a comped
+                // enrollment, so it must never be released later (e.g. if this
+                // now-ACTIVE participant is later removed, that removal must NOT
+                // fire a +1 — see withdrawAndReleaseHold, which only releases when
+                // inventoryHeldAt is still set).
+                inventoryHeldAt: null,
             };
 
             // Scope to the pending request so approving a non-pending/nonexistent

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -96,26 +96,14 @@ export const POST = withAuth(
                 });
             }
 
-            // Shopify is the source of truth for program capacity (product decision
-            // 2026-07-06, extended): an approved payment-plan/scholarship participant
-            // consumes a real seat exactly like a paid one, so it decrements Shopify
-            // inventory too — both member/non-member pools in parallel, same call
-            // shape as the PATCH /api/programs/[id] maxParticipants propagation (see
-            // the interim two-pool mirror note in webhooks/shopify/route.ts).
-            // Non-fatal: approval already committed above, so a Shopify failure here
-            // surfaces as a warning, not a rejected approval.
-            let warning: string | undefined;
-            const program = await prisma.program.findUnique({ where: { id: programId } });
-            if (program && (program.shopifyOrgMemberVariantId || program.shopifyNonOrgMemberVariantId)) {
-                const ok = await adjustProgramInventory(program, -1);
-                if (!ok) {
-                    warning = "Payment plan approved, but the Shopify inventory adjustment failed. Capacity may be out of sync — check System Status > Link Status.";
-                }
-            }
-
-            const responseObj: Record<string, unknown> = { success: true };
-            if (warning) responseObj.warning = warning;
-            return NextResponse.json(responseObj);
+            // Scholarship lifecycle drives inventory (product decision 2026-07-06):
+            // the seat was already decremented from Shopify at APPLICATION time
+            // (POST .../request-payment-plan), so approval performs NO Shopify
+            // operation — the applicant already holds the seat; approval just
+            // stops billing them for it. This supersedes the earlier approve-time
+            // decrement (see PR history — that double-counted against the
+            // apply-time decrement added alongside it).
+            return NextResponse.json({ success: true });
         } catch (error) {
             logger.error("Failed to approve payment plan:", error);
             return apiError("Failed to approve payment plan", 500);

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -6,6 +6,7 @@ import { handler } from "@/security/handler";
 import { apiError } from "@/lib/api-response";
 import { isActiveOrgMember, ACTIVE_ORG_MEMBER_INCLUDE } from "@/lib/orgMembership";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
+import { adjustProgramInventory } from "@/lib/shopify";
 
 export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
     const [requests, boardSettings] = await Promise.all([
@@ -95,7 +96,26 @@ export const POST = withAuth(
                 });
             }
 
-            return NextResponse.json({ success: true });
+            // Shopify is the source of truth for program capacity (product decision
+            // 2026-07-06, extended): an approved payment-plan/scholarship participant
+            // consumes a real seat exactly like a paid one, so it decrements Shopify
+            // inventory too — both member/non-member pools in parallel, same call
+            // shape as the PATCH /api/programs/[id] maxParticipants propagation (see
+            // the interim two-pool mirror note in webhooks/shopify/route.ts).
+            // Non-fatal: approval already committed above, so a Shopify failure here
+            // surfaces as a warning, not a rejected approval.
+            let warning: string | undefined;
+            const program = await prisma.program.findUnique({ where: { id: programId } });
+            if (program && (program.shopifyOrgMemberVariantId || program.shopifyNonOrgMemberVariantId)) {
+                const ok = await adjustProgramInventory(program, -1);
+                if (!ok) {
+                    warning = "Payment plan approved, but the Shopify inventory adjustment failed. Capacity may be out of sync — check System Status > Link Status.";
+                }
+            }
+
+            const responseObj: Record<string, unknown> = { success: true };
+            if (warning) responseObj.warning = warning;
+            return NextResponse.json(responseObj);
         } catch (error) {
             logger.error("Failed to approve payment plan:", error);
             return apiError("Failed to approve payment plan", 500);

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -6,7 +6,6 @@ import { handler } from "@/security/handler";
 import { apiError } from "@/lib/api-response";
 import { isActiveOrgMember, ACTIVE_ORG_MEMBER_INCLUDE } from "@/lib/orgMembership";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
-import { adjustProgramInventory } from "@/lib/shopify";
 
 export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
     const [requests, boardSettings] = await Promise.all([

--- a/checkin-app/src/app/api/programs/[id]/discount-code/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/discount-code/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { apiError } from "@/lib/api-response";
+import { isActiveOrgMember } from "@/lib/orgMembership";
+import { mintMemberDiscountCode } from "@/lib/shopify";
+
+// Server-minted, single-use member discount code for a single-pool program's
+// checkout link (see mintMemberDiscountCode in lib/shopify.ts). Recomputes
+// membership from the session server-side — never trusts a client-supplied
+// "I'm a member" flag for a pricing decision. Always 200s with { code: null }
+// when a discount doesn't apply (not a member / legacy program / mint
+// failure) — the caller falls back to an undiscounted checkout link and never
+// blocks checkout on this route.
+export const POST = withAuth({}, async (_req, auth, { params }: { params: Promise<{ id: string }> }) => {
+    if (auth.type !== 'session') return apiError("Unauthorized", 401);
+    const { id } = await params;
+    const programId = parseInt(id, 10);
+    if (isNaN(programId)) return apiError("Invalid program ID", 400);
+
+    const program = await prisma.program.findUnique({ where: { id: programId } });
+    if (!program) return apiError("Program not found", 404);
+
+    // Legacy (two-variant) programs already charge the right tier via variant
+    // choice — no discount code needed. Both prices must be known to compute
+    // the discount amount.
+    if (!program.shopifyVariantId || program.orgMemberPriceCents == null || program.nonOrgMemberPriceCents == null) {
+        return NextResponse.json({ code: null });
+    }
+
+    const isMember = await isActiveOrgMember(auth.user.id);
+    if (!isMember) return NextResponse.json({ code: null });
+
+    const amountOffCents = program.nonOrgMemberPriceCents - program.orgMemberPriceCents;
+    if (amountOffCents <= 0) return NextResponse.json({ code: null });
+
+    const code = await mintMemberDiscountCode(programId, program.shopifyVariantId, amountOffCents);
+    return NextResponse.json({ code });
+});

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -221,7 +221,11 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
             }
         });
 
-        const responseObj: Record<string, unknown> = { success: true, enrollment };
+        // No raw enrollment echo: this route is reachable by the program's lead
+        // mentor, and the deleted row carries board/finance-confidential hardship
+        // fields (paymentPlanDeniedAt, inventoryHeldAt). The audit log above keeps
+        // the full row server-side.
+        const responseObj: Record<string, unknown> = { success: true, released };
         if (released && !shopifyOk) {
             responseObj.warning = "Participant removed, but the Shopify inventory release failed. Capacity may be out of sync — check System Status > Link Status.";
         }

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -3,7 +3,7 @@ import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
-import { lockProgramAndCheckCapacity, ProgramCapacityError } from "@/lib/program/capacity";
+import { lockProgramAndCheckCapacity, ProgramCapacityError, withdrawAndReleaseHold } from "@/lib/program/capacity";
 import { checkProgramAge } from "@/lib/programAge";
 import { apiError } from "@/lib/api-response";
 
@@ -203,14 +203,12 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
             return apiError("Forbidden: Not authorized to remove this participant", 403);
         }
 
-        const enrollment = await prisma.programParticipant.delete({
-            where: {
-                programId_personId: {
-                    programId,
-                    personId: participantId
-                }
-            }
-        });
+        // Hold-ledger (product decision 2026-07-06): withdrawal is one of the
+        // three release paths — if this PENDING participant was holding a
+        // scholarship seat (inventoryHeldAt set), releasing it back to
+        // Shopify (+1) happens with the removal, exactly once (see
+        // withdrawAndReleaseHold).
+        const { enrollment, released, shopifyOk } = await withdrawAndReleaseHold(programId, participantId, currentProgram);
 
         await prisma.auditLog.create({
             data: {
@@ -223,7 +221,11 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
             }
         });
 
-        return NextResponse.json({ success: true, enrollment });
+        const responseObj: Record<string, unknown> = { success: true, enrollment };
+        if (released && !shopifyOk) {
+            responseObj.warning = "Participant removed, but the Shopify inventory release failed. Capacity may be out of sync — check System Status > Link Status.";
+        }
+        return NextResponse.json(responseObj);
     } catch (error) {
         // P2025 = row to delete not found. Benign double-submit (participant
         // already un-enrolled); idempotent 200 instead of a 500.

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -78,13 +78,18 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         // fires -1. Branch 2 (inventoryHeldAt already set): re-application while
         // holding (or an idempotent re-POST) — just (re)flips the request flag
         // and clears any denial stamp, no second decrement.
+        // Both stamps are compare-and-set on status: 'PENDING' (matching
+        // approve/refuse) — the findUnique status read above is stale by write
+        // time, and without this a concurrent approval (ACTIVE, hold consumed
+        // to null) would match branch 1, re-stamp the hold, fire a second -1,
+        // and reopen a resolved scholarship.
         const holdResult = await prisma.programParticipant.updateMany({
-            where: { programId, personId: participantId, inventoryHeldAt: null },
+            where: { programId, personId: participantId, status: 'PENDING', inventoryHeldAt: null },
             data: { isPaymentPlanRequested: true, inventoryHeldAt: new Date(), paymentPlanDeniedAt: null },
         });
         if (holdResult.count === 0) {
             await prisma.programParticipant.updateMany({
-                where: { programId, personId: participantId, inventoryHeldAt: { not: null } },
+                where: { programId, personId: participantId, status: 'PENDING', inventoryHeldAt: { not: null } },
                 data: { isPaymentPlanRequested: true, paymentPlanDeniedAt: null },
             });
         }

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
+import { adjustProgramInventory } from "@/lib/shopify";
 
 export const POST = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
     if (auth.type !== 'session') return apiError("Unauthorized", 401);
@@ -65,20 +66,38 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             return apiError("This enrollment is not awaiting payment", 409);
         }
 
-        const updatedParticipant = await prisma.programParticipant.update({
-            where: {
-                programId_personId: { programId, personId: participantId }
-            },
-            data: {
-                isPaymentPlanRequested: true
-            }
+        // Scholarship lifecycle drives inventory (product decision 2026-07-06):
+        // APPLICATION takes a seat out of Shopify's pool, same as a normal paid
+        // checkout would. Transactional false->true guard: only fires -1 the
+        // moment isPaymentPlanRequested actually flips (count>0); an idempotent
+        // re-POST while already requested is a no-op (count=0, no second -1).
+        // Re-application after a refusal (isPaymentPlanRequested reset to false
+        // by the refuse endpoint) is a fresh false->true transition, so it fires
+        // -1 again — intentional (the applicant is asking to hold a seat again).
+        const { count } = await prisma.programParticipant.updateMany({
+            where: { programId, personId: participantId, isPaymentPlanRequested: false },
+            data: { isPaymentPlanRequested: true },
+        });
+
+        const updatedParticipant = await prisma.programParticipant.findUniqueOrThrow({
+            where: { programId_personId: { programId, personId: participantId } },
         });
 
         // Send email to finances
         // In a real implementation this would trigger an actual email via SendGrid, NodeMailer, etc.
         logger.info(`[EMAIL DISPATCH] To: finance@innovationtreehouse.org, Subject: Scholarship / Payment Plan Request for ${participant.person?.name || 'User'} in ${participant.program?.name || 'Program'}`);
 
-        return NextResponse.json({ success: true, participant: updatedParticipant });
+        let warning: string | undefined;
+        if (count > 0 && participant.program) {
+            const ok = await adjustProgramInventory(participant.program, -1);
+            if (!ok) {
+                warning = "Payment plan requested, but the Shopify inventory adjustment failed. Capacity may be out of sync — check System Status > Link Status.";
+            }
+        }
+
+        const responseObj: Record<string, unknown> = { success: true, participant: updatedParticipant };
+        if (warning) responseObj.warning = warning;
+        return NextResponse.json(responseObj);
     } catch (error) {
         logger.error("Payment plan request error:", error);
         return apiError("Failed to request payment plan", 500);

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -66,18 +66,26 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             return apiError("This enrollment is not awaiting payment", 409);
         }
 
-        // Scholarship lifecycle drives inventory (product decision 2026-07-06):
-        // APPLICATION takes a seat out of Shopify's pool, same as a normal paid
-        // checkout would. Transactional false->true guard: only fires -1 the
-        // moment isPaymentPlanRequested actually flips (count>0); an idempotent
-        // re-POST while already requested is a no-op (count=0, no second -1).
-        // Re-application after a refusal (isPaymentPlanRequested reset to false
-        // by the refuse endpoint) is a fresh false->true transition, so it fires
-        // -1 again — intentional (the applicant is asking to hold a seat again).
-        const { count } = await prisma.programParticipant.updateMany({
-            where: { programId, personId: participantId, isPaymentPlanRequested: false },
-            data: { isPaymentPlanRequested: true },
+        // Hold-ledger (product decision 2026-07-06): APPLICATION takes a seat out
+        // of Shopify's pool (-1), stamping inventoryHeldAt so every later release
+        // path (withdrawal / payment / grace-expiry) or approval knows there's a
+        // hold to account for. Guard is on inventoryHeldAt, NOT isPaymentPlanRequested:
+        // a denied re-applicant still holds the seat (refuse no longer releases
+        // it — see the refuse route), so re-applying must NOT decrement twice.
+        // Branch 1 (inventoryHeldAt null -> now): the seat is genuinely free —
+        // fires -1. Branch 2 (inventoryHeldAt already set): re-application while
+        // holding (or an idempotent re-POST) — just (re)flips the request flag
+        // and clears any denial stamp, no second decrement.
+        const holdResult = await prisma.programParticipant.updateMany({
+            where: { programId, personId: participantId, inventoryHeldAt: null },
+            data: { isPaymentPlanRequested: true, inventoryHeldAt: new Date(), paymentPlanDeniedAt: null },
         });
+        if (holdResult.count === 0) {
+            await prisma.programParticipant.updateMany({
+                where: { programId, personId: participantId, inventoryHeldAt: { not: null } },
+                data: { isPaymentPlanRequested: true, paymentPlanDeniedAt: null },
+            });
+        }
 
         const updatedParticipant = await prisma.programParticipant.findUniqueOrThrow({
             where: { programId_personId: { programId, personId: participantId } },
@@ -88,7 +96,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         logger.info(`[EMAIL DISPATCH] To: finance@innovationtreehouse.org, Subject: Scholarship / Payment Plan Request for ${participant.person?.name || 'User'} in ${participant.program?.name || 'Program'}`);
 
         let warning: string | undefined;
-        if (count > 0 && participant.program) {
+        if (holdResult.count > 0 && participant.program) {
             const ok = await adjustProgramInventory(participant.program, -1);
             if (!ok) {
                 warning = "Payment plan requested, but the Shopify inventory adjustment failed. Capacity may be out of sync — check System Status > Link Status.";

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -37,16 +37,18 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         }
 
         // Authorization: only the participant themselves, a lead of their household,
-        // the program's lead mentor, or a isSysadmin/board member may request a payment
-        // plan for this enrollment. Without this gate any authenticated user could flip
-        // isPaymentPlanRequested on an arbitrary participant's enrollment (IDOR).
+        // or a isSysadmin/board member may request a payment plan for this enrollment.
+        // Without this gate any authenticated user could flip isPaymentPlanRequested
+        // on an arbitrary participant's enrollment (IDOR). Deliberately NOT the
+        // program's lead mentor: scholarship requested/denied is board/finance-
+        // confidential, and a program volunteer should neither initiate it nor
+        // observe the hardship fields.
         const currentUserId = auth.user.id;
         const isSelf = currentUserId === participantId;
         const isSysAdminOrBoard = auth.user.isSysadmin || auth.user.isBoardMember;
-        const isLeadMentor = participant.program?.leadMentorId === currentUserId;
 
         let isHouseholdLead = false;
-        if (!isSelf && !isSysAdminOrBoard && !isLeadMentor && participant.person?.householdId) {
+        if (!isSelf && !isSysAdminOrBoard && participant.person?.householdId) {
             const leadRecord = await prisma.person.findFirst({
                 where: {
                     id: currentUserId,
@@ -58,7 +60,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             isHouseholdLead = !!leadRecord;
         }
 
-        if (!isSelf && !isSysAdminOrBoard && !isLeadMentor && !isHouseholdLead) {
+        if (!isSelf && !isSysAdminOrBoard && !isHouseholdLead) {
             return apiError("Forbidden: Not authorized to request a payment plan for this participant", 403);
         }
 
@@ -87,10 +89,6 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             });
         }
 
-        const updatedParticipant = await prisma.programParticipant.findUniqueOrThrow({
-            where: { programId_personId: { programId, personId: participantId } },
-        });
-
         // Send email to finances
         // In a real implementation this would trigger an actual email via SendGrid, NodeMailer, etc.
         logger.info(`[EMAIL DISPATCH] To: finance@innovationtreehouse.org, Subject: Scholarship / Payment Plan Request for ${participant.person?.name || 'User'} in ${participant.program?.name || 'Program'}`);
@@ -99,11 +97,24 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         if (holdResult.count > 0 && participant.program) {
             const ok = await adjustProgramInventory(participant.program, -1);
             if (!ok) {
-                warning = "Payment plan requested, but the Shopify inventory adjustment failed. Capacity may be out of sync — check System Status > Link Status.";
+                // The seat was never taken out of Shopify — leaving inventoryHeldAt
+                // set would be a phantom hold whose later release (+1) credits a
+                // seat that was never removed (oversell). Roll the stamp back so
+                // the ledger stays true; a re-submit retries the -1 via the
+                // inventoryHeldAt:null branch above. (adjustProgramInventory has
+                // already emailed sysadmins/board via reportShopifyFailure.)
+                await prisma.programParticipant.updateMany({
+                    where: { programId, personId: participantId, inventoryHeldAt: { not: null } },
+                    data: { inventoryHeldAt: null },
+                });
+                warning = "Payment plan requested and finance notified, but the Shopify seat hold failed and was rolled back. Re-submit to retry, or check System Status > Link Status.";
             }
         }
 
-        const responseObj: Record<string, unknown> = { success: true, participant: updatedParticipant };
+        // Deliberately no raw ProgramParticipant echo: non-board callers (self /
+        // household lead) must not read the hardship fields (paymentPlanDeniedAt,
+        // inventoryHeldAt) off this response.
+        const responseObj: Record<string, unknown> = { success: true };
         if (warning) responseObj.warning = warning;
         return NextResponse.json(responseObj);
     } catch (error) {

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -120,7 +120,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
 
         const body = await req.json();
         let { leadMentorId } = body;
-        const { name, startAt, endAt, orgMemberOnly, phase, enrollmentStatus, minAge, maxAge, maxParticipants, leadMentorNotificationSettings, memberPrice, nonMemberPrice, shopifyProductId, shopifyOrgMemberVariantId, shopifyNonOrgMemberVariantId } = body;
+        const { name, startAt, endAt, orgMemberOnly, phase, enrollmentStatus, minAge, maxAge, maxParticipants, leadMentorNotificationSettings, memberPrice, nonMemberPrice, shopifyProductId, shopifyVariantId, shopifyOrgMemberVariantId, shopifyNonOrgMemberVariantId } = body;
 
         if (body.hasOwnProperty('leadMentorId')) {
             if (!leadMentorId) {
@@ -156,6 +156,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
             // Empty string clears the field. This is the manual repair path when there's
             // no live Shopify to sync against (local/testing).
             ...(isSysAdminOrBoard && shopifyProductId !== undefined && { shopifyProductId: shopifyProductId || null }),
+            ...(isSysAdminOrBoard && shopifyVariantId !== undefined && { shopifyVariantId: shopifyVariantId || null }),
             ...(isSysAdminOrBoard && shopifyOrgMemberVariantId !== undefined && { shopifyOrgMemberVariantId: shopifyOrgMemberVariantId || null }),
             ...(isSysAdminOrBoard && shopifyNonOrgMemberVariantId !== undefined && { shopifyNonOrgMemberVariantId: shopifyNonOrgMemberVariantId || null }),
         };
@@ -191,7 +192,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
         let warning: string | undefined;
         const oldMax = currentProgram.maxParticipants;
         const newMax = updatedProgram.maxParticipants;
-        const hasShopifyVariant = !!(updatedProgram.shopifyOrgMemberVariantId || updatedProgram.shopifyNonOrgMemberVariantId);
+        const hasShopifyVariant = !!(updatedProgram.shopifyVariantId || updatedProgram.shopifyOrgMemberVariantId || updatedProgram.shopifyNonOrgMemberVariantId);
 
         if (oldMax !== newMax && hasShopifyVariant) {
             if (oldMax !== null && newMax !== null) {

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { handler, notFound, forbidden, badRequest } from "@/security/handler";
 import { isActiveOrgMember } from "@/lib/orgMembership";
 import { notifyNewProgramAnnounced } from "@/lib/notifications";
+import { adjustProgramInventory } from "@/lib/shopify";
 import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
 import { validateProgramAgeBounds } from "@/lib/programAge";
@@ -183,7 +184,33 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
             await notifyNewProgramAnnounced(updatedProgram.name);
         }
 
-        return NextResponse.json({ success: true, program: updatedProgram });
+        // Shopify is the source of truth for program capacity (product decision
+        // 2026-07-06): cap edits propagate as relative inventory adjustments.
+        // Only fires when the program already has Shopify checkout wired up —
+        // creation and sync-shopify set inventory absolutely and are unaffected.
+        let warning: string | undefined;
+        const oldMax = currentProgram.maxParticipants;
+        const newMax = updatedProgram.maxParticipants;
+        const hasShopifyVariant = !!(updatedProgram.shopifyOrgMemberVariantId || updatedProgram.shopifyNonOrgMemberVariantId);
+
+        if (oldMax !== newMax && hasShopifyVariant) {
+            if (oldMax !== null && newMax !== null) {
+                const ok = await adjustProgramInventory(updatedProgram, newMax - oldMax);
+                if (!ok) {
+                    warning = "Program updated, but the Shopify inventory adjustment failed. Capacity may be out of sync — check System Status > Link Status.";
+                }
+            } else {
+                // Null transition (capped <-> uncapped): a relative adjust can't express
+                // "start/stop tracking inventory" — that needs an inventory_management
+                // flip on the variant, which this PR intentionally doesn't attempt.
+                logger.warn(`[SHOPIFY] Program ${updatedProgram.id} maxParticipants transitioned ${oldMax} -> ${newMax} (capped/uncapped); inventory not adjusted automatically.`);
+                warning = "Capacity changed between capped and uncapped. Shopify inventory was not updated automatically — run Sync to Shopify or edit inventory directly in Shopify.";
+            }
+        }
+
+        const responseObj: Record<string, unknown> = { success: true, program: updatedProgram };
+        if (warning) responseObj.warning = warning;
+        return NextResponse.json(responseObj);
     } catch (error) {
         logger.error("Program update error:", error);
         return apiError("Failed to update program", 500);

--- a/checkin-app/src/app/api/programs/[id]/sync-shopify/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/sync-shopify/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
-import { createShopifyProgramVariants } from "@/lib/shopify";
+import { createShopifyProgramVariants, createShopifySingleVariantProgram } from "@/lib/shopify";
 import { isProgramCheckoutBroken } from "@/lib/programCheckout";
 import { logBackendError } from "@/lib/logger";
 import { apiError } from "@/lib/api-response";
@@ -11,11 +11,19 @@ import { apiError } from "@/lib/api-response";
 // (api/programs/[id] PATCH) can, since PATCH never mints variants. Mirrors the
 // creation call so the dev/local mock branch (config.shopifyMockActive) works too.
 //
-// ponytail: recreates the whole product+variants and overwrites all three IDs.
-// For the common prod case (made free, then priced → no product at all) that's
-// exactly right. For the rarer partial case (one variant exists, the other tier
-// was added later) it orphans the old product. Upgrade to patching only the
-// missing variant onto the existing product if partial repair ever matters.
+// Single-pool transition: a program already carrying ONE of the legacy
+// org/non-org variant ids is mid-flight on the OLD model (or was created
+// before the single-pool switch) — repair it the same way (both legacy
+// columns, keeping the matching one). A program with NEITHER legacy column set
+// is either new or never got that far — repair it onto the single-pool model
+// instead, writing shopifyVariantId.
+//
+// ponytail: the legacy branch recreates the whole product+variants and
+// overwrites all IDs. For the common prod case (made free, then priced → no
+// product at all) that's exactly right. For the rarer partial case (one
+// variant exists, the other tier was added later) it orphans the old product.
+// Upgrade to patching only the missing variant onto the existing product if
+// partial repair ever matters.
 export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (_req, auth, ctx: { params: Promise<{ id: string }> }) => {
     if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await ctx.params;
@@ -29,23 +37,43 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
     }
 
     try {
-        const shopifyData = await createShopifyProgramVariants(
-            program.name,
-            program.orgMemberPriceCents,
-            program.nonOrgMemberPriceCents,
-            program.maxParticipants,
-        );
-        if (!shopifyData) {
+        const isLegacy = !!(program.shopifyOrgMemberVariantId || program.shopifyNonOrgMemberVariantId);
+
+        let updateData: { shopifyProductId: string; shopifyOrgMemberVariantId: string | null; shopifyNonOrgMemberVariantId: string | null }
+            | { shopifyProductId: string; shopifyVariantId: string }
+            | null = null;
+
+        if (isLegacy) {
+            const shopifyData = await createShopifyProgramVariants(
+                program.name,
+                program.orgMemberPriceCents,
+                program.nonOrgMemberPriceCents,
+                program.maxParticipants,
+            );
+            if (shopifyData) {
+                updateData = {
+                    shopifyProductId: shopifyData.shopifyProductId,
+                    shopifyOrgMemberVariantId: shopifyData.shopifyOrgMemberVariantId,
+                    shopifyNonOrgMemberVariantId: shopifyData.shopifyNonOrgMemberVariantId,
+                };
+            }
+        } else {
+            const basePriceCents = program.nonOrgMemberPriceCents ?? program.orgMemberPriceCents ?? null;
+            const shopifyData = basePriceCents
+                ? await createShopifySingleVariantProgram(program.name, basePriceCents, program.maxParticipants)
+                : null;
+            if (shopifyData) {
+                updateData = { shopifyProductId: shopifyData.shopifyProductId, shopifyVariantId: shopifyData.shopifyVariantId };
+            }
+        }
+
+        if (!updateData) {
             return apiError("Shopify sync failed or is not configured. Check Shopify credentials.", 502);
         }
 
         const updated = await prisma.program.update({
             where: { id: programId },
-            data: {
-                shopifyProductId: shopifyData.shopifyProductId,
-                shopifyOrgMemberVariantId: shopifyData.shopifyOrgMemberVariantId,
-                shopifyNonOrgMemberVariantId: shopifyData.shopifyNonOrgMemberVariantId,
-            },
+            data: updateData,
         });
 
         await prisma.auditLog.create({

--- a/checkin-app/src/app/api/programs/route.ts
+++ b/checkin-app/src/app/api/programs/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { withAuth, getOptionalSessionUser } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
-import { createShopifyProgramVariants } from "@/lib/shopify";
+import { createShopifySingleVariantProgram } from "@/lib/shopify";
 import { logBackendError, logger } from "@/lib/logger";
 import { isActiveOrgMember } from "@/lib/orgMembership";
 import { dollarsToCentsOrNull } from "@inventory/money";
@@ -96,7 +96,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
     if (auth.type !== 'session') return apiError("Unauthorized", 401);
 
     // Hoisted so the catch can name an orphaned Shopify product (created, but DB write failed) for manual cleanup.
-    let shopifyData: { shopifyProductId: string, shopifyOrgMemberVariantId: string | null, shopifyNonOrgMemberVariantId: string | null } | null = null;
+    let shopifyData: { shopifyProductId: string, shopifyVariantId: string } | null = null;
 
     try {
         const body = await req.json();
@@ -120,10 +120,17 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         const nmPrice = dollarsToCentsOrNull(nonMemberPrice != null ? String(nonMemberPrice) : undefined);
         const maxPart = maxParticipants ? parseInt(maxParticipants, 10) : null;
 
-        // Try to create Shopify entities
-        // Only try to create if at least one price is provided. Otherwise it's a free program.
-        if ((mPrice && mPrice > 0) || (nmPrice && nmPrice > 0)) {
-            shopifyData = await createShopifyProgramVariants(name, mPrice, nmPrice, maxPart);
+        // Single-pool model (product decision 2026-07-06): ONE Shopify variant,
+        // priced at the base/non-member rate — replaces the two-variant model for
+        // NEW program creation going forward (legacy programs keep working via
+        // the columns createShopifyProgramVariants still writes; see
+        // sync-shopify's repair route). ponytail: falls back to the member price
+        // only when no non-member price is set (e.g. a members-only-priced
+        // program with no listed non-member tier) — normally sells at the
+        // non-member/base rate per the design.
+        const basePriceCents = nmPrice ?? mPrice ?? null;
+        if (basePriceCents && basePriceCents > 0) {
+            shopifyData = await createShopifySingleVariantProgram(name, basePriceCents, maxPart);
         }
 
         const newProgram = await prisma.program.create({
@@ -139,8 +146,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                 nonOrgMemberPriceCents: nmPrice,
                 maxParticipants: maxPart,
                 shopifyProductId: shopifyData?.shopifyProductId || null,
-                shopifyOrgMemberVariantId: shopifyData?.shopifyOrgMemberVariantId || null,
-                shopifyNonOrgMemberVariantId: shopifyData?.shopifyNonOrgMemberVariantId || null,
+                shopifyVariantId: shopifyData?.shopifyVariantId || null,
             }
         });
 

--- a/checkin-app/src/app/api/settings/membership/route.ts
+++ b/checkin-app/src/app/api/settings/membership/route.ts
@@ -16,7 +16,8 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
 /**
  * PUT /api/settings/membership — update board settings.
  * Body may include: normalDuesCents, volunteerDuesCents, orgMembershipYearBoundary (ISO|null),
- * orgMembershipVariantId (string|null), volunteerDiscountCode (string|null).
+ * orgMembershipVariantId (string|null), volunteerDiscountCode (string|null),
+ * scholarshipDenialGraceDays (positive int|null — null disables the grace-period expiry cron).
  * Dues must be finite and >= 0; an invalid value rejects the whole update (400) so the
  * previous value survives rather than silently collapsing to zero. (The Averity consent
  * link is an env var, not a board setting. Email sender identity lives in /api/settings/email.)
@@ -30,6 +31,7 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
         orgMembershipVariantId?: string | null;
         volunteerDiscountCode?: string | null;
         bgRecheckMonths?: number;
+        scholarshipDenialGraceDays?: number | null;
     };
     try {
         body = await req.json();
@@ -59,6 +61,15 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
         data.volunteerDiscountCode = body.volunteerDiscountCode?.trim() || null;
     }
     if (body.bgRecheckMonths !== undefined) data.bgRecheckMonths = Math.max(0, Math.round(body.bgRecheckMonths));
+    // scholarshipDenialGraceDays: null = feature off (never guess a default); otherwise a positive integer.
+    if (body.scholarshipDenialGraceDays !== undefined) {
+        if (body.scholarshipDenialGraceDays !== null) {
+            if (!Number.isFinite(body.scholarshipDenialGraceDays) || !Number.isInteger(body.scholarshipDenialGraceDays) || body.scholarshipDenialGraceDays <= 0) {
+                return apiError("scholarshipDenialGraceDays must be a positive whole number of days, or null", 400);
+            }
+        }
+        data.scholarshipDenialGraceDays = body.scholarshipDenialGraceDays;
+    }
 
     const settings = await prisma.boardSettings.upsert({
         where: { id: 1 },

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -143,9 +143,14 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                 // built from — not order total. Fail CLOSED: no variant
                 // configured on the Program, or
                 // no line-item match, means we do NOT activate.
+                // Single-pool model (product decision 2026-07-06): shopifyVariantId,
+                // when set, is matched alongside the legacy pair during the
+                // transition — old programs never get shopifyVariantId, new ones
+                // never get the legacy pair, so this is additive, not a widening
+                // of what any one program accepts.
                 const program = await prisma.program.findUnique({ where: { id: programId } });
                 const programVariantIds = new Set(
-                    [program?.shopifyOrgMemberVariantId, program?.shopifyNonOrgMemberVariantId].filter(
+                    [program?.shopifyVariantId, program?.shopifyOrgMemberVariantId, program?.shopifyNonOrgMemberVariantId].filter(
                         (v): v is string => !!v,
                     ),
                 );
@@ -191,16 +196,17 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                     }
                 }
 
-                // Interim two-pool mirror model (product decision 2026-07-06, extended):
-                // the org-member and non-org-member variants each carry their OWN
-                // Shopify inventory pool, both seeded to maxParticipants — so Shopify
-                // only auto-decrements the pool for the tier actually purchased. Mirror
-                // the same drop onto the SIBLING pool so both pools keep meaning
-                // "remaining shared capacity" (mod webhook lag/races) until the planned
-                // customer-segment/single-variant redesign collapses them into one.
-                // Deliberately AFTER activation is committed, and never allowed to fail
-                // the webhook response — Shopify retries the whole order on a non-2xx.
-                if (activatedCount > 0) {
+                // LEGACY-ONLY two-pool mirror (product decision 2026-07-06, single-
+                // pool redesign): the org-member and non-org-member variants each
+                // carry their OWN Shopify inventory pool, both seeded to
+                // maxParticipants — so Shopify only auto-decrements the pool for the
+                // tier actually purchased, and the sibling pool needs a compensating
+                // mirror. Single-pool (shopifyVariantId) programs need NO mirror —
+                // there's exactly one pool, and Shopify already auto-decremented it
+                // on the sale. Deliberately AFTER activation is committed, and never
+                // allowed to fail the webhook response — Shopify retries the whole
+                // order on a non-2xx.
+                if (activatedCount > 0 && !program?.shopifyVariantId) {
                     const siblingOnly = purchasedOrgMember
                         ? { shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: program?.shopifyNonOrgMemberVariantId ?? null }
                         : { shopifyOrgMemberVariantId: program?.shopifyOrgMemberVariantId ?? null, shopifyNonOrgMemberVariantId: null };

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -180,18 +180,22 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                             continue;
                         }
 
-                        await prisma.programParticipant.update({
-                            where: {
-                                programId_personId: { programId, personId: participantId }
-                            },
+                        // Guarded transactionally (status PENDING -> ACTIVE) so a webhook
+                        // redelivery — or a participant already activated elsewhere —
+                        // can't inflate activatedCount and double-fire the sibling
+                        // mirror's -1 below.
+                        const activated = await prisma.programParticipant.updateMany({
+                            where: { programId, personId: participantId, status: 'PENDING' },
                             data: {
                                 status: 'ACTIVE',
                                 pendingSince: null, // clear out the pending timer
                             }
                         });
-                        activatedCount++;
+                        activatedCount += activated.count;
 
-                        logger.info(`[SHOPIFY WEBHOOK] Marked participant ${participantId} as ACTIVE for program ${programId}`);
+                        if (activated.count > 0) {
+                            logger.info(`[SHOPIFY WEBHOOK] Marked participant ${participantId} as ACTIVE for program ${programId}`);
+                        }
 
                         // Hold-ledger (product decision 2026-07-06): NORMAL PAYMENT is
                         // one of the three release paths. A denied scholarship

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -5,6 +5,7 @@ import { logger } from "@/lib/logger";
 import { activateByProcessId } from "@/lib/membership/payment";
 import { withWebhook } from "@/lib/webhookAuth";
 import { config, DEV_MOCK_MEMBERSHIP_VARIANT_ID } from "@/lib/config";
+import { adjustProgramInventory } from "@/lib/shopify";
 
 interface ShopifyOrder {
     id?: number | string;
@@ -150,6 +151,15 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                 );
                 const hasProgramItem = (order.line_items ?? []).some((li) => programVariantIds.has(String(li.variant_id)));
 
+                // Which tier Shopify actually sold — needed below to mirror inventory
+                // onto the SIBLING pool. buildShopifyCheckoutUrl fixes ONE variant per
+                // order (one household = one tier per checkout), so if hasProgramItem
+                // matched and this is false, the non-member tier is the one purchased.
+                const purchasedOrgMember = !!program?.shopifyOrgMemberVariantId &&
+                    (order.line_items ?? []).some((li) => String(li.variant_id) === program.shopifyOrgMemberVariantId);
+
+                let activatedCount = 0;
+
                 for (const participantId of participantIds) {
                     // Find existing participant
                     const existing = await prisma.programParticipant.findUnique({
@@ -173,10 +183,30 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                                 pendingSince: null, // clear out the pending timer
                             }
                         });
+                        activatedCount++;
 
                         logger.info(`[SHOPIFY WEBHOOK] Marked participant ${participantId} as ACTIVE for program ${programId}`);
                     } else {
                         logger.warn(`[SHOPIFY WEBHOOK] Participant ${participantId} not found in Program ${programId}. Ignoring payment.`);
+                    }
+                }
+
+                // Interim two-pool mirror model (product decision 2026-07-06, extended):
+                // the org-member and non-org-member variants each carry their OWN
+                // Shopify inventory pool, both seeded to maxParticipants — so Shopify
+                // only auto-decrements the pool for the tier actually purchased. Mirror
+                // the same drop onto the SIBLING pool so both pools keep meaning
+                // "remaining shared capacity" (mod webhook lag/races) until the planned
+                // customer-segment/single-variant redesign collapses them into one.
+                // Deliberately AFTER activation is committed, and never allowed to fail
+                // the webhook response — Shopify retries the whole order on a non-2xx.
+                if (activatedCount > 0) {
+                    const siblingOnly = purchasedOrgMember
+                        ? { shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: program?.shopifyNonOrgMemberVariantId ?? null }
+                        : { shopifyOrgMemberVariantId: program?.shopifyOrgMemberVariantId ?? null, shopifyNonOrgMemberVariantId: null };
+                    const ok = await adjustProgramInventory(siblingOnly, -activatedCount);
+                    if (!ok) {
+                        logger.error(`[SHOPIFY WEBHOOK] Failed to mirror sibling-variant inventory for program ${programId} after activating ${activatedCount} participant(s) — pools may be out of sync.`);
                     }
                 }
             }

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -164,6 +164,7 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                     (order.line_items ?? []).some((li) => String(li.variant_id) === program.shopifyOrgMemberVariantId);
 
                 let activatedCount = 0;
+                let releasedHoldCount = 0;
 
                 for (const participantId of participantIds) {
                     // Find existing participant
@@ -191,8 +192,43 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                         activatedCount++;
 
                         logger.info(`[SHOPIFY WEBHOOK] Marked participant ${participantId} as ACTIVE for program ${programId}`);
+
+                        // Hold-ledger (product decision 2026-07-06): NORMAL PAYMENT is
+                        // one of the three release paths. A denied scholarship
+                        // applicant who pays anyway still had inventoryHeldAt set
+                        // from application time; this sale just made Shopify
+                        // auto-decrement a SECOND unit for the same seat. Release the
+                        // hold (+1) to compensate, guarded transactionally
+                        // (inventoryHeldAt NOT NULL -> NULL) so a webhook retry can't
+                        // release twice. Without this, every denied-then-paying
+                        // applicant permanently leaks a seat of capacity.
+                        if (existing.inventoryHeldAt) {
+                            const release = await prisma.programParticipant.updateMany({
+                                where: { programId, personId: participantId, inventoryHeldAt: { not: null } },
+                                data: { inventoryHeldAt: null },
+                            });
+                            releasedHoldCount += release.count;
+                        }
                     } else {
                         logger.warn(`[SHOPIFY WEBHOOK] Participant ${participantId} not found in Program ${programId}. Ignoring payment.`);
+                    }
+                }
+
+                // Release path (b), continued: fire the compensating +1 for every
+                // hold released above, in one call. Never allowed to fail the
+                // webhook response — same non-fatal posture as the sibling-mirror
+                // block below (Shopify retries the whole order on a non-2xx).
+                if (releasedHoldCount > 0) {
+                    const ok = await adjustProgramInventory(
+                        {
+                            shopifyVariantId: program?.shopifyVariantId ?? null,
+                            shopifyOrgMemberVariantId: program?.shopifyOrgMemberVariantId ?? null,
+                            shopifyNonOrgMemberVariantId: program?.shopifyNonOrgMemberVariantId ?? null,
+                        },
+                        releasedHoldCount,
+                    );
+                    if (!ok) {
+                        logger.error(`[SHOPIFY WEBHOOK] Failed to release ${releasedHoldCount} scholarship inventory hold(s) for program ${programId} after payment — capacity may be out of sync.`);
                     }
                 }
 

--- a/checkin-app/src/app/dev/shopify/page.tsx
+++ b/checkin-app/src/app/dev/shopify/page.tsx
@@ -33,7 +33,7 @@ export default async function DevShopifyPage() {
             personId: true,
             person: { select: { name: true } },
             program: {
-                select: { id: true, name: true, shopifyOrgMemberVariantId: true, shopifyNonOrgMemberVariantId: true },
+                select: { id: true, name: true, shopifyVariantId: true, shopifyOrgMemberVariantId: true, shopifyNonOrgMemberVariantId: true },
             },
         },
     });
@@ -51,7 +51,7 @@ export default async function DevShopifyPage() {
                 programName: pp.program.name,
                 personId: pp.personId,
                 personName: pp.person.name ?? `Person #${pp.personId}`,
-                hasVariant: !!(pp.program.shopifyOrgMemberVariantId ?? pp.program.shopifyNonOrgMemberVariantId),
+                hasVariant: !!(pp.program.shopifyVariantId ?? pp.program.shopifyOrgMemberVariantId ?? pp.program.shopifyNonOrgMemberVariantId),
             }))}
         />
     );

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -49,6 +49,8 @@ export default function PendingParticipantsPage() {
   const [message, setMessage] = useState("");
   const [confirmApproveOpened, { open: openConfirmApprove, close: closeConfirmApprove }] = useDisclosure(false);
   const [pendingApproval, setPendingApproval] = useState<{ programId: number; participantId: number } | null>(null);
+  const [confirmRefuseOpened, { open: openConfirmRefuse, close: closeConfirmRefuse }] = useDisclosure(false);
+  const [pendingRefusal, setPendingRefusal] = useState<{ programId: number; participantId: number } | null>(null);
 
   const fetchRequests = useCallback(async () => {
     try {
@@ -110,6 +112,45 @@ export default function PendingParticipantsPage() {
     await doApprove(programId, participantId);
   };
 
+  const handleRefuse = (programId: number, participantId: number) => {
+    setPendingRefusal({ programId, participantId });
+    openConfirmRefuse();
+  };
+
+  const doRefuse = async (programId: number, participantId: number) => {
+    try {
+      const res = await fetch('/api/finance-ops/payment-plans/refuse', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ programId, participantId })
+      });
+
+      if (res.ok) {
+        setRequests(prev => prev.filter(r => !(r.programId === programId && r.personId === participantId)));
+        notifyNavRefresh();
+        notifications.show({ color: 'green', message: 'Scholarship / payment plan refused.' });
+      } else {
+        const data = await res.json();
+        if (data.error === "No pending payment-plan request") {
+          notifications.show({ color: 'red', message: data.error, autoClose: 4000 });
+          fetchRequests();
+        } else {
+          notifications.show({ color: 'red', message: data.error || "Failed to refuse.", autoClose: false });
+        }
+      }
+    } catch {
+      notifications.show({ color: 'red', message: "Network error processing refusal.", autoClose: false });
+    }
+  };
+
+  const confirmRefuse = async () => {
+    if (!pendingRefusal) return;
+    closeConfirmRefuse();
+    const { programId, participantId } = pendingRefusal;
+    setPendingRefusal(null);
+    await doRefuse(programId, participantId);
+  };
+
   if (authLoading || loading) {
     return <PageLoader />;
   }
@@ -159,14 +200,24 @@ export default function PendingParticipantsPage() {
       header: 'Actions',
       align: 'right',
       render: (req) => (
-        <Button
-          size="xs" fz={15} color="green" variant="light"
-          disabled={ownHousehold(req)}
-          title={ownHousehold(req) ? "You can't approve your own household's plan — a sysadmin must." : undefined}
-          onClick={() => handleApprove(req.programId, req.personId)}
-        >
-          Approve &amp; Mark Active
-        </Button>
+        <Group justify="flex-end" gap="xs" wrap="nowrap">
+          <Button
+            size="xs" fz={15} color="red" variant="light"
+            disabled={ownHousehold(req)}
+            title={ownHousehold(req) ? "You can't refuse your own household's plan — a sysadmin must." : undefined}
+            onClick={() => handleRefuse(req.programId, req.personId)}
+          >
+            Refuse
+          </Button>
+          <Button
+            size="xs" fz={15} color="green" variant="light"
+            disabled={ownHousehold(req)}
+            title={ownHousehold(req) ? "You can't approve your own household's plan — a sysadmin must." : undefined}
+            onClick={() => handleApprove(req.programId, req.personId)}
+          >
+            Approve &amp; Mark Active
+          </Button>
+        </Group>
       ),
     },
   ];
@@ -201,6 +252,21 @@ export default function PendingParticipantsPage() {
         <Group justify="flex-end">
           <Button variant="default" onClick={closeConfirmApprove}>Cancel</Button>
           <Button color="green" onClick={confirmApprove}>Approve &amp; Mark Active</Button>
+        </Group>
+      </Modal>
+
+      <Modal
+        opened={confirmRefuseOpened}
+        onClose={closeConfirmRefuse}
+        title={<Text span fw={700} fz="lg">Refuse Scholarship / Payment Plan</Text>}
+        centered
+      >
+        <Text mb="lg">
+          Refuse this request? The participant stays enrolled and can pay normally, withdraw, or re-request later.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmRefuse}>Cancel</Button>
+          <Button color="red" onClick={confirmRefuse}>Refuse</Button>
         </Group>
       </Modal>
     </Stack>

--- a/checkin-app/src/app/program-ops/programs/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/page.tsx
@@ -17,6 +17,7 @@ type Program = {
   endAt?: string | null;
   orgMemberPriceCents?: number | null;
   nonOrgMemberPriceCents?: number | null;
+  shopifyVariantId?: string | null;
   shopifyOrgMemberVariantId?: string | null;
   shopifyNonOrgMemberVariantId?: string | null;
   _count?: { participants?: number; events?: number };

--- a/checkin-app/src/app/programs/[id]/__tests__/enroll.test.ts
+++ b/checkin-app/src/app/programs/[id]/__tests__/enroll.test.ts
@@ -64,4 +64,20 @@ describe('buildShopifyCheckoutUrl', () => {
             'https://shop.example.com/cart/gid123:1?attributes[CheckMeIn_Account_ID]=11&attributes[Program_ID]=7'
         );
     });
+
+    // Single-pool model: a member's checkout carries a server-minted discount
+    // code (mintMemberDiscountCode) prepended, mirroring buildMembershipCheckoutUrl.
+    it('prepends discount=<code> when a discount code is given', () => {
+        const url = buildShopifyCheckoutUrl('shop.example.com', 'gid123', [11], '7', 'PRG7-ABCD');
+        expect(url).toBe(
+            'https://shop.example.com/cart/gid123:1?discount=PRG7-ABCD&attributes[CheckMeIn_Account_ID]=11&attributes[Program_ID]=7'
+        );
+    });
+
+    it('omits the discount param entirely when the code is null/undefined', () => {
+        const url = buildShopifyCheckoutUrl('shop.example.com', 'gid123', [11], '7', null);
+        expect(url).toBe(
+            'https://shop.example.com/cart/gid123:1?attributes[CheckMeIn_Account_ID]=11&attributes[Program_ID]=7'
+        );
+    });
 });

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -424,6 +424,62 @@ describe("ProgramEnrollmentPage", () => {
         }
     });
 
+    // Single-pool model: an ACTIVE member checking out into a single-variant
+    // program fetches a server-minted discount code before redirecting.
+    it("fetches a member discount code before redirecting for a single-pool program", async () => {
+        setSession({ id: 101 });
+        const prevDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
+        process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN = "shop.example.com";
+        try {
+            const memberHousehold = { household: { ...household.household, orgMembership: { status: "ACTIVE" } } };
+            const fetchMock = mockFetchJson({
+                "/api/programs/10/discount-code": { code: "PRG10-MOCKED" },
+                "/api/household": memberHousehold,
+                "/api/programs/10": baseProgram({
+                    orgMemberPriceCents: 4000, nonOrgMemberPriceCents: 5000, minAge: null, maxAge: null,
+                    shopifyVariantId: "gid://single-pool", shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+                }),
+                "/api/programs/10/participants": { ok: true },
+            });
+            renderPage();
+            await screen.findByText("Robotics Club");
+            fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+            await screen.findByText("Which of your household wants to enroll?");
+            fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
+
+            expect(await screen.findByText("Redirecting to Shopify for secure payment...")).toBeInTheDocument();
+            await waitFor(() =>
+                expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/api/programs/10/discount-code"))).toBe(true),
+            );
+        } finally {
+            process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN = prevDomain;
+        }
+    });
+
+    it("does NOT fetch a discount code for a legacy two-variant program", async () => {
+        setSession({ id: 101 });
+        const prevDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
+        process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN = "shop.example.com";
+        try {
+            const memberHousehold = { household: { ...household.household, orgMembership: { status: "ACTIVE" } } };
+            const fetchMock = mockFetchJson({
+                "/api/household": memberHousehold,
+                "/api/programs/10": baseProgram({ orgMemberPriceCents: 5000, minAge: null, maxAge: null, shopifyOrgMemberVariantId: "gid://member", shopifyNonOrgMemberVariantId: "gid://nonmember" }),
+                "/api/programs/10/participants": { ok: true },
+            });
+            renderPage();
+            await screen.findByText("Robotics Club");
+            fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+            await screen.findByText("Which of your household wants to enroll?");
+            fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
+
+            await screen.findByText("Redirecting to Shopify for secure payment...");
+            expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/discount-code"))).toBe(false);
+        } finally {
+            process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN = prevDomain;
+        }
+    });
+
     it("shows different closed-enrollment reasons depending on fullness, phase, and count source", async () => {
         setSession({ id: 101 });
         const cases: [string, Record<string, unknown>][] = [

--- a/checkin-app/src/app/programs/[id]/enroll.ts
+++ b/checkin-app/src/app/programs/[id]/enroll.ts
@@ -49,13 +49,22 @@ export function aggregateEnrollOutcomes(outcomes: EnrollOutcome[]): {
  * comma-joined. The orders/paid webhook splits CheckMeIn_Account_ID on ',' and
  * activates each (webhooks/shopify/route.ts). Constraint: holds only while one
  * household = one membership tier = one variant.
+ *
+ * `discountCode` (single-pool model only — see mintMemberDiscountCode in
+ * lib/shopify.ts) is prepended as `discount=<code>`, mirroring
+ * buildMembershipCheckoutUrl's existing discount-code convention.
  */
 export function buildShopifyCheckoutUrl(
     storeDomain: string | undefined,
     variantId: string,
     enrolledIds: number[],
     programId: string | number,
+    discountCode?: string | null,
 ): string {
     const accountIds = enrolledIds.join(',');
-    return `https://${storeDomain}/cart/${variantId}:${enrolledIds.length}?attributes[CheckMeIn_Account_ID]=${accountIds}&attributes[Program_ID]=${programId}`;
+    const parts: string[] = [];
+    if (discountCode) parts.push(`discount=${encodeURIComponent(discountCode)}`);
+    parts.push(`attributes[CheckMeIn_Account_ID]=${accountIds}`);
+    parts.push(`attributes[Program_ID]=${programId}`);
+    return `https://${storeDomain}/cart/${variantId}:${enrolledIds.length}?${parts.join('&')}`;
 }

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -31,6 +31,11 @@ type ProgramDetail = {
   enrollmentStatus: string;
   orgMemberPriceCents: number | null;
   nonOrgMemberPriceCents: number | null;
+  // Single-pool model (product decision 2026-07-06): when set, this is the
+  // ONE variant for both tiers — member pricing comes from a checkout-time
+  // discount code (see handleEnroll), not a separate variant. Legacy programs
+  // leave this null and keep using the pair below.
+  shopifyVariantId: string | null;
   shopifyOrgMemberVariantId: string | null;
   shopifyNonOrgMemberVariantId: string | null;
   minAge: number | null;
@@ -239,14 +244,16 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
       // Variant is always required — local synthesizes dev-mock-variant ids, so a null
       // one is a real config gap in every env.
       let mockPay = false;
+      let isMember = false;
       if (isPayingOnShopify && program) {
         const householdRes = await fetch('/api/household');
-        let isMember = false;
         if (householdRes.ok) {
           const householdData = await householdRes.json();
           isMember = householdData.household?.orgMembership?.status === "ACTIVE" || false;
         }
-        variantId = isMember ? program.shopifyOrgMemberVariantId : program.shopifyNonOrgMemberVariantId;
+        // Single-pool programs sell the SAME variant to everyone — the discount
+        // code (below, at redirect time) does the member pricing, not a variant pick.
+        variantId = program.shopifyVariantId || (isMember ? program.shopifyOrgMemberVariantId : program.shopifyNonOrgMemberVariantId);
         storeDomain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
         mockPay = isLocalInstance;
         if (!variantId || (!mockPay && !storeDomain)) {
@@ -292,9 +299,23 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
           fetchProgram();
         } else if (isPayingOnShopify && program && variantId && storeDomain) {
           setSuccessMessage("Redirecting to Shopify for secure payment...");
-          // qty=N single variant + comma-joined account ids — see buildShopifyCheckoutUrl.
           navigating = true;
-          window.location.href = buildShopifyCheckoutUrl(storeDomain, variantId, enrolledIds, id);
+          // Single-pool model only: a member checking out gets a per-enrollee,
+          // single-use discount code minted server-side (the browser never has
+          // Shopify credentials to do this itself). Legacy two-variant programs
+          // already charged the right tier via the variant pick above — no code
+          // needed. Failure here is non-fatal: an undiscounted link is always a
+          // safe fallback (never blocks checkout), per lib/shopify.ts's
+          // mintMemberDiscountCode contract.
+          let discountCode: string | null = null;
+          if (program.shopifyVariantId && isMember) {
+            try {
+              const discRes = await fetch(`/api/programs/${id}/discount-code`, { method: 'POST' });
+              if (discRes.ok) discountCode = (await discRes.json()).code ?? null;
+            } catch { /* undiscounted link is an acceptable fallback */ }
+          }
+          // qty=N single variant + comma-joined account ids — see buildShopifyCheckoutUrl.
+          window.location.href = buildShopifyCheckoutUrl(storeDomain, variantId, enrolledIds, id, discountCode);
           return; // spinner stays; page unloads on redirect
         } else {
           notifications.show({ color: "green", message: enrolledIds.length > 1 ? `Successfully enrolled ${enrolledIds.length} members!` : "Successfully enrolled!" });

--- a/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
@@ -16,6 +16,7 @@ const SETTINGS = {
   orgMembershipVariantId: "123456",
   volunteerDiscountCode: "VOLUNTEER",
   bgRecheckMonths: 24,
+  scholarshipDenialGraceDays: 14,
 };
 
 beforeEach(() => {
@@ -69,6 +70,34 @@ describe("MembershipSettingsPage", () => {
     fireEvent.change(screen.getByDisplayValue("VOLUNTEER"), { target: { value: "" } });
     fireEvent.change(screen.getByLabelText("Background check valid for"), { target: { value: "12" } });
     expect(screen.queryByText(/Background-check interval is/)).not.toBeInTheDocument();
+  });
+
+  it("edits the scholarship grace period, blank clears it to null, and rejects a non-positive value", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({ "/api/settings/membership": { settings: SETTINGS } });
+    renderWithProviders(<MembershipSettingsPage />);
+    const graceInput = await screen.findByDisplayValue("14");
+
+    // Blank -> null.
+    fireEvent.change(graceInput, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/settings/membership", expect.objectContaining({ method: "PUT" })));
+    let [, putOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PUT")!;
+    expect(JSON.parse(putOpts!.body as string)).toEqual(expect.objectContaining({ scholarshipDenialGraceDays: null }));
+
+    // Non-positive -> client-side validation error, no PUT fires for it.
+    fetchMock.mockClear();
+    fireEvent.change(graceInput, { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    expect(await screen.findByText(/Enter a positive whole number of days/)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/settings/membership", expect.objectContaining({ method: "PUT" }));
+
+    // A positive value saves cleanly.
+    fireEvent.change(graceInput, { target: { value: "30" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/settings/membership", expect.objectContaining({ method: "PUT" })));
+    [, putOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PUT")!;
+    expect(JSON.parse(putOpts!.body as string)).toEqual(expect.objectContaining({ scholarshipDenialGraceDays: 30 }));
   });
 
   it("unlocks and edits the membership-year boundary, which is included on save", async () => {

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -15,6 +15,7 @@ interface Settings {
   orgMembershipVariantId: string | null;
   volunteerDiscountCode: string | null;
   bgRecheckMonths: number;
+  scholarshipDenialGraceDays: number | null;
 }
 
 const dollars = (cents: number) => (cents / 100).toFixed(2);
@@ -34,6 +35,7 @@ export default function MembershipSettingsPage() {
   const [normalDues, setNormalDues] = useState("0");
   const [volunteerDues, setVolunteerDues] = useState("0");
   const [bgRecheckMonths, setBgRecheckMonths] = useState("0");
+  const [scholarshipGraceDays, setScholarshipGraceDays] = useState("");
   const [boundary, setBoundary] = useState("");
   const [boundaryUnlocked, setBoundaryUnlocked] = useState(false);
   const [variantId, setVariantId] = useState("");
@@ -50,7 +52,7 @@ export default function MembershipSettingsPage() {
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [fieldErrors, setFieldErrors] = useState<{ normalDues?: string; volunteerDues?: string; variantId?: string }>({});
+  const [fieldErrors, setFieldErrors] = useState<{ normalDues?: string; volunteerDues?: string; variantId?: string; scholarshipGraceDays?: string }>({});
   const [saveNotice, setSaveNotice] = useState<{ text: string; err: boolean } | null>(null);
   const [renewalNotice, setRenewalNotice] = useState<{ text: string; err: boolean } | null>(null);
 
@@ -64,6 +66,7 @@ export default function MembershipSettingsPage() {
           normalDues: dollars(settings.normalDuesCents),
           volunteerDues: dollars(settings.volunteerDuesCents),
           bgRecheckMonths: String(settings.bgRecheckMonths ?? 0),
+          scholarshipGraceDays: settings.scholarshipDenialGraceDays != null ? String(settings.scholarshipDenialGraceDays) : "",
           boundary: settings.orgMembershipYearBoundary ? settings.orgMembershipYearBoundary.slice(0, 10) : "",
           variantId: settings.orgMembershipVariantId ?? "",
           discountCode: settings.volunteerDiscountCode ?? "",
@@ -71,6 +74,7 @@ export default function MembershipSettingsPage() {
         setNormalDues(snap.normalDues);
         setVolunteerDues(snap.volunteerDues);
         setBgRecheckMonths(snap.bgRecheckMonths);
+        setScholarshipGraceDays(snap.scholarshipGraceDays);
         setBoundary(snap.boundary);
         setVariantId(snap.variantId);
         setDiscountCode(snap.discountCode);
@@ -90,11 +94,15 @@ export default function MembershipSettingsPage() {
   const saveSettings = async () => {
     setSaveNotice(null);
     setFieldErrors({});
-    const fe: { normalDues?: string; volunteerDues?: string; variantId?: string } = {};
+    const fe: { normalDues?: string; volunteerDues?: string; variantId?: string; scholarshipGraceDays?: string } = {};
     const nd = parseFloat(normalDues); if (normalDues.trim() === "" || isNaN(nd) || nd < 0) fe.normalDues = "Enter a dollar amount of 0 or more.";
     const vd = parseFloat(volunteerDues); if (volunteerDues.trim() === "" || isNaN(vd) || vd < 0) fe.volunteerDues = "Enter a dollar amount of 0 or more.";
     if (variantId.trim() !== "" && !/^\d+$/.test(variantId.trim())) fe.variantId = "Must be a numeric Shopify variant ID.";
-    if (fe.normalDues || fe.volunteerDues || fe.variantId) { setFieldErrors(fe); return; }
+    if (scholarshipGraceDays.trim() !== "") {
+      const g = parseInt(scholarshipGraceDays.trim(), 10);
+      if (!Number.isInteger(g) || g <= 0 || String(g) !== scholarshipGraceDays.trim()) fe.scholarshipGraceDays = "Enter a positive whole number of days, or leave blank to disable.";
+    }
+    if (fe.normalDues || fe.volunteerDues || fe.variantId || fe.scholarshipGraceDays) { setFieldErrors(fe); return; }
     setSaving(true);
     try {
       const res = await fetch("/api/settings/membership", {
@@ -106,6 +114,7 @@ export default function MembershipSettingsPage() {
           orgMembershipVariantId: variantId.trim() || null,
           volunteerDiscountCode: discountCode.trim() || null,
           bgRecheckMonths: Math.round(parseInt(bgRecheckMonths || "0", 10)),
+          scholarshipDenialGraceDays: scholarshipGraceDays.trim() === "" ? null : parseInt(scholarshipGraceDays.trim(), 10),
           // Send the boundary when the unlock is checked, or when it was never set (no
           // unlock shown then — nothing to protect from an accidental shift).
           ...(boundaryUnlocked || !boundaryWasSet ? { orgMembershipYearBoundary: boundary || null } : {}),
@@ -136,7 +145,7 @@ export default function MembershipSettingsPage() {
 
   const isDirty =
     !!initial &&
-    !shallowEqual(initial, { normalDues, volunteerDues, bgRecheckMonths, boundary, variantId, discountCode });
+    !shallowEqual(initial, { normalDues, volunteerDues, bgRecheckMonths, scholarshipGraceDays, boundary, variantId, discountCode });
   useUnsavedGuard(isDirty);
 
   return (
@@ -178,6 +187,17 @@ export default function MembershipSettingsPage() {
                 error={(!bgRecheckMonths || parseInt(bgRecheckMonths, 10) <= 0) ? "Required — not configured." : undefined}
                 value={bgRecheckMonths}
                 onChange={(e) => setBgRecheckMonths(e.currentTarget.value)}
+              />
+              <TextInput
+                label="Scholarship denial grace period"
+                description="Days a denied scholarship applicant keeps their held seat before auto-release. Blank disables auto-release."
+                rightSection={<Text size="sm" c="dimmed">days</Text>}
+                rightSectionWidth={44}
+                inputMode="numeric"
+                w={220}
+                error={fieldErrors.scholarshipGraceDays}
+                value={scholarshipGraceDays}
+                onChange={(e) => { setScholarshipGraceDays(e.currentTarget.value); setFieldErrors((f) => ({ ...f, scholarshipGraceDays: undefined })); }}
               />
             </Group>
 

--- a/checkin-app/src/lib/__tests__/programCheckout.test.ts
+++ b/checkin-app/src/lib/__tests__/programCheckout.test.ts
@@ -50,4 +50,23 @@ describe("isProgramCheckoutBroken", () => {
       shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
     })).toBe(false);
   });
+
+  // Single-pool model (product decision 2026-07-06): shopifyVariantId alone
+  // covers both tiers — never flag broken when it's set, regardless of the
+  // legacy pair's state.
+  it("shopifyVariantId set covers both priced tiers — not broken", () => {
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 8000,
+      shopifyVariantId: "single-pool-gid",
+      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+    })).toBe(false);
+  });
+
+  it("a priced program with neither shopifyVariantId nor a legacy variant is broken", () => {
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 8000,
+      shopifyVariantId: null,
+      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+    })).toBe(true);
+  });
 });

--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -1,4 +1,4 @@
-import { createShopifyProgramVariants, resetTokenCache } from '../shopify';
+import { createShopifyProgramVariants, adjustProgramInventory, resetTokenCache } from '../shopify';
 import { sendEmail } from '../email';
 import prisma from '../prisma';
 
@@ -284,5 +284,113 @@ describe('createShopifyProgramVariants', () => {
             expect.stringContaining('timed out after 20000ms'),
         );
         timeoutSpy.mockRestore();
+    });
+});
+
+describe('adjustProgramInventory', () => {
+    let originalEnv: NodeJS.ProcessEnv;
+    let fetchMock: jest.Mock;
+
+    const program = {
+        shopifyOrgMemberVariantId: '67890',
+        shopifyNonOrgMemberVariantId: '11111',
+    };
+
+    beforeEach(() => {
+        originalEnv = { ...process.env };
+        process.env.SHOPIFY_STORE_DOMAIN = 'test.myshopify.com';
+        process.env.SHOPIFY_CLIENT_ID = 'test_client_id';
+        process.env.SHOPIFY_CLIENT_SECRET = 'test_client_secret';
+
+        fetchMock = jest.fn();
+        global.fetch = fetchMock;
+
+        jest.clearAllMocks();
+        resetTokenCache();
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+        jest.restoreAllMocks();
+    });
+
+    it('resolves inventory_item_ids for both variants and adjusts both by delta at the store location', async () => {
+        mockTokenResponse(fetchMock);
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 555 }] }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { inventory_item_id: 111 } }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // adjust member
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { inventory_item_id: 222 } }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // adjust non-member
+
+        const result = await adjustProgramInventory(program, 5);
+
+        expect(result).toBe(true);
+        expect(fetchMock).toHaveBeenCalledTimes(6); // token + locations + 2 * (variant get + adjust)
+
+        const adjustCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('inventory_levels/adjust.json'));
+        expect(adjustCalls).toHaveLength(2);
+        for (const [, init] of adjustCalls) {
+            const body = JSON.parse(init.body as string);
+            expect(body).toEqual({ location_id: 555, inventory_item_id: expect.any(Number), available_adjustment: 5 });
+        }
+    });
+
+    it('adjusts only the configured variant when the program has just one', async () => {
+        mockTokenResponse(fetchMock);
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 555 }] }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { inventory_item_id: 111 } }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+        const result = await adjustProgramInventory(
+            { shopifyOrgMemberVariantId: '67890', shopifyNonOrgMemberVariantId: null },
+            -3,
+        );
+
+        expect(result).toBe(true);
+        expect(fetchMock).toHaveBeenCalledTimes(4); // token + locations + variant get + adjust
+    });
+
+    it('returns false and emails admins (non-fatal) when the adjust call fails', async () => {
+        mockTokenResponse(fetchMock);
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 555 }] }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { inventory_item_id: 111 } }) });
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => '{"errors":"bad adjustment"}' });
+
+        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce([{ email: 'admin@test.com' }]);
+
+        const result = await adjustProgramInventory(
+            { shopifyOrgMemberVariantId: '67890', shopifyNonOrgMemberVariantId: null },
+            5,
+        );
+
+        expect(result).toBe(false);
+        expect(sendEmail).toHaveBeenCalledWith(
+            'admin@test.com',
+            'Shopify Integration Error',
+            expect.stringContaining('Failed to adjust Shopify inventory'),
+        );
+    });
+
+    it('returns false without calling fetch when credentials are missing', async () => {
+        delete process.env.SHOPIFY_STORE_DOMAIN;
+        delete process.env.SHOPIFY_CLIENT_ID;
+        delete process.env.SHOPIFY_CLIENT_SECRET;
+
+        const result = await adjustProgramInventory(program, 5);
+
+        expect(result).toBe(false);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('no-ops successfully when the Shopify mock is active', async () => {
+        process.env.CHECKIN_ENV = 'local';
+        delete process.env.SHOPIFY_STORE_DOMAIN;
+        delete process.env.SHOPIFY_CLIENT_ID;
+        delete process.env.SHOPIFY_CLIENT_SECRET;
+
+        const result = await adjustProgramInventory(program, 5);
+
+        expect(result).toBe(true);
+        expect(fetchMock).not.toHaveBeenCalled();
     });
 });

--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -1,4 +1,4 @@
-import { createShopifyProgramVariants, adjustProgramInventory, resetTokenCache } from '../shopify';
+import { createShopifyProgramVariants, createShopifySingleVariantProgram, adjustProgramInventory, mintMemberDiscountCode, resetTokenCache } from '../shopify';
 import { sendEmail } from '../email';
 import prisma from '../prisma';
 
@@ -391,6 +391,201 @@ describe('adjustProgramInventory', () => {
         const result = await adjustProgramInventory(program, 5);
 
         expect(result).toBe(true);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    // Single-pool model (product decision 2026-07-06): shopifyVariantId, when
+    // set, IS the whole capacity — adjust ONLY that id, never the legacy pair,
+    // even if stale legacy values linger on the row.
+    describe('single-pool preference', () => {
+        it('adjusts only shopifyVariantId when set, ignoring the legacy pair', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 555 }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { inventory_item_id: 999 } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+            const result = await adjustProgramInventory(
+                { shopifyVariantId: 'single-pool-variant', shopifyOrgMemberVariantId: '67890', shopifyNonOrgMemberVariantId: '11111' },
+                -1,
+            );
+
+            expect(result).toBe(true);
+            expect(fetchMock).toHaveBeenCalledTimes(4); // token + locations + one variant get + one adjust
+            expect(String(fetchMock.mock.calls[2][0])).toContain('single-pool-variant');
+        });
+
+        it('no-ops in mock mode logging only shopifyVariantId, not the legacy pair', async () => {
+            process.env.CHECKIN_ENV = 'local';
+            delete process.env.SHOPIFY_STORE_DOMAIN;
+            delete process.env.SHOPIFY_CLIENT_ID;
+            delete process.env.SHOPIFY_CLIENT_SECRET;
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+            const result = await adjustProgramInventory(
+                { shopifyVariantId: 'single-pool-variant', shopifyOrgMemberVariantId: '67890', shopifyNonOrgMemberVariantId: '11111' },
+                -1,
+            );
+
+            expect(result).toBe(true);
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('single-pool-variant'));
+            expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('67890'));
+            logSpy.mockRestore();
+        });
+    });
+});
+
+describe('createShopifySingleVariantProgram', () => {
+    let originalEnv: NodeJS.ProcessEnv;
+    let fetchMock: jest.Mock;
+
+    beforeEach(() => {
+        originalEnv = { ...process.env };
+        process.env.SHOPIFY_STORE_DOMAIN = 'test.myshopify.com';
+        process.env.SHOPIFY_CLIENT_ID = 'test_client_id';
+        process.env.SHOPIFY_CLIENT_SECRET = 'test_client_secret';
+
+        fetchMock = jest.fn();
+        global.fetch = fetchMock;
+
+        jest.clearAllMocks();
+        resetTokenCache();
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+        jest.restoreAllMocks();
+    });
+
+    it('returns null for a free program (no base price) without calling fetch', async () => {
+        const result = await createShopifySingleVariantProgram('Free Prog', null);
+        expect(result).toBeNull();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns a synthetic single variant id on local (mock active)', async () => {
+        process.env.CHECKIN_ENV = 'local';
+        delete process.env.SHOPIFY_STORE_DOMAIN;
+        delete process.env.SHOPIFY_CLIENT_ID;
+        delete process.env.SHOPIFY_CLIENT_SECRET;
+
+        const result = await createShopifySingleVariantProgram('Test Program', 3500, 10);
+        expect(result).not.toBeNull();
+        expect(result?.shopifyProductId).toMatch(/^dev-mock-product-/);
+        expect(result?.shopifyVariantId).toMatch(/^dev-mock-variant-/);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('creates one product + one variant at the base price and sets inventory', async () => {
+        mockTokenResponse(fetchMock);
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 700 } }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { id: 800, inventory_item_id: 900 } }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 950 }] }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+        const result = await createShopifySingleVariantProgram('Single Pool Program', 3500, 10);
+
+        expect(result).toEqual({ shopifyProductId: '700', shopifyVariantId: '800' });
+        expect(fetchMock).toHaveBeenCalledTimes(5); // token + product + variant + locations + inventory set
+        const variantCall = fetchMock.mock.calls[2];
+        expect(JSON.parse((variantCall[1] as RequestInit).body as string)).toMatchObject({
+            variant: { price: '35.00', inventory_management: 'shopify', inventory_policy: 'deny' },
+        });
+    });
+
+    it('returns null and emails admins when variant creation fails', async () => {
+        mockTokenResponse(fetchMock);
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 701 } }) });
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => '{"errors":"bad variant"}' });
+        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce([{ email: 'admin@test.com' }]);
+
+        const result = await createShopifySingleVariantProgram('Broken Program', 3500);
+
+        expect(result).toBeNull();
+        expect(sendEmail).toHaveBeenCalledWith(
+            'admin@test.com',
+            'Shopify Integration Error',
+            expect.stringContaining('Shopify API responded with status: 422'),
+        );
+    });
+});
+
+describe('mintMemberDiscountCode', () => {
+    let originalEnv: NodeJS.ProcessEnv;
+    let fetchMock: jest.Mock;
+
+    beforeEach(() => {
+        originalEnv = { ...process.env };
+        process.env.SHOPIFY_STORE_DOMAIN = 'test.myshopify.com';
+        process.env.SHOPIFY_CLIENT_ID = 'test_client_id';
+        process.env.SHOPIFY_CLIENT_SECRET = 'test_client_secret';
+
+        fetchMock = jest.fn();
+        global.fetch = fetchMock;
+
+        jest.clearAllMocks();
+        resetTokenCache();
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+        jest.restoreAllMocks();
+    });
+
+    it('returns null for a zero/negative discount without calling fetch', async () => {
+        const result = await mintMemberDiscountCode(1, 'variant-1', 0);
+        expect(result).toBeNull();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns a synthesized code on local (mock active), no network', async () => {
+        process.env.CHECKIN_ENV = 'local';
+        delete process.env.SHOPIFY_STORE_DOMAIN;
+        delete process.env.SHOPIFY_CLIENT_ID;
+        delete process.env.SHOPIFY_CLIENT_SECRET;
+
+        const result = await mintMemberDiscountCode(42, '999888', 1000);
+        expect(result).toMatch(/^PRG42-/);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('creates a price rule + discount code and returns the code', async () => {
+        mockTokenResponse(fetchMock);
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ price_rule: { id: 123 } }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+        const result = await mintMemberDiscountCode(42, '999888', 1000);
+
+        expect(result).toMatch(/^PRG42-/);
+        expect(fetchMock).toHaveBeenCalledTimes(3); // token + price_rules + discount_codes
+        const priceRuleCall = fetchMock.mock.calls[1];
+        expect(String(priceRuleCall[0])).toContain('/price_rules.json');
+        const body = JSON.parse((priceRuleCall[1] as RequestInit).body as string);
+        expect(body.price_rule).toMatchObject({
+            value_type: 'fixed_amount',
+            value: '-10.00',
+            usage_limit: 1,
+            once_per_customer: true,
+            entitled_variant_ids: [999888],
+        });
+    });
+
+    it('returns null and does NOT email admins when minting fails (quiet fallback, never blocks checkout)', async () => {
+        mockTokenResponse(fetchMock);
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => '{"errors":"bad price rule"}' });
+
+        const result = await mintMemberDiscountCode(42, '999888', 1000);
+
+        expect(result).toBeNull();
+        expect(sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('returns null without calling fetch when credentials are missing', async () => {
+        delete process.env.SHOPIFY_STORE_DOMAIN;
+        delete process.env.SHOPIFY_CLIENT_ID;
+        delete process.env.SHOPIFY_CLIENT_SECRET;
+
+        const result = await mintMemberDiscountCode(42, '999888', 1000);
+        expect(result).toBeNull();
         expect(fetchMock).not.toHaveBeenCalled();
     });
 });

--- a/checkin-app/src/lib/program/capacity.ts
+++ b/checkin-app/src/lib/program/capacity.ts
@@ -1,4 +1,7 @@
 import type { TxClient } from "@/lib/db-client";
+import type { ProgramParticipant } from "@/generated/prisma/client";
+import prisma from "@/lib/prisma";
+import { adjustProgramInventory } from "@/lib/shopify";
 
 /** Thrown by {@link lockProgramAndCheckCapacity} when a program is full. */
 export class ProgramCapacityError extends Error {
@@ -37,4 +40,41 @@ export async function lockProgramAndCheckCapacity(
     if (count + seats > maxParticipants) {
         throw new ProgramCapacityError(Math.max(0, maxParticipants - count));
     }
+}
+
+/**
+ * Delete a PENDING participant and release its scholarship inventory hold
+ * (+1), exactly once. This is the ONE implementation of "exit a participant"
+ * shared by every code path that does it — manual self/admin withdrawal
+ * (DELETE /api/programs/[id]/participants), the non-payment kick
+ * (cron/pending-participants), and grace-period auto-withdrawal
+ * (cron/scholarship-grace-expiry) — so the hold-ledger invariant (every
+ * scholarship -1 comes back +1 exactly once) has one implementation, not
+ * three.
+ *
+ * `delete()` IS the atomicity boundary: a given row can be deleted at most
+ * once, so "was inventoryHeldAt set on the row we just deleted" can never be
+ * double-counted even under concurrent callers — a second delete() throws
+ * Prisma P2025 (row already gone), which callers handle as an idempotent
+ * no-op and never reach this function for.
+ *
+ * Never throws on the Shopify leg (adjustProgramInventory already logs +
+ * emails on failure); the boolean return lets the caller surface a
+ * non-fatal warning the same way every other Shopify-adjusting endpoint does.
+ */
+export async function withdrawAndReleaseHold(
+    programId: number,
+    personId: number,
+    program: { shopifyVariantId?: string | null; shopifyOrgMemberVariantId: string | null; shopifyNonOrgMemberVariantId: string | null },
+): Promise<{ enrollment: ProgramParticipant; released: boolean; shopifyOk: boolean }> {
+    const enrollment = await prisma.programParticipant.delete({
+        where: { programId_personId: { programId, personId } },
+    });
+
+    if (!enrollment.inventoryHeldAt) {
+        return { enrollment, released: false, shopifyOk: true };
+    }
+
+    const shopifyOk = await adjustProgramInventory(program, 1);
+    return { enrollment, released: true, shopifyOk };
 }

--- a/checkin-app/src/lib/programCheckout.ts
+++ b/checkin-app/src/lib/programCheckout.ts
@@ -11,6 +11,12 @@ import type { Prisma } from "@/generated/prisma/client";
  * FREE tiers legitimately have no variant, so gate on the tier's price being > 0
  * — never flag on a missing variant alone.
  *
+ * Single-pool model (product decision 2026-07-06): `shopifyVariantId`, when
+ * set, covers BOTH tiers by itself (member pricing is a discount code, not a
+ * separate variant) — a program is checkout-OK with either shopifyVariantId
+ * alone, or the full legacy pair. Legacy programs (no shopifyVariantId) keep
+ * the original per-tier check.
+ *
  * The JS predicate and the Prisma WHERE below MUST stay in lockstep: the count
  * query (nav/todo-counts) and the per-row/detail UI are the same condition on two
  * sides of the wire. Change one, change the other. programCheckout.test.ts guards
@@ -19,11 +25,13 @@ import type { Prisma } from "@/generated/prisma/client";
 type CheckoutFields = {
   orgMemberPriceCents?: number | null;
   nonOrgMemberPriceCents?: number | null;
+  shopifyVariantId?: string | null;
   shopifyOrgMemberVariantId?: string | null;
   shopifyNonOrgMemberVariantId?: string | null;
 };
 
 export function isProgramCheckoutBroken(p: CheckoutFields): boolean {
+  if (p.shopifyVariantId) return false; // single pool covers both tiers
   return (
     ((p.orgMemberPriceCents ?? 0) > 0 && !p.shopifyOrgMemberVariantId) ||
     ((p.nonOrgMemberPriceCents ?? 0) > 0 && !p.shopifyNonOrgMemberVariantId)
@@ -31,6 +39,7 @@ export function isProgramCheckoutBroken(p: CheckoutFields): boolean {
 }
 
 export const PROGRAM_CHECKOUT_BROKEN_WHERE: Prisma.ProgramWhereInput = {
+  shopifyVariantId: null,
   OR: [
     { orgMemberPriceCents: { gt: 0 }, shopifyOrgMemberVariantId: null },
     { nonOrgMemberPriceCents: { gt: 0 }, shopifyNonOrgMemberVariantId: null },

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -288,3 +288,125 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
     return null;
   }
 }
+
+/**
+ * Shopify is the source of truth for program capacity (product decision 2026-07-06):
+ * cap edits propagate as relative inventory adjustments. Called from
+ * PATCH /api/programs/[id] whenever an edit changes maxParticipants on a program
+ * that already has at least one Shopify variant.
+ *
+ * RELATIVE (inventory_levels/adjust, `available_adjustment: delta`) is deliberate,
+ * not absolute set: Shopify decrements `available` itself as seats sell, and an
+ * absolute set here would require reconstructing how many seats already sold to
+ * avoid clobbering that ledger. A relative delta (newMax - oldMax) rides on top of
+ * whatever Shopify already has without the app needing to know that number.
+ *
+ * The schema doesn't persist inventory_item_id (only the variant id), so it's
+ * resolved here per call via GET .../variants/{id}.json — one extra round trip per
+ * configured variant, acceptable for an admin-triggered edit.
+ *
+ * Never throws: mirrors createShopifyProgramVariants' failure handling (log +
+ * admin email), returns false so the caller can surface a non-fatal warning.
+ */
+export async function adjustProgramInventory(
+    program: { shopifyOrgMemberVariantId: string | null; shopifyNonOrgMemberVariantId: string | null },
+    delta: number,
+): Promise<boolean> {
+    const variantIds = [program.shopifyOrgMemberVariantId, program.shopifyNonOrgMemberVariantId]
+        .filter((id): id is string => !!id);
+
+    if (variantIds.length === 0) return true;
+
+    // See createShopifyProgramVariants for why this branch exists (CHECKIN_ENV=local mock).
+    if (config.shopifyMockActive()) {
+        console.log(`[SHOPIFY] (mock) Would adjust inventory by ${delta} for variants: ${variantIds.join(", ")}`);
+        return true;
+    }
+
+    const storeDomain = config.shopifyStoreDomain();
+    const accessToken = await getAccessToken();
+
+    if (!storeDomain || !accessToken) {
+        console.warn("Shopify integration is disabled: Missing credentials or unable to obtain access token");
+        return false;
+    }
+
+    try {
+        // Store's primary location — same lookup pattern as createShopifyProgramVariants.
+        const locRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/locations.json`, {
+            headers: { 'X-Shopify-Access-Token': accessToken },
+        }, "Shopify get locations");
+        if (!locRes.ok) throw new Error(`Shopify locations lookup failed: ${locRes.status}`);
+        const locData = await locRes.json();
+        const locationId = locData.locations?.[0]?.id;
+        if (!locationId) throw new Error("Shopify store has no locations configured");
+
+        for (const variantId of variantIds) {
+            const variantRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/variants/${variantId}.json`, {
+                headers: { 'X-Shopify-Access-Token': accessToken },
+            }, "Shopify get variant");
+            if (!variantRes.ok) throw new Error(`Shopify variant lookup failed for ${variantId}: ${variantRes.status}`);
+            const variantData = await variantRes.json();
+            const inventoryItemId = variantData.variant?.inventory_item_id;
+            if (!inventoryItemId) throw new Error(`Shopify variant ${variantId} has no inventory_item_id`);
+
+            const adjustRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/adjust.json`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Shopify-Access-Token': accessToken,
+                },
+                body: JSON.stringify({
+                    location_id: locationId,
+                    inventory_item_id: inventoryItemId,
+                    available_adjustment: delta,
+                }),
+            }, "Shopify adjust inventory");
+            if (!adjustRes.ok) {
+                throw new Error(`Shopify inventory adjust failed for variant ${variantId}: ${adjustRes.status} ${await adjustRes.text()}`);
+            }
+
+            console.log(`[SHOPIFY] Adjusted inventory for variant ${variantId} by ${delta} at location ${locationId}`);
+        }
+
+        return true;
+    } catch (error) {
+        console.error("[Shopify Error] Failed to adjust program inventory:", error);
+
+        await logIntegrationError("shopify", error, {
+            operation: "adjustProgramInventory",
+            shopifyOrgMemberVariantId: program.shopifyOrgMemberVariantId,
+            shopifyNonOrgMemberVariantId: program.shopifyNonOrgMemberVariantId,
+            delta,
+        });
+
+        try {
+            const admins = await prisma.person.findMany({
+                where: {
+                    OR: [{ isSysadmin: true }, { isBoardMember: true }],
+                    email: { not: null }
+                },
+                select: { email: true }
+            });
+
+            const emailPromises = admins
+                .map(a => a.email)
+                .filter((e): e is string => typeof e === 'string' && e.length > 0)
+                .map(email =>
+                    sendEmail(
+                        email,
+                        "Shopify Integration Error",
+                        `<p>Failed to adjust Shopify inventory (delta ${delta}) after a program capacity change.</p><p>Error details:</p><pre>${escapeHtml(error instanceof Error ? error.message : String(error))}</pre>`
+                    )
+                );
+
+            if (emailPromises.length > 0) {
+                await Promise.all(emailPromises);
+            }
+        } catch (dbError) {
+            console.error("Failed to send Shopify error notifications:", dbError);
+        }
+
+        return false;
+    }
+}

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -603,7 +603,11 @@ export async function mintMemberDiscountCode(
                     target_type: 'line_item',
                     target_selection: 'entitled',
                     entitled_variant_ids: [Number(variantId)],
-                    allocation_method: 'across',
+                    // 'each' applies the amount PER UNIT: a member household enrolling
+                    // N kids buys quantity N of the variant, and each seat gets the
+                    // member price ('across' would subtract the amount once from the
+                    // whole line, overcharging N-1 seats).
+                    allocation_method: 'each',
                     value_type: 'fixed_amount',
                     value: `-${(amountOffCents / 100).toFixed(2)}`,
                     customer_selection: 'all',

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -1,6 +1,7 @@
 // Shopify API integration using Client Credentials Grant (post-Jan 2026)
 // Tokens expire after 24 hours and are cached in-memory.
 
+import crypto from "crypto";
 import prisma from "@/lib/prisma";
 import { sendEmail } from "@/lib/email";
 import { escapeHtml } from "@/lib/email-templates/base";
@@ -91,6 +92,93 @@ export async function getAccessToken(): Promise<string | null> {
     cachedToken = null;
     return null;
   }
+}
+
+/**
+ * Shared failure path for Shopify write operations: log to IntegrationErrorLog
+ * (System Status > Link Status) and best-effort email admins/board. Never
+ * throws — callers return false/null regardless of whether this succeeds.
+ */
+async function reportShopifyFailure(
+    operation: string,
+    error: unknown,
+    context: Record<string, unknown>,
+    emailIntroHtml: string,
+): Promise<void> {
+    await logIntegrationError("shopify", error, { operation, ...context });
+
+    try {
+        const admins = await prisma.person.findMany({
+            where: {
+                OR: [{ isSysadmin: true }, { isBoardMember: true }],
+                email: { not: null }
+            },
+            select: { email: true }
+        });
+
+        const emailPromises = admins
+            .map(a => a.email)
+            .filter((e): e is string => typeof e === 'string' && e.length > 0)
+            .map(email =>
+                sendEmail(
+                    email,
+                    "Shopify Integration Error",
+                    `<p>${emailIntroHtml}</p><p>Error details:</p><pre>${escapeHtml(error instanceof Error ? error.message : String(error))}</pre>`
+                )
+            );
+
+        if (emailPromises.length > 0) {
+            await Promise.all(emailPromises);
+        }
+    } catch (dbError) {
+        console.error("Failed to send Shopify error notifications:", dbError);
+    }
+}
+
+/**
+ * Best-effort: resolve the store's primary location, then set an absolute
+ * inventory level for one inventory_item_id. Used at variant-creation time
+ * (both the legacy two-variant path and the single-variant path) where
+ * `available` should be exactly maxParticipants. Never throws — a failure
+ * here doesn't undo the variant that was just created successfully.
+ */
+async function setInitialShopifyInventory(
+    storeDomain: string,
+    accessToken: string,
+    inventoryItemId: number,
+    quantity: number,
+    label: string,
+): Promise<void> {
+    try {
+        const locRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/locations.json`, {
+            headers: { 'X-Shopify-Access-Token': accessToken },
+        }, "Shopify get locations");
+        if (locRes.ok) {
+            const locData = await locRes.json();
+            const locationId = locData.locations?.[0]?.id;
+            if (locationId) {
+                const invRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/set.json`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Shopify-Access-Token': accessToken,
+                    },
+                    body: JSON.stringify({
+                        location_id: locationId,
+                        inventory_item_id: inventoryItemId,
+                        available: quantity,
+                    })
+                }, "Shopify set inventory");
+                if (invRes.ok) {
+                    console.log(`[SHOPIFY] Set inventory for variant ${label} to ${quantity} at location ${locationId}`);
+                } else {
+                    console.error(`[SHOPIFY] Failed to set inventory: ${invRes.status}`, await invRes.text());
+                }
+            }
+        }
+    } catch (invErr) {
+        console.error("Failed to set Shopify inventory level:", invErr);
+    }
 }
 
 export async function createShopifyProgramVariants(name: string, orgMemberPriceCents: number | null, nonOrgMemberPriceCents: number | null, maxParticipants: number | null = null) {
@@ -200,37 +288,7 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
 
                 // Set inventory level if maxParticipants is configured
                 if (maxParticipants && variantData.variant.inventory_item_id) {
-                    try {
-                        // Get the store's primary location
-                        const locRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/locations.json`, {
-                            headers: { 'X-Shopify-Access-Token': accessToken },
-                        }, "Shopify get locations");
-                        if (locRes.ok) {
-                            const locData = await locRes.json();
-                            const locationId = locData.locations?.[0]?.id;
-                            if (locationId) {
-                                const invRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/set.json`, {
-                                    method: 'POST',
-                                    headers: {
-                                        'Content-Type': 'application/json',
-                                        'X-Shopify-Access-Token': accessToken,
-                                    },
-                                    body: JSON.stringify({
-                                        location_id: locationId,
-                                        inventory_item_id: variantData.variant.inventory_item_id,
-                                        available: maxParticipants,
-                                    })
-                                }, "Shopify set inventory");
-                                if (invRes.ok) {
-                                    console.log(`[SHOPIFY] Set inventory for variant ${variant.option1} to ${maxParticipants} at location ${locationId}`);
-                                } else {
-                                    console.error(`[SHOPIFY] Failed to set inventory: ${invRes.status}`, await invRes.text());
-                                }
-                            }
-                        }
-                    } catch (invErr) {
-                        console.error("Failed to set Shopify inventory level:", invErr);
-                    }
+                    await setInitialShopifyInventory(storeDomain, accessToken, variantData.variant.inventory_item_id, maxParticipants, variant.option1);
                 }
             } else {
                 console.error("Failed to create Shopify variant:", await variantRes.text());
@@ -250,39 +308,12 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
         console.error("[Shopify] Orphaned product after variant failure, manual cleanup needed:", productId);
     }
 
-    // Persist for System Status > Link Status (was email-only before).
-    await logIntegrationError("shopify", error, {
-        operation: "createShopifyProgramVariants",
-        program: name,
-        orphanedProductId: productId ?? null,
-    });
-
-    try {
-        const admins = await prisma.person.findMany({
-            where: {
-                OR: [{ isSysadmin: true }, { isBoardMember: true }],
-                email: { not: null }
-            },
-            select: { email: true }
-        });
-
-        const emailPromises = admins
-            .map(a => a.email)
-            .filter((e): e is string => typeof e === 'string' && e.length > 0)
-            .map(email =>
-                sendEmail(
-                    email,
-                    "Shopify Integration Error",
-                    `<p>An error occurred in the Shopify integration while creating variants for program: <strong>${escapeHtml(name)}</strong>.</p><p>Error details:</p><pre>${escapeHtml(error instanceof Error ? error.message : String(error))}</pre>`
-                )
-            );
-
-        if (emailPromises.length > 0) {
-            await Promise.all(emailPromises);
-        }
-    } catch (dbError) {
-        console.error("Failed to send Shopify error notifications:", dbError);
-    }
+    await reportShopifyFailure(
+        "createShopifyProgramVariants",
+        error,
+        { program: name, orphanedProductId: productId ?? null },
+        `An error occurred in the Shopify integration while creating variants for program: <strong>${escapeHtml(name)}</strong>.`,
+    );
 
     // We log it but do not crash the app. Admin will need to create variants manually.
     return null;
@@ -290,30 +321,156 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
 }
 
 /**
+ * Single-pool model (product decision 2026-07-06): mints ONE Shopify variant
+ * per program, priced at the base/non-member rate — inventory IS the whole
+ * program capacity, not a per-tier pool. Members buy the same variant and get
+ * a per-enrollee discount code at checkout (see {@link mintMemberDiscountCode})
+ * instead of a separate variant/pool. This is the creation path for NEW
+ * programs going forward; {@link createShopifyProgramVariants} above stays
+ * only for programs already on the legacy two-variant model — sync-shopify's
+ * repair route picks between the two based on whether a program already has a
+ * legacy variant configured (expand-only transition; see prisma/schema.prisma).
+ */
+export async function createShopifySingleVariantProgram(
+    name: string,
+    basePriceCents: number | null,
+    maxParticipants: number | null = null,
+): Promise<{ shopifyProductId: string; shopifyVariantId: string } | null> {
+    if (!basePriceCents || basePriceCents <= 0) return null; // free program: no Shopify object needed
+
+    // See createShopifyProgramVariants above for why this branch exists (CHECKIN_ENV=local mock).
+    if (config.shopifyMockActive()) {
+        const slug = name.replace(/\W+/g, "-").toLowerCase().slice(0, 24);
+        return {
+            shopifyProductId: `dev-mock-product-${slug}`,
+            shopifyVariantId: `dev-mock-variant-${slug}`,
+        };
+    }
+
+    const storeDomain = config.shopifyStoreDomain();
+    const accessToken = await getAccessToken();
+
+    if (!storeDomain || !accessToken) {
+        console.warn("Shopify integration is disabled: Missing credentials or unable to obtain access token");
+        return null;
+    }
+
+    // Hoisted so the catch can name an orphaned product (created, but variant/DB failed) for manual cleanup.
+    let productId: string | number | null = null;
+
+    try {
+        const productRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/products.json`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Shopify-Access-Token': accessToken,
+            },
+            body: JSON.stringify({
+                product: {
+                    title: `Program Enrollment: ${name}`,
+                    status: 'active',
+                    product_type: "Educational Services",
+                }
+            })
+        }, "Shopify create product");
+
+        if (!productRes.ok) {
+            const errorData = await productRes.text();
+            console.error(`[Shopify API Error] ${productRes.status} ${productRes.statusText}`, errorData);
+            throw new Error(`Shopify API responded with status: ${productRes.status}`);
+        }
+
+        const productData = await productRes.json();
+        productId = productData.product.id;
+
+        const variantRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/products/${productId}/variants.json`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Shopify-Access-Token': accessToken,
+            },
+            body: JSON.stringify({
+                variant: {
+                    product_id: productId,
+                    price: (basePriceCents / 100).toFixed(2),
+                    requires_shipping: false,
+                    inventory_management: maxParticipants ? 'shopify' : null,
+                    inventory_policy: maxParticipants ? 'deny' : 'continue',
+                }
+            })
+        }, "Shopify create variant");
+
+        if (!variantRes.ok) {
+            const errorData = await variantRes.text();
+            console.error("Failed to create Shopify variant:", errorData);
+            throw new Error(`Shopify API responded with status: ${variantRes.status}`);
+        }
+
+        const variantData = await variantRes.json();
+        const variantId = variantData.variant.id.toString();
+
+        if (maxParticipants && variantData.variant.inventory_item_id) {
+            await setInitialShopifyInventory(storeDomain, accessToken, variantData.variant.inventory_item_id, maxParticipants, "Standard");
+        }
+
+        return {
+            shopifyProductId: productId!.toString(),
+            shopifyVariantId: variantId,
+        };
+    } catch (error) {
+        console.error("[Shopify Error] Failed to create single-variant product:", error);
+        if (productId) {
+            console.error("[Shopify] Orphaned product after variant failure, manual cleanup needed:", productId);
+        }
+
+        await reportShopifyFailure(
+            "createShopifySingleVariantProgram",
+            error,
+            { program: name, orphanedProductId: productId ?? null },
+            `An error occurred in the Shopify integration while creating the variant for program: <strong>${escapeHtml(name)}</strong>.`,
+        );
+
+        return null;
+    }
+}
+
+/**
  * Shopify is the source of truth for program capacity (product decision 2026-07-06):
- * cap edits propagate as relative inventory adjustments. Called from
- * PATCH /api/programs/[id] whenever an edit changes maxParticipants on a program
- * that already has at least one Shopify variant.
+ * cap edits and the scholarship lifecycle (apply/refuse) propagate as relative
+ * inventory adjustments. Called from PATCH /api/programs/[id] (maxParticipants
+ * edits), POST /api/programs/[id]/request-payment-plan (apply, -1), and
+ * POST /api/finance-ops/payment-plans/refuse (refusal, +1) — approval performs
+ * NO Shopify operation (the applicant already holds the seat since apply-time).
+ *
+ * Single-pool preference: when `shopifyVariantId` is set (the single-pool
+ * model), it IS the program's whole capacity and is the only id adjusted —
+ * the legacy pair is ignored even if stale values linger on the row. Legacy
+ * (two-variant) programs fall through to the pre-existing both-pools behavior.
  *
  * RELATIVE (inventory_levels/adjust, `available_adjustment: delta`) is deliberate,
  * not absolute set: Shopify decrements `available` itself as seats sell, and an
  * absolute set here would require reconstructing how many seats already sold to
- * avoid clobbering that ledger. A relative delta (newMax - oldMax) rides on top of
- * whatever Shopify already has without the app needing to know that number.
+ * avoid clobbering that ledger. A relative delta rides on top of whatever
+ * Shopify already has without the app needing to know that number.
  *
  * The schema doesn't persist inventory_item_id (only the variant id), so it's
  * resolved here per call via GET .../variants/{id}.json — one extra round trip per
- * configured variant, acceptable for an admin-triggered edit.
+ * configured variant, acceptable for an admin/scholarship-triggered edit.
  *
  * Never throws: mirrors createShopifyProgramVariants' failure handling (log +
  * admin email), returns false so the caller can surface a non-fatal warning.
  */
 export async function adjustProgramInventory(
-    program: { shopifyOrgMemberVariantId: string | null; shopifyNonOrgMemberVariantId: string | null },
+    program: {
+        shopifyVariantId?: string | null;
+        shopifyOrgMemberVariantId: string | null;
+        shopifyNonOrgMemberVariantId: string | null;
+    },
     delta: number,
 ): Promise<boolean> {
-    const variantIds = [program.shopifyOrgMemberVariantId, program.shopifyNonOrgMemberVariantId]
-        .filter((id): id is string => !!id);
+    const variantIds = program.shopifyVariantId
+        ? [program.shopifyVariantId]
+        : [program.shopifyOrgMemberVariantId, program.shopifyNonOrgMemberVariantId].filter((id): id is string => !!id);
 
     if (variantIds.length === 0) return true;
 
@@ -373,40 +530,124 @@ export async function adjustProgramInventory(
     } catch (error) {
         console.error("[Shopify Error] Failed to adjust program inventory:", error);
 
-        await logIntegrationError("shopify", error, {
-            operation: "adjustProgramInventory",
-            shopifyOrgMemberVariantId: program.shopifyOrgMemberVariantId,
-            shopifyNonOrgMemberVariantId: program.shopifyNonOrgMemberVariantId,
-            delta,
-        });
-
-        try {
-            const admins = await prisma.person.findMany({
-                where: {
-                    OR: [{ isSysadmin: true }, { isBoardMember: true }],
-                    email: { not: null }
-                },
-                select: { email: true }
-            });
-
-            const emailPromises = admins
-                .map(a => a.email)
-                .filter((e): e is string => typeof e === 'string' && e.length > 0)
-                .map(email =>
-                    sendEmail(
-                        email,
-                        "Shopify Integration Error",
-                        `<p>Failed to adjust Shopify inventory (delta ${delta}) after a program capacity change.</p><p>Error details:</p><pre>${escapeHtml(error instanceof Error ? error.message : String(error))}</pre>`
-                    )
-                );
-
-            if (emailPromises.length > 0) {
-                await Promise.all(emailPromises);
-            }
-        } catch (dbError) {
-            console.error("Failed to send Shopify error notifications:", dbError);
-        }
+        await reportShopifyFailure(
+            "adjustProgramInventory",
+            error,
+            {
+                shopifyVariantId: program.shopifyVariantId ?? null,
+                shopifyOrgMemberVariantId: program.shopifyOrgMemberVariantId,
+                shopifyNonOrgMemberVariantId: program.shopifyNonOrgMemberVariantId,
+                delta,
+            },
+            `Failed to adjust Shopify inventory (delta ${delta}) after a program capacity change.`,
+        );
 
         return false;
+    }
+}
+
+/**
+ * Mints a server-side, single-use fixed-amount discount code for one
+ * enrollee's checkout. Single-pool programs ({@link Program.shopifyVariantId})
+ * sell at the base/non-member price; an ACTIVE org member gets this code
+ * appended to their cart link (`?discount=<code>`) to bring the price down to
+ * the member rate. Interim mechanism —
+ * docs/designs/SHOPIFY_MEMBER_SEGMENT_PRICING.md's segment-gated automatic
+ * discount (its §5) is the planned upgrade once checkout identity is solved;
+ * this mints one real Shopify object per checkout in the meantime.
+ *
+ * ponytail: one Price Rule + Discount Code per enrollee/checkout — fine at
+ * Treehouse's program-enrollment volume. Upgrade to the segment design above
+ * if that stops being true.
+ *
+ * Never throws: a failure returns null so the caller falls back to an
+ * undiscounted checkout link rather than blocking it (member pays full price
+ * and can contact the board — better than a broken checkout).
+ */
+export async function mintMemberDiscountCode(
+    programId: number,
+    variantId: string,
+    amountOffCents: number,
+): Promise<string | null> {
+    if (amountOffCents <= 0) return null;
+
+    const code = `PRG${programId}-${crypto.randomBytes(4).toString('hex').toUpperCase()}`;
+
+    // See createShopifyProgramVariants above for why this branch exists (CHECKIN_ENV=local mock).
+    if (config.shopifyMockActive()) {
+        console.log(`[SHOPIFY] (mock) Would mint discount code ${code} for program ${programId} (-$${(amountOffCents / 100).toFixed(2)})`);
+        return code;
+    }
+
+    const storeDomain = config.shopifyStoreDomain();
+    const accessToken = await getAccessToken();
+
+    if (!storeDomain || !accessToken) {
+        console.warn("Shopify integration is disabled: Missing credentials or unable to obtain access token");
+        return null;
+    }
+
+    try {
+        const startsAt = new Date();
+        const endsAt = new Date(startsAt.getTime() + 48 * 60 * 60 * 1000); // ~48h, per design
+
+        const priceRuleRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/price_rules.json`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Shopify-Access-Token': accessToken,
+            },
+            body: JSON.stringify({
+                price_rule: {
+                    title: code,
+                    target_type: 'line_item',
+                    target_selection: 'entitled',
+                    entitled_variant_ids: [Number(variantId)],
+                    allocation_method: 'across',
+                    value_type: 'fixed_amount',
+                    value: `-${(amountOffCents / 100).toFixed(2)}`,
+                    customer_selection: 'all',
+                    usage_limit: 1,
+                    once_per_customer: true,
+                    starts_at: startsAt.toISOString(),
+                    ends_at: endsAt.toISOString(),
+                },
+            }),
+        }, "Shopify create price rule");
+        if (!priceRuleRes.ok) {
+            throw new Error(`Shopify price rule creation failed: ${priceRuleRes.status} ${await priceRuleRes.text()}`);
+        }
+        const priceRuleData = await priceRuleRes.json();
+        const priceRuleId = priceRuleData.price_rule?.id;
+        if (!priceRuleId) throw new Error("Shopify price rule response missing id");
+
+        const codeRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/price_rules/${priceRuleId}/discount_codes.json`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Shopify-Access-Token': accessToken,
+            },
+            body: JSON.stringify({ discount_code: { code } }),
+        }, "Shopify create discount code");
+        if (!codeRes.ok) {
+            throw new Error(`Shopify discount code creation failed: ${codeRes.status} ${await codeRes.text()}`);
+        }
+
+        console.log(`[SHOPIFY] Minted single-use discount code ${code} for program ${programId} (-$${(amountOffCents / 100).toFixed(2)}, expires ${endsAt.toISOString()})`);
+        return code;
+    } catch (error) {
+        console.error("[Shopify Error] Failed to mint member discount code:", error);
+        // Quieter than reportShopifyFailure (no admin email): a per-checkout mint
+        // failure degrades gracefully to an undiscounted link (never blocks
+        // checkout) rather than signaling a structural integration break —
+        // logged for Link Status visibility, not urgent enough to page the board
+        // every time.
+        await logIntegrationError("shopify", error, {
+            operation: "mintMemberDiscountCode",
+            programId,
+            variantId,
+            amountOffCents,
+        });
+        return null;
     }
 }

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -116,6 +116,7 @@ export const classifications = {
         shopifyNormalVariantId: 'internal',
         shopifyVolunteerVariantId: 'internal',
         shopifyPriceSyncedAt: 'internal',
+        scholarshipDenialGraceDays: 'public',
         updatedAt: 'internal',
     },
     AppSettings: {
@@ -207,6 +208,8 @@ export const classifications = {
         isPaymentPlanRequested: 'personal',
         pendingSince: 'internal',
         wasOrgMemberAtApproval: 'internal',
+        inventoryHeldAt: 'internal',
+        paymentPlanDeniedAt: 'personal',
     },
     Fee: {
         id: 'public',

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -193,6 +193,7 @@ export const classifications = {
         shopifyProductId: 'public',
         shopifyOrgMemberVariantId: 'public',
         shopifyNonOrgMemberVariantId: 'public',
+        shopifyVariantId: 'public',
     },
     ProgramVolunteer: {
         programId: 'public',

--- a/checkin-app/tests/security/routeAuthDrift.test.ts
+++ b/checkin-app/tests/security/routeAuthDrift.test.ts
@@ -304,6 +304,8 @@ const FIX_1 =
 const EDGE_INCLUDE_ALLOWLIST: Record<string, string> = {
     'cron/nightly': 'cron-gated — withCron, no user-facing response',
     'cron/pending-participants': 'cron-gated — withCron, no user-facing response',
+    'cron/reminders': 'cron-gated — withCron, reads RSVPs to send reminders',
+    'cron/scholarship-grace-expiry': 'cron-gated — withCron, no user-facing response',
     'events/[id]': 'admission-gated — handler GET throws forbidden() unless staff (sysadmin/board/leadMentor/coreVol)',
     'events/mine': 'query-shaped — self + own household only (activityMembers → where participantId in memberIds)',
     'facility/trends': 'admin-role-gated — sysadmin/board',

--- a/checkin-app/tests/security/routeAuthDrift.test.ts
+++ b/checkin-app/tests/security/routeAuthDrift.test.ts
@@ -304,7 +304,6 @@ const FIX_1 =
 const EDGE_INCLUDE_ALLOWLIST: Record<string, string> = {
     'cron/nightly': 'cron-gated — withCron, no user-facing response',
     'cron/pending-participants': 'cron-gated — withCron, no user-facing response',
-    'cron/reminders': 'cron-gated — withCron, reads RSVPs to send reminders',
     'cron/scholarship-grace-expiry': 'cron-gated — withCron, no user-facing response',
     'events/[id]': 'admission-gated — handler GET throws forbidden() unless staff (sysadmin/board/leadMentor/coreVol)',
     'events/mine': 'query-shaped — self + own household only (activityMembers → where participantId in memberIds)',


### PR DESCRIPTION
## ⚠️ Branch status: now conflicts with `main` (not resolved in this pass)

Since this branch's last push, `main` advanced with overlapping, unrelated work —
most notably #931 ("snapshot org-membership status at scholarship approval"), which
added its own new column to `ProgramParticipant` and its own new field to the exact
same approve-route `data` object this PR also edits, plus touches to the same
`schema.prisma`, `settings/membership/route.ts`, and
`programPaymentPlansAPI.integration.test.ts`. GitHub now reports this PR's merge
state as **CONFLICTING**. The two features are orthogonal (their
`wasOrgMemberAtApproval` snapshot vs. this PR's hold-ledger fields) and the conflicts
look mechanical, not semantic — but resolving them (rebase, reconcile both new
migrations under `main`'s new "coalesce" release gate, re-verify) is a distinct piece
of work not attempted here. **This PR needs a rebase onto `main` before it can merge.**

## Design evolution

This PR has now shipped three designs in sequence, each superseding the last:

1. **Two-pool mirror** (original): two Shopify variants per program (org-member /
   non-org-member), each with its own inventory pool, kept in sync via a
   sibling-mirror adjustment on every seat-consuming event.
2. **Single pool** (first revision): one Shopify variant per program at the base
   price; members get a per-checkout discount code instead of a second pool. Fixes
   the two-pool model's real bug (Shopify could sell up to 2× the intended cap
   across two independently-tracked pools).
3. **Hold ledger + grace period** (this update — final): reworks the scholarship
   lifecycle from "approve-time decrement, deny-time restore" into a ledger where
   every application-time `-1` is tracked (`ProgramParticipant.inventoryHeldAt`) and
   released `+1` **exactly once**, or consumed permanently by approval. This
   directly resolves the "open policy question" the previous revision of this PR
   flagged (see below) — denial no longer touches Shopify at all, so DB capacity and
   Shopify's count can no longer silently drift apart from a denied-but-not-withdrawn
   applicant.

## What changed (cumulative)

### Program creation & repair, member pricing — unchanged from the prior revision
`createShopifySingleVariantProgram`, `createShopifyProgramVariants` (legacy path),
`mintMemberDiscountCode`, and the `sync-shopify` repair route's branching are all
unchanged by this update — see the single-pool section below for what they do.

- **`createShopifySingleVariantProgram`** (`src/lib/shopify.ts`): one Shopify variant
  at the base/non-member price, inventory = `maxParticipants`. `POST /api/programs`
  uses this for all new programs.
- **`createShopifyProgramVariants`** (legacy two-variant) stays, unchanged, for
  programs already on that model.
- **`mintMemberDiscountCode`**: mints a Shopify Price Rule + Discount Code (fixed
  amount off, usage limit 1, ~48h expiry) per checkout for an ACTIVE org member on a
  single-pool program, via `POST /api/programs/[id]/discount-code`. A failed mint
  degrades to an undiscounted link — checkout is never blocked. Interim mechanism;
  `docs/designs/SHOPIFY_MEMBER_SEGMENT_PRICING.md` is the upgrade path once checkout
  identity is solved (addendum added to that doc's status header in this update).

### Scholarship lifecycle — now a hold ledger (THIS UPDATE reworks this section)

**Schema (additive migration `20260706160000_scholarship_hold_ledger`):**
`ProgramParticipant.inventoryHeldAt` / `.paymentPlanDeniedAt` (both nullable
`DateTime?`), `BoardSettings.scholarshipDenialGraceDays` (nullable `Int?`, **NULL =
the expiry feature is off**). Verified: applies cleanly to a populated
`ProgramParticipant`/`BoardSettings` table, and `prisma migrate diff` shows no drift
against `schema.prisma`.

- **APPLICATION** (`POST /api/programs/[id]/request-payment-plan`): keeps the `-1`,
  additionally stamps `inventoryHeldAt = now()` and clears `paymentPlanDeniedAt`.
  Guard is now on `inventoryHeldAt` (not `isPaymentPlanRequested`): a denied
  re-applicant already holds the seat, so re-applying just flips the request flag
  and clears the denial stamp — it does **not** fire a second `-1`.
- **DENIAL** (`POST /api/finance-ops/payment-plans/refuse`, reworked): **removes the
  `+1`** this PR previously shipped here. Flips `isPaymentPlanRequested` false,
  stamps `paymentPlanDeniedAt = now()`, audit-logs. The seat stays held — the
  applicant may still pay normally, or withdraw.
- **APPROVAL** (`POST /api/finance-ops/payment-plans`): still no Shopify operation.
  Additionally clears `inventoryHeldAt` to `null` **without** a `+1` — the hold is
  **consumed**, not released, so a later removal of this now permanently-comped
  participant can never credit a seat back that was never returned to Shopify.
- **RELEASE, exactly once, three paths** — all share one implementation
  (`withdrawAndReleaseHold`, `src/lib/program/capacity.ts`): `delete()` is the
  atomicity boundary (a row can be deleted at most once), so double-release across
  concurrent callers isn't possible.
  - **(a) Withdrawal** — `DELETE /api/programs/[id]/participants` (the one route
    handles both self-withdraw and admin removal) and the non-payment kick
    (`cron/pending-participants`, switched from a bulk `deleteMany` to a per-row
    loop specifically so this release can run per participant, with per-row
    failure isolation).
  - **(b) Normal payment** — the `orders/paid` webhook's activation path. A denied
    applicant who pays anyway makes Shopify auto-decrement a *second* unit for the
    same seat; the webhook now releases the hold (`+1`) to compensate, guarded
    transactionally, never allowed to fail the webhook's 200.
  - **(c) Grace-period expiry** — new `GET /api/cron/scholarship-grace-expiry`
    (same `withCron`/`CRON_SECRET` auth as every other cron route). Sweeps `PENDING`
    rows with a denial stamp older than `scholarshipDenialGraceDays`, auto-withdraws
    each one (reusing path (a) — **auto-withdrawal + seat restore**) and audit-logs
    with a distinct `reason: "scholarship_grace_expired"` context. Per-row failure
    isolation; a no-op entirely when the setting is `NULL`.
- **Settings**: `scholarshipDenialGraceDays` exposed on `/settings/membership`
  alongside the other board policy knobs (`bgRecheckMonths`, dues) — board/sysadmin
  only, client-validates a positive integer or blank→null, audit-logged.

**One interpretation to flag:** grace-period expiry is implemented as
**auto-withdrawal + seat restore** (the row is deleted, same as a manual withdrawal,
and the seat becomes sellable again — the person could re-enroll if seats remain).
An alternative reading of "expire the hold" would be **restore-only**: release the
`+1` but leave the `PENDING` row in place (denied, unpaid, no longer holding a
seat). We went with auto-withdrawal because it matches the plain-language framing
("their spot is freed up") and reuses the existing withdrawal path outright rather
than inventing a fourth participant state. If the board would rather the row stay
and only the seat capacity release, that's a small, isolated change (drop the
`delete()` call in the sweep, keep just the `+1`) — flagging now in case the
restore-only reading is what's actually wanted.

### Webhook / inventory model — unchanged from the prior revision except the new release (b) above
Variant matching (`shopifyVariantId` or legacy pair), the legacy-only sibling
mirror, `adjustProgramInventory`'s single-pool preference, and the
`PATCH /api/programs/[id]` delta propagation are all unchanged.

## Docs (new in this update)

- **New `checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md`**: single-pool
  design, Shopify-as-source-of-truth, the discount-code mechanism (pointing at
  `SHOPIFY_MEMBER_SEGMENT_PRICING.md` as the segment upgrade path), the full
  hold-ledger state machine, the grace setting, and the legacy two-variant
  expand/contract transition.
- One-line `AGENTS.md` docs-map entry pointing at the new doc.
- Short addendum to `docs/designs/SHOPIFY_MEMBER_SEGMENT_PRICING.md`'s status
  header: single-pool + per-enrollee codes shipped as interim; segments remain the
  end-state.
- This section replaces the previous revision's "Flagged edge — open policy
  question" section, which is now resolved by the hold-ledger design above.

## Tests

- **New**: `cronScholarshipGraceExpiry.integration.test.ts` (NULL-setting no-op,
  sweep boundary — inside-window untouched vs. outside-window released +
  auto-withdrawn, per-row failure isolation via a `delete()` spy, never touches
  `ACTIVE` rows).
- **Updated**: `programPaymentPlansAPI.integration.test.ts` (denial → no Shopify op
  + hold persists + `paymentPlanDeniedAt` stamped, double-refuse no-op; re-apply
  while holding → no second `-1` + denial stamp clears; approval → hold consumed +
  a later removal fires no `+1` — these replace the old deny-time-`+1` assertions).
- **Updated**: `programsParticipantsAPI.integration.test.ts` (withdrawal releases a
  held seat exactly once; double-withdraw no-op).
- **Updated**: `webhookShopify.integration.test.ts` (denied-then-paid participant:
  activates AND releases the hold).
- **Updated**: `membershipSettingsAPI.integration.test.ts`,
  `settings/membership/__tests__/page.test.tsx` (grace-days validation: positive
  integer, blank→null).
- **Full suite**: 200 unit suites / 1619 tests green (`npx jest --ci`); 115
  integration suites / 963 tests green (`INTEGRATION_DB=1`); `tsc --noEmit` clean;
  `eslint --max-warnings 0` clean; migration verified against a populated DB with
  `prisma migrate diff` showing no drift.

## Cross-references

Supersedes this PR's own deny-time `+1` (previous revision) and the two-pool mirror
before that. Builds on #926, #927, #929 as before. See the branch-status note at the
top of this body for the new conflict with #931 (merged to `main` after this
branch's last sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz7egoZoDp37iL9FpC8tH
