### PR TITLE
feat: sync program mailing lists into Google Groups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ Read these before changing the relevant area — start here, then follow links.
 - `DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md` — infra rules + order of operations for schema migrations vs. deploys (read before writing a migration); `.claude/skills/migration-safety/` fires this as a checklist whenever a migration is being built.
 - `MIGRATION_COALESCE_FLOW.md` — the pre-release migration-coalesce policy + script (`scripts/coalesce-migrations.ts`), the release gate (at most 1 new migration per release), and the dev/prod ledger-reconcile procedure.
 - `PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md` — single-pool Shopify capacity model + the scholarship hold-ledger state machine (read before touching `Program`/`ProgramParticipant` capacity or payment-plan logic).
+- `designs/PROGRAM_GOOGLE_GROUP_SYNC.md` — program → Google Group membership sync (event push + nightly reconcile; service-account creds are an infra follow-up; read before touching activation/withdrawal hooks or `lib/googleGroups.ts`).
 
 **Subprojects** (each has its own `README.md`)
 - `client/` — the Raspberry-Pi kiosk client (Python).

--- a/checkin-app/docs/designs/PROGRAM_GOOGLE_GROUP_SYNC.md
+++ b/checkin-app/docs/designs/PROGRAM_GOOGLE_GROUP_SYNC.md
@@ -1,0 +1,178 @@
+# Program mailing lists → Google Groups sync
+
+Status: implemented (integration credentials are an **infra follow-up** — see
+§"Provisioning"). Product decisions from the 2026-07 interview are recorded
+inline as **[decision]**.
+
+## Problem
+
+A program (a class/cohort) wants a single mailing list its active participants
+can reach. Treehouse already runs on Google Workspace, so the natural list is a
+**Google Group**. We want the app to keep that group's membership in lockstep
+with who is actively enrolled: add people when they become active, remove them
+when they withdraw, and self-heal any drift — without ever letting a Google
+outage break the enrollment/withdrawal actions that trigger it.
+
+## Decisions
+
+- **[decision] Config lives on the program.** `Program.googleGroupEmail`
+  (`String?`, `@sensitivity:internal`) is the group address, board-set on the
+  program-ops program settings surface and **validated as an email** server-side.
+  Null = this program has no group; sync is a no-op for it. Internal tier because
+  it is operational config, not public catalog data; the `GET /api/programs/[id]`
+  view already grants `everyones:internal` to sysadmin/board (the only roles that
+  see/edit the config card), and hides it from lead mentors / the public.
+
+- **[decision] Who gets added — mirrors how notifications resolve recipients
+  today.** `lib/notifications.ts › sendCheckinNotifications` notifies **the
+  participant themselves** (their own `Person.email`) **plus every household
+  lead** (`Person` in the same household with `isHouseholdLead = true`). We reuse
+  that exact rule for group membership: a participant contributes their own email
+  and all their household leads' emails (deduped, lowercased). Consequences,
+  identical to notifications: a dependent child with no email of their own is
+  represented in the group by their household lead(s); an adult who self-enrolls
+  and is their own lead resolves to just their one address.
+
+- **[decision] Event-driven push, best-effort.** When a participant becomes
+  **ACTIVE**, their resolved emails are **added**; on withdrawal/removal they are
+  **removed** (but only the ones no other active participant of the same program
+  still needs — a shared household lead stays). A Google failure **must never
+  fail the triggering user action**: the push is fire-and-forget at the service
+  level, wrapped so it can only log + report (Link Status), never throw. The
+  nightly reconcile is the safety net that heals anything a push dropped.
+
+- **[decision] Nightly reconcile + manual "Sync now".** A cron does a full diff
+  per configured program (desired = active participants' resolved emails;
+  current = the group's members): add missing, remove extras. A board-only
+  "Sync now" button on program-ops runs the same reconcile for one program on
+  demand.
+
+- **[decision] Directory API over a service account with domain-wide
+  delegation.** Auth is the Google **Admin SDK Directory API**
+  (`admin.directory.group.member` scope) via a Workspace **service account**
+  impersonating an admin (`sub`). Credentials come from env
+  (`GOOGLE_SA_KEY_JSON` = the full service-account key JSON, `GOOGLE_SA_SUBJECT`
+  = the admin user to impersonate). **When either is absent the integration is
+  cleanly OFF**: the config UI still works, every sync path logs-and-skips, and
+  config-health reports it unconfigured (see §Off-state).
+
+- **[decision] No new npm dependency.** The Directory API is plain REST, and its
+  OAuth2 is a JWT-bearer assertion we sign with Node's built-in `crypto`
+  (`RSA-SHA256` over `base64url(header).base64url(claims)`, exchanged at
+  `oauth2.googleapis.com/token`). That is ~20 lines and avoids pulling in
+  `googleapis`/`google-auth-library` (hundreds of transitive deps) for three
+  endpoints. If Google's auth ever grows hairier than a static JWT (e.g. workload
+  identity federation), `googleapis` becomes the justified fallback — it is not
+  needed today.
+
+## Data model
+
+One additive, nullable column (expand-only, no backfill):
+
+```
+Program.googleGroupEmail  String?   /// @sensitivity:internal
+```
+
+Migration `20260708050000_program_google_group`. No new tables: the Google Group
+itself is the state store; the app holds only the address.
+
+## Components
+
+- `lib/googleGroups.ts` — the **client**. Owns JWT signing + token cache (5-min
+  early refresh), and `listGroupMembers` / `addGroupMember` / `removeGroupMember`.
+  Every network call goes through `googleFetch` (a 15s `AbortSignal.timeout`
+  wrapper — the same seam `lib/shopify.ts › shopifyFetch` uses, so tests mock
+  `global.fetch`). Typed failures are `GoogleGroupsError`. Idempotency is baked
+  into the client: add treats **409** (already a member) as success, remove
+  treats **404** (not a member) as success — so retries and reconcile overlap are
+  harmless.
+
+- `lib/program/groupSync.ts` — the **shared service** that maps program/person →
+  emails and drives the client:
+  - `resolveParticipantGroupEmails(personId)` — self + household-lead emails.
+  - `reconcileProgramGroup(program)` — full diff for one program. Removes only
+    members whose Directory `role` is `MEMBER`; **never removes OWNER/MANAGER**
+    (so a human owner or the service account isn't reconciled out of its own
+    group). Throws on a Google failure so callers decide how loud to be.
+  - `pushGroupAddOnActivation(program, personId)` /
+    `pushGroupRemoveOnWithdrawal(program, personId)` — the best-effort event
+    pushes. Both **swallow all errors** into `logger.error` +
+    `logIntegrationError("google-groups", …)`; they return `void` and never
+    throw, so no user action can fail on them. Both no-op immediately when the
+    program has no group or the integration is unconfigured.
+
+## Flows
+
+**Activation → add.** The three post-#930 activation points each call
+`pushGroupAddOnActivation` from the service level:
+1. `POST /api/webhooks/shopify` (paid order flips PENDING→ACTIVE),
+2. `POST /api/finance-ops/payment-plans` (scholarship/payment-plan approval),
+3. `POST /api/programs/[id]/participants` (free program / board comp override
+   creates an ACTIVE row directly).
+
+Adding is idempotent, so no diff is needed on the hot path — we just add the
+one person's emails.
+
+**Withdrawal/removal → remove.** Fired from **one** place:
+`lib/program/capacity.ts › withdrawAndReleaseHold`, the single shared exit path
+that DELETE `/api/programs/[id]/participants` and both withdrawal crons
+(`pending-participants`, `scholarship-grace-expiry`) already route through. The
+person is deleted from the roster first, so the removal recomputes the program's
+*remaining* desired set and removes only the leaving person's emails that no
+remaining active participant still needs. PENDING kicks (crons) were never in the
+group, so their removal is a harmless no-op.
+
+**Reconcile.** `GET /api/cron/program-google-group-reconcile` (withCron +
+`CRON_SECRET`) iterates programs with a group set and reconciles each, isolating
+a failing program from the rest (log + Link Status, continue). **Schedule is an
+infra follow-up** — like the other crons, the route exists but nothing invokes it
+until an EventBridge/scheduler entry is added in the infra repo (mirror the
+existing cron schedule wiring).
+
+**Manual sync.** `POST /api/programs/[id]/sync-google-group` (withAuth,
+sysadmin/board) runs `reconcileProgramGroup` for one program and returns
+`{ added, removed }`, surfacing a 502 if Google errors (also logged to Link
+Status). Backs the "Sync now" button on the program-ops general tab.
+
+## Off-state (unconfigured) — mirrors Zoho/Shopify
+
+`config.googleGroupsConfigured()` is true only when **both** env vars are set.
+When false:
+- `pushGroupAdd/Remove` and `reconcileProgramGroup` return early (log-and-skip);
+- the manual-sync route returns 503 "not configured";
+- the reconcile cron returns `{ configured: false }` and does nothing;
+- `lib/configHealth.ts` gains a `google-groups` check that reports the state.
+  Following the `resend-email` idiom, it is a **gap only in prod** (green in
+  dev/local, where the feature is legitimately off), and its detail names the two
+  env vars to set. This is where the pending infra provisioning surfaces to the
+  board on System Status.
+
+Failures of a *configured* integration are reported exactly like Shopify's:
+`logIntegrationError("google-groups", …)` → System Status › Link Status.
+
+## Provisioning (infra follow-up — NOT done in this PR)
+
+To turn the integration on in an environment:
+1. Create a Workspace service account, enable the Admin SDK, and grant it
+   **domain-wide delegation** for scope
+   `https://www.googleapis.com/auth/admin.directory.group.member`.
+2. Set `GOOGLE_SA_KEY_JSON` to the downloaded key JSON and `GOOGLE_SA_SUBJECT`
+   to an admin user's email (the `sub` the service account impersonates — DWD
+   cannot act as the service account itself for Directory writes).
+3. Add a scheduler entry that hits the reconcile cron with the `CRON_SECRET`
+   bearer, on the desired cadence (nightly).
+
+## Deliberately deferred
+
+- **No new group creation** — the group must already exist in Workspace; the app
+  only manages membership of an address it's given.
+- **Group is treated as app-owned for its MEMBER role.** Reconcile removes
+  MEMBER-role addresses that aren't active participants. Don't hand-add members
+  you want to keep; add them as OWNER/MANAGER (never touched) or, better, keep
+  manual lists in a different group. `ponytail:` naive full-diff per program —
+  fine at Treehouse's program count; batch the Directory calls if it grows.
+- **No per-role mapping** (mentors/volunteers) — only active *participants* sync,
+  matching the notification-recipient rule above.
+- **Email-change lag** — if a person changes their email, the old address lingers
+  in the group until the next reconcile removes it (it's no longer in the desired
+  set). Acceptable; the nightly diff heals it.

--- a/checkin-app/prisma/migrations/20260708050000_program_google_group/migration.sql
+++ b/checkin-app/prisma/migrations/20260708050000_program_google_group/migration.sql
@@ -1,0 +1,5 @@
+-- Additive, nullable: the Google Group address a program's active participants
+-- are synced into (self + household-lead emails). Null = no group configured;
+-- sync is a no-op for that program. Board-set on program-ops, validated as an
+-- email in the app. See docs/designs/PROGRAM_GOOGLE_GROUP_SYNC.md.
+ALTER TABLE "Program" ADD COLUMN "googleGroupEmail" TEXT;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -721,6 +721,12 @@ model Program {
   /// @sensitivity:public
   shopifyVariantId          String?
 
+  /// Google Group address this program's active participants are synced into
+  /// (self + household-lead emails; see docs/designs/PROGRAM_GOOGLE_GROUP_SYNC.md).
+  /// Null = no group. Board-set on program-ops, validated as an email.
+  /// @sensitivity:internal
+  googleGroupEmail          String?
+
   volunteers   ProgramVolunteer[]
   participants ProgramParticipant[]
   fees         Fee[]

--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -90,6 +90,8 @@ const AUTHZ_TESTED = new Set<string>([
     'programs',
     // POST deny-path (401 anon / 403 non-board) in authzRoleRejection.integration.test.ts.
     'programs/[id]/sync-shopify',
+    // POST deny-path (401 anon / 403 non-board) in authzRoleRejection.integration.test.ts.
+    'programs/[id]/sync-google-group',
     'roles',
     'safety/board-contacts',
     'safety/emergency-contacts',

--- a/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
@@ -35,6 +35,7 @@ import { GET as EVENT_GET, PATCH as EVENT_PATCH } from '@/app/api/events/[id]/ro
 import { GET as EVENTS_LIST_GET } from '@/app/api/events/route';
 import { POST as PROGRAMS_POST } from '@/app/api/programs/route';
 import { POST as PROGRAM_SYNC_SHOPIFY_POST } from '@/app/api/programs/[id]/sync-shopify/route';
+import { POST as PROGRAM_SYNC_GROUP_POST } from '@/app/api/programs/[id]/sync-google-group/route';
 import { GET as NOTIFICATIONS_GET } from '@/app/api/notifications/route';
 import { POST as CONTRACT_SYNC_POST } from '@/app/api/membership/contract/sync/route';
 import { POST as ONBOARDING_POST } from '@/app/api/profile/onboarding/route';
@@ -168,6 +169,7 @@ describe('Protected-route role rejection', () => {
         { name: 'GET /api/events (standalone list)', invoke: () => EVENTS_LIST_GET(nreq('http://localhost/api/events')) },
         { name: 'POST /api/programs', invoke: () => PROGRAMS_POST(nreq('http://localhost/api/programs', 'POST', {})) },
         { name: 'POST /api/programs/[id]/sync-shopify', invoke: () => PROGRAM_SYNC_SHOPIFY_POST(nreq('http://localhost/api/programs/1/sync-shopify', 'POST', {}), idCtx(1)) },
+        { name: 'POST /api/programs/[id]/sync-google-group', invoke: () => PROGRAM_SYNC_GROUP_POST(nreq('http://localhost/api/programs/1/sync-google-group', 'POST', {}), idCtx(1)) },
 
         // ---- drift-guard sweep: one row per method of each role-gated route ----
         // The withAuth roles gate fires before any body/param work, so dummy

--- a/checkin-app/src/app/__tests__/programGoogleGroupSync.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programGoogleGroupSync.integration.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the program → Google Group feature against a real DB:
+ *  1. Config save — PATCH /api/programs/[id] persists (normalizes) a valid
+ *     googleGroupEmail and rejects a malformed one.
+ *  2. A sync run — POST /api/programs/[id]/sync-google-group reconciles the
+ *     group against the ACTIVE roster, with the Google Directory API stubbed via
+ *     a mocked global.fetch (token → list → add/remove).
+ *
+ * Real service-account creds aren't used: GOOGLE_SA_KEY_JSON holds a locally
+ * generated RSA key just so the JWT-bearer assertion signs, and every HTTP call
+ * is intercepted. Mirrors programSyncShopifyAPI.integration.test.ts.
+ */
+import crypto from "crypto";
+import { PATCH } from "@/app/api/programs/[id]/route";
+import { POST as SYNC } from "@/app/api/programs/[id]/sync-google-group/route";
+import { resetTokenCache } from "@/lib/googleGroups";
+import prisma from "@/lib/prisma";
+import { getServerSession } from "next-auth/next";
+
+jest.mock("next-auth/next", () => ({ getServerSession: jest.fn() }));
+
+const TAG = "google-group-sync-test";
+const GROUP = `${TAG}-group@example.org`;
+const params = (id: number) => ({ params: Promise.resolve({ id: id.toString() }) }) as unknown as never;
+const patchReq = (body: unknown) =>
+    new Request("http://localhost/api/programs/x", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", cookie: "session=test" },
+        body: JSON.stringify(body),
+    }) as unknown as import("next/server").NextRequest;
+const syncReq = () =>
+    new Request("http://localhost/api/programs/x/sync-google-group", { method: "POST", headers: { cookie: "session=test" } }) as unknown as import("next/server").NextRequest;
+
+const { privateKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+describe("program Google Group sync", () => {
+    let boardId: number;
+    let leadId: number;
+    let kidId: number;
+    let programId: number;
+    let savedEnv: Record<string, string | undefined>;
+    let savedFetch: typeof global.fetch;
+
+    beforeAll(async () => {
+        savedEnv = { KEY: process.env.GOOGLE_SA_KEY_JSON, SUB: process.env.GOOGLE_SA_SUBJECT };
+        process.env.GOOGLE_SA_KEY_JSON = JSON.stringify({ client_email: "sa@proj.iam.gserviceaccount.com", private_key: privateKey });
+        process.env.GOOGLE_SA_SUBJECT = "admin@example.org";
+        savedFetch = global.fetch;
+
+        const board = await prisma.person.create({
+            data: { email: `board-${TAG}@example.com`, name: "Board", isBoardMember: true, household: { create: { name: "Board HH" } } },
+        });
+        boardId = board.id;
+
+        // One household: a lead (with email) + a dependent kid (with email).
+        const lead = await prisma.person.create({
+            data: { email: `lead-${TAG}@example.org`, name: "Lead", isHouseholdLead: true, household: { create: { name: `HH ${TAG}` } } },
+        });
+        leadId = lead.id;
+        const kid = await prisma.person.create({
+            data: { email: `kid-${TAG}@example.org`, name: "Kid", householdId: lead.householdId },
+        });
+        kidId = kid.id;
+
+        const program = await prisma.program.create({ data: { name: `Prog ${TAG}`, phase: "RUNNING", googleGroupEmail: GROUP } });
+        programId = program.id;
+        await prisma.programParticipant.create({ data: { programId, personId: kidId, status: "ACTIVE" } });
+    });
+
+    afterAll(async () => {
+        const ids = [boardId, leadId, kidId];
+        await prisma.auditLog.deleteMany({ where: { OR: [{ actorId: { in: ids } }, { secondaryAffectedEntity: programId }] } });
+        await prisma.programParticipant.deleteMany({ where: { programId } });
+        await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { id: { in: ids } } });
+        await prisma.household.deleteMany({ where: { name: { contains: TAG } } });
+        if (savedEnv.KEY === undefined) delete process.env.GOOGLE_SA_KEY_JSON; else process.env.GOOGLE_SA_KEY_JSON = savedEnv.KEY;
+        if (savedEnv.SUB === undefined) delete process.env.GOOGLE_SA_SUBJECT; else process.env.GOOGLE_SA_SUBJECT = savedEnv.SUB;
+        global.fetch = savedFetch;
+    });
+
+    beforeEach(() => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+        resetTokenCache();
+    });
+
+    describe("config save (PATCH /api/programs/[id])", () => {
+        it("persists a valid group email, normalized to lowercase/trimmed", async () => {
+            const res = await PATCH(patchReq({ googleGroupEmail: `  NEW-${TAG}@Example.ORG ` }), params(programId));
+            expect(res.status).toBe(200);
+            const persisted = await prisma.program.findUnique({ where: { id: programId } });
+            expect(persisted?.googleGroupEmail).toBe(`new-${TAG}@example.org`);
+            // restore for the sync test
+            await prisma.program.update({ where: { id: programId }, data: { googleGroupEmail: GROUP } });
+        });
+
+        it("rejects a malformed email (400) and does not change the stored value", async () => {
+            const res = await PATCH(patchReq({ googleGroupEmail: "not-an-email" }), params(programId));
+            expect(res.status).toBe(400);
+            const persisted = await prisma.program.findUnique({ where: { id: programId } });
+            expect(persisted?.googleGroupEmail).toBe(GROUP);
+        });
+
+        it("clears the group when given an empty string", async () => {
+            const res = await PATCH(patchReq({ googleGroupEmail: "" }), params(programId));
+            expect(res.status).toBe(200);
+            const persisted = await prisma.program.findUnique({ where: { id: programId } });
+            expect(persisted?.googleGroupEmail).toBeNull();
+            await prisma.program.update({ where: { id: programId }, data: { googleGroupEmail: GROUP } });
+        });
+    });
+
+    describe("sync run (POST /api/programs/[id]/sync-google-group)", () => {
+        it("reconciles the group: adds the ACTIVE roster (self + lead), removes a stale MEMBER", async () => {
+            const calls: { method: string; url: string }[] = [];
+            global.fetch = jest.fn(async (url: string | URL | Request, init?: RequestInit) => {
+                const u = String(url);
+                const method = init?.method ?? "GET";
+                calls.push({ method, url: u });
+                if (u.includes("oauth2.googleapis.com/token")) {
+                    return { ok: true, status: 200, json: async () => ({ access_token: "tok", expires_in: 3599 }) } as Response;
+                }
+                if (u.includes("/members") && method === "GET") {
+                    // Current group: one stale MEMBER that isn't on the roster.
+                    return { ok: true, status: 200, json: async () => ({ members: [{ email: `stale-${TAG}@example.org`, role: "MEMBER" }] }) } as Response;
+                }
+                // add (POST) / remove (DELETE)
+                return { ok: true, status: 200, json: async () => ({}), text: async () => "" } as Response;
+            }) as unknown as typeof global.fetch;
+
+            const res = await SYNC(syncReq(), params(programId));
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            // desired = kid + lead (2 adds), stale removed (1).
+            expect(data).toEqual({ success: true, added: 2, removed: 1 });
+
+            const posts = calls.filter((c) => c.method === "POST" && c.url.includes("/members"));
+            const deletes = calls.filter((c) => c.method === "DELETE");
+            expect(posts).toHaveLength(2);
+            expect(deletes).toHaveLength(1);
+            expect(deletes[0].url).toContain(encodeURIComponent(`stale-${TAG}@example.org`));
+        });
+
+        it("returns 400 when the program has no group configured", async () => {
+            await prisma.program.update({ where: { id: programId }, data: { googleGroupEmail: null } });
+            const res = await SYNC(syncReq(), params(programId));
+            expect(res.status).toBe(400);
+            await prisma.program.update({ where: { id: programId }, data: { googleGroupEmail: GROUP } });
+        });
+    });
+});

--- a/checkin-app/src/app/api/cron/program-google-group-reconcile/route.ts
+++ b/checkin-app/src/app/api/cron/program-google-group-reconcile/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { withCron } from "@/lib/cronAuth";
+import prisma from "@/lib/prisma";
+import { config } from "@/lib/config";
+import { logger, logIntegrationError } from "@/lib/logger";
+import { reconcileProgramGroup } from "@/lib/program/groupSync";
+
+/**
+ * GET /api/cron/program-google-group-reconcile — the nightly self-heal for
+ * program → Google Group membership. For every program with a group configured,
+ * diffs the group's members against its current ACTIVE participants (add missing,
+ * remove MEMBER-role extras — see reconcileProgramGroup). This is the backstop
+ * for anything the best-effort event pushes dropped during a Google outage.
+ *
+ * One failing program is isolated (log + Link Status) so the rest still reconcile.
+ * No-ops cleanly when the integration is unconfigured. Authorized by
+ * `Authorization: Bearer $CRON_SECRET` (lib/cronAuth.ts).
+ *
+ * SCHEDULE IS AN INFRA FOLLOW-UP: this route exists but nothing invokes it until
+ * a scheduler entry is added in the infra repo (mirror the other crons' wiring).
+ * See docs/designs/PROGRAM_GOOGLE_GROUP_SYNC.md.
+ */
+export const GET = withCron(async () => {
+    if (!config.googleGroupsConfigured()) {
+        return NextResponse.json({ success: true, configured: false, programs: 0, added: 0, removed: 0, failed: 0 });
+    }
+
+    const programs = await prisma.program.findMany({
+        where: { googleGroupEmail: { not: null } },
+        select: { id: true, googleGroupEmail: true },
+    });
+
+    let added = 0;
+    let removed = 0;
+    let failed = 0;
+
+    for (const program of programs) {
+        try {
+            const result = await reconcileProgramGroup(program);
+            if ("added" in result) {
+                added += result.added;
+                removed += result.removed;
+            }
+        } catch (err) {
+            failed++;
+            logger.error(`[CRON] Google Group reconcile failed for program ${program.id} (${program.googleGroupEmail}):`, err);
+            await logIntegrationError("google-groups", err, { operation: "reconcile", programId: program.id });
+        }
+    }
+
+    return NextResponse.json({ success: true, configured: true, programs: programs.length, added, removed, failed });
+});

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -6,6 +6,7 @@ import { handler } from "@/security/handler";
 import { apiError } from "@/lib/api-response";
 import { isActiveOrgMember, ACTIVE_ORG_MEMBER_INCLUDE } from "@/lib/orgMembership";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
+import { pushGroupAddOnActivation } from "@/lib/program/groupSync";
 
 export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
     const [requests, boardSettings] = await Promise.all([
@@ -109,6 +110,12 @@ export const POST = withAuth(
             // stops billing them for it. This supersedes the earlier approve-time
             // decrement (see PR history — that double-counted against the
             // apply-time decrement added alongside it).
+
+            // Approval flips the participant PENDING→ACTIVE — best-effort Google
+            // Group add (never throws / fails the approval; reconcile heals).
+            const program = await prisma.program.findUnique({ where: { id: programId }, select: { id: true, googleGroupEmail: true } });
+            if (program) await pushGroupAddOnActivation(program, participantId);
+
             return NextResponse.json({ success: true });
         } catch (error) {
             logger.error("Failed to approve payment plan:", error);

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
 import { lockProgramAndCheckCapacity, ProgramCapacityError, withdrawAndReleaseHold } from "@/lib/program/capacity";
+import { pushGroupAddOnActivation } from "@/lib/program/groupSync";
 import { checkProgramAge } from "@/lib/programAge";
 import { apiError } from "@/lib/api-response";
 
@@ -145,6 +146,13 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
 
         // Trigger notification
         await sendNotification(participantId, 'PROGRAM_ENROLLMENT', { programName: currentProgram.name });
+
+        // A free program / board-comp override enrolls straight to ACTIVE (the
+        // paid path activates later, in the orders/paid webhook). Sync the group
+        // for the ACTIVE case here; best-effort, never fails the enrollment.
+        if (initialStatus === 'ACTIVE') {
+            await pushGroupAddOnActivation(currentProgram, participantId);
+        }
 
         return NextResponse.json({ success: true, enrollment });
     } catch (error) {

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -9,6 +9,7 @@ import { adjustProgramInventory } from "@/lib/shopify";
 import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
 import { validateProgramAgeBounds } from "@/lib/programAge";
+import { isValidEmail } from "@/lib/emergencyContacts/identity";
 
 export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ auth, params }) => {
     const programId = parseInt(params.id, 10);
@@ -120,7 +121,13 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
 
         const body = await req.json();
         let { leadMentorId } = body;
-        const { name, startAt, endAt, orgMemberOnly, phase, enrollmentStatus, minAge, maxAge, maxParticipants, leadMentorNotificationSettings, memberPrice, nonMemberPrice, shopifyProductId, shopifyVariantId, shopifyOrgMemberVariantId, shopifyNonOrgMemberVariantId } = body;
+        const { name, startAt, endAt, orgMemberOnly, phase, enrollmentStatus, minAge, maxAge, maxParticipants, leadMentorNotificationSettings, memberPrice, nonMemberPrice, shopifyProductId, shopifyVariantId, shopifyOrgMemberVariantId, shopifyNonOrgMemberVariantId, googleGroupEmail } = body;
+
+        // Google Group address is board-set config (sysadmin/board only, like the
+        // Shopify ids below); validate as an email when non-empty, empty string clears it.
+        if (isSysAdminOrBoard && googleGroupEmail !== undefined && googleGroupEmail !== null && googleGroupEmail !== "" && !isValidEmail(googleGroupEmail)) {
+            return apiError("googleGroupEmail must be a valid email address", 400);
+        }
 
         if (body.hasOwnProperty('leadMentorId')) {
             if (!leadMentorId) {
@@ -159,6 +166,8 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
             ...(isSysAdminOrBoard && shopifyVariantId !== undefined && { shopifyVariantId: shopifyVariantId || null }),
             ...(isSysAdminOrBoard && shopifyOrgMemberVariantId !== undefined && { shopifyOrgMemberVariantId: shopifyOrgMemberVariantId || null }),
             ...(isSysAdminOrBoard && shopifyNonOrgMemberVariantId !== undefined && { shopifyNonOrgMemberVariantId: shopifyNonOrgMemberVariantId || null }),
+            // Empty string clears the group (sync becomes a no-op for the program).
+            ...(isSysAdminOrBoard && googleGroupEmail !== undefined && { googleGroupEmail: googleGroupEmail ? googleGroupEmail.trim().toLowerCase() : null }),
         };
 
         const updatedProgram = await prisma.program.update({

--- a/checkin-app/src/app/api/programs/[id]/sync-google-group/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/sync-google-group/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { config } from "@/lib/config";
+import { logIntegrationError } from "@/lib/logger";
+import { apiError } from "@/lib/api-response";
+import { reconcileProgramGroup } from "@/lib/program/groupSync";
+
+/**
+ * POST /api/programs/[id]/sync-google-group — the board-only "Sync now" button on
+ * program-ops. Runs the same full diff as the nightly reconcile for ONE program,
+ * on demand. Unlike the best-effort event pushes, this surfaces a Google failure
+ * to the caller (502, also logged to Link Status) so a manual sync gives feedback.
+ */
+export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (_req, auth, ctx: { params: Promise<{ id: string }> }) => {
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
+    const { id } = await ctx.params;
+    const programId = parseInt(id, 10);
+    if (isNaN(programId)) return apiError("Invalid program ID", 400);
+
+    const program = await prisma.program.findUnique({ where: { id: programId }, select: { id: true, googleGroupEmail: true } });
+    if (!program) return apiError("Program not found", 404);
+    if (!program.googleGroupEmail) return apiError("This program has no Google Group configured.", 400);
+    if (!config.googleGroupsConfigured()) return apiError("Google Directory integration is not configured on this server.", 503);
+
+    try {
+        const result = await reconcileProgramGroup(program);
+        return NextResponse.json({ success: true, ...result });
+    } catch (error) {
+        await logIntegrationError("google-groups", error, { operation: "manual-sync", programId });
+        return apiError("Google Group sync failed. Check System Status > Link Status.", 502);
+    }
+});

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -6,6 +6,7 @@ import { activateByProcessId } from "@/lib/membership/payment";
 import { withWebhook } from "@/lib/webhookAuth";
 import { config, DEV_MOCK_MEMBERSHIP_VARIANT_ID } from "@/lib/config";
 import { adjustProgramInventory } from "@/lib/shopify";
+import { pushGroupAddOnActivation } from "@/lib/program/groupSync";
 
 interface ShopifyOrder {
     id?: number | string;
@@ -195,6 +196,9 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
 
                         if (activated.count > 0) {
                             logger.info(`[SHOPIFY WEBHOOK] Marked participant ${participantId} as ACTIVE for program ${programId}`);
+                            // Best-effort Google Group add on activation. Never throws —
+                            // must not fail (and thus force Shopify to retry) the webhook.
+                            if (program) await pushGroupAddOnActivation(program, participantId);
                         }
 
                         // Hold-ledger (product decision 2026-07-06): NORMAL PAYMENT is

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -45,6 +45,7 @@ export type ProgramDetail = {
   shopifyProductId: string | null;
   shopifyOrgMemberVariantId: string | null;
   shopifyNonOrgMemberVariantId: string | null;
+  googleGroupEmail: string | null;
 };
 
 export type ParticipantOption = { id: number; name: string | null; email: string; dateOfBirth?: string | null };
@@ -82,6 +83,10 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
   const [orgVariantInput, setOrgVariantInput] = useState("");
   const [nonOrgVariantInput, setNonOrgVariantInput] = useState("");
 
+  // Google Group address, board-set (sysadmin/board only).
+  const [googleGroupInput, setGoogleGroupInput] = useState("");
+  const [syncingGroup, setSyncingGroup] = useState(false);
+
   // EntityPicker owns the transient query/results/loading; we keep only the selected id + its display label.
   const [mentorSearch, setMentorSearch] = useState("");
   const [isEditingMentor, setIsEditingMentor] = useState(false);
@@ -114,6 +119,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
         setShopifyProductIdInput(data.shopifyProductId ?? "");
         setOrgVariantInput(data.shopifyOrgMemberVariantId ?? "");
         setNonOrgVariantInput(data.shopifyNonOrgMemberVariantId ?? "");
+        setGoogleGroupInput(data.googleGroupEmail ?? "");
         setIsEditingMentor(false);
       } else if (res.status === 404) {
         setMessage("Program not found.");
@@ -217,6 +223,45 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
       notifications.show({ color: "red", message: "Network error.", autoClose: false });
     } finally {
       setSyncing(false);
+    }
+  };
+
+  const handleSaveGoogleGroup = async () => {
+    setSyncingGroup(true);
+    try {
+      const res = await fetch(`/api/programs/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ googleGroupEmail: googleGroupInput.trim() || null }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        notifications.show({ color: "green", message: "Google Group saved." });
+        fetchProgram();
+      } else {
+        notifications.show({ color: "red", message: data.error || "Failed to save.", autoClose: false });
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
+    } finally {
+      setSyncingGroup(false);
+    }
+  };
+
+  const handleSyncGoogleGroup = async () => {
+    setSyncingGroup(true);
+    try {
+      const res = await fetch(`/api/programs/${id}/sync-google-group`, { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        notifications.show({ color: "green", message: `Group synced (added ${data.added ?? 0}, removed ${data.removed ?? 0}).` });
+      } else {
+        notifications.show({ color: "red", message: data.error || "Failed to sync group.", autoClose: false });
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
+    } finally {
+      setSyncingGroup(false);
     }
   };
 
@@ -341,6 +386,31 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                     <Group mt="sm">
                       <Button type="button" variant="light" size="xs" loading={syncing} onClick={handleSaveShopifyIds}>
                         Save Shopify IDs
+                      </Button>
+                    </Group>
+                  </Card>
+                )}
+
+                {isSysAdminOrBoard && (
+                  <Card withBorder radius="md" padding="md">
+                    <Text fw={500} mb={4}>Google Group Mailing List</Text>
+                    <Text size="xs" c="dimmed" mb="sm">
+                      Admin/Board only. Active participants (and their household leads) are synced into this Google Group.
+                      Leave blank for none. Requires the Google service account to be configured on the server — see System Status.
+                    </Text>
+                    <TextInput
+                      label="Group Email"
+                      type="email"
+                      value={googleGroupInput}
+                      onChange={e => setGoogleGroupInput(e.currentTarget.value)}
+                      placeholder="e.g. robotics-2026@innovationtreehouse.org"
+                    />
+                    <Group mt="sm">
+                      <Button type="button" variant="light" size="xs" loading={syncingGroup} onClick={handleSaveGoogleGroup}>
+                        Save Group
+                      </Button>
+                      <Button type="button" variant="default" size="xs" loading={syncingGroup} disabled={!program.googleGroupEmail} onClick={handleSyncGoogleGroup}>
+                        Sync now
                       </Button>
                     </Group>
                   </Card>

--- a/checkin-app/src/lib/__tests__/configHealth.test.ts
+++ b/checkin-app/src/lib/__tests__/configHealth.test.ts
@@ -5,7 +5,7 @@ import { getConfigHealth, openConfigIssues, type ConfigCheck } from "@/lib/confi
 // mock's NODE_ENV !== "production" fuse is always satisfied; CHECKIN_ENV drives prod.
 
 const ZOHO_KEYS = ["ZOHO_CLIENT_ID", "ZOHO_CLIENT_SECRET", "ZOHO_REFRESH_TOKEN"];
-const ALL_KEYS = [...ZOHO_KEYS, "ZOHO_WEBHOOK_SECRET", "AGREEMENT_PDF_S3_BUCKET", "RESEND_API_KEY", "CHECKIN_ENV"];
+const ALL_KEYS = [...ZOHO_KEYS, "ZOHO_WEBHOOK_SECRET", "AGREEMENT_PDF_S3_BUCKET", "RESEND_API_KEY", "GOOGLE_SA_KEY_JSON", "GOOGLE_SA_SUBJECT", "CHECKIN_ENV"];
 
 const saved: Record<string, string | undefined> = {};
 beforeEach(() => {
@@ -36,7 +36,9 @@ describe("getConfigHealth — prod, nothing configured", () => {
         expect(c["zoho-webhook-secret"].detail).toContain("ZOHO_WEBHOOK_SECRET");
         expect(c["resend-email"].ok).toBe(false);
         expect(c["resend-email"].detail).toContain("RESEND_API_KEY");
-        expect(openConfigIssues(checks)).toBe(4);
+        expect(c["google-groups"].ok).toBe(false);
+        expect(c["google-groups"].detail).toContain("GOOGLE_SA_KEY_JSON");
+        expect(openConfigIssues(checks)).toBe(5);
     });
 });
 
@@ -49,6 +51,8 @@ describe("getConfigHealth — prod, all configured", () => {
         process.env.ZOHO_WEBHOOK_SECRET = "whsecret";
         process.env.AGREEMENT_PDF_S3_BUCKET = "bucket";
         process.env.RESEND_API_KEY = "re_key";
+        process.env.GOOGLE_SA_KEY_JSON = "{}";
+        process.env.GOOGLE_SA_SUBJECT = "admin@innovationtreehouse.org";
         expect(openConfigIssues(getConfigHealth())).toBe(0);
     });
 });

--- a/checkin-app/src/lib/__tests__/googleGroups.test.ts
+++ b/checkin-app/src/lib/__tests__/googleGroups.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for the Google Directory client (lib/googleGroups.ts). Mirrors
+ * shopify.test.ts: mock global.fetch, drive env vars live (config reads them per
+ * call). A real RSA keypair is generated so the JWT-bearer assertion actually
+ * signs; we then assert its SHAPE loosely (3 segments, RS256 header, jwt-bearer
+ * grant) rather than verifying the signature against Google.
+ */
+import crypto from "crypto";
+import {
+    listGroupMembers,
+    addGroupMember,
+    removeGroupMember,
+    resetTokenCache,
+    GoogleGroupsError,
+} from "../googleGroups";
+
+const { privateKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+const SA_JSON = JSON.stringify({ client_email: "sa@proj.iam.gserviceaccount.com", private_key: privateKey });
+const GROUP = "robotics-2026@example.org";
+
+let fetchMock: jest.Mock;
+let originalEnv: NodeJS.ProcessEnv;
+
+/** First call in every write/list is the token exchange — stub it. */
+function mockTokenResponse() {
+    fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "ya29.test-token", expires_in: 3599 }),
+    });
+}
+
+beforeEach(() => {
+    originalEnv = { ...process.env };
+    process.env.GOOGLE_SA_KEY_JSON = SA_JSON;
+    process.env.GOOGLE_SA_SUBJECT = "admin@example.org";
+    fetchMock = jest.fn();
+    global.fetch = fetchMock;
+    jest.clearAllMocks();
+    resetTokenCache();
+});
+
+afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+});
+
+function decodeSegment(seg: string): Record<string, unknown> {
+    return JSON.parse(Buffer.from(seg, "base64url").toString());
+}
+
+describe("JWT-bearer token exchange", () => {
+    it("posts a well-formed RS256 assertion to the Google token endpoint", async () => {
+        mockTokenResponse();
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ members: [] }) }); // list
+
+        await listGroupMembers(GROUP);
+
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(String(url)).toBe("https://oauth2.googleapis.com/token");
+        const params = new URLSearchParams((init as RequestInit).body as string);
+        expect(params.get("grant_type")).toBe("urn:ietf:params:oauth:grant-type:jwt-bearer");
+
+        const assertion = params.get("assertion")!;
+        const segments = assertion.split(".");
+        expect(segments).toHaveLength(3);
+        expect(decodeSegment(segments[0])).toEqual({ alg: "RS256", typ: "JWT" });
+        const claims = decodeSegment(segments[1]);
+        expect(claims.iss).toBe("sa@proj.iam.gserviceaccount.com");
+        expect(claims.sub).toBe("admin@example.org"); // impersonated admin (DWD)
+        expect(claims.scope).toContain("admin.directory.group.member");
+        expect(claims.aud).toBe("https://oauth2.googleapis.com/token");
+    });
+
+    it("caches the token across calls (one exchange for two operations)", async () => {
+        mockTokenResponse();
+        fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) }); // add
+        fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) }); // add again
+
+        await addGroupMember(GROUP, "a@example.org");
+        await addGroupMember(GROUP, "b@example.org");
+
+        const tokenCalls = fetchMock.mock.calls.filter(([u]) => String(u).includes("/token"));
+        expect(tokenCalls).toHaveLength(1);
+    });
+
+    it("throws GoogleGroupsError when the token exchange fails", async () => {
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 401, text: async () => "invalid_grant" });
+        await expect(addGroupMember(GROUP, "a@example.org")).rejects.toBeInstanceOf(GoogleGroupsError);
+    });
+});
+
+describe("unconfigured (integration OFF)", () => {
+    it("throws a clear error when creds are absent (no network)", async () => {
+        delete process.env.GOOGLE_SA_KEY_JSON;
+        delete process.env.GOOGLE_SA_SUBJECT;
+        await expect(addGroupMember(GROUP, "a@example.org")).rejects.toThrow(/not configured/i);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe("addGroupMember", () => {
+    it("POSTs the member with role MEMBER", async () => {
+        mockTokenResponse();
+        fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) });
+
+        await addGroupMember(GROUP, "kid@example.org");
+
+        const [url, init] = fetchMock.mock.calls[1];
+        expect(String(url)).toContain(`/groups/${encodeURIComponent(GROUP)}/members`);
+        expect((init as RequestInit).method).toBe("POST");
+        expect(JSON.parse((init as RequestInit).body as string)).toEqual({ email: "kid@example.org", role: "MEMBER" });
+    });
+
+    it("treats 409 (already a member) as success — idempotent", async () => {
+        mockTokenResponse();
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 409, text: async () => "Member already exists." });
+        await expect(addGroupMember(GROUP, "dup@example.org")).resolves.toBeUndefined();
+    });
+
+    it("throws on a real failure (e.g. 403)", async () => {
+        mockTokenResponse();
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 403, text: async () => "forbidden" });
+        await expect(addGroupMember(GROUP, "x@example.org")).rejects.toBeInstanceOf(GoogleGroupsError);
+    });
+});
+
+describe("removeGroupMember", () => {
+    it("DELETEs the member", async () => {
+        mockTokenResponse();
+        fetchMock.mockResolvedValueOnce({ ok: true, status: 204, text: async () => "" });
+
+        await removeGroupMember(GROUP, "gone@example.org");
+
+        const [url, init] = fetchMock.mock.calls[1];
+        expect(String(url)).toContain(`/members/${encodeURIComponent("gone@example.org")}`);
+        expect((init as RequestInit).method).toBe("DELETE");
+    });
+
+    it("treats 404 (not a member) as success — idempotent", async () => {
+        mockTokenResponse();
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 404, text: async () => "Resource Not Found" });
+        await expect(removeGroupMember(GROUP, "missing@example.org")).resolves.toBeUndefined();
+    });
+
+    it("throws on a real failure (e.g. 500)", async () => {
+        mockTokenResponse();
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => "boom" });
+        await expect(removeGroupMember(GROUP, "x@example.org")).rejects.toBeInstanceOf(GoogleGroupsError);
+    });
+});
+
+describe("listGroupMembers", () => {
+    it("paginates and returns lowercased email + role", async () => {
+        mockTokenResponse();
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                members: [{ email: "Owner@Example.org", role: "OWNER" }, { email: "A@Example.org", role: "MEMBER" }],
+                nextPageToken: "page2",
+            }),
+        });
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ members: [{ email: "B@Example.org", role: "MEMBER" }] }),
+        });
+
+        const members = await listGroupMembers(GROUP);
+
+        expect(members).toEqual([
+            { email: "owner@example.org", role: "OWNER" },
+            { email: "a@example.org", role: "MEMBER" },
+            { email: "b@example.org", role: "MEMBER" },
+        ]);
+        // token + 2 pages
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(String(fetchMock.mock.calls[2][0])).toContain("pageToken=page2");
+    });
+
+    it("throws GoogleGroupsError when the list call fails", async () => {
+        mockTokenResponse();
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 404, text: async () => "no such group" });
+        await expect(listGroupMembers(GROUP)).rejects.toBeInstanceOf(GoogleGroupsError);
+    });
+});

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -204,6 +204,17 @@ export const config = {
     // /dev/bg-consent + its complete route. Always false in prod. See bgMockActiveEnv.
     bgMockActive: (): boolean => bgMockActiveEnv(),
 
+    // Google Workspace service account for Directory group-member sync (see
+    // lib/googleGroups.ts). GOOGLE_SA_KEY_JSON is the FULL service-account key JSON;
+    // GOOGLE_SA_SUBJECT is the admin user the SA impersonates via domain-wide
+    // delegation. Both null when unset — integration cleanly OFF. There is no
+    // dev/local mock (unlike Shopify/Zoho): unconfigured just log-and-skips. Wiring
+    // real creds is an infra follow-up. See docs/designs/PROGRAM_GOOGLE_GROUP_SYNC.md.
+    googleSaKeyJson: (): string | null => process.env.GOOGLE_SA_KEY_JSON || null,
+    googleSaSubject: (): string | null => process.env.GOOGLE_SA_SUBJECT || null,
+    // True only when BOTH are present — real Directory access wired.
+    googleGroupsConfigured: (): boolean => !!(process.env.GOOGLE_SA_KEY_JSON && process.env.GOOGLE_SA_SUBJECT),
+
     // App
     checkinEnv: (): CheckinEnv => readCheckinEnv(),
     // Production (default when unset). Consumers should call this rather than

--- a/checkin-app/src/lib/configHealth.ts
+++ b/checkin-app/src/lib/configHealth.ts
@@ -62,6 +62,19 @@ export function getConfigHealth(): ConfigCheck[] {
                   ? "NOT configured — set RESEND_API_KEY (outbound email disabled)."
                   : "Not set (fine outside prod; outbound email disabled).",
         },
+        {
+            id: "google-groups",
+            label: "Google Groups sync",
+            // No mock/fallback (unlike Zoho/Shopify) — the integration is simply OFF
+            // when unset. Same shape as resend-email: a real gap only in prod (a dev
+            // box legitimately runs without it). Provisioning is an infra follow-up.
+            ok: !config.isProd() || config.googleGroupsConfigured(),
+            detail: config.googleGroupsConfigured()
+                ? "Service account configured."
+                : config.isProd()
+                  ? "NOT configured — set GOOGLE_SA_KEY_JSON / GOOGLE_SA_SUBJECT (program → Google Group sync disabled; infra follow-up)."
+                  : "Not set (fine outside prod; program → Google Group sync disabled).",
+        },
     ];
 }
 

--- a/checkin-app/src/lib/googleGroups.ts
+++ b/checkin-app/src/lib/googleGroups.ts
@@ -1,0 +1,203 @@
+// Google Admin SDK Directory API client for program → Google Group membership
+// sync. Auth is a service account with domain-wide delegation: we mint an OAuth2
+// access token from a self-signed JWT-bearer assertion (no googleapis dependency
+// — it's plain REST + a crypto-signed JWT). Structure mirrors lib/shopify.ts:
+// a googleFetch() timeout seam so tests mock global.fetch, a cached token, typed
+// errors, and idempotent writes. See docs/designs/PROGRAM_GOOGLE_GROUP_SYNC.md.
+
+import crypto from "crypto";
+import { config } from "@/lib/config";
+
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const DIRECTORY_BASE = "https://admin.googleapis.com/admin/directory/v1";
+const SCOPE = "https://www.googleapis.com/auth/admin.directory.group.member";
+
+/** Hard per-request deadline for every Google call — same rationale as
+ * SHOPIFY_FETCH_TIMEOUT_MS: a hung TCP connection must surface as an error, not
+ * pin a request worker until the platform timeout. */
+const GOOGLE_FETCH_TIMEOUT_MS = 15_000;
+
+/** Typed failure for every Google Directory error, carrying the HTTP status when
+ * there was one, so callers (best-effort push vs. loud manual sync) can branch. */
+export class GoogleGroupsError extends Error {
+    constructor(message: string, public readonly status?: number) {
+        super(message);
+        this.name = "GoogleGroupsError";
+    }
+}
+
+export interface GroupMember {
+    email: string;
+    /** OWNER | MANAGER | MEMBER — reconcile only removes MEMBER-role addresses. */
+    role: string;
+}
+
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0;
+
+/** @internal - exported only for test isolation (mirrors shopify.resetTokenCache). */
+export function resetTokenCache() {
+    cachedToken = null;
+    tokenExpiresAt = 0;
+}
+
+interface ServiceAccountKey {
+    client_email: string;
+    private_key: string;
+}
+
+/** Parse GOOGLE_SA_KEY_JSON → {client_email, private_key}, or null when unset /
+ * malformed / missing a required field (treated as "unconfigured", not an error). */
+function loadServiceAccount(): ServiceAccountKey | null {
+    const raw = config.googleSaKeyJson();
+    if (!raw) return null;
+    try {
+        const parsed = JSON.parse(raw);
+        if (typeof parsed?.client_email === "string" && typeof parsed?.private_key === "string") {
+            return { client_email: parsed.client_email, private_key: parsed.private_key };
+        }
+    } catch {
+        // fall through
+    }
+    console.error("[GOOGLE-GROUPS] GOOGLE_SA_KEY_JSON is set but not valid service-account JSON.");
+    return null;
+}
+
+function base64url(input: string | Buffer): string {
+    return Buffer.from(input).toString("base64url");
+}
+
+/** Build + RS256-sign the JWT-bearer assertion Google exchanges for an access
+ * token. `sub` is the admin the service account impersonates (domain-wide
+ * delegation). */
+function signJwtAssertion(sa: ServiceAccountKey, subject: string): string {
+    const now = Math.floor(Date.now() / 1000);
+    const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+    const claims = base64url(
+        JSON.stringify({
+            iss: sa.client_email,
+            sub: subject,
+            scope: SCOPE,
+            aud: GOOGLE_TOKEN_URL,
+            iat: now,
+            exp: now + 3600,
+        }),
+    );
+    const signingInput = `${header}.${claims}`;
+    const signature = crypto.createSign("RSA-SHA256").update(signingInput).sign(sa.private_key);
+    return `${signingInput}.${base64url(signature)}`;
+}
+
+/** fetch with a hard timeout that surfaces as a GoogleGroupsError instead of hanging. */
+export async function googleFetch(input: string, init: RequestInit, label: string): Promise<Response> {
+    try {
+        return await fetch(input, { ...init, signal: AbortSignal.timeout(GOOGLE_FETCH_TIMEOUT_MS) });
+    } catch (err) {
+        if (err instanceof DOMException && (err.name === "TimeoutError" || err.name === "AbortError")) {
+            throw new GoogleGroupsError(`${label} timed out after ${GOOGLE_FETCH_TIMEOUT_MS}ms`);
+        }
+        throw err;
+    }
+}
+
+/** Mint (and cache, refreshing ~5 min early) an access token from the JWT-bearer
+ * assertion. Returns null when the integration is unconfigured; throws
+ * GoogleGroupsError on a real token-exchange failure. */
+async function getAccessToken(): Promise<string | null> {
+    const sa = loadServiceAccount();
+    const subject = config.googleSaSubject();
+    if (!sa || !subject) return null;
+
+    if (cachedToken && Date.now() < tokenExpiresAt - 5 * 60 * 1000) {
+        return cachedToken;
+    }
+
+    const assertion = signJwtAssertion(sa, subject);
+    const res = await googleFetch(
+        GOOGLE_TOKEN_URL,
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({
+                grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                assertion,
+            }).toString(),
+        },
+        "Google token exchange",
+    );
+
+    if (!res.ok) {
+        cachedToken = null;
+        throw new GoogleGroupsError(`Google token exchange failed: ${res.status} ${await res.text()}`, res.status);
+    }
+
+    const data = await res.json();
+    cachedToken = data.access_token;
+    // expires_in is seconds (Google returns 3599); default defensively.
+    tokenExpiresAt = Date.now() + (Number(data.expires_in) || 3600) * 1000;
+    return cachedToken;
+}
+
+/** Require a token or fail with a clear typed error (the service layer gates on
+ * config.googleGroupsConfigured() before calling, so null here is unexpected). */
+async function requireToken(): Promise<string> {
+    const token = await getAccessToken();
+    if (!token) throw new GoogleGroupsError("Google Directory integration is not configured");
+    return token;
+}
+
+/** All members of a group (paginated), lowercased, with their Directory role. */
+export async function listGroupMembers(groupEmail: string): Promise<GroupMember[]> {
+    const token = await requireToken();
+    const members: GroupMember[] = [];
+    let pageToken: string | undefined;
+
+    do {
+        const url =
+            `${DIRECTORY_BASE}/groups/${encodeURIComponent(groupEmail)}/members?maxResults=200` +
+            (pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : "");
+        const res = await googleFetch(url, { headers: { Authorization: `Bearer ${token}` } }, "Google list members");
+        if (!res.ok) {
+            throw new GoogleGroupsError(`Google list members failed for ${groupEmail}: ${res.status} ${await res.text()}`, res.status);
+        }
+        const data = await res.json();
+        for (const m of data.members ?? []) {
+            if (m?.email) members.push({ email: String(m.email).toLowerCase(), role: String(m.role ?? "MEMBER") });
+        }
+        pageToken = data.nextPageToken;
+    } while (pageToken);
+
+    return members;
+}
+
+/** Add one address to the group. Idempotent: a 409 (already a member) is success. */
+export async function addGroupMember(groupEmail: string, email: string): Promise<void> {
+    const token = await requireToken();
+    const res = await googleFetch(
+        `${DIRECTORY_BASE}/groups/${encodeURIComponent(groupEmail)}/members`,
+        {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+            body: JSON.stringify({ email, role: "MEMBER" }),
+        },
+        "Google add member",
+    );
+    if (res.status === 409) return; // already a member — idempotent
+    if (!res.ok) {
+        throw new GoogleGroupsError(`Google add member failed (${email} → ${groupEmail}): ${res.status} ${await res.text()}`, res.status);
+    }
+}
+
+/** Remove one address from the group. Idempotent: a 404 (not a member) is success. */
+export async function removeGroupMember(groupEmail: string, email: string): Promise<void> {
+    const token = await requireToken();
+    const res = await googleFetch(
+        `${DIRECTORY_BASE}/groups/${encodeURIComponent(groupEmail)}/members/${encodeURIComponent(email)}`,
+        { method: "DELETE", headers: { Authorization: `Bearer ${token}` } },
+        "Google remove member",
+    );
+    if (res.status === 404) return; // not a member — idempotent
+    if (!res.ok) {
+        throw new GoogleGroupsError(`Google remove member failed (${email} → ${groupEmail}): ${res.status} ${await res.text()}`, res.status);
+    }
+}

--- a/checkin-app/src/lib/program/__tests__/groupSync.test.ts
+++ b/checkin-app/src/lib/program/__tests__/groupSync.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the shared program → Google Group sync service
+ * (lib/program/groupSync.ts). Prisma, the Google client, and logIntegrationError
+ * are mocked, so this pins the RECIPIENT RULE (self + household leads), the
+ * removal safety net (shared lead stays), the reconcile diff (add missing /
+ * remove MEMBER-only), and the BEST-EFFORT contract (a Google failure on the push
+ * paths never throws — it must not fail the enrollment/withdrawal that triggered it).
+ */
+import {
+    resolveGroupEmails,
+    pushGroupAddOnActivation,
+    pushGroupRemoveOnWithdrawal,
+    reconcileProgramGroup,
+} from "../groupSync";
+
+jest.mock("@/lib/prisma", () => ({
+    __esModule: true,
+    default: {
+        person: { findUnique: jest.fn() },
+        programParticipant: { findMany: jest.fn() },
+    },
+}));
+
+jest.mock("@/lib/googleGroups", () => ({
+    addGroupMember: jest.fn().mockResolvedValue(undefined),
+    removeGroupMember: jest.fn().mockResolvedValue(undefined),
+    listGroupMembers: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("@/lib/logger", () => ({
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    logIntegrationError: jest.fn().mockResolvedValue(undefined),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const prisma = require("@/lib/prisma").default;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { addGroupMember, removeGroupMember, listGroupMembers } = require("@/lib/googleGroups");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { logIntegrationError } = require("@/lib/logger");
+
+const GROUP = "prog@example.org";
+const program = { id: 7, googleGroupEmail: GROUP };
+
+/** person.findUnique row shape: self email + household-lead emails. */
+function person(email: string | null, leadEmails: string[]) {
+    return { email, household: { householdMembers: leadEmails.map((e) => ({ email: e })) } };
+}
+
+let originalEnv: NodeJS.ProcessEnv;
+beforeEach(() => {
+    originalEnv = { ...process.env };
+    process.env.GOOGLE_SA_KEY_JSON = "{}";
+    process.env.GOOGLE_SA_SUBJECT = "admin@example.org";
+    jest.clearAllMocks();
+});
+afterEach(() => {
+    process.env = originalEnv;
+});
+
+describe("resolveGroupEmails — recipient rule (self + household leads)", () => {
+    it("returns self + lead emails, deduped and lowercased", async () => {
+        prisma.person.findUnique.mockResolvedValue(person("Kid@Example.org", ["Lead@Example.org", "kid@example.org"]));
+        const emails = await resolveGroupEmails(1);
+        expect(emails.sort()).toEqual(["kid@example.org", "lead@example.org"]);
+    });
+
+    it("a dependent with no email is represented by the household lead(s)", async () => {
+        prisma.person.findUnique.mockResolvedValue(person(null, ["lead@example.org"]));
+        expect(await resolveGroupEmails(1)).toEqual(["lead@example.org"]);
+    });
+
+    it("empty when the person is gone", async () => {
+        prisma.person.findUnique.mockResolvedValue(null);
+        expect(await resolveGroupEmails(1)).toEqual([]);
+    });
+});
+
+describe("pushGroupAddOnActivation", () => {
+    it("adds each resolved email to the group", async () => {
+        prisma.person.findUnique.mockResolvedValue(person("kid@example.org", ["lead@example.org"]));
+        await pushGroupAddOnActivation(program, 1);
+        expect(addGroupMember).toHaveBeenCalledTimes(2);
+        expect(addGroupMember).toHaveBeenCalledWith(GROUP, "kid@example.org");
+        expect(addGroupMember).toHaveBeenCalledWith(GROUP, "lead@example.org");
+    });
+
+    it("no-ops when the program has no group", async () => {
+        await pushGroupAddOnActivation({ id: 7, googleGroupEmail: null }, 1);
+        expect(prisma.person.findUnique).not.toHaveBeenCalled();
+        expect(addGroupMember).not.toHaveBeenCalled();
+    });
+
+    it("no-ops when the integration is unconfigured", async () => {
+        delete process.env.GOOGLE_SA_KEY_JSON;
+        await pushGroupAddOnActivation(program, 1);
+        expect(addGroupMember).not.toHaveBeenCalled();
+    });
+
+    it("BEST-EFFORT: never throws when Google fails — logs to Link Status instead", async () => {
+        prisma.person.findUnique.mockResolvedValue(person("kid@example.org", []));
+        addGroupMember.mockRejectedValueOnce(new Error("Google 500"));
+        await expect(pushGroupAddOnActivation(program, 1)).resolves.toBeUndefined();
+        expect(logIntegrationError).toHaveBeenCalledWith("google-groups", expect.any(Error), expect.objectContaining({ operation: "add", programId: 7, personId: 1 }));
+    });
+});
+
+describe("pushGroupRemoveOnWithdrawal", () => {
+    it("removes only the leaving person's emails NOT still needed by the remaining roster", async () => {
+        // Leaving kid contributed self + a shared household lead.
+        prisma.person.findUnique.mockResolvedValue(person("kid1@example.org", ["lead@example.org"]));
+        // Remaining ACTIVE roster still includes a sibling under the same lead.
+        prisma.programParticipant.findMany.mockResolvedValue([
+            { person: person("kid2@example.org", ["lead@example.org"]) },
+        ]);
+
+        await pushGroupRemoveOnWithdrawal(program, 1);
+
+        // kid1's own address goes; the shared lead stays (sibling still needs it).
+        expect(removeGroupMember).toHaveBeenCalledTimes(1);
+        expect(removeGroupMember).toHaveBeenCalledWith(GROUP, "kid1@example.org");
+    });
+
+    it("BEST-EFFORT: never throws when Google fails", async () => {
+        prisma.person.findUnique.mockResolvedValue(person("kid1@example.org", []));
+        prisma.programParticipant.findMany.mockResolvedValue([]);
+        removeGroupMember.mockRejectedValueOnce(new Error("Google 500"));
+        await expect(pushGroupRemoveOnWithdrawal(program, 1)).resolves.toBeUndefined();
+        expect(logIntegrationError).toHaveBeenCalledWith("google-groups", expect.any(Error), expect.objectContaining({ operation: "remove" }));
+    });
+});
+
+describe("reconcileProgramGroup — full diff", () => {
+    it("adds missing desired members and removes MEMBER-role extras, keeping OWNER/MANAGER", async () => {
+        prisma.programParticipant.findMany.mockResolvedValue([
+            { person: person("keep@example.org", []) },
+            { person: person("new@example.org", []) },
+        ]);
+        listGroupMembers.mockResolvedValue([
+            { email: "keep@example.org", role: "MEMBER" }, // desired + present → left alone
+            { email: "stale@example.org", role: "MEMBER" }, // not desired → removed
+            { email: "owner@example.org", role: "OWNER" }, // not desired but OWNER → kept
+        ]);
+
+        const result = await reconcileProgramGroup(program);
+
+        expect(result).toEqual({ added: 1, removed: 1 });
+        expect(addGroupMember).toHaveBeenCalledWith(GROUP, "new@example.org");
+        expect(removeGroupMember).toHaveBeenCalledWith(GROUP, "stale@example.org");
+        expect(removeGroupMember).not.toHaveBeenCalledWith(GROUP, "owner@example.org");
+    });
+
+    it("skips cleanly when unconfigured", async () => {
+        delete process.env.GOOGLE_SA_SUBJECT;
+        expect(await reconcileProgramGroup(program)).toEqual({ skipped: "integration not configured" });
+        expect(listGroupMembers).not.toHaveBeenCalled();
+    });
+});

--- a/checkin-app/src/lib/program/capacity.ts
+++ b/checkin-app/src/lib/program/capacity.ts
@@ -2,6 +2,7 @@ import type { TxClient } from "@/lib/db-client";
 import type { ProgramParticipant } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { adjustProgramInventory } from "@/lib/shopify";
+import { pushGroupRemoveOnWithdrawal } from "@/lib/program/groupSync";
 
 /** Thrown by {@link lockProgramAndCheckCapacity} when a program is full. */
 export class ProgramCapacityError extends Error {
@@ -65,11 +66,18 @@ export async function lockProgramAndCheckCapacity(
 export async function withdrawAndReleaseHold(
     programId: number,
     personId: number,
-    program: { shopifyVariantId?: string | null; shopifyOrgMemberVariantId: string | null; shopifyNonOrgMemberVariantId: string | null },
+    program: { id?: number; googleGroupEmail?: string | null; shopifyVariantId?: string | null; shopifyOrgMemberVariantId: string | null; shopifyNonOrgMemberVariantId: string | null },
 ): Promise<{ enrollment: ProgramParticipant; released: boolean; shopifyOk: boolean }> {
     const enrollment = await prisma.programParticipant.delete({
         where: { programId_personId: { programId, personId } },
     });
+
+    // Best-effort Google Group removal AFTER the row is gone (so the remaining
+    // roster is recomputed without this person). Never throws — a Google failure
+    // must not fail the withdrawal. Fires for every exit path this shared fn
+    // serves (self/admin removal + both withdrawal crons); PENDING kicks were
+    // never in the group, so it's a harmless no-op for them.
+    await pushGroupRemoveOnWithdrawal({ id: program.id ?? programId, googleGroupEmail: program.googleGroupEmail }, personId);
 
     if (!enrollment.inventoryHeldAt) {
         return { enrollment, released: false, shopifyOk: true };

--- a/checkin-app/src/lib/program/groupSync.ts
+++ b/checkin-app/src/lib/program/groupSync.ts
@@ -1,0 +1,163 @@
+// Shared service that keeps a program's Google Group membership in step with its
+// active participants. This is the ONE place that maps program/person → the set
+// of emails, so the event pushes and the nightly/manual reconcile all agree on
+// "who should be in the group". Recipient rule mirrors notifications exactly:
+// the participant's own email + every household lead (see resolveGroupEmails).
+// See docs/designs/PROGRAM_GOOGLE_GROUP_SYNC.md.
+
+import prisma from "@/lib/prisma";
+import { config } from "@/lib/config";
+import { logger, logIntegrationError } from "@/lib/logger";
+import { cleanEmail } from "@/lib/emergencyContacts/identity";
+import { addGroupMember, removeGroupMember, listGroupMembers } from "@/lib/googleGroups";
+
+/** Just the program fields the sync needs — any full Program row satisfies it. */
+export type ProgramGroupRef = { id: number; googleGroupEmail?: string | null };
+
+/** Prisma select that pulls a person's own email + their household leads' emails
+ * — the two inputs the recipient rule combines. */
+const PERSON_EMAIL_SELECT = {
+    email: true,
+    household: {
+        select: {
+            householdMembers: {
+                where: { isHouseholdLead: true },
+                select: { email: true },
+            },
+        },
+    },
+} as const;
+
+type PersonWithLeads = {
+    email: string | null;
+    household: { householdMembers: { email: string | null }[] } | null;
+};
+
+/** self + household-lead emails, deduped + lowercased (empty ones dropped). */
+function collectEmails(person: PersonWithLeads): string[] {
+    const set = new Set<string>();
+    const self = cleanEmail(person.email);
+    if (self) set.add(self);
+    for (const lead of person.household?.householdMembers ?? []) {
+        const e = cleanEmail(lead.email);
+        if (e) set.add(e);
+    }
+    return [...set];
+}
+
+/** The group emails one participant contributes (self + their household leads).
+ * Reads the Person, not the enrollment, so it works even after the participant
+ * row has been deleted (the withdrawal path deletes first). */
+export async function resolveGroupEmails(personId: number): Promise<string[]> {
+    const person = await prisma.person.findUnique({ where: { id: personId }, select: PERSON_EMAIL_SELECT });
+    return person ? collectEmails(person) : [];
+}
+
+/** The full desired membership for a program: every ACTIVE participant's
+ * contributed emails. This is the reconcile target and the removal safety net
+ * (a leaving person's shared household lead stays if another active kid needs it). */
+async function desiredProgramEmails(programId: number): Promise<Set<string>> {
+    const participants = await prisma.programParticipant.findMany({
+        where: { programId, status: "ACTIVE" },
+        select: { person: { select: PERSON_EMAIL_SELECT } },
+    });
+    const desired = new Set<string>();
+    for (const p of participants) {
+        for (const e of collectEmails(p.person)) desired.add(e);
+    }
+    return desired;
+}
+
+/** True when this program actually syncs (has a group AND creds are wired). */
+function syncEnabled(program: ProgramGroupRef): program is ProgramGroupRef & { googleGroupEmail: string } {
+    return !!program.googleGroupEmail && config.googleGroupsConfigured();
+}
+
+/**
+ * Best-effort: add a newly-ACTIVE participant's emails to the program's group.
+ * Adding is idempotent client-side, so no diff on the hot path. NEVER throws —
+ * a Google failure must not fail the enrollment/payment action that triggered
+ * this; it is logged + reported to Link Status, and the nightly reconcile heals.
+ */
+export async function pushGroupAddOnActivation(program: ProgramGroupRef, personId: number): Promise<void> {
+    if (!program.googleGroupEmail) return;
+    if (!config.googleGroupsConfigured()) {
+        logger.info(`[GOOGLE-GROUPS] Skipping add for program ${program.id} — integration not configured.`);
+        return;
+    }
+    const groupEmail = program.googleGroupEmail;
+    try {
+        const emails = await resolveGroupEmails(personId);
+        for (const email of emails) await addGroupMember(groupEmail, email);
+        if (emails.length) {
+            logger.info(`[GOOGLE-GROUPS] Added ${emails.length} address(es) to ${groupEmail} for person ${personId} (program ${program.id}).`);
+        }
+    } catch (err) {
+        logger.error(`[GOOGLE-GROUPS] Failed to add person ${personId} to ${groupEmail} (program ${program.id}):`, err);
+        await logIntegrationError("google-groups", err, { operation: "add", programId: program.id, personId });
+    }
+}
+
+/**
+ * Best-effort: remove a withdrawn participant's emails from the program's group,
+ * but only the ones no remaining ACTIVE participant still needs (a shared
+ * household lead stays). Call AFTER the participant row is gone. NEVER throws —
+ * same non-fatal posture as the add above.
+ */
+export async function pushGroupRemoveOnWithdrawal(program: ProgramGroupRef, personId: number): Promise<void> {
+    if (!syncEnabled(program)) return;
+    const groupEmail = program.googleGroupEmail;
+    try {
+        const emails = await resolveGroupEmails(personId);
+        if (emails.length === 0) return;
+        const stillDesired = await desiredProgramEmails(program.id); // roster AFTER this person left
+        const toRemove = emails.filter((e) => !stillDesired.has(e));
+        for (const email of toRemove) await removeGroupMember(groupEmail, email);
+        if (toRemove.length) {
+            logger.info(`[GOOGLE-GROUPS] Removed ${toRemove.length} address(es) from ${groupEmail} for person ${personId} (program ${program.id}).`);
+        }
+    } catch (err) {
+        logger.error(`[GOOGLE-GROUPS] Failed to remove person ${personId} from ${groupEmail} (program ${program.id}):`, err);
+        await logIntegrationError("google-groups", err, { operation: "remove", programId: program.id, personId });
+    }
+}
+
+export type ReconcileResult =
+    | { added: number; removed: number }
+    | { skipped: string };
+
+/**
+ * Full diff for one program: add every desired-but-absent address, remove every
+ * MEMBER-role address that is no longer an active participant. OWNER/MANAGER
+ * roles are never removed (protects a human owner / the service account).
+ * THROWS GoogleGroupsError on a Google failure — callers decide loudness (the
+ * cron isolates + logs per program; the manual-sync route surfaces a 502).
+ */
+export async function reconcileProgramGroup(program: ProgramGroupRef): Promise<ReconcileResult> {
+    if (!program.googleGroupEmail) return { skipped: "no group configured" };
+    if (!config.googleGroupsConfigured()) return { skipped: "integration not configured" };
+    const groupEmail = program.googleGroupEmail;
+
+    const desired = await desiredProgramEmails(program.id);
+    const members = await listGroupMembers(groupEmail);
+    const currentEmails = new Set(members.map((m) => m.email));
+
+    let added = 0;
+    let removed = 0;
+
+    for (const email of desired) {
+        if (!currentEmails.has(email)) {
+            await addGroupMember(groupEmail, email);
+            added++;
+        }
+    }
+    for (const m of members) {
+        // Only reconcile MEMBER-role addresses; never remove OWNER/MANAGER.
+        if (m.role === "MEMBER" && !desired.has(m.email)) {
+            await removeGroupMember(groupEmail, m.email);
+            removed++;
+        }
+    }
+
+    return { added, removed };
+}

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -195,6 +195,7 @@ export const classifications = {
         shopifyOrgMemberVariantId: 'public',
         shopifyNonOrgMemberVariantId: 'public',
         shopifyVariantId: 'public',
+        googleGroupEmail: 'internal',
     },
     ProgramVolunteer: {
         programId: 'public',


### PR DESCRIPTION
## What & why

Programs want a single mailing list their active participants can reach. This
wires **program → Google Group** membership sync so the app keeps a group in
step with who is actively enrolled — add on activation, remove on withdrawal,
plus a nightly reconcile and a manual "Sync now" that self-heal drift.

Design: `checkin-app/docs/designs/PROGRAM_GOOGLE_GROUP_SYNC.md`.

## Decisions (from the product interview)

- **Config** — board-set `Program.googleGroupEmail` (`@sensitivity:internal`),
  validated as an email on the program-ops general tab. Null = no group.
- **Recipients** — the participant's own email **plus every household lead**,
  mirroring exactly how `lib/notifications.ts › sendCheckinNotifications` resolves
  recipients today (documented in the design doc). A dependent with no email is
  represented by their household lead(s).
- **Event-driven push, best-effort** — fired at the shared service level from the
  three post-#930 activation points (orders/paid webhook, payment-plan approval,
  free/board-override enroll) and from the one shared exit path
  (`withdrawAndReleaseHold`). A Google failure **never** fails the triggering user
  action — it logs + reports to System Status › Link Status; the reconcile heals.
- **Nightly reconcile cron + manual "Sync now"** — full diff per program: add
  missing, remove **MEMBER-role** extras (OWNER/MANAGER are never removed).
- **Auth** — Admin SDK Directory API via a Workspace service account with
  domain-wide delegation. OAuth2 is a JWT-bearer assertion signed with node
  `crypto` — **no new npm dependency** (avoids `googleapis` for three endpoints).
- **Cleanly OFF when unconfigured** — when `GOOGLE_SA_KEY_JSON` /
  `GOOGLE_SA_SUBJECT` are absent the integration is off: config UI still works,
  sync paths log-and-skip, and `lib/configHealth.ts` reports it unconfigured
  (mirrors the Zoho/Shopify idiom; a gap only in prod).

## Infra follow-up (NOT in this PR)

Provisioning the service account (DWD for
`admin.directory.group.member`), setting the two env vars, and scheduling the
reconcile cron are an explicit infra follow-up — see the design doc's
"Provisioning" section. The cron route exists but nothing invokes it yet.

## Data model

Migration `20260708050000_program_google_group` — additive, nullable
`Program.googleGroupEmail TEXT`. `npx prisma generate` regenerated
`classifications.ts` (committed).

## Testing

- **Unit** — `lib/googleGroups.test.ts` (11): JWT assertion shape, token caching,
  idempotent add(409)/remove(404), list pagination, failure + unconfigured paths.
  `lib/program/__tests__/groupSync.test.ts` (11): recipient rule, removal safety
  net (shared lead stays), reconcile diff, best-effort never-throws contract.
  `configHealth.test.ts` updated for the new check.
- **Integration** (real Postgres, mocked `fetch`) —
  `programGoogleGroupSync.integration.test.ts` (5): config save (persist/normalize
  valid, reject malformed, clear on empty) + a reconcile sync run.
  `authzRoleRejection.integration.test.ts` gains the 401/403 deny-path for the new
  role-gated route (registered in the authz drift guard).
- Full pre-commit suite (`test:ci`), `tsc --noEmit`, and `eslint --max-warnings 0`
  on all touched files: green. Route auth drift-guard + config-health route tests: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
