### PR TITLE
feat(membership-ops): disable Add Participant & Grant Membership for staff households

### DIFF
--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -166,6 +166,11 @@ export default function AdminHouseholdsPage() {
               const ownGrantBlocked =
                 !hasActiveMembership && me?.isSysadmin !== true && sharesHousehold(me?.householdId, household.id);
               const hasBrokenEmail = household.householdMembers?.some((p) => p.emailUndeliverableAt) ?? false;
+              // Staff households (@innovationtreehouse.org) aren't program families: block
+              // adding participants and granting membership. Revoke stays allowed.
+              const isStaffHousehold = household.householdMembers?.some(
+                (p) => p.email?.toLowerCase().endsWith('@innovationtreehouse.org')
+              ) ?? false;
 
               return (
                 <Table.Tr key={household.id}>
@@ -227,6 +232,8 @@ export default function AdminHouseholdsPage() {
                       <Button
                         size="xs" fz={15}
                         variant="light"
+                        disabled={isStaffHousehold}
+                        title={isStaffHousehold ? "Staff households can't add participants." : undefined}
                         onClick={() => router.push(`/membership-ops/participants/new?householdId=${household.id}`)}
                       >
                         + Add Participant
@@ -246,8 +253,14 @@ export default function AdminHouseholdsPage() {
                             size="xs" fz={15}
                             variant="light"
                             color={hasActiveMembership ? 'red' : 'green'}
-                            disabled={ownGrantBlocked}
-                            title={ownGrantBlocked ? "You can't grant your own household's membership — a sysadmin must." : undefined}
+                            disabled={ownGrantBlocked || (!hasActiveMembership && isStaffHousehold)}
+                            title={
+                              !hasActiveMembership && isStaffHousehold
+                                ? "Staff households can't be granted membership."
+                                : ownGrantBlocked
+                                  ? "You can't grant your own household's membership — a sysadmin must."
+                                  : undefined
+                            }
                             onClick={() => toggleMembership(household.id, hasActiveMembership)}
                           >
                             {hasActiveMembership ? "Revoke Membership" : "Grant Membership"}


### PR DESCRIPTION
## What

On the membership-ops **Households** page, disable two action buttons for any household containing an `@innovationtreehouse.org` member:

- **+ Add Participant** — fully disabled
- **Grant Membership** — disabled (only in the grant state; **Revoke Membership** stays enabled)

## Why

Staff households (`@innovationtreehouse.org`) aren't program families. Adding participants or granting them facility membership doesn't apply, so the actions are blocked to prevent mistakes.

## How

- New per-row flag `isStaffHousehold`: true if any `householdMembers[].email` ends with `@innovationtreehouse.org`.
- Wires `disabled` + `title` on the two buttons.
- Grant button reuses the existing disabled-title precedence pattern (`ownGrantBlocked`); revoke remains allowed, same as that pattern.
- `email` is already in the `/api/membership-ops/households` select — no API change needed.

## Reviewer notes

- **UI-disable only.** No server-side guard was added to `POST /api/membership-ops/households` or the participant-create route. If enrollment for staff households must be *enforced* (not just discouraged in the UI), that's a follow-up.
- Detection is by email domain. If staff households are meant to be keyed some other way (flag / org relation), the flag definition is the one line to change.
- No test added; `households/__tests__/page.test.tsx` exists if coverage is wanted (staff-email member → both buttons `disabled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)