### PR TITLE
security(scopes): opt PaymentException out of a scoped route, pending one

### DIFF
--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -151,6 +151,12 @@ export const OPT_OUT_PENDING_ROUTE = new Set<string>([
     'BackgroundCheckAttestation', // bind their_own at migration, keep notes `internal`
     'Corporation', // has leads→participantId; a corp-lead view is plausible
     'VolunteerDesignation', // has createdById; confirm whether a self view is warranted
+    // Lands ahead of the model itself (#1031, the Shopify payment reconciler), so the
+    // boundary change ships alone and reviewable — inert until that PR adds the model
+    // (an entry here is only ever read as `pendingRoute.has(model)`). Board/admin only,
+    // served via withAuth on finance-ops/payments; a household-facing "your payment
+    // problem" route is plausible later, and that is when this earns a real binding.
+    'PaymentException',
 ]);
 
 /**


### PR DESCRIPTION
Boundary change for #1031 (the Shopify payment reconciler), **split out to ship alone** as the security-boundary isolation gate requires.

## What

One entry added to `OPT_OUT_PENDING_ROUTE`.

`PaymentException` is #1031's triage record — which family, which order, what went wrong, who resolved it. Its fields are sensitive and it carries actor FKs (`personId`, `resolvedById`), so `validateBindings`' coverage rule would demand a scope binding. But the only thing that reads it today is the board/admin `finance-ops/payments` queue behind `withAuth`, and there is no scoped `handler()` route to bind it to. That is exactly what this set is for — the work queue of models awaiting a route, not a permanent exemption.

It earns a real binding when a household-facing "your payment problem" view exists.

## Why it lands first, and why it's safe

Registry-first, per the isolation gate's own guidance: *"land the registry entry in its own PR first (a defineRoute for an endpoint nothing serves yet is inert), then land the route handler in the feature PR."*

An entry here is only ever read as `pendingRoute.has(model)` — `validateBindings` never validates opt-out entries against the schema — so this is **inert until #1031 adds the model**. Nothing widens: an opt-out only suppresses a "you forgot to bind this" error for a model that does not yet exist.

Not a re-tier, not a grant, no change to the token grammar, handler, or stripper.

## Verification

`scopeValidators` green (14 tests, both suites) **on this tree** — i.e. with no `PaymentException` model present, which is what confirms the entry is inert rather than merely unused. `tsc` clean.

Merging this unblocks #1031, whose `scopeValidators` run is red by design until the entry exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)