### PR TITLE
fix(tests): localization suite leaked America/New_York into worker-mates (the 1034 queue failures)

### DIFF
--- a/checkin-app/src/app/__tests__/eventsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventsAPI.integration.test.ts
@@ -22,7 +22,19 @@ describe('Events API Integration Tests', () => {
     let testLeadMentorId: number;
     let testProgramId: number;
 
+    let prevAppSettings: { id: number; timezone: string; locale: string } | null = null;
+
     beforeAll(async () => {
+        // This suite asserts America/Chicago wall-clock semantics; pin the
+        // AppSettings singleton rather than trusting whatever a worker-mate
+        // left behind (the localization suite once leaked America/New_York).
+        prevAppSettings = await prisma.appSettings.findUnique({ where: { id: 1 } });
+        await prisma.appSettings.upsert({
+            where: { id: 1 },
+            create: { id: 1, timezone: 'America/Chicago' },
+            update: { timezone: 'America/Chicago' },
+        });
+
         // Clean up any leaked state
         await prisma.event.deleteMany({
             where: { name: { contains: 'Test Event' } }
@@ -63,6 +75,10 @@ describe('Events API Integration Tests', () => {
     });
 
     afterAll(async () => {
+        // Same singleton discipline as the pin above: put back what we found.
+        if (prevAppSettings) await prisma.appSettings.update({ where: { id: 1 }, data: { timezone: prevAppSettings.timezone, locale: prevAppSettings.locale } });
+        else await prisma.appSettings.deleteMany({ where: { id: 1 } });
+
         // Clean up
         await prisma.event.deleteMany({
             where: { name: { contains: 'Test Event' } }

--- a/checkin-app/src/app/__tests__/localizationSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/localizationSettingsAPI.integration.test.ts
@@ -50,8 +50,13 @@ describe('Localization settings API', () => {
         })).map((p) => p.householdId);
         await prisma.person.deleteMany({ where: { id: { in: [adminId, plainId] } } });
         await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
-        // Restore the singleton so other suites see the original values.
+        // Restore the singleton so other suites see the original values. When NO
+        // row existed before this suite (every fresh per-worker CI database),
+        // restoring means DELETING the row this suite's PUTs created — leaving it
+        // would leak America/New_York to whatever suite shares the worker next
+        // (the intermittent eventsAPI 13:00-vs-12:00 failures in the merge queue).
         if (prevSettings) await prisma.appSettings.update({ where: { id: 1 }, data: prevSettings });
+        else await prisma.appSettings.deleteMany({ where: { id: 1 } });
         await prisma.$disconnect();
     });
 


### PR DESCRIPTION
## The failure (three merge-queue ejections of #1034)

`eventsAPI.integration` intermittently failed expecting `13:00:00` and receiving `12:00:00` — stored `17:00Z`, i.e. the input was converted as **13:00 EDT**: the org timezone was `America/New_York` during those runs.

## Root cause

`localizationSettingsAPI.integration` captures the AppSettings singleton before mutating it, but on a **fresh per-worker CI database no row exists** — `prevSettings = null` — and its `afterAll` only restores `if (prevSettings)`. So the `America/New_York` row its PUTs create **outlives the suite**, and whichever suite shares that jest worker next inherits Eastern time. `getAppSettings()` is uncached (queried per call), and per-worker databases isolate workers — so the leak is strictly intra-worker, and intermittent because jest's persisted timing cache (#1019) plus new suites (#1031) reshuffle suite-to-worker packing between runs. Same tree passed one queue run and failed the next — worker packing was the only variable.

## Fix (both sides)

- **Source**: the restore now deletes the row when none pre-existed — "restore" means restoring the absence.
- **Consumer**: `eventsAPI.integration` pins the singleton to `America/Chicago` in `beforeAll` and restores what it found in `afterAll` — it asserts Chicago wall-clock semantics, so it owns that precondition instead of trusting worker-mates.

tsc + lint clean; the integration tier itself is CI-run (no local Postgres here). Once merged, re-queue #1034 — its own gate check is already satisfied by the #1036 coalesce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe