### PR TITLE
ci(deploy): every app deploy migrates and deploys its s-read counterpart

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -244,3 +244,14 @@ jobs:
 
           gh pr comment "$PR" --body "$BODY"
           echo "Posted result on PR #$PR"
+
+  # s-read rides every dev deploy (issue #235's decision: the checkin pipeline
+  # owns s-read deploys; deploy-s-read.yml's manual dispatch remains for ad-hoc
+  # runs). Runs after the app is out; same commit; migrate-and-code mode.
+  s-read:
+    name: Deploy s-read (dev)
+    needs: deploy
+    uses: ./.github/workflows/deploy-s-read.yml
+    with:
+      environment: dev
+      ref: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -307,3 +307,15 @@ jobs:
               echo "- Prod still runs the previous image."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  # s-read rides every prod release, after the human-approved app deploy. The
+  # called job carries `environment: production` (required by the prod deploy
+  # role's OIDC trust), so the release gets a SECOND approval prompt for the
+  # s-read half — a deliberate gate, not an accident. Same released tag.
+  s-read:
+    name: Deploy s-read (prod)
+    needs: deploy
+    uses: ./.github/workflows/deploy-s-read.yml
+    with:
+      environment: prod
+      ref: ${{ github.event.release.tag_name }}

--- a/.github/workflows/deploy-s-read.yml
+++ b/.github/workflows/deploy-s-read.yml
@@ -56,6 +56,23 @@ on:
           - migrate-and-code
           - code-only
         default: migrate-and-code
+  # Called by deploy-dev.yml (environment: dev) and deploy-prod.yml
+  # (environment: prod) so every app deploy migrates + deploys its s-read
+  # counterpart; the dispatch trigger above remains for ad-hoc runs.
+  workflow_call:
+    inputs:
+      environment:
+        description: "s-read environment (dev | prod)"
+        type: string
+        required: true
+      mode:
+        description: "Deploy mode (migrate-and-code | code-only)"
+        type: string
+        default: migrate-and-code
+      ref:
+        description: "Commit/tag to build; empty = the triggering commit"
+        type: string
+        default: ""
 
 permissions:
   id-token: write   # assume the deploy role via OIDC
@@ -73,15 +90,28 @@ env:
   SYNC_TASK_FAMILY: s-read-${{ inputs.environment }}-sync
   MIGRATE_TASK_FAMILY: s-read-${{ inputs.environment }}-migrate
   MIGRATE_LOG_GROUP: /ecs/s-read-${{ inputs.environment }}-migrate
-  DEPLOY_ROLE: arn:aws:iam::639595353568:role/checkin-deploy-dev
+  # Per-env deploy role: the prod role's OIDC trust requires the job to carry
+  # `environment: production` (sub repo:...:environment:production); the dev
+  # role's trust is the bare main-ref sub, so the dev path must carry NO
+  # environment — hence the conditional `environment:` on the job below (an
+  # empty name means none).
+  DEPLOY_ROLE: arn:aws:iam::639595353568:role/checkin-deploy-${{ inputs.environment == 'prod' && 'prod' || 'dev' }}
 
 jobs:
   deploy:
     name: Build, push, migrate, register (${{ inputs.environment }})
     runs-on: ubuntu-24.04-arm  # native ARM64 — the task defs are arm64 (runtime_platform)
+    # prod: rides the production environment gate (human approval + the OIDC
+    # sub the prod role trusts). dev: no environment — see DEPLOY_ROLE comment.
+    environment: ${{ inputs.environment == 'prod' && 'production' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # Empty on dispatch = the triggering commit, exactly as before; the
+          # pipelines pass the deployed app commit/tag so app and s-read ship
+          # the same tree.
+          ref: ${{ inputs.ref || '' }}
 
       - name: Resolve commit
         id: vars


### PR DESCRIPTION
## What

- **`deploy-s-read.yml` becomes callable** (`workflow_call` with `environment` / `mode` / `ref` inputs) while keeping its manual `workflow_dispatch` for ad-hoc runs. New `ref` input pins the build to the caller's deployed commit; empty keeps today's dispatch behavior.
- **deploy-dev** calls it with `environment: dev` after the app rollout (`needs: deploy`), pinned to the same `head_sha` the app shipped — every merge to main now migrates + deploys s-read-dev in `migrate-and-code` mode.
- **deploy-prod** calls it with `environment: prod` after the human-approved app deploy, pinned to the released tag.

## OIDC / approval-gate changes (deliberate)

The deploy role is now per-environment (`checkin-deploy-dev` / `checkin-deploy-prod`) instead of the dev role for both. Because the prod role's trust requires the job to carry `environment: production`:

- **prod s-read deploys now sit behind the production approval gate** — a release gets a *second* approval prompt for the s-read half. That's a feature: s-read prod changes were previously deployable via the dev role with no gate.
- The dev path must carry **no** environment (the dev role trusts the bare main-ref sub), hence the conditional `environment:` expression on the job (empty name = none). Called-workflow permissions are within both callers' ceilings.

## Why now

#1029 (cart-attribute capture in the mirror) lands schema + query changes that only take effect when s-read is deployed — previously a manual dispatch someone had to remember. With this, merge → dev deploy picks it up automatically, and the next release carries it to prod, with its migration applied through s-read's own ledger.

First live run to watch: the dev pipeline on this PR's own merge (the s-read job will build, migrate s-read-dev, and register both task-def families).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe