### PR TITLE
fix(s-read): read the mirror's naive timestamps as UTC, not process-local

### DIFF
--- a/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
+++ b/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
@@ -6,6 +6,10 @@
  * the wiring the reconciler's integration tests don't: that an unconfigured env never
  * opens a pool at all, and that the read is a single newest-first row.
  *
+ * The order reads below are guarded the same way, and for the same reason: both pin
+ * the shape of the SQL rather than a round-tripped Date, because the round trip
+ * passes either way under TZ=UTC (which is what CI and the deployed tasks both run).
+ *
  * The client caches its Pool in a module-level singleton, so each case re-imports the
  * module under jest.isolateModules to get a fresh one.
  */
@@ -39,7 +43,7 @@ function freshClient(): Client {
 const MIRROR_URL = 'postgresql://checkin_dev_dml:pw@host:5432/shopify_read_dev';
 
 // Both inputs of the resolved url. SHOPIFY_READ_DB must be cleared too, or an ambient
-// value derives a url and the "unwired" case below can never actually be unwired.
+// value derives a url and the "unwired" cases below can never actually be unwired.
 const MIRROR_KEYS = ['SHOPIFY_READ_DATABASE_URL', 'SHOPIFY_READ_DB'] as const;
 const prev: Record<string, string | undefined> = {};
 for (const k of MIRROR_KEYS) prev[k] = process.env[k];
@@ -121,5 +125,58 @@ describe('latestSyncRun', () => {
         const opts = poolCtor.mock.calls[0][0];
         expect(opts.min).toBe(0);
         expect(opts.idleTimeoutMillis).toBeGreaterThan(0);
+    });
+});
+
+/** The SQL of the Nth query, whitespace-collapsed so indentation doesn't matter. */
+const sqlOf = (call: number) => (queryMock.mock.calls[call][0] as string).replace(/\s+/g, ' ');
+
+describe('order reads', () => {
+    // s-read's columns are `timestamp WITHOUT time zone` holding UTC, and node-pg
+    // resolves those against the Node process's zone — drop these casts and a non-UTC
+    // container reads every mirror timestamp at an offset. Deployed tasks set no TZ
+    // (so the container is UTC and the naive read is accidentally right), which is
+    // exactly why nothing else fails if this regresses.
+    it('ordersChangedSince pins both timestamps to UTC', async () => {
+        queryMock.mockResolvedValue({ rows: [] });
+        await freshClient().ordersChangedSince(new Date('2026-07-01T00:00:00Z'));
+        const sql = sqlOf(0);
+
+        expect(sql).toContain(`cancelled_at AT TIME ZONE 'UTC' AS "cancelledAt"`);
+        expect(sql).toContain(`updated_at AT TIME ZONE 'UTC' AS "updatedAt"`);
+    });
+
+    it('ordersChangedSince casts the cursor param, not the column', async () => {
+        queryMock.mockResolvedValue({ rows: [] });
+        await freshClient().ordersChangedSince(new Date('2026-07-01T00:00:00Z'));
+        const sql = sqlOf(0);
+
+        // The WHERE must move with the projection: this is the reconciler's high-water
+        // cursor (reconcile.ts reads updatedAt, stores it, feeds it back as `since`),
+        // so casting one side only would shift it by the offset. Naive column vs a
+        // timestamptz param would ALSO resolve against the session TimeZone — a second
+        // offset, unrelated to node's.
+        expect(sql).toContain(`updated_at > ($1::timestamptz AT TIME ZONE 'UTC')`);
+        // Param-side cast keeps the comparison sargable for any future index.
+        expect(sql).not.toMatch(/updated_at AT TIME ZONE 'UTC'\s*>/);
+    });
+
+    it('ordersByLegacyIds pins both timestamps to UTC', async () => {
+        queryMock.mockResolvedValue({ rows: [] });
+        await freshClient().ordersByLegacyIds(['123']);
+        const sql = sqlOf(0);
+
+        expect(sql).toContain(`cancelled_at AT TIME ZONE 'UTC' AS "cancelledAt"`);
+        expect(sql).toContain(`updated_at AT TIME ZONE 'UTC' AS "updatedAt"`);
+    });
+
+    it('neither read opens a pool when the mirror is unwired', async () => {
+        delete process.env.SHOPIFY_READ_DATABASE_URL;
+        const client = freshClient();
+
+        expect(await client.ordersChangedSince(null)).toEqual([]);
+        expect(await client.ordersByLegacyIds(['123'])).toEqual([]);
+        expect(poolCtor).not.toHaveBeenCalled();
+        expect(queryMock).not.toHaveBeenCalled();
     });
 });

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -88,9 +88,17 @@ export interface MirrorOrder {
     noteAttributes: { key: string; value: string | null }[] | null;
 }
 
+/**
+ * AT TIME ZONE 'UTC' on the timestamps for the reason spelled out on latestSyncRun
+ * below: the mirror's columns are naive `timestamp` holding UTC, and node-pg resolves
+ * those against the node process's zone. The rule is the whole file's — EVERY
+ * timestamp read from this mirror carries the cast.
+ */
 const ORDER_COLS = `shopify_gid AS "orderGid", legacy_id AS "legacyId", customer_email AS "customerEmail",
     financial_status AS "financialStatus", total_cents AS "totalCents", subtotal_cents AS "subtotalCents",
-    total_refunded_cents AS "totalRefundedCents", cancelled_at AS "cancelledAt", updated_at AS "updatedAt",
+    total_refunded_cents AS "totalRefundedCents",
+    cancelled_at AT TIME ZONE 'UTC' AS "cancelledAt",
+    updated_at AT TIME ZONE 'UTC' AS "updatedAt",
     note_attributes AS "noteAttributes"`;
 
 /** Read one cart attribute off a mirrored order. Null when absent (or pre-#1029). */
@@ -107,8 +115,13 @@ export async function ordersChangedSince(since: Date | null, limit = 1000): Prom
     const p = getPool();
     if (!p) return [];
     const rows = await p.query<MirrorOrder>(
+        // `$1 AT TIME ZONE 'UTC'` on the PARAM side, not the column: it turns the
+        // JS Date into the naive-UTC value the column stores, so the comparison is
+        // naive-vs-naive and stays sargable. Casting the column instead would work
+        // but would rule out any future index on updated_at. Both sides must move
+        // together — casting only one direction shifts the cursor by the offset.
         `SELECT ${ORDER_COLS} FROM shop_order
-         WHERE test = false AND ($1::timestamptz IS NULL OR updated_at > $1)
+         WHERE test = false AND ($1::timestamptz IS NULL OR updated_at > ($1::timestamptz AT TIME ZONE 'UTC'))
          ORDER BY updated_at ASC NULLS FIRST
          LIMIT $2`,
         [since, limit],


### PR DESCRIPTION
## What

Every timestamp `lib/shopifyRead/client.ts` reads out of the s-read mirror is now anchored to UTC explicitly — on both the SELECT projection and the reconciler's cursor comparison.

**This is the order-read half of the bug #1041 fixed on `sync_run`.** #1041 pinned `started_at`/`finished_at`; the order reads in the same file had the identical latent bug on `shop_order.updated_at` and `cancelled_at`. Rebased on top of #1041, and the tests join the describe block in the file it created.

## Why

The mirror's timestamp columns are `timestamp WITHOUT time zone` holding UTC — Prisma's default `DateTime` mapping. `shop_order.updated_at` and `cancelled_at` are both `TIMESTAMP(3)` in `packages/s-ingest-core/prisma/migrations/0000000000000_init/migration.sql`.

node-pg resolves a naive `timestamp` against the **node process's** timezone, not UTC. So on any instance where `TZ != UTC`, every mirror timestamp read through this bridge came back shifted by the local offset. #1041 proved this concretely by driving the real page on a Chicago-zoned laptop.

There were two independent offsets in `ordersChangedSince`:

1. **The SELECT projection** (shared with `ordersByLegacyIds` through `ORDER_COLS`) — `updated_at`/`cancelled_at` parsed against the process TZ.
2. **The WHERE** — a naive column compared against a `timestamptz` param, which Postgres resolves against the **session** TimeZone. A second offset, unrelated to node's.

Both matter because `ordersChangedSince` is the reconciler's high-water cursor: `lib/finance/reconcile.ts` reads `updatedAt` off a row, stores it, and feeds it back as `since`. A shifted read skips or re-scans orders. `cancelled_at` separately feeds the Live payment column on `/finance-ops/payments`.

## How

`AT TIME ZONE 'UTC'` on the projection re-labels the naive value as the UTC instant it already is, producing a `timestamptz` that node-pg parses correctly at any TZ.

The WHERE casts the **param** side back to naive-UTC instead of casting the column:

```sql
WHERE test = false AND ($1::timestamptz IS NULL OR updated_at > ($1::timestamptz AT TIME ZONE 'UTC'))
```

Both directions are correct; the param side keeps the comparison naive-vs-naive and sargable. `shop_order` has no index on `updated_at` today (only `store_id,legacy_id` and `store_id,name`), so that's insurance rather than a live win. Both sides had to move together — casting one alone would shift the cursor by the offset.

## Not a live bug

Deployed ECS tasks set no `TZ` env var, so the container defaults to UTC and the naive read is accidentally correct. Nothing in `infra modules/checkin/compute.tf` sets `TZ`. Same standing as #1041: correctness-by-accident, converted to a guarantee.

## Reviewer notes

- **Mirror schema untouched.** `packages/s-ingest-core` is s-read's; checkin only reads.
- **`disputedOrderGids` needs no change** — it selects no timestamps.
- **The `ORDER_COLS` doc comment defers to #1041's,** which already spells out the node-pg mechanic in full a few lines down. One explanation, not two.
- **The guards are verified load-bearing:** reverting the three casts fails exactly the three cast assertions and leaves #1041's six `latestSyncRun` tests green. Without that check the assertions prove nothing — everything here runs at TZ=UTC, so a round-trip test would pass either way. That's why these pin SQL text.
- **Conflict resolution with #1041** touched only the test file (`client.ts` auto-merged cleanly). I left #1041's shared harness and setup exactly as-is and followed its per-test `mockResolvedValue` idiom rather than adding a `beforeEach` default that would have quietly changed behaviour for its six tests.

## Testing

- `shopifyRead|config|payments` — 60/60 pass, including #1041's suites.
- Mutation-checked as described above.