### PR TITLE
ci: upgrade node20-runtime actions to node24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
       # duplicate save with a warning, not a failure).
       - name: Restore Jest cache
         if: needs.changes.outputs.app == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: checkin-app/.jest-cache
           key: jest-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
@@ -224,7 +224,7 @@ jobs:
       # even when the test step above fails the job.
       - name: Publish test results
         if: always() && needs.changes.outputs.app == 'true'
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         with:
           name: Jest Tests (unit)
           path: checkin-app/test-results/junit.xml
@@ -238,7 +238,7 @@ jobs:
       # ran leaves nothing to upload, which is fine, this job is already red.
       - name: Upload unit coverage artifact
         if: always() && needs.changes.outputs.app == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-unit
           path: checkin-app/coverage/coverage-final.json
@@ -295,7 +295,7 @@ jobs:
       # Same cache, same key scheme as unit-tests above.
       - name: Restore Jest cache
         if: needs.changes.outputs.app == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: checkin-app/.jest-cache
           key: jest-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
@@ -348,7 +348,7 @@ jobs:
 
       - name: Publish test results
         if: always() && needs.changes.outputs.app == 'true'
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         with:
           name: Jest Tests (integration)
           path: checkin-app/test-results/junit.xml
@@ -357,7 +357,7 @@ jobs:
 
       - name: Upload integration coverage artifact
         if: always() && needs.changes.outputs.app == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-integration
           path: checkin-app/coverage/coverage-final.json
@@ -404,7 +404,7 @@ jobs:
       - name: Download unit coverage artifact
         if: needs.changes.outputs.app == 'true'
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: coverage-unit
           path: coverage-artifacts/unit
@@ -412,7 +412,7 @@ jobs:
       - name: Download integration coverage artifact
         if: needs.changes.outputs.app == 'true'
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: coverage-integration
           path: coverage-artifacts/integration

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -105,7 +105,7 @@ jobs:
       url: https://ops.innovationtreehouse.org
     steps:
       - name: Checkout released tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
 
@@ -120,7 +120,7 @@ jobs:
           echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -257,7 +257,7 @@ jobs:
     name: Released migrations immutable (+ accumulation warning)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/security-boundary-isolation.yml
+++ b/.github/workflows/security-boundary-isolation.yml
@@ -29,7 +29,7 @@ jobs:
   isolation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/shopify-live.yml
+++ b/.github/workflows/shopify-live.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
Part of the org-wide sweep for actions still on the retiring node20 runner runtime (each action's `runs.using`, verified from its action.yml at the pinned ref). Most of this repo already migrated (checkout@v5 ×11, setup-node@v5 ×5, configure-aws-credentials@v6 ×4, login-action@v4 ×3); this catches the stragglers:

| Action | From (node20) | To (node24) | Count |
|---|---|---|---|
| actions/checkout | v4 | v5 | 3 |
| actions/setup-node | v4 | v5 | 1 |
| actions/cache | v4 | v5 | 2 |
| actions/download-artifact | v4 | v7 | 2 |
| actions/upload-artifact | v4 | v6 | 2 |
| aws-actions/configure-aws-credentials | v4 | v6 | 1 |
| dorny/test-reporter | v1 | v3 | 2 |

Notes on the two bigger jumps:
- **artifact actions**: v5 majors are still node20, so the minimal node24 targets are upload **v6** / download **v7**. Both stay on the v4 artifact API generation, so the coverage gate's cross-job junit/coverage artifact merge (`merge-multiple`) is unaffected — and this PR's own CI run exercises exactly that path.
- **dorny/test-reporter v1→v3**: v2 is node20; v3 is the node24 major. Inputs (name/path/reporter) unchanged; the junit reports on this PR's checks are the validation.

Sibling PRs: arbor#113, infra#137 (same sweep). Wiki left as-is deliberately: its workflows are upstream requarks/wiki files that have never run in the fork and push to registries the fork can't reach — bumping their action majors buys nothing and adds divergence against future upstream syncs (wiki#5 already handled its node 20 → 24 build pins, which upstream's main Dockerfile had itself moved to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe