### PR TITLE
feat(settings): extract the membership variant ID from a pasted product URL

### DIFF
--- a/checkin-app/prisma/migrations/20260715210000_org_membership_product_url/migration.sql
+++ b/checkin-app/prisma/migrations/20260715210000_org_membership_product_url/migration.sql
@@ -1,0 +1,5 @@
+-- Board admins configure the membership dues product by pasting its storefront
+-- URL; the server extracts the Shopify variant ID from it. Stored so the board
+-- can see which product the variant ID came from and re-run the extraction.
+-- Additive only.
+ALTER TABLE "BoardSettings" ADD COLUMN "orgMembershipProductUrl" TEXT;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -457,6 +457,14 @@ model BoardSettings {
   /// public (contrast Program.shopify*VariantId, which the browser builds from).
   /// @sensitivity:internal
   orgMembershipVariantId     String?
+  /// Storefront URL of the membership product ("https://<store>/products/<handle>"),
+  /// pasted by the board in membership settings. "Extract variant from URL" resolves
+  /// orgMembershipVariantId from it server-side (lib/shopify.ts) — the Shopify admin
+  /// UI hides the lone variant of a single-variant product, so the variant ID is not
+  /// visible anywhere an admin could copy it from. The checkout link is always built
+  /// from the variant ID above, never from this URL.
+  /// @sensitivity:internal
+  orgMembershipProductUrl    String?
   /// Discount code (created in Shopify by the board) appended to the checkout
   /// link for volunteer households so Shopify applies their discount.
   /// @sensitivity:internal

--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -98,6 +98,10 @@ const AUTHZ_TESTED = new Set<string>([
     'settings/email',
     'settings/membership',
     'settings/membership/bulk-open-renewals',
+    // POST deny-path (401 anon / 403 non-board) in its colocated unit test,
+    // api/settings/membership/extract-variant/__tests__/route.test.ts (no DB —
+    // the route never touches Prisma, only the pinned Shopify fetch).
+    'settings/membership/extract-variant',
     'settings/membership/volunteer-designations',
     'shop/tools/[id]',
     'system-status/audit-log',

--- a/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
@@ -78,6 +78,18 @@ describe('Membership settings + volunteer designations API', () => {
         expect(settings.volunteerDuesCents).toBe(3000);
     });
 
+    it('saves and clears the membership product URL', async () => {
+        asBoard(boardId);
+        const url = 'https://test-store.myshopify.com/products/annual-membership';
+        const putRes = await SETTINGS_PUT(jsonReq('PUT', { orgMembershipProductUrl: `  ${url}  ` }));
+        expect(putRes.status).toBe(200);
+        expect((await putRes.json()).settings.orgMembershipProductUrl).toBe(url); // trimmed
+
+        const cleared = await SETTINGS_PUT(jsonReq('PUT', { orgMembershipProductUrl: null }));
+        expect(cleared.status).toBe(200);
+        expect((await cleared.json()).settings.orgMembershipProductUrl).toBeNull();
+    });
+
     it('rejects negative dues and keeps the previous value', async () => {
         asBoard(boardId);
         // Establish a known good value.

--- a/checkin-app/src/app/api/settings/membership/extract-variant/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/settings/membership/extract-variant/__tests__/route.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * POST /api/settings/membership/extract-variant — the whole flow, with fetch
+ * mocked: the SSRF pinning (https / exact store host / /products/<handle>
+ * path, all rejected BEFORE any fetch), URL normalization (query/hash/trailing
+ * slash stripped, `.js` appended), the 429 retry, response-shape failures, and
+ * the variant-selection semantics (one → { variantId }, several → 409 listing
+ * "id — title — price").
+ */
+import { POST } from '../route';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+const STORE = 'test-store.myshopify.com';
+const GOOD_URL = `https://${STORE}/products/annual-membership`;
+const JS_URL = `https://${STORE}/products/annual-membership.js`;
+
+function asBoard() {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: 1, isSysadmin: false, isBoardMember: true } });
+}
+function req(body?: unknown) {
+    return new Request('http://localhost:4000/api/settings/membership/extract-variant', {
+        method: 'POST',
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+}
+function jsonResponse(status: number, body: unknown) {
+    return { ok: status >= 200 && status < 300, status, json: async () => body } as Response;
+}
+const variant = (id: number, title: string, price: number) => ({ id, title, price });
+
+describe('POST /api/settings/membership/extract-variant', () => {
+    let fetchMock: jest.Mock;
+    const prevDomain = process.env.SHOPIFY_STORE_DOMAIN;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        process.env.SHOPIFY_STORE_DOMAIN = STORE;
+        fetchMock = jest.fn();
+        global.fetch = fetchMock;
+        asBoard();
+    });
+
+    afterAll(() => {
+        if (prevDomain === undefined) delete process.env.SHOPIFY_STORE_DOMAIN;
+        else process.env.SHOPIFY_STORE_DOMAIN = prevDomain;
+    });
+
+    it('401 when unauthenticated, and never fetches', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue(null);
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(401);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('403 for a plain member, and never fetches', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: 2, isSysadmin: false, isBoardMember: false } });
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(403);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('400 when productUrl is missing or blank', async () => {
+        expect((await POST(req({}))).status).toBe(400);
+        expect((await POST(req({ productUrl: '   ' }))).status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('extracts the id of a single-variant product, normalizing query/hash/trailing slash', async () => {
+        fetchMock.mockResolvedValue(jsonResponse(200, { id: 8819108249771, variants: [variant(45678901234, 'Default Title', 15000)] }));
+        const res = await POST(req({ productUrl: `${GOOD_URL}/?utm_source=admin#reviews` }));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ variantId: '45678901234' });
+        // The fetch goes to the normalized product path + .js, refusing redirects.
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0][0]).toBe(JS_URL);
+        expect(fetchMock.mock.calls[0][1]).toEqual(expect.objectContaining({ redirect: 'error' }));
+        expect(fetchMock.mock.calls[0][1].headers['User-Agent']).toMatch(/Mozilla/);
+    });
+
+    it('409 lists id — title — price for a multi-variant product', async () => {
+        fetchMock.mockResolvedValue(jsonResponse(200, {
+            variants: [variant(111, 'Member', 15000), variant(222, 'Non-Member', 25000)],
+        }));
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(409);
+        const { error } = await res.json();
+        expect(error).toContain('2 variants');
+        expect(error).toContain('111 — Member — $150.00');
+        expect(error).toContain('222 — Non-Member — $250.00');
+    });
+
+    // ── SSRF pinning: each rejection happens BEFORE any fetch ──────────────
+
+    const rejectedBeforeFetch: Array<[string, string]> = [
+        ['not a URL at all', 'annual-membership'],
+        ['http, not https', `http://${STORE}/products/annual-membership`],
+        ['wrong host', 'https://evil.example.com/products/annual-membership'],
+        ['store domain as a suffix of another host', `https://evil-${STORE}/products/annual-membership`],
+        ['explicit non-default port', `https://${STORE}:8443/products/annual-membership`],
+        ['non-product path', `https://${STORE}/cart/12345:1`],
+        ['nested path under products', `https://${STORE}/products/annual-membership/extra`],
+        ['path traversal in the handle', `https://${STORE}/products/..%2Fadmin`],
+    ];
+    it.each(rejectedBeforeFetch)('400 without fetching: %s', async (_label, url) => {
+        const res = await POST(req({ productUrl: url }));
+        expect(res.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('400 without fetching when SHOPIFY_STORE_DOMAIN is not configured', async () => {
+        delete process.env.SHOPIFY_STORE_DOMAIN;
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    // ── Upstream failures ───────────────────────────────────────────────────
+
+    it('retries a 429 with backoff and succeeds on the second attempt', async () => {
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse(429, {}))
+            .mockResolvedValueOnce(jsonResponse(200, { variants: [variant(333, 'Default Title', 15000)] }));
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ variantId: '333' });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    }, 15000);
+
+    it('429 with a "throttled, try again in a minute" message once retries are exhausted', async () => {
+        fetchMock.mockResolvedValue(jsonResponse(429, {}));
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(429);
+        expect((await res.json()).error).toMatch(/throttled.*try again in a minute/);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    }, 15000);
+
+    it('404 with a clear message when Shopify has no product at the URL', async () => {
+        fetchMock.mockResolvedValue(jsonResponse(404, {}));
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(404);
+        expect((await res.json()).error).toMatch(/no product at that URL/);
+    });
+
+    it('502 when the response is not JSON', async () => {
+        fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => { throw new SyntaxError('not json'); } } as unknown as Response);
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(502);
+        expect((await res.json()).error).toMatch(/not product JSON/);
+    });
+
+    it('502 when the JSON has no variant list', async () => {
+        fetchMock.mockResolvedValue(jsonResponse(200, { id: 8819108249771 }));
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(502);
+        expect((await res.json()).error).toMatch(/no variant list/);
+    });
+
+    it('400 when the product has zero variants', async () => {
+        fetchMock.mockResolvedValue(jsonResponse(200, { variants: [] }));
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(/no variants/);
+    });
+
+    it('502 when fetch itself rejects (network failure or refused redirect)', async () => {
+        fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(502);
+        expect((await res.json()).error).toMatch(/failed or was redirected/);
+    });
+
+    it('504 when the request times out', async () => {
+        fetchMock.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
+        const res = await POST(req({ productUrl: GOOD_URL }));
+        expect(res.status).toBe(504);
+        expect((await res.json()).error).toMatch(/did not answer/);
+    });
+});

--- a/checkin-app/src/app/api/settings/membership/extract-variant/route.ts
+++ b/checkin-app/src/app/api/settings/membership/extract-variant/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { fetchStorefrontProductVariants, ProductUrlError } from "@/lib/shopify";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/settings/membership/extract-variant — resolve the Shopify variant
+ * ID of the membership product from its storefront URL. Board members or
+ * sysadmins only, same gate as the settings routes beside it.
+ *
+ * Body: { productUrl: string }. The URL is pinned hard before the server-side
+ * fetch (fetchStorefrontProductVariants in lib/shopify.ts): https only, host
+ * exactly SHOPIFY_STORE_DOMAIN, /products/<handle> path, no redirects.
+ * Exactly one variant → { variantId } for the client to fill into the
+ * variant-ID field (the normal settings save persists it). Several variants →
+ * 409 listing "id — title — price" for each so the admin can pick manually.
+ */
+export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
+    let body: { productUrl?: string };
+    try {
+        body = await req.json();
+    } catch {
+        return apiError("Invalid JSON", 400);
+    }
+    const productUrl = body.productUrl?.trim();
+    if (!productUrl) return apiError("productUrl is required", 400);
+
+    try {
+        const variants = await fetchStorefrontProductVariants(productUrl);
+        if (variants.length === 0) return apiError("The product at that URL has no variants — check the link.", 400);
+        if (variants.length > 1) {
+            const listing = variants
+                .map((v) => `${v.id} — ${v.title} — ${v.priceCents != null ? `$${(v.priceCents / 100).toFixed(2)}` : "price unknown"}`)
+                .join("; ");
+            return apiError(`The product has ${variants.length} variants — paste the ID of the right one into the variant-ID field: ${listing}`, 409);
+        }
+        return NextResponse.json({ variantId: variants[0].id });
+    } catch (err) {
+        if (err instanceof ProductUrlError) return apiError(err.message, err.status);
+        throw err;
+    }
+});

--- a/checkin-app/src/app/api/settings/membership/route.ts
+++ b/checkin-app/src/app/api/settings/membership/route.ts
@@ -17,7 +17,8 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
 /**
  * PUT /api/settings/membership — update board settings.
  * Body may include: normalDuesCents, volunteerDuesCents, orgMembershipYearBoundary (ISO|null),
- * orgMembershipVariantId (string|null), volunteerDiscountCode (string|null),
+ * orgMembershipVariantId (string|null), orgMembershipProductUrl (string|null),
+ * volunteerDiscountCode (string|null),
  * scholarshipDenialGraceDays (positive int|null — null disables the grace-period expiry cron).
  * Dues must be finite and >= 0; an invalid value rejects the whole update (400) so the
  * previous value survives rather than silently collapsing to zero. (The Averity consent
@@ -30,6 +31,7 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
         volunteerDuesCents?: number;
         orgMembershipYearBoundary?: string | null;
         orgMembershipVariantId?: string | null;
+        orgMembershipProductUrl?: string | null;
         volunteerDiscountCode?: string | null;
         bgRecheckMonths?: number;
         devSigningTarget?: string | null;
@@ -58,6 +60,11 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
         const variantId = body.orgMembershipVariantId?.trim();
         if (variantId && !/^\d+$/.test(variantId)) return apiError("orgMembershipVariantId must be a numeric Shopify variant ID", 400);
         data.orgMembershipVariantId = variantId || null;
+    }
+    // Reference only — the checkout link is built from the variant ID, never this
+    // URL, and /extract-variant re-validates it hard before any server-side fetch.
+    if (body.orgMembershipProductUrl !== undefined) {
+        data.orgMembershipProductUrl = body.orgMembershipProductUrl?.trim() || null;
     }
     if (body.volunteerDiscountCode !== undefined) {
         data.volunteerDiscountCode = body.volunteerDiscountCode?.trim() || null;

--- a/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
@@ -14,6 +14,7 @@ const SETTINGS = {
   volunteerDuesCents: 5000,
   orgMembershipYearBoundary: "2025-09-01T00:00:00.000Z",
   orgMembershipVariantId: "123456",
+  orgMembershipProductUrl: "https://test-store.myshopify.com/products/annual-membership",
   volunteerDiscountCode: "VOLUNTEER",
   bgRecheckMonths: 24,
   scholarshipDenialGraceDays: 14,
@@ -70,6 +71,64 @@ describe("MembershipSettingsPage", () => {
     fireEvent.change(screen.getByDisplayValue("VOLUNTEER"), { target: { value: "" } });
     fireEvent.change(screen.getByLabelText("Background check valid for"), { target: { value: "12" } });
     expect(screen.queryByText(/Background-check interval is/)).not.toBeInTheDocument();
+  });
+
+  it("extracts the variant from the product URL, fills the field, and saves both", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({
+      // Listed first: mockFetchJson matches by substring in insertion order, and
+      // the extract-variant URL also contains "/api/settings/membership".
+      "/api/settings/membership/extract-variant": { variantId: "789789" },
+      "/api/settings/membership": { settings: SETTINGS },
+    });
+    renderWithProviders(<MembershipSettingsPage />);
+    await screen.findByDisplayValue("123456");
+
+    fireEvent.change(screen.getByLabelText("Membership product URL"), {
+      target: { value: "https://test-store.myshopify.com/products/new-membership" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Extract variant from URL" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/settings/membership/extract-variant",
+        expect.objectContaining({ method: "POST", body: JSON.stringify({ productUrl: "https://test-store.myshopify.com/products/new-membership" }) }),
+      ),
+    );
+    // The extracted id lands in the variant-ID field, with a reminder to Save.
+    expect(await screen.findByDisplayValue("789789")).toBeInTheDocument();
+    expect(notifications.show).toHaveBeenCalledWith(
+      expect.objectContaining({ color: "green", message: expect.stringMatching(/789789.*Save settings/) }),
+    );
+
+    // The normal save persists both the URL and the extracted variant ID.
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/settings/membership", expect.objectContaining({ method: "PUT" })));
+    const [, putOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PUT")!;
+    expect(JSON.parse(putOpts!.body as string)).toEqual(
+      expect.objectContaining({
+        orgMembershipVariantId: "789789",
+        orgMembershipProductUrl: "https://test-store.myshopify.com/products/new-membership",
+      }),
+    );
+  });
+
+  it("shows the server's message when extraction fails (e.g. a multi-variant 409)", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/settings/membership": { settings: SETTINGS } });
+    renderWithProviders(<MembershipSettingsPage />);
+    await screen.findByDisplayValue("123456");
+
+    global.fetch = jest.fn(async () => ({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "The product has 2 variants — paste the ID of the right one into the variant-ID field: 111 — Member — $150.00; 222 — Non-Member — $250.00" }),
+    })) as unknown as typeof fetch;
+    fireEvent.click(screen.getByRole("button", { name: "Extract variant from URL" }));
+
+    expect(await screen.findByText(/The product has 2 variants/)).toBeInTheDocument();
+    // The variant-ID field keeps its previous value.
+    expect(screen.getByDisplayValue("123456")).toBeInTheDocument();
   });
 
   it("edits the scholarship grace period, blank clears it to null, and rejects a non-positive value", async () => {

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -14,6 +14,7 @@ interface Settings {
   volunteerDuesCents: number;
   orgMembershipYearBoundary: string | null;
   orgMembershipVariantId: string | null;
+  orgMembershipProductUrl: string | null;
   volunteerDiscountCode: string | null;
   bgRecheckMonths: number;
   devSigningTarget: string | null;
@@ -41,6 +42,8 @@ export default function MembershipSettingsPage() {
   const [boundary, setBoundary] = useState("");
   const [boundaryUnlocked, setBoundaryUnlocked] = useState(false);
   const [variantId, setVariantId] = useState("");
+  const [productUrl, setProductUrl] = useState("");
+  const [extracting, setExtracting] = useState(false);
   const [discountCode, setDiscountCode] = useState("");
   // Dev-instance-only: where contract signing requests go ('zoho' | 'debug').
   const isDev = useIsDevInstance();
@@ -74,6 +77,7 @@ export default function MembershipSettingsPage() {
           scholarshipGraceDays: settings.scholarshipDenialGraceDays != null ? String(settings.scholarshipDenialGraceDays) : "",
           boundary: settings.orgMembershipYearBoundary ? settings.orgMembershipYearBoundary.slice(0, 10) : "",
           variantId: settings.orgMembershipVariantId ?? "",
+          productUrl: settings.orgMembershipProductUrl ?? "",
           discountCode: settings.volunteerDiscountCode ?? "",
           signingTarget: settings.devSigningTarget ?? "zoho",
         };
@@ -83,6 +87,7 @@ export default function MembershipSettingsPage() {
         setScholarshipGraceDays(snap.scholarshipGraceDays);
         setBoundary(snap.boundary);
         setVariantId(snap.variantId);
+        setProductUrl(snap.productUrl);
         setDiscountCode(snap.discountCode);
         setSigningTarget(snap.signingTarget);
         setInitial(snap);
@@ -119,6 +124,7 @@ export default function MembershipSettingsPage() {
           normalDuesCents: Math.round(parseFloat(normalDues || "0") * 100),
           volunteerDuesCents: Math.round(parseFloat(volunteerDues || "0") * 100),
           orgMembershipVariantId: variantId.trim() || null,
+          orgMembershipProductUrl: productUrl.trim() || null,
           volunteerDiscountCode: discountCode.trim() || null,
           bgRecheckMonths: Math.round(parseInt(bgRecheckMonths || "0", 10)),
           scholarshipDenialGraceDays: scholarshipGraceDays.trim() === "" ? null : parseInt(scholarshipGraceDays.trim(), 10),
@@ -133,6 +139,31 @@ export default function MembershipSettingsPage() {
       else { const d = await res.json().catch(() => ({})); setSaveNotice({ text: d.error || "Save failed.", err: true }); }
     } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }
     finally { setSaving(false); }
+  };
+
+  // Ask the server to pull the variant ID out of the pasted product URL (the
+  // Shopify admin UI hides the lone variant of a single-variant product, so
+  // there is nowhere to copy it from). Fills the variant-ID field only —
+  // nothing is persisted until the admin presses Save settings.
+  const extractVariant = async () => {
+    setSaveNotice(null);
+    setExtracting(true);
+    try {
+      const res = await fetch("/api/settings/membership/extract-variant", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ productUrl: productUrl.trim() }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        setVariantId(data.variantId);
+        setFieldErrors((f) => ({ ...f, variantId: undefined }));
+        notifications.show({ color: "green", message: `Variant ${data.variantId} filled in — press Save settings to keep it.` });
+      } else {
+        setSaveNotice({ text: data.error || "Could not extract the variant.", err: true });
+      }
+    } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }
+    finally { setExtracting(false); }
   };
 
   const bulkOpenRenewals = async () => {
@@ -154,7 +185,7 @@ export default function MembershipSettingsPage() {
 
   const isDirty =
     !!initial &&
-    !shallowEqual(initial, { normalDues, volunteerDues, bgRecheckMonths, scholarshipGraceDays, boundary, variantId, discountCode, signingTarget });
+    !shallowEqual(initial, { normalDues, volunteerDues, bgRecheckMonths, scholarshipGraceDays, boundary, variantId, productUrl, discountCode, signingTarget });
   useUnsavedGuard(isDirty);
 
   return (
@@ -226,6 +257,19 @@ export default function MembershipSettingsPage() {
 
             <Title order={4} mt="lg" mb="sm">Shopify checkout</Title>
             <Stack gap="md">
+              <Group align="flex-end" gap="sm" wrap="wrap">
+                <TextInput
+                  label="Membership product URL"
+                  description="Paste the product's storefront page URL; “Extract variant from URL” fills the variant ID below from it."
+                  placeholder="https://your-store.myshopify.com/products/membership"
+                  w={420}
+                  value={productUrl}
+                  onChange={(e) => setProductUrl(e.currentTarget.value)}
+                />
+                <Button variant="light" loading={extracting} disabled={extracting || !productUrl.trim()} onClick={extractVariant}>
+                  Extract variant from URL
+                </Button>
+              </Group>
               <TextInput
                 label="Membership product variant ID"
                 description="The Shopify variant ID of the membership product. We build the “Pay with Shopify” link from it as https://<store>/cart/<variantId>:1."

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -94,6 +94,108 @@ export async function getAccessToken(): Promise<string | null> {
   }
 }
 
+/** Thrown by fetchStorefrontProductVariants; status maps straight onto the API response. */
+export class ProductUrlError extends Error {
+    constructor(message: string, public readonly status: number) {
+        super(message);
+        this.name = "ProductUrlError";
+    }
+}
+
+export interface StorefrontVariant {
+    id: string;
+    title: string;
+    /** The public product JSON reports prices in cents; null when the shape is unexpected. */
+    priceCents: number | null;
+}
+
+/**
+ * Resolve the variants of a membership product from its storefront URL via
+ * Shopify's public product JSON (`https://<store>/products/<handle>.js`).
+ * Backs the "Extract variant from URL" action in membership settings: for a
+ * single-variant product the Shopify admin UI hides the lone "Default Title"
+ * variant entirely, so the product ID is the only number an admin can see —
+ * and pasting THAT into the variant-ID field 410s the cart permalink checkout
+ * (lib/membership/payment.ts builds https://<store>/cart/<variantId>:1).
+ *
+ * SSRF pinning — this is a server-side fetch of an admin-supplied URL, so the
+ * URL is pinned hard before any request goes out: https only, host must
+ * EXACTLY equal the configured SHOPIFY_STORE_DOMAIN, path must match
+ * /products/<handle> after normalization (query, hash, and trailing slash
+ * stripped), and redirects are refused rather than followed. Everything else
+ * is a 400 before fetch.
+ *
+ * Shopify bot-throttles the .js endpoint for non-browser callers (429s
+ * observed from server IPs), so the request carries a browser User-Agent and
+ * retries twice with a short backoff; a still-throttled request surfaces as
+ * "try again in a minute", not a generic failure. The Admin API would be the
+ * throttle-proof alternative if this keeps biting.
+ */
+export async function fetchStorefrontProductVariants(productUrl: string): Promise<StorefrontVariant[]> {
+    const storeDomain = config.shopifyStoreDomain();
+    if (!storeDomain) throw new ProductUrlError("SHOPIFY_STORE_DOMAIN is not configured on this instance, so the URL cannot be verified.", 400);
+
+    let parsed: URL;
+    try {
+        parsed = new URL(productUrl.trim());
+    } catch {
+        throw new ProductUrlError("That is not a valid URL.", 400);
+    }
+    if (parsed.protocol !== "https:") throw new ProductUrlError("The product URL must start with https://.", 400);
+    // URL lowercases the hostname and drops a default :443, so an exact host
+    // comparison also rejects any explicit non-default port.
+    if (parsed.host !== storeDomain.toLowerCase()) {
+        throw new ProductUrlError(`The product URL must be on the store domain ${storeDomain}.`, 400);
+    }
+    const productPath = parsed.pathname.replace(/\/+$/, "");
+    if (!/^\/products\/[a-z0-9-]+$/.test(productPath)) {
+        throw new ProductUrlError(`The URL must be a product page: https://${storeDomain}/products/<product-handle>.`, 400);
+    }
+
+    let res: Response | undefined;
+    for (let attempt = 0; attempt < 3; attempt++) {
+        if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+        try {
+            res = await fetch(`https://${storeDomain}${productPath}.js`, {
+                headers: {
+                    // Browser User-Agent: see the throttling note in the doc comment.
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+                    Accept: "application/json",
+                },
+                redirect: "error", // any redirect could leave the pinned host — refuse it
+                signal: AbortSignal.timeout(10_000),
+            });
+        } catch (err) {
+            if (err instanceof DOMException && (err.name === "TimeoutError" || err.name === "AbortError")) {
+                throw new ProductUrlError("Shopify did not answer within 10 seconds — try again.", 504);
+            }
+            // undici surfaces a refused redirect (and any network failure) as a TypeError.
+            throw new ProductUrlError("Could not fetch the product from Shopify — the request failed or was redirected.", 502);
+        }
+        if (res.status !== 429) break;
+    }
+    if (!res || res.status === 429) throw new ProductUrlError("Shopify throttled the request — try again in a minute.", 429);
+    if (res.status === 404) throw new ProductUrlError("Shopify has no product at that URL — check the link.", 404);
+    if (!res.ok) throw new ProductUrlError(`Shopify returned ${res.status} for the product URL — check the link and try again.`, 502);
+
+    let product: { variants?: Array<{ id?: number | string; title?: string; price?: unknown }> };
+    try {
+        product = await res.json();
+    } catch {
+        throw new ProductUrlError("Shopify's response was not product JSON — check that the URL is the product page.", 502);
+    }
+    if (!Array.isArray(product?.variants)) {
+        throw new ProductUrlError("Shopify's response has no variant list — check that the URL is the product page.", 502);
+    }
+    return product.variants
+        .filter((v) => v?.id !== undefined && v?.id !== null)
+        .map((v) => ({
+            id: String(v.id),
+            title: v.title || "Default Title",
+            priceCents: typeof v.price === "number" ? v.price : null,
+        }));
+}
+
 /**
  * Shared failure path for Shopify write operations: log to IntegrationErrorLog
  * (System Status > Link Status) and best-effort email admins/board. Never

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -108,6 +108,7 @@ export const classifications = {
         volunteerDuesCents: 'public',
         orgMembershipYearBoundary: 'public',
         orgMembershipVariantId: 'internal',
+        orgMembershipProductUrl: 'internal',
         volunteerDiscountCode: 'internal',
         bgRecheckMonths: 'public',
         devSigningTarget: 'internal',


### PR DESCRIPTION
## Incident

Tonight prod's first membership payment 410'd at Shopify: `BoardSettings.orgMembershipVariantId` held the PRODUCT id (8819108249771). For a single-variant product the Shopify admin UI hides the lone "Default Title" variant entirely, so the product ID is the only number an admin can see — and the settings route accepted any numeric string. The cart permalink built in `src/lib/membership/payment.ts` (`https://<storeDomain>/cart/<variantId>:1?...`) requires a VARIANT id, so checkout 410'd.

## Design

1. **Admins paste the product link.** New "Membership product URL" field in membership settings, persisted on `BoardSettings.orgMembershipProductUrl` (new nullable string column, additive migration — the one new migration for this release; main had zero pending).
2. **The server appends `.js` and pulls the variant out.** New `POST /api/settings/membership/extract-variant` (board/sysadmin, same `withAuth` gate as the sibling settings routes) normalizes the URL (strips query/hash/trailing slash), fetches `https://<store>/products/<handle>.js` server-side, and parses the public product JSON. The fetch itself lives in `src/lib/shopify.ts`, the only file the route-coverage lint allows Shopify-host fetches in.
3. **UI.** "Extract variant from URL" button next to the variant-ID field. On success it fills the variant-ID field client-side and shows a notification reminding the admin to press **Save settings** (the existing save flow persists both fields). Admins see both the product URL and the extracted variant ID.
4. The existing numeric-only validation on save stays as the backstop.

## SSRF pinning (server-side fetch of an admin-supplied URL)

Rejected with a clear 400 **before any fetch** unless ALL hold:
- `https:` only;
- host EXACTLY equals the configured `SHOPIFY_STORE_DOMAIN` (the same domain `payment.ts` builds the checkout link from) — `URL` lowercases the hostname and drops a default `:443`, so an explicit non-default port also fails the exact match;
- path matches `^/products/[a-z0-9-]+$` after normalization.

The fetch runs with `redirect: "error"` (a redirect can never leave the pinned host because it is refused outright) and a 10s `AbortSignal.timeout`.

## Variant selection

- Exactly one variant → `{ variantId }`, filled into the field client-side.
- Multiple variants → 409 listing `id — title — price` for each so the admin can choose manually.
- Zero variants, non-JSON, missing variant list, 404, other non-200 → distinct, clear errors.

## Throttling caveat

Shopify bot-throttles the public `.js` endpoints — we observed 429s from server IPs tonight. The request sends a browser User-Agent and retries twice with a short backoff (1s, 2s); if still throttled it surfaces "Shopify throttled the request — try again in a minute" rather than a generic failure. If this keeps biting, the throttle-proof alternative is resolving the product through the **Admin API** (`getAccessToken()` + `GET /admin/api/.../products/{id}.json`), which the app already has credentials for.

## Tests

- `checkin-app/src/app/api/settings/membership/extract-variant/__tests__/route.test.ts` — the whole flow with fetch mocked: happy single-variant (incl. query/hash/trailing-slash normalization and the `.js` URL), multi-variant 409 listing, wrong host / suffix host / non-default port / http / weird paths (all rejected before any fetch), unset store domain, 429 retry-then-success and retries-exhausted, 404, non-JSON, missing variant list, zero variants, network failure/refused redirect, timeout, plus 401 anon / 403 non-board deny paths (registered in the authz drift guard).
- `checkin-app/src/app/settings/membership/__tests__/page.test.tsx` — extract fills the variant field + "press Save settings" notification, save PUTs both fields; server error message (multi-variant 409) surfaces and leaves the field untouched.
- `checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts` — settings save trims/persists and clears the new column.

Results: full unit suite 1759 passed / 0 failed; `npx tsc --noEmit` clean; `npm run lint` clean; `npm run check-route-coverage` — no errors from this change (the new route carries the same advisory "unmigrated" warning as every sibling settings route; the regenerated `src/security/generated/classifications.ts` is committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe