### PR TITLE
feat(settings): Shopify Webhook tab verifies the store's webhook wiring end-to-end

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -99,6 +99,9 @@ const AUTHZ_TESTED = new Set<string>([
     'settings/membership',
     'settings/membership/bulk-open-renewals',
     'settings/membership/volunteer-designations',
+    // GET deny-path (401 anon / 403 non-board) unit-tested through the real
+    // withAuth in api/settings/shopify-webhook/__tests__/route.test.ts.
+    'settings/shopify-webhook',
     'shop/tools/[id]',
     'system-status/audit-log',
     'system-status/errors',

--- a/checkin-app/src/app/api/settings/shopify-webhook/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/settings/shopify-webhook/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for GET /api/settings/shopify-webhook — the deny paths (401 anon /
+ * 403 plain member, through the REAL withAuth with a mocked session) and the
+ * payload shape the Shopify Webhook settings tab renders. Referenced by the
+ * authz drift guard (authzRegistry.test.ts).
+ */
+import { GET } from '../route';
+import prisma from '@/lib/prisma';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockSession = require('next-auth/next').getServerSession;
+
+const findMany = jest.fn();
+
+function req() {
+    return new Request('http://localhost/api/settings/shopify-webhook');
+}
+
+beforeAll(() => {
+    process.env.NEXTAUTH_URL = 'https://checkin.example.org';
+    process.env.SHOPIFY_STORE_DOMAIN = 'test-store.example.com';
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    findMany.mockResolvedValue([]);
+    prisma.auditLog.findMany = findMany as unknown as typeof prisma.auditLog.findMany;
+});
+
+describe('GET /api/settings/shopify-webhook', () => {
+    it('401 when unauthenticated', async () => {
+        mockSession.mockResolvedValue(null);
+        const res = await GET(req());
+        expect(res.status).toBe(401);
+        expect(findMany).not.toHaveBeenCalled();
+    });
+
+    it('403 for a signed-in member without board or sysadmin role', async () => {
+        mockSession.mockResolvedValue({ user: { id: 5, isSysadmin: false, isBoardMember: false } });
+        const res = await GET(req());
+        expect(res.status).toBe(403);
+        expect(findMany).not.toHaveBeenCalled();
+    });
+
+    it('200 for a board member with the endpoint URL, store domain, and latest receipts', async () => {
+        mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+        findMany.mockResolvedValue([
+            {
+                id: 42,
+                newData: {
+                    topic: 'orders/paid',
+                    shopDomain: 'test-store.example.com',
+                    hmacValid: false,
+                    test: true,
+                    orderId: '820982911946154508',
+                    outcome: 'rejected: bad hmac',
+                    receivedAt: '2026-07-15T12:00:00.000Z',
+                },
+            },
+        ]);
+
+        const res = await GET(req());
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.webhookUrl).toBe('https://checkin.example.org/api/webhooks/shopify');
+        expect(body.storeDomain).toBe('test-store.example.com');
+        expect(body.receipts).toEqual([
+            {
+                id: 42,
+                topic: 'orders/paid',
+                shopDomain: 'test-store.example.com',
+                hmacValid: false,
+                test: true,
+                orderId: '820982911946154508',
+                outcome: 'rejected: bad hmac',
+                receivedAt: '2026-07-15T12:00:00.000Z',
+            },
+        ]);
+
+        // Queries the receipt rows only, newest first, capped.
+        expect(findMany).toHaveBeenCalledWith({
+            where: { tableName: 'ShopifyWebhookReceipt' },
+            orderBy: { id: 'desc' },
+            take: 20,
+        });
+    });
+
+    it('200 for a sysadmin', async () => {
+        mockSession.mockResolvedValue({ user: { id: 5, isSysadmin: true } });
+        const res = await GET(req());
+        expect(res.status).toBe(200);
+    });
+});

--- a/checkin-app/src/app/api/settings/shopify-webhook/route.ts
+++ b/checkin-app/src/app/api/settings/shopify-webhook/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { config } from "@/lib/config";
+import { normalizeAuditData } from "@/lib/auditPayload";
+import { SHOPIFY_WEBHOOK_RECEIPT_TABLE, type ShopifyWebhookReceipt } from "@/lib/shopifyWebhookReceipt";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/settings/shopify-webhook — webhook-wiring status for the Shopify
+ * Webhook settings tab. Returns:
+ *   - webhookUrl: where this environment expects the store's orders/paid
+ *     webhook to point (same config.baseUrl() the app builds links from),
+ *   - storeDomain: for the deep link into the store's notification settings,
+ *   - receipts: the latest deliveries the inbound webhook route recorded as
+ *     ShopifyWebhookReceipt audit rows — INCLUDING deliveries whose signature
+ *     failed, which is the secret-mismatch diagnostic the tab exists for.
+ * Board + sysadmin, same as the sibling settings routes.
+ */
+export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async () => {
+    const rows = await prisma.auditLog.findMany({
+        where: { tableName: SHOPIFY_WEBHOOK_RECEIPT_TABLE },
+        orderBy: { id: "desc" },
+        take: 20,
+    });
+    return NextResponse.json({
+        webhookUrl: `${config.baseUrl()}/api/webhooks/shopify`,
+        storeDomain: config.shopifyStoreDomain(),
+        // normalizeAuditData tolerates legacy string-encoded newData; receipts are
+        // written as raw objects, so this is belt-and-suspenders.
+        receipts: rows.map((r) => ({ id: r.id, ...(normalizeAuditData(r.newData) as ShopifyWebhookReceipt) })),
+    });
+});

--- a/checkin-app/src/app/api/webhooks/shopify/__tests__/receiptRecording.test.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/__tests__/receiptRecording.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for the delivery-receipt recording wired into
+ * POST /api/webhooks/shopify (settings → Shopify Webhook tab):
+ *   - a valid delivery is recorded (hmacValid true, outcome from the branch taken),
+ *   - a failed-HMAC delivery is ALSO recorded (that is the secret-mismatch
+ *     diagnostic) and still rejected with 401 exactly as before,
+ *   - a failed receipt insert never breaks settlement,
+ *   - Shopify's "Send test notification" sample is flagged test: true.
+ * Settlement/DB behavior itself is covered by webhookShopify.integration.test.ts.
+ */
+import crypto from 'crypto';
+import { POST } from '../route';
+import prisma from '@/lib/prisma';
+import { activateByProcessId } from '@/lib/membership/payment';
+
+jest.mock('@/lib/membership/payment', () => ({
+    activateByProcessId: jest.fn(),
+}));
+jest.mock('@/lib/shopify', () => ({
+    adjustProgramInventory: jest.fn().mockResolvedValue(true),
+}));
+jest.mock('@/lib/logger', () => ({
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    logIntegrationError: jest.fn(),
+}));
+
+const SECRET = 'receipt-test-secret';
+const activate = activateByProcessId as jest.Mock;
+const auditCreate = jest.fn();
+const boardSettingsFindUnique = jest.fn();
+
+function sign(body: string, secret = SECRET): string {
+    return crypto.createHmac('sha256', secret).update(body, 'utf8').digest('base64');
+}
+
+function webhookReq(body: string, signature: string | null) {
+    const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'x-shopify-topic': 'orders/paid',
+        'x-shopify-shop-domain': 'test-store.example.com',
+        // Distinct per-file IP keeps this suite clear of the shared rate-limit bucket.
+        'x-forwarded-for': '10.99.99.1',
+    };
+    if (signature !== null) headers['x-shopify-hmac-sha256'] = signature;
+    return new Request('http://localhost/api/webhooks/shopify', { method: 'POST', headers, body });
+}
+
+// The failure-path recording is fire-and-forget from the synchronous HMAC
+// verify — flush the microtask/immediate queue before asserting on it.
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+const MEMBERSHIP_BODY = JSON.stringify({
+    id: 999001,
+    note_attributes: [{ name: 'Membership_Process_ID', value: '12' }],
+    line_items: [],
+});
+
+beforeAll(() => {
+    process.env.SHOPIFY_WEBHOOK_SECRET = SECRET;
+});
+
+afterAll(() => {
+    delete process.env.SHOPIFY_WEBHOOK_SECRET;
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    auditCreate.mockResolvedValue({});
+    boardSettingsFindUnique.mockResolvedValue(null);
+    activate.mockResolvedValue({ status: 'ACTIVE' });
+    prisma.auditLog.create = auditCreate as unknown as typeof prisma.auditLog.create;
+    prisma.boardSettings.findUnique = boardSettingsFindUnique as unknown as typeof prisma.boardSettings.findUnique;
+});
+
+describe('POST /api/webhooks/shopify — delivery receipts', () => {
+    it('records a valid membership delivery with hmacValid true and a settled outcome', async () => {
+        const res = await POST(webhookReq(MEMBERSHIP_BODY, sign(MEMBERSHIP_BODY)));
+        expect(res.status).toBe(200);
+        expect(activate).toHaveBeenCalledWith(12, '999001', false);
+        expect(auditCreate).toHaveBeenCalledTimes(1);
+        const { data } = auditCreate.mock.calls[0][0];
+        expect(data.tableName).toBe('ShopifyWebhookReceipt');
+        expect(data.actorId).toBe(0);
+        expect(data.newData).toMatchObject({
+            topic: 'orders/paid',
+            shopDomain: 'test-store.example.com',
+            hmacValid: true,
+            test: false,
+            orderId: '999001',
+            outcome: 'settled process 12',
+        });
+    });
+
+    it('records a failed-HMAC delivery (hmacValid false) and still rejects with 401', async () => {
+        const res = await POST(webhookReq(MEMBERSHIP_BODY, 'bogus-signature'));
+        expect(res.status).toBe(401);
+        await flush();
+        expect(auditCreate).toHaveBeenCalledTimes(1);
+        expect(auditCreate.mock.calls[0][0].data.newData).toMatchObject({
+            hmacValid: false,
+            orderId: '999001',
+            outcome: 'rejected: bad hmac',
+        });
+        expect(activate).not.toHaveBeenCalled();
+    });
+
+    it('records a missing-signature delivery and still rejects with 401', async () => {
+        const res = await POST(webhookReq(MEMBERSHIP_BODY, null));
+        expect(res.status).toBe(401);
+        await flush();
+        expect(auditCreate.mock.calls[0][0].data.newData).toMatchObject({
+            hmacValid: false,
+            outcome: 'rejected: missing signature',
+        });
+        expect(activate).not.toHaveBeenCalled();
+    });
+
+    it('a failed receipt insert does not break settlement (still 200, still activates)', async () => {
+        auditCreate.mockRejectedValueOnce(new Error('db down'));
+        const res = await POST(webhookReq(MEMBERSHIP_BODY, sign(MEMBERSHIP_BODY)));
+        expect(res.status).toBe(200);
+        expect((await res.json()).success).toBe(true);
+        expect(activate).toHaveBeenCalledWith(12, '999001', false);
+    });
+
+    it('flags Shopify\'s "Send test notification" sample as test: true', async () => {
+        // Raw string, not JSON.stringify: the sample order id exceeds 2^53, and the
+        // detection must survive JSON.parse rounding it. No cart attributes, like
+        // the real sample payload.
+        const body = '{"id":820982911946154508,"test":true,"line_items":[]}';
+        const res = await POST(webhookReq(body, sign(body)));
+        expect(res.status).toBe(200);
+        expect(auditCreate).toHaveBeenCalledTimes(1);
+        expect(auditCreate.mock.calls[0][0].data.newData).toMatchObject({
+            hmacValid: true,
+            test: true,
+            outcome: 'no membership or program attributes — ignored',
+        });
+        expect(activate).not.toHaveBeenCalled();
+    });
+
+    it('flags the sample order id as test even without the test flag', async () => {
+        const body = '{"id":820982911946154508,"line_items":[]}';
+        const res = await POST(webhookReq(body, sign(body)));
+        expect(res.status).toBe(200);
+        expect(auditCreate.mock.calls[0][0].data.newData).toMatchObject({ test: true });
+    });
+});

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -6,6 +6,7 @@ import { activateByProcessId } from "@/lib/membership/payment";
 import { withWebhook } from "@/lib/webhookAuth";
 import { config, DEV_MOCK_MEMBERSHIP_VARIANT_ID } from "@/lib/config";
 import { adjustProgramInventory } from "@/lib/shopify";
+import { recordShopifyWebhookReceipt, tryParseJson } from "@/lib/shopifyWebhookReceipt";
 
 interface ShopifyOrder {
     id?: number | string;
@@ -17,16 +18,26 @@ interface ShopifyOrder {
  * Verify the Shopify HMAC over the EXACT raw bytes. Config-not-set is a server
  * error (500); missing/wrong signature is unauthorized (401). Must run on the raw
  * body before it is parsed — re-serializing JSON would change the bytes.
+ *
+ * Every rejected delivery is also recorded to the receipt log (settings →
+ * Shopify Webhook): a delivery that arrives but fails the signature IS the
+ * secret-mismatch diagnostic the tab exists to surface. Recording is
+ * fire-and-forget (`void`) because verify is synchronous by contract, and the
+ * helper never throws — the rejection below is returned exactly as before.
+ * This hook lives here in the Shopify route's own verify, NOT in withWebhook,
+ * so other providers' webhooks are untouched.
  */
 function verifyShopifyHmac(req: Request, rawBody: string): { ok: true } | { ok: false; status: number; error: string } {
     const secret = config.shopifyWebhookSecret();
     if (!secret) {
         logger.error("Shopify webhook received but SHOPIFY_WEBHOOK_SECRET is not configured.");
+        void recordShopifyWebhookReceipt(req, tryParseJson(rawBody), { hmacValid: false, outcome: "rejected: webhook secret not configured" });
         return { ok: false, status: 500, error: "Configuration Error" };
     }
 
     const headerSignature = req.headers.get("x-shopify-hmac-sha256");
     if (!headerSignature) {
+        void recordShopifyWebhookReceipt(req, tryParseJson(rawBody), { hmacValid: false, outcome: "rejected: missing signature" });
         return { ok: false, status: 401, error: "Missing signature" };
     }
 
@@ -42,6 +53,7 @@ function verifyShopifyHmac(req: Request, rawBody: string): { ok: true } | { ok: 
 
     if (!crypto.timingSafeEqual(generatedBuffer, headerBuffer)) {
         logger.error("Shopify webhook signature mismatch.");
+        void recordShopifyWebhookReceipt(req, tryParseJson(rawBody), { hmacValid: false, outcome: "rejected: bad hmac" });
         return { ok: false, status: 401, error: "Invalid signature" };
     }
 
@@ -56,7 +68,7 @@ function verifyShopifyHmac(req: Request, rawBody: string): { ok: true } | { ok: 
 // The HMAC secret differs per env (config.shopifyWebhookSecret). The only env-branched
 // logic is the synthetic dev-mock variant fallback, gated on config.shopifyMockActive()
 // (⇔ CHECKIN_ENV=local) below.
-export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac }, async (_req, order: ShopifyOrder) => {
+export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac }, async (req, order: ShopifyOrder) => {
         // Iterate through line items to find CheckMeIn_Account_ID and Program_ID
         // We set these custom attributes in the permalink URL:
         // https://[store].myshopify.com/cart/[VariantID]:1?attributes[CheckMeIn_Account_ID]=123&attributes[Program_ID]=456
@@ -97,6 +109,9 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
         // token / Shopify-side segment exists.
         if (membershipProcessIdStr) {
             const processId = parseInt(membershipProcessIdStr, 10);
+            // Receipt outcome for the delivery log (settings → Shopify Webhook);
+            // mirrors the logger lines below, recorded just before each return.
+            let outcome = "invalid Membership_Process_ID — ignored";
             if (!isNaN(processId)) {
                 const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
                 const membershipVariantIds = new Set(
@@ -111,21 +126,31 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                 const hasMembershipItem = (order.line_items ?? []).some((li) => membershipVariantIds.has(String(li.variant_id)));
                 const proc = await activateByProcessId(processId, order.id ? String(order.id) : "", hasMembershipItem);
                 if (proc?.status === "ACTIVE") {
+                    outcome = `settled process ${processId}`;
                     logger.info(`[SHOPIFY WEBHOOK] Activated membership for process ${processId}`);
                 } else if (proc?.status === "BLOCKED") {
+                    outcome = `payment recorded for BLOCKED process ${processId} — membership not activated`;
                     logger.warn(`[SHOPIFY WEBHOOK] Payment recorded for BLOCKED process ${processId} — membership NOT activated; board notified for refund`);
                 } else if (proc?.status === "PENDING_BG_CLEARANCE") {
+                    outcome = `payment recorded for process ${processId} — awaiting background check clearance`;
                     logger.info(`[SHOPIFY WEBHOOK] Payment recorded for process ${processId}; awaiting background-check clearance`);
                 } else {
+                    outcome = `no state change for process ${processId} — already processed`;
                     logger.info(`[SHOPIFY WEBHOOK] Payment webhook for process ${processId} — no state change (already processed)`);
                 }
             }
+            await recordShopifyWebhookReceipt(req, order, { hmacValid: true, outcome });
             return NextResponse.json({ success: true });
         }
+
+        // Receipt outcome for the delivery log — the default also covers Shopify's
+        // "Send test notification" sample order, which carries no cart attributes.
+        let outcome = "no membership or program attributes — ignored";
 
         if (accountIdStr && programIdStr) {
             const participantIds = accountIdStr.split(',').map((id: string) => parseInt(id.trim(), 10)).filter((id: number) => !isNaN(id));
             const programId = parseInt(programIdStr, 10);
+            outcome = "invalid CheckMeIn_Account_ID or Program_ID — ignored";
 
             if (participantIds.length > 0 && !isNaN(programId)) {
                 // Guard mirrors the membership H2 fix above: note_attributes
@@ -254,11 +279,14 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                         logger.error(`[SHOPIFY WEBHOOK] Failed to mirror sibling-variant inventory for program ${programId} after activating ${activatedCount} participant(s) — pools may be out of sync.`);
                     }
                 }
+
+                outcome = `program ${programId}: activated ${activatedCount} of ${participantIds.length} participant(s)`;
             }
         } else {
              logger.info(`[SHOPIFY WEBHOOK] Payload received but missing CheckMeIn_Account_ID or Program_ID attributes. Ignoring.`);
         }
 
         // Always return 200 OK to Shopify to acknowledge receipt, even if missing attributes.
+        await recordShopifyWebhookReceipt(req, order, { hmacValid: true, outcome });
         return NextResponse.json({ success: true });
 });

--- a/checkin-app/src/app/settings/shopify-webhook/page.tsx
+++ b/checkin-app/src/app/settings/shopify-webhook/page.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Anchor,
+  Badge,
+  Button,
+  Card,
+  Center,
+  Code,
+  CopyButton,
+  Group,
+  List,
+  Loader,
+  Stack,
+  Table,
+  Text,
+  Title,
+} from "@mantine/core";
+import { SettingsTabs } from "@/components/admin/SettingsTabs";
+import { useRequireRole } from "@/hooks/useRequireRole";
+import type { ShopifyWebhookReceipt } from "@/lib/shopifyWebhookReceipt";
+
+type Receipt = ShopifyWebhookReceipt & { id: number };
+
+interface Status {
+  webhookUrl: string;
+  storeDomain: string | null;
+  receipts: Receipt[];
+}
+
+/**
+ * Shopify Webhook settings tab — verifies the store's webhook wiring
+ * end-to-end from the RECEIVING side. Shopify's Admin API cannot trigger its
+ * "Send test notification" button, and an app token cannot even list webhooks
+ * created in the store admin (they belong to the admin pseudo-app), so the
+ * only reliable check is: press the button in Shopify, then confirm the
+ * delivery — and its signature verdict — arrived here. The inbound webhook
+ * route records every delivery (valid or not) as a receipt; this page shows
+ * the latest ones.
+ */
+export default function ShopifyWebhookSettingsPage() {
+  // Same gate as the sibling settings pages: board + sysadmin, redirected client-side
+  // before any content renders. The status route re-enforces the same roles.
+  const { ready, loading: authLoading } = useRequireRole(["isSysadmin", "isBoardMember"]);
+
+  const [status, setStatus] = useState<Status | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setFailed(false);
+    try {
+      const res = await fetch("/api/settings/shopify-webhook");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setStatus((await res.json()) as Status);
+    } catch {
+      setFailed(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (ready) load();
+  }, [ready, load]);
+
+  if (authLoading) return <Center mih="60vh"><Loader /></Center>;
+  if (!ready) return null; // redirect to / is in flight
+
+  const badSignature = status?.receipts.some((r) => !r.hmacValid) ?? false;
+
+  return (
+    <Stack>
+      <SettingsTabs active="shopify-webhook" />
+
+      {loading && !status ? (
+        <Center py="xl"><Loader /></Center>
+      ) : failed && !status ? (
+        <Text c="red">Failed to load webhook status.</Text>
+      ) : status ? (
+        <>
+          <Card withBorder radius="md" padding="lg">
+            <Title order={3} mb="xs">Webhook endpoint</Title>
+            <Text size="sm" c="dimmed" mb="md">
+              Membership and program payments settle <strong>only</strong> when Shopify delivers an{" "}
+              <Code>orders/paid</Code> webhook to this endpoint. If the store has no webhook registered — or it
+              signs with the wrong secret — the application silently never learns that members paid.
+            </Text>
+            <Group gap="sm">
+              <Code style={{ fontSize: "var(--mantine-font-size-sm)" }}>{status.webhookUrl}</Code>
+              <CopyButton value={status.webhookUrl}>
+                {({ copied, copy }) => (
+                  <Button size="xs" variant="light" color={copied ? "teal" : undefined} onClick={copy}>
+                    {copied ? "Copied" : "Copy"}
+                  </Button>
+                )}
+              </CopyButton>
+            </Group>
+          </Card>
+
+          <Card withBorder radius="md" padding="lg">
+            <Title order={3} mb="xs">How to verify the wiring</Title>
+            <List type="ordered" size="sm" spacing="xs">
+              <List.Item>
+                In Shopify, open{" "}
+                {status.storeDomain ? (
+                  <Anchor href={`https://${status.storeDomain}/admin/settings/notifications`} target="_blank" rel="noreferrer">
+                    the store&apos;s notification settings
+                  </Anchor>
+                ) : (
+                  <>the store&apos;s notification settings (the Shopify store domain is not configured for this environment)</>
+                )}{" "}
+                and create or verify an <Code>orders/paid</Code> webhook pointing at the URL above.
+              </List.Item>
+              <List.Item>Press <strong>Send test notification</strong> next to that webhook.</List.Item>
+              <List.Item>Press <strong>Refresh</strong> below — the test delivery should appear within a few seconds.</List.Item>
+            </List>
+          </Card>
+
+          <Card withBorder radius="md" padding="lg">
+            <Group justify="space-between" mb="xs">
+              <Title order={3}>Recent deliveries</Title>
+              <Button size="xs" variant="light" onClick={load} loading={loading}>
+                Refresh
+              </Button>
+            </Group>
+            <Text size="sm" c="dimmed" mb="md">
+              Every delivery this environment received on the endpoint above, newest first — including
+              deliveries whose signature failed verification.
+            </Text>
+
+            {badSignature && (
+              <Alert color="red" variant="light" mb="md">
+                A delivery with signature ✗ reached this endpoint but failed verification: the secret the
+                store signs webhooks with and the webhook secret configured for this environment are not the
+                matching pair. Fix the configuration — until then, payments will not settle.
+              </Alert>
+            )}
+
+            {status.receipts.length === 0 ? (
+              <Alert color="yellow" variant="light">
+                No deliveries recorded. If you pressed <strong>Send test notification</strong> and still see
+                nothing after refreshing, Shopify cannot reach the endpoint above — the webhook is not
+                registered, or it points at the wrong URL.
+              </Alert>
+            ) : (
+              <Table.ScrollContainer minWidth={700}>
+                <Table striped highlightOnHover verticalSpacing="sm">
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Time</Table.Th>
+                      <Table.Th>Topic</Table.Th>
+                      <Table.Th>Test</Table.Th>
+                      <Table.Th>Signature</Table.Th>
+                      <Table.Th>Order</Table.Th>
+                      <Table.Th>Outcome</Table.Th>
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {status.receipts.map((r) => (
+                      <Table.Tr key={r.id}>
+                        <Table.Td style={{ whiteSpace: "nowrap" }}>{new Date(r.receivedAt).toLocaleString()}</Table.Td>
+                        <Table.Td>{r.topic ? <Code>{r.topic}</Code> : <Text c="dimmed">—</Text>}</Table.Td>
+                        <Table.Td>{r.test ? <Badge color="gray" variant="light">test</Badge> : <Text c="dimmed">—</Text>}</Table.Td>
+                        <Table.Td>
+                          {r.hmacValid ? <Text c="green" component="span">✓</Text> : <Text c="red" component="span" fw={700}>✗</Text>}
+                        </Table.Td>
+                        <Table.Td>{r.orderId ?? <Text c="dimmed">—</Text>}</Table.Td>
+                        <Table.Td>{r.outcome}</Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
+              </Table.ScrollContainer>
+            )}
+          </Card>
+        </>
+      ) : null}
+    </Stack>
+  );
+}

--- a/checkin-app/src/components/admin/SettingsTabs.tsx
+++ b/checkin-app/src/components/admin/SettingsTabs.tsx
@@ -9,13 +9,14 @@ import { useTodoCounts } from "@/hooks/useTodoCounts";
 import { settingsMisconfigBadge } from "@/components/navBadges";
 import { CountBadge } from "@/components/ui/CountBadge";
 
-export type SettingsTab = "membership" | "roles" | "localization" | "email";
+export type SettingsTab = "membership" | "roles" | "localization" | "email" | "shopify-webhook";
 
 // sysadminOnly tabs are hidden from board members (the /settings layout admits both).
 const TABS: { value: SettingsTab; label: string; href: string; sysadminOnly?: boolean }[] = [
   { value: "membership", label: "Membership Settings", href: "/settings/membership" },
   { value: "roles", label: "Role Assignment", href: "/settings/roles" },
   { value: "email", label: "Email", href: "/settings/email" },
+  { value: "shopify-webhook", label: "Shopify Webhook", href: "/settings/shopify-webhook" },
   { value: "localization", label: "Localization", href: "/settings/localization", sysadminOnly: true },
 ];
 

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -135,6 +135,7 @@ export const PAGES: PageEntry[] = [
   { href: '/settings/roles', label: 'Role Assignment', section: 'Settings', visible: BOARD },
   { href: '/settings/localization', label: 'Localization', section: 'Settings', visible: SYSADMIN },
   { href: '/settings/email', label: 'Email Settings', section: 'Settings', keywords: 'sender from reply-to identity', visible: BOARD },
+  { href: '/settings/shopify-webhook', label: 'Shopify Webhook', section: 'Settings', keywords: 'orders paid delivery test notification signature secret payment', visible: BOARD },
 ];
 
 // Routes that exist as page.tsx but are intentionally absent from the directory.

--- a/checkin-app/src/lib/__tests__/shopifyWebhookReceipt.test.ts
+++ b/checkin-app/src/lib/__tests__/shopifyWebhookReceipt.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for the Shopify webhook receipt helper: test-notification
+ * detection (the "Send test notification" sample id survives JSON.parse's
+ * precision loss), defensive payload reads, and the never-throws guarantee —
+ * a failed receipt insert must not break settlement.
+ */
+import prisma from '@/lib/prisma';
+import { logger } from '@/lib/logger';
+import {
+    SHOPIFY_WEBHOOK_RECEIPT_TABLE,
+    isShopifyTestNotification,
+    recordShopifyWebhookReceipt,
+    tryParseJson,
+} from '../shopifyWebhookReceipt';
+
+jest.mock('@/lib/logger', () => ({
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const auditCreate = jest.fn();
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    auditCreate.mockResolvedValue({});
+    prisma.auditLog.create = auditCreate as unknown as typeof prisma.auditLog.create;
+});
+
+function req(headers: Record<string, string> = {}) {
+    return new Request('http://localhost/api/webhooks/shopify', { method: 'POST', headers });
+}
+
+describe('isShopifyTestNotification', () => {
+    it('detects the explicit test flag', () => {
+        expect(isShopifyTestNotification({ test: true, id: 123 })).toBe(true);
+    });
+
+    it('detects the sample order id as a string', () => {
+        expect(isShopifyTestNotification({ id: '820982911946154508' })).toBe(true);
+    });
+
+    it('detects the sample order id through JSON.parse precision loss (> 2^53)', () => {
+        // Shopify sends the id as a bare JSON number; JSON.parse rounds it to the
+        // nearest double, so a strict string compare of the parsed value would miss.
+        expect(isShopifyTestNotification(tryParseJson('{"id":820982911946154508}'))).toBe(true);
+    });
+
+    it('is false for real orders and junk payloads', () => {
+        expect(isShopifyTestNotification({ id: 999001, test: false })).toBe(false);
+        expect(isShopifyTestNotification({ id: 999001 })).toBe(false);
+        expect(isShopifyTestNotification(null)).toBe(false);
+        expect(isShopifyTestNotification('not an order')).toBe(false);
+        expect(isShopifyTestNotification([])).toBe(false);
+        expect(isShopifyTestNotification({})).toBe(false);
+    });
+});
+
+describe('tryParseJson', () => {
+    it('parses valid JSON and swallows invalid bytes', () => {
+        expect(tryParseJson('{"id":1}')).toEqual({ id: 1 });
+        expect(tryParseJson('not json')).toBeNull();
+    });
+});
+
+describe('recordShopifyWebhookReceipt', () => {
+    it('writes one system AuditLog row with the delivery fields', async () => {
+        await recordShopifyWebhookReceipt(
+            req({ 'x-shopify-topic': 'orders/paid', 'x-shopify-shop-domain': 'test-store.example.com' }),
+            { id: 999001, test: false },
+            { hmacValid: true, outcome: 'settled process 12' },
+        );
+        expect(auditCreate).toHaveBeenCalledTimes(1);
+        const { data } = auditCreate.mock.calls[0][0];
+        expect(data.actorId).toBe(0);
+        expect(data.action).toBe('CREATE');
+        expect(data.tableName).toBe(SHOPIFY_WEBHOOK_RECEIPT_TABLE);
+        expect(data.newData).toMatchObject({
+            topic: 'orders/paid',
+            shopDomain: 'test-store.example.com',
+            hmacValid: true,
+            test: false,
+            orderId: '999001',
+            outcome: 'settled process 12',
+        });
+        expect(typeof data.newData.receivedAt).toBe('string');
+    });
+
+    it('records null topic/shopDomain/orderId when headers and payload are missing', async () => {
+        await recordShopifyWebhookReceipt(req(), null, { hmacValid: false, outcome: 'rejected: bad hmac' });
+        expect(auditCreate.mock.calls[0][0].data.newData).toMatchObject({
+            topic: null,
+            shopDomain: null,
+            orderId: null,
+            hmacValid: false,
+            test: false,
+        });
+    });
+
+    it('never throws when the insert fails — logs and moves on', async () => {
+        auditCreate.mockRejectedValueOnce(new Error('db down'));
+        await expect(
+            recordShopifyWebhookReceipt(req(), { id: 1 }, { hmacValid: true, outcome: 'x' }),
+        ).resolves.toBeUndefined();
+        expect(logger.error).toHaveBeenCalled();
+    });
+});

--- a/checkin-app/src/lib/shopifyWebhookReceipt.ts
+++ b/checkin-app/src/lib/shopifyWebhookReceipt.ts
@@ -1,0 +1,105 @@
+import prisma from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+
+/**
+ * Delivery log for the inbound Shopify webhook, surfaced on the "Shopify
+ * Webhook" settings tab so a board member can verify the store's webhook
+ * wiring end-to-end: press "Send test notification" in the Shopify admin,
+ * then see the receipt — or the signature failure — inside checkin. Settlement
+ * is driven ONLY by the orders/paid webhook, so a store with no webhook
+ * registered (or one signed with the wrong secret) silently never settles;
+ * this log is the in-app evidence either way.
+ *
+ * Stored as AuditLog rows (actorId 0 = system, the convention the audit-log
+ * viewer already renders as "System") rather than a new table: the repo allows
+ * at most one schema migration per release and a concurrent PR already carries
+ * it, and AuditLog's Json newData column fits an append-only event log fine.
+ * tableName is the query key.
+ */
+export const SHOPIFY_WEBHOOK_RECEIPT_TABLE = "ShopifyWebhookReceipt";
+
+/** Shape of one receipt, stored in AuditLog.newData. */
+export interface ShopifyWebhookReceipt {
+    /** X-Shopify-Topic header (e.g. "orders/paid"); null if absent. */
+    topic: string | null;
+    /** X-Shopify-Shop-Domain header — which store sent it; null if absent. */
+    shopDomain: string | null;
+    /** Whether HMAC verification passed. false = secret mismatch / missing signature. */
+    hmacValid: boolean;
+    /** True for Shopify's "Send test notification" sample and test-mode orders. */
+    test: boolean;
+    /** Shopify order id as a string; null when the payload has none / is unparseable. */
+    orderId: string | null;
+    /** One short line: what the webhook route did with the delivery. */
+    outcome: string;
+    /** ISO timestamp of receipt. */
+    receivedAt: string;
+}
+
+// Shopify's admin "Send test notification" button sends a fixed sample order
+// with this well-known id (the same across stores). Kept as a string: the
+// value exceeds Number.MAX_SAFE_INTEGER, so JSON.parse rounds it — the number
+// comparison below matches the rounded double, the string comparison matches
+// stores/clients that send the id as a string.
+const SHOPIFY_SAMPLE_ORDER_ID = "820982911946154508";
+
+/** JSON.parse that never throws — failed-HMAC bodies may be arbitrary bytes. */
+export function tryParseJson(raw: string): unknown {
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Detect Shopify's "Send test notification" sample (and test-mode orders).
+ * The payload is untrusted input of unknown shape, so read it defensively:
+ * test orders carry `"test": true`; the admin sample additionally uses the
+ * fixed sample order id (checked both as string and as the JSON.parse-rounded
+ * number, see SHOPIFY_SAMPLE_ORDER_ID).
+ */
+export function isShopifyTestNotification(order: unknown): boolean {
+    if (typeof order !== "object" || order === null) return false;
+    const o = order as { test?: unknown; id?: unknown };
+    if (o.test === true) return true;
+    if (o.id === undefined || o.id === null) return false;
+    return String(o.id) === SHOPIFY_SAMPLE_ORDER_ID || Number(o.id) === Number(SHOPIFY_SAMPLE_ORDER_ID);
+}
+
+/**
+ * Append one delivery receipt. NEVER throws: a failed insert must not break
+ * settlement (a non-2xx would make Shopify retry the whole order), so the
+ * write is fully swallowed — logged and moved past. Callers may await it
+ * (the webhook handler does) or fire-and-forget with `void` (the HMAC verify
+ * hook does — verify is synchronous by contract).
+ */
+export async function recordShopifyWebhookReceipt(
+    req: Request,
+    order: unknown,
+    opts: { hmacValid: boolean; outcome: string },
+): Promise<void> {
+    try {
+        const o = (typeof order === "object" && order !== null ? order : {}) as { id?: unknown };
+        const receipt: ShopifyWebhookReceipt = {
+            topic: req.headers.get("x-shopify-topic"),
+            shopDomain: req.headers.get("x-shopify-shop-domain"),
+            hmacValid: opts.hmacValid,
+            test: isShopifyTestNotification(order),
+            orderId: o.id === undefined || o.id === null ? null : String(o.id),
+            outcome: opts.outcome,
+            receivedAt: new Date().toISOString(),
+        };
+        await prisma.auditLog.create({
+            data: {
+                actorId: 0, // system — no session behind an inbound webhook
+                action: "CREATE",
+                tableName: SHOPIFY_WEBHOOK_RECEIPT_TABLE,
+                affectedEntityId: 0, // no entity row backs a receipt; newData IS the record
+                newData: { ...receipt },
+            },
+        });
+    } catch (error) {
+        logger.error("Failed to record Shopify webhook receipt (delivery log only — settlement unaffected):", error);
+    }
+}


### PR DESCRIPTION
## Incident context

Prod's first membership payment failed on a bad store-side configuration (a product ID configured where a variant ID belongs). The next likely gap in the same class is webhook wiring: settlement is driven **only** by Shopify's `orders/paid` webhook to `POST /api/webhooks/shopify` (HMAC-verified). Today the app has zero visibility into that wiring — if the store has no webhook registered, or it signs with a mismatched secret, the app silently never learns that members paid. Shopify's admin has a "Send test notification" button per webhook; this PR makes that button meaningful by showing the receipt (or the signature failure) inside checkin.

## Design: verify from the receiving side

Shopify's Admin API cannot trigger "Send test notification" (it is UI-only), and an app token cannot even **list** webhook subscriptions created in the store admin — they belong to the admin pseudo-app. So the app cannot poke Shopify; it can only prove deliveries arrive. The flow the new tab walks a board member through:

1. In Shopify, create/verify an `orders/paid` webhook pointing at the endpoint URL the tab shows (with copy-to-clipboard; deep link to `https://<store-domain>/admin/settings/notifications`, the old-style admin URL that redirects correctly regardless of store handle).
2. Press **Send test notification** in Shopify.
3. Press **Refresh** on the tab. Three possible stories:
   - a delivery with signature ✓ — wiring is good end-to-end;
   - a delivery with signature ✗ — Shopify reaches the endpoint, but the store's signing secret and the app's webhook secret are not the matching pair (a visible red callout explains this);
   - no delivery at all — Shopify cannot reach the endpoint (webhook missing or wrong URL; the empty state explains this).

## No schema migration: receipts are AuditLog rows

The repo enforces at most one schema migration per release and a concurrent PR already carries this release's migration. Deliveries are therefore recorded as `auditLog` rows (`actorId: 0` = system, the convention the audit-log viewer already renders as "System"; `tableName: "ShopifyWebhookReceipt"` as the query key; `newData` holds `{ topic, shopDomain, hmacValid, test, orderId, outcome, receivedAt }`).

Recording details:

- **Failed-HMAC deliveries are recorded too** — that is the secret-mismatch diagnostic — then rejected with 401 exactly as before. The hook lives inside `verifyShopifyHmac` in the Shopify route file itself (fire-and-forget, since the `withWebhook` verify contract is synchronous); the shared `withWebhook` wrapper and the other providers' webhooks are untouched.
- Success-path receipts are recorded in the handler with a per-branch outcome (`settled process 12`, `no membership or program attributes — ignored`, `program 5: activated 2 of 2 participant(s)`, …).
- Recording **never breaks settlement**: the helper swallows and logs its own failures, so a dead insert can't turn a paid order into a Shopify retry loop.
- Test notifications are detected defensively: the payload's `"test": true` flag **or** Shopify's well-known sample order id (compared both as string and as the JSON.parse-rounded number, since the id exceeds 2^53).

New status route `GET /api/settings/shopify-webhook` (board + sysadmin, same `withAuth` roles pattern as the sibling settings routes) returns the environment's expected endpoint URL (from the same `config.baseUrl()` the app already builds links from), the store domain, and the latest 20 receipts.

## Tests

New unit coverage:
- recording on a valid delivery (fields + `settled process N` outcome),
- recording on an invalid-HMAC delivery (and it still 401s; settlement untouched),
- recording on a missing-signature delivery (still 401s),
- a failed receipt insert does not break settlement (still 200, still activates),
- test-notification detection (explicit flag, sample id as string, sample id through JSON.parse precision loss),
- status route RBAC (401 anon / 403 non-board through the real `withAuth`) + payload shape,
- the authz drift guard entry for the new role-gated route.

## Verification results

- `npx tsc --noEmit` — clean
- `npm run lint` — clean (`--max-warnings 0`)
- `npm run check-route-coverage` — 0 errors (119 warnings, all the pre-existing unmigrated-route backlog; the new route carries the same advisory `unmigrated` warning as every sibling settings route)
- `npx jest` (full unit suite) — 212 suites, 1753 tests, all passing
- Integration tier not run locally (no Postgres reachable in this session); `webhookShopify.integration.test.ts` asserts nothing about `auditLog` and receipt rows use their own `tableName`, so no interference expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe