### PR TITLE
feat(finance-ops): flag next-year scholarship/payment-plan requests

### DIFF
--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -144,7 +144,7 @@ describe('Program payment-plan routes', () => {
 
             const res = await PlansGet(nextReq());
             expect(res.status).toBe(200);
-            const rows = await res.json();
+            const { ProgramParticipant: rows } = await res.json();
             const ids = rows.map((r: { personId: number }) => r.personId);
             expect(ids).toContain(selfId);
             expect(ids).not.toContain(noiseId);
@@ -157,12 +157,31 @@ describe('Program payment-plan routes', () => {
 
             const res = await PlansGet(nextReq());
             expect(res.status).toBe(200);
-            const rows = await res.json();
+            const { ProgramParticipant: rows } = await res.json();
             type Row = { personId: number; person: { household?: { orgMembership?: { status: string } | null } | null } };
             const memberRow = (rows as Row[]).find(r => r.personId === memberId);
             const nonMemberRow = (rows as Row[]).find(r => r.personId === selfId);
             expect(memberRow?.person.household?.orgMembership?.status).toBe('ACTIVE');
             expect(nonMemberRow?.person.household?.orgMembership).toBeFalsy();
+        });
+
+        it('ships the next-year flag inputs: program.startAt + a BoardSettings key', async () => {
+            // The flag itself is derived on the client (the stripper drops ad-hoc
+            // booleans); the route's job is only to ship both inputs — the program's
+            // start date and the membership-year cutoff singleton. Don't mutate the
+            // BoardSettings singleton here (it's global across the integration DB);
+            // just assert the key rides along and startAt round-trips.
+            const startAt = new Date('2999-10-01T00:00:00Z');
+            await prisma.program.update({ where: { id: programId }, data: { startAt } });
+            await enroll(selfId, { requested: true });
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+            const res = await PlansGet(nextReq());
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body).toHaveProperty('BoardSettings');
+            const row = body.ProgramParticipant.find((r: { personId: number }) => r.personId === selfId);
+            expect(row.program.startAt).toBe(startAt.toISOString());
         });
     });
 

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -8,25 +8,33 @@ import { isActiveOrgMember, ACTIVE_ORG_MEMBER_INCLUDE } from "@/lib/orgMembershi
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 
 export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
-    const requests = await prisma.programParticipant.findMany({
-        where: {
-            isPaymentPlanRequested: true,
-            status: 'PENDING'
-        },
-        include: {
-            // Nests household->orgMembership (same shape as ACTIVE_ORG_MEMBER_INCLUDE)
-            // so the board can see CURRENT membership while a request is still
-            // pending — wasOrgMemberAtApproval is null until approved, so it can't
-            // answer this. Derive live client-side; nothing new to stamp/store here.
-            person: { include: ACTIVE_ORG_MEMBER_INCLUDE },
-            program: true
-        },
-        orderBy: {
-            pendingSince: 'asc'
-        }
-    });
+    const [requests, boardSettings] = await Promise.all([
+        prisma.programParticipant.findMany({
+            where: {
+                isPaymentPlanRequested: true,
+                status: 'PENDING'
+            },
+            include: {
+                // Nests household->orgMembership (same shape as ACTIVE_ORG_MEMBER_INCLUDE)
+                // so the board can see CURRENT membership while a request is still
+                // pending — wasOrgMemberAtApproval is null until approved, so it can't
+                // answer this. Derive live client-side; nothing new to stamp/store here.
+                person: { include: ACTIVE_ORG_MEMBER_INCLUDE },
+                program: true // carries startAt (public) — half of the next-year flag
+            },
+            orderBy: {
+                pendingSince: 'asc'
+            }
+        }),
+        // The membership-year cutoff. Shipped so the board can flag requests whose
+        // program lands in the NEXT membership year (program.startAt >= next cutoff).
+        // Derived on the client, not stamped: the security stripper drops ad-hoc
+        // booleans, so we ship the two classified inputs (startAt + this boundary)
+        // and compare client-side — same pattern as the Member/Non-member column.
+        prisma.boardSettings.findUnique({ where: { id: 1 } })
+    ]);
 
-    return { ProgramParticipant: requests };
+    return { ProgramParticipant: requests, BoardSettings: boardSettings };
 });
 
 export const POST = withAuth(

--- a/checkin-app/src/app/finance-ops/payment-plan/__tests__/page.test.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/__tests__/page.test.tsx
@@ -23,7 +23,7 @@ const requests = [
 describe("finance-ops/payment-plan page", () => {
   it("loads and renders pending payment plan requests", async () => {
     setSession({ id: 1, isSysadmin: true });
-    mockFetchJson({ "/api/finance-ops/payment-plans": requests });
+    mockFetchJson({ "/api/finance-ops/payment-plans": { ProgramParticipant: requests, BoardSettings: null } });
     renderWithProviders(<PendingParticipantsPage />);
 
     expect(await screen.findByText("Pat Participant")).toBeInTheDocument();
@@ -35,7 +35,7 @@ describe("finance-ops/payment-plan page", () => {
   it("approves a request and removes it from the list", async () => {
     setSession({ id: 1, isSysadmin: true });
     const fetchMock = mockFetchJson({
-      "/api/finance-ops/payment-plans": () => requests,
+      "/api/finance-ops/payment-plans": () => ({ ProgramParticipant: requests, BoardSettings: null }),
     });
     renderWithProviders(<PendingParticipantsPage />);
     await screen.findByText("Pat Participant");

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { Button, Group, Modal, Stack, Text } from '@mantine/core';
+import { Badge, Button, Group, Modal, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
@@ -11,6 +11,7 @@ import { formatDateTime } from '@/lib/time';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { sharesHousehold } from '@/lib/conflictOfInterest';
 import { formatCents } from '@inventory/money';
+import { landsNextYear } from '@/lib/programYear';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 type PaymentPlanRequest = {
@@ -31,6 +32,7 @@ type PaymentPlanRequest = {
     name: string;
     orgMemberPriceCents: number | null;
     nonOrgMemberPriceCents: number | null;
+    startAt: string | null;
   };
 };
 
@@ -42,6 +44,7 @@ export default function PendingParticipantsPage() {
     me?.isSysadmin !== true && sharesHousehold(me?.householdId, req.person.householdId);
 
   const [requests, setRequests] = useState<PaymentPlanRequest[]>([]);
+  const [cutoff, setCutoff] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState("");
   const [confirmApproveOpened, { open: openConfirmApprove, close: closeConfirmApprove }] = useDisclosure(false);
@@ -52,7 +55,8 @@ export default function PendingParticipantsPage() {
       const res = await fetch('/api/finance-ops/payment-plans');
       if (res.ok) {
         const data = await res.json();
-        setRequests(data);
+        setRequests(data.ProgramParticipant ?? []);
+        setCutoff(data.BoardSettings?.orgMembershipYearBoundary ?? null);
       } else {
         setMessage("Failed to load requests. You may not have access.");
       }
@@ -128,7 +132,12 @@ export default function PendingParticipantsPage() {
       sortBy: (req) => req.program.name.toLowerCase(),
       render: (req) => (
         <>
-          <Text fw={500}>{req.program.name}</Text>
+          <Group gap="xs">
+            <Text fw={500}>{req.program.name}</Text>
+            {landsNextYear(req.program.startAt, cutoff) && (
+              <Badge size="sm" color="orange" variant="light">Next year</Badge>
+            )}
+          </Group>
           <Text size="sm" c="dimmed">
             Price: M {formatCents(req.program.orgMemberPriceCents)} / NM {formatCents(req.program.nonOrgMemberPriceCents)}
           </Text>

--- a/checkin-app/src/lib/__tests__/programYear.test.ts
+++ b/checkin-app/src/lib/__tests__/programYear.test.ts
@@ -1,0 +1,33 @@
+import { nextBoundary, landsNextYear } from '@/lib/programYear';
+
+// Anchor "now" so the rollover branch is deterministic.
+const NOW = new Date('2026-07-06T00:00:00Z');
+const SEPT1 = '2000-09-01T00:00:00Z'; // stored boundary — only month/day matter
+
+describe('nextBoundary', () => {
+    it('picks this year when the boundary month/day is still ahead', () => {
+        // Sept 1 2026 is after Jul 6 2026.
+        expect(nextBoundary(new Date(SEPT1), NOW).toISOString()).toBe('2026-09-01T00:00:00.000Z');
+    });
+
+    it('rolls to next year when the boundary month/day has already passed', () => {
+        const now = new Date('2026-10-01T00:00:00Z'); // past Sept 1
+        expect(nextBoundary(new Date(SEPT1), now).toISOString()).toBe('2027-09-01T00:00:00.000Z');
+    });
+});
+
+describe('landsNextYear', () => {
+    it('true when the program starts on/after the next cutoff', () => {
+        expect(landsNextYear('2026-09-15T00:00:00Z', SEPT1, NOW)).toBe(true); // after Sept 1 2026
+        expect(landsNextYear('2026-09-01T00:00:00Z', SEPT1, NOW)).toBe(true); // exactly the cutoff
+    });
+
+    it('false when the program starts before the next cutoff (current year)', () => {
+        expect(landsNextYear('2026-08-01T00:00:00Z', SEPT1, NOW)).toBe(false);
+    });
+
+    it('false (unknown) when start date or cutoff is missing', () => {
+        expect(landsNextYear(null, SEPT1, NOW)).toBe(false);
+        expect(landsNextYear('2026-09-15T00:00:00Z', null, NOW)).toBe(false);
+    });
+});

--- a/checkin-app/src/lib/programYear.ts
+++ b/checkin-app/src/lib/programYear.ts
@@ -1,0 +1,21 @@
+// Pure, prisma-free helpers for the finance-ops board's "next year" flag, so a
+// client component can import them (lib/membership/renewal.nextBoundary pulls in
+// prisma and can't cross into the browser bundle). Kept dependency-free and
+// unit-tested in __tests__/programYear.test.ts.
+
+/** Next occurrence (>= now) of the membership-year boundary's month/day. */
+export function nextBoundary(boundary: Date, now: Date): Date {
+    const b = new Date(Date.UTC(now.getUTCFullYear(), boundary.getUTCMonth(), boundary.getUTCDate()));
+    if (b.getTime() < now.getTime()) b.setUTCFullYear(b.getUTCFullYear() + 1);
+    return b;
+}
+
+/**
+ * A scholarship/payment-plan request "lands next year" when its program starts
+ * on/after the next membership-year cutoff. No cutoff configured, or no program
+ * start date → unknown (false). ISO strings in (as they arrive over the wire).
+ */
+export function landsNextYear(startAt: string | null, cutoff: string | null, now: Date = new Date()): boolean {
+    if (!startAt || !cutoff) return false;
+    return new Date(startAt).getTime() >= nextBoundary(new Date(cutoff), now).getTime();
+}

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -216,7 +216,7 @@ defineRoute({
     endpoint: 'GET /api/finance-ops/payment-plans',
     authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
     envelope: null,
-    returns: ['ProgramParticipant', 'Person', 'Program', 'Household', 'OrgMembership'],
+    returns: ['ProgramParticipant', 'Person', 'Program', 'Household', 'OrgMembership', 'BoardSettings'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],


### PR DESCRIPTION
## What

A complementary function for PR #931 ... it correctly makes sure to capture "as of" information, but that means we should also highlight to our finance folk when that "as of" might be hit in the most general case (expiring membership year)

Adds an orange **"Next year"** badge to the finance-ops payment-plan board for any scholarship/payment-plan request whose program starts **on/after the next membership-year cutoff** (`BoardSettings.orgMembershipYearBoundary`).

## Why

Every pending request currently surfaces to finance identically — a request for a program starting next August looks exactly like one starting next week. No finance-awareness surface (email, board list, nav badge) filters or signals by program date. This adds the missing signal so the board can tell current-year requests apart from next-year ones at a glance.

## How it works

The flag is **derived on the client, not stamped server-side**. The security stripper drops ad-hoc booleans (only schema-classified fields survive on the wire), so the GET route ships the two classified *inputs* instead:

- `program.startAt` (already included), and
- the `BoardSettings` membership-year cutoff singleton (newly shipped),

and the page compares them client-side — the same pattern as the existing Member/Non-member column. This flips the GET response from a bare array to `{ ProgramParticipant, BoardSettings }`, which ripples to the client + tests.

## Changes

- `payment-plans/route.ts` — GET also ships `BoardSettings` (parallel query)
- `lib/programYear.ts` (+unit test) — pure, prisma-free `landsNextYear` / `nextBoundary` (kept prisma-free so a client component can import it)
- `payment-plan/page.tsx` — reads new response shape, renders the badge
- `security/registry.ts` — `BoardSettings` added to `returns` (view is already `everyones:*`)
- `page.test` + integration test — updated to the new response shape; integration adds an inputs-ship assertion

## Reviewer notes

- No cutoff configured or no program start date → badge simply doesn't show. No new gating, no change to which requests reach finance.
- Only the exception is labeled — no "current year" badge. Add when the board wants both.
- Full CI suite passes locally (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)