### PR TITLE
feat(program-ops): hide non-member price for members-only programs

### DIFF
--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -400,9 +400,9 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                 <Checkbox checked={isFree} disabled label="This is a free program (Pricing cannot be changed)" />
 
                 {!isFree && (
-                  <SimpleGrid cols={{ base: 1, sm: 2 }}>
+                  <SimpleGrid cols={{ base: 1, sm: orgMemberOnly ? 1 : 2 }}>
                     <NumberInput label="Treehouse Member Price ($)" value={memberPrice} disabled />
-                    <NumberInput label="Non-Member Price ($)" value={nonMemberPrice} disabled />
+                    {!orgMemberOnly && <NumberInput label="Non-Member Price ($)" value={nonMemberPrice} disabled />}
                   </SimpleGrid>
                 )}
 


### PR DESCRIPTION
## What

On the program-ops program detail page, hide the **Non-Member Price** field when a program is marked **Treehouse Members-Only** (`orgMemberOnly`). The Member Price then spans full width.

## Why

For a members-only program the non-member price is never charged, so showing the field is confusing.

## Notes

- Purely display-side; no pricing/state logic changed.
- The unlimited-purchase warning at line 395 still keys off `nonMemberPrice`'s stored value even when the field is hidden — harmless (value persists), left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)