### PR TITLE
fix(membership): scholarship request confirms first and stays received across reloads

### DIFF
--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -948,3 +948,45 @@ describe("payment holdoff visibility refetch", () => {
     await waitFor(() => expect(stateCalls()).toBeGreaterThan(before));
   });
 });
+
+describe("scholarship / payment-plan request", () => {
+  const pendingPayment = (extra: Record<string, unknown> = {}) => ({
+    "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
+    "/api/membership": state({
+      process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT", ...extra },
+      external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
+    }),
+  });
+
+  it("asks for confirmation before sending — cancel fires nothing", async () => {
+    setSession({ id: 1 });
+    const fetchMock = mockFetchJson(pendingPayment());
+    renderWithProviders(<MembershipPage />);
+    fireEvent.click(await screen.findByRole("button", { name: /Request a scholarship or payment plan/ }));
+    expect(await screen.findByText(/This sends your request to the board/)).toBeInTheDocument();
+    const requestCalls = () => fetchMock.mock.calls.filter((c) => String(c[0]).includes("request-payment-plan")).length;
+    expect(requestCalls()).toBe(0);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(requestCalls()).toBe(0);
+    expect(screen.getByRole("button", { name: /Request a scholarship or payment plan/ })).toBeInTheDocument();
+  });
+
+  it("confirm sends the request and swaps the button for the received state", async () => {
+    setSession({ id: 1 });
+    const fetchMock = mockFetchJson({ ...pendingPayment(), "/api/membership/request-payment-plan": { ok: true } });
+    renderWithProviders(<MembershipPage />);
+    fireEvent.click(await screen.findByRole("button", { name: /Request a scholarship or payment plan/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "Send request" }));
+    expect(await screen.findByText(/requested — the finance committee will follow up/)).toBeInTheDocument();
+    expect(fetchMock.mock.calls.filter((c) => String(c[0]).includes("request-payment-plan")).length).toBe(1);
+    expect(screen.queryByRole("button", { name: /Request a scholarship or payment plan/ })).not.toBeInTheDocument();
+  });
+
+  it("a reload after requesting still shows the received state (server flag)", async () => {
+    setSession({ id: 1 });
+    mockFetchJson(pendingPayment({ isPaymentPlanRequested: true }));
+    renderWithProviders(<MembershipPage />);
+    expect(await screen.findByText(/requested — the finance committee will follow up/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Request a scholarship or payment plan/ })).not.toBeInTheDocument();
+  });
+});

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -5,10 +5,11 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import type { OrgMembershipProcessStatus, OrgMembershipStatus } from "@/generated/prisma/client";
 import {
-  Alert, Anchor, Box, Button, Card, Checkbox, Container, Group,
+  Alert, Anchor, Box, Button, Card, Checkbox, Container, Group, Modal,
   SimpleGrid, Stack, Text, Textarea, TextInput, ThemeIcon, Title,
 } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
+import { useDisclosure } from "@mantine/hooks";
 import { AlertBanner, type AlertTone } from "@/components/admin/AlertBanner";
 import MembershipFlowStepper from "@/components/MembershipFlowStepper";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
@@ -152,7 +153,10 @@ export default function MembershipPage() {
   // process out of PENDING_PAYMENT, or explicitly via the escape-hatch link.
   const [awaitingPayment, setAwaitingPayment] = useState<{ processId: number } | null>(null);
   // Flips true once the household asks the finance committee for a payment plan.
+  // Seeded from the server flag so a reload (or another device) still shows the
+  // request as received rather than resurrecting the button.
   const [planRequested, setPlanRequested] = useState(false);
+  const [confirmPlanOpened, { open: openConfirmPlan, close: closeConfirmPlan }] = useDisclosure(false);
   // Self-attest gate for the background-check task (#875): the confirm checkbox
   // unlocks only after the applicant has opened the Averity consent link this
   // visit, so they can't attest to a form they never saw.
@@ -533,7 +537,12 @@ export default function MembershipPage() {
   // Ask the board's finance committee for a payment plan on membership dues.
   // Mirrors the program-page request; the finance-ops Membership Payment Plan tab
   // picks it up and activates the membership on approval (no Shopify payment).
+  useEffect(() => {
+    if (state?.process?.isPaymentPlanRequested) setPlanRequested(true);
+  }, [state?.process?.isPaymentPlanRequested]);
+
   const requestPaymentPlan = async () => {
+    closeConfirmPlan();
     if (!state?.process) return;
     try {
       const res = await fetch("/api/membership/request-payment-plan", {
@@ -911,6 +920,17 @@ export default function MembershipPage() {
                     ) : (
                       <Text c="yellow" mt="md">The payment link isn&apos;t available yet. Please check back shortly.</Text>
                     )}
+                    <Modal opened={confirmPlanOpened} onClose={closeConfirmPlan} title="Request a scholarship or payment plan?" centered>
+                      <Text size="sm">
+                        This sends your request to the board&apos;s Finance Committee, who will review
+                        your household&apos;s dues and follow up with you. You won&apos;t be charged
+                        anything now, and you can still pay online at any time.
+                      </Text>
+                      <Group justify="flex-end" mt="md">
+                        <Button variant="default" onClick={closeConfirmPlan}>Cancel</Button>
+                        <Button color="green" onClick={requestPaymentPlan}>Send request</Button>
+                      </Group>
+                    </Modal>
                     {planRequested ? (
                       <Text c="green" mt="md">Scholarship or payment plan requested — the finance committee will follow up.</Text>
                     ) : (
@@ -918,7 +938,7 @@ export default function MembershipPage() {
                         variant="light"
                         type="button"
                         mt="md"
-                        onClick={requestPaymentPlan}
+                        onClick={openConfirmPlan}
                         styles={{ root: { height: 'auto', paddingBlock: 'var(--mantine-spacing-xs)' }, label: { whiteSpace: 'normal' } }}
                       >
                         Request a scholarship or payment plan from the Finance Committee of the Board

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -50,7 +50,7 @@ interface IntakeState {
   hasHousehold: boolean;
   isLead: boolean;
   membershipStatus: OrgMembershipStatus | null;
-  process: { id: number; kind: string; status: OrgMembershipProcessStatus } | null;
+  process: { id: number; kind: string; status: OrgMembershipProcessStatus; isPaymentPlanRequested?: boolean } | null;
   external: ExternalStatus | null;
   prefill: {
     household: ({ name: string | null; notes: string | null; emergencyContactName: string | null; emergencyContactPhone: string | null; emergencyContactEmail: string | null } & Partial<StructuredAddress>) | null;

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -116,7 +116,7 @@ export async function getIntakeState(userId: number) {
         hasHousehold: !!household,
         isLead: leadIds.has(userId),
         membershipStatus: membership?.status ?? null,
-        process: process ? { id: process.id, kind: process.kind, status: process.status } : null,
+        process: process ? { id: process.id, kind: process.kind, status: process.status, isPaymentPlanRequested: process.isPaymentPlanRequested } : null,
         external,
         prefill: {
             household: household


### PR DESCRIPTION
Dogfooding report: the "Request a scholarship or payment plan" button fired with no "are you sure," and while it did swap to the received text, that state was client-memory only — a reload brought the button back, making the request look un-received and inviting duplicates.

- **Confirmation modal** before anything sends: what the request does, that nothing is charged, and that paying online remains available. Cancel fires no request (asserted).
- **Durable received state**: the membership state GET now includes the process's `isPaymentPlanRequested`, and the page seeds from it — the green "requested — the finance committee will follow up" survives reloads and other devices. (The server flag already existed and was already idempotent; it just was never surfaced.)

3 new RTL cases: cancel → zero request calls; confirm → exactly one call + button swaps; server-flag-only load → received state, no button. 67/67 page suite, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe