### PR TITLE
ci: extract the migration release gate to a callable workflow, advisory on PRs

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -73,64 +73,21 @@ jobs:
     secrets: inherit
 
   # Release gate: a release may apply AT MOST ONE new database migration.
-  # Migrations accumulate on main between releases and must be coalesced into
-  # a single migration (checkin-app/scripts/coalesce-migrations.ts, a manual
-  # PR) before a release ships them — see
-  # checkin-app/docs/MIGRATION_COALESCE_FLOW.md for the policy and flow.
+  # The rule lives in the callable migration-release-gate.yml — the same
+  # workflow runs advisory (allowed to fail) on every PR, so the "coalesce
+  # before preparing a release" signal shows up long before this blocking
+  # call. Passing exclude_tag makes the gate compare against the release's
+  # true predecessor; with no previous release, every migration counts.
   #
   # This is not a step inside `validate`: that job is a reusable-workflow
   # `uses: ./.github/workflows/ci.yml` call, which has no step surface of its
   # own to add to. Runs as its own job instead; `deploy` needs both.
   migration-release-gate:
     name: Release gate — at most 1 new migration
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout released tag (full history + tags)
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.release.tag_name }}
-          fetch-depth: 0
-
-      - name: Find the previous v* release tag and count added migrations
-        run: |
-          set -euo pipefail
-          CURRENT_TAG="${{ github.event.release.tag_name }}"
-          git fetch --tags --force
-
-          # `git tag -l` lists annotated and lightweight tags identically — no
-          # special-casing needed for either kind. `sort -V` is a real version
-          # sort (v1.2.10 sorts after v1.2.9), not a lexical one.
-          mapfile -t TAGS < <(git tag -l 'v*' | sort -V)
-
-          PREV_TAG=""
-          for i in "${!TAGS[@]}"; do
-            if [ "${TAGS[$i]}" = "$CURRENT_TAG" ]; then
-              if [ "$i" -gt 0 ]; then PREV_TAG="${TAGS[$((i-1))]}"; fi
-              break
-            fi
-          done
-
-          if [ -z "$PREV_TAG" ]; then
-            echo "No v* release tag found before $CURRENT_TAG — this is the first release, nothing to gate against. Skipping."
-            exit 0
-          fi
-          echo "Previous release tag: $PREV_TAG"
-
-          # Count ADDED migration directories only — a coalesce release
-          # deletes many old ones and adds exactly 1, and that must PASS, not
-          # fail on the deletes. Count directories, not files: a coalesce
-          # baseline adds both migration.sql and reconcile.sql under one dir.
-          # --no-renames: a rewritten baseline must never be mistaken for a
-          # rename of one of the migrations it replaces.
-          mapfile -t ADDED < <(git diff --no-renames --name-status "$PREV_TAG"..HEAD -- checkin-app/prisma/migrations \
-            | awk '$1=="A" {print $2}' | awk -F/ '{print $4}' | grep -v '^migration_lock.toml$' | sort -u)
-          echo "New migration dir(s) since $PREV_TAG (${#ADDED[@]}): ${ADDED[*]:-none}"
-
-          if [ "${#ADDED[@]}" -gt 1 ]; then
-            echo "::error::This release would apply ${#ADDED[@]} new migrations (${ADDED[*]}) — a release may apply at most 1. Coalesce them into a single migration first: checkin-app/docs/MIGRATION_COALESCE_FLOW.md"
-            exit 1
-          fi
-          echo "OK — at most 1 new migration since the previous release."
+    uses: ./.github/workflows/migration-release-gate.yml
+    with:
+      ref: ${{ github.event.release.tag_name }}
+      exclude_tag: ${{ github.event.release.tag_name }}
 
   deploy:
     name: Build, migrate, roll out

--- a/.github/workflows/migration-release-gate.yml
+++ b/.github/workflows/migration-release-gate.yml
@@ -1,0 +1,86 @@
+name: Migration release gate
+
+# A release may apply AT MOST ONE new database migration: `prisma migrate
+# deploy` is not transactional ACROSS migrations, so a multi-migration release
+# that fails mid-batch leaves prod partially migrated behind a P3009 (the
+# 2026-07-02 incident). Migrations may accumulate freely on main/dev between
+# releases — the rule is they get COALESCED into a single migration
+# (checkin-app/scripts/coalesce-migrations.ts, a manual PR) before a release
+# ships them. Policy and flow: checkin-app/docs/MIGRATION_COALESCE_FLOW.md.
+#
+# One rule, two call sites:
+#   - pull_request (this file's own trigger): ADVISORY. The job is
+#     continue-on-error on PR runs — a red gate job warns early that the next
+#     release would carry 2+ migrations, without blocking merges while work
+#     accumulates on dev.
+#   - deploy-prod.yml (workflow_call, exclude_tag = the tag being released):
+#     BLOCKING. A release carrying 2+ new migrations fails before the human
+#     approval gate is ever asked.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:
+    inputs:
+      ref:
+        description: Commit/tag to check (defaults to the triggering commit)
+        type: string
+        required: false
+        default: ''
+      exclude_tag:
+        description: Tag being released — excluded when resolving the previous release
+        type: string
+        required: false
+        default: ''
+
+jobs:
+  count:
+    name: At most 1 new migration per release
+    runs-on: ubuntu-latest
+    # Advisory on PRs (allowed to fail); blocking when called from deploy-prod
+    # (a called workflow inherits the caller's event: release).
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || '' }}
+          # Full history + tags: the gate resolves the previous v* release by
+          # reachability from HEAD.
+          fetch-depth: 0
+
+      - name: Count migrations added since the previous v* release
+        env:
+          EXCLUDE_TAG: ${{ inputs.exclude_tag || '' }}
+        run: |
+          set -euo pipefail
+          # `git tag -l` lists annotated and lightweight tags identically — no
+          # special-casing needed. `sort -V` is a real version sort (v1.2.10
+          # sorts after v1.2.9). Only tags REACHABLE from HEAD count as a
+          # previous release; the tag being released (EXCLUDE_TAG) is excluded
+          # so the release compares against its true predecessor.
+          PREV_RELEASE=$(git tag --list 'v*' --merged HEAD | grep -vxF -- "$EXCLUDE_TAG" | sort -V | tail -n1 || true)
+
+          # Set difference of migration DIRECTORIES (ls-tree, not git diff):
+          # a coalesce release deletes many old dirs and adds exactly 1, and
+          # that must PASS; edits to already-shipped migrations count as 0;
+          # directories not files, since a coalesce baseline ships both
+          # migration.sql and reconcile.sql under one dir. With no previous
+          # release reachable, EVERY migration counts against the same limit.
+          HEAD_DIRS=$(git ls-tree --name-only "HEAD:checkin-app/prisma/migrations" | grep -v '^migration_lock\.toml$' | sort)
+          if [ -n "$PREV_RELEASE" ]; then
+            NEW_DIRS=$(comm -13 \
+              <(git ls-tree --name-only "$PREV_RELEASE:checkin-app/prisma/migrations" | grep -v '^migration_lock\.toml$' | sort) \
+              <(printf '%s\n' "$HEAD_DIRS"))
+          else
+            NEW_DIRS="$HEAD_DIRS"
+          fi
+          COUNT=$(printf '%s' "$NEW_DIRS" | grep -c . || true)
+          echo "Migrations added since ${PREV_RELEASE:-the beginning (no previous v* release reachable)}: $COUNT"
+          [ -z "$NEW_DIRS" ] || printf '%s\n' "$NEW_DIRS"
+
+          if [ "$COUNT" -gt 1 ]; then
+            echo "::error::$COUNT new migrations (listed above) — a release may apply at most 1. Coalesce them into a single migration before preparing a release (checkin-app/docs/MIGRATION_COALESCE_FLOW.md): prisma migrate deploy is not transactional across migrations, so a multi-migration release risks a partial apply (P3009)."
+            exit 1
+          fi
+          echo "OK — at most 1 new migration."


### PR DESCRIPTION
## Why

The at-most-**one**-migration-per-release rule (#937) lived inline in `deploy-prod.yml`, so the first anyone heard of a violation was at release time. Migrations may accumulate freely on main/dev — the policy is they get **coalesced** into a single migration before a release is prepared (`checkin-app/docs/MIGRATION_COALESCE_FLOW.md`). What was missing is the early signal.

## What

- **New `migration-release-gate.yml`** (`workflow_call` + its own `pull_request` trigger): counts migration directories added since the previous `v*` release.
  - On **PRs**: advisory — the job runs with `continue-on-error`, so a red gate warns "coalesce before preparing a release" without blocking merges.
  - From **deploy-prod** (`workflow_call`): blocking, before the `production` approval gate — unchanged behavior, now via `uses:` with `exclude_tag: <released tag>`.
- **deploy-prod.yml**: inline job replaced by the call; `deploy` still `needs: [validate, migration-release-gate]`.
- **deploy-dev.yml**: untouched (an earlier revision of this PR gated dev deploys; that was the wrong place — dev may accumulate migrations).

## Behavior changes vs the inline job

- Previous release = latest `v*` tag **reachable** from HEAD (excluding the tag being released), not position in the globally version-sorted tag list — required for PR contexts, and immune to tags on abandoned branches.
- **No previous release → every migration counts against the same limit of one.** The inline job skipped first releases; now they're gated too.
- Count = `ls-tree` set difference of migration directories: a coalesce release (deletes the chain, adds one baseline) still counts as **1**, edits to shipped migrations as **0**.

## Verification (gate script run locally against real refs)

- main (1 unreleased migration: `20260715160000_renewal_bg_request_flow`) → pass
- Simulated release excluding its own tag → compares against v1.0.0 → 1 → pass
- Simulated re-release of v1.0.0 (excludes itself → no previous release) → counts all = 1 → pass
- Synthetic second migration dir → 2 → fails with the coalesce error
- This PR itself will exercise the advisory path live (expect a green gate job: main carries exactly one unreleased migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe