### PR TITLE
style(shopify): program product title puts the name first

### DIFF
--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -260,7 +260,7 @@ export async function createShopifyProgramVariants(name: string, orgMemberPriceC
 
   try {
     // Determine product title
-    const productTitle = `Program Enrollment: ${name}`;
+    const productTitle = `${name} Program Enrollment`;
 
     // Variants go INLINE in the product-create call. Creating the product bare
     // makes Shopify mint a "Default Title" variant (price $0, requires_shipping
@@ -411,7 +411,7 @@ export async function createShopifySingleVariantProgram(
             },
             body: JSON.stringify({
                 product: {
-                    title: `Program Enrollment: ${name}`,
+                    title: `${name} Program Enrollment`,
                     status: 'active',
                     product_type: "Educational Services",
                     variants: [{


### PR DESCRIPTION
Program products are now titled `<Program Name> Program Enrollment` (e.g. "Robotics 101 Program Enrollment") instead of `Program Enrollment: <Program Name>` — the name is what people scan for in the storefront, cart, and order lists.

Both build sites updated (product creation and the rename path in `src/lib/shopify.ts`); no tests pin the old format. Existing Shopify products keep their current titles — this affects products created or renamed after merge; renaming a program from the app will migrate its title to the new format as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24