### PR TITLE
fix(ui): restore breathing room above tab bars; normalize double-padded pages

### DIFF
--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -10,6 +10,7 @@ import {
   SimpleGrid, Stack, Text, TextInput, Title,
 } from "@mantine/core";
 import { formatTime, isYouth } from "@/lib/time";
+import { PageContainer } from "@/components/ui/PageContainer";
 import { formatPhone } from "@/lib/phone";
 import { getKioskDisplayNames } from "@/lib/kiosk-names";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
@@ -338,13 +339,9 @@ function KioskDisplayInner() {
 
   const userId = (session?.user as SessionUser)?.id;
 
-  return (
-    <Box style={isKioskMode ? { cursor: "none", marginTop: -25, paddingLeft: 8, display: "flow-root" } : { maxWidth: 1200, margin: "0 auto", marginTop: 0, paddingLeft: 8, display: "flow-root" }}>
-      {!isKioskMode && (
-        <Box style={{ maxWidth: 1200, margin: "0 auto" }}>
-          <AttendanceTabs />
-        </Box>
-      )}
+  const pageBody = (
+    <>
+      {!isKioskMode && <AttendanceTabs />}
       <Card withBorder radius="md" padding="lg" style={{ width: "100%", maxWidth: 1200, margin: "0 auto" }}>
         {/* Check-in button — hidden in kiosk mode */}
         {!isKioskMode && (
@@ -549,7 +546,18 @@ function KioskDisplayInner() {
           <Button color="red" onClick={confirmForceCheckout}>Force Checkout</Button>
         </Group>
       </Modal>
-    </Box>
+    </>
+  );
+
+  // Kiosk mode is a fullscreen board surface with its own chrome (cursor
+  // hidden, content pulled up under the header); the member-facing page rides
+  // the canonical PageContainer like every other page — no hand-rolled copy of
+  // its margins (PR #1026 review). A plain conditional (not a per-render
+  // wrapper component) so the subtree never remounts when state changes.
+  return isKioskMode ? (
+    <Box style={{ cursor: "none", marginTop: -25, paddingLeft: 8, display: "flow-root" }}>{pageBody}</Box>
+  ) : (
+    <PageContainer>{pageBody}</PageContainer>
   );
 }
 

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -339,7 +339,7 @@ function KioskDisplayInner() {
   const userId = (session?.user as SessionUser)?.id;
 
   return (
-    <Box style={isKioskMode ? { cursor: "none", marginTop: -25, paddingLeft: 8, display: "flow-root" } : { maxWidth: 1200, margin: "0 auto", marginTop: -25, paddingLeft: 8, display: "flow-root" }}>
+    <Box style={isKioskMode ? { cursor: "none", marginTop: -25, paddingLeft: 8, display: "flow-root" } : { maxWidth: 1200, margin: "0 auto", marginTop: 0, paddingLeft: 8, display: "flow-root" }}>
       {!isKioskMode && (
         <Box style={{ maxWidth: 1200, margin: "0 auto" }}>
           <AttendanceTabs />

--- a/checkin-app/src/app/safety/pickup/page.tsx
+++ b/checkin-app/src/app/safety/pickup/page.tsx
@@ -46,7 +46,7 @@ export default function TrustedAdultPickupPage() {
     }
 
     return (
-        <Stack p="md">
+        <Stack>
             <div>
                 <Title order={2}>Trusted Adults — Pickup List</Title>
                 <Text c="dimmed" size="sm">

--- a/checkin-app/src/app/safety/trusted-adults/page.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/page.tsx
@@ -196,7 +196,7 @@ export default function AdminTrustedAdultsPage() {
     if (!ready) return null;
 
     return (
-        <Stack p="md">
+        <Stack>
             <Modal opened={!!prompt} onClose={() => setPrompt(null)} title={prompt?.title} centered>
                 <Textarea
                     data-autofocus

--- a/checkin-app/src/app/trusted-adults/page.tsx
+++ b/checkin-app/src/app/trusted-adults/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { Stack, Title } from "@mantine/core";
+import { PageContainer } from "@/components/ui/PageContainer";
 import TrustedAdultPanel from "@/components/TrustedAdultPanel";
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -22,9 +23,11 @@ export default function TrustedAdultsPage() {
     if (!isLead) return null; // redirect in flight
 
     return (
-        <Stack>
-            <Title order={2}>Trusted Adults</Title>
-            <TrustedAdultPanel />
-        </Stack>
+        <PageContainer>
+            <Stack>
+                <Title order={2}>Trusted Adults</Title>
+                <TrustedAdultPanel />
+            </Stack>
+        </PageContainer>
     );
 }

--- a/checkin-app/src/app/trusted-adults/page.tsx
+++ b/checkin-app/src/app/trusted-adults/page.tsx
@@ -22,7 +22,7 @@ export default function TrustedAdultsPage() {
     if (!isLead) return null; // redirect in flight
 
     return (
-        <Stack p="md">
+        <Stack>
             <Title order={2}>Trusted Adults</Title>
             <TrustedAdultPanel />
         </Stack>

--- a/checkin-app/src/components/ui/PageContainer.tsx
+++ b/checkin-app/src/components/ui/PageContainer.tsx
@@ -2,14 +2,16 @@ import { Box } from "@mantine/core";
 
 // Canonical page wrapper: same left indent + top position for every top-level
 // page/tab layout, so tabs and headings don't "dance" when navigating between
-// sections. The negative top margin trims part of the AppShell's md padding
-// (16px) for a tighter look — must stay smaller than it, or content slides up
-// behind the fixed 60px header (z-index 200) and its top gets clipped, which is
-// exactly what a -25 overshoot did to the ops tab bars. paddingLeft adds a small
-// indent past the content edge.
+// sections. No top margin: the full AppShell md padding (16px) stands, so tab
+// bars get real breathing room under the fixed 60px header (z-index 200)
+// instead of rendering flush against it. Do not push this negative again — a
+// -25 overshoot once did exactly that, sliding content up behind the header
+// and clipping the ops tab bars (fixed by #1007); a negative value here must
+// never exceed the AppShell's md padding. paddingLeft adds a small indent past
+// the content edge.
 export function PageContainer({ children }: { children: React.ReactNode }) {
   return (
-    <Box style={{ maxWidth: 1200, margin: "0 auto", marginTop: -8, paddingLeft: 8, display: "flow-root" }}>
+    <Box style={{ maxWidth: 1200, margin: "0 auto", marginTop: 0, paddingLeft: 8, display: "flow-root" }}>
       {children}
     </Box>
   );


### PR DESCRIPTION
## What

The attendance tab bar ("Current | Add Past Visit | Household Check-ins") — and to a lesser degree every section's tab bar — rendered flush under the fixed 60px header (user screenshot, prod `/attendance/current`). Two audits, five changed lines:

- **Shared system** (`PageContainer.tsx`): `marginTop: -8` → `0`, so all 12 section layouts and every standalone `PageContainer` page get the AppShell's full 16px of space under the header. The comment keeps the #1007 incident lesson (a negative margin exceeding the AppShell padding clips content behind the header).
- **`attendance/current`**: its non-kiosk branch carried its own stale `marginTop: -25` — the *exact* overshoot constant from the #1007 incident, surviving in a pre-`PageContainer` copy. Now `0`. This is the bar in the screenshot.
- **Double-padding normalization**: `safety/pickup`, `safety/trusted-adults`, and top-level `trusted-adults` stacked their own `p="md"` on the AppShell's 16px (32px total, inconsistent with sibling pages) — dropped.

## Audit coverage

Both agents produced full audit tables (in the commit messages): all 12 section layouts, every `PageContainer` page, every page-level tab bar / heading, kiosk & board-display surfaces (deliberately skipped), and mid-page sub-tab bars (not page nav — untouched). No other inconsistencies found; the `mb="md"`-vs-`Stack` gap split is the documented `SectionTabs` pattern, not drift.

## Verification

Full unit suite on the integrated branch: 1732 passed; tsc and lint clean. No test encoded the old spacing values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe