### PR TITLE
feat(finance): surface s-read sync status on the board's payments page

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -68,8 +68,8 @@ const AUTHZ_TESTED = new Set<string>([
     'facility/visits',
     'finance-ops/payments',
     'finance-ops/payments/[id]',
-    // POST deny-paths (401 anon / 403 non-board) in s-read/sync/__tests__/route.test.ts,
-    // which also assert the Lambda is never invoked on a denied request.
+    // POST + GET deny-paths (401 anon / 403 non-board) in s-read/sync/__tests__/route.test.ts,
+    // which also assert a denied request never invokes the Lambda or reads the mirror.
     'finance-ops/s-read/sync',
     'kioskdisplay/certifications',
     'membership-audit/compliance',

--- a/checkin-app/src/app/api/finance-ops/s-read/sync/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/sync/__tests__/route.test.ts
@@ -2,15 +2,15 @@
  * @jest-environment node
  */
 /**
- * Unit tests for POST /api/finance-ops/s-read/sync — the deny paths (401 anon /
- * 403 plain member, through the REAL withAuth with a mocked session), the
- * unwired-env 503, and the invocation contract.
+ * Unit tests for /api/finance-ops/s-read/sync — the deny paths (401 anon / 403 plain
+ * member, through the REAL withAuth with a mocked session), the unwired-env 503s, the
+ * POST's invocation contract, and the GET's status read.
  *
  * The load-bearing test here is "ignores a caller-supplied mode": the trigger
  * Lambda also accepts {"mode":"backfill"}, which submits a Shopify Bulk Operation.
  * The route must never let the body reach the payload.
  */
-import { POST } from '../route';
+import { GET, POST } from '../route';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
 
@@ -18,6 +18,16 @@ const sendMock = jest.fn();
 jest.mock('@aws-sdk/client-lambda', () => ({
     LambdaClient: jest.fn().mockImplementation(() => ({ send: sendMock })),
     InvokeCommand: jest.fn().mockImplementation((input) => ({ input })),
+}));
+
+// The mirror is stubbed at the client boundary (the house pattern — see
+// finance/__tests__/reconcile.integration.test.ts). Its SQL is covered separately in
+// lib/shopifyRead/__tests__/client.test.ts.
+const isConfiguredMock = jest.fn(() => true);
+const latestSyncRunMock = jest.fn();
+jest.mock('@/lib/shopifyRead/client', () => ({
+    isConfigured: () => isConfiguredMock(),
+    latestSyncRun: () => latestSyncRunMock(),
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -41,6 +51,8 @@ beforeEach(() => {
     jest.clearAllMocks();
     process.env.S_READ_TRIGGER_FUNCTION = 's-read-dev-trigger';
     sendMock.mockResolvedValue({ StatusCode: 200 });
+    isConfiguredMock.mockReturnValue(true);
+    latestSyncRunMock.mockResolvedValue(null);
 });
 
 afterAll(() => {
@@ -95,6 +107,78 @@ describe('POST /api/finance-ops/s-read/sync', () => {
         sendMock.mockRejectedValue(new Error('AccessDeniedException'));
 
         const res = await POST(req());
+        expect(res.status).toBe(500);
+    });
+});
+
+describe('GET /api/finance-ops/s-read/sync', () => {
+    const getReq = () => new Request('http://localhost/api/finance-ops/s-read/sync');
+
+    it('401 when unauthenticated, without reading the mirror', async () => {
+        mockSession.mockResolvedValue(null);
+        const res = await GET(getReq());
+        expect(res.status).toBe(401);
+        expect(latestSyncRunMock).not.toHaveBeenCalled();
+    });
+
+    it('403 for a signed-in member without board or sysadmin role, without reading the mirror', async () => {
+        mockSession.mockResolvedValue({ user: { id: 5, isSysadmin: false, isBoardMember: false } });
+        const res = await GET(getReq());
+        expect(res.status).toBe(403);
+        expect(latestSyncRunMock).not.toHaveBeenCalled();
+    });
+
+    it('returns the latest run for a board member', async () => {
+        const run = {
+            status: 'COMPLETED',
+            kind: 'INCREMENTAL',
+            startedAt: '2026-07-16T09:00:00.000Z',
+            finishedAt: '2026-07-16T09:02:00.000Z',
+            counts: { orders: 12 },
+            error: null,
+        };
+        latestSyncRunMock.mockResolvedValue(run);
+        mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+
+        const res = await GET(getReq());
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ run });
+    });
+
+    it('returns a null run when the mirror has never synced', async () => {
+        latestSyncRunMock.mockResolvedValue(null);
+        mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+
+        const res = await GET(getReq());
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ run: null });
+    });
+
+    it('surfaces a non-terminal run verbatim (the page polls on RUNNING)', async () => {
+        latestSyncRunMock.mockResolvedValue({
+            status: 'RUNNING', kind: 'INCREMENTAL',
+            startedAt: '2026-07-16T09:00:00.000Z', finishedAt: null, counts: null, error: null,
+        });
+        mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+
+        expect((await (await GET(getReq())).json()).run.status).toBe('RUNNING');
+    });
+
+    it('503 when the MIRROR is unwired, even though the trigger is configured', async () => {
+        // The two gates are separate wiring; the GET must not read the trigger's.
+        isConfiguredMock.mockReturnValue(false);
+        mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+
+        const res = await GET(getReq());
+        expect(res.status).toBe(503);
+        expect(latestSyncRunMock).not.toHaveBeenCalled();
+    });
+
+    it('500 when the mirror read fails', async () => {
+        latestSyncRunMock.mockRejectedValue(new Error('ECONNREFUSED'));
+        mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+
+        const res = await GET(getReq());
         expect(res.status).toBe(500);
     });
 });

--- a/checkin-app/src/app/api/finance-ops/s-read/sync/route.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/sync/route.ts
@@ -4,6 +4,7 @@ import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { config } from "@/lib/config";
+import { isConfigured, latestSyncRun } from "@/lib/shopifyRead/client";
 
 /**
  * POST /api/finance-ops/s-read/sync — the board forces an s-read incremental sync
@@ -34,6 +35,8 @@ import { config } from "@/lib/config";
  *
  * No AuditLog row: it takes a non-null tableName + affectedEntityId and this touches
  * no checkin entity. The actor is logged here, and s-read stamps its own `sync_run`.
+ *
+ * GET on the same path reports the latest run's status — see below.
  */
 export const POST = withAuth(
     { roles: ['isSysadmin', 'isBoardMember'] },
@@ -66,6 +69,44 @@ export const POST = withAuth(
         } catch (error) {
             logger.error("Failed to trigger s-read sync:", error);
             return apiError("Failed to start the Shopify sync", 500);
+        }
+    },
+);
+
+/**
+ * GET /api/finance-ops/s-read/sync — the latest s-read run, so the payments page can
+ * say how fresh "Live payment" is and tell whether a sync it just started has landed.
+ *
+ * Gated on the MIRROR, not on the trigger the POST gates on: the two are separate
+ * wiring (SHOPIFY_READ_DATABASE_URL vs S_READ_TRIGGER_FUNCTION), and an env can
+ * legitimately have one without the other. Unwired → 503, matching the POST, so the
+ * page can just hide the status line rather than special-case a success body that
+ * means "no answer".
+ *
+ * Same board/sysadmin gate as the POST. `sync_run` is operational metadata (status,
+ * kind, timings, row counts) about the store as a whole — no per-person or
+ * per-order data — but it rides the same queue-level boundary as the rest of
+ * finance-ops rather than being widened for no caller.
+ *
+ * The status is read verbatim from the mirror; the caller decides what to do with a
+ * value it does not recognise (s-read owns that enum and may extend it).
+ */
+export const GET = withAuth(
+    { roles: ['isSysadmin', 'isBoardMember'] },
+    async (_req, auth) => {
+        if (auth.type !== 'session') {
+            return apiError("Unauthorized", 401);
+        }
+
+        if (!isConfigured()) {
+            return apiError("The Shopify mirror is not wired in this environment", 503);
+        }
+
+        try {
+            return NextResponse.json({ run: await latestSyncRun() });
+        } catch (error) {
+            logger.error("Failed to read the s-read sync status:", error);
+            return apiError("Failed to read the Shopify sync status", 500);
         }
     },
 );

--- a/checkin-app/src/app/api/finance-ops/s-read/sync/route.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/sync/route.ts
@@ -78,7 +78,7 @@ export const POST = withAuth(
  * say how fresh "Live payment" is and tell whether a sync it just started has landed.
  *
  * Gated on the MIRROR, not on the trigger the POST gates on: the two are separate
- * wiring (SHOPIFY_READ_DATABASE_URL vs S_READ_TRIGGER_FUNCTION), and an env can
+ * wiring (the mirror connection vs S_READ_TRIGGER_FUNCTION), and an env can
  * legitimately have one without the other. Unwired → 503, matching the POST, so the
  * page can just hide the status line rather than special-case a success body that
  * means "no answer".

--- a/checkin-app/src/app/finance-ops/payments/page.tsx
+++ b/checkin-app/src/app/finance-ops/payments/page.tsx
@@ -7,7 +7,7 @@ import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { formatDateTime } from '@/lib/time';
+import { formatDateTime, relTime } from '@/lib/time';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { formatCents } from '@inventory/money';
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -34,6 +34,37 @@ type PaymentException = {
   } | null;
 };
 
+// Mirrors GET /api/finance-ops/s-read/sync. `status` is s-read's enum, read verbatim
+// — treat anything outside the known set as "no longer running" (see isTerminal).
+type SyncRun = {
+  status: string;
+  kind: string;
+  startedAt: string;
+  finishedAt: string | null;
+  error: string | null;
+};
+
+// Polling budget after a manual sync: 20 × 6s ≈ 2 minutes. Bounded on purpose —
+// every poll queries the mirror and keeps the scale-to-zero Aurora cluster awake,
+// which is the cost that makes the automatic sync daily rather than continuous
+// (infra#129). A sync still running at the cap is not lost, just no longer watched;
+// the status line picks it up on the next page load.
+const POLL_INTERVAL_MS = 6_000;
+const POLL_MAX_ATTEMPTS = 20;
+
+// RUNNING is the only non-terminal state. COMPLETED / FAILED / ABANDONED all mean
+// "stop watching" — ABANDONED being s-read's reaper relabelling a run whose process
+// was killed, which is exactly why polling must not treat "not COMPLETED" as "keep
+// waiting". An unrecognised status also stops: s-read owns this enum, and a value we
+// do not know is not grounds to poll forever.
+const isTerminal = (status: string) => status !== 'RUNNING';
+
+/** "12 min ago · completed", or "· running" while in flight. */
+function describeSync(run: SyncRun): string {
+  const when = isTerminal(run.status) && run.finishedAt ? run.finishedAt : run.startedAt;
+  return `${relTime(when)} · ${run.status.toLowerCase()}`;
+}
+
 export default function PaymentProblemsPage() {
   const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
 
@@ -44,6 +75,23 @@ export default function PaymentProblemsPage() {
   const [pendingResolve, setPendingResolve] = useState<PaymentException | null>(null);
   const [note, setNote] = useState("");
   const [syncing, setSyncing] = useState(false);
+  // null = no run yet or the mirror isn't wired in this env (the GET 503s) — either
+  // way there is nothing to say, so the status line just doesn't render.
+  const [syncRun, setSyncRun] = useState<SyncRun | null>(null);
+
+  const fetchSyncRun = useCallback(async (): Promise<SyncRun | null> => {
+    try {
+      const res = await fetch('/api/finance-ops/s-read/sync');
+      if (!res.ok) return null;
+      const run: SyncRun | null = (await res.json()).run;
+      setSyncRun(run);
+      return run;
+    } catch {
+      // Freshness is decoration on this page; a failed status read must never
+      // surface as an error over the queue itself.
+      return null;
+    }
+  }, []);
 
   const fetchRows = useCallback(async () => {
     try {
@@ -61,8 +109,11 @@ export default function PaymentProblemsPage() {
   }, []);
 
   useEffect(() => {
-    if (ready) fetchRows();
-  }, [ready, fetchRows]);
+    if (ready) {
+      fetchRows();
+      fetchSyncRun();
+    }
+  }, [ready, fetchRows, fetchSyncRun]);
 
   const patch = async (id: number, action: 'acknowledge' | 'resolve', noteText?: string) => {
     try {
@@ -87,22 +138,49 @@ export default function PaymentProblemsPage() {
 
   // Force an s-read incremental sync. The mirror behind "Live payment" refreshes once
   // a day, so a problem fixed in Shopify this morning still reads stale here until
-  // tomorrow. The sync runs in the background (this returns as soon as it is started),
-  // and the reconciler picks the fresh data up on its next run — so this does NOT
-  // refetch the table: there would be nothing new to see yet.
+  // tomorrow. The POST only STARTS the sync, so we then poll the run's status and
+  // refetch the table once it lands — "Live payment" reads straight from the mirror,
+  // so those amounts can differ the moment the sync finishes.
+  //
+  // Note the queue ROWS themselves are the reconciler's output, not the sync's, and
+  // the reconciler runs on its own daily tick — so a finished sync refreshes the live
+  // amounts, but a problem it resolves stays listed until the next reconcile.
   const triggerSync = async () => {
     setSyncing(true);
     try {
       const res = await fetch('/api/finance-ops/s-read/sync', { method: 'POST' });
-      if (res.ok) {
-        notifications.show({
-          color: 'green',
-          message: 'Shopify sync started. Live payment amounts refresh once it finishes — check back in a few minutes.',
-        });
-      } else {
+      if (!res.ok) {
         const data = await res.json();
         notifications.show({ color: 'red', message: data.error || "Failed to start the Shopify sync.", autoClose: false });
+        return;
       }
+      notifications.show({ color: 'green', message: 'Shopify sync started…' });
+
+      for (let i = 0; i < POLL_MAX_ATTEMPTS; i++) {
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+        const run = await fetchSyncRun();
+        // A null run means the status read failed or the mirror isn't wired — there is
+        // nothing to watch, so stop rather than burn the whole budget on empty polls.
+        if (!run) break;
+        if (!isTerminal(run.status)) continue;
+
+        await fetchRows();
+        if (run.status === 'COMPLETED') {
+          notifications.show({ color: 'green', message: 'Shopify sync finished. Live payment amounts are up to date.' });
+        } else {
+          notifications.show({
+            color: 'red',
+            message: `Shopify sync ${run.status.toLowerCase()}. Live payment amounts may still be stale.`,
+            autoClose: false,
+          });
+        }
+        return;
+      }
+      // Ran out of budget with the sync still going — it is still running server-side.
+      notifications.show({
+        color: 'yellow',
+        message: 'Shopify sync is still running. Reload the page in a few minutes to see the result.',
+      });
     } catch {
       notifications.show({ color: 'red', message: "Network error starting the Shopify sync.", autoClose: false });
     } finally {
@@ -220,6 +298,7 @@ export default function PaymentProblemsPage() {
       <Text size="sm" c="dimmed">
         Shopify data syncs automatically once a day. If you&apos;ve just changed something in Shopify
         and want it reflected here sooner, sync now.
+        {syncRun && ` Last Shopify sync: ${describeSync(syncRun)}.`}
       </Text>
 
       <AlertBanner message={message} tone="error" />

--- a/checkin-app/src/components/DevDashboard.tsx
+++ b/checkin-app/src/components/DevDashboard.tsx
@@ -13,6 +13,7 @@ import {
     getRecentActivity,
     type ActionResult,
 } from "@/lib/dev/actions";
+import { relTime } from "@/lib/time";
 
 /**
  * The dev dashboard (DEV_DASHBOARD_DESIGN.md §7) — a slide-up drawer from the bottom of the
@@ -35,16 +36,6 @@ interface PersonaOption {
     email: string;
     name: string | null;
     isSysadmin?: boolean;
-}
-
-function relTime(when: string | Date): string {
-    const ms = Date.now() - new Date(when).getTime();
-    const min = Math.floor(ms / 60000);
-    if (min < 1) return "just now";
-    if (min < 60) return `${min} min ago`;
-    const hr = Math.floor(min / 60);
-    if (hr < 24) return `${hr} hr ago`;
-    return `${Math.floor(hr / 24)} d ago`;
 }
 
 function describe(e: Entry): string {

--- a/checkin-app/src/lib/__tests__/configHealth.test.ts
+++ b/checkin-app/src/lib/__tests__/configHealth.test.ts
@@ -5,13 +5,18 @@ import { getConfigHealth, openConfigIssues, type ConfigCheck } from "@/lib/confi
 // mocks (NODE_ENV was eliminated as a fuse, #951); CHECKIN_ENV drives prod.
 
 const ZOHO_KEYS = ["ZOHO_CLIENT_ID", "ZOHO_CLIENT_SECRET", "ZOHO_REFRESH_TOKEN"];
+// The mirror check reads a RESOLVED url, so BOTH of its inputs have to be cleared:
+// SHOPIFY_READ_DB (+ DATABASE_URL) feed the derived path and SHOPIFY_READ_DATABASE_URL
+// the override. Miss one and an ambient value silently turns the "nothing configured"
+// case green — the check would then never be able to fail here.
+const MIRROR_KEYS = ["SHOPIFY_READ_DATABASE_URL", "SHOPIFY_READ_DB", "DATABASE_URL"];
 const ALL_KEYS = [
     ...ZOHO_KEYS,
+    ...MIRROR_KEYS,
     "ZOHO_WEBHOOK_SECRET",
     "AGREEMENT_PDF_S3_BUCKET",
     "RESEND_API_KEY",
     "S_READ_TRIGGER_FUNCTION",
-    "SHOPIFY_READ_DATABASE_URL",
     "CHECKIN_ENV",
 ];
 
@@ -47,7 +52,7 @@ describe("getConfigHealth — prod, nothing configured", () => {
         expect(c["s-read-trigger"].ok).toBe(false);
         expect(c["s-read-trigger"].detail).toContain("S_READ_TRIGGER_FUNCTION");
         expect(c["s-read-mirror"].ok).toBe(false);
-        expect(c["s-read-mirror"].detail).toContain("SHOPIFY_READ_DATABASE_URL");
+        expect(c["s-read-mirror"].detail).toContain("SHOPIFY_READ_DB");
         expect(openConfigIssues(checks)).toBe(6);
     });
 });
@@ -62,7 +67,10 @@ describe("getConfigHealth — prod, all configured", () => {
         process.env.AGREEMENT_PDF_S3_BUCKET = "bucket";
         process.env.RESEND_API_KEY = "re_key";
         process.env.S_READ_TRIGGER_FUNCTION = "s-read-prod-trigger";
-        process.env.SHOPIFY_READ_DATABASE_URL = "postgresql://s_read_prod_ro:pw@host:5432/shopify_read_prod";
+        // The mirror the way AWS actually wires it: no connection string of its own,
+        // just the app's own credential pointed at the mirror's database name.
+        process.env.DATABASE_URL = "postgresql://checkin_prod_dml:pw@host:5432/checkin_prod?sslmode=verify-full";
+        process.env.SHOPIFY_READ_DB = "shopify_read_prod";
         expect(openConfigIssues(getConfigHealth())).toBe(0);
     });
 });

--- a/checkin-app/src/lib/__tests__/configHealth.test.ts
+++ b/checkin-app/src/lib/__tests__/configHealth.test.ts
@@ -11,6 +11,7 @@ const ALL_KEYS = [
     "AGREEMENT_PDF_S3_BUCKET",
     "RESEND_API_KEY",
     "S_READ_TRIGGER_FUNCTION",
+    "SHOPIFY_READ_DATABASE_URL",
     "CHECKIN_ENV",
 ];
 
@@ -45,7 +46,9 @@ describe("getConfigHealth — prod, nothing configured", () => {
         expect(c["resend-email"].detail).toContain("RESEND_API_KEY");
         expect(c["s-read-trigger"].ok).toBe(false);
         expect(c["s-read-trigger"].detail).toContain("S_READ_TRIGGER_FUNCTION");
-        expect(openConfigIssues(checks)).toBe(5);
+        expect(c["s-read-mirror"].ok).toBe(false);
+        expect(c["s-read-mirror"].detail).toContain("SHOPIFY_READ_DATABASE_URL");
+        expect(openConfigIssues(checks)).toBe(6);
     });
 });
 
@@ -59,6 +62,7 @@ describe("getConfigHealth — prod, all configured", () => {
         process.env.AGREEMENT_PDF_S3_BUCKET = "bucket";
         process.env.RESEND_API_KEY = "re_key";
         process.env.S_READ_TRIGGER_FUNCTION = "s-read-prod-trigger";
+        process.env.SHOPIFY_READ_DATABASE_URL = "postgresql://s_read_prod_ro:pw@host:5432/shopify_read_prod";
         expect(openConfigIssues(getConfigHealth())).toBe(0);
     });
 });

--- a/checkin-app/src/lib/configHealth.ts
+++ b/checkin-app/src/lib/configHealth.ts
@@ -74,6 +74,19 @@ export function getConfigHealth(): ConfigCheck[] {
                   ? "Not set (fine on local; no AWS to invoke)."
                   : "NOT configured — set S_READ_TRIGGER_FUNCTION (the board's 'Sync Shopify now' button 503s without it).",
         },
+        {
+            id: "s-read-mirror",
+            label: "Shopify mirror (read)",
+            // Distinct from the trigger above: that one ASKS s-read to sync, this one READS
+            // what s-read wrote. Separate env vars pointing at different things, and an env
+            // can have either without the other — so they are two checks, not one.
+            ok: config.isLocal() || !!config.shopifyReadDatabaseUrl(),
+            detail: config.shopifyReadDatabaseUrl()
+                ? "Mirror connection configured."
+                : config.isLocal()
+                  ? "Not set (fine on local; no mirror to read)."
+                  : "NOT configured — set SHOPIFY_READ_DATABASE_URL ('Live payment' stays blank and the reconciler backstop no-ops).",
+        },
     ];
 }
 

--- a/checkin-app/src/lib/configHealth.ts
+++ b/checkin-app/src/lib/configHealth.ts
@@ -78,14 +78,20 @@ export function getConfigHealth(): ConfigCheck[] {
             id: "s-read-mirror",
             label: "Shopify mirror (read)",
             // Distinct from the trigger above: that one ASKS s-read to sync, this one READS
-            // what s-read wrote. Separate env vars pointing at different things, and an env
-            // can have either without the other — so they are two checks, not one.
+            // what s-read wrote. Different wiring, and an env can have either without the
+            // other — so they are two checks, not one.
+            //
+            // Deliberately checks the RESOLVED url, not a raw env var: in AWS there is no
+            // mirror connection string — it's derived from DATABASE_URL + SHOPIFY_READ_DB
+            // (config.shopifyReadDatabaseUrl()), and SHOPIFY_READ_DATABASE_URL is only a
+            // local-dev override. Naming one var would report a false gap on whichever of
+            // the two paths the env doesn't use.
             ok: config.isLocal() || !!config.shopifyReadDatabaseUrl(),
             detail: config.shopifyReadDatabaseUrl()
                 ? "Mirror connection configured."
                 : config.isLocal()
                   ? "Not set (fine on local; no mirror to read)."
-                  : "NOT configured — set SHOPIFY_READ_DATABASE_URL ('Live payment' stays blank and the reconciler backstop no-ops).",
+                  : "NOT configured — set SHOPIFY_READ_DB ('Live payment' stays blank and the reconciler backstop no-ops).",
         },
     ];
 }

--- a/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
+++ b/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
@@ -31,17 +31,30 @@ function freshClient(): Client {
     return mod;
 }
 
-const MIRROR_URL = 'postgresql://s_read_dev_ro:pw@host:5432/shopify_read_dev';
-const prevUrl = process.env.SHOPIFY_READ_DATABASE_URL;
+// The app's OWN credential pointed at the mirror's database — there is no mirror
+// credential (its SELECT grant reaches checkin's DML role via NOLOGIN-grant-holder
+// membership). Set through the SHOPIFY_READ_DATABASE_URL override rather than the
+// DATABASE_URL + SHOPIFY_READ_DB derivation: this file tests the client, and
+// config.shopifyReadDatabaseUrl()'s derivation has its own tests in config.test.ts.
+const MIRROR_URL = 'postgresql://checkin_dev_dml:pw@host:5432/shopify_read_dev';
+
+// Both inputs of the resolved url. SHOPIFY_READ_DB must be cleared too, or an ambient
+// value derives a url and the "unwired" case below can never actually be unwired.
+const MIRROR_KEYS = ['SHOPIFY_READ_DATABASE_URL', 'SHOPIFY_READ_DB'] as const;
+const prev: Record<string, string | undefined> = {};
+for (const k of MIRROR_KEYS) prev[k] = process.env[k];
 
 beforeEach(() => {
     jest.clearAllMocks();
+    for (const k of MIRROR_KEYS) delete process.env[k];
     process.env.SHOPIFY_READ_DATABASE_URL = MIRROR_URL;
 });
 
 afterAll(() => {
-    if (prevUrl === undefined) delete process.env.SHOPIFY_READ_DATABASE_URL;
-    else process.env.SHOPIFY_READ_DATABASE_URL = prevUrl;
+    for (const k of MIRROR_KEYS) {
+        if (prev[k] === undefined) delete process.env[k];
+        else process.env[k] = prev[k];
+    }
 });
 
 describe('latestSyncRun', () => {

--- a/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
+++ b/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for the mirror client's sync-status read. `pg` is mocked — this covers
+ * the wiring the reconciler's integration tests don't: that an unconfigured env never
+ * opens a pool at all, and that the read is a single newest-first row.
+ *
+ * The client caches its Pool in a module-level singleton, so each case re-imports the
+ * module under jest.isolateModules to get a fresh one.
+ */
+const queryMock = jest.fn();
+const poolCtor = jest.fn();
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation((...args: unknown[]) => {
+        poolCtor(...args);
+        return { query: queryMock, on: jest.fn() };
+    }),
+}));
+
+type Client = typeof import('../client');
+
+/** Load a fresh copy of the client against the current process.env. */
+function freshClient(): Client {
+    let mod!: Client;
+    jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        mod = require('../client');
+    });
+    return mod;
+}
+
+const MIRROR_URL = 'postgresql://s_read_dev_ro:pw@host:5432/shopify_read_dev';
+const prevUrl = process.env.SHOPIFY_READ_DATABASE_URL;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SHOPIFY_READ_DATABASE_URL = MIRROR_URL;
+});
+
+afterAll(() => {
+    if (prevUrl === undefined) delete process.env.SHOPIFY_READ_DATABASE_URL;
+    else process.env.SHOPIFY_READ_DATABASE_URL = prevUrl;
+});
+
+describe('latestSyncRun', () => {
+    it('returns null without opening a pool when the mirror is unwired', async () => {
+        delete process.env.SHOPIFY_READ_DATABASE_URL;
+        const client = freshClient();
+
+        expect(client.isConfigured()).toBe(false);
+        expect(await client.latestSyncRun()).toBeNull();
+        // The load-bearing half: an env with no mirror must not connect to anything.
+        expect(poolCtor).not.toHaveBeenCalled();
+        expect(queryMock).not.toHaveBeenCalled();
+    });
+
+    it('returns the most recent run', async () => {
+        const row = {
+            status: 'COMPLETED',
+            kind: 'INCREMENTAL',
+            startedAt: new Date('2026-07-16T09:00:00Z'),
+            finishedAt: new Date('2026-07-16T09:02:00Z'),
+            counts: { orders: 12 },
+            error: null,
+        };
+        queryMock.mockResolvedValue({ rows: [row] });
+
+        expect(await freshClient().latestSyncRun()).toEqual(row);
+    });
+
+    it('returns null when the mirror has never run a sync', async () => {
+        queryMock.mockResolvedValue({ rows: [] });
+        expect(await freshClient().latestSyncRun()).toBeNull();
+    });
+
+    it('reads exactly one row, newest first', async () => {
+        queryMock.mockResolvedValue({ rows: [] });
+        await freshClient().latestSyncRun();
+
+        const sql = queryMock.mock.calls[0][0].replace(/\s+/g, ' ');
+        expect(sql).toContain('FROM sync_run');
+        expect(sql).toContain('ORDER BY started_at DESC');
+        expect(sql).toContain('LIMIT 1');
+    });
+
+    it("pins both timestamps to UTC", async () => {
+        queryMock.mockResolvedValue({ rows: [] });
+        await freshClient().latestSyncRun();
+
+        // s-read's columns are `timestamp WITHOUT time zone` holding UTC, and node-pg
+        // resolves those against the Node process's zone — drop these casts and a
+        // non-UTC container reports a 12-minute-old sync as "just now" (a future
+        // instant makes the age negative). Caught by driving the real page on a
+        // Chicago-zoned laptop; nothing else fails if this regresses.
+        const sql = queryMock.mock.calls[0][0].replace(/\s+/g, ' ');
+        expect(sql).toContain(`started_at AT TIME ZONE 'UTC'`);
+        expect(sql).toContain(`finished_at AT TIME ZONE 'UTC'`);
+    });
+
+    it('honours the scale-to-zero pool invariant', async () => {
+        queryMock.mockResolvedValue({ rows: [] });
+        await freshClient().latestSyncRun();
+
+        // min 0 + a finite idle reap is what lets the shared Aurora cluster auto-pause;
+        // a pool that holds a connection open would keep it awake forever (PR #1030).
+        const opts = poolCtor.mock.calls[0][0];
+        expect(opts.min).toBe(0);
+        expect(opts.idleTimeoutMillis).toBeGreaterThan(0);
+    });
+});

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -18,11 +18,13 @@ import { logger } from "@/lib/logger";
  * (isolated by database + role, not by cluster), so this pool is bound by the same
  * scale-to-zero invariant as lib/prisma.ts — see getPool below.
  *
- * The connection string SHOULD point at a read-only role — in a deployed env it is
- * s_read_<env>_ro, a SELECT-only role provisioned by the checkin-bootstrap task
- * (infra modules/s-read/init.sql). Null env → isConfigured() is false and the
- * reconciler no-ops, so an env without the mirror runs no reconciliation rather
- * than crashing.
+ * Reads are SELECT-only by GRANT, not by convention: in a deployed env the app
+ * connects with its OWN database-url credential, whose DML role is a member of the
+ * mirror's SELECT-only NOLOGIN grant-holder (infra modules/s-read/init.sql) — there
+ * is no separate mirror credential to hold or rotate. See config.shopifyReadDatabaseUrl()
+ * for how the URL is derived (DATABASE_URL + SHOPIFY_READ_DB). Not wired →
+ * isConfigured() is false and the reconciler no-ops, so an env without the mirror
+ * runs no reconciliation rather than crashing.
  *
  * ponytail: no store_id filter — each env has its own `shopify_read_<env>` DB with
  * exactly one store, so filtering would only risk a myshopify-vs-storefront domain

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -18,9 +18,11 @@ import { logger } from "@/lib/logger";
  * (isolated by database + role, not by cluster), so this pool is bound by the same
  * scale-to-zero invariant as lib/prisma.ts — see getPool below.
  *
- * The connection string SHOULD point at a read-only role. Null env → isConfigured()
- * is false and the reconciler no-ops, so an env without the mirror runs no
- * reconciliation rather than crashing.
+ * The connection string SHOULD point at a read-only role — in a deployed env it is
+ * s_read_<env>_ro, a SELECT-only role provisioned by the checkin-bootstrap task
+ * (infra modules/s-read/init.sql). Null env → isConfigured() is false and the
+ * reconciler no-ops, so an env without the mirror runs no reconciliation rather
+ * than crashing.
  *
  * ponytail: no store_id filter — each env has its own `shopify_read_<env>` DB with
  * exactly one store, so filtering would only risk a myshopify-vs-storefront domain
@@ -121,6 +123,54 @@ export async function ordersByLegacyIds(legacyIds: string[]): Promise<MirrorOrde
         [legacyIds],
     );
     return rows.rows;
+}
+
+/** The `sync_run` columns the board needs to judge how fresh the mirror is. */
+export interface MirrorSyncRun {
+    /**
+     * RUNNING | COMPLETED | FAILED | ABANDONED. ABANDONED is s-read's stale-run
+     * reaper relabelling a run whose process was killed (timeout/OOM) — so a dead
+     * run never sits as RUNNING forever. Read verbatim; not narrowed to a union,
+     * since the mirror's enum is s-read's to extend and an unknown value must
+     * surface rather than break the read.
+     */
+    status: string;
+    /** BACKFILL | INCREMENTAL | ADMIN. */
+    kind: string;
+    startedAt: Date;
+    finishedAt: Date | null;
+    /** s-read's per-object row counts. Shape is s-read's; passed through untouched. */
+    counts: unknown;
+    error: string | null;
+}
+
+/**
+ * The most recent sync run, or null when the mirror has never run one (or is
+ * unconfigured). Ordered by started_at — s-read stamps it on insert, so it is
+ * non-null for every row, unlike finished_at.
+ *
+ * ⚠ AT TIME ZONE 'UTC' is load-bearing, not decoration. s-read's timestamps are
+ * `timestamp WITHOUT time zone` holding UTC (Prisma's default mapping for DateTime),
+ * and node-pg resolves a naive timestamp against the NODE PROCESS's zone — so a
+ * container running anything but UTC reads every run at an offset and reports
+ * nonsense freshness ("just now" for an hours-old sync, since a future instant makes
+ * the difference negative). The cast pins the interpretation to UTC and hands the
+ * driver a timestamptz, which is unambiguous everywhere. Deployed tasks happen to
+ * run TZ=UTC today; this makes that a non-issue rather than a dependency.
+ */
+export async function latestSyncRun(): Promise<MirrorSyncRun | null> {
+    const p = getPool();
+    if (!p) return null;
+    const rows = await p.query<MirrorSyncRun>(
+        `SELECT status::text AS status, kind::text AS kind,
+                started_at  AT TIME ZONE 'UTC' AS "startedAt",
+                finished_at AT TIME ZONE 'UTC' AS "finishedAt",
+                counts, error
+         FROM sync_run
+         ORDER BY started_at DESC
+         LIMIT 1`,
+    );
+    return rows.rows[0] ?? null;
 }
 
 /**

--- a/checkin-app/src/lib/time.ts
+++ b/checkin-app/src/lib/time.ts
@@ -29,6 +29,22 @@ export function formatDateTime(date: Date | string | number | null | undefined, 
 }
 
 /**
+ * Coarse "how long ago" for freshness lines ("just now", "12 min ago", "3 hr ago",
+ * "2 d ago"). No timezone involved — it's a difference, not a wall-clock reading.
+ * Deliberately coarse: it answers "is this stale?", not "exactly when?" — pair it
+ * with formatDateTime when the precise instant matters.
+ */
+export function relTime(when: string | Date, now: Date | number = Date.now()): string {
+    const ms = new Date(now).getTime() - new Date(when).getTime();
+    const min = Math.floor(ms / 60000);
+    if (min < 1) return "just now";
+    if (min < 60) return `${min} min ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr} hr ago`;
+    return `${Math.floor(hr / 24)} d ago`;
+}
+
+/**
  * Visit time range for display: "1:35 PM-2:19 PM (44 minutes)" once departed,
  * or "1:35 PM-" while still active (no end time, no length — too dynamic).
  * Times are shown without seconds.


### PR DESCRIPTION
> #1043 has merged; this is rebased onto `main` and targets `main` directly.

## Why

#1038 gave the board a "Sync Shopify now" button that genuinely refreshes the s-read mirror — but nothing visible changes, because checkin couldn't read what s-read wrote. #1043 supplies the mirror connection; this PR surfaces what's in it.

Two things have been dark in every deployed env: the reconciler backstop (`runReconcile()` returns `{configured: false}`, and `reconcile.ts` is the **only** writer of `PaymentException`), and the "Live payment" column, which re-reads amounts from the mirror.

## What

- **`latestSyncRun()`** in `lib/shopifyRead/client.ts`, following the file's conventions: a raw parameterized `pg` SELECT (not a second Prisma client — see the header), reusing the existing pool, so the documented scale-to-zero invariant (`min 0`, idle reaped) is untouched. `status` is read verbatim rather than narrowed to a union: s-read owns that enum, and an unrecognised value should surface rather than break the read.
- **`GET /api/finance-ops/s-read/sync`** on the existing route file, reusing the POST's `withAuth({ roles: ['isSysadmin', 'isBoardMember'] })`. Its 503 gates on the **mirror**, not on the trigger the POST gates on — separate wiring, and an env can have either without the other.
- **UI**: "Last Shopify sync: 12 min ago · completed". After `triggerSync()`, poll while RUNNING, then refetch the table (Live payment reads the mirror, so amounts can differ the moment a sync lands).
- **Config-health check** `s-read-mirror`. It keys on the **resolved** url rather than a named env var — with #1043 the url has two possible sources (derived from `DATABASE_URL` + `SHOPIFY_READ_DB` in AWS, or the `SHOPIFY_READ_DATABASE_URL` override locally), so naming one would report a false gap on whichever path an env doesn't use. Its exact failing-count assertion moves 5 → 6.
- `relTime` moves from `DevDashboard` into `lib/time` rather than being duplicated — it already produced exactly this format.

**Polling is bounded**: 20 × 6s ≈ 2 min, then it reports the sync as still running rather than watching forever. Every poll queries the mirror and keeps the auto-pausing Aurora cluster awake — the cost that makes the scheduled sync daily (infra#129). It stops on any non-RUNNING status. ABANDONED is why `!== COMPLETED` is the wrong stop condition: that state is s-read's reaper relabelling a run killed by timeout/OOM, so treating it as in-flight would burn the whole budget every time.

## A real bug the end-to-end drive caught

`sync_run.started_at` / `finished_at` are `timestamp WITHOUT time zone` holding UTC (Prisma's default mapping), and **node-pg resolves a naive timestamp against the Node process's zone**. Without a cast, a non-UTC container reads every run at an offset and reports a 12-minute-old sync as **"just now"** — a future instant makes the age negative. Both timestamps are now pinned with `AT TIME ZONE 'UTC'`.

`tsc` and the mocked tests are both blind to this; it only appeared by driving the real page on a Chicago-zoned laptop. Deployed tasks run `TZ=UTC` today, so the cast converts an accident into a guarantee. A regression test pins the SQL contract.

## Rebase note — worth a reviewer's eye

This PR was originally built on the **superseded** design (a dedicated `s_read_<env>_ro` LOGIN role + its own secret; infra #134/#135, now replaced by infra#136 + #1043). Rebasing onto #1043 **auto-merged with no conflict**, which was the hazard: it left `client.ts` contradicting itself — my header still described a separate credential while `getPool()` immediately below correctly described membership in the NOLOGIN grant-holder. Since `s_read_<env>_ro` is now NOLOGIN, the old header wasn't just stale, it was impossible (a NOLOGIN role cannot appear in a connection string).

The second commit realigns it. Both test files also had to clear `SHOPIFY_READ_DB` alongside `SHOPIFY_READ_DATABASE_URL` — the mirror check reads a *resolved* url with two inputs, so clearing only one let an ambient value silently turn the "nothing configured" case green, meaning the check could never have failed. `grep` for `s_read_.*_ro` under `src/` is now zero.

## Verification

- **Full local end-to-end**: throwaway Postgres, `shopify_read` DB built by applying the real `packages/s-ingest-core` migrations (not a hand-rolled table), driven in a browser as the seeded board-member persona. All three states render correctly: `12 min ago · completed`, `2 min ago · running`, `1 min ago · abandoned` (which also exercises the enum `::text` cast).
- Unit tests for `latestSyncRun()` (wired / unwired / empty / SQL contract / pool invariant) and the GET (401, 403, wired, not-wired 503, null run, RUNNING passthrough, 500).
- `npx tsc --noEmit` clean; `npm run lint` clean; **full unit suite green — 216 suites / 1834 tests** (on top of #1043).
- `authzRegistry` already covered `finance-ops/s-read/sync` (it keys on route *path*, not method), so the GET needs no new entry; the comment and deny-path tests are extended to cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
