### PR TITLE
fix(deploy-prod): cd checkin-app before prisma migrate deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -219,7 +219,7 @@ jobs:
             "containerOverrides": [{
               "name": "checkin-migrate",
               "command": ["sh", "-c",
-                "for i in 1 2 3 4 5; do npx prisma migrate deploy && exit 0; echo \"attempt $i failed — DB may be resuming from auto-pause; retrying in 20s\"; sleep 20; done; exit 1"]
+                "cd checkin-app && for i in 1 2 3 4 5; do npx prisma migrate deploy && exit 0; echo \"attempt $i failed — DB may be resuming from auto-pause; retrying in 20s\"; sleep 20; done; exit 1"]
             }]
           }
           EOF


### PR DESCRIPTION
## What

One line: prefix the prod migrate container override with `cd checkin-app && `, exactly as deploy-dev.yml:137 already does.

## Why

v1.0.0 (run 29387368725) got through the reviewer gate, built and pushed the GHCR image, then failed in **Run database migrations**: all five retry attempts printed

```
Error: Could not find Prisma Schema that is required for this command.
```

The override ran `npx prisma migrate deploy` from the image's WORKDIR (repo root); the schema lives at `checkin-app/prisma/schema.prisma`. The retry loop's P1001/auto-pause raison d'être never got a chance — Prisma failed before touching the network. The dev override carries the `cd`; the prod override was written fresh in #1003's scrub and missed it.

No database changes occurred (`checkin_prod` is still empty of app tables); re-cutting v1.0.0 after this merges runs the coalesced baseline for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9naXJVyJnLYpFZapZW24