### PR TITLE
ci: migration release gate counts per database — checkin and the s-read mirror each get one

### DIFF
--- a/.github/workflows/migration-release-gate.yml
+++ b/.github/workflows/migration-release-gate.yml
@@ -1,6 +1,6 @@
 name: Migration release gate
 
-# A release may apply AT MOST ONE new database migration: `prisma migrate
+# A release may apply AT MOST ONE new migration PER DATABASE: `prisma migrate
 # deploy` is not transactional ACROSS migrations, so a multi-migration release
 # that fails mid-batch leaves prod partially migrated behind a P3009 (the
 # 2026-07-02 incident). Migrations may accumulate freely on main/dev between
@@ -35,7 +35,7 @@ on:
 
 jobs:
   count:
-    name: At most 1 new migration per release
+    name: At most 1 new migration per database per release
     runs-on: ubuntu-latest
     # Advisory on PRs (allowed to fail); blocking when called from deploy-prod
     # (a called workflow inherits the caller's event: release).
@@ -49,9 +49,18 @@ jobs:
           # reachability from HEAD.
           fetch-depth: 0
 
-      - name: Count migrations added since the previous v* release
+      - name: Count migrations added since the previous v* release (per database)
         env:
           EXCLUDE_TAG: ${{ inputs.exclude_tag || '' }}
+          # One entry per DATABASE the repo migrates — each chain gets its own
+          # at-most-one budget (a release may carry one checkin migration AND
+          # one mirror migration; the limits are independent because each
+          # database has its own ledger and its own non-transactional
+          # `prisma migrate deploy`). Add new databases here when they appear;
+          # a brand-new chain should arrive as a single squashed baseline.
+          MIGRATION_DIRS: |
+            checkin-app/prisma/migrations
+            packages/s-ingest-core/prisma/migrations
         run: |
           set -euo pipefail
           # `git tag -l` lists annotated and lightweight tags identically — no
@@ -61,26 +70,24 @@ jobs:
           # so the release compares against its true predecessor.
           PREV_RELEASE=$(git tag --list 'v*' --merged HEAD | grep -vxF -- "$EXCLUDE_TAG" | sort -V | tail -n1 || true)
 
-          # Set difference of migration DIRECTORIES (ls-tree, not git diff):
-          # a coalesce release deletes many old dirs and adds exactly 1, and
-          # that must PASS; edits to already-shipped migrations count as 0;
-          # directories not files, since a coalesce baseline ships both
-          # migration.sql and reconcile.sql under one dir. With no previous
-          # release reachable, EVERY migration counts against the same limit.
-          HEAD_DIRS=$(git ls-tree --name-only "HEAD:checkin-app/prisma/migrations" | grep -v '^migration_lock\.toml$' | sort)
-          if [ -n "$PREV_RELEASE" ]; then
-            NEW_DIRS=$(comm -13 \
-              <(git ls-tree --name-only "$PREV_RELEASE:checkin-app/prisma/migrations" | grep -v '^migration_lock\.toml$' | sort) \
-              <(printf '%s\n' "$HEAD_DIRS"))
-          else
-            NEW_DIRS="$HEAD_DIRS"
-          fi
-          COUNT=$(printf '%s' "$NEW_DIRS" | grep -c . || true)
-          echo "Migrations added since ${PREV_RELEASE:-the beginning (no previous v* release reachable)}: $COUNT"
-          [ -z "$NEW_DIRS" ] || printf '%s\n' "$NEW_DIRS"
+          FAILED=0
+          for DIR in $MIGRATION_DIRS; do
+            [ -z "$DIR" ] && continue
+            HEAD_DIRS=$(git ls-tree --name-only "HEAD:$DIR" 2>/dev/null | grep -v '^migration_lock\.toml$' | sort || true)
+            if [ -n "$PREV_RELEASE" ]; then
+              BASE_DIRS=$(git ls-tree --name-only "$PREV_RELEASE:$DIR" 2>/dev/null | grep -v '^migration_lock\.toml$' | sort || true)
+            else
+              BASE_DIRS=""
+            fi
+            NEW_DIRS=$(comm -13 <(printf '%s\n' "$BASE_DIRS") <(printf '%s\n' "$HEAD_DIRS"))
+            COUNT=$(printf '%s' "$NEW_DIRS" | grep -c . || true)
+            echo "[$DIR] migrations added since ${PREV_RELEASE:-the beginning (no previous v* release reachable)}: $COUNT"
+            [ -z "$NEW_DIRS" ] || printf '%s\n' "$NEW_DIRS"
+            if [ "$COUNT" -gt 1 ]; then
+              echo "::error::$DIR carries $COUNT new migrations (listed above) — a release may apply at most 1 PER DATABASE. Coalesce that chain's unreleased migrations into one before preparing a release (checkin-app/docs/MIGRATION_COALESCE_FLOW.md): prisma migrate deploy is not transactional across migrations, so a multi-migration release risks a partial apply (P3009)."
+              FAILED=1
+            fi
+          done
+          [ "$FAILED" -eq 0 ]
+          echo "OK — at most 1 new migration per database."
 
-          if [ "$COUNT" -gt 1 ]; then
-            echo "::error::$COUNT new migrations (listed above) — a release may apply at most 1. Coalesce them into a single migration before preparing a release (checkin-app/docs/MIGRATION_COALESCE_FLOW.md): prisma migrate deploy is not transactional across migrations, so a multi-migration release risks a partial apply (P3009)."
-            exit 1
-          fi
-          echo "OK — at most 1 new migration."


### PR DESCRIPTION
## Why

The gate counted only `checkin-app/prisma/migrations`; the s-read mirror chain (`packages/s-ingest-core/prisma/migrations`) was invisible to it. That was merely incomplete before — with #1032 making every prod release apply mirror migrations through s-read's own ledger, it became a real hole: a release could carry any number of mirror migrations ungated, with the same non-transactional `prisma migrate deploy` partial-apply risk the rule exists for.

## Rule (as directed)

**At most one new migration per database per release.** The budgets are independent — one checkin migration *and* one mirror migration in the same release passes (separate ledgers, separate migrate deploys); two in either single chain fails with the chain named. Restricting to one-total-across-databases would block legitimate releases for no safety gain.

## Mechanics

The count step iterates a `MIGRATION_DIRS` list (the two chains today; new databases get a line, and a new chain should arrive as a single squashed baseline). Per chain: same ls-tree set-difference vs the previous reachable `v*` tag, same coalesce-counts-as-one semantics, missing-path tolerated (`|| true` under pipefail — the #1023 lesson). Advisory-on-PR / blocking-on-release plumbing unchanged.

## Verification (real refs)

- `v1.0.1..main`: checkin = 1 (`org_membership_product_url`), mirror = 1 (`order_note_attributes`) → **pass** — exactly the currently-pending release shape.
- `v1.0.0..main` checkin = 2 → **fail** with the per-chain error.

Note for release planning: if #1031 (adds a second checkin migration) merges before the next release is cut, the checkin chain hits 2 and this gate will rightly block — cut a release first or coalesce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe