### PR TITLE
feat(lifecycle): phase-1 declarative lifecycle definition primitives

### DIFF
--- a/checkin-app/src/lib/lifecycle/__tests__/lifecycle.test.ts
+++ b/checkin-app/src/lib/lifecycle/__tests__/lifecycle.test.ts
@@ -26,15 +26,25 @@ type OrderStateName = 'draft' | 'awaiting_activation' | 'active' | 'cancelled';
 type FakeWhere = {
     status?: OrderStatus | { in: readonly OrderStatus[] };
     paidAt?: null | { not: null };
+    rush?: boolean; // genuine boolean column (Boolean @default(false)) → value-equality
 };
 
 // Row shape the client-safe predicate sees: presence as a boolean, not Date|null.
-type OrderRow = { status: OrderStatus; paidAt: boolean };
+type OrderRow = { status: OrderStatus; paidAt: boolean; rush: boolean };
 
 const activeSet = defineStateSet<FakeWhere>()({ statuses: ['ACTIVE'] as const });
 const paidPendingSet = defineStateSet<FakeWhere>()({
     statuses: ['PAID'] as const,
     flags: { paidAt: true },
+});
+// A boolean-column set (like enrollment's isPaymentPlanRequested): equals, not presence.
+const rushSet = defineStateSet<FakeWhere>()({
+    statuses: ['PAID'] as const,
+    equals: { rush: true },
+});
+const nonRushSet = defineStateSet<FakeWhere>()({
+    statuses: ['PAID'] as const,
+    equals: { rush: false },
 });
 
 function classify(row: OrderRow): OrderStateName | null {
@@ -72,18 +82,30 @@ const ALL_STATES: OrderStatus[] = ['DRAFT', 'PAID', 'ACTIVE', 'CANCELLED', 'ORPH
 // ---- StateSet: has/where derive from one spec -------------------------------
 
 describe('defineStateSet', () => {
-    test('has() agrees with the spec across a status × flags matrix', () => {
+    test('has() agrees with the spec across a status × flags × equals matrix', () => {
         for (const status of ALL_STATES) {
             for (const paidAt of [true, false]) {
-                const row: OrderRow = { status, paidAt };
-                expect(paidPendingSet.has(row)).toBe(status === 'PAID' && paidAt);
-                expect(activeSet.has(row)).toBe(status === 'ACTIVE');
+                for (const rush of [true, false]) {
+                    const row: OrderRow = { status, paidAt, rush };
+                    expect(paidPendingSet.has(row)).toBe(status === 'PAID' && paidAt);
+                    expect(activeSet.has(row)).toBe(status === 'ACTIVE');
+                    // equals matches the boolean VALUE, independent of presence.
+                    expect(rushSet.has(row)).toBe(status === 'PAID' && rush === true);
+                    expect(nonRushSet.has(row)).toBe(status === 'PAID' && rush === false);
+                }
             }
         }
     });
 
     test('where mirrors has for the flagged set', () => {
         expect(paidPendingSet.where).toEqual({ status: { in: ['PAID'] }, paidAt: { not: null } });
+    });
+
+    test('equals emits value-equality where, not presence', () => {
+        // A boolean column: where is { rush: true/false } — NOT { not: null },
+        // which would match both true and false and diverge from has.
+        expect(rushSet.where).toEqual({ status: { in: ['PAID'] }, rush: true });
+        expect(nonRushSet.where).toEqual({ status: { in: ['PAID'] }, rush: false });
     });
 
     test('where for a flagless set is status-only', () => {
@@ -100,6 +122,18 @@ describe('defineStateSet', () => {
         expect(unpaidDraft.where).toEqual({ status: { in: ['DRAFT'] }, paidAt: null });
     });
 
+    test('flags and equals combine in one set', () => {
+        const both = defineStateSet<FakeWhere>()({
+            statuses: ['PAID'] as const,
+            flags: { paidAt: true },
+            equals: { rush: false },
+        });
+        expect(both.has({ status: 'PAID', paidAt: true, rush: false })).toBe(true);
+        expect(both.has({ status: 'PAID', paidAt: true, rush: true })).toBe(false);
+        expect(both.has({ status: 'PAID', paidAt: false, rush: false })).toBe(false);
+        expect(both.where).toEqual({ status: { in: ['PAID'] }, paidAt: { not: null }, rush: false });
+    });
+
     test('statuses are exposed', () => {
         expect(paidPendingSet.statuses).toEqual(['PAID']);
     });
@@ -109,15 +143,15 @@ describe('defineStateSet', () => {
 
 describe('classify (exhaustive switch)', () => {
     test('maps on-diagram rows to their state', () => {
-        expect(classify({ status: 'DRAFT', paidAt: false })).toBe('draft');
-        expect(classify({ status: 'PAID', paidAt: true })).toBe('awaiting_activation');
-        expect(classify({ status: 'ACTIVE', paidAt: true })).toBe('active');
-        expect(classify({ status: 'CANCELLED', paidAt: false })).toBe('cancelled');
+        expect(classify({ status: 'DRAFT', paidAt: false, rush: false })).toBe('draft');
+        expect(classify({ status: 'PAID', paidAt: true, rush: false })).toBe('awaiting_activation');
+        expect(classify({ status: 'ACTIVE', paidAt: true, rush: false })).toBe('active');
+        expect(classify({ status: 'CANCELLED', paidAt: false, rush: false })).toBe('cancelled');
     });
 
     test('returns null for off-diagram combinations', () => {
-        expect(classify({ status: 'PAID', paidAt: false })).toBeNull();
-        expect(classify({ status: 'ORPHAN', paidAt: false })).toBeNull();
+        expect(classify({ status: 'PAID', paidAt: false, rush: false })).toBeNull();
+        expect(classify({ status: 'ORPHAN', paidAt: false, rush: false })).toBeNull();
     });
 });
 
@@ -129,13 +163,13 @@ describe('assertNever', () => {
 
 describe('validate', () => {
     test('returns null when every invariant holds', () => {
-        expect(validate({ status: 'PAID', paidAt: true })).toBeNull();
-        expect(validate({ status: 'ACTIVE', paidAt: true })).toBeNull();
+        expect(validate({ status: 'PAID', paidAt: true, rush: false })).toBeNull();
+        expect(validate({ status: 'ACTIVE', paidAt: true, rush: false })).toBeNull();
     });
 
     test('returns the first violated invariant, in list order', () => {
-        expect(validate({ status: 'PAID', paidAt: false })).toEqual({ invariant: 'paid-has-timestamp' });
-        expect(validate({ status: 'CANCELLED', paidAt: true })).toEqual({ invariant: 'cancelled-is-unpaid' });
+        expect(validate({ status: 'PAID', paidAt: false, rush: false })).toEqual({ invariant: 'paid-has-timestamp' });
+        expect(validate({ status: 'CANCELLED', paidAt: true, rush: false })).toEqual({ invariant: 'cancelled-is-unpaid' });
     });
 });
 

--- a/checkin-app/src/lib/lifecycle/__tests__/lifecycle.test.ts
+++ b/checkin-app/src/lib/lifecycle/__tests__/lifecycle.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for lib/lifecycle primitives, driven by a tiny in-test fixture
+ * machine (a fake "Order" entity). Pure — no DB, no Prisma value import.
+ */
+import {
+    defineStateSet,
+    assertNever,
+    defineValidator,
+    isLegalTransition,
+    reachability,
+    bfsStates,
+    reachableStatesViolating,
+    assertEnumParity,
+    type Transition,
+    type Invariant,
+    type Equal,
+    type Expect,
+} from '..';
+
+// ---- Fixture machine -------------------------------------------------------
+
+type OrderStatus = 'DRAFT' | 'PAID' | 'ACTIVE' | 'CANCELLED' | 'ORPHAN';
+type OrderStateName = 'draft' | 'awaiting_activation' | 'active' | 'cancelled';
+
+// Stand-in for a Prisma `WhereInput` — a plain shape, no Prisma import.
+type FakeWhere = {
+    status?: OrderStatus | { in: readonly OrderStatus[] };
+    paidAt?: null | { not: null };
+};
+
+// Row shape the client-safe predicate sees: presence as a boolean, not Date|null.
+type OrderRow = { status: OrderStatus; paidAt: boolean };
+
+const activeSet = defineStateSet<FakeWhere>()({ statuses: ['ACTIVE'] as const });
+const paidPendingSet = defineStateSet<FakeWhere>()({
+    statuses: ['PAID'] as const,
+    flags: { paidAt: true },
+});
+
+function classify(row: OrderRow): OrderStateName | null {
+    switch (row.status) {
+        case 'DRAFT':
+            return 'draft';
+        case 'PAID':
+            // PAID with no payment timestamp is an off-diagram combination.
+            return row.paidAt ? 'awaiting_activation' : null;
+        case 'ACTIVE':
+            return 'active';
+        case 'CANCELLED':
+            return 'cancelled';
+        case 'ORPHAN':
+            return null;
+        default:
+            return assertNever(row.status);
+    }
+}
+
+const invariants: Invariant<OrderRow>[] = [
+    { name: 'paid-has-timestamp', holds: (r) => r.status !== 'PAID' || r.paidAt },
+    { name: 'cancelled-is-unpaid', holds: (r) => r.status !== 'CANCELLED' || !r.paidAt },
+];
+const validate = defineValidator(invariants);
+
+const transitions: Transition<OrderStatus>[] = [
+    { from: 'DRAFT', to: 'PAID', event: 'pay', actor: 'member', guardSite: 'route' },
+    { from: 'DRAFT', to: 'CANCELLED', event: 'cancel', actor: 'member', guardSite: 'route' },
+    { from: 'PAID', to: 'ACTIVE', event: 'activate', actor: 'system', guardSite: 'updateMany', kind: 'INITIAL' },
+    { from: 'PAID', to: 'CANCELLED', event: 'cancel', actor: 'member', guardSite: 'route' },
+];
+const ALL_STATES: OrderStatus[] = ['DRAFT', 'PAID', 'ACTIVE', 'CANCELLED', 'ORPHAN'];
+
+// ---- StateSet: has/where derive from one spec -------------------------------
+
+describe('defineStateSet', () => {
+    test('has() agrees with the spec across a status × flags matrix', () => {
+        for (const status of ALL_STATES) {
+            for (const paidAt of [true, false]) {
+                const row: OrderRow = { status, paidAt };
+                expect(paidPendingSet.has(row)).toBe(status === 'PAID' && paidAt);
+                expect(activeSet.has(row)).toBe(status === 'ACTIVE');
+            }
+        }
+    });
+
+    test('where mirrors has for the flagged set', () => {
+        expect(paidPendingSet.where).toEqual({ status: { in: ['PAID'] }, paidAt: { not: null } });
+    });
+
+    test('where for a flagless set is status-only', () => {
+        expect(activeSet.where).toEqual({ status: { in: ['ACTIVE'] } });
+    });
+
+    test('a false flag requires absence in both has and where', () => {
+        const unpaidDraft = defineStateSet<FakeWhere>()({
+            statuses: ['DRAFT'] as const,
+            flags: { paidAt: false },
+        });
+        expect(unpaidDraft.has({ status: 'DRAFT', paidAt: false })).toBe(true);
+        expect(unpaidDraft.has({ status: 'DRAFT', paidAt: true })).toBe(false);
+        expect(unpaidDraft.where).toEqual({ status: { in: ['DRAFT'] }, paidAt: null });
+    });
+
+    test('statuses are exposed', () => {
+        expect(paidPendingSet.statuses).toEqual(['PAID']);
+    });
+});
+
+// ---- classify / validate ----------------------------------------------------
+
+describe('classify (exhaustive switch)', () => {
+    test('maps on-diagram rows to their state', () => {
+        expect(classify({ status: 'DRAFT', paidAt: false })).toBe('draft');
+        expect(classify({ status: 'PAID', paidAt: true })).toBe('awaiting_activation');
+        expect(classify({ status: 'ACTIVE', paidAt: true })).toBe('active');
+        expect(classify({ status: 'CANCELLED', paidAt: false })).toBe('cancelled');
+    });
+
+    test('returns null for off-diagram combinations', () => {
+        expect(classify({ status: 'PAID', paidAt: false })).toBeNull();
+        expect(classify({ status: 'ORPHAN', paidAt: false })).toBeNull();
+    });
+});
+
+describe('assertNever', () => {
+    test('throws when reached at runtime', () => {
+        expect(() => assertNever('surprise' as never)).toThrow(/unhandled status/);
+    });
+});
+
+describe('validate', () => {
+    test('returns null when every invariant holds', () => {
+        expect(validate({ status: 'PAID', paidAt: true })).toBeNull();
+        expect(validate({ status: 'ACTIVE', paidAt: true })).toBeNull();
+    });
+
+    test('returns the first violated invariant, in list order', () => {
+        expect(validate({ status: 'PAID', paidAt: false })).toEqual({ invariant: 'paid-has-timestamp' });
+        expect(validate({ status: 'CANCELLED', paidAt: true })).toEqual({ invariant: 'cancelled-is-unpaid' });
+    });
+});
+
+// ---- transitions ------------------------------------------------------------
+
+describe('isLegalTransition', () => {
+    test('accepts declared edges, rejects undeclared', () => {
+        expect(isLegalTransition(transitions, 'DRAFT', 'PAID')).toBe(true);
+        expect(isLegalTransition(transitions, 'DRAFT', 'ACTIVE')).toBe(false);
+    });
+
+    test('filters by kind when given', () => {
+        expect(isLegalTransition(transitions, 'PAID', 'ACTIVE', 'INITIAL')).toBe(true);
+        expect(isLegalTransition(transitions, 'PAID', 'ACTIVE', 'RENEWAL')).toBe(false);
+    });
+});
+
+describe('reachability', () => {
+    test('detects reachable, terminal, unreachable, and dead-end states', () => {
+        const r = reachability(transitions, ALL_STATES, ['DRAFT'], ['ACTIVE', 'CANCELLED']);
+        expect(new Set(r.reachable)).toEqual(new Set(['DRAFT', 'PAID', 'ACTIVE', 'CANCELLED']));
+        expect(new Set(r.terminal)).toEqual(new Set(['ACTIVE', 'CANCELLED', 'ORPHAN']));
+        expect(r.unreachable).toEqual(['ORPHAN']);
+        expect(r.deadEnds).toEqual([]); // both reachable terminals are designated accepting
+    });
+
+    test('a reachable terminal not marked accepting is a dead-end', () => {
+        const r = reachability(transitions, ALL_STATES, ['DRAFT'], ['ACTIVE']);
+        expect(r.deadEnds).toEqual(['CANCELLED']);
+    });
+});
+
+describe('bfsStates + reachableStatesViolating', () => {
+    test('enumerates reachable states in discovery order', () => {
+        expect(bfsStates(transitions, ['DRAFT'])).toEqual(['DRAFT', 'PAID', 'CANCELLED', 'ACTIVE']);
+    });
+
+    test('reports reachable states that violate an invariant', () => {
+        // Invariant: "every reachable state is classifiable (not off-diagram-only)".
+        const violations = reachableStatesViolating(transitions, ['DRAFT'], (s) => s !== 'CANCELLED');
+        expect(violations).toEqual(['CANCELLED']);
+    });
+
+    test('empty when the invariant holds everywhere reachable', () => {
+        expect(reachableStatesViolating(transitions, ['DRAFT'], (s) => s !== 'ORPHAN')).toEqual([]);
+    });
+});
+
+// ---- enum parity ------------------------------------------------------------
+
+describe('assertEnumParity', () => {
+    // In a real entity this would be `import { ProgramParticipantStatus } from
+    // '@/generated/prisma/client'` (allowed in a TEST, not in client code).
+    const FakePrismaEnum = { DRAFT: 'DRAFT', PAID: 'PAID', ACTIVE: 'ACTIVE', CANCELLED: 'CANCELLED', ORPHAN: 'ORPHAN' };
+    const LOCAL_STATUSES: OrderStatus[] = ['DRAFT', 'PAID', 'ACTIVE', 'CANCELLED', 'ORPHAN'];
+
+    test('passes when the local union matches the enum keys', () => {
+        expect(() => assertEnumParity(LOCAL_STATUSES, FakePrismaEnum, 'OrderStatus')).not.toThrow();
+    });
+
+    test('throws when the enum gained a value the local union lacks', () => {
+        const grown = { ...FakePrismaEnum, REFUNDED: 'REFUNDED' };
+        expect(() => assertEnumParity(LOCAL_STATUSES, grown, 'OrderStatus')).toThrow(/REFUNDED/);
+    });
+
+    test('throws when the local union has an extra value', () => {
+        expect(() => assertEnumParity([...LOCAL_STATUSES, 'GHOST'], FakePrismaEnum)).toThrow(/GHOST/);
+    });
+
+    test('compile-time Equal/Expect proves union parity', () => {
+        // Fails to COMPILE if OrderStatus and the enum-keys union diverge.
+        type _Parity = Expect<Equal<OrderStatus, keyof typeof FakePrismaEnum>>;
+        const ok: _Parity = true;
+        expect(ok).toBe(true);
+    });
+});

--- a/checkin-app/src/lib/lifecycle/classify.ts
+++ b/checkin-app/src/lib/lifecycle/classify.ts
@@ -1,0 +1,50 @@
+/**
+ * classify / validate harness.
+ *
+ * `classify(row) → StateName | null` — null ⟺ off-diagram. Expressed as a TOTAL
+ * function over the status enum: the entity writes an exhaustive `switch` whose
+ * `default` hands the value to `assertNever`, so adding an enum value fails to
+ * compile until every branch is handled.
+ *
+ * `validate(row) → { invariant } | null` — runs a list of named invariant
+ * predicates and returns the FIRST violated, or null when clean.
+ *
+ * Pure, client-safe: no imports.
+ */
+
+/**
+ * Exhaustiveness guard for a `switch` over a status union. Reaching it at runtime
+ * means the union grew but a branch was missed — but the point is compile-time:
+ * `case`-coverage that misses a value makes the `default: return assertNever(x)`
+ * a type error (`x` is not `never`).
+ *
+ *   function classify(row: Row): State | null {
+ *       switch (row.status) {
+ *           case 'PENDING': return row.paidAt ? 'awaiting_review' : 'unpaid';
+ *           case 'ACTIVE':  return 'active';
+ *           default:        return assertNever(row.status);  // ← fails to compile if a status is added
+ *       }
+ *   }
+ */
+export function assertNever(value: never): never {
+    throw new Error(`lifecycle: unhandled status ${JSON.stringify(value)}`);
+}
+
+/** A named invariant: `holds` returns false when the row violates it. */
+export type Invariant<Row> = {
+    readonly name: string;
+    holds(row: Row): boolean;
+};
+
+/**
+ * Build an entity `validate(row)`: returns `{ invariant }` for the first failing
+ * invariant (in list order), or null if all hold.
+ */
+export function defineValidator<Row>(invariants: readonly Invariant<Row>[]) {
+    return function validate(row: Row): { invariant: string } | null {
+        for (const inv of invariants) {
+            if (!inv.holds(row)) return { invariant: inv.name };
+        }
+        return null;
+    };
+}

--- a/checkin-app/src/lib/lifecycle/enumParity.ts
+++ b/checkin-app/src/lib/lifecycle/enumParity.ts
@@ -1,0 +1,49 @@
+/**
+ * Enum-parity: prove a LOCAL string-literal union stays in lockstep with a Prisma
+ * enum, WITHOUT value-importing the generated enum into the client bundle.
+ *
+ * Two layers:
+ *  - compile-time (`Expect`/`Equal`): a type-only check. The entity does
+ *      import type { ProgramParticipantStatus } from '@/generated/prisma/client';
+ *      type _Parity = Expect<Equal<LocalStatus, ProgramParticipantStatus>>;
+ *    `import type` is erased at build → no Prisma in the client bundle. If the
+ *    schema enum changes, this line stops compiling.
+ *  - runtime (`assertEnumParity`): for a dev/TEST assertion. A TEST may value-
+ *    import the Prisma enum (tests aren't the client bundle) and pass it here to
+ *    fail loudly on a mismatch. This file itself imports nothing.
+ */
+
+/** Exact type equality (both directions), the standard invariant-position trick. */
+export type Equal<A, B> =
+    (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+/** Compile error unless `T` is exactly `true`. Use: `type _ = Expect<Equal<X, Y>>`. */
+export type Expect<T extends true> = T;
+
+/**
+ * Runtime parity check for dev/tests. `prismaEnum` is the generated enum object
+ * (Prisma emits `{ PENDING: 'PENDING', ACTIVE: 'ACTIVE' }`); its keys must equal
+ * the local `statuses`, as a set. Throws with the diff on mismatch.
+ *
+ * Keep this OUT of client code — call it only from tests or a dev-time guard, and
+ * only there value-import the Prisma enum.
+ */
+export function assertEnumParity(
+    statuses: readonly string[],
+    prismaEnum: Record<string, string>,
+    label = 'enum',
+): void {
+    const local = new Set(statuses);
+    const prisma = new Set(Object.keys(prismaEnum));
+
+    const missingLocally = [...prisma].filter((k) => !local.has(k));
+    const extraLocally = [...local].filter((k) => !prisma.has(k));
+
+    if (missingLocally.length > 0 || extraLocally.length > 0) {
+        throw new Error(
+            `lifecycle enum-parity mismatch for ${label}: ` +
+                `missing in local union [${missingLocally.join(', ')}], ` +
+                `extra in local union [${extraLocally.join(', ')}]`,
+        );
+    }
+}

--- a/checkin-app/src/lib/lifecycle/index.ts
+++ b/checkin-app/src/lib/lifecycle/index.ts
@@ -1,0 +1,21 @@
+/**
+ * lib/lifecycle — pure, dependency-free, client-safe primitives for declaring an
+ * entity's lifecycle as one definition. DEFINITION/VALIDATION layer only: it
+ * emits predicates, Prisma `where` fragments, and static analyses — it never
+ * executes transitions. Postgres stays the runtime authority.
+ *
+ * Client-safe: nothing here value-imports Prisma. Prisma `where` types are
+ * caller-supplied generic params; the enum-parity check is type-only at build
+ * and value-based only in tests.
+ */
+export { defineStateSet, type StateSet, type FlagRule } from './stateSet';
+export { assertNever, defineValidator, type Invariant } from './classify';
+export {
+    type Transition,
+    isLegalTransition,
+    reachability,
+    type Reachability,
+    bfsStates,
+    reachableStatesViolating,
+} from './transitions';
+export { type Equal, type Expect, assertEnumParity } from './enumParity';

--- a/checkin-app/src/lib/lifecycle/stateSet.ts
+++ b/checkin-app/src/lib/lifecycle/stateSet.ts
@@ -19,15 +19,9 @@ export type StateSet<Row, Where> = {
 };
 
 /**
- * A presence-flag rule: field name → required presence.
- *
- * `true`  ⟺ the (nullable) column must be present  → `has`: `row.field === true`,
- *                                                     `where`: `{ field: { not: null } }`
- * `false` ⟺ the column must be absent              → `has`: `row.field === false`,
- *                                                     `where`: `{ field: null }`
- *
- * Callers pass the column's presence as a boolean into `has` (e.g. `!!row.paidAt`),
- * keeping `Date | null` out of the client-safe predicate.
+ * A field-rule map: field name → required boolean. Reused for both `flags`
+ * (presence of a nullable column) and `equals` (value of a boolean column) —
+ * see `defineStateSet`. The two differ only in how the boolean maps to `where`.
  */
 export type FlagRule = Readonly<Record<string, boolean>>;
 
@@ -37,37 +31,63 @@ export type FlagRule = Readonly<Record<string, boolean>>;
  *
  *   defineStateSet<Prisma.ProgramParticipantWhereInput>()({
  *       statuses: ['ACTIVE'],
- *       flags: { paidAt: true },
+ *       flags: { paidAt: true },              // nullable-timestamp PRESENCE
+ *       equals: { isPaymentPlanRequested: true }, // boolean-column VALUE
  *   })
  *
- * `has` and `where` are derived from the same `statuses`/`flags`, so adding a flag
- * updates both sides at once — they cannot diverge.
+ * Two rule kinds, because a nullable timestamp and a real boolean column need
+ * different `where`:
+ *
+ * - `flags` — PRESENCE of a nullable column (timestamps like `paidAt`):
+ *     `true`  → `has`: `row.field === true`,  `where`: `{ field: { not: null } }`
+ *     `false` → `has`: `row.field === false`, `where`: `{ field: null }`
+ *   Callers pass presence as a boolean (`!!row.paidAt`), keeping `Date | null`
+ *   out of the client-safe predicate.
+ *
+ * - `equals` — VALUE of a genuine boolean column (`Boolean @default(false)`):
+ *     `req`   → `has`: `row.field === req`,   `where`: `{ field: req }`
+ *   `{ not: null }` would match BOTH true and false, so presence is wrong here.
+ *
+ * `has` and `where` derive from the same `flags`/`equals`, so they can't diverge.
  */
 export function defineStateSet<Where>() {
-    return function <S extends string, Flags extends FlagRule = Record<never, boolean>>(spec: {
+    return function <
+        S extends string,
+        Flags extends FlagRule = Record<never, boolean>,
+        Equals extends FlagRule = Record<never, boolean>,
+    >(spec: {
         statuses: readonly S[];
         flags?: Flags;
-    }): StateSet<{ status: string } & Record<keyof Flags, boolean>, Where> {
-        const { statuses, flags } = spec;
+        equals?: Equals;
+    }): StateSet<{ status: string } & Record<keyof Flags | keyof Equals, boolean>, Where> {
+        const { statuses, flags, equals } = spec;
         const flagEntries = flags ? Object.entries(flags) : [];
+        const equalEntries = equals ? Object.entries(equals) : [];
         const statusSet = new Set<string>(statuses);
 
         // `status: string` (not the set's own literal): callers pass a full row
         // typed with the entity's whole status union, not one narrowed to this set.
-        const has = (row: { status: string } & Record<keyof Flags, boolean>): boolean => {
+        const has = (row: { status: string } & Record<keyof Flags | keyof Equals, boolean>): boolean => {
             if (!statusSet.has(row.status)) return false;
+            const r = row as Record<string, unknown>;
             for (const [field, required] of flagEntries) {
-                if (Boolean((row as Record<string, unknown>)[field]) !== required) return false;
+                if (Boolean(r[field]) !== required) return false;
+            }
+            for (const [field, required] of equalEntries) {
+                if (Boolean(r[field]) !== required) return false;
             }
             return true;
         };
 
         // Plain object literal → no Prisma runtime dependency. Cast once: the shape
-        // is built dynamically from `flags`, so TS can't check it against an
-        // arbitrary caller `Where`; the caller's type arg is the contract.
+        // is built dynamically, so TS can't check it against an arbitrary caller
+        // `Where`; the caller's type arg is the contract.
         const where = {
             status: { in: statuses },
+            // presence: nullable column not-null / null
             ...Object.fromEntries(flagEntries.map(([f, req]) => [f, req ? { not: null } : null])),
+            // value-equality: boolean column === req
+            ...Object.fromEntries(equalEntries.map(([f, req]) => [f, req])),
         } as Where;
 
         return { statuses, has, where };

--- a/checkin-app/src/lib/lifecycle/stateSet.ts
+++ b/checkin-app/src/lib/lifecycle/stateSet.ts
@@ -1,0 +1,75 @@
+/**
+ * StateSet — a named set of statuses (+ optional presence-flag rule) that emits
+ * BOTH a client-safe runtime predicate (`has`) AND a server Prisma `where`
+ * fragment from ONE spec, so the two can never drift apart.
+ *
+ * Client-safety (see lifecycle/README intent): this file value-imports NOTHING.
+ * The Prisma `where` type is a caller-supplied generic param (`Where`), so no
+ * `@/generated/prisma` value ever reaches the client bundle. The `where` value
+ * is a plain object literal — inert data, no Prisma runtime dependency.
+ */
+
+export type StateSet<Row, Where> = {
+    /** The status literals this set matches. */
+    readonly statuses: readonly string[];
+    /** Client-safe predicate. Booleans in, no Prisma. */
+    has(row: Row): boolean;
+    /** Prisma `where` fragment. Plain object literal, typed only via the generic. */
+    readonly where: Where;
+};
+
+/**
+ * A presence-flag rule: field name → required presence.
+ *
+ * `true`  ⟺ the (nullable) column must be present  → `has`: `row.field === true`,
+ *                                                     `where`: `{ field: { not: null } }`
+ * `false` ⟺ the column must be absent              → `has`: `row.field === false`,
+ *                                                     `where`: `{ field: null }`
+ *
+ * Callers pass the column's presence as a boolean into `has` (e.g. `!!row.paidAt`),
+ * keeping `Date | null` out of the client-safe predicate.
+ */
+export type FlagRule = Readonly<Record<string, boolean>>;
+
+/**
+ * Build a StateSet. Curried so an entity fixes its own Prisma `WhereInput` as the
+ * `Where` type arg while the status/flag types still infer from the spec:
+ *
+ *   defineStateSet<Prisma.ProgramParticipantWhereInput>()({
+ *       statuses: ['ACTIVE'],
+ *       flags: { paidAt: true },
+ *   })
+ *
+ * `has` and `where` are derived from the same `statuses`/`flags`, so adding a flag
+ * updates both sides at once — they cannot diverge.
+ */
+export function defineStateSet<Where>() {
+    return function <S extends string, Flags extends FlagRule = Record<never, boolean>>(spec: {
+        statuses: readonly S[];
+        flags?: Flags;
+    }): StateSet<{ status: string } & Record<keyof Flags, boolean>, Where> {
+        const { statuses, flags } = spec;
+        const flagEntries = flags ? Object.entries(flags) : [];
+        const statusSet = new Set<string>(statuses);
+
+        // `status: string` (not the set's own literal): callers pass a full row
+        // typed with the entity's whole status union, not one narrowed to this set.
+        const has = (row: { status: string } & Record<keyof Flags, boolean>): boolean => {
+            if (!statusSet.has(row.status)) return false;
+            for (const [field, required] of flagEntries) {
+                if (Boolean((row as Record<string, unknown>)[field]) !== required) return false;
+            }
+            return true;
+        };
+
+        // Plain object literal → no Prisma runtime dependency. Cast once: the shape
+        // is built dynamically from `flags`, so TS can't check it against an
+        // arbitrary caller `Where`; the caller's type arg is the contract.
+        const where = {
+            status: { in: statuses },
+            ...Object.fromEntries(flagEntries.map(([f, req]) => [f, req ? { not: null } : null])),
+        } as Where;
+
+        return { statuses, has, where };
+    };
+}

--- a/checkin-app/src/lib/lifecycle/transitions.ts
+++ b/checkin-app/src/lib/lifecycle/transitions.ts
@@ -1,0 +1,124 @@
+/**
+ * Transition-table shape + PURE helpers over it.
+ *
+ * This is a DEFINITION/VALIDATION layer, never a runtime executor: nothing here
+ * "runs" a transition against a real row. The helpers feed doc-artifact
+ * generation (diagram, coverage matrix, reachability) and tests. Postgres stays
+ * the runtime authority.
+ *
+ * Pure, client-safe: no imports.
+ */
+
+/**
+ * One declared transition. `State`/`Event`/`Kind` are LOCAL string-literal unions
+ * (verified against the Prisma enum by a type-only parity check — see enumParity).
+ */
+export type Transition<
+    State extends string = string,
+    Event extends string = string,
+    Kind extends string = string,
+> = {
+    readonly from: State;
+    readonly to: State;
+    /** The domain event that drives it (e.g. 'payment.captured'). */
+    readonly event: Event;
+    /** Who performs it (e.g. 'member', 'board', 'system'). */
+    readonly actor: string;
+    /** Where the guard lives (e.g. 'updateMany compare-and-set', 'route handler'). */
+    readonly guardSite: string;
+    /** Optional discriminator for entities whose table splits by kind (e.g. INITIAL vs RENEWAL). */
+    readonly kind?: Kind;
+    /** Marks a transition kept only for backfilled/legacy rows. */
+    readonly legacy?: boolean;
+};
+
+/** True if some declared transition matches from→to (optionally within `kind`). */
+export function isLegalTransition<S extends string, E extends string, K extends string>(
+    transitions: readonly Transition<S, E, K>[],
+    from: S,
+    to: S,
+    kind?: K,
+): boolean {
+    return transitions.some(
+        (t) => t.from === from && t.to === to && (kind === undefined || t.kind === undefined || t.kind === kind),
+    );
+}
+
+export type Reachability<S extends string> = {
+    /** States reachable from any initial state, following edges. */
+    readonly reachable: readonly S[];
+    /** States with zero outgoing transitions (intended end states or stuck states). */
+    readonly terminal: readonly S[];
+    /** In `allStates` but not reachable from any initial → dead code / drift. */
+    readonly unreachable: readonly S[];
+    /** Reachable states with no exit that are NOT designated `accepting` → a lint smell. */
+    readonly deadEnds: readonly S[];
+};
+
+/**
+ * Static reachability analysis over a transition table.
+ *
+ * @param allStates    every declared state (to compute `unreachable`)
+ * @param initials     entry state(s)
+ * @param accepting    designated legit terminal states; a reachable terminal NOT in
+ *                     here is reported as a dead-end. Omit to treat every reachable
+ *                     terminal as a dead-end.
+ */
+export function reachability<S extends string>(
+    transitions: readonly Transition<S>[],
+    allStates: readonly S[],
+    initials: readonly S[],
+    accepting: readonly S[] = [],
+): Reachability<S> {
+    const reachable = bfsStates(transitions, initials);
+    const reachableSet = new Set<S>(reachable);
+    const acceptingSet = new Set<S>(accepting);
+
+    const hasOutgoing = new Set<S>(transitions.map((t) => t.from));
+    const terminal = allStates.filter((s) => !hasOutgoing.has(s));
+    const unreachable = allStates.filter((s) => !reachableSet.has(s));
+    const deadEnds = terminal.filter((s) => reachableSet.has(s) && !acceptingSet.has(s));
+
+    return { reachable, terminal, unreachable, deadEnds };
+}
+
+/**
+ * Exhaustive BFS: enumerate every state reachable from `initials`, in discovery
+ * order. Pure graph walk — no rows involved.
+ */
+export function bfsStates<S extends string>(
+    transitions: readonly Transition<S>[],
+    initials: readonly S[],
+): S[] {
+    const adjacency = new Map<S, S[]>();
+    for (const t of transitions) {
+        (adjacency.get(t.from) ?? adjacency.set(t.from, []).get(t.from)!).push(t.to);
+    }
+
+    const seen = new Set<S>();
+    const order: S[] = [];
+    const queue: S[] = [...initials];
+    while (queue.length > 0) {
+        const state = queue.shift()!;
+        if (seen.has(state)) continue;
+        seen.add(state);
+        order.push(state);
+        for (const next of adjacency.get(state) ?? []) {
+            if (!seen.has(next)) queue.push(next);
+        }
+    }
+    return order;
+}
+
+/**
+ * Assert an invariant holds on EVERY reachable state. Returns the states that
+ * violate it (empty ⟺ invariant holds everywhere). For tests/doc-checks, e.g.
+ * "every reachable state maps to a diagram node".
+ */
+export function reachableStatesViolating<S extends string>(
+    transitions: readonly Transition<S>[],
+    initials: readonly S[],
+    invariant: (state: S) => boolean,
+): S[] {
+    return bfsStates(transitions, initials).filter((s) => !invariant(s));
+}


### PR DESCRIPTION
## What

Foundational `src/lib/lifecycle/` primitives — **Phase 1** of the "entity lifecycle as one declarative definition" effort. Pure, dependency-free, **client-safe** primitives + unit tests. **No consumers, no entity modules, no schema changes — inert until imported.** Later phases (ProgramParticipant enrollment, OrgMembershipProcess membership) will instance these.

## Why

Two entities have implicit state machines smeared across server guards, client predicates, and SQL indexes, which drift apart. The fix: one declarative definition per entity that emits BOTH a runtime predicate AND a Prisma `where` from one source, plus a validator that flags off-diagram field combinations. This PR delivers only the primitives — a **definition/validation layer, never a runtime executor**. Postgres stays the runtime authority; existing compare-and-set guards are untouched.

## Files (`checkin-app/src/lib/lifecycle/`)

- `stateSet.ts` — `defineStateSet` + `StateSet`/`FlagRule` types
- `classify.ts` — `assertNever`, `defineValidator`, `Invariant`
- `transitions.ts` — `Transition`, `isLegalTransition`, `reachability`, `bfsStates`, `reachableStatesViolating`
- `enumParity.ts` — `Equal`/`Expect` (type-only), `assertEnumParity` (runtime, test-only)
- `index.ts` — barrel
- `__tests__/lifecycle.test.ts` — 23 unit tests over an in-test fixture machine

## Exported surface

- **StateSet** — `defineStateSet<Where>()({ statuses, flags?, equals? })` -> `{ statuses, has, where }`. Curried so each entity fixes its own `Prisma.XWhereInput` while status/flag types infer. `has` (booleans in) and `where` (plain object literal) both derive from the same spec, so they can't diverge.
  - `flags` — **presence** of a nullable column (timestamps): `has: !!row.f === req`, `where: { f: req ? {not:null} : null }`
  - `equals` — **value** of a genuine boolean column (`Boolean @default(false)`): `has: row.f === req`, `where: { f: req }`. (Presence `{not:null}` would match both true and false and diverge — the second commit fixes exactly this, needed for enrollment's `HELD`/`HELD_DENIED` on `isPaymentPlanRequested`.)
- **classify/validate** — `assertNever(never)` powers an exhaustive status `switch` (a new enum value -> compile error); `defineValidator(invariants)(row)` returns the first violated `{ invariant }` or null.
- **transitions** — typed `Transition` (from/to/event/actor/guardSite/kind?/legacy?), `isLegalTransition(t, from, to, kind?)`, and pure analyses: `reachability` (reachable / terminal / unreachable / dead-ends), `bfsStates`, `reachableStatesViolating`. Not executed against real rows.
- **enumParity** — `Expect<Equal<Local, PrismaEnumType>>` (type-only, build-erased) + `assertEnumParity(local, prismaEnum, label?)` for a test/dev value check, so a schema enum change fails loudly.

## Client-safety (critical)

The client bundle imports **zero** Prisma today, deliberately. `lib/lifecycle` stays client-importable:
- Prisma `where` types are **caller-supplied generic params** — no value import of `@/generated/prisma`.
- Predicates take **booleans**, not `Date | null`.
- `where` values are inert plain object literals.
- Enum parity is **type-only** at build; the runtime `assertEnumParity` is test-only.

Confirmed: **no runtime `require`/`import` of Prisma anywhere in the module** (grep-verified; only doc-comment mentions).

## Testing

- Unit run scoped to `src/lib/lifecycle` -> **23 passed / 23** (~0.65s). Covers: `has`/`where` agreement over a status × flags × equals matrix; boolean-column `where` is `{ field: true/false }` not `{ not: null }`; `flags`+`equals` combined; `validate` first-violated ordering; `isLegalTransition` incl. kind filtering; reachability (terminal / unreachable / dead-end); BFS + reachable-invariant; enum-parity (runtime + compile-time).
- Full-project `tsc --noEmit` -> **0 errors** (proves the compile-time parity machinery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
