### PR TITLE
feat(participants): admin can mark a person 25+ in the Details modal

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
@@ -30,6 +30,7 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
             }
             updateData.phone = body.phone === "" || body.phone === null ? null : formatPhone(body.phone);
         }
+        if (body.isDeclaredAdult !== undefined) updateData.isDeclaredAdult = Boolean(body.isDeclaredAdult);
 
         if (Object.keys(updateData).length === 0) {
             return apiError("No fields to update provided", 400);
@@ -37,7 +38,7 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
 
         const prior = await prisma.person.findUnique({
             where: { id },
-            select: { name: true, email: true, phone: true },
+            select: { name: true, email: true, phone: true, isDeclaredAdult: true },
         });
 
         const updatedParticipant = await prisma.person.update({
@@ -64,6 +65,8 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
             name: updatedParticipant.name,
             email: updatedParticipant.email,
             phone: updatedParticipant.phone,
+            dateOfBirth: updatedParticipant.dateOfBirth,
+            isDeclaredAdult: updatedParticipant.isDeclaredAdult,
             isBoardMember: updatedParticipant.isBoardMember,
             isKeyholder: updatedParticipant.isKeyholder,
             household: updatedParticipant.household,

--- a/checkin-app/src/app/api/people/search/route.ts
+++ b/checkin-app/src/app/api/people/search/route.ts
@@ -41,6 +41,8 @@ export const GET = withAuth(
                 name: p.name,
                 email: p.email,
                 phone: p.phone,
+                dateOfBirth: p.dateOfBirth,
+                isDeclaredAdult: p.isDeclaredAdult,
                 isMember: personRecordIsActiveOrgMember(p),
                 isBoardMember: p.isBoardMember,
                 isKeyholder: p.isKeyholder,

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Alert, Box, Button, Card, Group, Modal, Paper, Stack, Table, Text, TextInput, UnstyledButton } from "@mantine/core";
+import { Alert, Box, Button, Card, Group, Modal, Paper, Stack, Switch, Table, Text, TextInput, UnstyledButton } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons-react";
 import { EntityPicker } from "@/components/admin/EntityPicker";
@@ -19,6 +19,8 @@ type PersonRow = {
   name: string | null;
   email: string | null;
   phone: string | null;
+  dateOfBirth?: string | null;
+  isDeclaredAdult?: boolean;
   household?: HouseholdRef | null;
 };
 
@@ -87,7 +89,7 @@ export default function AdminParticipantsIndex() {
   // Edit Participant State
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingParticipant, setEditingParticipant] = useState<PersonRow | null>(null);
-  const [editForm, setEditForm] = useState({ name: "", email: "", phone: "" });
+  const [editForm, setEditForm] = useState({ name: "", email: "", phone: "", isDeclaredAdult: false });
   const [savingDetails, setSavingDetails] = useState(false);
 
   // Admin edit of household's own info (name, address, emergency contact)
@@ -240,7 +242,7 @@ export default function AdminParticipantsIndex() {
                           )}
                           <Button size="xs" fz={15} variant="default" onClick={() => {
                             setEditingParticipant(p);
-                            setEditForm({ name: p.name || "", email: p.email || "", phone: p.phone || "" });
+                            setEditForm({ name: p.name || "", email: p.email || "", phone: p.phone || "", isDeclaredAdult: !!p.isDeclaredAdult });
                             setEditModalOpen(true);
                           }}>
                             Details
@@ -329,6 +331,16 @@ export default function AdminParticipantsIndex() {
             <TextInput label="Name" required value={editForm.name} onChange={(e) => { const value = e.currentTarget.value; setEditForm(f => ({ ...f, name: value })); }} />
             <TextInput type="email" label="Email Address" value={editForm.email} onChange={(e) => { const value = e.currentTarget.value; setEditForm(f => ({ ...f, email: value })); }} />
             <TextInput type="tel" label="Phone Number" value={editForm.phone} onChange={(e) => { const value = e.currentTarget.value; setEditForm(f => ({ ...f, phone: value })); }} placeholder="(555) 123-4567" />
+            {editingParticipant?.dateOfBirth ? (
+              <Text size="sm" c="dimmed">Age is derived from date of birth on file; the adult declaration doesn&apos;t apply.</Text>
+            ) : (
+              <Switch
+                label="Adult (25 or older)"
+                description="Set this when there's no date of birth on file so the person shows as 'Adult' instead of 'Age Unavailable'."
+                checked={editForm.isDeclaredAdult}
+                onChange={(e) => { const checked = e.currentTarget.checked; setEditForm(f => ({ ...f, isDeclaredAdult: checked })); }}
+              />
+            )}
             {editingParticipant?.household && (
               <div>
                 <Text fw={500} size="sm" mb={4}>Household</Text>


### PR DESCRIPTION
## What

Adds an **Adult (25 or older)** switch to the Edit Person (Details) modal off `membership-ops/participants`, letting an admin declare a person an adult.

## Why

The `Person.isDeclaredAdult` field already existed in the schema but was never wired to any admin UI — only backfill/import paths set it. Without a DOB on file, a person renders as "Age Unavailable" (red). This gives admins a way to mark them "Adult" instead.

## Changes

- **`api/people/search`** — returns `isDeclaredAdult` + `dateOfBirth` so the modal can show current state.
- **`api/membership-ops/participants/[id]` PUT** — whitelists `isDeclaredAdult` (coerced to boolean), captures it in the audit log old/new, and returns it in the response.
- **`membership-ops/participants/page.tsx`** — Switch in the Details modal; hidden when a DOB is on file (age is derived, so the declaration is moot) and replaced by a dimmed note.

## Reviewer notes

- Route auth unchanged: PUT stays gated to `isSysadmin` / `isBoardMember`.
- **Label vs semantics:** the schema comment describes this flag as "25+", but the rest of the app (`my-household`, bg-check) treats `isDeclaredAdult` as the 18+ "Adult" flag. The switch label reads "25 or older" per the request; if we'd rather it match the 18+ semantics elsewhere, that's a one-line copy change.
- New fields on the API responses are optional; existing consumers/tests unaffected (13/13 participants page tests pass, tsc clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)