### PR TITLE
ui(programs): entry button reads 'Continue enrollment' when payment is pending

### DIFF
--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -144,6 +144,36 @@ describe("ProgramEnrollmentPage", () => {
         );
     });
 
+    it("labels the entry button 'Continue enrollment' when a household member is payment-pending", async () => {
+        setSession({ id: 101 });
+        mockFetchJson({
+            "/api/household": household,
+            // person.householdId is what links the participant to the viewer's
+            // household in myEnrolled (the real API includes it).
+            "/api/programs/10": baseProgram({
+                participants: [{ personId: 101, status: "PENDING", person: { name: "Kid One", householdId: 7 } }],
+            }),
+        });
+        renderPage();
+        await screen.findByText("Robotics Club");
+        expect(screen.getByText(/Kid One — Enrolled, payment pending/)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Continue enrollment" })).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Enroll" })).not.toBeInTheDocument();
+    });
+
+    it("keeps the plain 'Enroll' label when household enrollments are all paid", async () => {
+        setSession({ id: 101 });
+        mockFetchJson({
+            "/api/household": household,
+            "/api/programs/10": baseProgram({
+                participants: [{ personId: 101, status: "ACTIVE", person: { name: "Kid One", householdId: 7 } }],
+            }),
+        });
+        renderPage();
+        await screen.findByText("Robotics Club");
+        expect(screen.getByRole("button", { name: "Enroll" })).toBeInTheDocument();
+    });
+
     it("over-25 adult with only an already-enrolled child sees a no-eligible message, not a DOB error", async () => {
         setSession({ id: 200 });
         mockFetchJson({

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -464,7 +464,10 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
             <Group justify="center" wrap="wrap">
               {session ? (
                 <Button size="md" onClick={startEnrollmentProcess} disabled={isClosed}>
-                  {isClosed ? <>Enrollment Closed{closedSuffix}</> : "Enroll"}
+                  {/* A payment-pending household reads "Continue enrollment" — the
+                      button resumes their checkout (see the pending picker state),
+                      it doesn't start a new one. */}
+                  {isClosed ? <>Enrollment Closed{closedSuffix}</> : myEnrolled.some((m) => !m.active) ? "Continue enrollment" : "Enroll"}
                 </Button>
               ) : (
                 // Auth-first: route through /signin (which picks Google vs. the


### PR DESCRIPTION
Companion to #996. When any household member on the program is payment-pending, the entry button now reads **"Continue enrollment"** instead of "Enroll" — matching what it actually does since #996 (opens the picker with pending members preselected, one click from resuming checkout). All-paid or no enrollments keep the plain "Enroll"; the closed-state label is untouched.

One expression + two tests (pending → "Continue enrollment", all-ACTIVE → "Enroll"). Existing suites unaffected (60/60 in the page suites, lint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24