### PR TITLE
feat(prisma): scripted migration-coalesce flow + release gate (at most 1 migration/release)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -63,9 +63,69 @@ jobs:
       ref: ${{ github.event.release.tag_name }}
     secrets: inherit
 
+  # Release gate: a release may apply AT MOST ONE new database migration.
+  # Migrations accumulate on main between releases and must be coalesced into
+  # a single migration (checkin-app/scripts/coalesce-migrations.ts, a manual
+  # PR) before a release ships them — see
+  # checkin-app/docs/MIGRATION_COALESCE_FLOW.md for the policy and flow.
+  #
+  # This is not a step inside `validate`: that job is a reusable-workflow
+  # `uses: ./.github/workflows/ci.yml` call, which has no step surface of its
+  # own to add to. Runs as its own job instead; `deploy` needs both.
+  migration-release-gate:
+    name: Release gate — at most 1 new migration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout released tag (full history + tags)
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Find the previous v* release tag and count added migrations
+        run: |
+          set -euo pipefail
+          CURRENT_TAG="${{ github.event.release.tag_name }}"
+          git fetch --tags --force
+
+          # `git tag -l` lists annotated and lightweight tags identically — no
+          # special-casing needed for either kind. `sort -V` is a real version
+          # sort (v1.2.10 sorts after v1.2.9), not a lexical one.
+          mapfile -t TAGS < <(git tag -l 'v*' | sort -V)
+
+          PREV_TAG=""
+          for i in "${!TAGS[@]}"; do
+            if [ "${TAGS[$i]}" = "$CURRENT_TAG" ]; then
+              if [ "$i" -gt 0 ]; then PREV_TAG="${TAGS[$((i-1))]}"; fi
+              break
+            fi
+          done
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "No v* release tag found before $CURRENT_TAG — this is the first release, nothing to gate against. Skipping."
+            exit 0
+          fi
+          echo "Previous release tag: $PREV_TAG"
+
+          # Count ADDED migration directories only — a coalesce release
+          # deletes many old ones and adds exactly 1, and that must PASS, not
+          # fail on the deletes. Count directories, not files: a coalesce
+          # baseline adds both migration.sql and reconcile.sql under one dir.
+          # --no-renames: a rewritten baseline must never be mistaken for a
+          # rename of one of the migrations it replaces.
+          mapfile -t ADDED < <(git diff --no-renames --name-status "$PREV_TAG"..HEAD -- checkin-app/prisma/migrations \
+            | awk '$1=="A" {print $2}' | awk -F/ '{print $4}' | grep -v '^migration_lock.toml$' | sort -u)
+          echo "New migration dir(s) since $PREV_TAG (${#ADDED[@]}): ${ADDED[*]:-none}"
+
+          if [ "${#ADDED[@]}" -gt 1 ]; then
+            echo "::error::This release would apply ${#ADDED[@]} new migrations (${ADDED[*]}) — a release may apply at most 1. Coalesce them into a single migration first: checkin-app/docs/MIGRATION_COALESCE_FLOW.md"
+            exit 1
+          fi
+          echo "OK — at most 1 new migration since the previous release."
+
   deploy:
     name: Build, migrate, roll out
-    needs: validate   # do not build/migrate/roll out unless the tag re-passed all of CI
+    needs: [validate, migration-release-gate]   # do not build/migrate/roll out unless the tag re-passed all of CI and the release gate
     runs-on: ubuntu-24.04-arm  # native ARM64 — task defs require arm64 images
     environment:
       name: production

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -19,6 +19,16 @@ name: Migration safety (populated DB)
 #
 # Only runs when migrations (or this file) change — most PRs don't touch
 # migrations/prisma/schema.prisma, so there's nothing new to verify.
+#
+# Coalesce PRs (checkin-app/scripts/coalesce-migrations.ts — see
+# checkin-app/docs/MIGRATION_COALESCE_FLOW.md) are a special case the normal
+# "replay new migrations on the populated base DB" check CANNOT run: a
+# coalesce PR deletes the whole migration chain it replaces, so there is
+# nothing to replay on top of a base DB that already has that chain applied.
+# Detected by shape (deletes >=2 migration dirs, adds exactly 1) and routed to
+# a different check: does the PR's one baseline dump the SAME schema as the
+# full chain it replaces? Normal PRs are entirely unaffected — same steps,
+# same conditions, as before.
 on:
   pull_request:
     branches: [main]
@@ -70,9 +80,30 @@ jobs:
           if git diff --quiet "$BASE" HEAD -- checkin-app/prisma/migrations; then
             echo "No migration changes vs $BASE — nothing to verify, exiting early."
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "coalesce=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "New/changed migrations vs $BASE — running the populated-DB check."
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+          # Coalesce-PR signature: deletes >=2 migration dirs AND adds exactly 1
+          # (--no-renames: a wholly-rewritten baseline must never be detected as a
+          # rename of one of the migrations it replaces). Count DIRECTORIES, not
+          # files — a coalesce PR adds both migration.sql and reconcile.sql under
+          # its one new dir.
+          mapfile -t ADDED < <(git diff --no-renames --name-status "$BASE" HEAD -- checkin-app/prisma/migrations \
+            | awk '$1=="A" {print $2}' | awk -F/ '{print $4}' | grep -v '^migration_lock.toml$' | sort -u)
+          mapfile -t REMOVED < <(git diff --no-renames --name-status "$BASE" HEAD -- checkin-app/prisma/migrations \
+            | awk '$1=="D" {print $2}' | awk -F/ '{print $4}' | grep -v '^migration_lock.toml$' | sort -u)
+          echo "Added migration dir(s) (${#ADDED[@]}): ${ADDED[*]:-none}"
+          echo "Removed migration dir(s) (${#REMOVED[@]}): ${REMOVED[*]:-none}"
+
+          if [ "${#REMOVED[@]}" -ge 2 ] && [ "${#ADDED[@]}" -eq 1 ]; then
+            echo "Shape matches a coalesce PR — routing to the schema-identity check."
+            echo "coalesce=true" >> "$GITHUB_OUTPUT"
+            echo "baseline=${ADDED[0]}" >> "$GITHUB_OUTPUT"
           else
-            echo "New/changed migrations vs $BASE — running the populated-DB check."
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "coalesce=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Node.js
@@ -115,7 +146,7 @@ jobs:
       # personas) — this is what makes a destructive/non-applying migration
       # on those tables fail here instead of on dev.
       - name: Top up seed-empty tables the incident hit (Event/Fee/FeePayment/RSVP)
-        if: steps.base.outputs.skip == 'false'
+        if: steps.base.outputs.skip == 'false' && steps.base.outputs.coalesce == 'false'
         env:
           PGPASSWORD: testpassword
         run: |
@@ -144,13 +175,64 @@ jobs:
       # The actual regression test: apply ONLY the PR's new migrations on top
       # of a database that already has real rows in the tables they touch.
       # Failing here means the migration doesn't apply to a real database —
-      # exactly what wedged dev on 2026-07-02.
+      # exactly what wedged dev on 2026-07-02. Skipped for a coalesce PR: it
+      # deletes the whole chain this base DB already has applied, so there is
+      # nothing to "apply on top of" — see the coalesce-path steps below.
       - name: Apply PR's new migrations on top of the populated DB
-        if: steps.base.outputs.skip == 'false'
+        if: steps.base.outputs.skip == 'false' && steps.base.outputs.coalesce == 'false'
         run: npm -w checkin-app exec -- prisma migrate deploy
 
       # Proves the migrations land exactly on schema.prisma (Prisma 7:
       # --from-url was removed, use --from-config-datasource).
       - name: Drift check — migrations match schema.prisma
-        if: steps.base.outputs.skip == 'false'
+        if: steps.base.outputs.skip == 'false' && steps.base.outputs.coalesce == 'false'
         run: npm -w checkin-app exec -- prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code
+
+      # --- Coalesce PR path -----------------------------------------------
+      # The base DB (checkmein_migtest, migrated+seeded above) already has the
+      # FULL chain this PR replaces applied — its schema stands in for "TRUTH"
+      # without spinning up a third database. What we need to prove is
+      # different from the normal path: not "do the new migrations apply",
+      # but "does the PR's one baseline produce the SAME schema".
+      - name: "Coalesce: create a fresh DB for the candidate baseline"
+        if: steps.base.outputs.coalesce == 'true'
+        env:
+          PGPASSWORD: testpassword
+        run: psql -h localhost -U testuser -d checkmein_migtest -c 'CREATE DATABASE checkmein_migtest_candidate;'
+
+      # Runs through the PR's own (post-coalesce) prisma/migrations dir, which
+      # at this point contains exactly the one baseline — `migrate deploy`
+      # against an empty DB applies just that.
+      - name: "Coalesce: apply the PR's single baseline to the fresh DB"
+        if: steps.base.outputs.coalesce == 'true'
+        env:
+          DATABASE_URL: postgresql://testuser:testpassword@localhost:5432/checkmein_migtest_candidate
+        run: npm -w checkin-app exec -- prisma migrate deploy
+
+      # The actual coalesce regression test: the PR's single baseline must
+      # reproduce the exact schema the full chain it deletes produces. Shared
+      # normalize+diff logic with scripts/coalesce-migrations.ts (which runs
+      # this same check locally before the baseline is ever committed) — one
+      # comparison, one behavior.
+      - name: "Coalesce: verify candidate baseline is schema-identical to the replaced chain"
+        if: steps.base.outputs.coalesce == 'true'
+        run: |
+          bash checkin-app/scripts/compare-schema-dumps.sh \
+            "postgresql://testuser:testpassword@localhost:5432/checkmein_migtest" \
+            "postgresql://testuser:testpassword@localhost:5432/checkmein_migtest_candidate"
+
+      # Ledger-reconcile artifact convention (see MIGRATION_COALESCE_FLOW.md):
+      # prisma/migrations/<baseline>/reconcile.sql must ship alongside the
+      # baseline, or already-migrated envs (dev/prod) have no reconcile script
+      # to run and their next deploy fails looking for the deleted chain.
+      - name: "Coalesce: verify the reconcile.sql artifact is present"
+        if: steps.base.outputs.coalesce == 'true'
+        run: |
+          set -euo pipefail
+          BASELINE="${{ steps.base.outputs.baseline }}"
+          FILE="checkin-app/prisma/migrations/$BASELINE/reconcile.sql"
+          if [ ! -f "$FILE" ]; then
+            echo "::error::Coalesce PR is missing $FILE — already-migrated environments (dev, prod) need this to reconcile their _prisma_migrations ledger to the new baseline. See checkin-app/docs/MIGRATION_COALESCE_FLOW.md."
+            exit 1
+          fi
+          echo "Found $FILE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,9 @@ Read these before changing the relevant area — start here, then follow links.
 - `SECURITY-POLICY.md` — the response-stripper / `@sensitivity` registry rules (read before adding API responses or schema fields).
 - `pentest_findings_2026-04-21.md` — prior findings.
 
+**Deploy & migrations** (`checkin-app/docs/`)
+- `MIGRATION_COALESCE_FLOW.md` — the pre-release migration-coalesce policy + script (`scripts/coalesce-migrations.ts`), the release gate (at most 1 new migration per release), and the dev/prod ledger-reconcile procedure.
+
 **Subprojects** (each has its own `README.md`)
 - `client/` — the Raspberry-Pi kiosk client (Python).
 - `packages/*` (e.g. `monitoring-db`, `pg-test-harness`, `telemetry`), `layers/prisma-runtime/`, and the Lambda `*-function/` dirs (`s-read-function/`, `s-replay-function/`, `monitoring-relay-function/`, `monitoring-watchdog-function/`) — see the README in each; `s-read-function/` also has `MONITORING-PRD.md` + `FUTUREWORK.md`.

--- a/checkin-app/docs/MIGRATION_COALESCE_FLOW.md
+++ b/checkin-app/docs/MIGRATION_COALESCE_FLOW.md
@@ -1,0 +1,232 @@
+# Migration Coalesce Flow
+
+## Policy
+
+Migrations accumulate on `main` between releases — every PR that needs a
+schema change adds its own migration, same as always. **Before a release**,
+the accumulated migrations are coalesced into a single migration via a
+manual PR produced by `scripts/coalesce-migrations.ts`. **A release may apply
+at most one new database migration**, enforced by a release-gate step in
+`deploy-prod.yml`.
+
+```
+ PR merges to main            a coalesce PR                  a release
+┌──────────────────┐         ┌──────────────────┐         ┌──────────────────┐
+│ migration A       │         │ scripts/          │         │ deploy-prod.yml  │
+│ migration B       │  --->   │ coalesce-         │  --->   │ release gate:    │
+│ migration C       │         │ migrations.ts     │         │ "added migration │
+│ ...accumulate...  │         │ deletes A..N,     │         │  dirs since prev │
+│ migration N       │         │ adds ONE baseline │         │  release <= 1"   │
+└──────────────────┘         └──────────────────┘         └──────────────────┘
+```
+
+This repo hit both failure modes this policy exists to prevent, in the same
+week: #791 (Prisma generated a rename as DROP+ADD, wedging a populated DB
+mid-deploy) and #792, which manually squashed 49 accumulated migrations into
+one baseline by hand ahead of a release — real, but slow and error-prone
+(see "What #792 got right, by hand" below). This flow scripts and gates that
+same shape of work.
+
+Related docs: `.github/workflows/migration-safety.yml` (origin #794, the
+populated-DB migration check this flow adds a second path to) and
+`DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md` (landing in #933, not yet merged at
+the time this doc was written) — that doc covers the general deploy/migration
+sequencing rules (expand/cutover/contract); this one is specifically the
+coalesce-before-release mechanics.
+
+## When to run it
+
+Before cutting a release, if `checkin-app/prisma/migrations/` has
+accumulated more than one migration since the last release. Check with:
+
+```bash
+git fetch origin main
+git diff --name-status <previous-release-tag>..origin/main -- checkin-app/prisma/migrations/
+```
+
+If that shows more than one new migration directory, run the coalesce script
+and land its PR before cutting the release — the release gate (below) will
+otherwise block it anyway.
+
+## Running the script
+
+```bash
+cd checkin-app
+DATABASE_URL_SCRATCH=postgresql://prisma:prismapassword@localhost:5433/postgres \
+  npx tsx scripts/coalesce-migrations.ts
+```
+
+Defaults to a **dry run**: builds and validates the candidate baseline,
+writes nothing. Add `--commit` to actually replace `prisma/migrations/*`
+with it and write the reconcile artifacts.
+
+Flags / env:
+- `--scratch-url <postgres-url>` or `DATABASE_URL_SCRATCH` (required) — a
+  disposable Postgres server/maintenance DB, e.g. `.../postgres` on a scratch
+  instance. The script creates and always drops its own temp DBs there
+  (`coalesce_truth_*`, `coalesce_candidate_*`) and refuses to run at all if
+  the URL's own database name is `checkmein`, `checkin_dev`, or
+  `checkin_prod` — it never touches a real environment database.
+- `--commit` — write the coalesced baseline + `reconcile.sql`. Without it,
+  nothing in the repo changes.
+
+### What it does
+
+1. **Preflight**: clean git tree, on a branch (not detached HEAD), scratch
+   URL present and not pointed at a real environment.
+2. **Build TRUTH**: a fresh temp DB gets the full current migration chain
+   applied (`prisma migrate deploy`).
+3. **Generate candidate**: `prisma migrate diff --from-empty
+   --to-schema=prisma/schema.prisma --script` into a single migration named
+   `<timestamp>_coalesced_baseline`.
+4. **Validate**:
+   - Semantic schema identity: TRUTH's schema and a fresh DB with only the
+     candidate applied must dump the same schema
+     (`scripts/compare-schema-dumps.sh`, order-insensitive, ignoring pg_dump
+     noise and cosmetic `*_id_seq` naming — see that script and
+     `scripts/lib/schema-dump-compare.ts` for exactly what "noise" means).
+   - **Partial unique indexes**: Prisma's schema DSL cannot express a
+     `WHERE` clause, so `migrate diff --from-empty` has nothing in
+     `schema.prisma` to reconstruct one from and drops it silently. This
+     repo has three (`Visit_one_open_per_participant`,
+     `membership_one_inflight_initial`, `membership_one_inflight_renewal`).
+     The script diffs TRUTH's `pg_indexes` against the candidate's; anything
+     missing gets spliced back in verbatim from TRUTH and the candidate is
+     re-validated from scratch. A same-named index with a *different*
+     definition is a real divergence, not a diff-tool gap — the script fails
+     loud instead of patching over it.
+   - **No drift**: `prisma migrate diff --from-config-datasource
+     --to-schema=prisma/schema.prisma --exit-code` against the candidate DB
+     must be empty.
+5. **On `--commit`**: deletes every existing migration directory, writes the
+   one baseline (`migration.sql` + `reconcile.sql`), and prints the reconcile
+   instructions (below). Temp DBs are always dropped, success or failure.
+
+Unit tests for the pure parts (`scripts/__tests__/schema-dump-compare.test.ts`,
+`scripts/__tests__/partial-indexes.test.ts`) cover normalization and
+splicing without a database. The DB-orchestration path itself is proven by
+actually running the script — see "Dry-run evidence" in the PR that added
+this flow.
+
+## Reconcile procedure (dev / prod)
+
+`prisma`'s ledger (`_prisma_migrations`) records one row per applied
+migration, keyed by name, with a `checksum` = **sha256 hex of the
+migration.sql file** and `applied_steps_count = 1` for a clean apply
+(verified against this repo's own ledger while building this flow). An
+environment that already ran the migrations a coalesce baseline replaces
+needs its ledger reconciled to match the new baseline, or its next `prisma
+migrate deploy` looks for migrations that no longer exist in the repo and
+fails.
+
+`--commit` writes `prisma/migrations/<baseline>/reconcile.sql`:
+
+```sql
+BEGIN;
+DELETE FROM "_prisma_migrations";
+INSERT INTO "_prisma_migrations"
+    (id, checksum, migration_name, started_at, finished_at, applied_steps_count)
+VALUES
+    (gen_random_uuid(), '<sha256 of migration.sql>', '<baseline name>', now(), now(), 1);
+COMMIT;
+```
+
+**Convention**: this file always lives at
+`prisma/migrations/<baseline-name>/reconcile.sql`, committed alongside the
+baseline in the coalesce PR. The CI coalesce path (below) checks for it at
+exactly this path.
+
+### Applying it — the ECS one-off pattern
+
+Both `deploy-dev.yml` and `deploy-prod.yml` already run migrations via a
+one-off ECS task (`checkin-migrate-dev` / `checkin-migrate-prod`) that
+overrides the container command. Reconcile the same way, once the relevant
+image (built from a commit that includes the merged baseline) exists in ECR:
+
+```bash
+# dev
+aws ecs run-task \
+  --cluster checkin-dev \
+  --task-definition checkin-migrate-dev \
+  --network-configuration '<copy from the service, see deploy-dev.yml>' \
+  --overrides '{"containerOverrides":[{"name":"checkin-migrate","command":
+    ["sh","-c","cd checkin-app && npx prisma db execute --file prisma/migrations/<baseline>/reconcile.sql"]}]}'
+
+# prod
+aws ecs run-task \
+  --cluster treehouse-prod \
+  --task-definition checkin-migrate-prod \
+  --capacity-provider-strategy capacityProvider=treehouse-prod-c6g,weight=1 \
+  --overrides '{"containerOverrides":[{"name":"checkin-migrate","command":
+    ["sh","-c","cd checkin-app && npx prisma db execute --file prisma/migrations/<baseline>/reconcile.sql"]}]}'
+```
+
+`prisma db execute --file` (not `psql`) because the migrate image ships
+Prisma but not necessarily a `psql` binary, and the file already lives inside
+the image at that path once built from the merged commit.
+
+**Two honest paths — both are real, pick based on timing:**
+
+1. **Preemptive.** Dev auto-deploys on every merge to main
+   (`deploy-dev.yml`). Run the one-off reconcile task in the narrow
+   merge → deploy window, before the automatic migrate step gets there. For
+   prod, the equivalent window is between merging the coalesce PR and
+   cutting the release — reconcile prod before running `gh release create`.
+2. **Reactive (simpler, still correct).** Skip the race. Let the automatic
+   migrate step fail once — loudly, expectedly, because it can't find the
+   old chain in the ledger (`P3005`-shaped failure, not silent corruption).
+   Run the one-off reconcile task against the now-pushed image, then re-run
+   the failed GitHub Actions job (dev) or the failed workflow run (prod —
+   re-running reuses the same release tag/event). The retry's migrate step
+   now finds the ledger already at the new baseline and applies nothing new.
+
+Neither path is automated into the pipeline — reconciling a ledger is a
+one-time, per-environment, human-triggered action tied to exactly one
+coalesce merge, not something worth building always-on machinery for.
+
+## CI coalesce path (`migration-safety.yml`)
+
+The existing job replays a PR's new migrations on top of a **populated** DB
+cloned from the base commit — the right test for an ordinary migration PR,
+and structurally impossible for a coalesce PR: a coalesce PR **deletes** the
+whole chain that populated DB already has applied, so there's nothing to
+"apply on top of."
+
+The job detects a coalesce PR by shape: the diff vs `origin/main`'s merge
+base **deletes ≥2 migration directories and adds exactly 1** (the exact
+shape `coalesce-migrations.ts` produces). When detected, it runs a different
+check instead of the normal replay:
+
+1. The base checkout's full migration chain still gets applied + seeded into
+   the service DB, same as the normal path — that DB's schema stands in for
+   "the full chain," no separate database needed.
+2. The PR's single baseline gets applied to a second, fresh DB.
+3. `scripts/compare-schema-dumps.sh` (the same script `coalesce-migrations.ts`
+   uses locally) checks the two are schema-identical.
+4. The job checks `prisma/migrations/<baseline>/reconcile.sql` exists at the
+   documented path.
+
+Normal PRs are unaffected — same steps, same conditions as before shape
+detection was added.
+
+## Release gate (`deploy-prod.yml`)
+
+A new `migration-release-gate` job (deploy's `validate` job is a
+reusable-workflow call to `ci.yml` with no step surface to extend — this
+runs alongside it, and `deploy` needs both):
+
+1. Finds the previous `v*` release tag by fetching all tags, sorting with
+   `sort -V` (a real version sort, handles annotated and lightweight tags
+   identically — `git tag -l` doesn't distinguish them), and taking the one
+   immediately before the tag being released.
+2. **First release**: no previous `v*` tag exists — the gate logs a notice
+   and passes. There's nothing to have accumulated against yet.
+3. Otherwise, counts migration directories **added** (not deleted) between
+   the previous tag and this release. A normal release with exactly one new
+   migration passes. A coalesce release — which deletes many and adds
+   exactly one — also passes (only additions are counted). More than one
+   added migration directory fails the gate with a message pointing back at
+   this doc.
+
+This is a plain bash step (no new action, no dependency), matching the rest
+of the workflow's style.

--- a/checkin-app/package.json
+++ b/checkin-app/package.json
@@ -15,7 +15,8 @@
     "test:coverage": "INTEGRATION_DB=1 jest --ci --coverage --testPathIgnorePatterns \"/node_modules/|/\\.next/|/\\.claude/worktrees/|\\.flow\\.test\\.\"",
     "check-route-coverage": "ts-node --project scripts/tsconfig.json scripts/check-route-coverage.ts",
     "import:zoho": "tsx scripts/import-zoho.ts",
-    "shopify:webhook": "tsx scripts/register-shopify-webhook.ts"
+    "shopify:webhook": "tsx scripts/register-shopify-webhook.ts",
+    "coalesce-migrations": "tsx scripts/coalesce-migrations.ts"
   },
   "engines": {
     "node": ">=24"

--- a/checkin-app/scripts/__tests__/partial-indexes.test.ts
+++ b/checkin-app/scripts/__tests__/partial-indexes.test.ts
@@ -1,0 +1,60 @@
+import { isPartialIndex, findMissingPartialIndexes, splicePartialIndexes, type IndexRow } from "../lib/partial-indexes";
+
+const VISIT_ONE_OPEN: IndexRow = {
+    indexname: "Visit_one_open_per_participant",
+    indexdef: 'CREATE UNIQUE INDEX "Visit_one_open_per_participant" ON public."Visit" USING btree ("personId") WHERE ("departedAt" IS NULL)',
+};
+const PLAIN_INDEX: IndexRow = {
+    indexname: "Visit_personId_departedAt_idx",
+    indexdef: 'CREATE INDEX "Visit_personId_departedAt_idx" ON public."Visit" USING btree ("personId", "departedAt")',
+};
+
+describe("isPartialIndex", () => {
+    it("is true for an index with a WHERE clause", () => {
+        expect(isPartialIndex(VISIT_ONE_OPEN)).toBe(true);
+    });
+
+    it("is false for a plain index", () => {
+        expect(isPartialIndex(PLAIN_INDEX)).toBe(false);
+    });
+});
+
+describe("findMissingPartialIndexes", () => {
+    it("returns partial indexes present in truth but absent from candidate", () => {
+        const missing = findMissingPartialIndexes([VISIT_ONE_OPEN, PLAIN_INDEX], [PLAIN_INDEX]);
+        expect(missing).toEqual([VISIT_ONE_OPEN]);
+    });
+
+    it("returns nothing when every partial index is present with the same definition", () => {
+        const missing = findMissingPartialIndexes([VISIT_ONE_OPEN, PLAIN_INDEX], [VISIT_ONE_OPEN, PLAIN_INDEX]);
+        expect(missing).toEqual([]);
+    });
+
+    it("ignores non-partial indexes entirely, even if candidate is missing them", () => {
+        const missing = findMissingPartialIndexes([VISIT_ONE_OPEN, PLAIN_INDEX], [VISIT_ONE_OPEN]);
+        expect(missing).toEqual([]);
+    });
+
+    it("throws instead of silently patching when the same-named index has a different definition", () => {
+        const drifted: IndexRow = { ...VISIT_ONE_OPEN, indexdef: VISIT_ONE_OPEN.indexdef.replace("IS NULL", "IS NOT NULL") };
+        expect(() => findMissingPartialIndexes([VISIT_ONE_OPEN], [drifted])).toThrow(/different definitions/);
+    });
+});
+
+describe("splicePartialIndexes", () => {
+    it("is a no-op when nothing is missing", () => {
+        expect(splicePartialIndexes("-- sql", [])).toBe("-- sql");
+    });
+
+    it("appends each missing index's indexdef verbatim with a marker comment", () => {
+        const result = splicePartialIndexes("CREATE TABLE Foo (id int);", [VISIT_ONE_OPEN]);
+        expect(result).toContain(VISIT_ONE_OPEN.indexdef + ";");
+        expect(result).toContain("coalesce-migrations: partial unique index restored");
+        expect(result.indexOf("CREATE TABLE Foo")).toBeLessThan(result.indexOf(VISIT_ONE_OPEN.indexdef));
+    });
+
+    it("appends one block per missing index", () => {
+        const result = splicePartialIndexes("-- sql", [VISIT_ONE_OPEN, PLAIN_INDEX]);
+        expect(result.split("coalesce-migrations: partial unique index restored").length - 1).toBe(2);
+    });
+});

--- a/checkin-app/scripts/__tests__/schema-dump-compare.test.ts
+++ b/checkin-app/scripts/__tests__/schema-dump-compare.test.ts
@@ -1,0 +1,47 @@
+import { normalizeDump, compareDumps } from "../lib/schema-dump-compare";
+
+describe("normalizeDump", () => {
+    it("strips comments, SET lines, and restrict tokens", () => {
+        const raw = [
+            "--",
+            "-- PostgreSQL database dump",
+            "--",
+            "\\restrict abc123",
+            "SET statement_timeout = 0;",
+            "SELECT pg_catalog.set_config('search_path', '', false);",
+            'CREATE TABLE public."Foo" (',
+            '    "id" integer NOT NULL',
+            ");",
+            "\\unrestrict abc123",
+        ].join("\n");
+        expect(normalizeDump(raw)).toEqual([");", 'CREATE TABLE public."Foo" (', '"id" integer NOT NULL'].sort());
+    });
+
+    it("normalizes *_id_seq names so a rename-carried sequence name isn't a false diff", () => {
+        const a = normalizeDump('ALTER SEQUENCE public."Participant_id_seq" OWNED BY public."Person".id;');
+        const b = normalizeDump('ALTER SEQUENCE public."Person_id_seq" OWNED BY public."Person".id;');
+        expect(a).toEqual(b);
+    });
+});
+
+describe("compareDumps", () => {
+    it("is identical when only column order differs (order-insensitive)", () => {
+        const a = ['CREATE TABLE public."Foo" (', '    "id" integer NOT NULL,', '    "name" text', ");"].join("\n");
+        const b = ['CREATE TABLE public."Foo" (', '    "name" text,', '    "id" integer NOT NULL', ");"].join("\n");
+        expect(compareDumps(a, b).identical).toBe(true);
+    });
+
+    it("is identical when only the \\restrict token / comments differ", () => {
+        const a = ["\\restrict aaa", 'CREATE TABLE public."Foo" ("id" integer);', "\\unrestrict aaa"].join("\n");
+        const b = ["\\restrict zzz", 'CREATE TABLE public."Foo" ("id" integer);', "\\unrestrict zzz"].join("\n");
+        expect(compareDumps(a, b).identical).toBe(true);
+    });
+
+    it("flags a genuine schema difference", () => {
+        const a = ['CREATE TABLE public."Foo" (', '    "id" integer NOT NULL', ");"].join("\n");
+        const b = ['CREATE TABLE public."Foo" (', '    "id" integer NOT NULL,', '    "extra" text', ");"].join("\n");
+        const diff = compareDumps(a, b);
+        expect(diff.identical).toBe(false);
+        expect(diff.onlyInB).toContain('"extra" text');
+    });
+});

--- a/checkin-app/scripts/coalesce-migrations.ts
+++ b/checkin-app/scripts/coalesce-migrations.ts
@@ -1,0 +1,347 @@
+import { execFileSync, spawnSync } from "child_process";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { findMissingPartialIndexes, splicePartialIndexes, type IndexRow } from "./lib/partial-indexes";
+
+/**
+ * Coalesces the accumulated migrations on main into a single baseline
+ * migration, ahead of a release — see checkin-app/docs/MIGRATION_COALESCE_FLOW.md
+ * for the policy this implements (migrations accumulate between releases;
+ * they're coalesced via this script before a release; a release applies at
+ * most one new migration, enforced by the release gate in deploy-prod.yml).
+ *
+ *   npx tsx scripts/coalesce-migrations.ts --scratch-url <postgres-url> [--commit]
+ *   DATABASE_URL_SCRATCH=<postgres-url> npx tsx scripts/coalesce-migrations.ts [--commit]
+ *
+ * Defaults to a DRY RUN: builds and validates the candidate baseline but
+ * writes nothing. Pass --commit to replace prisma/migrations/* with it and
+ * emit the ledger-reconcile artifacts already-migrated environments need.
+ *
+ * --scratch-url must point at a disposable Postgres server/maintenance DB
+ * (e.g. postgresql://user:pass@host:5433/postgres) — this script creates and
+ * always drops its OWN temp DBs there. It refuses checkmein/checkin_dev/
+ * checkin_prod as a guard against pointing it at a real environment.
+ *
+ * What "validate" means (see #792, which did this by hand once and hit both
+ * of these the hard way):
+ *  1. Semantic schema identity: a fresh DB migrated through the FULL current
+ *     chain (TRUTH) must dump the same schema (scripts/compare-schema-dumps.sh)
+ *     as a fresh DB with only the generated candidate applied.
+ *  2. Partial unique indexes survive: `prisma migrate diff --from-empty` has
+ *     nothing in schema.prisma to reconstruct a partial (WHERE-clause) unique
+ *     index from, and drops it silently. Detected by diffing TRUTH's
+ *     pg_indexes against the candidate's; missing ones are spliced back in
+ *     verbatim and the candidate is re-validated from scratch.
+ *  3. No drift: `prisma migrate diff --exit-code` from the candidate DB
+ *     against schema.prisma must be empty.
+ */
+
+const CHECKIN_APP_DIR = path.resolve(__dirname, "..");
+const REPO_ROOT = path.resolve(CHECKIN_APP_DIR, "..");
+const MIGRATIONS_DIR = path.join(CHECKIN_APP_DIR, "prisma", "migrations");
+const PROTECTED_DB_NAMES = ["checkmein", "checkin_dev", "checkin_prod"];
+
+function arg(flag: string): string | undefined {
+    const i = process.argv.indexOf(flag);
+    return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const hasFlag = (flag: string) => process.argv.includes(flag);
+
+function step(label: string) {
+    console.log(`\n=== ${label} ===`);
+}
+
+function ensureCleanGitTree(): string {
+    const status = execFileSync("git", ["status", "--porcelain"], { cwd: REPO_ROOT, encoding: "utf8" });
+    if (status.trim().length > 0) {
+        throw new Error(`Git working tree is not clean — commit or stash before running this script:\n${status}`);
+    }
+    const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: REPO_ROOT, encoding: "utf8" }).trim();
+    if (branch === "HEAD") {
+        throw new Error("Detached HEAD — check out a branch first (--commit rewrites prisma/migrations/ in place).");
+    }
+    return branch;
+}
+
+function guardScratchUrl(url: string) {
+    let dbName: string;
+    try {
+        dbName = new URL(url).pathname.replace(/^\//, "").toLowerCase();
+    } catch {
+        throw new Error(`--scratch-url / DATABASE_URL_SCRATCH is not a valid postgres URL: ${url}`);
+    }
+    if (PROTECTED_DB_NAMES.includes(dbName)) {
+        throw new Error(
+            `--scratch-url points at "${dbName}", a real environment database. Point it at a neutral ` +
+                `maintenance DB on a disposable scratch server instead (e.g. .../postgres) — this script ` +
+                `creates and drops its own temp DBs there, it never touches the DB the URL itself names.`,
+        );
+    }
+}
+
+function withDatabase(url: string, dbName: string): string {
+    const u = new URL(url);
+    u.pathname = `/${dbName}`;
+    return u.toString();
+}
+
+function createDatabase(adminUrl: string, dbName: string) {
+    execFileSync("psql", [adminUrl, "-v", "ON_ERROR_STOP=1", "-c", `DROP DATABASE IF EXISTS "${dbName}"; CREATE DATABASE "${dbName}";`], {
+        stdio: ["ignore", "pipe", "inherit"],
+    });
+}
+
+function dropDatabase(adminUrl: string, dbName: string) {
+    try {
+        execFileSync("psql", [adminUrl, "-v", "ON_ERROR_STOP=1", "-c", `DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE);`], {
+            stdio: ["ignore", "pipe", "inherit"],
+        });
+    } catch (e) {
+        console.warn(`Warning: failed to drop temp DB "${dbName}" — clean it up manually.`, e);
+    }
+}
+
+function applySql(url: string, sql: string) {
+    const tmpFile = path.join(os.tmpdir(), `coalesce-candidate-${process.pid}.sql`);
+    fs.writeFileSync(tmpFile, sql);
+    execFileSync("psql", [url, "-v", "ON_ERROR_STOP=1", "-f", tmpFile], { stdio: ["ignore", "pipe", "inherit"] });
+}
+
+function applyFullChain(truthUrl: string) {
+    console.log("Applying the full current migration chain to the TRUTH DB (prisma migrate deploy)...");
+    const out = execFileSync("npx", ["prisma", "migrate", "deploy"], {
+        cwd: CHECKIN_APP_DIR,
+        env: { ...process.env, DATABASE_URL: truthUrl },
+        encoding: "utf8",
+    });
+    console.log(out);
+}
+
+function generateCandidateSql(): string {
+    console.log("Generating candidate baseline: prisma migrate diff --from-empty --to-schema=prisma/schema.prisma --script");
+    const sql = execFileSync("npx", ["prisma", "migrate", "diff", "--from-empty", "--to-schema=prisma/schema.prisma", "--script"], {
+        cwd: CHECKIN_APP_DIR,
+        encoding: "utf8",
+    });
+    console.log(`Generated ${sql.split("\n").length} lines of candidate SQL.`);
+    return sql;
+}
+
+function queryPartialIndexes(url: string): IndexRow[] {
+    const sql = `SELECT indexname || chr(31) || indexdef FROM pg_indexes WHERE schemaname = 'public' AND indexdef ILIKE '%WHERE%' ORDER BY indexname;`;
+    const out = execFileSync("psql", [url, "-t", "-A", "-c", sql], { encoding: "utf8" });
+    return out
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .map((line) => {
+            const [indexname, indexdef] = line.split("\x1f");
+            return { indexname, indexdef };
+        });
+}
+
+function compareSchemas(urlA: string, urlB: string): { identical: boolean; report: string } {
+    const scriptPath = path.join(__dirname, "compare-schema-dumps.sh");
+    const result = spawnSync("bash", [scriptPath, urlA, urlB], { encoding: "utf8" });
+    const report = [result.stdout, result.stderr].filter(Boolean).join("\n");
+    if (result.status !== 0 && result.status !== 1) {
+        throw new Error(`compare-schema-dumps.sh failed unexpectedly (exit ${result.status}):\n${report}`);
+    }
+    return { identical: result.status === 0, report };
+}
+
+function checkNoDrift(candidateUrl: string): void {
+    const result = spawnSync(
+        "npx",
+        ["prisma", "migrate", "diff", "--from-config-datasource", "--to-schema=prisma/schema.prisma", "--exit-code"],
+        { cwd: CHECKIN_APP_DIR, env: { ...process.env, DATABASE_URL: candidateUrl }, encoding: "utf8" },
+    );
+    if (result.status === 0) return;
+    if (result.status === 2) {
+        throw new Error(`Candidate baseline drifts from schema.prisma (migrate diff --exit-code):\n${result.stdout}\n${result.stderr}`);
+    }
+    throw new Error(`prisma migrate diff --exit-code failed unexpectedly (exit ${result.status}):\n${result.stdout}\n${result.stderr}`);
+}
+
+function migrationTimestamp(d = new Date()): string {
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}`;
+}
+
+function listMigrationDirs(): string[] {
+    return fs
+        .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .sort();
+}
+
+function sha256Hex(content: string): string {
+    return crypto.createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function renderReconcileSql(baselineName: string, checksumHex: string): string {
+    return `-- Ledger reconcile for the "${baselineName}" coalesce baseline.
+--
+-- Run ONCE against every already-migrated environment (dev, prod) so
+-- Prisma's ledger (_prisma_migrations) shows exactly this baseline as
+-- applied, instead of \`prisma migrate deploy\` trying (and failing) to
+-- replay the squashed history this migration replaced.
+--
+-- See checkin-app/docs/MIGRATION_COALESCE_FLOW.md for the ECS one-off
+-- command to run this against dev/prod. Safe to re-run (idempotent DELETE).
+BEGIN;
+DELETE FROM "_prisma_migrations";
+INSERT INTO "_prisma_migrations"
+    (id, checksum, migration_name, started_at, finished_at, applied_steps_count)
+VALUES
+    (gen_random_uuid(), '${checksumHex}', '${baselineName}', now(), now(), 1);
+COMMIT;
+`;
+}
+
+function renderReconcileInstructions(baselineName: string, checksumHex: string): string {
+    return `
+=== Ledger reconcile required for already-migrated environments ===
+
+prisma/migrations/${baselineName}/reconcile.sql   (checksum ${checksumHex})
+
+Any environment that already ran the migrations this baseline replaces (dev,
+prod) needs that file applied to its _prisma_migrations ledger BEFORE its
+next \`prisma migrate deploy\` — otherwise that deploy looks for migrations
+that no longer exist in the repo and fails.
+
+Two honest paths (full commands in checkin-app/docs/MIGRATION_COALESCE_FLOW.md):
+  1. Preemptive: dev auto-deploys on every merge to main — run the ECS
+     one-off reconcile task in the merge -> deploy window, before the
+     automatic migrate step gets there.
+  2. Reactive (simpler, still correct): let the automatic migrate step fail
+     once, loudly (expected — it can't find the old chain in the ledger).
+     Run the one-off reconcile task, then re-run the failed GitHub Actions
+     job/workflow run. Its migrate step now finds the ledger already at this
+     baseline and applies nothing new.
+
+Prod deploys are gated behind the release gate (deploy-prod.yml), which
+blocks a release carrying more than one new migration directory — the
+coalesce PR's baseline ships as that release's one new migration. Reconcile
+prod the same way, in the window between merging and cutting that release.
+`;
+}
+
+function writeBaseline(baselineName: string, sql: string, oldDirs: string[]): string {
+    for (const dir of oldDirs) {
+        fs.rmSync(path.join(MIGRATIONS_DIR, dir), { recursive: true, force: true });
+    }
+    const newDir = path.join(MIGRATIONS_DIR, baselineName);
+    fs.mkdirSync(newDir, { recursive: true });
+    const finalSql = sql.endsWith("\n") ? sql : `${sql}\n`;
+    fs.writeFileSync(path.join(newDir, "migration.sql"), finalSql);
+    return finalSql;
+}
+
+async function main() {
+    const commit = hasFlag("--commit");
+    const scratchUrl = arg("--scratch-url") ?? process.env.DATABASE_URL_SCRATCH;
+    if (!scratchUrl) {
+        throw new Error(
+            "Provide a scratch Postgres server via --scratch-url <postgres-url> or DATABASE_URL_SCRATCH env " +
+                "(point it at a maintenance DB like 'postgres' on a disposable server — this script creates/drops " +
+                "its OWN temp DBs there, never checkmein/checkin_dev/checkin_prod).",
+        );
+    }
+    guardScratchUrl(scratchUrl);
+
+    const branch = ensureCleanGitTree();
+    console.log(`Preflight OK — clean tree on branch "${branch}".`);
+
+    const existingMigrations = listMigrationDirs();
+    console.log(`Found ${existingMigrations.length} existing migration(s): ${existingMigrations.join(", ")}`);
+    if (existingMigrations.length <= 1) {
+        console.log("Nothing to coalesce (0 or 1 migration already) — exiting without changes.");
+        return;
+    }
+
+    const ts = migrationTimestamp();
+    const baselineName = `${ts}_coalesced_baseline`;
+    const suffix = crypto.randomBytes(3).toString("hex");
+    const truthDb = `coalesce_truth_${ts}_${suffix}`;
+    const candidateDb = `coalesce_candidate_${ts}_${suffix}`;
+    const truthUrl = withDatabase(scratchUrl, truthDb);
+    const candidateUrl = withDatabase(scratchUrl, candidateDb);
+
+    try {
+        step("Build TRUTH DB (full current migration chain)");
+        createDatabase(scratchUrl, truthDb);
+        applyFullChain(truthUrl);
+
+        step("Generate candidate baseline");
+        let candidateSql = generateCandidateSql();
+
+        let dumpDiff: { identical: boolean; report: string } | undefined;
+        let truthPartialIndexes: IndexRow[] = [];
+        const maxAttempts = 2; // 1 initial + 1 splice-and-retry; a 2nd miss means something's really wrong
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            step(`Validate candidate (attempt ${attempt}/${maxAttempts})`);
+            createDatabase(scratchUrl, candidateDb);
+            applySql(candidateUrl, candidateSql);
+
+            dumpDiff = compareSchemas(truthUrl, candidateUrl);
+            console.log(dumpDiff.report);
+
+            truthPartialIndexes = queryPartialIndexes(truthUrl);
+            const candidatePartialIndexes = queryPartialIndexes(candidateUrl);
+            const missing = findMissingPartialIndexes(truthPartialIndexes, candidatePartialIndexes);
+
+            if (dumpDiff.identical && missing.length === 0) {
+                checkNoDrift(candidateUrl);
+                console.log("No-drift check passed: candidate matches schema.prisma exactly.");
+                break;
+            }
+
+            if (missing.length > 0 && attempt < maxAttempts) {
+                console.log(
+                    `Missing ${missing.length} partial unique index(es) in the candidate ` +
+                        `(${missing.map((m) => m.indexname).join(", ")}) — splicing from TRUTH and re-validating from scratch.`,
+                );
+                candidateSql = splicePartialIndexes(candidateSql, missing);
+                continue;
+            }
+
+            throw new Error(
+                `Candidate baseline failed validation after ${attempt} attempt(s).\n` +
+                    (dumpDiff.identical ? "" : "Schema dump comparison found real differences (see report above).\n") +
+                    (missing.length > 0 ? `Still missing partial index(es) after splicing: ${missing.map((m) => m.indexname).join(", ")}\n` : ""),
+            );
+        }
+
+        console.log(
+            `\nValidation verdict: candidate baseline is semantically identical to the full current chain ` +
+                `(${existingMigrations.length} migrations); ${truthPartialIndexes.length} partial unique index(es) verified; no drift vs schema.prisma.`,
+        );
+
+        if (!commit) {
+            console.log("\nDRY RUN — no changes written. Re-run with --commit to replace prisma/migrations/ with this baseline.");
+            return;
+        }
+
+        step("Writing coalesced baseline + reconcile artifacts");
+        const finalSql = writeBaseline(baselineName, candidateSql, existingMigrations);
+        const checksum = sha256Hex(finalSql);
+        fs.writeFileSync(path.join(MIGRATIONS_DIR, baselineName, "reconcile.sql"), renderReconcileSql(baselineName, checksum));
+        console.log(`Wrote prisma/migrations/${baselineName}/ (migration.sql + reconcile.sql).`);
+        console.log(renderReconcileInstructions(baselineName, checksum));
+    } finally {
+        step("Dropping temp databases");
+        dropDatabase(scratchUrl, truthDb);
+        dropDatabase(scratchUrl, candidateDb);
+    }
+}
+
+if (require.main === module) {
+    main().catch((e) => {
+        console.error(e instanceof Error ? e.message : e);
+        process.exit(1);
+    });
+}

--- a/checkin-app/scripts/coalesce-migrations.ts
+++ b/checkin-app/scripts/coalesce-migrations.ts
@@ -88,7 +88,14 @@ function withDatabase(url: string, dbName: string): string {
 }
 
 function createDatabase(adminUrl: string, dbName: string) {
-    execFileSync("psql", [adminUrl, "-v", "ON_ERROR_STOP=1", "-c", `DROP DATABASE IF EXISTS "${dbName}"; CREATE DATABASE "${dbName}";`], {
+    // DROP/CREATE DATABASE cannot run inside a transaction block, and psql
+    // sends a single `-c` argument as one query string — even semicolon-
+    // separated statements in it run as one implicit transaction. Two
+    // separate `-c` invocations, not one combined string.
+    execFileSync("psql", [adminUrl, "-v", "ON_ERROR_STOP=1", "-c", `DROP DATABASE IF EXISTS "${dbName}";`], {
+        stdio: ["ignore", "pipe", "inherit"],
+    });
+    execFileSync("psql", [adminUrl, "-v", "ON_ERROR_STOP=1", "-c", `CREATE DATABASE "${dbName}";`], {
         stdio: ["ignore", "pipe", "inherit"],
     });
 }

--- a/checkin-app/scripts/compare-schema-dumps.sh
+++ b/checkin-app/scripts/compare-schema-dumps.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Dumps two Postgres databases (--schema-only) and reports whether they are
+# semantically identical — ignoring pg_dump noise (comments/SET lines/
+# \restrict tokens), column/enum declaration order, and cosmetic *_id_seq
+# naming (see scripts/lib/schema-dump-compare.ts for why those are noise, not
+# signal). The actual normalize+diff logic lives there so it's jest-unit-
+# testable; this wrapper just supplies the two dumps.
+#
+# Shared by .github/workflows/migration-safety.yml (validates a coalesce PR's
+# single baseline against the pre-coalesce chain) and
+# checkin-app/scripts/coalesce-migrations.ts (validates its generated
+# candidate against a from-scratch TRUTH DB) — one comparison, one behavior,
+# used identically in CI and locally.
+#
+# Usage: compare-schema-dumps.sh <database-url-a> <database-url-b>
+# Exit codes: 0 identical, 1 different, 2 usage/tool error.
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <database-url-a> <database-url-b>" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# _prisma_migrations is Prisma's own ledger bookkeeping, not app schema — a DB
+# that ever ran `migrate deploy` has it, a DB seeded via raw `psql -f` doesn't.
+# Excluding it keeps the comparison about the schema, not how each side was built.
+pg_dump "$1" --schema-only --no-owner --no-privileges --exclude-table=_prisma_migrations > "$TMP_DIR/a.sql"
+pg_dump "$2" --schema-only --no-owner --no-privileges --exclude-table=_prisma_migrations > "$TMP_DIR/b.sql"
+
+cd "$SCRIPT_DIR/.."
+npx tsx scripts/lib/schema-dump-compare.ts "$TMP_DIR/a.sql" "$TMP_DIR/b.sql"

--- a/checkin-app/scripts/lib/partial-indexes.ts
+++ b/checkin-app/scripts/lib/partial-indexes.ts
@@ -1,0 +1,65 @@
+/**
+ * Prisma's schema DSL cannot express a partial (`WHERE ...`) unique index —
+ * this repo has three, hand-written straight into migration.sql (see
+ * `Visit_one_open_per_participant`, `membership_one_inflight_initial`,
+ * `membership_one_inflight_renewal`). `prisma migrate diff --from-empty
+ * --to-schema=schema.prisma` only knows what's in schema.prisma, so it drops
+ * these silently — not "the WHERE clause" specifically, the whole index,
+ * because schema.prisma has no `@@unique` for them to reconstruct at all.
+ * This module detects that gap against a real (TRUTH) database and splices
+ * the missing index back in verbatim.
+ */
+
+export interface IndexRow {
+    indexname: string;
+    indexdef: string;
+}
+
+export function isPartialIndex(row: IndexRow): boolean {
+    return /\bWHERE\b/i.test(row.indexdef);
+}
+
+/**
+ * Diffs TRUTH's partial indexes against CANDIDATE's.
+ * - Present in both, same `indexdef` -> fine, omitted from the result.
+ * - Present in both, DIFFERENT `indexdef` -> a real divergence, not a diff
+ *   tool limitation — throws instead of returning, so the caller fails loud
+ *   rather than silently patching over an actual schema difference.
+ * - Missing from candidate entirely -> returned, for splicing.
+ */
+export function findMissingPartialIndexes(truthIndexes: IndexRow[], candidateIndexes: IndexRow[]): IndexRow[] {
+    const candidateByName = new Map(candidateIndexes.map((r) => [r.indexname, r]));
+    const missing: IndexRow[] = [];
+    for (const truth of truthIndexes.filter(isPartialIndex)) {
+        const candidate = candidateByName.get(truth.indexname);
+        if (!candidate) {
+            missing.push(truth);
+        } else if (candidate.indexdef !== truth.indexdef) {
+            throw new Error(
+                `Partial index "${truth.indexname}" exists in both databases but with different definitions — ` +
+                    `a real schema divergence, not something to auto-splice over.\n` +
+                    `  truth:     ${truth.indexdef}\n` +
+                    `  candidate: ${candidate.indexdef}`,
+            );
+        }
+    }
+    return missing;
+}
+
+/**
+ * Appends each missing index's TRUTH-DB `indexdef` verbatim (it's already a
+ * complete, valid `CREATE [UNIQUE] INDEX ... WHERE ...` statement) to the
+ * generated migration SQL, with a marker comment recording provenance.
+ */
+export function splicePartialIndexes(migrationSql: string, missing: IndexRow[]): string {
+    if (missing.length === 0) return migrationSql;
+    const blocks = missing.map(
+        (idx) =>
+            `\n-- coalesce-migrations: partial unique index restored — prisma migrate diff --from-empty\n` +
+            `-- has no @@unique/@@index in schema.prisma to reconstruct this from (Prisma's DSL can't\n` +
+            `-- express a WHERE clause) and drops it silently. Spliced verbatim from the TRUTH DB's\n` +
+            `-- pg_indexes.indexdef for "${idx.indexname}".\n` +
+            `${idx.indexdef};\n`,
+    );
+    return migrationSql.replace(/\s*$/, "\n") + blocks.join("");
+}

--- a/checkin-app/scripts/lib/schema-dump-compare.ts
+++ b/checkin-app/scripts/lib/schema-dump-compare.ts
@@ -1,0 +1,81 @@
+import * as fs from "fs";
+
+/**
+ * Compares two `pg_dump --schema-only` outputs for semantic identity —
+ * used to prove a coalesced single-migration baseline reproduces the exact
+ * schema the full migration chain it replaces produces.
+ *
+ * Two DBs migrated by different paths never dump byte-identical SQL even when
+ * the schema is identical:
+ * - pg_dump emits a fresh `\restrict`/`\unrestrict` token and timestamp comment
+ *   every run.
+ * - Column/enum-value order in a dump reflects the order operations happened
+ *   in, not the schema's — a chain of migrations that ADD COLUMN over time
+ *   dumps columns in a different order than one CREATE TABLE with every column
+ *   already present.
+ * - `ALTER TABLE ... RENAME` never renames the table's backing sequence, so a
+ *   dump replayed through a rename migration can carry an old table's
+ *   `_id_seq` name where a fresh single-baseline dump would not.
+ *
+ * None of that is a real schema difference, so normalize it away before
+ * comparing. What's left after normalization is the actual signal.
+ */
+
+const NOISE_PREFIXES = ["--", "SET ", "SELECT pg_catalog.set_config", "\\restrict", "\\unrestrict"];
+
+export function normalizeDump(raw: string): string[] {
+    const lines = raw
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0)
+        .filter((l) => !NOISE_PREFIXES.some((p) => l.startsWith(p)));
+
+    return lines
+        .map((l) => l.replace(/"[A-Za-z0-9_]+_id_seq"/g, '"_id_seq"'))
+        // Trailing list-separator commas are positional, not semantic — once every
+        // line is sorted as an independent element, a reordered column/enum-value
+        // list must not be told apart from the same list in its original order by
+        // whichever line happens to have landed last (commaless).
+        .map((l) => l.replace(/,$/, ""))
+        .sort();
+}
+
+export interface DumpDiff {
+    identical: boolean;
+    onlyInA: string[];
+    onlyInB: string[];
+}
+
+export function compareDumps(dumpA: string, dumpB: string): DumpDiff {
+    const a = normalizeDump(dumpA);
+    const b = normalizeDump(dumpB);
+    const setA = new Set(a);
+    const setB = new Set(b);
+    const onlyInA = a.filter((l) => !setB.has(l));
+    const onlyInB = b.filter((l) => !setA.has(l));
+    return { identical: onlyInA.length === 0 && onlyInB.length === 0, onlyInA, onlyInB };
+}
+
+/**
+ * CLI: tsx schema-dump-compare.ts <dumpA.sql> <dumpB.sql>
+ * Prints the verdict and exits 0 (identical) or 1 (different) — the shared
+ * exit-code contract scripts/compare-schema-dumps.sh and its callers rely on.
+ */
+if (require.main === module) {
+    const [fileA, fileB] = process.argv.slice(2);
+    if (!fileA || !fileB) {
+        console.error("Usage: schema-dump-compare.ts <dumpA.sql> <dumpB.sql>");
+        process.exit(2);
+    }
+    const diff = compareDumps(fs.readFileSync(fileA, "utf8"), fs.readFileSync(fileB, "utf8"));
+    if (diff.identical) {
+        console.log(`Schemas are semantically identical (${normalizeDump(fs.readFileSync(fileA, "utf8")).length} normalized statement lines).`);
+        process.exit(0);
+    }
+    console.error("Schemas DIFFER after normalization:");
+    console.error(`Only in ${fileA} (${diff.onlyInA.length}):`);
+    diff.onlyInA.forEach((l) => console.error(`  < ${l}`));
+    console.error(`Only in ${fileB} (${diff.onlyInB.length}):`);
+    diff.onlyInB.forEach((l) => console.error(`  > ${l}`));
+    process.exit(1);
+}


### PR DESCRIPTION
## Policy

Migrations accumulate on `main` between releases — every PR that needs a schema
change still just adds its own migration, same as always. **Before a release**,
the accumulated migrations are coalesced into a single migration via a manual PR
produced by a script. **A release may apply at most one new database migration**,
enforced in the release pipeline.

```
 PR merges to main            a coalesce PR                  a release
┌──────────────────┐         ┌──────────────────┐         ┌──────────────────┐
│ migration A       │         │ scripts/          │         │ deploy-prod.yml  │
│ migration B       │  --->   │ coalesce-         │  --->   │ release gate:    │
│ migration C       │         │ migrations.ts     │         │ "added migration │
│ ...accumulate...  │         │ deletes A..N,     │         │  dirs since prev │
│ migration N       │         │ adds ONE baseline │         │  release <= 1"   │
└──────────────────┘         └──────────────────┘         └──────────────────┘
```

Full write-up: `checkin-app/docs/MIGRATION_COALESCE_FLOW.md`.

## Precedent: #792, automated

#792 did this exact coalesce by hand once (squashed 49 migrations into
`20260703130000_squashed_init`) ahead of a release. It worked, but by-hand
squashing hit two sharp edges that this PR automates detection/handling for:

1. **Partial unique indexes get silently dropped.** Prisma's schema DSL can't
   express a `WHERE` clause, so `prisma migrate diff --from-empty
   --to-schema=schema.prisma` has nothing in `schema.prisma` to reconstruct one
   from and just omits it — not "ships it without the WHERE," omits the index
   entirely. This schema has three (`Visit_one_open_per_participant`,
   `membership_one_inflight_initial`, `membership_one_inflight_renewal`).
   `scripts/coalesce-migrations.ts` diffs the TRUTH DB's `pg_indexes` against the
   candidate's, splices any missing ones back in verbatim, and re-validates from
   scratch. A same-named index with a genuinely *different* definition fails
   loud instead of being patched over.
2. **Already-migrated environments need a ledger reconcile.** Prisma's
   `_prisma_migrations.checksum` is exactly the sha256 hex of `migration.sql`,
   `applied_steps_count = 1` for a clean apply (confirmed against this repo's
   own ledger while building this). `--commit` now emits
   `prisma/migrations/<baseline>/reconcile.sql` (`DELETE` + one-row `INSERT`)
   alongside the baseline, plus printed instructions for applying it to dev/prod.

## What's in this PR (tooling only — see "what's NOT in this PR")

1. **`checkin-app/scripts/coalesce-migrations.ts`** (dry-run by default, `--commit`
   to write) — builds a TRUTH DB (full current chain via `prisma migrate deploy`),
   generates a candidate baseline (`prisma migrate diff --from-empty`), validates:
   - semantic schema identity (TRUTH vs candidate, order-insensitive, ignoring
     pg_dump noise and cosmetic `*_id_seq` renaming from historical `ALTER TABLE
     ... RENAME`s — see `scripts/lib/schema-dump-compare.ts`)
   - partial-unique-index preservation (splice-and-retry, described above)
   - no drift vs `schema.prisma`

   then on `--commit` replaces `prisma/migrations/*` with the one baseline +
   `reconcile.sql`. Always drops its own scratch temp DBs, success or failure;
   refuses to run against `checkmein`/`checkin_dev`/`checkin_prod`.

2. **`checkin-app/scripts/compare-schema-dumps.sh`** — the schema-identity check
   factored out so `coalesce-migrations.ts` and CI's coalesce path (below) run the
   *exact same* comparison, not two implementations of "should be the same idea."

3. **`checkin-app/scripts/lib/{schema-dump-compare,partial-indexes}.ts`** + jest
   units (`scripts/__tests__/*.test.ts`, 19 tests) for the pure normalize/diff/
   splice logic — no DB required.

4. **`.github/workflows/migration-safety.yml`** — detects a coalesce PR by shape
   (diff vs merge-base deletes ≥2 migration dirs, adds exactly 1 — the shape
   `coalesce-migrations.ts` produces) and swaps the normal populated-DB replay
   (structurally impossible for a coalesce PR — it deletes the chain that DB
   already has applied) for: apply the base chain to the service DB (as today,
   stands in for TRUTH), apply the PR's one baseline to a second fresh DB, run
   `compare-schema-dumps.sh` between them, and check
   `prisma/migrations/<baseline>/reconcile.sql` exists. **Normal PRs: same steps,
   same conditions, unchanged** (origin: #794).

5. **`.github/workflows/deploy-prod.yml`** — new `migration-release-gate` job
   (sibling to `validate`, since `validate` is a `uses: ./.github/workflows/ci.yml`
   reusable-workflow call with no step surface to extend — noted as a design
   deviation from "a new step in validate" below). Finds the previous `v*` tag via
   `sort -V` (handles annotated/lightweight tags identically), counts migration
   directories **added** since it, fails if >1. Handles first release (no
   previous tag → notice + pass) and coalesce releases (many deletes + one add →
   passes, since only additions are counted).

6. **`checkin-app/docs/MIGRATION_COALESCE_FLOW.md`** + one `AGENTS.md` docs-map
   line.

### What's NOT in this PR

The actual coalesce of this repo's current 6 post-#792 migrations. Deliberately —
this PR ships tooling only; running `--commit` for real is a separate, later PR
(and only makes sense once there's enough post-#792 accumulation to bother with).

## Dry-run evidence (real run, this repo's current state)

Ran for real against a genuine test case — this repo's actual post-#792 state,
6 accumulated migrations — on scratch Postgres (`localhost:5433`, its own
disposable temp DBs, dropped after):

```
Preflight OK — clean tree on branch "feat/migration-coalesce-flow".
Found 6 existing migration(s): 20260703130000_squashed_init, 20260704120000_trusted_adult_modified_resubmit,
  20260705120000_household_intake_notes, 20260705130000_membership_payment_plan_requested,
  20260705140000_person_bg_process, 20260705160000_household_name_not_null

=== Build TRUTH DB (full current migration chain) ===
Applying migration `20260703130000_squashed_init`
... (all 6 applied) ...
All migrations have been successfully applied.

=== Generate candidate baseline ===
Generated 692 lines of candidate SQL.

=== Validate candidate (attempt 1/2) ===
Schemas DIFFER after normalization:
Only in TRUTH (3):
  < CREATE UNIQUE INDEX "Visit_one_open_per_participant" ... WHERE ("departedAt" IS NULL);
  < CREATE UNIQUE INDEX membership_one_inflight_initial ... WHERE ((kind = 'INITIAL'::...) AND (status = ANY (...)));
  < CREATE UNIQUE INDEX membership_one_inflight_renewal ... WHERE ((kind = 'RENEWAL'::...) AND (status = ANY (...)));
Missing 3 partial unique index(es) in the candidate — splicing from TRUTH and re-validating from scratch.

=== Validate candidate (attempt 2/2) ===
Schemas are semantically identical (777 normalized statement lines).
No-drift check passed: candidate matches schema.prisma exactly.

Validation verdict: candidate baseline is semantically identical to the full current
chain (6 migrations); 3 partial unique index(es) verified; no drift vs schema.prisma.

DRY RUN — no changes written. Re-run with --commit to replace prisma/migrations/ with this baseline.

=== Dropping temp databases ===
```

Exactly the designed-for scenario: the naive `migrate diff --from-empty` output
was missing all three partial indexes on the first pass, got spliced
automatically, and the re-validated candidate came out semantically identical
with no drift. Repo tree stayed clean throughout (dry run); temp DBs were
confirmed dropped afterward.

## Design notes / open items

- **"New step in `validate`" → new sibling job instead.** `deploy-prod.yml`'s
  `validate` job is `uses: ./.github/workflows/ci.yml` — a reusable-workflow
  call has no step surface to add to. Added `migration-release-gate` as a
  parallel job instead; `deploy` now needs both.
- **Reconcile isn't pipeline-automated, by design.** Reconciling a ledger is a
  one-time, per-environment, human-triggered action tied to exactly one coalesce
  merge — not worth always-on machinery for. Docs give both an honest preemptive
  path (race the merge→deploy window) and a reactive one (let the first
  automatic migrate step fail once loudly, reconcile, re-run the job).
- **`AGENTS.md` conflict with #933 expected.** #933 (open, unmerged) adds a
  `DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md` doc + its own `AGENTS.md` docs-map
  section in roughly the same spot this PR's one-line entry lands. A trivial
  merge conflict there is expected and fine — `MIGRATION_COALESCE_FLOW.md`
  cross-references #933's doc by name rather than duplicating its
  expand/cutover/contract content (this PR is specifically the
  coalesce-before-release mechanics).
- Cross-refs: `.github/workflows/migration-safety.yml` origin #794; squash
  precedent #792.

## Verification

- [x] `npx jest --testPathPatterns 'scripts/__tests__'` — 19/19 passing (incl. the
      2 new pure-logic files)
- [x] Real dry run against this repo's current state (above) — validated,
      partial indexes spliced correctly, no drift
- [x] `bash -n` on `scripts/compare-schema-dumps.sh`
- [x] YAML-parsed both workflows + `bash -n`'d every embedded `run:` block
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint scripts/` clean
- [x] Synthetic tag-history test of the release-gate's tag-discovery + added-dir
      counting (first release / normal +1 / coalesce -N+1 / bad +2 all behave
      correctly) — not committed, throwaway repo used only to sanity-check the
      bash logic locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz7egoZoDp37iL9FpC8tH
