### PR TITLE
fix(shopify): capped programs created sold out — harden initial inventory set

### DIFF
--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -15,6 +15,11 @@ jest.mock('../prisma', () => ({
     }
 }));
 
+jest.mock('../logger', () => ({
+    logIntegrationError: jest.fn().mockResolvedValue(undefined),
+}));
+import { logIntegrationError } from '../logger';
+
 // Helper: mock a successful token response
 function mockTokenResponse(fetchMock: jest.Mock) {
     fetchMock.mockResolvedValueOnce({
@@ -215,42 +220,102 @@ describe('createShopifyProgramVariants', () => {
             });
         });
 
-        it('logs and does not fail the whole call when inventory_levels/set itself fails (non-fatal)', async () => {
+        it('picks an ACTIVE location, not locations[0], to avoid a 422 that leaves the product sold out', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 510, variants: [{ id: 610, option1: 'Member', inventory_item_id: 710 }] } }) });
+            // A deactivated location sorts first; the active one is second.
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 111, active: false }, { id: 222, active: true }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // set
+
+            const result = await createShopifyProgramVariants('Active Location Program', 10, null, 4);
+
+            expect(result?.shopifyOrgMemberVariantId).toBe('610');
+            const invCall = fetchMock.mock.calls[3];
+            expect(String(invCall[0])).toContain('/inventory_levels/set.json');
+            expect(JSON.parse((invCall[1] as RequestInit).body as string)).toEqual({
+                location_id: 222, // the ACTIVE location, not the first (deactivated) one
+                inventory_item_id: 710,
+                available: 4,
+            });
+            expect(logIntegrationError).not.toHaveBeenCalled();
+        });
+
+        it('connects the inventory item then retries set when the first set 422s (not stocked at location)', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 520, variants: [{ id: 620, option1: 'Member', inventory_item_id: 720 }] } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 990, active: true }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => 'inventory item is not stocked at location' }); // set → 422
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // connect
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // set retry
+
+            const result = await createShopifyProgramVariants('Not Stocked Program', 10, null, 6);
+
+            expect(result?.shopifyOrgMemberVariantId).toBe('620');
+            expect(fetchMock).toHaveBeenCalledTimes(6); // token, product, locations, set(422), connect, set(retry)
+            expect(String(fetchMock.mock.calls[4][0])).toContain('/inventory_levels/connect.json');
+            expect(JSON.parse((fetchMock.mock.calls[4][1] as RequestInit).body as string)).toEqual({ location_id: 990, inventory_item_id: 720 });
+            expect(String(fetchMock.mock.calls[5][0])).toContain('/inventory_levels/set.json');
+            expect(JSON.parse((fetchMock.mock.calls[5][1] as RequestInit).body as string)).toEqual({ location_id: 990, inventory_item_id: 720, available: 6 });
+            expect(logIntegrationError).not.toHaveBeenCalled(); // retry succeeded → no surfaced failure
+        });
+
+        it('surfaces to IntegrationErrorLog when inventory set ultimately fails — a sold-out product is visible, not silent', async () => {
             mockTokenResponse(fetchMock);
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 501, variants: [{ id: 601, option1: 'Member', inventory_item_id: 701 }] } }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 901 }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 901, active: true }] }) });
             fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'inventory boom' });
 
-            const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            jest.spyOn(console, 'error').mockImplementation(() => {});
             const result = await createShopifyProgramVariants('Inventory Fail Program', 10, null, 3);
 
-            // Non-fatal: the variant itself was created fine; only the inventory
-            // step failed, and it's logged rather than surfaced as an error email.
+            // Non-fatal to the create: the variant itself was made fine (returned),
+            // but the inventory failure is now logged to the Link Status tab so the
+            // resulting sold-out product doesn't ship silently. Still no admin email.
             expect(result).toEqual({
                 shopifyProductId: '501',
                 shopifyOrgMemberVariantId: '601',
                 shopifyNonOrgMemberVariantId: null,
             });
-            expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to set inventory: 500'), 'inventory boom');
+            expect(logIntegrationError).toHaveBeenCalledWith(
+                'shopify',
+                expect.objectContaining({ message: expect.stringContaining('inventory_levels/set returned 500') }),
+                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
+            );
             expect(sendEmail).not.toHaveBeenCalled();
-            // afterEach's jest.restoreAllMocks() cleans up errSpy — mockRestore()
-            // here would also wipe the calls we just asserted on.
         });
 
-        it('skips inventory_levels/set when the store has no locations configured', async () => {
+        it('surfaces (not silently skips) when the store has no locations configured', async () => {
             mockTokenResponse(fetchMock);
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 502, variants: [{ id: 602, option1: 'Member', inventory_item_id: 702 }] } }) });
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [] }) });
 
             const result = await createShopifyProgramVariants('No Location Program', 10, null, 2);
 
-            expect(result).toEqual({
-                shopifyProductId: '502',
-                shopifyOrgMemberVariantId: '602',
-                shopifyNonOrgMemberVariantId: null,
-            });
-            // No 4th call: locations returned empty, so inventory_levels/set is never reached.
+            expect(result?.shopifyOrgMemberVariantId).toBe('602');
+            // No inventory_levels/set call (no location), but the failure is surfaced.
             expect(fetchMock).toHaveBeenCalledTimes(3);
+            expect(logIntegrationError).toHaveBeenCalledWith(
+                'shopify',
+                expect.objectContaining({ message: expect.stringContaining('no Shopify location') }),
+                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
+            );
+        });
+
+        it('surfaces when the created variant has no inventory_item_id (would be sold out)', async () => {
+            mockTokenResponse(fetchMock);
+            // Product create response omits inventory_item_id on the tracked variant.
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 503, variants: [{ id: 603, option1: 'Member' }] } }) });
+
+            const result = await createShopifyProgramVariants('No Inventory Item Program', 10, null, 2);
+
+            expect(result?.shopifyOrgMemberVariantId).toBe('603');
+            // Bails before locations/set (nothing to set stock on), but surfaces it.
+            expect(fetchMock).toHaveBeenCalledTimes(2); // token, product only
+            expect(logIntegrationError).toHaveBeenCalledWith(
+                'shopify',
+                expect.objectContaining({ message: expect.stringContaining('no inventory_item_id') }),
+                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
+            );
         });
     });
 

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -136,48 +136,85 @@ async function reportShopifyFailure(
 }
 
 /**
- * Best-effort: resolve the store's primary location, then set an absolute
- * inventory level for one inventory_item_id. Used at variant-creation time
- * (both the legacy two-variant path and the single-variant path) where
- * `available` should be exactly maxParticipants. Never throws — a failure
- * here doesn't undo the variant that was just created successfully.
+ * Set the initial absolute inventory (== maxParticipants) for one variant's
+ * inventory_item_id. A capped program's variant is created inline with
+ * inventory_management='shopify' + inventory_policy='deny' and Shopify's default
+ * 0 available, so WITHOUT this the storefront immediately shows "Sold out". This
+ * call is the only thing that lifts it off zero.
+ *
+ * Hardened against the two real-store failure modes that previously left products
+ * silently sold out:
+ *   - `/locations.json` returns deactivated + fulfillment-service locations in an
+ *     arbitrary order; setting at an inactive one 422s. We pick an ACTIVE location,
+ *     not blindly `locations[0]`.
+ *   - a freshly-created inventory item is often not stocked at that location yet,
+ *     so REST `set` 422s ("not stocked at location"). We `connect` it, then retry.
+ *
+ * Still never throws (a failure must not undo the created variant), but now RETURNS
+ * whether stock was actually set and SURFACES failures to IntegrationErrorLog
+ * (System Status → Link Status) — a sold-out product is visible instead of silent.
  */
 async function setInitialShopifyInventory(
     storeDomain: string,
     accessToken: string,
-    inventoryItemId: number,
+    inventoryItemId: number | undefined,
     quantity: number,
     label: string,
-): Promise<void> {
+): Promise<boolean> {
+    const jsonHeaders = { 'Content-Type': 'application/json', 'X-Shopify-Access-Token': accessToken };
     try {
+        if (!inventoryItemId) {
+            // The product-create response carried no inventory_item_id for this tracked
+            // variant, so we can't set stock — it would ship sold out. Surface it.
+            await logIntegrationError("shopify", new Error(`Variant '${label}' has no inventory_item_id; cannot set initial stock (product would be sold out)`), { operation: "setInitialShopifyInventory", label, quantity });
+            return false;
+        }
+
         const locRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/locations.json`, {
             headers: { 'X-Shopify-Access-Token': accessToken },
         }, "Shopify get locations");
-        if (locRes.ok) {
-            const locData = await locRes.json();
-            const locationId = locData.locations?.[0]?.id;
-            if (locationId) {
-                const invRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/set.json`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Shopify-Access-Token': accessToken,
-                    },
-                    body: JSON.stringify({
-                        location_id: locationId,
-                        inventory_item_id: inventoryItemId,
-                        available: quantity,
-                    })
-                }, "Shopify set inventory");
-                if (invRes.ok) {
-                    console.log(`[SHOPIFY] Set inventory for variant ${label} to ${quantity} at location ${locationId}`);
-                } else {
-                    console.error(`[SHOPIFY] Failed to set inventory: ${invRes.status}`, await invRes.text());
-                }
-            }
+        if (!locRes.ok) {
+            await logIntegrationError("shopify", new Error(`locations.json returned ${locRes.status}`), { operation: "setInitialShopifyInventory", label, quantity });
+            return false;
         }
+
+        const locData = await locRes.json();
+        const locations: Array<{ id?: number; active?: boolean }> = locData.locations ?? [];
+        // Prefer an active location; `locations[0]` may be a deactivated or
+        // fulfillment-service location that `set` can't write to.
+        const locationId = (locations.find((l) => l.active !== false) ?? locations[0])?.id;
+        if (!locationId) {
+            await logIntegrationError("shopify", new Error("no Shopify location available to set inventory"), { operation: "setInitialShopifyInventory", label, quantity });
+            return false;
+        }
+
+        const setUrl = `https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/set.json`;
+        const setBody = JSON.stringify({ location_id: locationId, inventory_item_id: inventoryItemId, available: quantity });
+        let invRes = await shopifyFetch(setUrl, { method: 'POST', headers: jsonHeaders, body: setBody }, "Shopify set inventory");
+
+        // A just-created inventory item is often not stocked at this location yet, so
+        // `set` 422s ("not stocked at location"). Connect it, then retry the set.
+        if (!invRes.ok && invRes.status === 422) {
+            await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/connect.json`, {
+                method: 'POST',
+                headers: jsonHeaders,
+                body: JSON.stringify({ location_id: locationId, inventory_item_id: inventoryItemId }),
+            }, "Shopify connect inventory");
+            invRes = await shopifyFetch(setUrl, { method: 'POST', headers: jsonHeaders, body: setBody }, "Shopify set inventory (retry)");
+        }
+
+        if (invRes.ok) {
+            console.log(`[SHOPIFY] Set inventory for variant ${label} to ${quantity} at location ${locationId}`);
+            return true;
+        }
+        const errBody = await invRes.text();
+        console.error(`[SHOPIFY] Failed to set inventory: ${invRes.status}`, errBody);
+        await logIntegrationError("shopify", new Error(`inventory_levels/set returned ${invRes.status}: ${errBody}`), { operation: "setInitialShopifyInventory", label, quantity, locationId });
+        return false;
     } catch (invErr) {
         console.error("Failed to set Shopify inventory level:", invErr);
+        await logIntegrationError("shopify", invErr, { operation: "setInitialShopifyInventory", label, quantity });
+        return false;
     }
 }
 
@@ -279,7 +316,7 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
         }
 
         // Set inventory level if maxParticipants is configured
-        if (maxParticipants && created.inventory_item_id) {
+        if (maxParticipants) {
             await setInitialShopifyInventory(storeDomain, accessToken, created.inventory_item_id, maxParticipants, created.option1);
         }
     }
@@ -393,7 +430,7 @@ export async function createShopifySingleVariantProgram(
         }
         const variantId = variant.id.toString();
 
-        if (maxParticipants && variant.inventory_item_id) {
+        if (maxParticipants) {
             await setInitialShopifyInventory(storeDomain, accessToken, variant.inventory_item_id, maxParticipants, "Standard");
         }
 


### PR DESCRIPTION
## The bug

Creating a **capped** program (with `maxParticipants`) produces a Shopify product that's immediately **Sold out**.

## Root cause

In `src/lib/shopify.ts`, a capped program's variant is created inline with:

```js
inventory_management: maxParticipants ? 'shopify' : null,
inventory_policy:     maxParticipants ? 'deny'    : 'continue',
```

A new tracked Shopify variant defaults to **0 available**, and `deny` blocks purchase at 0 → **Sold out**. The only thing that lifts it off zero is a *separate* follow-up `inventory_levels/set` call in `setInitialShopifyInventory()`, which was **best-effort and swallowed every failure** (its doc comment: *"Never throws"*). So a capped program shipped sold-out whenever that set didn't land — and nobody was alerted. The prior tests even pinned the silent-failure behavior (`"logs and does not fail … when inventory_levels/set itself fails"`, `"skips … when the store has no locations"`).

Three real-store triggers, all silent before:
1. **Wrong location** — `set` used `locations[0]`, but `/locations.json` returns deactivated + fulfillment-service locations in arbitrary order; an inactive one `422`s (*"not stocked at location"*).
2. **Not stocked yet** — a freshly-created inventory item often isn't connected to the chosen location, so even the right location `422`s on the first `set`.
3. **Missing `inventory_item_id`** — the product-create response occasionally omits it, so the set was skipped entirely (`&& created.inventory_item_id` guard).

(Uncapped programs use `inventory_management:null` → untracked → can never be sold out; unaffected.)

## The fix

`setInitialShopifyInventory` now:
- **picks an ACTIVE location** (`locations.find(l => l.active !== false)`), not blindly `locations[0]`;
- on a **422**, `POST /inventory_levels/connect.json` then **retries** the set (the documented way to stock a new item at a location);
- **returns** whether stock was set, and **surfaces** any remaining failure — plus the missing-`inventory_item_id` case — to **IntegrationErrorLog (System Status → Link Status)**, so a sold-out product is visible instead of silent.

The two call sites now route a missing `inventory_item_id` through the (surfacing) function instead of silently skipping. Prod create paths are otherwise unchanged; the happy path is still a single `set` call.

## Tests

`src/lib/__tests__/shopify.test.ts` — added: active-location selection (targets the active location, not the first/deactivated one), connect-then-retry on 422, surfaced failure on a hard set error, surfaced empty-locations, and surfaced missing-`inventory_item_id`. Updated the two tests that previously asserted silent skip to assert surfacing. **30/30 pass**, `tsc --noEmit` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)