### PR TITLE
ui(my-household): show renewal prompt to existing members

### DIFF
--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -151,6 +151,29 @@ describe("HouseholdPage", () => {
     expect(router.push).toHaveBeenCalledWith("/membership");
   });
 
+  it("prompts a former member to renew (REVOKED)", async () => {
+    setSession({ id: 10, email: "sam@example.com" });
+    mockRoutes({ "/api/household": { household: { ...householdData, orgMembership: { status: "REVOKED" } } } });
+    renderWithProviders(<HouseholdPage />);
+    await screen.findByRole("heading", { name: "Smith Household", level: 1 });
+
+    expect(screen.getByText("Renew your membership now!")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Renew!" }));
+    expect(router.push).toHaveBeenCalledWith("/membership");
+  });
+
+  it("prompts an ACTIVE member to renew when a renewal is open", async () => {
+    setSession({ id: 10, email: "sam@example.com" });
+    mockRoutes({ "/api/membership/renewal-status": { renewalDue: true } });
+    renderWithProviders(<HouseholdPage />);
+    await screen.findByRole("heading", { name: "Smith Household", level: 1 });
+
+    expect(await screen.findByText("Renew your membership now!")).toBeInTheDocument();
+    expect(screen.queryByText(/Member since/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Renew!" }));
+    expect(router.push).toHaveBeenCalledWith("/membership");
+  });
+
   it("shows a volunteer-only badge when memberSince is absent", async () => {
     setSession({ id: 10, email: "sam@example.com" });
     mockRoutes({ "/api/household": { household: { ...householdData, orgMembership: { status: "ACTIVE", isVolunteer: true } } } });

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -61,6 +61,9 @@ export default function HouseholdPage() {
 
   const [loading, setLoading] = useState(true);
   const [household, setHousehold] = useState<HouseholdData>(null);
+  // Open renewal for this household (lead-only, from /api/membership/renewal-status).
+  // Drives the "Renew now" copy for a still-ACTIVE member whose renewal has opened.
+  const [renewalDue, setRenewalDue] = useState(false);
   const [message, setMessage] = useState<{ text: string; tone: AlertTone } | null>(null);
   // Explicit tone per outcome so a real error can never render green (was
   // decided by `message.includes('success')`).
@@ -134,6 +137,10 @@ export default function HouseholdPage() {
     if (ready) {
       fetchHousehold();
       fetchContacts();
+      fetch('/api/membership/renewal-status')
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => setRenewalDue(!!d?.renewalDue))
+        .catch(() => {});
     }
   }, [ready, fetchHousehold, fetchContacts]);
 
@@ -354,7 +361,18 @@ export default function HouseholdPage() {
           <Title order={1} mb="md">{household?.name || 'My Household'}</Title>
 
           {household && (
-            household.orgMembership?.status === 'ACTIVE' ? (
+            // An existing member — still ACTIVE with an open renewal, or already
+            // REVOKED/lapsed — gets the "Renew now" nudge; a household that never
+            // joined gets the join prompt; an ACTIVE member with nothing due gets
+            // the plain member badge.
+            (renewalDue || household.orgMembership?.status === 'REVOKED') ? (
+              <Alert color="blue" mb="lg">
+                <Group justify="space-between" align="center" wrap="wrap">
+                  <Text c="dimmed">Renew your membership now!</Text>
+                  {viewerIsLead && <Button size="xs" fz={15} onClick={() => router.push('/membership')}>Renew!</Button>}
+                </Group>
+              </Alert>
+            ) : household.orgMembership?.status === 'ACTIVE' ? (
               <Alert color="green" mb="lg">
                 <Group gap="xs" wrap="wrap">
                   <Text fw={600}>✓ Member{household.orgMembership.memberSince ? ` since ${new Date(household.orgMembership.memberSince).getFullYear()}` : ''}</Text>


### PR DESCRIPTION
## What

The my-household membership banner is now three-way instead of ACTIVE-vs-not:

| Household state | Banner |
|---|---|
| Existing member with a renewal to do — ACTIVE + open renewal, or REVOKED (lapsed) | blue "Renew your membership now!" + **Renew!** |
| ACTIVE, nothing due | green "✓ Member since …" |
| Never joined (NONE / no membership) | blue "Your household isn't a member yet." + **Join the Treehouse!** |

## Why

The banner previously showed **"Your household isn't a member yet."** to every non-ACTIVE household. Wrong for two audiences:

- A **former member (REVOKED)** keeps app access but was told they'd never joined.
- A **current member up for renewal** never saw a renewal nudge here at all — membership stays ACTIVE through the renewal window, so they only saw "✓ Member since".

## How

- Added a `renewalDue` state fed by the existing `/api/membership/renewal-status` endpoint (lead-only signal, same source the global `RenewalBanner` already uses). No new API.
- "Renew now" fires when `renewalDue || status === 'REVOKED'`; the plain member badge and the join prompt keep their prior behavior otherwise.

## Reviewer notes

- `renewalDue` is lead-only by design (endpoint returns `false` for non-leads) — matches lead-driven renewal. Non-lead members of an ACTIVE household still see the plain member badge.
- Tests updated: kept the never-member case, added REVOKED and ACTIVE-with-open-renewal cases.
- Not run locally — worktree has no `node_modules`; CI should exercise `src/app/my-household`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)