### PR TITLE
fix(membership-ops): don't fail a household rename when the household has no membership

### DIFF
--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -181,7 +181,9 @@ export function AdminEditHouseholdModal({
       const res = await fetch(`/api/membership-ops/households/${householdId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(form),
+        // Membership fields are hidden without a membership; don't submit them
+        // either, or the server rejects the whole edit as membership-less.
+        body: JSON.stringify(hasMembership ? form : { ...form, memberSince: undefined, isVolunteer: undefined }),
       });
       if (res.ok) {
         const data = await res.json();

--- a/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
@@ -242,6 +242,27 @@ describe("AdminEditHouseholdModal", () => {
     expect(JSON.parse(patchOpts!.body as string)).toEqual(expect.objectContaining({ isVolunteer: true }));
   });
 
+  it("omits the membership fields from the PATCH body for a membership-less household", async () => {
+    const fetchMock = mockFetchJson({
+      "/api/membership-ops/households?id=55": { household },
+      "/api/membership-ops/households/55": { household },
+    });
+    renderWithProviders(<AdminEditHouseholdModal householdId={55} opened={true} onClose={jest.fn()} onSaved={jest.fn()} />);
+    await screen.findByDisplayValue("Smith Family");
+
+    fireEvent.change(screen.getByLabelText("Household Name"), { target: { value: "Smith Fam" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes — As Admin" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/api/membership-ops/households/55", expect.objectContaining({ method: "PATCH" })),
+    );
+    const [, patchOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PATCH")!;
+    const body = JSON.parse(patchOpts!.body as string);
+    expect(body).toEqual(expect.objectContaining({ name: "Smith Fam" }));
+    expect(body).not.toHaveProperty("isVolunteer");
+    expect(body).not.toHaveProperty("memberSince");
+  });
+
   it("shows the no-leads state for a household with no household leads", async () => {
     const noLeads = { ...household, householdLeads: undefined, name: null };
     mockFetchJson({ "/api/membership-ops/households?id=55": { household: noLeads } });


### PR DESCRIPTION
## The bug

On `membership-ops/household`, clicking **Edit Info**, renaming a household, and saving fails with:

> Household has no membership record

…even though the rename has nothing to do with the household's membership.

## Root cause

`AdminEditHouseholdModal` PATCHed its entire `form` object. `isVolunteer` is a boolean that defaults to `false`, so it was **always** present in the request body — including for households with no `OrgMembership`, where the modal correctly hides the membership fields (`hasMembership` is false) but kept submitting them anyway.

The route reads `typeof body.isVolunteer === "boolean"` as "this edit touches the membership", looks the membership up, finds none, and rejects the *whole* request with a 400. Net effect: a membership-less household could not be renamed at all. `memberSince` escaped this only because the server also checks `!== ""`.

## The fix

Strip `memberSince`/`isVolunteer` from the request body when the household has no membership — the fields are already hidden in the UI, so they shouldn't be submitted either.

The server-side check is deliberately left alone: "Household has no membership record" is the correct response when a caller genuinely asks to edit membership fields. This modal is the only caller of the route, so no sibling paths need the same guard.

## Reviewer notes

- New regression test asserts the PATCH body for a membership-less household carries `name` but neither `isVolunteer` nor `memberSince`.
- `npm test -- --testPathPatterns AdminEditHouseholdModal` → 14/14 pass.
- The existing "toggles the volunteer-only flag" test still covers the with-membership path, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)