### PR TITLE
feat(lifecycle): ProgramParticipant enrollment state machine (6-state)

### DIFF
--- a/checkin-app/src/app/__tests__/enrollmentStateOracle.integration.test.ts
+++ b/checkin-app/src/app/__tests__/enrollmentStateOracle.integration.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Validator-oracle integration tests (PROGRAM_ENROLLMENT_STATE_MACHINE §8).
+ *
+ * Drives each real transition (T3, T3f, T3m, T4, T5, T6, T7/T8/T9) against a real
+ * DB through its OWNING code — the route handler / shared mutator that carries the
+ * guard — then asserts the resulting row `classify`es to the expected state and
+ * `validate`s clean. A simulated crash window (activate's first updateMany, skip
+ * the release) must be flagged as an I1 violation.
+ *
+ * The definition is non-behavioral: this proves the guards land rows exactly on
+ * the six §3 states, never off-diagram.
+ */
+import { POST as RequestPost } from '@/app/api/programs/[id]/request-payment-plan/route';
+import { POST as ManualHoldPost } from '@/app/api/finance-ops/payment-plans/manual-hold/route';
+import { POST as PlansPost } from '@/app/api/finance-ops/payment-plans/route';
+import { POST as RefusePost } from '@/app/api/finance-ops/payment-plans/refuse/route';
+import { activateProgramEnrollment } from '@/lib/programs/activateEnrollment';
+import { withdrawAndReleaseHold } from '@/lib/program/capacity';
+import prisma from '@/lib/prisma';
+import { classify, validate, toRow, type EnrollmentStateName } from '@/lib/programs/enrollmentState';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/notifications', () => ({ sendNotification: jest.fn() }));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockSession = require('next-auth/next').getServerSession;
+
+const TAG = 'enroll-oracle-test';
+
+describe('enrollment state — validator oracle over real transitions', () => {
+    let programId: number;
+    let selfId: number;
+    let boardId: number;
+
+    beforeAll(async () => {
+        const self = await prisma.person.create({
+            data: { name: 'Oracle Self', email: `self-${TAG}@example.com`, household: { create: { name: 'HH' } } },
+        });
+        selfId = self.id;
+        const board = await prisma.person.create({
+            data: { name: 'Oracle Board', email: `board-${TAG}@example.com`, isBoardMember: true, household: { create: { name: 'HH' } } },
+        });
+        boardId = board.id;
+        // shopifyVariantId present so the apply-time hold logic engages (single pool).
+        const program = await prisma.program.create({
+            data: { name: `Oracle Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyVariantId: 'dev-mock-variant-oracle' },
+        });
+        programId = program.id;
+    });
+
+    afterAll(async () => {
+        await prisma.programParticipant.deleteMany({ where: { programId } });
+        await prisma.program.delete({ where: { id: programId } });
+        const ids = [selfId, boardId];
+        const people = await prisma.person.findMany({ where: { id: { in: ids } }, select: { householdId: true } });
+        await prisma.person.deleteMany({ where: { id: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: people.map((p) => p.householdId) } } });
+    });
+
+    beforeEach(() => jest.clearAllMocks());
+
+    // Seed the FROM row directly (setup, not a transition-under-test).
+    async function seed(fields: { req: boolean; held: boolean; den: boolean; status?: 'PENDING' | 'ACTIVE'; pendingSince?: Date }) {
+        const now = new Date();
+        await prisma.programParticipant.upsert({
+            where: { programId_personId: { programId, personId: selfId } },
+            update: {
+                status: fields.status ?? 'PENDING',
+                isPaymentPlanRequested: fields.req,
+                inventoryHeldAt: fields.held ? now : null,
+                paymentPlanDeniedAt: fields.den ? now : null,
+                pendingSince: fields.pendingSince ?? now,
+            },
+            create: {
+                programId, personId: selfId,
+                status: fields.status ?? 'PENDING',
+                isPaymentPlanRequested: fields.req,
+                inventoryHeldAt: fields.held ? now : null,
+                paymentPlanDeniedAt: fields.den ? now : null,
+                pendingSince: fields.pendingSince ?? now,
+            },
+        });
+    }
+
+    async function assertState(expected: EnrollmentStateName) {
+        const dbRow = await prisma.programParticipant.findUniqueOrThrow({
+            where: { programId_personId: { programId, personId: selfId } },
+        });
+        const r = toRow(dbRow);
+        expect(classify(r)).toBe(expected);
+        expect(validate(r)).toBeNull();
+    }
+
+    async function assertGone() {
+        const row = await prisma.programParticipant.findUnique({
+            where: { programId_personId: { programId, personId: selfId } },
+        });
+        expect(row).toBeNull(); // UNENROLLED
+    }
+
+    const reqReq = () => new Request(`http://localhost/api/programs/${programId}/request-payment-plan`, {
+        method: 'POST', headers: { cookie: 'session=test' }, body: JSON.stringify({ participantId: selfId }),
+    }) as unknown as import('next/server').NextRequest;
+    const params = () => ({ params: Promise.resolve({ id: String(programId) }) });
+    const financeReq = (url: string) => new Request(url, {
+        method: 'POST', headers: { cookie: 'session=test' }, body: JSON.stringify({ programId, participantId: selfId }),
+    }) as unknown as import('next/server').NextRequest;
+
+    it('T3 apply (−1 ok): PENDING_UNPAID → PENDING_HELD', async () => {
+        const prev = process.env.CHECKIN_ENV;
+        process.env.CHECKIN_ENV = 'local'; // arms the Shopify mock → the −1 "succeeds"
+        try {
+            await seed({ req: false, held: false, den: false }); // PENDING_UNPAID
+            mockSession.mockResolvedValue({ user: { id: selfId } });
+            const res = await RequestPost(reqReq(), params());
+            expect(res.status).toBe(200);
+            await assertState('PENDING_HELD');
+        } finally {
+            process.env.CHECKIN_ENV = prev;
+        }
+    });
+
+    it('T3f apply (−1 FAILS): PENDING_UNPAID → PENDING_HOLD_FAILED', async () => {
+        const prev = process.env.CHECKIN_ENV;
+        delete process.env.CHECKIN_ENV; // no mock, no creds → adjust returns false → rollback
+        try {
+            await seed({ req: false, held: false, den: false }); // PENDING_UNPAID
+            mockSession.mockResolvedValue({ user: { id: selfId } });
+            const res = await RequestPost(reqReq(), params());
+            expect(res.status).toBe(200);
+            expect((await res.json()).warning).toMatch(/board/i);
+            await assertState('PENDING_HOLD_FAILED');
+        } finally {
+            if (prev !== undefined) process.env.CHECKIN_ENV = prev;
+        }
+    });
+
+    it('T3m manual-hold: PENDING_HOLD_FAILED → PENDING_HELD', async () => {
+        await seed({ req: true, held: false, den: false }); // PENDING_HOLD_FAILED
+        mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+        const res = await ManualHoldPost(financeReq('http://localhost/api/finance-ops/payment-plans/manual-hold'));
+        expect(res.status).toBe(200);
+        await assertState('PENDING_HELD');
+    });
+
+    it('T4 activate (payment) from PENDING_HELD → ACTIVE, hold released', async () => {
+        await seed({ req: true, held: true, den: false }); // PENDING_HELD
+        const { activatedCount, releasedHoldCount } = await activateProgramEnrollment({
+            programId, personIds: [selfId], shopifyOrderId: 'order-oracle-1', hasProgramItem: true, purchasedOrgMember: null,
+        });
+        expect(activatedCount).toBe(1);
+        expect(releasedHoldCount).toBe(1);
+        await assertState('ACTIVE');
+    });
+
+    it('T4 activate (payment) from PENDING_UNPAID → ACTIVE, no hold to release', async () => {
+        await seed({ req: false, held: false, den: false }); // PENDING_UNPAID
+        const { activatedCount, releasedHoldCount } = await activateProgramEnrollment({
+            programId, personIds: [selfId], shopifyOrderId: 'order-oracle-2', hasProgramItem: true, purchasedOrgMember: null,
+        });
+        expect(activatedCount).toBe(1);
+        expect(releasedHoldCount).toBe(0);
+        await assertState('ACTIVE');
+    });
+
+    it('T5 approve: PENDING_HELD → ACTIVE (hold consumed, not released)', async () => {
+        await seed({ req: true, held: true, den: false }); // PENDING_HELD
+        mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+        const res = await PlansPost(financeReq('http://localhost/api/finance-ops/payment-plans'));
+        expect(res.status).toBe(200);
+        await assertState('ACTIVE');
+    });
+
+    it('T6 deny: PENDING_HELD → PENDING_HELD_DENIED', async () => {
+        await seed({ req: true, held: true, den: false }); // PENDING_HELD
+        mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+        const res = await RefusePost(financeReq('http://localhost/api/finance-ops/payment-plans/refuse'));
+        expect(res.status).toBe(200);
+        await assertState('PENDING_HELD_DENIED');
+    });
+
+    // T7/T8/T9 all funnel through the one shared exit (withdrawAndReleaseHold);
+    // their end-state is UNENROLLED (row deleted), with +1 iff the row still held.
+    it('T7 non-payment kick: PENDING_UNPAID → ∅ (no hold, no +1)', async () => {
+        await seed({ req: false, held: false, den: false }); // PENDING_UNPAID
+        const program = await prisma.program.findUniqueOrThrow({ where: { id: programId } });
+        const { released } = await withdrawAndReleaseHold(programId, selfId, program);
+        expect(released).toBe(false);
+        await assertGone();
+    });
+
+    it('T8 grace expiry: PENDING_HELD_DENIED → ∅ (held → +1)', async () => {
+        await seed({ req: false, held: true, den: true }); // PENDING_HELD_DENIED
+        const program = await prisma.program.findUniqueOrThrow({ where: { id: programId } });
+        const { released } = await withdrawAndReleaseHold(programId, selfId, program);
+        expect(released).toBe(true);
+        await assertGone();
+    });
+
+    it('T9 withdraw: PENDING_HELD → ∅ (held → +1)', async () => {
+        await seed({ req: true, held: true, den: false }); // PENDING_HELD
+        const program = await prisma.program.findUniqueOrThrow({ where: { id: programId } });
+        const { released } = await withdrawAndReleaseHold(programId, selfId, program);
+        expect(released).toBe(true);
+        await assertGone();
+    });
+
+    it('crash window (activate step 1 committed, release skipped) → I1 violation flagged', async () => {
+        await seed({ req: true, held: true, den: false }); // PENDING_HELD, seat held
+        // Reproduce ONLY activate's first updateMany (status→ACTIVE); crash before
+        // the hold-release updateMany. The committed intermediate row holds a seat
+        // while ACTIVE — the exact §7 two-step crash window.
+        await prisma.programParticipant.updateMany({
+            where: { programId, personId: selfId, status: 'PENDING' },
+            data: { status: 'ACTIVE', pendingSince: null, shopifyOrderId: 'order-crash' },
+        });
+        const dbRow = await prisma.programParticipant.findUniqueOrThrow({
+            where: { programId_personId: { programId, personId: selfId } },
+        });
+        const r = toRow(dbRow);
+        expect(classify(r)).toBeNull(); // off-diagram
+        expect(validate(r)).toEqual({ invariant: 'I1' });
+    });
+});

--- a/checkin-app/src/app/api/cron/pending-participants/route.ts
+++ b/checkin-app/src/app/api/cron/pending-participants/route.ts
@@ -3,18 +3,19 @@ import { logger } from "@/lib/logger";
 import { withCron } from "@/lib/cronAuth";
 import prisma from "@/lib/prisma";
 import { withdrawAndReleaseHold } from "@/lib/program/capacity";
+import { STATES } from "@/lib/programs/enrollmentState";
 
 export const GET = withCron(async () => {
         const now = new Date();
         const pendingParticipants = await prisma.programParticipant.findMany({
             where: {
-                status: 'PENDING',
-                isPaymentPlanRequested: false,
-                // Denied scholarship applicants are governed by the
-                // scholarship-grace-expiry cron (scholarshipDenialGraceDays),
-                // not this 7-day clock — a denial never resets pendingSince, so
-                // without this exclusion they'd be kicked the night after denial.
-                paymentPlanDeniedAt: null,
+                // The 7-day non-payment clock owns exactly PENDING_UNPAID
+                // (enrollmentState §3). Its `where` carries isPaymentPlanRequested:false,
+                // which is what keeps HOLD_FAILED (req=true) and denied applicants
+                // (den≠null, governed by the grace-expiry cron) out of this sweep —
+                // a denial never resets pendingSince, so without that they'd be
+                // kicked the night after denial.
+                ...STATES.PENDING_UNPAID.where,
                 pendingSince: { not: null }
             },
             include: {

--- a/checkin-app/src/app/api/cron/scholarship-grace-expiry/route.ts
+++ b/checkin-app/src/app/api/cron/scholarship-grace-expiry/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import { withCron } from "@/lib/cronAuth";
 import prisma from "@/lib/prisma";
 import { withdrawAndReleaseHold } from "@/lib/program/capacity";
+import { STATES } from "@/lib/programs/enrollmentState";
 
 const SYSTEM_ACTOR = 0;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -32,9 +33,9 @@ export const GET = withCron(async () => {
     const cutoff = new Date(Date.now() - graceDays * DAY_MS);
     const expired = await prisma.programParticipant.findMany({
         where: {
-            status: 'PENDING',
-            isPaymentPlanRequested: false,
-            inventoryHeldAt: { not: null },
+            // This sweep owns exactly the PENDING_HELD_DENIED state (enrollmentState
+            // §3); consume its `where` and add the grace cutoff onto the denial stamp.
+            ...STATES.PENDING_HELD_DENIED.where,
             paymentPlanDeniedAt: { not: null, lte: cutoff },
         },
         include: { program: true, person: true },

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -6,6 +6,7 @@ import { handler } from "@/security/handler";
 import { apiError } from "@/lib/api-response";
 import { isActiveOrgMember, ACTIVE_ORG_MEMBER_INCLUDE } from "@/lib/orgMembership";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
+import { STATES } from "@/lib/programs/enrollmentState";
 
 // Two DISJOINT board queues over PENDING + isPaymentPlanRequested rows, split on
 // whether a Shopify seat is actually held (inventoryHeldAt):
@@ -20,15 +21,11 @@ export const GET = handler('GET /api/finance-ops/payment-plans', async ({ req })
     const holdsQueue = new URL(req.url).searchParams.get('queue') === 'holds';
     const [requests, boardSettings] = await Promise.all([
         prisma.programParticipant.findMany({
-            where: {
-                isPaymentPlanRequested: true,
-                status: 'PENDING',
-                // held=null is PENDING_HOLD_FAILED (reconciliation queue); held!=null +
-                // den=null is a genuine pending request (scholarship queue).
-                ...(holdsQueue
-                    ? { inventoryHeldAt: null }
-                    : { inventoryHeldAt: { not: null }, paymentPlanDeniedAt: null }),
-            },
+            // The two queues ARE two lifecycle states (enrollmentState §3): the
+            // scholarship queue is PENDING_HELD, the reconciliation queue is
+            // PENDING_HOLD_FAILED. Consume the definition's `where` so the split
+            // can't drift from the state table.
+            where: holdsQueue ? STATES.PENDING_HOLD_FAILED.where : STATES.PENDING_HELD.where,
             include: {
                 // Nests household->orgMembership (same shape as ACTIVE_ORG_MEMBER_INCLUDE)
                 // so the board can see CURRENT membership while a request is still

--- a/checkin-app/src/lib/programs/enrollmentState.test.ts
+++ b/checkin-app/src/lib/programs/enrollmentState.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the ProgramParticipant enrollment definition (enrollmentState.ts).
+ * Pure — no DB. Value-imports the Prisma enum ONLY here (a test, not the client
+ * bundle) for the runtime parity check.
+ */
+import { ProgramParticipantStatus } from '@/generated/prisma/client';
+import {
+    STATES,
+    classify,
+    validate,
+    toRow,
+    TRANSITIONS,
+    type EnrollmentRow,
+    type LifecycleState,
+} from './enrollmentState';
+import { assertEnumParity, reachability, type Expect, type Equal } from '@/lib/lifecycle';
+
+const LOCAL_STATUSES = ['PENDING', 'ACTIVE'] as const;
+
+// A DB-shaped row: nullable timestamps as Date|null, req as a real boolean.
+type DbRow = {
+    status: 'PENDING' | 'ACTIVE';
+    inventoryHeldAt: Date | null;
+    isPaymentPlanRequested: boolean;
+    paymentPlanDeniedAt: boolean; // presence, kept boolean for matrix brevity
+};
+
+const D = new Date('2026-01-01T00:00:00Z');
+
+function db(status: 'PENDING' | 'ACTIVE', held: boolean, req: boolean, den: boolean): DbRow {
+    return { status, inventoryHeldAt: held ? D : null, isPaymentPlanRequested: req, paymentPlanDeniedAt: den };
+}
+function row(status: 'PENDING' | 'ACTIVE', held: boolean, req: boolean, den: boolean): EnrollmentRow {
+    return { status, inventoryHeldAt: held, isPaymentPlanRequested: req, paymentPlanDeniedAt: den };
+}
+
+// Interpret the subset of Prisma `where` shapes our StateSets emit, so we can
+// assert `where` and `has` agree WITHOUT a DB. Shapes: status:{in}, field:null,
+// field:{not:null}, field:<boolean>.
+function whereMatches(where: Record<string, unknown>, r: DbRow): boolean {
+    for (const [k, v] of Object.entries(where)) {
+        const val = (r as unknown as Record<string, unknown>)[k];
+        if (k === 'status') {
+            if (!(v as { in: string[] }).in.includes(val as string)) return false;
+        } else if (v === null) {
+            const present = val instanceof Date ? true : val === true;
+            if (present) return false;
+        } else if (typeof v === 'boolean') {
+            if (val !== v) return false;
+        } else if (v && typeof v === 'object' && (v as { not?: unknown }).not === null) {
+            const present = val instanceof Date ? true : val === true;
+            if (!present) return false;
+        } else {
+            throw new Error(`whereMatches: unhandled shape for ${k}: ${JSON.stringify(v)}`);
+        }
+    }
+    return true;
+}
+
+// ---- classify: the six legal tuples --------------------------------------
+
+describe('classify — the legal states (§3 table)', () => {
+    test('each legal tuple maps to its named state', () => {
+        expect(classify(row('PENDING', false, false, false))).toBe('PENDING_UNPAID');
+        expect(classify(row('PENDING', false, true, false))).toBe('PENDING_HOLD_FAILED');
+        expect(classify(row('PENDING', true, true, false))).toBe('PENDING_HELD');
+        expect(classify(row('PENDING', true, false, true))).toBe('PENDING_HELD_DENIED');
+        expect(classify(row('ACTIVE', false, false, false))).toBe('ACTIVE');
+    });
+
+    test('the two held=null PENDING states classify APART on req', () => {
+        expect(classify(row('PENDING', false, false, false))).toBe('PENDING_UNPAID');
+        expect(classify(row('PENDING', false, true, false))).toBe('PENDING_HOLD_FAILED');
+    });
+
+    test('ACTIVE with vestigial req/den flags is still ACTIVE (§3 note)', () => {
+        // held=null is all that matters at ACTIVE; req/den are inert.
+        expect(classify(row('ACTIVE', false, true, false))).toBe('ACTIVE');
+        expect(classify(row('ACTIVE', false, false, true))).toBe('ACTIVE');
+        expect(classify(row('ACTIVE', false, true, true))).toBe('ACTIVE');
+    });
+
+    test('off-diagram tuples classify to null', () => {
+        expect(classify(row('ACTIVE', true, false, false))).toBeNull(); // I1: held on ACTIVE
+        expect(classify(row('PENDING', false, false, true))).toBeNull(); // I4: den on held=null (unpaid)
+        expect(classify(row('PENDING', false, true, true))).toBeNull(); // I4: den on held=null (hold-failed)
+        expect(classify(row('PENDING', true, false, false))).toBeNull(); // I3: held, neither awaiting nor denied
+        expect(classify(row('PENDING', true, true, true))).toBeNull(); // I3: held, req∧den
+    });
+});
+
+// ---- validate: I1–I4 --------------------------------------------------------
+
+describe('validate — invariants I1–I4', () => {
+    test('the legal tuples validate clean', () => {
+        for (const r of [
+            row('PENDING', false, false, false),
+            row('PENDING', false, true, false),
+            row('PENDING', true, true, false),
+            row('PENDING', true, false, true),
+            row('ACTIVE', false, false, false),
+            row('ACTIVE', false, true, true), // vestigial flags, still legal
+        ]) {
+            expect(validate(r)).toBeNull();
+        }
+    });
+
+    test('I1 — ACTIVE holding a seat', () => {
+        expect(validate(row('ACTIVE', true, false, false))).toEqual({ invariant: 'I1' });
+    });
+
+    test('I3 — held + neither awaiting nor denied (and held + both)', () => {
+        expect(validate(row('PENDING', true, false, false))).toEqual({ invariant: 'I3' });
+        expect(validate(row('PENDING', true, true, true))).toEqual({ invariant: 'I3' });
+    });
+
+    test('I4 — denial stamped on a held=null row', () => {
+        expect(validate(row('PENDING', false, false, true))).toEqual({ invariant: 'I4' });
+        expect(validate(row('PENDING', false, true, true))).toEqual({ invariant: 'I4' });
+    });
+
+    test('every off-diagram tuple classify=null also fails validate, and vice versa', () => {
+        for (const status of LOCAL_STATUSES) {
+            for (const held of [true, false]) {
+                for (const req of [true, false]) {
+                    for (const den of [true, false]) {
+                        const r = row(status, held, req, den);
+                        const classified = classify(r) !== null;
+                        const valid = validate(r) === null;
+                        expect(classified).toBe(valid);
+                    }
+                }
+            }
+        }
+    });
+});
+
+// ---- STATES: where agrees with has across the full matrix -------------------
+
+describe('STATES — where and has derive from one spec (no drift)', () => {
+    const names = Object.keys(STATES) as (keyof typeof STATES)[];
+
+    test('where agrees with has on every status × held × req × den row', () => {
+        for (const name of names) {
+            const set = STATES[name];
+            for (const status of LOCAL_STATUSES) {
+                for (const held of [true, false]) {
+                    for (const req of [true, false]) {
+                        for (const den of [true, false]) {
+                            const predicate = set.has(row(status, held, req, den));
+                            const query = whereMatches(set.where as Record<string, unknown>, db(status, held, req, den));
+                            expect(query).toBe(predicate);
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    test("each STATES[x].has matches exactly the rows classify names x", () => {
+        for (const name of names) {
+            for (const status of LOCAL_STATUSES) {
+                for (const held of [true, false]) {
+                    for (const req of [true, false]) {
+                        for (const den of [true, false]) {
+                            const r = row(status, held, req, den);
+                            // has ⟹ classify names this state. (classify may name a
+                            // state whose set doesn't `has` it only for the ACTIVE
+                            // vestigial cases, which the ACTIVE set intentionally
+                            // does NOT gate on req/den — so has ⊆ classify=name.)
+                            if (STATES[name].has(r)) expect(classify(r)).toBe(name);
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    test('the refactored query fragments equal the literals they replaced (behavior-preserving)', () => {
+        expect(STATES.PENDING_HELD.where).toEqual({
+            status: { in: ['PENDING'] }, inventoryHeldAt: { not: null }, paymentPlanDeniedAt: null, isPaymentPlanRequested: true,
+        });
+        expect(STATES.PENDING_HOLD_FAILED.where).toEqual({
+            status: { in: ['PENDING'] }, inventoryHeldAt: null, paymentPlanDeniedAt: null, isPaymentPlanRequested: true,
+        });
+        expect(STATES.PENDING_HELD_DENIED.where).toEqual({
+            status: { in: ['PENDING'] }, inventoryHeldAt: { not: null }, paymentPlanDeniedAt: { not: null }, isPaymentPlanRequested: false,
+        });
+        expect(STATES.PENDING_UNPAID.where).toEqual({
+            status: { in: ['PENDING'] }, inventoryHeldAt: null, paymentPlanDeniedAt: null, isPaymentPlanRequested: false,
+        });
+    });
+});
+
+// ---- toRow ------------------------------------------------------------------
+
+describe('toRow', () => {
+    test('collapses nullable timestamps to presence booleans', () => {
+        expect(toRow({ status: 'PENDING', inventoryHeldAt: D, isPaymentPlanRequested: true, paymentPlanDeniedAt: null }))
+            .toEqual({ status: 'PENDING', inventoryHeldAt: true, isPaymentPlanRequested: true, paymentPlanDeniedAt: false });
+    });
+});
+
+// ---- enum parity ------------------------------------------------------------
+
+describe('enum parity', () => {
+    test('local union matches the Prisma enum keys at runtime', () => {
+        expect(() => assertEnumParity([...LOCAL_STATUSES], ProgramParticipantStatus, 'ProgramParticipantStatus')).not.toThrow();
+    });
+
+    test('compile-time parity holds', () => {
+        type _P = Expect<Equal<'PENDING' | 'ACTIVE', ProgramParticipantStatus>>;
+        const ok: _P = true;
+        expect(ok).toBe(true);
+    });
+});
+
+// ---- transitions ------------------------------------------------------------
+
+describe('TRANSITIONS (§5 table as data)', () => {
+    const ALL: LifecycleState[] = ['UNENROLLED', 'PENDING_UNPAID', 'PENDING_HOLD_FAILED', 'PENDING_HELD', 'PENDING_HELD_DENIED', 'ACTIVE'];
+
+    test('all five present states + ACTIVE are reachable from ∅', () => {
+        const r = reachability(TRANSITIONS, ALL, ['UNENROLLED'], ['UNENROLLED', 'ACTIVE']);
+        expect(r.unreachable).toEqual([]);
+    });
+
+    test('every edge references declared states only', () => {
+        for (const t of TRANSITIONS) {
+            expect(ALL).toContain(t.from);
+            expect(ALL).toContain(t.to);
+        }
+    });
+});

--- a/checkin-app/src/lib/programs/enrollmentState.ts
+++ b/checkin-app/src/lib/programs/enrollmentState.ts
@@ -30,6 +30,7 @@ export type ProgramParticipantStatus = 'PENDING' | 'ACTIVE';
 
 // Parity: fails to compile if the schema enum and this union diverge (§3.4).
 // The runtime twin (assertEnumParity) lives in the unit test.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _Parity = Expect<Equal<ProgramParticipantStatus, PrismaStatus>>;
 
 type Where = Prisma.ProgramParticipantWhereInput;

--- a/checkin-app/src/lib/programs/enrollmentState.ts
+++ b/checkin-app/src/lib/programs/enrollmentState.ts
@@ -1,0 +1,195 @@
+/**
+ * ProgramParticipant enrollment lifecycle — ONE declarative definition.
+ *
+ * Instances the `@/lib/lifecycle` primitives per docs/designs/
+ * PROGRAM_ENROLLMENT_STATE_MACHINE.md (§3 states, §4 invariants I1–I4, §5
+ * transitions). This is the DEFINITION/VALIDATION layer only — it emits the
+ * `where`/predicate the existing compare-and-set guards already hand-write; it
+ * never executes a transition. Postgres stays the runtime authority.
+ *
+ * Client-safe (LIFECYCLE_ARCHITECTURE §3.4): value-imports NOTHING from
+ * `@/generated/prisma`. The status union is a local string-literal type checked
+ * against the Prisma enum by a TYPE-ONLY parity line; the `where` fragments are
+ * typed via `import type { Prisma }` (erased at build).
+ */
+import {
+    defineStateSet,
+    assertNever,
+    defineValidator,
+    type Invariant,
+    type Transition,
+    type Expect,
+    type Equal,
+} from '@/lib/lifecycle';
+// Type-only: erased at build, so no Prisma value reaches the client bundle.
+import type { Prisma, ProgramParticipantStatus as PrismaStatus } from '@/generated/prisma/client';
+
+/** Local status union — the trunk `status` column. `UNENROLLED` (∅/no row) is
+ *  not a status value; it appears only in the transition table. */
+export type ProgramParticipantStatus = 'PENDING' | 'ACTIVE';
+
+// Parity: fails to compile if the schema enum and this union diverge (§3.4).
+// The runtime twin (assertEnumParity) lives in the unit test.
+type _Parity = Expect<Equal<ProgramParticipantStatus, PrismaStatus>>;
+
+type Where = Prisma.ProgramParticipantWhereInput;
+
+/**
+ * The row shape the client-safe predicates see: nullable timestamps collapsed to
+ * PRESENCE booleans (§3.4 — keep `Date | null` out of the predicate). Map a DB
+ * row with `toRow` below.
+ */
+export type EnrollmentRow = {
+    status: ProgramParticipantStatus;
+    inventoryHeldAt: boolean;
+    isPaymentPlanRequested: boolean;
+    paymentPlanDeniedAt: boolean;
+};
+
+/** Collapse a persisted row's nullable columns to the presence booleans the
+ *  definition consumes. Client-safe (takes already-derived booleans is fine too). */
+export function toRow(db: {
+    status: ProgramParticipantStatus;
+    inventoryHeldAt: Date | null;
+    isPaymentPlanRequested: boolean;
+    paymentPlanDeniedAt: Date | null;
+}): EnrollmentRow {
+    return {
+        status: db.status,
+        inventoryHeldAt: db.inventoryHeldAt !== null,
+        isPaymentPlanRequested: db.isPaymentPlanRequested,
+        paymentPlanDeniedAt: db.paymentPlanDeniedAt !== null,
+    };
+}
+
+// ---- STATES (§3 table) ------------------------------------------------------
+// held = inventoryHeldAt (nullable TIMESTAMP → `flags`/presence);
+// req  = isPaymentPlanRequested (genuine BOOLEAN column → `equals`/value);
+// den  = paymentPlanDeniedAt (nullable TIMESTAMP → `flags`/presence).
+
+const mk = defineStateSet<Where>();
+
+export const STATES = {
+    /** PENDING, held=null, req=FALSE, den=null. Plain checkout, 7-day non-payment
+     *  clock. `req=false` is what makes the sweep SKIP PENDING_HOLD_FAILED. */
+    PENDING_UNPAID: mk({
+        statuses: ['PENDING'] as const,
+        flags: { inventoryHeldAt: false, paymentPlanDeniedAt: false },
+        equals: { isPaymentPlanRequested: false },
+    }),
+    /** PENDING, held=null, req=TRUE, den=null. Apply-time −1 failed → no seat held;
+     *  the board finishes it (reconciliation queue). NEVER auto-swept (req=true). */
+    PENDING_HOLD_FAILED: mk({
+        statuses: ['PENDING'] as const,
+        flags: { inventoryHeldAt: false, paymentPlanDeniedAt: false },
+        equals: { isPaymentPlanRequested: true },
+    }),
+    /** PENDING, held=set, req=TRUE, den=null. Applied, seat held, awaiting board. */
+    PENDING_HELD: mk({
+        statuses: ['PENDING'] as const,
+        flags: { inventoryHeldAt: true, paymentPlanDeniedAt: false },
+        equals: { isPaymentPlanRequested: true },
+    }),
+    /** PENDING, held=set, req=FALSE, den=set. Denied, seat still held, grace clock. */
+    PENDING_HELD_DENIED: mk({
+        statuses: ['PENDING'] as const,
+        flags: { inventoryHeldAt: true, paymentPlanDeniedAt: true },
+        equals: { isPaymentPlanRequested: false },
+    }),
+    /** ACTIVE, held=null. req/den are vestigial don't-cares once ACTIVE (§3 note);
+     *  the validator asserts only held=null (I1). */
+    ACTIVE: mk({
+        statuses: ['ACTIVE'] as const,
+        flags: { inventoryHeldAt: false },
+    }),
+} as const;
+
+// ---- classify (§3 table, total switch) --------------------------------------
+
+/** The named present-row states (UNENROLLED is the no-row state, so `classify`
+ *  never returns it — it only sees existing rows). */
+export type EnrollmentStateName =
+    | 'PENDING_UNPAID'
+    | 'PENDING_HOLD_FAILED'
+    | 'PENDING_HELD'
+    | 'PENDING_HELD_DENIED'
+    | 'ACTIVE';
+
+/**
+ * Name the row's legal state, or `null` if it is off-diagram (an I1–I4 violation,
+ * i.e. crash-window corruption or a future bug). Total over the status union:
+ * adding a status value fails to compile until handled (assertNever default).
+ */
+export function classify(row: EnrollmentRow): EnrollmentStateName | null {
+    switch (row.status) {
+        case 'ACTIVE':
+            // I1: ACTIVE ⟹ held null. A held seat on an ACTIVE row is off-diagram.
+            return row.inventoryHeldAt ? null : 'ACTIVE';
+        case 'PENDING':
+            if (!row.inventoryHeldAt) {
+                // held=null: I4 — a denial is only ever stamped on a held seat.
+                if (row.paymentPlanDeniedAt) return null;
+                // `req` is the discriminator between the two held=null states.
+                return row.isPaymentPlanRequested ? 'PENDING_HOLD_FAILED' : 'PENDING_UNPAID';
+            }
+            // held=set: I3 — exactly one of {req∧¬den} (awaiting) or {¬req∧den} (denied).
+            if (row.isPaymentPlanRequested && !row.paymentPlanDeniedAt) return 'PENDING_HELD';
+            if (!row.isPaymentPlanRequested && row.paymentPlanDeniedAt) return 'PENDING_HELD_DENIED';
+            return null; // both or neither → off-diagram
+        default:
+            return assertNever(row.status);
+    }
+}
+
+// ---- validate (§4 invariants I1–I4) -----------------------------------------
+
+const INVARIANTS: readonly Invariant<EnrollmentRow>[] = [
+    // I1 — ACTIVE ⟹ held = null. The money invariant (a −1 that never comes back).
+    { name: 'I1', holds: (r) => r.status !== 'ACTIVE' || !r.inventoryHeldAt },
+    // I2 — held ≠ null ⟹ status = PENDING. Corollary of I1.
+    { name: 'I2', holds: (r) => !r.inventoryHeldAt || r.status === 'PENDING' },
+    // I3 — PENDING ∧ held ⟹ exactly one of {req∧¬den} or {¬req∧den} (never both/neither).
+    {
+        name: 'I3',
+        holds: (r) => {
+            if (r.status !== 'PENDING' || !r.inventoryHeldAt) return true;
+            const awaiting = r.isPaymentPlanRequested && !r.paymentPlanDeniedAt;
+            const denied = !r.isPaymentPlanRequested && r.paymentPlanDeniedAt;
+            return awaiting !== denied; // exactly one (they can't both be true)
+        },
+    },
+    // I4 — PENDING ∧ held = null ⟹ den = null. UNPAID and HOLD_FAILED both satisfy
+    // this; they differ only by `req`, a discriminator not an invariant.
+    {
+        name: 'I4',
+        holds: (r) => !(r.status === 'PENDING' && !r.inventoryHeldAt && r.paymentPlanDeniedAt),
+    },
+];
+
+/** Return `{ invariant }` for the first violated invariant, or null when clean. */
+export const validate = defineValidator(INVARIANTS);
+
+// ---- TRANSITIONS (§5 table, as data — documentation + test oracle) ----------
+
+/** Every declared state, including the no-row `UNENROLLED` (∅). */
+export type LifecycleState = EnrollmentStateName | 'UNENROLLED';
+
+/**
+ * The §5 transition table as data. Drives the coverage matrix / reachability /
+ * BFS checks. NEVER executed: the guard `where`/`delete()`/`FOR UPDATE` at each
+ * `guardSite` stays byte-for-byte. `event` carries the T-id from the doc.
+ */
+export const TRANSITIONS: readonly Transition<LifecycleState>[] = [
+    { event: 'T1 enroll(paid)', from: 'UNENROLLED', to: 'PENDING_UNPAID', actor: 'user/admin', guardSite: 'participants/route.ts POST — FOR UPDATE capacity lock' },
+    { event: 'T2 enroll(comp)', from: 'UNENROLLED', to: 'ACTIVE', actor: 'user/admin', guardSite: 'participants/route.ts POST — initialStatus in same tx' },
+    { event: 'T3 apply(−1 ok)', from: 'PENDING_UNPAID', to: 'PENDING_HELD', actor: 'user', guardSite: 'request-payment-plan/route.ts — CAS status:PENDING, held:null' },
+    { event: 'T3 re-apply', from: 'PENDING_HELD_DENIED', to: 'PENDING_HELD', actor: 'user', guardSite: 'request-payment-plan/route.ts — CAS held:{not:null} (clears denial, no 2nd −1)' },
+    { event: 'T3f apply(−1 FAILS)', from: 'PENDING_UNPAID', to: 'PENDING_HOLD_FAILED', actor: 'user', guardSite: 'request-payment-plan/route.ts — roll held back to null; req stays true' },
+    { event: 'T3m manual-hold', from: 'PENDING_HOLD_FAILED', to: 'PENDING_HELD', actor: 'admin', guardSite: 'finance-ops/payment-plans/manual-hold/route.ts — CAS held:null, req:true → stamp held' },
+    { event: 'T4 activate(payment)', from: 'PENDING_UNPAID', to: 'ACTIVE', actor: 'shopify-webhook', guardSite: 'activateEnrollment.ts — CAS status:PENDING; release CAS held:{not:null}→null (fires on any PENDING)' },
+    { event: 'T5 approve', from: 'PENDING_HELD', to: 'ACTIVE', actor: 'admin', guardSite: 'finance-ops/payment-plans/route.ts — CAS req:true,status:PENDING; held→null WITHOUT +1; COI guard' },
+    { event: 'T6 deny', from: 'PENDING_HELD', to: 'PENDING_HELD_DENIED', actor: 'admin', guardSite: 'finance-ops/payment-plans/refuse/route.ts — CAS req:true,status:PENDING; stamp den; COI guard' },
+    { event: 'T7 non-payment kick', from: 'PENDING_UNPAID', to: 'UNENROLLED', actor: 'cron', guardSite: 'cron/pending-participants/route.ts — delete(); query filters req:false,den:null' },
+    { event: 'T8 grace expiry', from: 'PENDING_HELD_DENIED', to: 'UNENROLLED', actor: 'cron', guardSite: 'cron/scholarship-grace-expiry/route.ts — delete(); NULL graceDays = off' },
+    { event: 'T9 withdraw', from: 'PENDING_HELD', to: 'UNENROLLED', actor: 'user/admin', guardSite: 'capacity.ts withdrawAndReleaseHold — delete() = atomicity boundary; +1 iff held' },
+] as const;


### PR DESCRIPTION
## What

Phase 2a of the lifecycle work: instance the `@/lib/lifecycle` primitives (merged in #1063) for the **ProgramParticipant enrollment** machine, then refactor the enrollment read-queries to consume the definition. Pure refactor — no schema change, no behavior change, no transition guard altered.

Per `docs/designs/PROGRAM_ENROLLMENT_STATE_MACHINE.md` (6 states, invariants I1–I4, transitions T1–T9 incl. T3f/T3m).

### New module — `src/lib/programs/enrollmentState.ts` (client-safe: no runtime prisma import)
- **`STATES`** — the six §3 states as `StateSet`s. `flags` = nullable-timestamp presence (`inventoryHeldAt`, `paymentPlanDeniedAt`); `equals` = boolean-column value (`isPaymentPlanRequested`). `PENDING_UNPAID` carries `req=false`, which is what keeps `PENDING_HOLD_FAILED` (`req=true`) out of the 7-day non-payment sweep.
- **`classify(row)`** — total switch over the status union (`assertNever` default), encoding the §3 table incl. the `req` discriminator between the two `held=null` PENDING states and the ACTIVE `held`-must-be-null rule.
- **`validate(row)`** — invariants I1–I4 (§4).
- **`TRANSITIONS`** — the §5 table (T1–T9 incl. T3f/T3m) as data.
- Type-only enum parity vs the Prisma enum (§3.4) — no value import of `@/generated/prisma`.

### Refactor read filters to `STATES.*.where` (guards stay byte-for-byte)
- `finance-ops/payment-plans` GET: scholarship queue → `PENDING_HELD`, `?queue=holds` → `PENDING_HOLD_FAILED`.
- `cron/scholarship-grace-expiry`: `PENDING_HELD_DENIED` (+ `lte: cutoff`).
- `cron/pending-participants`: `PENDING_UNPAID` (+ `pendingSince`).

## Why

Class-A anti-drift (LIFECYCLE_ARCHITECTURE §1): the legal `(status, held, req, den)` tuples had no name, and the queue/cron `where` filters were hand-coded in four places with nothing forcing them to agree. One definition now emits both the predicate and the Prisma `where`, so they can't diverge.

## Reviewer notes
- **No transition guard touched.** The CAS `updateMany`s, `delete()`-as-boundary, and `FOR UPDATE` locks are unchanged — they encode "from-state ∧ nothing-changed-under-me", deliberately narrower than a state predicate. They're asserted against `classify`/`STATES.*.has` in tests, not rewritten.
- **Client-safe:** module value-imports nothing from `@/generated/prisma` (`import type` only).
- Behavior-preserving: the refactored `where`s equal the literals they replaced on all legal data (asserted in unit tests).

## Tests
- **Unit** (`enrollmentState.test.ts`, 17 cases): classify/validate over the 6 tuples + ACTIVE vestigial-flag cases + I1–I4 violations; `where` ⇔ `has` across a status×held×req×den matrix; enum parity.
- **Integration** (`enrollmentStateOracle.integration.test.ts`): drive T3/T3f/T3m/T4–T9 against a real DB, assert each row `classify`es to the expected state and `validate`s clean; a simulated crash window (activate step-1 committed, release skipped) is flagged as an I1 violation.
- Full unit suite **1960 passed / 222 suites**; integration **55 passed** incl. pre-existing `programPaymentPlansAPI`, `cronPendingParticipants`, `cronScholarshipGraceExpiry`; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)