### PR TITLE
fix(membership-ops): disable "Grant for coming year" once the year is settled

### DIFF
--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -4,7 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
-import { isRenewalSeason } from "@/lib/membership/renewal";
+import { renewalSeasonWindow } from "@/lib/membership/renewal";
 
 export const dynamic = 'force-dynamic';
 
@@ -65,13 +65,29 @@ export const GET = withAuth(
                 ]
             } : {};
 
+            // Renewal-season only: a household whose membership process for the coming
+            // cycle is already settled (member finished renewal, or an admin used the
+            // override) has a terminal ACTIVE process stamped inside this window. Same
+            // "handled this cycle" test runRenewalSweep uses to skip re-opening.
+            const window = await renewalSeasonWindow(new Date());
+
             const households = await prisma.household.findMany({
                 where: whereClause,
                 include: {
                     householdMembers: {
                         select: { id: true, name: true, email: true, isBoardMember: true, emailUndeliverableAt: true }
                     },
-                    orgMembership: true,
+                    orgMembership: {
+                        include: {
+                            // Out of season the button is hidden anyway, so a window start of
+                            // "never" (matches no row) keeps one query shape and one type.
+                            processes: {
+                                where: { status: "ACTIVE", stageEnteredAt: { gte: window?.windowStart ?? new Date(8.64e15) } },
+                                select: { id: true },
+                                take: 1,
+                            },
+                        },
+                    },
                     emergencyContacts: {
                         where: PRIMARY_CONTACT_WHERE,
                         orderBy: [{ priority: "asc" }, { id: "asc" }],
@@ -86,8 +102,15 @@ export const GET = withAuth(
             });
 
             return NextResponse.json({
-                households: households.map(withFlatContact),
-                renewalSeason: await isRenewalSeason(new Date()),
+                households: households.map((h) => {
+                    const { processes, ...orgMembership } = h.orgMembership ?? { processes: [] };
+                    return {
+                        ...withFlatContact(h),
+                        orgMembership: h.orgMembership ? orgMembership : null,
+                        settledForComingYear: processes.length > 0,
+                    };
+                }),
+                renewalSeason: window !== null,
             });
         } catch (error) {
             logger.error("Failed to fetch households:", error);

--- a/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
@@ -168,6 +168,22 @@ describe("membership-ops/households page", () => {
       );
     });
 
+    it("disables it once the coming year is settled", async () => {
+      setSession({ id: 1, isSysadmin: true });
+      mockFetchJson({
+        "/api/membership-ops/households": {
+          ...inSeason,
+          households: [{ ...inSeason.households[0], settledForComingYear: true }, inSeason.households[1]],
+        },
+      });
+      renderWithProviders(<AdminHouseholdsPage />);
+      await screen.findByText("The Smiths");
+
+      expect(screen.getByRole("button", { name: "Granted for coming year" })).toBeDisabled();
+      // The un-settled household keeps a live button.
+      expect(screen.getByRole("button", { name: "Grant for coming year" })).toBeEnabled();
+    });
+
     it("disables it for a board member's OWN household (conflict of interest)", async () => {
       setSession({ id: 99, isBoardMember: true, householdId: 2 }); // same household as The Joneses (id 2)
       mockFetchJson({ "/api/membership-ops/households": inSeason });

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -15,6 +15,9 @@ type Household = {
   id: number;
   name?: string | null;
   orgMembership?: { status: string } | null;
+  // Renewal season only: the coming cycle is already settled — the member finished
+  // renewal, or an admin already used the override.
+  settledForComingYear?: boolean;
   householdMembers?: { id: number; name?: string | null; email?: string | null; isBoardMember?: boolean; emailUndeliverableAt?: string | null }[] | null;
 };
 
@@ -199,6 +202,7 @@ export default function AdminHouseholdsPage() {
               const isStaffHousehold = household.householdMembers?.some(
                 (p) => p.email?.toLowerCase().endsWith('@innovationtreehouse.org')
               ) ?? false;
+              const settledForComingYear = household.settledForComingYear === true;
 
               return (
                 <Table.Tr key={household.id}>
@@ -312,17 +316,19 @@ export default function AdminHouseholdsPage() {
                         size="xs" fz={15}
                         variant="light"
                         color="green"
-                        disabled={ownHouseholdConflict || isStaffHousehold}
+                        disabled={settledForComingYear || ownHouseholdConflict || isStaffHousehold}
                         title={
-                          isStaffHousehold
-                            ? "Staff households can't be granted membership."
-                            : ownHouseholdConflict
-                              ? "You can't grant your own household's membership — a sysadmin must."
-                              : undefined
+                          settledForComingYear
+                            ? "This household is already set for the coming year."
+                            : isStaffHousehold
+                              ? "Staff households can't be granted membership."
+                              : ownHouseholdConflict
+                                ? "You can't grant your own household's membership — a sysadmin must."
+                                : undefined
                         }
                         onClick={() => grantForComingYear(household.id)}
                       >
-                        Grant for coming year
+                        {settledForComingYear ? "Granted for coming year" : "Grant for coming year"}
                       </Button>
                     )}
                     </Stack>

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -78,12 +78,22 @@ export function renewalWindow(configuredBoundary: Date, now: Date): { boundary: 
  * ⇒ not renewal season. Drives the admin "Grant for coming year" button.
  */
 export async function isRenewalSeason(now: Date): Promise<boolean> {
+    return (await renewalSeasonWindow(now)) !== null;
+}
+
+/**
+ * The live renewal window when `now` is inside it, else null. Callers that need
+ * the window bounds (e.g. "was this cycle already resolved?") use this instead of
+ * re-reading BoardSettings themselves.
+ */
+export async function renewalSeasonWindow(now: Date): Promise<{ boundary: Date; windowStart: Date } | null> {
     const settings = await prisma.boardSettings.findUnique({
         where: { id: 1 },
         select: { orgMembershipYearBoundary: true },
     });
-    if (!settings?.orgMembershipYearBoundary) return false;
-    return renewalWindow(settings.orgMembershipYearBoundary, now).inSeason;
+    if (!settings?.orgMembershipYearBoundary) return null;
+    const { boundary, windowStart, inSeason } = renewalWindow(settings.orgMembershipYearBoundary, now);
+    return inSeason ? { boundary, windowStart } : null;
 }
 
 /**


### PR DESCRIPTION
## What

The renewal-season override button now disables (and relabels to **Granted for coming year**) when the household's coming cycle is already settled.

## Why

Two ways to reach a stale-live button, both reported:

1. Click **Grant for coming year** on an existing member — the grant succeeds, the row refetches, and the button comes back live.
2. A household that completed the full renewal flow on its own still gets an enabled button.

Either invites a duplicate grant, which writes a second terminal process for the same cycle.

## How

Both cases share one end state: a terminal `ACTIVE` process stamped inside the current renewal window. That's the same "handled this cycle" test `runRenewalSweep` already uses to decide not to re-open a renewal, so this reuses it rather than inventing a second definition of "done".

- `renewal.ts` — new `renewalSeasonWindow(now)` returns the window bounds (or null out of season). `isRenewalSeason()` is now a null-check on it, so the `BoardSettings` read stays in one place and existing callers/tests are untouched.
- `households` GET — probes for that process per household and returns a `settledForComingYear` flag. Out of season the probe uses a "never" window start so the query keeps one shape and one inferred type; the button is hidden then anyway.
- `page.tsx` — `disabled` + tooltip + label off the flag. The page already refetches after a grant, so it settles on the click.

## Reviewer notes

- **Not covered:** the endpoint still accepts a repeat `comingYear: true` POST. The UI no longer offers that path, but there's no server guard yet — happy to add one if you want it in this PR.
- The `ACTIVE`-in-window probe deliberately excludes `ARCHIVED` processes: a superseded process isn't a completed one.

## Testing

- Jest, scoped to the households page and renewal lib suites — 23 passed, including a new case asserting the settled household's button is disabled while an unsettled sibling stays live.
- `tsc --noEmit` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)