### PR TITLE
fix(s-read): Shop has no legacyResourceId — first live sync failed

### DIFF
--- a/s-read-function/src/shopify/queries.ts
+++ b/s-read-function/src/shopify/queries.ts
@@ -29,12 +29,13 @@ export const SHOP_PING_QUERY = `
   }
 `;
 
-/** Authoritative store identity, resolved at sync start to derive store_id. */
+/** Authoritative store identity, resolved at sync start to derive store_id.
+ * NOTE: unlike Order/Payout, the Shop type does NOT expose legacyResourceId —
+ * requesting it fails the whole query. The numeric id is derived from the gid. */
 export const SHOP_IDENTITY_QUERY = `
   query ShopIdentity {
     shop {
       id
-      legacyResourceId
       myshopifyDomain
       name
     }

--- a/s-read-function/src/sync/store.ts
+++ b/s-read-function/src/sync/store.ts
@@ -17,13 +17,15 @@ export interface StoreIdentity {
 
 export async function resolveStoreIdentity(client: ShopifyClient): Promise<StoreIdentity> {
   const data = await client.request<{
-    shop: { id: string; legacyResourceId?: string | number | null; myshopifyDomain: string; name?: string | null };
+    shop: { id: string; myshopifyDomain: string; name?: string | null };
   }>(SHOP_IDENTITY_QUERY);
   const shop = data.shop;
   return {
     storeId: shop.myshopifyDomain,
     shopGid: shop.id,
-    numericId: shop.legacyResourceId != null ? String(shop.legacyResourceId) : (legacyIdFromGid(shop.id) ?? ""),
+    // Shop has no legacyResourceId field (see SHOP_IDENTITY_QUERY) — the
+    // numeric id comes from the gid's last path segment.
+    numericId: legacyIdFromGid(shop.id) ?? "",
     name: shop.name ?? null,
   };
 }

--- a/s-read-function/test/unit/store.test.ts
+++ b/s-read-function/test/unit/store.test.ts
@@ -1,6 +1,7 @@
 /**
- * Store identity resolution (store.ts): the API → identity field mapping (including
- * the legacyResourceId → legacyIdFromGid fallback), the registry upsert, and the
+ * Store identity resolution (store.ts): the API → identity field mapping (the
+ * numeric id always derives from the gid — the Shop type has no legacyResourceId
+ * field, which the live API taught us the hard way), the registry upsert, and the
  * non-fatal warning when a configured STORE_ID disagrees with the live store.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -23,26 +24,25 @@ const shopResp = (shop: Record<string, unknown>) => ({ shop });
 beforeEach(() => vi.clearAllMocks());
 
 describe("resolveStoreIdentity", () => {
-  it("maps the API shop onto the canonical identity (storeId = myshopifyDomain)", async () => {
+  it("maps the API shop onto the canonical identity (storeId = myshopifyDomain, numericId from the gid)", async () => {
     const client = fakeClient(
-      shopResp({ id: "gid://shopify/Shop/123", legacyResourceId: 123, myshopifyDomain: "acme.myshopify.com", name: "Acme" }),
+      shopResp({ id: "gid://shopify/Shop/123", myshopifyDomain: "acme.myshopify.com", name: "Acme" }),
     );
     const id = await resolveStoreIdentity(client);
 
     expect(id).toEqual({ storeId: "acme.myshopify.com", shopGid: "gid://shopify/Shop/123", numericId: "123", name: "Acme" });
-    expect(legacyIdFromGid).not.toHaveBeenCalled(); // legacyResourceId was present
+    expect(legacyIdFromGid).toHaveBeenCalledWith("gid://shopify/Shop/123");
   });
 
-  it("derives numericId from the gid when legacyResourceId is absent", async () => {
+  it("maps an absent name to null", async () => {
     const client = fakeClient(shopResp({ id: "gid://shopify/Shop/777", myshopifyDomain: "x.myshopify.com" }));
     const id = await resolveStoreIdentity(client);
 
     expect(id.numericId).toBe("777");
-    expect(legacyIdFromGid).toHaveBeenCalledWith("gid://shopify/Shop/777");
-    expect(id.name).toBeNull(); // absent name → null
+    expect(id.name).toBeNull();
   });
 
-  it("falls back to an empty numericId when neither source yields one", async () => {
+  it("falls back to an empty numericId when the gid has no numeric segment", async () => {
     const client = fakeClient(shopResp({ id: "gid://shopify/Shop/abc", myshopifyDomain: "x.myshopify.com" }));
     const id = await resolveStoreIdentity(client);
     expect(id.numericId).toBe("");
@@ -51,7 +51,7 @@ describe("resolveStoreIdentity", () => {
 
 describe("ensureStore", () => {
   const client = fakeClient(
-    shopResp({ id: "gid://shopify/Shop/123", legacyResourceId: 123, myshopifyDomain: "acme.myshopify.com", name: "Acme" }),
+    shopResp({ id: "gid://shopify/Shop/123", myshopifyDomain: "acme.myshopify.com", name: "Acme" }),
   );
 
   it("upserts the registry row keyed on myshopifyDomain and returns the identity", async () => {


### PR DESCRIPTION
The first real dev sync (post infra#114/#117/#120 + #989, task `9be5b063...` on `s-read-dev`) failed at store-identity resolution:

```
Shopify GraphQL error: Field 'legacyResourceId' doesn't exist on type 'Shop'
```

Unlike Order/Payout, the `Shop` type doesn't expose `legacyResourceId`, and GraphQL rejects the entire query when any requested field is unknown. The unit tests couldn't catch this — they mock the API response, so the mock happily "returned" the field the real schema refuses.

Fix: drop the field from `SHOP_IDENTITY_QUERY` (with a comment so nobody helpfully re-adds it) and always derive `numericId` via `legacyIdFromGid(shop.id)` — the fallback that already existed, was already tested, and produces the same value. Tests updated to the real contract; the now-dead "field present" branch is removed.

Verified: typecheck + all 115 s-read-function unit tests pass. Everything upstream of this line is proven working by the same failed run: secret injection, image pull, DB connection, and client-credentials token minting all succeeded — the sync got as far as its first real GraphQL query.

After merge: dispatch `Deploy s-read` (dev, **code-only** — the migration already ran), then re-invoke the trigger; expect `incremental sync done` in `/ecs/s-read-dev-sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24