### PR TITLE
fix(s-read): payout summary field is refundsFeeGross, not refundsGross

### DIFF
--- a/packages/s-ingest-core/src/shopify/schemas.ts
+++ b/packages/s-ingest-core/src/shopify/schemas.ts
@@ -185,7 +185,8 @@ const payoutSummarySchema = z
   .object({
     chargesGross: moneyV2.nullish(),
     chargesFee: moneyV2.nullish(),
-    refundsGross: moneyV2.nullish(),
+    // sic: Shopify's name for GROSS refunds on the payout summary (no `refundsGross` exists)
+    refundsFeeGross: moneyV2.nullish(),
     refundsFee: moneyV2.nullish(),
     adjustmentsGross: moneyV2.nullish(),
     adjustmentsFee: moneyV2.nullish(),
@@ -237,7 +238,7 @@ export function normalizePayout(node: PayoutNode): NormalizedPayout {
     netCents: v2Cents(node.net),
     chargesGrossCents: v2Cents(s.chargesGross),
     chargesFeeCents: v2Cents(s.chargesFee),
-    refundsGrossCents: v2Cents(s.refundsGross),
+    refundsGrossCents: v2Cents(s.refundsFeeGross),
     refundsFeeCents: v2Cents(s.refundsFee),
     adjustmentsGrossCents: v2Cents(s.adjustmentsGross),
     adjustmentsFeeCents: v2Cents(s.adjustmentsFee),

--- a/packages/s-ingest-core/test/fixtures/payout-with-refund.json
+++ b/packages/s-ingest-core/test/fixtures/payout-with-refund.json
@@ -10,7 +10,7 @@
       "summary": {
         "chargesGross": { "amount": "100.00", "currencyCode": "USD" },
         "chargesFee": { "amount": "3.00", "currencyCode": "USD" },
-        "refundsGross": { "amount": "-20.00", "currencyCode": "USD" },
+        "refundsFeeGross": { "amount": "-20.00", "currencyCode": "USD" },
         "refundsFee": { "amount": "0.00", "currencyCode": "USD" },
         "adjustmentsGross": { "amount": "0.00", "currencyCode": "USD" },
         "adjustmentsFee": { "amount": "0.00", "currencyCode": "USD" },

--- a/s-read-function/src/shopify/queries.ts
+++ b/s-read-function/src/shopify/queries.ts
@@ -5,13 +5,10 @@
  * `associatedOrder`, `sourceOrderTransactionId`, `associatedPayout`) and the `processed_at`
  * search filter all exist.
  *
- * ⚠️ ONE FIELD STILL TO CONFIRM — `PAYOUT_FIELDS.summary` selects `refundsGross`, but the
- * documented sibling on ShopifyPaymentsPayoutSummary is `refundsFeeGross`. GraphQL rejects
- * the ENTIRE request on an unknown field, so confirm the exact spelling before the first live
- * payouts run:
- *   https://shopify.dev/docs/api/admin-graphql/2025-07/objects/ShopifyPaymentsPayoutSummary
- * The Zod schemas are lenient (a missing value degrades to 0/undefined), but the query itself
- * must validate.
+ * CONFIRMED live (2026-07-13, first dev payouts run): ShopifyPaymentsPayoutSummary has NO
+ * `refundsGross` — the gross-refunds field is named `refundsFeeGross` (sic; Shopify's naming,
+ * verified against the schema docs and the live API). GraphQL rejects the ENTIRE request on an
+ * unknown field. Internally we still call it refundsGrossCents, because that's what it is.
  */
 
 const MONEY_BAG = `{ shopMoney { amount currencyCode } }`;
@@ -176,7 +173,7 @@ const PAYOUT_FIELDS = `
   summary {
     chargesGross ${MONEY_V2}
     chargesFee ${MONEY_V2}
-    refundsGross ${MONEY_V2}
+    refundsFeeGross ${MONEY_V2}
     refundsFee ${MONEY_V2}
     adjustmentsGross ${MONEY_V2}
     adjustmentsFee ${MONEY_V2}


### PR DESCRIPTION
Second (and per the live schema, last) unknown-field bug in the s-read queries — same class as #990. The dev payouts run failed with:

```
Shopify GraphQL error: Field 'refundsGross' doesn't exist on type 'ShopifyPaymentsPayoutSummary'
```

`queries.ts`'s own header had flagged exactly this field as "⚠️ STILL TO CONFIRM before the first live payouts run" — this was that run. The real field is `refundsFeeGross` (sic, Shopify's naming for gross refunds on the payout summary; all eight summary fields we select are now verified against the schema docs). Renamed in the query + zod schema + cents mapping; the internal `refundsGrossCents` name stays because that's what the value actually is.

**Verified beyond mocks this time**: ran the actual `cli.ts incremental` locally against the live dev store (real client credentials, throwaway local Postgres, migrations applied) — the orders phase completes end-to-end including customer fields; payouts now reach the API and are blocked only by the store's not-yet-effective `read_shopify_payments_*` scopes (a Shopify Dashboard action, tracked separately), not by any query. Typecheck + all 115 unit tests pass.

Once the payments scopes land on the installed app version, the same local harness will validate payouts + balance transactions before the next deploy — no more deploy-to-discover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24