### PR TITLE
feat(finance): board button to force an s-read Shopify sync

### DIFF
--- a/checkin-app/package.json
+++ b/checkin-app/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",
+    "@aws-sdk/client-lambda": "^3.1075.0",
     "@aws-sdk/client-s3": "^3.1075.0",
     "@inventory/money": "*",
     "@mantine/core": "^7.17.8",

--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -68,6 +68,9 @@ const AUTHZ_TESTED = new Set<string>([
     'facility/visits',
     'finance-ops/payments',
     'finance-ops/payments/[id]',
+    // POST deny-paths (401 anon / 403 non-board) in s-read/sync/__tests__/route.test.ts,
+    // which also assert the Lambda is never invoked on a denied request.
+    'finance-ops/s-read/sync',
     'kioskdisplay/certifications',
     'membership-audit/compliance',
     // POST deny-path (403 non-board) in personBgManualSubmit.integration.test.ts.

--- a/checkin-app/src/app/api/finance-ops/s-read/sync/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/sync/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for POST /api/finance-ops/s-read/sync — the deny paths (401 anon /
+ * 403 plain member, through the REAL withAuth with a mocked session), the
+ * unwired-env 503, and the invocation contract.
+ *
+ * The load-bearing test here is "ignores a caller-supplied mode": the trigger
+ * Lambda also accepts {"mode":"backfill"}, which submits a Shopify Bulk Operation.
+ * The route must never let the body reach the payload.
+ */
+import { POST } from '../route';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+const sendMock = jest.fn();
+jest.mock('@aws-sdk/client-lambda', () => ({
+    LambdaClient: jest.fn().mockImplementation(() => ({ send: sendMock })),
+    InvokeCommand: jest.fn().mockImplementation((input) => ({ input })),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockSession = require('next-auth/next').getServerSession;
+
+function req(body?: unknown) {
+    return new Request('http://localhost/api/finance-ops/s-read/sync', {
+        method: 'POST',
+        ...(body ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) } : {}),
+    });
+}
+
+/** The single InvokeCommand input the route built. */
+function invokedWith() {
+    return sendMock.mock.calls[0][0].input;
+}
+
+const prevFunction = process.env.S_READ_TRIGGER_FUNCTION;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.S_READ_TRIGGER_FUNCTION = 's-read-dev-trigger';
+    sendMock.mockResolvedValue({ StatusCode: 200 });
+});
+
+afterAll(() => {
+    process.env.S_READ_TRIGGER_FUNCTION = prevFunction;
+});
+
+describe('POST /api/finance-ops/s-read/sync', () => {
+    it('401 when unauthenticated, without invoking', async () => {
+        mockSession.mockResolvedValue(null);
+        const res = await POST(req());
+        expect(res.status).toBe(401);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('403 for a signed-in member without board or sysadmin role, without invoking', async () => {
+        mockSession.mockResolvedValue({ user: { id: 5, isSysadmin: false, isBoardMember: false } });
+        const res = await POST(req());
+        expect(res.status).toBe(403);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('invokes the configured trigger with a hardcoded incremental mode for a board member', async () => {
+        mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+        const res = await POST(req());
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ success: true });
+        expect(sendMock).toHaveBeenCalledTimes(1);
+        expect(invokedWith().FunctionName).toBe('s-read-dev-trigger');
+        expect(JSON.parse(invokedWith().Payload)).toEqual({ mode: 'incremental' });
+    });
+
+    it('ignores a caller-supplied mode — the body can never reach the payload', async () => {
+        mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+        const res = await POST(req({ mode: 'backfill' }));
+
+        expect(res.status).toBe(200);
+        expect(JSON.parse(invokedWith().Payload)).toEqual({ mode: 'incremental' });
+    });
+
+    it('503 when no trigger function is configured, without invoking', async () => {
+        delete process.env.S_READ_TRIGGER_FUNCTION;
+        mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+
+        const res = await POST(req());
+        expect(res.status).toBe(503);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('500 when the invoke fails', async () => {
+        mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+        sendMock.mockRejectedValue(new Error('AccessDeniedException'));
+
+        const res = await POST(req());
+        expect(res.status).toBe(500);
+    });
+});

--- a/checkin-app/src/app/api/finance-ops/s-read/sync/route.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/sync/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+import { logger } from "@/lib/logger";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { config } from "@/lib/config";
+
+/**
+ * POST /api/finance-ops/s-read/sync — the board forces an s-read incremental sync
+ * now, instead of waiting for the daily 09:00 UTC tick.
+ *
+ * The reconciler (api/cron/reconcile-shopify) reads a mirror that s-read refreshes
+ * once a day, so a payment problem fixed in Shopify this morning still shows as OPEN
+ * on the payments queue until tomorrow. This button closes that gap: it re-reads
+ * Shopify into the mirror, after which the next reconcile run sees current truth.
+ *
+ * Invokes the `s-read-<env>-trigger` Lambda — the same entry point the EventBridge
+ * schedule uses, which RunTasks the sync family with a SYNC_MODE override
+ * (s-read-function/DEPLOY.md). This is deliberately NOT a direct ecs:RunTask from
+ * here: the trigger Lambda already owns the cluster/task-def/network wiring, so
+ * reusing it keeps this app's IAM grant to a single lambda:InvokeFunction on a
+ * single function ARN, and keeps checkin out of the s-read VPC entirely.
+ *
+ * SECURITY — the mode is a hardcoded literal and the request body is never read.
+ * The trigger Lambda also accepts {"mode":"backfill"}, which submits a Shopify Bulk
+ * Operation; letting a caller name the mode would turn one board click into an
+ * API-budget burn. The IAM grant must likewise cover ONLY this function — never
+ * s-replay-function, whose replay/reset-watermark ops re-project financial history
+ * and are IAM-gated with mandatory actor/reason audit by design.
+ *
+ * Concurrency is s-read's problem and s-read already solves it: reserved
+ * concurrency = 1 plus the per-store `withSyncRun` lock means a second run while one
+ * is in flight is skipped, not corrupted.
+ *
+ * No AuditLog row: it takes a non-null tableName + affectedEntityId and this touches
+ * no checkin entity. The actor is logged here, and s-read stamps its own `sync_run`.
+ */
+export const POST = withAuth(
+    { roles: ['isSysadmin', 'isBoardMember'] },
+    async (_req, auth) => {
+        if (auth.type !== 'session') {
+            return apiError("Unauthorized", 401);
+        }
+
+        const functionName = config.sReadTriggerFunction();
+        if (!functionName) {
+            return apiError("Shopify sync is not wired in this environment", 503);
+        }
+
+        try {
+            const client = new LambdaClient({ region: config.awsRegion() });
+            await client.send(
+                new InvokeCommand({
+                    FunctionName: functionName,
+                    // RequestResponse, not Event: the trigger Lambda only calls RunTask and
+                    // returns — it does not wait for the sync itself — so this stays fast
+                    // while still surfacing a failed invoke to the board member instead of
+                    // silently succeeding.
+                    InvocationType: "RequestResponse",
+                    Payload: JSON.stringify({ mode: "incremental" }),
+                }),
+            );
+
+            logger.info(`[s-read] manual incremental sync triggered by user ${auth.user.id}`);
+            return NextResponse.json({ success: true });
+        } catch (error) {
+            logger.error("Failed to trigger s-read sync:", error);
+            return apiError("Failed to start the Shopify sync", 500);
+        }
+    },
+);

--- a/checkin-app/src/app/finance-ops/payments/page.tsx
+++ b/checkin-app/src/app/finance-ops/payments/page.tsx
@@ -43,6 +43,7 @@ export default function PaymentProblemsPage() {
   const [resolveOpened, { open: openResolve, close: closeResolve }] = useDisclosure(false);
   const [pendingResolve, setPendingResolve] = useState<PaymentException | null>(null);
   const [note, setNote] = useState("");
+  const [syncing, setSyncing] = useState(false);
 
   const fetchRows = useCallback(async () => {
     try {
@@ -81,6 +82,31 @@ export default function PaymentProblemsPage() {
       }
     } catch {
       notifications.show({ color: 'red', message: "Network error updating the payment problem.", autoClose: false });
+    }
+  };
+
+  // Force an s-read incremental sync. The mirror behind "Live payment" refreshes once
+  // a day, so a problem fixed in Shopify this morning still reads stale here until
+  // tomorrow. The sync runs in the background (this returns as soon as it is started),
+  // and the reconciler picks the fresh data up on its next run — so this does NOT
+  // refetch the table: there would be nothing new to see yet.
+  const triggerSync = async () => {
+    setSyncing(true);
+    try {
+      const res = await fetch('/api/finance-ops/s-read/sync', { method: 'POST' });
+      if (res.ok) {
+        notifications.show({
+          color: 'green',
+          message: 'Shopify sync started. Live payment amounts refresh once it finishes — check back in a few minutes.',
+        });
+      } else {
+        const data = await res.json();
+        notifications.show({ color: 'red', message: data.error || "Failed to start the Shopify sync.", autoClose: false });
+      }
+    } catch {
+      notifications.show({ color: 'red', message: "Network error starting the Shopify sync.", autoClose: false });
+    } finally {
+      setSyncing(false);
     }
   };
 
@@ -175,10 +201,25 @@ export default function PaymentProblemsPage() {
 
   return (
     <Stack>
-      <Text c="dimmed">
-        Reconciler-detected Shopify payment problems awaiting board review. Nothing here is changed
-        automatically — acknowledge to mark a problem as seen, or resolve once you&apos;ve handled it
-        (e.g. in Shopify or on the membership record).
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <Text c="dimmed">
+          Reconciler-detected Shopify payment problems awaiting board review. Nothing here is changed
+          automatically — acknowledge to mark a problem as seen, or resolve once you&apos;ve handled it
+          (e.g. in Shopify or on the membership record).
+        </Text>
+        <Button
+          variant="light"
+          onClick={triggerSync}
+          loading={syncing}
+          style={{ flexShrink: 0 }}
+        >
+          Sync Shopify now
+        </Button>
+      </Group>
+
+      <Text size="sm" c="dimmed">
+        Shopify data syncs automatically once a day. If you&apos;ve just changed something in Shopify
+        and want it reflected here sooner, sync now.
       </Text>
 
       <AlertBanner message={message} tone="error" />

--- a/checkin-app/src/lib/__tests__/configHealth.test.ts
+++ b/checkin-app/src/lib/__tests__/configHealth.test.ts
@@ -5,7 +5,14 @@ import { getConfigHealth, openConfigIssues, type ConfigCheck } from "@/lib/confi
 // mocks (NODE_ENV was eliminated as a fuse, #951); CHECKIN_ENV drives prod.
 
 const ZOHO_KEYS = ["ZOHO_CLIENT_ID", "ZOHO_CLIENT_SECRET", "ZOHO_REFRESH_TOKEN"];
-const ALL_KEYS = [...ZOHO_KEYS, "ZOHO_WEBHOOK_SECRET", "AGREEMENT_PDF_S3_BUCKET", "RESEND_API_KEY", "CHECKIN_ENV"];
+const ALL_KEYS = [
+    ...ZOHO_KEYS,
+    "ZOHO_WEBHOOK_SECRET",
+    "AGREEMENT_PDF_S3_BUCKET",
+    "RESEND_API_KEY",
+    "S_READ_TRIGGER_FUNCTION",
+    "CHECKIN_ENV",
+];
 
 const saved: Record<string, string | undefined> = {};
 beforeEach(() => {
@@ -36,7 +43,9 @@ describe("getConfigHealth — prod, nothing configured", () => {
         expect(c["zoho-webhook-secret"].detail).toContain("ZOHO_WEBHOOK_SECRET");
         expect(c["resend-email"].ok).toBe(false);
         expect(c["resend-email"].detail).toContain("RESEND_API_KEY");
-        expect(openConfigIssues(checks)).toBe(4);
+        expect(c["s-read-trigger"].ok).toBe(false);
+        expect(c["s-read-trigger"].detail).toContain("S_READ_TRIGGER_FUNCTION");
+        expect(openConfigIssues(checks)).toBe(5);
     });
 });
 
@@ -49,6 +58,7 @@ describe("getConfigHealth — prod, all configured", () => {
         process.env.ZOHO_WEBHOOK_SECRET = "whsecret";
         process.env.AGREEMENT_PDF_S3_BUCKET = "bucket";
         process.env.RESEND_API_KEY = "re_key";
+        process.env.S_READ_TRIGGER_FUNCTION = "s-read-prod-trigger";
         expect(openConfigIssues(getConfigHealth())).toBe(0);
     });
 });

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -199,6 +199,18 @@ export const config = {
     // instead of throwing, so an env without the mirror simply runs no reconciliation.
     shopifyReadDatabaseUrl: (): string | null => process.env.SHOPIFY_READ_DATABASE_URL || null,
 
+    // s-read sync trigger — name of the `s-read-<env>-trigger` Lambda that RunTasks
+    // the sync family (s-read-function/DEPLOY.md). Null when unset → the board's
+    // manual-sync route reports "not wired" (503) rather than throwing, matching the
+    // mirror accessor above.
+    //
+    // Named EXPLICITLY per env rather than derived from checkinEnv(): that predicate
+    // fails safe to 'prod' for any unset/unrecognized value, which is right for the
+    // Zoho/Shopify mocks (a misconfigured box must not get the mock) but exactly
+    // backwards here — it would point an unconfigured box at PROD's sync trigger. An
+    // explicit name fails to null, i.e. to doing nothing.
+    sReadTriggerFunction: (): string | null => process.env.S_READ_TRIGGER_FUNCTION || null,
+
     // Shopify — Client Credentials Grant integration (see shopify.ts). All three
     // null when unset (integration "off").
     shopifyStoreDomain: (): string | null => process.env.SHOPIFY_STORE_DOMAIN || null,

--- a/checkin-app/src/lib/configHealth.ts
+++ b/checkin-app/src/lib/configHealth.ts
@@ -62,6 +62,18 @@ export function getConfigHealth(): ConfigCheck[] {
                   ? "NOT configured — set RESEND_API_KEY (outbound email disabled)."
                   : "Not set (fine outside prod; outbound email disabled).",
         },
+        {
+            id: "s-read-trigger",
+            label: "Shopify sync trigger",
+            // A laptop has no AWS to invoke, so this is only a gap on a deployed instance
+            // (dev included — dev has its own s-read-dev-trigger). Same shape as Resend above.
+            ok: config.isLocal() || !!config.sReadTriggerFunction(),
+            detail: config.sReadTriggerFunction()
+                ? "Trigger function configured."
+                : config.isLocal()
+                  ? "Not set (fine on local; no AWS to invoke)."
+                  : "NOT configured — set S_READ_TRIGGER_FUNCTION (the board's 'Sync Shopify now' button 503s without it).",
+        },
     ];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",
+        "@aws-sdk/client-lambda": "^3.1075.0",
         "@aws-sdk/client-s3": "^3.1075.0",
         "@inventory/money": "*",
         "@mantine/core": "^7.17.8",
@@ -331,6 +332,25 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1088.0.tgz",
+      "integrity": "sha512-wyg0qrN58C4Qckfwfs8zDFyMO/6Hbo6qcWWuf8gkZjDhLR3vj160h99mh7L16jBbQUUjJFasymOjJ0pxm0zj2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.1075.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1075.0.tgz",
@@ -378,17 +398,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
-      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@aws-sdk/xml-builder": "^3.972.31",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.6",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -397,15 +417,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.49",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
-      "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -413,17 +433,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
-      "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -431,23 +451,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
-      "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.3.tgz",
+      "integrity": "sha512-WpuqYX4gGkx++fCTSWE8+41JzkZVcrI50SH48Ml4CsG1pyuHKyMmpw/FixBHDrmjoQ553PmeCLa/fZIcst+WyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/credential-provider-env": "^3.972.49",
-        "@aws-sdk/credential-provider-http": "^3.972.51",
-        "@aws-sdk/credential-provider-login": "^3.972.55",
-        "@aws-sdk/credential-provider-process": "^3.972.49",
-        "@aws-sdk/credential-provider-sso": "^3.972.55",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.65",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -455,16 +475,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
-      "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.65.tgz",
+      "integrity": "sha512-xr9rgjYEdmC2Tpg2lwt9o+nOEaK9Qpd+dBjzrVCuWWyQfvhO91Ezu0Hh9ts2VUxOZxmS/k5T9msa34e4R1bnrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -472,21 +492,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
-      "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.69.tgz",
+      "integrity": "sha512-wbJGGesd0Tl18bmUcbj1xJ+e7CpuRJ6PIpMywLFuUttGy615lua87cJ0EA8pFpY/QgPuUXbnupWBtSPJ9tyZhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.49",
-        "@aws-sdk/credential-provider-http": "^3.972.51",
-        "@aws-sdk/credential-provider-ini": "^3.972.56",
-        "@aws-sdk/credential-provider-process": "^3.972.49",
-        "@aws-sdk/credential-provider-sso": "^3.972.55",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/credential-provider-imds": "^4.3.7",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.3",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -494,15 +514,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.49",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
-      "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -510,17 +530,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
-      "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/token-providers": "3.1074.0",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -528,16 +548,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
-      "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -575,20 +595,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
-      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -596,14 +614,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
-      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -611,16 +629,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1074.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
-      "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.23",
-        "@aws-sdk/nested-clients": "^3.997.23",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -628,12 +646,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
-      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -653,12 +671,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
-      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -666,9 +684,9 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -820,7 +838,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -830,7 +848,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -864,7 +882,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -1162,7 +1180,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -4717,13 +4735,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
-      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4731,13 +4748,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
-      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
+      "integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.26.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4745,13 +4762,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.7.tgz",
-      "integrity": "sha512-NslaM2ir0N2hisDmzXLstPaVINZheh8SokyOC++kzFPloZucL2R7Y7bS57mSzx/1Fc/fqmn7twjkeezTTrV0EA==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.7.tgz",
+      "integrity": "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.7",
-        "@smithy/types": "^4.14.4",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4771,13 +4788,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.8.tgz",
-      "integrity": "sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==",
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+      "integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.7",
-        "@smithy/types": "^4.14.4",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4785,13 +4802,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.7.tgz",
-      "integrity": "sha512-LwQZazFayImv+IOm0S0enoLeUJwmAlhGC5O6YCcLWezyu08dF46GOxPOq35OpBIHkgd7OvNvBStIFwVNyrvoBw==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
+      "integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.7",
-        "@smithy/types": "^4.14.4",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4799,9 +4816,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
-      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5332,7 +5349,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -13757,7 +13774,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",


### PR DESCRIPTION
## What

Adds a **Sync Shopify now** button to the board's payment-problems queue (`/finance-ops/payments`), so a board member can force an s-read incremental sync instead of waiting for the daily tick.

## Why

The mirror behind the queue's "Live payment" column refreshes once a day at 09:00 UTC (`api/cron/reconcile-shopify` runs 15 min behind it). So a payment problem fixed in Shopify this morning still reads stale to the board until tomorrow. This closes that gap on demand, without touching the daily cadence — which is a deliberate scale-to-zero cost constraint, not a taste call (infra#129).

## How

`POST /api/finance-ops/s-read/sync` invokes the `s-read-<env>-trigger` Lambda — the same entry point the EventBridge schedule uses, which `RunTask`s the sync family with a `SYNC_MODE` override.

Deliberately **not** a direct `ecs:RunTask` from checkin: the trigger Lambda already owns the cluster/task-def/network wiring, so reusing it keeps checkin's IAM grant to a single `lambda:InvokeFunction` on a single function ARN, and keeps checkin out of the s-read VPC entirely.

## Reviewer notes — security

- **The mode is a hardcoded literal; the request body is never read.** The trigger also accepts `{"mode":"backfill"}`, which submits a Shopify Bulk Operation — a caller-supplied mode would turn one board click into an API-budget burn. There's a test asserting a `{"mode":"backfill"}` body still sends `incremental`.
- **The grant must cover only this function — never `s-replay-function`**, whose replay/reset-watermark ops re-project financial history and are IAM-gated with mandatory actor/reason audit by design.
- **Concurrency is already s-read's problem and s-read solves it:** reserved concurrency 1 + the per-store `withSyncRun` lock means a second run while one is in flight is skipped, not corrupted.
- Env isolation is structural, not just naming: the trigger Lambda bakes `CLUSTER_ARN`/`TASK_FAMILY` per env and the payload carries only `mode`, so store, credentials, and mirror DB are unreachable from the caller. dev → `treehouse-dev-4folhtgx` → `shopify_read_dev`; prod → the real store → `shopify_read_prod`.

## Reviewer notes — design calls

- **`S_READ_TRIGGER_FUNCTION` is named explicitly per env, not derived from `checkinEnv()`.** That predicate fails safe to `'prod'` for any unset value — correct for the Zoho/Shopify mocks, but exactly backwards here: it would point an unconfigured box at **prod's** sync trigger. Explicit fails to null, i.e. to doing nothing (503 + a config-health row).
- **No throttle.** The gate is board-only, so the real cost (each run wakes the scale-to-zero Aurora cluster) is bounded by a handful of known humans. Add a "last run < 10 min ago" refusal if anyone leans on it.
- **No AuditLog row.** It takes a non-null `tableName` + `affectedEntityId` and this touches no checkin entity. The actor is logged, and s-read stamps its own `sync_run`.
- `authzRegistry.test.ts` gained an entry — its drift guard requires every role-gated route to declare its negative-authz tests.

## Blocked on infra before this works

Two changes live in the infra repo, not this one:

1. `S_READ_TRIGGER_FUNCTION=s-read-dev-trigger` on the checkin-dev ECS task def — without it the button 503s.
2. `lambda:InvokeFunction` on `arn:...:function:s-read-dev-trigger` for the checkin-dev task role — without it the button 500s on `AccessDenied`.

`module "checkin_prod"` is still `count = 0` (staged, no real image), so this is dev-only in practice today; prod needs its own var + grant when it launches.

## Testing

- New route test: 401 anon / 403 non-board (both asserting the Lambda is never invoked), the hardcoded-mode contract, the ignore-caller-mode case, 503 unwired, 500 on invoke failure.
- `tsc --noEmit` clean; full unit suite 1818/1818 passing.
- Not exercised end-to-end against real AWS — that needs the two infra changes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)