### PR TITLE
fix(ui): restore PageContainer top margin to -8

### DIFF
--- a/checkin-app/src/components/ui/PageContainer.tsx
+++ b/checkin-app/src/components/ui/PageContainer.tsx
@@ -2,16 +2,14 @@ import { Box } from "@mantine/core";
 
 // Canonical page wrapper: same left indent + top position for every top-level
 // page/tab layout, so tabs and headings don't "dance" when navigating between
-// sections. No top margin: the full AppShell md padding (16px) stands, so tab
-// bars get real breathing room under the fixed 60px header (z-index 200)
-// instead of rendering flush against it. Do not push this negative again — a
-// -25 overshoot once did exactly that, sliding content up behind the header
-// and clipping the ops tab bars (fixed by #1007); a negative value here must
-// never exceed the AppShell's md padding. paddingLeft adds a small indent past
-// the content edge.
+// sections. marginTop -8 trims half the AppShell md padding (16px) while
+// leaving tab bars clear of the fixed 60px header (z-index 200). A negative
+// value here must never exceed the AppShell's md padding — a -25 overshoot
+// once slid content up behind the header and clipped the ops tab bars (fixed
+// by #1007). paddingLeft adds a small indent past the content edge.
 export function PageContainer({ children }: { children: React.ReactNode }) {
   return (
-    <Box style={{ maxWidth: 1200, margin: "0 auto", marginTop: 0, paddingLeft: 8, display: "flow-root" }}>
+    <Box style={{ maxWidth: 1200, margin: "0 auto", marginTop: -8, paddingLeft: 8, display: "flow-root" }}>
       {children}
     </Box>
   );


### PR DESCRIPTION
## What

Restore `PageContainer`'s `marginTop: -8`, reverting the `-8 → 0` change from #1026 for the shared page wrapper.

## Why #1026's reasoning doesn't hold

#1026 justified the change as giving every page "the AppShell's full 16px of space under the header" — reading the `-8` as consuming half the buffer, and therefore as the thing making tab bars render flush.

That measured the wrong quantity. The actual distance from the top of the viewport to the first line of tab text is:

- **60px** fixed header — `AppFrame.tsx`: `header={{ height: 60 }}`
- **16px** AppShell `padding="md"` on `AppShell.Main`
- **~8-10px** of the tab bar's own internal padding

≈ **85px** of vertical space before a user sees content. The 16px is one slice of that stack, not the buffer anyone perceives. Against ~85px, the `-8` isn't halving a buffer — it recovers roughly 9% of dead space at the top of every page, above the fold. That's ground worth regaining, not a problem to fix.

## Safety

`-8` stays well inside the #1007 guardrail: a negative margin here must never exceed the AppShell's 16px md padding, or content slides up behind the fixed header (z-index 200). `-8` is half of it. The overshoot that caused #1007 was `-25`.

## Not touched

#1026's other two changes stand:
- `attendance/current`'s stale `marginTop: -25` → `0` — that one was the real #1007 bug
- the `p="md"` double-padding removal on `safety/pickup`, `safety/trusted-adults`, `trusted-adults`

## Verification

Single-constant change to a shared style; no test encoded the old value (per #1026's own audit). Lint clean via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)