### PR TITLE
Snapshot org-membership status at scholarship/payment-plan approval

### DIFF
--- a/checkin-app/prisma/migrations/20260706120000_program_participant_org_member_snapshot/migration.sql
+++ b/checkin-app/prisma/migrations/20260706120000_program_participant_org_member_snapshot/migration.sql
@@ -1,0 +1,3 @@
+-- Point-in-time snapshot of household org-membership status at scholarship/
+-- payment-plan approval. Additive nullable column, no backfill, no data loss.
+ALTER TABLE "ProgramParticipant" ADD COLUMN "wasOrgMemberAtApproval" BOOLEAN;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -719,6 +719,12 @@ model ProgramParticipant {
   isPaymentPlanRequested Boolean                  @default(false)
   /// @sensitivity:internal
   pendingSince         DateTime?                @default(now())
+  /// Point-in-time snapshot of the household's org-membership status the moment a
+  /// scholarship/payment-plan request was APPROVED (status flipped to ACTIVE).
+  /// Membership changes over time, so this can't be derived later from the live
+  /// OrgMembership row — it must be stamped at approval. Null until approved.
+  /// @sensitivity:internal
+  wasOrgMemberAtApproval Boolean?
 
   program Program     @relation(fields: [programId], references: [id])
   person  Person @relation(fields: [personId], references: [id])

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -37,6 +37,7 @@ describe('Program payment-plan routes', () => {
     let selfId: number;
     let otherId: number;
     let noiseId: number;
+    let memberId: number;
     const householdIds: number[] = [];
 
     beforeAll(async () => {
@@ -74,6 +75,13 @@ describe('Program payment-plan routes', () => {
         });
         noiseId = noise.id;
         householdIds.push(noise.householdId);
+
+        // Household with an ACTIVE org membership, for the point-in-time snapshot tests.
+        const member = await prisma.person.create({
+            data: { name: 'PP Member', email: `member-${TAG}@example.com`, household: { create: { name: "Member HH", orgMembership: { create: { status: 'ACTIVE' } } } } },
+        });
+        memberId = member.id;
+        householdIds.push(member.householdId);
     });
 
     beforeEach(() => {
@@ -84,8 +92,9 @@ describe('Program payment-plan routes', () => {
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.program.delete({ where: { id: programId } });
         await prisma.person.deleteMany({
-            where: { id: { in: [mentorId, boardId, selfId, otherId, noiseId] } },
+            where: { id: { in: [mentorId, boardId, selfId, otherId, noiseId, memberId] } },
         });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: householdIds } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
     });
 
@@ -129,6 +138,21 @@ describe('Program payment-plan routes', () => {
             expect(ids).toContain(selfId);
             expect(ids).not.toContain(noiseId);
         });
+
+        it('includes each participant\'s CURRENT household org-membership status (live, for the board to decide)', async () => {
+            await enroll(memberId, { requested: true });
+            await enroll(selfId, { requested: true }); // selfId's household has no OrgMembership row
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+            const res = await PlansGet(nextReq());
+            expect(res.status).toBe(200);
+            const rows = await res.json();
+            type Row = { personId: number; person: { household?: { orgMembership?: { status: string } | null } | null } };
+            const memberRow = (rows as Row[]).find(r => r.personId === memberId);
+            const nonMemberRow = (rows as Row[]).find(r => r.personId === selfId);
+            expect(memberRow?.person.household?.orgMembership?.status).toBe('ACTIVE');
+            expect(nonMemberRow?.person.household?.orgMembership).toBeFalsy();
+        });
     });
 
     describe('POST /api/finance-ops/payment-plans (approve)', () => {
@@ -160,6 +184,38 @@ describe('Program payment-plan routes', () => {
             expect(row?.status).toBe('ACTIVE');
             expect(row?.isPaymentPlanRequested).toBe(false);
             expect(row?.pendingSince).toBeNull();
+        });
+
+        it('stamps wasOrgMemberAtApproval=true approving a participant from an ACTIVE-membership household', async () => {
+            await enroll(memberId, { requested: true });
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+            const res = await PlansPost(nextReq('http://localhost', {
+                method: 'POST',
+                body: JSON.stringify({ programId, participantId: memberId }),
+            }));
+            expect(res.status).toBe(200);
+
+            const row = await prisma.programParticipant.findUnique({
+                where: { programId_personId: { programId, personId: memberId } },
+            });
+            expect(row?.wasOrgMemberAtApproval).toBe(true);
+        });
+
+        it('stamps wasOrgMemberAtApproval=false approving a participant from a non-member household', async () => {
+            await enroll(selfId, { requested: true }); // selfId's household has no OrgMembership row
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+            const res = await PlansPost(nextReq('http://localhost', {
+                method: 'POST',
+                body: JSON.stringify({ programId, participantId: selfId }),
+            }));
+            expect(res.status).toBe(200);
+
+            const row = await prisma.programParticipant.findUnique({
+                where: { programId_personId: { programId, personId: selfId } },
+            });
+            expect(row?.wasOrgMemberAtApproval).toBe(false);
         });
     });
 

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { handler } from "@/security/handler";
 import { apiError } from "@/lib/api-response";
+import { isActiveOrgMember, ACTIVE_ORG_MEMBER_INCLUDE } from "@/lib/orgMembership";
 
 export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
     const requests = await prisma.programParticipant.findMany({
@@ -12,7 +13,11 @@ export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
             status: 'PENDING'
         },
         include: {
-            person: true,
+            // Nests household->orgMembership (same shape as ACTIVE_ORG_MEMBER_INCLUDE)
+            // so the board can see CURRENT membership while a request is still
+            // pending — wasOrgMemberAtApproval is null until approved, so it can't
+            // answer this. Derive live client-side; nothing new to stamp/store here.
+            person: { include: ACTIVE_ORG_MEMBER_INCLUDE },
             program: true
         },
         orderBy: {
@@ -35,10 +40,16 @@ export const POST = withAuth(
                 return apiError("programId and participantId are required", 400);
             }
 
+            // Point-in-time snapshot: membership status changes over time, so this
+            // must be stamped now, at approval — not derived later from the live
+            // OrgMembership row. Reuses the canonical org-member check (lib/orgMembership.ts).
+            const wasOrgMemberAtApproval = await isActiveOrgMember(participantId);
+
             const data = {
                 status: 'ACTIVE' as const,
                 isPaymentPlanRequested: false, // cleared since it's approved
-                pendingSince: null // reset
+                pendingSince: null, // reset
+                wasOrgMemberAtApproval
             };
 
             // Scope to the pending request so approving a non-pending/nonexistent

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -20,6 +20,9 @@ type PaymentPlanRequest = {
     id: number;
     name: string | null;
     email: string;
+    // Current (live) membership, not the point-in-time snapshot — nothing is
+    // stamped until the request is approved, so this is derived on render.
+    household?: { orgMembership?: { status: string } | null } | null;
   };
   program: {
     id: number;
@@ -124,6 +127,12 @@ export default function PendingParticipantsPage() {
             Price: M {formatCents(req.program.orgMemberPriceCents)} / NM {formatCents(req.program.nonOrgMemberPriceCents)}
           </Text>
         </>
+      ),
+    },
+    {
+      header: 'Membership',
+      render: (req) => (
+        <Text size="sm">{req.person.household?.orgMembership?.status === 'ACTIVE' ? 'Member' : 'Non-member'}</Text>
       ),
     },
     {

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -205,6 +205,7 @@ export const classifications = {
         status: 'public',
         isPaymentPlanRequested: 'personal',
         pendingSince: 'internal',
+        wasOrgMemberAtApproval: 'internal',
     },
     Fee: {
         id: 'public',

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -206,14 +206,17 @@ defineRoute({
 });
 
 // Board's payment-plan approval queue. Returns pending ProgramParticipant rows
-// with the full participant + program nested. Board/sysadmin only, and they hold
-// everyones:* so they see every field — the win is the declared policy: any role
-// later added to this view is field-stripped automatically.
+// with the full participant + program nested, plus the participant's
+// household/orgMembership (so the board can see CURRENT membership while
+// deciding — wasOrgMemberAtApproval is only stamped on approval). Board/sysadmin
+// only, and they hold everyones:* so they see every field — the win is the
+// declared policy: any role later added to this view is field-stripped
+// automatically.
 defineRoute({
     endpoint: 'GET /api/finance-ops/payment-plans',
     authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
     envelope: null,
-    returns: ['ProgramParticipant', 'Person', 'Program'],
+    returns: ['ProgramParticipant', 'Person', 'Program', 'Household', 'OrgMembership'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],


### PR DESCRIPTION
## Summary

Adds `ProgramParticipant.wasOrgMemberAtApproval`, a point-in-time snapshot of whether the participant's household was an active Treehouse Member the moment their scholarship/payment-plan request was **approved** (`POST /api/finance-ops/payment-plans`, PENDING → ACTIVE).

**Why a snapshot and not a derived value:** `OrgMembership.status` changes over time (renewals lapse, memberships get revoked/denied, new members join). If we only ever read the *current* status, a scholarship approved for a member household 8 months ago would silently start reading as "non-member" the moment that household's membership lapses — that's not what happened at approval time. This field answers "was this household a member *when we said yes*", which is only knowable if it's captured at that moment. It's nullable and stays `null` for anything not yet approved.

## What's stamped vs. derived live

- **Stamped (stored):** `wasOrgMemberAtApproval` — set once, in the same `updateMany` that flips the participant to `ACTIVE`, using the existing canonical check `isActiveOrgMember()` from `src/lib/orgMembership.ts` (no new membership logic). Included in the `AuditLog.newData` for the approval since it's part of the same `data` object already written there.
- **Derived live (not stored):** the board's *pending*-request queue (same `GET /api/finance-ops/payment-plans`) now also nests `person.household.orgMembership` (reusing the existing `ACTIVE_ORG_MEMBER_INCLUDE` shape) so the board can see **current** membership while a request is still pending — `wasOrgMemberAtApproval` is `null` at that point, so it can't answer that question. This is computed fresh on every read, never written anywhere.
  - Note on why this isn't a synthetic `isCurrentlyOrgMember` boolean field: the security-classification stripper (`src/security/stripper.ts`) only forwards fields declared in `prisma/schema.prisma` via `/// @sensitivity` — an ad hoc boolean tacked onto the response bag would be silently dropped. Returning the real, already-classified `Household`/`OrgMembership` relations sidesteps that and lets the (already fully-trusted, `everyones:*`) board/sysadmin view see it for free.
- Added a "Membership" column to the finance-ops payment-plan table (`Member`/`Non-member`, derived from the live nested data above) — the page was already a simple `DataTable` with a plain columns array, so this was a few lines; no new UI surface built.

## Schema / security

- `wasOrgMemberAtApproval Boolean?` — additive nullable column, hand-written migration (`ALTER TABLE ... ADD COLUMN`), verified with `prisma migrate deploy` + `prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code` on a scratch DB (no drift).
- `/// @sensitivity:internal` — matches `pendingSince` and other board/audit-only derived facts on this same model; not exposed to the participant or the public.
- `src/security/generated/classifications.ts` regenerated and committed.
- `src/security/registry.ts`: added `Household`/`OrgMembership` to this route's `returns` list (documentation of what the bag can now contain; the route's existing `everyones:*` grants already cover their fields, so no `orderedView` change needed).

## Out of scope

**Membership-side payment plans** (`OrgMembershipProcess`/`finance-ops/membership-payment-plans`) are explicitly untouched — approving a *membership* payment plan is itself how a household *becomes* a member, so "was this household a member at approval" isn't a meaningful question there.

## Merge-order note

Two other open PRs touch `src/app/api/finance-ops/payment-plans/route.ts`:
- #926 (409 guard + tests on the *request* route) — different file, no overlap expected.
- #930 (`adjustProgramInventory(-1)` on this same *approval* route) — same POST handler body as this PR. Edits here are scoped to a new `wasOrgMemberAtApproval` line and one new key in the `data` object, kept away from the inventory-adjustment call site where possible, but a small rebase may be needed depending on merge order.

## Test plan

Extended `src/app/__tests__/programPaymentPlansAPI.integration.test.ts` (existing integration suite for this route):
- [x] Approving a participant from an ACTIVE-membership household → `wasOrgMemberAtApproval: true`.
- [x] Approving a participant from a non-member household → `wasOrgMemberAtApproval: false`.
- [x] GET pending-list response includes each participant's *current* household org-membership status (live nested data).
- [x] Existing approval/request/IDOR coverage still green.

Ran (all green): touched integration suite (15/15), `payment-plans-strip.test.ts` unit strip test, `authzRegistry`/`pageRegistry` unit tests, `registryAuthz.integration`/`policy.contract.integration` (87/87), `tsc --noEmit`, `eslint` on touched files, and the migration drift check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz7egoZoDp37iL9FpC8tH