### PR TITLE
fix(shopify): program creation — variant never stored + product asked for shipping

### DIFF
--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -80,22 +80,13 @@ describe('createShopifyProgramVariants', () => {
         // Token request
         mockTokenResponse(fetchMock);
 
-        // Product creation
+        // Product creation — variants come back inline on the created product
         fetchMock.mockResolvedValueOnce({
             ok: true,
-            json: async () => ({ product: { id: 12345 } })
-        });
-
-        // Member variant
-        fetchMock.mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({ variant: { id: 67890 } })
-        });
-
-        // Non-member variant
-        fetchMock.mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({ variant: { id: 11111 } })
+            json: async () => ({ product: { id: 12345, variants: [
+                { id: 67890, option1: 'Member' },
+                { id: 11111, option1: 'Non-Member' },
+            ] } })
         });
 
         const result = await createShopifyProgramVariants('Test Program', 10, 20);
@@ -106,7 +97,16 @@ describe('createShopifyProgramVariants', () => {
             shopifyNonOrgMemberVariantId: '11111'
         });
 
-        expect(fetchMock).toHaveBeenCalledTimes(4); // token + product + 2 variants
+        // ONE product call with inline variants — a bare product create would
+        // mint a physical $0 "Default Title" variant and 422 the follow-up
+        // variant POSTs (the original bug).
+        expect(fetchMock).toHaveBeenCalledTimes(2); // token + product (variants inline)
+        const productBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
+        expect(productBody.product.options).toEqual([{ name: 'Membership Type' }]);
+        expect(productBody.product.variants).toEqual([
+            expect.objectContaining({ option1: 'Member', price: '0.10', requires_shipping: false }),
+            expect.objectContaining({ option1: 'Non-Member', price: '0.20', requires_shipping: false }),
+        ]);
         expect(sendEmail).not.toHaveBeenCalled();
     });
 
@@ -189,12 +189,11 @@ describe('createShopifyProgramVariants', () => {
     });
 
     describe('inventory branch (maxParticipants configured, real Shopify path)', () => {
-        // Single priced tier (member only) keeps the fetch sequence to one variant:
-        // token, product, variant, locations, [inventory_levels/set] — see shopify.ts:157-238.
+        // Single priced tier (member only) keeps the fetch sequence short:
+        // token, product (variant inline), locations, [inventory_levels/set].
         it('sets inventory at the store location when maxParticipants is configured', async () => {
             mockTokenResponse(fetchMock);
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 500 } }) }); // product
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { id: 600, inventory_item_id: 700 } }) }); // member variant
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 500, variants: [{ id: 600, option1: 'Member', inventory_item_id: 700 }] } }) }); // product + inline variant
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 900 }] }) }); // locations
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/set
 
@@ -205,9 +204,9 @@ describe('createShopifyProgramVariants', () => {
                 shopifyOrgMemberVariantId: '600',
                 shopifyNonOrgMemberVariantId: null,
             });
-            expect(fetchMock).toHaveBeenCalledTimes(5);
-            expect(String(fetchMock.mock.calls[3][0])).toContain('/locations.json');
-            const invCall = fetchMock.mock.calls[4];
+            expect(fetchMock).toHaveBeenCalledTimes(4);
+            expect(String(fetchMock.mock.calls[2][0])).toContain('/locations.json');
+            const invCall = fetchMock.mock.calls[3];
             expect(String(invCall[0])).toContain('/inventory_levels/set.json');
             expect(JSON.parse((invCall[1] as RequestInit).body as string)).toEqual({
                 location_id: 900,
@@ -218,8 +217,7 @@ describe('createShopifyProgramVariants', () => {
 
         it('logs and does not fail the whole call when inventory_levels/set itself fails (non-fatal)', async () => {
             mockTokenResponse(fetchMock);
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 501 } }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { id: 601, inventory_item_id: 701 } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 501, variants: [{ id: 601, option1: 'Member', inventory_item_id: 701 }] } }) });
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 901 }] }) });
             fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'inventory boom' });
 
@@ -241,8 +239,7 @@ describe('createShopifyProgramVariants', () => {
 
         it('skips inventory_levels/set when the store has no locations configured', async () => {
             mockTokenResponse(fetchMock);
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 502 } }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { id: 602, inventory_item_id: 702 } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 502, variants: [{ id: 602, option1: 'Member', inventory_item_id: 702 }] } }) });
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [] }) });
 
             const result = await createShopifyProgramVariants('No Location Program', 10, null, 2);
@@ -252,8 +249,8 @@ describe('createShopifyProgramVariants', () => {
                 shopifyOrgMemberVariantId: '602',
                 shopifyNonOrgMemberVariantId: null,
             });
-            // No 5th call: locations returned empty, so inventory_levels/set is never reached.
-            expect(fetchMock).toHaveBeenCalledTimes(4);
+            // No 4th call: locations returned empty, so inventory_levels/set is never reached.
+            expect(fetchMock).toHaveBeenCalledTimes(3);
         });
     });
 
@@ -475,27 +472,30 @@ describe('createShopifySingleVariantProgram', () => {
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it('creates one product + one variant at the base price and sets inventory', async () => {
+    it('creates the product with its ONE variant inline (non-physical, base price) and sets inventory', async () => {
         mockTokenResponse(fetchMock);
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 700 } }) });
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { id: 800, inventory_item_id: 900 } }) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 700, variants: [{ id: 800, inventory_item_id: 900 }] } }) });
         fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 950 }] }) });
         fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
         const result = await createShopifySingleVariantProgram('Single Pool Program', 3500, 10);
 
         expect(result).toEqual({ shopifyProductId: '700', shopifyVariantId: '800' });
-        expect(fetchMock).toHaveBeenCalledTimes(5); // token + product + variant + locations + inventory set
-        const variantCall = fetchMock.mock.calls[2];
-        expect(JSON.parse((variantCall[1] as RequestInit).body as string)).toMatchObject({
-            variant: { price: '35.00', inventory_management: 'shopify', inventory_policy: 'deny' },
+        expect(fetchMock).toHaveBeenCalledTimes(4); // token + product (variant inline) + locations + inventory set
+
+        // The variant MUST ride inside the product create: a bare create mints a
+        // physical $0 "Default Title" variant that 422s the follow-up variant
+        // POST (no variant stored) and makes checkout ask for shipping.
+        const productCall = fetchMock.mock.calls[1];
+        expect(String(productCall[0])).toContain('/products.json');
+        expect(JSON.parse((productCall[1] as RequestInit).body as string)).toMatchObject({
+            product: { variants: [{ price: '35.00', requires_shipping: false, inventory_management: 'shopify', inventory_policy: 'deny' }] },
         });
     });
 
-    it('returns null and emails admins when variant creation fails', async () => {
+    it('returns null and emails admins when product creation fails', async () => {
         mockTokenResponse(fetchMock);
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 701 } }) });
-        fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => '{"errors":"bad variant"}' });
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 422, statusText: 'Unprocessable Entity', text: async () => '{"errors":"bad variant"}' });
         (prisma.person.findMany as jest.Mock).mockResolvedValueOnce([{ email: 'admin@test.com' }]);
 
         const result = await createShopifySingleVariantProgram('Broken Program', 3500);
@@ -505,6 +505,21 @@ describe('createShopifySingleVariantProgram', () => {
             'admin@test.com',
             'Shopify Integration Error',
             expect.stringContaining('Shopify API responded with status: 422'),
+        );
+    });
+
+    it('returns null and emails admins when the created product comes back without a variant', async () => {
+        mockTokenResponse(fetchMock);
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 702, variants: [] } }) });
+        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce([{ email: 'admin@test.com' }]);
+
+        const result = await createShopifySingleVariantProgram('Variantless Program', 3500);
+
+        expect(result).toBeNull();
+        expect(sendEmail).toHaveBeenCalledWith(
+            'admin@test.com',
+            'Shopify Integration Error',
+            expect.stringContaining('missing the created variant'),
         );
     });
 });

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -213,7 +213,34 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
     // Determine product title
     const productTitle = `Program Enrollment: ${name}`;
 
-    // 1. Create Product
+    // Variants go INLINE in the product-create call. Creating the product bare
+    // makes Shopify mint a "Default Title" variant (price $0, requires_shipping
+    // true), which then collides with any follow-up POST /variants.json that
+    // doesn't set a distinct option1 (422 "The variant 'Default Title' already
+    // exists") AND leaves a physical $0 variant on the product so checkout asks
+    // for a shipping address. Inline variants replace the default entirely.
+    const variants = [];
+
+    if (orgMemberPriceCents !== null && orgMemberPriceCents > 0) {
+        variants.push({
+            option1: "Member",
+            price: (orgMemberPriceCents / 100).toFixed(2),
+            requires_shipping: false,
+            inventory_management: maxParticipants ? 'shopify' : null,
+            inventory_policy: maxParticipants ? 'deny' : 'continue',
+        });
+    }
+
+    if (nonOrgMemberPriceCents !== null && nonOrgMemberPriceCents > 0) {
+        variants.push({
+            option1: "Non-Member",
+            price: (nonOrgMemberPriceCents / 100).toFixed(2),
+            requires_shipping: false,
+            inventory_management: maxParticipants ? 'shopify' : null,
+            inventory_policy: maxParticipants ? 'deny' : 'continue',
+        });
+    }
+
     const productRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/products.json`, {
       method: 'POST',
       headers: {
@@ -225,7 +252,7 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
           title: productTitle,
           status: 'active',
           product_type: "Educational Services",
-          options: [{ name: "Membership Type" }]
+          ...(variants.length > 0 ? { options: [{ name: "Membership Type" }], variants } : {}),
         }
       })
     }, "Shopify create product");
@@ -239,60 +266,21 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
     const productData = await productRes.json();
     productId = productData.product.id;
 
-    // 2. Create Variants
-    const variants = [];
-
-    if (orgMemberPriceCents !== null && orgMemberPriceCents > 0) {
-        variants.push({
-            product_id: productId,
-            option1: "Member",
-            price: (orgMemberPriceCents / 100).toFixed(2),
-            requires_shipping: false,
-            inventory_management: maxParticipants ? 'shopify' : null,
-            inventory_policy: maxParticipants ? 'deny' : 'continue',
-        });
-    }
-
-    if (nonOrgMemberPriceCents !== null && nonOrgMemberPriceCents > 0) {
-        variants.push({
-            product_id: productId,
-            option1: "Non-Member",
-            price: (nonOrgMemberPriceCents / 100).toFixed(2),
-            requires_shipping: false,
-            inventory_management: maxParticipants ? 'shopify' : null,
-            inventory_policy: maxParticipants ? 'deny' : 'continue',
-        });
-    }
-
     let memberVariantId: string | null = null;
     let nonMemberVariantId: string | null = null;
 
-    if (variants.length > 0) {
-        for (const variant of variants) {
-            const variantRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/products/${productId}/variants.json`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Shopify-Access-Token': accessToken,
-                },
-                body: JSON.stringify({ variant })
-            }, "Shopify create variant");
+    for (const created of productData.product.variants ?? []) {
+        if (created.option1 === "Member") {
+            memberVariantId = created.id.toString();
+        } else if (created.option1 === "Non-Member") {
+            nonMemberVariantId = created.id.toString();
+        } else {
+            continue; // e.g. a default variant on the no-priced-tiers path — nothing to track
+        }
 
-            if (variantRes.ok) {
-                const variantData = await variantRes.json();
-                if (variant.option1 === "Member") {
-                    memberVariantId = variantData.variant.id.toString();
-                } else {
-                    nonMemberVariantId = variantData.variant.id.toString();
-                }
-
-                // Set inventory level if maxParticipants is configured
-                if (maxParticipants && variantData.variant.inventory_item_id) {
-                    await setInitialShopifyInventory(storeDomain, accessToken, variantData.variant.inventory_item_id, maxParticipants, variant.option1);
-                }
-            } else {
-                console.error("Failed to create Shopify variant:", await variantRes.text());
-            }
+        // Set inventory level if maxParticipants is configured
+        if (maxParticipants && created.inventory_item_id) {
+            await setInitialShopifyInventory(storeDomain, accessToken, created.inventory_item_id, maxParticipants, created.option1);
         }
     }
 
@@ -359,6 +347,13 @@ export async function createShopifySingleVariantProgram(
     let productId: string | number | null = null;
 
     try {
+        // The variant goes INLINE in the product-create call. Creating the
+        // product bare makes Shopify mint a "Default Title" variant (price $0,
+        // requires_shipping true), and the follow-up POST /variants.json —
+        // which has no option1 either — collides with it (422 "The variant
+        // 'Default Title' already exists"). Net effect of the old two-call
+        // shape: no variant id ever stored, and the orphaned product kept its
+        // physical $0 default variant so checkout demanded a shipping address.
         const productRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/products.json`, {
             method: 'POST',
             headers: {
@@ -370,6 +365,12 @@ export async function createShopifySingleVariantProgram(
                     title: `Program Enrollment: ${name}`,
                     status: 'active',
                     product_type: "Educational Services",
+                    variants: [{
+                        price: (basePriceCents / 100).toFixed(2),
+                        requires_shipping: false,
+                        inventory_management: maxParticipants ? 'shopify' : null,
+                        inventory_policy: maxParticipants ? 'deny' : 'continue',
+                    }],
                 }
             })
         }, "Shopify create product");
@@ -383,34 +384,17 @@ export async function createShopifySingleVariantProgram(
         const productData = await productRes.json();
         productId = productData.product.id;
 
-        const variantRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/products/${productId}/variants.json`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-Shopify-Access-Token': accessToken,
-            },
-            body: JSON.stringify({
-                variant: {
-                    product_id: productId,
-                    price: (basePriceCents / 100).toFixed(2),
-                    requires_shipping: false,
-                    inventory_management: maxParticipants ? 'shopify' : null,
-                    inventory_policy: maxParticipants ? 'deny' : 'continue',
-                }
-            })
-        }, "Shopify create variant");
-
-        if (!variantRes.ok) {
-            const errorData = await variantRes.text();
-            console.error("Failed to create Shopify variant:", errorData);
-            throw new Error(`Shopify API responded with status: ${variantRes.status}`);
+        // Unlike the legacy path, the single variant is the whole point here —
+        // without its id the program can never match a webhook line-item, so a
+        // missing variant is a hard failure (the catch names the orphan).
+        const variant = productData.product.variants?.[0];
+        if (!variant?.id) {
+            throw new Error("Shopify product creation response is missing the created variant");
         }
+        const variantId = variant.id.toString();
 
-        const variantData = await variantRes.json();
-        const variantId = variantData.variant.id.toString();
-
-        if (maxParticipants && variantData.variant.inventory_item_id) {
-            await setInitialShopifyInventory(storeDomain, accessToken, variantData.variant.inventory_item_id, maxParticipants, "Standard");
+        if (maxParticipants && variant.inventory_item_id) {
+            await setInitialShopifyInventory(storeDomain, accessToken, variant.inventory_item_id, maxParticipants, "Standard");
         }
 
         return {


### PR DESCRIPTION
Fixes #969

## Problem

Creating a paid program produced two symptoms:

1. **The variant id was never stored** on the program row, so checkout/webhook matching was broken.
2. **The Shopify product was "physical"** — checkout asked for a shipping address even though program enrollments are non-physical services.

The same failure also broke the **"Sync to Shopify" repair button** (#969): the sync route reuses the same creation functions, gets `null` back when the variant POST 422s, and surfaces the misleading "Shopify sync failed or is not configured. Check Shopify credentials." error — credentials were fine, the variant creation was what failed.

## Root cause (verified against current Shopify Admin API docs, not memory)

Both symptoms share one cause. `createShopifySingleVariantProgram` (and the legacy `createShopifyProgramVariants`) created the product **bare**, then added variants with a second `POST /products/{id}/variants.json` call. Per Shopify's REST docs, a product created without variants gets an auto-minted **"Default Title" variant — price $0.00, `requires_shipping: true`**. The follow-up variant POST carried no distinct `option1`, so it also resolved to "Default Title" and failed with **422 "The variant 'Default Title' already exists"**. The function threw, returned `null`, the program stored no Shopify ids — and the orphaned product stayed in the store with only its physical $0 default variant, which is why checkout demanded shipping.

## Fix

Send the variant(s) **inline in the product-create payload** (the documented way to replace the default variant entirely), with `requires_shipping: false`:

- `createShopifySingleVariantProgram` (single-pool path used by program creation): one `POST /products.json` with the variant inline; hard-fails with admin notification if the response somehow lacks the variant.
- `createShopifyProgramVariants` (legacy two-variant repair path used by sync-shopify): Member/Non-Member variants inline with the `Membership Type` option.

Side benefit: one API call instead of two/three per program.

## Notes

- REST product endpoints are deprecated (legacy as of Oct 2024) but remain supported for custom apps under 100 variants; this app qualifies. A GraphQL migration is a separate, larger change.
- Existing broken programs (null ids) can be repaired via the existing **sync-shopify** route, which now works; the previously orphaned physical products in the store need manual deletion.

Sources: [REST Product resource](https://shopify.dev/docs/api/admin-rest/latest/resources/product), [REST ProductVariant resource](https://shopify.dev/docs/api/admin-rest/latest/resources/product-variant), [new GraphQL product API deprecation timelines](https://shopify.dev/changelog/deprecation-timelines-related-to-new-graphql-product-apis), [community: Default Title already exists](https://community.shopify.com/c/technical-q-a/post-product-fails-with-quot-the-variant-default-title-already/m-p/1184483)

## Verification

- `src/lib/__tests__/shopify.test.ts` updated to the single-call shape, with explicit assertions that variants ride inside the product POST with `requires_shipping: false` (27/27 pass).
- Full unit suite: 208 suites / 1706 tests pass; `tsc --noEmit` clean.
- Not exercised against a real Shopify store (local env uses the CHECKIN_ENV=local mock) — worth one manual program-create on dev before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
