### PR TITLE
feat(participants): board can record last BG check review date in Details modal

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
@@ -31,6 +31,19 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
             updateData.phone = body.phone === "" || body.phone === null ? null : formatPhone(body.phone);
         }
         if (body.isDeclaredAdult !== undefined) updateData.isDeclaredAdult = Boolean(body.isDeclaredAdult);
+        if (body.lastBackgroundCheck !== undefined) {
+            // "" or null clears the date; otherwise expect a YYYY-MM-DD string
+            const raw = body.lastBackgroundCheck;
+            if (raw === "" || raw === null) {
+                updateData.lastBackgroundCheck = null;
+            } else {
+                const d = new Date(raw);
+                if (isNaN(d.getTime())) {
+                    return apiError("Invalid background check review date", 400);
+                }
+                updateData.lastBackgroundCheck = d;
+            }
+        }
 
         if (Object.keys(updateData).length === 0) {
             return apiError("No fields to update provided", 400);
@@ -38,7 +51,7 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
 
         const prior = await prisma.person.findUnique({
             where: { id },
-            select: { name: true, email: true, phone: true, isDeclaredAdult: true },
+            select: { name: true, email: true, phone: true, isDeclaredAdult: true, lastBackgroundCheck: true },
         });
 
         const updatedParticipant = await prisma.person.update({
@@ -67,6 +80,7 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
             phone: updatedParticipant.phone,
             dateOfBirth: updatedParticipant.dateOfBirth,
             isDeclaredAdult: updatedParticipant.isDeclaredAdult,
+            lastBackgroundCheck: updatedParticipant.lastBackgroundCheck,
             isBoardMember: updatedParticipant.isBoardMember,
             isKeyholder: updatedParticipant.isKeyholder,
             household: updatedParticipant.household,

--- a/checkin-app/src/app/api/people/search/route.ts
+++ b/checkin-app/src/app/api/people/search/route.ts
@@ -43,6 +43,7 @@ export const GET = withAuth(
                 phone: p.phone,
                 dateOfBirth: p.dateOfBirth,
                 isDeclaredAdult: p.isDeclaredAdult,
+                lastBackgroundCheck: p.lastBackgroundCheck,
                 isMember: personRecordIsActiveOrgMember(p),
                 isBoardMember: p.isBoardMember,
                 isKeyholder: p.isKeyholder,

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -21,6 +21,7 @@ type PersonRow = {
   phone: string | null;
   dateOfBirth?: string | null;
   isDeclaredAdult?: boolean;
+  lastBackgroundCheck?: string | null;
   household?: HouseholdRef | null;
 };
 
@@ -89,7 +90,7 @@ export default function AdminParticipantsIndex() {
   // Edit Participant State
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingParticipant, setEditingParticipant] = useState<PersonRow | null>(null);
-  const [editForm, setEditForm] = useState({ name: "", email: "", phone: "", isDeclaredAdult: false });
+  const [editForm, setEditForm] = useState({ name: "", email: "", phone: "", isDeclaredAdult: false, lastBackgroundCheck: "" });
   const [savingDetails, setSavingDetails] = useState(false);
 
   // Admin edit of household's own info (name, address, emergency contact)
@@ -242,7 +243,7 @@ export default function AdminParticipantsIndex() {
                           )}
                           <Button size="xs" fz={15} variant="default" onClick={() => {
                             setEditingParticipant(p);
-                            setEditForm({ name: p.name || "", email: p.email || "", phone: p.phone || "", isDeclaredAdult: !!p.isDeclaredAdult });
+                            setEditForm({ name: p.name || "", email: p.email || "", phone: p.phone || "", isDeclaredAdult: !!p.isDeclaredAdult, lastBackgroundCheck: p.lastBackgroundCheck ? p.lastBackgroundCheck.slice(0, 10) : "" });
                             setEditModalOpen(true);
                           }}>
                             Details
@@ -341,6 +342,13 @@ export default function AdminParticipantsIndex() {
                 onChange={(e) => { const checked = e.currentTarget.checked; setEditForm(f => ({ ...f, isDeclaredAdult: checked })); }}
               />
             )}
+            <TextInput
+              type="date"
+              label="Last Background Check Review"
+              description="Date the board last reviewed this person's background check. Clear the field to remove it."
+              value={editForm.lastBackgroundCheck}
+              onChange={(e) => { const value = e.currentTarget.value; setEditForm(f => ({ ...f, lastBackgroundCheck: value })); }}
+            />
             {editingParticipant?.household && (
               <div>
                 <Text fw={500} size="sm" mb={4}>Household</Text>


### PR DESCRIPTION
## What

Adds a **Last Background Check Review** date field to the Details modal in
`membership-ops/participants`, so the board can record the date they last
reviewed a person's background check.

The `Person.lastBackgroundCheck` field already existed in the schema but was
never editable from the UI. No schema change or migration — this just wires
the existing field through the read, write, and form layers.

## Changes

- **`api/people/search`** — return `lastBackgroundCheck` in the person payload.
- **`api/membership-ops/participants/[id]` (PUT)** — whitelist `lastBackgroundCheck`:
  `""` or `null` clears it; an unparseable date returns 400. Old/new values are
  captured in the audit log and the updated value is returned.
- **Details modal (`participants/page.tsx`)** — native `type="date"` `TextInput`;
  clearing the field removes the date. Value is loaded from the ISO date
  (`.slice(0, 10)`).

## Reviewer notes

- Follows the same wiring pattern as #1008 (`isDeclaredAdult` in the same modal).
- The page and both routes are already gated to `isSysadmin` / `isBoardMember`,
  so no new authorization was added.
- Native date input (no `@mantine/dates` dependency), matching the existing
  precedent in `AuditLogPanel`.
- `tsc --noEmit` is clean on the three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
