### PR TITLE
feat(mirror): derive the s-read mirror URL from DATABASE_URL + SHOPIFY_READ_DB

### DIFF
--- a/checkin-app/src/app/api/cron/reconcile-shopify/route.ts
+++ b/checkin-app/src/app/api/cron/reconcile-shopify/route.ts
@@ -24,7 +24,7 @@ import { runReconcile } from "@/lib/finance/reconcile";
  * Recovers missed orders/paid webhooks (advancing families past the paid
  * checkpoint) and raises refund/chargeback/cancel problems for the board. See
  * lib/finance/reconcile.ts. No-op when the mirror isn't wired
- * (SHOPIFY_READ_DATABASE_URL unset).
+ * (config.shopifyReadDatabaseUrl() null — no SHOPIFY_READ_DB / override set).
  */
 export const GET = withCron(async () => {
     const result = await runReconcile();

--- a/checkin-app/src/lib/__tests__/config.test.ts
+++ b/checkin-app/src/lib/__tests__/config.test.ts
@@ -6,6 +6,7 @@ const ENV_KEYS = [
     "AWS_REGION", "AGREEMENT_PDF_S3_BUCKET", "AGREEMENT_PDF_S3_KEY", "ZOHO_CLIENT_ID", "ZOHO_CLIENT_SECRET",
     "ZOHO_REFRESH_TOKEN", "ZOHO_ACCOUNTS_URL", "ZOHO_SIGN_API", "CHECKIN_ENV", "VERCEL_URL", "NODE_ENV",
     "SHOPIFY_STORE_DOMAIN", "SHOPIFY_CLIENT_ID", "SHOPIFY_CLIENT_SECRET", "SHOPIFY_WEBHOOK_SECRET",
+    "SHOPIFY_READ_DATABASE_URL", "SHOPIFY_READ_DB",
 ];
 
 let saved: Record<string, string | undefined>;
@@ -310,5 +311,33 @@ describe("baseUrl / nextAuthUrl", () => {
         expect(config.nextAuthUrl()).toBe("http://localhost:4000");
         process.env.NEXTAUTH_URL = "https://checkin.example";
         expect(config.nextAuthUrl()).toBe("https://checkin.example");
+    });
+});
+
+describe("shopifyReadDatabaseUrl", () => {
+    it("derives the mirror URL from DATABASE_URL + SHOPIFY_READ_DB, keeping credentials and params", () => {
+        delete process.env.SHOPIFY_READ_DATABASE_URL;
+        process.env.DATABASE_URL = "postgresql://checkin_dev_dml:p%40ss@host.example:5432/checkin_dev?sslmode=verify-full";
+        process.env.SHOPIFY_READ_DB = "shopify_read_dev";
+        expect(config.shopifyReadDatabaseUrl()).toBe(
+            "postgresql://checkin_dev_dml:p%40ss@host.example:5432/shopify_read_dev?sslmode=verify-full",
+        );
+    });
+    it("prefers the explicit SHOPIFY_READ_DATABASE_URL override", () => {
+        process.env.SHOPIFY_READ_DATABASE_URL = "postgresql://ro:x@elsewhere:5432/mirror";
+        process.env.DATABASE_URL = "postgresql://a:b@host:5432/checkin_dev";
+        process.env.SHOPIFY_READ_DB = "shopify_read_dev";
+        expect(config.shopifyReadDatabaseUrl()).toBe("postgresql://ro:x@elsewhere:5432/mirror");
+    });
+    it("is null (mirror off) when SHOPIFY_READ_DB or DATABASE_URL is missing or unparsable", () => {
+        delete process.env.SHOPIFY_READ_DATABASE_URL;
+        delete process.env.SHOPIFY_READ_DB;
+        process.env.DATABASE_URL = "postgresql://a:b@host:5432/checkin_dev";
+        expect(config.shopifyReadDatabaseUrl()).toBeNull();
+        process.env.SHOPIFY_READ_DB = "shopify_read_dev";
+        delete process.env.DATABASE_URL;
+        expect(config.shopifyReadDatabaseUrl()).toBeNull();
+        process.env.DATABASE_URL = "not a url";
+        expect(config.shopifyReadDatabaseUrl()).toBeNull();
     });
 });

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -194,10 +194,31 @@ export const config = {
     cronSecret: (): string | null => process.env.CRON_SECRET || null,
 
     // s-read mirror — read-only connection string to the `shopify_read` Postgres
-    // (the s-read-function's Shopify order/refund/payout mirror). Null when unset →
-    // the hourly reconciler (lib/finance/reconcile.ts) short-circuits as "not wired"
-    // instead of throwing, so an env without the mirror simply runs no reconciliation.
-    shopifyReadDatabaseUrl: (): string | null => process.env.SHOPIFY_READ_DATABASE_URL || null,
+    // (the s-read-function's Shopify order/refund/payout mirror). Null when not
+    // wired → the reconciler (lib/finance/reconcile.ts) short-circuits as "not
+    // wired" instead of throwing, so an env without the mirror simply runs no
+    // reconciliation.
+    //
+    // In AWS there is NO mirror connection string of its own: the app's DML role
+    // is a member of the mirror's SELECT-only NOLOGIN grant-holder (infra
+    // modules/checkin-bootstrap/bootstrap.sh), so the URL is DATABASE_URL with the
+    // database name swapped to SHOPIFY_READ_DB ("shopify_read_<env>", a plain task
+    // env — see infra modules/checkin/overview.tf, incl. why it is explicit per
+    // env rather than derived from checkinEnv()). SHOPIFY_READ_DATABASE_URL stays
+    // as a full-URL override for local dev, where the mirror may live anywhere.
+    shopifyReadDatabaseUrl: (): string | null => {
+        if (process.env.SHOPIFY_READ_DATABASE_URL) return process.env.SHOPIFY_READ_DATABASE_URL;
+        const db = process.env.SHOPIFY_READ_DB;
+        const base = process.env.DATABASE_URL;
+        if (!db || !base) return null;
+        try {
+            const url = new URL(base);
+            url.pathname = `/${db}`;
+            return url.toString();
+        } catch {
+            return null;
+        }
+    },
 
     // s-read sync trigger — name of the `s-read-<env>-trigger` Lambda that RunTasks
     // the sync family (s-read-function/DEPLOY.md). Null when unset → the board's

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -48,6 +48,10 @@ function getPool(): Pool | null {
             // on long-held connections, and nothing here holds one.
             idleTimeoutMillis: 10_000,
             min: 0,
+            // Mirror reads run under checkin's OWN role (membership in the mirror's
+            // NOLOGIN grant-holder — no separate credential), so name the session:
+            // it's what tells these apart from app queries in pg_stat_activity.
+            application_name: "checkin-shopify-read",
         });
         pool.on("error", (e) => logger.error("shopify_read pool error:", e));
     }


### PR DESCRIPTION
Companion to infra#136 (mirror read access via NOLOGIN grant-holder — replaces the merged infra#134 design and supersedes infra#135).

## What changes

- `config.shopifyReadDatabaseUrl()` — when the explicit `SHOPIFY_READ_DATABASE_URL` override is absent, derives the mirror URL from `DATABASE_URL` with the database name swapped to `SHOPIFY_READ_DB`. Both unset ⇒ null ⇒ reconciler + "Live payment" stay off, exactly as before. The var is explicit per env (infra sets `shopify_read_dev`/`shopify_read_prod`) rather than derived from `CHECKIN_ENV`, which fails safe to prod — the wrong direction for infra wiring.
- The mirror pool sets `application_name: "checkin-shopify-read"` — mirror reads now run under checkin's own role, so the session name is what distinguishes them from app queries in `pg_stat_activity`.

## Why there's no separate credential anymore

`s_read_<env>_ro` is now `NOLOGIN`: a pure privilege container that cannot authenticate and holds no password. `checkin_<env>_dml` is granted membership and inherits exactly its SELECT — inside the mirror database the app has no other privilege, so the write-protection boundary is unchanged while a whole credential (secret, rotation, injection, IAM) disappears. Full security rationale in infra#136.

## Ordering

Safe to merge before or after infra#136 — until `SHOPIFY_READ_DB` appears in the task def *and* the bootstrap task has applied the grant, the accessor returns null (or the derived URL simply isn't used yet). No migration, no schema change.

## Testing

- 3 new unit tests: derivation preserves credentials/params, override wins, null on missing/unparsable inputs. `config.test.ts`: 43/43 pass.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe