### PR TITLE
docs(readme): map the monorepo — layout, corrected quick start, documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,17 @@ A member check-in and program management system built with Next.js, Prisma, and 
 
 ## Repository layout
 
-- **`/`** — Next.js + Prisma backend (this README's "Local Setup" applies here)
-- **`client/`** — Python kiosk client that runs on Raspberry Pi devices at the facility entrance. See [`client/README.md`](client/README.md).
+An npm-workspaces monorepo. The web app lives in `checkin-app/`; the rest are satellites around it.
+
+- **[`checkin-app/`](checkin-app/)** — the Next.js + Prisma web app: membership, programs, attendance, payments, ops.
+- **[`client/`](client/README.md)** — Python kiosk client for Raspberry Pi devices at the facility entrance (a transparent Ed25519 signing proxy in front of the backend).
+- **[`s-read-function/`](s-read-function/README.md)** — Lambda that pulls Shopify orders/payouts/balance transactions into a dedicated Postgres ([deploy notes](s-read-function/DEPLOY.md), [monitoring PRD](s-read-function/MONITORING-PRD.md)).
+- **[`s-replay-function/`](s-replay-function/README.md)** — admin/replay operations for that ingestion pipeline (pure database consumer).
+- **[`monitoring-watchdog-function/`](monitoring-watchdog-function/README.md)** / **[`monitoring-relay-function/`](monitoring-relay-function/README.md)** — the detection and delivery halves of fleet monitoring.
+- **[`packages/`](packages/)** — shared workspaces: [`telemetry`](packages/telemetry/README.md) (emission core), [`monitoring-db`](packages/monitoring-db/README.md) (monitoring Postgres layer), [`pg-test-harness`](packages/pg-test-harness/README.md) (throwaway-Postgres integration testing).
+- **[`layers/prisma-runtime/`](layers/prisma-runtime/README.md)** — shared Lambda layer with the Prisma 7 driver-adapter runtime.
+- **[`deploy/`](deploy/)** — docker-compose stacks (local dev DB, self-hosted prod, flow tests) and Caddyfile.
+- **[`docs/`](docs/)** — cross-cutting documentation: setup, designs, security (see the map below).
 
 ## Local Setup
 
@@ -18,11 +27,49 @@ Follow the guide for your operating system:
 
 ```bash
 npm install
-docker compose up -d db
-npx prisma generate
-npx prisma db push
-npx ts-node --compiler-options '{"module":"CommonJS"}' prisma/seed.ts
-npm run dev
+docker compose -f deploy/docker-compose.yml up -d db
+npm -w checkin-app exec -- prisma generate
+npm -w checkin-app exec -- prisma db push
+npm -w checkin-app exec -- prisma db seed
+npm -w checkin-app run dev
 ```
 
-The app runs at **http://localhost:4000**.
+The app runs at **http://localhost:4000** (Postgres on port **5433**). Environment
+variables go in `checkin-app/.env` — the setup guides list them.
+
+## Documentation map
+
+### Start here
+
+- **[AGENTS.md](AGENTS.md)** — orientation for contributors and agents: the three test classes and how to run each, repo conventions, editing rules.
+- **[CONSTITUTION.md](CONSTITUTION.md)** — purpose and core principles (security, privacy, auditability); what must never be weakened.
+- **[Canonical Vocabulary](checkin-app/docs/VOCABULARY.md)** — what every domain word means (people, roles, money, tools, attendance).
+- **[Critical User Journeys](docs/designs/CUJS.md)** — all user-facing flows, organized by persona.
+- **[Design Specification](docs/designs/DESIGN.md)** — the original system design; further design notes live in [`docs/designs/`](docs/designs/).
+
+### Deployment & operations
+
+- **[Production Launch Runbook](docs/designs/PRODUCTION_PLAN.md)** — the ordered checklist behind ops.innovationtreehouse.org.
+- **[Deploy / Migration Order of Operations](checkin-app/docs/DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md)** — why migrations run before rollout and what that implies for schema changes.
+- **[Migration Coalesce Flow](checkin-app/docs/MIGRATION_COALESCE_FLOW.md)** — a release may apply at most **one** new migration; how to coalesce accumulated migrations ([`checkin-app/scripts/coalesce-migrations.ts`](checkin-app/scripts/coalesce-migrations.ts)).
+- **[`.github/workflows/`](.github/workflows/)** — [`ci.yml`](.github/workflows/ci.yml) (lint, tests, build — also reused to revalidate release tags), [`deploy-dev.yml`](.github/workflows/deploy-dev.yml) (merge to main → dev), [`deploy-prod.yml`](.github/workflows/deploy-prod.yml) (published `v*` release → prod, human-approved), [`migration-safety.yml`](.github/workflows/migration-safety.yml) (new migrations must apply to a *populated* DB), [`flow-tests.yml`](.github/workflows/flow-tests.yml), [`shopify-live.yml`](.github/workflows/shopify-live.yml), [`security-boundary-isolation.yml`](.github/workflows/security-boundary-isolation.yml).
+
+### Security
+
+- **[Security Policy Layer](docs/security/SECURITY-POLICY.md)** — the declarative model-security layer and its contract tests.
+- [`docs/security/`](docs/security/) also holds the [auth-consistency analysis](docs/security/auth-consistency-analysis.md), [presence/identity tiering](docs/security/presence-identity-tiering.md), and [pentest findings (2026-04-21)](docs/security/pentest_findings_2026-04-21.md).
+
+### Money & Shopify
+
+- **[s-read-function/README.md](s-read-function/README.md)** — the Shopify → Postgres ingestion pipeline; [DEPLOY.md](s-read-function/DEPLOY.md) for rollout, [FUTUREWORK.md](s-read-function/FUTUREWORK.md) for the backlog.
+- **[Program Capacity & Scholarships](checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md)** — capacity as single-pool Shopify inventory and the scholarship hold-ledger lifecycle.
+
+### Testing
+
+- **[AGENTS.md](AGENTS.md)** defines the three test classes (unit / integration / flow) and their commands — run them from `checkin-app/`.
+- **[Test Coverage Plan](docs/test-coverage-plan.md)** — the path to 80% line coverage and how to re-measure.
+- **[pg-test-harness](packages/pg-test-harness/README.md)** — the fleet template for real-Postgres integration tiers.
+
+---
+
+Licensing: [LICENSE](LICENSE) · [TRADEMARKS.md](TRADEMARKS.md)


### PR DESCRIPTION
## Why

The README predated the npm-workspaces restructure (#231): it said the Next.js app lives at the repo root, and its Quick Start ran `npx prisma db push` / `ts-node prisma/seed.ts` from the root, where neither resolves anymore. It also linked to none of the documentation that has accumulated since (deployment runbook, migration policies, security layer, the Shopify pipeline, monitoring).

## What

- **Repository layout** rewritten to the real workspace map: `checkin-app/` plus each satellite (`client/`, `s-read-function/`, `s-replay-function/`, both monitoring functions, `packages/*`, `layers/prisma-runtime/`, `deploy/`, `docs/`), one line each, linked to its own README.
- **Quick Start corrected** to workspace-aware commands, verified against `deploy/docker-compose.yml` (db service, port 5433) and `checkin-app/package.json` (`prisma db seed` → `tsx prisma/seed.ts`; dev server on 4000). Notes that `.env` lives in `checkin-app/`.
- **Documentation map** added, curated rather than exhaustive — five sections with one-line descriptions:
  - *Start here*: AGENTS.md, CONSTITUTION.md, VOCABULARY.md, CUJs, design spec
  - *Deployment & operations*: production runbook, deploy/migration order of operations, migration coalesce flow (+ the at-most-one-migration-per-release rule), the workflows directory
  - *Security*: SECURITY-POLICY.md + the analyses in `docs/security/`
  - *Money & Shopify*: s-read pipeline docs, program capacity & scholarships
  - *Testing*: the three test classes (AGENTS.md), coverage plan, pg-test-harness

Deliberately not linked: `docs/designs/ARCHITECT_IDEAS_*`, scoping one-offs, and bot-internal files (`.jules/`, `GEMINI.md` stays discoverable but isn't front-page) — the map points at load-bearing docs, and `docs/designs/` is linked as a directory for the rest.

Every relative link checked to resolve against the tree (small script in the commit run; no broken anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe