### PR TITLE
fix(s-read): quote datetimes in Shopify search filters

### DIFF
--- a/s-read-function/src/shopify/queries.ts
+++ b/s-read-function/src/shopify/queries.ts
@@ -103,7 +103,7 @@ export const ORDERS_PROBE_QUERY = `
   }
 `;
 
-/** Paginated orders query. Pass query: "updated_at:>=<iso> status:any". */
+/** Paginated orders query. Pass query: "updated_at:>='<iso>' status:any" (datetime quoted — see streams.ts). */
 export const ORDERS_QUERY = `
   query Orders($first: Int!, $after: String, $query: String) {
     orders(first: $first, after: $after, query: $query, sortKey: UPDATED_AT) {
@@ -182,7 +182,7 @@ const PAYOUT_FIELDS = `
   }
 `;
 
-/** Paginated payouts query. Pass query: "issued_at:>=<iso>". */
+/** Paginated payouts query. Pass query: "issued_at:>='<iso>'" (datetime quoted — see streams.ts). */
 export const PAYOUTS_QUERY = `
   query Payouts($first: Int!, $after: String, $query: String) {
     shopifyPaymentsAccount {
@@ -253,7 +253,7 @@ export const CURRENT_BULK_OPERATION_QUERY = `
 export function buildOrdersBulkQuery(updatedAtFloorIso: string): string {
   return `
     {
-      orders(query: "updated_at:>=${updatedAtFloorIso} status:any", sortKey: UPDATED_AT) {
+      orders(query: "updated_at:>='${updatedAtFloorIso}' status:any", sortKey: UPDATED_AT) {
         edges {
           node {
             id

--- a/s-read-function/src/sync/streams.ts
+++ b/s-read-function/src/sync/streams.ts
@@ -53,7 +53,11 @@ export async function syncOrders(
   syncRunId?: bigint,
 ): Promise<StreamSummary> {
   const since = await readSinceIso(prisma, storeId, ObjectType.ORDER, cfg.cutoverDate);
-  const filter = `updated_at:>=${since} status:any`;
+  // Datetimes in Shopify search filters MUST be quoted: ':' is the syntax's
+  // own separator, so an unquoted ISO value truncates at 'T00' — the payments
+  // API rejects it (first real-store backfill, 2026-07-14); the orders parser
+  // silently tolerates the truncation, which is worse.
+  const filter = `updated_at:>='${since}' status:any`;
   logger.info("sync orders", { since, source });
   const summary = await ingestStream(prisma, storeId, ObjectType.ORDER, source, fetchOrders(client, filter), syncRunId);
   await advanceWatermark(prisma, storeId, ObjectType.ORDER, summary.maxOccurredAt);
@@ -69,7 +73,7 @@ export async function syncPayouts(
   syncRunId?: bigint,
 ): Promise<StreamSummary> {
   const since = await readSinceIso(prisma, storeId, ObjectType.PAYOUT, cfg.cutoverDate);
-  const filter = `issued_at:>=${since}`;
+  const filter = `issued_at:>='${since}'`;
   logger.info("sync payouts", { since, source });
   const summary = await ingestStream(prisma, storeId, ObjectType.PAYOUT, source, fetchPayouts(client, filter), syncRunId);
   await advanceWatermark(prisma, storeId, ObjectType.PAYOUT, summary.maxOccurredAt);
@@ -88,7 +92,7 @@ export async function syncBalanceTransactions(
   // `processed_at` (the search field) is the same instant as the node's `transactionDate`,
   // which is what occurredAt/the watermark tracks — filter axis == watermark axis. See
   // BALANCE_TRANSACTIONS_QUERY for the schema verification.
-  const filter = `processed_at:>=${since}`;
+  const filter = `processed_at:>='${since}'`;
   logger.info("sync balance transactions", { since, source });
   const summary = await ingestStream(
     prisma,

--- a/s-read-function/test/unit/fetchers.test.ts
+++ b/s-read-function/test/unit/fetchers.test.ts
@@ -30,11 +30,11 @@ const balanceTxnPage = (nodes: unknown[], hasNextPage: boolean, endCursor: strin
 describe("fetchOrders pagination", () => {
   it("yields a single page and stops when hasNextPage is false", async () => {
     const client = fakeClient(ordersPage([{ id: "o1" }, { id: "o2" }], false, "c1"));
-    const nodes = await drain(fetchOrders(client, "updated_at:>=X status:any"));
+    const nodes = await drain(fetchOrders(client, "updated_at:>='X' status:any"));
 
     expect(nodes).toEqual([{ id: "o1" }, { id: "o2" }]);
     expect(client.calls).toHaveLength(1);
-    expect(client.calls[0].variables).toMatchObject({ first: 50, after: null, query: "updated_at:>=X status:any" });
+    expect(client.calls[0].variables).toMatchObject({ first: 50, after: null, query: "updated_at:>='X' status:any" });
   });
 
   it("threads endCursor into the next page's `after` and concatenates pages", async () => {
@@ -70,10 +70,10 @@ describe("fetchOrders pagination", () => {
 describe("fetchPayouts pagination (singleton account)", () => {
   it("reaches through shopifyPaymentsAccount.payouts and uses the 100-item page size", async () => {
     const client = fakeClient(payoutsPage([{ id: "p1" }], false, null));
-    const nodes = await drain(fetchPayouts(client, "issued_at:>=X"));
+    const nodes = await drain(fetchPayouts(client, "issued_at:>='X'"));
 
     expect(nodes).toEqual([{ id: "p1" }]);
-    expect(client.calls[0].variables).toMatchObject({ first: 100, after: null, query: "issued_at:>=X" });
+    expect(client.calls[0].variables).toMatchObject({ first: 100, after: null, query: "issued_at:>='X'" });
   });
 
   it("yields nothing when shopifyPaymentsAccount is null (Payments not enabled)", async () => {
@@ -91,10 +91,10 @@ describe("fetchPayouts pagination (singleton account)", () => {
 describe("fetchBalanceTransactions pagination (singleton account)", () => {
   it("reaches through shopifyPaymentsAccount.balanceTransactions", async () => {
     const client = fakeClient(balanceTxnPage([{ id: "b1" }, { id: "b2" }], false, null));
-    const nodes = await drain(fetchBalanceTransactions(client, "processed_at:>=X"));
+    const nodes = await drain(fetchBalanceTransactions(client, "processed_at:>='X'"));
 
     expect(nodes).toEqual([{ id: "b1" }, { id: "b2" }]);
-    expect(client.calls[0].variables).toMatchObject({ first: 100, query: "processed_at:>=X" });
+    expect(client.calls[0].variables).toMatchObject({ first: 100, query: "processed_at:>='X'" });
   });
 
   it("yields nothing when the balanceTransactions connection is absent", async () => {

--- a/s-read-function/test/unit/streams.test.ts
+++ b/s-read-function/test/unit/streams.test.ts
@@ -93,7 +93,7 @@ describe("syncOrders", () => {
 
     const summary = await syncOrders(prismaSentinel, client, "store-1", cfg, EventSource.INCREMENTAL, 7n);
 
-    expect(vi.mocked(fetchOrders).mock.calls[0][1]).toBe("updated_at:>=2026-02-01T00:00:00.000Z status:any");
+    expect(vi.mocked(fetchOrders).mock.calls[0][1]).toBe("updated_at:>='2026-02-01T00:00:00.000Z' status:any");
     expect(advanceWatermark).toHaveBeenCalledWith(prismaSentinel, "store-1", ObjectType.ORDER, occurredAt);
     expect(summary.count).toBe(1);
   });
@@ -106,7 +106,7 @@ describe("syncPayouts", () => {
 
     await syncPayouts(prismaSentinel, client, "store-1", cfg, EventSource.BACKFILL);
 
-    expect(vi.mocked(fetchPayouts).mock.calls[0][1]).toBe("issued_at:>=2026-02-01T00:00:00.000Z");
+    expect(vi.mocked(fetchPayouts).mock.calls[0][1]).toBe("issued_at:>='2026-02-01T00:00:00.000Z'");
     expect(advanceWatermark).toHaveBeenCalledWith(prismaSentinel, "store-1", ObjectType.PAYOUT, expect.anything());
   });
 });
@@ -118,7 +118,7 @@ describe("syncBalanceTransactions", () => {
 
     await syncBalanceTransactions(prismaSentinel, client, "store-1", cfg, EventSource.INCREMENTAL);
 
-    expect(vi.mocked(fetchBalanceTransactions).mock.calls[0][1]).toBe("processed_at:>=2026-02-01T00:00:00.000Z");
+    expect(vi.mocked(fetchBalanceTransactions).mock.calls[0][1]).toBe("processed_at:>='2026-02-01T00:00:00.000Z'");
     expect(advanceWatermark).toHaveBeenCalledWith(prismaSentinel, "store-1", ObjectType.BALANCE_TXN, expect.anything());
   });
 


### PR DESCRIPTION
## The failure (first s-read-prod backfill, today)

```
Shopify GraphQL error: Invalid `issued_at` filter value: "2025-01-01T00". Expected an ISO 8601 datetime string
```

Shopify's search syntax uses `:` as its own field separator, so an **unquoted** ISO datetime in a filter truncates at the value's first colon. The payments API's parser rejects the truncation; the orders parser **silently tolerates it** (treating `updated_at:>=2026-07-08T23` as hour-granularity) — which is arguably worse, and means even dev's "working" incremental filters were coarser than intended. Dev structurally couldn't catch the payouts case: no payments account on a dev store → the filter is never parsed. This is exactly the "payout verification is prod-only" gap, cashing out.

## Fix

All four filter-construction sites quote the datetime per Shopify's documented syntax (`field:>='<iso>'`): the three incremental filters in `streams.ts` (orders / payouts / balance transactions) and the bulk-export floor in `queries.ts`.

## Verified

- 115/115 unit tests (filter-string expectations updated).
- Full dev-store harness run green (orders + balance-txn paths, quoted).
- **Differential probe against the real store's payments parser** (read-only, `first: 1`): quoted → OK and returns a real payout; unquoted → reproduces the exact production error.

## After merge

`Deploy s-read` env=prod `code-only`, then re-run the backfill — the orders Bulk Operation from the failed run is already processing server-side and will be collected; payouts and balance transactions then backfill with real rows for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24