### PR TITLE
feat(nav): red broken-email pill on Membership Ops + per-household flag

### DIFF
--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -15,7 +15,6 @@
 import { GET } from '@/app/api/nav/todo-counts/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
-import { ORG_DOMAIN } from '@/lib/config';
 
 jest.mock('next-auth/next', () => ({
     getServerSession: jest.fn(),
@@ -291,28 +290,5 @@ describe('Nav todo-counts API', () => {
 
         await prisma.orgMembershipProcess.deleteMany({ where: { id: { in: [...reviewerProcs.map((p) => p.id), blocked.id] } } });
         await prisma.orgMembership.delete({ where: { id: reviewerMembership.id } });
-    });
-
-    it('counts member families but excludes org-email-only (staff) households', async () => {
-        const memberFamilies = async () => {
-            const res = await callAs({ id: boardId, householdId: householdBId, isBoardMember: true });
-            return (await res.json()).admin.memberFamilies as number;
-        };
-        const before = await memberFamilies();
-
-        // Staff household: only an org-email participant → must NOT count.
-        const staff = await prisma.person.create({
-            data: { email: `staff-${TAG}@${ORG_DOMAIN}`, name: 'Staff', household: { create: { name: "Test HH" } } },
-        });
-        expect(await memberFamilies()).toBe(before);
-
-        // Member family: a non-org email → +1.
-        const member = await prisma.person.create({
-            data: { email: `family-${TAG}@example.com`, name: 'Family', household: { create: { name: "Test HH" } } },
-        });
-        expect(await memberFamilies()).toBe(before + 1);
-
-        await prisma.person.deleteMany({ where: { id: { in: [staff.id, member.id] } } });
-        await prisma.household.deleteMany({ where: { id: { in: [staff.householdId, member.householdId] } } });
     });
 });

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -69,7 +69,7 @@ export const GET = withAuth(
                 where: whereClause,
                 include: {
                     householdMembers: {
-                        select: { id: true, name: true, email: true, isBoardMember: true }
+                        select: { id: true, name: true, email: true, isBoardMember: true, emailUndeliverableAt: true }
                     },
                     orgMembership: true,
                     emergencyContacts: {

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -6,7 +6,6 @@ import { countHouseholdsMissingValidContact } from "@/lib/emergencyContacts/serv
 import { canReviewBackgroundChecks, reviewQueueCounts } from "@/lib/membership/review";
 import { getLeadConflicts } from "@/lib/attendanceConflicts";
 import { pickAddress, validateAddress } from "@/lib/address";
-import { ORG_DOMAIN } from "@/lib/config";
 import { openConfigIssues } from "@/lib/configHealth";
 import { PROGRAM_CHECKOUT_BROKEN_WHERE } from "@/lib/programCheckout";
 import { apiError } from "@/lib/api-response";
@@ -66,16 +65,14 @@ export type TodoCounts = {
     // Applications tab — mirrors what /api/admin/membership lists.
     // `brokenEmails` = people whose email Resend has reported as undeliverable
     // (bounce/complaint) and no later delivery has cleared — see webhooks/resend.
+    // Red pill on the Membership Ops nav item + the Manage Memberships (households) tab.
     // `brokenHouseholds` = households with no lead at all (red — blocking board action).
-    // `memberFamilies` = total member families (gray), shown on the Manage Memberships tab:
-    // households with >=1 non-org-email (or null-email) participant. Staff households hold
-    // only the org-email lead, so they fall out.
     // `settingsMisconfig` = how many required Shopify-checkout board settings are still
     // unset (0–2): the membership variant ID and the volunteer discount code. Red pill on
     // the Settings nav + Membership Settings tab — checkout is broken until both are set.
     // `programsMisconfig` = how many programs have a price but no matching Shopify variant
     // (paid enrollment silently can't check out). Red pill on the Program Ops Programs tab.
-    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; membershipPaymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; brokenEmails: number; memberFamilies: number; settingsMisconfig: number; programsMisconfig: number };
+    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; membershipPaymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; brokenEmails: number; settingsMisconfig: number; programsMisconfig: number };
     // Config-health gaps (admins + board only): number of failing system-config checks
     // (e.g. Zoho e-sign unconfigured). Drives the red System Status nav badge; the full
     // list lives at /api/system-status/config-health. See lib/configHealth.ts.
@@ -363,7 +360,7 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     // ---- Admin surface (board's own queue) — only for board/isSysadmin ----
     if (user.isSysadmin || user.isBoardMember) {
-        const [membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, memberFamilies, programsMisconfig, boardSettings] = await Promise.all([
+        const [membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, programsMisconfig, boardSettings] = await Promise.all([
             prisma.orgMembershipProcess.count({
                 where: { status: { in: BOARD_ACTIONABLE_MEMBERSHIP } },
             }),
@@ -407,16 +404,6 @@ export const GET = withAuth({}, async (_req, auth) => {
             prisma.person.count({
                 where: { emailUndeliverableAt: { not: null } },
             }),
-            // Member families: households with >=1 non-org-email participant. A null email is
-            // not an org address, but Prisma's `NOT endsWith` skips null rows — list it
-            // explicitly so null-email members (e.g. children) count.
-            prisma.household.count({
-                where: {
-                    householdMembers: {
-                        some: { OR: [{ email: null }, { NOT: { email: { endsWith: `@${ORG_DOMAIN}` } } }] },
-                    },
-                },
-            }),
             // Programs priced on a tier with no matching Shopify variant — paid enrollment
             // silently can't check out. Same condition as the list/detail UI, shared via
             // PROGRAM_CHECKOUT_BROKEN_WHERE (see lib/programCheckout.ts).
@@ -435,7 +422,7 @@ export const GET = withAuth({}, async (_req, auth) => {
             (boardSettings?.volunteerDiscountCode ? 0 : 1) +
             ((boardSettings?.bgRecheckMonths ?? 0) > 0 ? 0 : 1) +
             (boardSettings?.orgMembershipYearBoundary ? 0 : 1);
-        result.admin = { membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, memberFamilies, settingsMisconfig, programsMisconfig };
+        result.admin = { membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, settingsMisconfig, programsMisconfig };
         // System-config health (env-var/deploy gaps). Synchronous, no DB — just presence
         // checks. Same admin+board gate as the rest of this block.
         result.configHealth = { openIssues: openConfigIssues() };

--- a/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
@@ -91,6 +91,31 @@ describe("membership-ops/households page", () => {
     expect(screen.getByRole("button", { name: "Grant Membership" })).toBeEnabled();
   });
 
+  it("flags a household whose member has an undeliverable email", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({
+      "/api/membership-ops/households": {
+        households: [
+          {
+            id: 3,
+            name: "The Bounces",
+            orgMembership: { status: "ACTIVE" },
+            householdMembers: [{ id: 30, name: "Bo Bounce", email: "bo@example.com", isBoardMember: false, emailUndeliverableAt: "2026-07-01T00:00:00.000Z" }],
+          },
+          ...households.households,
+        ],
+      },
+    });
+    renderWithProviders(<AdminHouseholdsPage />);
+    await screen.findByText("The Bounces");
+
+    // Household-level flag next to the name, and the per-member marker in the list.
+    expect(screen.getByText("✉ Broken email")).toBeInTheDocument();
+    expect(screen.getByText("✉ undeliverable")).toBeInTheDocument();
+    // Households with all-deliverable emails carry neither.
+    expect(screen.getAllByText("✉ Broken email")).toHaveLength(1);
+  });
+
   it("navigates to the add-participant page for a household", async () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({ "/api/membership-ops/households": households });

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { Button, Group, List, Modal, Stack, Table, Text, TextInput } from '@mantine/core';
+import { Badge, Button, Group, List, Modal, Stack, Table, Text, TextInput, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
@@ -15,7 +15,7 @@ type Household = {
   id: number;
   name?: string | null;
   orgMembership?: { status: string } | null;
-  householdMembers?: { id: number; name?: string | null; email?: string | null; isBoardMember?: boolean }[] | null;
+  householdMembers?: { id: number; name?: string | null; email?: string | null; isBoardMember?: boolean; emailUndeliverableAt?: string | null }[] | null;
 };
 
 export default function AdminHouseholdsPage() {
@@ -165,24 +165,41 @@ export default function AdminHouseholdsPage() {
               // Mirrors the server guard; disabled state is UX only. Revoke stays allowed.
               const ownGrantBlocked =
                 !hasActiveMembership && me?.isSysadmin !== true && sharesHousehold(me?.householdId, household.id);
+              const hasBrokenEmail = household.householdMembers?.some((p) => p.emailUndeliverableAt) ?? false;
 
               return (
                 <Table.Tr key={household.id}>
                   <Table.Td>
-                    <Text
-                      fw={600}
-                      c="blue"
-                      style={{ cursor: "pointer" }}
-                      onClick={() => router.push(`/membership-ops/households/${household.id}`)}
-                    >
-                      {household.name || `Household #${household.id}`}
-                    </Text>
+                    <Group gap="xs" wrap="nowrap">
+                      <Text
+                        fw={600}
+                        c="blue"
+                        style={{ cursor: "pointer" }}
+                        onClick={() => router.push(`/membership-ops/households/${household.id}`)}
+                      >
+                        {household.name || `Household #${household.id}`}
+                      </Text>
+                      {hasBrokenEmail && (
+                        <Tooltip label="A member's email is undeliverable — update their address">
+                          <Badge color="red" variant="filled" size="sm" style={{ cursor: "default" }}>
+                            ✉ Broken email
+                          </Badge>
+                        </Tooltip>
+                      )}
+                    </Group>
                   </Table.Td>
                   <Table.Td>
                     {household.householdMembers && household.householdMembers.length > 0 ? (
                       <List size="sm">
                         {household.householdMembers.map((p) => (
-                          <List.Item key={p.id}>{p.name || p.email}</List.Item>
+                          <List.Item key={p.id}>
+                            {p.name || p.email}
+                            {p.emailUndeliverableAt && (
+                              <Tooltip label="This email bounced or was marked spam — undeliverable">
+                                <Text span c="red" fw={700} ml={4}>✉ undeliverable</Text>
+                              </Tooltip>
+                            )}
+                          </List.Item>
                         ))}
                       </List>
                     ) : (

--- a/checkin-app/src/app/membership-ops/layout.tsx
+++ b/checkin-app/src/app/membership-ops/layout.tsx
@@ -6,7 +6,7 @@ import { MEMBERSHIP_OPS_NAV_LINKS } from "@/lib/membershipOpsNav";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { useTodoCounts } from "@/hooks/useTodoCounts";
 import { tabBadgeFor, reviewBadges } from "@/components/navBadges";
-import { CountBadge } from "@/components/ui/CountBadge";
+import { CountBadge, badgeIntentFor } from "@/components/ui/CountBadge";
 import { SectionTabs } from "@/components/ui/SectionTabs";
 import { PageContainer } from "@/components/ui/PageContainer";
 
@@ -27,9 +27,6 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
   const navLinks = MEMBERSHIP_OPS_NAV_LINKS.filter((l) =>
     l.href === "/membership-ops/review" ? canReview : isAdmin,
   );
-
-  // Total member families, shown as a gray counter on the Manage Memberships tab.
-  const memberFamilies = todoCounts?.admin?.memberFamilies ?? null;
 
   if (loading) {
     return (
@@ -63,21 +60,14 @@ export default function MembershipOpsLayout({ children }: { children: React.Reac
         </Group>
       );
     }
+    // Honor the badge's intent color (gray Applications total vs. red broken-email
+    // count on Households) — same color→intent mapping the audit layout and left-nav use.
     const badge = tabBadgeFor(href, todoCounts);
-    if (badge) {
+    const intent = badge ? badgeIntentFor(badge.color) : null;
+    if (badge && intent) {
       return (
-        <CountBadge intent="info" aria-label={badge.label}>
+        <CountBadge intent={intent} aria-label={badge.label}>
           {badge.count}
-        </CountBadge>
-      );
-    }
-    if (href === "/membership-ops/households" && memberFamilies !== null) {
-      return (
-        <CountBadge
-          intent="info"
-          aria-label={`${memberFamilies} org member famil${memberFamilies === 1 ? "y" : "ies"}`}
-        >
-          {memberFamilies}
         </CountBadge>
       );
     }

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -109,7 +109,6 @@ const admin = (over: Partial<NonNullable<TodoCounts['admin']>> = {}): TodoCounts
     unclaimedHouseholds: 0,
     brokenHouseholds: 0,
     brokenEmails: 0,
-    memberFamilies: 0,
     settingsMisconfig: 0,
     programsMisconfig: 0,
     ...over,
@@ -164,6 +163,32 @@ describe('reviewBadges (Review tab + Membership Ops nav)', () => {
       .toEqual([{ count: 43, color: 'gray', label: '40 in-flight applications; 3 you approved awaiting a second reviewer' }]);
     // Nothing anywhere → no badges.
     expect(navBadgeFor('/membership-ops', { ...admin(), review: { canActOn: 0, approvedAwaitingSecond: 0 } })).toEqual([]);
+  });
+
+  it('prepends a red broken-email pill (before green/gray) on the Membership Ops nav item', () => {
+    expect(navBadgeFor('/membership-ops', admin({ brokenEmails: 2 }))).toEqual([
+      { count: 2, color: 'red', label: '2 members with an undeliverable email' },
+    ]);
+    // Ordering: red first, then green, then gray.
+    const counts: TodoCounts = {
+      ...admin({ brokenEmails: 1, membership: 2, applicationsTotal: 40 }),
+      review: { canActOn: 0, approvedAwaitingSecond: 0 },
+    };
+    expect(navBadgeFor('/membership-ops', counts).map((b) => b.color)).toEqual(['red', 'treehouseGreen', 'gray']);
+    // Singularized, and hidden at 0.
+    expect(navBadgeFor('/membership-ops', admin({ brokenEmails: 1 })))
+      .toEqual([{ count: 1, color: 'red', label: '1 member with an undeliverable email' }]);
+    expect(navBadgeFor('/membership-ops', admin({ brokenEmails: 0 }))).toEqual([]);
+  });
+});
+
+describe('tabBadgeFor — Manage Memberships broken-email pill', () => {
+  it('red count on the households tab, singularized, null at 0', () => {
+    expect(tabBadgeFor('/membership-ops/households', admin({ brokenEmails: 3 })))
+      .toEqual({ count: 3, color: 'red', label: '3 members with an undeliverable email' });
+    expect(tabBadgeFor('/membership-ops/households', admin({ brokenEmails: 1 })))
+      .toEqual({ count: 1, color: 'red', label: '1 member with an undeliverable email' });
+    expect(tabBadgeFor('/membership-ops/households', admin({ brokenEmails: 0 }))).toBeNull();
   });
 });
 

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -137,7 +137,15 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
       const awaiting = counts.review?.approvedAwaitingSecond ?? 0;
       const info = apps + awaiting;
       const infoLabel = `${apps} in-flight application${plural(apps, '', 's')}; ${awaiting} you approved awaiting a second reviewer`;
+      // Red (blocking): people whose email bounced/complained — surfaced on the
+      // Manage Memberships (households) tab, where the board fixes the address.
+      // Mirrors the /membership-ops/households tab pill (tabBadgeFor below).
+      const brokenEmails = counts.admin ? counts.admin.brokenEmails : 0;
+      const red = brokenEmails > 0
+        ? [{ count: brokenEmails, color: 'red', label: `${brokenEmails} member${plural(brokenEmails, '', 's')} with an undeliverable email` }]
+        : [];
       return [
+        ...red,
         ...green(action, actionLabel),
         ...gray(info, infoLabel),
       ];
@@ -215,6 +223,13 @@ export function tabBadgeFor(href: string, counts: TodoCounts | null): NavBadge |
     // section badge, which is green board-actionable (BLOCKED) only.
     case '/membership-ops/applications':
       return gray(admin.applicationsTotal, `${admin.applicationsTotal} application${plural(admin.applicationsTotal, '', 's')}`);
+    // Manage Memberships (households). Red, blocking: members whose email Resend
+    // reported undeliverable (bounce/complaint) — the board fixes the address on
+    // this page. Same count as the /membership-ops section-nav red pill.
+    case '/membership-ops/households':
+      return admin.brokenEmails > 0
+        ? { count: admin.brokenEmails, color: 'red', label: `${admin.brokenEmails} member${plural(admin.brokenEmails, '', 's')} with an undeliverable email` }
+        : null;
     // Membership Audit — mirrors the /membership-audit section badge: broken is
     // red (board must assign a lead — blocking), the other two gray (household's own gaps).
     case '/membership-audit/emergency-contacts':


### PR DESCRIPTION
## What

Wires PR #928's `admin.brokenEmails` count (people Resend flagged undeliverable) into the UI. #928 computed and returned the count but nothing consumed it — this makes it addressable, mirroring the `brokenHouseholds` pattern.

- **todo-counts API**: drop `memberFamilies` (query + type + result); keep `brokenEmails`.
- **navBadges**: red `brokenEmails` on the `/membership-ops` left-nav item and a new `/membership-ops/households` subtab case. Both hide at 0, singularized.
- **membership-ops layout**: honor badge intent color via `badgeIntentFor` (gray Applications vs red Households) — was hardcoded gray.
- **households API**: expose `emailUndeliverableAt` per member.
- **households page**: red "✉ Broken email" badge next to the household name + "✉ undeliverable" marker on the offending member.

## Why

#928 shipped the count as data only (no navbar pill, no subtab pill, no landing page) — a client would have to invent its own UI. This replaces the old gray member-family total pill with a red, blocking pill the board can act on, and flags the specific broken household/member so they can find and fix the address.

## Reviewer notes

- Per-household flag reuses #928's `emailUndeliverableAt`. It stays at 0 (pills hide) until Resend webhooks are live and `RESEND_WEBHOOK_SECRET` is set — #928's ops step.
- **Judgment call**: fully removed `memberFamilies` (including the query), not just the pill. Say if you wanted the count kept in the API and only the pill swapped.
- Integration tests need a DB — not run here; the only edit there was deleting the now-dead `memberFamilies` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)