### PR TITLE
fix(auth): normalize participant email on read (#292)

### DIFF
--- a/checkin-app/src/lib/__tests__/auth-options-adapter.test.ts
+++ b/checkin-app/src/lib/__tests__/auth-options-adapter.test.ts
@@ -111,6 +111,17 @@ describe('PrismaAdapter user-model shim (auth-options.ts)', () => {
         );
     });
 
+    // #292: Google hands NextAuth its own casing; the stored value is lowercased
+    // on write, so the lookup key must be lowercased too or a mixed-case sign-in
+    // misses the existing row and NextAuth mints a duplicate participant/household.
+    test('getUserByEmail lowercases the lookup key (#292 read normalization)', async () => {
+        mockPersonFindUnique.mockResolvedValue(null);
+        await adapter.getUserByEmail('John.Doe@Example.com');
+        expect(mockPersonFindUnique).toHaveBeenCalledWith(
+            expect.objectContaining({ where: expect.objectContaining({ email: 'john.doe@example.com' }) }),
+        );
+    });
+
     test('getUser resolves numeric ids against prisma.person', async () => {
         mockPersonFindUnique.mockResolvedValue({ id: 42, email: 'p@example.com' });
         const user = await adapter.getUser('42');

--- a/checkin-app/src/lib/__tests__/auth-options-jwt.test.ts
+++ b/checkin-app/src/lib/__tests__/auth-options-jwt.test.ts
@@ -185,6 +185,23 @@ describe('jwt() callback — initial sign-in branch (user present)', () => {
         expect(result.emailVerified).toBe(true);
     });
 
+    it('lowercases a mixed-case user.email before the lookup (#292 read normalization)', async () => {
+        mockFindUnique.mockResolvedValue(dbParticipant({ isSysadmin: false }));
+
+        await jwt({
+            token: {},
+            user: { email: 'John.Doe@Example.com' },
+            account: { provider: 'google' },
+            profile: { email_verified: true },
+        } as unknown as Parameters<JwtCallback>[0]);
+
+        // Stored emails are lowercased on write, so the sign-in lookup key must be too —
+        // otherwise Google's casing misses the row and NextAuth mints a duplicate.
+        expect(mockFindUnique).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { email: 'john.doe@example.com' } }),
+        );
+    });
+
     it('promotes a BOOTSTRAP_SYSADMINS email to isSysadmin on sign-in', async () => {
         const prevEnv = process.env.BOOTSTRAP_SYSADMINS;
         process.env.BOOTSTRAP_SYSADMINS = 'Boss@Example.com';

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -13,6 +13,7 @@ import { recordLedger } from "@/lib/dev/ledger";
 import { assignParticipantClaims } from "@/lib/authClaims";
 import { addHouseholdLead } from "@/lib/household/leads";
 import { withAuroraResumeRetry } from "@/lib/auroraResumeRetry";
+import { normalizeEmail } from "@/lib/prismaEmailNormalize";
 
 // Stable id for the dev/local persona-mint credential flow.
 export const PERSONA_MINT_PROVIDER_ID = "persona-mint";
@@ -90,8 +91,12 @@ const patchedAdapter = {
         return user ? toAdapterUser(user) : null;
     },
 
+    // NextAuth hands us the provider's email verbatim (Google's casing). The
+    // stored value is lowercased on write, so the lookup key must be too — else
+    // a differently-cased address misses the row and NextAuth mints a duplicate
+    // (issue #292). Read normalization mirrors the write extension.
     getUserByEmail: async (email: string) => {
-        const user = await prisma.person.findUnique({ where: { email } });
+        const user = await prisma.person.findUnique({ where: { email: normalizeEmail(email) } });
         return user ? toAdapterUser(user) : null;
     },
 
@@ -321,7 +326,9 @@ export const authOptions: NextAuthOptions = {
             // a logged-out visitor, while the persona-mint block above still stamped the gate claims
             // + impersonatedBy so the dev gate passes and "Return to me" works.
             if (user?.email) {
-                const email = user.email;
+                // Normalize the lookup key to match the lowercased stored value
+                // (issue #292); Google's casing is otherwise passed through verbatim.
+                const email = normalizeEmail(user.email);
                 const dbParticipant = await withAuroraResumeRetry(() => prisma.person.findUnique({
                     where: { email },
                     include: {

--- a/checkin-app/src/lib/prismaEmailNormalize.ts
+++ b/checkin-app/src/lib/prismaEmailNormalize.ts
@@ -20,6 +20,15 @@ import { Prisma } from '@/generated/prisma/client'
  * future nested-write path must lowercase email itself.
  */
 
+/**
+ * The single definition of how a Person.email is normalized. Writes lowercase
+ * through this (below); every email *lookup* must run its key through the same
+ * function or a differently-cased address (`John.Doe@x` vs the stored
+ * `john.doe@x`) misses the row — the read half of issue #292. Keep read and
+ * write on this one function so they can never drift.
+ */
+export const normalizeEmail = (email: string): string => email.toLowerCase()
+
 /** Lowercase `data.email`, handling the plain (`email: "X"`) and wrapped
  * (`email: { set: "X" }`) forms. Null/undefined/non-string emails are left
  * untouched. Idempotent. Mutates `data` in place. */
@@ -28,14 +37,14 @@ function lowerEmailOnData(data: unknown): void {
     const d = data as { email?: unknown }
     const email = d.email
     if (typeof email === 'string' && email.length > 0) {
-        d.email = email.toLowerCase()
+        d.email = normalizeEmail(email)
         return
     }
     // Wrapped update form: { email: { set: "X" } }
     if (email != null && typeof email === 'object' && 'set' in email) {
         const wrapped = email as { set?: unknown }
         if (typeof wrapped.set === 'string' && wrapped.set.length > 0) {
-            wrapped.set = wrapped.set.toLowerCase()
+            wrapped.set = normalizeEmail(wrapped.set)
         }
     }
 }


### PR DESCRIPTION
Fixes #292 (read half).

## Context

Write-side normalization already shipped in #883: the `emailNormalizeExtension` prisma extension lowercases `Person.email` on every top-level write, so the *stored* value is always lowercase. The read side was still passing Google's verbatim casing straight into the lookups, so the two halves were mismatched.

## The bug

The OAuth flow resolves a participant by email in two places, both un-normalized:
- **Adapter `getUserByEmail`** — NextAuth's account-linking probe.
- **jwt callback** — `findUnique({ where: { email: user.email } })` to stamp claims.

A mixed-case sign-in (`John.Doe@org.com`) misses the stored `john.doe@org.com` row. And now that writes normalize, the follow-on `createUser` collides on the `@unique` column — so instead of silently minting the duplicate participant + household this issue is about, sign-in now *errors*. Either way it's broken, and it's exactly the path the Zoho importer (#291) exposes for org members whose Zoho email wasn't already lowercase.

## The fix

Lowercase the lookup key at both OAuth read paths, routed through a shared `normalizeEmail()` in `prismaEmailNormalize.ts` that the write extension now also uses — so read and write normalization are one definition and can't drift.

- `getUserByEmail` -> `where: { email: normalizeEmail(email) }`
- jwt callback -> `const email = normalizeEmail(user.email)`

## Acceptance

- Any-cased sign-in resolves to the same Participant (no new household). Adapter + jwt lookups both normalize; regression tests assert `John.Doe@Example.com` -> `john.doe@example.com` before the query.
- No two participants can differ only by email case. Met going forward — the write extension lowercases every real write path, so a case-variant can't be stored. Not yet enforced at the DB level (see below).

## Deliberately deferred: backfill + DB constraint (issue part 3)

Backfilling existing rows to lowercase and adding a `lower(email)` unique index is left as an **ops-gated follow-up**, because the issue itself requires auditing prod for existing casing-only duplicates *first* — a backfill `UPDATE` (or the index build) will fail against unaudited prod data if any collide, blocking the deploy. It also wants its own reviewable migration PR. The write extension already prevents *new* case-variants, so this is defense-in-depth, not the active bug.

## Tests

- `auth-options-adapter.test.ts` — `getUserByEmail` lowercases the lookup key.
- `auth-options-jwt.test.ts` — jwt callback lowercases `user.email` before the resolve.
- Full CI suite green (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)