### PR TITLE
fix(prisma): coalesce reconcile also clears the failed-attempt ledger row

### DIFF
--- a/checkin-app/prisma/migrations/20260716150000_coalesced_post_v1_0_1/reconcile.sql
+++ b/checkin-app/prisma/migrations/20260716150000_coalesced_post_v1_0_1/reconcile.sql
@@ -4,10 +4,16 @@
 -- next release). Scoped to the replaced names — NOT a wholesale ledger wipe,
 -- because the released 20260711 baseline row must survive.
 BEGIN;
+-- Includes the coalesced name itself: the deploy that runs between the merge
+-- and this reconcile ATTEMPTS the coalesced migration against the already-
+-- migrated schema and records it as a FAILED ledger row (the P3009 every
+-- subsequent deploy short-circuits on). That row must go before the applied
+-- row below is inserted, or P3009 survives the reconcile.
 DELETE FROM "_prisma_migrations"
  WHERE migration_name IN
    ('20260715210000_org_membership_product_url',
-    '20260716120000_payment_reconciliation');
+    '20260716120000_payment_reconciliation',
+    '20260716150000_coalesced_post_v1_0_1');
 INSERT INTO "_prisma_migrations"
     (id, checksum, migration_name, started_at, finished_at, applied_steps_count)
 VALUES


### PR DESCRIPTION
## What dev looks like right now (post-#1036)

As the runbook predicted, deploy-dev's migrate fails after the coalesce merge — but with a consequence the runbook (and the reconcile file) missed: the first attempt **recorded `20260716150000_coalesced_post_v1_0_1` as a failed migration in dev's ledger** (19:14:29Z), so every subsequent deploy short-circuits with **P3009** before applying anything, and the `s-read (dev)` job keeps getting skipped behind the failed deploy.

`reconcile.sql` deleted only the two *replaced* migration names — running it as-is would leave the failed marker and P3009 would survive. This adds the coalesced name itself to the DELETE (before its applied row is inserted). Harmless no-op anywhere no failed attempt happened — prod's ledger has none of these rows and needs no reconcile at all.

## Updated dev runbook (after THIS merges)

1. This PR's own merge triggers deploy-dev: its migrate **still fails with P3009 (expected)** — but the freshly registered migrate task definition now carries the fixed `reconcile.sql`.
2. Dispatch **`db-reconcile-dev`** with `baseline: 20260716150000_coalesced_post_v1_0_1`.
3. Re-run the failed deploy-dev → migrate is a clean no-op, the app rolls out, and `s-read (dev)` finally runs — which is also the first live exercise of #1032's callable dev path and ships #1029's mirror capture to s-read-dev.

`migration.sql` is untouched (its checksum, referenced by the reconcile INSERT, stays valid); only the reconcile artifact changes, so the migration-safety normal path applies no new migrations and just re-verifies drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe