### PR TITLE
feat(membership-ops): renewal-season "Grant for coming year" button

### DIFF
--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -30,6 +30,7 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
     let boardHouseholdId: number;
     let inactiveHouseholdId: number;
     let activeHouseholdId: number;
+    let comingYearHouseholdId: number;
 
     beforeAll(async () => {
         const leaked = await prisma.person.findMany({
@@ -57,6 +58,12 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         });
         activeHouseholdId = active.householdId;
         await prisma.orgMembership.create({ data: { householdId: activeHouseholdId, status: 'ACTIVE' } });
+
+        // A non-member household for the renewal-season "grant for coming year" override.
+        const comingYear = await prisma.person.create({
+            data: { email: `comingyear-${TAG}@example.com`, name: 'Coming Year', household: { create: { name: "Test HH" } } },
+        });
+        comingYearHouseholdId = comingYear.householdId;
     });
 
     afterAll(async () => {
@@ -64,6 +71,11 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
             where: { email: { contains: TAG } }, select: { id: true, householdId: true },
         });
         await prisma.auditLog.deleteMany({ where: { actorId: { in: ids.map(u => u.id) } } });
+        const memberships = await prisma.orgMembership.findMany({
+            where: { householdId: { in: ids.map(u => u.householdId) } }, select: { id: true },
+        });
+        // Processes FK onto membership with onDelete Restrict — clear them first.
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembershipId: { in: memberships.map(m => m.id) } } });
         await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids.map(u => u.householdId) } } });
         await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
         await prisma.household.deleteMany({ where: { id: { in: ids.map(u => u.householdId) } } });
@@ -100,6 +112,40 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         expect(ok.status).toBe(200);
         const after = await prisma.orgMembership.findUnique({ where: { householdId: boardHouseholdId } });
         expect(after?.status).toBe('ACTIVE');
+    });
+
+    it('grants a non-member for the coming year: ACTIVE + a terminal INITIAL process + audit row', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+        const res = await post({ householdId: comingYearHouseholdId, comingYear: true });
+        expect(res.status).toBe(200);
+
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: comingYearHouseholdId } });
+        expect(membership?.status).toBe('ACTIVE');
+
+        // No prior membership → INITIAL, and the process is completed (ACTIVE) with the
+        // three gates stamped satisfied and the acting admin recorded.
+        const process = await prisma.orgMembershipProcess.findFirst({
+            where: { orgMembershipId: membership!.id }, orderBy: { id: 'desc' },
+        });
+        expect(process?.kind).toBe('INITIAL');
+        expect(process?.status).toBe('ACTIVE');
+        expect(process?.certifiedById).toBe(boardId);
+        expect(process?.paidAt).not.toBeNull();
+        expect(process?.bgClearedAt).not.toBeNull();
+        expect(process?.contractSignedAt).not.toBeNull();
+
+        const audit = await prisma.auditLog.findFirst({
+            where: { actorId: boardId, tableName: 'OrgMembershipProcess', affectedEntityId: process!.id },
+            orderBy: { id: 'desc' },
+        });
+        expect((audit!.newData as { comingYearOverride: boolean }).comingYearOverride).toBe(true);
+    });
+
+    it("refuses coming-year grant for the actor's OWN household (conflict of interest)", async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+        const res = await post({ householdId: boardHouseholdId, comingYear: true });
+        expect(res.status).toBe(403);
     });
 
     it('revokes an active household, sets REVOKED, and writes an audit row', async () => {

--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -31,6 +31,8 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
     let inactiveHouseholdId: number;
     let activeHouseholdId: number;
     let comingYearHouseholdId: number;
+    let midFlowHouseholdId: number;
+    let midFlowProcessId: number;
 
     beforeAll(async () => {
         const leaked = await prisma.person.findMany({
@@ -64,6 +66,17 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
             data: { email: `comingyear-${TAG}@example.com`, name: 'Coming Year', household: { create: { name: "Test HH" } } },
         });
         comingYearHouseholdId = comingYear.householdId;
+
+        // An ACTIVE household mid-flow — a payable PENDING_PAYMENT renewal — that the
+        // coming-year override must supersede (ARCHIVE) rather than leave alongside.
+        const midFlow = await prisma.person.create({
+            data: { email: `midflow-${TAG}@example.com`, name: 'Mid Flow', household: { create: { name: "Test HH" } } },
+        });
+        midFlowHouseholdId = midFlow.householdId;
+        const midMembership = await prisma.orgMembership.create({ data: { householdId: midFlowHouseholdId, status: 'ACTIVE' } });
+        midFlowProcessId = (await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: midMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT' },
+        })).id;
     });
 
     afterAll(async () => {
@@ -140,6 +153,31 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
             orderBy: { id: 'desc' },
         });
         expect((audit!.newData as { comingYearOverride: boolean }).comingYearOverride).toBe(true);
+    });
+
+    it('supersedes an in-flight process (ARCHIVED) when granting for the coming year', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+        const res = await post({ householdId: midFlowHouseholdId, comingYear: true });
+        expect(res.status).toBe(200);
+
+        // The payable PENDING_PAYMENT renewal is disposed, not left alongside the grant.
+        const old = await prisma.orgMembershipProcess.findUnique({ where: { id: midFlowProcessId } });
+        expect(old?.status).toBe('ARCHIVED');
+        const supersedeAudit = await prisma.auditLog.findFirst({
+            where: { actorId: boardId, tableName: 'OrgMembershipProcess', affectedEntityId: midFlowProcessId },
+            orderBy: { id: 'desc' },
+        });
+        expect((supersedeAudit!.newData as { supersededByOverride: boolean }).supersededByOverride).toBe(true);
+
+        // And a fresh terminal ACTIVE RENEWAL is the live process.
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: midFlowHouseholdId } });
+        expect(membership?.status).toBe('ACTIVE');
+        const live = await prisma.orgMembershipProcess.findMany({
+            where: { orgMembershipId: membership!.id, status: 'ACTIVE' },
+        });
+        expect(live).toHaveLength(1);
+        expect(live[0].kind).toBe('RENEWAL');
     });
 
     it("refuses coming-year grant for the actor's OWN household (conflict of interest)", async () => {

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -127,6 +127,27 @@ describe('Membership renewal', () => {
         expect(second).toBeDefined();
     });
 
+    it('does not re-open for a household already renewed this cycle (terminal RENEWAL in-window)', async () => {
+        await setBoundary(new Date(Date.UTC(2000, 7, 1))); // Aug 1
+        const now = new Date(Date.UTC(2026, 6, 1)); // Jul 1 — within the window
+        const m = await makeActiveMembership('Renewed', null, `renewed-lead-${TAG}@example.com`);
+        // A completed renewal this cycle (early finisher, or the admin coming-year
+        // override): terminal ACTIVE RENEWAL with stageEnteredAt inside the window.
+        await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: m.orgMembershipId, kind: 'RENEWAL', status: 'ACTIVE', stageEnteredAt: now },
+        });
+
+        await runRenewalSweep(now);
+
+        // No fresh PENDING_RENEWAL opened — the terminal row counts as handled.
+        const opened = await prisma.orgMembershipProcess.findFirst({
+            where: { orgMembershipId: m.orgMembershipId, status: 'PENDING_RENEWAL' },
+        });
+        expect(opened).toBeNull();
+        const count = await prisma.orgMembershipProcess.count({ where: { orgMembershipId: m.orgMembershipId } });
+        expect(count).toBe(1);
+    });
+
     it('beginRenewal with a valid parent background check: re-sign only — bgClearedAt stamped, signature opens payment', async () => {
         await setBoundary(new Date(Date.UTC(2000, 7, 1)));
         const m = await makeActiveMembership('Fresh', new Date()); // recent background check

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
+import { isRenewalSeason } from "@/lib/membership/renewal";
 
 export const dynamic = 'force-dynamic';
 
@@ -84,7 +85,10 @@ export const GET = withAuth(
                 ...(q && { take: 20 })
             });
 
-            return NextResponse.json({ households: households.map(withFlatContact) });
+            return NextResponse.json({
+                households: households.map(withFlatContact),
+                renewalSeason: await isRenewalSeason(new Date()),
+            });
         } catch (error) {
             logger.error("Failed to fetch households:", error);
             return apiError("Failed to fetch households", 500);
@@ -97,7 +101,7 @@ export const POST = withAuth(
     async (req, auth) => {
         try {
             const body = await req.json();
-            const { householdId, active, deny } = body;
+            const { householdId, active, deny, comingYear } = body;
 
             if (!householdId) {
                 return apiError("Household ID is required", 400);
@@ -145,6 +149,54 @@ export const POST = withAuth(
                 }
 
                 return NextResponse.json({ success: true, membership });
+            }
+
+            // Renewal-season admin override: grant the household for the COMING year in
+            // one click, skipping the sign/pay/background-check flow. Produces the same
+            // end-state a completed renewal would — membership ACTIVE plus a terminal
+            // RENEWAL process (INITIAL for a household with no prior membership) with the
+            // three gates stamped satisfied and the acting admin recorded. The COI guard
+            // matches the grant path: this bypasses payment + BG, so a board member may
+            // not do it for their own household (sysadmin may).
+            if (comingYear) {
+                if (auth.type === 'session' && await hasHouseholdConflict(prisma, auth.user.id, householdId, { isSysadmin: auth.user.isSysadmin === true })) {
+                    return apiError("You cannot grant your own household's membership — a sysadmin must.", 403);
+                }
+                const actorId = auth.type === 'session' ? auth.user.id : null;
+                const now = new Date();
+                const result = await prisma.$transaction(async (tx) => {
+                    const membership = await tx.orgMembership.upsert({
+                        where: { householdId },
+                        create: { householdId, status: "ACTIVE" },
+                        update: { status: "ACTIVE" },
+                    });
+                    const process = await tx.orgMembershipProcess.create({
+                        data: {
+                            orgMembershipId: membership.id,
+                            kind: existingMembership ? "RENEWAL" : "INITIAL",
+                            status: "ACTIVE",
+                            contractSignedAt: now,
+                            bgClearedAt: now,
+                            paidAt: now,
+                            certifiedById: actorId,
+                        },
+                    });
+                    if (actorId !== null) {
+                        await tx.auditLog.create({
+                            data: {
+                                actorId,
+                                action: "CREATE",
+                                tableName: "OrgMembershipProcess",
+                                affectedEntityId: process.id,
+                                secondaryAffectedEntity: householdId,
+                                oldData: { status: existingMembership?.status ?? "NONE" },
+                                newData: { kind: process.kind, status: "ACTIVE", comingYearOverride: true },
+                            },
+                        });
+                    }
+                    return { membership, process };
+                });
+                return NextResponse.json({ success: true, ...result });
             }
 
             if (active) {

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -170,6 +170,38 @@ export const POST = withAuth(
                         create: { householdId, status: "ACTIVE" },
                         update: { status: "ACTIVE" },
                     });
+                    // Supersede any in-flight process so the override doesn't coexist with a
+                    // stale flow: a payable PENDING_PAYMENT that activate() would later settle
+                    // (double process + a charge for an already-granted household), a review
+                    // still sitting in the queue, or the member's /membership page showing the
+                    // old cards. Board disposal = the terminal ARCHIVED status (same as
+                    // archiveApplication); it drops off every live read with one status check.
+                    // Anything already terminal (a prior cycle's ACTIVE, an earlier ARCHIVED)
+                    // is left alone. Archiving the in-flight RENEWAL also clears the
+                    // one-inflight-renewal partial index before the new terminal row is written.
+                    const superseded = await tx.orgMembershipProcess.findMany({
+                        where: { orgMembershipId: membership.id, status: { notIn: ["ACTIVE", "ARCHIVED"] } },
+                        select: { id: true, status: true },
+                    });
+                    for (const p of superseded) {
+                        await tx.orgMembershipProcess.update({
+                            where: { id: p.id },
+                            data: { status: "ARCHIVED", stageEnteredAt: now },
+                        });
+                        if (actorId !== null) {
+                            await tx.auditLog.create({
+                                data: {
+                                    actorId,
+                                    action: "EDIT",
+                                    tableName: "OrgMembershipProcess",
+                                    affectedEntityId: p.id,
+                                    secondaryAffectedEntity: householdId,
+                                    oldData: { status: p.status },
+                                    newData: { status: "ARCHIVED", supersededByOverride: true },
+                                },
+                            });
+                        }
+                    }
                     const process = await tx.orgMembershipProcess.create({
                         data: {
                             orgMembershipId: membership.id,

--- a/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
@@ -126,4 +126,58 @@ describe("membership-ops/households page", () => {
 
     expect(router.push).toHaveBeenCalledWith("/membership-ops/participants/new?householdId=1");
   });
+
+  describe("Grant for coming year (renewal season)", () => {
+    const inSeason = { ...households, renewalSeason: true };
+
+    it("is hidden outside renewal season", async () => {
+      setSession({ id: 1, isSysadmin: true });
+      mockFetchJson({ "/api/membership-ops/households": households }); // no renewalSeason flag
+      renderWithProviders(<AdminHouseholdsPage />);
+      await screen.findByText("The Smiths");
+
+      expect(screen.queryByRole("button", { name: "Grant for coming year" })).not.toBeInTheDocument();
+    });
+
+    it("shows for both an existing member and a non-member in renewal season", async () => {
+      setSession({ id: 1, isSysadmin: true });
+      mockFetchJson({ "/api/membership-ops/households": inSeason });
+      renderWithProviders(<AdminHouseholdsPage />);
+      await screen.findByText("The Smiths");
+
+      // The Smiths (ACTIVE) and The Joneses (non-member) both get the button.
+      expect(screen.getAllByRole("button", { name: "Grant for coming year" })).toHaveLength(2);
+    });
+
+    it("posts comingYear when clicked", async () => {
+      setSession({ id: 1, isSysadmin: true });
+      const fetchMock = mockFetchJson({ "/api/membership-ops/households": inSeason });
+      renderWithProviders(<AdminHouseholdsPage />);
+      await screen.findByText("The Smiths");
+
+      fireEvent.click(screen.getAllByRole("button", { name: "Grant for coming year" })[0]);
+
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith(
+          "/api/membership-ops/households",
+          expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({ householdId: 1, comingYear: true }),
+          }),
+        ),
+      );
+    });
+
+    it("disables it for a board member's OWN household (conflict of interest)", async () => {
+      setSession({ id: 99, isBoardMember: true, householdId: 2 }); // same household as The Joneses (id 2)
+      mockFetchJson({ "/api/membership-ops/households": inSeason });
+      renderWithProviders(<AdminHouseholdsPage />);
+      await screen.findByText("The Joneses");
+
+      // Two buttons: the Smiths' is enabled, the Joneses' (own household) disabled.
+      const buttons = screen.getAllByRole("button", { name: "Grant for coming year" });
+      expect(buttons.some((b) => (b as HTMLButtonElement).disabled)).toBe(true);
+      expect(buttons.some((b) => !(b as HTMLButtonElement).disabled)).toBe(true);
+    });
+  });
 });

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -23,6 +23,7 @@ export default function AdminHouseholdsPage() {
   const router = useRouter();
 
   const [households, setHouseholds] = useState<Household[]>([]);
+  const [renewalSeason, setRenewalSeason] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [editHouseholdId, setEditHouseholdId] = useState<number | null>(null);
@@ -36,6 +37,7 @@ export default function AdminHouseholdsPage() {
       if (res.ok) {
         const data = await res.json();
         setHouseholds(data.households);
+        setRenewalSeason(data.renewalSeason ?? false);
       } else {
         setError("Failed to fetch households.");
       }
@@ -63,6 +65,29 @@ export default function AdminHouseholdsPage() {
         notifications.show({ color: 'green', message: currentActive ? 'Membership revoked.' : 'Membership granted.' });
       } else {
         notifications.show({ color: 'red', message: 'Failed to update membership.', autoClose: false });
+      }
+    } catch {
+      notifications.show({ color: 'red', message: 'Network error.', autoClose: false });
+    }
+  };
+
+  // Renewal-season only: admin override that grants the household for the coming year
+  // in one click (server creates a completed RENEWAL/INITIAL process). Same COI rules
+  // as Grant Membership — the server rejects a board member's own household.
+  const grantForComingYear = async (householdId: number) => {
+    try {
+      const res = await fetch('/api/membership-ops/households', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ householdId, comingYear: true })
+      });
+
+      if (res.ok) {
+        fetchHouseholds();
+        notifications.show({ color: 'green', message: 'Granted for the coming year.' });
+      } else {
+        const data = await res.json().catch(() => ({}));
+        notifications.show({ color: 'red', message: data.error || 'Failed to grant for the coming year.', autoClose: false });
       }
     } catch {
       notifications.show({ color: 'red', message: 'Network error.', autoClose: false });
@@ -163,8 +188,11 @@ export default function AdminHouseholdsPage() {
               // Conflict of interest: a board member may not GRANT their own household
               // membership (bypasses payment + background check). Sysadmin keeps the button.
               // Mirrors the server guard; disabled state is UX only. Revoke stays allowed.
-              const ownGrantBlocked =
-                !hasActiveMembership && me?.isSysadmin !== true && sharesHousehold(me?.householdId, household.id);
+              // A board member may not grant their own household (bypasses payment + BG).
+              // Grant Membership only offers on non-members; the coming-year override applies
+              // to existing members too, so it needs the conflict regardless of current status.
+              const ownHouseholdConflict = me?.isSysadmin !== true && sharesHousehold(me?.householdId, household.id);
+              const ownGrantBlocked = !hasActiveMembership && ownHouseholdConflict;
               const hasBrokenEmail = household.householdMembers?.some((p) => p.emailUndeliverableAt) ?? false;
               // Staff households (@innovationtreehouse.org) aren't program families: block
               // adding participants and granting membership. Revoke stays allowed.
@@ -221,6 +249,7 @@ export default function AdminHouseholdsPage() {
                     )}
                   </Table.Td>
                   <Table.Td>
+                    <Stack gap="xs" align="flex-start">
                     <Group gap="xs" wrap="nowrap">
                       <Button
                         size="xs" fz={15}
@@ -278,6 +307,25 @@ export default function AdminHouseholdsPage() {
                         </>
                       )}
                     </Group>
+                    {renewalSeason && !isDenied && (
+                      <Button
+                        size="xs" fz={15}
+                        variant="light"
+                        color="green"
+                        disabled={ownHouseholdConflict || isStaffHousehold}
+                        title={
+                          isStaffHousehold
+                            ? "Staff households can't be granted membership."
+                            : ownHouseholdConflict
+                              ? "You can't grant your own household's membership — a sysadmin must."
+                              : undefined
+                        }
+                        onClick={() => grantForComingYear(household.id)}
+                      >
+                        Grant for coming year
+                      </Button>
+                    )}
+                    </Stack>
                   </Table.Td>
                 </Table.Tr>
               );

--- a/checkin-app/src/lib/membership/__tests__/renewal.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/renewal.test.ts
@@ -11,7 +11,7 @@
  *     each cycle) and only a still-valid background check with no household
  *     note pre-stamps bgClearedAt.
  */
-import { householdBgIsFresh, beginRenewal, RenewalError } from '@/lib/membership/renewal';
+import { householdBgIsFresh, beginRenewal, isRenewalSeason, RenewalError } from '@/lib/membership/renewal';
 
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
@@ -76,6 +76,28 @@ describe('householdBgIsFresh', () => {
     it('no lead with a fresh-enough background check → not fresh', async () => {
         prisma.person.findFirst.mockResolvedValue(null);
         expect(await householdBgIsFresh(42, boundary, 12)).toBe(false);
+    });
+});
+
+describe('isRenewalSeason', () => {
+    // Boundary month/day = Sep 1; lead window is 2 months → season opens Jul 1.
+    const boundaryConfig = new Date(Date.UTC(2020, 8, 1)); // year is ignored (month/day only)
+
+    it('no boundary configured → not renewal season', async () => {
+        prisma.boardSettings.findUnique.mockResolvedValue({ orgMembershipYearBoundary: null });
+        expect(await isRenewalSeason(new Date(Date.UTC(2026, 7, 15)))).toBe(false);
+    });
+
+    it('inside the 2-month lead window → renewal season', async () => {
+        prisma.boardSettings.findUnique.mockResolvedValue({ orgMembershipYearBoundary: boundaryConfig });
+        // 2026-08-01 is within [2026-07-01, 2026-09-01).
+        expect(await isRenewalSeason(new Date(Date.UTC(2026, 7, 1)))).toBe(true);
+    });
+
+    it('before the lead window opens → not renewal season', async () => {
+        prisma.boardSettings.findUnique.mockResolvedValue({ orgMembershipYearBoundary: boundaryConfig });
+        // 2026-06-30 is one day before the window opens.
+        expect(await isRenewalSeason(new Date(Date.UTC(2026, 5, 30)))).toBe(false);
     });
 });
 

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -62,6 +62,30 @@ function monthsBefore(date: Date, months: number): Date {
 }
 
 /**
+ * From a configured boundary date, the next boundary occurrence and whether `now`
+ * sits inside the renewal lead window before it. Pure; the single source of the
+ * "are we in renewal season" calc shared by runRenewalSweep and isRenewalSeason.
+ */
+export function renewalWindow(configuredBoundary: Date, now: Date): { boundary: Date; inSeason: boolean } {
+    const boundary = nextBoundary(configuredBoundary, now);
+    return { boundary, inSeason: now.getTime() >= monthsBefore(boundary, RENEWAL_LEAD_MONTHS).getTime() };
+}
+
+/**
+ * True when `now` sits inside the renewal lead window before the configured
+ * boundary — the same window runRenewalSweep opens/reminds on. No boundary set
+ * ⇒ not renewal season. Drives the admin "Grant for coming year" button.
+ */
+export async function isRenewalSeason(now: Date): Promise<boolean> {
+    const settings = await prisma.boardSettings.findUnique({
+        where: { id: 1 },
+        select: { orgMembershipYearBoundary: true },
+    });
+    if (!settings?.orgMembershipYearBoundary) return false;
+    return renewalWindow(settings.orgMembershipYearBoundary, now).inSeason;
+}
+
+/**
  * Open renewal processes for every ACTIVE membership due within the lead window,
  * unless one was already opened this cycle. Returns a summary.
  */
@@ -71,9 +95,8 @@ export async function runRenewalSweep(now: Date) {
         return { opened: 0, skipped: 0, reason: "no membership-year boundary configured" };
     }
 
-    const boundary = nextBoundary(settings.orgMembershipYearBoundary, now);
-    const windowStart = monthsBefore(boundary, RENEWAL_LEAD_MONTHS);
-    if (now.getTime() < windowStart.getTime()) {
+    const { boundary, inSeason } = renewalWindow(settings.orgMembershipYearBoundary, now);
+    if (!inSeason) {
         return { opened: 0, skipped: 0, reason: "not yet within renewal window" };
     }
 

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -66,9 +66,10 @@ function monthsBefore(date: Date, months: number): Date {
  * sits inside the renewal lead window before it. Pure; the single source of the
  * "are we in renewal season" calc shared by runRenewalSweep and isRenewalSeason.
  */
-export function renewalWindow(configuredBoundary: Date, now: Date): { boundary: Date; inSeason: boolean } {
+export function renewalWindow(configuredBoundary: Date, now: Date): { boundary: Date; windowStart: Date; inSeason: boolean } {
     const boundary = nextBoundary(configuredBoundary, now);
-    return { boundary, inSeason: now.getTime() >= monthsBefore(boundary, RENEWAL_LEAD_MONTHS).getTime() };
+    const windowStart = monthsBefore(boundary, RENEWAL_LEAD_MONTHS);
+    return { boundary, windowStart, inSeason: now.getTime() >= windowStart.getTime() };
 }
 
 /**
@@ -95,16 +96,32 @@ export async function runRenewalSweep(now: Date) {
         return { opened: 0, skipped: 0, reason: "no membership-year boundary configured" };
     }
 
-    const { boundary, inSeason } = renewalWindow(settings.orgMembershipYearBoundary, now);
+    const { boundary, windowStart, inSeason } = renewalWindow(settings.orgMembershipYearBoundary, now);
     if (!inSeason) {
         return { opened: 0, skipped: 0, reason: "not yet within renewal window" };
     }
 
     const memberships = await prisma.orgMembership.findMany({
         where: { status: "ACTIVE" },
-        // "Already open" = an in-flight RENEWAL by status (matches the partial unique
-        // index + openRenewalsForAllActive), not the leakier createdAt window.
-        select: { id: true, householdId: true, processes: { where: { kind: "RENEWAL", status: { in: [...IN_FLIGHT_RENEWAL_STATUSES] } }, select: { id: true } } },
+        // "Handled this cycle" = an in-flight RENEWAL by status (matches the partial
+        // unique index + openRenewalsForAllActive), OR a RENEWAL already resolved this
+        // cycle — a member who finished renewal early, or the admin "Grant for coming
+        // year" override, both leave a terminal (ACTIVE/ARCHIVED) RENEWAL with
+        // stageEnteredAt in this window. Without the second clause a completed renewal
+        // gets re-opened + re-reminded, since terminal rows aren't in-flight.
+        select: {
+            id: true, householdId: true,
+            processes: {
+                where: {
+                    kind: "RENEWAL",
+                    OR: [
+                        { status: { in: [...IN_FLIGHT_RENEWAL_STATUSES] } },
+                        { status: { in: ["ACTIVE", "ARCHIVED"] }, stageEnteredAt: { gte: windowStart } },
+                    ],
+                },
+                select: { id: true },
+            },
+        },
     });
 
     let opened = 0;


### PR DESCRIPTION
## What

Adds a **Grant for coming year** action to the households board ([membership-ops/households](checkin-app/src/app/membership-ops/households/page.tsx)), shown only during renewal season, in the same button column below grant/revoke. Works for both existing members and non-members.

It is an **admin override**: one click sets the household's membership `ACTIVE` and creates a *completed* `RENEWAL` process (or `INITIAL`, for a household with no prior membership) — the same end-state a member's finished renewal produces — skipping the sign / pay / background-check flow. The acting admin is recorded (`certifiedById` + audit row with `comingYearOverride: true`).

## Why

Grant/revoke cover the normal case, but during renewal season the board needs a way to renew a household for the coming year (or bring a new family on for it) without walking the full external flow.

## How it works

- **"Renewal season" is derived server-side** from the existing `BoardSettings.orgMembershipYearBoundary` + 2-month lead window — the same window the renewal cron/reminders use. Returned as a `renewalSeason` flag on `GET /api/membership-ops/households`; the button only renders in season.
- The window calc was **duplicated** in `runRenewalSweep`; extracted a pure `renewalWindow()` helper that both it and the new `isRenewalSeason()` share.
- **Conflict-of-interest guard matches Grant**: a board member cannot grant their own household (bypasses payment + BG); a sysadmin can. Enforced server-side, disabled in UI.

## Notes for reviewers

- **No schema change / no migration.** `OrgMembership` has no year field, so "renewed for the coming year" is expressed purely through the process record (membership ACTIVE + terminal process). The three gate timestamps (`contractSignedAt`/`bgClearedAt`/`paidAt`) are stamped to mirror a normally-completed process; the audit row flags it as an override so the truth is preserved.
- The override creates a terminal (`ACTIVE`) renewal process, so the cron sweep could still open a fresh `PENDING_RENEWAL` later in the same window — but that is **identical to how an early manual renewal behaves today**, not a new bug. Flagged in case re-nagging is worth fixing in the sweep separately.
- Staff-household block on the button stays UI-only, matching today's Grant path.

## Tests

- Unit: `isRenewalSeason` window boundaries; button show/hide by season, both household kinds, COI disable.
- Integration: the override write (ACTIVE + terminal `INITIAL` process + audit row) and the own-household refusal. Ran green against a throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)