### PR TITLE
feat(pricing): member pricing requires membership valid for the program's duration

### DIFF
--- a/checkin-app/src/app/__tests__/programDiscountCodeAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programDiscountCodeAPI.integration.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for POST /api/programs/[id]/discount-code — the
+ * membership-DURATION guard: member pricing (and this discount code) applies
+ * only when the buyer's membership covers the program's whole run, not just
+ * "is a member today". CHECKIN_ENV=local arms the Shopify mock
+ * (config.shopifyMockActive) so mintMemberDiscountCode short-circuits without
+ * real Shopify credentials, mirroring programVariantRoundtripShopify.
+ */
+import { POST } from '@/app/api/programs/[id]/discount-code/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+const TAG = 'discount-code-duration-test';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function post(programId: number) {
+    const req = new Request(`http://localhost:4000/api/programs/${programId}/discount-code`, {
+        method: 'POST',
+        // CHECKIN_ENV=local also arms the keyless-kiosk fallback in
+        // authenticateRequest, which hijacks any cookie-less request as kiosk
+        // (403) before the session gate runs — see programsIdAPI's Shopify block.
+        headers: { cookie: 'session=test' },
+    });
+    return POST(req as unknown as import('next/server').NextRequest, { params: Promise.resolve({ id: String(programId) }) });
+}
+
+describe('POST /api/programs/[id]/discount-code — membership duration', () => {
+    let prevCheckinEnv: string | undefined;
+    let prevBoardSettings: { orgMembershipYearBoundary: Date | null; bgRecheckMonths: number } | null = null;
+
+    // now + 45 days sits inside the 2-month renewal lead window, so the
+    // "settled" probe (ACTIVE process stamped inside the window) is reachable.
+    const boundary = new Date(Date.now() + 45 * DAY_MS);
+    const coveredEndAt = new Date(boundary.getTime() - 5 * DAY_MS); // before the boundary
+    const uncoveredEndAt = new Date(boundary.getTime() + 10 * DAY_MS); // after the boundary, within +1y
+
+    let unsettledPersonId: number;
+    let settledPersonId: number;
+    let settledHouseholdId: number;
+    let nonMemberPersonId: number;
+    let coveredProgramId: number;
+    let uncoveredProgramId: number;
+
+    async function wipe() {
+        const people = await prisma.person.findMany({ where: { email: { contains: TAG } }, select: { id: true, householdId: true } });
+        const householdIds = people.map((p) => p.householdId);
+        if (householdIds.length) {
+            const memberships = await prisma.orgMembership.findMany({ where: { householdId: { in: householdIds } }, select: { id: true } });
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembershipId: { in: memberships.map((m) => m.id) } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: householdIds } } });
+        }
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
+        await prisma.household.deleteMany({ where: { name: { contains: TAG } } });
+        await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
+    }
+
+    beforeAll(async () => {
+        prevCheckinEnv = process.env.CHECKIN_ENV;
+        process.env.CHECKIN_ENV = 'local';
+
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevBoardSettings = existing
+            ? { orgMembershipYearBoundary: existing.orgMembershipYearBoundary, bgRecheckMonths: existing.bgRecheckMonths }
+            : null;
+        await wipe();
+
+        await prisma.boardSettings.upsert({
+            where: { id: 1 },
+            create: { id: 1, orgMembershipYearBoundary: boundary, bgRecheckMonths: existing?.bgRecheckMonths ?? 12 },
+            update: { orgMembershipYearBoundary: boundary },
+        });
+
+        // Unsettled member: ACTIVE membership, no renewal process — valid only
+        // through the upcoming boundary.
+        const unsettled = await prisma.person.create({
+            data: {
+                email: `unsettled-${TAG}@example.com`, name: 'Unsettled Member',
+                household: { create: { name: `Unsettled HH ${TAG}`, orgMembership: { create: { status: 'ACTIVE' } } } },
+            },
+            select: { id: true, householdId: true },
+        });
+        unsettledPersonId = unsettled.id;
+
+        // Settled member: ACTIVE membership + a terminal ACTIVE process stamped
+        // inside the current renewal window — valid one boundary further.
+        const settled = await prisma.person.create({
+            data: {
+                email: `settled-${TAG}@example.com`, name: 'Settled Member',
+                household: { create: { name: `Settled HH ${TAG}`, orgMembership: { create: { status: 'ACTIVE' } } } },
+            },
+            select: { id: true, householdId: true },
+        });
+        settledPersonId = settled.id;
+        settledHouseholdId = settled.householdId;
+        const settledMembership = await prisma.orgMembership.findUniqueOrThrow({ where: { householdId: settledHouseholdId } });
+        await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: settledMembership.id, kind: 'RENEWAL', status: 'ACTIVE', stageEnteredAt: new Date() },
+        });
+
+        const nonMember = await prisma.person.create({
+            data: { email: `nonmember-${TAG}@example.com`, name: 'Non Member', household: { create: { name: `Non Member HH ${TAG}` } } },
+            select: { id: true },
+        });
+        nonMemberPersonId = nonMember.id;
+
+        // Single-pool program (shopifyVariantId set) that the discount-code route
+        // handles; two price tiers so it computes a non-zero discount amount.
+        const covered = await prisma.program.create({
+            data: {
+                name: `Covered Prog ${TAG}`, phase: 'UPCOMING', endAt: coveredEndAt,
+                shopifyVariantId: 'dev-mock-variant-discount-code-covered',
+                orgMemberPriceCents: 4000, nonOrgMemberPriceCents: 5000,
+            },
+        });
+        coveredProgramId = covered.id;
+
+        const uncovered = await prisma.program.create({
+            data: {
+                name: `Uncovered Prog ${TAG}`, phase: 'UPCOMING', endAt: uncoveredEndAt,
+                shopifyVariantId: 'dev-mock-variant-discount-code-uncovered',
+                orgMemberPriceCents: 4000, nonOrgMemberPriceCents: 5000,
+            },
+        });
+        uncoveredProgramId = uncovered.id;
+    });
+
+    afterAll(async () => {
+        await wipe();
+        if (prevBoardSettings) await prisma.boardSettings.update({ where: { id: 1 }, data: prevBoardSettings });
+        if (prevCheckinEnv === undefined) delete process.env.CHECKIN_ENV;
+        else process.env.CHECKIN_ENV = prevCheckinEnv;
+        await prisma.$disconnect();
+    });
+
+    it('mints a code when the member\'s validity covers the program\'s endAt', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: unsettledPersonId } });
+        const res = await post(coveredProgramId);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.code).toEqual(expect.stringContaining(`PRG${coveredProgramId}-`));
+        expect(data.reason).toBeUndefined();
+    });
+
+    it('returns { code: null, reason } when the program ends after an unsettled member\'s boundary', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: unsettledPersonId } });
+        const res = await post(uncoveredProgramId);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.code).toBeNull();
+        expect(data.reason).toBe('membership_ends_before_program');
+    });
+
+    it('mints a code for the same past-boundary program once the household is settled for the coming year', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: settledPersonId } });
+        const res = await post(uncoveredProgramId);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.code).toEqual(expect.stringContaining(`PRG${uncoveredProgramId}-`));
+        expect(data.reason).toBeUndefined();
+    });
+
+    it('a non-member still gets { code: null } with no reason (unchanged behavior)', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: nonMemberPersonId } });
+        const res = await post(coveredProgramId);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.code).toBeNull();
+        expect(data.reason).toBeUndefined();
+    });
+});

--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -274,6 +274,65 @@ describe('Individual Program API Integration Tests', () => {
         });
     });
 
+    // viewerIsMember / viewerMemberPricingEligible: additive, session-only fields
+    // computed AFTER the registry response (see route.ts) — membership pricing
+    // applies only when the buyer's membership covers the program's whole run.
+    describe('GET /api/programs/[id] — viewer membership-pricing fields', () => {
+        let prevBoardSettings: { orgMembershipYearBoundary: Date | null; bgRecheckMonths: number } | null = null;
+        let pastBoundaryProgramId: number;
+        const DAY_MS = 24 * 60 * 60 * 1000;
+        // Inside the 2-month renewal lead window relative to "now" — irrelevant
+        // here (memberId's household has no renewal process, so it's never
+        // "settled"), but kept consistent with the other duration tests.
+        const boundary = new Date(Date.now() + 45 * DAY_MS);
+
+        beforeAll(async () => {
+            const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+            prevBoardSettings = existing
+                ? { orgMembershipYearBoundary: existing.orgMembershipYearBoundary, bgRecheckMonths: existing.bgRecheckMonths }
+                : null;
+            await prisma.boardSettings.upsert({
+                where: { id: 1 },
+                create: { id: 1, orgMembershipYearBoundary: boundary, bgRecheckMonths: existing?.bgRecheckMonths ?? 12 },
+                update: { orgMembershipYearBoundary: boundary },
+            });
+
+            const pastBoundaryProgram = await prisma.program.create({
+                data: { name: 'Past Boundary Prog ID API Test', phase: 'UPCOMING', endAt: new Date(boundary.getTime() + 10 * DAY_MS) },
+            });
+            pastBoundaryProgramId = pastBoundaryProgram.id;
+        });
+
+        afterAll(async () => {
+            await prisma.program.delete({ where: { id: pastBoundaryProgramId } });
+            if (prevBoardSettings) await prisma.boardSettings.update({ where: { id: 1 }, data: prevBoardSettings });
+        });
+
+        it('an unrenewed member sees viewerIsMember: true and viewerMemberPricingEligible: false for a program past their boundary', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: memberId } });
+
+            const req = new Request(`http://localhost:4000/api/programs/${pastBoundaryProgramId}`, { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest, createParams(pastBoundaryProgramId) as unknown as never);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.viewerIsMember).toBe(true);
+            expect(data.viewerMemberPricingEligible).toBe(false);
+        });
+
+        it('omits both fields for an anonymous caller', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue(null);
+
+            const req = new Request(`http://localhost:4000/api/programs/${pastBoundaryProgramId}`, { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest, createParams(pastBoundaryProgramId) as unknown as never);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.viewerIsMember).toBeUndefined();
+            expect(data.viewerMemberPricingEligible).toBeUndefined();
+        });
+    });
+
     describe('PATCH /api/programs/[id]', () => {
         it('should return 401 Unauthorized without session', async () => {
              (getServerSession as jest.Mock).mockResolvedValue(null);

--- a/checkin-app/src/app/api/programs/[id]/discount-code/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/discount-code/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
-import { isActiveOrgMember } from "@/lib/orgMembership";
+import { isActiveOrgMember, isActiveOrgMemberThrough, programCoverageDate } from "@/lib/orgMembership";
 import { mintMemberDiscountCode } from "@/lib/shopify";
 
 // Server-minted, single-use member discount code for a single-pool program's
@@ -28,8 +28,14 @@ export const POST = withAuth({}, async (_req, auth, { params }: { params: Promis
         return NextResponse.json({ code: null });
     }
 
-    const isMember = await isActiveOrgMember(auth.user.id);
-    if (!isMember) return NextResponse.json({ code: null });
+    const isMemberNow = await isActiveOrgMember(auth.user.id);
+    if (!isMemberNow) return NextResponse.json({ code: null });
+
+    // A current member isn't necessarily covered for the program's WHOLE run — a
+    // not-yet-renewed household is valid only through the upcoming membership-year
+    // boundary, so a program ending after that boundary must charge full price.
+    const covers = await isActiveOrgMemberThrough(auth.user.id, programCoverageDate(program));
+    if (!covers) return NextResponse.json({ code: null, reason: "membership_ends_before_program" });
 
     const amountOffCents = program.nonOrgMemberPriceCents - program.orgMemberPriceCents;
     if (amountOffCents <= 0) return NextResponse.json({ code: null });

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -10,6 +10,39 @@ import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
 import { validateProgramAgeBounds } from "@/lib/programAge";
 
+// ORDER MATTERS: this export sits ABOVE getProgram so the routeAuthDrift
+// guard attributes getProgram's edge-model reads to the nearest preceding
+// exported METHOD (this GET) — moving it below silently un-attributes them.
+// The registry stripper (security/stripper.ts) is a strict allowlist over each
+// model's CLASSIFIED schema fields (see security/generated/classifications.ts,
+// generated from /// @sensitivity comments) — it has no channel for a
+// viewer-computed scalar that isn't a real Program column, and adding one
+// would mean a schema change this feature doesn't get. So viewerIsMember /
+// viewerMemberPricingEligible are computed AFTER the registry response comes
+// back and merged on top, session callers only — the registry envelope above
+// (association gate, per-tier stripping) runs completely untouched first.
+// startAt/endAt are 'public' tier, so they always ride in `body` regardless of
+// caller privilege; re-authenticating here is the same cheap session read
+// authenticateRequest always does, just called a second time.
+export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+    const res = await getProgram(req, ctx);
+    if (res.status !== 200) return res;
+
+    const auth = await authenticateRequest(req);
+    if (auth.type !== 'session') return res;
+
+    const body = (await res.json()) as { startAt: string | null; endAt: string | null };
+    const coverageDate = programCoverageDate({
+        startAt: body.startAt ? new Date(body.startAt) : null,
+        endAt: body.endAt ? new Date(body.endAt) : null,
+    });
+    const [viewerIsMember, viewerMemberPricingEligible] = await Promise.all([
+        isActiveOrgMember(auth.user.id),
+        isActiveOrgMemberThrough(auth.user.id, coverageDate),
+    ]);
+    return NextResponse.json({ ...body, viewerIsMember, viewerMemberPricingEligible });
+}
+
 const getProgram = handler<{ id: string }>('GET /api/programs/[id]', async ({ auth, params }) => {
     const programId = parseInt(params.id, 10);
     if (isNaN(programId)) throw badRequest('Invalid program ID');
@@ -92,35 +125,6 @@ const getProgram = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
     return { Program: program };
 });
 
-// The registry stripper (security/stripper.ts) is a strict allowlist over each
-// model's CLASSIFIED schema fields (see security/generated/classifications.ts,
-// generated from /// @sensitivity comments) — it has no channel for a
-// viewer-computed scalar that isn't a real Program column, and adding one
-// would mean a schema change this feature doesn't get. So viewerIsMember /
-// viewerMemberPricingEligible are computed AFTER the registry response comes
-// back and merged on top, session callers only — the registry envelope above
-// (association gate, per-tier stripping) runs completely untouched first.
-// startAt/endAt are 'public' tier, so they always ride in `body` regardless of
-// caller privilege; re-authenticating here is the same cheap session read
-// authenticateRequest always does, just called a second time.
-export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
-    const res = await getProgram(req, ctx);
-    if (res.status !== 200) return res;
-
-    const auth = await authenticateRequest(req);
-    if (auth.type !== 'session') return res;
-
-    const body = (await res.json()) as { startAt: string | null; endAt: string | null };
-    const coverageDate = programCoverageDate({
-        startAt: body.startAt ? new Date(body.startAt) : null,
-        endAt: body.endAt ? new Date(body.endAt) : null,
-    });
-    const [viewerIsMember, viewerMemberPricingEligible] = await Promise.all([
-        isActiveOrgMember(auth.user.id),
-        isActiveOrgMemberThrough(auth.user.id, coverageDate),
-    ]);
-    return NextResponse.json({ ...body, viewerIsMember, viewerMemberPricingEligible });
-}
 
 // withAuth rejects unauthenticated AND denied households at admission (closes
 // GAP-1: this PATCH previously had no denied check), so a denied lead mentor can

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -1,16 +1,16 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
-import { withAuth } from "@/lib/auth";
+import { withAuth, authenticateRequest } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { handler, notFound, forbidden, badRequest } from "@/security/handler";
-import { isActiveOrgMember } from "@/lib/orgMembership";
+import { isActiveOrgMember, isActiveOrgMemberThrough, programCoverageDate } from "@/lib/orgMembership";
 import { notifyNewProgramAnnounced } from "@/lib/notifications";
 import { adjustProgramInventory } from "@/lib/shopify";
 import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
 import { validateProgramAgeBounds } from "@/lib/programAge";
 
-export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ auth, params }) => {
+const getProgram = handler<{ id: string }>('GET /api/programs/[id]', async ({ auth, params }) => {
     const programId = parseInt(params.id, 10);
     if (isNaN(programId)) throw badRequest('Invalid program ID');
 
@@ -91,6 +91,36 @@ export const GET = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
 
     return { Program: program };
 });
+
+// The registry stripper (security/stripper.ts) is a strict allowlist over each
+// model's CLASSIFIED schema fields (see security/generated/classifications.ts,
+// generated from /// @sensitivity comments) — it has no channel for a
+// viewer-computed scalar that isn't a real Program column, and adding one
+// would mean a schema change this feature doesn't get. So viewerIsMember /
+// viewerMemberPricingEligible are computed AFTER the registry response comes
+// back and merged on top, session callers only — the registry envelope above
+// (association gate, per-tier stripping) runs completely untouched first.
+// startAt/endAt are 'public' tier, so they always ride in `body` regardless of
+// caller privilege; re-authenticating here is the same cheap session read
+// authenticateRequest always does, just called a second time.
+export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+    const res = await getProgram(req, ctx);
+    if (res.status !== 200) return res;
+
+    const auth = await authenticateRequest(req);
+    if (auth.type !== 'session') return res;
+
+    const body = (await res.json()) as { startAt: string | null; endAt: string | null };
+    const coverageDate = programCoverageDate({
+        startAt: body.startAt ? new Date(body.startAt) : null,
+        endAt: body.endAt ? new Date(body.endAt) : null,
+    });
+    const [viewerIsMember, viewerMemberPricingEligible] = await Promise.all([
+        isActiveOrgMember(auth.user.id),
+        isActiveOrgMemberThrough(auth.user.id, coverageDate),
+    ]);
+    return NextResponse.json({ ...body, viewerIsMember, viewerMemberPricingEligible });
+}
 
 // withAuth rejects unauthenticated AND denied households at admission (closes
 // GAP-1: this PATCH previously had no denied check), so a denied lead mentor can

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -544,6 +544,66 @@ describe("ProgramEnrollmentPage", () => {
         expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/discount-code"))).toBe(false);
     });
 
+    // Membership-duration guard: pricing decisions use the server-computed
+    // viewerMemberPricingEligible flag over the household-status-derived isMember,
+    // so a current member not covered through the program's end doesn't get the
+    // discount even though /api/household still reports an ACTIVE membership.
+    it("does NOT fetch a member discount code when the server flag says pricing-ineligible, despite an ACTIVE household membership", async () => {
+        setSession({ id: 101 });
+        setShopifyStoreDomain("shop.example.com");
+        const memberHousehold = { household: { ...household.household, orgMembership: { status: "ACTIVE" } } };
+        const fetchMock = mockFetchJson({
+            "/api/household": memberHousehold,
+            "/api/programs/10": baseProgram({
+                orgMemberPriceCents: 4000, nonOrgMemberPriceCents: 5000, minAge: null, maxAge: null,
+                shopifyVariantId: "gid://single-pool", shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+                viewerIsMember: true, viewerMemberPricingEligible: false,
+            }),
+            "/api/programs/10/participants": { ok: true },
+        });
+        renderPage();
+        await screen.findByText("Robotics Club");
+        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+        await screen.findByText("Which of your household wants to enroll?");
+        // The household/EC probes that gate the button's disabled state are still
+        // in flight right after the panel appears — wait for it to actually enable
+        // before clicking (avoids a race with populateHousehold's fetches).
+        await waitFor(() => expect(screen.getByRole("button", { name: "Pay on Shopify" })).toBeEnabled());
+        fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
+
+        await screen.findByText("Redirecting to Shopify for secure payment...");
+        expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/discount-code"))).toBe(false);
+    });
+
+    it("shows the renew notice when the viewer is a member but not eligible for member pricing on this program", async () => {
+        setSession({ id: 101 });
+        mockFetchJson({
+            "/api/household": household,
+            "/api/programs/10": baseProgram({ viewerIsMember: true, viewerMemberPricingEligible: false }),
+        });
+        renderPage();
+        expect(await screen.findByText(/renew your membership first to enroll at the member price/)).toBeInTheDocument();
+    });
+
+    it("does not show the renew notice when the member is pricing-eligible or the fields are absent", async () => {
+        setSession({ id: 101 });
+        mockFetchJson({
+            "/api/household": household,
+            "/api/programs/10": baseProgram({ viewerIsMember: true, viewerMemberPricingEligible: true }),
+        });
+        renderPage();
+        await screen.findByText("Robotics Club");
+        expect(screen.queryByText(/renew your membership first/)).not.toBeInTheDocument();
+    });
+
+    it("does not show the renew notice for an anonymous caller (fields absent)", async () => {
+        setSession(null, "unauthenticated");
+        mockFetchJson({ "/api/programs/10": baseProgram() });
+        renderPage();
+        await screen.findByText("Robotics Club");
+        expect(screen.queryByText(/renew your membership first/)).not.toBeInTheDocument();
+    });
+
     it("shows different closed-enrollment reasons depending on fullness, phase, and count source", async () => {
         setSession({ id: 101 });
         const cases: [string, Record<string, unknown>][] = [

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -41,6 +41,13 @@ type ProgramDetail = {
   minAge: number | null;
   maxAge: number | null;
   orgMemberOnly: boolean;
+  // Server-computed, session callers only (route.ts) — undefined for an
+  // anonymous caller or an older cached response. viewerMemberPricingEligible
+  // is the pricing-relevant flag: a current member whose membership ends
+  // before this program's coverage date (endAt, else startAt) is NOT eligible
+  // for member pricing even though viewerIsMember is true.
+  viewerIsMember?: boolean;
+  viewerMemberPricingEligible?: boolean;
 };
 
 type SessionUser = { isSysadmin?: boolean; isBoardMember?: boolean; id: number; householdId?: number | null };
@@ -258,15 +265,20 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
       // one is a real config gap in every env.
       let mockPay = false;
       let isMember = false;
+      // Pricing goes by the server-computed duration-aware flag when present (a
+      // member not covered through this program's end must pay full price);
+      // ?? isMember is the fallback for an older cached response missing it.
+      let pricingEligible = false;
       if (isPayingOnShopify && program) {
         const householdRes = await fetch('/api/household');
         if (householdRes.ok) {
           const householdData = await householdRes.json();
           isMember = householdData.household?.orgMembership?.status === "ACTIVE" || false;
         }
+        pricingEligible = program.viewerMemberPricingEligible ?? isMember;
         // Single-pool programs sell the SAME variant to everyone — the discount
         // code (below, at redirect time) does the member pricing, not a variant pick.
-        variantId = program.shopifyVariantId || (isMember ? program.shopifyOrgMemberVariantId : program.shopifyNonOrgMemberVariantId);
+        variantId = program.shopifyVariantId || (pricingEligible ? program.shopifyOrgMemberVariantId : program.shopifyNonOrgMemberVariantId);
         storeDomain = shopifyStoreDomain ?? undefined;
         mockPay = isLocalInstance;
         if (!variantId || (!mockPay && !storeDomain)) {
@@ -321,7 +333,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
           // safe fallback (never blocks checkout), per lib/shopify.ts's
           // mintMemberDiscountCode contract.
           let discountCode: string | null = null;
-          if (program.shopifyVariantId && isMember) {
+          if (program.shopifyVariantId && pricingEligible) {
             try {
               const discRes = await fetch(`/api/programs/${id}/discount-code`, { method: 'POST' });
               if (discRes.ok) discountCode = (await discRes.json()).code ?? null;
@@ -455,6 +467,15 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
             )}
           </Stack>
         </Card>
+
+        {/* A current member whose membership doesn't cover this program's whole
+            run doesn't get member pricing on it — the discount-code fetch's
+            `reason` reinforces this at checkout time, so it isn't repeated here. */}
+        {program.viewerIsMember === true && program.viewerMemberPricingEligible === false && (
+          <Alert color="yellow" variant="light" mb="lg">
+            Your membership ends before this program finishes, so member pricing doesn&apos;t apply — renew your membership first to enroll at the member price.
+          </Alert>
+        )}
 
         {message && <Alert color="red" mb="lg">{message}</Alert>}
         {successMessage && <Alert color="green" mb="lg">{successMessage}</Alert>}

--- a/checkin-app/src/lib/__tests__/orgMembership.test.ts
+++ b/checkin-app/src/lib/__tests__/orgMembership.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for the membership-duration guard added to lib/orgMembership.ts:
+ *   - membershipValidThrough: a household's covered-through boundary — the
+ *     upcoming membership-year boundary, or one boundary further once the
+ *     household is settled for the coming year (same probe as the
+ *     households-ops list's settledForComingYear).
+ *   - isActiveOrgMemberThrough: does a person's membership cover a program
+ *     running through a given date.
+ *   - programCoverageDate: the date a program's member pricing must be valid
+ *     through (endAt, else startAt, else null).
+ * Prisma mocked — no DB. nextBoundary/renewalSeasonWindow run for real (from
+ * @/lib/membership/renewal) so the boundary arithmetic is exercised, not stubbed.
+ */
+import { membershipValidThrough, isActiveOrgMemberThrough, programCoverageDate } from '@/lib/orgMembership';
+import { nextBoundary } from '@/lib/membership/renewal';
+
+jest.mock('@/lib/prisma', () => ({
+    __esModule: true,
+    default: {
+        household: { findUnique: jest.fn() },
+        boardSettings: { findUnique: jest.fn() },
+        orgMembershipProcess: { findFirst: jest.fn() },
+        person: { findFirst: jest.fn(), findUnique: jest.fn() },
+    },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const prisma = require('@/lib/prisma').default;
+
+const BOUNDARY = new Date(Date.UTC(2000, 11, 25)); // Dec 25 — mirrors the repo's other boundary tests
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('membershipValidThrough', () => {
+    it('ACTIVE + boundary configured, not settled → the upcoming boundary occurrence', async () => {
+        prisma.household.findUnique.mockResolvedValue({ orgMembership: { id: 7, status: 'ACTIVE' } });
+        prisma.boardSettings.findUnique.mockResolvedValue({ orgMembershipYearBoundary: BOUNDARY });
+        prisma.orgMembershipProcess.findFirst.mockResolvedValue(null); // not settled
+
+        const now = new Date(Date.UTC(2026, 0, 1));
+        const result = await membershipValidThrough(1, now);
+        expect(result).toEqual(nextBoundary(BOUNDARY, now));
+    });
+
+    it('settled for the coming year → one year past the upcoming boundary', async () => {
+        prisma.household.findUnique.mockResolvedValue({ orgMembership: { id: 7, status: 'ACTIVE' } });
+        prisma.boardSettings.findUnique.mockResolvedValue({ orgMembershipYearBoundary: BOUNDARY });
+        prisma.orgMembershipProcess.findFirst.mockResolvedValue({ id: 99 }); // settled
+
+        const now = new Date(Date.UTC(2026, 0, 1));
+        const result = await membershipValidThrough(1, now);
+        const boundary = nextBoundary(BOUNDARY, now);
+        expect(result).toEqual(new Date(Date.UTC(boundary.getUTCFullYear() + 1, boundary.getUTCMonth(), boundary.getUTCDate())));
+    });
+
+    it('not ACTIVE → null', async () => {
+        prisma.household.findUnique.mockResolvedValue({ orgMembership: { id: 7, status: 'REVOKED' } });
+        const result = await membershipValidThrough(1, new Date());
+        expect(result).toBeNull();
+        expect(prisma.boardSettings.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('no boundary configured → null', async () => {
+        prisma.household.findUnique.mockResolvedValue({ orgMembership: { id: 7, status: 'ACTIVE' } });
+        prisma.boardSettings.findUnique.mockResolvedValue({ orgMembershipYearBoundary: null });
+        const result = await membershipValidThrough(1, new Date());
+        expect(result).toBeNull();
+    });
+});
+
+describe('isActiveOrgMemberThrough', () => {
+    it('not an active member → false, regardless of through', async () => {
+        prisma.person.findFirst.mockResolvedValue(null); // isActiveOrgMember: no match
+        const result = await isActiveOrgMemberThrough(1, new Date());
+        expect(result).toBe(false);
+    });
+
+    it('through === null → true (status-only, no program dates)', async () => {
+        prisma.person.findFirst.mockResolvedValue({ id: 1 }); // active member
+        const result = await isActiveOrgMemberThrough(1, null);
+        expect(result).toBe(true);
+    });
+
+    it('ACTIVE + no boundary configured → true (cannot compute a horizon)', async () => {
+        prisma.person.findFirst.mockResolvedValue({ id: 1 });
+        prisma.person.findUnique.mockResolvedValue({ householdId: 5 });
+        prisma.household.findUnique.mockResolvedValue({ orgMembership: { id: 7, status: 'ACTIVE' } });
+        prisma.boardSettings.findUnique.mockResolvedValue({ orgMembershipYearBoundary: null });
+
+        const result = await isActiveOrgMemberThrough(1, new Date(Date.UTC(2030, 0, 1)));
+        expect(result).toBe(true);
+    });
+
+    it('a through-date on the valid-through day → true', async () => {
+        prisma.person.findFirst.mockResolvedValue({ id: 1 });
+        prisma.person.findUnique.mockResolvedValue({ householdId: 5 });
+        prisma.household.findUnique.mockResolvedValue({ orgMembership: { id: 7, status: 'ACTIVE' } });
+        prisma.boardSettings.findUnique.mockResolvedValue({ orgMembershipYearBoundary: BOUNDARY });
+        prisma.orgMembershipProcess.findFirst.mockResolvedValue(null);
+
+        const boundary = nextBoundary(BOUNDARY, new Date());
+        const result = await isActiveOrgMemberThrough(1, boundary);
+        expect(result).toBe(true);
+    });
+
+    it('a through-date after the valid-through day → false', async () => {
+        prisma.person.findFirst.mockResolvedValue({ id: 1 });
+        prisma.person.findUnique.mockResolvedValue({ householdId: 5 });
+        prisma.household.findUnique.mockResolvedValue({ orgMembership: { id: 7, status: 'ACTIVE' } });
+        prisma.boardSettings.findUnique.mockResolvedValue({ orgMembershipYearBoundary: BOUNDARY });
+        prisma.orgMembershipProcess.findFirst.mockResolvedValue(null);
+
+        const boundary = nextBoundary(BOUNDARY, new Date());
+        const dayAfter = new Date(Date.UTC(boundary.getUTCFullYear(), boundary.getUTCMonth(), boundary.getUTCDate() + 1));
+        const result = await isActiveOrgMemberThrough(1, dayAfter);
+        expect(result).toBe(false);
+    });
+});
+
+describe('programCoverageDate', () => {
+    it('endAt wins when both are set', () => {
+        const startAt = new Date('2026-01-01');
+        const endAt = new Date('2026-06-01');
+        expect(programCoverageDate({ startAt, endAt })).toBe(endAt);
+    });
+
+    it('falls back to startAt when endAt is null', () => {
+        const startAt = new Date('2026-01-01');
+        expect(programCoverageDate({ startAt, endAt: null })).toBe(startAt);
+    });
+
+    it('both null → null', () => {
+        expect(programCoverageDate({ startAt: null, endAt: null })).toBeNull();
+    });
+});

--- a/checkin-app/src/lib/orgMembership.ts
+++ b/checkin-app/src/lib/orgMembership.ts
@@ -1,5 +1,6 @@
 import type { OrgMembershipStatus, Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
+import { nextBoundary, renewalSeasonWindow } from "@/lib/membership/renewal";
 
 /**
  * Canonical "is this person an active Treehouse Member?" read model.
@@ -60,4 +61,74 @@ export function orgMembershipStatusBlocksLogin(
     status: OrgMembershipStatus | null | undefined,
 ): boolean {
     return status === "DENIED";
+}
+
+/**
+ * How far a household's membership currently covers, as a boundary date — or
+ * null when no horizon can be computed (not ACTIVE, or the board hasn't set
+ * {@link BoardSettings.orgMembershipYearBoundary}). A membership always runs
+ * boundary-to-boundary: an un-renewed ACTIVE household is covered through the
+ * UPCOMING boundary; one already "settled for the coming year" (a terminal
+ * ACTIVE {@link OrgMembershipProcess} stamped inside this cycle's renewal
+ * window — the same probe households-ops uses for its `settledForComingYear`
+ * flag) is covered one boundary further.
+ */
+export async function membershipValidThrough(householdId: number, now = new Date()): Promise<Date | null> {
+    const household = await prisma.household.findUnique({
+        where: { id: householdId },
+        select: { orgMembership: { select: { id: true, status: true } } },
+    });
+    if (household?.orgMembership?.status !== "ACTIVE") return null;
+
+    const settings = await prisma.boardSettings.findUnique({
+        where: { id: 1 },
+        select: { orgMembershipYearBoundary: true },
+    });
+    if (!settings?.orgMembershipYearBoundary) return null;
+
+    const boundary = nextBoundary(settings.orgMembershipYearBoundary, now);
+    const window = await renewalSeasonWindow(now);
+    const settled = (await prisma.orgMembershipProcess.findFirst({
+        where: {
+            orgMembershipId: household.orgMembership.id,
+            status: "ACTIVE",
+            stageEnteredAt: { gte: window?.windowStart ?? new Date(8.64e15) },
+        },
+        select: { id: true },
+    })) !== null;
+
+    return settled
+        ? new Date(Date.UTC(boundary.getUTCFullYear() + 1, boundary.getUTCMonth(), boundary.getUTCDate()))
+        : boundary;
+}
+
+/**
+ * Does this Person's org membership cover a program running through `through`?
+ * `through === null` means the program has no dates to compare against, so
+ * today's status-only behavior applies. When a horizon CAN'T be computed (no
+ * boundary configured) an ACTIVE membership still passes — preserves current
+ * behavior rather than penalizing every member for a board settings gap.
+ */
+export async function isActiveOrgMemberThrough(personId: number, through: Date | null): Promise<boolean> {
+    if (!(await isActiveOrgMember(personId))) return false;
+    if (through === null) return true;
+
+    const person = await prisma.person.findUnique({ where: { id: personId }, select: { householdId: true } });
+    const validThrough = person ? await membershipValidThrough(person.householdId) : null;
+    if (validThrough === null) return true;
+
+    const throughDay = Date.UTC(through.getUTCFullYear(), through.getUTCMonth(), through.getUTCDate());
+    const validDay = Date.UTC(validThrough.getUTCFullYear(), validThrough.getUTCMonth(), validThrough.getUTCDate());
+    return validDay >= throughDay;
+}
+
+/**
+ * The date a program's member pricing must be valid through: its end date, or
+ * (an ongoing program with no end) its start date. Shared by the discount-code
+ * route and the program detail route so both apply the same coverage rule.
+ * POLICY (flag for veto): an ongoing program (endAt null) requires validity
+ * only through its START, not indefinitely.
+ */
+export function programCoverageDate(p: { startAt: Date | null; endAt: Date | null }): Date | null {
+    return p.endAt ?? p.startAt ?? null;
 }


### PR DESCRIPTION
Implements the pricing rule: **member pricing applies only when the buyer's membership covers the program's duration** — a current-year member who hasn't renewed doesn't get member pricing on a program running past the year boundary.

## One source of truth

`lib/orgMembership.ts` gains `membershipValidThrough(householdId)`: an ACTIVE membership is valid through the **upcoming year boundary**, +1 year when the household is **settled for the coming cycle** (the same terminal-ACTIVE-in-renewal-window test `runRenewalSweep` and the ops views use). `isActiveOrgMemberThrough(personId, date)` compares by UTC day. Fallbacks preserve today's behavior exactly: no boundary configured, or a program with no dates ⇒ status-only.

## Enforced on both pricing paths

- **Discount-code mint** (single-pool, server-authoritative): a member whose validity ends before the program's coverage date gets `{ code: null, reason: "membership_ends_before_program" }` — additive field, existing consumers unaffected.
- **Legacy two-variant choice** (was client-side off bare `status === "ACTIVE"`): the program detail API now returns server-computed `viewerIsMember` / `viewerMemberPricingEligible`, and the enroll page uses the server flag for variant selection (graceful fallback to the old derivation when absent).

## The security-registry note (reviewer attention here)

The detail route's stripper is a strict allowlist over classified schema fields with no channel for a synthetic scalar. Rather than touching the schema or the stripper, the registry handler runs **completely untouched** and a thin wrapper merges the two viewer fields afterward — **session callers only, 200 responses only**, computed solely from the caller's own session plus the already-stripped (public-tier) `startAt`/`endAt`. Non-200s and anonymous responses pass through byte-identical.

## UX

A member blocked purely by the horizon sees: *"Your membership ends before this program finishes, so member pricing doesn't apply — renew your membership first to enroll at the member price."* — the restriction doubles as the renewal nudge.

## Policy calls (veto here)

1. **Ongoing programs** (`endAt` null): validity required only through the **start** — a strict duration reading would deny member pricing to every un-renewed member for the whole year.
2. **No boundary configured**: status-only (no horizon computable), i.e. today's behavior.

## Testing

12 unit (validity math incl. settled +1y, day-edge, fallbacks) · 4 new discount-code integration (covers→code, lapsing→null+reason, settled→code, non-member unchanged) · 2 new detail-route integration (viewer fields present/absent) · 4 new RTL (notice shown exactly when member-but-ineligible; variant follows the server flag). Regression sweep: 494 unit/RTL + 186 integration green. `tsc --noEmit` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe