### PR TITLE
feat(membership): grant comps payment for parallel-track renewals, BG stays gating

### DIFF
--- a/checkin-app/src/app/__tests__/householdsListGrantableAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsListGrantableAPI.integration.test.ts
@@ -33,6 +33,7 @@ describe('GET /api/membership-ops/households — renewalGrantable + dates', () =
     let notStartedHouseholdId: number;
     let grantableHouseholdId: number;
     let staleBgHouseholdId: number;
+    let parallelTrackHouseholdId: number;
 
     async function wipe() {
         const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
@@ -80,14 +81,25 @@ describe('GET /api/membership-ops/households — renewalGrantable + dates', () =
         const grantableMembership = await prisma.orgMembership.create({ data: { householdId: grantableHouseholdId, status: 'ACTIVE' } });
         await prisma.orgMembershipProcess.create({ data: { orgMembershipId: grantableMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() } });
 
-        // Gate-parity case: PENDING_PAYMENT + bgClearedAt set, but the lead's background
-        // check is stale (older than the recheck window) — householdBgIsFresh must reject it.
+        // Stale-BG case: PENDING_PAYMENT + bgClearedAt set, lead's own check is stale.
+        // Grant comps PAYMENT only and BG still gates ACTIVE, so this IS grantable —
+        // lead BG freshness no longer gates the button (behavior (a)).
         const staleBg = await prisma.person.create({
             data: { email: `stalebg-${TAG}@example.com`, name: 'Stale Lead', isHouseholdLead: true, lastBackgroundCheck: new Date(Date.UTC(2015, 0, 1)), household: { create: { name: `Stale HH ${TAG}` } } },
         });
         staleBgHouseholdId = staleBg.householdId;
         const staleBgMembership = await prisma.orgMembership.create({ data: { householdId: staleBgHouseholdId, status: 'ACTIVE' } });
         await prisma.orgMembershipProcess.create({ data: { orgMembershipId: staleBgMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() } });
+
+        // Parallel-track case: PENDING_PAYMENT with bgClearedAt NULL (BG still in review,
+        // consent recorded). Under (a) the button shows — grant comps payment and the row
+        // settles to PENDING_BG_CLEARANCE, staying INACTIVE until reviewers clear it.
+        const parallel = await prisma.person.create({
+            data: { email: `parallel-${TAG}@example.com`, name: 'Parallel Lead', isHouseholdLead: true, lastBackgroundCheck: daysAgo(30), household: { create: { name: `Parallel HH ${TAG}` } } },
+        });
+        parallelTrackHouseholdId = parallel.householdId;
+        const parallelMembership = await prisma.orgMembership.create({ data: { householdId: parallelTrackHouseholdId, status: 'ACTIVE' } });
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: parallelMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT', bgClearedAt: null, bgConsentAt: new Date() } });
     });
 
     afterAll(async () => {
@@ -115,13 +127,22 @@ describe('GET /api/membership-ops/households — renewalGrantable + dates', () =
         expect(h.renewalGrantable).toBe(true);
     });
 
-    it('renewalGrantable is false for PENDING_PAYMENT + bgClearedAt but a stale lead background check (gate parity)', async () => {
+    it('renewalGrantable is true for PENDING_PAYMENT even when the lead background check is stale (grant comps payment; BG still gates ACTIVE)', async () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
         const res = await get();
         const data = await res.json();
         const h = data.households.find((x: { id: number }) => x.id === staleBgHouseholdId);
         expect(h).toBeDefined();
-        expect(h.renewalGrantable).toBe(false);
+        expect(h.renewalGrantable).toBe(true);
+    });
+
+    it('renewalGrantable is true for a parallel-track renewal (PENDING_PAYMENT, bgClearedAt null, BG in review)', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+        const res = await get();
+        const data = await res.json();
+        const h = data.households.find((x: { id: number }) => x.id === parallelTrackHouseholdId);
+        expect(h).toBeDefined();
+        expect(h.renewalGrantable).toBe(true);
     });
 
     it('derives per-household validUntil from the boundary and includes orgMembership.memberSince', async () => {

--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -6,9 +6,11 @@
  * actions in POST /api/membership-ops/households — granting (ACTIVE) and revoking
  * (REVOKED) must each write an AuditLog row recording who acted and what changed.
  *
- * Also covers the "Grant for coming year" override: it completes the payment
- * gate on a household's in-flight RENEWAL already at PENDING_PAYMENT with a
- * valid, cleared background check — never archives, never bypasses BG.
+ * Also covers the "Grant for coming year" override: it comps the PAYMENT gate on
+ * a household's in-flight RENEWAL at PENDING_PAYMENT — never archives, never
+ * bypasses BG. A bgClearedAt row settles to ACTIVE; a parallel-track row
+ * (bgClearedAt null, BG still in review) settles to PENDING_BG_CLEARANCE and
+ * stays INACTIVE until reviewers clear it.
  */
 
 import { POST } from '@/app/api/membership-ops/households/route';
@@ -118,16 +120,17 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         const peMembership = await prisma.orgMembership.create({ data: { householdId: pendingExternalHouseholdId, status: 'ACTIVE' } });
         await prisma.orgMembershipProcess.create({ data: { orgMembershipId: peMembership.id, kind: 'RENEWAL', status: 'PENDING_EXTERNAL_ACTION' } });
 
-        // PENDING_PAYMENT but bgClearedAt not yet stamped, lead BG otherwise fresh
-        // (isolates the bgClearedAt-null reject from a bg-freshness reject) → 403.
+        // Parallel-track: PENDING_PAYMENT with bgClearedAt null, BG consent recorded
+        // (review runs in parallel). Grant comps payment → PENDING_BG_CLEARANCE (200).
         midFlowHouseholdId = await makeHousehold('midflow');
         const midMembership = await prisma.orgMembership.create({ data: { householdId: midFlowHouseholdId, status: 'ACTIVE' } });
         midFlowProcessId = (await prisma.orgMembershipProcess.create({
-            data: { orgMembershipId: midMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT' },
+            data: { orgMembershipId: midMembership.id, kind: 'RENEWAL', status: 'PENDING_PAYMENT', bgConsentAt: new Date() },
         })).id;
         await setLead(midFlowHouseholdId, new Date());
 
-        // PENDING_PAYMENT with bgClearedAt set, but no lead has a fresh check → 403.
+        // PENDING_PAYMENT with bgClearedAt set, no lead has a fresh check. Grant comps
+        // payment; BG is already cleared on the process → settles to ACTIVE (200).
         bgNotFreshHouseholdId = await makeHousehold('bgnotfresh');
         const bnfMembership = await prisma.orgMembership.create({ data: { householdId: bgNotFreshHouseholdId, status: 'ACTIVE' } });
         bgNotFreshProcessId = (await prisma.orgMembershipProcess.create({
@@ -228,26 +231,28 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         expect(process?.status).toBe('PENDING_EXTERNAL_ACTION');
     });
 
-    it('coming-year grant: PENDING_PAYMENT but bgClearedAt not stamped → 403, unchanged', async () => {
+    it('coming-year grant: parallel-track (PENDING_PAYMENT, bgClearedAt null) → 200, settles to PENDING_BG_CLEARANCE (payment comped, BG still gating)', async () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
 
         const res = await post({ householdId: midFlowHouseholdId, comingYear: true, reason: 'Renewal grant test' });
-        expect(res.status).toBe(403);
+        expect(res.status).toBe(200);
 
+        // BG gate NOT bypassed: process parks at PENDING_BG_CLEARANCE (paid, awaiting
+        // the check), NOT ACTIVE — reviewers must still clear it.
         const process = await prisma.orgMembershipProcess.findUnique({ where: { id: midFlowProcessId } });
-        expect(process?.status).toBe('PENDING_PAYMENT');
-        expect(process?.paidAt).toBeNull();
+        expect(process?.status).toBe('PENDING_BG_CLEARANCE');
+        expect(process?.paidAt).not.toBeNull();
     });
 
-    it("coming-year grant: bgClearedAt set but no household lead has a fresh check → 403, unchanged", async () => {
+    it("coming-year grant: bgClearedAt set but no household lead has a fresh check → 200, settles to ACTIVE (BG already cleared on the process)", async () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
 
         const res = await post({ householdId: bgNotFreshHouseholdId, comingYear: true, reason: 'Renewal grant test' });
-        expect(res.status).toBe(403);
+        expect(res.status).toBe(200);
 
         const process = await prisma.orgMembershipProcess.findUnique({ where: { id: bgNotFreshProcessId } });
-        expect(process?.status).toBe('PENDING_PAYMENT');
-        expect(process?.paidAt).toBeNull();
+        expect(process?.status).toBe('ACTIVE');
+        expect(process?.paidAt).not.toBeNull();
     });
 
     it("refuses coming-year grant for the actor's OWN household (conflict of interest); sysadmin overrides", async () => {

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -4,7 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
-import { renewalSeasonWindow, nextBoundary, householdBgIsFresh, bgValidUntilBoundary, grantRenewalPayment } from "@/lib/membership/renewal";
+import { renewalSeasonWindow, nextBoundary, bgValidUntilBoundary, grantRenewalPayment } from "@/lib/membership/renewal";
 import { PaymentError } from "@/lib/membership/payment";
 
 export const dynamic = 'force-dynamic';
@@ -128,8 +128,9 @@ export const GET = withAuth(
                         // JSON at the same trust level as the rest of the row.
                         select: { id: true, name: true, email: true, isBoardMember: true, emailUndeliverableAt: true, isHouseholdLead: true, lastBackgroundCheck: true }
                     },
-                    // ONE probe serves both flags computed below: the payable-renewal rows
-                    // (PENDING_PAYMENT + bgClearedAt) decide grantability, and a terminal
+                    // ONE probe serves both flags computed below: any PENDING_PAYMENT
+                    // renewal is grantable (grant comps payment; BG proceeds in parallel
+                    // and still gates ACTIVE — see grantRenewalPayment), and a terminal
                     // ACTIVE process stamped inside the renewal window — the same "handled
                     // this cycle" test runRenewalSweep uses — marks the coming year settled.
                     // Out of season the window start is "never" (matches no row), keeping one
@@ -140,7 +141,7 @@ export const GET = withAuth(
                             processes: {
                                 where: {
                                     OR: [
-                                        { kind: "RENEWAL", status: "PENDING_PAYMENT", bgClearedAt: { not: null } },
+                                        { kind: "RENEWAL", status: "PENDING_PAYMENT" },
                                         { status: "ACTIVE", stageEnteredAt: { gte: window?.windowStart ?? new Date(8.64e15) } },
                                     ],
                                 },
@@ -168,34 +169,28 @@ export const GET = withAuth(
             const recheckMonths = settings?.bgRecheckMonths ?? 0;
             const bgSettings = { orgMembershipYearBoundary: settings?.orgMembershipYearBoundary ?? null, bgRecheckMonths: recheckMonths };
 
-            const withGrantable = await Promise.all(
-                households.map(async (h) => {
-                    // Split the single OR probe: PENDING_PAYMENT rows = payable renewal
-                    // (grantability); an ACTIVE row = the coming cycle is already settled
-                    // (member finished renewal, or an admin used the override).
-                    const { processes = [], ...orgMembership } = h.orgMembership ?? {};
-                    const hasPayableRenewal = processes.some((p) => p.status === "PENDING_PAYMENT");
-                    const settledForComingYear = processes.some((p) => p.status === "ACTIVE");
-                    const renewalGrantable =
-                        hasPayableRenewal && boundary
-                            ? await householdBgIsFresh(h.id, boundary, recheckMonths)
-                            : false;
-                    // Household-level BG "valid until" — later lastBackgroundCheck among leads
-                    // who passed; no per-member values in the list response.
-                    const latestLeadBg = h.householdMembers
-                        .filter((m) => m.isHouseholdLead && m.lastBackgroundCheck)
-                        .reduce<Date | null>((acc, m) => (!acc || m.lastBackgroundCheck! > acc ? m.lastBackgroundCheck! : acc), null);
-                    const bgValidUntil = bgValidUntilBoundary(latestLeadBg, bgSettings);
-                    return {
-                        ...withFlatContact(h),
-                        orgMembership: h.orgMembership ? orgMembership : null,
-                        renewalGrantable,
-                        settledForComingYear,
-                        bgValidUntil,
-                        validUntil: h.orgMembership?.status === "ACTIVE" ? derivedValidUntil(boundary, settledForComingYear) : null,
-                    };
-                }),
-            );
+            const withGrantable = households.map((h) => {
+                // Split the single OR probe: a PENDING_PAYMENT renewal is grantable
+                // (grant comps payment, BG runs in parallel); an ACTIVE row = the coming
+                // cycle is already settled (member finished renewal, or admin overrode).
+                const { processes = [], ...orgMembership } = h.orgMembership ?? {};
+                const renewalGrantable = processes.some((p) => p.status === "PENDING_PAYMENT");
+                const settledForComingYear = processes.some((p) => p.status === "ACTIVE");
+                // Household-level BG "valid until" — later lastBackgroundCheck among leads
+                // who passed; no per-member values in the list response.
+                const latestLeadBg = h.householdMembers
+                    .filter((m) => m.isHouseholdLead && m.lastBackgroundCheck)
+                    .reduce<Date | null>((acc, m) => (!acc || m.lastBackgroundCheck! > acc ? m.lastBackgroundCheck! : acc), null);
+                const bgValidUntil = bgValidUntilBoundary(latestLeadBg, bgSettings);
+                return {
+                    ...withFlatContact(h),
+                    orgMembership: h.orgMembership ? orgMembership : null,
+                    renewalGrantable,
+                    settledForComingYear,
+                    bgValidUntil,
+                    validUntil: h.orgMembership?.status === "ACTIVE" ? derivedValidUntil(boundary, settledForComingYear) : null,
+                };
+            });
 
             return NextResponse.json({
                 households: withGrantable,

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -331,36 +331,28 @@ export async function householdBgIsFresh(householdId: number, boundary: Date, re
 }
 
 /**
- * Admin "Grant for coming year": complete the payment gate on a household's
- * in-flight RENEWAL that's already at PENDING_PAYMENT (contract signed) with a
- * valid, cleared background check — via the same settlement path a real
- * payment takes. Never archives, never stamps a gate, never creates a process.
+ * Admin "Grant for coming year": comp the payment gate on a household's
+ * in-flight RENEWAL that's at PENDING_PAYMENT (contract signed) — via the same
+ * settlement path a real payment takes. This comps PAYMENT ONLY; it never
+ * bypasses the background-check gate. A row whose BG is already cleared
+ * (bgClearedAt set) settles straight to ACTIVE; a parallel-track row (BG still
+ * in review, bgConsentAt set, bgClearedAt null) settles to PENDING_BG_CLEARANCE
+ * and stays INACTIVE until reviewers clear it — exactly what a real payment on
+ * that row does (see activate()'s `activating = !!bgClearedAt`).
+ *
+ * Any PENDING_PAYMENT renewal has bgClearedAt OR bgConsentAt set
+ * (advanceExternalIfComplete won't advance without one), so comping here can
+ * never skip review. Never archives, never stamps a gate, never creates a process.
  */
 export async function grantRenewalPayment(
     householdId: number,
     actor: { actorId: number; isSysadmin: boolean; reason: string },
 ): Promise<import("@/generated/prisma/client").OrgMembershipProcess> {
-    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const boundary = settings?.orgMembershipYearBoundary
-        ? nextBoundary(settings.orgMembershipYearBoundary, new Date())
-        : null;
-
     const process = await prisma.orgMembershipProcess.findFirst({
         where: { orgMembership: { householdId }, kind: "RENEWAL", status: "PENDING_PAYMENT" },
         orderBy: { id: "desc" },
     });
     if (!process) throw new PaymentError("wrong_phase", "No renewal is awaiting payment.");
-
-    // Belt-and-suspenders BG gate: the process's own bgClearedAt (cleared this
-    // cycle) AND a household lead's check still fresh at the boundary. A
-    // note-held renewal never reaches PENDING_PAYMENT, so fresh-but-unstamped
-    // can't occur here — both checks agree once either is true.
-    const bgFresh = boundary
-        ? await householdBgIsFresh(householdId, boundary, settings?.bgRecheckMonths ?? 0)
-        : false;
-    if (!process.bgClearedAt || !bgFresh) {
-        throw new PaymentError("forbidden", "This renewal's background check is not valid — grant blocked.");
-    }
 
     // COI is enforced INSIDE certifyPaymentPlan (single source): a board member
     // certifying their own household throws PaymentError('forbidden'); sysadmin bypasses.


### PR DESCRIPTION
## What

Resolves the design/behavior gap in the **"Grant for coming year"** admin override (`grantRenewalPayment`). The code enforced *(b)* — only settle renewals whose background check is already cleared — while its comments promised *(a)* — comp payment via the same path a real payment takes, BG proceeding in parallel. **(a) is the intended behavior**, so the code now matches its comments.

Grant now comps the **payment gate only** on any in-flight `RENEWAL` at `PENDING_PAYMENT`:
- BG already cleared (`bgClearedAt` set) → settles to **ACTIVE**.
- Parallel-track (`bgClearedAt` null, `bgConsentAt` set, BG still in review) → settles to **PENDING_BG_CLEARANCE**, staying **INACTIVE** until reviewers clear it.

This is exactly what a real payment does on the same row (`activate()` sets `activating = !!bgClearedAt`).

## Why it's safe (BG gate never bypassed)

- The BG gate is preserved automatically: a parallel-track row can only reach `PENDING_BG_CLEARANCE`, never `ACTIVE`, without a review clearing it.
- Any `PENDING_PAYMENT` renewal already has `bgClearedAt` **or** `bgConsentAt` set (`advanceExternalIfComplete` won't advance without one), so comping here can never skip review.
- COI check stays inside `certifyPaymentPlan` (a board member can't certify their own household; sysadmin overrides).

## Changes

- **`src/lib/membership/renewal.ts`** — remove the `!bgClearedAt || !bgFresh → forbidden` guard and its now-dead `boundary`/`bgFresh` computation. Doc comment rewritten to describe actual behavior.
- **`src/app/api/membership-ops/households/route.ts`** — drop `bgClearedAt: { not: null }` from the grantability probe and the `householdBgIsFresh` requirement from `renewalGrantable`, so the button surfaces on parallel-track renewals. Removed the now-unused import; map callback is sync.
- **Tests** — flip the two guard tests that encoded *(b)*; add parallel-track cases proving the button shows and the grant parks at `PENDING_BG_CLEARANCE` (BG-not-bypassed proof).

## Reviewer notes

- Context: surfaced during review of Phase-2b PR #1067, which deliberately deferred this product decision. This branch predates the Phase-2b lifecycle refactor (no `lifecycle.ts`/`grantableRenewalWhere` here); the same guard/filter exist inline.
- The referenced `docs/designs/ORG_MEMBERSHIP_STATE_MACHINE.md §7.3` **does not exist in the repo** — no doc to update. Flagging in case it should be created.
- No transactional guard, lock, `updateMany`, or partial index changed.

## Verification

- `tsc --noEmit` clean (required a `prisma generate` first — the worktree's generated client was stale re: `certificationNote`, pre-existing/unrelated).
- `households/__tests__/page.test.tsx`: 13/13.
- `householdsListGrantableAPI` + `householdsMembershipAuditAPI` integration: 16/16.
- Broader membership/payment/renewal integration sweep: 114 suites / 1047 tests pass; the 8 failures are all environmental (missing `SHOPIFY_*` / `ZOHO_WEBHOOK_SECRET`, email-dispatch config, a cold-DB hook timeout) in notifications/localization/seed-helpers — none in the grant path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)