### PR TITLE
s-read: ECS deploy pipeline — Dockerfile, deploy workflow, ops runbook (#235)

### DIFF
--- a/.github/workflows/deploy-s-read.yml
+++ b/.github/workflows/deploy-s-read.yml
@@ -72,8 +72,6 @@ jobs:
         run: |
           SHA=$(git rev-parse HEAD)
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "short_sha=${SHA:0:7}" >> "$GITHUB_OUTPUT"
-
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -200,7 +198,7 @@ jobs:
       - name: Report result
         if: always()
         env:
-          SHORT_SHA: ${{ steps.vars.outputs.short_sha }}
+          IMAGE: ${{ steps.build.outputs.image }}
           STATUS: ${{ job.status }}
           MODE: ${{ inputs.mode }}
           SYNC_ARN: ${{ steps.register_sync.outputs.sync_arn }}
@@ -210,7 +208,7 @@ jobs:
           if [ "$STATUS" = "success" ]; then
             {
               echo "### ✅ s-read deployed (\`$MODE\`)"
-              echo "- Image: \`$IMAGE_REPO:$SHORT_SHA\`"
+              echo "- Image: \`$IMAGE\`"
               echo "- Sync task def: \`$SYNC_ARN\` (the hourly schedule picks it up on its next tick)"
               if [ "$MODE" = "migrate-and-code" ]; then echo "- Migrations: applied before the sync task-def update"; fi
               echo "- [Deploy run]($RUN_URL)"

--- a/.github/workflows/deploy-s-read.yml
+++ b/.github/workflows/deploy-s-read.yml
@@ -2,25 +2,32 @@ name: Deploy s-read
 
 # Manual deploy of the s-read-function ECS image (v1: workflow_dispatch only, no
 # auto-trigger — run it deliberately after the change has merged and CI is green
-# on main). Builds the container image, pushes it to ECR, registers new revisions
-# of BOTH task-def families, and (in migrate-and-code mode) runs the migration
-# task in between. There is no ECS service to roll: the hourly EventBridge rule
-# targets the revision-less s-read-sync family ARN, so it runs the latest ACTIVE
-# revision on its next tick — no terraform involved.
+# on main). Builds the container image, pushes it to ghcr.io, registers new
+# revisions of BOTH task-def families, and (in migrate-and-code mode) runs the
+# migration task in between. There is no ECS service to roll: the schedule runs
+# tasks against the revision-less s-read-sync family ARN, so it uses the latest
+# ACTIVE revision on its next tick — no terraform involved.
 #
 # Ordering (migrate-and-code): migrations run BEFORE the new sync revision is
 # registered — expand/contract, same as deploy-dev.yml. The previous code keeps
 # running against the migrated schema until the next scheduled tick.
 #
-# Auth is GitHub OIDC — assumes the checkin-deploy-dev role. That role's trust
-# policy is pinned to refs/heads/main, so this workflow MUST be dispatched from
-# the main branch; a dispatch from any other ref fails at the credentials step.
+# Registry is ghcr.io with the GITHUB_TOKEN login/push pattern from deploy-dev.yml
+# (one pipeline convention, no registry credentials to manage). The package stays
+# PRIVATE — the task defs pull it via repositoryCredentials -> the shared
+# ghcr-pull-credentials secret (infra modules/shared-iam), like every other ECS
+# workload in this account. We push a unique :<git-sha> tag, never :latest.
+#
+# AWS auth (GitHub OIDC, checkin-deploy-dev role) is still needed for the
+# register-task-definition / run-task steps. That role's trust policy is pinned
+# to refs/heads/main, so this workflow MUST be dispatched from the main branch;
+# a dispatch from any other ref fails at the credentials step.
 #
 # Infra preconditions (NOT done here — innovationtreehouse/infra#112, whose PR
 # body is the authoritative contract for every resource name used below):
-#   - ECR repo `s-read` (IMMUTABLE tags — we push a unique :<git-sha>, never :latest),
-#     cluster `s-read`, task-def families `s-read-sync` / `s-read-migrate`,
-#     EventBridge rule, secret shells + IAM applied.
+#   - cluster `s-read`, task-def families `s-read-sync` / `s-read-migrate` (with
+#     the ghcr repositoryCredentials), the s-read-trigger Lambda + its schedule,
+#     secret shells + IAM applied.
 #   - init.sql run by hand + secret VALUES set (see s-read-function/DEPLOY.md).
 #   - Repo variable S_READ_NETWORK_CONFIG set (see the migrate step).
 
@@ -38,6 +45,7 @@ on:
 permissions:
   id-token: write   # assume the deploy role via OIDC
   contents: read    # checkout
+  packages: write   # push the image to ghcr.io
 
 concurrency:
   group: s-read-deploy
@@ -45,8 +53,7 @@ concurrency:
 
 env:
   AWS_REGION: us-east-2
-  ECR_REGISTRY: 639595353568.dkr.ecr.us-east-2.amazonaws.com
-  ECR_REPOSITORY: s-read
+  IMAGE_REPO: ghcr.io/innovationtreehouse/s-read
   ECS_CLUSTER: s-read
   SYNC_TASK_FAMILY: s-read-sync
   MIGRATE_TASK_FAMILY: s-read-migrate
@@ -73,13 +80,17 @@ jobs:
           role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Log in to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
         id: build
         env:
-          IMAGE: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.vars.outputs.sha }}
+          IMAGE: ${{ env.IMAGE_REPO }}:${{ steps.vars.outputs.sha }}
         run: |
           set -euo pipefail
           # Repo-root build context (workspace install) — see s-read-function/Dockerfile.
@@ -169,7 +180,7 @@ jobs:
           IMAGE: ${{ steps.build.outputs.image }}
         run: |
           set -euo pipefail
-          # New revision with the new image; the EventBridge rule targets the
+          # New revision with the new image; the s-read-trigger Lambda RunTasks the
           # revision-less family ARN, so the next hourly tick runs this revision —
           # no service update, no terraform.
           aws ecs describe-task-definition \
@@ -199,7 +210,7 @@ jobs:
           if [ "$STATUS" = "success" ]; then
             {
               echo "### ✅ s-read deployed (\`$MODE\`)"
-              echo "- Image: \`$ECR_REPOSITORY:$SHORT_SHA\`"
+              echo "- Image: \`$IMAGE_REPO:$SHORT_SHA\`"
               echo "- Sync task def: \`$SYNC_ARN\` (the hourly schedule picks it up on its next tick)"
               if [ "$MODE" = "migrate-and-code" ]; then echo "- Migrations: applied before the sync task-def update"; fi
               echo "- [Deploy run]($RUN_URL)"

--- a/.github/workflows/deploy-s-read.yml
+++ b/.github/workflows/deploy-s-read.yml
@@ -1,0 +1,213 @@
+name: Deploy s-read
+
+# Manual deploy of the s-read-function ECS image (v1: workflow_dispatch only, no
+# auto-trigger — run it deliberately after the change has merged and CI is green
+# on main). Builds the container image, pushes it to ECR, registers new revisions
+# of BOTH task-def families, and (in migrate-and-code mode) runs the migration
+# task in between. There is no ECS service to roll: the hourly EventBridge rule
+# targets the revision-less s-read-sync family ARN, so it runs the latest ACTIVE
+# revision on its next tick — no terraform involved.
+#
+# Ordering (migrate-and-code): migrations run BEFORE the new sync revision is
+# registered — expand/contract, same as deploy-dev.yml. The previous code keeps
+# running against the migrated schema until the next scheduled tick.
+#
+# Auth is GitHub OIDC — assumes the checkin-deploy-dev role. That role's trust
+# policy is pinned to refs/heads/main, so this workflow MUST be dispatched from
+# the main branch; a dispatch from any other ref fails at the credentials step.
+#
+# Infra preconditions (NOT done here — innovationtreehouse/infra#112, whose PR
+# body is the authoritative contract for every resource name used below):
+#   - ECR repo `s-read` (IMMUTABLE tags — we push a unique :<git-sha>, never :latest),
+#     cluster `s-read`, task-def families `s-read-sync` / `s-read-migrate`,
+#     EventBridge rule, secret shells + IAM applied.
+#   - init.sql run by hand + secret VALUES set (see s-read-function/DEPLOY.md).
+#   - Repo variable S_READ_NETWORK_CONFIG set (see the migrate step).
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Deploy mode"
+        type: choice
+        options:
+          - migrate-and-code
+          - code-only
+        default: migrate-and-code
+
+permissions:
+  id-token: write   # assume the deploy role via OIDC
+  contents: read    # checkout
+
+concurrency:
+  group: s-read-deploy
+  cancel-in-progress: false  # serialize deploys; never abandon one mid-flight
+
+env:
+  AWS_REGION: us-east-2
+  ECR_REGISTRY: 639595353568.dkr.ecr.us-east-2.amazonaws.com
+  ECR_REPOSITORY: s-read
+  ECS_CLUSTER: s-read
+  SYNC_TASK_FAMILY: s-read-sync
+  MIGRATE_TASK_FAMILY: s-read-migrate
+  DEPLOY_ROLE: arn:aws:iam::639595353568:role/checkin-deploy-dev
+
+jobs:
+  deploy:
+    name: Build, push, migrate, register
+    runs-on: ubuntu-24.04-arm  # native ARM64 — the task defs are arm64 (runtime_platform)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve commit
+        id: vars
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.DEPLOY_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push image
+        id: build
+        env:
+          IMAGE: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.vars.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Repo-root build context (workspace install) — see s-read-function/Dockerfile.
+          docker build -f s-read-function/Dockerfile -t "$IMAGE" .
+          docker push "$IMAGE"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      # Both families get a new revision pointing at the new image (infra#112's
+      # deploy contract) — the migrate one first, since migrations ship in the image.
+      - name: Register new migrate task definition
+        id: register_migrate
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          # New revision with the new image, keeping only the fields
+          # register-task-definition accepts. Goes through a real temp file:
+          # the runner's aws CLI cannot read file:///dev/stdin.
+          aws ecs describe-task-definition \
+            --task-definition "$MIGRATE_TASK_FAMILY" \
+            --query taskDefinition --output json \
+            | jq --arg IMG "$IMAGE" '
+                .containerDefinitions[0].image = $IMG
+                | {family, taskRoleArn, executionRoleArn, networkMode,
+                   containerDefinitions, requiresCompatibilities, cpu, memory,
+                   runtimePlatform}' > "$RUNNER_TEMP/migrate-taskdef.json"
+          MIGRATE_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "file://$RUNNER_TEMP/migrate-taskdef.json" \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          CONTAINER_NAME=$(jq -r '.containerDefinitions[0].name' "$RUNNER_TEMP/migrate-taskdef.json")
+          echo "Registered migrate task def: $MIGRATE_ARN (container: $CONTAINER_NAME)"
+          echo "migrate_arn=$MIGRATE_ARN" >> "$GITHUB_OUTPUT"
+          echo "container_name=$CONTAINER_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Run database migrations
+        if: inputs.mode == 'migrate-and-code'
+        env:
+          MIGRATE_ARN: ${{ steps.register_migrate.outputs.migrate_arn }}
+          CONTAINER_NAME: ${{ steps.register_migrate.outputs.container_name }}
+          # Full run-task networkConfiguration JSON from the infra#112 outputs
+          # (`s_read_compute_sg_id` + the three default-VPC public subnets), e.g.
+          #   {"awsvpcConfiguration":{"subnets":["subnet-0597513f1c0c3173e","subnet-0a67d72908bffbcd4","subnet-0c84ac2840be3a2bc"],"securityGroups":["sg-..."],"assignPublicIp":"ENABLED"}}
+          # Set as a repo variable (Settings > Variables) — there is no ECS service
+          # here to copy placement from (deploy-dev.yml reads its service's; this
+          # fleet's tasks are schedule/run-task only).
+          NETWORK_CONFIG: ${{ vars.S_READ_NETWORK_CONFIG }}
+        run: |
+          set -euo pipefail
+          if [ -z "$NETWORK_CONFIG" ]; then
+            echo "::error::Repo variable S_READ_NETWORK_CONFIG is not set (subnets/SG for run-task) — see the workflow comments."
+            exit 1
+          fi
+
+          # Same command the migrate task-def bakes (npm run db:deploy — container-safe,
+          # prisma reads SHOPIFY_READ_DATABASE_URL from the ECS-injected DDL secret),
+          # wrapped in the house retry loop: the shared Aurora Serverless v2 cluster has
+          # min-capacity-0 auto-pause, and the first connection races the ~30s resume
+          # (Prisma fails fast with P1001).
+          jq -n --arg NAME "$CONTAINER_NAME" '
+            {containerOverrides: [{name: $NAME, command: ["sh", "-c",
+              "for i in 1 2 3 4 5; do npm run db:deploy -w @inventory/s-ingest-core && exit 0; echo \"attempt $i failed — DB may be resuming from auto-pause; retrying in 20s\"; sleep 20; done; exit 1"
+            ]}]}' > "$RUNNER_TEMP/migrate-overrides.json"
+
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "$ECS_CLUSTER" \
+            --task-definition "$MIGRATE_ARN" \
+            --launch-type FARGATE \
+            --network-configuration "$NETWORK_CONFIG" \
+            --overrides "file://$RUNNER_TEMP/migrate-overrides.json" \
+            --query 'tasks[0].taskArn' --output text)
+          echo "Migration task: $TASK_ARN (logs: /ecs/s-read-migrate)"
+
+          aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN"
+
+          EXIT_CODE=$(aws ecs describe-tasks \
+            --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' --output text)
+          echo "Migration exit code: $EXIT_CODE"
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::error::Database migration failed (exit $EXIT_CODE) — sync task def NOT updated; the schedule keeps running the previous revision."
+            exit 1
+          fi
+
+      - name: Register new sync task definition
+        id: register_sync
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          # New revision with the new image; the EventBridge rule targets the
+          # revision-less family ARN, so the next hourly tick runs this revision —
+          # no service update, no terraform.
+          aws ecs describe-task-definition \
+            --task-definition "$SYNC_TASK_FAMILY" \
+            --query taskDefinition --output json \
+            | jq --arg IMG "$IMAGE" '
+                .containerDefinitions[0].image = $IMG
+                | {family, taskRoleArn, executionRoleArn, networkMode,
+                   containerDefinitions, requiresCompatibilities, cpu, memory,
+                   runtimePlatform}' > "$RUNNER_TEMP/sync-taskdef.json"
+          SYNC_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "file://$RUNNER_TEMP/sync-taskdef.json" \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "Registered sync task def: $SYNC_ARN"
+          echo "sync_arn=$SYNC_ARN" >> "$GITHUB_OUTPUT"
+
+      - name: Report result
+        if: always()
+        env:
+          SHORT_SHA: ${{ steps.vars.outputs.short_sha }}
+          STATUS: ${{ job.status }}
+          MODE: ${{ inputs.mode }}
+          SYNC_ARN: ${{ steps.register_sync.outputs.sync_arn }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ "$STATUS" = "success" ]; then
+            {
+              echo "### ✅ s-read deployed (\`$MODE\`)"
+              echo "- Image: \`$ECR_REPOSITORY:$SHORT_SHA\`"
+              echo "- Sync task def: \`$SYNC_ARN\` (the hourly schedule picks it up on its next tick)"
+              if [ "$MODE" = "migrate-and-code" ]; then echo "- Migrations: applied before the sync task-def update"; fi
+              echo "- [Deploy run]($RUN_URL)"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### ❌ s-read deploy failed (status: \`$STATUS\`, mode: \`$MODE\`)"
+              echo "- [Deploy run]($RUN_URL) — check the logs (migrate task logs: \`/ecs/s-read-migrate\`)."
+              echo "- The schedule keeps running the previous task-def revision."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/packages/s-ingest-core/package.json
+++ b/packages/s-ingest-core/package.json
@@ -15,7 +15,7 @@
     "postinstall": "prisma generate",
     "db:generate": "prisma generate",
     "db:migrate": "node --env-file=.env node_modules/.bin/prisma migrate dev && node node_modules/.bin/prisma generate",
-    "db:deploy": "node --env-file=.env node_modules/.bin/prisma migrate deploy",
+    "db:deploy": "prisma migrate deploy",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },

--- a/s-read-function/DEPLOY.md
+++ b/s-read-function/DEPLOY.md
@@ -1,0 +1,132 @@
+# s-read deployment runbook
+
+Go-live checklist for the s-read sync as a **scheduled ECS task** (infra:
+innovationtreehouse/infra#112 — its PR body is the authoritative resource
+contract; app chain: checkin#940 → infra#112 → this). Region `us-east-2`,
+account `639595353568`. Work through it **in order** — each step assumes the
+previous ones are done.
+
+How the pieces fit:
+
+```
+EventBridge rule (hourly, targets the revision-less s-read-sync FAMILY = latest revision)
+   └─▶ ECS task s-read-sync — image CMD runs `src/cli.ts` in ${SYNC_MODE:-incremental} mode
+Deploy workflow (.github/workflows/deploy-s-read.yml, manual dispatch from main)
+   └─▶ build+push image → register migrate revision → (run migrate task, wait for exit 0)
+       → register sync revision
+Backfill = one-off `aws ecs run-task` of s-read-sync with a SYNC_MODE=backfill env override
+```
+
+## 1. Shopify app: scopes, release, install
+
+The app (Dev Dashboard) needs the four scopes from [README](README.md#where-to-put-credentials):
+`read_orders`, `read_customers`, `read_shopify_payments_accounts`,
+`read_shopify_payments_payouts` (the legacy umbrella `read_shopify_payments` is
+split — you need both `_accounts` and `_payouts`).
+
+Add the scopes, **release a new app version**, and **install/update it on the
+store** — scopes don't take effect until the store accepts the new version. Note
+the app's **Client ID** and **Client Secret** (app Settings) for step 3.
+
+## 2. Infra applied + database bootstrap
+
+1. infra#112 `terraform apply`d (ECR repo `s-read` — IMMUTABLE tags, cluster
+   `s-read`, task-def families `s-read-sync`/`s-read-migrate`, hourly EventBridge
+   rule, secret shells, IAM, `s-read-compute` SG).
+2. Run `modules/s-read/init.sql` **by hand** against the shared Aurora cluster's
+   master user (creates the `shopify_read` database + the `s_read_ddl` /
+   `s_read_dml` roles — Terraform cannot `CREATE DATABASE`). Cluster is
+   Serverless v2 with auto-pause: the first connection can take ~30s to wake it.
+
+## 3. Secret values (4)
+
+Shells exist after step 2; set the values out-of-band:
+
+```bash
+aws secretsmanager put-secret-value --secret-id s-read/database-url     --secret-string 'postgresql://s_read_dml:...@.../shopify_read'
+aws secretsmanager put-secret-value --secret-id s-read/database-url-ddl --secret-string 'postgresql://s_read_ddl:...@.../shopify_read'
+aws secretsmanager put-secret-value --secret-id s-read/shopify-client-id     --secret-string '...'
+aws secretsmanager put-secret-value --secret-id s-read/shopify-client-secret --secret-string '...'
+```
+
+ECS injects these natively via the task definitions' `secrets` blocks as
+`SHOPIFY_READ_DATABASE_URL` (DML for the sync task, DDL for the migrate task),
+`SHOPIFY_CLIENT_ID`, `SHOPIFY_CLIENT_SECRET` — the code reads only `process.env`
+(no AWS SDK calls; see [README "Where to put credentials"](README.md#where-to-put-credentials)).
+The migrate task runs `npm run db:deploy -w @inventory/s-ingest-core`, which is
+container-safe: prisma resolves the URL from `process.env`; a package-local
+`.env` is optional (local-dev convenience via `prisma.config.ts`'s dotenv import).
+
+## 4. Terraform variables
+
+- `cutover_date` → becomes the task's `CUTOVER_DATE` env var: the ISO date the
+  backfill starts from (and the boundary income-app hands off at). Choose it
+  deliberately; changing it later does not re-run a completed backfill.
+- `shopify_shop` → `SHOPIFY_SHOP`.
+
+Set both (they're `TODO` placeholders in `live/mgmt/main.tf`), `terraform apply`.
+
+## 5. First deploy (workflow, `migrate-and-code`)
+
+One-time prep: set the repo variable `S_READ_NETWORK_CONFIG` (Settings →
+Variables) to the run-task network JSON — SG id from the infra output
+`s_read_compute_sg_id`, subnets are the three default-VPC public ones:
+
+```json
+{"awsvpcConfiguration":{"subnets":["subnet-0597513f1c0c3173e","subnet-0a67d72908bffbcd4","subnet-0c84ac2840be3a2bc"],"securityGroups":["sg-..."],"assignPublicIp":"ENABLED"}}
+```
+
+Then run **Actions → "Deploy s-read" → Run workflow** (from `main` — the OIDC
+role's trust is pinned to `refs/heads/main`) with mode **migrate-and-code**.
+It builds/pushes the image, runs the migrate task (waits for exit 0), then
+registers the new `s-read-sync` revision. From that moment the hourly schedule
+runs real syncs.
+
+## 6. One-time backfill
+
+The backfill is a **Bulk Operation lifecycle**: the first run submits the export
+and returns (`action: "STARTED"`); later runs poll and, once Shopify completes
+it, download + ingest (`action: "INGESTED"`). Payouts/balance transactions
+backfill inline on each run. Re-run until you've seen `INGESTED` (afterwards it
+reports `NONE`). Ready-to-paste command in the infra output
+`s_read_manual_invoke_backfill`; equivalent by hand:
+
+```bash
+aws ecs run-task \
+  --cluster s-read \
+  --task-definition s-read-sync \
+  --launch-type FARGATE \
+  --network-configuration "$S_READ_NETWORK_CONFIG" \
+  --overrides '{"containerOverrides":[{"name":"s-read-sync","environment":[{"name":"SYNC_MODE","value":"backfill"}]}]}'
+```
+
+(Verified against the image: the container CMD runs
+`src/cli.ts ${SYNC_MODE:-incremental}`, and cli.ts's `backfill` command calls
+`handler({ mode: "backfill" })` — the same orchestrator the old Lambda event
+selected.) The run lock makes an overlap with the hourly incremental resolve
+cleanly (one of them skips).
+
+## 7. Verify
+
+- **Logs**: CloudWatch log group `/ecs/s-read-sync` — the backfill run logs
+  `backfill step done` with counts; incremental runs log `incremental sync done`.
+  Migrate task logs land in `/ecs/s-read-migrate`.
+- **Rows**: against `shopify_read` (DML role):
+
+  ```sql
+  SELECT source, count(*) FROM shopify_raw_event GROUP BY source;  -- BACKFILL + INCREMENTAL rows
+  SELECT count(*) FROM shop_order;                                  -- projected orders > 0
+  ```
+
+- **Freshness**: `SELECT max(finished_at) FROM sync_run WHERE status = 'COMPLETED';`
+  should advance every hour.
+
+## Day-2
+
+- **Code-only change**: run the workflow with mode `code-only` (skips the migrate
+  task run; both task-def families still get new revisions).
+- **Schema change**: mode `migrate-and-code` — migrations always run **before**
+  the new sync revision is registered, so write them expand/contract (the old
+  revision keeps running against the new schema until the next tick).
+- **Rollback**: re-run the workflow from the last good commit (`code-only`), or
+  register a task-def revision pointing at the previous image tag by hand.

--- a/s-read-function/DEPLOY.md
+++ b/s-read-function/DEPLOY.md
@@ -9,13 +9,22 @@ previous ones are done.
 How the pieces fit:
 
 ```
-EventBridge rule (hourly, targets the revision-less s-read-sync FAMILY = latest revision)
-   └─▶ ECS task s-read-sync — image CMD runs `src/cli.ts` in ${SYNC_MODE:-incremental} mode
+Schedule (hourly) ─▶ Lambda s-read-trigger  ({"mode":"incremental"|"backfill"}; not
+   │                 VPC-attached; also the hook for future event sources)
+   └─▶ ecs:RunTask on the revision-less s-read-sync FAMILY (= latest ACTIVE revision)
+          └─▶ ECS task s-read-sync — image CMD runs `src/cli.ts` in ${SYNC_MODE:-incremental} mode
 Deploy workflow (.github/workflows/deploy-s-read.yml, manual dispatch from main)
-   └─▶ build+push image → register migrate revision → (run migrate task, wait for exit 0)
-       → register sync revision
-Backfill = one-off `aws ecs run-task` of s-read-sync with a SYNC_MODE=backfill env override
+   └─▶ build+push image to ghcr.io → register migrate revision → (run migrate task,
+       wait for exit 0) → register sync revision
+Backfill / manual sync = `aws lambda invoke` on s-read-trigger with the mode payload
+Migrate task = raw run-task from the workflow only (deliberately NOT invocable via the trigger)
 ```
+
+The image lives at **`ghcr.io/innovationtreehouse/s-read`** (pushed by the
+workflow with the GITHUB_TOKEN, tagged `:<git-sha>`) and stays **private**: the
+task defs pull it via `repositoryCredentials` → the shared ghcr-pull-credentials
+secret (infra `modules/shared-iam`), same as every other ECS workload in this
+account — no make-public step, no per-service pull PAT.
 
 ## 1. Shopify app: scopes, release, install
 
@@ -30,9 +39,10 @@ the app's **Client ID** and **Client Secret** (app Settings) for step 3.
 
 ## 2. Infra applied + database bootstrap
 
-1. infra#112 `terraform apply`d (ECR repo `s-read` — IMMUTABLE tags, cluster
-   `s-read`, task-def families `s-read-sync`/`s-read-migrate`, hourly EventBridge
-   rule, secret shells, IAM, `s-read-compute` SG).
+1. infra#112 `terraform apply`d (cluster `s-read`, task-def families
+   `s-read-sync`/`s-read-migrate` with the ghcr `repositoryCredentials`, the
+   `s-read-trigger` Lambda + hourly schedule, secret shells, IAM,
+   `s-read-compute` SG).
 2. Run `modules/s-read/init.sql` **by hand** against the shared Aurora cluster's
    master user (creates the `shopify_read` database + the `s_read_ddl` /
    `s_read_dml` roles — Terraform cannot `CREATE DATABASE`). Cluster is
@@ -88,8 +98,17 @@ The backfill is a **Bulk Operation lifecycle**: the first run submits the export
 and returns (`action: "STARTED"`); later runs poll and, once Shopify completes
 it, download + ingest (`action: "INGESTED"`). Payouts/balance transactions
 backfill inline on each run. Re-run until you've seen `INGESTED` (afterwards it
-reports `NONE`). Ready-to-paste command in the infra output
-`s_read_manual_invoke_backfill`; equivalent by hand:
+reports `NONE`). Invoke through the trigger Lambda (it RunTasks the sync family
+with the right `SYNC_MODE` override — this is also how a manual incremental sync
+is kicked, with `"mode":"incremental"`):
+
+```bash
+aws lambda invoke --function-name s-read-trigger \
+  --cli-binary-format raw-in-base64-out \
+  --payload '{"mode":"backfill"}' out.json && cat out.json
+```
+
+Fallback if the trigger Lambda is unavailable — the raw run-task it performs:
 
 ```bash
 aws ecs run-task \
@@ -102,9 +121,10 @@ aws ecs run-task \
 
 (Verified against the image: the container CMD runs
 `src/cli.ts ${SYNC_MODE:-incremental}`, and cli.ts's `backfill` command calls
-`handler({ mode: "backfill" })` — the same orchestrator the old Lambda event
-selected.) The run lock makes an overlap with the hourly incremental resolve
-cleanly (one of them skips).
+`handler({ mode: "backfill" })`.) The run lock makes an overlap with the hourly
+incremental resolve cleanly (one of them skips). The **migrate** task is
+deliberately NOT invocable through the trigger — it runs only as a raw run-task
+from the deploy workflow.
 
 ## 7. Verify
 

--- a/s-read-function/Dockerfile
+++ b/s-read-function/Dockerfile
@@ -1,0 +1,63 @@
+# s-read-function — the scheduled Shopify orders/payouts/balance-transaction sync,
+# packaged as an ECS task image (infra: innovationtreehouse/infra#112).
+#
+# Build context is the REPO ROOT (same convention as checkin-app/Dockerfile) so the
+# workspace install can see the root package.json + lockfile and every workspace
+# manifest. Build with:  docker build -f s-read-function/Dockerfile .
+#
+# The container runs the EXISTING CLI entry (src/cli.ts) via tsx — the same code path
+# proven locally — not a bundled artifact. The default CMD selects the sync mode from
+# the SYNC_MODE env var (contract with infra#112):
+#   - the s-read-sync task-def / hourly schedule sets SYNC_MODE=incremental
+#   - the one-time backfill is a run-task with a SYNC_MODE=backfill env override
+#   - the s-read-migrate task-def overrides the command entirely:
+#       ["npm", "run", "db:deploy", "-w", "@inventory/s-ingest-core"]
+#     (works from this image's WORKDIR /app; the script is container-safe — prisma reads
+#     SHOPIFY_READ_DATABASE_URL from process.env, and a package-local .env is optional)
+# (CMD, not ENTRYPOINT, on purpose: ECS containerOverrides replace the command wholesale,
+# and the migrate task-def's command — plus the shell that expands SYNC_MODE — would be
+# mangled by an ENTRYPOINT prefix.)
+FROM node:22-slim
+WORKDIR /app
+
+# Prisma's migrate engine links libssl, which node:22-slim doesn't ship — without it
+# prisma falls back to a guessed openssl version with a "may not work" warning.
+RUN apt-get update -y && apt-get install -y --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+
+# Manifests + lockfile first for a cache-friendly `npm ci` layer. ALL workspace
+# manifests are copied (npm needs the full workspace graph to validate the lockfile)
+# but only the three workspaces s-read needs are installed below.
+COPY package.json package-lock.json tsconfig.base.json ./
+COPY checkin-app/package.json checkin-app/
+COPY s-read-function/package.json s-read-function/
+COPY s-replay-function/package.json s-replay-function/
+COPY monitoring-relay-function/package.json monitoring-relay-function/
+COPY monitoring-watchdog-function/package.json monitoring-watchdog-function/
+COPY packages/money/package.json packages/money/
+COPY packages/monitoring-db/package.json packages/monitoring-db/
+COPY packages/pg-test-harness/package.json packages/pg-test-harness/
+COPY packages/s-ingest-core/package.json packages/s-ingest-core/
+COPY packages/telemetry/package.json packages/telemetry/
+
+# Scoped install: s-read-function + the two DB packages it imports (their devDeps
+# carry the prisma CLI needed for generate + the migrate task's `db:deploy`).
+# --ignore-scripts: the DB packages' postinstall runs `prisma generate`, which can't
+# work in this manifests-only layer (no schema yet) — it runs explicitly below.
+RUN npm ci -w s-read-function -w @inventory/s-ingest-core -w @inventory/monitoring-db --ignore-scripts
+
+COPY packages/ packages/
+COPY s-read-function/ s-read-function/
+RUN npm run db:generate -w @inventory/s-ingest-core && npm run db:generate -w @inventory/monitoring-db
+
+# RDS TLS (same as checkin-app/Dockerfile): the pg driver verifies the server cert and
+# Amazon's RDS CA is not in the OS trust store — without this every query dies with
+# "unable to get local issuer certificate".
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /app/rds-global-bundle.pem
+ENV NODE_EXTRA_CA_CERTS=/app/rds-global-bundle.pem
+
+# WORKDIR stays /app (the workspace root) so the migrate task-def's baked
+# `npm run ... -w ...` command resolves the workspace graph. No --env-file anywhere:
+# config comes from real env vars (ECS task-def `secrets` + `environment`) and fails
+# loud (exit 1) on missing/invalid config via the Zod loaders in s-ingest-core.
+# `exec` so node is PID 1 and receives ECS stop signals directly.
+CMD ["sh", "-c", "exec node --import tsx s-read-function/src/cli.ts \"${SYNC_MODE:-incremental}\""]

--- a/s-read-function/README.md
+++ b/s-read-function/README.md
@@ -176,6 +176,11 @@ order status transitions (cancellation/refund), and watermark advancement.
 
 ## Deployment (Terraform)
 
+> **Ops runbook: [DEPLOY.md](DEPLOY.md)** — the ordered go-live checklist (Shopify app
+> scopes, init.sql, secrets, first deploy via the `deploy-s-read` workflow, one-time
+> backfill, verification). The shipped architecture is a **scheduled ECS task**
+> (infra#112) built from [`Dockerfile`](Dockerfile), not the Lambda sketch below.
+
 When this is deployed, **Terraform provisions the infrastructure** — it does **not** run
 schema migrations (those are a separate deploy-time step; see
 [FUTUREWORK.md](FUTUREWORK.md)). What Terraform owns:
@@ -208,7 +213,9 @@ programmatic token acquisition (#237) are **built** — see
 [`s-replay-function`](../s-replay-function), the stale-run reaper above, and "Getting the
 token" above.)
 
-- Deployment infra (EventBridge schedule, RDS Proxy, packaging) is **not** wired yet.
+- Deployment: packaging ([`Dockerfile`](Dockerfile)), the manual deploy workflow
+  (`.github/workflows/deploy-s-read.yml`), and the ops runbook ([DEPLOY.md](DEPLOY.md))
+  are in this repo; the AWS resources (ECR/ECS/EventBridge/secrets) are infra#112.
 - Cross-database de-duplication against `income-app` is **future work**; this
   function persists the identifiers income-app records (legacy order id, order name,
   payout id) so that reconciliation can be deterministic later.


### PR DESCRIPTION
Closes #235 (deploy side) · with #237 · **Stacked on #940** (base branch: `feat/s-read-client-credentials` — merge #940 first, then retarget/merge this)

## The three-PR chain

| PR | What it carries |
|---|---|
| checkin#940 | Shopify token via client-credentials grant (`SHOPIFY_CLIENT_ID`/`SECRET`, static `SHOPIFY_ADMIN_TOKEN` fallback) — this PR's base |
| infra#112 | The AWS resources (its PR body is the authoritative contract): ECS cluster `s-read`, task-def families `s-read-sync`/`s-read-migrate`, the `s-read-trigger` Lambda fronting the hourly schedule, 4 secret shells, `s-read-compute` SG, IAM |
| **this** | The container image, the deploy workflow, and the ops runbook |

The architecture is a **scheduled ECS task** — secrets are injected natively by ECS (`secrets`/`valueFrom`), so the function code stays pure `process.env`: no AWS SDK usage, no handler changes. Manual invocations (backfill, ad-hoc sync) go through the **`s-read-trigger` Lambda** (`{"mode":"incremental"|"backfill"}`), which RunTasks the sync family and is the hook for future event sources.

## What's in here

### `s-read-function/Dockerfile`
node:22-slim, repo-root build context (same convention as `checkin-app/Dockerfile`), workspace-scoped `npm ci` (s-read-function + `@inventory/s-ingest-core` + `@inventory/monitoring-db`), `prisma generate` for both DB packages, RDS CA bundle for Aurora TLS. Default CMD runs the existing CLI (`src/cli.ts`) in **`${SYNC_MODE:-incremental}`** mode — the schedule/trigger sets `SYNC_MODE`; the migrate task-def overrides the command wholesale (which is why it's CMD, not ENTRYPOINT). No new runtime logic → no new unit tests.

### `packages/s-ingest-core` — `db:deploy` made container-safe (⚠️ note for infra#112)
infra#112 bakes `command = ["npm","run","db:deploy","-w","@inventory/s-ingest-core"]` into the migrate task-def. The old script (`node --env-file=.env node_modules/.bin/prisma migrate deploy`) fails in the container twice over: `--env-file` **errors when `.env` is absent** (secrets arrive as real env vars), and `node_modules/.bin/prisma` doesn't exist workspace-locally in a hoisted install. Fixed **keeping the same script name** (zero contract drift): `db:deploy` is now just `prisma migrate deploy` — npm puts the root bin on PATH, prisma reads `SHOPIFY_READ_DATABASE_URL` from `process.env` via `prisma.config.ts`, and local `.env` files still load through that config's `dotenv` import (verified both paths, see below).

### `.github/workflows/deploy-s-read.yml`
`workflow_dispatch` only for v1 (inputs: `mode = migrate-and-code | code-only`, default `migrate-and-code`). Steps: build → push **`ghcr.io/innovationtreehouse/s-read:<git-sha>`** (GITHUB_TOKEN login/push, the exact deploy-dev.yml pattern — one pipeline convention, simpler auth than ECR; `packages: write`) → register a new **migrate** task-def revision → *(migrate mode)* run it with the house Aurora-auto-pause retry loop and **wait for exit 0** → register the new **sync** task-def revision (the trigger Lambda RunTasks the revision-less family ARN, so it takes effect on the next tick — no service, no terraform). AWS steps still authenticate via OIDC as `checkin-deploy-dev` (trust pinned to `refs/heads/main` → dispatch from main, noted in the workflow). Migrations always run **before** the new code revision exists (expand/contract). Serialized via a concurrency group; step summary like the house workflows.

**ghcr visibility**: the package stays **private** — the task defs pull via `repositoryCredentials` → the shared ghcr-pull-credentials secret (infra `modules/shared-iam`), exactly how checkin/arbor/bootstrap task defs pull today. No make-public step, no per-service pull PAT.

One-time repo setup: set the **`S_READ_NETWORK_CONFIG`** repo variable (run-task subnets/SG JSON — values in DEPLOY.md §5; there's no ECS service to copy placement from, unlike deploy-dev.yml).

### `s-read-function/DEPLOY.md` (linked from README)
The ordered go-live runbook:
1. Shopify app: add the four `read_*` scopes, **release + install** on the store; note client id/secret.
2. infra#112 applied; run `modules/s-read/init.sql` by hand (DB + DDL/DML roles).
3. `put-secret-value` × 4 (`s-read/database-url`, `-ddl`, `shopify-client-id`, `shopify-client-secret`).
4. Terraform vars: `cutover_date` (→ `CUTOVER_DATE`), `shopify_shop`.
5. Set `S_READ_NETWORK_CONFIG`, then first deploy via the workflow (`migrate-and-code`).
6. One-time backfill: `aws lambda invoke --function-name s-read-trigger --cli-binary-format raw-in-base64-out --payload '{"mode":"backfill"}' out.json`, re-run until the Bulk Operation reports `INGESTED` (raw `ecs run-task` with the `SYNC_MODE=backfill` env override documented as the fallback; the **migrate** task is deliberately NOT invocable through the trigger — workflow run-task only).
7. Verify: `/ecs/s-read-sync` logs + row counts in `shopify_raw_event`/`shop_order` + `sync_run` freshness.

## Contract vs infra#112
Confirmed from its current PR body: cluster `s-read` (Fargate run-task only), families `s-read-sync` (`SYNC_MODE=incremental` default, native secrets) / `s-read-migrate` (`npm run db:deploy -w @inventory/s-ingest-core`, DDL secret), revision-less-family targeting, subnets `subnet-0597513f1c0c3173e/-0a67d72908bffbcd4/-0c84ac2840be3a2bc` + `s-read-compute` SG + `assignPublicIp=ENABLED`, log groups `/ecs/s-read-sync`/`/ecs/s-read-migrate`.

**Confirmed against infra#112's final (v3) contract** — image `ghcr.io/innovationtreehouse/s-read:<git-sha>` pulled via `repositoryCredentials` on the shared `ghcr-pull-credentials` secret (no new secret, no make-public step), and trigger Lambda `s-read-trigger` with payload `{"mode":"incremental"|"backfill"}` RunTasking the `s-read-sync` family. All names verified identical on both sides; nothing left to re-check. Other intentional delta: the workflow wraps the migrate command in the house 5×-retry loop (Aurora Serverless v2 auto-pause resume races the first connection with P1001) — same command inside the loop.

## Validation
- `npm test -w s-read-function` → **113/113**; `npm test -w @inventory/s-ingest-core` → **88/88**; `tsc --noEmit` clean for s-read-function.
- Workflow YAML parses; `bash -n` clean on every run block (re-run after the ghcr rework); the jq override programs verified standalone.
- **Image built + smoked locally** (evidence, not committed; Dockerfile unchanged by the registry move): default CMD with no env → Zod fail-loud on `SHOPIFY_READ_DATABASE_URL`, exit 1; `SYNC_MODE=backfill` routes to the backfill orchestrator (Zod then demands `SHOPIFY_SHOP`/`CUTOVER_DATE`); `SYNC_MODE=sideways` fails loud with the CLI's command list; the exact baked migrate command `npm run db:deploy -w @inventory/s-ingest-core` runs in-container to `P1001` against a dummy host (config resolves from `process.env`, no `.env` needed) and exits non-zero. Local `.env` loading for `db:deploy` re-verified after the script change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz7egoZoDp37iL9FpC8tH

