### PR TITLE
feat(ops): URL-synced status filter for the membership-ops applications board

### DIFF
--- a/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
@@ -1,13 +1,43 @@
 /* eslint-disable @typescript-eslint/no-require-imports -- jest.mock factories are hoisted above imports */
 import { screen, fireEvent, waitFor } from "@testing-library/react";
-jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+
+// Reactive next/navigation mock (mirrors src/components/__tests__/StatusFilter.test.tsx):
+// router.replace writes back into `search` so a `rerender()` after a click picks up
+// the new useSearchParams() value, same as a real app-router navigation would.
+let search = "";
+const replace = jest.fn((url: string) => {
+    search = url.split("?")[1] ?? "";
+});
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({ replace }),
+    usePathname: () => "/membership-ops/applications",
+    useSearchParams: () => new URLSearchParams(search),
+}));
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+import { MantineProvider } from "@mantine/core";
+import { EnvProvider } from "@/components/EnvProvider";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
 import { notifications } from "@mantine/notifications";
 import AdminMembershipPage from "../page";
 
-beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
+// rerender() replaces the whole root, so re-supplying it must mirror renderWithProviders'
+// wrapper tree (same component types at each level) or React remounts instead of
+// reconciling, losing the page's already-fetched rows state.
+const rewrapped = () => (
+    <MantineProvider>
+        <EnvProvider value={{ checkinEnv: "prod", shopifyStoreDomain: null }}>
+            <AdminMembershipPage />
+        </EnvProvider>
+    </MantineProvider>
+);
+
+beforeEach(() => {
+    resetRtl();
+    (notifications.show as jest.Mock).mockClear();
+    search = "";
+    replace.mockClear();
+});
 
 function household(name: string, id: number) {
     return { name, householdMembers: [{ id: 1, name: "Lead One", email: "lead@example.com", isHouseholdLead: true }], householdId: id };
@@ -97,5 +127,44 @@ describe("AdminMembershipPage", () => {
 
         fireEvent.click(screen.getByRole("button", { name: /Override/ }));
         await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Overridden to payment." })));
+    });
+
+    it("clicking a legend badge narrows the list to that status; clicking again restores it", async () => {
+        mockFetchJson({ "/api/membership-ops/applications": { processes: rows } });
+        const { rerender } = renderWithProviders(<AdminMembershipPage />);
+        await screen.findByText("Awaiting Family");
+
+        fireEvent.click(screen.getByRole("button", { name: "PENDING PAYMENT: 1" }));
+        rerender(rewrapped());
+
+        expect(screen.queryByText("Awaiting Family")).not.toBeInTheDocument();
+        expect(screen.queryByText("Blocked Family")).not.toBeInTheDocument();
+        expect(screen.getByText("Payment Family")).toBeInTheDocument();
+        expect(screen.getByText(/Showing only/)).toBeInTheDocument();
+        // counts stay computed from all rows while filtered
+        expect(screen.getByText("PENDING EXTERNAL ACTION: 1")).toBeInTheDocument();
+        expect(screen.getByText("BLOCKED: 1")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "PENDING PAYMENT: 1" }));
+        rerender(rewrapped());
+
+        expect(screen.getByText("Awaiting Family")).toBeInTheDocument();
+        expect(screen.getByText("Blocked Family")).toBeInTheDocument();
+        expect(screen.getByText("Payment Family")).toBeInTheDocument();
+        expect(screen.queryByText(/Showing only/)).not.toBeInTheDocument();
+    });
+
+    it("shows a clear-filter empty state when the active status has no matching rows", async () => {
+        search = "status=PENDING_BG_REVIEW";
+        mockFetchJson({ "/api/membership-ops/applications": { processes: rows } });
+        renderWithProviders(<AdminMembershipPage />);
+
+        expect(await screen.findByText(/No applications in PENDING BG REVIEW/)).toBeInTheDocument();
+        expect(screen.queryByText("Awaiting Family")).not.toBeInTheDocument();
+
+        // Two "Clear filter" actions are visible here: the ActiveFilterNotice and the
+        // empty-state card's own clear button. Either should reset the same param.
+        fireEvent.click(screen.getAllByRole("button", { name: "Clear filter" })[0]);
+        await waitFor(() => expect(replace).toHaveBeenCalledWith("/membership-ops/applications", { scroll: false }));
     });
 });

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { Alert, Badge, Button, Card, Center, Group, Loader, Stack, Text } from "@mantine/core";
+import { useState, useEffect, useCallback, Suspense } from "react";
+import { Alert, Button, Card, Center, Group, Loader, Stack, Text } from "@mantine/core";
 import { AlertBanner } from "@/components/admin/AlertBanner";
 import { notifications } from "@mantine/notifications";
 import { modals } from "@mantine/modals";
 import { useSession } from "next-auth/react";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 import { sharesHousehold } from "@/lib/conflictOfInterest";
+import { PageLoader } from "@/components/ui/PageLoader";
+import { StatusFilterBadge, ActiveFilterNotice, useStatusFilter } from "@/components/StatusFilter";
 
 interface Person {
   id: number;
@@ -61,6 +63,14 @@ const awaitingBg = (r: ProcessRow) =>
     ((r.status === "PENDING_PAYMENT" || r.status === "PENDING_BG_CLEARANCE") && !!r.bgConsentAt));
 
 export default function AdminMembershipPage() {
+  return (
+    <Suspense fallback={<PageLoader />}>
+      <ApplicationsBoard />
+    </Suspense>
+  );
+}
+
+function ApplicationsBoard() {
   const { data: session } = useSession();
   const me = session?.user;
   // Conflict of interest: a board member may not certify/override their OWN household's
@@ -74,6 +84,7 @@ export default function AdminMembershipPage() {
   const [busyId, setBusyId] = useState<number | null>(null);
   const [message, setMessage] = useState("");
   const [messageId, setMessageId] = useState<number | null>(null);
+  const { active, toggle, clear } = useStatusFilter();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -221,6 +232,7 @@ export default function AdminMembershipPage() {
   };
 
   const statusCounts = rows.reduce<Record<string, number>>((acc, r) => { acc[r.status] = (acc[r.status] || 0) + 1; return acc; }, {});
+  const visibleRows = rows.filter((r) => !active || r.status === active);
 
   return (
     <Stack>
@@ -233,20 +245,29 @@ export default function AdminMembershipPage() {
       {!loading && rows.length > 0 && (
         <>
           {rows.some((r) => r.status === "BLOCKED") && (
-            <Alert color="red" variant="light" fw={600}>
+            <Alert
+              color="red"
+              variant="light"
+              fw={600}
+              onClick={() => toggle("BLOCKED")}
+              title="Click to filter to blocked applications"
+              style={{ cursor: "pointer" }}
+            >
               🚨 {rows.filter((r) => r.status === "BLOCKED").length} application(s) blocked at
               background review — board attention needed.
             </Alert>
           )}
           <Group gap="xs">
             {Object.entries(statusCounts).map(([status, count]) => (
-              <Badge key={status} color={statusColor(status)} variant="light">
+              <StatusFilterBadge key={status} value={status} active={active} onToggle={toggle} color={statusColor(status)}>
                 {statusLabel(status)}: {count}
-              </Badge>
+              </StatusFilterBadge>
             ))}
           </Group>
         </>
       )}
+
+      <ActiveFilterNotice active={active} label={statusLabel} onClear={clear} />
 
       {loading ? (
         <Center py="xl"><Loader /></Center>
@@ -254,9 +275,18 @@ export default function AdminMembershipPage() {
         <Card withBorder radius="md" padding="xl" ta="center">
           <Text c="dimmed">No in-flight membership applications.</Text>
         </Card>
+      ) : visibleRows.length === 0 ? (
+        <Card withBorder radius="md" padding="xl" ta="center">
+          <Stack align="center" gap="xs">
+            <Text c="dimmed">
+              No applications in {statusLabel(active as string)} — clear the filter to see everything.
+            </Text>
+            <Button size="xs" variant="light" onClick={clear}>Clear filter</Button>
+          </Stack>
+        </Card>
       ) : (
         <Stack>
-          {rows.map((r) => (
+          {visibleRows.map((r) => (
             <Card key={r.id} withBorder radius="md" padding="lg">
               <Group justify="space-between" align="center" wrap="wrap">
                 <div>
@@ -266,7 +296,9 @@ export default function AdminMembershipPage() {
                     {r.orgMembership?.isVolunteer && <Text component="span" c="green"> · volunteer</Text>}
                   </Text>
                 </div>
-                <Badge color={statusColor(r.status)}>{statusLabel(r.status)}</Badge>
+                <StatusFilterBadge value={r.status} active={active} onToggle={toggle} color={statusColor(r.status)}>
+                  {statusLabel(r.status)}
+                </StatusFilterBadge>
               </Group>
 
               {r.status === "PENDING_EXTERNAL_ACTION" && (

--- a/checkin-app/src/components/StatusFilter.tsx
+++ b/checkin-app/src/components/StatusFilter.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Badge, type BadgeProps, Button, Group, Text } from "@mantine/core";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+/**
+ * URL-synced single-status list filter for the ops pages: clicking a status
+ * badge shows only rows in that status; clicking it again (or the notice's
+ * clear button) shows everything. The active value lives in a query param so
+ * a filtered view survives refresh and can be linked. Client-side only — the
+ * ops lists are already fully loaded, so callers just apply
+ * `rows.filter((r) => !active || r.status === active)`.
+ */
+export function useStatusFilter(param: string = "status") {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const active = searchParams.get(param);
+
+    const setParam = useCallback(
+        (value: string | null) => {
+            const params = new URLSearchParams(searchParams.toString());
+            if (value === null) params.delete(param);
+            else params.set(param, value);
+            const qs = params.toString();
+            // replace (not push): filter flips shouldn't pile up in history.
+            router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+        },
+        [router, pathname, searchParams, param],
+    );
+
+    const toggle = useCallback(
+        (value: string) => setParam(active === value ? null : value),
+        [active, setParam],
+    );
+    const clear = useCallback(() => setParam(null), [setParam]);
+
+    return { active, toggle, clear };
+}
+
+/**
+ * A status Badge that acts as the filter toggle. Filled when it is the active
+ * filter, light otherwise; exposes the state to assistive tech via
+ * aria-pressed. Everything else (color, size, children) is the caller's.
+ */
+export function StatusFilterBadge({
+    value,
+    active,
+    onToggle,
+    children,
+    ...badgeProps
+}: {
+    value: string;
+    active: string | null;
+    onToggle: (value: string) => void;
+    children: React.ReactNode;
+} & Omit<BadgeProps, "variant">) {
+    const isActive = active === value;
+    return (
+        <Badge
+            {...badgeProps}
+            component="button"
+            type="button"
+            onClick={() => onToggle(value)}
+            variant={isActive ? "filled" : "light"}
+            aria-pressed={isActive}
+            title={isActive ? "Clear this filter" : "Show only this status"}
+            style={{ cursor: "pointer", ...badgeProps.style }}
+        >
+            {children}
+        </Badge>
+    );
+}
+
+/** One-line "filtering is on" notice with the way out. Renders nothing when inactive. */
+export function ActiveFilterNotice({
+    active,
+    label,
+    onClear,
+}: {
+    active: string | null;
+    label: (status: string) => string;
+    onClear: () => void;
+}) {
+    if (!active) return null;
+    return (
+        <Group gap="xs">
+            <Text size="sm" c="dimmed">
+                Showing only <Text component="span" fw={600}>{label(active)}</Text>
+            </Text>
+            <Button size="compact-xs" variant="subtle" onClick={onClear}>
+                Clear filter
+            </Button>
+        </Group>
+    );
+}

--- a/checkin-app/src/components/__tests__/StatusFilter.test.tsx
+++ b/checkin-app/src/components/__tests__/StatusFilter.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * The URL-synced status filter primitive: toggle semantics (click = filter,
+ * click again = clear), replace-not-push history, and the badge/notice UI
+ * states. Pages test their own row filtering; this file owns the primitive.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { useStatusFilter, StatusFilterBadge, ActiveFilterNotice } from '@/components/StatusFilter';
+
+const replace = jest.fn();
+let search = '';
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ replace }),
+    usePathname: () => '/membership-ops/applications',
+    useSearchParams: () => new URLSearchParams(search),
+}));
+
+function Probe() {
+    const { active, toggle, clear } = useStatusFilter();
+    return (
+        <div>
+            <StatusFilterBadge value="PENDING_PAYMENT" active={active} onToggle={toggle} color="orange">
+                PENDING PAYMENT: 2
+            </StatusFilterBadge>
+            <ActiveFilterNotice active={active} label={(s) => s.replace(/_/g, ' ')} onClear={clear} />
+        </div>
+    );
+}
+
+const renderProbe = () => render(<MantineProvider><Probe /></MantineProvider>);
+
+beforeEach(() => {
+    replace.mockClear();
+    search = '';
+});
+
+it('clicking an inactive badge sets the status param (replace, no scroll)', () => {
+    renderProbe();
+    fireEvent.click(screen.getByRole('button', { name: /PENDING PAYMENT/ }));
+    expect(replace).toHaveBeenCalledWith(
+        '/membership-ops/applications?status=PENDING_PAYMENT',
+        { scroll: false },
+    );
+});
+
+it('clicking the active badge clears the param; badge shows pressed state', () => {
+    search = 'status=PENDING_PAYMENT';
+    renderProbe();
+    const badge = screen.getByRole('button', { name: /PENDING PAYMENT/ });
+    expect(badge).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(badge);
+    expect(replace).toHaveBeenCalledWith('/membership-ops/applications', { scroll: false });
+});
+
+it('notice renders only while filtering and its clear button clears', () => {
+    renderProbe();
+    expect(screen.queryByText(/Showing only/)).toBeNull();
+
+    search = 'status=PENDING_PAYMENT';
+    renderProbe();
+    expect(screen.getByText(/Showing only/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filter' }));
+    expect(replace).toHaveBeenCalledWith('/membership-ops/applications', { scroll: false });
+});
+
+it('other query params survive a toggle', () => {
+    search = 'q=smith';
+    renderProbe();
+    fireEvent.click(screen.getByRole('button', { name: /PENDING PAYMENT/ }));
+    expect(replace).toHaveBeenCalledWith(
+        '/membership-ops/applications?q=smith&status=PENDING_PAYMENT',
+        { scroll: false },
+    );
+});


### PR DESCRIPTION
## Summary
- Shared `StatusFilter` primitive (`useStatusFilter`, `StatusFilterBadge`, `ActiveFilterNotice`): URL-synced single-status filter, toggle semantics, replace-not-push history (commit from `feat/ops-status-filter`).
- Applications board wiring: the status-count legend and per-row status badges are now clickable filters; clicking a status (e.g. PENDING PAYMENT) narrows the list to it, clicking again clears.
- Legend counts and the BLOCKED alert stay computed from the unfiltered rows — the legend always shows the whole picture; the filter narrows only the list below it.
- The aggregate BLOCKED alert is clickable and applies the BLOCKED filter.
- Filtered-to-empty gets a dedicated empty state with a clear-filter action.
- `useSearchParams` Suspense boundary added around the board, mirroring the repo's existing pages (signin, participants/new, etc.).

Note: the households-page wiring is in flight on a sibling branch and can be pushed onto this branch before merge.

## Test plan
- [x] `npx jest --testPathPatterns "membership-ops/applications" --testPathPatterns StatusFilter` — 2 suites, 9/9 pass (filter narrow/restore, counts-from-all-rows, filtered-empty state, plus all pre-existing page tests)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe