### PR TITLE
feat(household): allow phone input when adding a household member

### DIFF
--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { reconcileAndWarn } from "@/lib/emergencyContacts/service";
 import { isValidEmail } from "@/lib/emergencyContacts/identity";
+import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
 import { isOrgAccount } from "@/lib/orgAccount";
 import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
 import { householdLeadship } from "@/lib/household/leads";
@@ -53,7 +54,7 @@ export const PATCH = withAuth(
             }
 
             const body = await req.json();
-            const { memberName, memberEmail, memberDob, memberOver25, memberAllergies } = body;
+            const { memberName, memberEmail, memberDob, memberPhone, memberOver25, memberAllergies } = body;
 
             const hh = await householdLeadship(userId);
 
@@ -67,6 +68,10 @@ export const PATCH = withAuth(
 
             if (memberEmail && !isValidEmail(memberEmail)) {
                 return apiError("Invalid email format", 400);
+            }
+
+            if (memberPhone && !isValidPhone(memberPhone)) {
+                return apiError(PHONE_ERROR, 400);
             }
 
             if (!memberDob && !memberOver25) {
@@ -87,6 +92,7 @@ export const PATCH = withAuth(
                         name: memberName,
                         ...(memberEmail && { email: memberEmail.toLowerCase() }),
                         dateOfBirth: memberDob ? new Date(memberDob) : null,
+                        ...(memberPhone && { phone: formatPhone(memberPhone) }),
                         isDeclaredAdult: !memberDob && !!memberOver25,
                         allergies: memberAllergies || null,
                         householdId,

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -89,6 +89,8 @@ describe("HouseholdPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "+ Add Household Member" }));
     fireEvent.change(screen.getByLabelText("Full Name"), { target: { value: "Robin Smith" } });
     fireEvent.click(screen.getByLabelText("Individual is over 25"));
+    // Phone must be capturable on ADD, not only on a later edit.
+    fireEvent.change(screen.getByLabelText("Phone (optional)"), { target: { value: "5125551234" } });
     // Allergies (safety data) must be capturable on ADD, not only on a later edit.
     fireEvent.change(screen.getByLabelText("Allergies (optional)"), { target: { value: "Bees" } });
     fireEvent.click(screen.getByRole("button", { name: "Save / Invite" }));
@@ -98,7 +100,7 @@ describe("HouseholdPage", () => {
         "/api/household",
         expect.objectContaining({
           method: "PATCH",
-          body: JSON.stringify({ memberName: "Robin Smith", memberEmail: "", memberDob: "", memberOver25: true, memberAllergies: "Bees" }),
+          body: JSON.stringify({ memberName: "Robin Smith", memberEmail: "", memberDob: "", memberPhone: "5125551234", memberOver25: true, memberAllergies: "Bees" }),
         }),
       ),
     );

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -25,11 +25,12 @@ const DOB_ERROR = "Date of birth is required for anyone under 25.";
 
 // Shared client validation for the member add/edit forms. Returns red-ring +
 // subtext errors keyed by field; empty object means valid.
-function validateHouseholdMemberFields(f: { name: string; email: string; dob: string; over25: boolean }) {
-  const e: { name?: string; email?: string; dob?: string } = {};
+function validateHouseholdMemberFields(f: { name: string; email: string; dob: string; over25: boolean; phone?: string }) {
+  const e: { name?: string; email?: string; dob?: string; phone?: string } = {};
   if (!f.name.trim()) e.name = "Name is required.";
   if (f.email && !isValidEmail(f.email)) e.email = EMAIL_ERROR;
   if (!f.over25 && !f.dob) e.dob = DOB_ERROR;
+  if (f.phone && !isValidPhone(f.phone)) e.phone = PHONE_ERROR;
   return e;
 }
 
@@ -74,8 +75,8 @@ export default function HouseholdPage() {
   const warn = (text: string) => setMessage({ text, tone: "warning" });
   const [addingHouseholdMember, setAddingHouseholdMember] = useState(false);
 
-  const [householdMemberForm, setHouseholdMemberForm] = useState({ name: "", email: "", dob: "", over25: false, allergies: "" });
-  const [householdMemberErrors, setHouseholdMemberErrors] = useState<{ name?: string; email?: string; dob?: string }>({});
+  const [householdMemberForm, setHouseholdMemberForm] = useState({ name: "", email: "", dob: "", phone: "", over25: false, allergies: "" });
+  const [householdMemberErrors, setHouseholdMemberErrors] = useState<{ name?: string; email?: string; dob?: string; phone?: string }>({});
 
   const [editingHouseholdMemberId, setEditingHouseholdMemberId] = useState<number | null>(null);
   const [editForm, setEditForm] = useState({ name: "", email: "", dob: "", phone: "", isLead: false, over25: false, allergies: "" });
@@ -255,11 +256,11 @@ export default function HouseholdPage() {
       const res = await fetch('/api/household', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ memberName: householdMemberForm.name, memberEmail: householdMemberForm.email, memberDob: householdMemberForm.over25 ? "" : householdMemberForm.dob, memberOver25: householdMemberForm.over25, memberAllergies: householdMemberForm.allergies })
+        body: JSON.stringify({ memberName: householdMemberForm.name, memberEmail: householdMemberForm.email, memberDob: householdMemberForm.over25 ? "" : householdMemberForm.dob, memberPhone: householdMemberForm.phone, memberOver25: householdMemberForm.over25, memberAllergies: householdMemberForm.allergies })
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        setHouseholdMemberForm({ name: "", email: "", dob: "", over25: false, allergies: "" });
+        setHouseholdMemberForm({ name: "", email: "", dob: "", phone: "", over25: false, allergies: "" });
         setHouseholdMemberErrors({});
         setAddingHouseholdMember(false);
         fetchHousehold();
@@ -275,8 +276,7 @@ export default function HouseholdPage() {
   const handleEditHouseholdMember = async (e: React.FormEvent, participantId: number) => {
     e.preventDefault();
     setMessage(null);
-    const errs: { name?: string; email?: string; dob?: string; phone?: string } = validateHouseholdMemberFields(editForm);
-    if (editForm.phone && !isValidPhone(editForm.phone)) errs.phone = PHONE_ERROR;
+    const errs = validateHouseholdMemberFields(editForm);
     setEditErrors(errs);
     if (Object.keys(errs).length > 0) return;
     try {
@@ -477,6 +477,7 @@ export default function HouseholdPage() {
                       {!householdMemberForm.over25 && (
                         <TextInput type="date" label="Date of Birth" value={householdMemberForm.dob} error={householdMemberErrors.dob} onChange={(e) => { setHouseholdMemberForm({ ...householdMemberForm, dob: e.currentTarget.value }); setHouseholdMemberErrors({ ...householdMemberErrors, dob: undefined }); }} />
                       )}
+                      <TextInput type="tel" label="Phone (optional)" value={householdMemberForm.phone} error={householdMemberErrors.phone} onChange={(e) => { setHouseholdMemberForm({ ...householdMemberForm, phone: e.currentTarget.value }); setHouseholdMemberErrors({ ...householdMemberErrors, phone: undefined }); }} />
                       <TextInput label="Allergies (optional)" value={householdMemberForm.allergies} onChange={(e) => setHouseholdMemberForm({ ...householdMemberForm, allergies: e.currentTarget.value })} />
                       <Group grow>
                         <Button type="submit" color="green">Save / Invite</Button>


### PR DESCRIPTION
## What

Adds an optional **Phone** field to the "Add Household Member" form and pipes it through to the create API, so a lead can record a member's phone at add-time instead of adding then editing.

## Why

The data model (`Person.phone`), the member **edit** path, and the "TODO: Add phone number" nudge all already supported phone — only the **add** form and its API (`PATCH /api/household`) omitted it, forcing a two-step add-then-edit.

## Changes

- **[my-household/page.tsx](checkin-app/src/app/my-household/page.tsx)** — phone in add-form state, a `type="tel"` phone input, phone in the submit payload (`memberPhone`) and form reset.
- **[api/household/route.ts](checkin-app/src/app/api/household/route.ts)** — accept/validate/write `memberPhone` on create, reusing `@/lib/phone` (`isValidPhone`, `formatPhone`, `PHONE_ERROR`).
- Phone validation folded into the shared `validateHouseholdMemberFields`, so add and edit validate identically; the edit form's duplicate inline check was removed.

## Reviewer notes

- Phone is **optional** (mirrors the edit form). Invalid-but-nonempty phone is rejected client- and server-side with `PHONE_ERROR`.
- No migration — `Person.phone` already exists.
- Pre-existing `tsc` errors from the un-generated Prisma client are unrelated; this change adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)