### PR TITLE
ci: run the s-read workspace tests (vitest) on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,57 @@ jobs:
   # see) slipped through CI and broke the post-merge deploy. Building here gates the MR.
   # It ALSO boots the built image and probes `/` (smoke test) — `docker build` alone can't
   # catch a runtime crash on startup, which only surfaced post-merge as a hung ECS rollout.
+  # The s-read workspaces (s-read-function + s-ingest-core vitest suites) were
+  # invisible to CI — the `test` job runs only checkin-app's jest, so a failing
+  # s-read test could merge green (and nearly did: PR #992's first push carried
+  # a failing normalize test behind all-green checks). Same always-report
+  # pattern as `test` so this can be added as a required check.
+  s-read-tests:
+    name: s-read tests
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip notice (client-only change)
+        if: needs.changes.outputs.app != 'true'
+        run: echo "Only client/** changed — nothing to test; reporting success."
+
+      - name: Checkout code
+        if: needs.changes.outputs.app == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}   # empty on push/PR = default ref; the tag when called by deploy-prod
+
+      - name: Setup Node.js
+        if: needs.changes.outputs.app == 'true'
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: needs.changes.outputs.app == 'true'
+        run: npm ci
+
+      # prisma generate only writes clients — no database needed. Both s-read
+      # packages' generated clients are imported by the code under test.
+      - name: Generate Prisma clients
+        if: needs.changes.outputs.app == 'true'
+        run: |
+          npm run db:generate -w @inventory/s-ingest-core
+          npm run db:generate -w @inventory/monitoring-db
+
+      - name: Typecheck s-read-function
+        if: needs.changes.outputs.app == 'true'
+        run: npm run typecheck -w s-read-function
+
+      - name: Test s-ingest-core
+        if: needs.changes.outputs.app == 'true'
+        run: npm test -w @inventory/s-ingest-core
+
+      - name: Test s-read-function
+        if: needs.changes.outputs.app == 'true'
+        run: npm test -w s-read-function
+
   deploy-build:
     name: Deploy build (no deploy)
     needs: changes


### PR DESCRIPTION
## Why

The s-read workspaces have real test suites — `s-read-function` (115 vitest tests) and `@inventory/s-ingest-core` (88, including the payout-summary normalize test) — but CI never ran them: the `Run Tests` job covers only checkin-app's jest. Proof this matters: #992's first push carried a **failing** s-ingest-core test behind all-green PR checks (the fixture missed the `refundsFeeGross` rename; caught only by running the suite by hand).

## What

New `s-read tests` job in ci.yml: npm ci → prisma generate for both s-read packages (no DB needed) → typecheck → both vitest suites. It follows the house always-report pattern (`needs: changes`, skip-notice on client-only PRs), so it's eligible to be added as a **required status check** — recommended, in branch protection settings, once it's proven on a few PRs.

## Verified

- YAML validates; the exact same command sequence passes locally on current main + #992 (88 + 115 green).
- No database service needed: `prisma generate` doesn't connect, and the s-ingest-core integration tests self-skip without their env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24