### PR TITLE
fix(shopify-live): janitor sweeps GraphQL discounts, not REST price rules

### DIFF
--- a/checkin-app/scripts/shopify-live-janitor.ts
+++ b/checkin-app/scripts/shopify-live-janitor.ts
@@ -1,7 +1,7 @@
 /**
  * Janitor for the Shopify LIVE test suite: deletes citest-tagged products and
- * PRG9999999xx price rules older than MAX_AGE_HOURS from the DEV store, so a
- * crashed run can never accumulate junk. Runs before and after the suite in
+ * PRG9999999xx discount codes older than MAX_AGE_HOURS from the DEV store, so
+ * a crashed run can never accumulate junk. Runs before and after the suite in
  * .github/workflows/shopify-live.yml; safe to run by hand:
  *
  *   npx tsx scripts/shopify-live-janitor.ts
@@ -13,7 +13,8 @@ import { assertLiveTestStore, CITEST_PREFIX, CITEST_PROGRAM_ID_BASE } from "../s
 const MAX_AGE_HOURS = Number(process.env.SHOPIFY_LIVE_JANITOR_MAX_AGE_HOURS ?? 24);
 const API_VERSION = "2026-01"; // keep aligned with lib/shopify.ts SHOPIFY_API_VERSION
 
-const PRICE_RULE_RE = new RegExp(`^PRG${CITEST_PROGRAM_ID_BASE.toString().slice(0, -2)}\\d{2}-`);
+// Matches the reserved live-test program-id range in minted code titles.
+const TEST_DISCOUNT_RE = new RegExp(`^PRG${CITEST_PROGRAM_ID_BASE.toString().slice(0, -2)}\\d{2}-`);
 
 async function main(): Promise<void> {
     const domain = assertLiveTestStore(process.env);
@@ -51,13 +52,39 @@ async function main(): Promise<void> {
         }
     }
 
-    const rulesRes = await fetch(`${base}/price_rules.json?limit=250`, { headers, signal: AbortSignal.timeout(20_000) });
-    if (!rulesRes.ok) throw new Error(`janitor: price_rules list failed ${rulesRes.status}`);
-    const { price_rules } = (await rulesRes.json()) as { price_rules: { id: number; title: string; created_at: string }[] };
-    for (const r of price_rules) {
-        if (PRICE_RULE_RE.test(r.title) && isStale(r.created_at)) {
-            const del = await fetch(`${base}/price_rules/${r.id}.json`, { method: "DELETE", headers, signal: AbortSignal.timeout(20_000) });
-            console.log(`janitor: price_rule ${r.id} "${r.title}" -> ${del.status}`);
+    // Discount codes are GraphQL-native (mintMemberDiscountCode uses
+    // discountCodeBasicCreate; the REST price_rules API needs a scope the app
+    // deliberately doesn't have — the canary's very first run caught this).
+    const gqlHeaders = { ...headers, "Content-Type": "application/json" };
+    const listRes = await fetch(`${base}/graphql.json`, {
+        method: "POST",
+        headers: gqlHeaders,
+        body: JSON.stringify({
+            query: `{ codeDiscountNodes(first: 250) { nodes { id codeDiscount { __typename ... on DiscountCodeBasic { title startsAt } } } } }`,
+        }),
+        signal: AbortSignal.timeout(20_000),
+    });
+    if (!listRes.ok) throw new Error(`janitor: discount list failed ${listRes.status}`);
+    const listBody = (await listRes.json()) as {
+        errors?: unknown[];
+        data?: { codeDiscountNodes: { nodes: { id: string; codeDiscount: { __typename: string; title?: string; startsAt?: string } }[] } };
+    };
+    if (listBody.errors?.length) throw new Error(`janitor: discount list errors ${JSON.stringify(listBody.errors).slice(0, 200)}`);
+    for (const n of listBody.data?.codeDiscountNodes.nodes ?? []) {
+        const { title, startsAt } = n.codeDiscount;
+        // startsAt is the mint time for our codes — same staleness axis the
+        // REST sweep used created_at for.
+        if (title && startsAt && TEST_DISCOUNT_RE.test(title) && isStale(startsAt)) {
+            const del = await fetch(`${base}/graphql.json`, {
+                method: "POST",
+                headers: gqlHeaders,
+                body: JSON.stringify({
+                    query: `mutation($id: ID!) { discountCodeDelete(id: $id) { deletedCodeDiscountId userErrors { message } } }`,
+                    variables: { id: n.id },
+                }),
+                signal: AbortSignal.timeout(20_000),
+            });
+            console.log(`janitor: discount ${n.id} "${title}" -> ${del.status}`);
             deleted++;
         }
     }


### PR DESCRIPTION
The shopify-live canary was enabled today (variables + secrets provisioned) and its first-ever run failed in under a minute — **in its own janitor**: the pre-test sweep still lists REST `price_rules.json`, which 403s for the exact reason #995 existed (`write_price_rules` was never granted to the app; the tests never got to start). A fittingly ironic first catch.

The sweep now matches the post-#995 world: `codeDiscountNodes` (first 250) filtered by the reserved live-test code pattern and staleness on `startsAt` (the mint time — same axis the REST version used `created_at` for), deleted via `discountCodeDelete`. The products sweep is untouched; its scopes exist.

Verified by running the janitor by hand against the live dev store with real credentials: clean pass. After merge I'll re-dispatch the canary for its first full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24