### PR TITLE
fix(docker): pin standalone bind host against runtime HOSTNAME injection

### DIFF
--- a/checkin-app/Dockerfile
+++ b/checkin-app/Dockerfile
@@ -72,6 +72,11 @@ ENV PORT=4000
 # Bind all interfaces. The Next standalone server listens on $HOSTNAME, which
 # Docker otherwise sets to the container id — that resolves to the bridge IP
 # only, so published ports can miss it. 0.0.0.0 covers the bridge IP locally and
-# the task ENI in ECS.
+# the task ENI in ECS. The ENV alone is not enough: a runtime that sets a
+# container hostname injects HOSTNAME into the env OVER the image value — ECS
+# Managed Instances host-mode tasks inject HOSTNAME=default, which is
+# unresolvable, so the server exited at boot (the v1.0.0 launch failure; dev on
+# Fargate/awsvpc never injects). Pin the bind address in the command itself so
+# no runtime injection can override it.
 ENV HOSTNAME=0.0.0.0
-CMD ["node", "checkin-app/server.js"]
+CMD ["sh", "-c", "HOSTNAME=0.0.0.0 exec node checkin-app/server.js"]


### PR DESCRIPTION
## Problem
v1.0.0 prod deploy failed at **Deploy to ECS** ([run 29422682506](https://github.com/innovationtreehouse/checkin/actions/runs/29422682506)): every task exited 1 at boot with

```
⨯ Failed to start server
Error: getaddrinfo EAI_AGAIN default
```

## Root cause
The Next standalone `server.js` binds to `process.env.HOSTNAME || '0.0.0.0'`. The Dockerfile sets `ENV HOSTNAME=0.0.0.0`, but ECS **Managed Instances host-network** tasks set a container hostname at create time, which injects `HOSTNAME=default` into the runtime env **over** the image ENV. The server then tries to bind to a host literally named `default` → DNS failure → exit 1 → crash loop → `services-stable` waiter timeout.

Dev never hit this: Fargate/awsvpc doesn't support container hostnames, so nothing overrides the image ENV.

## Fix
Pin the bind address in the CMD itself — `sh -c "HOSTNAME=0.0.0.0 exec node …"` — so no runtime injection can override it. `exec` keeps node as PID 1 for signal handling. The migrate task overrides the command entirely and is unaffected.

Verified: `env HOSTNAME=default sh -c 'HOSTNAME=0.0.0.0 exec node -p "process.env.HOSTNAME"'` → `0.0.0.0`; CI's deploy-build smoke test boots the image with the new CMD.

After merge: delete + re-cut the v1.0.0 release (third time — migrations already applied and are idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)