### PR TITLE
feat(programs): require max participants on program creation, default 50

### DIFF
--- a/checkin-app/__tests__/programSignupIntegration.test.ts
+++ b/checkin-app/__tests__/programSignupIntegration.test.ts
@@ -112,6 +112,7 @@ describe('Full Program Signup Integration Flow', () => {
                 memberPrice: 50,
                 nonMemberPrice: 100,
                 leadMentorId: sysAdminId,
+                maxParticipants: 50,
             }),
         });
         const createProgramRes = await CreateProgram(createProgramReq as unknown as import("next/server").NextRequest);

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -136,7 +136,8 @@ describe('AuditLog Integration Tests', () => {
                 name: 'Audit Test Program',
                 enrollmentStatus: 'OPEN',
                 startAt: new Date(),
-                leadMentorId: testAdminId
+                leadMentorId: testAdminId,
+                maxParticipants: 50
             })
         });
 

--- a/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
@@ -71,7 +71,7 @@ describe('Program price round-trip (dollars -> cents) Integration Tests', () => 
             const name = `${PROGRAM_NAME_TAG} decimal`;
             const req = new Request('http://localhost:4000/api/programs', {
                 method: 'POST',
-                body: JSON.stringify({ name, leadMentorId: leadId, memberPrice: '25.99', nonMemberPrice: '100' }),
+                body: JSON.stringify({ name, leadMentorId: leadId, memberPrice: '25.99', nonMemberPrice: '100', maxParticipants: 50 }),
             });
             const res = await POST(req as unknown as import('next/server').NextRequest);
             expect(res.status).toBe(200);
@@ -87,7 +87,7 @@ describe('Program price round-trip (dollars -> cents) Integration Tests', () => 
             const name = `${PROGRAM_NAME_TAG} wholedollar`;
             const req = new Request('http://localhost:4000/api/programs', {
                 method: 'POST',
-                body: JSON.stringify({ name, leadMentorId: leadId, memberPrice: '30', nonMemberPrice: '' }),
+                body: JSON.stringify({ name, leadMentorId: leadId, memberPrice: '30', nonMemberPrice: '', maxParticipants: 50 }),
             });
             const res = await POST(req as unknown as import('next/server').NextRequest);
             expect(res.status).toBe(200);
@@ -103,7 +103,7 @@ describe('Program price round-trip (dollars -> cents) Integration Tests', () => 
             const name = `${PROGRAM_NAME_TAG} null`;
             const req = new Request('http://localhost:4000/api/programs', {
                 method: 'POST',
-                body: JSON.stringify({ name, leadMentorId: leadId }),
+                body: JSON.stringify({ name, leadMentorId: leadId, maxParticipants: 50 }),
             });
             const res = await POST(req as unknown as import('next/server').NextRequest);
             expect(res.status).toBe(200);

--- a/checkin-app/src/app/__tests__/programVariantRoundtripShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programVariantRoundtripShopify.integration.test.ts
@@ -114,6 +114,7 @@ describe('Shopify variant round-trip: create -> persist -> webhook match', () =>
             leadMentorId: leadId,
             memberPrice: '25.00',
             nonMemberPrice: '35.00',
+            maxParticipants: 50,
         }));
         expect(res.status).toBe(200);
         const data = await res.json();
@@ -168,6 +169,7 @@ describe('Shopify variant round-trip: create -> persist -> webhook match', () =>
                 leadMentorId: leadId,
                 memberPrice: '25.00',
                 nonMemberPrice: '35.00',
+                maxParticipants: 50,
             }));
             expect(res.status).toBe(200);
             const data = await res.json();

--- a/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
@@ -160,22 +160,36 @@ describe('Programs API Integration Tests', () => {
              expect(res.status).toBe(400);
         });
 
+        it('should require max participants', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+             const req = new Request('http://localhost:4000/api/programs', {
+                 method: 'POST',
+                 body: JSON.stringify({ name: 'New API Test Program', leadMentorId: leadId })
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest);
+             expect(res.status).toBe(400);
+             const data = await res.json();
+             expect(data.error).toMatch(/Max participants/);
+        });
+
         it('should allow admins to create a program', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
 
              const req = new Request('http://localhost:4000/api/programs', {
                  method: 'POST',
-                 body: JSON.stringify({ name: 'Created API Test Program', leadMentorId: leadId, minAge: 12, maxAge: 17 })
+                 body: JSON.stringify({ name: 'Created API Test Program', leadMentorId: leadId, minAge: 12, maxAge: 17, maxParticipants: 50 })
              });
              const res = await POST(req as unknown as import("next/server").NextRequest);
              expect(res.status).toBe(200);
-             
+
              const data = await res.json();
              expect(data.success).toBe(true);
              expect(data.program.name).toBe('Created API Test Program');
              expect(data.program.leadMentorId).toBe(leadId);
              expect(data.program.minAge).toBe(12);
              expect(data.program.maxAge).toBe(17);
+             expect(data.program.maxParticipants).toBe(50);
         });
     });
 });

--- a/checkin-app/src/app/api/programs/__tests__/programsCreateDate.test.ts
+++ b/checkin-app/src/app/api/programs/__tests__/programsCreateDate.test.ts
@@ -87,6 +87,7 @@ describe('POST /api/programs — startAt/endAt date preservation (issue #154)', 
                 leadMentorId: 7,
                 startAt: beginStr,
                 endAt: endStr,
+                maxParticipants: 50,
             }),
         }) as unknown as import('next/server').NextRequest;
 
@@ -138,6 +139,7 @@ describe('POST /api/programs — startAt/endAt date preservation (issue #154)', 
             body: JSON.stringify({
                 name: 'No-Date Program',
                 leadMentorId: 7,
+                maxParticipants: 50,
                 // startAt and endAt intentionally absent — simulates form left blank
             }),
         }) as unknown as import('next/server').NextRequest;

--- a/checkin-app/src/app/api/programs/route.ts
+++ b/checkin-app/src/app/api/programs/route.ts
@@ -110,6 +110,11 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
             return apiError("Lead Mentor is required", 400);
         }
 
+        const maxPart = maxParticipants != null ? parseInt(maxParticipants, 10) : null;
+        if (maxPart == null || isNaN(maxPart) || maxPart < 1) {
+            return apiError("Max participants is required and must be at least 1", 400);
+        }
+
         const ageErr = validateProgramAgeBounds(minAge, maxAge);
         if (ageErr) {
             return apiError(ageErr, 400);
@@ -118,7 +123,6 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         // Client sends a raw dollar string; tolerate a number too. Convert to cents here.
         const mPrice = dollarsToCentsOrNull(memberPrice != null ? String(memberPrice) : undefined);
         const nmPrice = dollarsToCentsOrNull(nonMemberPrice != null ? String(nonMemberPrice) : undefined);
-        const maxPart = maxParticipants ? parseInt(maxParticipants, 10) : null;
 
         // Single-pool model (product decision 2026-07-06): ONE Shopify variant,
         // priced at the base/non-member rate — replaces the two-variant model for

--- a/checkin-app/src/app/program-ops/new/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/new/__tests__/page.test.tsx
@@ -66,7 +66,7 @@ describe("CreateProgramPage", () => {
     expect(screen.getByText("End date must be on or after start date.")).toBeInTheDocument();
   });
 
-  it("warns when the member price exceeds the non-member price and no max participants is set", async () => {
+  it("warns when the member price exceeds the non-member price", async () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({});
     renderWithProviders(<CreateProgramPage />);
@@ -77,10 +77,23 @@ describe("CreateProgramPage", () => {
     fireEvent.change(screen.getByLabelText("Non-Member Price ($)"), { target: { value: "20" } });
 
     expect(screen.getByText(/Member price is higher than non-member price/)).toBeInTheDocument();
-    expect(screen.getByText(/No max participants set/)).toBeInTheDocument();
+  });
 
-    fireEvent.change(screen.getByLabelText("Max Participants (Optional)"), { target: { value: "30" } });
-    expect(screen.queryByText(/No max participants set/)).not.toBeInTheDocument();
+  it("defaults max participants to 50 and disables submit when it is cleared", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/people/search": { people: [mentor] } });
+    renderWithProviders(<CreateProgramPage />);
+    const nameInput = await screen.findByLabelText("Program Name", { exact: false });
+
+    const maxInput = screen.getByLabelText("Max Participants", { exact: false });
+    expect(maxInput).toHaveValue("50");
+
+    fireEvent.change(nameInput, { target: { value: "FRC Robotics 2026" } });
+    await pickMentor();
+    expect(screen.getByRole("button", { name: "Create Program" })).toBeEnabled();
+
+    fireEvent.change(maxInput, { target: { value: "" } });
+    expect(screen.getByRole("button", { name: "Create Program" })).toBeDisabled();
   });
 
   it("searches for and selects a lead mentor, then clears the selection", async () => {
@@ -141,7 +154,7 @@ describe("CreateProgramPage", () => {
             maxAge: 18,
             memberPrice: null,
             nonMemberPrice: null,
-            maxParticipants: null,
+            maxParticipants: 50,
             leadMentorId: 7,
           }),
         }),

--- a/checkin-app/src/app/program-ops/new/page.tsx
+++ b/checkin-app/src/app/program-ops/new/page.tsx
@@ -28,7 +28,7 @@ export default function CreateProgramPage() {
   const [isFree, setIsFree] = useState(true);
   const [memberPrice, setMemberPrice] = useState("");
   const [nonMemberPrice, setNonMemberPrice] = useState("");
-  const [maxParticipants, setMaxParticipants] = useState("");
+  const [maxParticipants, setMaxParticipants] = useState("50");
   const [orgMemberOnly, setMemberOnly] = useState(false);
   const [saving, setSaving] = useState(false);
   const [submitted, setSubmitted] = useState(false);
@@ -61,7 +61,7 @@ export default function CreateProgramPage() {
           maxAge: maxAge ? parseInt(maxAge) : null,
           memberPrice: (!isFree && memberPrice) ? memberPrice : null,
           nonMemberPrice: (!isFree && !orgMemberOnly && nonMemberPrice) ? nonMemberPrice : null,
-          maxParticipants: maxParticipants ? parseInt(maxParticipants) : null,
+          maxParticipants: parseInt(maxParticipants),
           leadMentorId: leadMentorId ? parseInt(leadMentorId) : null
         })
       });
@@ -85,7 +85,7 @@ export default function CreateProgramPage() {
   const isDirty =
     !submitted &&
     !shallowEqual(
-      { name: "", startAt: "", endAt: "", minAge: "", maxAge: "", isFree: true, memberPrice: "", nonMemberPrice: "", maxParticipants: "", orgMemberOnly: false, leadMentorId: "" },
+      { name: "", startAt: "", endAt: "", minAge: "", maxAge: "", isFree: true, memberPrice: "", nonMemberPrice: "", maxParticipants: "50", orgMemberOnly: false, leadMentorId: "" },
       { name, startAt, endAt, minAge, maxAge, isFree, memberPrice, nonMemberPrice, maxParticipants, orgMemberOnly, leadMentorId },
     );
   useUnsavedGuard(isDirty);
@@ -188,21 +188,14 @@ export default function CreateProgramPage() {
               </>
             )}
 
-            <div>
-              <NumberInput
-                label="Max Participants (Optional)"
-                value={maxParticipants}
-                onChange={(v) => setMaxParticipants(String(v))}
-                min={1}
-                placeholder="Leave blank for unlimited"
-                description="Sets the inventory limit on Shopify. Leave blank for unlimited enrollment."
-              />
-              {(memberPrice || nonMemberPrice) && !maxParticipants && (
-                <Alert color="yellow" variant="light" mt="xs">
-                  ⚠️ No max participants set — Shopify will allow unlimited purchases for this program.
-                </Alert>
-              )}
-            </div>
+            <NumberInput
+              label="Max Participants"
+              required
+              value={maxParticipants}
+              onChange={(v) => setMaxParticipants(String(v))}
+              min={1}
+              description="Sets the inventory limit on Shopify."
+            />
 
             <Checkbox
               checked={orgMemberOnly}
@@ -216,7 +209,7 @@ export default function CreateProgramPage() {
             )}
 
             <Group justify="flex-end">
-              <Button type="submit" color="green" disabled={saving || !name.trim() || !leadMentorId || datesInvalid} loading={saving}>
+              <Button type="submit" color="green" disabled={saving || !name.trim() || !leadMentorId || !maxParticipants || datesInvalid} loading={saving}>
                 Create Program
               </Button>
             </Group>


### PR DESCRIPTION
## What

Makes **Max Participants** a required field in the Create Program flow, defaulted to **50**. Previously it was optional, and leaving it blank meant unlimited Shopify inventory.

## Changes

- **Create Program form** ([program-ops/new/page.tsx](checkin-app/src/app/program-ops/new/page.tsx)): field defaults to `50`, is marked `required`, drops the "leave blank for unlimited" copy and the no-cap warning alert, and submit is disabled until a value is present. The unsaved-changes baseline was updated so the pre-filled `50` doesn't register as a dirty edit.
- **POST /api/programs** ([route.ts](checkin-app/src/app/api/programs/route.ts)): rejects requests without a `maxParticipants >= 1` (400).
- **Shopify**: the value already flows through to Shopify via `createShopifySingleVariantProgram`, which sets `inventory_management: 'shopify'`, `inventory_policy: 'deny'`, and the `available` quantity. Because a cap is now always provided, inventory is always enforced for paid programs.

## Tests

- New `programsAPI` case asserting a create without `maxParticipants` returns 400.
- Updated the `programsAPI`, `auditLog`, and `programSignup` integration tests' create-program payloads to include `maxParticipants` and assert it persists.

> Note: node isn't available in my local environment, so the Jest/lint suites were not run locally — they run in Docker/CI per the repo's `test:flow:standalone` setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)