### PR TITLE
fix(programs): payment-pending enrollment is resumable, not a dead end

### DIFF
--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -166,12 +166,13 @@ describe("ProgramEnrollmentPage", () => {
         // Declared adult reads as "(Adult)", never the confusing "(DOB missing)".
         expect(screen.getByText("(Adult)")).toBeInTheDocument();
         expect(screen.queryByText("(DOB missing)")).not.toBeInTheDocument();
-        // PENDING enrollment reads as payment-pending, not a bare "Enrolled".
-        expect(screen.getByText("(Enrolled — Payment Pending)")).toBeInTheDocument();
-        // No enrollable member -> first-time setup affordance (replaces the old
-        // dead-end alert), no direct enroll button.
-        expect(screen.getByRole("button", { name: "Finish setting up your household to enroll" })).toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "Complete Enrollment" })).not.toBeInTheDocument();
+        // PENDING enrollment is a RESUMABLE state, not a dead end: labeled as
+        // payment-pending, preselected, with the enroll button available — NOT
+        // the misleading household-setup affordance.
+        expect(screen.getByText("(Payment pending — select to finish payment)")).toBeInTheDocument();
+        expect(screen.getByLabelText("Only Kid")).toBeChecked();
+        expect(screen.queryByRole("button", { name: "Finish setting up your household to enroll" })).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Complete Enrollment" })).toBeInTheDocument();
     });
 
     it("priced program with no Shopify variant configured aborts before enrolling", async () => {
@@ -438,6 +439,54 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Robotics Club");
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
+        fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
+
+        expect(await screen.findByText("Redirecting to Shopify for secure payment...")).toBeInTheDocument();
+        await waitFor(() =>
+            expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/api/programs/10/discount-code"))).toBe(true),
+        );
+    });
+
+    // The payment-pending resume path: an already-enrolled-but-unpaid household
+    // must be able to re-run checkout (participants POST 409s -> folded back in;
+    // a FRESH single-use discount code is minted — the old one is 48h/one-use).
+    it("lets a payment-pending member resume checkout with a fresh discount code", async () => {
+        setSession({ id: 101 });
+        setShopifyStoreDomain("shop.example.com");
+        // One-member household whose only participant is already PENDING — the
+        // resume case: nobody new to enroll, payment still owed.
+        const memberHousehold = { household: {
+            householdMembers: [{ id: 101, name: "Kid One", dateOfBirth: "2015-01-01" }],
+            orgMembership: { status: "ACTIVE" },
+        } };
+        const fetchMock = mockFetchJson({
+            "/api/programs/10/discount-code": { code: "PRG10-FRESH" },
+            "/api/household": memberHousehold,
+            "/api/programs/10": baseProgram({
+                participants: [{ personId: 101, status: "PENDING" }],
+                orgMemberPriceCents: 4000, nonOrgMemberPriceCents: 5000, minAge: null, maxAge: null,
+                shopifyVariantId: "gid://single-pool", shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+            }),
+            "/api/programs/10/participants": () => ({ error: "Participant is already enrolled in this program." }),
+        });
+        // 409 for the already-enrolled participant — the idempotent re-checkout path.
+        const baseImpl = fetchMock.getMockImplementation()!;
+        fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url = String(input);
+            if (url.includes("/api/programs/10/participants") && init?.method === "POST") {
+                return { ok: false, status: 409, json: async () => ({ error: "Participant is already enrolled in this program." }) } as Response;
+            }
+            return baseImpl(input, init);
+        });
+        renderPage();
+        await screen.findByText("Robotics Club");
+        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+        await screen.findByText("Which of your household wants to enroll?");
+
+        // Preselected and selectable, not disabled.
+        expect(screen.getByLabelText("Kid One")).toBeChecked();
+        expect(screen.getByText("(Payment pending — select to finish payment)")).toBeInTheDocument();
+
         fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
 
         expect(await screen.findByText("Redirecting to Shopify for secure payment...")).toBeInTheDocument();

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -94,11 +94,17 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   // Why a member can't be enrolled. Shared by the default selection and the row
   // render so an ineligible member is never auto-selected and then POSTed (which
   // returned a confusing "Date of Birth is missing" for over-25 adults).
-  const enrollBlock = (member: { id: number; dateOfBirth: string | null; isDeclaredAdult?: boolean }): { reason: 'enrolled' | 'age' | 'dob' | null; label: string } => {
+  const enrollBlock = (member: { id: number; dateOfBirth: string | null; isDeclaredAdult?: boolean }): { reason: 'enrolled' | 'pending' | 'age' | 'dob' | null; label: string } => {
     const enrolledRow = (program?.participants ?? []).find(p => p.personId === member.id);
-    // ACTIVE = paid/free/override (truly done). PENDING = payment still owed,
-    // including a requested-but-incomplete payment plan — don't imply completion.
-    if (enrolledRow) return { reason: 'enrolled', label: enrolledRow.status === 'ACTIVE' ? 'Enrolled' : 'Enrolled — Payment Pending' };
+    // ACTIVE = paid/free/override (truly done) — locked. PENDING = payment still
+    // owed: SELECTABLE, so the household can re-run checkout to finish paying
+    // (the participants POST 409s and aggregateEnrollOutcomes folds a 409 back
+    // into the checkout set — the same idempotent path as a double-click).
+    if (enrolledRow) {
+        return enrolledRow.status === 'ACTIVE'
+            ? { reason: 'enrolled', label: 'Enrolled' }
+            : { reason: 'pending', label: 'Payment pending — select to finish payment' };
+    }
     if (!program) return { reason: null, label: '' };
     // Same eligibility rule as the enroll route: a declared over-25 adult clears
     // a youth minimum like "16 and up" without a DOB on file.
@@ -127,9 +133,15 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
       const def = me && enrollBlock(me).reason === null
         ? me.id
         : members.find((m) => enrollBlock(m).reason === null)?.id;
-      setSelectedParticipantIds(def != null ? [def] : []);
+      if (def != null) {
+        setSelectedParticipantIds([def]);
+      } else {
+        // Nobody new to enroll — preselect everyone with a payment still owed,
+        // so the page loads ready to finish that checkout in one click.
+        setSelectedParticipantIds(members.filter((m) => enrollBlock(m).reason === 'pending').map((m) => m.id));
+      }
 
-      const hasEnrollable = members.some((m) => enrollBlock(m).reason === null);
+      const hasEnrollable = members.some((m) => { const r = enrollBlock(m).reason; return r === null || r === 'pending'; });
       // Emergency contact isn't in /api/household; probe the process-free intake
       // state for it. Fail open (treat as present) if the probe can't answer, so
       // a household with an enrollable member is never blocked by an EC hiccup.
@@ -487,7 +499,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                   <Stack>
                     {householdMembers.map((member) => {
                       const { reason, label } = enrollBlock(member);
-                      const disabled = reason !== null;
+                      const disabled = reason !== null && reason !== 'pending';
 
                       return (
                         <Card key={member.id} withBorder radius="md" padding="sm" opacity={disabled ? 0.5 : 1}>
@@ -497,7 +509,8 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                               disabled={disabled}
                               label={member.name || 'Unnamed Participant'}
                             />
-                            {reason === 'enrolled' && <Text size="sm" c={label.includes('Pending') ? 'yellow' : 'green'}>({label})</Text>}
+                            {reason === 'enrolled' && <Text size="sm" c="green">({label})</Text>}
+                            {reason === 'pending' && <Text size="sm" c="yellow">({label})</Text>}
                             {disabled && reason !== 'enrolled' && <Text size="sm" c="red">({label})</Text>}
                           </Group>
                         </Card>


### PR DESCRIPTION
## Symptom (screenshot in session)

A household with enrolled-but-unpaid participants lands on the program page with every member shown as **"(Enrolled — Payment Pending)" and disabled**, and — because nobody is selectable — the page falls through to the wrong CTA: **"Finish setting up your household to enroll"**. There is no way to get back to Shopify checkout and pay.

## Fix

`PENDING` becomes its own **selectable** picker state:

- Label: *"Payment pending — select to finish payment"* (yellow); ACTIVE (paid) members stay locked with the green "(Enrolled)".
- When nobody new is enrollable, pending members are **preselected**, so the page loads one click from finishing payment.
- `needsSetup` counts pending members as enrollable — the household-setup CTA now only appears for genuinely unset-up households.

The payment resume itself needed **zero new backend**: the participants POST returns 409 for an existing row, `aggregateEnrollOutcomes` already folds 409 into the checkout set (the double-click idempotency path), and the member discount is minted **fresh** at redirect — which is required, not just convenient, since codes are single-use with a ~48h window.

## Tests

- The old test that deliberately pinned the dead-end behavior is rewritten to the resumable contract (selectable + preselected + enroll button, no setup CTA).
- New test: all-pending household → preselected → Pay on Shopify → participants 409 folds in → fresh `discount-code` fetch → redirect.
- 58/58 in the program-page suites; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24