### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage via database-backed error logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** Found early returns checking buffer lengths (e.g., `providedBuffer.length !== expectedBuffer.length`) on webhook secrets and cron auth tokens before using `crypto.timingSafeEqual`.
 **Learning:** Returning early on length mismatch leaks the exact length of the expected secret.
 **Prevention:** Hash both the expected and provided secrets to a fixed length (e.g., using SHA-256) before passing them to `crypto.timingSafeEqual` to avoid leaking secret lengths while still safely catching any mismatch.
+
+## 2024-05-24 - Information Leakage via Database-Backed Error Logs
+**Vulnerability:** The application was persisting raw error stack traces (`error.stack`) into the `ErrorLog` table using `logBackendError`, which feeds an administrative UI dashboard (`ErrorLogPanel.tsx`).
+**Learning:** Persisting raw stack traces to application tables exposed via dashboards risks leaking sensitive internal server information (e.g., directory structures, dependency versions, and internal logic flows) to potentially compromised administrative accounts or unauthorized users if access controls fail.
+**Prevention:** To maintain defense-in-depth, do not persist raw error stack traces in database tables that feed application dashboards. Stack traces should only be sent to secure, centralized logging infrastructure (e.g., stdout/stderr).

--- a/checkin-app/src/lib/logger.ts
+++ b/checkin-app/src/lib/logger.ts
@@ -18,12 +18,17 @@ export async function logBackendError(error: unknown, route?: string, context?: 
         const message = error instanceof Error ? error.message : String(error);
         const stack = error instanceof Error ? error.stack : undefined;
 
-        // 1. Insert the new error log
+        // Log stack trace securely to centralized logging infrastructure
+        if (stack) {
+            console.error(`Backend Error Trace [${route || 'Unknown Route'}]:`, stack);
+        }
+
+        // 1. Insert the new error log without the stack trace
         await prisma.errorLog.create({
             data: {
                 message,
                 route,
-                stack,
+                // stack intentionally omitted to prevent information leakage to the admin dashboard
                 context: context ? JSON.parse(JSON.stringify(context)) : undefined, // Ensure it's JSON serializable
             }
         });


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The application was persisting raw error stack traces (`error.stack`) into the `ErrorLog` database table. This table directly feeds an administrative UI dashboard (`ErrorLogPanel.tsx`).
🎯 **Impact**: Exposing stack traces in an application dashboard risks leaking sensitive internal server information (such as directory structures, internal logic flows, and dependency versions) to anyone with access to the dashboard. If an administrative account is compromised or access controls are bypassed, this provides attackers with valuable reconnaissance data.
🔧 **Fix**: Modified `logBackendError` in `src/lib/logger.ts` to stop persisting `error.stack` to the database. Instead, stack traces are logged securely to `console.error` for ingestion by centralized logging infrastructure, while only safe metadata (message, route, context) is stored in the database.
✅ **Verification**: Code review of `src/lib/logger.ts` confirms that `stack` is no longer passed to `prisma.errorLog.create`.

---
*PR created automatically by Jules for task [12366657151652948973](https://jules.google.com/task/12366657151652948973) started by @dkaygithub*