### PR TITLE
fix(db): codify pool idle-reaping — the scale-to-zero invariant, written down

### DIFF
--- a/checkin-app/src/lib/prisma.ts
+++ b/checkin-app/src/lib/prisma.ts
@@ -32,6 +32,15 @@ const pool = new Pool({
     // whether an EARLIER orphaned one is still silently holding a lock).
     keepAlive: true,
     keepAliveInitialDelayMillis: 10_000,
+    // Scale-to-zero invariant: idle connections MUST be reaped (and `min` must
+    // stay 0) or this pool alone keeps the shared Aurora cluster from ever
+    // auto-pausing — the cluster pauses only after ~5 minutes with zero
+    // connections and zero queries. These are pg-pool's defaults, written out
+    // so a future tuning pass can't silently pin the database awake; if you
+    // need warm connections, wake latency is already handled by the
+    // aurora-resume-retry extension below, not by holding sockets open.
+    idleTimeoutMillis: 10_000,
+    min: 0,
     // Server-side backstops for tests (#688 → #701's other half): #701 put
     // statement/idle-in-transaction timeouts into deploy/docker-compose.yml's
     // Postgres, but CI's `services:` container and the per-worker integration

--- a/checkin-app/src/lib/prisma.ts
+++ b/checkin-app/src/lib/prisma.ts
@@ -35,11 +35,12 @@ const pool = new Pool({
     // Scale-to-zero invariant: idle connections MUST be reaped (and `min` must
     // stay 0) or this pool alone keeps the shared Aurora cluster from ever
     // auto-pausing — the cluster pauses only after ~5 minutes with zero
-    // connections and zero queries. These are pg-pool's defaults, written out
-    // so a future tuning pass can't silently pin the database awake; if you
-    // need warm connections, wake latency is already handled by the
+    // connections and zero queries. One minute (vs pg-pool's 10s default)
+    // keeps a connection warm across a user's click-to-click gaps without
+    // meaningfully delaying the pause window; if you need longer-lived warm
+    // connections, wake latency is already handled by the
     // aurora-resume-retry extension below, not by holding sockets open.
-    idleTimeoutMillis: 10_000,
+    idleTimeoutMillis: 60_000,
     min: 0,
     // Server-side backstops for tests (#688 → #701's other half): #701 put
     // statement/idle-in-transaction timeouts into deploy/docker-compose.yml's


### PR DESCRIPTION
From a scale-to-zero review of database connection behavior (paired with [infra#129](https://github.com/innovationtreehouse/infra/pull/129)):

The app already closes idle connections — but only via pg-pool **defaults** (`idleTimeoutMillis` 10s, `min` 0). Since the shared Aurora cluster's min-capacity-0 auto-pause engages only after ~5 minutes of zero connections *and* zero queries, one innocent tuning change (`min: 2`, or `idleTimeoutMillis: 0`) would silently pin the database awake around the clock. This writes the two values out explicitly with the invariant documented in place, and points warm-latency concerns at the existing aurora-resume-retry extension instead of held sockets.

Behavior change: idle reaping is set to one minute (vs the 10s pg-pool default) — warm across click-to-click gaps, still far inside the ~5-minute pause window. Review findings that needed no checkin change: `/api/health` is DB-free (infra#129 points the ALB probe at it), sessions are JWT, no server-side timers touch Prisma, and #1027 already removed the last client-side poller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe
