### PR TITLE
chore(ui): rename browser tab title to Innovation Treehouse

### DIFF
--- a/checkin-app/src/app/layout.tsx
+++ b/checkin-app/src/app/layout.tsx
@@ -22,7 +22,7 @@ import { config } from '@/lib/config';
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'CheckMeIn Next',
+  title: 'Innovation Treehouse',
   description: 'The Innovation Treehouse next-generation check-in system',
 };
 


### PR DESCRIPTION
## What

Changes the browser tab title (document `<title>`) from **"CheckMeIn Next"** to **"Innovation Treehouse"**.

## Why

The tab name should show the org name families recognize, not the internal product codename.

## Change

`checkin-app/src/app/layout.tsx` — `metadata.title`. The `description` metadata was already Treehouse-branded and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)