### PR TITLE
ci(deploy): run both migrate tasks on Fargate Spot

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -139,10 +139,14 @@ jobs:
           }
           EOF
 
+          # FARGATE_SPOT (associated on the cluster) instead of on-demand
+          # --launch-type FARGATE: matches prod's migrate path; a Spot reclaim
+          # mid-run fails the step loudly and a re-run is safe (one small
+          # migration per release, retry loop below handles DB wake-up).
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \
             --task-definition "$MIGRATE_ARN" \
-            --launch-type FARGATE \
+            --capacity-provider-strategy capacityProvider=FARGATE_SPOT,weight=1 \
             --network-configuration "$NETWORK_CONFIG" \
             --overrides "file://$RUNNER_TEMP/migrate-overrides.json" \
             --query 'tasks[0].taskArn' --output text)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -53,7 +53,14 @@ env:
   # the infra repo — see the "prod infra" note in the PR description.
   ECS_CLUSTER: treehouse-prod
   ECS_SERVICE: checkin-prod
-  ECS_CAPACITY_PROVIDER: treehouse-prod-c6g
+  # Migrations run on FARGATE_SPOT, not the prepaid c6g (a one-off 512-MiB task
+  # can't place there while the wiki is awake — the v1.0.1 wedge). awsvpc needs
+  # explicit networking: the default-VPC public subnets + the checkin-prod
+  # service SG (Aurora ingress: infra network module, database_from_checkin_prod;
+  # public IP for the ghcr pull — no NAT). Values come from the infra repo
+  # (live/mgmt + modules/network); update together if infra changes them.
+  MIGRATE_SUBNETS: subnet-0597513f1c0c3173e,subnet-0a67d72908bffbcd4,subnet-0c84ac2840be3a2bc
+  MIGRATE_SG: sg-0a37ac72f79b2fd5b # checkin-prod-service
   APP_TASK_FAMILY: checkin-prod
   MIGRATE_TASK_FAMILY: checkin-migrate-prod
   DEPLOY_ROLE: arn:aws:iam::639595353568:role/checkin-deploy-prod
@@ -235,7 +242,8 @@ jobs:
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \
             --task-definition "$MIGRATE_ARN" \
-            --capacity-provider-strategy capacityProvider=$ECS_CAPACITY_PROVIDER,weight=1 \
+            --capacity-provider-strategy capacityProvider=FARGATE_SPOT,weight=1 \
+            --network-configuration "awsvpcConfiguration={subnets=[$MIGRATE_SUBNETS],securityGroups=[$MIGRATE_SG],assignPublicIp=ENABLED}" \
             --overrides "file://$RUNNER_TEMP/migrate-overrides.json" \
             --query 'tasks[0].taskArn' --output text)
           echo "Migration task: $TASK_ARN"


### PR DESCRIPTION
## What

Both deploy workflows' one-off `prisma migrate deploy` tasks move to **Fargate Spot**:

- **deploy-dev**: `--launch-type FARGATE` (on-demand) → `--capacity-provider-strategy capacityProvider=FARGATE_SPOT,weight=1`. The `checkin-dev` cluster has had `FARGATE_SPOT` associated all along; the network config (copied from the service) is unchanged.
- **deploy-prod**: `--capacity-provider-strategy capacityProvider=treehouse-prod-c6g` → `FARGATE_SPOT`, plus an explicit `--network-configuration` (default-VPC public subnets, `checkin-prod-service` SG, public IP) since awsvpc tasks don't inherit the host-mode service's networking. The SG's Aurora ingress (`database_from_checkin_prod`) already exists in infra.

## Why

The v1.0.1 release migration wedged in `PENDING`: `checkin-migrate-prod` (512 MiB) targets the single prepaid c6g.medium, which only has room for it while the wiki is asleep — awake, the wiki's 1024-MiB reservation leaves ~12 MiB and the task can't place at all. Fargate Spot decouples migrations from instance capacity for good, and makes dev/prod migrate paths identical.

## Ordering + residual

- **Merge after [infra#127](https://github.com/innovationtreehouse/infra/pull/127) applies** (flips the migrate task defs to awsvpc/FARGATE and associates FARGATE_SPOT on `treehouse-prod`). The workflows re-register the migrate task def by copying the latest registered revision (`networkMode`/`requiresCompatibilities` included), so the infra flip propagates automatically on the next deploy.
- Accepted residual (deliberate decision): a Spot reclaim mid-migration can partially apply — `prisma migrate deploy` is not transactional. Bounded by the at-most-one-migration-per-release gate; the step fails loudly (exit code + CloudWatch log tail already surfaced by both workflows) and a re-run is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe