### PR TITLE
chore(prisma): coalesce the two post-v1.0.1 migrations into one

### DIFF
--- a/checkin-app/prisma/migrations/20260715210000_org_membership_product_url/migration.sql
+++ b/checkin-app/prisma/migrations/20260715210000_org_membership_product_url/migration.sql
@@ -1,5 +1,0 @@
--- Board admins configure the membership dues product by pasting its storefront
--- URL; the server extracts the Shopify variant ID from it. Stored so the board
--- can see which product the variant ID came from and re-run the extraction.
--- Additive only.
-ALTER TABLE "BoardSettings" ADD COLUMN "orgMembershipProductUrl" TEXT;

--- a/checkin-app/prisma/migrations/20260716150000_coalesced_post_v1_0_1/migration.sql
+++ b/checkin-app/prisma/migrations/20260716150000_coalesced_post_v1_0_1/migration.sql
@@ -1,3 +1,15 @@
+-- Coalesce of the two migrations accumulated since v1.0.1 (#1021 + #1031),
+-- per MIGRATION_COALESCE_FLOW.md: a release applies at most one migration
+-- per database. Both parts additive; original order preserved.
+
+-- ── 20260715210000_org_membership_product_url ──────────────────────────────
+-- Board admins configure the membership dues product by pasting its storefront
+-- URL; the server extracts the Shopify variant ID from it. Stored so the board
+-- can see which product the variant ID came from and re-run the extraction.
+-- Additive only.
+ALTER TABLE "BoardSettings" ADD COLUMN "orgMembershipProductUrl" TEXT;
+
+-- ── 20260716120000_payment_reconciliation ──────────────────────────────────
 -- Shopify payment reconciliation (lib/finance/reconcile.ts). Additive only:
 -- new enums, a new PaymentException triage table, a reconciler high-water cursor
 -- on BoardSettings, and a Shopify order-id on ProgramParticipant so a later

--- a/checkin-app/prisma/migrations/20260716150000_coalesced_post_v1_0_1/reconcile.sql
+++ b/checkin-app/prisma/migrations/20260716150000_coalesced_post_v1_0_1/reconcile.sql
@@ -1,0 +1,15 @@
+-- Ledger reconcile for environments that already applied the two migrations
+-- this coalesce replaces (dev; prod applied NEITHER — v1.0.1 predates both, so
+-- prod needs no reconcile and simply applies the coalesced migration at the
+-- next release). Scoped to the replaced names — NOT a wholesale ledger wipe,
+-- because the released 20260711 baseline row must survive.
+BEGIN;
+DELETE FROM "_prisma_migrations"
+ WHERE migration_name IN
+   ('20260715210000_org_membership_product_url',
+    '20260716120000_payment_reconciliation');
+INSERT INTO "_prisma_migrations"
+    (id, checksum, migration_name, started_at, finished_at, applied_steps_count)
+VALUES
+    (gen_random_uuid(), 'a3c95e6aff9c216910b957aab7c3fb03603b6a077e44c3aa5169890520f9ea25', '20260716150000_coalesced_post_v1_0_1', now(), now(), 1);
+COMMIT;


### PR DESCRIPTION
## What

`20260715210000_org_membership_product_url` (#1021) + `20260716120000_payment_reconciliation` (#1031) → **`20260716150000_coalesced_post_v1_0_1`**, concatenated in original order (both additive DDL). With this, the checkin chain has exactly **one** unreleased migration and the per-database gate (#1034) verifies green (mirror chain already at one).

Deviation from the scripted whole-chain flow, deliberately: `coalesce-migrations.ts` rebuilds the entire chain into a baseline and needs a scratch Postgres (unavailable where this was prepared). This PR coalesces only the unreleased tail — the released `20260711` baseline and `20260715160000` renewal migrations are untouched — and `reconcile.sql` is **scoped to the two replaced names** rather than the script's wholesale ledger wipe, precisely so the released rows survive. The mechanical contracts all hold: migration-safety detects the coalesce shape (removes 2, adds 1) and **proves schema identity in CI against the populated base DB**, and the reconcile artifact is present where `db-reconcile-dev` expects it (name passes its validation regex).

## Runbook after merge (dev only — prod needs nothing)

Dev already applied both replaced migrations, so its ledger must be reconciled:

1. Merge → deploy-dev builds/pushes the image and registers task defs; **its migrate step then fails** (ledger references the two now-deleted names) — expected, one-time.
2. Dispatch **`db-reconcile-dev`** with `baseline: 20260716150000_coalesced_post_v1_0_1` (the just-registered migrate task def carries the new `reconcile.sql`).
3. Re-run the failed deploy-dev — migrate is now a no-op and the rollout completes.

Prod's ledger contains neither replaced migration (v1.0.1 predates both), so the next release simply applies the coalesced migration as its one-per-database budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe