### PR TITLE
fix(reconcile): variant-id membership match, kill couponed AMOUNT_MISMATCH false-positive

### DIFF
--- a/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
@@ -23,13 +23,20 @@ jest.mock("@/lib/shopifyRead/client", () => ({
     ordersChangedSince: jest.fn(async () => [] as MirrorOrder[]),
     ordersByLegacyIds: jest.fn(async () => [] as MirrorOrder[]),
     disputedOrderGids: jest.fn(async () => new Set<string>()),
+    // Default [] = a pre-#1048 order with no mirrored line variant ids, which drives
+    // the reconciler's transitional amount-gate fallback. Tests of the variant path
+    // set this explicitly.
+    orderLineVariantIds: jest.fn(async () => [] as string[]),
 }));
 import * as mirror from "@/lib/shopifyRead/client";
 
 const TAG = "reconcile-matrix-test";
+// A membership variant id the board has configured; #1048 mirrors it onto order lines.
+const MEMBERSHIP_VARIANT = "variant-normal-1";
 const ordersChangedSince = mirror.ordersChangedSince as jest.Mock;
 const ordersByLegacyIds = mirror.ordersByLegacyIds as jest.Mock;
 const disputedOrderGids = mirror.disputedOrderGids as jest.Mock;
+const orderLineVariantIds = mirror.orderLineVariantIds as jest.Mock;
 
 function order(overrides: Partial<MirrorOrder> & { legacyId: string }): MirrorOrder {
     return {
@@ -39,6 +46,8 @@ function order(overrides: Partial<MirrorOrder> & { legacyId: string }): MirrorOr
         totalCents: 5000,
         subtotalCents: 5000,
         totalRefundedCents: 0,
+        discountCents: 0,
+        discountCodes: [],
         cancelledAt: null,
         updatedAt: new Date(),
         // Default null = an order synced before #1029, i.e. the email-fallback path.
@@ -83,8 +92,8 @@ async function makeApplicant(opts: {
 beforeAll(async () => {
     await prisma.boardSettings.upsert({
         where: { id: 1 },
-        create: { id: 1, normalDuesCents: 5000, volunteerDuesCents: 2000 },
-        update: { normalDuesCents: 5000, volunteerDuesCents: 2000, shopifyReconcileCursorAt: null },
+        create: { id: 1, normalDuesCents: 5000, volunteerDuesCents: 2000, shopifyNormalVariantId: MEMBERSHIP_VARIANT },
+        update: { normalDuesCents: 5000, volunteerDuesCents: 2000, shopifyNormalVariantId: MEMBERSHIP_VARIANT, shopifyReconcileCursorAt: null },
     });
 });
 
@@ -92,6 +101,7 @@ afterEach(async () => {
     ordersChangedSince.mockResolvedValue([]);
     ordersByLegacyIds.mockResolvedValue([]);
     disputedOrderGids.mockResolvedValue(new Set());
+    orderLineVariantIds.mockResolvedValue([]);
     // Reset cursor so each test scans its own fixtures from scratch.
     await prisma.boardSettings.update({ where: { id: 1 }, data: { shopifyReconcileCursorAt: null } });
 });
@@ -149,6 +159,46 @@ describe("forward recovery", () => {
         await runReconcile();
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe("PENDING_PAYMENT");
+        expect(await prisma.paymentException.findFirst({ where: { kind: "AMOUNT_MISMATCH", shopifyOrderId: oid } })).toBeTruthy();
+    });
+
+    it("recovers a couponed order below gross dues (variant match), no AMOUNT_MISMATCH", async () => {
+        // #1048: the volunteer rate / promos are Shopify coupons, so a valid order's
+        // total is below gross dues. It carries a known membership variant line → recover.
+        const email = `coupon-${TAG}@ex.com`;
+        const oid = `${TAG}-120`;
+        const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true });
+        orderLineVariantIds.mockResolvedValue([MEMBERSHIP_VARIANT]);
+        ordersChangedSince.mockResolvedValue([
+            order({ legacyId: oid, customerEmail: email, totalCents: 2000, discountCents: 3000, discountCodes: ["VOLUNTEER50"] }),
+        ]);
+        await runReconcile();
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(proc?.status).toBe("ACTIVE");
+        expect(proc?.shopifyOrderId).toBe(oid);
+        expect(await prisma.paymentException.count({ where: { kind: "AMOUNT_MISMATCH", processId } })).toBe(0);
+    });
+
+    it("raises NO_ITEM when a variant-mirrored order contains no membership product", async () => {
+        const email = `noitem-${TAG}@ex.com`;
+        const oid = `${TAG}-121`;
+        const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true });
+        // Order lines are mirrored, but none is a membership variant (e.g. a t-shirt).
+        orderLineVariantIds.mockResolvedValue(["variant-tshirt-99"]);
+        ordersChangedSince.mockResolvedValue([order({ legacyId: oid, customerEmail: email, totalCents: 5000 })]);
+        await runReconcile();
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: processId } }))?.status).toBe("PENDING_PAYMENT");
+        expect(await prisma.paymentException.findFirst({ where: { kind: "NO_ITEM", shopifyOrderId: oid } })).toBeTruthy();
+    });
+
+    it("pre-backfill order (no variant ids) genuinely short of dues still raises AMOUNT_MISMATCH", async () => {
+        // orderLineVariantIds default [] = pre-#1048, no discount codes → amount fallback.
+        const email = `prebackfill-${TAG}@ex.com`;
+        const oid = `${TAG}-122`;
+        const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true });
+        ordersChangedSince.mockResolvedValue([order({ legacyId: oid, customerEmail: email, totalCents: 1000, discountCents: 0, discountCodes: [] })]);
+        await runReconcile();
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: processId } }))?.status).toBe("PENDING_PAYMENT");
         expect(await prisma.paymentException.findFirst({ where: { kind: "AMOUNT_MISMATCH", shopifyOrderId: oid } })).toBeTruthy();
     });
 
@@ -254,6 +304,17 @@ describe("reversal detection", () => {
         await runReconcile();
         const ex = await prisma.paymentException.findFirst({ where: { kind: "CHARGEBACK", processId } });
         expect(ex?.severity).toBe("CRITICAL");
+    });
+
+    it("does not raise AMOUNT_MISMATCH on a couponed order below gross dues (post-activation)", async () => {
+        // ACTIVE membership paid with a coupon: total is below gross dues but the
+        // discount explains the gap — not a post-activation edit-down. No exception.
+        const oid = `${TAG}-203`;
+        const { processId } = await makeApplicant({ email: `revcoupon-${TAG}@ex.com`, status: "ACTIVE", paid: true, shopifyOrderId: oid });
+        ordersByLegacyIds.mockResolvedValue([order({ legacyId: oid, financialStatus: "PAID", totalCents: 2000, discountCents: 3000, discountCodes: ["VOLUNTEER50"] })]);
+        await runReconcile();
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: processId } }))?.status).toBe("ACTIVE");
+        expect(await prisma.paymentException.count({ where: { kind: "AMOUNT_MISMATCH", processId } })).toBe(0);
     });
 
     it("raises CANCELLED for a cancelled order", async () => {

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
+import { config, DEV_MOCK_MEMBERSHIP_VARIANT_ID } from "@/lib/config";
 import { activateByProcessId } from "@/lib/membership/payment";
 import { notifyBoardPaymentException } from "@/lib/membership/boardAlerts";
 import * as mirror from "@/lib/shopifyRead/client";
@@ -27,12 +28,15 @@ import type { MirrorOrder } from "@/lib/shopifyRead/client";
  * exact. Orders synced before that carry no attributes and fall back to customer
  * email → household lead → the family's single pending process.
  *
- * What still can't be replicated is the webhook's variant-id check that the order
- * really contains the membership/program product: the mirror's order lines carry
- * sku/title, not variant ids. Membership recovery therefore gates on the order
- * covering the family's dues instead. Nothing is guessed: an attribute naming an
- * unknown process, an ambiguous email match, or an amount short of dues raises a
- * problem for the board rather than activating.
+ * Membership recovery replicates the webhook's variant-id check that the order
+ * really contains the membership product: the mirror's order lines carry variant
+ * ids since #1048, so recovery gates on the order containing one of checkin's known
+ * membership variants — the exact set the webhook builds — not on order total.
+ * (Orders synced before #1048 and not yet backfilled carry no line variant ids;
+ * those fall back to a discount-aware dues amount gate — see reconcileForwardMembership.)
+ * Nothing is guessed: an attribute naming an unknown process, an ambiguous email
+ * match, or an order with no membership item raises a problem for the board rather
+ * than activating.
  */
 
 export type PaymentExceptionKind =
@@ -140,7 +144,8 @@ type ResolvedProcess = { id: number; orgMembershipId: number | null } | "none" |
  * null on those). Fuzzier, so it refuses to guess: zero or several pending
  * processes resolve to "none"/"ambiguous" rather than picking one.
  *
- * Either way the caller amount-gates before activating, and only a PENDING_PAYMENT
+ * Either way the caller checks the order contains a membership variant before
+ * activating (amount-gating only pre-#1048 orders), and only a PENDING_PAYMENT
  * process is ever a recovery candidate.
  */
 async function resolveMembershipProcess(order: MirrorOrder): Promise<ResolvedProcess> {
@@ -201,21 +206,60 @@ async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> 
     }
     if (!isPaid(order)) return true; // pending/authorized/etc — nothing to do yet, but it IS this family's order.
 
-    // Amount gate: the mirror has no line variant id, so we cannot replicate the
-    // webhook's variant-id membership-item check — gate on the order covering dues
-    // instead (matched to THIS pending process). Short → mismatch, not activation.
-    const membership = proc.orgMembershipId
-        ? await prisma.orgMembership.findUnique({ where: { id: proc.orgMembershipId }, select: { isVolunteer: true } })
-        : null;
-    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 }, select: { normalDuesCents: true, volunteerDuesCents: true } });
-    const expected = membership?.isVolunteer ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
-    if (expected > 0 && order.totalCents + AMOUNT_TOLERANCE_CENTS < expected) {
-        await raisePaymentException("AMOUNT_MISMATCH", { shopifyOrderId: order.legacyId, processId: proc.id });
-        return true;
+    // Membership-item gate, parity with the orders/paid webhook: recover only if the
+    // order actually CONTAINS a membership product (its variant id), the same
+    // {orgMembership, normal, volunteer} variant set the webhook builds — mirrored
+    // onto order lines since #1048. A variant id is stable and can't drift; the old
+    // total-price gate false-raised AMOUNT_MISMATCH on every couponed order (volunteer
+    // rate, promo), whose sub-dues total is indistinguishable from an underpayment by
+    // amount alone. See the H2 note in payment.ts and the webhook route.
+    const settings = await prisma.boardSettings.findUnique({
+        where: { id: 1 },
+        select: {
+            orgMembershipVariantId: true,
+            shopifyNormalVariantId: true,
+            shopifyVolunteerVariantId: true,
+            normalDuesCents: true,
+            volunteerDuesCents: true,
+        },
+    });
+    const membershipVariantIds = new Set(
+        [
+            settings?.orgMembershipVariantId,
+            settings?.shopifyNormalVariantId,
+            settings?.shopifyVolunteerVariantId,
+            config.shopifyMockActive() ? DEV_MOCK_MEMBERSHIP_VARIANT_ID : null,
+        ].filter((v): v is string => !!v),
+    );
+    const lineVariantIds = await mirror.orderLineVariantIds(order.orderGid);
+
+    if (lineVariantIds.length > 0) {
+        // Post-#1048 order: variant ids are mirrored, so the item check is authoritative.
+        if (!lineVariantIds.some((v) => membershipVariantIds.has(v))) {
+            // Attributed to a pending process, paid, but no membership product on it —
+            // the webhook's NO_ITEM case (activate() fails closed there).
+            await raisePaymentException("NO_ITEM", { shopifyOrderId: order.legacyId, processId: proc.id });
+            return true;
+        }
+    } else {
+        // TRANSITIONAL (remove once the #1048 backfill re-pull is universal): rows
+        // synced before #1048 carry no line variant ids, so the item check is
+        // impossible — fall back to the old dues amount gate, made discount-aware by
+        // adding the coupon back so a couponed pre-backfill order compares its GROSS
+        // figure to gross dues and no longer false-raises AMOUNT_MISMATCH.
+        const membership = proc.orgMembershipId
+            ? await prisma.orgMembership.findUnique({ where: { id: proc.orgMembershipId }, select: { isVolunteer: true } })
+            : null;
+        const expected = membership?.isVolunteer ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
+        if (expected > 0 && order.totalCents + order.discountCents + AMOUNT_TOLERANCE_CENTS < expected) {
+            await raisePaymentException("AMOUNT_MISMATCH", { shopifyOrderId: order.legacyId, processId: proc.id });
+            return true;
+        }
     }
 
-    // Recover: advance past the paid checkpoint. hasMembershipItem=true — matched to
-    // this specific pending process and the amount covers dues (honest missed-webhook
+    // Recover: advance past the paid checkpoint. hasMembershipItem=true — the order
+    // contains a known membership variant (or, for a pre-backfill order, covers dues)
+    // and is matched to this specific pending process (honest missed-webhook
     // assumption; the reconciler is not the attack surface the public webhook is, and
     // it leaves a full AuditLog trail via activate()).
     const result = await activateByProcessId(proc.id, order.legacyId ?? "", true);
@@ -295,10 +339,13 @@ async function activateProgramFromOrder(order: MirrorOrder, programId: number, p
         programId,
         personIds,
         shopifyOrderId: order.legacyId ?? "",
-        // The mirror carries no line variant id, so the webhook's variant check can't
-        // be replicated — the order is matched to THIS program's pending enrollments
-        // (by cart attribute, or by household for pre-#1029 orders). Tier unknown →
-        // no legacy sibling-inventory mirror.
+        // Line variant ids are mirrored since #1048, but this program path still
+        // matches by cart attribute / household rather than the program's variant id —
+        // program recovery has no amount gate, so it never had the coupon false-positive
+        // the membership path did, and widening it to a variant check is deferred (the
+        // membership fix was the scoped concern). So hasProgramItem stays true here: the
+        // order is matched to THIS program's pending enrollments. Tier unknown → no
+        // legacy sibling-inventory mirror.
         hasProgramItem: true,
         purchasedOrgMember: null,
     });
@@ -373,8 +420,11 @@ async function reconcileReversals(): Promise<number> {
         let kind = classifyReversal(o, disputed.has(o.orderGid));
         if (!kind) {
             // Not reversed — but was the order edited down below dues after activation?
+            // Discount-aware: add the coupon back so an ordinary couponed order (volunteer
+            // rate, promo) isn't mistaken for a post-activation edit-down — only a real
+            // shortfall below GROSS dues counts. Keeps the "edited down" purpose intact.
             const expected = isVolunteerById.get(proc.orgMembershipId ?? -1) ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
-            if (expected > 0 && o.totalCents + AMOUNT_TOLERANCE_CENTS < expected) kind = "AMOUNT_MISMATCH";
+            if (expected > 0 && o.totalCents + o.discountCents + AMOUNT_TOLERANCE_CENTS < expected) kind = "AMOUNT_MISMATCH";
         }
         if (kind) {
             await raisePaymentException(kind, { shopifyOrderId: proc.shopifyOrderId, processId: proc.id });

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -78,6 +78,16 @@ export interface MirrorOrder {
     totalCents: number;
     subtotalCents: number;
     totalRefundedCents: number;
+    /** Coupon amount Shopify took off the order (pre-existing column). Added back to
+     * reconstruct the gross figure when amount-gating a couponed order. */
+    discountCents: number;
+    /**
+     * Coupon codes applied at checkout, mirrored since #1048. Empty [] for orders
+     * synced before that shipped (until a backfill re-pull) AND for genuinely
+     * un-couponed orders — absence is not distinguishable, so treat non-empty as
+     * "a coupon explains a sub-dues total", never empty as "definitely no coupon".
+     */
+    discountCodes: string[];
     cancelledAt: Date | null;
     updatedAt: Date | null;
     /**
@@ -97,6 +107,7 @@ export interface MirrorOrder {
 const ORDER_COLS = `shopify_gid AS "orderGid", legacy_id AS "legacyId", customer_email AS "customerEmail",
     financial_status AS "financialStatus", total_cents AS "totalCents", subtotal_cents AS "subtotalCents",
     total_refunded_cents AS "totalRefundedCents",
+    discount_cents AS "discountCents", discount_codes AS "discountCodes",
     cancelled_at AT TIME ZONE 'UTC' AS "cancelledAt",
     updated_at AT TIME ZONE 'UTC' AS "updatedAt",
     note_attributes AS "noteAttributes"`;
@@ -138,6 +149,26 @@ export async function ordersByLegacyIds(legacyIds: string[]): Promise<MirrorOrde
         [legacyIds],
     );
     return rows.rows;
+}
+
+/**
+ * Distinct variant legacy ids on one order's lines — the join key checkin owns
+ * (BoardSettings/Program shopify*VariantId), mirrored onto shop_order_line since
+ * #1048. This is the reconciler's replica of the webhook's membership/program-item
+ * check ("lines whose variant is one of checkin's known ids"). Lines with a null
+ * variant_legacy_id (custom/deleted product, or a row synced before #1048 and not
+ * yet backfilled) are dropped, so an EMPTY result means "no attributable variant
+ * ids" — the reconciler reads that as pre-backfill and falls back to its amount gate.
+ */
+export async function orderLineVariantIds(orderGid: string): Promise<string[]> {
+    const p = getPool();
+    if (!p) return [];
+    const rows = await p.query<{ variantLegacyId: string }>(
+        `SELECT DISTINCT variant_legacy_id AS "variantLegacyId" FROM shop_order_line
+         WHERE order_gid = $1 AND variant_legacy_id IS NOT NULL`,
+        [orderGid],
+    );
+    return rows.rows.map((r) => r.variantLegacyId);
 }
 
 /** The `sync_run` columns the board needs to judge how fresh the mirror is. */


### PR DESCRIPTION
## Problem

The daily Shopify reconciler (`lib/finance/reconcile.ts`) amount-gated on the Shopify order **total**, which is post-coupon, against a **gross** dues figure from `BoardSettings`. Any Shopify coupon (volunteer rate, time-boxed promo) makes `totalCents < expected` and false-raised `AMOUNT_MISMATCH`:

- forward pass (`reconcile.ts:212`) — **blocked recovery** of a `PENDING_PAYMENT` process
- reversal pass (`reconcile.ts:377`) — **paged the board** on an already-`ACTIVE` process

Dues are not the charged price by design (charged price = Shopify product less the volunteer code), so an amount gate is the wrong check.

## Fix — parity with the orders/paid webhook

Follow-up consumer work for #1048, which mirrored the line variant ids and discount data the app never read. The webhook checks the order **contains a membership variant** (a stable id) rather than comparing price. The reconciler now does the same.

- **`shopifyRead/client.ts`**: read `discount_cents` / `discount_codes` onto `MirrorOrder`; add `orderLineVariantIds(orderGid)` over `shop_order_line.variant_legacy_id` (patterned after `disputedOrderGids`).
- **forward pass**: recover iff the order contains one of checkin's known membership variants — `{orgMembershipVariantId, shopifyNormalVariantId, shopifyVolunteerVariantId}` + dev mock, the exact set the webhook builds. No membership item then NO_ITEM (the pre-existing, previously-unused exception kind). Amount comparison dropped.
- **reversal pass**: discount-aware "edited down below dues" check (add `discount_cents` back), so a coupon isn't counted as a post-activation shortfall. Purpose (detect real edit-downs on ACTIVE processes) preserved.

## Transitional — prevents a regression

#1048 is additive: rows synced before it carry NULL `variant_legacy_id` / empty `discount_codes` until a backfill re-pull. When no line variant ids are mirrored, the reconciler falls back to the **amount gate made discount-aware** (`totalCents + discountCents + tolerance < expected`), so a couponed pre-backfill order still doesn't false-positive. Commented as removable once backfill is universal.

## Out of scope

- Discount-code **eligibility** policy — #625/#278.
- Program variant matching — `reconcileForwardProgram` has no amount gate, so no coupon bug; left as-is (stale comment corrected).
- Any s-ingest-core / mirror-schema change — the mirror half shipped in #1048.

## Reviewer notes

- Corrects the now-false "the mirror has no line variant id" comments (header, forward, program path).
- `tsc --noEmit` clean.
- Reconcile integration suite: 17/17 pass, including new couponed-forward, couponed-reversal, NO_ITEM, and pre-backfill-still-mismatches cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)