### PR TITLE
feat(membership): payment holdoff message after Shopify checkout

### DIFF
--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -4,7 +4,7 @@ jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
-import { screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { notifications } from "@mantine/notifications";
 import { renderWithProviders, mockFetchJson, setSession, setCheckinEnv, resetRtl } from "@/test-helpers/rtl";
 import MembershipPage from "../page";
@@ -354,6 +354,8 @@ describe("membership page", () => {
   });
 
   // ── PENDING_PAYMENT payment holdoff ──────────────────────────────────────────
+  const HOLDOFF_MSG = "We'll update your status here when we receive your payment — refresh this page after you finish checkout.";
+
   it("clicking the Shopify checkout link shows the holdoff message and persists it to sessionStorage", async () => {
     setSession({ id: 1 });
     mockFetchJson({
@@ -367,39 +369,41 @@ describe("membership page", () => {
 
     fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
 
-    expect(await screen.findByText("We'll update your status here when we receive your payment.")).toBeInTheDocument();
+    expect(await screen.findByText(HOLDOFF_MSG)).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /Pay here with Shopify/ })).not.toBeInTheDocument();
     expect(sessionStorage.getItem("membership_awaiting_payment_1")).not.toBeNull();
   });
 
-  it("clears the holdoff and shows the paid-state card once a poll finds the payment settled", async () => {
+  it("restores the holdoff on a page load while still pending, then clears it (and sessionStorage) on a load after the payment settled", async () => {
     setSession({ id: 1 });
-    jest.useFakeTimers();
-    try {
-      let status = "PENDING_PAYMENT";
-      mockFetchJson({
-        "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
-        "/api/membership": () => state({
-          process: { id: 1, kind: "INITIAL", status },
-          external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
-        }),
-      });
-      renderWithProviders(<MembershipPage />);
-      fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
-      await screen.findByText("We'll update your status here when we receive your payment.");
+    mockFetchJson({
+      "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
+      "/api/membership": state({
+        process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" },
+        external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
+      }),
+    });
+    const first = renderWithProviders(<MembershipPage />);
+    fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
+    await screen.findByText(HOLDOFF_MSG);
+    first.unmount();
 
-      // Simulate the orders/paid webhook settling the payment server-side —
-      // the next poll's load() picks up the new status.
-      status = "PENDING_BG_CLEARANCE";
-      await act(async () => {
-        await jest.advanceTimersByTimeAsync(10_000);
-      });
+    // Next page load, payment still pending: the sessionStorage record restores
+    // the message instead of flashing the pay button back.
+    const second = renderWithProviders(<MembershipPage />);
+    expect(await screen.findByText(HOLDOFF_MSG)).toBeInTheDocument();
+    second.unmount();
 
-      expect(await screen.findByText("Payment received", { exact: false })).toBeInTheDocument();
-      expect(sessionStorage.getItem("membership_awaiting_payment_1")).toBeNull();
-    } finally {
-      jest.useRealTimers();
-    }
+    // The orders/paid webhook settles the payment server-side; the next page
+    // load renders the real (paid) state and drops the sessionStorage record.
+    mockFetchJson({
+      "/api/membership": state({ process: { id: 1, kind: "INITIAL", status: "PENDING_BG_CLEARANCE" } }),
+    });
+    renderWithProviders(<MembershipPage />);
+
+    expect(await screen.findByText("Payment received", { exact: false })).toBeInTheDocument();
+    expect(screen.queryByText(HOLDOFF_MSG)).not.toBeInTheDocument();
+    await waitFor(() => expect(sessionStorage.getItem("membership_awaiting_payment_1")).toBeNull());
   });
 
   it("the 'Show the payment button again' escape hatch restores the pay button without waiting", async () => {
@@ -410,7 +414,7 @@ describe("membership page", () => {
     });
     renderWithProviders(<MembershipPage />);
     fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
-    await screen.findByText("We'll update your status here when we receive your payment.");
+    await screen.findByText(HOLDOFF_MSG);
 
     fireEvent.click(screen.getByText("Show the payment button again"));
 
@@ -434,36 +438,8 @@ describe("membership page", () => {
     fireEvent.click(await screen.findByRole("button", { name: /Pay now \(local mock\)/ }));
 
     await waitFor(() => expect(screen.getByText("Payment mocked (local) — updating status.")).toBeInTheDocument());
-    expect(screen.queryByText("We'll update your status here when we receive your payment.")).not.toBeInTheDocument();
+    expect(screen.queryByText(HOLDOFF_MSG)).not.toBeInTheDocument();
     expect(sessionStorage.getItem("membership_awaiting_payment_1")).toBeNull();
-  });
-
-  it("clears the poll interval on unmount", async () => {
-    setSession({ id: 1 });
-    jest.useFakeTimers();
-    try {
-      const fetchMock = mockFetchJson({
-        "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
-        "/api/membership": state({
-          process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" },
-          external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
-        }),
-      });
-      const { unmount } = renderWithProviders(<MembershipPage />);
-      fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
-      await screen.findByText("We'll update your status here when we receive your payment.");
-
-      const callsBeforeUnmount = fetchMock.mock.calls.length;
-      unmount();
-
-      await act(async () => {
-        await jest.advanceTimersByTimeAsync(60_000);
-      });
-
-      expect(fetchMock.mock.calls.length).toBe(callsBeforeUnmount);
-    } finally {
-      jest.useRealTimers();
-    }
   });
 
   // ── PENDING_EXTERNAL_ACTION branches ─────────────────────────────────────────

--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -402,58 +402,6 @@ describe("membership page", () => {
     }
   });
 
-  it("restores the pay button and shows a soft note after the 10-minute holdoff times out", async () => {
-    setSession({ id: 1 });
-    jest.useFakeTimers();
-    try {
-      mockFetchJson({
-        "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
-        "/api/membership": state({
-          process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" },
-          external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
-        }),
-      });
-      renderWithProviders(<MembershipPage />);
-      fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
-      await screen.findByText("We'll update your status here when we receive your payment.");
-
-      await act(async () => {
-        await jest.advanceTimersByTimeAsync(10 * 60 * 1000);
-      });
-
-      expect(await screen.findByRole("link", { name: /Pay here with Shopify/ })).toBeInTheDocument();
-      expect(screen.getByText("We haven't seen your payment yet", { exact: false })).toBeInTheDocument();
-      expect(sessionStorage.getItem("membership_awaiting_payment_1")).toBeNull();
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it("dismissing the soft timeout note hides it", async () => {
-    setSession({ id: 1 });
-    jest.useFakeTimers();
-    try {
-      mockFetchJson({
-        "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
-        "/api/membership": state({ process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" } }),
-      });
-      renderWithProviders(<MembershipPage />);
-      fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
-      await screen.findByText("We'll update your status here when we receive your payment.");
-
-      await act(async () => {
-        await jest.advanceTimersByTimeAsync(10 * 60 * 1000);
-      });
-      const note = await screen.findByText("We haven't seen your payment yet", { exact: false });
-
-      fireEvent.click(note.closest(".mantine-Alert-root")!.querySelector(".mantine-Alert-closeButton")!);
-
-      expect(screen.queryByText("We haven't seen your payment yet", { exact: false })).not.toBeInTheDocument();
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
   it("the 'Show the payment button again' escape hatch restores the pay button without waiting", async () => {
     setSession({ id: 1 });
     mockFetchJson({

--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -4,12 +4,12 @@ jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { notifications } from "@mantine/notifications";
-import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import { renderWithProviders, mockFetchJson, setSession, setCheckinEnv, resetRtl } from "@/test-helpers/rtl";
 import MembershipPage from "../page";
 
-beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
+beforeEach(() => { resetRtl(); sessionStorage.clear(); (notifications.show as jest.Mock).mockClear(); });
 afterEach(() => window.history.pushState({}, "", "/"));
 
 const emptyPrefill = { household: null, primaryParent: null, secondaryParent: null, children: [] };
@@ -351,6 +351,171 @@ describe("membership page", () => {
     renderWithProviders(<MembershipPage />);
 
     expect(await screen.findByText("Preparing your invoice…")).toBeInTheDocument();
+  });
+
+  // ── PENDING_PAYMENT payment holdoff ──────────────────────────────────────────
+  it("clicking the Shopify checkout link shows the holdoff message and persists it to sessionStorage", async () => {
+    setSession({ id: 1 });
+    mockFetchJson({
+      "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
+      "/api/membership": state({
+        process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" },
+        external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
+      }),
+    });
+    renderWithProviders(<MembershipPage />);
+
+    fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
+
+    expect(await screen.findByText("We'll update your status here when we receive your payment.")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Pay here with Shopify/ })).not.toBeInTheDocument();
+    expect(sessionStorage.getItem("membership_awaiting_payment_1")).not.toBeNull();
+  });
+
+  it("clears the holdoff and shows the paid-state card once a poll finds the payment settled", async () => {
+    setSession({ id: 1 });
+    jest.useFakeTimers();
+    try {
+      let status = "PENDING_PAYMENT";
+      mockFetchJson({
+        "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
+        "/api/membership": () => state({
+          process: { id: 1, kind: "INITIAL", status },
+          external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
+        }),
+      });
+      renderWithProviders(<MembershipPage />);
+      fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
+      await screen.findByText("We'll update your status here when we receive your payment.");
+
+      // Simulate the orders/paid webhook settling the payment server-side —
+      // the next poll's load() picks up the new status.
+      status = "PENDING_BG_CLEARANCE";
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(await screen.findByText("Payment received", { exact: false })).toBeInTheDocument();
+      expect(sessionStorage.getItem("membership_awaiting_payment_1")).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("restores the pay button and shows a soft note after the 10-minute holdoff times out", async () => {
+    setSession({ id: 1 });
+    jest.useFakeTimers();
+    try {
+      mockFetchJson({
+        "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
+        "/api/membership": state({
+          process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" },
+          external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
+        }),
+      });
+      renderWithProviders(<MembershipPage />);
+      fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
+      await screen.findByText("We'll update your status here when we receive your payment.");
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(10 * 60 * 1000);
+      });
+
+      expect(await screen.findByRole("link", { name: /Pay here with Shopify/ })).toBeInTheDocument();
+      expect(screen.getByText("We haven't seen your payment yet", { exact: false })).toBeInTheDocument();
+      expect(sessionStorage.getItem("membership_awaiting_payment_1")).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("dismissing the soft timeout note hides it", async () => {
+    setSession({ id: 1 });
+    jest.useFakeTimers();
+    try {
+      mockFetchJson({
+        "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
+        "/api/membership": state({ process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" } }),
+      });
+      renderWithProviders(<MembershipPage />);
+      fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
+      await screen.findByText("We'll update your status here when we receive your payment.");
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(10 * 60 * 1000);
+      });
+      const note = await screen.findByText("We haven't seen your payment yet", { exact: false });
+
+      fireEvent.click(note.closest(".mantine-Alert-root")!.querySelector(".mantine-Alert-closeButton")!);
+
+      expect(screen.queryByText("We haven't seen your payment yet", { exact: false })).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("the 'Show the payment button again' escape hatch restores the pay button without waiting", async () => {
+    setSession({ id: 1 });
+    mockFetchJson({
+      "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
+      "/api/membership": state({ process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" } }),
+    });
+    renderWithProviders(<MembershipPage />);
+    fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
+    await screen.findByText("We'll update your status here when we receive your payment.");
+
+    fireEvent.click(screen.getByText("Show the payment button again"));
+
+    expect(await screen.findByRole("link", { name: /Pay here with Shopify/ })).toBeInTheDocument();
+    expect(sessionStorage.getItem("membership_awaiting_payment_1")).toBeNull();
+  });
+
+  it("never shows the payment holdoff for the local mock payment path", async () => {
+    setSession({ id: 1 });
+    setCheckinEnv("local");
+    mockFetchJson({
+      "/api/membership/payment": { amountCents: 9900, checkoutUrl: null },
+      "/api/dev/shopify/orders-paid": {},
+      "/api/membership": state({
+        process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" },
+        external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
+      }),
+    });
+    renderWithProviders(<MembershipPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Pay now \(local mock\)/ }));
+
+    await waitFor(() => expect(screen.getByText("Payment mocked (local) — updating status.")).toBeInTheDocument());
+    expect(screen.queryByText("We'll update your status here when we receive your payment.")).not.toBeInTheDocument();
+    expect(sessionStorage.getItem("membership_awaiting_payment_1")).toBeNull();
+  });
+
+  it("clears the poll interval on unmount", async () => {
+    setSession({ id: 1 });
+    jest.useFakeTimers();
+    try {
+      const fetchMock = mockFetchJson({
+        "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
+        "/api/membership": state({
+          process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" },
+          external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
+        }),
+      });
+      const { unmount } = renderWithProviders(<MembershipPage />);
+      fireEvent.click(await screen.findByRole("link", { name: /Pay here with Shopify/ }));
+      await screen.findByText("We'll update your status here when we receive your payment.");
+
+      const callsBeforeUnmount = fetchMock.mock.calls.length;
+      unmount();
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(60_000);
+      });
+
+      expect(fetchMock.mock.calls.length).toBe(callsBeforeUnmount);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   // ── PENDING_EXTERNAL_ACTION branches ─────────────────────────────────────────

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import type { OrgMembershipProcessStatus, OrgMembershipStatus } from "@/generated/prisma/client";
 import {
-  Alert, Anchor, Box, Button, Card, Checkbox, Container, Group, Loader,
+  Alert, Anchor, Box, Button, Card, Checkbox, Container, Group,
   SimpleGrid, Stack, Text, Textarea, TextInput, ThemeIcon, Title,
 } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
@@ -24,9 +24,8 @@ import { useIsLocalInstance } from "@/components/EnvProvider";
 import { PageLoader } from "@/components/ui/PageLoader";
 const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
 
-// Payment holdoff (below): how often we poll for a status change after a real
-// Shopify checkout click.
-const AWAITING_PAYMENT_POLL_MS = 10 * 1000;
+// Payment holdoff (below): sessionStorage key for the awaiting-payment record
+// set by a real Shopify checkout click.
 const awaitingPaymentKey = (processId: number) => `membership_awaiting_payment_${processId}`;
 
 interface PersonPrefill {
@@ -157,8 +156,8 @@ export default function MembershipPage() {
   // Serialized form as last loaded/saved; isDirty compares it to current state.
   const [savedForm, setSavedForm] = useState<string | null>(null);
 
-  // Drop the holdoff and its sessionStorage record, if one is set. Shared by the
-  // escape hatch, the implicit status-change clear, and the timeout below.
+  // Drop the holdoff and its sessionStorage record — the "Show the payment
+  // button again" escape hatch for an abandoned checkout.
   const clearAwaitingPayment = useCallback(() => {
     setAwaitingPayment((cur) => {
       if (cur) sessionStorage.removeItem(awaitingPaymentKey(cur.processId));
@@ -293,23 +292,18 @@ export default function MembershipPage() {
     if (sessionStorage.getItem(awaitingPaymentKey(processId))) setAwaitingPayment({ processId });
   }, [state?.process?.id, state?.process?.status]);
 
-  // Implicit clearing: once the process is no longer PENDING_PAYMENT — the
-  // orders/paid webhook settled it, or (possibly, in the future) an s-read
-  // reconciliation did — drop the holdoff and its sessionStorage record.
+  // Implicit clearing, at page-load time: if the process has moved out of
+  // PENDING_PAYMENT — the orders/paid webhook settled it, or (possibly, in the
+  // future) an s-read reconciliation did — drop the holdoff and its
+  // sessionStorage record. Deliberately no background polling or focus
+  // listeners: the dev instance scales to zero, and an idle tab must not keep
+  // it (and the database) awake. The message resolves on the next page load.
   useEffect(() => {
-    if (state?.process?.status === "PENDING_PAYMENT") return;
-    clearAwaitingPayment();
-  }, [state?.process?.status, clearAwaitingPayment]);
-
-  // While awaiting payment, poll the existing load() every ~10s: a status
-  // change re-renders the card out of PENDING_PAYMENT (handled above) — no
-  // separate "clear" path needed for that. Polling runs as long as the message
-  // shows; the escape-hatch link is the way out of an abandoned checkout.
-  useEffect(() => {
-    if (!awaitingPayment) return;
-    const timer = setInterval(load, AWAITING_PAYMENT_POLL_MS);
-    return () => clearInterval(timer);
-  }, [awaitingPayment, load]);
+    const processId = state?.process?.id;
+    if (!processId || state?.process?.status === "PENDING_PAYMENT") return;
+    sessionStorage.removeItem(awaitingPaymentKey(processId));
+    setAwaitingPayment(null);
+  }, [state?.process?.id, state?.process?.status]);
 
   const flash = (msg: string, error = false) => {
     setMessage(msg ? { text: msg, tone: error ? "error" : "success" } : undefined);
@@ -862,10 +856,10 @@ export default function MembershipPage() {
                     </Text>
                     {awaitingPayment ? (
                       <Stack gap="xs" mt="md" align="flex-start">
-                        <Group gap="sm">
-                          <Loader size="sm" />
-                          <Text>We&apos;ll update your status here when we receive your payment.</Text>
-                        </Group>
+                        <Text>
+                          We&apos;ll update your status here when we receive your payment — refresh
+                          this page after you finish checkout.
+                        </Text>
                         <Anchor component="button" type="button" size="sm" c="dimmed" onClick={clearAwaitingPayment}>
                           Show the payment button again
                         </Anchor>

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -24,10 +24,8 @@ import { useIsLocalInstance } from "@/components/EnvProvider";
 import { PageLoader } from "@/components/ui/PageLoader";
 const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
 
-// Payment holdoff (below): how long we wait after a real Shopify checkout click
-// before giving up and restoring the pay button, and how often we poll for a
-// status change in the meantime.
-const AWAITING_PAYMENT_TIMEOUT_MS = 10 * 60 * 1000;
+// Payment holdoff (below): how often we poll for a status change after a real
+// Shopify checkout click.
 const AWAITING_PAYMENT_POLL_MS = 10 * 1000;
 const awaitingPaymentKey = (processId: number) => `membership_awaiting_payment_${processId}`;
 
@@ -147,11 +145,8 @@ export default function MembershipPage() {
   // sessionStorage keyed by process id, so a tab refresh mid-checkout keeps the
   // message. Cleared implicitly whenever a server-side path — the orders/paid
   // webhook today, an s-read reconciliation possibly in the future — moves the
-  // process out of PENDING_PAYMENT, or after a 10-minute timeout.
-  const [awaitingPayment, setAwaitingPayment] = useState<{ processId: number; startedAt: number } | null>(null);
-  // Soft note shown once the holdoff times out with no status change. Distinct
-  // from a payment-received message — a timeout isn't a confirmation.
-  const [paymentTimedOut, setPaymentTimedOut] = useState(false);
+  // process out of PENDING_PAYMENT, or explicitly via the escape-hatch link.
+  const [awaitingPayment, setAwaitingPayment] = useState<{ processId: number } | null>(null);
   // Flips true once the household asks the finance committee for a payment plan.
   const [planRequested, setPlanRequested] = useState(false);
   // Self-attest gate for the background-check task (#875): the confirm checkbox
@@ -291,16 +286,11 @@ export default function MembershipPage() {
     return () => { cancelled = true; };
   }, [state?.process?.status]);
 
-  // Restore an in-flight payment holdoff after a tab refresh mid-Shopify-checkout
-  // — same process, still inside the 10-minute window.
+  // Restore an in-flight payment holdoff after a tab refresh mid-Shopify-checkout.
   useEffect(() => {
     const processId = state?.process?.id;
     if (!processId || state?.process?.status !== "PENDING_PAYMENT") return;
-    const raw = sessionStorage.getItem(awaitingPaymentKey(processId));
-    if (!raw) return;
-    const startedAt = Number(raw);
-    if (Date.now() - startedAt < AWAITING_PAYMENT_TIMEOUT_MS) setAwaitingPayment({ processId, startedAt });
-    else sessionStorage.removeItem(awaitingPaymentKey(processId));
+    if (sessionStorage.getItem(awaitingPaymentKey(processId))) setAwaitingPayment({ processId });
   }, [state?.process?.id, state?.process?.status]);
 
   // Implicit clearing: once the process is no longer PENDING_PAYMENT — the
@@ -309,27 +299,17 @@ export default function MembershipPage() {
   useEffect(() => {
     if (state?.process?.status === "PENDING_PAYMENT") return;
     clearAwaitingPayment();
-    setPaymentTimedOut(false);
   }, [state?.process?.status, clearAwaitingPayment]);
 
   // While awaiting payment, poll the existing load() every ~10s: a status
   // change re-renders the card out of PENDING_PAYMENT (handled above) — no
-  // separate "clear" path needed for that. One interval also carries the
-  // 10-minute deadline check.
+  // separate "clear" path needed for that. Polling runs as long as the message
+  // shows; the escape-hatch link is the way out of an abandoned checkout.
   useEffect(() => {
     if (!awaitingPayment) return;
-    const { startedAt } = awaitingPayment;
-    const timer = setInterval(() => {
-      if (Date.now() - startedAt >= AWAITING_PAYMENT_TIMEOUT_MS) {
-        clearInterval(timer);
-        clearAwaitingPayment();
-        setPaymentTimedOut(true);
-        return;
-      }
-      load();
-    }, AWAITING_PAYMENT_POLL_MS);
+    const timer = setInterval(load, AWAITING_PAYMENT_POLL_MS);
     return () => clearInterval(timer);
-  }, [awaitingPayment, load, clearAwaitingPayment]);
+  }, [awaitingPayment, load]);
 
   const flash = (msg: string, error = false) => {
     setMessage(msg ? { text: msg, tone: error ? "error" : "success" } : undefined);
@@ -346,10 +326,8 @@ export default function MembershipPage() {
   // The local mock below settles synchronously and never needs one.
   const handlePayClick = () => {
     if (!state?.process) return;
-    const startedAt = Date.now();
-    sessionStorage.setItem(awaitingPaymentKey(state.process.id), String(startedAt));
-    setPaymentTimedOut(false);
-    setAwaitingPayment({ processId: state.process.id, startedAt });
+    sessionStorage.setItem(awaitingPaymentKey(state.process.id), "1");
+    setAwaitingPayment({ processId: state.process.id });
   };
 
   // Local dev has no Shopify store, so instead of a checkout redirect we fire the
@@ -902,13 +880,6 @@ export default function MembershipPage() {
                       </Button>
                     ) : (
                       <Text c="yellow" mt="md">The payment link isn&apos;t available yet. Please check back shortly.</Text>
-                    )}
-                    {paymentTimedOut && (
-                      <Alert color="yellow" variant="light" mt="md" withCloseButton onClose={() => setPaymentTimedOut(false)}>
-                        We haven&apos;t seen your payment yet — payments can take a few minutes to
-                        confirm. If you completed checkout, check back shortly; otherwise you can pay
-                        again below.
-                      </Alert>
                     )}
                     {planRequested ? (
                       <Text c="green" mt="md">Scholarship or payment plan requested — the finance committee will follow up.</Text>

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import type { OrgMembershipProcessStatus, OrgMembershipStatus } from "@/generated/prisma/client";
 import {
-  Alert, Anchor, Box, Button, Card, Checkbox, Container, Group,
+  Alert, Anchor, Box, Button, Card, Checkbox, Container, Group, Loader,
   SimpleGrid, Stack, Text, Textarea, TextInput, ThemeIcon, Title,
 } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
@@ -23,6 +23,13 @@ import { useIsLocalInstance } from "@/components/EnvProvider";
 
 import { PageLoader } from "@/components/ui/PageLoader";
 const blankAddress: StructuredAddress = { line1: "", line2: "", city: "", state: "", postalCode: "" };
+
+// Payment holdoff (below): how long we wait after a real Shopify checkout click
+// before giving up and restoring the pay button, and how often we poll for a
+// status change in the meantime.
+const AWAITING_PAYMENT_TIMEOUT_MS = 10 * 60 * 1000;
+const AWAITING_PAYMENT_POLL_MS = 10 * 1000;
+const awaitingPaymentKey = (processId: number) => `membership_awaiting_payment_${processId}`;
 
 interface PersonPrefill {
   id: number;
@@ -135,6 +142,16 @@ export default function MembershipPage() {
   const [children, setChildren] = useState<ChildForm[]>([]);
   const [notes, setNotes] = useState("");
   const [payment, setPayment] = useState<{ amountCents: number; checkoutUrl: string | null } | null>(null);
+  // Set when the applicant clicks the real Shopify checkout link (not the local
+  // mock, which settles synchronously and never needs a holdoff). Persisted to
+  // sessionStorage keyed by process id, so a tab refresh mid-checkout keeps the
+  // message. Cleared implicitly whenever a server-side path — the orders/paid
+  // webhook today, an s-read reconciliation possibly in the future — moves the
+  // process out of PENDING_PAYMENT, or after a 10-minute timeout.
+  const [awaitingPayment, setAwaitingPayment] = useState<{ processId: number; startedAt: number } | null>(null);
+  // Soft note shown once the holdoff times out with no status change. Distinct
+  // from a payment-received message — a timeout isn't a confirmation.
+  const [paymentTimedOut, setPaymentTimedOut] = useState(false);
   // Flips true once the household asks the finance committee for a payment plan.
   const [planRequested, setPlanRequested] = useState(false);
   // Self-attest gate for the background-check task (#875): the confirm checkbox
@@ -144,6 +161,15 @@ export default function MembershipPage() {
   const [bgAttesting, setBgAttesting] = useState(false);
   // Serialized form as last loaded/saved; isDirty compares it to current state.
   const [savedForm, setSavedForm] = useState<string | null>(null);
+
+  // Drop the holdoff and its sessionStorage record, if one is set. Shared by the
+  // escape hatch, the implicit status-change clear, and the timeout below.
+  const clearAwaitingPayment = useCallback(() => {
+    setAwaitingPayment((cur) => {
+      if (cur) sessionStorage.removeItem(awaitingPaymentKey(cur.processId));
+      return null;
+    });
+  }, []);
 
   const hydrate = useCallback((s: IntakeState) => {
     setState(s);
@@ -265,6 +291,46 @@ export default function MembershipPage() {
     return () => { cancelled = true; };
   }, [state?.process?.status]);
 
+  // Restore an in-flight payment holdoff after a tab refresh mid-Shopify-checkout
+  // — same process, still inside the 10-minute window.
+  useEffect(() => {
+    const processId = state?.process?.id;
+    if (!processId || state?.process?.status !== "PENDING_PAYMENT") return;
+    const raw = sessionStorage.getItem(awaitingPaymentKey(processId));
+    if (!raw) return;
+    const startedAt = Number(raw);
+    if (Date.now() - startedAt < AWAITING_PAYMENT_TIMEOUT_MS) setAwaitingPayment({ processId, startedAt });
+    else sessionStorage.removeItem(awaitingPaymentKey(processId));
+  }, [state?.process?.id, state?.process?.status]);
+
+  // Implicit clearing: once the process is no longer PENDING_PAYMENT — the
+  // orders/paid webhook settled it, or (possibly, in the future) an s-read
+  // reconciliation did — drop the holdoff and its sessionStorage record.
+  useEffect(() => {
+    if (state?.process?.status === "PENDING_PAYMENT") return;
+    clearAwaitingPayment();
+    setPaymentTimedOut(false);
+  }, [state?.process?.status, clearAwaitingPayment]);
+
+  // While awaiting payment, poll the existing load() every ~10s: a status
+  // change re-renders the card out of PENDING_PAYMENT (handled above) — no
+  // separate "clear" path needed for that. One interval also carries the
+  // 10-minute deadline check.
+  useEffect(() => {
+    if (!awaitingPayment) return;
+    const { startedAt } = awaitingPayment;
+    const timer = setInterval(() => {
+      if (Date.now() - startedAt >= AWAITING_PAYMENT_TIMEOUT_MS) {
+        clearInterval(timer);
+        clearAwaitingPayment();
+        setPaymentTimedOut(true);
+        return;
+      }
+      load();
+    }, AWAITING_PAYMENT_POLL_MS);
+    return () => clearInterval(timer);
+  }, [awaitingPayment, load, clearAwaitingPayment]);
+
   const flash = (msg: string, error = false) => {
     setMessage(msg ? { text: msg, tone: error ? "error" : "success" } : undefined);
     // Clear stale warnings when starting an action (msg === "") or on a hard
@@ -275,6 +341,16 @@ export default function MembershipPage() {
   // Prefer the API's user-facing error string; fall back to a friendly default.
   const apiError = (data: { error?: string } | null | undefined, fallback: string) =>
     data?.error || fallback;
+
+  // Real Shopify checkout only (opens a new tab) — starts the payment holdoff.
+  // The local mock below settles synchronously and never needs one.
+  const handlePayClick = () => {
+    if (!state?.process) return;
+    const startedAt = Date.now();
+    sessionStorage.setItem(awaitingPaymentKey(state.process.id), String(startedAt));
+    setPaymentTimedOut(false);
+    setAwaitingPayment({ processId: state.process.id, startedAt });
+  };
 
   // Local dev has no Shopify store, so instead of a checkout redirect we fire the
   // mock orders/paid webhook in-app (same endpoint the Debug → Shopify tool uses),
@@ -806,8 +882,18 @@ export default function MembershipPage() {
                     <Text c="dimmed">
                       Your annual household dues are <strong>${(payment.amountCents / 100).toFixed(2)}</strong>.
                     </Text>
-                    {payment.checkoutUrl ? (
-                      <Button component="a" href={payment.checkoutUrl} target="_blank" rel="noopener noreferrer" color="green" mt="md">
+                    {awaitingPayment ? (
+                      <Stack gap="xs" mt="md" align="flex-start">
+                        <Group gap="sm">
+                          <Loader size="sm" />
+                          <Text>We&apos;ll update your status here when we receive your payment.</Text>
+                        </Group>
+                        <Anchor component="button" type="button" size="sm" c="dimmed" onClick={clearAwaitingPayment}>
+                          Show the payment button again
+                        </Anchor>
+                      </Stack>
+                    ) : payment.checkoutUrl ? (
+                      <Button component="a" href={payment.checkoutUrl} target="_blank" rel="noopener noreferrer" color="green" mt="md" onClick={handlePayClick}>
                         Pay here with Shopify →
                       </Button>
                     ) : isLocalInstance ? (
@@ -816,6 +902,13 @@ export default function MembershipPage() {
                       </Button>
                     ) : (
                       <Text c="yellow" mt="md">The payment link isn&apos;t available yet. Please check back shortly.</Text>
+                    )}
+                    {paymentTimedOut && (
+                      <Alert color="yellow" variant="light" mt="md" withCloseButton onClose={() => setPaymentTimedOut(false)}>
+                        We haven&apos;t seen your payment yet — payments can take a few minutes to
+                        confirm. If you completed checkout, check back shortly; otherwise you can pay
+                        again below.
+                      </Alert>
                     )}
                     {planRequested ? (
                       <Text c="green" mt="md">Scholarship or payment plan requested — the finance committee will follow up.</Text>


### PR DESCRIPTION
## Summary

Adds a payment holdoff on the membership page's PENDING_PAYMENT card: after clicking the real Shopify checkout link ("Pay here with Shopify →", not the local mock), the page replaces the pay button with "We'll update your status here when we receive your payment — refresh this page after you finish checkout." plus a subtle "Show the payment button again" escape hatch.

## Clearing conditions

The holdoff clears on:
1. **The Shopify `orders/paid` webhook settling the payment** — handled with **no backend change**, resolved at page-load time: the page's existing mount-time `load()` refetches `/api/membership`; once the webhook has updated the process's status server-side, the next page load renders the card in its real state (e.g. "Payment received 🎉" / background-check-pending) and an effect watching `state.process.status` drops the holdoff's `sessionStorage` record.
2. **Any other server-side path** (e.g. a future s-read reconciliation) — satisfied the same way as (1): the clearing logic only cares that the *status* changed, not which server-side path changed it. Called out in a code comment for when that reconciliation path is built.
3. **The "Show the payment button again" escape hatch** — a subtle link under the message that restores the pay button immediately, covering an abandoned checkout.

## No background polling (scale-to-zero friendly)

Earlier revisions polled `/api/membership` every ~10 s while the message showed; per review, that would keep the scale-to-zero dev instance and its database awake for as long as a tab sat open. Polling is removed entirely — no intervals, no focus/visibility listeners. All checks happen at page load only, so an idle tab generates zero requests. Consequences reflected in the UI: the Loader spinner is gone (nothing is actively watching) and the copy tells the member to refresh after checkout.

(Also removed earlier at the maintainer's direction: the original 10-minute timeout + "we haven't seen your payment yet" note — the escape hatch covers the abandoned-checkout case.)

## Other design notes

- Only the real Shopify anchor (`payment.checkoutUrl`) starts the holdoff. The local-dev mock path (`settleMockPayment`, which settles synchronously via an in-app webhook simulation) is untouched and never shows it.
- The holdoff is persisted to `sessionStorage` keyed by process id, so a tab refresh mid-checkout restores the message instead of flashing the pay button back. The record clears on a page load that finds the status changed, or via the escape hatch.
- The scholarship/payment-plan request section and the background-check status alert stay visible under the holdoff — only the pay-button area is replaced.

## Test coverage

In `checkin-app/src/app/membership/__tests__/page.test.tsx`:
- Clicking the checkout link sets the holdoff message and the `sessionStorage` record.
- A page load (remount) while still pending restores the message from `sessionStorage`; a page load after the payment settled renders the paid-state card and clears the record.
- The "Show the payment button again" escape hatch restores the pay button immediately and clears `sessionStorage`.
- The local mock payment path never shows the holdoff.

Verification run from `checkin-app/`: page suite (120/120), `npx tsc --noEmit` (clean), `npm run lint` (clean, 0 warnings), full `npx jest` (1784/1784 across 213 suites, after merging latest main into the branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe