### PR TITLE
fix(ux): six prod-dogfooding fixes — auth bounce, mobile overflow, copy, consent re-access

### DIFF
--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -170,13 +170,16 @@ describe("membership page", () => {
     mockFetchJson({
       "/api/membership": state({
         process: { id: 1, kind: "INITIAL", status: "PENDING_EXTERNAL_ACTION" },
-        external: { contractSigned: true, contractStarted: true, bgConsented: false, bgCleared: true, deepLinkUrl: null },
+        // deepLinkUrl still set (the server keeps returning it) to prove the reopen
+        // link is hidden because the household is cleared, not because it's absent.
+        external: { contractSigned: true, contractStarted: true, bgConsented: false, bgCleared: true, deepLinkUrl: "https://averity.example/consent" },
       }),
     });
     renderWithProviders(<MembershipPage />);
 
     expect(await screen.findByText("Agreement signed — thank you!")).toBeInTheDocument();
     expect(screen.getByText("Background check")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Reopen the Averity consent form/ })).not.toBeInTheDocument();
   });
 
   it("renders PENDING_PAYMENT with a checkout link", async () => {
@@ -455,6 +458,9 @@ describe("membership page", () => {
 
     expect(await screen.findByRole("button", { name: "Resume signing →" })).toBeInTheDocument();
     expect(screen.getByText("Background check started", { exact: false })).toBeInTheDocument();
+    // Consented (honor-system) but not yet reviewer-cleared: the Averity link stays
+    // reachable so a mis-click or an unfinished form isn't a dead end.
+    expect(screen.getByRole("link", { name: /Reopen the Averity consent form/ })).toHaveAttribute("href", "https://averity.example/consent");
   });
 
   it("shows a not-yet-available background-check link and refreshes status on demand", async () => {

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -89,7 +89,7 @@ export const serializeMembershipForm = (v: FormValues) =>
     v.notes,
   ]);
 
-function ExternalTask({ done, title, doneText, children }: { done: boolean; title: string; doneText: string; children: React.ReactNode }) {
+function ExternalTask({ done, title, doneText, doneExtra, children }: { done: boolean; title: string; doneText: string; doneExtra?: React.ReactNode; children: React.ReactNode }) {
   return (
     <Card withBorder radius="md" padding="md" bg={done ? "var(--mantine-color-green-light)" : undefined}>
       <Group align="flex-start" wrap="nowrap">
@@ -98,7 +98,12 @@ function ExternalTask({ done, title, doneText, children }: { done: boolean; titl
         </ThemeIcon>
         <Box style={{ flex: 1 }}>
           <Text fw={600} mb="xs">{title}</Text>
-          {done ? <Text c="green">{doneText}</Text> : children}
+          {done ? (
+            <>
+              <Text c="green">{doneText}</Text>
+              {doneExtra}
+            </>
+          ) : children}
         </Box>
       </Group>
     </Card>
@@ -679,11 +684,11 @@ export default function MembershipPage() {
         <Group align="flex-start" gap="xl" wrap="wrap">
           {/* Renewals ride the same stepper as new applications — same phases, same
               progress, whether the background check is valid, expired, or first-time. */}
-          <Box style={{ flex: "0 0 auto" }}>
+          <Box style={{ flex: "0 1 auto", maxWidth: "100%", overflowX: "auto" }}>
             <MembershipFlowStepper currentStatus={inStatus} />
           </Box>
 
-          <Box style={{ flex: "1 1 420px", minWidth: 320 }}>
+          <Box style={{ flex: "1 1 420px", minWidth: "min(320px, 100%)" }}>
             {isIntake ? (
               <Card withBorder radius="md" padding="lg">
                 <Stack gap="lg">
@@ -695,6 +700,9 @@ export default function MembershipPage() {
                       errors={{ line1: fieldErrors.address, city: fieldErrors.addrCity, state: fieldErrors.addrState, postalCode: fieldErrors.addrZip }}
                       onErrorClear={(f) => clearErr(f === "line1" ? "address" : f === "city" ? "addrCity" : f === "state" ? "addrState" : "addrZip")}
                     />
+                    <Text c="dimmed" size="sm" mt="md" mb="xs">
+                      Someone we can call in an emergency — must be an adult outside your household.
+                    </Text>
                     <EmergencyContactForm
                       emName={emName} setEmName={setEmName}
                       emPhone={emPhone} setEmPhone={setEmPhone}
@@ -796,7 +804,8 @@ export default function MembershipPage() {
                     <Stack gap="xs" align="flex-start">
                       <Text c="dimmed">
                         Sign your personalized membership agreement online. This page updates
-                        automatically once it&apos;s signed.
+                        automatically once it&apos;s signed. Have your insurance details handy — the
+                        agreement asks for your provider and policy number.
                       </Text>
                       <Button color="green" disabled={saving} loading={saving} onClick={startSigning}>
                         {state.external?.contractStarted ? "Resume signing →" : "Sign your membership agreement →"}
@@ -809,7 +818,19 @@ export default function MembershipPage() {
                       <Text c="dimmed" />
                     </ExternalTask>
                   ) : (
-                    <ExternalTask done={!!state.external?.bgConsented} title="Start your background check" doneText="Background check started — we&apos;ll finish it in the background.">
+                    <ExternalTask
+                      done={!!state.external?.bgConsented}
+                      title="Start your background check"
+                      doneText="Background check started — we&apos;ll finish it in the background."
+                      doneExtra={state.external?.deepLinkUrl ? (
+                        <Text size="sm" c="dimmed" mt="xs">
+                          Checked it by mistake, or still need to finish the form?{" "}
+                          <Anchor href={state.external.deepLinkUrl} target="_blank" rel="noopener noreferrer">
+                            Reopen the Averity consent form →
+                          </Anchor>
+                        </Text>
+                      ) : undefined}
+                    >
                       <Stack gap="xs" align="flex-start">
                         <Text c="dimmed">
                           Consent to your background check on Averity. It runs in the background — you

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -91,7 +91,7 @@ describe("HouseholdPage", () => {
     fireEvent.click(screen.getByLabelText("Individual is over 25"));
     // Allergies (safety data) must be capturable on ADD, not only on a later edit.
     fireEvent.change(screen.getByLabelText("Allergies (optional)"), { target: { value: "Bees" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save / Invite Household Member" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save / Invite" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
@@ -218,19 +218,19 @@ describe("HouseholdPage", () => {
     expect(screen.queryByLabelText("Full Name")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "+ Add Household Member" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save / Invite Household Member" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save / Invite" }));
     expect(await screen.findByText("Name is required.")).toBeInTheDocument();
     expect(screen.getByText("Date of birth is required for anyone under 25.")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Full Name"), { target: { value: "Robin Smith" } });
     fireEvent.change(screen.getByLabelText("Email (Optional)"), { target: { value: "not-an-email" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save / Invite Household Member" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save / Invite" }));
     expect(await screen.findByText("Enter a valid email address.")).toBeInTheDocument();
     expect(screen.getByText("Date of birth is required for anyone under 25.")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Email (Optional)"), { target: { value: "" } });
     fireEvent.change(screen.getByLabelText("Date of Birth"), { target: { value: "2000-01-01" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save / Invite Household Member" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save / Invite" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith("/api/household", expect.objectContaining({ method: "PATCH" })),
@@ -257,10 +257,10 @@ describe("HouseholdPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "+ Add Household Member" }));
     fireEvent.change(screen.getByLabelText("Full Name"), { target: { value: "Robin Smith" } });
     fireEvent.click(screen.getByLabelText("Individual is over 25"));
-    fireEvent.click(screen.getByRole("button", { name: "Save / Invite Household Member" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save / Invite" }));
     expect(await screen.findByText("Household is full.")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Save / Invite Household Member" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save / Invite" }));
     await waitFor(() => expectToast("Network error adding household member."));
   });
 

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -479,7 +479,7 @@ export default function HouseholdPage() {
                       )}
                       <TextInput label="Allergies (optional)" value={householdMemberForm.allergies} onChange={(e) => setHouseholdMemberForm({ ...householdMemberForm, allergies: e.currentTarget.value })} />
                       <Group grow>
-                        <Button type="submit" color="green">Save / Invite Household Member</Button>
+                        <Button type="submit" color="green">Save / Invite</Button>
                         <Button type="button" variant="default" onClick={() => { setAddingHouseholdMember(false); setHouseholdMemberErrors({}); }}>Cancel</Button>
                       </Group>
                     </Stack>

--- a/checkin-app/src/app/page.tsx
+++ b/checkin-app/src/app/page.tsx
@@ -26,11 +26,12 @@ import { useIsDevInstance, useIsLocalInstance } from '@/components/EnvProvider';
 import JoinTreehouseBanner from '@/components/JoinTreehouseBanner';
 import Notifications from '@/components/Notifications';
 import { RoleBadge } from '@/components/ui/RoleBadge';
+import { PageLoader } from '@/components/ui/PageLoader';
 import type { SessionUser } from '@/types/participant';
 
 export default function Home() {
   const router = useRouter();
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const isDevInstance = useIsDevInstance();
   const isLocalInstance = useIsLocalInstance();
   const [loading, setLoading] = useState(false);
@@ -99,6 +100,10 @@ export default function Home() {
       .catch(() => { /* non-blocking: leave banner hidden on error */ });
     return () => { cancelled = true; };
   }, [session]);
+
+  // While the session is still resolving, `session` is undefined — rendering the
+  // ternary below as-is would flash the signed-out landing at a signed-in user.
+  if (status === "loading") return <PageLoader />;
 
   const handleToggleCheckin = async () => {
     if (!session?.user) return;

--- a/checkin-app/src/app/signin/__tests__/page.test.tsx
+++ b/checkin-app/src/app/signin/__tests__/page.test.tsx
@@ -4,7 +4,7 @@ jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 import { screen, fireEvent } from "@testing-library/react";
 import { signIn } from "next-auth/react";
-import { renderWithProviders, setSession, resetRtl } from "@/test-helpers/rtl";
+import { renderWithProviders, setSession, resetRtl, router } from "@/test-helpers/rtl";
 import SignInPage from "../page";
 
 beforeEach(() => resetRtl());
@@ -23,5 +23,19 @@ describe("SignInPage", () => {
         renderWithProviders(<SignInPage />);
 
         expect(screen.getByRole("link", { name: /continue as ann admin/i })).toBeInTheDocument();
+    });
+
+    it("redirects an authenticated, org-OK visitor straight to the callback URL", () => {
+        setSession({ id: 1, name: "Ann Admin" });
+        renderWithProviders(<SignInPage />);
+
+        expect(router.replace).toHaveBeenCalledWith("/");
+    });
+
+    it("renders no sign-in button while the session is still loading", () => {
+        setSession(null, "loading");
+        renderWithProviders(<SignInPage />);
+
+        expect(screen.queryByRole("button", { name: /sign in with google/i })).not.toBeInTheDocument();
     });
 });

--- a/checkin-app/src/app/signin/page.tsx
+++ b/checkin-app/src/app/signin/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Suspense } from "react";
-import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { ORG_DOMAIN } from "@/lib/config";
 import { useCheckinEnv, useIsDevInstance, useIsLocalInstance } from "@/components/EnvProvider";
@@ -33,12 +33,17 @@ const heroStyle: React.CSSProperties = {
  * Styled to match the real homepage hero.
  */
 function SignInInner() {
+    const router = useRouter();
     const params = useSearchParams();
     const { data: session, status } = useSession();
     const isDevInstance = useIsDevInstance();
     const isLocalInstance = useIsLocalInstance();
     const checkinEnv = useCheckinEnv();
-    const callbackUrl = params.get("callbackUrl") || "/";
+    // Same-origin relative paths only: this value comes off the query string and
+    // feeds a client-side redirect, so an absolute (or protocol-relative) URL here
+    // would be an open redirect for any authenticated visitor.
+    const rawCallback = params.get("callbackUrl") || "/";
+    const callbackUrl = rawCallback.startsWith("/") && !rawCallback.startsWith("//") ? rawCallback : "/";
     const error = params.get("error");
 
     const signedIn = status === "authenticated" && !!session?.user;
@@ -49,6 +54,15 @@ function SignInInner() {
     // the cloud dev instance; local sessions never carry the hd claim.
     const orgVerified = session?.user?.hd === ORG_DOMAIN && session?.user?.emailVerified === true;
     const wrongAccount = signedIn && checkinEnv === "dev" && !orgVerified;
+
+    // An authenticated, org-OK visitor lands here after an OAuth bounce (e.g. the
+    // dev middleware's hd gate, or a stale /signin link) — send them straight on
+    // instead of stranding them behind a redundant "Sign in with Google" button.
+    useEffect(() => {
+        if (status === "authenticated" && !wrongAccount) {
+            router.replace(callbackUrl);
+        }
+    }, [status, wrongAccount, callbackUrl, router]);
 
     return (
         <main style={mainStyle}>
@@ -140,7 +154,7 @@ function SignInInner() {
                             Continue as {session.user?.name || session.user?.email}
                         </a>
                     </div>
-                ) : (
+                ) : status === "loading" ? null : (
                     <div
                         style={{
                             width: "100%",


### PR DESCRIPTION
Fixes the six issues from dogfooding v1.0.3 on mobile.

| # | Report | Root cause → fix |
|---|--------|------------------|
| 1 | Had to auth with Google twice | `/signin` computed `signedIn` but never acted on it — an authenticated visitor (e.g. after an OAuth bounce) saw the sign-in button again and re-ran the whole flow. Now: authenticated + org-OK → `router.replace(callbackUrl)`; loading state renders nothing instead of the button; same status-blindness fixed on the landing page. **Hardening**: `callbackUrl` is query-string input feeding a client redirect, so it's pinned to same-origin relative paths (no `//` or absolute URLs). |
| 2 | Emergency-contact rule only appears as an error | Always-visible line above the fields: "Someone we can call in an emergency — must be an adult outside your household." Validation and error string unchanged. |
| 3 | "Save/Invite H…" truncated on mobile | Label → "Save / Invite" (the `Group grow` already stretches it; the nowrap label width was the overflow). RTL references updated. |
| 4 | Cards clipped at right edge on phone | The stepper column was `flex: 0 0 auto` — it can never shrink, so its intrinsic width stretched the row past the viewport and clipped every card. Now `0 1 auto` + `maxWidth: 100%` + internal overflow-x, and the task column's `minWidth` is `min(320px, 100%)`. (The stepper itself was already vertical/sm — the spec's horizontal-stepper branch didn't apply.) |
| 5 | Insurance fields mid-signing were a surprise | Sign-agreement card now says to have provider + policy number handy before starting. |
| 6 | "What if I fat-finger 'I finished my background check'? How do I re-access it?" | Answer: the stamp is honor-system and **cannot activate anything** (clearance still takes two reviewer approvals) — but the Averity link vanished with no way back, leaving the board waiting on a result that never comes. The done-state card now keeps a "Reopen the Averity consent form →" link whenever the deep link exists (it was never server-gated by consent state). `ExternalTask` gains an additive `doneExtra` prop; a bgCleared household deliberately does *not* show the link (asserted). |

Testing: 88 RTL tests green across signin / landing / membership / my-household suites (+2 new signin tests, reopen-link presence/absence assertions); `tsc --noEmit` + eslint clean. True-device 375px rendering verified by inspection of the flex math, not a browser — worth one glance on your phone after deploy.

No overlap with the open stack (#1054/#1055 touch different files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe