### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Sensitive Data Exposure via Stack Traces in Dashboard

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** Found early returns checking buffer lengths (e.g., `providedBuffer.length !== expectedBuffer.length`) on webhook secrets and cron auth tokens before using `crypto.timingSafeEqual`.
 **Learning:** Returning early on length mismatch leaks the exact length of the expected secret.
 **Prevention:** Hash both the expected and provided secrets to a fixed length (e.g., using SHA-256) before passing them to `crypto.timingSafeEqual` to avoid leaking secret lengths while still safely catching any mismatch.
+
+## 2024-07-10 - Sensitive Data Exposure via Stack Traces in Dashboard
+**Vulnerability:** Raw error stack traces were being persisted in the `ErrorLog` database table and displayed directly on the admin dashboard, exposing internal server structures, file paths, and potentially dependency versions.
+**Learning:** Storing and displaying raw stack traces in application-level databases and dashboards violates defense-in-depth principles. Such detailed technical information should remain confined to secure, centralized logging infrastructure.
+**Prevention:** Never persist raw error stack traces in database tables that feed application dashboards. Ensure stack traces are only sent to secure server logs using mechanisms like `console.error` or centralized logging services.

--- a/checkin-app/src/components/admin/ErrorLogPanel.tsx
+++ b/checkin-app/src/components/admin/ErrorLogPanel.tsx
@@ -8,7 +8,6 @@ type ErrorLogRow = {
   timestamp: string;
   route: string | null;
   message: string;
-  stack: string | null;
   context: unknown;
 };
 
@@ -51,7 +50,7 @@ export function ErrorLogPanel() {
     <Card withBorder radius="md" padding="lg">
       <Title order={4} mb="md">Recent Backend Errors</Title>
       <Text c="dimmed" size="sm" mb="md">
-        Up to 100 most recent entries (auto-purged after 30 days). Click a row to expand stack/context.
+        Up to 100 most recent entries (auto-purged after 30 days). Click a row to expand context.
       </Text>
       <Table.ScrollContainer minWidth={600}>
         <Table striped highlightOnHover verticalSpacing="sm">
@@ -79,19 +78,13 @@ export function ErrorLogPanel() {
                   <Table.Tr>
                     <Table.Td colSpan={3}>
                       <Stack gap="xs">
-                        {e.stack && (
-                          <div>
-                            <Text size="xs" fw={700} tt="uppercase" c="dimmed">Stack</Text>
-                            <Code block fz="xs">{e.stack}</Code>
-                          </div>
-                        )}
                         {e.context != null && (
                           <div>
                             <Text size="xs" fw={700} tt="uppercase" c="dimmed">Context</Text>
                             <Code block fz="xs">{JSON.stringify(e.context, null, 2)}</Code>
                           </div>
                         )}
-                        {!e.stack && e.context == null && (
+                        {e.context == null && (
                           <Text c="dimmed" size="sm">No additional detail.</Text>
                         )}
                       </Stack>

--- a/checkin-app/src/components/admin/__tests__/ErrorLogPanel.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/ErrorLogPanel.test.tsx
@@ -10,7 +10,6 @@ const errors = [
     timestamp: "2026-06-01T12:00:00Z",
     route: "/api/checkin",
     message: "Boom",
-    stack: "Error: Boom\n  at x",
     context: { userId: 9 },
   },
 ];
@@ -23,16 +22,16 @@ describe("ErrorLogPanel", () => {
     expect(screen.getByText("/api/checkin")).toBeInTheDocument();
   });
 
-  it("expands and collapses a row to show stack/context", async () => {
+  it("expands and collapses a row to show context", async () => {
     mockFetchJson({ "/api/system-status/errors": { errors } });
     renderWithProviders(<ErrorLogPanel />);
     const row = await screen.findByText("Boom");
 
     fireEvent.click(row);
-    expect(await screen.findByText(/Error: Boom/)).toBeInTheDocument();
+    expect(await screen.findByText(/"userId": 9/)).toBeInTheDocument();
 
     fireEvent.click(row);
-    expect(screen.queryByText(/Error: Boom/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"userId": 9/)).not.toBeInTheDocument();
   });
 
   it("shows the empty message when there are no errors", async () => {

--- a/checkin-app/src/lib/logger.ts
+++ b/checkin-app/src/lib/logger.ts
@@ -14,16 +14,16 @@ export const logger = {
  * @param context Optional additional context to help with debugging
  */
 export async function logBackendError(error: unknown, route?: string, context?: unknown) {
+    logger.error("Backend Error:", error);
     try {
         const message = error instanceof Error ? error.message : String(error);
-        const stack = error instanceof Error ? error.stack : undefined;
 
         // 1. Insert the new error log
         await prisma.errorLog.create({
             data: {
                 message,
                 route,
-                stack,
+                stack: undefined, // Sentinel: Never persist stack traces to DB
                 context: context ? JSON.parse(JSON.stringify(context)) : undefined, // Ensure it's JSON serializable
             }
         });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw error stack traces were being persisted in the `ErrorLog` database table and displayed directly on the admin dashboard, exposing internal server structures, file paths, and potentially dependency versions.
🎯 Impact: An attacker who gains access to the dashboard (or through an IDOR vulnerability) could learn detailed information about the server environment, file structure, and dependencies, which can aid in crafting further attacks.
🔧 Fix: Stopped persisting stack traces to the `ErrorLog` table. Stack traces are now only output to the secure centralized logger (`logger.error`). The UI was also updated to remove stack trace rendering.
✅ Verification: Trigger an error on the backend and view the Error Log dashboard. The stack trace should no longer be displayed, but the error message and context (if any) will still be visible. Verify the server logs contain the full error stack.

---
*PR created automatically by Jules for task [1315780719122588713](https://jules.google.com/task/1315780719122588713) started by @dkaygithub*