### PR TITLE
fix(ui): stop PageContainer margin clipping ops tab bars behind header

### DIFF
--- a/checkin-app/src/components/ui/PageContainer.tsx
+++ b/checkin-app/src/components/ui/PageContainer.tsx
@@ -2,11 +2,14 @@ import { Box } from "@mantine/core";
 
 // Canonical page wrapper: same left indent + top position for every top-level
 // page/tab layout, so tabs and headings don't "dance" when navigating between
-// sections. The negative top margin trims a bit of the AppShell's md padding;
-// paddingLeft adds a small indent past the content edge.
+// sections. The negative top margin trims part of the AppShell's md padding
+// (16px) for a tighter look — must stay smaller than it, or content slides up
+// behind the fixed 60px header (z-index 200) and its top gets clipped, which is
+// exactly what a -25 overshoot did to the ops tab bars. paddingLeft adds a small
+// indent past the content edge.
 export function PageContainer({ children }: { children: React.ReactNode }) {
   return (
-    <Box style={{ maxWidth: 1200, margin: "0 auto", marginTop: -25, paddingLeft: 8, display: "flow-root" }}>
+    <Box style={{ maxWidth: 1200, margin: "0 auto", marginTop: -8, paddingLeft: 8, display: "flow-root" }}>
       {children}
     </Box>
   );


### PR DESCRIPTION
## Problem
Subtabs on the ops layouts (program-ops/new, etc.) are cut off at the top.

## Root cause
`PageContainer` used `marginTop: -25`, which exceeds `AppShell.Main`'s `md` padding (16px). Mantine sets `Main`'s `padding-top = headerHeight(60) + padding(16) = 76px`, so content starts at y=76; `-25` pulls it to y=51 — 9px up into the fixed 60px header (z-index 200), which paints over the top of whatever's first on the page. The ops tab layouts show it worst because the `SectionTabs` row is the first element.

## Fix
Trim to `-8` — still tighter than the default gap, but stays under the 16px padding so nothing slides behind the header. One-line change in the shared wrapper, so it corrects every ops tab bar (program-ops, shop-ops, membership-ops, …) at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)