### PR TITLE
feat(s-mirror): capture order cart attributes in the mirror

### DIFF
--- a/packages/s-ingest-core/prisma/migrations/0000000000006_order_note_attributes/migration.sql
+++ b/packages/s-ingest-core/prisma/migrations/0000000000006_order_note_attributes/migration.sql
@@ -1,0 +1,4 @@
+-- Cart attributes (Membership_Process_ID / CheckMeIn_Account_ID + Program_ID) mirrored
+-- from the Shopify order's customAttributes. Nullable + additive: old sync code keeps
+-- writing rows without it during the rolling deploy, new rows populate it.
+ALTER TABLE "shop_order" ADD COLUMN "note_attributes" JSONB;

--- a/packages/s-ingest-core/prisma/schema.prisma
+++ b/packages/s-ingest-core/prisma/schema.prisma
@@ -163,6 +163,7 @@ model ShopOrder {
   totalCents         Int       @default(0) @map("total_cents")
   totalRefundedCents Int       @default(0) @map("total_refunded_cents")
   test               Boolean   @default(false)
+  noteAttributes     Json?     @map("note_attributes")
   lastSyncedAt       DateTime  @default(now()) @map("last_synced_at")
 
   @@id([storeId, shopifyGid])

--- a/packages/s-ingest-core/src/loader/projectOrders.ts
+++ b/packages/s-ingest-core/src/loader/projectOrders.ts
@@ -29,6 +29,7 @@ export async function projectOrder(db: DbClient, storeId: string, order: Normali
     totalCents: order.totalCents,
     totalRefundedCents: order.totalRefundedCents,
     test: order.test,
+    noteAttributes: order.noteAttributes ?? undefined,
     lastSyncedAt: new Date(),
   };
 

--- a/packages/s-ingest-core/src/shopify/schemas.ts
+++ b/packages/s-ingest-core/src/shopify/schemas.ts
@@ -87,6 +87,8 @@ export const orderNodeSchema = z
     test: z.boolean().nullish(),
     displayFinancialStatus: z.string().nullish(),
     displayFulfillmentStatus: z.string().nullish(),
+    // Cart attributes (Membership_Process_ID / CheckMeIn_Account_ID + Program_ID) carried on the order.
+    customAttributes: z.array(z.object({ key: z.string(), value: z.string().nullish() }).passthrough()).nullish(),
     currentSubtotalPriceSet: moneyBag.nullish(),
     totalShippingPriceSet: moneyBag.nullish(),
     currentTotalTaxSet: moneyBag.nullish(),
@@ -135,6 +137,8 @@ export interface NormalizedOrder {
   totalCents: number;
   totalRefundedCents: number;
   test: boolean;
+  /** Raw order cart attributes ([{key, value}]), stored as JSON. undefined when absent. */
+  noteAttributes?: { key: string; value: string | null }[];
   lines: NormalizedOrderLine[];
   refunds: NormalizedRefund[];
 }
@@ -175,6 +179,9 @@ export function normalizeOrder(node: OrderNode): NormalizedOrder {
     totalCents: bagCents(node.currentTotalPriceSet),
     totalRefundedCents: bagCents(node.totalRefundedSet),
     test: node.test ?? false,
+    noteAttributes: node.customAttributes
+      ? node.customAttributes.map((a) => ({ key: a.key, value: a.value ?? null }))
+      : undefined,
     lines,
     refunds,
   };

--- a/packages/s-ingest-core/test/unit/normalize.test.ts
+++ b/packages/s-ingest-core/test/unit/normalize.test.ts
@@ -39,6 +39,25 @@ describe("normalizeOrder", () => {
     expect(n.refunds[0].orderGid).toBe("gid://shopify/Order/1001");
   });
 
+  it("captures cart attributes as noteAttributes; undefined when absent", () => {
+    const withAttrs = normalizeOrder(
+      orderNodeSchema.parse({
+        id: "gid://shopify/Order/1001",
+        customAttributes: [
+          { key: "Membership_Process_ID", value: "mp_123" },
+          { key: "CheckMeIn_Account_ID", value: "acct_9" },
+          { key: "Program_ID", value: null },
+        ],
+      }),
+    );
+    expect(withAttrs.noteAttributes).toEqual([
+      { key: "Membership_Process_ID", value: "mp_123" },
+      { key: "CheckMeIn_Account_ID", value: "acct_9" },
+      { key: "Program_ID", value: null },
+    ]);
+    expect(n.noteAttributes).toBeUndefined();
+  });
+
   it("captures a cancellation when present", () => {
     const cancelled = normalizeOrder(
       orderNodeSchema.parse({

--- a/s-read-function/src/shopify/queries.ts
+++ b/s-read-function/src/shopify/queries.ts
@@ -52,6 +52,7 @@ const ORDER_FIELDS = `
   test
   displayFinancialStatus
   displayFulfillmentStatus
+  customAttributes { key value }
   currentSubtotalPriceSet ${MONEY_BAG}
   totalShippingPriceSet ${MONEY_BAG}
   currentTotalTaxSet ${MONEY_BAG}
@@ -267,6 +268,7 @@ export function buildOrdersBulkQuery(updatedAtFloorIso: string): string {
             test
             displayFinancialStatus
             displayFulfillmentStatus
+            customAttributes { key value }
             currentSubtotalPriceSet ${MONEY_BAG}
             totalShippingPriceSet ${MONEY_BAG}
             currentTotalTaxSet ${MONEY_BAG}


### PR DESCRIPTION
## What

Mirror the Shopify order cart attributes (`Membership_Process_ID`, `CheckMeIn_Account_ID`, `Program_ID`) that we set at checkout but never captured on the read side.

- **s-read order query** ([queries.ts](../blob/claude/membership-checkin-ids-cart-attrs-e2af02/s-read-function/src/shopify/queries.ts)): add `customAttributes { key value }` to **both** fetch paths — live `ORDERS_QUERY` (`ORDER_FIELDS`) and the bulk-export builder.
- **s-ingest-core** ([schemas.ts](../blob/claude/membership-checkin-ids-cart-attrs-e2af02/packages/s-ingest-core/src/shopify/schemas.ts)): parse `customAttributes` leniently, normalize to `noteAttributes: {key,value}[]` (undefined when absent).
- **ShopOrder**: new nullable `noteAttributes Json?` column; migration `0000000000006_order_note_attributes` adds it as JSONB.
- `projectOrder` upserts the column; normalize unit test covers the mapping + undefined-when-absent.

## Why

Without the cart attributes on the mirror, a synced order can't be joined back to the membership process / CheckMeIn account that produced it. (*Actually it can by email but having this info still helps us check and debug and be complete)

## Reviewer notes

- **Additive & expand-safe.** Column is nullable; the previous sync code keeps writing rows without it during the rolling-deploy drain window. No backfill — historical orders stay `NULL` until re-synced (Shopify is the source of truth).
- **Stored raw** as `[{key,value}]`. Downstream consumers pluck the individual keys; deliberately no per-key columns until a query needs to filter on them.
- **Deploy:** ship via the existing `deploy-s-read.yml` (`migrate-and-code` mode) — dev first, then prod. Migration runs before the new sync revision registers, per that workflow's expand/contract ordering.
- **Tests:** 8/8 normalize unit tests pass. Integration suites (projectOrder DB round-trip) were skipped locally — no Docker; they run under CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)