### PR TITLE
ci(deploy-prod): one approval per release — fold s-read into the app deploy job

### DIFF
--- a/.github/actions/deploy-s-read/action.yml
+++ b/.github/actions/deploy-s-read/action.yml
@@ -1,0 +1,202 @@
+name: Deploy s-read
+description: >
+  Build the s-read image, register new revisions of BOTH task-def families, and
+  (in migrate-and-code mode) run the migrate task in between — for ONE env. The
+  runnable half of what deploy-s-read.yml used to inline. The CALLER must have
+  already checked out the ref to build (this action does not checkout — it builds
+  from the current workspace) and must run in a job whose OIDC sub the target
+  deploy role trusts: for prod that means `environment: production`, which is
+  exactly why folding this into the app deploy job collapses the release to a
+  SINGLE approval (one job enters `production`, not two).
+
+inputs:
+  environment:
+    description: "s-read environment (dev | prod)"
+    required: true
+  mode:
+    description: "migrate-and-code | code-only"
+    default: migrate-and-code
+  network-config:
+    description: >
+      run-task networkConfiguration JSON (the S_READ_NETWORK_CONFIG repo var).
+      Required for migrate-and-code; unused in code-only.
+    default: ""
+  aws-region:
+    description: "AWS region"
+    default: us-east-2
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve commit
+      id: vars
+      shell: bash
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+    - name: Configure AWS credentials (OIDC)
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        # Per-env deploy role. The prod role's OIDC trust requires the calling
+        # job to carry `environment: production` (sub …:environment:production);
+        # the dev role's trust is the bare main-ref sub. When this action runs
+        # inside the prod app-deploy job, the job already assumed this same role
+        # — re-assuming it here is a harmless no-op that keeps the action
+        # self-contained for the dev/dispatch wrapper too.
+        role-to-assume: arn:aws:iam::639595353568:role/checkin-deploy-${{ inputs.environment == 'prod' && 'prod' || 'dev' }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Log in to ghcr.io
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Build and push image
+      id: build
+      shell: bash
+      env:
+        IMAGE: ghcr.io/innovationtreehouse/s-read:${{ steps.vars.outputs.sha }}
+      run: |
+        set -euo pipefail
+        # Repo-root build context (workspace install) — see s-read-function/Dockerfile.
+        docker build -f s-read-function/Dockerfile -t "$IMAGE" .
+        docker push "$IMAGE"
+        echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+    # Both families get a new revision pointing at the new image (infra#112's
+    # deploy contract) — the migrate one first, since migrations ship in the image.
+    - name: Register new migrate task definition
+      id: register_migrate
+      shell: bash
+      env:
+        IMAGE: ${{ steps.build.outputs.image }}
+        MIGRATE_TASK_FAMILY: s-read-${{ inputs.environment }}-migrate
+      run: |
+        set -euo pipefail
+        # New revision with the new image, keeping only the fields
+        # register-task-definition accepts. Goes through a real temp file:
+        # the runner's aws CLI cannot read file:///dev/stdin.
+        aws ecs describe-task-definition \
+          --task-definition "$MIGRATE_TASK_FAMILY" \
+          --query taskDefinition --output json \
+          | jq --arg IMG "$IMAGE" '
+              .containerDefinitions[0].image = $IMG
+              | {family, taskRoleArn, executionRoleArn, networkMode,
+                 containerDefinitions, requiresCompatibilities, cpu, memory,
+                 runtimePlatform}' > "$RUNNER_TEMP/migrate-taskdef.json"
+        MIGRATE_ARN=$(aws ecs register-task-definition \
+          --cli-input-json "file://$RUNNER_TEMP/migrate-taskdef.json" \
+          --query 'taskDefinition.taskDefinitionArn' --output text)
+        CONTAINER_NAME=$(jq -r '.containerDefinitions[0].name' "$RUNNER_TEMP/migrate-taskdef.json")
+        echo "Registered migrate task def: $MIGRATE_ARN (container: $CONTAINER_NAME)"
+        echo "migrate_arn=$MIGRATE_ARN" >> "$GITHUB_OUTPUT"
+        echo "container_name=$CONTAINER_NAME" >> "$GITHUB_OUTPUT"
+
+    - name: Run database migrations
+      if: inputs.mode == 'migrate-and-code'
+      shell: bash
+      env:
+        ECS_CLUSTER: s-read-${{ inputs.environment }}
+        MIGRATE_LOG_GROUP: /ecs/s-read-${{ inputs.environment }}-migrate
+        MIGRATE_ARN: ${{ steps.register_migrate.outputs.migrate_arn }}
+        CONTAINER_NAME: ${{ steps.register_migrate.outputs.container_name }}
+        # Full run-task networkConfiguration JSON from the infra outputs
+        # (`s_read_compute_sg_id` + the three default-VPC public subnets), e.g.
+        #   {"awsvpcConfiguration":{"subnets":["subnet-0597513f1c0c3173e","subnet-0a67d72908bffbcd4","subnet-0c84ac2840be3a2bc"],"securityGroups":["sg-..."],"assignPublicIp":"ENABLED"}}
+        # Passed from the caller's S_READ_NETWORK_CONFIG repo var. One value for both envs.
+        NETWORK_CONFIG: ${{ inputs.network-config }}
+      run: |
+        set -euo pipefail
+        if [ -z "$NETWORK_CONFIG" ]; then
+          echo "::error::network-config input is empty (repo variable S_READ_NETWORK_CONFIG) — subnets/SG for run-task; see the workflow comments."
+          exit 1
+        fi
+
+        # Same command the migrate task-def bakes (npm run db:deploy — container-safe,
+        # prisma reads SHOPIFY_READ_DATABASE_URL from the ECS-injected DDL secret),
+        # wrapped in the house retry loop: the shared Aurora Serverless v2 cluster has
+        # min-capacity-0 auto-pause, and the first connection races the ~30s resume
+        # (Prisma fails fast with P1001).
+        jq -n --arg NAME "$CONTAINER_NAME" '
+          {containerOverrides: [{name: $NAME, command: ["sh", "-c",
+            "for i in 1 2 3 4 5; do npm run db:deploy -w @inventory/s-ingest-core && exit 0; echo \"attempt $i failed — DB may be resuming from auto-pause; retrying in 20s\"; sleep 20; done; exit 1"
+          ]}]}' > "$RUNNER_TEMP/migrate-overrides.json"
+
+        # FARGATE_SPOT strategy (associated on the cluster — infra#131), not
+        # on-demand --launch-type: matches the checkin migrate tasks. A Spot
+        # reclaim mid-migration fails the step loudly and a rerun is clean —
+        # one small migration per release, gated per database.
+        TASK_ARN=$(aws ecs run-task \
+          --cluster "$ECS_CLUSTER" \
+          --task-definition "$MIGRATE_ARN" \
+          --capacity-provider-strategy capacityProvider=FARGATE_SPOT,weight=1 \
+          --network-configuration "$NETWORK_CONFIG" \
+          --overrides "file://$RUNNER_TEMP/migrate-overrides.json" \
+          --query 'tasks[0].taskArn' --output text)
+        echo "Migration task: $TASK_ARN (logs: $MIGRATE_LOG_GROUP)"
+
+        aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN"
+
+        EXIT_CODE=$(aws ecs describe-tasks \
+          --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN" \
+          --query 'tasks[0].containers[0].exitCode' --output text)
+        echo "Migration exit code: $EXIT_CODE"
+        if [ "$EXIT_CODE" != "0" ]; then
+          echo "::error::Database migration failed (exit $EXIT_CODE) — sync task def NOT updated; the schedule keeps running the previous revision."
+          exit 1
+        fi
+
+    - name: Register new sync task definition
+      id: register_sync
+      shell: bash
+      env:
+        IMAGE: ${{ steps.build.outputs.image }}
+        SYNC_TASK_FAMILY: s-read-${{ inputs.environment }}-sync
+      run: |
+        set -euo pipefail
+        # New revision with the new image; the s-read-<env>-trigger Lambda RunTasks
+        # the revision-less family ARN, so the next hourly tick runs this revision —
+        # no service update, no terraform.
+        aws ecs describe-task-definition \
+          --task-definition "$SYNC_TASK_FAMILY" \
+          --query taskDefinition --output json \
+          | jq --arg IMG "$IMAGE" '
+              .containerDefinitions[0].image = $IMG
+              | {family, taskRoleArn, executionRoleArn, networkMode,
+                 containerDefinitions, requiresCompatibilities, cpu, memory,
+                 runtimePlatform}' > "$RUNNER_TEMP/sync-taskdef.json"
+        SYNC_ARN=$(aws ecs register-task-definition \
+          --cli-input-json "file://$RUNNER_TEMP/sync-taskdef.json" \
+          --query 'taskDefinition.taskDefinitionArn' --output text)
+        echo "Registered sync task def: $SYNC_ARN"
+        echo "sync_arn=$SYNC_ARN" >> "$GITHUB_OUTPUT"
+
+    - name: Report s-read result
+      if: always()
+      shell: bash
+      env:
+        IMAGE: ${{ steps.build.outputs.image }}
+        STATUS: ${{ job.status }}
+        MODE: ${{ inputs.mode }}
+        TARGET_ENV: ${{ inputs.environment }}
+        SYNC_ARN: ${{ steps.register_sync.outputs.sync_arn }}
+        MIGRATE_LOG_GROUP: /ecs/s-read-${{ inputs.environment }}-migrate
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        if [ "$STATUS" = "success" ]; then
+          {
+            echo "### ✅ s-read \`$TARGET_ENV\` deployed (\`$MODE\`)"
+            echo "- Image: \`$IMAGE\`"
+            echo "- Sync task def: \`$SYNC_ARN\` (the schedule picks it up on its next tick)"
+            if [ "$MODE" = "migrate-and-code" ]; then echo "- Migrations: applied before the sync task-def update"; fi
+            echo "- [Deploy run]($RUN_URL)"
+          } >> "$GITHUB_STEP_SUMMARY"
+        else
+          {
+            echo "### ❌ s-read \`$TARGET_ENV\` deploy failed (status: \`$STATUS\`, mode: \`$MODE\`)"
+            echo "- [Deploy run]($RUN_URL) — check the logs (migrate task logs: \`$MIGRATE_LOG_GROUP\`)."
+            echo "- The schedule keeps running the previous task-def revision."
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -282,6 +282,18 @@ jobs:
           echo "::error::Smoke test failed: $APP_URL never answered with 200/redirect"
           exit 1
 
+      # s-read rides every prod release, in THIS job — after the app is live, on
+      # the same released tag (still checked out) and the same already-assumed
+      # checkin-deploy-prod credentials. Folded in (rather than a separate job
+      # carrying its own `environment: production`) so the release takes ONE
+      # approval instead of two: only this job enters the production environment.
+      # The composite writes its own step-summary section.
+      - name: Deploy s-read (prod)
+        uses: ./.github/actions/deploy-s-read
+        with:
+          environment: prod
+          network-config: ${{ vars.S_READ_NETWORK_CONFIG }}
+
       - name: Report result
         if: always()
         env:
@@ -294,28 +306,16 @@ jobs:
           set -euo pipefail
           if [ "$STATUS" = "success" ]; then
             {
-              echo "### ✅ Released $TAG to prod"
+              echo "### ✅ Released $TAG to prod (app + s-read)"
               echo "Commit \`$SHORT_SHA\` is live on [$APP_URL]($APP_URL)."
               echo "- Image: \`$IMAGE_REPO:$TAG\`"
-              echo "- Migrations: applied · Service: stable"
+              echo "- Migrations: applied · Service: stable · s-read: deployed"
               echo "- [Release]($RELEASE_URL) · [Deploy run]($RUN_URL)"
             } >> "$GITHUB_STEP_SUMMARY"
           else
             {
               echo "### ❌ Prod deploy of $TAG failed (status: \`$STATUS\`)"
-              echo "- [Deploy run]($RUN_URL) — check the logs."
-              echo "- Prod still runs the previous image."
+              echo "- [Deploy run]($RUN_URL) — check the logs (app and/or s-read)."
+              echo "- The app rolls out before s-read: if the app step passed, prod runs the new image and only s-read needs a rerun; otherwise prod still runs the previous image."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
-
-  # s-read rides every prod release, after the human-approved app deploy. The
-  # called job carries `environment: production` (required by the prod deploy
-  # role's OIDC trust), so the release gets a SECOND approval prompt for the
-  # s-read half — a deliberate gate, not an accident. Same released tag.
-  s-read:
-    name: Deploy s-read (prod)
-    needs: deploy
-    uses: ./.github/workflows/deploy-s-read.yml
-    with:
-      environment: prod
-      ref: ${{ github.event.release.tag_name }}

--- a/.github/workflows/deploy-s-read.yml
+++ b/.github/workflows/deploy-s-read.yml
@@ -1,43 +1,32 @@
 name: Deploy s-read
 
-# Manual deploy of the s-read-function ECS image (workflow_dispatch only, no
-# auto-trigger — run it deliberately after the change has merged and CI is green
-# on main). Pick the ENVIRONMENT (dev | prod): every AWS resource name below is
-# env-suffixed since infra#114 split s-read into per-env instances. Builds the
-# container image, pushes it to ghcr.io (ONE image repo shared by both envs —
-# envs differ only in config/secrets, never in code), registers new revisions of
-# BOTH task-def families, and (in migrate-and-code mode) runs the migration task
-# in between. There is no ECS service to roll: the schedule runs tasks against
-# the revision-less s-read-<env>-sync family ARN, so it uses the latest ACTIVE
-# revision on its next tick — no terraform involved.
+# Thin wrapper around the reusable `.github/actions/deploy-s-read` composite
+# action (which holds all the build/register/migrate logic). Two entry points:
 #
-# Ordering (migrate-and-code): migrations run BEFORE the new sync revision is
-# registered — expand/contract, same as deploy-dev.yml. The previous code keeps
-# running against the migrated schema until the next scheduled tick.
+#   • workflow_dispatch — ad-hoc deploy of one env (dev | prod), run deliberately
+#     after the change has merged and CI is green on main. A prod dispatch keeps
+#     its own `environment: production` approval gate below.
+#   • workflow_call — used by deploy-dev.yml (environment: dev) so every DEV app
+#     deploy also ships its s-read counterpart. PROD does NOT call this workflow:
+#     deploy-prod.yml runs the same composite action inside its already-approved
+#     app-deploy job, so a prod release takes ONE approval, not two (that was the
+#     whole point of extracting the composite).
 #
-# Registry is ghcr.io with the GITHUB_TOKEN login/push pattern from deploy-dev.yml
-# (one pipeline convention, no registry credentials to manage). The package stays
-# PRIVATE — the task defs pull it via repositoryCredentials -> the shared
-# ghcr-pull-credentials secret (infra modules/shared-iam), like every other ECS
-# workload in this account. We push a unique :<git-sha> tag, never :latest.
+# Builds the container image, pushes it to ghcr.io (ONE image repo shared by both
+# envs — envs differ only in config/secrets, never in code), registers new
+# revisions of BOTH task-def families, and (in migrate-and-code mode) runs the
+# migration task in between. There is no ECS service to roll: the schedule runs
+# tasks against the revision-less s-read-<env>-sync family ARN, so it uses the
+# latest ACTIVE revision on its next tick — no terraform involved.
 #
-# AWS auth (GitHub OIDC, checkin-deploy-dev role) is still needed for the
-# register-task-definition / run-task steps — for BOTH s-read envs: infra wires
-# PassRole on both envs' task roles onto this one role (checkin-deploy-prod
-# doesn't exist until checkin-prod launches). The role's trust policy is pinned
-# to refs/heads/main, so this workflow MUST be dispatched from the main branch;
-# a dispatch from any other ref fails at the credentials step.
-#
-# Infra preconditions (NOT done here — infra#114/#117 on top of infra#112's
-# original contract):
-#   - per env: cluster `s-read-<env>`, task-def families `s-read-<env>-sync` /
-#     `s-read-<env>-migrate` (with the ghcr repositoryCredentials), the
-#     `s-read-<env>-trigger` Lambda + its schedule, secret shells + IAM applied.
-#   - secret VALUES set: database URLs via the bootstrap task (infra
-#     modules/checkin-bootstrap, TARGETS=s-read), Shopify client pair by hand
-#     (see s-read-function/DEPLOY.md).
-#   - Repo variable S_READ_NETWORK_CONFIG set (see the migrate step). Shared by
-#     both envs — same SG + subnets by design.
+# AWS auth (GitHub OIDC) uses the per-env checkin-deploy-<env> role; infra wires
+# PassRole on both envs' s-read task roles onto both checkin deploy roles. The
+# dev role's trust is pinned to refs/heads/main, so a dev dispatch/call MUST come
+# from main; the prod role additionally requires `environment: production` (the
+# gate below). Infra preconditions (per env: cluster, both task-def families with
+# ghcr repositoryCredentials, the trigger Lambda + schedule, secret shells + IAM;
+# secret VALUES via the bootstrap task + Shopify creds by hand; repo variable
+# S_READ_NETWORK_CONFIG set) are unchanged — see s-read-function/DEPLOY.md.
 
 on:
   workflow_dispatch:
@@ -56,9 +45,6 @@ on:
           - migrate-and-code
           - code-only
         default: migrate-and-code
-  # Called by deploy-dev.yml (environment: dev) and deploy-prod.yml
-  # (environment: prod) so every app deploy migrates + deploys its s-read
-  # counterpart; the dispatch trigger above remains for ad-hoc runs.
   workflow_call:
     inputs:
       environment:
@@ -83,191 +69,28 @@ concurrency:
   group: s-read-deploy-${{ inputs.environment }}
   cancel-in-progress: false  # serialize deploys per env; never abandon one mid-flight
 
-env:
-  AWS_REGION: us-east-2
-  IMAGE_REPO: ghcr.io/innovationtreehouse/s-read
-  ECS_CLUSTER: s-read-${{ inputs.environment }}
-  SYNC_TASK_FAMILY: s-read-${{ inputs.environment }}-sync
-  MIGRATE_TASK_FAMILY: s-read-${{ inputs.environment }}-migrate
-  MIGRATE_LOG_GROUP: /ecs/s-read-${{ inputs.environment }}-migrate
-  # Per-env deploy role: the prod role's OIDC trust requires the job to carry
-  # `environment: production` (sub repo:...:environment:production); the dev
-  # role's trust is the bare main-ref sub, so the dev path must carry NO
-  # environment — hence the conditional `environment:` on the job below (an
-  # empty name means none).
-  DEPLOY_ROLE: arn:aws:iam::639595353568:role/checkin-deploy-${{ inputs.environment == 'prod' && 'prod' || 'dev' }}
-
 jobs:
   deploy:
     name: Build, push, migrate, register (${{ inputs.environment }})
     runs-on: ubuntu-24.04-arm  # native ARM64 — the task defs are arm64 (runtime_platform)
-    # prod: rides the production environment gate (human approval + the OIDC
-    # sub the prod role trusts). dev: no environment — see DEPLOY_ROLE comment.
+    # prod dispatch rides the production environment gate (human approval + the
+    # OIDC sub the prod role trusts). dev: no environment — the dev role's trust
+    # is the bare main-ref sub, so the dev path must carry NO environment (an
+    # empty name means none).
     environment: ${{ inputs.environment == 'prod' && 'production' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          # Empty on dispatch = the triggering commit, exactly as before; the
-          # pipelines pass the deployed app commit/tag so app and s-read ship
-          # the same tree.
+          # Empty on dispatch = the triggering commit; deploy-dev passes the
+          # deployed app commit so app and s-read ship the same tree. Checked
+          # out here so the local composite action is on disk and builds the
+          # right ref.
           ref: ${{ inputs.ref || '' }}
 
-      - name: Resolve commit
-        id: vars
-        run: |
-          SHA=$(git rev-parse HEAD)
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
+      - name: Deploy s-read
+        uses: ./.github/actions/deploy-s-read
         with:
-          role-to-assume: ${{ env.DEPLOY_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push image
-        id: build
-        env:
-          IMAGE: ${{ env.IMAGE_REPO }}:${{ steps.vars.outputs.sha }}
-        run: |
-          set -euo pipefail
-          # Repo-root build context (workspace install) — see s-read-function/Dockerfile.
-          docker build -f s-read-function/Dockerfile -t "$IMAGE" .
-          docker push "$IMAGE"
-          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
-
-      # Both families get a new revision pointing at the new image (infra#112's
-      # deploy contract) — the migrate one first, since migrations ship in the image.
-      - name: Register new migrate task definition
-        id: register_migrate
-        env:
-          IMAGE: ${{ steps.build.outputs.image }}
-        run: |
-          set -euo pipefail
-          # New revision with the new image, keeping only the fields
-          # register-task-definition accepts. Goes through a real temp file:
-          # the runner's aws CLI cannot read file:///dev/stdin.
-          aws ecs describe-task-definition \
-            --task-definition "$MIGRATE_TASK_FAMILY" \
-            --query taskDefinition --output json \
-            | jq --arg IMG "$IMAGE" '
-                .containerDefinitions[0].image = $IMG
-                | {family, taskRoleArn, executionRoleArn, networkMode,
-                   containerDefinitions, requiresCompatibilities, cpu, memory,
-                   runtimePlatform}' > "$RUNNER_TEMP/migrate-taskdef.json"
-          MIGRATE_ARN=$(aws ecs register-task-definition \
-            --cli-input-json "file://$RUNNER_TEMP/migrate-taskdef.json" \
-            --query 'taskDefinition.taskDefinitionArn' --output text)
-          CONTAINER_NAME=$(jq -r '.containerDefinitions[0].name' "$RUNNER_TEMP/migrate-taskdef.json")
-          echo "Registered migrate task def: $MIGRATE_ARN (container: $CONTAINER_NAME)"
-          echo "migrate_arn=$MIGRATE_ARN" >> "$GITHUB_OUTPUT"
-          echo "container_name=$CONTAINER_NAME" >> "$GITHUB_OUTPUT"
-
-      - name: Run database migrations
-        if: inputs.mode == 'migrate-and-code'
-        env:
-          MIGRATE_ARN: ${{ steps.register_migrate.outputs.migrate_arn }}
-          CONTAINER_NAME: ${{ steps.register_migrate.outputs.container_name }}
-          # Full run-task networkConfiguration JSON from the infra outputs
-          # (`s_read_compute_sg_id` + the three default-VPC public subnets), e.g.
-          #   {"awsvpcConfiguration":{"subnets":["subnet-0597513f1c0c3173e","subnet-0a67d72908bffbcd4","subnet-0c84ac2840be3a2bc"],"securityGroups":["sg-..."],"assignPublicIp":"ENABLED"}}
-          # Set as a repo variable (Settings > Variables) — there is no ECS service
-          # here to copy placement from (deploy-dev.yml reads its service's; this
-          # fleet's tasks are schedule/run-task only). One value for both envs.
-          NETWORK_CONFIG: ${{ vars.S_READ_NETWORK_CONFIG }}
-        run: |
-          set -euo pipefail
-          if [ -z "$NETWORK_CONFIG" ]; then
-            echo "::error::Repo variable S_READ_NETWORK_CONFIG is not set (subnets/SG for run-task) — see the workflow comments."
-            exit 1
-          fi
-
-          # Same command the migrate task-def bakes (npm run db:deploy — container-safe,
-          # prisma reads SHOPIFY_READ_DATABASE_URL from the ECS-injected DDL secret),
-          # wrapped in the house retry loop: the shared Aurora Serverless v2 cluster has
-          # min-capacity-0 auto-pause, and the first connection races the ~30s resume
-          # (Prisma fails fast with P1001).
-          jq -n --arg NAME "$CONTAINER_NAME" '
-            {containerOverrides: [{name: $NAME, command: ["sh", "-c",
-              "for i in 1 2 3 4 5; do npm run db:deploy -w @inventory/s-ingest-core && exit 0; echo \"attempt $i failed — DB may be resuming from auto-pause; retrying in 20s\"; sleep 20; done; exit 1"
-            ]}]}' > "$RUNNER_TEMP/migrate-overrides.json"
-
-          # FARGATE_SPOT strategy (associated on the cluster — infra#131), not
-          # on-demand --launch-type: matches the checkin migrate tasks. A Spot
-          # reclaim mid-migration fails the step loudly and a rerun is clean —
-          # one small migration per release, gated per database.
-          TASK_ARN=$(aws ecs run-task \
-            --cluster "$ECS_CLUSTER" \
-            --task-definition "$MIGRATE_ARN" \
-            --capacity-provider-strategy capacityProvider=FARGATE_SPOT,weight=1 \
-            --network-configuration "$NETWORK_CONFIG" \
-            --overrides "file://$RUNNER_TEMP/migrate-overrides.json" \
-            --query 'tasks[0].taskArn' --output text)
-          echo "Migration task: $TASK_ARN (logs: $MIGRATE_LOG_GROUP)"
-
-          aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN"
-
-          EXIT_CODE=$(aws ecs describe-tasks \
-            --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN" \
-            --query 'tasks[0].containers[0].exitCode' --output text)
-          echo "Migration exit code: $EXIT_CODE"
-          if [ "$EXIT_CODE" != "0" ]; then
-            echo "::error::Database migration failed (exit $EXIT_CODE) — sync task def NOT updated; the schedule keeps running the previous revision."
-            exit 1
-          fi
-
-      - name: Register new sync task definition
-        id: register_sync
-        env:
-          IMAGE: ${{ steps.build.outputs.image }}
-        run: |
-          set -euo pipefail
-          # New revision with the new image; the s-read-<env>-trigger Lambda RunTasks
-          # the revision-less family ARN, so the next hourly tick runs this revision —
-          # no service update, no terraform.
-          aws ecs describe-task-definition \
-            --task-definition "$SYNC_TASK_FAMILY" \
-            --query taskDefinition --output json \
-            | jq --arg IMG "$IMAGE" '
-                .containerDefinitions[0].image = $IMG
-                | {family, taskRoleArn, executionRoleArn, networkMode,
-                   containerDefinitions, requiresCompatibilities, cpu, memory,
-                   runtimePlatform}' > "$RUNNER_TEMP/sync-taskdef.json"
-          SYNC_ARN=$(aws ecs register-task-definition \
-            --cli-input-json "file://$RUNNER_TEMP/sync-taskdef.json" \
-            --query 'taskDefinition.taskDefinitionArn' --output text)
-          echo "Registered sync task def: $SYNC_ARN"
-          echo "sync_arn=$SYNC_ARN" >> "$GITHUB_OUTPUT"
-
-      - name: Report result
-        if: always()
-        env:
-          IMAGE: ${{ steps.build.outputs.image }}
-          STATUS: ${{ job.status }}
-          MODE: ${{ inputs.mode }}
-          TARGET_ENV: ${{ inputs.environment }}
-          SYNC_ARN: ${{ steps.register_sync.outputs.sync_arn }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          if [ "$STATUS" = "success" ]; then
-            {
-              echo "### ✅ s-read \`$TARGET_ENV\` deployed (\`$MODE\`)"
-              echo "- Image: \`$IMAGE\`"
-              echo "- Sync task def: \`$SYNC_ARN\` (the hourly schedule picks it up on its next tick)"
-              if [ "$MODE" = "migrate-and-code" ]; then echo "- Migrations: applied before the sync task-def update"; fi
-              echo "- [Deploy run]($RUN_URL)"
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo "### ❌ s-read \`$TARGET_ENV\` deploy failed (status: \`$STATUS\`, mode: \`$MODE\`)"
-              echo "- [Deploy run]($RUN_URL) — check the logs (migrate task logs: \`$MIGRATE_LOG_GROUP\`)."
-              echo "- The schedule keeps running the previous task-def revision."
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          environment: ${{ inputs.environment }}
+          mode: ${{ inputs.mode }}
+          network-config: ${{ vars.S_READ_NETWORK_CONFIG }}


### PR DESCRIPTION
## Problem
Publishing a release prompts for **two** production approvals: first the app `deploy` job, then the `s-read` job. Both jobs carry `environment: production` (required for OIDC — `checkin-deploy-prod`'s trust is pinned to sub `…:environment:production`), and GitHub reviews *every* job that references a protected environment. Because `s-read` had `needs: deploy`, its prompt appeared only after the app deploy finished → two sequential clicks. The second gate was a side effect of s-read being a separate job, not a real second decision (same tag, same reviewer).

## Approach (Option A — no OIDC/trust change)
The only way to a single approval without touching the exact-match sub is to have **one job enter `production`**. Since a job can't both `uses:` a reusable workflow and have `steps:`, the s-read deploy is extracted into a **composite action** (`.github/actions/deploy-s-read/`) and run as a step inside the already-approved app `deploy` job.

- **`.github/actions/deploy-s-read/action.yml`** — the build/register-both-task-defs/migrate logic, verbatim, with per-step `env:` so nothing leaks into the caller job. Assumes the workspace is already at the ref to build (the caller checks out); configures its own `checkin-deploy-<env>` creds so it's self-contained.
- **`deploy-prod.yml`** — the separate `s-read` job is gone; the composite runs in the `deploy` job after the smoke test, on the same checked-out tag and the credentials the job already assumed. One environment entry ⇒ one approval.
- **`deploy-s-read.yml`** — now a thin wrapper around the same composite, so `deploy-dev.yml` (environment: dev) and ad-hoc `workflow_dispatch` are unchanged. A **prod dispatch keeps its own** `environment: production` gate.

`deploy-dev.yml` is untouched (dev has no approval, so two jobs there is fine).

## Ordering & auth unchanged
Same sequence (app migrate → app rollout → smoke → s-read migrate → s-read register), same tag, same `ubuntu-24.04-arm` runner (arm64 image), same `checkin-deploy-prod` role — which already holds PassRole on the s-read prod task roles (infra `checkin_deploy_s_read`).

## Trade-off (called out)
App + s-read are now one job:
- An s-read failure marks the job red even though the app is already live. The report step distinguishes this ("if the app step passed, prod runs the new image and only s-read needs a rerun").
- A rerun replays the idempotent app steps (migrate deploy / rollout) too — you can no longer rerun just the s-read half. Acceptable for collapsing to one gate.

## Validation
- `actionlint` (docker) clean on all three workflows — including that the local `uses: ./.github/actions/deploy-s-read` step and its inputs resolve. (The one SC2129 style note is pre-existing, in the unrelated "Resolve released commit" step.)
- YAML parses; composite `job`/`github`/`inputs` contexts are all valid in composite steps.

First real exercise is the next release; a prod `workflow_dispatch` of Deploy s-read is a safe way to smoke the composite path independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe