### PR TITLE
feat(finance): s-read diagnostics — name the first broken link in the chain

### DIFF
--- a/checkin-app/docs/designs/S_READ_DIAGNOSTICS.md
+++ b/checkin-app/docs/designs/S_READ_DIAGNOSTICS.md
@@ -1,0 +1,170 @@
+# s-read sync diagnostics
+
+**Status:** implemented — `/api/finance-ops/s-read/diagnose` + the card on `/system-status/health`
+**Motivating pain:** the sync-status feature (#1041, #1045) sits at the end of an
+eight-link chain, and today *every* broken link collapses into one of two
+indistinguishable symptoms: the status line silently doesn't render, or the board
+sees "sync started, but its status can't be read in this environment." Nothing on
+any surface says *which* link broke, so debugging means guessing between env vars,
+grants, migrations, IAM, and s-read itself.
+
+## The chain and how each link fails today
+
+The feature only works when all of these hold, in order. Column 3 is what the
+board/operator actually sees when that link is the broken one — note how many rows
+are identical.
+
+| # | Link | Symptom today | Real distinguishing signal |
+|---|------|---------------|---------------------------|
+| 1 | `SHOPIFY_READ_DB` + `DATABASE_URL` set (or local `SHOPIFY_READ_DATABASE_URL` override) so `config.shopifyReadDatabaseUrl()` resolves | GET 503 → status line hidden; configHealth row red | env presence (configHealth already catches this one — the only link it covers) |
+| 2 | Derived URL reaches a live Postgres (network/DNS/pause) | GET 500 → line hidden / red toast after manual sync | pg error `ETIMEDOUT`/`ENOTFOUND`/`ECONNREFUSED` |
+| 3 | checkin's credential authenticates against that host | same | pg code `28P01`/`28000` |
+| 4 | Database named by `SHOPIFY_READ_DB` exists (name not typo'd, bootstrap created it) | same | pg code `3D000` |
+| 5 | `sync_run` table exists (s-read migrated the mirror) | same | pg code `42P01` |
+| 6 | checkin's DML role is a member of the mirror's NOLOGIN SELECT grant-holder (infra#136 bootstrap step) | same | pg code `42501` |
+| 7 | s-read has actually run ≥1 sync (rows exist) | GET 200 `run: null` → line hidden — **identical to link 1's symptom** | `sync_run` count = 0 |
+| 8 | Timestamps read sanely (UTC casts; #1042) | line renders but freshness is nonsense ("just now" for old runs) | negative computed age |
+| 9 | Trigger side: `S_READ_TRIGGER_FUNCTION` set, IAM `lambda:InvokeFunction` granted, function exists | POST 503 or red "Failed to start" toast | env presence / AWS error class |
+
+Links 2–6 are one opaque 500. Links 1 and 7 render identically. That is the whole
+problem, and it is why "it's not doing its job and I can't tell why" is the
+expected experience, not an anomaly.
+
+configHealth cannot fix this: it is presence-only **by design** — it runs on every
+nav-badge poll, and anything that touches the mirror wakes the scale-to-zero Aurora
+cluster. Deep probes must be on-demand.
+
+## Design
+
+One new endpoint that walks the chain and reports the **first broken link with its
+specific cause**, plus one button that runs it. Nothing scheduled, nothing
+persisted, nothing added to s-read.
+
+### `GET /api/finance-ops/s-read/diagnose`
+
+- Same `withAuth` gate as the sync route: `['isSysadmin', 'isBoardMember']`,
+  session-only.
+- On-demand only — a human clicked a button. Never polled, never cron'd
+  (Aurora scale-to-zero; every probe is a paid wake-up).
+- Returns an ordered list of step results:
+
+```ts
+type DiagStep = {
+  id: string;          // stable slug, see below
+  ok: boolean | null;  // null = skipped (an earlier step already failed)
+  detail: string;      // human sentence; NEVER a secret, NEVER a connection string
+  code?: string;       // pg SQLSTATE or AWS error name, when there is one
+};
+```
+
+### Steps (server-side)
+
+**`env`** — pure inspection, no I/O. Reports which resolution path won
+(`SHOPIFY_READ_DATABASE_URL` override vs `DATABASE_URL`+`SHOPIFY_READ_DB`
+derivation vs nothing), and the derived **database name and host only** (no
+credentials, no full URL). Fails when `shopifyReadDatabaseUrl()` is null, naming
+which input is missing.
+
+**`mirror-read`** — links 2–7 are deliberately **one probe**, not six:
+`SELECT count(*)::int AS runs FROM sync_run` through the existing
+`shopifyRead/client` pool (reuse `getPool`; do not build a second pool — the
+scale-to-zero comment in client.ts is load-bearing). One round trip either
+succeeds or fails with a pg error whose `code` discriminates every layer:
+
+| outcome | verdict emitted |
+|---|---|
+| `ENOTFOUND`/`ECONNREFUSED`/`ETIMEDOUT` | "Can't reach the mirror host — network/security-group/cluster-paused problem, not a grant problem." |
+| `28P01`/`28000` | "Host reached, but checkin's credential was rejected." |
+| `3D000` | "Connected, but database `<name>` doesn't exist — check `SHOPIFY_READ_DB` spelling / bootstrap created the DB." |
+| `42P01` | "Database exists, but `sync_run` is missing — s-read has never migrated this mirror." |
+| `42501` | "Table exists, but SELECT is denied — the DML role isn't a member of the NOLOGIN grant-holder yet (infra#136 bootstrap step)." |
+| success, `runs = 0` | "Mirror readable but s-read has never completed a run — trigger a sync or check s-read's own logs." |
+| success, `runs > 0` | ok, with the count |
+
+**`latest-run`** — only when `mirror-read` succeeded with rows: the verbatim
+latest `sync_run` (status, kind, startedAt, finishedAt, error, counts) via the
+existing `latestSyncRun()`. This puts s-read's own `error` column — which today
+nobody ever sees — in front of the operator.
+
+**`clock`** — computed age of the latest run; flags `ok: false` when the age is
+negative ("mirror timestamps are ahead of this server — timezone handling
+regression, see #1042") and reports `process.env.TZ ?? '(unset)'`.
+
+**`trigger-env`** — is `S_READ_TRIGGER_FUNCTION` set (report the function name —
+it's a resource name, not a secret).
+
+**`trigger-invoke`** — Lambda invoke with `InvocationType: "DryRun"`: validates
+IAM permission *and* function existence **without running a sync**. Classifies
+`AccessDeniedException` (IAM grant missing) vs `ResourceNotFoundException`
+(function name wrong/env mismatch) vs success.
+
+Steps after a failed prerequisite return `ok: null, detail: "skipped"` — the
+report reads as "first broken link", not six cascading reds.
+
+### Surfacing
+
+1. **System-status health page** (`/system-status/health`): a "Shopify mirror
+   (s-read)" card next to `ConfigHealthBox`, one "Run diagnostics" button →
+   renders the step list, green/red per row, `detail` verbatim. No auto-run on
+   page load (wake-up cost).
+2. **Payments page**: the red "status can't be read" notification (#1045) gains
+   one trailing sentence: "Run diagnostics on the System Status page to see
+   why." No new UI on the payments page itself.
+3. **Server log** already carries the underlying error
+   (`"Failed to read the s-read sync status:"` in the sync route) — unchanged;
+   the endpoint just makes the same information reachable without log access.
+
+### Security notes
+
+- The endpoint is inspection-only except `trigger-invoke`'s DryRun, which
+  executes nothing.
+- Never emit a connection string, password, or full URL. Host + database name
+  only, and only to the board/sysadmin gate that already sees configHealth.
+- pg error **codes** are safe to return; pg error **messages** can embed host
+  detail — return our own sentences keyed on the code, log the raw error
+  server-side.
+- IAM: DryRun uses the same `lambda:InvokeFunction` grant the POST already has —
+  no new permissions.
+
+### Tests
+
+- Route test at the client-module boundary (same pattern as the existing sync
+  route tests): script each pg error code and assert the emitted step
+  verdicts — this pins the code→sentence table above.
+- One page test: button click → scripted diagnose response → rows render.
+  (`mockFetchJson` can't do non-200s/method splits — use a local fetch mock,
+  same as `payments/__tests__/page.test.tsx` does since #1045.)
+- The negative-age clock case, with a future `startedAt` fixture — the one
+  class tsc and mocks were blind to in #1041.
+
+### Deliberately out of scope
+
+- **No scheduled/continuous monitoring.** Every probe wakes Aurora; the daily
+  sync cadence exists *because* of that cost (infra#129). Diagnostics are a
+  human-clicked tool.
+- **No result persistence / history.** Run it, read it, fix the link, run again.
+- **No s-read-side changes.** `sync_run` (with `status`, `error`, `counts`) *is*
+  s-read's telemetry; the gap was only that checkin never displayed it.
+- **No new pool, no new Prisma client** — reuse `shopifyRead/client`.
+- **No widening of configHealth** — it stays presence-only and cheap; the deep
+  probe is a separate, on-demand thing. The configHealth mirror row's `detail`
+  can mention the diagnostics page, nothing more.
+
+## Runbook — diagnosing TODAY, before this is built
+
+The most likely current state (per #1041's own warning: the feature is **inert
+until infra's companion PR is applied and the bootstrap task has run**):
+
+1. **Check the server log** for `Failed to read the s-read sync status:` — the
+   attached error's `code` field maps directly to the table above. This is the
+   single fastest discriminator and it already exists.
+2. **No such log line and no status line?** Then the GET is 503ing (link 1) or
+   returning `run: null` (link 7). Check the env for `SHOPIFY_READ_DB`; if set,
+   the mirror is readable but empty — check s-read's own logs / trigger a sync.
+3. **Grant check from psql** (as checkin's role):
+   `SELECT count(*) FROM sync_run;` against the `shopify_read_<env>` DB —
+   `42501` = bootstrap grant not applied (infra#136), `42P01` = mirror never
+   migrated, `3D000` = wrong DB name.
+4. **Trigger side**: red "Failed to start the Shopify sync" toast + server log
+   `Failed to trigger s-read sync:` → IAM or function-name problem;
+   `AccessDeniedException` vs `ResourceNotFoundException` in the logged error.

--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -71,6 +71,9 @@ const AUTHZ_TESTED = new Set<string>([
     // POST + GET deny-paths (401 anon / 403 non-board) in s-read/sync/__tests__/route.test.ts,
     // which also assert a denied request never invokes the Lambda or reads the mirror.
     'finance-ops/s-read/sync',
+    // GET deny-path (401 anon / 403 non-board) in s-read/diagnose/__tests__/route.test.ts,
+    // which also asserts a denied request never probes the mirror or the Lambda.
+    'finance-ops/s-read/diagnose',
     'kioskdisplay/certifications',
     'membership-audit/compliance',
     // POST deny-path (403 non-board) in personBgManualSubmit.integration.test.ts.

--- a/checkin-app/src/app/api/finance-ops/s-read/diagnose/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/diagnose/__tests__/route.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for /api/finance-ops/s-read/diagnose — the deny paths (401 anon /
+ * 403 plain member, through the REAL withAuth with a mocked session, which must
+ * never probe the mirror or the Lambda), and the code→verdict table: each pg
+ * error code the mirror probe can throw must map to the layer it proves broken.
+ * That table IS the feature — a regression here turns the diagnostic back into
+ * the opaque 500 it exists to replace.
+ */
+import { GET } from '../route';
+import type { DiagStep } from '../route';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+const sendMock = jest.fn();
+jest.mock('@aws-sdk/client-lambda', () => ({
+    LambdaClient: jest.fn().mockImplementation(() => ({ send: sendMock })),
+    InvokeCommand: jest.fn().mockImplementation((input) => ({ input })),
+}));
+
+// Mirror stubbed at the client boundary, same as the sync route's tests — the
+// probe SQL itself is covered in lib/shopifyRead/__tests__/client.test.ts.
+const countSyncRunsMock = jest.fn();
+const latestSyncRunMock = jest.fn();
+jest.mock('@/lib/shopifyRead/client', () => ({
+    countSyncRuns: () => countSyncRunsMock(),
+    latestSyncRun: () => latestSyncRunMock(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockSession = require('next-auth/next').getServerSession;
+
+const req = () => new Request('http://localhost/api/finance-ops/s-read/diagnose');
+const asBoard = () => mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+
+async function stepsOf(res: Response): Promise<Map<string, DiagStep>> {
+    const { steps } = await res.json();
+    return new Map((steps as DiagStep[]).map((s) => [s.id, s]));
+}
+
+const pgError = (code: string) => Object.assign(new Error(`probe failed (${code})`), { code });
+
+const ENV_KEYS = ['DATABASE_URL', 'SHOPIFY_READ_DB', 'SHOPIFY_READ_DATABASE_URL', 'S_READ_TRIGGER_FUNCTION'] as const;
+const prevEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    // The AWS derivation path: no override, URL built from DATABASE_URL + SHOPIFY_READ_DB.
+    delete process.env.SHOPIFY_READ_DATABASE_URL;
+    process.env.DATABASE_URL = 'postgresql://checkin_dev_dml:secret@db.example.internal:5432/checkin_dev';
+    process.env.SHOPIFY_READ_DB = 'shopify_read_dev';
+    process.env.S_READ_TRIGGER_FUNCTION = 's-read-dev-trigger';
+    countSyncRunsMock.mockResolvedValue(3);
+    latestSyncRunMock.mockResolvedValue({
+        status: 'COMPLETED', kind: 'INCREMENTAL',
+        startedAt: new Date(Date.now() - 12 * 60000), finishedAt: new Date(Date.now() - 10 * 60000),
+        counts: { orders: 12 }, error: null,
+    });
+    sendMock.mockResolvedValue({ StatusCode: 204 });
+});
+
+afterAll(() => {
+    for (const k of ENV_KEYS) {
+        if (prevEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = prevEnv[k];
+    }
+});
+
+describe('GET /api/finance-ops/s-read/diagnose — deny paths', () => {
+    it('401 when unauthenticated, without probing anything', async () => {
+        mockSession.mockResolvedValue(null);
+        expect((await GET(req())).status).toBe(401);
+        expect(countSyncRunsMock).not.toHaveBeenCalled();
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('403 for a signed-in member without board or sysadmin role, without probing anything', async () => {
+        mockSession.mockResolvedValue({ user: { id: 5, isSysadmin: false, isBoardMember: false } });
+        expect((await GET(req())).status).toBe(403);
+        expect(countSyncRunsMock).not.toHaveBeenCalled();
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('env step', () => {
+    it('reports host + db name for the derived path, never the credential', async () => {
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        const env = steps.get('env')!;
+        expect(env.ok).toBe(true);
+        expect(env.detail).toContain('shopify_read_dev');
+        expect(env.detail).toContain('db.example.internal');
+        expect(env.detail).not.toContain('secret');
+        expect(env.detail).not.toContain('checkin_dev_dml');
+    });
+
+    it('unset SHOPIFY_READ_DB → env fails naming it, mirror steps skipped, trigger still probed', async () => {
+        delete process.env.SHOPIFY_READ_DB;
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        expect(steps.get('env')!.ok).toBe(false);
+        expect(steps.get('env')!.detail).toContain('SHOPIFY_READ_DB');
+        expect(steps.get('mirror-read')!.ok).toBeNull();
+        expect(steps.get('latest-run')!.ok).toBeNull();
+        expect(steps.get('clock')!.ok).toBeNull();
+        expect(countSyncRunsMock).not.toHaveBeenCalled();
+        // The two sides are separate wiring — a missing mirror must not hide trigger results.
+        expect(steps.get('trigger-invoke')!.ok).toBe(true);
+    });
+});
+
+describe('mirror-read step — the code→verdict table', () => {
+    // Each row: [pg code, fragment the verdict must contain]. This pins the layer
+    // diagnosis: get one wrong and the operator is sent to fix the wrong thing.
+    const table: [string, RegExp][] = [
+        ['ENOTFOUND', /can't reach the mirror host/i],
+        ['ECONNREFUSED', /can't reach the mirror host/i],
+        ['ETIMEDOUT', /can't reach the mirror host/i],
+        ['28P01', /credential was rejected/i],
+        ['28000', /credential was rejected/i],
+        ['3D000', /"shopify_read_dev" doesn't exist/i],
+        ['42P01', /sync_run table is missing/i],
+        ['42501', /grant-holder/i],
+    ];
+
+    it.each(table)('%s → the matching layer verdict, with the code attached', async (code, fragment) => {
+        countSyncRunsMock.mockRejectedValue(pgError(code));
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        const probe = steps.get('mirror-read')!;
+        expect(probe.ok).toBe(false);
+        expect(probe.code).toBe(code);
+        expect(probe.detail).toMatch(fragment);
+        expect(steps.get('latest-run')!.ok).toBeNull();
+    });
+
+    it('codeless pool connect timeout → network verdict', async () => {
+        countSyncRunsMock.mockRejectedValue(new Error('timeout exceeded when trying to connect'));
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        expect(steps.get('mirror-read')!.ok).toBe(false);
+        expect(steps.get('mirror-read')!.detail).toMatch(/timed out connecting/i);
+    });
+
+    it('readable but zero runs → "s-read has never started a run", not a grant/network claim', async () => {
+        countSyncRunsMock.mockResolvedValue(0);
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        expect(steps.get('mirror-read')!.ok).toBe(false);
+        expect(steps.get('mirror-read')!.detail).toMatch(/never started a run/i);
+        expect(steps.get('latest-run')!.ok).toBeNull();
+        expect(latestSyncRunMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('latest-run + clock steps', () => {
+    it('healthy mirror → all six steps ok', async () => {
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        for (const id of ['env', 'mirror-read', 'latest-run', 'clock', 'trigger-env', 'trigger-invoke']) {
+            expect(steps.get(id)!.ok).toBe(true);
+        }
+    });
+
+    it("surfaces s-read's own FAILED run and error text — the answer nobody could see before", async () => {
+        latestSyncRunMock.mockResolvedValue({
+            status: 'FAILED', kind: 'INCREMENTAL',
+            startedAt: new Date(Date.now() - 30 * 60000), finishedAt: new Date(Date.now() - 29 * 60000),
+            counts: null, error: 'Shopify 429: throttled',
+        });
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        const latest = steps.get('latest-run')!;
+        expect(latest.ok).toBe(false);
+        expect(latest.detail).toContain('FAILED');
+        expect(latest.detail).toContain('Shopify 429: throttled');
+    });
+
+    it('a future startedAt fails the clock step as a timezone regression — the #1041/#1042 bug class', async () => {
+        latestSyncRunMock.mockResolvedValue({
+            status: 'COMPLETED', kind: 'INCREMENTAL',
+            startedAt: new Date(Date.now() + 5 * 3600_000), finishedAt: null, counts: null, error: null,
+        });
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        expect(steps.get('clock')!.ok).toBe(false);
+        expect(steps.get('clock')!.detail).toMatch(/future/i);
+        expect(steps.get('clock')!.detail).toMatch(/timezone/i);
+    });
+});
+
+describe('trigger steps', () => {
+    it('probes with a DryRun invocation and no payload — diagnostics must never start a sync', async () => {
+        asBoard();
+        await GET(req());
+        expect(sendMock).toHaveBeenCalledTimes(1);
+        const input = sendMock.mock.calls[0][0].input;
+        expect(input.FunctionName).toBe('s-read-dev-trigger');
+        expect(input.InvocationType).toBe('DryRun');
+        expect(input.Payload).toBeUndefined();
+    });
+
+    it('AccessDeniedException → IAM verdict', async () => {
+        sendMock.mockRejectedValue(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        const invoke = steps.get('trigger-invoke')!;
+        expect(invoke.ok).toBe(false);
+        expect(invoke.code).toBe('AccessDeniedException');
+        expect(invoke.detail).toMatch(/IAM/);
+    });
+
+    it('ResourceNotFoundException → wrong-name/wrong-env verdict', async () => {
+        sendMock.mockRejectedValue(Object.assign(new Error('missing'), { name: 'ResourceNotFoundException' }));
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        const invoke = steps.get('trigger-invoke')!;
+        expect(invoke.ok).toBe(false);
+        expect(invoke.detail).toMatch(/misspelled|another environment/i);
+    });
+
+    it('unset S_READ_TRIGGER_FUNCTION → trigger-env fails, invoke skipped, mirror still probed', async () => {
+        delete process.env.S_READ_TRIGGER_FUNCTION;
+        asBoard();
+        const steps = await stepsOf(await GET(req()));
+        expect(steps.get('trigger-env')!.ok).toBe(false);
+        expect(steps.get('trigger-invoke')!.ok).toBeNull();
+        expect(sendMock).not.toHaveBeenCalled();
+        expect(steps.get('mirror-read')!.ok).toBe(true);
+    });
+});

--- a/checkin-app/src/app/api/finance-ops/s-read/diagnose/route.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/diagnose/route.ts
@@ -1,0 +1,212 @@
+import { NextResponse } from "next/server";
+import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+import { logger } from "@/lib/logger";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { config } from "@/lib/config";
+import { countSyncRuns, latestSyncRun } from "@/lib/shopifyRead/client";
+import { relTime } from "@/lib/time";
+
+/**
+ * GET /api/finance-ops/s-read/diagnose — walk the s-read feature's dependency
+ * chain and report the FIRST broken link with its specific cause.
+ *
+ * Why this exists (docs/designs/S_READ_DIAGNOSTICS.md): the sync-status feature
+ * sits at the end of a nine-link chain (env → derived URL → network → auth → DB
+ * exists → table exists → SELECT grant → rows exist → trigger IAM), and without
+ * this endpoint every broken link collapses into "the status line doesn't render"
+ * or one generic red toast. configHealth can't help — it is presence-only by
+ * design because it runs on nav-badge polls, and anything touching the mirror
+ * wakes the scale-to-zero Aurora cluster.
+ *
+ * ON-DEMAND ONLY. A human clicked "Run diagnostics" on the system-status page.
+ * Never poll or cron this: every probe is a paid Aurora wake-up — the same cost
+ * that makes the automatic sync daily rather than continuous (infra#129).
+ *
+ * The mirror probe is deliberately ONE query, not six checks: the pg error code
+ * from `SELECT count(*) FROM sync_run` discriminates every layer on its own
+ * (see classifyMirrorError). The trigger probe is a Lambda DryRun invoke —
+ * validates IAM permission and function existence without running a sync, under
+ * the same lambda:InvokeFunction grant the POST already uses.
+ *
+ * SECURITY — never returns a connection string, credential, or raw error
+ * message (pg messages can embed host detail). Host + database name only, and
+ * our own sentences keyed on the error code; the raw error goes to the server
+ * log. Same board/sysadmin gate as the sync route.
+ */
+
+export type DiagStep = {
+    /** Stable slug: env | mirror-read | latest-run | clock | trigger-env | trigger-invoke. */
+    id: string;
+    /** null = skipped because an earlier step already failed. */
+    ok: boolean | null;
+    /** Human sentence — never a secret, never a raw driver message. */
+    detail: string;
+    /** pg SQLSTATE / node errno / AWS error name, when there is one. */
+    code?: string;
+};
+
+/**
+ * Map a mirror-read failure to the layer it proves broken. Order matters only
+ * for readability — the codes are mutually exclusive. Node system errors
+ * (ENOTFOUND/ECONNREFUSED/ETIMEDOUT) surface on err.code just like pg SQLSTATEs;
+ * pool connection timeouts carry no code at all, only a "timeout" message.
+ */
+function classifyMirrorError(err: unknown, dbName: string): { detail: string; code?: string } {
+    const e = err as { code?: string; message?: string };
+    switch (e.code) {
+        case "ENOTFOUND":
+        case "ECONNREFUSED":
+        case "ETIMEDOUT":
+            return {
+                code: e.code,
+                detail: "Can't reach the mirror host — network / security-group / cluster-paused problem, not a grant problem.",
+            };
+        case "28P01":
+        case "28000":
+            return { code: e.code, detail: "Host reached, but checkin's credential was rejected." };
+        case "3D000":
+            return {
+                code: e.code,
+                detail: `Connected, but database "${dbName}" doesn't exist — check SHOPIFY_READ_DB spelling and that bootstrap created the DB.`,
+            };
+        case "42P01":
+            return {
+                code: e.code,
+                detail: "Database exists, but the sync_run table is missing — s-read has never migrated this mirror.",
+            };
+        case "42501":
+            return {
+                code: e.code,
+                detail: "Table exists, but SELECT is denied — checkin's DML role isn't a member of the mirror's NOLOGIN grant-holder yet (infra#136 bootstrap step).",
+            };
+    }
+    if (/timeout/i.test(e.message ?? "")) {
+        return { detail: "Timed out connecting to the mirror — network / security-group / cluster-paused problem." };
+    }
+    return {
+        code: e.code,
+        detail: "Mirror read failed for an unrecognised reason — see the server log for the raw error.",
+    };
+}
+
+const skipped = (id: string): DiagStep => ({ id, ok: null, detail: "Skipped — an earlier step already failed." });
+
+export const GET = withAuth(
+    { roles: ['isSysadmin', 'isBoardMember'] },
+    async (_req, auth) => {
+        if (auth.type !== 'session') {
+            return apiError("Unauthorized", 401);
+        }
+
+        const steps: DiagStep[] = [];
+
+        // env — pure inspection, no I/O. Which resolution path won, and where it
+        // points (host + db name only — never the credential part of the URL).
+        const url = config.shopifyReadDatabaseUrl();
+        const source = process.env.SHOPIFY_READ_DATABASE_URL ? "SHOPIFY_READ_DATABASE_URL (local override)" : "DATABASE_URL + SHOPIFY_READ_DB";
+        let dbName = "";
+        if (url) {
+            const parsed = new URL(url);
+            dbName = parsed.pathname.replace(/^\//, "");
+            steps.push({ id: "env", ok: true, detail: `Resolved via ${source}: database "${dbName}" on ${parsed.hostname}.` });
+        } else {
+            steps.push({
+                id: "env",
+                ok: false,
+                detail: process.env.DATABASE_URL
+                    ? "Not wired — SHOPIFY_READ_DB is unset (and no SHOPIFY_READ_DATABASE_URL override)."
+                    : "Not wired — DATABASE_URL itself is unset, so no mirror URL can be derived.",
+            });
+        }
+
+        // mirror-read — links 2–7 as ONE probe; the error code discriminates them.
+        let runs: number | null = null;
+        if (!url) {
+            steps.push(skipped("mirror-read"));
+        } else {
+            try {
+                runs = await countSyncRuns();
+                steps.push(
+                    runs === 0
+                        ? { id: "mirror-read", ok: false, detail: "Mirror is readable but s-read has never started a run — trigger a sync or check s-read's own logs." }
+                        : { id: "mirror-read", ok: true, detail: `Mirror readable; ${runs} sync run(s) recorded.` },
+                );
+            } catch (error) {
+                logger.error("[s-read diagnose] mirror probe failed:", error);
+                steps.push({ id: "mirror-read", ok: false, ...classifyMirrorError(error, dbName) });
+            }
+        }
+
+        // latest-run + clock — only meaningful once the mirror has rows.
+        if (!runs) {
+            steps.push(skipped("latest-run"), skipped("clock"));
+        } else {
+            try {
+                // Non-null: runs > 0 was just observed, and this endpoint is a
+                // human-paced click — no concurrent writer deletes sync runs.
+                const run = (await latestSyncRun())!;
+                steps.push({
+                    id: "latest-run",
+                    // FAILED/ABANDONED is s-read's own reported outcome — a real answer,
+                    // surfaced red so the operator reads s-read's error text.
+                    ok: run.status === "FAILED" || run.status === "ABANDONED" ? false : true,
+                    detail:
+                        `${run.kind} ${run.status}, started ${relTime(run.startedAt)}` +
+                        (run.finishedAt ? `, finished ${relTime(run.finishedAt)}` : "") +
+                        (run.error ? ` — s-read error: ${run.error}` : "") +
+                        `.`,
+                });
+                const ageMs = Date.now() - run.startedAt.getTime();
+                steps.push(
+                    ageMs < 0
+                        ? {
+                              id: "clock",
+                              ok: false,
+                              detail: `Latest run's startedAt is ${Math.round(-ageMs / 60000)} min in the FUTURE — timezone handling regression (see #1042). Process TZ: ${process.env.TZ ?? "(unset)"}.`,
+                          }
+                        : { id: "clock", ok: true, detail: `Timestamps sane; latest run started ${relTime(run.startedAt)}. Process TZ: ${process.env.TZ ?? "(unset)"}.` },
+                );
+            } catch (error) {
+                logger.error("[s-read diagnose] latest-run read failed:", error);
+                steps.push({ id: "latest-run", ok: false, detail: "Counting runs worked but reading the latest failed — see the server log." }, skipped("clock"));
+            }
+        }
+
+        // trigger-env — separate wiring from the mirror; an env can have either
+        // without the other (same split the sync route's POST/GET gates encode).
+        const fn = config.sReadTriggerFunction();
+        steps.push(
+            fn
+                ? { id: "trigger-env", ok: true, detail: `S_READ_TRIGGER_FUNCTION = ${fn}.` }
+                : { id: "trigger-env", ok: false, detail: "S_READ_TRIGGER_FUNCTION is unset — the 'Sync Shopify now' button 503s." },
+        );
+
+        // trigger-invoke — DryRun validates IAM + function existence, runs nothing.
+        if (!fn) {
+            steps.push(skipped("trigger-invoke"));
+        } else {
+            try {
+                const client = new LambdaClient({ region: config.awsRegion() });
+                await client.send(new InvokeCommand({ FunctionName: fn, InvocationType: "DryRun" }));
+                steps.push({ id: "trigger-invoke", ok: true, detail: "Trigger Lambda exists and this app is permitted to invoke it (dry run — no sync started)." });
+            } catch (error) {
+                logger.error("[s-read diagnose] trigger dry-run failed:", error);
+                const name = (error as { name?: string }).name;
+                steps.push({
+                    id: "trigger-invoke",
+                    ok: false,
+                    code: name,
+                    detail:
+                        name === "AccessDeniedException"
+                            ? "IAM denies lambda:InvokeFunction on the trigger — the app's grant is missing or names a different ARN."
+                            : name === "ResourceNotFoundException"
+                              ? "No Lambda by that name in this region — S_READ_TRIGGER_FUNCTION is misspelled or points at another environment."
+                              : "Dry-run invoke failed for an unrecognised reason — see the server log.",
+                });
+            }
+        }
+
+        return NextResponse.json({ steps });
+    },
+);

--- a/checkin-app/src/app/finance-ops/payments/page.tsx
+++ b/checkin-app/src/app/finance-ops/payments/page.tsx
@@ -180,7 +180,7 @@ export default function PaymentProblemsPage() {
           // it must survive long enough to be read and acted on.
           notifications.show({
             color: 'red',
-            message: "Shopify sync started, but its status can't be read in this environment.",
+            message: "Shopify sync started, but its status can't be read in this environment. Run diagnostics on the System Status page to see why.",
             autoClose: false,
           });
           return;

--- a/checkin-app/src/app/system-status/health/page.tsx
+++ b/checkin-app/src/app/system-status/health/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Card, Group, List, SimpleGrid, Stack, Text, Title } from "@mantine/core";
-import { BadgeScanChart, ConfigHealthBox, SystemVersionBox } from "@/components/admin/SystemHealthPanels";
+import { BadgeScanChart, ConfigHealthBox, SReadDiagnosticsBox, SystemVersionBox } from "@/components/admin/SystemHealthPanels";
 
 export default function SystemStatusHealthPage() {
   return (
@@ -50,6 +50,8 @@ export default function SystemStatusHealthPage() {
       </SimpleGrid>
 
       <ConfigHealthBox />
+
+      <SReadDiagnosticsBox />
 
       <SystemVersionBox />
 

--- a/checkin-app/src/components/admin/SystemHealthPanels.tsx
+++ b/checkin-app/src/components/admin/SystemHealthPanels.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Anchor, Badge, Card, Center, Code, Group, List, Loader, Stack, Text, Title } from "@mantine/core";
+import { Anchor, Badge, Button, Card, Center, Code, Group, List, Loader, Stack, Text, Title } from "@mantine/core";
 
 type DailyStat = {
   date: string;
@@ -126,6 +126,78 @@ export function ConfigHealthBox() {
                 </Text>
               </Group>
               <Text size="xs" c="dimmed">{c.detail}</Text>
+            </List.Item>
+          ))}
+        </List>
+      )}
+    </Card>
+  );
+}
+
+// Mirrors DiagStep in api/finance-ops/s-read/diagnose/route.ts.
+type DiagStep = { id: string; ok: boolean | null; detail: string; code?: string };
+
+// Human labels for the diagnose route's stable step slugs.
+const DIAG_LABELS: Record<string, string> = {
+  "env": "Mirror env wiring",
+  "mirror-read": "Mirror read (network → auth → DB → table → grant → rows)",
+  "latest-run": "Latest sync run",
+  "clock": "Timestamp sanity",
+  "trigger-env": "Sync trigger env wiring",
+  "trigger-invoke": "Sync trigger invoke (dry run)",
+};
+
+/**
+ * On-demand deep probe of the s-read chain (docs/designs/S_READ_DIAGNOSTICS.md).
+ * Deliberately NOT run on page load and never polled: every probe wakes the
+ * scale-to-zero Aurora cluster, so it fires only on an explicit click. This is
+ * the deep counterpart to ConfigHealthBox above, which stays presence-only.
+ */
+export function SReadDiagnosticsBox() {
+  const [steps, setSteps] = useState<DiagStep[] | null>(null);
+  const [running, setRunning] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const run = async () => {
+    setRunning(true);
+    setFailed(false);
+    try {
+      const res = await fetch('/api/finance-ops/s-read/diagnose');
+      if (!res.ok) throw new Error();
+      setSteps((await res.json()).steps as DiagStep[]);
+    } catch {
+      setSteps(null);
+      setFailed(true);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <Card withBorder radius="md" padding="lg">
+      <Group justify="space-between" mb="md">
+        <Title order={4}>Shopify Mirror (s-read) Diagnostics</Title>
+        <Button size="xs" variant="light" onClick={run} loading={running}>Run diagnostics</Button>
+      </Group>
+      <Text size="sm" c="dimmed" mb={steps || failed ? "md" : 0}>
+        Probes each link the payments page&apos;s sync status depends on and names the first
+        broken one. Wakes the database cluster — run it when something is wrong, not on a timer.
+      </Text>
+
+      {failed && <Text c="red">Diagnostics failed to run — see the server log.</Text>}
+      {steps && (
+        <List spacing="sm" listStyleType="none">
+          {steps.map((s) => (
+            <List.Item key={s.id}>
+              <Group justify="space-between" wrap="nowrap" align="flex-start">
+                <span>{DIAG_LABELS[s.id] ?? s.id}</span>
+                <Text c={s.ok === null ? 'dimmed' : s.ok ? 'green' : 'red'} fw={s.ok === false ? 700 : undefined} ta="right">
+                  ● {s.ok === null ? 'Skipped' : s.ok ? 'OK' : 'FAIL'}
+                </Text>
+              </Group>
+              <Text size="xs" c="dimmed">
+                {s.detail}{s.code ? <> <Code>{s.code}</Code></> : null}
+              </Text>
             </List.Item>
           ))}
         </List>

--- a/checkin-app/src/components/admin/__tests__/SystemHealthPanels.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/SystemHealthPanels.test.tsx
@@ -1,6 +1,6 @@
-import { screen } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
-import { SystemVersionBox, BadgeScanChart } from "../SystemHealthPanels";
+import { SystemVersionBox, BadgeScanChart, SReadDiagnosticsBox } from "../SystemHealthPanels";
 
 beforeEach(() => resetRtl());
 
@@ -47,5 +47,37 @@ describe("BadgeScanChart", () => {
     mockFetchJson({});
     renderWithProviders(<BadgeScanChart />);
     expect(await screen.findByText("Failed to load metrics.")).toBeInTheDocument();
+  });
+});
+
+describe("SReadDiagnosticsBox", () => {
+  it("does not probe until clicked, then renders each step's verdict and code", async () => {
+    mockFetchJson({
+      "/api/finance-ops/s-read/diagnose": {
+        steps: [
+          { id: "env", ok: true, detail: 'Resolved via DATABASE_URL + SHOPIFY_READ_DB: database "shopify_read_dev" on db.internal.' },
+          { id: "mirror-read", ok: false, code: "42501", detail: "Table exists, but SELECT is denied — grant-holder membership missing." },
+          { id: "latest-run", ok: null, detail: "Skipped — an earlier step already failed." },
+        ],
+      },
+    });
+    renderWithProviders(<SReadDiagnosticsBox />);
+
+    // On-load the box must be inert — probing wakes the Aurora cluster.
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Run diagnostics/ }));
+    expect(await screen.findByText(/SELECT is denied/)).toBeInTheDocument();
+    expect(screen.getByText("42501")).toBeInTheDocument();
+    expect(screen.getByText("● OK")).toBeInTheDocument();
+    expect(screen.getByText("● FAIL")).toBeInTheDocument();
+    expect(screen.getByText("● Skipped")).toBeInTheDocument();
+  });
+
+  it("shows a failure line when the endpoint itself is unreachable", async () => {
+    mockFetchJson({});
+    renderWithProviders(<SReadDiagnosticsBox />);
+    fireEvent.click(screen.getByRole("button", { name: /Run diagnostics/ }));
+    expect(await screen.findByText(/Diagnostics failed to run/)).toBeInTheDocument();
   });
 });

--- a/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
+++ b/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
@@ -131,6 +131,26 @@ describe('latestSyncRun', () => {
 /** The SQL of the Nth query, whitespace-collapsed so indentation doesn't matter. */
 const sqlOf = (call: number) => (queryMock.mock.calls[call][0] as string).replace(/\s+/g, ' ');
 
+describe('countSyncRuns (the diagnose route\'s probe)', () => {
+    it('returns the run count', async () => {
+        queryMock.mockResolvedValue({ rows: [{ runs: 3 }] });
+        expect(await freshClient().countSyncRuns()).toBe(3);
+        expect(sqlOf(0)).toContain('FROM sync_run');
+    });
+
+    it('throws when unconfigured rather than opening a pool', async () => {
+        delete process.env.SHOPIFY_READ_DATABASE_URL;
+        await expect(freshClient().countSyncRuns()).rejects.toThrow(/not configured/);
+        expect(poolCtor).not.toHaveBeenCalled();
+    });
+
+    it('lets pg errors escape untouched — the caller owns the code→verdict mapping', async () => {
+        const err = Object.assign(new Error('permission denied for table sync_run'), { code: '42501' });
+        queryMock.mockRejectedValue(err);
+        await expect(freshClient().countSyncRuns()).rejects.toBe(err);
+    });
+});
+
 describe('order reads', () => {
     // s-read's columns are `timestamp WITHOUT time zone` holding UTC, and node-pg
     // resolves those against the Node process's zone — drop these casts and a non-UTC

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -189,6 +189,21 @@ export async function latestSyncRun(): Promise<MirrorSyncRun | null> {
 }
 
 /**
+ * Diagnostic probe: how many sync runs the mirror holds. One round trip whose
+ * FAILURE is as informative as its success — the thrown pg error's `code`
+ * discriminates every layer between here and the data (network, auth, database
+ * missing, table missing, SELECT grant missing), which is why the diagnose route
+ * calls this instead of six separate checks. Errors are deliberately NOT caught
+ * here: the caller owns the code→verdict mapping.
+ */
+export async function countSyncRuns(): Promise<number> {
+    const p = getPool();
+    if (!p) throw new Error("shopify_read mirror is not configured");
+    const rows = await p.query<{ runs: number }>(`SELECT count(*)::int AS runs FROM sync_run`);
+    return rows.rows[0].runs;
+}
+
+/**
  * Order GIDs that have a chargeback/dispute balance transaction, among the given
  * GIDs. Shopify Payments surfaces a dispute as a signed balance transaction whose
  * `type` names the dispute — this distinguishes a chargeback (CRITICAL) from an


### PR DESCRIPTION
## What

`GET /api/finance-ops/s-read/diagnose` (board/sysadmin) walks the s-read feature's dependency chain and reports the **first broken link with its specific cause**, surfaced as a "Run diagnostics" card on `/system-status/health`. Design + runbook: `checkin-app/docs/designs/S_READ_DIAGNOSTICS.md`.

## Why

The sync-status feature (#1041, #1045) sits at the end of a nine-link chain (env → derived URL → network → auth → DB exists → table exists → SELECT grant → rows exist → trigger IAM), and every broken link collapses into the same two symptoms: the status line silently not rendering, or one generic red toast. Links 2–6 are a single opaque 500; links 1 and 7 render identically. Debugging means guessing between env vars, grants, migrations, and IAM. configHealth can't close this — it's presence-only by design (runs on nav-badge polls; touching the mirror wakes the scale-to-zero Aurora cluster).

## How

- **One probe, not six checks**: the pg error code from `SELECT count(*) FROM sync_run` discriminates every layer — `ENOTFOUND`/`ECONNREFUSED`/`ETIMEDOUT` network, `28P01`/`28000` auth, `3D000` database name, `42P01` mirror never migrated, `42501` grant-holder membership missing (infra#136's bootstrap step), zero rows = s-read never ran.
- **latest-run** surfaces s-read's own status and `error` column — telemetry that existed all along but nothing displayed.
- **clock** flags a future `startedAt` as the #1042 timezone bug class.
- **Trigger probe** is a Lambda **DryRun** invoke: validates IAM permission + function existence without starting a sync, under the same `lambda:InvokeFunction` grant the POST already holds — no new permissions.
- Steps after a failed prerequisite report as **skipped**, so output reads "first broken link", not cascading reds.
- On-demand only — button click, never polled or cron'd (every probe is a paid Aurora wake-up, infra#129).
- The payments page's "status can't be read" toast (#1045) now points at the System Status page.

Security: never returns a connection string or raw driver message (pg messages can embed host detail) — host + database name only, own sentences keyed on error codes, raw error to the server log.

## Tests

- Route tests pin the **code→verdict table itself** (each pg code must map to the layer it proves broken — get one wrong and the operator fixes the wrong thing), deny paths never probing, the DryRun-no-payload contract, the future-timestamp clock case, and skip propagation.
- Component test pins the card staying **inert until clicked** (no probe on page load).
- authzRegistry entry with colocated 401/403 coverage; all drift guards green.

Independent of #1048 (no variant columns involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)