### PR TITLE
fix(nav): readable sidebar hover after Mantine NavLink token change

### DIFF
--- a/checkin-app/src/app/globals.css
+++ b/checkin-app/src/app/globals.css
@@ -20,3 +20,22 @@ body {
 .kiosk-mode * {
   cursor: none !important;
 }
+
+/*
+ * Colored sidebar nav (AppFrame): non-active NavLink hover.
+ *
+ * Mantine's NavLink hover fill for a non-active item is a near-white token
+ * (`--mantine-color-gray-0` in light, `--mantine-color-dark-6` in dark; see
+ * @mantine/core NavLink.css). On the purple sidebar the labels are white, so that
+ * near-white fill made hovered items unreadable — white-on-white (#284, and again
+ * after a Mantine bump moved the token off `default-hover`). Pin the hover to a
+ * translucent white instead: the purple just lightens and the white label stays
+ * legible, in both light and dark mode. Owning the rule here (rather than
+ * overriding whichever internal token Mantine happens to use) keeps it from
+ * silently regressing on the next Mantine upgrade. The `:not([data-active])` keeps
+ * the active item's own (readable) highlight untouched, and the class is only
+ * attached on the colored sidebar so plain-white sidebars are unaffected.
+ */
+.appframe-sidebar-navlink:not([data-active]):hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}

--- a/checkin-app/src/app/globals.css
+++ b/checkin-app/src/app/globals.css
@@ -21,21 +21,10 @@ body {
   cursor: none !important;
 }
 
-/*
- * Colored sidebar nav (AppFrame): non-active NavLink hover.
- *
- * Mantine's NavLink hover fill for a non-active item is a near-white token
- * (`--mantine-color-gray-0` in light, `--mantine-color-dark-6` in dark; see
- * @mantine/core NavLink.css). On the purple sidebar the labels are white, so that
- * near-white fill made hovered items unreadable — white-on-white (#284, and again
- * after a Mantine bump moved the token off `default-hover`). Pin the hover to a
- * translucent white instead: the purple just lightens and the white label stays
- * legible, in both light and dark mode. Owning the rule here (rather than
- * overriding whichever internal token Mantine happens to use) keeps it from
- * silently regressing on the next Mantine upgrade. The `:not([data-active])` keeps
- * the active item's own (readable) highlight untouched, and the class is only
- * attached on the colored sidebar so plain-white sidebars are unaffected.
- */
+/* Mantine's default NavLink hover fill is near-white — invisible under the white
+   labels on the purple sidebar. Own the hover here rather than overriding Mantine's
+   internal hover token, which has changed name across versions. Attached via
+   classNames in AppFrame.tsx (colored sidebar only). */
 .appframe-sidebar-navlink:not([data-active]):hover {
   background-color: rgba(255, 255, 255, 0.12);
 }

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -293,22 +293,15 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
         <AppShell.Navbar
           p="md"
           bg={brand.nav.sidebar}
-          // On the colored sidebar the white labels need a readable hover fill; that lives in
-          // globals.css (.appframe-sidebar-navlink) so it can't silently regress when a Mantine
-          // upgrade renames the internal NavLink hover token (which is what reintroduced the
-          // white-on-white bug, #284).
-          //
-          // overflowY:auto: when the nav list outgrows the viewport it scrolls instead of
-          // clipping. The <nav> element persists across route changes (only AppShell.Main's
-          // children swap), so the browser keeps its scrollTop — "back to X" leaves the
-          // sidebar scroll where it was rather than jumping to the top.
+          // overflowY:auto lets the nav scroll when it outgrows the viewport. The <nav>
+          // persists across route changes (only AppShell.Main's children swap), so its
+          // scrollTop survives navigation instead of jumping to the top.
           style={{ overflowY: 'auto' }}
         >
           {visibleItems.map((item) => {
             const href = item.hrefFor?.(user) ?? item.href;
             const active = isActive(pathname, href);
-            // On the colored sidebar all text is white; the 'light' variant gives a soft
-            // translucent overlay on the active item rather than a harsh solid fill.
+            // White labels on the colored sidebar; theme default (dark) elsewhere.
             const sidebarText = onColoredSidebar ? 'var(--mantine-color-white)' : undefined;
             // Badge keys off the canonical section href, not the per-role
             // destination — a reviewer-only user's link points at /review, but its
@@ -360,6 +353,7 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                 onClick={closeMobile}
                 mb={4}
                 classNames={
+                  // Readable hover fill; see globals.css .appframe-sidebar-navlink.
                   onColoredSidebar ? { root: 'appframe-sidebar-navlink' } : undefined
                 }
                 styles={{

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -293,23 +293,16 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
         <AppShell.Navbar
           p="md"
           bg={brand.nav.sidebar}
-          // On the dark sidebar, Mantine's hover fill for non-active items is the near-white
-          // `default-hover` token, which left white labels invisible (white-on-white, #284).
-          // Scope that token to a translucent white so hovering just lightens the purple and the
-          // white label stays readable — and it works in dark mode too, unlike a fixed color.
+          // On the colored sidebar the white labels need a readable hover fill; that lives in
+          // globals.css (.appframe-sidebar-navlink) so it can't silently regress when a Mantine
+          // upgrade renames the internal NavLink hover token (which is what reintroduced the
+          // white-on-white bug, #284).
           //
           // overflowY:auto: when the nav list outgrows the viewport it scrolls instead of
           // clipping. The <nav> element persists across route changes (only AppShell.Main's
           // children swap), so the browser keeps its scrollTop — "back to X" leaves the
           // sidebar scroll where it was rather than jumping to the top.
-          style={
-            {
-              overflowY: 'auto',
-              ...(onColoredSidebar
-                ? { '--mantine-color-default-hover': 'rgba(255, 255, 255, 0.12)' }
-                : {}),
-            } as React.CSSProperties
-          }
+          style={{ overflowY: 'auto' }}
         >
           {visibleItems.map((item) => {
             const href = item.hrefFor?.(user) ?? item.href;
@@ -366,6 +359,9 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                 color={brand.nav.accent}
                 onClick={closeMobile}
                 mb={4}
+                classNames={
+                  onColoredSidebar ? { root: 'appframe-sidebar-navlink' } : undefined
+                }
                 styles={{
                   root: { borderRadius: 'var(--mantine-radius-md)' },
                   label: { color: sidebarText, fontWeight: 600 },


### PR DESCRIPTION
## Problem

On the purple left sidebar (white labels), hovering a **non-active** nav item filled the button near-white, leaving the white label unreadable — white-on-white.

The sidebar had a fix for this already ([#284](https://github.com/innovationtreehouse/checkin/issues/284) / #429): it scoped `--mantine-color-default-hover` to a translucent white. But a later Mantine upgrade moved NavLink's non-active hover fill **off** that token onto `--mantine-color-gray-0` (light) / `--mantine-color-dark-6` (dark) — see `@mantine/core` `NavLink.css`. The old override became dead code and the bug silently came back.

### Before (hover — white-on-white, unreadable)
![before](https://github.com/innovationtreehouse/checkin/raw/pr-shots-left-panel-hover/pr-assets/before-bug.png)

## Fix

Stop depending on whichever internal token Mantine happens to use. Give the sidebar NavLinks their own class (`.appframe-sidebar-navlink`, attached only on the colored sidebar) and pin the non-active hover to a translucent white in `globals.css`:

- Specificity `(0,3,0)` beats Mantine's non-active hover rule `(0,2,0)`, so it wins regardless of Mantine's internal token churn.
- `:not([data-active])` leaves the active item's own (readable) highlight untouched.
- Translucent white works in both light and dark mode (the sidebar is purple in both).

### After (hover — label stays readable)
![after](https://github.com/innovationtreehouse/checkin/raw/pr-shots-left-panel-hover/pr-assets/after-fixed.png)

## Verification

- Screenshots above are real `:hover` captures against the running dev server (`/index`, signed out — only the always-visible **Programs** item shows).
- Pre-commit hook ran the full suite: **1705 tests passed**, plus ESLint + TypeScript checks.

> Note: the before/after screenshots are hosted on a throwaway `pr-shots-left-panel-hover` branch so they render here without adding binaries to this PR's diff. That branch can be deleted after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)