### PR TITLE
fix(communication): remove unbuilt newsletter subscription option

### DIFF
--- a/checkin-app/src/app/communication/__tests__/page.test.tsx
+++ b/checkin-app/src/app/communication/__tests__/page.test.tsx
@@ -11,15 +11,15 @@ describe("CommunicationPage", () => {
     it("loads current settings and persists a toggle", async () => {
         setSession({ id: 1, email: "a@example.com" });
         const fetchMock = mockFetchJson({
-            "/api/profile": { profile: { notificationSettings: { emailNewsletter: true } } },
+            "/api/profile": { profile: { notificationSettings: { emailCheckinReceipts: true } } },
         });
         renderWithProviders(<CommunicationPage />);
 
-        const newsletter = await screen.findByLabelText("Subscribe to the monthly newsletter");
-        expect(newsletter).toBeChecked();
+        const receipts = await screen.findByLabelText("Email me when I check in or out");
+        expect(receipts).toBeChecked();
 
-        fireEvent.click(newsletter);
-        await waitFor(() => expect(newsletter).not.toBeChecked());
+        fireEvent.click(receipts);
+        await waitFor(() => expect(receipts).not.toBeChecked());
         expect(fetchMock).toHaveBeenCalledWith("/api/profile", expect.objectContaining({ method: "PATCH" }));
     });
 
@@ -28,6 +28,6 @@ describe("CommunicationPage", () => {
         mockFetchJson({ "/api/profile": { profile: { notificationSettings: {} } } });
         renderWithProviders(<CommunicationPage />);
 
-        expect(await screen.findByLabelText("Subscribe to the monthly newsletter")).toBeDisabled();
+        expect(await screen.findByLabelText("Email me when I check in or out")).toBeDisabled();
     });
 });

--- a/checkin-app/src/app/communication/page.tsx
+++ b/checkin-app/src/app/communication/page.tsx
@@ -11,7 +11,6 @@ import { PageLoader } from "@/components/ui/PageLoader";
 const OPTIONS = [
   { key: 'emailCheckinReceipts', label: 'Email me when I check in or out' },
   { key: 'emailDependentCheckins', label: 'Email me realtime receipts when my dependents check in/out' },
-  { key: 'emailNewsletter', label: 'Subscribe to the monthly newsletter' },
   { key: 'notifyNewPrograms', label: 'Notify me when a new program is announced' },
 ] as const;
 
@@ -26,7 +25,6 @@ export default function CommunicationPage() {
   const [settings, setSettings] = useState({
     emailCheckinReceipts: false,
     emailDependentCheckins: false,
-    emailNewsletter: false,
     notifyNewPrograms: true
   });
 
@@ -39,7 +37,6 @@ export default function CommunicationPage() {
         setSettings({
           emailCheckinReceipts: s.emailCheckinReceipts || false,
           emailDependentCheckins: s.emailDependentCheckins || false,
-          emailNewsletter: s.emailNewsletter || false,
           notifyNewPrograms: s.notifyNewPrograms !== undefined ? s.notifyNewPrograms : true
         });
       } else {


### PR DESCRIPTION
## Summary
The communication/notification settings page offered a **"Subscribe to the monthly newsletter"** toggle, but there is no newsletter feature — no sending logic, templates, or delivery. Presenting the option implies we'll add users to a newsletter we can't actually deliver.

This removes the newsletter option from the UI, along with its local state default and the API-response merge line.

## What's left intact
- The generic `notificationSettings` JSON field on the schema and the profile API handling are untouched, so the infrastructure remains for whenever the newsletter is actually built.
- Non-user-facing references were intentionally left alone: `tests/security/stripper.test.ts` uses `emailNewsletter` only as an arbitrary JSON fixture key, and `docs/designs/DESIGN.md` mentions "newsletter access" as a future design concept.

## Tests
- Updated the two `CommunicationPage` tests that keyed off the newsletter label to use the "Email me when I check in or out" toggle instead.
- Full suite passes (1636 tests) via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)