### PR TITLE
ui(footer): show release tag before commit hash on prod builds

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -182,6 +182,7 @@ jobs:
           # deploy-dev.yml (the release-scrub found this job would die here).
           docker build \
             --build-arg NEXT_PUBLIC_GIT_SHA="${{ steps.vars.outputs.sha }}" \
+            --build-arg NEXT_PUBLIC_RELEASE_TAG="${{ steps.vars.outputs.tag }}" \
             -f checkin-app/Dockerfile \
             -t "$IMAGE" -t "$IMAGE_TAGGED" .
           docker push "$IMAGE"

--- a/checkin-app/Dockerfile
+++ b/checkin-app/Dockerfile
@@ -30,6 +30,10 @@ RUN npm -w checkin-app exec -- prisma generate
 # build-time). Empty in local/ad-hoc builds -> the footer shows "dev".
 ARG NEXT_PUBLIC_GIT_SHA
 ENV NEXT_PUBLIC_GIT_SHA=${NEXT_PUBLIC_GIT_SHA}
+# Release tag, passed by the prod deploy workflow only -> footer shows
+# "<tag> <sha>" on prod. Empty on dev/local builds -> footer shows the hash alone.
+ARG NEXT_PUBLIC_RELEASE_TAG
+ENV NEXT_PUBLIC_RELEASE_TAG=${NEXT_PUBLIC_RELEASE_TAG}
 # Needed for GitHub to build the image, overwritten by secrets in AWS at run time.
 # (next build imports auth-options.ts, which requires these to exist; the values
 # are never used — every route is dynamic — and never reach the runner stage.)

--- a/checkin-app/src/components/BuildInfoFooter.tsx
+++ b/checkin-app/src/components/BuildInfoFooter.tsx
@@ -9,15 +9,22 @@ import { Text } from "@mantine/core";
 // local dev -> "dev".
 const FULL_SHA =
   process.env.NEXT_PUBLIC_GIT_SHA || process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA;
+// Release tag (e.g. "v1.0.0"), set only by the prod deploy workflow. Empty on
+// dev/local builds -> the footer shows the hash alone.
+const RELEASE_TAG = process.env.NEXT_PUBLIC_RELEASE_TAG;
 
-/** Short, human-facing build label: the 7-char SHA, or "dev" when unbuilt. */
-export function buildLabel(sha: string | undefined | null): string {
+/**
+ * Human-facing build label: "<tag> <7-char sha>" on a tagged prod build,
+ * the 7-char SHA alone otherwise, or "dev" when unbuilt.
+ */
+export function buildLabel(sha: string | undefined | null, tag?: string | null): string {
   if (!sha) return "dev";
-  return sha.slice(0, 7);
+  const short = sha.slice(0, 7);
+  return tag ? `${tag} ${short}` : short;
 }
 
 export function BuildInfoFooter() {
-  const label = buildLabel(FULL_SHA);
+  const label = buildLabel(FULL_SHA, RELEASE_TAG);
   return (
     <Text
       component="div"

--- a/checkin-app/src/components/__tests__/BuildInfoFooter.test.tsx
+++ b/checkin-app/src/components/__tests__/BuildInfoFooter.test.tsx
@@ -28,6 +28,16 @@ describe("buildLabel", () => {
     expect(buildLabel(null)).toBe("dev");
     expect(buildLabel("")).toBe("dev");
   });
+
+  it("prefixes the release tag when both sha and tag are set", () => {
+    expect(buildLabel("0123456789abcdef0123456789abcdef01234567", "v1.0.0")).toBe(
+      "v1.0.0 0123456",
+    );
+  });
+
+  it("ignores the tag when there is no sha", () => {
+    expect(buildLabel(undefined, "v1.0.0")).toBe("dev");
+  });
 });
 
 describe("BuildInfoFooter", () => {


### PR DESCRIPTION
## Summary
- Dev footer is unchanged: `build fd77e83` (7-char hash only), since `deploy-dev.yml` never sets `NEXT_PUBLIC_RELEASE_TAG`.
- Prod footer now shows `build v1.0.0 fd77e83` (release tag + short hash), since `deploy-prod.yml` already computes the release tag (`steps.vars.outputs.tag`) and now passes it through as a build-arg.

## Changes
- `checkin-app/Dockerfile`: new `ARG`/`ENV` pair for `NEXT_PUBLIC_RELEASE_TAG`, mirroring the existing `NEXT_PUBLIC_GIT_SHA` pair. Empty on dev/local builds.
- `.github/workflows/deploy-prod.yml`: pass `--build-arg NEXT_PUBLIC_RELEASE_TAG="${{ steps.vars.outputs.tag }}"` to the docker build step. `deploy-dev.yml` and `ci.yml` are untouched.
- `checkin-app/src/components/BuildInfoFooter.tsx`: `buildLabel` takes an optional `tag` param — `dev` (no sha), `<sha7>` (sha, no tag), `<tag> <sha7>` (both). Tooltip still shows the full commit.
- Test: extended `BuildInfoFooter.test.tsx` with cases for the tag+sha and tag-without-sha shapes.

## Test plan
- [x] `npx jest --testPathPatterns src/components/__tests__/BuildInfoFooter.test.tsx` — 5/5 passing (from the worktree's `checkin-app/`)
- [ ] After merge + next release, confirm the prod footer reads `build v<tag> <sha7>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe