### PR TITLE
fix(shopify): connect inventory item to location BEFORE set (adopts #985)

### DIFF
--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -196,10 +196,12 @@ describe('createShopifyProgramVariants', () => {
     describe('inventory branch (maxParticipants configured, real Shopify path)', () => {
         // Single priced tier (member only) keeps the fetch sequence short:
         // token, product (variant inline), locations, [inventory_levels/set].
-        it('sets inventory at the store location when maxParticipants is configured', async () => {
+        // Connect-first: token, product, locations, inventory_levels/connect, inventory_levels/set.
+        it('connects the item to the location, THEN sets inventory, when maxParticipants is configured', async () => {
             mockTokenResponse(fetchMock);
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 500, variants: [{ id: 600, option1: 'Member', inventory_item_id: 700 }] } }) }); // product + inline variant
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 900 }] }) }); // locations
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/connect
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/set
 
             const result = await createShopifyProgramVariants('Inventory Program', 10, null, 5);
@@ -209,61 +211,92 @@ describe('createShopifyProgramVariants', () => {
                 shopifyOrgMemberVariantId: '600',
                 shopifyNonOrgMemberVariantId: null,
             });
-            expect(fetchMock).toHaveBeenCalledTimes(4);
+            expect(fetchMock).toHaveBeenCalledTimes(5);
             expect(String(fetchMock.mock.calls[2][0])).toContain('/locations.json');
-            const invCall = fetchMock.mock.calls[3];
+
+            // connect BEFORE set — a new tracked variant isn't stocked anywhere yet, and
+            // set alone 422s (that's the sold-out bug).
+            const connectCall = fetchMock.mock.calls[3];
+            expect(String(connectCall[0])).toContain('/inventory_levels/connect.json');
+            expect(JSON.parse((connectCall[1] as RequestInit).body as string)).toEqual({
+                location_id: 900,
+                inventory_item_id: 700,
+            });
+
+            const invCall = fetchMock.mock.calls[4];
             expect(String(invCall[0])).toContain('/inventory_levels/set.json');
             expect(JSON.parse((invCall[1] as RequestInit).body as string)).toEqual({
                 location_id: 900,
                 inventory_item_id: 700,
                 available: 5,
             });
+            expect(logIntegrationError).not.toHaveBeenCalled();
         });
 
-        it('picks an ACTIVE location, not locations[0], to avoid a 422 that leaves the product sold out', async () => {
+        it('picks an ACTIVE location, not locations[0], to connect+set against', async () => {
             mockTokenResponse(fetchMock);
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 510, variants: [{ id: 610, option1: 'Member', inventory_item_id: 710 }] } }) });
             // A deactivated location sorts first; the active one is second.
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 111, active: false }, { id: 222, active: true }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // connect
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // set
 
             const result = await createShopifyProgramVariants('Active Location Program', 10, null, 4);
 
             expect(result?.shopifyOrgMemberVariantId).toBe('610');
-            const invCall = fetchMock.mock.calls[3];
-            expect(String(invCall[0])).toContain('/inventory_levels/set.json');
-            expect(JSON.parse((invCall[1] as RequestInit).body as string)).toEqual({
-                location_id: 222, // the ACTIVE location, not the first (deactivated) one
+            // the ACTIVE location (222), not the first (deactivated, 111) one — for both calls
+            expect(JSON.parse((fetchMock.mock.calls[3][1] as RequestInit).body as string)).toEqual({
+                location_id: 222,
+                inventory_item_id: 710,
+            });
+            expect(JSON.parse((fetchMock.mock.calls[4][1] as RequestInit).body as string)).toEqual({
+                location_id: 222,
                 inventory_item_id: 710,
                 available: 4,
             });
             expect(logIntegrationError).not.toHaveBeenCalled();
         });
 
-        it('connects the inventory item then retries set when the first set 422s (not stocked at location)', async () => {
+        it('treats a 422 from connect as "level already exists" and still sets (e.g. a re-sync)', async () => {
             mockTokenResponse(fetchMock);
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 520, variants: [{ id: 620, option1: 'Member', inventory_item_id: 720 }] } }) });
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 990, active: true }] }) });
-            fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => 'inventory item is not stocked at location' }); // set → 422
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // connect
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // set retry
+            fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => 'inventory level already exists' }); // connect → 422
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // set still runs
 
-            const result = await createShopifyProgramVariants('Not Stocked Program', 10, null, 6);
+            const result = await createShopifyProgramVariants('Already Connected Program', 10, null, 6);
 
             expect(result?.shopifyOrgMemberVariantId).toBe('620');
-            expect(fetchMock).toHaveBeenCalledTimes(6); // token, product, locations, set(422), connect, set(retry)
-            expect(String(fetchMock.mock.calls[4][0])).toContain('/inventory_levels/connect.json');
-            expect(JSON.parse((fetchMock.mock.calls[4][1] as RequestInit).body as string)).toEqual({ location_id: 990, inventory_item_id: 720 });
-            expect(String(fetchMock.mock.calls[5][0])).toContain('/inventory_levels/set.json');
-            expect(JSON.parse((fetchMock.mock.calls[5][1] as RequestInit).body as string)).toEqual({ location_id: 990, inventory_item_id: 720, available: 6 });
-            expect(logIntegrationError).not.toHaveBeenCalled(); // retry succeeded → no surfaced failure
+            expect(fetchMock).toHaveBeenCalledTimes(5); // token, product, locations, connect(422), set
+            expect(String(fetchMock.mock.calls[4][0])).toContain('/inventory_levels/set.json');
+            expect(JSON.parse((fetchMock.mock.calls[4][1] as RequestInit).body as string)).toEqual({ location_id: 990, inventory_item_id: 720, available: 6 });
+            expect(logIntegrationError).not.toHaveBeenCalled(); // a 422 here is benign
+        });
+
+        it('surfaces and skips set when connect hard-fails (not a 422)', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 530, variants: [{ id: 630, option1: 'Member', inventory_item_id: 730 }] } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 991, active: true }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'connect boom' }); // connect → 500
+
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            const result = await createShopifyProgramVariants('Connect Fail Program', 10, null, 2);
+
+            expect(result?.shopifyOrgMemberVariantId).toBe('630');
+            expect(fetchMock).toHaveBeenCalledTimes(4); // no set — connect failed hard
+            expect(logIntegrationError).toHaveBeenCalledWith(
+                'shopify',
+                expect.objectContaining({ message: expect.stringContaining('inventory_levels/connect returned 500') }),
+                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
+            );
         });
 
         it('surfaces to IntegrationErrorLog when inventory set ultimately fails — a sold-out product is visible, not silent', async () => {
             mockTokenResponse(fetchMock);
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 501, variants: [{ id: 601, option1: 'Member', inventory_item_id: 701 }] } }) });
             fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 901, active: true }] }) });
-            fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'inventory boom' });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // connect ok
+            fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'inventory boom' }); // set fails
 
             jest.spyOn(console, 'error').mockImplementation(() => {});
             const result = await createShopifyProgramVariants('Inventory Fail Program', 10, null, 3);
@@ -541,12 +574,15 @@ describe('createShopifySingleVariantProgram', () => {
         mockTokenResponse(fetchMock);
         fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 700, variants: [{ id: 800, inventory_item_id: 900 }] } }) });
         fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 950 }] }) });
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/connect
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/set
 
         const result = await createShopifySingleVariantProgram('Single Pool Program', 3500, 10);
 
         expect(result).toEqual({ shopifyProductId: '700', shopifyVariantId: '800' });
-        expect(fetchMock).toHaveBeenCalledTimes(4); // token + product (variant inline) + locations + inventory set
+        expect(fetchMock).toHaveBeenCalledTimes(5); // token + product (variant inline) + locations + connect + set
+        expect(String(fetchMock.mock.calls[3][0])).toContain('/inventory_levels/connect.json');
+        expect(String(fetchMock.mock.calls[4][0])).toContain('/inventory_levels/set.json');
 
         // The variant MUST ride inside the product create: a bare create mints a
         // physical $0 "Default Title" variant that 422s the follow-up variant

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -188,20 +188,32 @@ async function setInitialShopifyInventory(
             return false;
         }
 
+        // CONNECT FIRST, unconditionally (credit: @dkaygithub, #985). A variant freshly
+        // minted with inventory_management:'shopify' is tracked but not yet *stocked* at
+        // any location, and `set` does NOT reliably auto-connect it — it 422s ("not
+        // stocked at the location"). Connecting first creates the inventory level (at 0)
+        // so the `set` below can write the absolute quantity.
+        //
+        // Deliberately not "optimistic set, connect+retry on 422": that costs an extra
+        // round trip on every capped create (the 422 is the norm for a new item, not the
+        // exception) and, worse, makes the whole fix hinge on Shopify returning exactly
+        // 422 — a different status and the product silently ships sold out again.
+        // A 422 HERE just means the level already exists (e.g. a re-sync) → fall through.
+        const connectRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/connect.json`, {
+            method: 'POST',
+            headers: jsonHeaders,
+            body: JSON.stringify({ location_id: locationId, inventory_item_id: inventoryItemId }),
+        }, "Shopify connect inventory");
+        if (!connectRes.ok && connectRes.status !== 422) {
+            const connectBody = await connectRes.text();
+            console.error(`[SHOPIFY] Failed to connect inventory item to location: ${connectRes.status}`, connectBody);
+            await logIntegrationError("shopify", new Error(`inventory_levels/connect returned ${connectRes.status}: ${connectBody}`), { operation: "setInitialShopifyInventory", label, quantity, locationId });
+            return false;
+        }
+
         const setUrl = `https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/set.json`;
         const setBody = JSON.stringify({ location_id: locationId, inventory_item_id: inventoryItemId, available: quantity });
-        let invRes = await shopifyFetch(setUrl, { method: 'POST', headers: jsonHeaders, body: setBody }, "Shopify set inventory");
-
-        // A just-created inventory item is often not stocked at this location yet, so
-        // `set` 422s ("not stocked at location"). Connect it, then retry the set.
-        if (!invRes.ok && invRes.status === 422) {
-            await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/connect.json`, {
-                method: 'POST',
-                headers: jsonHeaders,
-                body: JSON.stringify({ location_id: locationId, inventory_item_id: inventoryItemId }),
-            }, "Shopify connect inventory");
-            invRes = await shopifyFetch(setUrl, { method: 'POST', headers: jsonHeaders, body: setBody }, "Shopify set inventory (retry)");
-        }
+        const invRes = await shopifyFetch(setUrl, { method: 'POST', headers: jsonHeaders, body: setBody }, "Shopify set inventory");
 
         if (invRes.ok) {
             console.log(`[SHOPIFY] Set inventory for variant ${label} to ${quantity} at location ${locationId}`);


### PR DESCRIPTION
Follow-up to #986, adopting the call sequence from **@dkaygithub's #985** — which was closed as a duplicate, but had the better approach on this one point.

## Why #986 wasn't quite right

#986 fixed the sold-out bug, but connected the inventory item **reactively**: optimistic `set`, and `connect` + retry *only if* Shopify answered exactly `422`.

```js
if (!invRes.ok && invRes.status === 422) { connect; retry set; }
```

Two problems:

1. **Fragile.** The entire fix hinges on the not-stocked error arriving as a bare `422`. Any other status and we never connect — the product silently ships sold out again, i.e. the original bug returns.
2. **Wasteful.** A freshly-minted tracked variant is *never* stocked, so the 422 is the **norm**, not the exception. Every capped-program create paid **3 calls** (`set`→422, `connect`, `set`).

## This PR

**Connect first, unconditionally, then set** — 2 calls, and correctness no longer depends on parsing an error signature.

- A `422` from `connect` just means the level already exists (e.g. a re-sync) → fall through to `set`.
- A hard `connect` failure (non-422) is surfaced to IntegrationErrorLog and skips `set`.

Keeps everything #986 added that #985 didn't have: **active-location selection** (`locations[0]` may be deactivated), **surfacing to System Status → Link Status** (so a sold-out product is never silent), and the **missing-`inventory_item_id`** case.

## Tests

`shopify.test.ts` — **31/31 pass**. Reworked the inventory block for the connect-first sequence: connect-then-set happy path (both creation paths), active-location selection across both calls, `422`-from-connect still sets, connect-hard-fail surfaces and skips set. `tsc --noEmit` and `lint` clean.

## Still unverified against the real store

Same caveat both prior PRs carried: mocked tests prove the **call sequence**, not that the live `422` is gone. Definitive check is unchanged — **create a priced capped program against the dev store and confirm `available == maxParticipants`**, with no new `setInitialShopifyInventory` entries in Link Status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)