### PR TITLE
fix(deploy-s-read): env input for the infra#114 dev/prod split

### DIFF
--- a/.github/workflows/deploy-s-read.yml
+++ b/.github/workflows/deploy-s-read.yml
@@ -1,12 +1,15 @@
 name: Deploy s-read
 
-# Manual deploy of the s-read-function ECS image (v1: workflow_dispatch only, no
+# Manual deploy of the s-read-function ECS image (workflow_dispatch only, no
 # auto-trigger — run it deliberately after the change has merged and CI is green
-# on main). Builds the container image, pushes it to ghcr.io, registers new
-# revisions of BOTH task-def families, and (in migrate-and-code mode) runs the
-# migration task in between. There is no ECS service to roll: the schedule runs
-# tasks against the revision-less s-read-sync family ARN, so it uses the latest
-# ACTIVE revision on its next tick — no terraform involved.
+# on main). Pick the ENVIRONMENT (dev | prod): every AWS resource name below is
+# env-suffixed since infra#114 split s-read into per-env instances. Builds the
+# container image, pushes it to ghcr.io (ONE image repo shared by both envs —
+# envs differ only in config/secrets, never in code), registers new revisions of
+# BOTH task-def families, and (in migrate-and-code mode) runs the migration task
+# in between. There is no ECS service to roll: the schedule runs tasks against
+# the revision-less s-read-<env>-sync family ARN, so it uses the latest ACTIVE
+# revision on its next tick — no terraform involved.
 #
 # Ordering (migrate-and-code): migrations run BEFORE the new sync revision is
 # registered — expand/contract, same as deploy-dev.yml. The previous code keeps
@@ -19,21 +22,33 @@ name: Deploy s-read
 # workload in this account. We push a unique :<git-sha> tag, never :latest.
 #
 # AWS auth (GitHub OIDC, checkin-deploy-dev role) is still needed for the
-# register-task-definition / run-task steps. That role's trust policy is pinned
+# register-task-definition / run-task steps — for BOTH s-read envs: infra wires
+# PassRole on both envs' task roles onto this one role (checkin-deploy-prod
+# doesn't exist until checkin-prod launches). The role's trust policy is pinned
 # to refs/heads/main, so this workflow MUST be dispatched from the main branch;
 # a dispatch from any other ref fails at the credentials step.
 #
-# Infra preconditions (NOT done here — innovationtreehouse/infra#112, whose PR
-# body is the authoritative contract for every resource name used below):
-#   - cluster `s-read`, task-def families `s-read-sync` / `s-read-migrate` (with
-#     the ghcr repositoryCredentials), the s-read-trigger Lambda + its schedule,
-#     secret shells + IAM applied.
-#   - init.sql run by hand + secret VALUES set (see s-read-function/DEPLOY.md).
-#   - Repo variable S_READ_NETWORK_CONFIG set (see the migrate step).
+# Infra preconditions (NOT done here — infra#114/#117 on top of infra#112's
+# original contract):
+#   - per env: cluster `s-read-<env>`, task-def families `s-read-<env>-sync` /
+#     `s-read-<env>-migrate` (with the ghcr repositoryCredentials), the
+#     `s-read-<env>-trigger` Lambda + its schedule, secret shells + IAM applied.
+#   - secret VALUES set: database URLs via the bootstrap task (infra
+#     modules/checkin-bootstrap, TARGETS=s-read), Shopify client pair by hand
+#     (see s-read-function/DEPLOY.md).
+#   - Repo variable S_READ_NETWORK_CONFIG set (see the migrate step). Shared by
+#     both envs — same SG + subnets by design.
 
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: "s-read environment"
+        type: choice
+        options:
+          - dev
+          - prod
+        default: dev
       mode:
         description: "Deploy mode"
         type: choice
@@ -48,20 +63,21 @@ permissions:
   packages: write   # push the image to ghcr.io
 
 concurrency:
-  group: s-read-deploy
-  cancel-in-progress: false  # serialize deploys; never abandon one mid-flight
+  group: s-read-deploy-${{ inputs.environment }}
+  cancel-in-progress: false  # serialize deploys per env; never abandon one mid-flight
 
 env:
   AWS_REGION: us-east-2
   IMAGE_REPO: ghcr.io/innovationtreehouse/s-read
-  ECS_CLUSTER: s-read
-  SYNC_TASK_FAMILY: s-read-sync
-  MIGRATE_TASK_FAMILY: s-read-migrate
+  ECS_CLUSTER: s-read-${{ inputs.environment }}
+  SYNC_TASK_FAMILY: s-read-${{ inputs.environment }}-sync
+  MIGRATE_TASK_FAMILY: s-read-${{ inputs.environment }}-migrate
+  MIGRATE_LOG_GROUP: /ecs/s-read-${{ inputs.environment }}-migrate
   DEPLOY_ROLE: arn:aws:iam::639595353568:role/checkin-deploy-dev
 
 jobs:
   deploy:
-    name: Build, push, migrate, register
+    name: Build, push, migrate, register (${{ inputs.environment }})
     runs-on: ubuntu-24.04-arm  # native ARM64 — the task defs are arm64 (runtime_platform)
     steps:
       - name: Checkout
@@ -128,12 +144,12 @@ jobs:
         env:
           MIGRATE_ARN: ${{ steps.register_migrate.outputs.migrate_arn }}
           CONTAINER_NAME: ${{ steps.register_migrate.outputs.container_name }}
-          # Full run-task networkConfiguration JSON from the infra#112 outputs
+          # Full run-task networkConfiguration JSON from the infra outputs
           # (`s_read_compute_sg_id` + the three default-VPC public subnets), e.g.
           #   {"awsvpcConfiguration":{"subnets":["subnet-0597513f1c0c3173e","subnet-0a67d72908bffbcd4","subnet-0c84ac2840be3a2bc"],"securityGroups":["sg-..."],"assignPublicIp":"ENABLED"}}
           # Set as a repo variable (Settings > Variables) — there is no ECS service
           # here to copy placement from (deploy-dev.yml reads its service's; this
-          # fleet's tasks are schedule/run-task only).
+          # fleet's tasks are schedule/run-task only). One value for both envs.
           NETWORK_CONFIG: ${{ vars.S_READ_NETWORK_CONFIG }}
         run: |
           set -euo pipefail
@@ -159,7 +175,7 @@ jobs:
             --network-configuration "$NETWORK_CONFIG" \
             --overrides "file://$RUNNER_TEMP/migrate-overrides.json" \
             --query 'tasks[0].taskArn' --output text)
-          echo "Migration task: $TASK_ARN (logs: /ecs/s-read-migrate)"
+          echo "Migration task: $TASK_ARN (logs: $MIGRATE_LOG_GROUP)"
 
           aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN"
 
@@ -178,8 +194,8 @@ jobs:
           IMAGE: ${{ steps.build.outputs.image }}
         run: |
           set -euo pipefail
-          # New revision with the new image; the s-read-trigger Lambda RunTasks the
-          # revision-less family ARN, so the next hourly tick runs this revision —
+          # New revision with the new image; the s-read-<env>-trigger Lambda RunTasks
+          # the revision-less family ARN, so the next hourly tick runs this revision —
           # no service update, no terraform.
           aws ecs describe-task-definition \
             --task-definition "$SYNC_TASK_FAMILY" \
@@ -201,13 +217,14 @@ jobs:
           IMAGE: ${{ steps.build.outputs.image }}
           STATUS: ${{ job.status }}
           MODE: ${{ inputs.mode }}
+          TARGET_ENV: ${{ inputs.environment }}
           SYNC_ARN: ${{ steps.register_sync.outputs.sync_arn }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           if [ "$STATUS" = "success" ]; then
             {
-              echo "### ✅ s-read deployed (\`$MODE\`)"
+              echo "### ✅ s-read \`$TARGET_ENV\` deployed (\`$MODE\`)"
               echo "- Image: \`$IMAGE\`"
               echo "- Sync task def: \`$SYNC_ARN\` (the hourly schedule picks it up on its next tick)"
               if [ "$MODE" = "migrate-and-code" ]; then echo "- Migrations: applied before the sync task-def update"; fi
@@ -215,8 +232,8 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           else
             {
-              echo "### ❌ s-read deploy failed (status: \`$STATUS\`, mode: \`$MODE\`)"
-              echo "- [Deploy run]($RUN_URL) — check the logs (migrate task logs: \`/ecs/s-read-migrate\`)."
+              echo "### ❌ s-read \`$TARGET_ENV\` deploy failed (status: \`$STATUS\`, mode: \`$MODE\`)"
+              echo "- [Deploy run]($RUN_URL) — check the logs (migrate task logs: \`$MIGRATE_LOG_GROUP\`)."
               echo "- The schedule keeps running the previous task-def revision."
             } >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/s-read-function/DEPLOY.md
+++ b/s-read-function/DEPLOY.md
@@ -1,22 +1,24 @@
 # s-read deployment runbook
 
-Go-live checklist for the s-read sync as a **scheduled ECS task** (infra:
-innovationtreehouse/infra#112 — its PR body is the authoritative resource
-contract; app chain: checkin#940 → infra#112 → this). Region `us-east-2`,
-account `639595353568`. Work through it **in order** — each step assumes the
-previous ones are done.
+Go-live checklist for the s-read sync as a **scheduled ECS task**, once per
+**environment** (`dev` | `prod` — infra#114 split every resource per env;
+substitute `<env>` throughout). Resource contract: infra#112's PR body as
+amended by infra#114 (env split) and infra#117 (automated DB bootstrap); app
+chain: checkin#940 → infra#112/#114/#117 → this. Region `us-east-2`, account
+`639595353568`. Work through it **in order** — each step assumes the previous
+ones are done. Do dev first as the rehearsal.
 
 How the pieces fit:
 
 ```
-Schedule (hourly) ─▶ Lambda s-read-trigger  ({"mode":"incremental"|"backfill"}; not
+Schedule (hourly) ─▶ Lambda s-read-<env>-trigger  ({"mode":"incremental"|"backfill"}; not
    │                 VPC-attached; also the hook for future event sources)
-   └─▶ ecs:RunTask on the revision-less s-read-sync FAMILY (= latest ACTIVE revision)
-          └─▶ ECS task s-read-sync — image CMD runs `src/cli.ts` in ${SYNC_MODE:-incremental} mode
+   └─▶ ecs:RunTask on the revision-less s-read-<env>-sync FAMILY (= latest ACTIVE revision)
+          └─▶ ECS task s-read-<env>-sync — image CMD runs `src/cli.ts` in ${SYNC_MODE:-incremental} mode
 Deploy workflow (.github/workflows/deploy-s-read.yml, manual dispatch from main)
    └─▶ build+push image to ghcr.io → register migrate revision → (run migrate task,
        wait for exit 0) → register sync revision
-Backfill / manual sync = `aws lambda invoke` on s-read-trigger with the mode payload
+Backfill / manual sync = `aws lambda invoke` on s-read-<env>-trigger with the mode payload
 Migrate task = raw run-task from the workflow only (deliberately NOT invocable via the trigger)
 ```
 
@@ -39,24 +41,33 @@ the app's **Client ID** and **Client Secret** (app Settings) for step 3.
 
 ## 2. Infra applied + database bootstrap
 
-1. infra#112 `terraform apply`d (cluster `s-read`, task-def families
-   `s-read-sync`/`s-read-migrate` with the ghcr `repositoryCredentials`, the
-   `s-read-trigger` Lambda + hourly schedule, secret shells, IAM,
-   `s-read-compute` SG).
-2. Run `modules/s-read/init.sql` **by hand** against the shared Aurora cluster's
-   master user (creates the `shopify_read` database + the `s_read_ddl` /
-   `s_read_dml` roles — Terraform cannot `CREATE DATABASE`). Cluster is
-   Serverless v2 with auto-pause: the first connection can take ~30s to wake it.
+1. infra applied (auto-applies on merge to infra main): per env, cluster
+   `s-read-<env>`, task-def families `s-read-<env>-sync`/`s-read-<env>-migrate`
+   with the ghcr `repositoryCredentials`, the `s-read-<env>-trigger` Lambda +
+   hourly schedule, secret shells, IAM, and the shared `s-read-compute` SG.
+2. Run the **bootstrap task** (infra modules/checkin-bootstrap) scoped to
+   s-read — it creates `shopify_read_<env>` + the `s_read_<env>_ddl` /
+   `s_read_<env>_dml` roles for BOTH envs and writes their database-url
+   secrets itself (so step 3's DB pair is automated):
+
+   ```bash
+   # from infra/live/mgmt
+   $(terraform output -raw run_command) \
+     --overrides '{"containerOverrides":[{"name":"checkin-bootstrap","environment":[{"name":"TARGETS","value":"s-read"}]}]}'
+   ```
+
+   Watch `/ecs/checkin-bootstrap` for the `ok:` lines. Manual fallback:
+   `modules/s-read/init.sql` (see its header).
 
 ## 3. Secret values (4)
 
 Shells exist after step 2; set the values out-of-band:
 
 ```bash
-aws secretsmanager put-secret-value --secret-id s-read/database-url     --secret-string 'postgresql://s_read_dml:...@.../shopify_read'
-aws secretsmanager put-secret-value --secret-id s-read/database-url-ddl --secret-string 'postgresql://s_read_ddl:...@.../shopify_read'
-aws secretsmanager put-secret-value --secret-id s-read/shopify-client-id     --secret-string '...'
-aws secretsmanager put-secret-value --secret-id s-read/shopify-client-secret --secret-string '...'
+aws secretsmanager put-secret-value --secret-id s-read-<env>/database-url     --secret-string 'postgresql://s_read_dml:...@.../shopify_read'
+aws secretsmanager put-secret-value --secret-id s-read-<env>/database-url-ddl --secret-string 'postgresql://s_read_ddl:...@.../shopify_read'
+aws secretsmanager put-secret-value --secret-id s-read-<env>/shopify-client-id     --secret-string '...'
+aws secretsmanager put-secret-value --secret-id s-read-<env>/shopify-client-secret --secret-string '...'
 ```
 
 ECS injects these natively via the task definitions' `secrets` blocks as
@@ -89,7 +100,7 @@ Variables) to the run-task network JSON — SG id from the infra output
 Then run **Actions → "Deploy s-read" → Run workflow** (from `main` — the OIDC
 role's trust is pinned to `refs/heads/main`) with mode **migrate-and-code**.
 It builds/pushes the image, runs the migrate task (waits for exit 0), then
-registers the new `s-read-sync` revision. From that moment the hourly schedule
+registers the new `s-read-<env>-sync` revision. From that moment the hourly schedule
 runs real syncs.
 
 ## 6. One-time backfill
@@ -103,7 +114,7 @@ with the right `SYNC_MODE` override — this is also how a manual incremental sy
 is kicked, with `"mode":"incremental"`):
 
 ```bash
-aws lambda invoke --function-name s-read-trigger \
+aws lambda invoke --function-name s-read-<env>-trigger \
   --cli-binary-format raw-in-base64-out \
   --payload '{"mode":"backfill"}' out.json && cat out.json
 ```
@@ -112,11 +123,11 @@ Fallback if the trigger Lambda is unavailable — the raw run-task it performs:
 
 ```bash
 aws ecs run-task \
-  --cluster s-read \
-  --task-definition s-read-sync \
+  --cluster s-read-<env> \
+  --task-definition s-read-<env>-sync \
   --launch-type FARGATE \
   --network-configuration "$S_READ_NETWORK_CONFIG" \
-  --overrides '{"containerOverrides":[{"name":"s-read-sync","environment":[{"name":"SYNC_MODE","value":"backfill"}]}]}'
+  --overrides '{"containerOverrides":[{"name":"s-read-<env>-sync","environment":[{"name":"SYNC_MODE","value":"backfill"}]}]}'
 ```
 
 (Verified against the image: the container CMD runs
@@ -128,9 +139,9 @@ from the deploy workflow.
 
 ## 7. Verify
 
-- **Logs**: CloudWatch log group `/ecs/s-read-sync` — the backfill run logs
+- **Logs**: CloudWatch log group `/ecs/s-read-<env>-sync` — the backfill run logs
   `backfill step done` with counts; incremental runs log `incremental sync done`.
-  Migrate task logs land in `/ecs/s-read-migrate`.
+  Migrate task logs land in `/ecs/s-read-<env>-migrate`.
 - **Rows**: against `shopify_read` (DML role):
 
   ```sql


### PR DESCRIPTION
## What

`deploy-s-read.yml` predates the s-read env split (infra#114) and hardcoded the dead names — `ECS_CLUSTER: s-read`, `SYNC_TASK_FAMILY: s-read-sync`, `MIGRATE_TASK_FAMILY: s-read-migrate` have no ACTIVE revisions anymore, so the workflow fails at its first `describe-task-definition`.

- New `environment` dispatch input (`dev` | `prod`, default `dev`); cluster, both families, and the migrate log group derive from it.
- Concurrency group is per-env (a dev deploy shouldn't queue behind prod's).
- Deliberately unchanged: one GHCR image repo for both envs (code is identical; envs differ only in config/secrets), one shared `S_READ_NETWORK_CONFIG` (same SG + subnets), and `checkin-deploy-dev` as the OIDC role for both envs — infra wires PassRole on both envs' task roles onto it (`checkin-deploy-prod` doesn't exist until checkin-prod launches).
- `DEPLOY.md`: per-env names throughout; the "run init.sql by hand" step replaced by the automated bootstrap task (infra#117, `TARGETS=s-read`), with init.sql kept as documented fallback.

## Verified

- YAML validates; env-context usage (`inputs` in workflow-level `env` and `concurrency`) is within documented context availability.
- Names cross-checked against live AWS (clusters `s-read-dev`/`s-read-prod`, families `s-read-<env>-sync|migrate` rev 1, per-env trigger Lambdas + rules, 8 secret shells) — verified in-account 2026-07-13.
- Grep confirms no pre-split names remain in the workflow or DEPLOY.md.

## Remaining prerequisites before first dispatch (tracked separately)

1. infra#120 (bootstrap image workflow) merged → bootstrap task run with `TARGETS=s-read` → DB secrets populated.
2. Repo variable `S_READ_NETWORK_CONFIG` set.
3. Shopify pair for dev already populated (copied from checkin-dev, 2026-07-13); prod pair pending a prod-app decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24