### PR TITLE
fix(ci): isolation check dies on purely-additive classification diffs

### DIFF
--- a/.github/workflows/security-boundary-isolation.yml
+++ b/.github/workflows/security-boundary-isolation.yml
@@ -74,8 +74,12 @@ jobs:
           CLS=checkin-app/src/security/generated/classifications.ts
           if printf '%s\n' "${CHANGED[@]}" | grep -qx "$CLS"; then
             DIFF=$(git diff "$BASE_SHA"...HEAD -- "$CLS")
-            REMOVED=$(echo "$DIFF" | grep -E "^-\s+\w+: '" | sed -E "s/^-\s+(\w+): '(\w+)'.*/\1 \2/" | sort -u)
-            ADDED=$(echo "$DIFF"   | grep -E "^\+\s+\w+: '" | sed -E "s/^\+\s+(\w+): '(\w+)'.*/\1 \2/" | sort -u)
+            # `|| true`: under set -euo pipefail, grep's exit 1 on zero matches
+            # would kill the script mid-step with no verdict — which failed every
+            # PR whose classifications diff was PURELY ADDITIVE (the exact case
+            # the comment above exempts; first hit by checkin#1021).
+            REMOVED=$(echo "$DIFF" | grep -E "^-\s+\w+: '" | sed -E "s/^-\s+(\w+): '(\w+)'.*/\1 \2/" | sort -u || true)
+            ADDED=$(echo "$DIFF"   | grep -E "^\+\s+\w+: '" | sed -E "s/^\+\s+(\w+): '(\w+)'.*/\1 \2/" | sort -u || true)
             while read -r field oldtier; do
               [ -z "$field" ] && continue
               newtier=$(echo "$ADDED" | awk -v f="$field" '$1 == f { print $2 }' | head -1)


### PR DESCRIPTION
## Bug

`security-boundary-isolation.yml` runs under `set -euo pipefail`. Its re-tier detector extracts removed classification lines with `REMOVED=$(echo "$DIFF" | grep -E "^-\s+\w+: '" | …)`. A PR whose `classifications.ts` diff is **purely additive** — a brand-new field annotation, the exact case the workflow's own header exempts ("annotating a new column is not a boundary change to existing data") — gives that `grep` zero matches → exit 1 → the assignment fails → `set -e` kills the script **before any verdict prints**. The job fails in ~8s with only `Process completed with exit code 1`.

First real-world hit: #1021 (adds `orgMembershipProductUrl` with an `internal` annotation, nothing else security-related). Every prior classification-touching PR happened to also remove/rename lines, so the bug stayed latent.

## Fix

`|| true` on both the `REMOVED` and `ADDED` extractions (the whole pipelines — `pipefail` makes grep's status the pipeline's even through `sed|sort`). An empty `REMOVED` then flows into the existing loop, `RETIER` stays empty, and the job prints "No security-boundary changes in this PR — nothing to isolate," as designed. Reproduced both the failure and the fixed behavior locally with the exact `set -euo pipefail` semantics.

After this merges, #1021 needs its merge ref refreshed (rebase or empty commit) so its isolation re-run picks up the fixed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe