### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix stack trace exposure in error logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** Found early returns checking buffer lengths (e.g., `providedBuffer.length !== expectedBuffer.length`) on webhook secrets and cron auth tokens before using `crypto.timingSafeEqual`.
 **Learning:** Returning early on length mismatch leaks the exact length of the expected secret.
 **Prevention:** Hash both the expected and provided secrets to a fixed length (e.g., using SHA-256) before passing them to `crypto.timingSafeEqual` to avoid leaking secret lengths while still safely catching any mismatch.
+
+## 2024-07-12 - Prevent Leaking Stack Traces to Admin Dashboards
+**Vulnerability:** The `logBackendError` utility was saving raw error stack traces to the `ErrorLog` table, which feeds directly into the administrative UI (`ErrorLogPanel`).
+**Learning:** Persisting raw error stack traces in database tables accessible via application dashboards violates defense-in-depth principles. Stack traces can inadvertently expose internal server information, directory structures, and dependency versions to users with dashboard access.
+**Prevention:** Do not persist error stack traces to database tables. Stack traces should only be sent to secure, centralized logging infrastructure (e.g., via standard server logs like `console.error`) where access is strictly controlled.

--- a/checkin-app/src/lib/logger.ts
+++ b/checkin-app/src/lib/logger.ts
@@ -18,12 +18,15 @@ export async function logBackendError(error: unknown, route?: string, context?: 
         const message = error instanceof Error ? error.message : String(error);
         const stack = error instanceof Error ? error.stack : undefined;
 
+        if (stack) {
+            console.error(`[Backend Error Stack] ${route || 'Unknown route'}:`, stack);
+        }
+
         // 1. Insert the new error log
         await prisma.errorLog.create({
             data: {
                 message,
                 route,
-                stack,
                 context: context ? JSON.parse(JSON.stringify(context)) : undefined, // Ensure it's JSON serializable
             }
         });


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Raw error stack traces were being persisted in the `ErrorLog` table and displayed in the admin dashboard (`ErrorLogPanel`).
🎯 **Impact:** Exposes internal server information, directory structures, and dependency details to users with admin dashboard access, violating defense-in-depth.
🔧 **Fix:** Modified `logBackendError` to stop saving the `stack` property to the database. Instead, stack traces are sent to `console.error` for secure, centralized logging.
✅ **Verification:** Verified by checking that `logBackendError` no longer saves the stack trace, and ran all tests using `npm run test:ci` and `npm run lint`.

---
*PR created automatically by Jules for task [3513377155993381462](https://jules.google.com/task/3513377155993381462) started by @dkaygithub*