### PR TITLE
feat(facility-ops): allow deleting a visit with audit logging

### DIFF
--- a/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
@@ -6,7 +6,7 @@
  * Tests GET and PATCH /api/facility/visits for viewing and editing check-in records
  */
 
-import { GET, PATCH } from '@/app/api/facility/visits/route';
+import { GET, PATCH, DELETE } from '@/app/api/facility/visits/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 
@@ -276,6 +276,96 @@ describe('Admin Visits API Integration Tests', () => {
                 where: { actorId: testAdminId, action: 'EDIT', tableName: 'Visit' }
             });
             expect(currentAuditLogs).toBe(previousAuditLogs + 1);
+        });
+    });
+
+    describe('DELETE /api/facility/visits', () => {
+        it('should return 401 Unauthorized without session', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue(null);
+
+            const req = new Request('http://localhost:4000/api/facility/visits', {
+                method: 'DELETE',
+                body: JSON.stringify({ visitId: testVisitId })
+            });
+
+            const res = await DELETE(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(401);
+        });
+
+        it('should return 403 Forbidden for non-admin users', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testUserId }
+            });
+
+            const req = new Request('http://localhost:4000/api/facility/visits', {
+                method: 'DELETE',
+                body: JSON.stringify({ visitId: testVisitId })
+            });
+
+            const res = await DELETE(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(403);
+        });
+
+        it('should return 400 Bad Request if visitId is missing', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true }
+            });
+
+            const req = new Request('http://localhost:4000/api/facility/visits', {
+                method: 'DELETE',
+                body: JSON.stringify({})
+            });
+
+            const res = await DELETE(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(400);
+            const data = await res.json();
+            expect(data.error).toBe('visitId is required.');
+        });
+
+        it('should return 404 for a non-existent visit', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true }
+            });
+
+            const req = new Request('http://localhost:4000/api/facility/visits', {
+                method: 'DELETE',
+                body: JSON.stringify({ visitId: 999999999 })
+            });
+
+            const res = await DELETE(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(404);
+            const data = await res.json();
+            expect(data.error).toBe('Visit not found.');
+        });
+
+        it('should delete the visit and log to audit with oldData when an admin requests it', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true }
+            });
+
+            // Own throwaway visit so the shared testVisitId stays available for other runs.
+            const doomed = await prisma.visit.create({
+                data: { personId: testUserId, arrivedAt: new Date(Date.now() - 3600000) }
+            });
+
+            const req = new Request('http://localhost:4000/api/facility/visits', {
+                method: 'DELETE',
+                body: JSON.stringify({ visitId: doomed.id })
+            });
+
+            const res = await DELETE(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            expect(data.success).toBe(true);
+
+            const gone = await prisma.visit.findUnique({ where: { id: doomed.id } });
+            expect(gone).toBeNull();
+
+            const auditLog = await prisma.auditLog.findFirst({
+                where: { actorId: testAdminId, action: 'DELETE', tableName: 'Visit', affectedEntityId: doomed.id }
+            });
+            expect(auditLog).not.toBeNull();
+            expect((auditLog?.oldData as { id?: number })?.id).toBe(doomed.id);
         });
     });
 });

--- a/checkin-app/src/app/api/facility/visits/route.ts
+++ b/checkin-app/src/app/api/facility/visits/route.ts
@@ -93,3 +93,42 @@ export const PATCH = withAuth(
         }
     }
 );
+
+export const DELETE = withAuth(
+    { roles: ['isSysadmin', 'isBoardMember'] },
+    async (req, auth) => {
+        try {
+            const { visitId } = await req.json();
+
+            if (!visitId) {
+                return apiError("visitId is required.", 400);
+            }
+
+            const existing = await prisma.visit.findUnique({ where: { id: visitId } });
+            if (!existing) {
+                return apiError("Visit not found.", 404);
+            }
+
+            await prisma.visit.delete({ where: { id: visitId } });
+
+            // Log the manual deletion in the audit trail — keep the deleted row in oldData
+            // since it no longer exists anywhere else.
+            if (auth.type === 'session') {
+                await prisma.auditLog.create({
+                    data: {
+                        actorId: auth.user.id,
+                        action: "DELETE",
+                        tableName: "Visit",
+                        affectedEntityId: visitId,
+                        oldData: JSON.parse(JSON.stringify(existing)),
+                    },
+                });
+            }
+
+            return NextResponse.json({ success: true });
+        } catch (error) {
+            logger.error("Delete visit error:", error);
+            return apiError("Internal Server Error", 500);
+        }
+    }
+);

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -78,6 +78,8 @@ export default function AdminVisitsPage() {
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'arrivedAt', dir: 'desc' });
   const [confirmEditOpened, { open: openConfirmEdit, close: closeConfirmEdit }] = useDisclosure(false);
   const [pendingEditVisit, setPendingEditVisit] = useState<Visit | null>(null);
+  const [confirmDeleteOpened, { open: openConfirmDelete, close: closeConfirmDelete }] = useDisclosure(false);
+  const [pendingDeleteVisit, setPendingDeleteVisit] = useState<Visit | null>(null);
 
   const sortedVisits = useMemo(() => {
     return [...visits].sort((a, b) => {
@@ -176,6 +178,34 @@ export default function AdminVisitsPage() {
     }
   };
 
+  const handleDeleteClick = (visit: Visit) => {
+    setPendingDeleteVisit(visit);
+    openConfirmDelete();
+  };
+
+  const confirmDeleteClick = async () => {
+    if (!pendingDeleteVisit) return;
+    const id = pendingDeleteVisit.id;
+    closeConfirmDelete();
+    setPendingDeleteVisit(null);
+    try {
+      const res = await fetch(`/api/facility/visits`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ visitId: id })
+      });
+      if (res.ok) {
+        notifications.show({ color: "green", message: "Visit deleted." });
+        fetchVisits();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        notifications.show({ color: "red", message: data.error || "Failed to delete visit.", autoClose: false });
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error deleting visit.", autoClose: false });
+    }
+  };
+
   if (authLoading || loading) {
     return <PageLoader />;
   }
@@ -250,7 +280,10 @@ export default function AdminVisitsPage() {
                       ) : <Text component="span" c="yellow">Active</Text>}
                     </Table.Td>
                     <Table.Td>
-                      <Button size="xs" fz={15} variant="light" onClick={() => handleEditClick(v)}>Edit</Button>
+                      <Group gap="xs" wrap="nowrap">
+                        <Button size="xs" fz={15} variant="light" onClick={() => handleEditClick(v)}>Edit</Button>
+                        <Button size="xs" fz={15} variant="light" color="red" onClick={() => handleDeleteClick(v)}>Delete</Button>
+                      </Group>
                     </Table.Td>
                   </>
                 )}
@@ -272,6 +305,21 @@ export default function AdminVisitsPage() {
         <Group justify="flex-end">
           <Button variant="default" onClick={closeConfirmEdit}>Cancel</Button>
           <Button color="red" onClick={confirmEditClick}>Continue</Button>
+        </Group>
+      </Modal>
+
+      <Modal
+        opened={confirmDeleteOpened}
+        onClose={closeConfirmDelete}
+        title={<Text span fw={700} fz="lg">Delete Visit Record</Text>}
+        centered
+      >
+        <Text mb="lg">
+          Warning: You are permanently deleting a visit record using Admin overrides. This will be permanently logged.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmDelete}>Cancel</Button>
+          <Button color="red" onClick={confirmDeleteClick}>Delete</Button>
         </Group>
       </Modal>
     </Stack>


### PR DESCRIPTION
## What

Adds the ability to delete a visit record from the facility-ops visits admin page, with the deletion recorded in the audit trail.

- **API** — new `DELETE /api/facility/visits` handler. Loads the target visit (404 if missing), deletes it, then writes an `AuditLog` row: `action: DELETE`, `tableName: Visit`, `affectedEntityId`, and the full deleted row in `oldData`.
- **UI** — red **Delete** button per row in the visits table, behind a confirmation modal warning the action is permanent and logged (mirrors the existing edit-confirmation flow).
- **Tests** — DELETE integration cases: 401 (no session), 403 (non-admin), 400 (missing visitId), 404 (non-existent), and happy path asserting the row is gone and the audit record captured oldData.

## Why

The visits admin page could edit but not delete records. Deletion needs the same audit guarantees as edits — and because the row is gone afterward, the deleted contents are preserved in oldData (following the existing programs/[id]/participants delete-with-audit pattern).

## Reviewer notes

- Deletion is gated to the same roles as the existing GET/PATCH on this route: isSysadmin OR isBoardMember. The page component role-gates the UI to isSysadmin only, but the server role list is the real trust boundary — flag if DELETE should be sysadmin-only.
- Integration tests were NOT run in this environment (no Postgres / empty DATABASE_URL). They typecheck clean; run the adminVisitsAPI integration suite against a live DB to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)