### PR TITLE
fix(shopify): connect inventory item to location before set — new programs launched out of stock

### DIFF
--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -190,11 +190,12 @@ describe('createShopifyProgramVariants', () => {
 
     describe('inventory branch (maxParticipants configured, real Shopify path)', () => {
         // Single priced tier (member only) keeps the fetch sequence short:
-        // token, product (variant inline), locations, [inventory_levels/set].
-        it('sets inventory at the store location when maxParticipants is configured', async () => {
+        // token, product (variant inline), locations, connect, [inventory_levels/set].
+        it('connects then sets inventory at the store location when maxParticipants is configured', async () => {
             mockTokenResponse(fetchMock);
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 500, variants: [{ id: 600, option1: 'Member', inventory_item_id: 700 }] } }) }); // product + inline variant
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 900 }] }) }); // locations
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/connect
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/set
 
             const result = await createShopifyProgramVariants('Inventory Program', 10, null, 5);
@@ -204,9 +205,17 @@ describe('createShopifyProgramVariants', () => {
                 shopifyOrgMemberVariantId: '600',
                 shopifyNonOrgMemberVariantId: null,
             });
-            expect(fetchMock).toHaveBeenCalledTimes(4);
+            expect(fetchMock).toHaveBeenCalledTimes(5);
             expect(String(fetchMock.mock.calls[2][0])).toContain('/locations.json');
-            const invCall = fetchMock.mock.calls[3];
+            // Connect the fresh inventory item to the location before setting — a
+            // new variant is tracked but not stocked, so set alone would 422.
+            const connectCall = fetchMock.mock.calls[3];
+            expect(String(connectCall[0])).toContain('/inventory_levels/connect.json');
+            expect(JSON.parse((connectCall[1] as RequestInit).body as string)).toEqual({
+                location_id: 900,
+                inventory_item_id: 700,
+            });
+            const invCall = fetchMock.mock.calls[4];
             expect(String(invCall[0])).toContain('/inventory_levels/set.json');
             expect(JSON.parse((invCall[1] as RequestInit).body as string)).toEqual({
                 location_id: 900,
@@ -215,10 +224,55 @@ describe('createShopifyProgramVariants', () => {
             });
         });
 
+        it('proceeds to set inventory when connect returns 422 (level already exists, e.g. re-sync)', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 505, variants: [{ id: 605, option1: 'Member', inventory_item_id: 705 }] } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 905 }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => 'already connected' }); // connect: already exists
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // set still runs
+
+            const result = await createShopifyProgramVariants('Reconnect Program', 10, null, 4);
+
+            expect(result).toEqual({
+                shopifyProductId: '505',
+                shopifyOrgMemberVariantId: '605',
+                shopifyNonOrgMemberVariantId: null,
+            });
+            expect(fetchMock).toHaveBeenCalledTimes(5);
+            const invCall = fetchMock.mock.calls[4];
+            expect(String(invCall[0])).toContain('/inventory_levels/set.json');
+            expect(JSON.parse((invCall[1] as RequestInit).body as string)).toEqual({
+                location_id: 905,
+                inventory_item_id: 705,
+                available: 4,
+            });
+        });
+
+        it('logs and skips set when connect fails for a non-422 reason (non-fatal)', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 506, variants: [{ id: 606, option1: 'Member', inventory_item_id: 706 }] } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 906 }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'connect boom' }); // connect fails hard
+
+            const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const result = await createShopifyProgramVariants('Connect Fail Program', 10, null, 3);
+
+            expect(result).toEqual({
+                shopifyProductId: '506',
+                shopifyOrgMemberVariantId: '606',
+                shopifyNonOrgMemberVariantId: null,
+            });
+            // connect failed → set.json is never reached (no 5th call).
+            expect(fetchMock).toHaveBeenCalledTimes(4);
+            expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to connect inventory item to location: 500'), 'connect boom');
+            expect(sendEmail).not.toHaveBeenCalled();
+        });
+
         it('logs and does not fail the whole call when inventory_levels/set itself fails (non-fatal)', async () => {
             mockTokenResponse(fetchMock);
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 501, variants: [{ id: 601, option1: 'Member', inventory_item_id: 701 }] } }) });
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 901 }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // connect ok
             fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'inventory boom' });
 
             const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -476,12 +530,15 @@ describe('createShopifySingleVariantProgram', () => {
         mockTokenResponse(fetchMock);
         fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 700, variants: [{ id: 800, inventory_item_id: 900 }] } }) });
         fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 950 }] }) });
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/connect
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/set
 
         const result = await createShopifySingleVariantProgram('Single Pool Program', 3500, 10);
 
         expect(result).toEqual({ shopifyProductId: '700', shopifyVariantId: '800' });
-        expect(fetchMock).toHaveBeenCalledTimes(4); // token + product (variant inline) + locations + inventory set
+        expect(fetchMock).toHaveBeenCalledTimes(5); // token + product (variant inline) + locations + connect + inventory set
+        expect(String(fetchMock.mock.calls[3][0])).toContain('/inventory_levels/connect.json');
+        expect(String(fetchMock.mock.calls[4][0])).toContain('/inventory_levels/set.json');
 
         // The variant MUST ride inside the product create: a bare create mints a
         // physical $0 "Default Title" variant that 422s the follow-up variant

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -157,6 +157,32 @@ async function setInitialShopifyInventory(
             const locData = await locRes.json();
             const locationId = locData.locations?.[0]?.id;
             if (locationId) {
+                // Connect the inventory item to the location FIRST. A variant
+                // freshly minted with inventory_management:'shopify' is tracked
+                // but not yet stocked at any location, and inventory_levels/set
+                // does NOT reliably auto-connect a new item at a standard
+                // location — it 422s ("inventory item is not stocked at the
+                // location"). connect.json creates the inventory level (at 0),
+                // after which set.json can set the absolute quantity. Without
+                // this, set silently failed and every priced program launched
+                // out of stock. A 422 here means the level already exists
+                // (e.g. a re-sync), which is fine — fall through to set.
+                const connectRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/connect.json`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Shopify-Access-Token': accessToken,
+                    },
+                    body: JSON.stringify({
+                        location_id: locationId,
+                        inventory_item_id: inventoryItemId,
+                    })
+                }, "Shopify connect inventory");
+                if (!connectRes.ok && connectRes.status !== 422) {
+                    console.error(`[SHOPIFY] Failed to connect inventory item to location: ${connectRes.status}`, await connectRes.text());
+                    return;
+                }
+
                 const invRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/set.json`, {
                     method: 'POST',
                     headers: {


### PR DESCRIPTION
## Problem

Newly created **priced** programs show up **out of stock** in Shopify instead of being stocked with `maxParticipants` slots.

## Root cause

A variant freshly minted with `inventory_management: 'shopify'` is *tracked* but not yet *stocked/connected* at any location. In API version `2026-01`, `POST /inventory_levels/set.json` does **not** reliably auto-connect a new item at a standard location — it returns `422 "The specified inventory item is not stocked at the location."`

`setInitialShopifyInventory` swallows that as non-fatal (logs only, never throws), so the program was created "successfully" with `available` stuck at its default **0**, and with `inventory_policy: 'deny'` that reads as out of stock.

The recent #971 inline-variant fix repaired variant *creation* but left this inventory step silently broken — which is why the out-of-stock symptom persisted after that "fix."

## Fix

Connect the inventory item to the location **first** (`POST /inventory_levels/connect.json`, creating the level at 0), then set the absolute quantity (`POST /inventory_levels/set.json`).

- A `422` on connect means the level already exists (e.g. a re-sync) → falls through to set.
- Any other connect failure is logged and skips set — same non-fatal contract as before.
- Covers both creation paths (`createShopifySingleVariantProgram` and the legacy `createShopifyProgramVariants`), which both route through this helper.

## Testing

- `shopify.test.ts` updated (29 passing): connect step added to happy-path assertions, plus new cases for connect-returns-422-still-sets and connect-hard-fails-skips-set.
- `tsc --noEmit` clean.
- ⚠️ This is a live-Shopify-API behavior fix; mocked tests prove the call sequence but not that the real 422 is gone. Definitive check: create a priced program against the real store and confirm it lands at `available = maxParticipants`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)