### PR TITLE
fix(membership-ops): return to Households from a deep-linked add-participant

### DIFF
--- a/checkin-app/src/app/membership-ops/participants/new/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/__tests__/page.test.tsx
@@ -79,6 +79,16 @@ describe("membership-ops/participants/new page", () => {
     renderWithProviders(<NewParticipantPage />);
 
     expect(await screen.findByDisplayValue("The Smiths")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "← Households" })).toHaveAttribute("href", "/membership-ops/households");
+  });
+
+  it("keeps the generic back link when not deep-linked from a household", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({});
+    renderWithProviders(<NewParticipantPage />);
+
+    await screen.findByText("Register New User");
+    expect(screen.getByRole("link", { name: "← Membership Ops" })).toHaveAttribute("href", "/membership-ops");
   });
 
   it("redirects a caller without sysadmin/board-member role, and shows a loader while resolving", () => {

--- a/checkin-app/src/app/membership-ops/participants/new/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/page.tsx
@@ -123,7 +123,13 @@ function NewParticipantForm() {
   return (
     <Container size="md" pb="md">
       <Card withBorder radius="md" padding="lg">
-        <AdminPageHeader title="Register New User" back={{ href: '/membership-ops', label: '← Membership Ops' }} mb="md" />
+        <AdminPageHeader
+          title="Register New User"
+          back={queryHouseholdId
+            ? { href: '/membership-ops/households', label: '← Households' }
+            : { href: '/membership-ops', label: '← Membership Ops' }}
+          mb="md"
+        />
 
         <Text c="dimmed" mb="lg">
           System Administrators can manually register a new participant into the database. When they


### PR DESCRIPTION
## Problem

From `/membership-ops/households`, clicking **+ Add Participant** deep-links to `/membership-ops/participants/new?householdId=N`. Clicking the back link there lands you on `/membership-ops/participants` — not the Households page you came from.

The back link was hardcoded to `/membership-ops`, which `redirect()`s to the section's first nav tab (`MEMBERSHIP_OPS_NAV_LINKS[0].href` = `/membership-ops/participants`).

## Fix

The page already reads `householdId` from the query to prefill the household picker. Reuse that param for the back link: when present, it points at `/membership-ops/households` and reads `← Households`. Without it, the link is unchanged.

Sent to the households **list** rather than `/households/[id]` because the list is the only entry point into this flow — the detail page has no add-participant button.

## Not touched

`participants/import/page.tsx` has the same hardcoded pattern, but nothing deep-links to it with a `householdId`, so there is no bug to fix there yet.

## Testing

Ran the new-participant suite scoped to `participants/new` — 14/14 pass, including two new assertions covering the deep-linked and generic back links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)