### PR TITLE
fix(household): reject empty-string names on OAuth create; drop dead null fallbacks

### DIFF
--- a/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
@@ -19,7 +19,7 @@ type MembershipPaymentPlanRequest = {
     isVolunteer: boolean;
     household: {
       id: number;
-      name: string | null;
+      name: string;
     };
   };
 };
@@ -100,10 +100,10 @@ export default function MembershipPaymentPlansPage() {
   const columns: DataTableColumn<MembershipPaymentPlanRequest>[] = [
     {
       header: 'Household',
-      sortBy: (req) => (req.orgMembership.household.name ?? '').toLowerCase(),
+      sortBy: (req) => req.orgMembership.household.name.toLowerCase(),
       render: (req) => (
         <>
-          <Text fw={500}>{req.orgMembership.household.name ?? `Household #${req.orgMembership.household.id}`}</Text>
+          <Text fw={500}>{req.orgMembership.household.name}</Text>
           <Text size="sm" c="dimmed">{req.orgMembership.isVolunteer ? 'Volunteer household' : 'Standard household'}</Text>
         </>
       ),

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -62,7 +62,7 @@ export async function createParticipantWithHousehold(data: {
 }) {
     return prisma.$transaction(async (tx) => {
         const household = await tx.household.create({
-            data: { name: data.name ?? data.email ?? "Household" },
+            data: { name: data.name?.trim() || data.email?.trim() || "Household" },
         });
         const participant = await tx.person.create({
             data: { ...data, householdId: household.id },


### PR DESCRIPTION
## What

Follow-up to [#918](https://github.com/innovationtreehouse/checkin/pull/918) (`Household.name` NOT NULL). Addresses jee7s' post-merge review findings 1 and 3a.

## Why

**Finding 1 (bug).** The OAuth create path used `data.name ?? data.email ?? "Household"`. `??` only falls through on null/undefined, not `""`. A Google profile whose name resolves to empty string creates a household literally named `""`: satisfies NOT NULL, renders blank everywhere, defeats #918's goal. The PATCH rename route already `.trim()`-rejects; the create path missed it.

**Finding 3a (dead code).** With empty-string names now impossible, `membership-payment-plan/page.tsx` still typed `household.name` as `string | null` with two `??` fallbacks that can never fire.

## Changes

- `src/lib/auth-options.ts:65` — `?? ` → `?.trim() ||`, so empty/whitespace names fall through to email then the `"Household"` literal.
- `src/app/finance-ops/membership-payment-plan/page.tsx` — type `string | null` → `string`; removed the `?? ''` sort fallback and the `?? Household #id` render fallback.

## Reviewer notes

- **Finding 3b left intentionally.** `dev/shopify/page.tsx:46`'s `?? "(unnamed household)"` guards a *missing* `orgMembership`/`household` relation (via `?.` chaining), not a null name — still live, not touched.
- **Finding 2 (BEGIN/COMMIT wedge window) not addressed here** — the #918 migration already applied to the live/dev DB; can't retroactively edit an applied migration. Forward-looking note for future backfill + SET-NOT-NULL migrations.
- **Finding 4 (test-household factory) skipped** — YAGNI; the 183 fixtures work, add a factory the day per-suite unique naming is actually forced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)