### PR TITLE
feat(finance): reconcile Shopify payments against membership/program truth

### DIFF
--- a/checkin-app/prisma/migrations/20260716120000_payment_reconciliation/migration.sql
+++ b/checkin-app/prisma/migrations/20260716120000_payment_reconciliation/migration.sql
@@ -1,0 +1,44 @@
+-- Shopify payment reconciliation (lib/finance/reconcile.ts). Additive only:
+-- new enums, a new PaymentException triage table, a reconciler high-water cursor
+-- on BoardSettings, and a Shopify order-id on ProgramParticipant so a later
+-- refund/chargeback/cancel can be joined back to an activated enrollment.
+
+-- Enums
+CREATE TYPE "PaymentExceptionKind" AS ENUM (
+  'PAID_WHILE_BLOCKED',
+  'NO_ITEM',
+  'UNMATCHED_ORDER',
+  'REFUND',
+  'CHARGEBACK',
+  'CANCELLED',
+  'REVERSED_BEFORE_ACTIVATION',
+  'AMOUNT_MISMATCH',
+  'ACTIVE_WITHOUT_PAYMENT'
+);
+CREATE TYPE "PaymentExceptionSeverity" AS ENUM ('WARN', 'CRITICAL');
+CREATE TYPE "PaymentExceptionStatus" AS ENUM ('OPEN', 'ACKNOWLEDGED', 'RESOLVED');
+
+-- New nullable columns (additive, no backfill needed)
+ALTER TABLE "BoardSettings" ADD COLUMN "shopifyReconcileCursorAt" TIMESTAMP(3);
+ALTER TABLE "ProgramParticipant" ADD COLUMN "shopifyOrderId" TEXT;
+
+-- Triage table
+CREATE TABLE "PaymentException" (
+  "id"             SERIAL NOT NULL,
+  "kind"           "PaymentExceptionKind" NOT NULL,
+  "severity"       "PaymentExceptionSeverity" NOT NULL DEFAULT 'WARN',
+  "status"         "PaymentExceptionStatus" NOT NULL DEFAULT 'OPEN',
+  "shopifyOrderId" TEXT,
+  "processId"      INTEGER,
+  "programId"      INTEGER,
+  "personId"       INTEGER,
+  "resolvedById"   INTEGER,
+  "resolvedAt"     TIMESTAMP(3),
+  "resolutionNote" TEXT,
+  "detectedAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PaymentException_pkey" PRIMARY KEY ("id")
+);
+
+-- One row per (kind, order) so the hourly reconciler upserts instead of duplicating.
+CREATE UNIQUE INDEX "PaymentException_kind_shopifyOrderId_key" ON "PaymentException"("kind", "shopifyOrderId");
+CREATE INDEX "PaymentException_status_severity_idx" ON "PaymentException"("status", "severity");

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -499,6 +499,11 @@ model BoardSettings {
   shopifyVolunteerVariantId  String?
   /// @sensitivity:internal
   shopifyPriceSyncedAt       DateTime?
+  /// High-water mark for the hourly Shopify reconciler (lib/finance/reconcile.ts):
+  /// the mirror `updatedAt` of the newest order it has already processed. Only
+  /// orders changed after this are re-scanned each run. Null = scan from the start.
+  /// @sensitivity:internal
+  shopifyReconcileCursorAt   DateTime?
   /// Grace period (days) a denied scholarship applicant keeps their held seat
   /// before the grace-period expiry cron auto-withdraws them and releases it.
   /// NULL = the expiry feature is OFF (a denied hold is only ever released by
@@ -815,6 +820,11 @@ model ProgramParticipant {
   /// BoardSettings.scholarshipDenialGraceDays.
   /// @sensitivity:personal
   paymentPlanDeniedAt  DateTime?
+  /// Shopify order id (numeric, from the orders/paid webhook) this enrollment was
+  /// activated by. Stored so the reconciler can join a later refund/chargeback/cancel
+  /// on that order back to the enrollment (mirror shop_order.legacyId ↔ this).
+  /// @sensitivity:internal
+  shopifyOrderId       String?
 
   program Program     @relation(fields: [programId], references: [id])
   person  Person @relation(fields: [personId], references: [id])
@@ -1109,4 +1119,72 @@ model DevSentEmail {
   createdAt DateTime @default(now())
 
   @@index([createdAt])
+}
+
+// ── Payment reconciliation ───────────────────────────────────────────────────
+// The hourly reconciler (lib/finance/reconcile.ts) reads the s-read `shopify_read`
+// mirror and reconciles Shopify order truth against membership/program truth.
+// Clean recoveries (a missed orders/paid webhook) advance the family and are
+// recorded to AuditLog only. Everything a human must decide — refunds, chargebacks,
+// cancellations, unattributable payments — becomes a PaymentException row: a thin
+// TRIAGE record, deliberately NOT a copy of the mirror (amounts/status are re-read
+// live from shopify_read by shopifyOrderId at view time).
+
+enum PaymentExceptionKind {
+  PAID_WHILE_BLOCKED
+  NO_ITEM
+  UNMATCHED_ORDER
+  REFUND
+  CHARGEBACK
+  CANCELLED
+  REVERSED_BEFORE_ACTIVATION
+  AMOUNT_MISMATCH
+  ACTIVE_WITHOUT_PAYMENT
+}
+
+enum PaymentExceptionSeverity {
+  WARN
+  CRITICAL
+}
+
+enum PaymentExceptionStatus {
+  OPEN
+  ACKNOWLEDGED
+  RESOLVED
+}
+
+model PaymentException {
+  /// @sensitivity:public
+  id                   Int                      @id @default(autoincrement())
+  /// @sensitivity:internal
+  kind                 PaymentExceptionKind
+  /// @sensitivity:internal
+  severity             PaymentExceptionSeverity @default(WARN)
+  /// @sensitivity:internal
+  status               PaymentExceptionStatus   @default(OPEN)
+  /// Numeric Shopify order id (mirror shop_order.legacyId) — the pointer back INTO
+  /// the mirror. The dashboard re-reads live amounts/financialStatus from here.
+  /// @sensitivity:internal
+  shopifyOrderId       String?
+  /// The membership process this problem is about, when matched.
+  /// @sensitivity:internal
+  processId            Int?
+  /// The program enrollment this problem is about, when matched (composite key).
+  /// @sensitivity:internal
+  programId            Int?
+  /// @sensitivity:internal
+  personId             Int?
+  /// @sensitivity:internal
+  resolvedById         Int?
+  /// @sensitivity:internal
+  resolvedAt           DateTime?
+  /// @sensitivity:personal
+  resolutionNote       String?
+  /// @sensitivity:internal
+  detectedAt           DateTime                 @default(now())
+
+  // Idempotent re-detection: one open row per (kind, order) across hourly runs —
+  // the reconciler upserts on this key instead of duplicating every hour.
+  @@unique([kind, shopifyOrderId])
+  @@index([status, severity])
 }

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -499,7 +499,7 @@ model BoardSettings {
   shopifyVolunteerVariantId  String?
   /// @sensitivity:internal
   shopifyPriceSyncedAt       DateTime?
-  /// High-water mark for the hourly Shopify reconciler (lib/finance/reconcile.ts):
+  /// High-water mark for the daily Shopify reconciler (lib/finance/reconcile.ts):
   /// the mirror `updatedAt` of the newest order it has already processed. Only
   /// orders changed after this are re-scanned each run. Null = scan from the start.
   /// @sensitivity:internal
@@ -1122,7 +1122,7 @@ model DevSentEmail {
 }
 
 // ── Payment reconciliation ───────────────────────────────────────────────────
-// The hourly reconciler (lib/finance/reconcile.ts) reads the s-read `shopify_read`
+// The daily reconciler (lib/finance/reconcile.ts) reads the s-read `shopify_read`
 // mirror and reconciles Shopify order truth against membership/program truth.
 // Clean recoveries (a missed orders/paid webhook) advance the family and are
 // recorded to AuditLog only. Everything a human must decide — refunds, chargebacks,
@@ -1183,8 +1183,8 @@ model PaymentException {
   /// @sensitivity:internal
   detectedAt           DateTime                 @default(now())
 
-  // Idempotent re-detection: one open row per (kind, order) across hourly runs —
-  // the reconciler upserts on this key instead of duplicating every hour.
+  // Idempotent re-detection: one open row per (kind, order) across daily runs —
+  // the reconciler upserts on this key instead of duplicating each run.
   @@unique([kind, shopifyOrderId])
   @@index([status, severity])
 }

--- a/checkin-app/scripts/register-shopify-reversal-webhooks.ts
+++ b/checkin-app/scripts/register-shopify-reversal-webhooks.ts
@@ -1,0 +1,104 @@
+/**
+ * Register the Shopify REVERSAL webhook subscriptions (the fast-path complement to
+ * the hourly reconciler): refunds/create, orders/cancelled, disputes/create,
+ * disputes/update — all pointing at /api/webhooks/shopify/reversals. Deliberately a
+ * separate, simpler script than register-shopify-webhook.ts (which owns the single
+ * orders/paid subscription with careful stale-duplicate handling): these topics are
+ * a latency optimization over the reconciler backstop, so create-if-absent per topic
+ * is enough.
+ *
+ *   npx tsx scripts/register-shopify-reversal-webhooks.ts --url https://<host>/api/webhooks/shopify/reversals [--commit]
+ *
+ * Without --commit it prints the plan and changes nothing (dry run). SHOPIFY_* creds
+ * must be set, and SHOPIFY_WEBHOOK_SECRET must match the store's signing secret or
+ * every delivery 401s.
+ *
+ * ponytail: no update/dedup pass — if a topic already points elsewhere it's left
+ * alone and reported; fix duplicates in the store admin. Upgrade to the full
+ * decision logic (see register-shopify-webhook.ts) only if that becomes a problem.
+ */
+import * as dotenv from "dotenv";
+import { getAccessToken, shopifyFetch, SHOPIFY_API_VERSION } from "../src/lib/shopify";
+import { config } from "../src/lib/config";
+
+dotenv.config();
+
+const TOPICS = ["refunds/create", "orders/cancelled", "disputes/create", "disputes/update"];
+const EXPECTED_PATH = "/api/webhooks/shopify/reversals";
+
+interface Webhook {
+    id: number;
+    topic: string;
+    address: string;
+}
+
+async function main() {
+    const url = process.argv.find((a, i) => process.argv[i - 1] === "--url");
+    const commit = process.argv.includes("--commit");
+    if (!url) throw new Error(`--url https://<host>${EXPECTED_PATH} is required.`);
+    if (!url.endsWith(EXPECTED_PATH)) {
+        console.warn(`Warning: --url does not end with ${EXPECTED_PATH}; deliveries won't reach the reversal handler.`);
+    }
+
+    const accessToken = await getAccessToken();
+    if (!accessToken) {
+        console.error("Shopify not configured (missing SHOPIFY_STORE_DOMAIN, SHOPIFY_CLIENT_ID, or SHOPIFY_CLIENT_SECRET) — nothing to register.");
+        process.exit(1);
+    }
+    const storeDomain = config.shopifyStoreDomain()!;
+    const apiBase = `https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}`;
+    const authHeader = { "X-Shopify-Access-Token": accessToken };
+
+    console.log(
+        "NOTE: Shopify signs API-created subscriptions with the app's client secret (SHOPIFY_CLIENT_SECRET),\n" +
+        "not the store's Notifications signing secret — SHOPIFY_WEBHOOK_SECRET must match or deliveries 401.\n",
+    );
+
+    for (const topic of TOPICS) {
+        const listRes = await shopifyFetch(
+            `${apiBase}/webhooks.json?topic=${encodeURIComponent(topic)}&limit=250`,
+            { headers: authHeader },
+            `Shopify list ${topic}`,
+        );
+        if (!listRes.ok) {
+            console.error(`Shopify API error listing ${topic}: ${listRes.status} ${await listRes.text()}`);
+            process.exit(1);
+        }
+        const existing: Webhook[] = (await listRes.json())?.webhooks ?? [];
+        const match = existing.find((w) => w.address === url);
+        if (match) {
+            console.log(`No change: ${topic} → ${url} (id ${match.id})`);
+            continue;
+        }
+        const others = existing.filter((w) => w.address !== url);
+        if (others.length) {
+            console.warn(`Note: ${topic} has ${others.length} other subscription(s) pointing elsewhere (id(s) ${others.map((w) => w.id).join(", ")}) — left as-is.`);
+        }
+        if (!commit) {
+            console.log(`Will CREATE ${topic} → ${url}`);
+            continue;
+        }
+        const res = await shopifyFetch(
+            `${apiBase}/webhooks.json`,
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json", ...authHeader },
+                body: JSON.stringify({ webhook: { topic, address: url, format: "json" } }),
+            },
+            `Shopify create ${topic}`,
+        );
+        if (!res.ok) {
+            console.error(`Shopify API error creating ${topic}: ${res.status} ${await res.text()}`);
+            process.exit(1);
+        }
+        const w: Webhook | undefined = (await res.json().catch(() => null))?.webhook;
+        console.log(`✅ Created ${topic}${w ? `: id=${w.id}` : ` (HTTP ${res.status})`}`);
+    }
+
+    if (!commit) console.log("\nDry run — re-run with --commit to apply.");
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -66,6 +66,8 @@ const AUTHZ_TESTED = new Set<string>([
     'facility/badges',
     'facility/trends',
     'facility/visits',
+    'finance-ops/payments',
+    'finance-ops/payments/[id]',
     'kioskdisplay/certifications',
     'membership-audit/compliance',
     // POST deny-path (403 non-board) in personBgManualSubmit.integration.test.ts.

--- a/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
@@ -31,6 +31,8 @@ import { GET as TRENDS_GET } from '@/app/api/facility/trends/route';
 import { GET as ADMIN_TA_GET } from '@/app/api/safety/trusted-adults/route';
 import { POST as TA_OVERRIDE_POST } from '@/app/api/safety/trusted-adults/override/route';
 import { PATCH as SHOP_TOOL_PATCH } from '@/app/api/shop/tools/[id]/route';
+import { GET as FIN_PAYMENTS_GET } from '@/app/api/finance-ops/payments/route';
+import { PATCH as FIN_PAYMENTS_PATCH } from '@/app/api/finance-ops/payments/[id]/route';
 import { GET as EVENT_GET, PATCH as EVENT_PATCH } from '@/app/api/events/[id]/route';
 import { GET as EVENTS_LIST_GET } from '@/app/api/events/route';
 import { POST as PROGRAMS_POST } from '@/app/api/programs/route';
@@ -177,6 +179,10 @@ describe('Protected-route role rejection', () => {
         { name: 'GET /api/admin/settings/localization', invoke: () => LOCALIZATION_GET(nreq('http://localhost/api/admin/settings/localization')) },
         { name: 'PUT /api/admin/settings/localization (sysadmin-only)', invoke: () => LOCALIZATION_PUT(nreq('http://localhost/api/admin/settings/localization', 'PUT', {})) },
         { name: 'GET /api/facility/badges', invoke: () => BADGES_GET(nreq('http://localhost/api/facility/badges')) },
+        // Payment problems queue (the Shopify reconciler's triage rows): family +
+        // order + what went wrong, board/sysadmin only.
+        { name: 'GET /api/finance-ops/payments', invoke: () => FIN_PAYMENTS_GET(nreq('http://localhost/api/finance-ops/payments')) },
+        { name: 'PATCH /api/finance-ops/payments/[id]', invoke: () => FIN_PAYMENTS_PATCH(nreq('http://localhost/api/finance-ops/payments/1', 'PATCH', {}), idCtx(1)) },
         { name: 'GET /api/facility/visits', invoke: () => FAC_VISITS_GET(nreq('http://localhost/api/facility/visits')) },
         { name: 'PATCH /api/facility/visits', invoke: () => FAC_VISITS_PATCH(nreq('http://localhost/api/facility/visits', 'PATCH', {})) },
         { name: 'GET /api/membership-audit/households-missing-contact', invoke: () => MISSING_CONTACT_GET(nreq('http://localhost/api/membership-audit/households-missing-contact')) },

--- a/checkin-app/src/app/__tests__/notificationsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsAPI.integration.test.ts
@@ -73,8 +73,10 @@ describe('Membership notifications API', () => {
     it('a plain user sees nothing', async () => {
         as(plainId);
         const data = await (await NOTIFS(req())).json();
+        // Exact shape on purpose: a plain user must see every count at zero, and a
+        // new board-only count added later must fail here until it's zeroed for them.
         expect(data).toEqual({
-            membership: { pendingReviews: 0, blocked: 0 },
+            membership: { pendingReviews: 0, blocked: 0, openPaymentExceptions: 0 },
             emergencyContacts: { householdsMissingValidContact: 0 },
         });
     });

--- a/checkin-app/src/app/api/cron/reconcile-shopify/route.ts
+++ b/checkin-app/src/app/api/cron/reconcile-shopify/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { withCron } from "@/lib/cronAuth";
+import { runReconcile } from "@/lib/finance/reconcile";
+
+/**
+ * Hourly Shopify reconciler — runs ~15 min past the hour, right after each s-read
+ * sync refreshes the `shopify_read` mirror. Recovers missed orders/paid webhooks
+ * (advancing families past the paid checkpoint) and raises refund/chargeback/cancel
+ * problems for the board. See lib/finance/reconcile.ts. No-op when the mirror isn't
+ * wired (SHOPIFY_READ_DATABASE_URL unset).
+ */
+export const GET = withCron(async () => {
+    const result = await runReconcile();
+    logger.info(`[reconcile] ${JSON.stringify(result)}`);
+    return NextResponse.json({ success: true, ...result });
+});

--- a/checkin-app/src/app/api/cron/reconcile-shopify/route.ts
+++ b/checkin-app/src/app/api/cron/reconcile-shopify/route.ts
@@ -4,11 +4,27 @@ import { withCron } from "@/lib/cronAuth";
 import { runReconcile } from "@/lib/finance/reconcile";
 
 /**
- * Hourly Shopify reconciler — runs ~15 min past the hour, right after each s-read
- * sync refreshes the `shopify_read` mirror. Recovers missed orders/paid webhooks
- * (advancing families past the paid checkpoint) and raises refund/chargeback/cancel
- * problems for the board. See lib/finance/reconcile.ts. No-op when the mirror isn't
- * wired (SHOPIFY_READ_DATABASE_URL unset).
+ * Daily Shopify reconciler — schedule at 09:15 UTC, ~15 min behind s-read's
+ * 09:00 UTC sync (infra#129), so it reads a mirror that was just refreshed.
+ *
+ * DAILY, NOT HOURLY, and the cadence is a scale-to-zero constraint, not a taste
+ * call: checkin and shopify_read share one Aurora cluster that auto-pauses at
+ * min-capacity 0 after ~5 minutes with zero connections and zero queries. Every
+ * run of this job opens connections and queries, i.e. WAKES that cluster — which
+ * is exactly why infra#129 dropped s-read from hourly to daily. Running this
+ * hourly would re-impose the cost that PR removes, and would re-read an unchanged
+ * mirror 23 times out of 24. Sitting just behind s-read's sync piggybacks on the
+ * wake s-read already causes (worst case one extra resume, absorbed by the
+ * aurora-resume-retry extension — this is a background job, latency is free).
+ *
+ * The trade: a missed orders/paid webhook is recovered within ~24h rather than
+ * ~1h. The reversal webhooks (api/webhooks/shopify/reversals) are the
+ * low-latency path; this is the guaranteed backstop.
+ *
+ * Recovers missed orders/paid webhooks (advancing families past the paid
+ * checkpoint) and raises refund/chargeback/cancel problems for the board. See
+ * lib/finance/reconcile.ts. No-op when the mirror isn't wired
+ * (SHOPIFY_READ_DATABASE_URL unset).
  */
 export const GET = withCron(async () => {
     const result = await runReconcile();

--- a/checkin-app/src/app/api/finance-ops/payments/[id]/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payments/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+
+/**
+ * PATCH /api/finance-ops/payments/[id] — the board acknowledges or resolves one
+ * reconciler-detected payment problem.
+ *   acknowledge → status ACKNOWLEDGED (seen, not yet cleared).
+ *   resolve     → status RESOLVED, stamped with who/when + a note.
+ * Only a real session may act (mirrors the payment-plans route); every change is
+ * audit-logged since the actor is not the affected household.
+ */
+export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
+    { roles: ['isSysadmin', 'isBoardMember'] },
+    async (request: NextRequest, auth, { params }) => {
+        if (auth.type !== 'session') {
+            return apiError("Unauthorized", 401);
+        }
+
+        try {
+            const { id: idParam } = await params;
+            const id = parseInt(idParam, 10);
+            if (Number.isNaN(id)) {
+                return apiError("Invalid exception ID", 400);
+            }
+
+            const body = await request.json();
+            const action = body.action;
+            if (action !== 'acknowledge' && action !== 'resolve') {
+                return apiError("action must be 'acknowledge' or 'resolve'", 400);
+            }
+
+            const data =
+                action === 'acknowledge'
+                    ? { status: 'ACKNOWLEDGED' as const }
+                    : {
+                          status: 'RESOLVED' as const,
+                          resolvedById: auth.user.id,
+                          resolvedAt: new Date(),
+                          resolutionNote: typeof body.note === 'string' ? body.note : null,
+                      };
+
+            const { count } = await prisma.paymentException.updateMany({
+                // Scope to the still-actionable states so acting twice (or on a
+                // resolved row) is a no-op error, not a silent re-write.
+                where: { id, status: { in: ['OPEN', 'ACKNOWLEDGED'] } },
+                data,
+            });
+
+            if (count === 0) {
+                return apiError("No open payment exception with that ID", 409);
+            }
+
+            await prisma.auditLog.create({
+                data: {
+                    actorId: auth.user.id,
+                    action: "EDIT",
+                    tableName: "PaymentException",
+                    affectedEntityId: id,
+                    newData: data,
+                },
+            });
+
+            return NextResponse.json({ success: true });
+        } catch (error) {
+            logger.error("Failed to update payment exception:", error);
+            return apiError("Failed to update payment exception", 500);
+        }
+    }
+);

--- a/checkin-app/src/app/api/finance-ops/payments/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payments/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { ordersByLegacyIds, type MirrorOrder } from "@/lib/shopifyRead/client";
+
+/**
+ * GET /api/finance-ops/payments — the board's queue of reconciler-detected
+ * payment problems (PaymentException) still needing action: OPEN or ACKNOWLEDGED,
+ * CRITICAL before WARN, newest first.
+ *
+ * Live order amounts are NOT stored on the row (they drift): we re-read them from
+ * the s-read mirror by shopifyOrderId. A mirror-less env (unconfigured) just
+ * yields no live block — the row still lists. See lib/shopifyRead/client.ts.
+ */
+export const GET = withAuth(
+    { roles: ['isSysadmin', 'isBoardMember'] },
+    async () => {
+        const exceptions = await prisma.paymentException.findMany({
+            where: { status: { in: ['OPEN', 'ACKNOWLEDGED'] } },
+            orderBy: [{ severity: 'desc' }, { detectedAt: 'desc' }], // CRITICAL(1) before WARN(0), newest first
+        });
+
+        // Batch the display-context lookups: households (via process), people, and
+        // programs — one query each, keyed back onto the rows below.
+        const processIds = [...new Set(exceptions.map((e) => e.processId).filter((v): v is number => v !== null))];
+        const personIds = [...new Set(exceptions.map((e) => e.personId).filter((v): v is number => v !== null))];
+        const programIds = [...new Set(exceptions.map((e) => e.programId).filter((v): v is number => v !== null))];
+        const orderIds = [...new Set(exceptions.map((e) => e.shopifyOrderId).filter((v): v is string => v !== null))];
+
+        const [processes, persons, programs, orders] = await Promise.all([
+            processIds.length
+                ? prisma.orgMembershipProcess.findMany({
+                      where: { id: { in: processIds } },
+                      select: {
+                          id: true,
+                          orgMembership: {
+                              select: {
+                                  household: {
+                                      select: {
+                                          name: true,
+                                          // The household lead carries the contact email shown in the queue.
+                                          householdMembers: {
+                                              where: { isHouseholdLead: true },
+                                              select: { name: true, email: true },
+                                              take: 1,
+                                          },
+                                      },
+                                  },
+                              },
+                          },
+                      },
+                  })
+                : Promise.resolve([]),
+            personIds.length
+                ? prisma.person.findMany({ where: { id: { in: personIds } }, select: { id: true, name: true, email: true } })
+                : Promise.resolve([]),
+            programIds.length
+                ? prisma.program.findMany({ where: { id: { in: programIds } }, select: { id: true, name: true } })
+                : Promise.resolve([]),
+            // Mirror read is best-effort: an unconfigured env returns [], and a
+            // transient mirror error must not take the whole queue down.
+            hydrateOrders(orderIds),
+        ]);
+
+        const procMap = new Map(processes.map((p) => [p.id, p]));
+        const personMap = new Map(persons.map((p) => [p.id, p]));
+        const programMap = new Map(programs.map((p) => [p.id, p]));
+        const orderMap = new Map(orders.filter((o) => o.legacyId !== null).map((o) => [o.legacyId as string, o]));
+
+        const rows = exceptions.map((e) => {
+            const proc = e.processId !== null ? procMap.get(e.processId) : undefined;
+            const household = proc?.orgMembership?.household;
+            const lead = household?.householdMembers[0];
+            const person = e.personId !== null ? personMap.get(e.personId) : undefined;
+            const program = e.programId !== null ? programMap.get(e.programId) : undefined;
+            const order = e.shopifyOrderId !== null ? orderMap.get(e.shopifyOrderId) : undefined;
+
+            return {
+                id: e.id,
+                kind: e.kind,
+                severity: e.severity,
+                status: e.status,
+                shopifyOrderId: e.shopifyOrderId,
+                processId: e.processId,
+                programId: e.programId,
+                personId: e.personId,
+                detectedAt: e.detectedAt,
+                familyName: person?.name ?? household?.name ?? null,
+                familyEmail: person?.email ?? lead?.email ?? null,
+                programName: program?.name ?? null,
+                live: order
+                    ? {
+                          financialStatus: order.financialStatus,
+                          totalCents: order.totalCents,
+                          totalRefundedCents: order.totalRefundedCents,
+                          cancelledAt: order.cancelledAt,
+                      }
+                    : null,
+            };
+        });
+
+        return NextResponse.json(rows);
+    }
+);
+
+/** Best-effort live-amount lookup; never throws (mirror unconfigured or down → []). */
+async function hydrateOrders(orderIds: string[]): Promise<MirrorOrder[]> {
+    if (orderIds.length === 0) return [];
+    try {
+        return await ordersByLegacyIds(orderIds);
+    } catch (error) {
+        logger.error("Failed to hydrate payment-exception order amounts:", error);
+        return [];
+    }
+}

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -73,7 +73,10 @@ export type TodoCounts = {
     // the Settings nav + Membership Settings tab — checkout is broken until both are set.
     // `programsMisconfig` = how many programs have a price but no matching Shopify variant
     // (paid enrollment silently can't check out). Red pill on the Program Ops Programs tab.
-    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; membershipPaymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; brokenEmails: number; settingsMisconfig: number; programsMisconfig: number };
+    // `openPaymentExceptions` = reconciler-detected payment problems (OPEN or
+    // ACKNOWLEDGED) awaiting board action — green pill on the Finance Ops Payment
+    // problems tab. Same count as getMembershipNotifications.openPaymentExceptions.
+    admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; membershipPaymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; brokenEmails: number; settingsMisconfig: number; programsMisconfig: number; openPaymentExceptions: number };
     // Config-health gaps (admins + board only): number of failing system-config checks
     // (e.g. Zoho e-sign unconfigured). Drives the red System Status nav badge; the full
     // list lives at /api/system-status/config-health. See lib/configHealth.ts.
@@ -361,7 +364,7 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     // ---- Admin surface (board's own queue) — only for board/isSysadmin ----
     if (user.isSysadmin || user.isBoardMember) {
-        const [membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, programsMisconfig, boardSettings] = await Promise.all([
+        const [membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, programsMisconfig, openPaymentExceptions, boardSettings] = await Promise.all([
             prisma.orgMembershipProcess.count({
                 where: { status: { in: BOARD_ACTIONABLE_MEMBERSHIP } },
             }),
@@ -401,6 +404,9 @@ export const GET = withAuth({}, async (_req, auth) => {
             // silently can't check out. Same condition as the list/detail UI, shared via
             // PROGRAM_CHECKOUT_BROKEN_WHERE (see lib/programCheckout.ts).
             prisma.program.count({ where: PROGRAM_CHECKOUT_BROKEN_WHERE }),
+            // Reconciler-detected payment problems still needing board action
+            // (OPEN or ACKNOWLEDGED). Green pill on the Finance Ops Payment problems tab.
+            prisma.paymentException.count({ where: { status: { in: ["OPEN", "ACKNOWLEDGED"] } } }),
             // Required membership settings — count how many are still unset so the board
             // sees a red pill until all are configured. Empty string counts as unset for
             // the Shopify fields; bgRecheckMonths <= 0 means the re-check interval is unset;
@@ -415,7 +421,7 @@ export const GET = withAuth({}, async (_req, auth) => {
             (boardSettings?.volunteerDiscountCode ? 0 : 1) +
             ((boardSettings?.bgRecheckMonths ?? 0) > 0 ? 0 : 1) +
             (boardSettings?.orgMembershipYearBoundary ? 0 : 1);
-        result.admin = { membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, settingsMisconfig, programsMisconfig };
+        result.admin = { membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, settingsMisconfig, programsMisconfig, openPaymentExceptions };
         // System-config health (env-var/deploy gaps). Synchronous, no DB — just presence
         // checks. Same admin+board gate as the rest of this block.
         result.configHealth = { openIssues: openConfigIssues() };

--- a/checkin-app/src/app/api/webhooks/shopify/reversals/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/reversals/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+import { logger } from "@/lib/logger";
+import { withWebhook } from "@/lib/webhookAuth";
+import { config } from "@/lib/config";
+import { raiseReversalByOrderId, type PaymentExceptionKind } from "@/lib/finance/reconcile";
+import { recordShopifyWebhookReceipt } from "@/lib/shopifyWebhookReceipt";
+
+/**
+ * Fast-path Shopify reversal webhooks — the low-latency complement to the hourly
+ * reconciler. Subscribed topics (register-shopify-webhook.ts):
+ *   refunds/create        → REFUND
+ *   orders/cancelled      → CANCELLED
+ *   disputes/create       → CHARGEBACK (critical)
+ *   disputes/update       → CHARGEBACK
+ *
+ * Each maps the affected Shopify order id to the membership process / program
+ * enrollment it activated and raises a PaymentException (board decides — we never
+ * auto-revert access). Whatever this drops, the hourly reconciler still catches.
+ * Same HMAC verify as the orders/paid route; the topic rides the x-shopify-topic
+ * header.
+ */
+
+interface ReversalPayload {
+    // orders/cancelled: the order object → id. refunds/create & disputes/*: order_id.
+    id?: number | string;
+    order_id?: number | string;
+}
+
+function verifyShopifyHmac(req: Request, rawBody: string): { ok: true } | { ok: false; status: number; error: string } {
+    const secret = config.shopifyWebhookSecret();
+    if (!secret) {
+        logger.error("Shopify reversal webhook received but SHOPIFY_WEBHOOK_SECRET is not configured.");
+        return { ok: false, status: 500, error: "Configuration Error" };
+    }
+    const headerSignature = req.headers.get("x-shopify-hmac-sha256");
+    if (!headerSignature) return { ok: false, status: 401, error: "Missing signature" };
+
+    const generated = crypto.createHmac("sha256", secret).update(rawBody, "utf8").digest("base64");
+    const a = crypto.createHash("sha256").update(generated).digest();
+    const b = crypto.createHash("sha256").update(headerSignature).digest();
+    if (!crypto.timingSafeEqual(a, b)) {
+        logger.error("Shopify reversal webhook signature mismatch.");
+        return { ok: false, status: 401, error: "Invalid signature" };
+    }
+    return { ok: true };
+}
+
+const TOPIC_KIND: Record<string, PaymentExceptionKind> = {
+    "refunds/create": "REFUND",
+    "orders/cancelled": "CANCELLED",
+    "disputes/create": "CHARGEBACK",
+    "disputes/update": "CHARGEBACK",
+};
+
+export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac }, async (req, payload: ReversalPayload) => {
+    const topic = req.headers.get("x-shopify-topic") ?? "";
+    const kind = TOPIC_KIND[topic];
+    // orders/cancelled sends the order (id); refunds/disputes send order_id.
+    const orderId = topic === "orders/cancelled" ? payload.id : payload.order_id;
+
+    let outcome: string;
+    if (!kind) {
+        outcome = `unhandled topic ${topic} — ignored`;
+        logger.info(`[SHOPIFY REVERSAL] ${outcome}`);
+    } else if (orderId == null) {
+        outcome = `${topic}: no order id in payload — ignored`;
+        logger.warn(`[SHOPIFY REVERSAL] ${outcome}`);
+    } else {
+        const matched = await raiseReversalByOrderId(String(orderId), kind);
+        outcome = matched
+            ? `${topic}: raised ${kind} for order ${orderId}`
+            : `${topic}: order ${orderId} not tied to any membership/enrollment — ignored`;
+        logger.info(`[SHOPIFY REVERSAL] ${outcome}`);
+    }
+
+    await recordShopifyWebhookReceipt(req, payload, { hmacValid: true, outcome });
+    return NextResponse.json({ success: true });
+});

--- a/checkin-app/src/app/api/webhooks/shopify/reversals/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/reversals/route.ts
@@ -7,7 +7,7 @@ import { raiseReversalByOrderId, type PaymentExceptionKind } from "@/lib/finance
 import { recordShopifyWebhookReceipt } from "@/lib/shopifyWebhookReceipt";
 
 /**
- * Fast-path Shopify reversal webhooks — the low-latency complement to the hourly
+ * Fast-path Shopify reversal webhooks — the low-latency complement to the daily
  * reconciler. Subscribed topics (register-shopify-webhook.ts):
  *   refunds/create        → REFUND
  *   orders/cancelled      → CANCELLED
@@ -16,7 +16,7 @@ import { recordShopifyWebhookReceipt } from "@/lib/shopifyWebhookReceipt";
  *
  * Each maps the affected Shopify order id to the membership process / program
  * enrollment it activated and raises a PaymentException (board decides — we never
- * auto-revert access). Whatever this drops, the hourly reconciler still catches.
+ * auto-revert access). Whatever this drops, the daily reconciler still catches (within ~24h).
  * Same HMAC verify as the orders/paid route; the topic rides the x-shopify-topic
  * header.
  */

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -5,7 +5,7 @@ import { logger } from "@/lib/logger";
 import { activateByProcessId } from "@/lib/membership/payment";
 import { withWebhook } from "@/lib/webhookAuth";
 import { config, DEV_MOCK_MEMBERSHIP_VARIANT_ID } from "@/lib/config";
-import { adjustProgramInventory } from "@/lib/shopify";
+import { activateProgramEnrollment } from "@/lib/programs/activateEnrollment";
 import { recordShopifyWebhookReceipt, tryParseJson } from "@/lib/shopifyWebhookReceipt";
 
 interface ShopifyOrder {
@@ -180,105 +180,23 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                 );
                 const hasProgramItem = (order.line_items ?? []).some((li) => programVariantIds.has(String(li.variant_id)));
 
-                // Which tier Shopify actually sold — needed below to mirror inventory
-                // onto the SIBLING pool. buildShopifyCheckoutUrl fixes ONE variant per
+                // Which tier Shopify actually sold — needed for the legacy two-pool
+                // sibling-inventory mirror. buildShopifyCheckoutUrl fixes ONE variant per
                 // order (one household = one tier per checkout), so if hasProgramItem
                 // matched and this is false, the non-member tier is the one purchased.
                 const purchasedOrgMember = !!program?.shopifyOrgMemberVariantId &&
                     (order.line_items ?? []).some((li) => String(li.variant_id) === program.shopifyOrgMemberVariantId);
 
-                let activatedCount = 0;
-                let releasedHoldCount = 0;
-
-                for (const participantId of participantIds) {
-                    // Find existing participant
-                    const existing = await prisma.programParticipant.findUnique({
-                        where: {
-                            programId_personId: { programId, personId: participantId }
-                        }
-                    });
-
-                    if (existing) {
-                        if (!hasProgramItem) {
-                            logger.warn(`[SHOPIFY WEBHOOK] Paid order ${order.id ?? "?"} for participant ${participantId} / program ${programId} did not contain the program's Shopify variant${programVariantIds.size === 0 ? " (program has no variant configured)" : ""} — participant left PENDING, NOT activated.`);
-                            continue;
-                        }
-
-                        // Guarded transactionally (status PENDING -> ACTIVE) so a webhook
-                        // redelivery — or a participant already activated elsewhere —
-                        // can't inflate activatedCount and double-fire the sibling
-                        // mirror's -1 below.
-                        const activated = await prisma.programParticipant.updateMany({
-                            where: { programId, personId: participantId, status: 'PENDING' },
-                            data: {
-                                status: 'ACTIVE',
-                                pendingSince: null, // clear out the pending timer
-                            }
-                        });
-                        activatedCount += activated.count;
-
-                        if (activated.count > 0) {
-                            logger.info(`[SHOPIFY WEBHOOK] Marked participant ${participantId} as ACTIVE for program ${programId}`);
-                        }
-
-                        // Hold-ledger (product decision 2026-07-06): NORMAL PAYMENT is
-                        // one of the three release paths. A denied scholarship
-                        // applicant who pays anyway still had inventoryHeldAt set
-                        // from application time; this sale just made Shopify
-                        // auto-decrement a SECOND unit for the same seat. Release the
-                        // hold (+1) to compensate, guarded transactionally
-                        // (inventoryHeldAt NOT NULL -> NULL) so a webhook retry can't
-                        // release twice. Without this, every denied-then-paying
-                        // applicant permanently leaks a seat of capacity.
-                        if (existing.inventoryHeldAt) {
-                            const release = await prisma.programParticipant.updateMany({
-                                where: { programId, personId: participantId, inventoryHeldAt: { not: null } },
-                                data: { inventoryHeldAt: null },
-                            });
-                            releasedHoldCount += release.count;
-                        }
-                    } else {
-                        logger.warn(`[SHOPIFY WEBHOOK] Participant ${participantId} not found in Program ${programId}. Ignoring payment.`);
-                    }
-                }
-
-                // Release path (b), continued: fire the compensating +1 for every
-                // hold released above, in one call. Never allowed to fail the
-                // webhook response — same non-fatal posture as the sibling-mirror
-                // block below (Shopify retries the whole order on a non-2xx).
-                if (releasedHoldCount > 0) {
-                    const ok = await adjustProgramInventory(
-                        {
-                            shopifyVariantId: program?.shopifyVariantId ?? null,
-                            shopifyOrgMemberVariantId: program?.shopifyOrgMemberVariantId ?? null,
-                            shopifyNonOrgMemberVariantId: program?.shopifyNonOrgMemberVariantId ?? null,
-                        },
-                        releasedHoldCount,
-                    );
-                    if (!ok) {
-                        logger.error(`[SHOPIFY WEBHOOK] Failed to release ${releasedHoldCount} scholarship inventory hold(s) for program ${programId} after payment — capacity may be out of sync.`);
-                    }
-                }
-
-                // LEGACY-ONLY two-pool mirror (product decision 2026-07-06, single-
-                // pool redesign): the org-member and non-org-member variants each
-                // carry their OWN Shopify inventory pool, both seeded to
-                // maxParticipants — so Shopify only auto-decrements the pool for the
-                // tier actually purchased, and the sibling pool needs a compensating
-                // mirror. Single-pool (shopifyVariantId) programs need NO mirror —
-                // there's exactly one pool, and Shopify already auto-decremented it
-                // on the sale. Deliberately AFTER activation is committed, and never
-                // allowed to fail the webhook response — Shopify retries the whole
-                // order on a non-2xx.
-                if (activatedCount > 0 && !program?.shopifyVariantId) {
-                    const siblingOnly = purchasedOrgMember
-                        ? { shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: program?.shopifyNonOrgMemberVariantId ?? null }
-                        : { shopifyOrgMemberVariantId: program?.shopifyOrgMemberVariantId ?? null, shopifyNonOrgMemberVariantId: null };
-                    const ok = await adjustProgramInventory(siblingOnly, -activatedCount);
-                    if (!ok) {
-                        logger.error(`[SHOPIFY WEBHOOK] Failed to mirror sibling-variant inventory for program ${programId} after activating ${activatedCount} participant(s) — pools may be out of sync.`);
-                    }
-                }
+                // Shared choke point — same path the reconciler uses to recover a
+                // MISSED webhook (lib/programs/activateEnrollment). Idempotent; the
+                // inventory side effects are non-fatal (Shopify retries on a non-2xx).
+                const { activatedCount } = await activateProgramEnrollment({
+                    programId,
+                    personIds: participantIds,
+                    shopifyOrderId: order.id ? String(order.id) : "",
+                    hasProgramItem,
+                    purchasedOrgMember,
+                });
 
                 outcome = `program ${programId}: activated ${activatedCount} of ${participantIds.length} participant(s)`;
             }

--- a/checkin-app/src/app/finance-ops/payments/page.tsx
+++ b/checkin-app/src/app/finance-ops/payments/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+import { Badge, Button, Group, Modal, Stack, Text, Textarea } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { AlertBanner } from '@/components/admin/AlertBanner';
+import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
+import { useRequireRole } from '@/hooks/useRequireRole';
+import { formatDateTime } from '@/lib/time';
+import { notifyNavRefresh } from '@/lib/nav-refresh';
+import { formatCents } from '@inventory/money';
+import { PageLoader } from "@/components/ui/PageLoader";
+
+// Mirrors the flat shape returned by GET /api/finance-ops/payments.
+type PaymentException = {
+  id: number;
+  kind: string;
+  severity: 'WARN' | 'CRITICAL';
+  status: 'OPEN' | 'ACKNOWLEDGED' | 'RESOLVED';
+  shopifyOrderId: string | null;
+  processId: number | null;
+  programId: number | null;
+  personId: number | null;
+  detectedAt: string;
+  familyName: string | null;
+  familyEmail: string | null;
+  programName: string | null;
+  live: {
+    financialStatus: string | null;
+    totalCents: number;
+    totalRefundedCents: number;
+    cancelledAt: string | null;
+  } | null;
+};
+
+export default function PaymentProblemsPage() {
+  const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
+
+  const [rows, setRows] = useState<PaymentException[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState("");
+  const [resolveOpened, { open: openResolve, close: closeResolve }] = useDisclosure(false);
+  const [pendingResolve, setPendingResolve] = useState<PaymentException | null>(null);
+  const [note, setNote] = useState("");
+
+  const fetchRows = useCallback(async () => {
+    try {
+      const res = await fetch('/api/finance-ops/payments');
+      if (res.ok) {
+        setRows(await res.json());
+      } else {
+        setMessage("Failed to load payment problems. You may not have access.");
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error loading payment problems.", autoClose: false });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (ready) fetchRows();
+  }, [ready, fetchRows]);
+
+  const patch = async (id: number, action: 'acknowledge' | 'resolve', noteText?: string) => {
+    try {
+      const res = await fetch(`/api/finance-ops/payments/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, note: noteText }),
+      });
+      if (res.ok) {
+        await fetchRows();
+        notifyNavRefresh();
+        notifications.show({ color: 'green', message: action === 'resolve' ? 'Payment problem resolved.' : 'Payment problem acknowledged.' });
+      } else {
+        const data = await res.json();
+        notifications.show({ color: 'red', message: data.error || "Failed to update.", autoClose: false });
+        if (res.status === 409) fetchRows();
+      }
+    } catch {
+      notifications.show({ color: 'red', message: "Network error updating the payment problem.", autoClose: false });
+    }
+  };
+
+  const handleResolve = (row: PaymentException) => {
+    setPendingResolve(row);
+    setNote("");
+    openResolve();
+  };
+
+  const confirmResolve = async () => {
+    if (!pendingResolve) return;
+    closeResolve();
+    const { id } = pendingResolve;
+    setPendingResolve(null);
+    await patch(id, 'resolve', note);
+  };
+
+  if (authLoading || loading) {
+    return <PageLoader />;
+  }
+
+  if (!ready) return null;
+
+  const columns: DataTableColumn<PaymentException>[] = [
+    {
+      header: 'Severity',
+      sortBy: (row) => row.severity,
+      render: (row) => (
+        <Badge color={row.severity === 'CRITICAL' ? 'red' : 'yellow'} variant="light">
+          {row.severity}
+        </Badge>
+      ),
+    },
+    {
+      header: 'Problem',
+      sortBy: (row) => row.kind,
+      render: (row) => (
+        <>
+          <Text fw={500}>{row.kind.replace(/_/g, ' ')}</Text>
+          {row.programName && <Text size="sm" c="dimmed">{row.programName}</Text>}
+        </>
+      ),
+    },
+    {
+      header: 'Family',
+      sortBy: (row) => row.familyName?.toLowerCase() ?? row.familyEmail?.toLowerCase() ?? '',
+      render: (row) => (
+        <>
+          <Text fw={500}>{row.familyName ?? '—'}</Text>
+          {row.familyEmail && <Text size="sm" c="dimmed">{row.familyEmail}</Text>}
+        </>
+      ),
+    },
+    {
+      header: 'Live payment',
+      render: (row) =>
+        row.live ? (
+          <>
+            <Text size="sm">{row.live.financialStatus ?? 'unknown'}</Text>
+            <Text size="sm" c="dimmed">
+              {formatCents(row.live.totalCents)}
+              {row.live.totalRefundedCents > 0 && ` (−${formatCents(row.live.totalRefundedCents)} refunded)`}
+              {row.live.cancelledAt && ' · cancelled'}
+            </Text>
+          </>
+        ) : (
+          <Text size="sm" c="dimmed">{row.shopifyOrderId ? `Order ${row.shopifyOrderId}` : 'No order'}</Text>
+        ),
+    },
+    {
+      header: 'Detected',
+      sortBy: (row) => row.detectedAt,
+      render: (row) => <Text size="sm" c="dimmed">{formatDateTime(row.detectedAt)}</Text>,
+    },
+    {
+      header: 'Actions',
+      align: 'right',
+      render: (row) => (
+        <Group justify="flex-end" gap="xs" wrap="nowrap">
+          {row.status === 'OPEN' && (
+            <Button size="xs" fz={15} variant="light" onClick={() => patch(row.id, 'acknowledge')}>
+              Acknowledge
+            </Button>
+          )}
+          <Button size="xs" fz={15} color="green" variant="light" onClick={() => handleResolve(row)}>
+            Resolve
+          </Button>
+        </Group>
+      ),
+    },
+  ];
+
+  return (
+    <Stack>
+      <Text c="dimmed">
+        Reconciler-detected Shopify payment problems awaiting board review. Nothing here is changed
+        automatically — acknowledge to mark a problem as seen, or resolve once you&apos;ve handled it
+        (e.g. in Shopify or on the membership record).
+      </Text>
+
+      <AlertBanner message={message} tone="error" />
+
+      <DataTable
+        columns={columns}
+        rows={rows}
+        getRowKey={(row) => row.id}
+        emptyMessage="No open payment problems."
+      />
+
+      <Modal
+        opened={resolveOpened}
+        onClose={closeResolve}
+        title={<Text span fw={700} fz="lg">Resolve Payment Problem</Text>}
+        centered
+      >
+        <Text mb="sm">
+          Mark this {pendingResolve?.kind.replace(/_/g, ' ').toLowerCase()} problem as resolved. Add a note
+          describing what was done.
+        </Text>
+        <Textarea
+          value={note}
+          onChange={(e) => setNote(e.currentTarget.value)}
+          placeholder="What did you do to resolve this? (optional)"
+          autosize
+          minRows={3}
+          mb="lg"
+        />
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeResolve}>Cancel</Button>
+          <Button color="green" onClick={confirmResolve}>Resolve</Button>
+        </Group>
+      </Modal>
+    </Stack>
+  );
+}

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -111,6 +111,7 @@ const admin = (over: Partial<NonNullable<TodoCounts['admin']>> = {}): TodoCounts
     brokenEmails: 0,
     settingsMisconfig: 0,
     programsMisconfig: 0,
+    openPaymentExceptions: 0,
     ...over,
   },
 });
@@ -272,8 +273,11 @@ describe('tabBadgeFor', () => {
       .toEqual({ count: 2, color: 'treehouseGreen', label: '2 program payment-plan approvals' });
     expect(tabBadgeFor('/finance-ops/membership-payment-plan', admin({ membershipPaymentPlanPending: 1 })))
       .toEqual({ count: 1, color: 'treehouseGreen', label: '1 membership payment-plan approval' });
+    expect(tabBadgeFor('/finance-ops/payments', admin({ openPaymentExceptions: 4 })))
+      .toEqual({ count: 4, color: 'treehouseGreen', label: '4 payment problems to review' });
     expect(tabBadgeFor('/finance-ops/payment-plan', admin())).toBeNull();
     expect(tabBadgeFor('/finance-ops/membership-payment-plan', admin())).toBeNull();
+    expect(tabBadgeFor('/finance-ops/payments', admin())).toBeNull();
   });
 });
 

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -245,6 +245,8 @@ export function tabBadgeFor(href: string, counts: TodoCounts | null): NavBadge |
       return green(admin.paymentPlanPending, `${admin.paymentPlanPending} program payment-plan approval${plural(admin.paymentPlanPending, '', 's')}`);
     case '/finance-ops/membership-payment-plan':
       return green(admin.membershipPaymentPlanPending, `${admin.membershipPaymentPlanPending} membership payment-plan approval${plural(admin.membershipPaymentPlanPending, '', 's')}`);
+    case '/finance-ops/payments':
+      return green(admin.openPaymentExceptions, `${admin.openPaymentExceptions} payment problem${plural(admin.openPaymentExceptions, '', 's')} to review`);
     // Safety — same count as the /safety section badge.
     case '/safety/trusted-adults':
       return green(admin.trustedAdults, `${admin.trustedAdults} trusted-adult disclosure${plural(admin.trustedAdults, '', 's')} to review`);

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -122,6 +122,7 @@ export const PAGES: PageEntry[] = [
   { href: '/finance-ops', label: 'Finance Ops', section: 'Finance Ops', visible: BOARD },
   { href: '/finance-ops/payment-plan', label: 'Program Payment Plan', section: 'Finance Ops', visible: BOARD },
   { href: '/finance-ops/membership-payment-plan', label: 'Membership Payment Plan', section: 'Finance Ops', visible: BOARD },
+  { href: '/finance-ops/payments', label: 'Payment problems', section: 'Finance Ops', keywords: 'reconcile exception refund chargeback unmatched shopify', visible: BOARD },
 
   // System Status — board
   { href: '/system-status', label: 'System Status', section: 'System Status', visible: BOARD },

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -193,6 +193,12 @@ export const config = {
     // Cron — shared secret gating the session-less cron routes (see cronAuth.ts).
     cronSecret: (): string | null => process.env.CRON_SECRET || null,
 
+    // s-read mirror — read-only connection string to the `shopify_read` Postgres
+    // (the s-read-function's Shopify order/refund/payout mirror). Null when unset →
+    // the hourly reconciler (lib/finance/reconcile.ts) short-circuits as "not wired"
+    // instead of throwing, so an env without the mirror simply runs no reconciliation.
+    shopifyReadDatabaseUrl: (): string | null => process.env.SHOPIFY_READ_DATABASE_URL || null,
+
     // Shopify — Client Credentials Grant integration (see shopify.ts). All three
     // null when unset (integration "off").
     shopifyStoreDomain: (): string | null => process.env.SHOPIFY_STORE_DOMAIN || null,

--- a/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Matrix test for the Shopify reconciler (lib/finance/reconcile.ts). Real app DB,
+ * mocked `shopify_read` mirror (fixtures) — so every taxonomy row is exercised
+ * against real membership/program state without needing a second Postgres. Each
+ * assertion also re-runs to prove idempotency (no double activation, no duplicate
+ * PaymentException).
+ */
+import prisma from "@/lib/prisma";
+import { runReconcile, raiseReversalByOrderId } from "@/lib/finance/reconcile";
+import type { MirrorOrder } from "@/lib/shopifyRead/client";
+
+jest.mock("@/lib/email", () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+
+// Mocked mirror — each test sets what the four read helpers return.
+jest.mock("@/lib/shopifyRead/client", () => ({
+    isConfigured: () => true,
+    ordersChangedSince: jest.fn(async () => [] as MirrorOrder[]),
+    ordersByLegacyIds: jest.fn(async () => [] as MirrorOrder[]),
+    disputedOrderGids: jest.fn(async () => new Set<string>()),
+}));
+import * as mirror from "@/lib/shopifyRead/client";
+
+const TAG = "reconcile-matrix-test";
+const ordersChangedSince = mirror.ordersChangedSince as jest.Mock;
+const ordersByLegacyIds = mirror.ordersByLegacyIds as jest.Mock;
+const disputedOrderGids = mirror.disputedOrderGids as jest.Mock;
+
+function order(overrides: Partial<MirrorOrder> & { legacyId: string }): MirrorOrder {
+    return {
+        orderGid: `gid://shopify/Order/${overrides.legacyId}`,
+        customerEmail: null,
+        financialStatus: "PAID",
+        totalCents: 5000,
+        subtotalCents: 5000,
+        totalRefundedCents: 0,
+        cancelledAt: null,
+        updatedAt: new Date(),
+        ...overrides,
+    };
+}
+
+/** A household whose lead has `email`, an OrgMembership, and one process. */
+async function makeApplicant(opts: {
+    email: string;
+    status: "PENDING_PAYMENT" | "ACTIVE";
+    bgCleared?: boolean;
+    isVolunteer?: boolean;
+    shopifyOrderId?: string;
+    paid?: boolean;
+}): Promise<{ householdId: number; processId: number; membershipId: number }> {
+    const hh = await prisma.household.create({ data: { name: `HH ${TAG} ${opts.email}` } });
+    await prisma.person.create({
+        data: { email: opts.email, name: `Lead ${opts.email}`, isHouseholdLead: true, householdId: hh.id },
+    });
+    const m = await prisma.orgMembership.create({
+        data: { householdId: hh.id, status: opts.status === "ACTIVE" ? "ACTIVE" : "NONE", isVolunteer: !!opts.isVolunteer },
+    });
+    const proc = await prisma.orgMembershipProcess.create({
+        data: {
+            orgMembershipId: m.id,
+            kind: "INITIAL",
+            status: opts.status,
+            bgClearedAt: opts.bgCleared ? new Date() : null,
+            shopifyOrderId: opts.shopifyOrderId ?? null,
+            paidAt: opts.paid ? new Date() : null,
+        },
+    });
+    return { householdId: hh.id, processId: proc.id, membershipId: m.id };
+}
+
+beforeAll(async () => {
+    await prisma.boardSettings.upsert({
+        where: { id: 1 },
+        create: { id: 1, normalDuesCents: 5000, volunteerDuesCents: 2000 },
+        update: { normalDuesCents: 5000, volunteerDuesCents: 2000, shopifyReconcileCursorAt: null },
+    });
+});
+
+afterEach(async () => {
+    ordersChangedSince.mockResolvedValue([]);
+    ordersByLegacyIds.mockResolvedValue([]);
+    disputedOrderGids.mockResolvedValue(new Set());
+    // Reset cursor so each test scans its own fixtures from scratch.
+    await prisma.boardSettings.update({ where: { id: 1 }, data: { shopifyReconcileCursorAt: null } });
+});
+
+afterAll(async () => {
+    const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+    const ids = hhs.map((h) => h.id);
+    if (ids.length) {
+        const procs = await prisma.orgMembershipProcess.findMany({ where: { orgMembership: { householdId: { in: ids } } }, select: { id: true } });
+        await prisma.paymentException.deleteMany({ where: { processId: { in: procs.map((p) => p.id) } } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: ids } } });
+    }
+    await prisma.paymentException.deleteMany({ where: { shopifyOrderId: { startsWith: `${TAG}-` } } });
+});
+
+describe("forward recovery", () => {
+    it("recovers a missed payment, advancing PENDING_PAYMENT past the paid checkpoint", async () => {
+        const email = `recover-${TAG}@ex.com`;
+        const oid = `${TAG}-100`;
+        const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true });
+        ordersChangedSince.mockResolvedValue([order({ legacyId: oid, customerEmail: email, totalCents: 5000 })]);
+
+        const r1 = await runReconcile();
+        expect(r1.configured).toBe(true);
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe("ACTIVE");
+        expect(proc?.paidAt).toBeTruthy();
+        expect(proc?.shopifyOrderId).toBe(oid);
+        // No exception for a clean recovery.
+        expect(await prisma.paymentException.count({ where: { processId } })).toBe(0);
+
+        // Idempotent: second run does nothing new (order now recorded on the process).
+        await runReconcile();
+        expect(await prisma.paymentException.count({ where: { processId } })).toBe(0);
+    });
+
+    it("holds at PENDING_BG_CLEARANCE when bg not cleared", async () => {
+        const email = `hold-${TAG}@ex.com`;
+        const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: false });
+        ordersChangedSince.mockResolvedValue([order({ legacyId: `${TAG}-101`, customerEmail: email })]);
+        await runReconcile();
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe("PENDING_BG_CLEARANCE");
+        expect(proc?.paidAt).toBeTruthy();
+    });
+
+    it("raises AMOUNT_MISMATCH and does not activate when the order underpays dues", async () => {
+        const email = `short-${TAG}@ex.com`;
+        const oid = `${TAG}-102`;
+        const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true });
+        ordersChangedSince.mockResolvedValue([order({ legacyId: oid, customerEmail: email, totalCents: 1000 })]);
+        await runReconcile();
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe("PENDING_PAYMENT");
+        expect(await prisma.paymentException.findFirst({ where: { kind: "AMOUNT_MISMATCH", shopifyOrderId: oid } })).toBeTruthy();
+    });
+
+    it("raises UNMATCHED_ORDER when the family has more than one pending process", async () => {
+        const email = `ambig-${TAG}@ex.com`;
+        const oid = `${TAG}-103`;
+        const a = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true });
+        // A second PENDING_PAYMENT process on the SAME membership (email is @unique, so
+        // ambiguity comes from two live processes for one family, not two households).
+        await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: a.membershipId, kind: "RENEWAL", status: "PENDING_PAYMENT", bgClearedAt: new Date() },
+        });
+        ordersChangedSince.mockResolvedValue([order({ legacyId: oid, customerEmail: email })]);
+        await runReconcile();
+        expect(await prisma.paymentException.findFirst({ where: { kind: "UNMATCHED_ORDER", shopifyOrderId: oid } })).toBeTruthy();
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: a.processId } });
+        expect(proc?.status).toBe("PENDING_PAYMENT");
+    });
+
+    it("ignores a paid order from an email with no pending membership (normal purchase)", async () => {
+        ordersChangedSince.mockResolvedValue([order({ legacyId: `${TAG}-104`, customerEmail: `nobody-${TAG}@ex.com` })]);
+        const before = await prisma.paymentException.count();
+        await runReconcile();
+        expect(await prisma.paymentException.count()).toBe(before);
+    });
+
+    it("raises REVERSED_BEFORE_ACTIVATION for a refunded order matching a pending process", async () => {
+        const email = `prerev-${TAG}@ex.com`;
+        const oid = `${TAG}-105`;
+        const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true });
+        ordersChangedSince.mockResolvedValue([order({ legacyId: oid, customerEmail: email, financialStatus: "REFUNDED", totalRefundedCents: 5000 })]);
+        await runReconcile();
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe("PENDING_PAYMENT");
+        expect(await prisma.paymentException.findFirst({ where: { kind: "REVERSED_BEFORE_ACTIVATION", shopifyOrderId: oid } })).toBeTruthy();
+    });
+});
+
+describe("reversal detection", () => {
+    it("raises REFUND for a refunded order on an ACTIVE membership, leaving it ACTIVE", async () => {
+        const oid = `${TAG}-200`;
+        const { processId } = await makeApplicant({ email: `ref-${TAG}@ex.com`, status: "ACTIVE", paid: true, shopifyOrderId: oid });
+        ordersByLegacyIds.mockResolvedValue([order({ legacyId: oid, financialStatus: "REFUNDED", totalRefundedCents: 5000 })]);
+
+        await runReconcile();
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe("ACTIVE"); // never auto-reverted
+        expect(await prisma.paymentException.count({ where: { kind: "REFUND", processId } })).toBe(1);
+
+        // Idempotent: a second run does not duplicate the exception.
+        await runReconcile();
+        expect(await prisma.paymentException.count({ where: { kind: "REFUND", processId } })).toBe(1);
+    });
+
+    it("raises CHARGEBACK (critical) when a dispute balance-txn exists", async () => {
+        const oid = `${TAG}-201`;
+        const { processId } = await makeApplicant({ email: `cb-${TAG}@ex.com`, status: "ACTIVE", paid: true, shopifyOrderId: oid });
+        const o = order({ legacyId: oid, financialStatus: "PAID" });
+        ordersByLegacyIds.mockResolvedValue([o]);
+        disputedOrderGids.mockResolvedValue(new Set([o.orderGid]));
+
+        await runReconcile();
+        const ex = await prisma.paymentException.findFirst({ where: { kind: "CHARGEBACK", processId } });
+        expect(ex?.severity).toBe("CRITICAL");
+    });
+
+    it("raises CANCELLED for a cancelled order", async () => {
+        const oid = `${TAG}-202`;
+        const { processId } = await makeApplicant({ email: `can-${TAG}@ex.com`, status: "ACTIVE", paid: true, shopifyOrderId: oid });
+        ordersByLegacyIds.mockResolvedValue([order({ legacyId: oid, cancelledAt: new Date() })]);
+        await runReconcile();
+        expect(await prisma.paymentException.findFirst({ where: { kind: "CANCELLED", processId } })).toBeTruthy();
+    });
+});
+
+describe("fast-path reversal webhook helper", () => {
+    it("raiseReversalByOrderId maps an order to its process and is idempotent", async () => {
+        const oid = `${TAG}-300`;
+        const { processId } = await makeApplicant({ email: `fp-${TAG}@ex.com`, status: "ACTIVE", paid: true, shopifyOrderId: oid });
+        expect(await raiseReversalByOrderId(oid, "REFUND")).toBe(true);
+        await raiseReversalByOrderId(oid, "REFUND");
+        expect(await prisma.paymentException.count({ where: { kind: "REFUND", processId } })).toBe(1);
+    });
+});

--- a/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
@@ -14,8 +14,11 @@ import type { MirrorOrder } from "@/lib/shopifyRead/client";
 
 jest.mock("@/lib/email", () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
 
-// Mocked mirror — each test sets what the four read helpers return.
+// Mocked mirror — each test sets what the read helpers return. Only the DB-backed
+// reads are stubbed; orderAttr stays REAL (it's a pure parse of the mirrored
+// note_attributes, and the tests should exercise the real thing).
 jest.mock("@/lib/shopifyRead/client", () => ({
+    ...jest.requireActual("@/lib/shopifyRead/client"),
     isConfigured: () => true,
     ordersChangedSince: jest.fn(async () => [] as MirrorOrder[]),
     ordersByLegacyIds: jest.fn(async () => [] as MirrorOrder[]),
@@ -38,9 +41,15 @@ function order(overrides: Partial<MirrorOrder> & { legacyId: string }): MirrorOr
         totalRefundedCents: 0,
         cancelledAt: null,
         updatedAt: new Date(),
+        // Default null = an order synced before #1029, i.e. the email-fallback path.
+        // Tests of the preferred path pass noteAttributes explicitly.
+        noteAttributes: null,
         ...overrides,
     };
 }
+
+/** Cart attributes as the mirror stores them (#1029). */
+const attrs = (o: Record<string, string>) => Object.entries(o).map(([key, value]) => ({ key, value }));
 
 /** A household whose lead has `email`, an OrgMembership, and one process. */
 async function makeApplicant(opts: {
@@ -141,6 +150,47 @@ describe("forward recovery", () => {
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe("PENDING_PAYMENT");
         expect(await prisma.paymentException.findFirst({ where: { kind: "AMOUNT_MISMATCH", shopifyOrderId: oid } })).toBeTruthy();
+    });
+
+    it("prefers the Membership_Process_ID cart attribute over the email heuristic", async () => {
+        const email = `attr-${TAG}@ex.com`;
+        const oid = `${TAG}-110`;
+        const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true });
+        // No customer email on the order at all — the attribute alone must carry it.
+        ordersChangedSince.mockResolvedValue([
+            order({ legacyId: oid, customerEmail: null, noteAttributes: attrs({ Membership_Process_ID: String(processId) }) }),
+        ]);
+        await runReconcile();
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe("ACTIVE");
+        expect(proc?.shopifyOrderId).toBe(oid);
+    });
+
+    it("attribute disambiguates what email alone could not (two pending processes)", async () => {
+        const email = `attrambig-${TAG}@ex.com`;
+        const oid = `${TAG}-111`;
+        const a = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true });
+        const second = await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: a.membershipId, kind: "RENEWAL", status: "PENDING_PAYMENT", bgClearedAt: new Date() },
+        });
+        // Email-only would raise UNMATCHED_ORDER here; the attribute names the process.
+        ordersChangedSince.mockResolvedValue([
+            order({ legacyId: oid, customerEmail: email, noteAttributes: attrs({ Membership_Process_ID: String(second.id) }) }),
+        ]);
+        await runReconcile();
+        expect(await prisma.paymentException.findFirst({ where: { kind: "UNMATCHED_ORDER", shopifyOrderId: oid } })).toBeNull();
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: second.id } }))?.status).toBe("ACTIVE");
+        // The sibling is untouched — the money was credited to exactly one process.
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: a.processId } }))?.status).toBe("PENDING_PAYMENT");
+    });
+
+    it("raises UNMATCHED_ORDER when the attribute names a process that does not exist", async () => {
+        const oid = `${TAG}-112`;
+        ordersChangedSince.mockResolvedValue([
+            order({ legacyId: oid, noteAttributes: attrs({ Membership_Process_ID: "99999999" }) }),
+        ]);
+        await runReconcile();
+        expect(await prisma.paymentException.findFirst({ where: { kind: "UNMATCHED_ORDER", shopifyOrderId: oid } })).toBeTruthy();
     });
 
     it("raises UNMATCHED_ORDER when the family has more than one pending process", async () => {

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -16,9 +16,11 @@ import type { MirrorOrder } from "@/lib/shopifyRead/client";
  *              back, or cancelled: raise a PaymentException for the board. We never
  *              auto-revert access (a chargeback can be a bank error).
  *
- * Runs hourly from api/cron/reconcile-shopify. Idempotent: forward recovery is a
- * no-op once activate() has recorded the order (activate stores shopifyOrderId and
- * short-circuits on paidAt), and every exception upserts on (kind, order).
+ * Runs once daily from api/cron/reconcile-shopify (09:15 UTC, just behind s-read's
+ * 09:00 sync — the cadence is a scale-to-zero constraint, see that route).
+ * Idempotent: forward recovery is a no-op once activate() has recorded the order
+ * (activate stores shopifyOrderId and short-circuits on paidAt), and every
+ * exception upserts on (kind, order).
  *
  * Matching key is the order's customer EMAIL → household lead → the family's single
  * PENDING_PAYMENT process (the mirror carries no cart note-attributes and no line
@@ -55,7 +57,7 @@ interface ExceptionRef {
 }
 
 /**
- * Upsert a PaymentException, idempotent across hourly runs. One open row per
+ * Upsert a PaymentException, idempotent across daily runs. One open row per
  * (kind, order); a resolved row that re-detects reopens (the problem came back). A
  * newly-opened or reopened row escalates to the board (CRITICAL emails immediately;
  * WARN is surfaced on the dashboard + red-dot only — see notifyBoardPaymentException).
@@ -248,7 +250,7 @@ function classifyReversal(o: MirrorOrder, disputed: boolean): PaymentExceptionKi
  * Fast-path entry for the reversal webhooks (refunds/create, orders/cancelled,
  * disputes/*): map a Shopify order id to the membership process and/or program
  * enrollment it activated and raise the given problem. Returns true if anything
- * matched. Shares the same idempotent raise as the hourly reconciler.
+ * matched. Shares the same idempotent raise as the daily reconciler.
  */
 export async function raiseReversalByOrderId(orderLegacyId: string, kind: PaymentExceptionKind): Promise<boolean> {
     let matched = false;

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -22,11 +22,17 @@ import type { MirrorOrder } from "@/lib/shopifyRead/client";
  * (activate stores shopifyOrderId and short-circuits on paidAt), and every
  * exception upserts on (kind, order).
  *
- * Matching key is the order's customer EMAIL → household lead → the family's single
- * PENDING_PAYMENT process (the mirror carries no cart note-attributes and no line
- * variant id, so we cannot use the webhook's exact process-id / variant match). A
- * zero/ambiguous email match, or an amount that does not cover dues, raises a
- * problem instead of guessing.
+ * Matching uses the SAME cart attribute the webhook credits — Membership_Process_ID
+ * (or CheckMeIn_Account_ID + Program_ID), mirrored since #1029 — so attribution is
+ * exact. Orders synced before that carry no attributes and fall back to customer
+ * email → household lead → the family's single pending process.
+ *
+ * What still can't be replicated is the webhook's variant-id check that the order
+ * really contains the membership/program product: the mirror's order lines carry
+ * sku/title, not variant ids. Membership recovery therefore gates on the order
+ * covering the family's dues instead. Nothing is guessed: an attribute naming an
+ * unknown process, an ambiguous email match, or an amount short of dues raises a
+ * problem for the board rather than activating.
  */
 
 export type PaymentExceptionKind =
@@ -120,38 +126,73 @@ function isReversed(o: MirrorOrder): boolean {
 
 // ── forward pass (recover missed payments) ───────────────────────────────────
 
+type ResolvedProcess = { id: number; orgMembershipId: number | null } | "none" | "ambiguous";
+
 /**
- * Try to attribute one mirror order to a membership process by customer email and
- * act on it. Returns true if the order was claimed (recovered or raised), false if
- * it is not a membership order (so a program pass may still claim it).
+ * Which membership process (if any) is this order paying for?
+ *
+ * Preferred: the `Membership_Process_ID` cart attribute the checkout link itself
+ * set — mirrored since #1029, and the exact same key the orders/paid webhook
+ * credits. Exact, so no ambiguity.
+ *
+ * Fallback: customer email → household lead → the family's single PENDING_PAYMENT
+ * process. Only reached for orders synced before #1029 shipped (note_attributes is
+ * null on those). Fuzzier, so it refuses to guess: zero or several pending
+ * processes resolve to "none"/"ambiguous" rather than picking one.
+ *
+ * Either way the caller amount-gates before activating, and only a PENDING_PAYMENT
+ * process is ever a recovery candidate.
+ */
+async function resolveMembershipProcess(order: MirrorOrder): Promise<ResolvedProcess> {
+    const raw = mirror.orderAttr(order, "Membership_Process_ID");
+    if (raw) {
+        const id = parseInt(raw, 10);
+        if (isNaN(id)) return "ambiguous"; // tagged as a membership order, but unusably
+        const p = await prisma.orgMembershipProcess.findUnique({
+            where: { id },
+            select: { id: true, status: true, orgMembershipId: true },
+        });
+        // Attribute names a process that doesn't exist — forged/replayed/stale. Never guess.
+        if (!p) return "ambiguous";
+        // It IS a membership order; it just isn't awaiting payment (already settled,
+        // still in review, archived...). activate() would no-op — nothing to recover.
+        if (p.status !== "PENDING_PAYMENT") return "none";
+        return { id: p.id, orgMembershipId: p.orgMembershipId };
+    }
+
+    const email = order.customerEmail?.toLowerCase().trim();
+    if (!email) return "none";
+    const leads = await prisma.person.findMany({ where: { email, isHouseholdLead: true }, select: { householdId: true } });
+    const householdIds = [...new Set(leads.map((l) => l.householdId))];
+    if (householdIds.length === 0) return "none";
+
+    const pending = await prisma.orgMembershipProcess.findMany({
+        where: { orgMembership: { householdId: { in: householdIds } }, status: "PENDING_PAYMENT" },
+        select: { id: true, orgMembershipId: true },
+    });
+    if (pending.length === 0) return "none"; // family has no membership awaiting payment.
+    if (pending.length > 1) return "ambiguous"; // can't safely pick which one this paid for.
+    return pending[0];
+}
+
+/**
+ * Try to attribute one mirror order to a membership process and act on it. Returns
+ * true if the order was claimed (recovered or raised), false if it is not a
+ * membership order (so a program pass may still claim it).
  */
 async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> {
-    const email = order.customerEmail?.toLowerCase().trim();
-    if (!email) return false;
-
     // Already recorded on a process? Then it is not a missed payment.
     if (order.legacyId) {
         const known = await prisma.orgMembershipProcess.findFirst({ where: { shopifyOrderId: order.legacyId }, select: { id: true } });
         if (known) return true;
     }
 
-    const leads = await prisma.person.findMany({ where: { email, isHouseholdLead: true }, select: { householdId: true } });
-    const householdIds = [...new Set(leads.map((l) => l.householdId))];
-    if (householdIds.length === 0) return false;
-
-    const pending = await prisma.orgMembershipProcess.findMany({
-        where: { orgMembership: { householdId: { in: householdIds } }, status: "PENDING_PAYMENT" },
-        select: { id: true, orgMembershipId: true },
-    });
-    if (pending.length === 0) return false; // family has no membership awaiting payment.
-
-    if (pending.length > 1) {
-        // Can't safely pick which pending membership this order paid for.
+    const proc = await resolveMembershipProcess(order);
+    if (proc === "none") return false; // not a membership order — a program pass may claim it.
+    if (proc === "ambiguous") {
         await raisePaymentException("UNMATCHED_ORDER", { shopifyOrderId: order.legacyId });
         return true;
     }
-
-    const proc = pending[0];
 
     // Paid then reversed before we ever activated — keep it PENDING, tell the board.
     if (isReversed(order)) {
@@ -191,8 +232,6 @@ async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> 
  * webhook). Returns true if claimed.
  */
 async function reconcileForwardProgram(order: MirrorOrder): Promise<boolean> {
-    const email = order.customerEmail?.toLowerCase().trim();
-    if (!email) return false;
     if (!isPaid(order)) return false;
 
     if (order.legacyId) {
@@ -200,8 +239,32 @@ async function reconcileForwardProgram(order: MirrorOrder): Promise<boolean> {
         if (known) return true;
     }
 
-    // The purchaser (household lead) and everyone in their household — enrollment is
-    // per person, but the order pays under the lead's email.
+    // Preferred: the cart attributes the enroll flow's checkout link set — the same
+    // keys the orders/paid webhook credits (mirrored since #1029). CheckMeIn_Account_ID
+    // is a comma-separated person list, matching the webhook's own parse.
+    const programRaw = mirror.orderAttr(order, "Program_ID");
+    const accountRaw = mirror.orderAttr(order, "CheckMeIn_Account_ID");
+    if (programRaw && accountRaw) {
+        const programId = parseInt(programRaw, 10);
+        const ids = accountRaw.split(",").map((s) => parseInt(s.trim(), 10)).filter((n) => !isNaN(n));
+        if (isNaN(programId) || ids.length === 0) {
+            await raisePaymentException("UNMATCHED_ORDER", { shopifyOrderId: order.legacyId });
+            return true;
+        }
+        // Only those actually awaiting payment; a redelivery/re-run finds none and no-ops.
+        const pending = await prisma.programParticipant.findMany({
+            where: { programId, personId: { in: ids }, status: "PENDING" },
+            select: { programId: true, personId: true },
+        });
+        if (pending.length === 0) return true; // it IS this program's order, nothing to recover.
+        return activateProgramFromOrder(order, programId, pending.map((p) => p.personId));
+    }
+
+    // Fallback for pre-#1029 orders (no attributes mirrored): the purchaser
+    // (household lead) and everyone in their household — enrollment is per person,
+    // but the order pays under the lead's email.
+    const email = order.customerEmail?.toLowerCase().trim();
+    if (!email) return false;
     const leads = await prisma.person.findMany({ where: { email, isHouseholdLead: true }, select: { householdId: true } });
     const householdIds = [...new Set(leads.map((l) => l.householdId))];
     if (householdIds.length === 0) return false;
@@ -215,25 +278,31 @@ async function reconcileForwardProgram(order: MirrorOrder): Promise<boolean> {
     if (pending.length === 0) return false;
 
     // A single order can enroll a whole household in one program; more than one
-    // distinct program among the pending set is unattributable from the mirror.
+    // distinct program among the pending set is unattributable without attributes.
     const programs = [...new Set(pending.map((p) => p.programId))];
     if (programs.length > 1) {
         await raisePaymentException("UNMATCHED_ORDER", { shopifyOrderId: order.legacyId });
         return true;
     }
 
+    return activateProgramFromOrder(order, programs[0], pending.map((p) => p.personId));
+}
+
+/** Shared tail for both program-matching paths: activate through the one choke point. */
+async function activateProgramFromOrder(order: MirrorOrder, programId: number, personIds: number[]): Promise<boolean> {
     const { activateProgramEnrollment } = await import("@/lib/programs/activateEnrollment");
     const res = await activateProgramEnrollment({
-        programId: programs[0],
-        personIds: pending.map((p) => p.personId),
+        programId,
+        personIds,
         shopifyOrderId: order.legacyId ?? "",
-        // No line variant id in the mirror — trust the email+pending match for the
-        // recovery path (see the membership amount-gate note). Tier unknown → no
-        // legacy sibling-inventory mirror.
+        // The mirror carries no line variant id, so the webhook's variant check can't
+        // be replicated — the order is matched to THIS program's pending enrollments
+        // (by cart attribute, or by household for pre-#1029 orders). Tier unknown →
+        // no legacy sibling-inventory mirror.
         hasProgramItem: true,
         purchasedOrgMember: null,
     });
-    logger.info(`[reconcile] recovered program payment: program ${programs[0]} ← order ${order.legacyId} (${res.activatedCount} activated)`);
+    logger.info(`[reconcile] recovered program payment: program ${programId} ← order ${order.legacyId} (${res.activatedCount} activated)`);
     return true;
 }
 

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -1,0 +1,364 @@
+import prisma from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+import { activateByProcessId } from "@/lib/membership/payment";
+import { notifyBoardPaymentException } from "@/lib/membership/boardAlerts";
+import * as mirror from "@/lib/shopifyRead/client";
+import type { MirrorOrder } from "@/lib/shopifyRead/client";
+
+/**
+ * Shopify payment reconciler. Reads the s-read `shopify_read` mirror and aligns
+ * Shopify order truth with membership/program truth, both directions:
+ *
+ *   forward  — a paid order whose family is still stuck at PENDING_PAYMENT is a
+ *              MISSED orders/paid webhook: recover it (activate), advancing the
+ *              family past the paid checkpoint. Application AND renewal.
+ *   reversal — an order we already activated on that is later refunded, charged
+ *              back, or cancelled: raise a PaymentException for the board. We never
+ *              auto-revert access (a chargeback can be a bank error).
+ *
+ * Runs hourly from api/cron/reconcile-shopify. Idempotent: forward recovery is a
+ * no-op once activate() has recorded the order (activate stores shopifyOrderId and
+ * short-circuits on paidAt), and every exception upserts on (kind, order).
+ *
+ * Matching key is the order's customer EMAIL → household lead → the family's single
+ * PENDING_PAYMENT process (the mirror carries no cart note-attributes and no line
+ * variant id, so we cannot use the webhook's exact process-id / variant match). A
+ * zero/ambiguous email match, or an amount that does not cover dues, raises a
+ * problem instead of guessing.
+ */
+
+export type PaymentExceptionKind =
+    | "PAID_WHILE_BLOCKED"
+    | "NO_ITEM"
+    | "UNMATCHED_ORDER"
+    | "REFUND"
+    | "CHARGEBACK"
+    | "CANCELLED"
+    | "REVERSED_BEFORE_ACTIVATION"
+    | "AMOUNT_MISMATCH"
+    | "ACTIVE_WITHOUT_PAYMENT";
+
+type Severity = "WARN" | "CRITICAL";
+
+const CRITICAL_KINDS = new Set<PaymentExceptionKind>(["CHARGEBACK"]);
+
+// A recovered payment may come in a cent or two under the recorded dues (rounding,
+// a stale settings copy). Only a shortfall beyond this is a real mismatch.
+const AMOUNT_TOLERANCE_CENTS = 100;
+
+interface ExceptionRef {
+    shopifyOrderId?: string | null;
+    processId?: number | null;
+    programId?: number | null;
+    personId?: number | null;
+    severity?: Severity;
+}
+
+/**
+ * Upsert a PaymentException, idempotent across hourly runs. One open row per
+ * (kind, order); a resolved row that re-detects reopens (the problem came back). A
+ * newly-opened or reopened row escalates to the board (CRITICAL emails immediately;
+ * WARN is surfaced on the dashboard + red-dot only — see notifyBoardPaymentException).
+ */
+export async function raisePaymentException(kind: PaymentExceptionKind, ref: ExceptionRef): Promise<void> {
+    const severity: Severity = ref.severity ?? (CRITICAL_KINDS.has(kind) ? "CRITICAL" : "WARN");
+    const orderId = ref.shopifyOrderId ?? null;
+
+    // Find an existing row for this (kind, order). When orderId is null the unique
+    // index treats rows as distinct, so fall back to the linked entity.
+    const existing = orderId
+        ? await prisma.paymentException.findFirst({ where: { kind, shopifyOrderId: orderId } })
+        : await prisma.paymentException.findFirst({
+              where: { kind, shopifyOrderId: null, processId: ref.processId ?? null, programId: ref.programId ?? null, personId: ref.personId ?? null },
+          });
+
+    if (existing) {
+        if (existing.status === "RESOLVED") {
+            await prisma.paymentException.update({
+                where: { id: existing.id },
+                data: { status: "OPEN", severity, resolvedAt: null, resolvedById: null, resolutionNote: null, detectedAt: new Date() },
+            });
+            await notifyBoardPaymentException(kind, severity, existing.id);
+        }
+        return; // already tracked and still open/acknowledged — nothing to do.
+    }
+
+    try {
+        const created = await prisma.paymentException.create({
+            data: {
+                kind,
+                severity,
+                shopifyOrderId: orderId,
+                processId: ref.processId ?? null,
+                programId: ref.programId ?? null,
+                personId: ref.personId ?? null,
+            },
+        });
+        await notifyBoardPaymentException(kind, severity, created.id);
+    } catch (e: unknown) {
+        // Unique-index race (two runs, same order) — the other run created it. Safe.
+        if (e && typeof e === "object" && "code" in e && (e as { code?: string }).code === "P2002") return;
+        throw e;
+    }
+}
+
+// ── predicates over a mirror order ───────────────────────────────────────────
+
+/** Shopify displayFinancialStatus that means "money is in" and not reversed. */
+function isPaid(o: MirrorOrder): boolean {
+    const s = (o.financialStatus ?? "").toUpperCase();
+    return (s === "PAID" || s === "PARTIALLY_PAID") && !o.cancelledAt && o.totalRefundedCents === 0;
+}
+
+/** Any sign the money came back out. */
+function isReversed(o: MirrorOrder): boolean {
+    const s = (o.financialStatus ?? "").toUpperCase();
+    return !!o.cancelledAt || o.totalRefundedCents > 0 || s === "REFUNDED" || s === "PARTIALLY_REFUNDED" || s === "VOIDED";
+}
+
+// ── forward pass (recover missed payments) ───────────────────────────────────
+
+/**
+ * Try to attribute one mirror order to a membership process by customer email and
+ * act on it. Returns true if the order was claimed (recovered or raised), false if
+ * it is not a membership order (so a program pass may still claim it).
+ */
+async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> {
+    const email = order.customerEmail?.toLowerCase().trim();
+    if (!email) return false;
+
+    // Already recorded on a process? Then it is not a missed payment.
+    if (order.legacyId) {
+        const known = await prisma.orgMembershipProcess.findFirst({ where: { shopifyOrderId: order.legacyId }, select: { id: true } });
+        if (known) return true;
+    }
+
+    const leads = await prisma.person.findMany({ where: { email, isHouseholdLead: true }, select: { householdId: true } });
+    const householdIds = [...new Set(leads.map((l) => l.householdId))];
+    if (householdIds.length === 0) return false;
+
+    const pending = await prisma.orgMembershipProcess.findMany({
+        where: { orgMembership: { householdId: { in: householdIds } }, status: "PENDING_PAYMENT" },
+        select: { id: true, orgMembershipId: true },
+    });
+    if (pending.length === 0) return false; // family has no membership awaiting payment.
+
+    if (pending.length > 1) {
+        // Can't safely pick which pending membership this order paid for.
+        await raisePaymentException("UNMATCHED_ORDER", { shopifyOrderId: order.legacyId });
+        return true;
+    }
+
+    const proc = pending[0];
+
+    // Paid then reversed before we ever activated — keep it PENDING, tell the board.
+    if (isReversed(order)) {
+        await raisePaymentException("REVERSED_BEFORE_ACTIVATION", { shopifyOrderId: order.legacyId, processId: proc.id });
+        return true;
+    }
+    if (!isPaid(order)) return true; // pending/authorized/etc — nothing to do yet, but it IS this family's order.
+
+    // Amount gate: the mirror has no line variant id, so we cannot replicate the
+    // webhook's variant-id membership-item check — gate on the order covering dues
+    // instead (matched to THIS pending process). Short → mismatch, not activation.
+    const membership = proc.orgMembershipId
+        ? await prisma.orgMembership.findUnique({ where: { id: proc.orgMembershipId }, select: { isVolunteer: true } })
+        : null;
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 }, select: { normalDuesCents: true, volunteerDuesCents: true } });
+    const expected = membership?.isVolunteer ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
+    if (expected > 0 && order.totalCents + AMOUNT_TOLERANCE_CENTS < expected) {
+        await raisePaymentException("AMOUNT_MISMATCH", { shopifyOrderId: order.legacyId, processId: proc.id });
+        return true;
+    }
+
+    // Recover: advance past the paid checkpoint. hasMembershipItem=true — matched to
+    // this specific pending process and the amount covers dues (honest missed-webhook
+    // assumption; the reconciler is not the attack surface the public webhook is, and
+    // it leaves a full AuditLog trail via activate()).
+    const result = await activateByProcessId(proc.id, order.legacyId ?? "", true);
+    logger.info(`[reconcile] recovered missed payment: process ${proc.id} ← order ${order.legacyId} (${result?.status})`);
+    if (result?.status === "BLOCKED") {
+        await raisePaymentException("PAID_WHILE_BLOCKED", { shopifyOrderId: order.legacyId, processId: proc.id });
+    }
+    return true;
+}
+
+/**
+ * Program forward recovery: a paid order matched by email to persons who have a
+ * PENDING enrollment. Uses the shared activateProgramEnrollment (extracted from the
+ * webhook). Returns true if claimed.
+ */
+async function reconcileForwardProgram(order: MirrorOrder): Promise<boolean> {
+    const email = order.customerEmail?.toLowerCase().trim();
+    if (!email) return false;
+    if (!isPaid(order)) return false;
+
+    if (order.legacyId) {
+        const known = await prisma.programParticipant.findFirst({ where: { shopifyOrderId: order.legacyId }, select: { programId: true } });
+        if (known) return true;
+    }
+
+    // The purchaser (household lead) and everyone in their household — enrollment is
+    // per person, but the order pays under the lead's email.
+    const leads = await prisma.person.findMany({ where: { email, isHouseholdLead: true }, select: { householdId: true } });
+    const householdIds = [...new Set(leads.map((l) => l.householdId))];
+    if (householdIds.length === 0) return false;
+    const people = await prisma.person.findMany({ where: { householdId: { in: householdIds } }, select: { id: true } });
+    const personIds = people.map((p) => p.id);
+
+    const pending = await prisma.programParticipant.findMany({
+        where: { personId: { in: personIds }, status: "PENDING" },
+        select: { programId: true, personId: true },
+    });
+    if (pending.length === 0) return false;
+
+    // A single order can enroll a whole household in one program; more than one
+    // distinct program among the pending set is unattributable from the mirror.
+    const programs = [...new Set(pending.map((p) => p.programId))];
+    if (programs.length > 1) {
+        await raisePaymentException("UNMATCHED_ORDER", { shopifyOrderId: order.legacyId });
+        return true;
+    }
+
+    const { activateProgramEnrollment } = await import("@/lib/programs/activateEnrollment");
+    const res = await activateProgramEnrollment({
+        programId: programs[0],
+        personIds: pending.map((p) => p.personId),
+        shopifyOrderId: order.legacyId ?? "",
+        // No line variant id in the mirror — trust the email+pending match for the
+        // recovery path (see the membership amount-gate note). Tier unknown → no
+        // legacy sibling-inventory mirror.
+        hasProgramItem: true,
+        purchasedOrgMember: null,
+    });
+    logger.info(`[reconcile] recovered program payment: program ${programs[0]} ← order ${order.legacyId} (${res.activatedCount} activated)`);
+    return true;
+}
+
+// ── reversal pass (raise problems on money that came back out) ────────────────
+
+function classifyReversal(o: MirrorOrder, disputed: boolean): PaymentExceptionKind | null {
+    if (o.cancelledAt) return "CANCELLED";
+    if (disputed) return "CHARGEBACK";
+    if (isReversed(o)) return "REFUND";
+    return null;
+}
+
+/**
+ * Fast-path entry for the reversal webhooks (refunds/create, orders/cancelled,
+ * disputes/*): map a Shopify order id to the membership process and/or program
+ * enrollment it activated and raise the given problem. Returns true if anything
+ * matched. Shares the same idempotent raise as the hourly reconciler.
+ */
+export async function raiseReversalByOrderId(orderLegacyId: string, kind: PaymentExceptionKind): Promise<boolean> {
+    let matched = false;
+    const proc = await prisma.orgMembershipProcess.findFirst({ where: { shopifyOrderId: orderLegacyId }, select: { id: true } });
+    if (proc) {
+        await raisePaymentException(kind, { shopifyOrderId: orderLegacyId, processId: proc.id });
+        matched = true;
+    }
+    const enrolls = await prisma.programParticipant.findMany({ where: { shopifyOrderId: orderLegacyId }, select: { programId: true, personId: true } });
+    for (const e of enrolls) {
+        await raisePaymentException(kind, { shopifyOrderId: orderLegacyId, programId: e.programId, personId: e.personId });
+        matched = true;
+    }
+    return matched;
+}
+
+async function reconcileReversals(): Promise<number> {
+    // App-side activated orders: money recorded (paidAt) with an order id. BLOCKED
+    // stays out — a refund on a paid-while-blocked application is the expected fix.
+    const procs = await prisma.orgMembershipProcess.findMany({
+        where: { shopifyOrderId: { not: null }, paidAt: { not: null }, status: { in: ["ACTIVE", "PENDING_BG_CLEARANCE"] } },
+        select: { id: true, shopifyOrderId: true, orgMembershipId: true },
+    });
+    const enrolls = await prisma.programParticipant.findMany({
+        where: { shopifyOrderId: { not: null }, status: "ACTIVE" },
+        select: { programId: true, personId: true, shopifyOrderId: true },
+    });
+
+    const orderIds = [
+        ...procs.map((p) => p.shopifyOrderId!),
+        ...enrolls.map((e) => e.shopifyOrderId!),
+    ];
+    if (orderIds.length === 0) return 0;
+
+    const orders = await mirror.ordersByLegacyIds([...new Set(orderIds)]);
+    const byLegacy = new Map(orders.map((o) => [o.legacyId ?? "", o]));
+    const disputed = await mirror.disputedOrderGids(orders.map((o) => o.orderGid));
+
+    // Expected dues per membership (for the "order edited down below dues" case).
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 }, select: { normalDuesCents: true, volunteerDuesCents: true } });
+    const memberIds = procs.map((p) => p.orgMembershipId).filter((v): v is number => v != null);
+    const members = memberIds.length
+        ? await prisma.orgMembership.findMany({ where: { id: { in: memberIds } }, select: { id: true, isVolunteer: true } })
+        : [];
+    const isVolunteerById = new Map(members.map((m) => [m.id, m.isVolunteer]));
+
+    let raised = 0;
+    for (const proc of procs) {
+        const o = byLegacy.get(proc.shopifyOrderId!);
+        if (!o) continue; // pre-cutover / not yet mirrored — can't judge.
+        let kind = classifyReversal(o, disputed.has(o.orderGid));
+        if (!kind) {
+            // Not reversed — but was the order edited down below dues after activation?
+            const expected = isVolunteerById.get(proc.orgMembershipId ?? -1) ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
+            if (expected > 0 && o.totalCents + AMOUNT_TOLERANCE_CENTS < expected) kind = "AMOUNT_MISMATCH";
+        }
+        if (kind) {
+            await raisePaymentException(kind, { shopifyOrderId: proc.shopifyOrderId, processId: proc.id });
+            raised++;
+        }
+    }
+    for (const e of enrolls) {
+        const o = byLegacy.get(e.shopifyOrderId!);
+        if (!o) continue;
+        const kind = classifyReversal(o, disputed.has(o.orderGid));
+        if (kind) {
+            await raisePaymentException(kind, { shopifyOrderId: e.shopifyOrderId, programId: e.programId, personId: e.personId });
+            raised++;
+        }
+    }
+    return raised;
+}
+
+// ── entry point ──────────────────────────────────────────────────────────────
+
+export interface ReconcileResult {
+    configured: boolean;
+    ordersScanned: number;
+    reversalsRaised: number;
+}
+
+/**
+ * One reconciliation pass. No-op (configured:false) when the mirror isn't wired.
+ * Advances BoardSettings.shopifyReconcileCursorAt to the newest order it processed
+ * so the next run only re-scans changed orders.
+ */
+export async function runReconcile(): Promise<ReconcileResult> {
+    if (!mirror.isConfigured()) return { configured: false, ordersScanned: 0, reversalsRaised: 0 };
+
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 }, select: { shopifyReconcileCursorAt: true } });
+    const cursor = settings?.shopifyReconcileCursorAt ?? null;
+
+    const orders = await mirror.ordersChangedSince(cursor);
+    let newCursor = cursor;
+    for (const order of orders) {
+        try {
+            const claimed = await reconcileForwardMembership(order);
+            if (!claimed) await reconcileForwardProgram(order);
+        } catch (e) {
+            logger.error(`[reconcile] forward pass failed for order ${order.legacyId ?? order.orderGid}:`, e);
+        }
+        if (order.updatedAt && (!newCursor || order.updatedAt > newCursor)) newCursor = order.updatedAt;
+    }
+
+    const reversalsRaised = await reconcileReversals();
+
+    // Advance the cursor only after a clean pass, so a mid-run failure re-scans.
+    if (newCursor && newCursor !== cursor) {
+        await prisma.boardSettings.update({ where: { id: 1 }, data: { shopifyReconcileCursorAt: newCursor } });
+    }
+
+    return { configured: true, ordersScanned: orders.length, reversalsRaised };
+}

--- a/checkin-app/src/lib/financeNav.ts
+++ b/checkin-app/src/lib/financeNav.ts
@@ -7,4 +7,5 @@ import type { NavLink } from "@/lib/nav/types";
 export const FINANCE_NAV_LINKS: NavLink[] = [
   { name: "Program Payment Plan", href: "/finance-ops/payment-plan", icon: "⏳" },
   { name: "Membership Payment Plan", href: "/finance-ops/membership-payment-plan", icon: "⏳" },
+  { name: "Payment problems", href: "/finance-ops/payments", icon: "⚠️" },
 ];

--- a/checkin-app/src/lib/membership/boardAlerts.ts
+++ b/checkin-app/src/lib/membership/boardAlerts.ts
@@ -23,3 +23,38 @@ export async function notifyBoardPaidReject(processId: number): Promise<void> {
         "Paid-reject board ping failed:",
     );
 }
+
+/** One-line human description per payment-exception kind, for the board email. */
+const EXCEPTION_BLURB: Record<string, string> = {
+    PAID_WHILE_BLOCKED: "a household paid but its application is blocked at background check — a refund may be needed",
+    NO_ITEM: "a paid order did not contain the membership/program product",
+    UNMATCHED_ORDER: "a paid order could not be attributed to a family (no or ambiguous match)",
+    REFUND: "an active membership/enrollment's order was refunded",
+    CHARGEBACK: "a chargeback/dispute was filed against an active membership/enrollment's payment",
+    CANCELLED: "an active membership/enrollment's order was cancelled",
+    REVERSED_BEFORE_ACTIVATION: "a payment was refunded/cancelled before the family was activated",
+    AMOUNT_MISMATCH: "a payment does not cover the expected dues/price",
+    ACTIVE_WITHOUT_PAYMENT: "a membership/enrollment is active with no matching payment on file",
+};
+
+/**
+ * Escalate a payment reconciliation problem to the board. CRITICAL (a chargeback)
+ * emails immediately; WARN-level problems are surfaced on the finance-ops payments
+ * dashboard + the red-dot count only, so the board isn't emailed every hour for
+ * routine refunds. (A daily WARN digest can be added later — see
+ * notifyBoardPaymentExceptionDigest.) Never throws — email failures are swallowed.
+ */
+export async function notifyBoardPaymentException(
+    kind: string,
+    severity: "WARN" | "CRITICAL",
+    exceptionId: number,
+): Promise<void> {
+    if (severity !== "CRITICAL") return; // WARN → dashboard + red-dot only.
+    const base = config.baseUrl();
+    const blurb = EXCEPTION_BLURB[kind] ?? "a payment problem was detected";
+    await emailBoardMembers(
+        `Payment problem (${kind}) — board action needed`,
+        `<p>A payment problem needs the board's attention: ${blurb} (#${exceptionId}). Nothing was changed automatically. <a href="${base}/finance-ops/payments">Open payment problems</a></p>`,
+        "Payment-exception board ping failed:",
+    );
+}

--- a/checkin-app/src/lib/membership/boardAlerts.ts
+++ b/checkin-app/src/lib/membership/boardAlerts.ts
@@ -40,9 +40,10 @@ const EXCEPTION_BLURB: Record<string, string> = {
 /**
  * Escalate a payment reconciliation problem to the board. CRITICAL (a chargeback)
  * emails immediately; WARN-level problems are surfaced on the finance-ops payments
- * dashboard + the red-dot count only, so the board isn't emailed every hour for
- * routine refunds. (A daily WARN digest can be added later — see
- * notifyBoardPaymentExceptionDigest.) Never throws — email failures are swallowed.
+ * dashboard + the red-dot count only, so a routine refund doesn't put mail in five
+ * inboxes. The reconciler that raises these runs once daily, so the dashboard is
+ * itself effectively a daily digest — a separate WARN digest email would just be
+ * the same list, pushed. Never throws — email failures are swallowed.
  */
 export async function notifyBoardPaymentException(
     kind: string,

--- a/checkin-app/src/lib/membership/notifications.ts
+++ b/checkin-app/src/lib/membership/notifications.ts
@@ -6,6 +6,8 @@ export interface MembershipNotifications {
     pendingReviews: number;
     /** Applications stuck at BLOCKED (board/isSysadmin). */
     blocked: number;
+    /** Open payment-reconciliation problems needing board action (board/isSysadmin). */
+    openPaymentExceptions: number;
 }
 
 /**
@@ -20,9 +22,10 @@ export async function getMembershipNotifications(user: {
     isBoardMember?: boolean;
 }): Promise<MembershipNotifications> {
     const pendingReviews = canReviewBackgroundChecks(user) ? (await eligibleReviewProcessIds(user.id)).length : 0;
-    const blocked =
-        user.isSysadmin || user.isBoardMember
-            ? await prisma.orgMembershipProcess.count({ where: { status: "BLOCKED" } })
-            : 0;
-    return { pendingReviews, blocked };
+    const forBoard = !!(user.isSysadmin || user.isBoardMember);
+    const blocked = forBoard ? await prisma.orgMembershipProcess.count({ where: { status: "BLOCKED" } }) : 0;
+    const openPaymentExceptions = forBoard
+        ? await prisma.paymentException.count({ where: { status: { in: ["OPEN", "ACKNOWLEDGED"] } } })
+        : 0;
+    return { pendingReviews, blocked, openPaymentExceptions };
 }

--- a/checkin-app/src/lib/programs/activateEnrollment.ts
+++ b/checkin-app/src/lib/programs/activateEnrollment.ts
@@ -1,0 +1,103 @@
+import prisma from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+import { adjustProgramInventory } from "@/lib/shopify";
+
+/**
+ * Activate paid program enrollments — the single choke point the Shopify
+ * orders/paid webhook AND the reconciler both call (mirrors membership's
+ * activate()). Extracted from the webhook route so a MISSED webhook can be
+ * recovered by the reconciler through the exact same, idempotent path.
+ *
+ * Per participant: a transactionally-guarded PENDING → ACTIVE flip (so a webhook
+ * redelivery or a reconciler re-run can't double-activate or double-count),
+ * clearing the pending timer, stamping the paying order id, and releasing any
+ * scholarship inventory hold (compensating Shopify's sale-time auto-decrement).
+ *
+ * The membership-item / tier check lives with the CALLER, because only the webhook
+ * has the order's line-item variant ids — the mirror does not. The webhook passes
+ * the computed values; the reconciler passes hasProgramItem=true (it matched the
+ * order to a pending enrollment by email) and purchasedTier=null (tier unknown), in
+ * which case the legacy two-pool sibling-inventory mirror is skipped.
+ */
+export interface ActivateEnrollmentInput {
+    programId: number;
+    /** Person ids to activate (all must belong to this program's pending set). */
+    personIds: number[];
+    /** Numeric Shopify order id, stored on each activated participant for reversal joins. */
+    shopifyOrderId: string;
+    /** Did the paid order contain this program's product? Fail-closed: false = don't activate. */
+    hasProgramItem: boolean;
+    /**
+     * Which tier Shopify sold (true = org-member variant), for the legacy two-pool
+     * sibling-inventory mirror. null = unknown (reconciler path) → skip the mirror.
+     */
+    purchasedOrgMember: boolean | null;
+}
+
+export interface ActivateEnrollmentResult {
+    activatedCount: number;
+    releasedHoldCount: number;
+}
+
+export async function activateProgramEnrollment(input: ActivateEnrollmentInput): Promise<ActivateEnrollmentResult> {
+    const { programId, personIds, shopifyOrderId, hasProgramItem, purchasedOrgMember } = input;
+    const program = await prisma.program.findUnique({ where: { id: programId } });
+
+    let activatedCount = 0;
+    let releasedHoldCount = 0;
+
+    for (const personId of personIds) {
+        const existing = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId } } });
+        if (!existing) {
+            logger.warn(`[enroll] Participant ${personId} not found in program ${programId} — ignoring payment.`);
+            continue;
+        }
+        if (!hasProgramItem) {
+            logger.warn(`[enroll] Order ${shopifyOrderId || "?"} for participant ${personId} / program ${programId} did not contain the program's Shopify variant — left PENDING, NOT activated.`);
+            continue;
+        }
+
+        // Guarded PENDING → ACTIVE so a redelivery / re-run can't inflate the count.
+        const activated = await prisma.programParticipant.updateMany({
+            where: { programId, personId, status: "PENDING" },
+            data: { status: "ACTIVE", pendingSince: null, shopifyOrderId },
+        });
+        activatedCount += activated.count;
+        if (activated.count > 0) logger.info(`[enroll] Marked participant ${personId} ACTIVE for program ${programId}`);
+
+        // Release a scholarship hold if one was set (compensates the sale's auto-decrement),
+        // guarded (NOT NULL → NULL) so a retry can't release twice.
+        if (existing.inventoryHeldAt) {
+            const release = await prisma.programParticipant.updateMany({
+                where: { programId, personId, inventoryHeldAt: { not: null } },
+                data: { inventoryHeldAt: null },
+            });
+            releasedHoldCount += release.count;
+        }
+    }
+
+    // Compensating +1 for every hold released, in one call. Never fatal.
+    if (releasedHoldCount > 0) {
+        const ok = await adjustProgramInventory(
+            {
+                shopifyVariantId: program?.shopifyVariantId ?? null,
+                shopifyOrgMemberVariantId: program?.shopifyOrgMemberVariantId ?? null,
+                shopifyNonOrgMemberVariantId: program?.shopifyNonOrgMemberVariantId ?? null,
+            },
+            releasedHoldCount,
+        );
+        if (!ok) logger.error(`[enroll] Failed to release ${releasedHoldCount} scholarship hold(s) for program ${programId} — capacity may be out of sync.`);
+    }
+
+    // LEGACY two-pool sibling mirror: only when we know the tier. Single-pool programs
+    // (shopifyVariantId) need no mirror; the reconciler (tier unknown) skips it.
+    if (activatedCount > 0 && !program?.shopifyVariantId && purchasedOrgMember !== null) {
+        const siblingOnly = purchasedOrgMember
+            ? { shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: program?.shopifyNonOrgMemberVariantId ?? null }
+            : { shopifyOrgMemberVariantId: program?.shopifyOrgMemberVariantId ?? null, shopifyNonOrgMemberVariantId: null };
+        const ok = await adjustProgramInventory({ shopifyVariantId: null, ...siblingOnly }, -activatedCount);
+        if (!ok) logger.error(`[enroll] Failed to mirror sibling-variant inventory for program ${programId} — pools may be out of sync.`);
+    }
+
+    return { activatedCount, releasedHoldCount };
+}

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -72,11 +72,23 @@ export interface MirrorOrder {
     totalRefundedCents: number;
     cancelledAt: Date | null;
     updatedAt: Date | null;
+    /**
+     * The cart attributes we set on the checkout link (Membership_Process_ID,
+     * CheckMeIn_Account_ID, Program_ID), mirrored since #1029. Null for orders
+     * synced before that shipped — callers must handle absence.
+     */
+    noteAttributes: { key: string; value: string | null }[] | null;
 }
 
 const ORDER_COLS = `shopify_gid AS "orderGid", legacy_id AS "legacyId", customer_email AS "customerEmail",
     financial_status AS "financialStatus", total_cents AS "totalCents", subtotal_cents AS "subtotalCents",
-    total_refunded_cents AS "totalRefundedCents", cancelled_at AS "cancelledAt", updated_at AS "updatedAt"`;
+    total_refunded_cents AS "totalRefundedCents", cancelled_at AS "cancelledAt", updated_at AS "updatedAt",
+    note_attributes AS "noteAttributes"`;
+
+/** Read one cart attribute off a mirrored order. Null when absent (or pre-#1029). */
+export function orderAttr(o: MirrorOrder, key: string): string | null {
+    return o.noteAttributes?.find((a) => a.key === key)?.value ?? null;
+}
 
 /**
  * Orders whose mirror row changed after `since` (the reconciler's high-water mark),

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -1,0 +1,113 @@
+import { Pool } from "pg";
+import { config } from "@/lib/config";
+import { logger } from "@/lib/logger";
+
+/**
+ * Read-only bridge to the s-read `shopify_read` Postgres — the mirror the
+ * s-read-function keeps of Shopify orders/refunds/payouts/balance-transactions.
+ * The reconciler (lib/finance/reconcile.ts) reads it to align Shopify order truth
+ * with membership/program truth.
+ *
+ * Deliberately raw `pg` (parameterized SELECTs), NOT a second Prisma client: we
+ * read a handful of columns from four tables, and a raw pool avoids wiring the
+ * s-ingest-core generated client across the monorepo boundary (transpilePackages,
+ * a second generate step, schema-version coupling). The mirror's own DDL owner
+ * migrates it; we only ever read.
+ *
+ * The connection string SHOULD point at a read-only role. Null env → isConfigured()
+ * is false and the reconciler no-ops, so an env without the mirror runs no
+ * reconciliation rather than crashing.
+ *
+ * ponytail: no store_id filter — each env has its own `shopify_read_<env>` DB with
+ * exactly one store, so filtering would only risk a myshopify-vs-storefront domain
+ * mismatch. Add a store filter if a single mirror DB ever holds multiple stores.
+ */
+
+let pool: Pool | null = null;
+
+function getPool(): Pool | null {
+    const url = config.shopifyReadDatabaseUrl();
+    if (!url) return null;
+    if (!pool) {
+        pool = new Pool({
+            connectionString: url,
+            max: 3,
+            connectionTimeoutMillis: 10_000,
+            keepAlive: true,
+        });
+        pool.on("error", (e) => logger.error("shopify_read pool error:", e));
+    }
+    return pool;
+}
+
+export function isConfigured(): boolean {
+    return !!config.shopifyReadDatabaseUrl();
+}
+
+/** A row of `shop_order` — only the columns the reconciler needs. */
+export interface MirrorOrder {
+    /** Shopify order GID, e.g. gid://shopify/Order/123. */
+    orderGid: string;
+    /** Numeric order id — joins to OrgMembershipProcess/ProgramParticipant.shopifyOrderId. */
+    legacyId: string | null;
+    customerEmail: string | null;
+    /** Shopify displayFinancialStatus, verbatim (uppercase): PAID, REFUNDED, … */
+    financialStatus: string | null;
+    totalCents: number;
+    subtotalCents: number;
+    totalRefundedCents: number;
+    cancelledAt: Date | null;
+    updatedAt: Date | null;
+}
+
+const ORDER_COLS = `shopify_gid AS "orderGid", legacy_id AS "legacyId", customer_email AS "customerEmail",
+    financial_status AS "financialStatus", total_cents AS "totalCents", subtotal_cents AS "subtotalCents",
+    total_refunded_cents AS "totalRefundedCents", cancelled_at AS "cancelledAt", updated_at AS "updatedAt"`;
+
+/**
+ * Orders whose mirror row changed after `since` (the reconciler's high-water mark),
+ * excluding Shopify test orders. Oldest-first so the caller can advance the cursor
+ * to the last row it processed. `since` null → from the beginning.
+ */
+export async function ordersChangedSince(since: Date | null, limit = 1000): Promise<MirrorOrder[]> {
+    const p = getPool();
+    if (!p) return [];
+    const rows = await p.query<MirrorOrder>(
+        `SELECT ${ORDER_COLS} FROM shop_order
+         WHERE test = false AND ($1::timestamptz IS NULL OR updated_at > $1)
+         ORDER BY updated_at ASC NULLS FIRST
+         LIMIT $2`,
+        [since, limit],
+    );
+    return rows.rows;
+}
+
+/** Look up specific orders by their numeric legacy id (the id the app stored on activation). */
+export async function ordersByLegacyIds(legacyIds: string[]): Promise<MirrorOrder[]> {
+    const p = getPool();
+    if (!p || legacyIds.length === 0) return [];
+    const rows = await p.query<MirrorOrder>(
+        `SELECT ${ORDER_COLS} FROM shop_order WHERE legacy_id = ANY($1::text[])`,
+        [legacyIds],
+    );
+    return rows.rows;
+}
+
+/**
+ * Order GIDs that have a chargeback/dispute balance transaction, among the given
+ * GIDs. Shopify Payments surfaces a dispute as a signed balance transaction whose
+ * `type` names the dispute — this distinguishes a chargeback (CRITICAL) from an
+ * ordinary refund. Case-insensitive LIKE so 'dispute'/'chargeback'/'adjustment'
+ * variants all match.
+ */
+export async function disputedOrderGids(orderGids: string[]): Promise<Set<string>> {
+    const p = getPool();
+    if (!p || orderGids.length === 0) return new Set();
+    const rows = await p.query<{ orderGid: string }>(
+        `SELECT DISTINCT order_gid AS "orderGid" FROM shop_balance_transaction
+         WHERE order_gid = ANY($1::text[])
+           AND (lower(type) LIKE '%dispute%' OR lower(type) LIKE '%chargeback%')`,
+        [orderGids],
+    );
+    return new Set(rows.rows.map((r) => r.orderGid));
+}

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -14,6 +14,10 @@ import { logger } from "@/lib/logger";
  * a second generate step, schema-version coupling). The mirror's own DDL owner
  * migrates it; we only ever read.
  *
+ * Note `shopify_read_<env>` lives on the SAME Aurora cluster as `checkin_<env>`
+ * (isolated by database + role, not by cluster), so this pool is bound by the same
+ * scale-to-zero invariant as lib/prisma.ts — see getPool below.
+ *
  * The connection string SHOULD point at a read-only role. Null env → isConfigured()
  * is false and the reconciler no-ops, so an env without the mirror runs no
  * reconciliation rather than crashing.
@@ -33,7 +37,17 @@ function getPool(): Pool | null {
             connectionString: url,
             max: 3,
             connectionTimeoutMillis: 10_000,
-            keepAlive: true,
+            // Scale-to-zero invariant (same rule as lib/prisma.ts, see PR #1030):
+            // idle connections MUST be reaped and `min` MUST stay 0, or this pool
+            // alone keeps the shared Aurora cluster from ever auto-pausing — it
+            // pauses only after ~5 minutes with zero connections and zero queries.
+            // Reaped fast (10s) rather than prisma.ts's 60s: that 60s buys warmth
+            // across a USER's click-to-click gaps, and this pool has no user — it
+            // serves one daily batch (api/cron/reconcile-shopify) and should let go
+            // as soon as the run ends. No keepAlive: it exists to detect dead peers
+            // on long-held connections, and nothing here holds one.
+            idleTimeoutMillis: 10_000,
+            min: 0,
         });
         pool.on("error", (e) => logger.error("shopify_read pool error:", e));
     }

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -118,6 +118,7 @@ export const classifications = {
         shopifyNormalVariantId: 'internal',
         shopifyVolunteerVariantId: 'internal',
         shopifyPriceSyncedAt: 'internal',
+        shopifyReconcileCursorAt: 'internal',
         scholarshipDenialGraceDays: 'public',
         updatedAt: 'internal',
     },
@@ -212,6 +213,7 @@ export const classifications = {
         wasOrgMemberAtApproval: 'internal',
         inventoryHeldAt: 'internal',
         paymentPlanDeniedAt: 'personal',
+        shopifyOrderId: 'internal',
     },
     Fee: {
         id: 'public',
@@ -333,6 +335,20 @@ export const classifications = {
         subject: 'internal',
         html: 'internal',
         createdAt: 'internal',
+    },
+    PaymentException: {
+        id: 'public',
+        kind: 'internal',
+        severity: 'internal',
+        status: 'internal',
+        shopifyOrderId: 'internal',
+        processId: 'internal',
+        programId: 'internal',
+        personId: 'internal',
+        resolvedById: 'internal',
+        resolvedAt: 'internal',
+        resolutionNote: 'personal',
+        detectedAt: 'internal',
     },
 } as const;
 
@@ -474,6 +490,8 @@ export const relations = {
     DevLedger: {
     },
     DevSentEmail: {
+    },
+    PaymentException: {
     },
 } as const;
 

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -151,6 +151,7 @@ export const OPT_OUT_PENDING_ROUTE = new Set<string>([
     'BackgroundCheckAttestation', // bind their_own at migration, keep notes `internal`
     'Corporation', // has leads→participantId; a corp-lead view is plausible
     'VolunteerDesignation', // has createdById; confirm whether a self view is warranted
+    'PaymentException', // board/admin only (finance-ops/payments via withAuth); a household-facing "your payment problem" route is plausible later
 ]);
 
 /**

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -151,7 +151,6 @@ export const OPT_OUT_PENDING_ROUTE = new Set<string>([
     'BackgroundCheckAttestation', // bind their_own at migration, keep notes `internal`
     'Corporation', // has leads→participantId; a corp-lead view is plausible
     'VolunteerDesignation', // has createdById; confirm whether a self view is warranted
-    'PaymentException', // board/admin only (finance-ops/payments via withAuth); a household-facing "your payment problem" route is plausible later
 ]);
 
 /**


### PR DESCRIPTION
> **Stacked on #1032-to-be** — the `OPT_OUT_PENDING_ROUTE` entry for `PaymentException` lives on branch `claude/security-paymentexception-optout` and must merge first (boundary changes ship alone). Until it does, this PR's `scopeValidators` run is red **by design** — that's the repo's registry-first flow, not a defect.

## Why

The `orders/paid` webhook was the **only** thing that moved a family's money-state. If it was dropped, the family paid but stayed stuck at `PENDING_PAYMENT` forever and nothing noticed.

Two gaps, not one:

1. **The intended backup was an orphan.** `s-read-function` mirrors Shopify into a separate `shopify_read` Postgres that **no app code read**. Nothing bridged the mirror back to membership truth, so the "backup" didn't exist end-to-end.
2. **The integration was forward-only.** No handling for refunds, chargebacks, cancellations, or order edits — a family could pay, activate, then charge back, and the app would never know. Money and access drift apart silently.

## What changed

A **daily reconciler** (`api/cron/reconcile-shopify`) reads the mirror **read-only** and converges both directions:

- **forward** — a paid order whose family is still at `PENDING_PAYMENT` is a missed webhook: recover it through the existing idempotent `activate()`, advancing the family past the paid checkpoint. Covers **initial and renewal** (both already funnel through that one exit).
- **reversal** — an order we already activated on that is later refunded / charged back / cancelled raises a `PaymentException` for the board. **Access is never auto-reverted** — a chargeback can be a bank error.

**Program enrollment reached parity** by extracting the webhook route's inline activation into `activateProgramEnrollment()`, so the webhook and reconciler share one idempotent choke point — mirroring how membership already worked.

**Fast-path webhooks** (`refunds/create`, `orders/cancelled`, `disputes/*`) route to the same raise; they are the low-latency path, and the daily reconciler is the backstop for whatever they drop.

## Matching: exact, thanks to #1029

Orders are credited by the **same cart attribute the webhook credits** — `Membership_Process_ID`, or `CheckMeIn_Account_ID` + `Program_ID` — now that #1029 mirrors them to `shop_order.note_attributes`. Attribution is exact, so the reconciler credits the process the checkout link actually named.

Orders synced **before #1029** carry no attributes and fall back to customer email → household lead → the family's *single* pending process. That fallback refuses to guess: zero or several pending processes raise `UNMATCHED_ORDER` rather than picking one.

What the mirror still **cannot** answer is whether the order really contained the membership product — its order lines carry `sku`/`title`, not variant ids — so the webhook's variant-id check can't be replicated, and membership recovery gates on the order **covering the family's dues** instead. Nothing is guessed: an attribute naming an unknown process (forged/replayed/stale), an ambiguous email match, or an amount short of dues all raise a problem instead of activating. Every recovery leaves an `activate()` AuditLog trail.

## Timing is a scale-to-zero constraint, not a taste call

Schedule at **09:15 UTC daily**, ~15 min behind s-read's 09:00 sync ([infra#129](https://github.com/innovationtreehouse/infra/pull/129)).

checkin and shopify_read share one Aurora cluster that auto-pauses at min-capacity 0 after ~5 min of zero connections and zero queries. Every reconciler run opens connections and queries — i.e. **wakes that cluster**. infra#129 dropped s-read from hourly to daily for exactly this reason, so an hourly reconciler would re-impose the cost that PR removes, *and* re-read an unchanged mirror 23 times out of 24. Sitting just behind s-read's sync reads a just-refreshed mirror and piggybacks on the wake s-read already causes (worst case one extra resume, absorbed by the aurora-resume-retry extension — background job, latency is free).

**The trade:** a missed webhook is recovered within ~24h rather than ~1h. The reversal webhooks cover latency; this is the guaranteed backstop.

The mirror pool honours the invariant [#1030](https://github.com/innovationtreehouse/checkin/pull/1030) writes down — `idleTimeoutMillis` + `min: 0` explicit, no `keepAlive` — so it can't be the thing that pins the cluster awake. 10s rather than prisma.ts's 60s: that 60s buys warmth across a *user's* click-to-click gaps, and this pool has no user.

> This is the PR infra#129 means by "the in-app cron endpoints have no AWS trigger yet (schedule them mindfully when wired)".

## Reviewer notes

- **`PaymentException` is a thin triage record, not a copy of the mirror** — linkage + classification + resolution state only. Live amounts/status are re-read from `shopify_read` at view time. Clean recoveries write **no row** (they audit-log, as `activate()` already does), so the table only ever holds things needing a human. `@@unique([kind, shopifyOrderId])` makes the job safe to re-run.
- **Dashboard is under `finance-ops`, not `membership-ops`** — payments cross membership *and* programs.
- **Escalation is deliberately asymmetric:** chargebacks (CRITICAL) email the board immediately; WARN-level problems are dashboard + red-dot only. The reconciler runs once daily, so the dashboard is itself effectively a daily digest — a WARN digest email would just be the same list, pushed.
- **Migration is additive only** — new enums, new table, new nullable columns. No drops, no renames, no backfill. The "at most 1 new migration per release" gate is **advisory on PRs** and reports 2 because `org_membership_product_url` is already unreleased on main; per `MIGRATION_COALESCE_FLOW.md` migrations accumulate freely between releases and are coalesced by a separate pre-release PR. Nothing to do here.
- **No s-read or infra change required.** Reconciler no-ops when `SHOPIFY_READ_DATABASE_URL` is unset, so an env without the mirror simply runs no reconciliation.

## Deliberate simplifications (`ponytail:` comments in code)

- Mirror bridge is raw `pg` read-only SELECTs, not a second Prisma client — avoids cross-package generate/transpile coupling for 4 tables.
- `ACTIVE_WITHOUT_PAYMENT` detection deferred (backfill-cutover false positives); enum + taxonomy kept.
- `orders/edited` not a fast-path topic — amount downgrades are caught by the reconciler's amount check.

## Before deploy

- [ ] **Wire the cron trigger at 09:15 UTC daily** (behind s-read's 09:00). No AWS trigger for `api/cron/*` exists yet per infra#129 — the route is written and cron-auth gated, but nothing fires it. Do not schedule it hourly (see above).
- [ ] Set `SHOPIFY_READ_DATABASE_URL` (read-only role) or the reconciler no-ops by design.
- [ ] Register the reversal webhook topics: `npx tsx scripts/register-shopify-reversal-webhooks.ts --url https://<host>/api/webhooks/shopify/reversals --commit` (optional — reconciler is the backstop regardless).

## Verification

- **13/13** reconciler matrix tests — real DB + mocked mirror, one per taxonomy row, plus the attribute path, the disambiguation email alone could not do, an attribute naming an unknown process, and **idempotency** (re-run = no double activation, no duplicate exception).
- Affected unit suites green — webhook behavior preserved across the program extraction, nav badges, page registry.
- `tsc --noEmit` and `eslint --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)