### PR TITLE
fix(ui): frame the header logo as a rounded white chip for dark mode

### DIFF
--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -220,7 +220,19 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
   const brandEl = (
     <Link href="/" onNavigate={guardNav} style={{ display: 'inline-flex', alignItems: 'center', gap: 8, textDecoration: 'none' }}>
       {brand.logo ? (
-        <Image src={brand.logo.src} alt={brand.logo.alt} width={brand.logo.width} height={brand.logo.height} priority />
+        // The logo art ships with a baked-in white background, so in dark mode a
+        // bare <Image> reads as a stark white rectangle. Framing it as a rounded
+        // white chip makes the white deliberate; in light mode the chip is
+        // invisible (white on white). Transparency isn't an option — the mark's
+        // own colors need the light background.
+        <Box
+          bg="white"
+          px={6}
+          py={2}
+          style={{ borderRadius: 'var(--mantine-radius-md)', display: 'inline-flex', alignItems: 'center' }}
+        >
+          <Image src={brand.logo.src} alt={brand.logo.alt} width={brand.logo.width} height={brand.logo.height} priority />
+        </Box>
       ) : (
         <Title order={3} tt="lowercase" c={`${brand.nav.accent}.7`}>
           {brand.appName}


### PR DESCRIPTION
Dark-mode dogfooding: the header logo's baked-in white background rendered as a hard-edged white rectangle on the dark header. Per the report — transparency can't work (the mark's own colors need a light background) — the logo is now framed as a **rounded white chip** (6/2 padding, `radius-md`), so the white reads as a deliberate badge in dark mode and disappears entirely (white on white) in light mode.

One-file change in `AppFrame.tsx`; the DEV badge and brand fallback title are untouched. AppFrame RTL 12/12, tsc clean. Worth one glance in both themes after deploy — chip padding is a taste call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe