### PR TITLE
feat(membership): warn volunteer-only applicants that intake pauses for review

### DIFF
--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -703,7 +703,14 @@ export default function MembershipPage() {
                   <section>
                     <Textarea
                       label="Anything else we should know?"
-                      description="Optional. Tell us anything that would help us review your application — for example, if your household is applying to volunteer only, with no students enrolled."
+                      description={
+                        <>
+                          Optional. Tell us anything that would help us review your application — for example, if your household is applying to volunteer only, with no students enrolled.{" "}
+                          <Text component="span" fw={700} c="red">
+                            Your application will pause for human review before you can pay
+                          </Text>
+                        </>
+                      }
                       autosize
                       minRows={3}
                       value={notes}


### PR DESCRIPTION
## What

Adds a bold red note under the **"Anything else we should know?"** field on the membership intake form (`checkin-app/src/app/membership/page.tsx`):

> **Your application will pause for human review before you can pay**

## Why

Volunteer-only households (no students enrolled) get flagged for human review, which blocks payment until an admin clears it. This sets that expectation up front on the form instead of surprising the applicant after submit.

## Notes

- Uses Mantine `Text` (already imported) with `fw={700} c="red"`; `description` accepts ReactNode.
- Copy-only change, no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)