### PR TITLE
fix(shopify): mint member discounts via GraphQL — REST scope was never granted

### DIFF
--- a/checkin-app/shopify-live/discount.shopify-live.ts
+++ b/checkin-app/shopify-live/discount.shopify-live.ts
@@ -2,10 +2,13 @@
  * @jest-environment node
  */
 /**
- * LIVE contract: the member-discount price rule minted for single-pool member
- * checkout. The per-unit pricing of multi-child household carts hangs entirely
- * on allocation_method 'each' semantics (see the #930 review) — this pins the
- * rule configuration Shopify actually stores, not what we think we sent.
+ * LIVE contract: the member discount minted for single-pool member checkout
+ * (GraphQL discountCodeBasicCreate; scope write_discounts — the 2026-07-14
+ * root cause: the legacy REST price_rules mint needed a scope no store app
+ * grants). The per-unit pricing of multi-child household carts hangs entirely
+ * on appliesOnEachItem semantics (REST's 'each'; see the #930 review) — this
+ * pins the discount configuration Shopify actually stores, not what we think
+ * we sent.
  */
 jest.mock("@/lib/prisma", () => ({ __esModule: true, default: {} }));
 jest.mock("@/lib/email", () => ({ sendEmail: jest.fn() }));
@@ -16,9 +19,9 @@ import {
     ensureLiveStore,
     testRunName,
     trackProduct,
-    trackPriceRule,
+    trackDiscount,
     cleanupTracked,
-    findPriceRuleByTitle,
+    findDiscountByCode,
 } from "./helpers";
 
 describe("live: member discount price-rule contract", () => {
@@ -36,33 +39,31 @@ describe("live: member discount price-rule contract", () => {
         await cleanupTracked();
     });
 
-    it("mints a code whose stored rule is fixed_amount, per-unit ('each'), scoped to the variant, single-use", async () => {
+    it("mints a code whose stored discount is fixed-amount, per-unit, scoped to the variant, single-use", async () => {
         // programId from the janitor-recognizable reserved range (PRG9999999xx-…).
         const code = await mintMemberDiscountCode(CITEST_PROGRAM_ID_BASE + 1, variantId, 1000);
         expect(code).toMatch(new RegExp(`^PRG${CITEST_PROGRAM_ID_BASE + 1}-[0-9A-F]{8}$`));
 
-        const rule = await findPriceRuleByTitle(code!);
-        expect(rule).not.toBeNull();
-        trackPriceRule(rule!.id);
+        const discount = await findDiscountByCode(code!);
+        expect(discount).not.toBeNull();
+        trackDiscount(discount!.id);
 
         // The load-bearing semantics for multi-child member carts (variant:N):
-        // fixed_amount + 'each' takes the amount off EVERY unit; 'across' would
-        // subtract it once from the whole line (the overcharge bug class).
-        expect(rule!.value_type).toBe("fixed_amount");
-        expect(rule!.value).toBe("-10.00");
-        expect(rule!.allocation_method).toBe("each");
-        expect(rule!.target_type).toBe("line_item");
-        expect(rule!.target_selection).toBe("entitled");
-        expect(rule!.entitled_variant_ids.map(String)).toEqual([variantId]);
-        expect(rule!.usage_limit).toBe(1);
-        expect(rule!.once_per_customer).toBe(true);
+        // appliesOnEachItem takes the amount off EVERY unit; amount-off-once
+        // would subtract it once from the whole line (the overcharge bug class).
+        expect(discount!.title).toBe(code);
+        expect(parseFloat(discount!.amount)).toBe(10);
+        expect(discount!.appliesOnEachItem).toBe(true);
+        expect(discount!.variantGids).toEqual([`gid://shopify/ProductVariant/${variantId}`]);
+        expect(discount!.usageLimit).toBe(1);
+        expect(discount!.appliesOncePerCustomer).toBe(true);
         // ~48h validity window per design.
-        const windowMs = new Date(rule!.ends_at!).getTime() - new Date(rule!.starts_at).getTime();
+        const windowMs = new Date(discount!.endsAt!).getTime() - new Date(discount!.startsAt).getTime();
         expect(windowMs).toBeGreaterThan(47 * 60 * 60 * 1000);
         expect(windowMs).toBeLessThan(49 * 60 * 60 * 1000);
     });
 
-    it("returns null (no rule) for a zero discount", async () => {
+    it("returns null (no discount) for a zero discount", async () => {
         expect(await mintMemberDiscountCode(CITEST_PROGRAM_ID_BASE + 2, variantId, 0)).toBeNull();
     });
 });

--- a/checkin-app/shopify-live/helpers.ts
+++ b/checkin-app/shopify-live/helpers.ts
@@ -38,6 +38,19 @@ export async function adminGet<T>(path: string): Promise<T> {
     return (await res.json()) as T;
 }
 
+/** POST a GraphQL query/mutation, throwing on transport or GraphQL-level errors. */
+export async function adminGraphql<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+    const res = await shopifyFetch(adminUrl("graphql.json"), {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({ query, variables }),
+    }, "live GraphQL");
+    if (!res.ok) throw new Error(`live GraphQL -> ${res.status}: ${(await res.text()).slice(0, 300)}`);
+    const data = (await res.json()) as { data?: T; errors?: unknown[] };
+    if (data.errors?.length) throw new Error(`live GraphQL errors: ${JSON.stringify(data.errors).slice(0, 300)}`);
+    return data.data as T;
+}
+
 /** DELETE an Admin resource; 404 counts as already-gone (idempotent cleanup). */
 export async function adminDelete(path: string): Promise<void> {
     const res = await shopifyFetch(adminUrl(path), { method: "DELETE", headers: await authHeaders() }, `live DELETE ${path}`);
@@ -50,6 +63,7 @@ export async function adminDelete(path: string): Promise<void> {
 // known, so afterAll deletes it even when a later assertion throws. ──────────
 const createdProductIds: string[] = [];
 const createdPriceRuleIds: string[] = [];
+const createdDiscountIds: string[] = []; // DiscountCodeNode gids (GraphQL discounts)
 
 export function trackProduct(id: string | number | null | undefined): void {
     if (id) createdProductIds.push(String(id));
@@ -58,7 +72,17 @@ export function trackPriceRule(id: string | number | null | undefined): void {
     if (id) createdPriceRuleIds.push(String(id));
 }
 
+export function trackDiscount(id: string | null | undefined): void {
+    if (id) createdDiscountIds.push(id);
+}
+
 export async function cleanupTracked(): Promise<void> {
+    for (const id of createdDiscountIds.splice(0)) {
+        await adminGraphql(
+            `mutation($id: ID!) { discountCodeDelete(id: $id) { deletedCodeDiscountId userErrors { message } } }`,
+            { id },
+        ).catch((e) => console.error("cleanup discount", id, e));
+    }
     for (const id of createdPriceRuleIds.splice(0)) {
         await adminDelete(`price_rules/${id}.json`).catch((e) => console.error("cleanup price_rule", id, e));
     }
@@ -109,4 +133,70 @@ export interface AdminPriceRule {
 export async function findPriceRuleByTitle(title: string): Promise<AdminPriceRule | null> {
     const data = await adminGet<{ price_rules: AdminPriceRule[] }>(`price_rules.json?limit=250`);
     return data.price_rules.find((r) => r.title === title) ?? null;
+}
+
+
+// ── GraphQL discount lookup (the member-discount mint is GraphQL-native). ───
+export interface LiveDiscountBasic {
+    id: string;
+    title: string;
+    usageLimit: number | null;
+    appliesOncePerCustomer: boolean;
+    startsAt: string;
+    endsAt: string | null;
+    amount: string;
+    appliesOnEachItem: boolean;
+    variantGids: string[];
+}
+
+/** Fetch the stored discount for a code, or null when Shopify has no such code. */
+export async function findDiscountByCode(code: string): Promise<LiveDiscountBasic | null> {
+    const data = await adminGraphql<{
+        codeDiscountNodeByCode: {
+            id: string;
+            codeDiscount: {
+                __typename: string;
+                title: string;
+                usageLimit: number | null;
+                appliesOncePerCustomer: boolean;
+                startsAt: string;
+                endsAt: string | null;
+                customerGets: {
+                    value: { __typename: string; amount?: { amount: string }; appliesOnEachItem?: boolean };
+                    items: { __typename: string; productVariants?: { nodes: { id: string }[] } };
+                };
+            };
+        } | null;
+    }>(
+        `query($code: String!) {
+            codeDiscountNodeByCode(code: $code) {
+                id
+                codeDiscount {
+                    __typename
+                    ... on DiscountCodeBasic {
+                        title usageLimit appliesOncePerCustomer startsAt endsAt
+                        customerGets {
+                            value { __typename ... on DiscountAmount { amount { amount } appliesOnEachItem } }
+                            items { __typename ... on DiscountProducts { productVariants(first: 10) { nodes { id } } } }
+                        }
+                    }
+                }
+            }
+        }`,
+        { code },
+    );
+    const node = data.codeDiscountNodeByCode;
+    if (!node) return null;
+    const d = node.codeDiscount;
+    return {
+        id: node.id,
+        title: d.title,
+        usageLimit: d.usageLimit,
+        appliesOncePerCustomer: d.appliesOncePerCustomer,
+        startsAt: d.startsAt,
+        endsAt: d.endsAt,
+        amount: d.customerGets.value.amount?.amount ?? "",
+        appliesOnEachItem: d.customerGets.value.appliesOnEachItem ?? false,
+        variantGids: d.customerGets.items.productVariants?.nodes.map((n) => n.id) ?? [],
+    };
 }

--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -664,35 +664,57 @@ describe('mintMemberDiscountCode', () => {
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it('creates a price rule + discount code and returns the code', async () => {
+    it('creates the discount via GraphQL discountCodeBasicCreate and returns the code', async () => {
         mockTokenResponse(fetchMock);
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ price_rule: { id: 123 } }) });
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ data: { discountCodeBasicCreate: { codeDiscountNode: { id: 'gid://shopify/DiscountCodeNode/1' }, userErrors: [] } } }),
+        });
 
         const result = await mintMemberDiscountCode(42, '999888', 1000);
 
         expect(result).toMatch(/^PRG42-/);
-        expect(fetchMock).toHaveBeenCalledTimes(3); // token + price_rules + discount_codes
-        const priceRuleCall = fetchMock.mock.calls[1];
-        expect(String(priceRuleCall[0])).toContain('/price_rules.json');
-        const body = JSON.parse((priceRuleCall[1] as RequestInit).body as string);
-        expect(body.price_rule).toMatchObject({
-            value_type: 'fixed_amount',
-            value: '-10.00',
-            usage_limit: 1,
-            once_per_customer: true,
-            entitled_variant_ids: [999888],
+        expect(fetchMock).toHaveBeenCalledTimes(2); // token + one GraphQL mutation
+        const gqlCall = fetchMock.mock.calls[1];
+        expect(String(gqlCall[0])).toContain('/graphql.json');
+        const body = JSON.parse((gqlCall[1] as RequestInit).body as string);
+        expect(body.query).toContain('discountCodeBasicCreate');
+        expect(body.variables.discount).toMatchObject({
+            usageLimit: 1,
+            appliesOncePerCustomer: true,
+            customerSelection: { all: true },
+            customerGets: {
+                // appliesOnEachItem carries the 'each' per-unit semantics (multi-child carts).
+                value: { discountAmount: { amount: '10.00', appliesOnEachItem: true } },
+                items: { products: { productVariantsToAdd: ['gid://shopify/ProductVariant/999888'] } },
+            },
         });
+        expect(body.variables.discount.title).toBe(result);
+        expect(body.variables.discount.code).toBe(result);
     });
 
     it('returns null and does NOT email admins when minting fails (quiet fallback, never blocks checkout)', async () => {
         mockTokenResponse(fetchMock);
-        fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => '{"errors":"bad price rule"}' });
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => '{"errors":"bad request"}' });
 
         const result = await mintMemberDiscountCode(42, '999888', 1000);
 
         expect(result).toBeNull();
         expect(sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('returns null (quiet fallback) when the mutation reports userErrors', async () => {
+        mockTokenResponse(fetchMock);
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ data: { discountCodeBasicCreate: { codeDiscountNode: null, userErrors: [{ field: ['basicCodeDiscount'], message: 'nope' }] } } }),
+        });
+
+        const result = await mintMemberDiscountCode(42, '999888', 1000);
+
+        expect(result).toBeNull();
+        expect(sendEmail).not.toHaveBeenCalled();
+        expect(logIntegrationError).toHaveBeenCalled();
     });
 
     it('returns null without calling fetch when credentials are missing', async () => {

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -589,9 +589,17 @@ export async function adjustProgramInventory(
  * discount (its §5) is the planned upgrade once checkout identity is solved;
  * this mints one real Shopify object per checkout in the meantime.
  *
- * ponytail: one Price Rule + Discount Code per enrollee/checkout — fine at
- * Treehouse's program-enrollment volume. Upgrade to the segment design above
- * if that stops being true.
+ * Implemented via GraphQL `discountCodeBasicCreate` (scope: write_discounts).
+ * NOT the legacy REST price_rules API: that needs the separate
+ * write_price_rules scope that neither store's app grants (the dev store
+ * 403'd every mint until 2026-07-14), and Shopify has deprecated it anyway.
+ * `appliesOnEachItem: true` carries the load-bearing 'each' semantics: a
+ * member household enrolling N kids buys quantity N of the variant and every
+ * seat gets the member price (amount-off-once would overcharge N-1 seats).
+ *
+ * ponytail: one discount code per enrollee/checkout — fine at Treehouse's
+ * program-enrollment volume. Upgrade to the segment design above if that
+ * stops being true.
  *
  * Never throws: a failure returns null so the caller falls back to an
  * undiscounted checkout link rather than blocking it (member pays full price
@@ -624,51 +632,47 @@ export async function mintMemberDiscountCode(
         const startsAt = new Date();
         const endsAt = new Date(startsAt.getTime() + 48 * 60 * 60 * 1000); // ~48h, per design
 
-        const priceRuleRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/price_rules.json`, {
+        const mutation = `
+            mutation MintMemberDiscount($discount: DiscountCodeBasicInput!) {
+                discountCodeBasicCreate(basicCodeDiscount: $discount) {
+                    codeDiscountNode { id }
+                    userErrors { field message }
+                }
+            }`;
+        const res = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 'X-Shopify-Access-Token': accessToken,
             },
             body: JSON.stringify({
-                price_rule: {
-                    title: code,
-                    target_type: 'line_item',
-                    target_selection: 'entitled',
-                    entitled_variant_ids: [Number(variantId)],
-                    // 'each' applies the amount PER UNIT: a member household enrolling
-                    // N kids buys quantity N of the variant, and each seat gets the
-                    // member price ('across' would subtract the amount once from the
-                    // whole line, overcharging N-1 seats).
-                    allocation_method: 'each',
-                    value_type: 'fixed_amount',
-                    value: `-${(amountOffCents / 100).toFixed(2)}`,
-                    customer_selection: 'all',
-                    usage_limit: 1,
-                    once_per_customer: true,
-                    starts_at: startsAt.toISOString(),
-                    ends_at: endsAt.toISOString(),
+                query: mutation,
+                variables: {
+                    discount: {
+                        title: code,
+                        code,
+                        startsAt: startsAt.toISOString(),
+                        endsAt: endsAt.toISOString(),
+                        usageLimit: 1,
+                        appliesOncePerCustomer: true,
+                        customerSelection: { all: true },
+                        customerGets: {
+                            // appliesOnEachItem: the 'each' semantics (see doc comment).
+                            value: { discountAmount: { amount: (amountOffCents / 100).toFixed(2), appliesOnEachItem: true } },
+                            items: { products: { productVariantsToAdd: [`gid://shopify/ProductVariant/${variantId}`] } },
+                        },
+                    },
                 },
             }),
-        }, "Shopify create price rule");
-        if (!priceRuleRes.ok) {
-            throw new Error(`Shopify price rule creation failed: ${priceRuleRes.status} ${await priceRuleRes.text()}`);
+        }, "Shopify mint member discount");
+        if (!res.ok) {
+            throw new Error(`Shopify discount create failed: ${res.status} ${await res.text()}`);
         }
-        const priceRuleData = await priceRuleRes.json();
-        const priceRuleId = priceRuleData.price_rule?.id;
-        if (!priceRuleId) throw new Error("Shopify price rule response missing id");
-
-        const codeRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/price_rules/${priceRuleId}/discount_codes.json`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-Shopify-Access-Token': accessToken,
-            },
-            body: JSON.stringify({ discount_code: { code } }),
-        }, "Shopify create discount code");
-        if (!codeRes.ok) {
-            throw new Error(`Shopify discount code creation failed: ${codeRes.status} ${await codeRes.text()}`);
-        }
+        const data = await res.json();
+        if (data.errors) throw new Error(`Shopify discount create GraphQL errors: ${JSON.stringify(data.errors)}`);
+        const result = data.data?.discountCodeBasicCreate;
+        if (result?.userErrors?.length) throw new Error(`Shopify discount create userErrors: ${JSON.stringify(result.userErrors)}`);
+        if (!result?.codeDiscountNode?.id) throw new Error("Shopify discount create response missing codeDiscountNode id");
 
         console.log(`[SHOPIFY] Minted single-use discount code ${code} for program ${programId} (-$${(amountOffCents / 100).toFixed(2)}, expires ${endsAt.toISOString()})`);
         return code;


### PR DESCRIPTION
## Symptom

Member discount codes were never created in the dev store — silently, because `mintMemberDiscountCode` deliberately never throws (members just got undiscounted checkout links).

## Root causes (three, stacked)

1. **The mint always 403s**: the REST `price_rules` API requires the `write_price_rules` scope, which **neither store's app grants** (live-probed on the dev store: `403 "requires merchant approval for write_price_rules"`, identical on 2026-01 and 2024-07 — not a version issue). Both apps DO grant `write_discounts`, the modern GraphQL discounts scope: the code and the app grants pointed at different APIs.
2. **The flow rarely reached the mint anyway**: zero mint log lines in 14 days of dev logs. The route null-exits silently unless the requester is an ACTIVE org member AND the program has a variant + both prices — dev test data likely never satisfied this (follow up separately: BoardSettings variant id + an ACTIVE test-household membership).
3. **The canary that pins this exact contract has never run**: `shopify-live.yml` skips nightly because the `SHOPIFY_LIVE_ENABLED` repo variable and `SHOPIFY_LIVE_*` secrets were never provisioned.

## Fix

`mintMemberDiscountCode` now uses GraphQL `discountCodeBasicCreate` — works with the already-granted `write_discounts`, escapes the deprecated REST discounts API, and preserves every behavior: code format, 48h window, single-use, once-per-customer, never-throws quiet fallback, and the load-bearing per-unit semantics (`appliesOnEachItem: true` ≙ REST `allocation_method: 'each'` — the multi-child-cart overcharge guard).

Live suite updated to pin the GraphQL-stored contract (`adminGraphql`, `findDiscountByCode`, `trackDiscount` + `discountCodeDelete` cleanup).

## Verified

- 32/32 unit tests (incl. new `userErrors` quiet-fallback case) + mutation-shape assertions.
- **Live canary 2/2 against the real dev store** with real credentials: code minted through the app's actual path, stored discount verified field-by-field, cleaned up after.
- Mutation pre-validated standalone before the rewrite (created + deleted a probe discount).

## Deployment / follow-ups

- **Dev needs no dashboard changes** — `write_discounts` is already granted.
- **Prod app must add `write_discounts`** (+ release/install) before launch, or member pricing silently fails there too — its scope introspection shows no discounts scopes at all.
- Enable the nightly canary: set repo variable `SHOPIFY_LIVE_ENABLED=true` + the `SHOPIFY_LIVE_CLIENT_ID`/`SECRET` secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24