### PR TITLE
ci(s-read): run the migrate task on Fargate Spot

### DIFF
--- a/.github/workflows/deploy-s-read.yml
+++ b/.github/workflows/deploy-s-read.yml
@@ -198,10 +198,14 @@ jobs:
               "for i in 1 2 3 4 5; do npm run db:deploy -w @inventory/s-ingest-core && exit 0; echo \"attempt $i failed — DB may be resuming from auto-pause; retrying in 20s\"; sleep 20; done; exit 1"
             ]}]}' > "$RUNNER_TEMP/migrate-overrides.json"
 
+          # FARGATE_SPOT strategy (associated on the cluster — infra#131), not
+          # on-demand --launch-type: matches the checkin migrate tasks. A Spot
+          # reclaim mid-migration fails the step loudly and a rerun is clean —
+          # one small migration per release, gated per database.
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \
             --task-definition "$MIGRATE_ARN" \
-            --launch-type FARGATE \
+            --capacity-provider-strategy capacityProvider=FARGATE_SPOT,weight=1 \
             --network-configuration "$NETWORK_CONFIG" \
             --overrides "file://$RUNNER_TEMP/migrate-overrides.json" \
             --query 'tasks[0].taskArn' --output text)


### PR DESCRIPTION
Completes the migrations-on-Spot pass for s-read (both environments — the workflow is env-parameterized, and both pipelines now call it via #1032): the migrate `run-task` swaps from on-demand `--launch-type FARGATE` to `--capacity-provider-strategy capacityProvider=FARGATE_SPOT,weight=1`, exactly matching the checkin migrate tasks (#1017). The scheduled sync task is unchanged.

**Merge after [infra#131](https://github.com/innovationtreehouse/infra/pull/131) applies** — a capacity-provider strategy may only reference providers associated with the cluster, and the s-read clusters gain the FARGATE/FARGATE_SPOT association there. Same accepted Spot residual as the checkin migrations: a reclaim mid-migration fails the step loudly, the migration budget is one per database per release (#1034), and a rerun is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe