### PR TITLE
fix(deploy-prod): grant checks:write — the reusable ci.yml call needs it

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -30,6 +30,12 @@ on:
 permissions:
   id-token: write   # assume the deploy role via OIDC (deploy job only)
   contents: read    # checkout the released tag (validate + deploy)
+  # checks: write is not used by THIS workflow — it's the ceiling for the
+  # reusable ci.yml call: its `test` job requests checks: write (dorny
+  # test-reporter), and a called job may never exceed the caller's grants.
+  # Without this line the run dies at startup_failure with zero jobs —
+  # which is exactly how v1.0.0's first deploy attempt failed (2026-07-14).
+  checks: write
 
 concurrency:
   group: checkin-deploy-prod


### PR DESCRIPTION
v1.0.0's first-ever `deploy-prod` firing died in **1 second, `startup_failure`, zero jobs**. Root cause: the workflow's explicit `permissions:` block (`id-token: write, contents: read`) sets every unlisted permission — including `checks` — to none, while the `validate` job's reusable `ci.yml` call contains a job requesting `checks: write` (the dorny test-reporter in `Run Tests`). GitHub validates reusable-call permissions at workflow startup: a called job may never exceed the caller's grants, so the run is rejected before any job exists.

Latent since the H1 validate rework (2026-06-27): `deploy-prod` fires only on published releases, and v1.0.0 was the first ever.

Fix: one line — `checks: write` on the caller, commented as the ceiling for the reusable call rather than a permission this workflow itself uses.

**Release mechanics after merge**: the release event runs the workflow from the *tag's* commit, so the fix must be inside the released tag. Recommended: delete the never-deployed v1.0.0 release + tag and re-cut v1.0.0 from post-merge main (nothing consumed the tag; prod never deployed) — alternatively cut v1.0.1 and leave the dead tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24