### PR TITLE
refactor(household-lead): contract phase — DROP HouseholdLead table + remove model

### DIFF
--- a/checkin-app/docs/designs/HOUSEHOLD_LEAD_MODEL.md
+++ b/checkin-app/docs/designs/HOUSEHOLD_LEAD_MODEL.md
@@ -2,17 +2,20 @@
 
 **Status:** design investigation → **option (a1) BUILT** (2026-07-05), shipped as a
 zero-downtime **expand-contract** in two PRs:
-- **This PR (expand):** additive `Person.isHouseholdLead` column + backfill
-  (`20260706110000_person_is_household_lead`) + full reader/writer cutover + an index
-  (`20260706120000`, `@@index([householdId, isHouseholdLead])`). The `HouseholdLead`
+- **Expand PR #917 (merged):** additive `Person.isHouseholdLead` column + backfill + full
+  reader/writer cutover + the `@@index([householdId, isHouseholdLead])` — all folded into
+  `20260706110000_person_is_household_lead` on merge. The `HouseholdLead`
   **table AND its Prisma model are kept** — unused, frozen at backfill, no code reads or
   writes them — so (a) draining old ECS tasks don't query a dropped table during the
   rolling deploy, and (b) `schema.prisma` still matches the physical DB (the drift check
   requires it). The scope binding + view-bag entries stay too; only the code that returns
   lead rows was cut over to `householdMembers`.
-- **Follow-up PR (contract):** `DROP TABLE "HouseholdLead"` + remove the model, relations,
-  scope binding, and view-bag entries together — merged only after this PR is fully rolled
-  out. Do NOT drop in the same release as the backfill (see DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md).
+- **Follow-up PR (contract) — BUILT (stacked on the expand PR):**
+  `DROP TABLE "HouseholdLead"` (`20260706130000_drop_household_lead`) + removed the Prisma
+  model, both relations (`Person.householdLeads`, `Household.leads`), and the three
+  `HouseholdLead` view-bag `returns:` entries in `security/registry.ts`, with
+  `classifications.ts` regenerated. Merge only after the expand PR is fully rolled out.
+  Do NOT drop in the same release as the backfill (see DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md).
 
 Verified: `tsc` clean, `eslint --max-warnings 0` clean, unit + integration suites green
 against a throwaway seeded Postgres.

--- a/checkin-app/prisma/migrations/20260706130000_drop_household_lead/migration.sql
+++ b/checkin-app/prisma/migrations/20260706130000_drop_household_lead/migration.sql
@@ -1,0 +1,7 @@
+-- a1 contract phase (HOUSEHOLD_LEAD_MODEL.md + DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md):
+-- the HouseholdLead join table was fully superseded by Person.isHouseholdLead in
+-- PR #917 (additive column + backfill in 20260706110000_person_is_household_lead
+-- + full reader/writer cutover, shipped and rolled out FIRST). No running task references
+-- the table, so it is safe to drop. This is the destructive half of the
+-- expand-contract split — it MUST land in a later release than #917's backfill.
+DROP TABLE "HouseholdLead";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -122,11 +122,6 @@ model Person {
   toolStatuses        ToolStatus[]
   bgAttestations      BackgroundCheckAttestation[] @relation("BgAttestations")
   personBgProcesses   OrgMembershipProcess[]       @relation("PersonBgSubject")
-  // DEPRECATED (a1): leadership is now the isHouseholdLead flag above. The
-  // HouseholdLead table is kept, unused, only until the follow-up contract
-  // migration drops it — no code reads or writes this relation. See
-  // docs/designs/HOUSEHOLD_LEAD_MODEL.md + DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md.
-  householdLeads      HouseholdLead[]
   corporationLeads    CorporationLead[]
   corporationMembers  CorporationMember[]
   programVolunteers   ProgramVolunteer[]
@@ -196,9 +191,6 @@ model Household {
   intakeNotes String?
 
   householdMembers  Person[]
-  // DEPRECATED (a1): superseded by Person.isHouseholdLead; kept unused until the
-  // follow-up contract migration drops the table (see HOUSEHOLD_LEAD_MODEL.md).
-  leads             HouseholdLead[]
   orgMembership     OrgMembership?
   trustedAdults     TrustedAdult[]
   emergencyContacts EmergencyContact[]
@@ -248,23 +240,6 @@ model EmergencyContact {
 
   @@index([householdId])
   @@index([phoneDigits])
-}
-
-/// DEPRECATED (a1): the household-lead join table. Leadership is now the boolean
-/// Person.isHouseholdLead. This model is retained ONLY so schema.prisma still
-/// matches the physical table during the expand phase — no code reads or writes
-/// it. The follow-up contract migration DROPs the table and removes this model.
-/// See docs/designs/HOUSEHOLD_LEAD_MODEL.md + DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md.
-model HouseholdLead {
-  /// @sensitivity:public
-  householdId   Int
-  /// @sensitivity:public
-  personId Int
-
-  household   Household   @relation(fields: [householdId], references: [id])
-  person Person @relation(fields: [personId], references: [id])
-
-  @@id([householdId, personId])
 }
 
 enum OrgMembershipStatus {

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -60,10 +60,6 @@ export const classifications = {
         createdAt: 'internal',
         updatedAt: 'internal',
     },
-    HouseholdLead: {
-        householdId: 'public',
-        personId: 'public',
-    },
     OrgMembership: {
         id: 'public',
         memberSince: 'public',
@@ -342,7 +338,6 @@ export const relations = {
         toolStatuses: { model: 'ToolStatus', isList: true },
         bgAttestations: { model: 'BackgroundCheckAttestation', isList: true },
         personBgProcesses: { model: 'OrgMembershipProcess', isList: true },
-        householdLeads: { model: 'HouseholdLead', isList: true },
         corporationLeads: { model: 'CorporationLead', isList: true },
         corporationMembers: { model: 'CorporationMember', isList: true },
         programVolunteers: { model: 'ProgramVolunteer', isList: true },
@@ -366,17 +361,12 @@ export const relations = {
     },
     Household: {
         householdMembers: { model: 'Person', isList: true },
-        leads: { model: 'HouseholdLead', isList: true },
         orgMembership: { model: 'OrgMembership', isList: false },
         trustedAdults: { model: 'TrustedAdult', isList: true },
         emergencyContacts: { model: 'EmergencyContact', isList: true },
     },
     EmergencyContact: {
         household: { model: 'Household', isList: false },
-    },
-    HouseholdLead: {
-        household: { model: 'Household', isList: false },
-        person: { model: 'Person', isList: false },
     },
     OrgMembership: {
         household: { model: 'Household', isList: false },

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -128,9 +128,9 @@ defineRoute({
     authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
     envelope: 'processes',
     // Bag: { OrgMembershipProcess } with attestations (BackgroundCheckAttestation),
-    // membership (OrgMembership → household Household → participants Person,
-    // leads HouseholdLead).
-    returns: ['OrgMembershipProcess', 'BackgroundCheckAttestation', 'OrgMembership', 'Household', 'Person', 'HouseholdLead'],
+    // membership (OrgMembership → household Household → householdMembers Person,
+    // leads flagged isHouseholdLead).
+    returns: ['OrgMembershipProcess', 'BackgroundCheckAttestation', 'OrgMembership', 'Household', 'Person'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
@@ -146,8 +146,8 @@ defineRoute({
     authorize: { anyRole: ['isBackgroundCheckReviewer', 'isBoardMember'] },
     envelope: 'queue',
     // Bag: { OrgMembershipProcess } with membership (OrgMembership → household Household
-    // → leads HouseholdLead → participant Person).
-    returns: ['OrgMembershipProcess', 'OrgMembership', 'Household', 'HouseholdLead', 'Person'],
+    // → householdMembers Person, leads flagged isHouseholdLead).
+    returns: ['OrgMembershipProcess', 'OrgMembership', 'Household', 'Person'],
     orderedView: [
         ['isBackgroundCheckReviewer', ['everyones:pii', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'member', 'public']],
@@ -174,9 +174,9 @@ defineRoute({
     endpoint: 'GET /api/safety/trusted-adults',
     authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
     envelope: 'trustedAdults',
-    // Bag: { TrustedAdult } with household (Household → leads HouseholdLead →
-    // participant Person), trustedAdultPerson (Person), reviews (TrustedAdultReview).
-    returns: ['TrustedAdult', 'Household', 'HouseholdLead', 'Person', 'TrustedAdultReview'],
+    // Bag: { TrustedAdult } with household (Household → householdMembers Person,
+    // leads flagged isHouseholdLead), trustedAdultPerson (Person), reviews (TrustedAdultReview).
+    returns: ['TrustedAdult', 'Household', 'Person', 'TrustedAdultReview'],
     orderedView: [
         ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -48,10 +48,6 @@ export const SCOPE_BINDINGS = {
         their_households: { field: 'householdId', eqCtx: 'householdId' },
         their_program_households: { field: 'householdId', inCtx: 'householdIdsInScopePrograms' },
     },
-    HouseholdLead: {
-        their_households: { field: 'householdId', eqCtx: 'householdId' },
-        their_own: { field: 'personId', eqCtx: 'selfId' },
-    },
     OrgMembership: { their_households: { field: 'householdId', eqCtx: 'householdId' } },
     Program: {
         their_program_participants: { field: 'id', inCtx: ['programsLed', 'programsCoreVolIn'] },

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -82,13 +82,8 @@ function referenceScopesHeld(
             if (householdId !== undefined && ctx.householdIdsInScopePrograms.has(householdId)) scopes.add('their_program_households');
             break;
         }
-        case 'HouseholdLead': {
-            const householdId = num(row.householdId);
-            const personId = num(row.personId);
-            if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
-            if (personId !== undefined && personId === ctx.selfId) scopes.add('their_own');
-            break;
-        }
+        // 'HouseholdLead': model dropped in the a1 contract phase (superseded by
+        // Person.isHouseholdLead). No binding, no rows, no case — gone entirely.
         case 'OrgMembership': {
             const householdId = num(row.householdId);
             if (householdId !== undefined && householdId === ctx.householdId) scopes.add('their_households');
@@ -317,6 +312,6 @@ describe('S1 — scopesHeld ≡ frozen switch + intentional deltas (personas × 
     it('covers every bound model', () => {
         // Guard against the row set silently not exercising a model.
         expect(MODELS).toEqual(expect.arrayContaining(Object.keys(SCOPE_BINDINGS)));
-        expect(Object.keys(SCOPE_BINDINGS).length).toBe(19); // -Fee (Blocker 1) +AuditLog (Blocker 2)
+        expect(Object.keys(SCOPE_BINDINGS).length).toBe(18); // -Fee (Blocker 1) +AuditLog (Blocker 2) -HouseholdLead (a1 contract)
     });
 });


### PR DESCRIPTION
## What

Contract half of the `HouseholdLead` → `Person.isHouseholdLead` expand-contract. The expand PR #917 (merged, `86f84840`) added + backfilled the flag and cut every reader/writer over, but deliberately kept the `HouseholdLead` table/model/scope-binding/view-bags frozen. This PR removes all of that and drops the table:

- **`20260706130000_drop_household_lead`** — `DROP TABLE "HouseholdLead"` (single statement; latest timestamp, after #917's `110000`).
- **`schema.prisma`** — remove `model HouseholdLead` + relations `Person.householdLeads`, `Household.leads`.
- **`security/scopeBindings.ts`** — remove the `HouseholdLead` scope binding (once the model leaves classifications, `scopes.ts` errors `binding for unknown model`).
- **`security/registry.ts`** — drop `HouseholdLead` from the three view-bag `returns:` arrays (routes traverse via `householdMembers` filtered `isHouseholdLead` now).
- **`security/generated/classifications.ts`** — regenerated (model + relation entries gone; `Person.isHouseholdLead` flag stays).
- **`tests/security/scopeBindingsEquivalence.test.ts`** — remove the frozen-switch oracle case + bound-model count `19 → 18`.
- **`HOUSEHOLD_LEAD_MODEL.md`** — mark contract complete; correct the merged-index migration reference.

## Why

Zero-downtime. DB migrations finish before the ECS rolling update starts, so dropping the table in #917's release would 500 the site during the drain window (old tasks still `SELECT householdLeads` → P2021). Splitting the destructive step into this follow-up, merged only after #917 is fully rolled out, avoids that. See `DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md` + the migration-safety checklist.

## Reviewer notes

- **Do NOT merge until #917 is fully rolled out in prod** (all old tasks drained), not just merged.
- **Before the drop lands**, run against prod: `SELECT hl.* FROM "HouseholdLead" hl JOIN "Person" p ON hl."personId"=p."id" WHERE hl."householdId" != p."householdId";` — expect zero rows (divergent leads the backfill intentionally skipped). If non-zero, STOP; dropping would silently lose them.
- Touches CODEOWNERS-gated security config (`scopeBindings.ts`, `registry.ts`, generated `classifications.ts`).
- Most of the teardown is tsc-blind — caught only by full jest.

## Verification

- `tsc --noEmit` clean · `eslint --max-warnings 0` clean · no `prisma generate` drift
- unit **1639/1639** (205 suites)
- integration **953/953** (113 suites) — globalSetup `migrate deploy` applied the full `110000 → 130000` chain and every test passes on the post-drop schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)