### PR TITLE
fix(attendance): send manual visit times as UTC instants

### DIFF
--- a/checkin-app/src/app/attendance/manual/page.tsx
+++ b/checkin-app/src/app/attendance/manual/page.tsx
@@ -53,7 +53,12 @@ export default function ManualAttendance() {
       const res = await fetch("/api/attendance/manual", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ arrivedAt, departedAt }),
+        // datetime-local gives a naive "YYYY-MM-DDTHH:mm" (no offset). Send a real
+        // instant so the server doesn't reparse it in ITS timezone (UTC in prod).
+        body: JSON.stringify({
+          arrivedAt: new Date(arrivedAt).toISOString(),
+          departedAt: departedAt ? new Date(departedAt).toISOString() : "",
+        }),
       });
 
       const data = await res.json().catch(() => ({}));


### PR DESCRIPTION
## What

The **Manual Time Entry** form (`attendance/manual`) posted its two `datetime-local` values as raw zoneless strings (`"YYYY-MM-DDTHH:mm"`). Now it converts each to a UTC instant with `toISOString()` before POSTing.

## Why

`new Date("2026-07-17T14:30")` resolves a zoneless datetime in the *local timezone of whatever machine parses it*. The client validated in the browser's zone, but the server (`/api/attendance/manual` line 30) reparses the same string in the **server's** zone — UTC in prod. A member entering 10:00am local was stored as 10:00 UTC, shifted by their offset.

Downstream fallout of the mis-zoned instant:
- future / same-day / 6-hour guards evaluated against the wrong time
- event association (`findAssociatedEventAt`) matched against `Event.startAt`/`endAt` with the shifted instant

Converting on the client (where the browser zone is correct) sends an unambiguous UTC timestamp the server reparses identically.

## Reviewer notes

- Server route unchanged — `new Date(iso)` parses an offset-bearing ISO string unambiguously.
- Audit log now records ISO strings instead of naive ones (consistent with what's stored).
- No new deps; single-line boundary conversion.

Verified the divergence: NY-local `10:00` → client `14:00Z` (correct) vs. old server-UTC `10:00Z` (wrong, 4h off).