### PR TITLE
feat(visits): cap visit duration at 24 hours

### DIFF
--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -380,9 +380,10 @@ describe('AuditLog Integration Tests', () => {
         createdVisitIds.push(visit.id);
 
         const newArrived = new Date('2020-01-01T10:00:00.000Z');
+        const newDeparted = new Date('2020-01-01T12:00:00.000Z');
         const req = new Request('http://localhost:4000/api/facility/visits', {
             method: 'PATCH',
-            body: JSON.stringify({ visitId: visit.id, arrivedAt: newArrived.toISOString() }),
+            body: JSON.stringify({ visitId: visit.id, arrivedAt: newArrived.toISOString(), departedAt: newDeparted.toISOString() }),
         });
 
         const res = await updateVisit(req as never);

--- a/checkin-app/src/app/api/attendance/manual/route.ts
+++ b/checkin-app/src/app/api/attendance/manual/route.ts
@@ -6,6 +6,7 @@ import { findAssociatedEventAt, processVisitCheckout } from "@/lib/attendanceTra
 import { sendCheckinNotifications } from "@/lib/notifications";
 import { logBackendError, logger } from "@/lib/logger";
 import { apiError } from "@/lib/api-response";
+import { withinMaxDuration } from "@/lib/visitTimes";
 
 // Self-service manual visit entry. INTENTIONAL by design: a member records a
 // visit for THEMSELVES only (participantId is forced to auth.user.id, never taken
@@ -50,6 +51,10 @@ export const POST = withAuth({}, async (req, auth) => {
 
         if (departureTime && departureTime <= arrivalTime) {
             return apiError("Departure time must be after arrival time", 400);
+        }
+
+        if (departureTime && !withinMaxDuration(arrivalTime, departureTime)) {
+            return apiError("A visit cannot be longer than 24 hours.", 400);
         }
 
         // Blank departure means "still in the building" → an open visit. Only allow

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -5,7 +5,7 @@ import { Prisma } from "@/generated/prisma/client";
 import { withAuth } from "@/lib/auth";
 import { handler, notFound, forbidden, badRequest } from "@/security/handler";
 import { apiError } from "@/lib/api-response";
-import { parseVisitTime, departureAfterArrival } from "@/lib/visitTimes";
+import { parseVisitTime, departureAfterArrival, withinMaxDuration } from "@/lib/visitTimes";
 
 // FAIL-CLOSED, staff-only. This payload is fundamentally a roster — who is
 // enrolled / RSVP'd / attended — and a participant's name, id, and the very
@@ -242,6 +242,9 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                     if (!dr.ok) return apiError(dr.error, 400);
                     if (!departureAfterArrival(ar.value, dr.value)) {
                         return apiError("Departure time must be after arrival time", 400);
+                    }
+                    if (!withinMaxDuration(ar.value, dr.value)) {
+                        return apiError("A visit cannot be longer than 24 hours.", 400);
                     }
                     dep = dr.value;
                 }

--- a/checkin-app/src/app/api/facility/visits/route.ts
+++ b/checkin-app/src/app/api/facility/visits/route.ts
@@ -3,7 +3,7 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
-import { parseVisitTime, departureAfterArrival } from "@/lib/visitTimes";
+import { parseVisitTime, departureAfterArrival, withinMaxDuration } from "@/lib/visitTimes";
 
 export const GET = withAuth(
     { roles: ['isSysadmin', 'isBoardMember'] },
@@ -63,6 +63,9 @@ export const PATCH = withAuth(
             }
             if (!departureAfterArrival(nextArrived, nextDeparted)) {
                 return apiError("Departure time must be after arrival time", 400);
+            }
+            if (!withinMaxDuration(nextArrived, nextDeparted)) {
+                return apiError("A visit cannot be longer than 24 hours.", 400);
             }
 
             const updatedVisit = await prisma.visit.update({

--- a/checkin-app/src/app/attendance/manual/page.tsx
+++ b/checkin-app/src/app/attendance/manual/page.tsx
@@ -6,6 +6,7 @@ import { notifications } from "@mantine/notifications";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
+import { MAX_VISIT_MS } from "@/lib/visitTimes";
 import { AttendanceTabs } from "../AttendanceTabs";
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -28,7 +29,7 @@ export default function ManualAttendance() {
       const dep = new Date(departedAt);
       if (isNaN(dep.getTime())) fe.departedAt = "Invalid departure time";
       else if (dep.getTime() <= arr.getTime()) fe.departedAt = "Departure time must be after arrival time";
-      else if (dep.getTime() - arr.getTime() > 24 * 60 * 60 * 1000) fe.departedAt = "A visit cannot be longer than 24 hours.";
+      else if (dep.getTime() - arr.getTime() > MAX_VISIT_MS) fe.departedAt = "A visit cannot be longer than 24 hours.";
     } else if (arrivedAt && !fe.arrivedAt) {
       const withinSixHours = now - arr.getTime() <= 6 * 60 * 60 * 1000;
       const sameDay = arr.toDateString() === new Date(now).toDateString();

--- a/checkin-app/src/app/attendance/manual/page.tsx
+++ b/checkin-app/src/app/attendance/manual/page.tsx
@@ -28,6 +28,7 @@ export default function ManualAttendance() {
       const dep = new Date(departedAt);
       if (isNaN(dep.getTime())) fe.departedAt = "Invalid departure time";
       else if (dep.getTime() <= arr.getTime()) fe.departedAt = "Departure time must be after arrival time";
+      else if (dep.getTime() - arr.getTime() > 24 * 60 * 60 * 1000) fe.departedAt = "A visit cannot be longer than 24 hours.";
     } else if (arrivedAt && !fe.arrivedAt) {
       const withinSixHours = now - arr.getTime() <= 6 * 60 * 60 * 1000;
       const sameDay = arr.toDateString() === new Date(now).toDateString();

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -153,6 +153,10 @@ export default function AdminVisitsPage() {
       setRowNotice({ id, text: "Departure time must be after arrival time", tone: "error" });
       return;
     }
+    if (editForm.arrivedAt && Date.parse(editForm.departedAt) - Date.parse(editForm.arrivedAt) > 24 * 60 * 60 * 1000) {
+      setRowNotice({ id, text: "A visit cannot be longer than 24 hours.", tone: "error" });
+      return;
+    }
     try {
       const res = await fetch(`/api/facility/visits`, {
         method: 'PATCH',

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -8,6 +8,7 @@ import { useRequireRole } from '@/hooks/useRequireRole';
 import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
 import { notifications } from '@mantine/notifications';
 import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
+import { MAX_VISIT_MS } from '@/lib/visitTimes';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 type VisitSource = 'SCANNER' | 'WEB' | 'SYSTEM';
@@ -153,7 +154,7 @@ export default function AdminVisitsPage() {
       setRowNotice({ id, text: "Departure time must be after arrival time", tone: "error" });
       return;
     }
-    if (editForm.arrivedAt && Date.parse(editForm.departedAt) - Date.parse(editForm.arrivedAt) > 24 * 60 * 60 * 1000) {
+    if (editForm.arrivedAt && Date.parse(editForm.departedAt) - Date.parse(editForm.arrivedAt) > MAX_VISIT_MS) {
       setRowNotice({ id, text: "A visit cannot be longer than 24 hours.", tone: "error" });
       return;
     }

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -181,6 +181,11 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
       setManualNotice({ ok: false, msg: "Departure time must be after arrival time" });
       return;
     }
+    if (manualStatus === 'Present' && manualArrived && manualDeparted &&
+        Date.parse(manualDeparted) - Date.parse(manualArrived) > 24 * 60 * 60 * 1000) {
+      setManualNotice({ ok: false, msg: "A visit cannot be longer than 24 hours." });
+      return;
+    }
     setActionLoading(true);
     setManualNotice(null);
     try {

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
+import { MAX_VISIT_MS } from '@/lib/visitTimes';
 import type { RSVPStatus } from '@/types/rsvp';
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -182,7 +183,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
       return;
     }
     if (manualStatus === 'Present' && manualArrived && manualDeparted &&
-        Date.parse(manualDeparted) - Date.parse(manualArrived) > 24 * 60 * 60 * 1000) {
+        Date.parse(manualDeparted) - Date.parse(manualArrived) > MAX_VISIT_MS) {
       setManualNotice({ ok: false, msg: "A visit cannot be longer than 24 hours." });
       return;
     }

--- a/checkin-app/src/lib/__tests__/visitTimes.test.ts
+++ b/checkin-app/src/lib/__tests__/visitTimes.test.ts
@@ -1,4 +1,4 @@
-import { parseVisitTime, departureAfterArrival } from "../visitTimes";
+import { parseVisitTime, departureAfterArrival, withinMaxDuration } from "../visitTimes";
 
 const now = new Date("2026-07-04T12:00:00Z");
 
@@ -45,5 +45,18 @@ describe("departureAfterArrival", () => {
   });
   it("false when before", () => {
     expect(departureAfterArrival(arrived, new Date("2026-07-04T09:00:00Z"))).toBe(false);
+  });
+});
+
+describe("withinMaxDuration", () => {
+  const arrived = new Date("2026-07-04T10:00:00Z");
+  it("true under 24h", () => {
+    expect(withinMaxDuration(arrived, new Date("2026-07-05T09:00:00Z"))).toBe(true);
+  });
+  it("true at exactly 24h", () => {
+    expect(withinMaxDuration(arrived, new Date("2026-07-05T10:00:00Z"))).toBe(true);
+  });
+  it("false past 24h", () => {
+    expect(withinMaxDuration(arrived, new Date("2026-07-05T10:00:01Z"))).toBe(false);
   });
 });

--- a/checkin-app/src/lib/visitTimes.ts
+++ b/checkin-app/src/lib/visitTimes.ts
@@ -27,3 +27,11 @@ export function parseVisitTime(
 export function departureAfterArrival(arrived: Date, departed: Date): boolean {
   return departed.getTime() > arrived.getTime();
 }
+
+/** A single visit can't span more than a day — a longer window is a missed
+ * checkout or a typo, not a real visit. Applies only to closed visits. */
+export const MAX_VISIT_MS = 24 * 60 * 60 * 1000;
+
+export function withinMaxDuration(arrived: Date, departed: Date): boolean {
+  return departed.getTime() - arrived.getTime() <= MAX_VISIT_MS;
+}


### PR DESCRIPTION
## What

A visit had no maximum-duration guard — the only time constraint was `departedAt > arrivedAt`. A member (self-entry) or an admin/board edit could record a closed visit spanning days or weeks.

Adds a 24-hour cap on **closed** visits.

## Why

A multi-day visit is a missed checkout or a typo, not a real visit, and it skews self-reported facility/trends hours. Bounding it keeps the data honest.

## Changes

- `withinMaxDuration()` + `MAX_VISIT_MS` in `visitTimes.ts` (24h, closed visits only)
- Enforced on all three closed-visit write paths:
  - `POST /api/attendance/manual` (self-entry — inline, bypasses the shared helper)
  - `PATCH /api/facility/visits` (sysadmin/board edit)
  - `PATCH /api/events/[id]` (Present status)
- Client-side mirror in each of the three entry UIs (manual page, facility-ops visits, program-ops session) for instant feedback — **server stays the trust boundary**
- Unit tests for the boundary (under / exactly 24h / over)

## Notes for reviewer

- Open visits (no departure) carry no entered duration, so the cap does not apply. The manual endpoint already bounds open backfills to 6h/same-day.
- 24h boundary is inclusive (exactly 24h passes).
- Client checks hand-roll the 24h math inline, matching the existing per-UI validation style (each already duplicates the "after arrival" check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)