### PR TITLE
ci(deploy-dev): boot the new image so services-stable is real

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -194,9 +194,14 @@ jobs:
             --query 'taskDefinition.taskDefinitionArn' --output text)
           echo "Registered app task def: $APP_ARN"
 
+          # --desired-count 1: with scale-to-zero (infra#107) dev normally sits at
+          # desired 0, where services-stable is vacuously true and a crash-looping
+          # image would deploy "green". Booting one task makes the wait real; the
+          # scaler tears it back down after the idle window.
           aws ecs update-service \
             --cluster "$ECS_CLUSTER" --service "$ECS_SERVICE" \
-            --task-definition "$APP_ARN" >/dev/null
+            --task-definition "$APP_ARN" \
+            --desired-count 1 >/dev/null
 
           echo "Waiting for the service to reach steady state..."
           aws ecs wait services-stable --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE"


### PR DESCRIPTION
With scale-to-zero ([infra#107](https://github.com/innovationtreehouse/infra/pull/107)) checkin-dev normally sits at `desiredCount=0`. There, `aws ecs wait services-stable` is vacuously true (0 running == 0 desired) — the new image never launches, so a crash-looping build deploys ✅ green and only surfaces later as an endless warming page on the next cold wake, with no red signal anywhere.

Fix: `update-service --desired-count 1` on deploy. The wait then actually validates that the new image reaches steady state (a bad image fails it, as it did pre-scale-to-zero), and the scale-to-zero reconciler tears the task back down after the idle window.

Companion to the infra#107 review fixes; harmless to merge before or after it (today dev already runs at desired 1, so this is a no-op until scale-to-zero lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)