### PR TITLE
fix(tests): server-side lock/statement timeouts on every test DB connection

### DIFF
--- a/checkin-app/src/lib/prisma.ts
+++ b/checkin-app/src/lib/prisma.ts
@@ -32,6 +32,23 @@ const pool = new Pool({
     // whether an EARLIER orphaned one is still silently holding a lock).
     keepAlive: true,
     keepAliveInitialDelayMillis: 10_000,
+    // Server-side backstops for tests (#688 → #701's other half): #701 put
+    // statement/idle-in-transaction timeouts into deploy/docker-compose.yml's
+    // Postgres, but CI's `services:` container and the per-worker integration
+    // DBs never got them — so an orphaned connection holding a lock
+    // mid-transaction (keepAlive above only catches DEAD peers, not live
+    // processes parked on an open transaction) stalled a whole CI run
+    // unboundedly (the 2026-07-16 hang on main). These are session-level
+    // settings the pg client applies on connect, so they cover every Postgres
+    // a test run touches — CI service container, worktree DBs, local — with
+    // one knob. Test-only: prod/Aurora long transactions stay governed by the
+    // server's own configuration.
+    ...(process.env.NODE_ENV === 'test'
+        ? {
+              statement_timeout: 60_000,
+              idle_in_transaction_session_timeout: 120_000,
+          }
+        : {}),
 })
 // In tests every file gets a fresh module registry, so each builds its own pool.
 // Those pools must close on $disconnect or they leak connections until the worker


### PR DESCRIPTION
## The hang (previously known: #688, half-fixed by #701)

CI run 29468191341 (push of the #1013 merge to main) sat 24+ minutes in `npm run test:coverage` against a 4m35s baseline — the #688 mechanism: a connection orphaned mid-transaction holds a lock (e.g. the scan route's `pg_advisory_xact_lock`), and every later query needing it waits forever. #701 fixed the *client* side (`connectionTimeoutMillis`, `keepAlive` — which only catches **dead** peers) and put the *server* timeouts into `deploy/docker-compose.yml` — but CI's `services: postgres` container and the per-worker integration databases never got those, so in CI the wait was unbounded on both layers. Same code was green on the PR minutes earlier; classic flake, canceled + re-run.

## Fix

`statement_timeout: 60s` + `idle_in_transaction_session_timeout: 120s` in the shared `pg` Pool config, gated to `NODE_ENV === 'test'` — the values #701 chose, now applied as session settings on connect, so they cover **every** Postgres a test run touches (CI service container, per-worker clones, worktrees, local) with one knob. An orphaned lock-holder is reaped by the server in ≤2 min and the waiting test fails loudly instead of poisoning the run. Prod/Aurora behavior untouched.

Complementary (rides the CI-parallelization PR, same file there): `timeout-minutes` on the CI test jobs, so even an unforeseen hang burns 20 minutes, not the 6-hour default.

Typecheck + unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe