### PR TITLE
fix(membership): re-run external advance after intake submit (#878)

### DIFF
--- a/checkin-app/src/lib/membership/__tests__/intake.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/intake.test.ts
@@ -30,7 +30,7 @@ jest.mock('@/lib/prisma', () => ({
     },
 }));
 
-jest.mock('@/lib/membership/external', () => ({ getExternalStatus: jest.fn() }));
+jest.mock('@/lib/membership/external', () => ({ getExternalStatus: jest.fn(), advanceExternalIfComplete: jest.fn() }));
 jest.mock('@/lib/emergencyContacts/service', () => ({
     upsertPrimaryContact: jest.fn(),
     reconcileHouseholdConflicts: jest.fn(),
@@ -57,6 +57,8 @@ const { addHouseholdLead, HouseholdLeadLimitError, MAX_HOUSEHOLD_LEADS } = requi
 const { householdBgIsFresh } = require('@/lib/membership/renewal');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { applyVolunteerStatus } = require('@/lib/membership/review');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { advanceExternalIfComplete } = require('@/lib/membership/external');
 
 const user = {
     id: 1,
@@ -415,6 +417,31 @@ describe('submitIntake', () => {
         // Fresh-check shortcut skips clearBackgroundCheck for the whole cycle, so
         // the designation allowlist must be matched here or never.
         expect(applyVolunteerStatus).toHaveBeenCalledWith(prisma, 42, 7, false);
+        expect(result).toEqual({ id: 11, status: 'PENDING_EXTERNAL_ACTION' });
+    });
+
+    it('re-runs the external advance after landing at PENDING_EXTERNAL_ACTION and returns its result (#878)', async () => {
+        householdBgIsFresh.mockResolvedValue(false);
+        // Board pre-marked contract + BG consent on the INTAKE row, so the gate is
+        // already met when we arrive — the advance carries the process to PENDING_PAYMENT.
+        advanceExternalIfComplete.mockResolvedValue({ id: 11, status: 'PENDING_PAYMENT' });
+
+        const result = await submitIntake(1);
+
+        expect(advanceExternalIfComplete).toHaveBeenCalledWith(11);
+        expect(result).toEqual({ id: 11, status: 'PENDING_PAYMENT' });
+    });
+
+    it('falls back to the update result when the external advance is a no-op (#878)', async () => {
+        householdBgIsFresh.mockResolvedValue(false);
+        // Nothing pre-marked ⇒ advanceExternalIfComplete finds the gate unmet and
+        // returns the still-PENDING_EXTERNAL_ACTION process (here left undefined to
+        // exercise the fallback); submitIntake reports the phase it advanced to.
+        advanceExternalIfComplete.mockResolvedValue(undefined);
+
+        const result = await submitIntake(1);
+
+        expect(advanceExternalIfComplete).toHaveBeenCalledWith(11);
         expect(result).toEqual({ id: 11, status: 'PENDING_EXTERNAL_ACTION' });
     });
 

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -1,7 +1,7 @@
 import prisma from "@/lib/prisma";
 import { Prisma } from "@/generated/prisma/client";
 import { IN_FLIGHT_INITIAL_STATUSES } from "@/lib/membership/phases";
-import { getExternalStatus } from "@/lib/membership/external";
+import { getExternalStatus, advanceExternalIfComplete } from "@/lib/membership/external";
 import { householdBgIsFresh, nextBoundary } from "@/lib/membership/renewal";
 import { applyVolunteerStatus } from "@/lib/membership/review";
 import { addHouseholdLead, HouseholdLeadLimitError, MAX_HOUSEHOLD_LEADS } from "@/lib/household/leads";
@@ -413,5 +413,12 @@ export async function submitIntake(userId: number) {
     // the volunteer-designation allowlist here or it would never be applied (#874).
     if (bgFresh) await applyVolunteerStatus(prisma, process.orgMembershipId!, household.id, false);
 
-    return advanced;
+    // The external actions (contract sign, BG consent) can already be satisfied the
+    // moment we land at PENDING_EXTERNAL_ACTION: bgFresh stamps bgClearedAt above,
+    // and the board can pre-mark contractSignedAt/bgConsentAt on the INTAKE row via
+    // the ops API (#878). advanceExternalIfComplete didn't re-fire on those marks
+    // (status wasn't PENDING_EXTERNAL_ACTION yet), so without this the process would
+    // strand here with its gate already met. Re-run the advance now — it's a no-op
+    // (status guard, contract/BG checks) when the actions aren't actually done.
+    return (await advanceExternalIfComplete(process.id)) ?? advanced;
 }


### PR DESCRIPTION
Closes #878.

## Problem

`markContractSigned` / `markBgConsent` (`src/lib/membership/external.ts`) have no phase guard, so a board member can pre-mark `contractSignedAt`/`bgConsentAt` on an `INTAKE`-stage process via the ops API. `advanceExternalIfComplete` correctly refuses to advance at that point (status isn't `PENDING_EXTERNAL_ACTION`), but nothing re-triggered it after the family submitted intake — `submitIntake` advanced to `PENDING_EXTERNAL_ACTION` without re-running the advance. Result: the process stranded there with its gate already satisfied and never moved on.

## Fix

`submitIntake` now calls `advanceExternalIfComplete(process.id)` after advancing to `PENDING_EXTERNAL_ACTION`. It is idempotent and a no-op (its own status / contract / BG guards) when the actions aren't actually done, and re-runs the advance when the board pre-marked them.

### Why not a phase guard on the mark functions (issue's option 1)

`markBgConsent` is legitimately called at `PENDING_BG_REVIEW` by the PERSON_BG flow (`personBgSubmit.submitPersonBgForReview`). A guard requiring `PENDING_EXTERNAL_ACTION` would break that path, so the safer, non-invasive fix is to re-fire the advance from `submitIntake`.

### Note on behavior

A pre-marked application now advances straight to payment, i.e. the applicant doesn't re-sign / re-consent in-app — consistent with the board manually asserting those out-of-band actions (the system never sees contract content). If a stricter "board may not pre-mark at all" shape is preferred, an alternative is a guard permitting the marks only at `PENDING_EXTERNAL_ACTION` (household) and `PENDING_BG_REVIEW` (PERSON_BG).

## Tests

- Added two `submitIntake` cases: pre-marked → advances to `PENDING_PAYMENT`; unmarked → no-op fallback to the update result.
- `intake` unit tests: 27 passed. `external` unit tests: 24 passed. Full pre-commit suite green. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)