### PR TITLE
fix(finance-ops): name PENDING_HOLD_FAILED, split hold-failed rows into a Shopify reconciliation queue

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -59,6 +59,8 @@ const AUTHZ_TESTED = new Set<string>([
     'finance-ops/payment-plans',
     // POST deny-path (401 anon / 403 non-board) in programPaymentPlansAPI.integration.test.ts.
     'finance-ops/payment-plans/refuse',
+    // POST deny-path (401 anon / 403 non-board) in programPaymentPlansAPI.integration.test.ts.
+    'finance-ops/payment-plans/manual-hold',
     // POST deny-path (401 anon / 403 non-board) in membershipPaymentPlansAPI.integration.test.ts.
     'finance-ops/membership-payment-plans',
     'admin/settings/localization',

--- a/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPendingParticipants.integration.test.ts
@@ -54,7 +54,8 @@ describe('Cron Pending-Participants API Integration Tests', () => {
         await mkParticipant('day3');
         await mkParticipant('day6');
         await mkParticipant('day7');
-        await mkParticipant('plan'); // isPaymentPlanRequested -> never swept
+        await mkParticipant('plan'); // PENDING_HELD (req=true, seat held) -> never swept
+        await mkParticipant('holdFailed'); // PENDING_HOLD_FAILED (req=true, held=null) -> also never swept
         await mkParticipant('denied'); // denied applicant -> grace-expiry cron's job, never this sweep's
 
         await prisma.programParticipant.createMany({
@@ -63,7 +64,12 @@ describe('Cron Pending-Participants API Integration Tests', () => {
                 { programId, personId: ids.day3, status: 'PENDING', pendingSince: daysAgo(now, 3) },
                 { programId, personId: ids.day6, status: 'PENDING', pendingSince: daysAgo(now, 6) },
                 { programId, personId: ids.day7, status: 'PENDING', pendingSince: daysAgo(now, 7) },
-                { programId, personId: ids.plan, status: 'PENDING', pendingSince: daysAgo(now, 8), isPaymentPlanRequested: true },
+                // A genuine held request stamps inventoryHeldAt (that's what the apply-time -1 does).
+                { programId, personId: ids.plan, status: 'PENDING', pendingSince: daysAgo(now, 8), isPaymentPlanRequested: true, inventoryHeldAt: daysAgo(now, 8) },
+                // PENDING_HOLD_FAILED: the apply-time -1 failed, so req=true but no seat is held.
+                // isPaymentPlanRequested=true still excludes it from the sweep — it is the board's
+                // problem (Shopify reconciliation queue), NEVER the applicant's, so it must survive.
+                { programId, personId: ids.holdFailed, status: 'PENDING', pendingSince: daysAgo(now, 9), isPaymentPlanRequested: true, inventoryHeldAt: null },
                 // Denied 10 days after enrolling: pendingSince is way past the 7-day
                 // kick, but paymentPlanDeniedAt hands the timeline to scholarship-grace-expiry.
                 { programId, personId: ids.denied, status: 'PENDING', pendingSince: daysAgo(now, 10), isPaymentPlanRequested: false, paymentPlanDeniedAt: daysAgo(now, 0), inventoryHeldAt: daysAgo(now, 10) },
@@ -111,11 +117,12 @@ describe('Cron Pending-Participants API Integration Tests', () => {
             expect(data.warned).toBe(3);
             expect(data.kicked).toBe(1);
 
-            // DB reality: only day7 deleted; the warned rows, the payment-plan row,
-            // and the denied-applicant row (grace-expiry cron's responsibility) survive.
+            // DB reality: only day7 deleted; the warned rows, both payment-plan rows
+            // (held AND hold-failed), and the denied-applicant row (grace-expiry cron's
+            // responsibility) survive.
             const survivors = await prisma.programParticipant.findMany({ where: { programId } });
             const survivorPids = survivors.map(s => s.personId).sort((a, b) => a - b);
-            expect(survivorPids).toEqual([ids.day1, ids.day3, ids.day6, ids.plan, ids.denied].sort((a, b) => a - b));
+            expect(survivorPids).toEqual([ids.day1, ids.day3, ids.day6, ids.plan, ids.holdFailed, ids.denied].sort((a, b) => a - b));
 
             const day7 = await prisma.programParticipant.findUnique({
                 where: { programId_personId: { programId, personId: ids.day7 } }

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -112,7 +112,9 @@ describe('Nav todo-counts API', () => {
         program1Id = program1.id;
         program2Id = program2.id;
         await prisma.programParticipant.create({ data: { programId: program1Id, personId: leadId, status: 'PENDING' } });
-        await prisma.programParticipant.create({ data: { programId: program2Id, personId: secondMemberId, status: 'PENDING', isPaymentPlanRequested: true } });
+        // A genuine held scholarship request (held seat) — the paymentPlanPending badge
+        // counts only these, mirroring the scholarship-queue filter (held != null).
+        await prisma.programParticipant.create({ data: { programId: program2Id, personId: secondMemberId, status: 'PENDING', isPaymentPlanRequested: true, inventoryHeldAt: new Date() } });
 
         // The lead also *runs* a program (leadMentorId). Three events: one ended
         // and unconfirmed (the inbox item), one ended but already confirmed, one

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -13,6 +13,7 @@
  */
 import { GET as PlansGet, POST as PlansPost } from '@/app/api/finance-ops/payment-plans/route';
 import { POST as RefusePost } from '@/app/api/finance-ops/payment-plans/refuse/route';
+import { POST as ManualHoldPost } from '@/app/api/finance-ops/payment-plans/manual-hold/route';
 import { POST as RequestPost } from '@/app/api/programs/[id]/request-payment-plan/route';
 import { POST as ParticipantsPost, DELETE as ParticipantsDelete } from '@/app/api/programs/[id]/participants/route';
 import prisma from '@/lib/prisma';
@@ -110,11 +111,16 @@ describe('Program payment-plan routes', () => {
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
     });
 
-    async function enroll(participantId: number, opts: { requested: boolean }) {
+    // A genuine held request stamps inventoryHeldAt (that's what the apply-time -1
+    // does): by default `held` follows `requested`, so enroll({requested:true}) is a
+    // real PENDING_HELD row (scholarship queue). Pass held:false explicitly to seed a
+    // PENDING_HOLD_FAILED row (the failed-apply state — reconciliation queue).
+    async function enroll(participantId: number, opts: { requested: boolean; held?: boolean }) {
+        const held = (opts.held ?? opts.requested) ? new Date() : null;
         await prisma.programParticipant.upsert({
             where: { programId_personId: { programId, personId: participantId } },
-            update: { status: 'PENDING', isPaymentPlanRequested: opts.requested, pendingSince: new Date() },
-            create: { programId, personId: participantId, status: 'PENDING', isPaymentPlanRequested: opts.requested, pendingSince: new Date() },
+            update: { status: 'PENDING', isPaymentPlanRequested: opts.requested, pendingSince: new Date(), inventoryHeldAt: held, paymentPlanDeniedAt: null },
+            create: { programId, personId: participantId, status: 'PENDING', isPaymentPlanRequested: opts.requested, pendingSince: new Date(), inventoryHeldAt: held },
         });
     }
 
@@ -739,7 +745,7 @@ describe('Program payment-plan routes', () => {
             expect(delBody.enrollment).toBeUndefined();
         });
 
-        it('rolls the hold back when the Shopify -1 fails (no phantom hold)', async () => {
+        it('a failed Shopify -1 leaves a clean PENDING_HOLD_FAILED row and reassures the applicant', async () => {
             // Default env: shopifyMockActive() is false and no credentials are
             // configured, so adjustProgramInventory returns false without throwing.
             const p = await prisma.program.create({
@@ -759,17 +765,130 @@ describe('Program payment-plan routes', () => {
                     params(p.id),
                 );
                 expect(res.status).toBe(200);
-                expect((await res.json()).warning).toMatch(/rolled back/);
+                // No "re-submit to retry": the request stands, the board finalizes it.
+                const body = await res.json();
+                expect(body.warning).toMatch(/board/i);
+                expect(body.warning).not.toMatch(/re-submit|retry|rolled back/i);
 
+                // The exact PENDING_HOLD_FAILED tuple: PENDING, held=null, req=true, den=null.
                 const row = await prisma.programParticipant.findUniqueOrThrow({
                     where: { programId_personId: { programId: p.id, personId: selfId } },
                 });
+                expect(row.status).toBe('PENDING');
                 expect(row.inventoryHeldAt).toBeNull(); // no phantom hold
-                expect(row.isPaymentPlanRequested).toBe(true); // finance request still stands
+                expect(row.isPaymentPlanRequested).toBe(true); // request still stands
+                expect(row.paymentPlanDeniedAt).toBeNull();
             } finally {
                 await prisma.programParticipant.deleteMany({ where: { programId: p.id } });
                 await prisma.program.delete({ where: { id: p.id } });
             }
+        });
+    });
+
+    // The PENDING_HOLD_FAILED model: hold-failed rows (req=true, held=null) are a
+    // distinct state served by a SEPARATE board queue, resolved by manual-hold, and
+    // approvable/deniable only as a deliberate override.
+    describe('PENDING_HOLD_FAILED — two queues, manual-hold, override', () => {
+        const holdReq = (body: unknown) => new Request('http://localhost/api/finance-ops/payment-plans/manual-hold', {
+            method: 'POST',
+            headers: { cookie: 'session=test' },
+            body: JSON.stringify(body),
+        }) as unknown as import('next/server').NextRequest;
+
+        it('the two queues return DISJOINT sets: scholarship = held, reconciliation = hold-failed', async () => {
+            await enroll(selfId, { requested: true, held: true });    // PENDING_HELD → scholarship queue
+            await enroll(otherId, { requested: true, held: false });  // PENDING_HOLD_FAILED → reconciliation queue
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+            const scholarship = await (await PlansGet(nextReq())).json();
+            const holds = await (await PlansGet(nextReq('http://localhost/api/finance-ops/payment-plans?queue=holds'))).json();
+            const sIds = scholarship.ProgramParticipant.map((r: { personId: number }) => r.personId);
+            const hIds = holds.ProgramParticipant.map((r: { personId: number }) => r.personId);
+
+            expect(sIds).toContain(selfId);
+            expect(sIds).not.toContain(otherId);
+            expect(hIds).toContain(otherId);
+            expect(hIds).not.toContain(selfId);
+        });
+
+        it('manual-hold stamps inventoryHeldAt, moving PENDING_HOLD_FAILED → PENDING_HELD (no Shopify call)', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch');
+            try {
+                await enroll(selfId, { requested: true, held: false }); // PENDING_HOLD_FAILED
+                mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+                const res = await ManualHoldPost(holdReq({ programId, participantId: selfId }));
+                expect(res.status).toBe(200);
+                expect(fetchSpy).not.toHaveBeenCalled(); // human removed the seat by hand; route touches no Shopify
+
+                const row = await prisma.programParticipant.findUniqueOrThrow({
+                    where: { programId_personId: { programId, personId: selfId } },
+                });
+                expect(row.inventoryHeldAt).not.toBeNull(); // now PENDING_HELD
+                expect(row.isPaymentPlanRequested).toBe(true);
+                expect(row.status).toBe('PENDING');
+
+                // The row now appears in the scholarship queue and no longer in the reconciliation queue.
+                const scholarship = await (await PlansGet(nextReq())).json();
+                expect(scholarship.ProgramParticipant.map((r: { personId: number }) => r.personId)).toContain(selfId);
+
+                // Second manual-hold is a no-op 409 (already held).
+                const second = await ManualHoldPost(holdReq({ programId, participantId: selfId }));
+                expect(second.status).toBe(409);
+            } finally {
+                fetchSpy.mockRestore();
+            }
+        });
+
+        it('manual-hold 409s on a genuine held request (nothing to reconcile)', async () => {
+            await enroll(selfId, { requested: true, held: true }); // already PENDING_HELD
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            const res = await ManualHoldPost(holdReq({ programId, participantId: selfId }));
+            expect(res.status).toBe(409);
+        });
+
+        it('401 without a session calling manual-hold', async () => {
+            mockSession.mockResolvedValue(null);
+            const res = await ManualHoldPost(holdReq({ programId, participantId: selfId }));
+            expect(res.status).toBe(401);
+        });
+
+        it('403 for a non-board user calling manual-hold', async () => {
+            mockSession.mockResolvedValue({ user: { id: selfId } });
+            const res = await ManualHoldPost(holdReq({ programId, participantId: selfId }));
+            expect(res.status).toBe(403);
+        });
+
+        it('approve override works on a hold-failed row (phantom comp — the gated path)', async () => {
+            await enroll(selfId, { requested: true, held: false }); // PENDING_HOLD_FAILED
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            const res = await PlansPost(nextReq('http://localhost', {
+                method: 'POST',
+                body: JSON.stringify({ programId, participantId: selfId }),
+            }));
+            expect(res.status).toBe(200);
+            const row = await prisma.programParticipant.findUniqueOrThrow({
+                where: { programId_personId: { programId, personId: selfId } },
+            });
+            expect(row.status).toBe('ACTIVE');
+            expect(row.isPaymentPlanRequested).toBe(false);
+        });
+
+        it('deny override works on a hold-failed row', async () => {
+            await enroll(selfId, { requested: true, held: false }); // PENDING_HOLD_FAILED
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            const res = await RefusePost(new Request('http://localhost/api/finance-ops/payment-plans/refuse', {
+                method: 'POST',
+                headers: { cookie: 'session=test' },
+                body: JSON.stringify({ programId, participantId: selfId }),
+            }) as unknown as import('next/server').NextRequest);
+            expect(res.status).toBe(200);
+            const row = await prisma.programParticipant.findUniqueOrThrow({
+                where: { programId_personId: { programId, personId: selfId } },
+            });
+            expect(row.status).toBe('PENDING');
+            expect(row.isPaymentPlanRequested).toBe(false);
+            expect(row.paymentPlanDeniedAt).not.toBeNull();
         });
     });
 });

--- a/checkin-app/src/app/api/finance-ops/payment-plans/manual-hold/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/manual-hold/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+
+// Board manual-hold confirmation for a PENDING_HOLD_FAILED row (the apply-time
+// Shopify -1 failed, so { status: PENDING, inventoryHeldAt: null,
+// isPaymentPlanRequested: true, paymentPlanDeniedAt: null } — no seat is actually
+// out of Shopify's pool). The board member removes the seat in Shopify BY HAND,
+// then confirms here. This confirmation stamps inventoryHeldAt=<now>, moving the
+// row into the normal PENDING_HELD state so the ordinary approve/deny flow
+// resumes.
+//
+// IMPORTANT: this does NOT call Shopify. inventoryHeldAt means "a real seat is out
+// of Shopify's pool," so the stamp is only trustworthy because the human already
+// did the decrement manually — the UI copy makes that precondition explicit.
+//
+// No conflict-of-interest gate (unlike approve/refuse): confirming a manual hold
+// confers no benefit on the applicant — it only records a seat the board already
+// removed, and the value-conferring approve step keeps its own CoI check.
+export const POST = withAuth(
+    { roles: ['isSysadmin', 'isBoardMember'] },
+    async (req, auth) => {
+        try {
+            const body = await req.json();
+            const programId = parseInt(body.programId, 10);
+            const participantId = parseInt(body.participantId, 10);
+
+            if (Number.isNaN(programId) || Number.isNaN(participantId)) {
+                return apiError("programId and participantId are required", 400);
+            }
+
+            const data = { inventoryHeldAt: new Date() };
+
+            // Compare-and-set on the exact PENDING_HOLD_FAILED tuple: only a row
+            // that is still PENDING, still requested, and still unheld flips. A
+            // concurrent approve/deny/manual-hold that already moved it 409s
+            // instead of double-stamping.
+            const { count } = await prisma.programParticipant.updateMany({
+                where: { programId, personId: participantId, status: 'PENDING', inventoryHeldAt: null, isPaymentPlanRequested: true },
+                data,
+            });
+
+            if (count === 0) {
+                return apiError("No hold-failed request to reconcile", 409);
+            }
+
+            if (auth.type === 'session') {
+                await prisma.auditLog.create({
+                    data: {
+                        actorId: auth.user.id,
+                        action: "EDIT",
+                        tableName: "ProgramParticipant",
+                        affectedEntityId: participantId,
+                        secondaryAffectedEntity: programId,
+                        newData: data,
+                    },
+                });
+            }
+
+            return NextResponse.json({ success: true });
+        } catch (error) {
+            logger.error("Failed to confirm manual hold:", error);
+            return apiError("Failed to confirm manual hold", 500);
+        }
+    }
+);

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -7,12 +7,27 @@ import { apiError } from "@/lib/api-response";
 import { isActiveOrgMember, ACTIVE_ORG_MEMBER_INCLUDE } from "@/lib/orgMembership";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 
-export const GET = handler('GET /api/finance-ops/payment-plans', async () => {
+// Two DISJOINT board queues over PENDING + isPaymentPlanRequested rows, split on
+// whether a Shopify seat is actually held (inventoryHeldAt):
+//   default            → the scholarship queue: genuine held-and-awaiting requests
+//                        (inventoryHeldAt set, paymentPlanDeniedAt null). Approve/deny act here.
+//   ?queue=holds       → the Shopify reconciliation queue: PENDING_HOLD_FAILED rows
+//                        (inventoryHeldAt null) — the apply-time -1 failed, so no seat
+//                        was ever removed. The board resolves these via manual-hold.
+// One endpoint (one security-boundary entry, one stripper policy) returning two
+// non-overlapping sets — NOT one list with both mixed in.
+export const GET = handler('GET /api/finance-ops/payment-plans', async ({ req }) => {
+    const holdsQueue = new URL(req.url).searchParams.get('queue') === 'holds';
     const [requests, boardSettings] = await Promise.all([
         prisma.programParticipant.findMany({
             where: {
                 isPaymentPlanRequested: true,
-                status: 'PENDING'
+                status: 'PENDING',
+                // held=null is PENDING_HOLD_FAILED (reconciliation queue); held!=null +
+                // den=null is a genuine pending request (scholarship queue).
+                ...(holdsQueue
+                    ? { inventoryHeldAt: null }
+                    : { inventoryHeldAt: { not: null }, paymentPlanDeniedAt: null }),
             },
             include: {
                 // Nests household->orgMembership (same shape as ACTIVE_ORG_MEMBER_INCLUDE)

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -372,8 +372,13 @@ export const GET = withAuth({}, async (_req, auth) => {
             prisma.orgMembershipProcess.count({
                 where: { status: { not: "ACTIVE" } },
             }),
+            // Scholarship-queue count: mirror GET /api/finance-ops/payment-plans'
+            // default filter exactly so the nav badge can't over-count. Excludes
+            // PENDING_HOLD_FAILED rows (inventoryHeldAt null) — those live in the
+            // Shopify reconciliation queue, and the board is already emailed when a
+            // hold fails, so they don't need a green "approval pending" pill.
             prisma.programParticipant.count({
-                where: { status: "PENDING", isPaymentPlanRequested: true },
+                where: { status: "PENDING", isPaymentPlanRequested: true, inventoryHeldAt: { not: null }, paymentPlanDeniedAt: null },
             }),
             // Households awaiting board approval of a membership-dues payment plan.
             prisma.orgMembershipProcess.count({

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -104,15 +104,23 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             if (!ok) {
                 // The seat was never taken out of Shopify — leaving inventoryHeldAt
                 // set would be a phantom hold whose later release (+1) credits a
-                // seat that was never removed (oversell). Roll the stamp back so
-                // the ledger stays true; a re-submit retries the -1 via the
-                // inventoryHeldAt:null branch above. (adjustProgramInventory has
-                // already emailed sysadmins/board via reportShopifyFailure.)
+                // seat that was never removed (oversell). Roll the stamp back to
+                // null. The row now sits at PENDING_HOLD_FAILED { status: PENDING,
+                // inventoryHeldAt: null, isPaymentPlanRequested: true,
+                // paymentPlanDeniedAt: null } — a legitimate state, NOT a bug: the
+                // applicant's request STANDS and it is the board's job to finish
+                // placing the hold (Shopify Hold Reconciliation queue → Confirm
+                // manual hold). isPaymentPlanRequested stays true, so the 7-day
+                // non-payment sweep (which filters isPaymentPlanRequested:false)
+                // never auto-kicks it. adjustProgramInventory has already emailed
+                // sysadmins/board via reportShopifyFailure.
                 await prisma.programParticipant.updateMany({
                     where: { programId, personId: participantId, inventoryHeldAt: { not: null } },
                     data: { inventoryHeldAt: null },
                 });
-                warning = "Payment plan requested and finance notified, but the Shopify seat hold failed and was rolled back. Re-submit to retry, or check System Status > Link Status.";
+                // Applicant-facing: never tell them to retry — the request is
+                // recorded and the board finalizes it. Nothing is required of them.
+                warning = "Your scholarship / payment-plan request has been recorded and the board notified. A seat-reservation step needs a board member to finish it — nothing more is required from you.";
             }
         }
 

--- a/checkin-app/src/app/finance-ops/shopify-holds/page.tsx
+++ b/checkin-app/src/app/finance-ops/shopify-holds/page.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+import { Alert, Button, Group, Modal, Stack, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { AlertBanner } from '@/components/admin/AlertBanner';
+import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
+import { useRequireRole } from '@/hooks/useRequireRole';
+import { formatDateTime } from '@/lib/time';
+import { notifyNavRefresh } from '@/lib/nav-refresh';
+import { sharesHousehold } from '@/lib/conflictOfInterest';
+import { PageLoader } from "@/components/ui/PageLoader";
+
+// The Shopify reconciliation queue: PENDING_HOLD_FAILED rows only (the apply-time
+// Shopify -1 failed, so isPaymentPlanRequested=true but no seat was ever removed —
+// inventoryHeldAt is null). Disjoint from the scholarship queue by construction
+// (same endpoint, ?queue=holds). The safe resolution is "Confirm manual hold":
+// the board member removes the seat in Shopify BY HAND, then confirms here, which
+// records the hold and hands the row back to the normal approve/deny flow.
+type HoldFailedRow = {
+  programId: number;
+  personId: number;
+  pendingSince: string;
+  person: { id: number; name: string | null; email: string; householdId: number | null };
+  program: { id: number; name: string };
+};
+
+type Target = { programId: number; participantId: number } | null;
+
+export default function ShopifyHoldsPage() {
+  const { user: me, ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
+  // Conflict of interest mirrors the scholarship queue: a board member may not
+  // approve/deny their OWN household's request (server enforces; this is UX). It
+  // does NOT gate the manual-hold action — that confers no benefit.
+  const ownHousehold = (row: HoldFailedRow) =>
+    me?.isSysadmin !== true && sharesHousehold(me?.householdId, row.person.householdId);
+
+  const [rows, setRows] = useState<HoldFailedRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState("");
+
+  const [holdOpened, { open: openHold, close: closeHold }] = useDisclosure(false);
+  const [approveOpened, { open: openApprove, close: closeApprove }] = useDisclosure(false);
+  const [denyOpened, { open: openDeny, close: closeDeny }] = useDisclosure(false);
+  const [target, setTarget] = useState<Target>(null);
+
+  const fetchRows = useCallback(async () => {
+    try {
+      const res = await fetch('/api/finance-ops/payment-plans?queue=holds');
+      if (res.ok) {
+        const data = await res.json();
+        setRows(data.ProgramParticipant ?? []);
+      } else {
+        setMessage("Failed to load the reconciliation queue. You may not have access.");
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error loading the reconciliation queue.", autoClose: false });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (ready) fetchRows();
+  }, [ready, fetchRows]);
+
+  const drop = (programId: number, participantId: number) =>
+    setRows(prev => prev.filter(r => !(r.programId === programId && r.personId === participantId)));
+
+  // One POST helper for all three actions — each moves the row OUT of this queue
+  // (manual-hold → scholarship queue; approve → ACTIVE; deny → denied), so all
+  // three drop it from the list on success.
+  const post = async (url: string, successMsg: string) => {
+    if (!target) return;
+    const { programId, participantId } = target;
+    setTarget(null);
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ programId, participantId }),
+      });
+      if (res.ok) {
+        drop(programId, participantId);
+        notifyNavRefresh();
+        notifications.show({ color: 'green', message: successMsg });
+      } else {
+        const data = await res.json();
+        notifications.show({ color: 'red', message: data.error || "Action failed.", autoClose: 4000 });
+        fetchRows();
+      }
+    } catch {
+      notifications.show({ color: 'red', message: "Network error.", autoClose: false });
+    }
+  };
+
+  const openFor = (row: HoldFailedRow, which: 'hold' | 'approve' | 'deny') => {
+    setTarget({ programId: row.programId, participantId: row.personId });
+    ({ hold: openHold, approve: openApprove, deny: openDeny })[which]();
+  };
+
+  if (authLoading || loading) return <PageLoader />;
+  if (!ready) return null;
+
+  const columns: DataTableColumn<HoldFailedRow>[] = [
+    {
+      header: 'Participant',
+      sortBy: (r) => r.person.name?.toLowerCase() ?? r.person.email.toLowerCase(),
+      render: (r) => (
+        <>
+          <Text fw={500}>{r.person.name}</Text>
+          <Text size="sm" c="dimmed">{r.person.email}</Text>
+        </>
+      ),
+    },
+    {
+      header: 'Program',
+      sortBy: (r) => r.program.name.toLowerCase(),
+      render: (r) => <Text fw={500}>{r.program.name}</Text>,
+    },
+    {
+      header: 'Requested On',
+      sortBy: (r) => r.pendingSince,
+      render: (r) => <Text size="sm" c="dimmed">{formatDateTime(r.pendingSince)}</Text>,
+    },
+    {
+      header: 'Actions',
+      align: 'right',
+      render: (r) => (
+        <Group justify="flex-end" gap="xs" wrap="nowrap">
+          <Button
+            size="xs" fz={15} color="red" variant="subtle"
+            disabled={ownHousehold(r)}
+            title={ownHousehold(r) ? "You can't deny your own household's plan — a sysadmin must." : undefined}
+            onClick={() => openFor(r, 'deny')}
+          >
+            Deny (override)
+          </Button>
+          <Button
+            size="xs" fz={15} color="red" variant="subtle"
+            disabled={ownHousehold(r)}
+            title={ownHousehold(r) ? "You can't approve your own household's plan — a sysadmin must." : undefined}
+            onClick={() => openFor(r, 'approve')}
+          >
+            Approve (override)
+          </Button>
+          <Button size="xs" fz={15} color="blue" onClick={() => openFor(r, 'hold')}>
+            Confirm manual hold
+          </Button>
+        </Group>
+      ),
+    },
+  ];
+
+  return (
+    <Stack>
+      <Text c="dimmed">
+        These scholarship / payment-plan requests were recorded, but the automatic Shopify
+        seat reservation failed — <strong>no seat has been removed from Shopify yet</strong>.
+        The applicant has done everything required; it is the board&apos;s job to finish placing
+        the hold. Remove the seat in Shopify by hand, then use <strong>Confirm manual hold</strong>.
+      </Text>
+
+      <AlertBanner message={message} tone="error" />
+
+      <DataTable
+        columns={columns}
+        rows={rows}
+        getRowKey={(r) => `${r.programId}-${r.personId}`}
+        emptyMessage="No failed seat holds to reconcile."
+      />
+
+      {/* Confirm manual hold — the safe path. */}
+      <Modal
+        opened={holdOpened}
+        onClose={closeHold}
+        title={<Text span fw={700} fz="lg">Confirm manual seat hold</Text>}
+        centered
+      >
+        <Text mb="md">
+          Only confirm this <strong>after</strong> you have removed one seat for this program in the
+          Shopify admin by hand. This records that the seat is held; it does <strong>not</strong> change
+          Shopify itself.
+        </Text>
+        <Text mb="lg" size="sm" c="dimmed">
+          Once confirmed, the request moves to the Program Payment Plan queue for the normal approve or deny.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeHold}>Cancel</Button>
+          <Button color="blue" onClick={() => { closeHold(); post('/api/finance-ops/payment-plans/manual-hold', 'Manual hold recorded — request moved to the payment-plan queue.'); }}>
+            I&apos;ve removed the seat — confirm
+          </Button>
+        </Group>
+      </Modal>
+
+      {/* Approve override — dangerous: no seat is held, so approving comps a phantom seat. */}
+      <Modal
+        opened={approveOpened}
+        onClose={closeApprove}
+        title={<Text span fw={700} fz="lg" c="red">Approve without a held seat?</Text>}
+        centered
+      >
+        <Alert color="red" mb="md">
+          No Shopify seat is held for this request. Approving now comps a seat that was never
+          taken out of Shopify — the program can then oversell.
+        </Alert>
+        <Text mb="lg">
+          The correct fix is <strong>Confirm manual hold</strong> on this Shopify Hold Reconciliation
+          queue first (remove the seat in Shopify, then record it), which returns the request to the
+          normal approval flow. Override only if you deliberately intend to comp this seat.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeApprove}>Go back</Button>
+          <Button color="red" onClick={() => { closeApprove(); post('/api/finance-ops/payment-plans', 'Approved (override) — no seat was held.'); }}>
+            Override &amp; approve anyway
+          </Button>
+        </Group>
+      </Modal>
+
+      {/* Deny override — same red gate; denial without a held seat is also deliberate. */}
+      <Modal
+        opened={denyOpened}
+        onClose={closeDeny}
+        title={<Text span fw={700} fz="lg" c="red">Deny without a held seat?</Text>}
+        centered
+      >
+        <Alert color="red" mb="md">
+          No Shopify seat is held for this request. This row is here because the seat reservation
+          failed, not because the applicant did anything wrong.
+        </Alert>
+        <Text mb="lg">
+          Prefer <strong>Confirm manual hold</strong> on this Shopify Hold Reconciliation queue so the
+          request can be judged on the normal payment-plan queue. Override only if you intend to deny
+          the request outright.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeDeny}>Go back</Button>
+          <Button color="red" onClick={() => { closeDeny(); post('/api/finance-ops/payment-plans/refuse', 'Denied (override).'); }}>
+            Override &amp; deny anyway
+          </Button>
+        </Group>
+      </Modal>
+    </Stack>
+  );
+}

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -122,6 +122,7 @@ export const PAGES: PageEntry[] = [
   { href: '/finance-ops', label: 'Finance Ops', section: 'Finance Ops', visible: BOARD },
   { href: '/finance-ops/payment-plan', label: 'Program Payment Plan', section: 'Finance Ops', visible: BOARD },
   { href: '/finance-ops/membership-payment-plan', label: 'Membership Payment Plan', section: 'Finance Ops', visible: BOARD },
+  { href: '/finance-ops/shopify-holds', label: 'Shopify Hold Reconciliation', section: 'Finance Ops', keywords: 'seat hold failed inventory scholarship manual reconcile shopify', visible: BOARD },
   { href: '/finance-ops/payments', label: 'Payment problems', section: 'Finance Ops', keywords: 'reconcile exception refund chargeback unmatched shopify', visible: BOARD },
 
   // System Status — board

--- a/checkin-app/src/lib/financeNav.ts
+++ b/checkin-app/src/lib/financeNav.ts
@@ -7,5 +7,6 @@ import type { NavLink } from "@/lib/nav/types";
 export const FINANCE_NAV_LINKS: NavLink[] = [
   { name: "Program Payment Plan", href: "/finance-ops/payment-plan", icon: "⏳" },
   { name: "Membership Payment Plan", href: "/finance-ops/membership-payment-plan", icon: "⏳" },
+  { name: "Shopify Hold Reconciliation", href: "/finance-ops/shopify-holds", icon: "🪑" },
   { name: "Payment problems", href: "/finance-ops/payments", icon: "⚠️" },
 ];


### PR DESCRIPTION
## The bug (prod today)

When a scholarship / payment-plan request's apply-time Shopify `-1` fails, `request-payment-plan` rolls `inventoryHeldAt` back to null but leaves `isPaymentPlanRequested=true`. That row — `{ status: PENDING, inventoryHeldAt: null, isPaymentPlanRequested: true, paymentPlanDeniedAt: null }` — was unnamed and mishandled:

- It showed up in the finance-ops **scholarship approval queue** mixed with genuine held requests.
- Approving it **comped a phantom seat** (approve requires no held seat).
- The applicant was told to **"re-submit to retry"** a failure that is the system's/board's problem, never theirs.

## The model

Name this state **`PENDING_HOLD_FAILED`**. The request STANDS; it is the board's job to finish placing the hold, and it must never be auto-kicked by the 7-day non-payment sweep. No new DB column — the tuple already uniquely identifies the state (only reachable via a failed apply-time `-1`).

## What changed

- **request-payment-plan** — on `-1` failure keep the row at `req=true, held=null` (the legit state), drop the "re-submit to retry" copy; applicant told the board finalizes it.
- **GET `/finance-ops/payment-plans`** — two **disjoint** queues over one endpoint: default = scholarship (`held!=null, den=null`); `?queue=holds` = Shopify reconciliation (`held=null`).
- **POST `/finance-ops/payment-plans/manual-hold`** (new) — after the board removes the seat in Shopify by hand, this confirmation stamps `inventoryHeldAt` (CAS on the hold-failed tuple) → moves the row to `PENDING_HELD` for the normal approve/deny flow. Does **not** call Shopify.
- **Reconciliation UI** `/finance-ops/shopify-holds` (new) — manual-hold is primary; approve/deny remain possible on a no-held-seat row but behind a **red-button confirm** that steers the board to place the hold first.
- **todo-counts** — the `paymentPlanPending` badge now mirrors the tightened scholarship filter so it can't over-count hold-failed rows.
- Nav tab + page-registry + authz-drift entries.

The 7-day non-payment cron already filters `isPaymentPlanRequested:false`, so a hold-failed row (req=true) is never swept — left as is.

## Reviewer notes

- **Two queues = one endpoint + `?queue=holds`**, not a second security-registry route. Rows are disjoint (tested). Deliberately avoids a new `security/registry.ts` boundary entry (CODEOWNERS + `security-boundary-isolation.yml` "own PR" rule).
- **Override lives on the reconciliation page.** Hold-failed rows are filtered out of the scholarship queue, so the gated approve/deny override is on the reconciliation page; the red confirm steers to **Confirm manual hold** (the safe path on that same queue) rather than a self-link.
- **Access**: board members + sysadmins (same `['isSysadmin','isBoardMember']` gate as every finance-ops tool, at all four layers — layout, page, list route, manual-hold route).
- **Design spec**: the `PROGRAM_ENROLLMENT_STATE_MACHINE.md` §2–§5 updates (new `PENDING_HOLD_FAILED` state, T3f/T3m edges) landed on the in-flight enrollment-state doc branch (`claude/jolly-euler-b9d31f`) where that doc actually lives — **not** in this PR. This PR is code + tests only. No `enrollmentState.ts` module here (that's the Phase 2a follow-up).

## Tests

Reconciled existing tests to the model (a genuine held request stamps `inventoryHeldAt`; hold-failed rows belong to the reconciliation queue) and added coverage: clean `PENDING_HOLD_FAILED` + new applicant message on `-1` failure, manual-hold moving it to held, the two queues returning disjoint sets, approve/deny override, manual-hold auth (401/403). Ran the affected integration + unit suites against a real Postgres — all green (89 tests across payment-plans, cron, todo-counts, registry guards, finance layout). tsc + eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)