### PR TITLE
feat(renewal): renewals walk the same external step — fresh agreement + background check request flow

### DIFF
--- a/checkin-app/prisma/migrations/20260715160000_renewal_bg_request_flow/migration.sql
+++ b/checkin-app/prisma/migrations/20260715160000_renewal_bg_request_flow/migration.sql
@@ -1,14 +1,16 @@
--- Stale-check renewals now go through the same background-check request flow as
--- new applications (PENDING_EXTERNAL_ACTION: consent on Averity, then payment
--- while the review runs in parallel) instead of parking at RENEWAL_PENDING_BG.
--- Move the already-parked open rows there so members stuck on the passive
--- "Renewal in progress" screen get the request flow on their next visit.
+-- Renewals now go through the same external step as new applications
+-- (PENDING_EXTERNAL_ACTION: sign a fresh agreement, and request a new background
+-- check on Averity if the previous one expired, then payment while the review
+-- runs in parallel) instead of parking at RENEWAL_PENDING_BG. Move the
+-- already-parked open rows there so members stuck on the passive "Renewal in
+-- progress" screen get the actionable flow on their next visit.
 -- bgConsentAt is always NULL on these rows (consent was unreachable from
 -- RENEWAL_PENDING_BG), and rows a reviewer already cleared (bgClearedAt set)
 -- have left this status, so the two predicates below are belt-and-braces.
--- Known edge, accepted: a fresh-check renewal held here only for its household
--- note is also moved and will be asked to consent once more (rare — the flow
--- shipped days ago; converges correctly via the note-hold at PENDING_BG_REVIEW).
+-- Known edge, accepted: a renewal held here only for its household note (its
+-- background check still valid) is also moved and will be asked to consent once
+-- more (rare — the flow shipped days ago; converges via the note-hold at
+-- PENDING_BG_REVIEW).
 UPDATE "OrgMembershipProcess"
 SET "status" = 'PENDING_EXTERNAL_ACTION',
     "stageEnteredAt" = NOW()

--- a/checkin-app/prisma/migrations/20260715160000_renewal_bg_request_flow/migration.sql
+++ b/checkin-app/prisma/migrations/20260715160000_renewal_bg_request_flow/migration.sql
@@ -1,0 +1,30 @@
+-- Stale-check renewals now go through the same background-check request flow as
+-- new applications (PENDING_EXTERNAL_ACTION: consent on Averity, then payment
+-- while the review runs in parallel) instead of parking at RENEWAL_PENDING_BG.
+-- Move the already-parked open rows there so members stuck on the passive
+-- "Renewal in progress" screen get the request flow on their next visit.
+-- bgConsentAt is always NULL on these rows (consent was unreachable from
+-- RENEWAL_PENDING_BG), and rows a reviewer already cleared (bgClearedAt set)
+-- have left this status, so the two predicates below are belt-and-braces.
+-- Known edge, accepted: a fresh-check renewal held here only for its household
+-- note is also moved and will be asked to consent once more (rare — the flow
+-- shipped days ago; converges correctly via the note-hold at PENDING_BG_REVIEW).
+UPDATE "OrgMembershipProcess"
+SET "status" = 'PENDING_EXTERNAL_ACTION',
+    "stageEnteredAt" = NOW()
+WHERE "kind" = 'RENEWAL'
+  AND "status" = 'RENEWAL_PENDING_BG'
+  AND "bgClearedAt" IS NULL;
+
+-- Renewals can now sit in the request-flow states, so the one-inflight-renewal
+-- guard must cover them or the sweep could open a duplicate cycle for a
+-- household mid-flow. Defense-in-depth behind the row lock in
+-- createRenewalProcess; must stay in step with IN_FLIGHT_RENEWAL_STATUSES
+-- (renewal.ts). No existing rows can violate the widened predicate: renewals
+-- never reached the added statuses before this migration.
+DROP INDEX IF EXISTS "membership_one_inflight_renewal";
+CREATE UNIQUE INDEX "membership_one_inflight_renewal" ON "OrgMembershipProcess" ("orgMembershipId")
+WHERE "kind" = 'RENEWAL' AND "status" IN (
+  'PENDING_RENEWAL', 'PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW',
+  'PENDING_PAYMENT', 'PENDING_BG_CLEARANCE', 'RENEWAL_PENDING_BG'
+);

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -302,10 +302,16 @@ describe('background check is non-blocking', () => {
         await beginRenewal(processId);
 
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
-        // Fresh check, so no request flow — but the note holds it for review at
-        // the same status INITIAL uses (RENEWAL_PENDING_BG is legacy, unwritten).
-        expect(proc?.status).toBe('PENDING_BG_REVIEW');
-        expect(proc?.bgClearedAt).toBeNull();
+        // Every renewal re-signs at the external step; the note disqualifies the
+        // bgClearedAt shortcut for the still-valid background check (mirrors
+        // submitIntake), so after sign + consent the advance holds at
+        // PENDING_BG_REVIEW instead of opening payment.
+        expect(proc?.status).toBe('PENDING_EXTERNAL_ACTION');
+        expect(proc?.bgClearedAt).toBeNull(); // shortcut disqualified by the note
+
+        await markContractSigned(processId);
+        await markBgConsent(processId, revA);
+        expect(await statusOf(processId)).toBe('PENDING_BG_REVIEW'); // held for the note
     });
 
     it('conflict of interest: a certifier in the applicant household is blocked; sysadmin overrides', async () => {

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -241,13 +241,17 @@ describe('background check is non-blocking', () => {
         expect(await isVolunteerOf(orgMembershipId)).toBe(true);
     });
 
-    it('fresh-check renewal matches a designation added since the last cycle (#874)', async () => {
+    it('renewal with a still-valid background check matches a designation added since the last cycle (#874)', async () => {
         await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
         const { orgMembershipId, processId, leadEmail } = await makeFreshRenewal();
         await prisma.volunteerDesignation.create({ data: { email: leadEmail } });
 
         await beginRenewal(processId);
+        expect(await statusOf(processId)).toBe('PENDING_EXTERNAL_ACTION');
 
+        // The advance's PENDING_PAYMENT transition applies the allowlist — dues
+        // are read at payment, which opens once the fresh agreement is signed.
+        await markContractSigned(processId);
         expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
         expect(await isVolunteerOf(orgMembershipId)).toBe(true);
     });
@@ -345,13 +349,15 @@ describe('background check is non-blocking', () => {
         expect(await statusOf(processId)).not.toBe('BLOCKED');
     });
 
-    it('renewal with a still-valid check → PENDING_PAYMENT + bgClearedAt, then paying activates (not stuck)', async () => {
+    it('renewal with a still-valid background check: bgClearedAt stamped, signature opens payment, paying activates (not stuck)', async () => {
         await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
         const { orgMembershipId, processId } = await makeFreshRenewal();
         await beginRenewal(processId);
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
-        expect(proc?.status).toBe('PENDING_PAYMENT');
+        expect(proc?.status).toBe('PENDING_EXTERNAL_ACTION');
         expect(proc?.bgClearedAt).not.toBeNull(); // the bug: was null → paid renewal stuck forever
+        await markContractSigned(processId);
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
         await activate(processId, { via: 'payment', shopifyOrderId: 'renew-pay' });
         expect(await statusOf(processId)).toBe('ACTIVE');
         expect(await membershipStatusOf(orgMembershipId)).toBe('ACTIVE');

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -302,7 +302,9 @@ describe('background check is non-blocking', () => {
         await beginRenewal(processId);
 
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
-        expect(proc?.status).toBe('RENEWAL_PENDING_BG');
+        // Fresh check, so no request flow — but the note holds it for review at
+        // the same status INITIAL uses (RENEWAL_PENDING_BG is legacy, unwritten).
+        expect(proc?.status).toBe('PENDING_BG_REVIEW');
         expect(proc?.bgClearedAt).toBeNull();
     });
 

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -9,7 +9,7 @@
 import { GET as CRON } from '@/app/api/cron/membership-renewals/route';
 import { runRenewalSweep, beginRenewal, nextBoundary } from '@/lib/membership/renewal';
 import { attest } from '@/lib/membership/review';
-import { markBgConsent } from '@/lib/membership/external';
+import { markBgConsent, markContractSigned } from '@/lib/membership/external';
 import prisma from '@/lib/prisma';
 
 jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
@@ -127,28 +127,38 @@ describe('Membership renewal', () => {
         expect(second).toBeDefined();
     });
 
-    it('beginRenewal goes straight to payment when a parent BG is fresh', async () => {
+    it('beginRenewal with a valid parent background check: re-sign only — bgClearedAt stamped, signature opens payment', async () => {
         await setBoundary(new Date(Date.UTC(2000, 7, 1)));
-        const m = await makeActiveMembership('Fresh', new Date()); // recent BG
+        const m = await makeActiveMembership('Fresh', new Date()); // recent background check
         const proc = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.orgMembershipId, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
         const out = await beginRenewal(proc.id);
-        expect(out.status).toBe('PENDING_PAYMENT');
+        // A fresh agreement is signed every cycle; the still-valid background check is
+        // pre-cleared, so the signature alone opens payment.
+        expect(out.status).toBe('PENDING_EXTERNAL_ACTION');
+        expect(out.bgClearedAt).not.toBeNull();
+
+        await markContractSigned(proc.id);
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: proc.id } }))?.status).toBe('PENDING_PAYMENT');
     });
 
-    it('beginRenewal with a stale BG enters the request flow; consent opens payment; review clears in parallel', async () => {
+    it('beginRenewal with an expired background check requires signature + consent; payment opens; review clears in parallel', async () => {
         await setBoundary(new Date(Date.UTC(2000, 7, 1)));
-        const m = await makeActiveMembership('Stale', null); // no BG on record
+        const m = await makeActiveMembership('Stale', null); // no background check on record
         const proc = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.orgMembershipId, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
         const out = await beginRenewal(proc.id);
-        // Same background-check request flow as a new applicant — the member must
-        // consent on Averity; nothing sits in the review queue yet.
+        // Same external step as a new applicant — the member must sign a fresh
+        // agreement AND consent on Averity; nothing sits in the review queue yet.
         expect(out.status).toBe('PENDING_EXTERNAL_ACTION');
+        expect(out.bgClearedAt).toBeNull();
         await expect(attest(rev1, proc.id, { result: 'APPROVE' })).rejects.toMatchObject({ code: 'wrong_phase' });
 
-        // Consent recorded → payment opens immediately (no contract re-sign at
-        // renewal); the 2-of-N review then runs in parallel: 2 approvals keep it
-        // at PENDING_PAYMENT (unpaid) rather than blocking it.
+        // Consent alone is not enough — the renewal re-signs the agreement too.
         await markBgConsent(proc.id, rev1);
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: proc.id } }))?.status).toBe('PENDING_EXTERNAL_ACTION');
+
+        // Signature lands → payment opens; the 2-of-N review runs in parallel:
+        // 2 approvals keep it at PENDING_PAYMENT (unpaid) rather than blocking it.
+        await markContractSigned(proc.id);
         expect((await prisma.orgMembershipProcess.findUnique({ where: { id: proc.id } }))?.status).toBe('PENDING_PAYMENT');
 
         await attest(rev1, proc.id, { result: 'APPROVE' });

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -9,6 +9,7 @@
 import { GET as CRON } from '@/app/api/cron/membership-renewals/route';
 import { runRenewalSweep, beginRenewal, nextBoundary } from '@/lib/membership/renewal';
 import { attest } from '@/lib/membership/review';
+import { markBgConsent } from '@/lib/membership/external';
 import prisma from '@/lib/prisma';
 
 jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
@@ -134,14 +135,22 @@ describe('Membership renewal', () => {
         expect(out.status).toBe('PENDING_PAYMENT');
     });
 
-    it('beginRenewal requires re-review when BG is stale', async () => {
+    it('beginRenewal with a stale BG enters the request flow; consent opens payment; review clears in parallel', async () => {
         await setBoundary(new Date(Date.UTC(2000, 7, 1)));
         const m = await makeActiveMembership('Stale', null); // no BG on record
         const proc = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.orgMembershipId, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
         const out = await beginRenewal(proc.id);
-        expect(out.status).toBe('RENEWAL_PENDING_BG');
+        // Same background-check request flow as a new applicant — the member must
+        // consent on Averity; nothing sits in the review queue yet.
+        expect(out.status).toBe('PENDING_EXTERNAL_ACTION');
+        await expect(attest(rev1, proc.id, { result: 'APPROVE' })).rejects.toMatchObject({ code: 'wrong_phase' });
 
-        // The 2-of-N review flow handles renewal BG too: 2 approvals -> PENDING_PAYMENT.
+        // Consent recorded → payment opens immediately (no contract re-sign at
+        // renewal); the 2-of-N review then runs in parallel: 2 approvals keep it
+        // at PENDING_PAYMENT (unpaid) rather than blocking it.
+        await markBgConsent(proc.id, rev1);
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: proc.id } }))?.status).toBe('PENDING_PAYMENT');
+
         await attest(rev1, proc.id, { result: 'APPROVE' });
         const final = await attest(rev2, proc.id, { result: 'APPROVE' });
         expect(final.status).toBe('PENDING_PAYMENT');

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -213,7 +213,7 @@ describe('Membership BG review API', () => {
         }
     });
 
-    it('board reset on a BLOCKED RENEWAL returns it to RENEWAL_PENDING_BG (not PENDING_BG_REVIEW), attestations cleared', async () => {
+    it('board reset on a BLOCKED RENEWAL without consent restarts the request flow (PENDING_EXTERNAL_ACTION), attestations cleared', async () => {
         const proc = await makeProcess('RenewalReset', 'RENEWAL', 'RENEWAL_PENDING_BG');
 
         // A reject from an eligible reviewer (different household) blocks it.
@@ -224,9 +224,11 @@ describe('Membership BG review API', () => {
         as(board, { isBoardMember: true });
         const res = await OVERRIDE(req({ processId: proc.processId, action: 'reset' }) as never);
         expect(res.status).toBe(200);
-        // Renewal branch: must restore the RENEWAL review phase, not the INITIAL one.
+        // No consent was ever recorded, so the reset must restart the member-facing
+        // request flow — the parallel review queue can't list an unconsented renewal
+        // (PENDING_PAYMENT rows only enter it once bgConsentAt is set).
         const after = await prisma.orgMembershipProcess.findUnique({ where: { id: proc.processId } });
-        expect(after?.status).toBe('RENEWAL_PENDING_BG');
+        expect(after?.status).toBe('PENDING_EXTERNAL_ACTION');
         expect(await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } })).toBe(0);
     });
 

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -609,8 +609,8 @@ export default function MembershipPage() {
           <Title order={2}>Time to renew</Title>
           <Text c="dimmed" my="md">
             Your household membership is up for renewal. You&apos;re still an active member — confirm
-            below to continue for another year. No contract to re-sign; we&apos;ll only re-check a
-            background if it has expired.
+            below to continue for another year. You&apos;ll sign a fresh membership agreement; a new
+            background check is only needed if your previous one has expired.
           </Text>
           <Text c="dimmed" mb="md">
             Did anything change — new members, address, phone, or email?{" "}
@@ -629,8 +629,8 @@ export default function MembershipPage() {
         </Card>
       ) : (
         <Group align="flex-start" gap="xl" wrap="wrap">
-          {/* Renewals ride the same stepper as new applications — same phases,
-              same progress, whether the check is fresh, expired, or first-time. */}
+          {/* Renewals ride the same stepper as new applications — same phases, same
+              progress, whether the background check is valid, expired, or first-time. */}
           <Box style={{ flex: "0 0 auto" }}>
             <MembershipFlowStepper currentStatus={inStatus} />
           </Box>
@@ -736,29 +736,25 @@ export default function MembershipPage() {
               <Card withBorder radius="md" padding="lg">
                 <Stack gap="md">
                   <div>
-                    <Title order={2}>{isRenewal ? "Start your background check" : "Sign & start your background check"}</Title>
+                    <Title order={2}>Sign &amp; start your background check</Title>
                     <Text c="dimmed">
                       {isRenewal
-                        ? "Your household's background check has expired, so this renewal needs a new one — no contract to re-sign. Once it's underway, we'll move you straight to payment, and your membership stays active in the meantime."
-                        : "Once your agreement is signed and your background check is underway, we'll move you straight to payment — you won't have to wait for the check to come back."}
+                        ? "Renewing means signing a fresh membership agreement for the year, and a new background check if your previous one has expired. Once both are underway, we'll move you straight to payment — your membership stays active in the meantime."
+                        : "Once your agreement is signed and your background check is underway, we'll move you straight to payment — you won't have to wait for the background check to come back."}
                     </Text>
                   </div>
 
-                  {/* Renewals never re-sign the agreement (renewal.ts) — only the
-                      background check brings them to this step. */}
-                  {!isRenewal && (
-                    <ExternalTask done={!!state.external?.contractSigned} title="Sign your membership agreement" doneText="Agreement signed — thank you!">
-                      <Stack gap="xs" align="flex-start">
-                        <Text c="dimmed">
-                          Sign your personalized membership agreement online. This page updates
-                          automatically once it&apos;s signed.
-                        </Text>
-                        <Button color="green" disabled={saving} loading={saving} onClick={startSigning}>
-                          {state.external?.contractStarted ? "Resume signing →" : "Sign your membership agreement →"}
-                        </Button>
-                      </Stack>
-                    </ExternalTask>
-                  )}
+                  <ExternalTask done={!!state.external?.contractSigned} title="Sign your membership agreement" doneText="Agreement signed — thank you!">
+                    <Stack gap="xs" align="flex-start">
+                      <Text c="dimmed">
+                        Sign your personalized membership agreement online. This page updates
+                        automatically once it&apos;s signed.
+                      </Text>
+                      <Button color="green" disabled={saving} loading={saving} onClick={startSigning}>
+                        {state.external?.contractStarted ? "Resume signing →" : "Sign your membership agreement →"}
+                      </Button>
+                    </Stack>
+                  </ExternalTask>
 
                   {state.external?.bgCleared ? (
                     <ExternalTask done title="Background check" doneText="Your household&apos;s background check is still valid — no new check needed.">

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -629,11 +629,11 @@ export default function MembershipPage() {
         </Card>
       ) : (
         <Group align="flex-start" gap="xl" wrap="wrap">
-          {!isRenewal && (
-            <Box style={{ flex: "0 0 auto" }}>
-              <MembershipFlowStepper currentStatus={inStatus} />
-            </Box>
-          )}
+          {/* Renewals ride the same stepper as new applications — same phases,
+              same progress, whether the check is fresh, expired, or first-time. */}
+          <Box style={{ flex: "0 0 auto" }}>
+            <MembershipFlowStepper currentStatus={inStatus} />
+          </Box>
 
           <Box style={{ flex: "1 1 420px", minWidth: 320 }}>
             {isIntake ? (
@@ -736,25 +736,29 @@ export default function MembershipPage() {
               <Card withBorder radius="md" padding="lg">
                 <Stack gap="md">
                   <div>
-                    <Title order={2}>Sign &amp; start your background check</Title>
+                    <Title order={2}>{isRenewal ? "Start your background check" : "Sign & start your background check"}</Title>
                     <Text c="dimmed">
-                      Once your agreement is signed and your background check is underway, we&apos;ll
-                      move you straight to payment — you won&apos;t have to wait for the check to come
-                      back.
+                      {isRenewal
+                        ? "Your household's background check has expired, so this renewal needs a new one — no contract to re-sign. Once it's underway, we'll move you straight to payment, and your membership stays active in the meantime."
+                        : "Once your agreement is signed and your background check is underway, we'll move you straight to payment — you won't have to wait for the check to come back."}
                     </Text>
                   </div>
 
-                  <ExternalTask done={!!state.external?.contractSigned} title="Sign your membership agreement" doneText="Agreement signed — thank you!">
-                    <Stack gap="xs" align="flex-start">
-                      <Text c="dimmed">
-                        Sign your personalized membership agreement online. This page updates
-                        automatically once it&apos;s signed.
-                      </Text>
-                      <Button color="green" disabled={saving} loading={saving} onClick={startSigning}>
-                        {state.external?.contractStarted ? "Resume signing →" : "Sign your membership agreement →"}
-                      </Button>
-                    </Stack>
-                  </ExternalTask>
+                  {/* Renewals never re-sign the agreement (renewal.ts) — only the
+                      background check brings them to this step. */}
+                  {!isRenewal && (
+                    <ExternalTask done={!!state.external?.contractSigned} title="Sign your membership agreement" doneText="Agreement signed — thank you!">
+                      <Stack gap="xs" align="flex-start">
+                        <Text c="dimmed">
+                          Sign your personalized membership agreement online. This page updates
+                          automatically once it&apos;s signed.
+                        </Text>
+                        <Button color="green" disabled={saving} loading={saving} onClick={startSigning}>
+                          {state.external?.contractStarted ? "Resume signing →" : "Sign your membership agreement →"}
+                        </Button>
+                      </Stack>
+                    </ExternalTask>
+                  )}
 
                   {state.external?.bgCleared ? (
                     <ExternalTask done title="Background check" doneText="Your household&apos;s background check is still valid — no new check needed.">

--- a/checkin-app/src/lib/membership/__tests__/external.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/external.test.ts
@@ -267,6 +267,26 @@ describe('advanceExternalIfComplete', () => {
         expect(prisma.orgMembershipProcess.updateMany).not.toHaveBeenCalled();
         expect(applyVolunteerStatus).not.toHaveBeenCalled();
     });
+
+    it('RENEWAL: consent alone advances — the contract gate is waived (no re-sign at renewal)', async () => {
+        const renewal = { ...readyProcess, kind: 'RENEWAL', contractSignedAt: null };
+        prisma.orgMembershipProcess.findUnique
+            .mockResolvedValueOnce(renewal)
+            .mockResolvedValueOnce({ ...renewal, status: 'PENDING_PAYMENT' });
+        prisma.orgMembershipProcess.updateMany.mockResolvedValue({ count: 1 });
+
+        await advanceExternalIfComplete(20);
+
+        // The conditional update must not require contractSignedAt for a renewal.
+        expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.not.objectContaining({ contractSignedAt: expect.anything() }),
+                data: expect.objectContaining({ status: 'PENDING_PAYMENT' }),
+            }),
+        );
+        expect(applyVolunteerStatus).toHaveBeenCalledWith(prisma, 42, 7, false);
+        expect(notifyReviewers).toHaveBeenCalledTimes(1); // check not cleared → review needed
+    });
 });
 
 describe('getOrCreateContractSigningUrl', () => {

--- a/checkin-app/src/lib/membership/__tests__/external.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/external.test.ts
@@ -268,24 +268,16 @@ describe('advanceExternalIfComplete', () => {
         expect(applyVolunteerStatus).not.toHaveBeenCalled();
     });
 
-    it('RENEWAL: consent alone advances — the contract gate is waived (no re-sign at renewal)', async () => {
-        const renewal = { ...readyProcess, kind: 'RENEWAL', contractSignedAt: null };
-        prisma.orgMembershipProcess.findUnique
-            .mockResolvedValueOnce(renewal)
-            .mockResolvedValueOnce({ ...renewal, status: 'PENDING_PAYMENT' });
-        prisma.orgMembershipProcess.updateMany.mockResolvedValue({ count: 1 });
+    it('RENEWAL: the contract gate applies too — an unsigned renewal does not advance on consent alone', async () => {
+        // A fresh agreement is signed every cycle (beginRenewal), so a renewal
+        // with consent but no signature must stay at PENDING_EXTERNAL_ACTION.
+        prisma.orgMembershipProcess.findUnique.mockResolvedValueOnce({ ...readyProcess, kind: 'RENEWAL', contractSignedAt: null });
 
         await advanceExternalIfComplete(20);
 
-        // The conditional update must not require contractSignedAt for a renewal.
-        expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith(
-            expect.objectContaining({
-                where: expect.not.objectContaining({ contractSignedAt: expect.anything() }),
-                data: expect.objectContaining({ status: 'PENDING_PAYMENT' }),
-            }),
-        );
-        expect(applyVolunteerStatus).toHaveBeenCalledWith(prisma, 42, 7, false);
-        expect(notifyReviewers).toHaveBeenCalledTimes(1); // check not cleared → review needed
+        expect(prisma.orgMembershipProcess.updateMany).not.toHaveBeenCalled();
+        expect(applyVolunteerStatus).not.toHaveBeenCalled();
+        expect(notifyReviewers).not.toHaveBeenCalled();
     });
 });
 

--- a/checkin-app/src/lib/membership/__tests__/renewal.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/renewal.test.ts
@@ -119,33 +119,45 @@ describe('beginRenewal', () => {
             expect(notifyReviewers).not.toHaveBeenCalled();
         });
 
-        it('stale check → RENEWAL_PENDING_BG, reviewers pinged, allowlist left to clearBackgroundCheck', async () => {
+        it('stale check → PENDING_EXTERNAL_ACTION (the request flow), no ping — reviewers wait for consent', async () => {
             prisma.person.findFirst.mockResolvedValue(null); // no valid check on file
-            prisma.orgMembershipProcess.findUniqueOrThrow.mockResolvedValue({ ...pending, status: 'RENEWAL_PENDING_BG' });
+            prisma.orgMembershipProcess.findUniqueOrThrow.mockResolvedValue({ ...pending, status: 'PENDING_EXTERNAL_ACTION' });
 
             await beginRenewal(5);
 
+            expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith({
+                where: { id: 5, status: 'PENDING_RENEWAL' },
+                data: expect.objectContaining({ status: 'PENDING_EXTERNAL_ACTION' }),
+            });
             expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith({
                 where: { id: 5, status: 'PENDING_RENEWAL' },
                 data: expect.not.objectContaining({ bgClearedAt: expect.anything() }),
             });
             expect(applyVolunteerStatus).not.toHaveBeenCalled();
-            expect(notifyReviewers).toHaveBeenCalledTimes(1);
+            // Nothing to review until the member consents on Averity — the
+            // advance (advanceExternalIfComplete) pings, same as INITIAL.
+            expect(notifyReviewers).not.toHaveBeenCalled();
         });
 
-        it('fresh check + household intake note → RENEWAL_PENDING_BG: the note must reach a reviewer before payment (#907)', async () => {
+        it('fresh check + household intake note → PENDING_BG_REVIEW: the note must reach a reviewer before payment (#907)', async () => {
             prisma.person.findFirst.mockResolvedValue({ id: 1 }); // a lead with a valid check
             prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 7, household: { intakeNotes: 'treat us as a volunteer household' } });
-            prisma.orgMembershipProcess.findUniqueOrThrow.mockResolvedValue({ ...pending, status: 'RENEWAL_PENDING_BG' });
+            prisma.orgMembershipProcess.findUniqueOrThrow.mockResolvedValue({ ...pending, status: 'PENDING_BG_REVIEW' });
 
             await beginRenewal(5);
 
             expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith({
                 where: { id: 5, status: 'PENDING_RENEWAL' },
-                data: expect.objectContaining({ status: 'RENEWAL_PENDING_BG' }),
+                // No bgClearedAt despite the fresh check: the review queue only
+                // lists uncleared rows, so clearing here would strand the note.
+                data: expect.not.objectContaining({ bgClearedAt: expect.anything() }),
+            });
+            expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith({
+                where: { id: 5, status: 'PENDING_RENEWAL' },
+                data: expect.objectContaining({ status: 'PENDING_BG_REVIEW' }),
             });
             expect(applyVolunteerStatus).not.toHaveBeenCalled(); // clearBackgroundCheck applies it after the review
-            expect(notifyReviewers).toHaveBeenCalledTimes(1);
+            expect(notifyReviewers).toHaveBeenCalledTimes(1); // the note is reviewable immediately
         });
 
         it('double-submit loser (count 0) → no audit, no allowlist match, no ping', async () => {

--- a/checkin-app/src/lib/membership/__tests__/renewal.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/renewal.test.ts
@@ -4,10 +4,12 @@
 /**
  * Unit tests for renewal.ts edge logic (prisma mocked, no DB):
  *   - householdBgIsFresh: the recheckMonths<=0 short-circuit, and the `gte`
- *     threshold boundary (a check exactly at the threshold counts as fresh).
+ *     threshold boundary (a background check exactly at the threshold counts
+ *     as fresh).
  *   - beginRenewal: a process not in PENDING_RENEWAL → RenewalError wrong_phase;
- *     the fresh-check path stamps bgClearedAt AND matches the volunteer
- *     allowlist at its PENDING_PAYMENT transition (#874).
+ *     every path lands at PENDING_EXTERNAL_ACTION (a fresh agreement is signed
+ *     each cycle) and only a still-valid background check with no household
+ *     note pre-stamps bgClearedAt.
  */
 import { householdBgIsFresh, beginRenewal, RenewalError } from '@/lib/membership/renewal';
 
@@ -45,7 +47,7 @@ describe('householdBgIsFresh', () => {
     const boundary = new Date(Date.UTC(2026, 8, 1)); // 2026-09-01
 
     it('recheckMonths = 0 → not fresh, and never queries (policy unset)', async () => {
-        // Even a recent check on file must not count when the board hasn't set the policy.
+        // Even a recent background check on file must not count when the board hasn't set the policy.
         prisma.person.findFirst.mockResolvedValue({ id: 1 });
 
         const result = await householdBgIsFresh(42, boundary, 0);
@@ -54,7 +56,7 @@ describe('householdBgIsFresh', () => {
         expect(prisma.person.findFirst).not.toHaveBeenCalled();
     });
 
-    it('a lead with a check at exactly the threshold → fresh (gte boundary)', async () => {
+    it('a lead with a background check at exactly the threshold → fresh (gte boundary)', async () => {
         prisma.person.findFirst.mockResolvedValue({ id: 1 });
 
         const result = await householdBgIsFresh(42, boundary, 12);
@@ -71,7 +73,7 @@ describe('householdBgIsFresh', () => {
         );
     });
 
-    it('no lead with a fresh-enough check → not fresh', async () => {
+    it('no lead with a fresh-enough background check → not fresh', async () => {
         prisma.person.findFirst.mockResolvedValue(null);
         expect(await householdBgIsFresh(42, boundary, 12)).toBe(false);
     });
@@ -104,23 +106,23 @@ describe('beginRenewal', () => {
             prisma.orgMembershipProcess.findUniqueOrThrow.mockResolvedValue({ ...pending, status: 'PENDING_PAYMENT' });
         });
 
-        it('fresh check → PENDING_PAYMENT + bgClearedAt + volunteer allowlist matched (#874), no reviewer ping', async () => {
-            prisma.person.findFirst.mockResolvedValue({ id: 1 }); // a lead with a valid check
+        it('valid background check → PENDING_EXTERNAL_ACTION with bgClearedAt stamped: only the signature is left', async () => {
+            prisma.person.findFirst.mockResolvedValue({ id: 1 }); // a lead with a valid background check
 
             await beginRenewal(5);
 
             expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith({
                 where: { id: 5, status: 'PENDING_RENEWAL' },
-                data: expect.objectContaining({ status: 'PENDING_PAYMENT', bgClearedAt: expect.any(Date) }),
+                data: expect.objectContaining({ status: 'PENDING_EXTERNAL_ACTION', bgClearedAt: expect.any(Date) }),
             });
-            // Fresh-check renewals skip clearBackgroundCheck, so a designation added
-            // since last cycle must be matched here or the household pays full dues.
-            expect(applyVolunteerStatus).toHaveBeenCalledWith(prisma, 9, 7, false);
+            // The advance's PENDING_PAYMENT transition matches the volunteer
+            // allowlist (#874) and pings reviewers — beginRenewal does neither.
+            expect(applyVolunteerStatus).not.toHaveBeenCalled();
             expect(notifyReviewers).not.toHaveBeenCalled();
         });
 
-        it('stale check → PENDING_EXTERNAL_ACTION (the request flow), no ping — reviewers wait for consent', async () => {
-            prisma.person.findFirst.mockResolvedValue(null); // no valid check on file
+        it('expired background check → PENDING_EXTERNAL_ACTION without bgClearedAt: sign + request a new background check', async () => {
+            prisma.person.findFirst.mockResolvedValue(null); // no valid background check on file
             prisma.orgMembershipProcess.findUniqueOrThrow.mockResolvedValue({ ...pending, status: 'PENDING_EXTERNAL_ACTION' });
 
             await beginRenewal(5);
@@ -139,25 +141,27 @@ describe('beginRenewal', () => {
             expect(notifyReviewers).not.toHaveBeenCalled();
         });
 
-        it('fresh check + household intake note → PENDING_BG_REVIEW: the note must reach a reviewer before payment (#907)', async () => {
-            prisma.person.findFirst.mockResolvedValue({ id: 1 }); // a lead with a valid check
+        it('valid background check + household intake note → no bgClearedAt shortcut: the note must reach a reviewer (#907)', async () => {
+            prisma.person.findFirst.mockResolvedValue({ id: 1 }); // a lead with a valid background check
             prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 7, household: { intakeNotes: 'treat us as a volunteer household' } });
-            prisma.orgMembershipProcess.findUniqueOrThrow.mockResolvedValue({ ...pending, status: 'PENDING_BG_REVIEW' });
+            prisma.orgMembershipProcess.findUniqueOrThrow.mockResolvedValue({ ...pending, status: 'PENDING_EXTERNAL_ACTION' });
 
             await beginRenewal(5);
 
             expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith({
                 where: { id: 5, status: 'PENDING_RENEWAL' },
-                // No bgClearedAt despite the fresh check: the review queue only
-                // lists uncleared rows, so clearing here would strand the note.
+                // No bgClearedAt despite the valid background check (mirrors submitIntake): the
+                // member consents anyway, and the advance holds at PENDING_BG_REVIEW
+                // so the note reaches a reviewer before payment. Clearing here would
+                // skip the hold — the review queue only lists uncleared rows.
                 data: expect.not.objectContaining({ bgClearedAt: expect.anything() }),
             });
             expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith({
                 where: { id: 5, status: 'PENDING_RENEWAL' },
-                data: expect.objectContaining({ status: 'PENDING_BG_REVIEW' }),
+                data: expect.objectContaining({ status: 'PENDING_EXTERNAL_ACTION' }),
             });
-            expect(applyVolunteerStatus).not.toHaveBeenCalled(); // clearBackgroundCheck applies it after the review
-            expect(notifyReviewers).toHaveBeenCalledTimes(1); // the note is reviewable immediately
+            expect(applyVolunteerStatus).not.toHaveBeenCalled(); // the advance / clearBackgroundCheck applies it
+            expect(notifyReviewers).not.toHaveBeenCalled(); // pinged at consent, not before
         });
 
         it('double-submit loser (count 0) → no audit, no allowlist match, no ping', async () => {

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -70,7 +70,9 @@ export async function getExternalStatus(process: {
 /**
  * Once the contract is signed AND the background check is handled — either a
  * still-valid prior check (bgClearedAt) or fresh consent recorded (bgConsentAt)
- * — advance from EXTERNAL straight to PENDING_PAYMENT. The check no longer gates
+ * — advance from EXTERNAL straight to PENDING_PAYMENT. RENEWAL processes only
+ * ever land here for an expired check (no re-sign at renewal), so for them the
+ * check alone advances. The check no longer gates
  * payment: when it still needs a human review (no prior valid check), it runs in
  * PARALLEL while the applicant pays, and only the final ACTIVE flip waits on it.
  * EXCEPTION: a household intake note holds the application at PENDING_BG_REVIEW
@@ -87,7 +89,10 @@ export async function advanceExternalIfComplete(processId: number) {
     const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) return process;
     if (process.status !== "PENDING_EXTERNAL_ACTION") return process;
-    if (!process.contractSignedAt) return process;
+    // Renewals don't re-sign the agreement (renewal.ts) — only an expired
+    // background check brings them here, so the contract gate is INITIAL-only.
+    const contractNeeded = process.kind !== "RENEWAL";
+    if (contractNeeded && !process.contractSignedAt) return process;
     if (!process.bgClearedAt && !process.bgConsentAt) return process;
 
     const advanced = await prisma.$transaction(async (tx) => {
@@ -111,7 +116,7 @@ export async function advanceExternalIfComplete(processId: number) {
             where: {
                 id: processId,
                 status: "PENDING_EXTERNAL_ACTION",
-                contractSignedAt: { not: null },
+                ...(contractNeeded ? { contractSignedAt: { not: null } } : {}),
                 OR: [{ bgClearedAt: { not: null } }, { bgConsentAt: { not: null } }],
             },
             data: { status: nextStatus, stageEnteredAt: new Date() },

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -70,11 +70,12 @@ export async function getExternalStatus(process: {
 /**
  * Once the contract is signed AND the background check is handled — either a
  * still-valid prior check (bgClearedAt) or fresh consent recorded (bgConsentAt)
- * — advance from EXTERNAL straight to PENDING_PAYMENT. RENEWAL processes only
- * ever land here for an expired check (no re-sign at renewal), so for them the
- * check alone advances. The check no longer gates
- * payment: when it still needs a human review (no prior valid check), it runs in
- * PARALLEL while the applicant pays, and only the final ACTIVE flip waits on it.
+ * — advance from EXTERNAL straight to PENDING_PAYMENT. RENEWAL processes take
+ * this gate too: a fresh agreement is signed every cycle (beginRenewal), and a
+ * still-valid background check arrives here pre-cleared so only the signature
+ * is pending. The background check no longer gates payment: when it still needs
+ * a human review (no still-valid prior background check), it runs in PARALLEL
+ * while the applicant pays, and only the final ACTIVE flip waits on it.
  * EXCEPTION: a household intake note holds the application at PENDING_BG_REVIEW
  * instead — payment opens only after the reviewers (who are shown the note) clear
  * the check, so a note like "treat us as a volunteer household" settles dues first.
@@ -89,10 +90,7 @@ export async function advanceExternalIfComplete(processId: number) {
     const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) return process;
     if (process.status !== "PENDING_EXTERNAL_ACTION") return process;
-    // Renewals don't re-sign the agreement (renewal.ts) — only an expired
-    // background check brings them here, so the contract gate is INITIAL-only.
-    const contractNeeded = process.kind !== "RENEWAL";
-    if (contractNeeded && !process.contractSignedAt) return process;
+    if (!process.contractSignedAt) return process;
     if (!process.bgClearedAt && !process.bgConsentAt) return process;
 
     const advanced = await prisma.$transaction(async (tx) => {
@@ -116,7 +114,7 @@ export async function advanceExternalIfComplete(processId: number) {
             where: {
                 id: processId,
                 status: "PENDING_EXTERNAL_ACTION",
-                ...(contractNeeded ? { contractSignedAt: { not: null } } : {}),
+                contractSignedAt: { not: null },
                 OR: [{ bgClearedAt: { not: null } }, { bgConsentAt: { not: null } }],
             },
             data: { status: nextStatus, stageEnteredAt: new Date() },

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -13,12 +13,34 @@ import { config } from "@/lib/config";
  * When the member begins renewal, the background-check rule decides the path: if
  * EITHER parent's check is still valid at the boundary (lastBackgroundCheck within
  * BoardSettings.bgRecheckMonths of it), skip straight to PENDING_PAYMENT; otherwise
- * re-run review (RENEWAL_PENDING_BG). The interval is board-configured, not hardcoded.
- * The Zoho contract is NOT re-signed at renewal. No auto-revoke — manual admin action.
+ * the member goes through the SAME background-check request flow as a new applicant
+ * (PENDING_EXTERNAL_ACTION: consent on Averity, then payment while the review runs
+ * in parallel — the contract half is waived for renewals, see external.ts). The
+ * interval is board-configured, not hardcoded. The Zoho contract is NOT re-signed
+ * at renewal. No auto-revoke — manual admin action. RENEWAL_PENDING_BG is legacy:
+ * nothing writes it anymore (a migration moved open rows to the request flow).
  */
 
 const SYSTEM_ACTOR = 0;
 const RENEWAL_LEAD_MONTHS = 2;
+
+/**
+ * A renewal cycle counts as open while its process sits in any of these — the
+ * request-flow states (PENDING_EXTERNAL_ACTION onward) included, or the sweep
+ * would open a duplicate renewal for a household mid-flow. Must stay in step
+ * with the partial unique index `membership_one_inflight_renewal` (raw SQL,
+ * see the 20260715 renewal_bg_request_flow migration). BLOCKED is deliberately
+ * out (pre-existing semantics: a blocked renewal is the board's to resolve).
+ * RENEWAL_PENDING_BG is legacy — unwritten since that migration, still guarded.
+ */
+const IN_FLIGHT_RENEWAL_STATUSES = [
+    "PENDING_RENEWAL",
+    "PENDING_EXTERNAL_ACTION",
+    "PENDING_BG_REVIEW",
+    "PENDING_PAYMENT",
+    "PENDING_BG_CLEARANCE",
+    "RENEWAL_PENDING_BG",
+] as const;
 
 export class RenewalError extends Error {
     constructor(public readonly code: "not_found" | "wrong_phase", message: string) {
@@ -60,7 +82,7 @@ export async function runRenewalSweep(now: Date) {
         where: { status: "ACTIVE" },
         // "Already open" = an in-flight RENEWAL by status (matches the partial unique
         // index + openRenewalsForAllActive), not the leakier createdAt window.
-        select: { id: true, householdId: true, processes: { where: { kind: "RENEWAL", status: { in: ["PENDING_RENEWAL", "RENEWAL_PENDING_BG", "PENDING_PAYMENT"] } }, select: { id: true } } },
+        select: { id: true, householdId: true, processes: { where: { kind: "RENEWAL", status: { in: [...IN_FLIGHT_RENEWAL_STATUSES] } }, select: { id: true } } },
     });
 
     let opened = 0;
@@ -75,9 +97,10 @@ export async function runRenewalSweep(now: Date) {
 }
 
 /**
- * Member begins renewal: PENDING_RENEWAL -> RENEWAL_PENDING_BG (re-review needed,
- * or a household intake note awaits a reviewer) or PENDING_PAYMENT (background
- * check still valid, no note). Idempotent-ish: only acts from PENDING_RENEWAL.
+ * Member begins renewal: PENDING_RENEWAL -> PENDING_EXTERNAL_ACTION (check expired
+ * or missing — the member requests a new check, same flow as INITIAL), or
+ * PENDING_BG_REVIEW (check fresh but a household intake note awaits a reviewer), or
+ * PENDING_PAYMENT (check fresh, no note). Idempotent-ish: only acts from PENDING_RENEWAL.
  */
 export async function beginRenewal(processId: number) {
     const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
@@ -92,35 +115,39 @@ export async function beginRenewal(processId: number) {
     if (!membership) throw new RenewalError("not_found", "Membership not found.");
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
     const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, new Date()) : new Date();
-    // A household note (#900) must reach a reviewer before payment (#907): even
-    // with a still-fresh check, the renewal goes through review so the note (e.g.
-    // "treat us as a volunteer household") can settle dues first. Households clear
-    // the note in my-household once it no longer applies.
-    const bgFresh =
-        (await householdBgIsFresh(membership.householdId, boundary, settings?.bgRecheckMonths ?? 0)) &&
-        !membership.household.intakeNotes?.trim();
+    const bgFresh = await householdBgIsFresh(membership.householdId, boundary, settings?.bgRecheckMonths ?? 0);
+    const hasNote = !!membership.household.intakeNotes?.trim();
 
-    const nextStatus = bgFresh ? "PENDING_PAYMENT" : "RENEWAL_PENDING_BG";
+    // Expired/missing check → the same background-check request flow INITIAL uses:
+    // the member consents on Averity at PENDING_EXTERNAL_ACTION (renewals skip the
+    // contract half — advanceExternalIfComplete waives it), then pays while the
+    // review runs in parallel. Reviewers are NOT pinged here — there is nothing to
+    // review until consent is recorded; the advance pings them, same as INITIAL.
+    // Fresh check + household note (#900): the note must reach a reviewer before
+    // payment (#907), so hold at PENDING_BG_REVIEW (reviewers pinged now — the note
+    // is reviewable immediately). Fresh check, no note: straight to payment.
+    const nextStatus = !bgFresh ? "PENDING_EXTERNAL_ACTION" : hasNote ? "PENDING_BG_REVIEW" : "PENDING_PAYMENT";
+    // Fresh + no note ⇒ no re-review at all, so clear the BG requirement here.
+    // Without this the renewal pays and parks at PENDING_BG_CLEARANCE forever.
+    // (Fresh + note must NOT set bgClearedAt — the review queue only lists
+    // uncleared rows.) Re-check renewals get bgClearedAt from clearBackgroundCheck.
+    const clearNow = bgFresh && !hasNote;
     // Conditional on status PENDING_RENEWAL: a double-submit has both callers reach
     // here, but only the winner's updateMany flips it (count === 1) — so the audit
     // row and reviewer ping fire exactly once. Mirrors external.ts markContractSigned.
-    // Fresh check ⇒ no re-review, so clear the BG requirement here (there's no
-    // consent step / reviewer queue for a fresh renewal). Without this the renewal
-    // pays and parks at PENDING_BG_CLEARANCE forever. Re-review renewals
-    // (RENEWAL_PENDING_BG) get bgClearedAt from clearBackgroundCheck instead.
     const { count } = await prisma.orgMembershipProcess.updateMany({
         where: { id: processId, status: "PENDING_RENEWAL" },
-        data: { status: nextStatus, stageEnteredAt: new Date(), ...(bgFresh ? { bgClearedAt: new Date() } : {}) },
+        data: { status: nextStatus, stageEnteredAt: new Date(), ...(clearNow ? { bgClearedAt: new Date() } : {}) },
     });
     if (count === 1) {
         await prisma.auditLog.create({
-            data: { actorId: SYSTEM_ACTOR, action: "EDIT", tableName: "OrgMembershipProcess", affectedEntityId: processId, oldData: { status: "PENDING_RENEWAL" }, newData: { status: nextStatus, ...(bgFresh ? { bgClearedAt: true } : {}) } },
+            data: { actorId: SYSTEM_ACTOR, action: "EDIT", tableName: "OrgMembershipProcess", affectedEntityId: processId, oldData: { status: "PENDING_RENEWAL" }, newData: { status: nextStatus, ...(clearNow ? { bgClearedAt: true } : {}) } },
         });
-        if (nextStatus === "RENEWAL_PENDING_BG") await notifyReviewers();
+        if (nextStatus === "PENDING_BG_REVIEW") await notifyReviewers();
         // Fresh check ⇒ clearBackgroundCheck never runs this cycle, so a household
         // designated volunteer since last cycle would pay full dues — match the
         // allowlist at this PENDING_PAYMENT transition too (#874).
-        if (bgFresh) await applyVolunteerStatus(prisma, process.orgMembershipId!, membership.householdId, false);
+        if (clearNow) await applyVolunteerStatus(prisma, process.orgMembershipId!, membership.householdId, false);
     }
     return prisma.orgMembershipProcess.findUniqueOrThrow({ where: { id: processId } });
 }
@@ -144,7 +171,7 @@ export async function createRenewalProcess(orgMembershipId: number, householdId:
             // Lock the membership row so overlapping opens serialize here, not at the INSERT.
             await tx.$queryRaw`SELECT id FROM "OrgMembership" WHERE id = ${orgMembershipId} FOR UPDATE`;
             const existing = await tx.orgMembershipProcess.findFirst({
-                where: { orgMembershipId, kind: "RENEWAL", status: { in: ["PENDING_RENEWAL", "RENEWAL_PENDING_BG", "PENDING_PAYMENT"] } },
+                where: { orgMembershipId, kind: "RENEWAL", status: { in: [...IN_FLIGHT_RENEWAL_STATUSES] } },
                 select: { id: true },
             });
             if (existing) return null; // someone else already opened the renewal
@@ -186,7 +213,7 @@ export async function openRenewalsForAllActive(now: Date, opts: { sendReminders?
         select: {
             id: true,
             householdId: true,
-            processes: { where: { kind: "RENEWAL", status: { in: ["PENDING_RENEWAL", "RENEWAL_PENDING_BG", "PENDING_PAYMENT"] } }, select: { id: true } },
+            processes: { where: { kind: "RENEWAL", status: { in: [...IN_FLIGHT_RENEWAL_STATUSES] } }, select: { id: true } },
         },
     });
 

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -2,7 +2,6 @@ import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { emailHouseholdLeads } from "@/lib/emailRecipients";
-import { notifyReviewers, applyVolunteerStatus } from "@/lib/membership/review";
 import { config } from "@/lib/config";
 
 /**
@@ -10,14 +9,14 @@ import { config } from "@/lib/config";
  * household. Two months out, the cron opens a RENEWAL process at PENDING_RENEWAL
  * and reminds the household — the membership stays ACTIVE throughout.
  *
- * When the member begins renewal, the background-check rule decides the path: if
- * EITHER parent's check is still valid at the boundary (lastBackgroundCheck within
- * BoardSettings.bgRecheckMonths of it), skip straight to PENDING_PAYMENT; otherwise
- * the member goes through the SAME background-check request flow as a new applicant
- * (PENDING_EXTERNAL_ACTION: consent on Averity, then payment while the review runs
- * in parallel — the contract half is waived for renewals, see external.ts). The
- * interval is board-configured, not hardcoded. The Zoho contract is NOT re-signed
- * at renewal. No auto-revoke — manual admin action. RENEWAL_PENDING_BG is legacy:
+ * When the member begins renewal they enter the SAME external step a new applicant
+ * gets (PENDING_EXTERNAL_ACTION): a fresh membership agreement is signed EVERY
+ * cycle, and the background-check rule decides the other half — if EITHER parent's
+ * background check is still valid at the boundary (lastBackgroundCheck within
+ * BoardSettings.bgRecheckMonths of it, board-configured), bgClearedAt is stamped
+ * and signing alone opens payment; otherwise the member requests a new background
+ * check on Averity and the 2-of-N review runs in parallel with payment, exactly
+ * like INITIAL. No auto-revoke — manual admin action. RENEWAL_PENDING_BG is legacy:
  * nothing writes it anymore (a migration moved open rows to the request flow).
  */
 
@@ -97,10 +96,11 @@ export async function runRenewalSweep(now: Date) {
 }
 
 /**
- * Member begins renewal: PENDING_RENEWAL -> PENDING_EXTERNAL_ACTION (check expired
- * or missing — the member requests a new check, same flow as INITIAL), or
- * PENDING_BG_REVIEW (check fresh but a household intake note awaits a reviewer), or
- * PENDING_PAYMENT (check fresh, no note). Idempotent-ish: only acts from PENDING_RENEWAL.
+ * Member begins renewal: PENDING_RENEWAL -> PENDING_EXTERNAL_ACTION, always — a
+ * fresh membership agreement is signed every cycle. A still-valid background
+ * check (no household note) is pre-cleared so only the signature is left;
+ * otherwise the member also requests a new background check, same flow as
+ * INITIAL. Idempotent-ish: only acts from PENDING_RENEWAL.
  */
 export async function beginRenewal(processId: number) {
     const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
@@ -118,36 +118,27 @@ export async function beginRenewal(processId: number) {
     const bgFresh = await householdBgIsFresh(membership.householdId, boundary, settings?.bgRecheckMonths ?? 0);
     const hasNote = !!membership.household.intakeNotes?.trim();
 
-    // Expired/missing check → the same background-check request flow INITIAL uses:
-    // the member consents on Averity at PENDING_EXTERNAL_ACTION (renewals skip the
-    // contract half — advanceExternalIfComplete waives it), then pays while the
-    // review runs in parallel. Reviewers are NOT pinged here — there is nothing to
-    // review until consent is recorded; the advance pings them, same as INITIAL.
-    // Fresh check + household note (#900): the note must reach a reviewer before
-    // payment (#907), so hold at PENDING_BG_REVIEW (reviewers pinged now — the note
-    // is reviewable immediately). Fresh check, no note: straight to payment.
-    const nextStatus = !bgFresh ? "PENDING_EXTERNAL_ACTION" : hasNote ? "PENDING_BG_REVIEW" : "PENDING_PAYMENT";
-    // Fresh + no note ⇒ no re-review at all, so clear the BG requirement here.
-    // Without this the renewal pays and parks at PENDING_BG_CLEARANCE forever.
-    // (Fresh + note must NOT set bgClearedAt — the review queue only lists
-    // uncleared rows.) Re-check renewals get bgClearedAt from clearBackgroundCheck.
+    // A still-valid background check with no household note ⇒ stamp bgClearedAt
+    // now: the external card shows "no new background check needed" and the
+    // signature alone opens payment. A note (#900) disqualifies the shortcut
+    // exactly like submitIntake —
+    // the member consents anyway and advanceExternalIfComplete holds the process
+    // at PENDING_BG_REVIEW so the note reaches a reviewer before payment (#907).
+    // Reviewers are NOT pinged here — nothing is reviewable until consent is
+    // recorded; the advance pings them, same as INITIAL. Volunteer allowlist
+    // matching (#874) also happens at the advance's PENDING_PAYMENT transition.
     const clearNow = bgFresh && !hasNote;
     // Conditional on status PENDING_RENEWAL: a double-submit has both callers reach
     // here, but only the winner's updateMany flips it (count === 1) — so the audit
-    // row and reviewer ping fire exactly once. Mirrors external.ts markContractSigned.
+    // row is written exactly once. Mirrors external.ts markContractSigned.
     const { count } = await prisma.orgMembershipProcess.updateMany({
         where: { id: processId, status: "PENDING_RENEWAL" },
-        data: { status: nextStatus, stageEnteredAt: new Date(), ...(clearNow ? { bgClearedAt: new Date() } : {}) },
+        data: { status: "PENDING_EXTERNAL_ACTION", stageEnteredAt: new Date(), ...(clearNow ? { bgClearedAt: new Date() } : {}) },
     });
     if (count === 1) {
         await prisma.auditLog.create({
-            data: { actorId: SYSTEM_ACTOR, action: "EDIT", tableName: "OrgMembershipProcess", affectedEntityId: processId, oldData: { status: "PENDING_RENEWAL" }, newData: { status: nextStatus, ...(clearNow ? { bgClearedAt: true } : {}) } },
+            data: { actorId: SYSTEM_ACTOR, action: "EDIT", tableName: "OrgMembershipProcess", affectedEntityId: processId, oldData: { status: "PENDING_RENEWAL" }, newData: { status: "PENDING_EXTERNAL_ACTION", ...(clearNow ? { bgClearedAt: true } : {}) } },
         });
-        if (nextStatus === "PENDING_BG_REVIEW") await notifyReviewers();
-        // Fresh check ⇒ clearBackgroundCheck never runs this cycle, so a household
-        // designated volunteer since last cycle would pay full dues — match the
-        // allowlist at this PENDING_PAYMENT transition too (#874).
-        if (clearNow) await applyVolunteerStatus(prisma, process.orgMembershipId!, membership.householdId, false);
     }
     return prisma.orgMembershipProcess.findUniqueOrThrow({ where: { id: processId } });
 }
@@ -240,7 +231,7 @@ export async function beginRenewalForUser(userId: number) {
 }
 
 /**
- * True if EITHER guardian (household lead) has a check still valid at the boundary,
+ * True if EITHER guardian (household lead) has a background check still valid at the boundary,
  * i.e. lastBackgroundCheck >= boundary - recheckMonths. When recheckMonths is 0 (the
  * board hasn't set the policy), nothing counts as fresh — renewals re-run review.
  */

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -383,13 +383,17 @@ export async function overrideBlocked(processId: number, actorId: number, action
 
     if (action === "reset") {
         // Restore the review state that matches the cycle. The check runs in parallel,
-        // so an initial application returns to PENDING_BG_CLEARANCE if it had already
-        // paid, else PENDING_PAYMENT; renewals go back to RENEWAL_PENDING_BG. An
-        // unpaid initial with a household intake note re-holds at PENDING_BG_REVIEW —
-        // the reset restarts review, and a note keeps payment gated on it (#907).
+        // so a household process returns to PENDING_BG_CLEARANCE if it had already
+        // paid, else PENDING_PAYMENT. An unpaid one with a household intake note
+        // re-holds at PENDING_BG_REVIEW — the reset restarts review, and a note keeps
+        // payment gated on it (#907). Renewals follow the same household path, except
+        // one blocked BEFORE consent was recorded (fresh-check note-hold, or a legacy
+        // RENEWAL_PENDING_BG row) restarts at the request flow itself — the parallel
+        // queue only lists PENDING_PAYMENT/PENDING_BG_CLEARANCE rows WITH consent, so
+        // parking an unconsented renewal there would strand it.
         const reviewStatus: OrgMembershipProcessStatus =
             process.kind === "PERSON_BG" ? "PENDING_BG_REVIEW"
-            : process.kind === "RENEWAL" ? "RENEWAL_PENDING_BG"
+            : process.kind === "RENEWAL" && !process.bgConsentAt ? "PENDING_EXTERNAL_ACTION"
             : process.paidAt ? "PENDING_BG_CLEARANCE"
             : process.orgMembership?.household.intakeNotes?.trim() ? "PENDING_BG_REVIEW"
             : "PENDING_PAYMENT";

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -387,10 +387,11 @@ export async function overrideBlocked(processId: number, actorId: number, action
         // paid, else PENDING_PAYMENT. An unpaid one with a household intake note
         // re-holds at PENDING_BG_REVIEW — the reset restarts review, and a note keeps
         // payment gated on it (#907). Renewals follow the same household path, except
-        // one blocked BEFORE consent was recorded (fresh-check note-hold, or a legacy
-        // RENEWAL_PENDING_BG row) restarts at the request flow itself — the parallel
-        // queue only lists PENDING_PAYMENT/PENDING_BG_CLEARANCE rows WITH consent, so
-        // parking an unconsented renewal there would strand it.
+        // one blocked BEFORE consent was recorded (only legacy RENEWAL_PENDING_BG
+        // rows — every current renewal path records consent before review can block)
+        // restarts at the external step itself — the parallel queue only lists
+        // PENDING_PAYMENT/PENDING_BG_CLEARANCE rows WITH consent, so parking an
+        // unconsented renewal there would strand it.
         const reviewStatus: OrgMembershipProcessStatus =
             process.kind === "PERSON_BG" ? "PENDING_BG_REVIEW"
             : process.kind === "RENEWAL" && !process.bgConsentAt ? "PENDING_EXTERNAL_ACTION"


### PR DESCRIPTION
## Problem

With `bgRecheckMonths` now set (29), an existing member whose background check was out of date hit a dead end at renewal: `beginRenewal` parked them at `RENEWAL_PENDING_BG` — a passive "Renewal in progress" screen that pinged reviewers but never asked the member to actually **request** a new background check on Averity. Reviewers had nothing to attest to, the member had nothing to do, and the renewal stalled. Renewals also skipped the membership agreement, and hid the progress stepper.

## Change

Every applicant now walks the same path and sees the same progress stepper — new applicant, renewing member with a valid background check, renewing member with an expired or missing one:

- **`beginRenewal` → `PENDING_EXTERNAL_ACTION`, always.** A fresh membership agreement is signed every cycle. The background-check rule decides the other half:
  - **Still-valid background check, no household note** → `bgClearedAt` is pre-stamped; the card shows "no new background check needed" and the signature alone opens payment.
  - **Expired/missing background check** → the member requests a new background check on Averity and self-attests consent, exactly like INITIAL; payment opens once signature + consent are in, and the 2-of-N review runs in parallel, gating only the final flip.
  - **Still-valid background check + household note** → the `bgClearedAt` shortcut is disqualified (mirrors `submitIntake`); after signature + consent the advance holds at `PENDING_BG_REVIEW` so the note reaches a reviewer before payment (#907).
- **`advanceExternalIfComplete` gates renewals like INITIAL** — contract signature AND (consent or pre-cleared background check). Reviewer pings and volunteer-allowlist matching (#874) happen at the advance, not at `beginRenewal` (nothing is reviewable before consent).
- **`overrideBlocked` reset**: a blocked renewal without recorded consent (only legacy `RENEWAL_PENDING_BG` rows can be in that state) restarts at the external step — the parallel review queue only lists `PENDING_PAYMENT`/`PENDING_BG_CLEARANCE` rows **with** consent, so resetting an unconsented renewal there would strand it. Consented renewals reset like any household process.
- **`/membership`**: the flow stepper now renders for renewals too; the external card shows both tasks (agreement + background check) with renewal-specific intro copy. The old "Renewal in progress" card remains only as a fallback for unmigrated rows.
- **Duplicate-cycle guard widened**: the sweep's "already open" status list and the `membership_one_inflight_renewal` partial unique index only knew the old trio (`PENDING_RENEWAL`/`RENEWAL_PENDING_BG`/`PENDING_PAYMENT`) — a household mid-flow would have gotten a second renewal opened by the next sweep. Both now cover all in-flight renewal statuses (shared `IN_FLIGHT_RENEWAL_STATUSES` constant; index rebuilt in the migration).
- **Migration** moves already-parked open `RENEWAL_PENDING_BG` rows (`bgClearedAt IS NULL`) to `PENDING_EXTERNAL_ACTION`, so anyone currently stuck gets the actionable flow on their next visit. `RENEWAL_PENDING_BG` becomes legacy: nothing writes it anymore; read-side support (review queue, ops list, page card) is kept.

## Accepted edges (called out in comments)

- A renewal parked at `RENEWAL_PENDING_BG` only for its household note (background check still valid) is migrated like the rest and will be asked to consent once more (rare — the renewal flow shipped days ago; converges via the note-hold).
- Same trade on a board **reset** of a blocked, unconsented legacy renewal: it restarts at the external step rather than recomputing background-check freshness.

## Tests

- Unit: full suite green (1730). `beginRenewal` routing (valid / expired / valid+note), advance contract gate applies to renewals, `householdBgIsFresh` unchanged.
- Integration (updated, run in CI — local test DB was down): valid background check renewal (signature alone opens payment), expired background check renewal end-to-end (signature + consent → payment; 2 approvals keep it at `PENDING_PAYMENT`), valid+note renewal (holds at `PENDING_BG_REVIEW` after signature + consent), board reset of unconsented blocked renewal → `PENDING_EXTERNAL_ACTION`.
- The populated-DB migration-safety job exercises the data migration + index rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe