### PR TITLE
feat(membership): OrgMembershipProcess lifecycle definition (Phase 2b) + 4 fixes

### DIFF
--- a/checkin-app/src/app/__tests__/householdsListGrantableAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsListGrantableAPI.integration.test.ts
@@ -81,9 +81,10 @@ describe('GET /api/membership-ops/households — renewalGrantable + dates', () =
         const grantableMembership = await prisma.orgMembership.create({ data: { householdId: grantableHouseholdId, status: 'ACTIVE' } });
         await prisma.orgMembershipProcess.create({ data: { orgMembershipId: grantableMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() } });
 
-        // Stale-BG case: PENDING_PAYMENT + bgClearedAt set, lead's own check is stale.
-        // Grant comps PAYMENT only and BG still gates ACTIVE, so this IS grantable —
-        // lead BG freshness no longer gates the button (behavior (a)).
+        // Stale-lead-BG case: PENDING_PAYMENT + bgClearedAt set, but the lead's own
+        // check is stale. Grant comps payment and BG (already cleared on the process)
+        // gates ACTIVE — lead freshness no longer gates the button (behavior (a)), so
+        // this IS grantable.
         const staleBg = await prisma.person.create({
             data: { email: `stalebg-${TAG}@example.com`, name: 'Stale Lead', isHouseholdLead: true, lastBackgroundCheck: new Date(Date.UTC(2015, 0, 1)), household: { create: { name: `Stale HH ${TAG}` } } },
         });
@@ -155,5 +156,131 @@ describe('GET /api/membership-ops/households — renewalGrantable + dates', () =
         const expected = nextBoundary(new Date(Date.UTC(2000, 11, 25)), new Date());
         expect(h.validUntil).toEqual(expect.stringMatching(new RegExp(`^${expected.toISOString().slice(0, 10)}`)));
         expect(h.orgMembership.memberSince).toBeTruthy();
+    });
+});
+
+/**
+ * settledForComingYear (membership doc §7.4, fix #4). The route's "handled this
+ * cycle" probe now consumes settledThisCycleWhere = kind=RENEWAL, status IN
+ * (ACTIVE, ARCHIVED), stageEnteredAt≥windowStart. Requires a boundary that puts
+ * `now` inside the renewal window so the probe is live (out of season it matches
+ * nothing, and settledForComingYear is trivially false — see the describe above).
+ */
+describe('GET /api/membership-ops/households — settledForComingYear (fix #4)', () => {
+    const TAG4 = 'households-settled-fix4-test';
+    let adminId: number;
+    let prev: { orgMembershipYearBoundary: Date | null; bgRecheckMonths: number } | null = null;
+
+    // A boundary ~1 month ahead ⇒ windowStart ~1 month ago ⇒ now is in-season and a
+    // stageEnteredAt of `now` sits inside the window.
+    const boundaryConfig = (() => {
+        const b = new Date();
+        b.setUTCMonth(b.getUTCMonth() + 1);
+        return b;
+    })();
+
+    let initialActiveHouseholdId: number; // stray INITIAL activation in-window
+    let archivedRenewalHouseholdId: number; // board-archived RENEWAL in-window
+    let activeRenewalHouseholdId: number; // finished RENEWAL in-window (control)
+
+    async function wipe() {
+        const hhs = await prisma.household.findMany({ where: { name: { contains: TAG4 } }, select: { id: true } });
+        const ids = hhs.map((h) => h.id);
+        if (ids.length) {
+            const memberships = await prisma.orgMembership.findMany({ where: { householdId: { in: ids } }, select: { id: true } });
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembershipId: { in: memberships.map((m) => m.id) } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.household.deleteMany({ where: { id: { in: ids } } });
+        }
+        await prisma.person.deleteMany({ where: { email: { contains: TAG4 } } });
+    }
+
+    beforeAll(async () => {
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prev = existing ? { orgMembershipYearBoundary: existing.orgMembershipYearBoundary, bgRecheckMonths: existing.bgRecheckMonths } : null;
+        await wipe();
+        await prisma.boardSettings.upsert({
+            where: { id: 1 },
+            create: { id: 1, orgMembershipYearBoundary: boundaryConfig, bgRecheckMonths: 12 },
+            update: { orgMembershipYearBoundary: boundaryConfig, bgRecheckMonths: 12 },
+        });
+
+        adminId = (await prisma.person.create({
+            data: { email: `admin-${TAG4}@example.com`, name: 'Admin', isSysadmin: true, household: { create: { name: `Admin HH ${TAG4}` } } },
+        })).id;
+
+        const now = new Date();
+
+        // Stray INITIAL activation stamped in-window: the pre-fix bug counted this as
+        // "settled" (any-kind ACTIVE) and flipped validUntil a year forward. Fix #4's
+        // kind=RENEWAL filter must now EXCLUDE it.
+        const a = await prisma.person.create({
+            data: { email: `initial-${TAG4}@example.com`, name: 'Initial Active', isHouseholdLead: true, household: { create: { name: `Initial HH ${TAG4}` } } },
+        });
+        initialActiveHouseholdId = a.householdId;
+        const am = await prisma.orgMembership.create({ data: { householdId: initialActiveHouseholdId, status: 'ACTIVE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: am.id, kind: 'INITIAL', status: 'ACTIVE', stageEnteredAt: now } });
+
+        // Board-archived RENEWAL in-window: the pre-fix route missed ARCHIVED; fix #4
+        // now counts it as settled.
+        const b = await prisma.person.create({
+            data: { email: `archived-${TAG4}@example.com`, name: 'Archived Renewal', isHouseholdLead: true, household: { create: { name: `Archived HH ${TAG4}` } } },
+        });
+        archivedRenewalHouseholdId = b.householdId;
+        const bm = await prisma.orgMembership.create({ data: { householdId: archivedRenewalHouseholdId, status: 'ACTIVE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: bm.id, kind: 'RENEWAL', status: 'ARCHIVED', stageEnteredAt: now } });
+
+        // Control: a finished RENEWAL (ACTIVE) in-window is settled, as before.
+        const c = await prisma.person.create({
+            data: { email: `renewalactive-${TAG4}@example.com`, name: 'Active Renewal', isHouseholdLead: true, household: { create: { name: `ActiveRenewal HH ${TAG4}` } } },
+        });
+        activeRenewalHouseholdId = c.householdId;
+        const cm = await prisma.orgMembership.create({ data: { householdId: activeRenewalHouseholdId, status: 'ACTIVE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: cm.id, kind: 'RENEWAL', status: 'ACTIVE', stageEnteredAt: now } });
+    });
+
+    afterAll(async () => {
+        await wipe();
+        if (prev) await prisma.boardSettings.update({ where: { id: 1 }, data: prev });
+        await prisma.$disconnect();
+    });
+
+    async function fetchHouseholds() {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+        const res = await get();
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        // sanity: we are actually in renewal season (else the probe is trivially empty)
+        expect(data.renewalSeason).toBe(true);
+        return data.households as { id: number; settledForComingYear: boolean; validUntil: string | null }[];
+    }
+
+    it('a stray INITIAL activation in-window is NOT settled (kind=RENEWAL filter)', async () => {
+        const households = await fetchHouseholds();
+        const h = households.find((x) => x.id === initialActiveHouseholdId);
+        expect(h).toBeDefined();
+        expect(h!.settledForComingYear).toBe(false);
+        // validUntil stays the upcoming boundary — NOT flipped a year forward.
+        const expected = nextBoundary(boundaryConfig, new Date());
+        expect(h!.validUntil).toEqual(expect.stringMatching(new RegExp(`^${expected.toISOString().slice(0, 10)}`)));
+    });
+
+    it('a board-archived RENEWAL in-window IS settled (ARCHIVED counted)', async () => {
+        const households = await fetchHouseholds();
+        const h = households.find((x) => x.id === archivedRenewalHouseholdId);
+        expect(h).toBeDefined();
+        expect(h!.settledForComingYear).toBe(true);
+        // settled ⇒ validUntil is the boundary a year later.
+        const boundary = nextBoundary(boundaryConfig, new Date());
+        const plusYear = new Date(Date.UTC(boundary.getUTCFullYear() + 1, boundary.getUTCMonth(), boundary.getUTCDate()));
+        expect(h!.validUntil).toEqual(expect.stringMatching(new RegExp(`^${plusYear.toISOString().slice(0, 10)}`)));
+    });
+
+    it('a finished RENEWAL (ACTIVE) in-window IS settled (control)', async () => {
+        const households = await fetchHouseholds();
+        const h = households.find((x) => x.id === activeRenewalHouseholdId);
+        expect(h).toBeDefined();
+        expect(h!.settledForComingYear).toBe(true);
     });
 });

--- a/checkin-app/src/app/__tests__/indexPredicateMatchesConstant.integration.test.ts
+++ b/checkin-app/src/app/__tests__/indexPredicateMatchesConstant.integration.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Index-parity drift alarm (membership doc §7.2, fix #2).
+ *
+ * The two partial unique indexes are hand-written raw SQL in migrations; the
+ * TS in-flight status lists are `IN_FLIGHT_INITIAL` / `IN_FLIGHT_RENEWAL` in
+ * lib/membership/lifecycle. Nothing but this test forces them equal. It READS
+ * pg_indexes.indexdef (never alters DDL) and asserts each index's
+ * `WHERE status = ANY (ARRAY[…])` set equals the constant — turning the old
+ * hand-sync comment into an enforced check. The 20260715 migration already had
+ * to widen the renewal index by hand to match a TS edit; this catches the next
+ * such drift automatically.
+ *
+ * Requires the migrate-deploy-provisioned integration DB (the partial indexes
+ * are migration-only, so a db-push schema would not have them).
+ */
+import prisma from '@/lib/prisma';
+import { IN_FLIGHT_INITIAL, IN_FLIGHT_RENEWAL } from '@/lib/membership/lifecycle';
+
+/** Pull the status literals out of an index's `status = ANY (ARRAY[…])` predicate. */
+async function indexStatuses(indexName: string): Promise<string[]> {
+    const rows = await prisma.$queryRaw<{ indexdef: string }[]>`
+        SELECT indexdef FROM pg_indexes WHERE indexname = ${indexName}
+    `;
+    if (rows.length === 0) throw new Error(`index ${indexName} not found in pg_indexes (is the test DB migrate-deployed?)`);
+    const def = rows[0].indexdef;
+    // pg normalizes `status IN (...)` to `status = ANY (ARRAY['A'::"…", 'B'::"…"])`.
+    // indexdef is a single line; `.` need not span newlines (no dotAll flag).
+    const arr = def.match(/status\s*=\s*ANY\s*\(ARRAY\[(.+?)\]/i);
+    if (!arr) throw new Error(`could not find a status ANY(ARRAY[…]) predicate in:\n${def}`);
+    return [...arr[1].matchAll(/'([A-Z_]+)'/g)].map((m) => m[1]);
+}
+
+describe('partial unique index predicates match the IN_FLIGHT_* constants', () => {
+    afterAll(async () => {
+        await prisma.$disconnect();
+    });
+
+    test('membership_one_inflight_initial === IN_FLIGHT_INITIAL', async () => {
+        const statuses = await indexStatuses('membership_one_inflight_initial');
+        expect(new Set(statuses)).toEqual(new Set(IN_FLIGHT_INITIAL));
+    });
+
+    test('membership_one_inflight_renewal === IN_FLIGHT_RENEWAL', async () => {
+        const statuses = await indexStatuses('membership_one_inflight_renewal');
+        expect(new Set(statuses)).toEqual(new Set(IN_FLIGHT_RENEWAL));
+    });
+});

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -5,6 +5,7 @@ import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 import { renewalSeasonWindow, nextBoundary, bgValidUntilBoundary, grantRenewalPayment } from "@/lib/membership/renewal";
+import { grantableRenewalWhere, settledThisCycleWhere } from "@/lib/membership/lifecycle";
 import { PaymentError } from "@/lib/membership/payment";
 
 export const dynamic = 'force-dynamic';
@@ -74,12 +75,16 @@ export const GET = withAuth(
                 const detailBoundary = settings?.orgMembershipYearBoundary
                     ? nextBoundary(settings.orgMembershipYearBoundary, new Date())
                     : null;
+                // "Settled this cycle" = a RENEWAL resolved (ACTIVE/ARCHIVED) inside the
+                // window (fix #4, settledThisCycleWhere) — same test the list branch and
+                // runRenewalSweep use, so a stray INITIAL activation no longer flips
+                // derivedValidUntil a year forward. Out of season the window start is
+                // "never" (matches nothing).
                 const detailSettled = household.orgMembership
                     ? (await prisma.orgMembershipProcess.findFirst({
                           where: {
                               orgMembershipId: household.orgMembership.id,
-                              status: "ACTIVE",
-                              stageEnteredAt: { gte: detailWindow?.windowStart ?? new Date(8.64e15) },
+                              ...settledThisCycleWhere(detailWindow?.windowStart ?? new Date(8.64e15)),
                           },
                           select: { id: true },
                       })) !== null
@@ -128,21 +133,21 @@ export const GET = withAuth(
                         // JSON at the same trust level as the rest of the row.
                         select: { id: true, name: true, email: true, isBoardMember: true, emailUndeliverableAt: true, isHouseholdLead: true, lastBackgroundCheck: true }
                     },
-                    // ONE probe serves both flags computed below: any PENDING_PAYMENT
-                    // renewal is grantable (grant comps payment; BG proceeds in parallel
-                    // and still gates ACTIVE — see grantRenewalPayment), and a terminal
-                    // ACTIVE process stamped inside the renewal window — the same "handled
-                    // this cycle" test runRenewalSweep uses — marks the coming year settled.
-                    // Out of season the window start is "never" (matches no row), keeping one
-                    // query shape and one inferred type. orgMembership's own scalars (status,
-                    // memberSince) still ride along via this include.
+                    // ONE probe serves both flags computed below, from the shared lifecycle
+                    // definitions: grantableRenewalWhere (payable renewal → grantability,
+                    // fix #3) and settledThisCycleWhere (a RENEWAL resolved ACTIVE/ARCHIVED
+                    // inside the renewal window → coming year settled, the same "handled this
+                    // cycle" test runRenewalSweep uses, fix #4). Out of season the window
+                    // start is "never" (matches no row), keeping one query shape and one
+                    // inferred type. orgMembership's own scalars (status, memberSince) still
+                    // ride along via this include.
                     orgMembership: {
                         include: {
                             processes: {
                                 where: {
                                     OR: [
-                                        { kind: "RENEWAL", status: "PENDING_PAYMENT" },
-                                        { status: "ACTIVE", stageEnteredAt: { gte: window?.windowStart ?? new Date(8.64e15) } },
+                                        grantableRenewalWhere,
+                                        settledThisCycleWhere(window?.windowStart ?? new Date(8.64e15)),
                                     ],
                                 },
                                 select: { id: true, status: true },
@@ -170,12 +175,15 @@ export const GET = withAuth(
             const bgSettings = { orgMembershipYearBoundary: settings?.orgMembershipYearBoundary ?? null, bgRecheckMonths: recheckMonths };
 
             const withGrantable = households.map((h) => {
-                // Split the single OR probe: a PENDING_PAYMENT renewal is grantable
-                // (grant comps payment, BG runs in parallel); an ACTIVE row = the coming
-                // cycle is already settled (member finished renewal, or admin overrode).
+                // Split the single OR probe by status: PENDING_PAYMENT = grantable renewal
+                // (grantableRenewalWhere — any payable renewal; the grant comps payment and
+                // BG stays an independent gate on ACTIVE, so no bgFresh gate); a terminal
+                // ACTIVE/ARCHIVED renewal = the coming cycle is already settled
+                // (settledThisCycleWhere: member finished renewal, admin override, or
+                // board-archived this cycle).
                 const { processes = [], ...orgMembership } = h.orgMembership ?? {};
                 const renewalGrantable = processes.some((p) => p.status === "PENDING_PAYMENT");
-                const settledForComingYear = processes.some((p) => p.status === "ACTIVE");
+                const settledForComingYear = processes.some((p) => p.status === "ACTIVE" || p.status === "ARCHIVED");
                 // Household-level BG "valid until" — later lastBackgroundCheck among leads
                 // who passed; no per-member values in the list response.
                 const latestLeadBg = h.householdMembers

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -11,6 +11,7 @@ import { notifyNavRefresh } from "@/lib/nav-refresh";
 import { sharesHousehold } from "@/lib/conflictOfInterest";
 import { PageLoader } from "@/components/ui/PageLoader";
 import { StatusFilterBadge, ActiveFilterNotice, useStatusFilter } from "@/components/StatusFilter";
+import { awaitingBgReview, type ProcessStatus } from "@/lib/membership/lifecycle";
 
 interface Person {
   id: number;
@@ -56,12 +57,10 @@ const statusColor = (status: string) => STATUS_COLORS[status] || "gray";
 const statusLabel = (status: string) => status.replace(/_/g, " ");
 
 // The background check is a parallel track: an application still needs review
-// when it hasn't cleared and is past consent (mirrors review.ts isAwaitingBgReview).
+// when it hasn't cleared and is past consent. ONE definition, shared with the
+// server (fix #1): awaitingBgReview.has — client-safe (booleans in, no Prisma).
 const awaitingBg = (r: ProcessRow) =>
-  !r.bgClearedAt &&
-  (r.status === "PENDING_BG_REVIEW" ||
-    r.status === "RENEWAL_PENDING_BG" ||
-    ((r.status === "PENDING_PAYMENT" || r.status === "PENDING_BG_CLEARANCE") && !!r.bgConsentAt));
+  awaitingBgReview.has({ status: r.status as ProcessStatus, bgConsentAt: !!r.bgConsentAt, bgClearedAt: !!r.bgClearedAt });
 
 export default function AdminMembershipPage() {
   return (

--- a/checkin-app/src/lib/membership/__tests__/lifecycle.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/lifecycle.test.ts
@@ -1,0 +1,239 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for the membership lifecycle definition (lib/membership/lifecycle).
+ * Pure — no DB. Proves the anti-drift guarantees the four fixes rely on:
+ *   - awaitingBgReview.has (client predicate) ≡ awaitingBgReview.where (server
+ *     Prisma fragment) across the full status × flags matrix (fix #1);
+ *   - grantableRenewalWhere / settledThisCycleWhere emit the exact fragments the
+ *     route + guard + sweep consume (fix #3/#4);
+ *   - isLegalTransition covers the doc §5 edges; reachability flags the legacy
+ *     RENEWAL_PENDING_BG as unreachable (doc §4.6 / §6.1);
+ *   - the local ProcessStatus/ProcessKind unions stay in lockstep with the Prisma
+ *     enums (value-based assertEnumParity here; type-only Expect<Equal> in-module).
+ */
+import {
+    OrgMembershipProcessStatus,
+    OrgMembershipProcessKind,
+} from '@/generated/prisma/client';
+import {
+    awaitingBgReview,
+    grantableRenewalWhere,
+    settledThisCycleWhere,
+    IN_FLIGHT_INITIAL,
+    IN_FLIGHT_RENEWAL,
+    LEGACY_STATUSES,
+    classify,
+    validate,
+    isLegalTransition,
+    TRANSITIONS,
+    ALL_STATUSES,
+    INITIAL_STATES,
+    type ProcessStatus,
+} from '@/lib/membership/lifecycle';
+import { assertEnumParity, reachability } from '@/lib/lifecycle';
+
+// ── fix #1: awaitingBgReview — has ≡ where on the full matrix ───────────────────
+
+/**
+ * Interpret awaitingBgReview.where against a row — the server-side semantics — so
+ * we can assert it agrees with the client-side `has` for EVERY combination. If the
+ * two ever drift (the whole point of the StateSet), this fails.
+ */
+function whereMatches(row: { status: ProcessStatus; bgConsentAt: boolean; bgClearedAt: boolean }): boolean {
+    const w = awaitingBgReview.where as {
+        bgClearedAt: null;
+        OR: { status: { in: string[] }; bgConsentAt?: { not: null } }[];
+    };
+    if (row.bgClearedAt) return false; // where pins bgClearedAt: null
+    return w.OR.some((clause) => {
+        if (!clause.status.in.includes(row.status)) return false;
+        if (clause.bgConsentAt) return row.bgConsentAt; // { not: null } ⇒ present
+        return true;
+    });
+}
+
+describe('awaitingBgReview', () => {
+    test('has ≡ where across status × bgConsentAt × bgClearedAt', () => {
+        for (const status of ALL_STATUSES) {
+            for (const bgConsentAt of [true, false]) {
+                for (const bgClearedAt of [true, false]) {
+                    const row = { status, bgConsentAt, bgClearedAt };
+                    expect(awaitingBgReview.has(row)).toBe(whereMatches(row));
+                }
+            }
+        }
+    });
+
+    test('encodes review.ts:75 exactly', () => {
+        // cleared ⇒ never awaiting, regardless of status
+        expect(awaitingBgReview.has({ status: 'PENDING_BG_REVIEW', bgConsentAt: true, bgClearedAt: true })).toBe(false);
+        // review states: awaiting whenever not cleared, consent irrelevant
+        expect(awaitingBgReview.has({ status: 'PENDING_BG_REVIEW', bgConsentAt: false, bgClearedAt: false })).toBe(true);
+        expect(awaitingBgReview.has({ status: 'RENEWAL_PENDING_BG', bgConsentAt: false, bgClearedAt: false })).toBe(true);
+        // parallel states: awaiting only once consent is recorded
+        expect(awaitingBgReview.has({ status: 'PENDING_PAYMENT', bgConsentAt: true, bgClearedAt: false })).toBe(true);
+        expect(awaitingBgReview.has({ status: 'PENDING_PAYMENT', bgConsentAt: false, bgClearedAt: false })).toBe(false);
+        expect(awaitingBgReview.has({ status: 'PENDING_BG_CLEARANCE', bgConsentAt: true, bgClearedAt: false })).toBe(true);
+        // unrelated statuses never await
+        expect(awaitingBgReview.has({ status: 'INTAKE', bgConsentAt: true, bgClearedAt: false })).toBe(false);
+        expect(awaitingBgReview.has({ status: 'ACTIVE', bgConsentAt: true, bgClearedAt: false })).toBe(false);
+    });
+
+    test('where is the exact AWAITING_BG_WHERE fragment it replaced', () => {
+        expect(awaitingBgReview.where).toEqual({
+            bgClearedAt: null,
+            OR: [
+                { status: { in: ['PENDING_BG_REVIEW', 'RENEWAL_PENDING_BG'] } },
+                { status: { in: ['PENDING_PAYMENT', 'PENDING_BG_CLEARANCE'] }, bgConsentAt: { not: null } },
+            ],
+        });
+    });
+});
+
+// ── fix #3 / #4: renewal where builders ────────────────────────────────────────
+
+describe('grantableRenewalWhere / settledThisCycleWhere', () => {
+    test('grantableRenewalWhere = payable renewal, NOT bg-gated (fix #3, behavior (a))', () => {
+        // Grant comps payment only; BG stays an independent gate on ACTIVE. So any
+        // PENDING_PAYMENT renewal qualifies — no bgClearedAt clause.
+        expect(grantableRenewalWhere).toEqual({ kind: 'RENEWAL', status: 'PENDING_PAYMENT' });
+    });
+
+    test('settledThisCycleWhere adds kind=RENEWAL + ARCHIVED + window (fix #4)', () => {
+        const windowStart = new Date('2026-06-01T00:00:00.000Z');
+        expect(settledThisCycleWhere(windowStart)).toEqual({
+            kind: 'RENEWAL',
+            status: { in: ['ACTIVE', 'ARCHIVED'] },
+            stageEnteredAt: { gte: windowStart },
+        });
+    });
+});
+
+// ── fix #2: in-flight lists ────────────────────────────────────────────────────
+
+describe('IN_FLIGHT lists', () => {
+    test('INITIAL is the 5 open INITIAL statuses', () => {
+        expect(IN_FLIGHT_INITIAL).toEqual([
+            'INTAKE',
+            'PENDING_EXTERNAL_ACTION',
+            'PENDING_BG_REVIEW',
+            'PENDING_PAYMENT',
+            'PENDING_BG_CLEARANCE',
+        ]);
+    });
+
+    test('RENEWAL is the 6 open RENEWAL statuses incl. legacy RENEWAL_PENDING_BG', () => {
+        expect(new Set(IN_FLIGHT_RENEWAL)).toEqual(
+            new Set([
+                'PENDING_RENEWAL',
+                'PENDING_EXTERNAL_ACTION',
+                'PENDING_BG_REVIEW',
+                'PENDING_PAYMENT',
+                'PENDING_BG_CLEARANCE',
+                'RENEWAL_PENDING_BG',
+            ]),
+        );
+        expect(IN_FLIGHT_RENEWAL).toContain('RENEWAL_PENDING_BG');
+        expect(LEGACY_STATUSES).toEqual(['RENEWAL_PENDING_BG']);
+        // legacy is never in the INITIAL set
+        expect(IN_FLIGHT_INITIAL).not.toContain('RENEWAL_PENDING_BG');
+    });
+});
+
+// ── classify / validate ────────────────────────────────────────────────────────
+
+describe('classify', () => {
+    const flags = { contractSignedAt: false, bgConsentAt: false, bgClearedAt: false, paidAt: false };
+
+    test('names on-diagram rows by status', () => {
+        expect(classify({ ...flags, status: 'PENDING_PAYMENT' })).toBe('PENDING_PAYMENT');
+        expect(classify({ ...flags, status: 'ACTIVE', bgClearedAt: true })).toBe('ACTIVE');
+        expect(classify({ ...flags, status: 'ARCHIVED' })).toBe('ARCHIVED');
+    });
+
+    test('returns null for off-diagram flag combinations', () => {
+        expect(classify({ ...flags, status: 'INTAKE', paidAt: true })).toBeNull(); // paid before external
+        expect(classify({ ...flags, status: 'ACTIVE', bgClearedAt: false })).toBeNull(); // active must be cleared
+    });
+});
+
+describe('validate', () => {
+    const flags = { contractSignedAt: false, bgConsentAt: false, bgClearedAt: false, paidAt: false };
+    test('clean rows validate null', () => {
+        expect(validate({ ...flags, status: 'ACTIVE', bgClearedAt: true })).toBeNull();
+        expect(validate({ ...flags, status: 'INTAKE' })).toBeNull();
+    });
+    test('flags the violated invariant', () => {
+        expect(validate({ ...flags, status: 'INTAKE', paidAt: true })).toEqual({ invariant: 'intake-is-unpaid' });
+        expect(validate({ ...flags, status: 'ACTIVE', bgClearedAt: false })).toEqual({ invariant: 'active-is-bg-cleared' });
+    });
+});
+
+// ── transitions (doc §5) ───────────────────────────────────────────────────────
+
+describe('isLegalTransition covers §5', () => {
+    test('accepts declared spine edges', () => {
+        expect(isLegalTransition('INTAKE', 'PENDING_EXTERNAL_ACTION')).toBe(true);
+        expect(isLegalTransition('PENDING_RENEWAL', 'PENDING_EXTERNAL_ACTION')).toBe(true);
+        expect(isLegalTransition('PENDING_EXTERNAL_ACTION', 'PENDING_PAYMENT')).toBe(true);
+        expect(isLegalTransition('PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW')).toBe(true);
+        expect(isLegalTransition('PENDING_PAYMENT', 'ACTIVE')).toBe(true);
+        expect(isLegalTransition('PENDING_PAYMENT', 'PENDING_BG_CLEARANCE')).toBe(true);
+        expect(isLegalTransition('PENDING_BG_REVIEW', 'PENDING_PAYMENT')).toBe(true);
+        expect(isLegalTransition('PENDING_BG_CLEARANCE', 'ACTIVE')).toBe(true);
+    });
+
+    test('accepts BLOCKED transitions (reject + override resets/approve)', () => {
+        expect(isLegalTransition('PENDING_BG_REVIEW', 'BLOCKED')).toBe(true);
+        expect(isLegalTransition('PENDING_PAYMENT', 'BLOCKED')).toBe(true);
+        expect(isLegalTransition('BLOCKED', 'PENDING_PAYMENT')).toBe(true);
+        expect(isLegalTransition('BLOCKED', 'PENDING_BG_CLEARANCE')).toBe(true);
+        expect(isLegalTransition('BLOCKED', 'PENDING_BG_REVIEW')).toBe(true);
+        expect(isLegalTransition('BLOCKED', 'ACTIVE')).toBe(true);
+    });
+
+    test('accepts archive from every pre-terminal status, not from ACTIVE', () => {
+        for (const from of ['INTAKE', 'PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW', 'PENDING_PAYMENT', 'PENDING_BG_CLEARANCE', 'PENDING_RENEWAL', 'BLOCKED'] as ProcessStatus[]) {
+            expect(isLegalTransition(from, 'ARCHIVED')).toBe(true);
+        }
+        expect(isLegalTransition('ACTIVE', 'ARCHIVED')).toBe(false);
+    });
+
+    test('rejects undeclared edges', () => {
+        expect(isLegalTransition('INTAKE', 'ACTIVE')).toBe(false);
+        expect(isLegalTransition('ACTIVE', 'PENDING_PAYMENT')).toBe(false);
+        expect(isLegalTransition('ARCHIVED', 'ACTIVE')).toBe(false);
+    });
+
+    test('filters by kind: grantRenewalPayment PENDING_PAYMENT→ACTIVE is RENEWAL-only', () => {
+        // The renewal-grant edge is tagged kind: RENEWAL; the generic activate edge
+        // (kind undefined) also matches PENDING_PAYMENT→ACTIVE, so both kinds pass —
+        // assert the RENEWAL edge exists explicitly in the table.
+        expect(TRANSITIONS.some((t) => t.from === 'PENDING_PAYMENT' && t.to === 'ACTIVE' && t.kind === 'RENEWAL')).toBe(true);
+    });
+});
+
+describe('reachability (doc §6.1)', () => {
+    test('flags the legacy RENEWAL_PENDING_BG as unreachable', () => {
+        const r = reachability(TRANSITIONS, ALL_STATUSES, INITIAL_STATES, ['ACTIVE', 'ARCHIVED']);
+        expect(r.unreachable).toContain('RENEWAL_PENDING_BG');
+        // every other status is reachable from an entry state
+        for (const s of ALL_STATUSES) {
+            if (s === 'RENEWAL_PENDING_BG') continue;
+            expect(r.reachable).toContain(s);
+        }
+    });
+});
+
+// ── enum parity (LIFECYCLE_ARCHITECTURE §3.4) ──────────────────────────────────
+
+describe('enum parity with Prisma', () => {
+    test('ProcessStatus union matches OrgMembershipProcessStatus keys', () => {
+        expect(() => assertEnumParity(ALL_STATUSES, OrgMembershipProcessStatus, 'OrgMembershipProcessStatus')).not.toThrow();
+    });
+    test('ProcessKind union matches OrgMembershipProcessKind keys', () => {
+        expect(() => assertEnumParity(['INITIAL', 'RENEWAL', 'PERSON_BG'], OrgMembershipProcessKind, 'OrgMembershipProcessKind')).not.toThrow();
+    });
+});

--- a/checkin-app/src/lib/membership/lifecycle.ts
+++ b/checkin-app/src/lib/membership/lifecycle.ts
@@ -1,0 +1,299 @@
+/**
+ * OrgMembershipProcess lifecycle — ONE declarative definition (Phase 2b).
+ *
+ * See docs/designs/ORG_MEMBERSHIP_STATE_MACHINE.md. This module instances the
+ * dependency-free primitives in `@/lib/lifecycle` for the membership machine:
+ * the states, the transition-set predicates (as StateSets that emit BOTH a
+ * client-safe `has` and a server Prisma `where` from one source), the
+ * transition table, and classify/validate. It is a DEFINITION layer only — it
+ * never executes a transition. Postgres stays the runtime authority; every
+ * `FOR UPDATE` lock, conditional `updateMany`, and partial-unique-index +
+ * P2002 catch is unchanged and merely *fed* the status set it names.
+ *
+ * CLIENT-SAFETY (doc §6.1, LIFECYCLE_ARCHITECTURE §3.4) — CRITICAL, pages import
+ * this file: NOTHING here value-imports `@/generated/prisma`. `Prisma` and the
+ * enums are `import type` only (erased at build); predicates take booleans, not
+ * `Date | null`; the `where` fragments are plain object literals typed via the
+ * generic. The enum-parity assertion is compile-time here (type-only) and
+ * value-based only in the test.
+ */
+import type { Prisma, OrgMembershipProcessStatus, OrgMembershipProcessKind } from "@/generated/prisma/client";
+import {
+    type StateSet,
+    assertNever,
+    defineValidator,
+    type Invariant,
+    isLegalTransition as baseIsLegalTransition,
+    type Transition,
+    type Expect,
+    type Equal,
+} from "@/lib/lifecycle";
+
+// ── Status / kind universe (local literal unions, checked against Prisma) ──────
+
+export type ProcessStatus =
+    | "INTAKE"
+    | "PENDING_EXTERNAL_ACTION"
+    | "PENDING_BG_REVIEW"
+    | "PENDING_PAYMENT"
+    | "PENDING_BG_CLEARANCE"
+    | "ACTIVE"
+    | "BLOCKED"
+    | "PENDING_RENEWAL"
+    | "RENEWAL_PENDING_BG"
+    | "ARCHIVED";
+
+export type ProcessKind = "INITIAL" | "RENEWAL" | "PERSON_BG";
+
+// Compile-time parity: these fail to compile if the schema enum drifts from the
+// local union (LIFECYCLE_ARCHITECTURE §3.4). `import type` keeps the enum out of
+// the client bundle; the TEST does the value-based `assertEnumParity` counterpart.
+// Type-only assertions — intentionally unreferenced; their value IS the compile check.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+type _StatusParity = Expect<Equal<ProcessStatus, OrgMembershipProcessStatus>>;
+type _KindParity = Expect<Equal<ProcessKind, OrgMembershipProcessKind>>;
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+/** Presence of the four parallel-track nullable timestamps, as booleans (client-safe). */
+export type ProcessFlags = {
+    contractSignedAt: boolean;
+    bgConsentAt: boolean;
+    bgClearedAt: boolean;
+    paidAt: boolean;
+};
+
+type Where = Prisma.OrgMembershipProcessWhereInput;
+
+// ── Legacy tag (doc §4.6) ──────────────────────────────────────────────────────
+// RENEWAL_PENDING_BG is dead-but-guarded: nothing writes it since the 20260715
+// migration, but surviving rows are still read/guarded and it stays in the renewal
+// in-flight index. Kept explicit here instead of quietly appearing in six lists.
+export const LEGACY_STATUSES: readonly ProcessStatus[] = ["RENEWAL_PENDING_BG"];
+
+// ── In-flight sets (fix #2): ONE source per kind ───────────────────────────────
+// Feeds the conditional `updateMany`/`findFirst` guards AND the index-parity test
+// (each partial unique index's `WHERE status IN (…)` must equal these). Callers
+// spread `[...IN_FLIGHT_*]` where Prisma's `in` wants a mutable array.
+
+/** INITIAL still-open statuses. Matches `membership_one_inflight_initial`. */
+export const IN_FLIGHT_INITIAL: readonly ProcessStatus[] = [
+    "INTAKE",
+    "PENDING_EXTERNAL_ACTION",
+    "PENDING_BG_REVIEW",
+    "PENDING_PAYMENT",
+    "PENDING_BG_CLEARANCE",
+];
+
+/**
+ * RENEWAL still-open statuses — includes the request-flow states and the legacy
+ * RENEWAL_PENDING_BG. Matches `membership_one_inflight_renewal` (widened by the
+ * 20260715 migration). BLOCKED is deliberately out (a blocked renewal is the
+ * board's to resolve).
+ */
+export const IN_FLIGHT_RENEWAL: readonly ProcessStatus[] = [
+    "PENDING_RENEWAL",
+    "PENDING_EXTERNAL_ACTION",
+    "PENDING_BG_REVIEW",
+    "PENDING_PAYMENT",
+    "PENDING_BG_CLEARANCE",
+    "RENEWAL_PENDING_BG",
+];
+
+// ── awaiting BG review (fix #1) ────────────────────────────────────────────────
+// Encodes review.ts:75 / AWAITING_BG_WHERE:97 EXACTLY, from one source. Not a
+// single defineStateSet: it's an OR of two sub-rules, both requiring
+// bgClearedAt=null. The two status arrays below are that one source; `has` and
+// `where` both derive from them, and lifecycle.test asserts them equal on a
+// status × flags matrix.
+const BG_REVIEW_STATES = ["PENDING_BG_REVIEW", "RENEWAL_PENDING_BG"] as const;
+const PARALLEL_BG_STATES = ["PENDING_PAYMENT", "PENDING_BG_CLEARANCE"] as const;
+
+type AwaitingBgRow = { status: ProcessStatus; bgConsentAt: boolean; bgClearedAt: boolean };
+
+/**
+ * A process is awaiting background-check review when it hasn't cleared and is past
+ * consent: the (legacy/renewal) review states unconditionally, or the INITIAL
+ * parallel states once consent is recorded. `.has` for client + in-tx predicate,
+ * `.where` for the reviewer-queue queries.
+ *
+ * NOTE — the ONE hand-authored StateSet: `has` and `where` are written SEPARATELY
+ * here (this is an OR of two sub-rules, so it does NOT go through `defineStateSet`,
+ * which mechanically derives one from the other). Their equivalence is therefore
+ * NOT structurally guaranteed — it rests ENTIRELY on the parity test in
+ * lifecycle.test.ts, which asserts `has` ≡ `where` across the FULL
+ * status × {bgConsentAt, bgClearedAt} matrix. That matrix must stay exhaustive; do
+ * not re-shape this into `defineStateSet` unless the OR is proven exactly equivalent.
+ */
+export const awaitingBgReview: StateSet<AwaitingBgRow, Where> = {
+    statuses: [...BG_REVIEW_STATES, ...PARALLEL_BG_STATES],
+    has: (row) => {
+        if (row.bgClearedAt) return false;
+        if ((BG_REVIEW_STATES as readonly string[]).includes(row.status)) return true;
+        if ((PARALLEL_BG_STATES as readonly string[]).includes(row.status) && row.bgConsentAt) return true;
+        return false;
+    },
+    where: {
+        bgClearedAt: null,
+        OR: [
+            { status: { in: [...BG_REVIEW_STATES] } },
+            { status: { in: [...PARALLEL_BG_STATES] }, bgConsentAt: { not: null } },
+        ],
+    },
+};
+
+// ── renewal grantability (fix #3) & settled-this-cycle (fix #4) ────────────────
+
+/**
+ * The "this renewal is payable now" set the coming-year grant derives from (doc
+ * §7.3): a RENEWAL at PENDING_PAYMENT — full stop. NOT gated on bgClearedAt: the
+ * grant comps PAYMENT ONLY and the background-check gate stays independent, so a
+ * parallel-track renewal (paid ahead of BG, bgClearedAt null) is grantable and
+ * settles to PENDING_BG_CLEARANCE, while a cleared one settles to ACTIVE — activate()
+ * makes that split, BG is never bypassed. Both the list route's `renewalGrantable`
+ * probe and `grantRenewalPayment`'s row lookup use this ONE fragment; the COI check
+ * inside certifyPaymentPlan stays on top.
+ */
+export const grantableRenewalWhere: Where = {
+    kind: "RENEWAL",
+    status: "PENDING_PAYMENT",
+};
+
+/**
+ * "Handled this renewal cycle" (doc §7.4): a RENEWAL that reached a terminal state
+ * (ACTIVE finished, or ARCHIVED by the board) stamped inside the current renewal
+ * window. Consumed by BOTH the households route probe and runRenewalSweep's
+ * skip-test so they can't disagree. The `kind=RENEWAL` and `ARCHIVED` clauses are
+ * the fix: without them a stray INITIAL activation in-window falsely settles the
+ * household (flipping derived validUntil a year forward), and a board-archived
+ * renewal is missed by the route.
+ */
+export const settledThisCycleWhere = (windowStart: Date): Where => ({
+    kind: "RENEWAL",
+    status: { in: ["ACTIVE", "ARCHIVED"] },
+    stageEnteredAt: { gte: windowStart },
+});
+
+// ── classify / validate (LIFECYCLE_ARCHITECTURE §3.2) ──────────────────────────
+
+/** Row shape classify/validate read — all four flags as booleans, no Prisma. */
+export type ClassifyRow = { status: ProcessStatus } & ProcessFlags;
+
+/**
+ * Name a row's lifecycle state, or null when it's off-diagram. Total over the
+ * status enum (exhaustive switch → assertNever): adding a status fails to compile
+ * until it's handled. The named state is the status itself; the off-diagram cases
+ * are impossible flag combinations a stranded/legacy row could carry.
+ */
+export function classify(row: ClassifyRow): ProcessStatus | null {
+    switch (row.status) {
+        case "INTAKE":
+            // Payment cannot precede the external step — a paid INTAKE row is off-diagram.
+            return row.paidAt ? null : "INTAKE";
+        case "ACTIVE":
+            // Convergence stamps bgClearedAt before flipping ACTIVE (payment.ts / review.ts).
+            return row.bgClearedAt ? "ACTIVE" : null;
+        case "PENDING_EXTERNAL_ACTION":
+            return "PENDING_EXTERNAL_ACTION";
+        case "PENDING_BG_REVIEW":
+            return "PENDING_BG_REVIEW";
+        case "PENDING_PAYMENT":
+            return "PENDING_PAYMENT";
+        case "PENDING_BG_CLEARANCE":
+            return "PENDING_BG_CLEARANCE";
+        case "BLOCKED":
+            return "BLOCKED";
+        case "PENDING_RENEWAL":
+            return "PENDING_RENEWAL";
+        case "RENEWAL_PENDING_BG":
+            return "RENEWAL_PENDING_BG";
+        case "ARCHIVED":
+            return "ARCHIVED";
+        default:
+            return assertNever(row.status);
+    }
+}
+
+/** Named invariants illegal tuples violate — the reconciler's future detection oracle. */
+export const INVARIANTS: readonly Invariant<ClassifyRow>[] = [
+    // Payment is stamped no earlier than PENDING_PAYMENT; INTAKE is pre-external.
+    { name: "intake-is-unpaid", holds: (r) => r.status !== "INTAKE" || !r.paidAt },
+    // ACTIVE is only reached through the two-track convergence, which stamps bgClearedAt.
+    { name: "active-is-bg-cleared", holds: (r) => r.status !== "ACTIVE" || r.bgClearedAt },
+];
+
+export const validate = defineValidator(INVARIANTS);
+
+// ── transition table (doc §5) — documentation + test oracle, never executed ────
+
+/** The origin pseudo-state for entry transitions (∅). */
+export type OriginState = "∅";
+type TState = ProcessStatus | OriginState;
+
+/**
+ * The 14 machine edges of doc §5, each carrying the (unchanged) enforcement site
+ * it feeds. Not a runtime executor — powers isLegalTransition + reachability in
+ * tests/doc-artifacts. Flag-only stamps (contractSignedAt/bgConsentAt) are not
+ * status edges and are omitted; they gate the advance, not a state change.
+ */
+export const TRANSITIONS: readonly Transition<TState, string, ProcessKind>[] = [
+    // Entry (§5 #1,#2 + §4.4 PERSON_BG)
+    { from: "∅", to: "INTAKE", event: "startIntake", actor: "applicant", guardSite: "intake.ts:154 FOR UPDATE + membership_one_inflight_initial + P2002", kind: "INITIAL" },
+    { from: "∅", to: "PENDING_RENEWAL", event: "createRenewalProcess", actor: "cron/board", guardSite: "renewal.ts:243 FOR UPDATE + membership_one_inflight_renewal + P2002", kind: "RENEWAL" },
+    { from: "∅", to: "PENDING_BG_REVIEW", event: "personBgTriggers", actor: "system", guardSite: "personBgTriggers", kind: "PERSON_BG" },
+    // External step (§5 #3,#4)
+    { from: "INTAKE", to: "PENDING_EXTERNAL_ACTION", event: "submitIntake", actor: "applicant", guardSite: "intake.ts:392", kind: "INITIAL" },
+    { from: "PENDING_RENEWAL", to: "PENDING_EXTERNAL_ACTION", event: "beginRenewal", actor: "member", guardSite: "renewal.ts:219 updateMany where status=PENDING_RENEWAL", kind: "RENEWAL" },
+    // Advance (§5 #7)
+    { from: "PENDING_EXTERNAL_ACTION", to: "PENDING_PAYMENT", event: "advanceExternalIfComplete", actor: "system", guardSite: "external.ts:113 updateMany" },
+    { from: "PENDING_EXTERNAL_ACTION", to: "PENDING_BG_REVIEW", event: "advanceExternalIfComplete", actor: "system", guardSite: "external.ts:113 updateMany (household note held, #907)" },
+    // Payment convergence (§5 #8, #12)
+    { from: "PENDING_PAYMENT", to: "ACTIVE", event: "activate", actor: "shopify/board", guardSite: "payment.ts:204 FOR UPDATE (bgClearedAt set)" },
+    { from: "PENDING_PAYMENT", to: "PENDING_BG_CLEARANCE", event: "activate", actor: "shopify/board", guardSite: "payment.ts:204 FOR UPDATE (not cleared)" },
+    { from: "PENDING_PAYMENT", to: "ACTIVE", event: "grantRenewalPayment", actor: "board/sysadmin", guardSite: "renewal.ts:339 → certifyPaymentPlan (COI) → activate", kind: "RENEWAL" },
+    // Clearance convergence (§5 #10, #14)
+    { from: "PENDING_BG_REVIEW", to: "PENDING_PAYMENT", event: "clearBackgroundCheck", actor: "reviewer", guardSite: "review.ts:256 FOR UPDATE (2nd APPROVE, unpaid)" },
+    { from: "PENDING_BG_REVIEW", to: "ACTIVE", event: "clearBackgroundCheck", actor: "reviewer", guardSite: "review.ts:256/304 FOR UPDATE (2nd APPROVE, paid / PERSON_BG subject)" },
+    { from: "PENDING_BG_CLEARANCE", to: "ACTIVE", event: "clearBackgroundCheck", actor: "reviewer", guardSite: "review.ts:326 FOR UPDATE (2nd APPROVE)" },
+    // Reject → BLOCKED (§5 #9)
+    { from: "PENDING_BG_REVIEW", to: "BLOCKED", event: "attest REJECT", actor: "reviewer", guardSite: "review.ts:247 FOR UPDATE" },
+    { from: "PENDING_PAYMENT", to: "BLOCKED", event: "attest REJECT", actor: "reviewer", guardSite: "review.ts:247 FOR UPDATE (parallel review)" },
+    { from: "PENDING_BG_CLEARANCE", to: "BLOCKED", event: "attest REJECT", actor: "reviewer", guardSite: "review.ts:247 FOR UPDATE" },
+    // overrideBlocked reset/approve (§5 #11)
+    { from: "BLOCKED", to: "PENDING_PAYMENT", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (unpaid, no note)" },
+    { from: "BLOCKED", to: "PENDING_BG_CLEARANCE", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (paid)" },
+    { from: "BLOCKED", to: "PENDING_BG_REVIEW", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (note / PERSON_BG)" },
+    { from: "BLOCKED", to: "PENDING_EXTERNAL_ACTION", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (RENEWAL, no consent)", kind: "RENEWAL", legacy: true },
+    { from: "BLOCKED", to: "ACTIVE", event: "overrideBlocked approve", actor: "board/sysadmin", guardSite: "review.ts:411 FOR UPDATE (paid)" },
+    // Archive (§5 #13) — every pre-terminal status
+    ...(["INTAKE", "PENDING_EXTERNAL_ACTION", "PENDING_BG_REVIEW", "PENDING_PAYMENT", "PENDING_BG_CLEARANCE", "PENDING_RENEWAL", "BLOCKED"] as const).map(
+        (from): Transition<TState, string, ProcessKind> => ({
+            from,
+            to: "ARCHIVED",
+            event: "archiveApplication",
+            actor: "board",
+            guardSite: "archive.ts:13 (status≠ACTIVE, idempotent)",
+        }),
+    ),
+];
+
+/** True if some declared §5 edge matches from→to (optionally within `kind`). */
+export function isLegalTransition(from: ProcessStatus, to: ProcessStatus, kind?: ProcessKind): boolean {
+    return baseIsLegalTransition(TRANSITIONS, from, to, kind);
+}
+
+/** Entry states for reachability analysis (the ∅-edges' targets). */
+export const INITIAL_STATES: readonly ProcessStatus[] = ["INTAKE", "PENDING_RENEWAL", "PENDING_BG_REVIEW"];
+
+/** Every declared status (for reachability's `unreachable` computation). */
+export const ALL_STATUSES: readonly ProcessStatus[] = [
+    "INTAKE",
+    "PENDING_EXTERNAL_ACTION",
+    "PENDING_BG_REVIEW",
+    "PENDING_PAYMENT",
+    "PENDING_BG_CLEARANCE",
+    "ACTIVE",
+    "BLOCKED",
+    "PENDING_RENEWAL",
+    "RENEWAL_PENDING_BG",
+    "ARCHIVED",
+];

--- a/checkin-app/src/lib/membership/phases.ts
+++ b/checkin-app/src/lib/membership/phases.ts
@@ -1,4 +1,5 @@
 import type { OrgMembershipProcess, OrgMembershipProcessStatus } from "@/generated/prisma/client";
+import { IN_FLIGHT_INITIAL } from "@/lib/membership/lifecycle";
 
 /**
  * Applicant-facing phases of an INITIAL membership application, in order.
@@ -45,19 +46,13 @@ export function stepperActiveIndex(status: OrgMembershipProcessStatus | null): n
 }
 
 /**
- * Statuses where an application is still open (work remains). Excludes the
- * terminal ACTIVE and the off-track BLOCKED. Renewal-specific statuses are not
- * part of the INITIAL flow. PENDING_BG_REVIEW is the held-for-review state (a
- * household intake note gates payment on the review, #907) and also covers any
- * legacy pre-parallel rows; PENDING_BG_CLEARANCE is the paid-awaiting-check state.
+ * Statuses where an INITIAL application is still open (work remains). The list
+ * itself is now defined ONCE in lib/membership/lifecycle (`IN_FLIGHT_INITIAL`,
+ * fix #2) — the single source the `membership_one_inflight_initial` partial index
+ * is verified against. This is a back-compat mutable alias for existing consumers
+ * (intake.ts, the intakeConcurrency suite) that pass it straight to Prisma's `in`.
  */
-export const IN_FLIGHT_INITIAL_STATUSES: OrgMembershipProcessStatus[] = [
-    "INTAKE",
-    "PENDING_EXTERNAL_ACTION",
-    "PENDING_BG_REVIEW",
-    "PENDING_PAYMENT",
-    "PENDING_BG_CLEARANCE",
-];
+export const IN_FLIGHT_INITIAL_STATUSES: OrgMembershipProcessStatus[] = [...IN_FLIGHT_INITIAL];
 
 /**
  * The latest process awaiting applicant external action (contract signing).

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -4,6 +4,7 @@ import { logger } from "@/lib/logger";
 import { emailHouseholdLeads } from "@/lib/emailRecipients";
 import { config } from "@/lib/config";
 import { certifyPaymentPlan, PaymentError } from "./payment";
+import { IN_FLIGHT_RENEWAL, grantableRenewalWhere, settledThisCycleWhere } from "@/lib/membership/lifecycle";
 
 /**
  * Annual renewal. A common membership-year boundary (BoardSettings) drives every
@@ -24,23 +25,10 @@ import { certifyPaymentPlan, PaymentError } from "./payment";
 const SYSTEM_ACTOR = 0;
 const RENEWAL_LEAD_MONTHS = 2;
 
-/**
- * A renewal cycle counts as open while its process sits in any of these — the
- * request-flow states (PENDING_EXTERNAL_ACTION onward) included, or the sweep
- * would open a duplicate renewal for a household mid-flow. Must stay in step
- * with the partial unique index `membership_one_inflight_renewal` (raw SQL,
- * see the 20260715 renewal_bg_request_flow migration). BLOCKED is deliberately
- * out (pre-existing semantics: a blocked renewal is the board's to resolve).
- * RENEWAL_PENDING_BG is legacy — unwritten since that migration, still guarded.
- */
-const IN_FLIGHT_RENEWAL_STATUSES = [
-    "PENDING_RENEWAL",
-    "PENDING_EXTERNAL_ACTION",
-    "PENDING_BG_REVIEW",
-    "PENDING_PAYMENT",
-    "PENDING_BG_CLEARANCE",
-    "RENEWAL_PENDING_BG",
-] as const;
+// The in-flight-renewal status list now lives ONCE in lib/membership/lifecycle
+// (`IN_FLIGHT_RENEWAL`, fix #2) — the single source the
+// `membership_one_inflight_renewal` partial index is verified against (index-parity
+// integration test), replacing the hand-sync comment that used to live here.
 
 export class RenewalError extends Error {
     constructor(public readonly code: "not_found" | "wrong_phase", message: string) {
@@ -160,8 +148,9 @@ export async function runRenewalSweep(now: Date) {
                 where: {
                     kind: "RENEWAL",
                     OR: [
-                        { status: { in: [...IN_FLIGHT_RENEWAL_STATUSES] } },
-                        { status: { in: ["ACTIVE", "ARCHIVED"] }, stageEnteredAt: { gte: windowStart } },
+                        { status: { in: [...IN_FLIGHT_RENEWAL] } },
+                        // "resolved this cycle" — shared with the households route (fix #4).
+                        settledThisCycleWhere(windowStart),
                     ],
                 },
                 select: { id: true },
@@ -247,7 +236,7 @@ export async function createRenewalProcess(orgMembershipId: number, householdId:
             // Lock the membership row so overlapping opens serialize here, not at the INSERT.
             await tx.$queryRaw`SELECT id FROM "OrgMembership" WHERE id = ${orgMembershipId} FOR UPDATE`;
             const existing = await tx.orgMembershipProcess.findFirst({
-                where: { orgMembershipId, kind: "RENEWAL", status: { in: [...IN_FLIGHT_RENEWAL_STATUSES] } },
+                where: { orgMembershipId, kind: "RENEWAL", status: { in: [...IN_FLIGHT_RENEWAL] } },
                 select: { id: true },
             });
             if (existing) return null; // someone else already opened the renewal
@@ -289,7 +278,7 @@ export async function openRenewalsForAllActive(now: Date, opts: { sendReminders?
         select: {
             id: true,
             householdId: true,
-            processes: { where: { kind: "RENEWAL", status: { in: [...IN_FLIGHT_RENEWAL_STATUSES] } }, select: { id: true } },
+            processes: { where: { kind: "RENEWAL", status: { in: [...IN_FLIGHT_RENEWAL] } }, select: { id: true } },
         },
     });
 
@@ -348,8 +337,13 @@ export async function grantRenewalPayment(
     householdId: number,
     actor: { actorId: number; isSysadmin: boolean; reason: string },
 ): Promise<import("@/generated/prisma/client").OrgMembershipProcess> {
+    // Share the "payable renewal" predicate with the list route's renewalGrantable
+    // probe (fix #3, grantableRenewalWhere): kind=RENEWAL, PENDING_PAYMENT — NOT
+    // bg-gated, so the button's query and this lookup agree on which rows qualify.
+    // No bgClearedAt/bgFresh gate here: the grant comps payment and BG stays an
+    // independent gate on ACTIVE (parallel-track rows settle to PENDING_BG_CLEARANCE).
     const process = await prisma.orgMembershipProcess.findFirst({
-        where: { orgMembership: { householdId }, kind: "RENEWAL", status: "PENDING_PAYMENT" },
+        where: { orgMembership: { householdId }, ...grantableRenewalWhere },
         orderBy: { id: "desc" },
     });
     if (!process) throw new PaymentError("wrong_phase", "No renewal is awaiting payment.");

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -10,6 +10,7 @@ import { canonicalizeEmail } from "@/lib/emailNormalize";
 import { openPersonBgForNewMember } from "@/lib/membership/personBgTriggers";
 import { hasHouseholdConflict, sharesHousehold } from "@/lib/conflictOfInterest";
 import { type DbClient, type TxClient } from "@/lib/db-client";
+import { awaitingBgReview } from "@/lib/membership/lifecycle";
 
 /**
  * Background-check review — now a PARALLEL track, not a blocking phase.
@@ -65,41 +66,23 @@ export class ReviewError extends Error {
 }
 
 /**
- * Whether a process is currently awaiting background-check review. The check is
- * a parallel track keyed off bgClearedAt (not status): a process needs review
- * when it hasn't cleared and is past consent —
- *   - PENDING_BG_REVIEW / RENEWAL_PENDING_BG: the (legacy/renewal) review states.
- *   - PENDING_PAYMENT / PENDING_BG_CLEARANCE: the INITIAL parallel states, once
- *     consent has been recorded (bgConsentAt set).
- */
-function isAwaitingBgReview(p: { status: OrgMembershipProcessStatus; bgConsentAt: Date | null; bgClearedAt: Date | null }): boolean {
-    if (p.bgClearedAt) return false;
-    if (p.status === "PENDING_BG_REVIEW" || p.status === "RENEWAL_PENDING_BG") return true;
-    if ((p.status === "PENDING_PAYMENT" || p.status === "PENDING_BG_CLEARANCE") && p.bgConsentAt) return true;
-    return false;
-}
-
-/**
+ * "Awaiting background-check review" now lives as ONE definition — the
+ * `awaitingBgReview` StateSet in lib/membership/lifecycle (fix #1). `.has(row)` is
+ * the in-tx / client predicate, `.where` the reviewer-queue Prisma fragment; both
+ * derive from the same status lists so they can't drift. Formerly three hand-kept
+ * encodings (this function, AWAITING_BG_WHERE, applications/page.tsx).
+ *
  * A PERSON_BG surfaces in the reviewer queue only once it's been SUBMITTED — i.e.
  * bgConsentAt is set (the board recorded that an external check exists via
  * submitPersonBgForReview). This mirrors how the household parallel track gates on
- * bgConsentAt in AWAITING_BG_WHERE. An unsubmitted PERSON_BG (bgConsentAt == null)
- * stays out: not listed, not counted, no reviewer ping — its subject isn't ready to
- * approve yet, and the queue GET now renders the subject once it is. A single `NOT`
- * key so it spreads cleanly alongside AWAITING_BG_WHERE's own `OR` (two spread
- * objects sharing an `OR` key would clobber it).
+ * bgConsentAt in awaitingBgReview.where. An unsubmitted PERSON_BG (bgConsentAt ==
+ * null) stays out: not listed, not counted, no reviewer ping — its subject isn't
+ * ready to approve yet, and the queue GET now renders the subject once it is. A
+ * single `NOT` key so it spreads cleanly alongside awaitingBgReview.where's own
+ * `OR` (two spread objects sharing an `OR` key would clobber it).
  */
 const QUEUE_EXCLUDES_UNSUBMITTED_PERSON_BG: Prisma.OrgMembershipProcessWhereInput = {
     NOT: { kind: "PERSON_BG", bgConsentAt: null },
-};
-
-/** Prisma `where` matching the same predicate as isAwaitingBgReview, for queue queries. */
-export const AWAITING_BG_WHERE: Prisma.OrgMembershipProcessWhereInput = {
-    bgClearedAt: null,
-    OR: [
-        { status: { in: ["PENDING_BG_REVIEW", "RENEWAL_PENDING_BG"] } },
-        { status: { in: ["PENDING_PAYMENT", "PENDING_BG_CLEARANCE"] }, bgConsentAt: { not: null } },
-    ],
 };
 
 /** Email every background-check reviewer that an application awaits review. */
@@ -164,7 +147,7 @@ export async function eligibleReviewProcessIds(reviewerId: number): Promise<numb
     if (!reviewer || !canReviewBackgroundChecks(reviewer)) return [];
 
     const processes = await prisma.orgMembershipProcess.findMany({
-        where: { ...AWAITING_BG_WHERE, ...QUEUE_EXCLUDES_UNSUBMITTED_PERSON_BG },
+        where: { ...awaitingBgReview.where, ...QUEUE_EXCLUDES_UNSUBMITTED_PERSON_BG },
         orderBy: { stageEnteredAt: "asc" },
         select: {
             id: true,
@@ -199,7 +182,7 @@ export async function reviewQueueCounts(reviewerId: number): Promise<{ canActOn:
     if (!reviewer || !canReviewBackgroundChecks(reviewer)) return { canActOn: 0, approvedAwaitingSecond: 0 };
     const [canActOnIds, approvedAwaitingSecond] = await Promise.all([
         eligibleReviewProcessIds(reviewerId),
-        prisma.orgMembershipProcess.count({ where: { ...AWAITING_BG_WHERE, ...QUEUE_EXCLUDES_UNSUBMITTED_PERSON_BG, attestations: { some: { reviewerId } } } }),
+        prisma.orgMembershipProcess.count({ where: { ...awaitingBgReview.where, ...QUEUE_EXCLUDES_UNSUBMITTED_PERSON_BG, attestations: { some: { reviewerId } } } }),
     ]);
     return { canActOn: canActOnIds.length, approvedAwaitingSecond };
 }
@@ -234,7 +217,7 @@ export async function attest(
             include: { attestations: { include: { reviewer: { select: { householdId: true } } } } },
         });
         if (!process) throw new ReviewError("not_found", "Application not found.");
-        if (!isAwaitingBgReview(process)) throw new ReviewError("wrong_phase", "This application is not awaiting background-check review.");
+        if (!awaitingBgReview.has({ status: process.status, bgConsentAt: !!process.bgConsentAt, bgClearedAt: !!process.bgClearedAt })) throw new ReviewError("wrong_phase", "This application is not awaiting background-check review.");
         const applicantHouseholdId = await applicantHousehold(tx, process);
         if (sharesHousehold(reviewer.householdId, applicantHouseholdId)) throw new ReviewError("same_household_applicant", "You cannot review an applicant in your own household.");
         if (process.attestations.some((a) => a.reviewerId === reviewerId)) throw new ReviewError("already_attested", "You have already reviewed this application.");


### PR DESCRIPTION
## Summary

Phase-2b of the membership lifecycle: instance the `lib/lifecycle` primitives for the `OrgMembershipProcess` machine in `src/lib/membership/lifecycle.ts` — one client-safe, dependency-free definition the server guards, the SQL indexes' verification, and the client gating all derive from — then route four drifted predicates through it. Includes the review-flag fixes below.

Every transactional guard is unchanged byte-for-byte (CAS `updateMany`, `FOR UPDATE`, partial unique indexes, P2002). No schema/migration/index DDL change. `lifecycle.ts` value-imports nothing from `@/generated/prisma` (client-safe; pages import `awaitingBgReview.has`).

## The four fixes

`#1`/`#2` are **pure refactors**; `#3` and `#4` each **change behavior**:

- **#1** — collapse the 3 `isAwaitingBgReview` encodings onto `awaitingBgReview.has` (client) + `.where` (server queue queries). Pure refactor.
- **#2** — single-source the in-flight status lists in `lifecycle.ts`; adds an index-parity integration test asserting each partial unique index's `WHERE status IN (…)` equals the constant. Pure refactor.
- **#3** *(behavior change — adopts grant design (a))* — reconcile the two "payable renewal" predicates onto `grantableRenewalWhere` **and** settle the coming-year-grant / BG question: the grant **comps payment only**; the background-check gate stays independent. `grantableRenewalWhere` is now plain `kind=RENEWAL, PENDING_PAYMENT` (no `bgClearedAt` clause); `grantRenewalPayment` drops the old `if (!bgClearedAt || !bgFresh) throw forbidden` runtime guard, and the route drops the `bgFresh` gate on `renewalGrantable`. A parallel-track renewal (paid ahead of BG, `bgClearedAt` null) is now grantable and, via the normal `activate()` path, settles to `PENDING_BG_CLEARANCE` (paid, INACTIVE until reviewers clear it); an already-cleared renewal settles to ACTIVE. **BG is never bypassed.** This corrects the base version, which required `bgClearedAt` at grant time — a coupling that contradicted the machine's parallel BG/payment design and the function's own "same path as a real payment" contract. COI inside `certifyPaymentPlan` unchanged.
- **#4** *(behavior change)* — route probe + `runRenewalSweep` skip-test consume `settledThisCycleWhere` (`kind=RENEWAL`, `status IN (ACTIVE, ARCHIVED)`, `stageEnteredAt≥windowStart`). Adds the missing `kind=RENEWAL` + `ARCHIVED` clauses, so a stray INITIAL activation no longer falsely settles a household (flipping derived `validUntil` a year forward), and a board-archived renewal is counted.

## Notes for reviewers

- **Grant design decision.** #3 adopts behavior **(a)** — grant comps payment, BG runs in parallel and independently gates ACTIVE — resolving the mismatch flagged during review (the base guard required BG already cleared while its comments described a real-payment path). This **matches #1068** (the standalone (a) work, now merged to `main`); this branch is rebased on top of it and reconciled cleanly (route/grant route through the shared `grantableRenewalWhere`/`settledThisCycleWhere` definitions, `#4` keeps the `ARCHIVED` clause #1068 doesn't have).
- **Hand-authored StateSet lockdown** — `awaitingBgReview` is the one StateSet whose `has`/`where` are authored separately (OR of two sub-rules, not via `defineStateSet`). Added a comment stating its parity is **not** mechanically derived and rests entirely on the `lifecycle.test.ts` matrix over the full `status × {bgConsentAt, bgClearedAt}` space; verified that matrix is exhaustive.

## Tests

- Unit `lifecycle.test.ts` — **19/19** (has≡where matrix, grantable/settled fragments, `isLegalTransition`/§5, enum parity).
- Integration — **8 suites / 46 tests**: `indexPredicateMatchesConstant`, `householdsListGrantableAPI` + `householdsMembershipAuditAPI` (updated to (a): parallel-track grant → 200 → `PENDING_BG_CLEARANCE`; stale-lead-BG w/ `bgClearedAt` → grantable/ACTIVE), and the 5 concurrency suites unchanged + green (`membershipReview`, `renewal`, `membershipBgNonBlocking`, `membershipExternal`, `intake`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

