### PR TITLE
fix(membership-ops): 'Grant for coming year' completes the renewal payment — never bypasses gates

### DIFF
--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -5,6 +5,10 @@
  * Integration tests for audit logging on the board grant/revoke membership
  * actions in POST /api/membership-ops/households — granting (ACTIVE) and revoking
  * (REVOKED) must each write an AuditLog row recording who acted and what changed.
+ *
+ * Also covers the "Grant for coming year" override: it completes the payment
+ * gate on a household's in-flight RENEWAL already at PENDING_PAYMENT with a
+ * valid, cleared background check — never archives, never bypasses BG.
  */
 
 import { POST } from '@/app/api/membership-ops/households/route';
@@ -16,6 +20,9 @@ jest.mock('next-auth/next', () => ({
 }));
 
 const TAG = 'membership-audit-test';
+// A real Treehouse-style interval so the BG-freshness rule has a configured value.
+const BG_RECHECK_MONTHS = 31;
+const BOUNDARY = new Date(Date.UTC(2000, 7, 1)); // Aug 1 (year rolls forward)
 
 function post(body: unknown) {
     return POST(new Request('http://localhost:4000/api/membership-ops/households', {
@@ -28,11 +35,33 @@ function post(body: unknown) {
 describe('POST /api/membership-ops/households — grant/revoke audit logging', () => {
     let boardId: number;
     let boardHouseholdId: number;
+    let boardProcessId: number;
     let inactiveHouseholdId: number;
     let activeHouseholdId: number;
-    let comingYearHouseholdId: number;
+    let noRenewalHouseholdId: number;
+    let pendingRenewalHouseholdId: number;
+    let pendingExternalHouseholdId: number;
     let midFlowHouseholdId: number;
     let midFlowProcessId: number;
+    let bgNotFreshHouseholdId: number;
+    let bgNotFreshProcessId: number;
+    let grantableHouseholdId: number;
+    let grantableProcessId: number;
+    let grantableMembershipId: number;
+
+    let prevBoundary: Date | null = null;
+
+    // A household with one person, no lead/BG stamped unless the caller sets it.
+    async function makeHousehold(label: string) {
+        const person = await prisma.person.create({
+            data: { email: `${label}-${TAG}@example.com`, name: label, household: { create: { name: `${label} ${TAG}` } } },
+        });
+        return person.householdId;
+    }
+
+    async function setLead(householdId: number, lastBackgroundCheck: Date | null) {
+        await prisma.person.updateMany({ where: { householdId }, data: { isHouseholdLead: true, lastBackgroundCheck } });
+    }
 
     beforeAll(async () => {
         const leaked = await prisma.person.findMany({
@@ -41,12 +70,26 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         await prisma.auditLog.deleteMany({ where: { actorId: { in: leaked.map(u => u.id) } } });
         await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
 
-        // Acting board member (in their own household).
+        const existingSettings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevBoundary = existingSettings?.orgMembershipYearBoundary ?? null;
+        await prisma.boardSettings.upsert({
+            where: { id: 1 },
+            create: { id: 1, normalDuesCents: 0, volunteerDuesCents: 0, orgMembershipYearBoundary: BOUNDARY, bgRecheckMonths: BG_RECHECK_MONTHS },
+            update: { orgMembershipYearBoundary: BOUNDARY, bgRecheckMonths: BG_RECHECK_MONTHS },
+        });
+
+        // Acting board member (in their own household). Also given a grantable
+        // renewal so the own-household COI test exercises the real 403, not a
+        // 409-no-renewal masking it.
         const board = await prisma.person.create({
-            data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, household: { create: { name: "Test HH" } } },
+            data: { email: `board-${TAG}@example.com`, name: 'Board Actor', isBoardMember: true, isHouseholdLead: true, lastBackgroundCheck: new Date(), household: { create: { name: "Test HH" } } },
         });
         boardId = board.id;
         boardHouseholdId = board.householdId;
+        const boardMembership = await prisma.orgMembership.create({ data: { householdId: boardHouseholdId, status: 'NONE' } });
+        boardProcessId = (await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: boardMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() },
+        })).id;
 
         // A household with no membership row → will be granted (ACTIVE).
         const inactive = await prisma.person.create({
@@ -61,22 +104,45 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         activeHouseholdId = active.householdId;
         await prisma.orgMembership.create({ data: { householdId: activeHouseholdId, status: 'ACTIVE' } });
 
-        // A non-member household for the renewal-season "grant for coming year" override.
-        const comingYear = await prisma.person.create({
-            data: { email: `comingyear-${TAG}@example.com`, name: 'Coming Year', household: { create: { name: "Test HH" } } },
-        });
-        comingYearHouseholdId = comingYear.householdId;
+        // No RENEWAL process at all → 409 (no renewal awaiting payment).
+        noRenewalHouseholdId = await makeHousehold('norenewal');
+        await prisma.orgMembership.create({ data: { householdId: noRenewalHouseholdId, status: 'ACTIVE' } });
 
-        // An ACTIVE household mid-flow — a payable PENDING_PAYMENT renewal — that the
-        // coming-year override must supersede (ARCHIVE) rather than leave alongside.
-        const midFlow = await prisma.person.create({
-            data: { email: `midflow-${TAG}@example.com`, name: 'Mid Flow', household: { create: { name: "Test HH" } } },
-        });
-        midFlowHouseholdId = midFlow.householdId;
+        // RENEWAL opened by the sweep, member hasn't engaged yet → 409.
+        pendingRenewalHouseholdId = await makeHousehold('pendingrenewal');
+        const prMembership = await prisma.orgMembership.create({ data: { householdId: pendingRenewalHouseholdId, status: 'ACTIVE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: prMembership.id, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
+
+        // RENEWAL awaiting the external step (sign + maybe BG consent) → 409.
+        pendingExternalHouseholdId = await makeHousehold('pendingexternal');
+        const peMembership = await prisma.orgMembership.create({ data: { householdId: pendingExternalHouseholdId, status: 'ACTIVE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: peMembership.id, kind: 'RENEWAL', status: 'PENDING_EXTERNAL_ACTION' } });
+
+        // PENDING_PAYMENT but bgClearedAt not yet stamped, lead BG otherwise fresh
+        // (isolates the bgClearedAt-null reject from a bg-freshness reject) → 403.
+        midFlowHouseholdId = await makeHousehold('midflow');
         const midMembership = await prisma.orgMembership.create({ data: { householdId: midFlowHouseholdId, status: 'ACTIVE' } });
         midFlowProcessId = (await prisma.orgMembershipProcess.create({
             data: { orgMembershipId: midMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT' },
         })).id;
+        await setLead(midFlowHouseholdId, new Date());
+
+        // PENDING_PAYMENT with bgClearedAt set, but no lead has a fresh check → 403.
+        bgNotFreshHouseholdId = await makeHousehold('bgnotfresh');
+        const bnfMembership = await prisma.orgMembership.create({ data: { householdId: bgNotFreshHouseholdId, status: 'ACTIVE' } });
+        bgNotFreshProcessId = (await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: bnfMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() },
+        })).id;
+        await setLead(bgNotFreshHouseholdId, null);
+
+        // PENDING_PAYMENT + bgClearedAt + fresh lead BG → grantable (success case).
+        grantableHouseholdId = await makeHousehold('grantable');
+        const grMembership = await prisma.orgMembership.create({ data: { householdId: grantableHouseholdId, status: 'ACTIVE' } });
+        grantableMembershipId = grMembership.id;
+        grantableProcessId = (await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: grMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() },
+        })).id;
+        await setLead(grantableHouseholdId, new Date());
     });
 
     afterAll(async () => {
@@ -92,6 +158,7 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids.map(u => u.householdId) } } });
         await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
         await prisma.household.deleteMany({ where: { id: { in: ids.map(u => u.householdId) } } });
+        await prisma.boardSettings.update({ where: { id: 1 }, data: { orgMembershipYearBoundary: prevBoundary } });
     });
 
     it('grants an inactive household, sets ACTIVE, and writes an audit row', async () => {
@@ -127,63 +194,106 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         expect(after?.status).toBe('ACTIVE');
     });
 
-    it('grants a non-member for the coming year: ACTIVE + a terminal INITIAL process + audit row', async () => {
+    it('coming-year grant: no in-flight renewal → 409, no mutation', async () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
 
-        const res = await post({ householdId: comingYearHouseholdId, comingYear: true });
-        expect(res.status).toBe(200);
+        const res = await post({ householdId: noRenewalHouseholdId, comingYear: true });
+        expect(res.status).toBe(409);
 
-        const membership = await prisma.orgMembership.findUnique({ where: { householdId: comingYearHouseholdId } });
-        expect(membership?.status).toBe('ACTIVE');
-
-        // No prior membership → INITIAL, and the process is completed (ACTIVE) with the
-        // three gates stamped satisfied and the acting admin recorded.
-        const process = await prisma.orgMembershipProcess.findFirst({
-            where: { orgMembershipId: membership!.id }, orderBy: { id: 'desc' },
-        });
-        expect(process?.kind).toBe('INITIAL');
-        expect(process?.status).toBe('ACTIVE');
-        expect(process?.certifiedById).toBe(boardId);
-        expect(process?.paidAt).not.toBeNull();
-        expect(process?.bgClearedAt).not.toBeNull();
-        expect(process?.contractSignedAt).not.toBeNull();
-
-        const audit = await prisma.auditLog.findFirst({
-            where: { actorId: boardId, tableName: 'OrgMembershipProcess', affectedEntityId: process!.id },
-            orderBy: { id: 'desc' },
-        });
-        expect((audit!.newData as { comingYearOverride: boolean }).comingYearOverride).toBe(true);
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: noRenewalHouseholdId } });
+        expect(membership?.status).toBe('ACTIVE'); // unchanged from fixture setup
+        const processCount = await prisma.orgMembershipProcess.count({ where: { orgMembershipId: membership!.id } });
+        expect(processCount).toBe(0);
     });
 
-    it('supersedes an in-flight process (ARCHIVED) when granting for the coming year', async () => {
+    it('coming-year grant: renewal at PENDING_RENEWAL (not started) → 409, unchanged', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+        const res = await post({ householdId: pendingRenewalHouseholdId, comingYear: true });
+        expect(res.status).toBe(409);
+
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: pendingRenewalHouseholdId } });
+        const process = await prisma.orgMembershipProcess.findFirst({ where: { orgMembershipId: membership!.id } });
+        expect(process?.status).toBe('PENDING_RENEWAL');
+    });
+
+    it('coming-year grant: renewal at PENDING_EXTERNAL_ACTION → 409, unchanged', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+        const res = await post({ householdId: pendingExternalHouseholdId, comingYear: true });
+        expect(res.status).toBe(409);
+
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: pendingExternalHouseholdId } });
+        const process = await prisma.orgMembershipProcess.findFirst({ where: { orgMembershipId: membership!.id } });
+        expect(process?.status).toBe('PENDING_EXTERNAL_ACTION');
+    });
+
+    it('coming-year grant: PENDING_PAYMENT but bgClearedAt not stamped → 403, unchanged', async () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
 
         const res = await post({ householdId: midFlowHouseholdId, comingYear: true });
-        expect(res.status).toBe(200);
+        expect(res.status).toBe(403);
 
-        // The payable PENDING_PAYMENT renewal is disposed, not left alongside the grant.
-        const old = await prisma.orgMembershipProcess.findUnique({ where: { id: midFlowProcessId } });
-        expect(old?.status).toBe('ARCHIVED');
-        const supersedeAudit = await prisma.auditLog.findFirst({
-            where: { actorId: boardId, tableName: 'OrgMembershipProcess', affectedEntityId: midFlowProcessId },
-            orderBy: { id: 'desc' },
-        });
-        expect((supersedeAudit!.newData as { supersededByOverride: boolean }).supersededByOverride).toBe(true);
-
-        // And a fresh terminal ACTIVE RENEWAL is the live process.
-        const membership = await prisma.orgMembership.findUnique({ where: { householdId: midFlowHouseholdId } });
-        expect(membership?.status).toBe('ACTIVE');
-        const live = await prisma.orgMembershipProcess.findMany({
-            where: { orgMembershipId: membership!.id, status: 'ACTIVE' },
-        });
-        expect(live).toHaveLength(1);
-        expect(live[0].kind).toBe('RENEWAL');
+        const process = await prisma.orgMembershipProcess.findUnique({ where: { id: midFlowProcessId } });
+        expect(process?.status).toBe('PENDING_PAYMENT');
+        expect(process?.paidAt).toBeNull();
     });
 
-    it("refuses coming-year grant for the actor's OWN household (conflict of interest)", async () => {
+    it("coming-year grant: bgClearedAt set but no household lead has a fresh check → 403, unchanged", async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+        const res = await post({ householdId: bgNotFreshHouseholdId, comingYear: true });
+        expect(res.status).toBe(403);
+
+        const process = await prisma.orgMembershipProcess.findUnique({ where: { id: bgNotFreshProcessId } });
+        expect(process?.status).toBe('PENDING_PAYMENT');
+        expect(process?.paidAt).toBeNull();
+    });
+
+    it("refuses coming-year grant for the actor's OWN household (conflict of interest); sysadmin overrides", async () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
         const res = await post({ householdId: boardHouseholdId, comingYear: true });
         expect(res.status).toBe(403);
+        const stillPending = await prisma.orgMembershipProcess.findUnique({ where: { id: boardProcessId } });
+        expect(stillPending?.status).toBe('PENDING_PAYMENT');
+
+        // Sysadmin is the deliberate remedy — same renewal, now grantable.
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isSysadmin: true } });
+        const ok = await post({ householdId: boardHouseholdId, comingYear: true });
+        expect(ok.status).toBe(200);
+        const settled = await prisma.orgMembershipProcess.findUnique({ where: { id: boardProcessId } });
+        expect(settled?.status).toBe('ACTIVE');
+    });
+
+    it('coming-year grant: PENDING_PAYMENT + bgClearedAt + fresh lead BG → 200, completes payment (no archive, no 2nd process)', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+        const res = await post({ householdId: grantableHouseholdId, comingYear: true });
+        expect(res.status).toBe(200);
+
+        const membership = await prisma.orgMembership.findUnique({ where: { householdId: grantableHouseholdId } });
+        expect(membership?.status).toBe('ACTIVE');
+
+        // The SAME process settles — no archive, no second process created.
+        const process = await prisma.orgMembershipProcess.findUnique({ where: { id: grantableProcessId } });
+        expect(process?.status).toBe('ACTIVE');
+        expect(process?.paidAt).not.toBeNull();
+        expect(process?.certifiedById).toBe(boardId);
+        const processCount = await prisma.orgMembershipProcess.count({ where: { orgMembershipId: grantableMembershipId } });
+        expect(processCount).toBe(1);
+
+        // Both the activate() transition audit (written first, inside
+        // certifyPaymentPlan) and the supplementary grant marker (written after)
+        // must exist for this process.
+        const audits = await prisma.auditLog.findMany({
+            where: { actorId: boardId, tableName: 'OrgMembershipProcess', affectedEntityId: grantableProcessId },
+            orderBy: { id: 'asc' },
+        });
+        const activateAudit = audits.find(a => (a.newData as { status?: string })?.status === 'ACTIVE');
+        expect(activateAudit).toBeTruthy();
+        expect((activateAudit!.newData as { via: string }).via).toBe('certified');
+        const grantAudit = audits.find(a => (a.newData as { comingYearGrant?: boolean })?.comingYearGrant === true);
+        expect(grantAudit).toBeTruthy();
     });
 
     it('revokes an active household, sets REVOKED, and writes an audit row', async () => {

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -4,7 +4,8 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
-import { isRenewalSeason } from "@/lib/membership/renewal";
+import { isRenewalSeason, grantRenewalPayment } from "@/lib/membership/renewal";
+import { PaymentError } from "@/lib/membership/payment";
 
 export const dynamic = 'force-dynamic';
 
@@ -151,84 +152,26 @@ export const POST = withAuth(
                 return NextResponse.json({ success: true, membership });
             }
 
-            // Renewal-season admin override: grant the household for the COMING year in
-            // one click, skipping the sign/pay/background-check flow. Produces the same
-            // end-state a completed renewal would — membership ACTIVE plus a terminal
-            // RENEWAL process (INITIAL for a household with no prior membership) with the
-            // three gates stamped satisfied and the acting admin recorded. The COI guard
-            // matches the grant path: this bypasses payment + BG, so a board member may
-            // not do it for their own household (sysadmin may).
+            // Renewal-season admin override: complete the payment gate on a household's
+            // in-flight RENEWAL that's already at PENDING_PAYMENT (contract signed) with
+            // a valid, cleared background check — by delegating to the same settlement
+            // path a real payment takes. No archive, no second process, no stamped gates.
             if (comingYear) {
-                if (auth.type === 'session' && await hasHouseholdConflict(prisma, auth.user.id, householdId, { isSysadmin: auth.user.isSysadmin === true })) {
-                    return apiError("You cannot grant your own household's membership — a sysadmin must.", 403);
+                // Certify requires a real actor; mirror the settings PUT convention.
+                if (auth.type !== "session") return apiError("Unauthorized", 401);
+                try {
+                    const process = await grantRenewalPayment(householdId, {
+                        actorId: auth.user.id,
+                        isSysadmin: auth.user.isSysadmin === true,
+                    });
+                    return NextResponse.json({ success: true, process });
+                } catch (e) {
+                    if (e instanceof PaymentError) {
+                        const status = e.code === "forbidden" ? 403 : e.code === "not_found" ? 404 : 409;
+                        return apiError(e.message, status);
+                    }
+                    throw e; // unexpected → outer catch → 500
                 }
-                const actorId = auth.type === 'session' ? auth.user.id : null;
-                const now = new Date();
-                const result = await prisma.$transaction(async (tx) => {
-                    const membership = await tx.orgMembership.upsert({
-                        where: { householdId },
-                        create: { householdId, status: "ACTIVE" },
-                        update: { status: "ACTIVE" },
-                    });
-                    // Supersede any in-flight process so the override doesn't coexist with a
-                    // stale flow: a payable PENDING_PAYMENT that activate() would later settle
-                    // (double process + a charge for an already-granted household), a review
-                    // still sitting in the queue, or the member's /membership page showing the
-                    // old cards. Board disposal = the terminal ARCHIVED status (same as
-                    // archiveApplication); it drops off every live read with one status check.
-                    // Anything already terminal (a prior cycle's ACTIVE, an earlier ARCHIVED)
-                    // is left alone. Archiving the in-flight RENEWAL also clears the
-                    // one-inflight-renewal partial index before the new terminal row is written.
-                    const superseded = await tx.orgMembershipProcess.findMany({
-                        where: { orgMembershipId: membership.id, status: { notIn: ["ACTIVE", "ARCHIVED"] } },
-                        select: { id: true, status: true },
-                    });
-                    for (const p of superseded) {
-                        await tx.orgMembershipProcess.update({
-                            where: { id: p.id },
-                            data: { status: "ARCHIVED", stageEnteredAt: now },
-                        });
-                        if (actorId !== null) {
-                            await tx.auditLog.create({
-                                data: {
-                                    actorId,
-                                    action: "EDIT",
-                                    tableName: "OrgMembershipProcess",
-                                    affectedEntityId: p.id,
-                                    secondaryAffectedEntity: householdId,
-                                    oldData: { status: p.status },
-                                    newData: { status: "ARCHIVED", supersededByOverride: true },
-                                },
-                            });
-                        }
-                    }
-                    const process = await tx.orgMembershipProcess.create({
-                        data: {
-                            orgMembershipId: membership.id,
-                            kind: existingMembership ? "RENEWAL" : "INITIAL",
-                            status: "ACTIVE",
-                            contractSignedAt: now,
-                            bgClearedAt: now,
-                            paidAt: now,
-                            certifiedById: actorId,
-                        },
-                    });
-                    if (actorId !== null) {
-                        await tx.auditLog.create({
-                            data: {
-                                actorId,
-                                action: "CREATE",
-                                tableName: "OrgMembershipProcess",
-                                affectedEntityId: process.id,
-                                secondaryAffectedEntity: householdId,
-                                oldData: { status: existingMembership?.status ?? "NONE" },
-                                newData: { kind: process.kind, status: "ACTIVE", comingYearOverride: true },
-                            },
-                        });
-                    }
-                    return { membership, process };
-                });
-                return NextResponse.json({ success: true, ...result });
             }
 
             if (active) {

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { emailHouseholdLeads } from "@/lib/emailRecipients";
 import { config } from "@/lib/config";
+import { certifyPaymentPlan, PaymentError } from "./payment";
 
 /**
  * Annual renewal. A common membership-year boundary (BoardSettings) drives every
@@ -283,6 +284,58 @@ export async function householdBgIsFresh(householdId: number, boundary: Date, re
         select: { id: true },
     });
     return fresh !== null;
+}
+
+/**
+ * Admin "Grant for coming year": complete the payment gate on a household's
+ * in-flight RENEWAL that's already at PENDING_PAYMENT (contract signed) with a
+ * valid, cleared background check — via the same settlement path a real
+ * payment takes. Never archives, never stamps a gate, never creates a process.
+ */
+export async function grantRenewalPayment(
+    householdId: number,
+    actor: { actorId: number; isSysadmin: boolean },
+): Promise<import("@/generated/prisma/client").OrgMembershipProcess> {
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    const boundary = settings?.orgMembershipYearBoundary
+        ? nextBoundary(settings.orgMembershipYearBoundary, new Date())
+        : null;
+
+    const process = await prisma.orgMembershipProcess.findFirst({
+        where: { orgMembership: { householdId }, kind: "RENEWAL", status: "PENDING_PAYMENT" },
+        orderBy: { id: "desc" },
+    });
+    if (!process) throw new PaymentError("wrong_phase", "No renewal is awaiting payment.");
+
+    // Belt-and-suspenders BG gate: the process's own bgClearedAt (cleared this
+    // cycle) AND a household lead's check still fresh at the boundary. A
+    // note-held renewal never reaches PENDING_PAYMENT, so fresh-but-unstamped
+    // can't occur here — both checks agree once either is true.
+    const bgFresh = boundary
+        ? await householdBgIsFresh(householdId, boundary, settings?.bgRecheckMonths ?? 0)
+        : false;
+    if (!process.bgClearedAt || !bgFresh) {
+        throw new PaymentError("forbidden", "This renewal's background check is not valid — grant blocked.");
+    }
+
+    // COI is enforced INSIDE certifyPaymentPlan (single source): a board member
+    // certifying their own household throws PaymentError('forbidden'); sysadmin bypasses.
+    await certifyPaymentPlan(process.id, actor.actorId, { isSysadmin: actor.isSysadmin });
+
+    // Supplementary audit marker (traceability) — the PENDING_PAYMENT→ACTIVE
+    // transition itself is already audited inside activate().
+    await prisma.auditLog.create({
+        data: {
+            actorId: actor.actorId,
+            action: "EDIT",
+            tableName: "OrgMembershipProcess",
+            affectedEntityId: process.id,
+            secondaryAffectedEntity: householdId,
+            newData: { comingYearGrant: true },
+        },
+    });
+
+    return prisma.orgMembershipProcess.findUniqueOrThrow({ where: { id: process.id } });
 }
 
 async function remindHousehold(householdId: number, boundary: Date) {


### PR DESCRIPTION
Fixes the incident where granting for the coming year **archived** an application that had a pending background check and activated the membership anyway. Problems 1 + 4 of the renewal-ops batch (problems 2 + 3 — button gating and the date displays — follow in a sibling PR).

## What was wrong

The `comingYear` branch archived every in-flight process (`status notIn [ACTIVE, ARCHIVED]`) and created a brand-new terminal `ACTIVE` process with `contractSignedAt`, `bgClearedAt`, **and** `paidAt` all stamped `now` — a full three-gate bypass. A pending background check was silently overwritten with a false clearance, and the real application vanished into `ARCHIVED`.

## What it does now

"Grant for coming year" = **complete the renewal payment**, nothing else:

- Requires the household's in-flight RENEWAL to be at `PENDING_PAYMENT` — the member has begun the flow and signed the contract (a sweep-opened `PENDING_RENEWAL` alone does not count as started).
- Requires the background check to be valid **both** ways: `bgClearedAt` set on the process this cycle **and** a household lead's check still fresh at the boundary (`householdBgIsFresh`). Belt-and-suspenders; they can't disagree here — a note-held renewal never reaches `PENDING_PAYMENT`, and reviewer clearance stamps `lastBackgroundCheck`.
- Settles via `certifyPaymentPlan` → `activate(via:'certified')` — the exact path a real payment takes, so `PENDING_PAYMENT → ACTIVE` happens in the state machine with its own FOR-UPDATE locking, idempotency, and audit row. If the check somehow weren't cleared, `activate()` holds at `PENDING_BG_CLEARANCE` (background-check approval) — the originally expected behavior.
- **Never archives, never creates a process, never stamps a gate.** A supplementary `comingYearGrant: true` audit row keeps the one-click origin traceable.
- COI is enforced in exactly one place (`certifyPaymentPlan`); the route's duplicate check is gone. Server rejects map `PaymentError` → 403/404/409.

## Notes for review

- No migration.
- The deliberate behavior change beyond the bypass removal: a board member clicking on their **own** household with no grantable renewal now sees 409 (no renewal awaiting payment) rather than 403 — COI fires once a grantable renewal exists. The COI test was reseeded accordingly.
- Two bypass-era tests asserted the old semantics ("grants a non-member", "supersedes an in-flight process") and were removed; the new reject matrix covers: no renewal, `PENDING_RENEWAL` only, `PENDING_EXTERNAL_ACTION`, `bgClearedAt` null, BG stale.
- Tests: 10/10 on the audit-API file, 484/484 across adjacent membership/payment suites, `tsc --noEmit` + eslint clean.

Sibling PR (button visibility so the ops UI only offers the grant when it can succeed, plus Member since / Valid until / BG-valid-until displays) lands next from `claude/renewal-ops-views`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe