### PR TITLE
feat(membership-ops): toggle volunteer-only household from Edit Household Info

### DIFF
--- a/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/[id]/route.ts
@@ -49,6 +49,11 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
         // "Member since" lives on the household's Membership (1:1). Treat the date
         // as date-only: parse at UTC midnight and only act on a real change, so an
         // unchanged field re-sent by the form never writes a spurious audit row.
+        // Both "member since" and the volunteer-only flag live on the household's
+        // Membership (1:1); fetch it once if either is being edited.
+        const editsMembership = (typeof body.memberSince === "string" && body.memberSince !== "") || typeof body.isVolunteer === "boolean";
+        const membership = editsMembership ? await prisma.orgMembership.findUnique({ where: { householdId: id } }) : null;
+
         let memberSinceChange: { orgMembershipId: number; oldValue: Date; newValue: Date } | null = null;
         if (typeof body.memberSince === "string" && body.memberSince !== "") {
             const parsed = new Date(`${body.memberSince}T00:00:00.000Z`);
@@ -59,7 +64,6 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
             if (parsed.getTime() < Date.UTC(2023, 10, 1)) {
                 return apiError("Member-since cannot be before Nov 1, 2023", 400);
             }
-            const membership = await prisma.orgMembership.findUnique({ where: { householdId: id } });
             if (!membership) {
                 return apiError("Household has no membership record", 400);
             }
@@ -68,7 +72,18 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
             }
         }
 
-        if (!editsHousehold && !memberSinceChange) {
+        // Volunteer-only household: reduced-fee volunteer family, flagged on the membership.
+        let isVolunteerChange: { orgMembershipId: number; oldValue: boolean; newValue: boolean } | null = null;
+        if (typeof body.isVolunteer === "boolean") {
+            if (!membership) {
+                return apiError("Household has no membership record", 400);
+            }
+            if (membership.isVolunteer !== body.isVolunteer) {
+                isVolunteerChange = { orgMembershipId: membership.id, oldValue: membership.isVolunteer, newValue: body.isVolunteer };
+            }
+        }
+
+        if (!editsHousehold && !memberSinceChange && !isVolunteerChange) {
             return apiError("No fields to update provided", 400);
         }
 
@@ -119,6 +134,24 @@ export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
                     secondaryAffectedEntity: id,
                     oldData: { memberSince: memberSinceChange.oldValue },
                     newData: { memberSince: memberSinceChange.newValue },
+                }
+            });
+        }
+
+        if (isVolunteerChange) {
+            await prisma.orgMembership.update({
+                where: { id: isVolunteerChange.orgMembershipId },
+                data: { isVolunteer: isVolunteerChange.newValue },
+            });
+            await prisma.auditLog.create({
+                data: {
+                    actorId: auth.user.id,
+                    action: "EDIT",
+                    tableName: "OrgMembership",
+                    affectedEntityId: isVolunteerChange.orgMembershipId,
+                    secondaryAffectedEntity: id,
+                    oldData: { isVolunteer: isVolunteerChange.oldValue },
+                    newData: { isVolunteer: isVolunteerChange.newValue },
                 }
             });
         }

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Alert, Button, Divider, Group, Loader, Modal, SimpleGrid, Stack, Text, TextInput } from "@mantine/core";
+import { Alert, Button, Divider, Group, Loader, Modal, SimpleGrid, Stack, Switch, Text, TextInput } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { modals } from "@mantine/modals";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
@@ -14,7 +14,7 @@ export type AdminHousehold = {
   emergencyContactPhone: string | null;
   householdMembers?: Array<{ id: number; name: string | null; email: string | null }>;
   householdLeads?: Array<{ personId: number }>;
-  orgMembership?: { memberSince: string | null } | null;
+  orgMembership?: { memberSince: string | null; isVolunteer?: boolean } | null;
 } & Partial<StructuredAddress>;
 
 type FormState = {
@@ -27,9 +27,10 @@ type FormState = {
   emergencyContactName: string;
   emergencyContactPhone: string;
   memberSince: string;
+  isVolunteer: boolean;
 };
 
-const EMPTY: FormState = { name: "", line1: "", line2: "", city: "", state: "", postalCode: "", emergencyContactName: "", emergencyContactPhone: "", memberSince: "" };
+const EMPTY: FormState = { name: "", line1: "", line2: "", city: "", state: "", postalCode: "", emergencyContactName: "", emergencyContactPhone: "", memberSince: "", isVolunteer: false };
 
 /** Deep-compares flat string form state. Exported for unit test. */
 export function isFormDirty(a: FormState, b: FormState): boolean {
@@ -85,6 +86,7 @@ export function AdminEditHouseholdModal({
           emergencyContactPhone: h.emergencyContactPhone || "",
           // date-only slice of the membership's join date (ISO → YYYY-MM-DD)
           memberSince: h.orgMembership?.memberSince ? h.orgMembership.memberSince.slice(0, 10) : "",
+          isVolunteer: !!h.orgMembership?.isVolunteer,
         };
         setForm(loaded);
         setInitial(loaded);
@@ -259,14 +261,22 @@ export function AdminEditHouseholdModal({
               />
             </SimpleGrid>
             {hasMembership ? (
-              <TextInput
-                type="date"
-                label="Member since"
-                description="Household's membership start date. Editing this is recorded in the audit log."
-                value={form.memberSince}
-                onChange={(e) => { update({ memberSince: e.currentTarget.value }); setFieldErrors({}); }}
-                error={fieldErrors.memberSince}
-              />
+              <>
+                <TextInput
+                  type="date"
+                  label="Member since"
+                  description="Household's membership start date. Editing this is recorded in the audit log."
+                  value={form.memberSince}
+                  onChange={(e) => { update({ memberSince: e.currentTarget.value }); setFieldErrors({}); }}
+                  error={fieldErrors.memberSince}
+                />
+                <Switch
+                  label="Volunteer-only household"
+                  description="Reduced-fee volunteer family (no youth enrolled). Editing this is recorded in the audit log."
+                  checked={form.isVolunteer}
+                  onChange={(e) => update({ isVolunteer: e.currentTarget.checked })}
+                />
+              </>
             ) : (
               <Text size="sm" c="dimmed">This household isn&apos;t an org member — no membership date.</Text>
             )}

--- a/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
@@ -7,7 +7,7 @@ import { modals } from "@mantine/modals";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
 import { AdminEditHouseholdModal, isFormDirty } from "../AdminEditHouseholdModal";
 
-const base = { name: "Smith", line1: "1 Main", line2: "", city: "Austin", state: "TX", postalCode: "78701", emergencyContactName: "Jo", emergencyContactPhone: "5550000", memberSince: "2020-01-15" };
+const base = { name: "Smith", line1: "1 Main", line2: "", city: "Austin", state: "TX", postalCode: "78701", emergencyContactName: "Jo", emergencyContactPhone: "5550000", memberSince: "2020-01-15", isVolunteer: false };
 
 describe("isFormDirty", () => {
   it("is false when snapshots match", () => {
@@ -18,6 +18,7 @@ describe("isFormDirty", () => {
     expect(isFormDirty(base, { ...base, name: "Jones" })).toBe(true);
     expect(isFormDirty(base, { ...base, emergencyContactPhone: "5551111" })).toBe(true);
     expect(isFormDirty(base, { ...base, memberSince: "2021-06-01" })).toBe(true);
+    expect(isFormDirty(base, { ...base, isVolunteer: true })).toBe(true);
   });
 });
 
@@ -220,6 +221,25 @@ describe("AdminEditHouseholdModal", () => {
     global.fetch = jest.fn(() => Promise.reject(new Error("net"))) as unknown as typeof fetch;
     fireEvent.click(screen.getAllByRole("button", { name: "Remove lead" })[0]);
     await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "red", message: "Network error.", autoClose: false })));
+  });
+
+  it("toggles the volunteer-only flag and sends isVolunteer in the PATCH body", async () => {
+    const withMembership = { ...household, orgMembership: { memberSince: "2024-01-15T00:00:00.000Z", isVolunteer: false } };
+    const fetchMock = mockFetchJson({
+      "/api/membership-ops/households?id=55": { household: withMembership },
+      "/api/membership-ops/households/55": { household: withMembership },
+    });
+    renderWithProviders(<AdminEditHouseholdModal householdId={55} opened={true} onClose={jest.fn()} onSaved={jest.fn()} />);
+    await screen.findByDisplayValue("Smith Family");
+
+    fireEvent.click(screen.getByText("Volunteer-only household"));
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes — As Admin" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/api/membership-ops/households/55", expect.objectContaining({ method: "PATCH" })),
+    );
+    const [, patchOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PATCH")!;
+    expect(JSON.parse(patchOpts!.body as string)).toEqual(expect.objectContaining({ isVolunteer: true }));
   });
 
   it("shows the no-leads state for a household with no household leads", async () => {


### PR DESCRIPTION
## What

Board members can flag a household as **volunteer-only** (reduced-fee volunteer family) directly from the **Edit Household Info** modal on `membership-ops/households`. Previously `OrgMembership.isVolunteer` was only set by a background-check reviewer.

## Changes

- **Modal** (`AdminEditHouseholdModal.tsx`): new "Volunteer-only household" `Switch` in the membership section. Gated on `hasMembership` — the flag lives on `OrgMembership`, so a household with no membership record has nowhere to store it.
- **PATCH route** (`membership-ops/households/[id]/route.ts`): accepts `body.isVolunteer`, writes it, and records a separate `OrgMembership` audit row. Mirrors the existing `memberSince` path exactly and shares one membership fetch.
- **Tests**: dirty-check + a toggle-sends-`isVolunteer`-in-PATCH-body case.

## Notes for reviewer

- `OrgMembership.isVolunteer` already existed and GET already returned it (`orgMembership: true`); this only wires the write path. No schema change, no migration.
- Gated to sysadmin + board (unchanged); every edit audited.
- The switch only shows when the household has a membership record (non-members show the existing "isn't an org member" copy) — the flag isn't settable pre-membership.
- No route/integration test added — the sibling `memberSince` edit shipped the same way; the handler is covered indirectly. Component test covers the client wire.

`tsc` clean, 13/13 modal tests pass.