### PR TITLE
feat(lifecycle): Phase 4 invariant-driven reconciler + System Status surface

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -123,6 +123,8 @@ const AUTHZ_TESTED = new Set<string>([
     'system-status/health',
     'system-status/links',
     'system-status/links/[id]',
+    // GET deny-path (401 anon / 403 non-board) in lifecycleReconcile.integration.test.ts.
+    'system-status/lifecycle',
 ]);
 
 // Role-gated routes deliberately WITHOUT a negative-authz test. Each entry must

--- a/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
+++ b/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
@@ -89,6 +89,10 @@ const ALLOWLIST: Record<string, string> = {
     'lib/membership/personBgTriggers.ts':
         'PERSON_BG create idempotency guard: where status in {PENDING_BG_REVIEW,BLOCKED}.',
 
+    // ── invariant-driven reconciler (Phase 4) ──
+    'lib/lifecycleDrift.ts':
+        'I1 heal query: where status=ACTIVE,inventoryHeldAt not null — the off-diagram violation set itself (has no StateSet; it is precisely what validate() rejects).',
+
     // ── read / query / probe filters (not yet migrated onto a StateSet.where) ──
     'app/api/facility/trends/route.ts': 'Read query: count ACTIVE enrollments for the trends view.',
     'app/api/membership-audit/compliance/route.ts': 'Read query: compliance count of PENDING_BG_CLEARANCE processes.',

--- a/checkin-app/src/app/__tests__/lifecycleReconcile.integration.test.ts
+++ b/checkin-app/src/app/__tests__/lifecycleReconcile.integration.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the invariant-driven lifecycle reconciler
+ * (LIFECYCLE_ARCHITECTURE §4.2) against a real DB.
+ *
+ *  - I1 heal: an ACTIVE enrollment with a stranded `inventoryHeldAt` (the §7
+ *    two-step crash window) is cleared, the missed `+1` is fired via
+ *    adjustProgramInventory, an AuditLog row records the heal, and the row then
+ *    validates clean.
+ *  - report-only: a non-I1 violation (membership `paidAt` on an INTAKE process)
+ *    is reported through the reused Shopify-failure channel but NEVER mutated.
+ *  - clean: a row that validates clean produces no violation.
+ *  - authz: the System Status GET rejects anon (401) and a plain user (403) —
+ *    the negative-authz coverage authzRegistry.test.ts requires.
+ *
+ * Shopify is mocked (no network): the reconciler imports only adjustProgramInventory
+ * + reportShopifyFailure from @/lib/shopify, so replacing the whole module with two
+ * jest.fn()s is sufficient (SWC's non-configurable exports block jest.spyOn).
+ */
+import { adjustProgramInventory, reportShopifyFailure } from '@/lib/shopify';
+import { runLifecycleReconcile, scanLifecycleViolations } from '@/lib/lifecycleDrift';
+import { GET as LIFECYCLE_GET } from '@/app/api/system-status/lifecycle/route';
+import prisma from '@/lib/prisma';
+import { toRow, validate } from '@/lib/programs/enrollmentState';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/shopify', () => ({
+    __esModule: true,
+    adjustProgramInventory: jest.fn(),
+    reportShopifyFailure: jest.fn(),
+}));
+
+const adjustSpy = adjustProgramInventory as jest.Mock;
+const reportSpy = reportShopifyFailure as jest.Mock;
+
+const TAG = 'lifecycle-reconcile-test';
+const VARIANT = `dev-mock-variant-${TAG}`;
+
+describe('lifecycle reconciler — invariant-driven sweep over a real DB', () => {
+    let programId: number;
+    let selfId: number;
+    const processIds: number[] = [];
+
+    beforeAll(async () => {
+        const self = await prisma.person.create({
+            data: { name: 'LCR Self', email: `self-${TAG}@example.com`, household: { create: { name: 'HH' } } },
+        });
+        selfId = self.id;
+        const program = await prisma.program.create({
+            data: { name: `LCR Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyVariantId: VARIANT },
+        });
+        programId = program.id;
+    });
+
+    afterAll(async () => {
+        await prisma.programParticipant.deleteMany({ where: { programId } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { id: { in: processIds } } });
+        await prisma.auditLog.deleteMany({ where: { tableName: 'ProgramParticipant', affectedEntityId: programId } });
+        await prisma.program.delete({ where: { id: programId } });
+        const person = await prisma.person.findUnique({ where: { id: selfId }, select: { householdId: true } });
+        await prisma.person.delete({ where: { id: selfId } });
+        if (person) await prisma.household.deleteMany({ where: { id: person.householdId } });
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Default: no network, calls succeed. Individual specs assert against these.
+        adjustSpy.mockResolvedValue(true);
+        reportSpy.mockResolvedValue(undefined);
+    });
+
+    afterEach(async () => {
+        await prisma.programParticipant.deleteMany({ where: { programId } });
+        if (processIds.length) await prisma.orgMembershipProcess.deleteMany({ where: { id: { in: processIds } } });
+        processIds.length = 0;
+    });
+
+    it('I1: heals ACTIVE + stranded hold — clears held, fires +1, audit-logs, validates clean', async () => {
+        await prisma.programParticipant.create({
+            data: { programId, personId: selfId, status: 'ACTIVE', inventoryHeldAt: new Date() },
+        });
+
+        const summary = await runLifecycleReconcile();
+
+        // Row healed: hold cleared, now on-diagram.
+        const row = await prisma.programParticipant.findUniqueOrThrow({
+            where: { programId_personId: { programId, personId: selfId } },
+        });
+        expect(row.inventoryHeldAt).toBeNull();
+        expect(row.status).toBe('ACTIVE');
+        expect(validate(toRow(row))).toBeNull();
+
+        // The missed release fired: adjustProgramInventory(program, +1).
+        expect(adjustSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ shopifyVariantId: VARIANT }),
+            1,
+        );
+
+        // Audit trail for the heal.
+        const audit = await prisma.auditLog.findFirst({
+            where: { tableName: 'ProgramParticipant', affectedEntityId: programId, secondaryAffectedEntity: selfId, action: 'EDIT' },
+        });
+        expect(audit).not.toBeNull();
+
+        // A healed row is NOT also reported to the board.
+        expect(summary.healed).toBeGreaterThanOrEqual(1);
+        const reportedMine = reportSpy.mock.calls.some(
+            (c) => typeof c[1]?.message === 'string' && c[1].message.includes(`person ${selfId}`),
+        );
+        expect(reportedMine).toBe(false);
+    });
+
+    it('non-I1: reports a membership INTAKE-with-payment violation but does NOT mutate it', async () => {
+        const proc = await prisma.orgMembershipProcess.create({
+            data: { kind: 'PERSON_BG', status: 'INTAKE', subjectPersonId: selfId, paidAt: new Date() },
+        });
+        processIds.push(proc.id);
+
+        await runLifecycleReconcile();
+
+        // Reported through the reused channel, keyed to this row + its invariant.
+        const reportedMine = reportSpy.mock.calls.some((c) => {
+            const ctx = c[2] as { key?: string; invariant?: string } | undefined;
+            return ctx?.key === `process ${proc.id}` && ctx?.invariant === 'intake-is-unpaid';
+        });
+        expect(reportedMine).toBe(true);
+
+        // NOT mutated — a human resolves ambiguous violations.
+        const after = await prisma.orgMembershipProcess.findUniqueOrThrow({ where: { id: proc.id } });
+        expect(after.status).toBe('INTAKE');
+        expect(after.paidAt).not.toBeNull();
+    });
+
+    it('clean: a row that validates clean produces no violation', async () => {
+        await prisma.programParticipant.create({
+            data: { programId, personId: selfId, status: 'ACTIVE', inventoryHeldAt: null },
+        });
+
+        const { violations } = await scanLifecycleViolations();
+
+        const mine = violations.find((v) => v.key === `program ${programId} / person ${selfId}`);
+        expect(mine).toBeUndefined();
+    });
+
+    it('authz: System Status GET rejects anon (401) and a plain user (403)', async () => {
+        const req = () => new Request('http://localhost/api/system-status/lifecycle') as never;
+
+        (getServerSession as jest.Mock).mockResolvedValue(null);
+        expect((await LIFECYCLE_GET(req())).status).toBe(401);
+
+        (getServerSession as jest.Mock).mockResolvedValue({
+            user: { id: selfId, isSysadmin: false, isBoardMember: false },
+        });
+        expect((await LIFECYCLE_GET(req())).status).toBe(403);
+    });
+});

--- a/checkin-app/src/app/api/cron/lifecycle-reconcile/route.ts
+++ b/checkin-app/src/app/api/cron/lifecycle-reconcile/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { withCron } from "@/lib/cronAuth";
+import { runLifecycleReconcile } from "@/lib/lifecycleDrift";
+
+/**
+ * Invariant-driven lifecycle reconciler (LIFECYCLE_ARCHITECTURE §4.2). Scans BOTH
+ * lifecycle models with the machines' OWN `validate()` oracles, auto-heals the one
+ * safe unambiguous case — enrollment I1 (`status=ACTIVE` with a stranded
+ * `inventoryHeldAt`: a Shopify `-1` the webhook took but died before releasing) by
+ * clearing the hold and firing the missed `+1` — and reports every other
+ * off-diagram row to the sysadmin/board channel for a human to resolve. Nothing
+ * ambiguous is auto-mutated.
+ *
+ * Complementary to `cron/reconcile-shopify` (order-driven recovery): this is the
+ * invariant-driven backstop for the dual-write crash window that the order path
+ * can't see. Same `withCron` auth as the other crons.
+ */
+export const GET = withCron(async () => {
+    const result = await runLifecycleReconcile();
+    logger.info(`[lifecycle-reconcile] ${JSON.stringify(result)}`);
+    return NextResponse.json({ success: true, ...result });
+});

--- a/checkin-app/src/app/api/system-status/lifecycle/route.ts
+++ b/checkin-app/src/app/api/system-status/lifecycle/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { scanLifecycleViolations } from "@/lib/lifecycleDrift";
+
+/**
+ * System Status "Lifecycle" data source (LIFECYCLE_ARCHITECTURE §6.2): the current
+ * off-diagram row set across both lifecycle models, computed live from the same
+ * `validate()` the reconciler cron uses — so the board sees drift without waiting
+ * for the cron email. Read-only; no predicate is re-derived here.
+ */
+export const GET = withAuth(
+    { roles: ["isSysadmin", "isBoardMember"] },
+    async () => {
+        try {
+            const { violations, scanned } = await scanLifecycleViolations();
+            return NextResponse.json({ violations, scanned });
+        } catch (error) {
+            logger.error("Failed to scan lifecycle violations:", error);
+            return apiError("Internal Server Error", 500);
+        }
+    },
+);

--- a/checkin-app/src/app/system-status/lifecycle/page.tsx
+++ b/checkin-app/src/app/system-status/lifecycle/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { LifecycleDriftPanel } from "@/components/admin/LifecycleDriftPanel";
+
+export default function SystemStatusLifecyclePage() {
+  return <LifecycleDriftPanel />;
+}

--- a/checkin-app/src/components/admin/LifecycleDriftPanel.tsx
+++ b/checkin-app/src/components/admin/LifecycleDriftPanel.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge, Card, Center, Group, Loader, Stack, Text } from "@mantine/core";
+
+type LifecycleViolation = {
+  model: "ProgramParticipant" | "OrgMembershipProcess";
+  key: string;
+  status: string;
+  invariant: string;
+};
+
+/**
+ * System Status "Lifecycle" panel (LIFECYCLE_ARCHITECTURE §6.2): read-only view of
+ * the current off-diagram rows across both lifecycle machines, from the same
+ * `validate()` the reconciler cron uses. The human face of the reconciler — the
+ * board sees drift live, without waiting for the cron email.
+ */
+export function LifecycleDriftPanel() {
+  const [violations, setViolations] = useState<LifecycleViolation[] | null>(null);
+  const [scanned, setScanned] = useState<number>(0);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/system-status/lifecycle");
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        setViolations(data.violations);
+        setScanned(data.scanned);
+      } catch {
+        setFailed(true);
+      }
+    })();
+  }, []);
+
+  if (failed) return <Text c="red">Failed to load lifecycle status.</Text>;
+  if (!violations) {
+    return (
+      <Center mih="30vh">
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (violations.length === 0) {
+    return (
+      <Card withBorder radius="md" padding="lg">
+        <Text c="green">● No off-diagram rows — every lifecycle row validates clean.</Text>
+        <Text size="sm" c="dimmed" mt="xs">
+          Scanned {scanned} enrollment / membership rows against the state-machine invariants.
+          The nightly reconciler auto-heals stranded holds and reports the rest here.
+        </Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Stack>
+      <Text size="sm" c="dimmed">
+        {violations.length} off-diagram of {scanned} scanned. Enrollment I1 (stranded hold)
+        auto-heals on the next reconciler run; the rest need a human.
+      </Text>
+      {violations.map((v) => (
+        <Card key={`${v.model}:${v.key}`} withBorder radius="md" padding="md">
+          <Group gap="xs" wrap="wrap">
+            <Badge color="red">{v.invariant}</Badge>
+            <Badge color="gray" variant="light">{v.model}</Badge>
+            <Text size="sm">{v.key}</Text>
+            <Text size="xs" c="dimmed">status {v.status}</Text>
+          </Group>
+        </Card>
+      ))}
+    </Stack>
+  );
+}

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -131,6 +131,7 @@ export const PAGES: PageEntry[] = [
   { href: '/system-status/errors', label: 'Errors', section: 'System Status', visible: BOARD },
   { href: '/system-status/audit-log', label: 'Audit Log', section: 'System Status', visible: BOARD },
   { href: '/system-status/links', label: 'Links', section: 'System Status', visible: BOARD },
+  { href: '/system-status/lifecycle', label: 'Lifecycle', section: 'System Status', keywords: 'invariant validate off-diagram drift reconcile enrollment membership state machine', visible: BOARD },
 
   // Settings — board
   { href: '/settings/membership', label: 'Membership Settings', section: 'Settings', visible: BOARD },

--- a/checkin-app/src/lib/__tests__/systemStatusNav.test.ts
+++ b/checkin-app/src/lib/__tests__/systemStatusNav.test.ts
@@ -21,6 +21,6 @@ describe("SYSTEM_STATUS_NAV_LINKS", () => {
 
   it("leaves the other tabs visible to everyone (sysadminOnly unset)", () => {
     const everyone = SYSTEM_STATUS_NAV_LINKS.filter((l) => !l.sysadminOnly).map((l) => l.name);
-    expect(everyone).toEqual(["System Status", "Link Status", "Errors"]);
+    expect(everyone).toEqual(["System Status", "Link Status", "Lifecycle", "Errors"]);
   });
 });

--- a/checkin-app/src/lib/lifecycleDrift.ts
+++ b/checkin-app/src/lib/lifecycleDrift.ts
@@ -1,0 +1,223 @@
+/**
+ * Invariant-driven lifecycle drift — the scan + reconcile that is the payoff for
+ * the two machines' `validate()` oracles (LIFECYCLE_ARCHITECTURE §4.2, §6.2).
+ *
+ * `scanLifecycleViolations` runs each machine's OWN `validate` over every live
+ * row and returns the off-diagram set — read-only, shared by the System Status
+ * surface (§6.2) and the reconciler cron. `runLifecycleReconcile` adds the one
+ * safe auto-heal (enrollment I1) and reports the rest to the existing
+ * sysadmin/board channel.
+ *
+ * This module NEVER re-derives an invariant: it calls the machines' `validate`,
+ * so picture, panel, and reconciler cannot disagree with the guards.
+ */
+import prisma from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+import {
+    toRow as toEnrollmentRow,
+    validate as validateEnrollment,
+} from "@/lib/programs/enrollmentState";
+import { validate as validateMembership } from "@/lib/membership/lifecycle";
+import { adjustProgramInventory, reportShopifyFailure } from "@/lib/shopify";
+
+export type LifecycleModel = "ProgramParticipant" | "OrgMembershipProcess";
+
+/** One off-diagram row: which model, a human key, the status, and the broken invariant. */
+export type LifecycleViolation = {
+    model: LifecycleModel;
+    /** Human-readable row key (composite for ProgramParticipant, id for the process). */
+    key: string;
+    status: string;
+    /** The invariant name `validate` returned (e.g. "I1", "active-is-bg-cleared"). */
+    invariant: string;
+};
+
+/**
+ * Scan BOTH models with their own `validate()` and return every off-diagram row.
+ * Read-only. Nullable timestamps are collapsed to presence booleans — the shape
+ * `validate` expects (never a `Date | null`).
+ */
+export async function scanLifecycleViolations(): Promise<{
+    violations: LifecycleViolation[];
+    scanned: number;
+}> {
+    const violations: LifecycleViolation[] = [];
+
+    const enrollments = await prisma.programParticipant.findMany({
+        select: {
+            programId: true,
+            personId: true,
+            status: true,
+            inventoryHeldAt: true,
+            isPaymentPlanRequested: true,
+            paymentPlanDeniedAt: true,
+        },
+    });
+    for (const e of enrollments) {
+        const bad = validateEnrollment(toEnrollmentRow(e));
+        if (bad) {
+            violations.push({
+                model: "ProgramParticipant",
+                key: `program ${e.programId} / person ${e.personId}`,
+                status: e.status,
+                invariant: bad.invariant,
+            });
+        }
+    }
+
+    const processes = await prisma.orgMembershipProcess.findMany({
+        select: {
+            id: true,
+            status: true,
+            contractSignedAt: true,
+            bgConsentAt: true,
+            bgClearedAt: true,
+            paidAt: true,
+        },
+    });
+    for (const p of processes) {
+        const bad = validateMembership({
+            status: p.status,
+            contractSignedAt: p.contractSignedAt !== null,
+            bgConsentAt: p.bgConsentAt !== null,
+            bgClearedAt: p.bgClearedAt !== null,
+            paidAt: p.paidAt !== null,
+        });
+        if (bad) {
+            violations.push({
+                model: "OrgMembershipProcess",
+                key: `process ${p.id}`,
+                status: p.status,
+                invariant: bad.invariant,
+            });
+        }
+    }
+
+    return { violations, scanned: enrollments.length + processes.length };
+}
+
+/** Summary returned by the reconciler cron. */
+export type ReconcileSummary = {
+    scanned: number;
+    violations: number;
+    healed: number;
+    reported: number;
+};
+
+/**
+ * Auto-heal the enrollment I1 rows (`status=ACTIVE` with `inventoryHeldAt` set):
+ * a `-1` the webhook took but never released. Per row, a guarded `updateMany`
+ * clears the stranded hold (CAS — a concurrent release wins and this no-ops),
+ * then `adjustProgramInventory(program, +1)` fires the missed release. §9 of the
+ * enrollment doc. Audit-logs each heal (actorId 0 = system). Returns the number
+ * healed. Per-row isolated; the Shopify leg is non-fatal.
+ */
+async function healEnrollmentI1(): Promise<number> {
+    // status=ACTIVE ∧ inventoryHeldAt≠null IS the I1 set (doc §4 I1) — no re-derivation.
+    const stranded = await prisma.programParticipant.findMany({
+        where: { status: "ACTIVE", inventoryHeldAt: { not: null } },
+        select: {
+            programId: true,
+            personId: true,
+            inventoryHeldAt: true,
+            program: {
+                select: {
+                    shopifyVariantId: true,
+                    shopifyOrgMemberVariantId: true,
+                    shopifyNonOrgMemberVariantId: true,
+                },
+            },
+        },
+    });
+
+    let healed = 0;
+    for (const row of stranded) {
+        try {
+            // Guarded CAS: only the caller that flips held→null gets count 1 and
+            // owns the compensating +1; a racing release/withdrawal takes count 0.
+            const { count } = await prisma.programParticipant.updateMany({
+                where: {
+                    programId: row.programId,
+                    personId: row.personId,
+                    status: "ACTIVE",
+                    inventoryHeldAt: { not: null },
+                },
+                data: { inventoryHeldAt: null },
+            });
+            if (count !== 1) continue; // already cleared under us — not ours to release.
+
+            // Fire the release the webhook missed. Non-fatal: adjustProgramInventory
+            // logs + emails on failure and returns false; the hold is already cleared.
+            const shopifyOk = await adjustProgramInventory(row.program, 1);
+            if (!shopifyOk) {
+                logger.error(
+                    `[lifecycle-reconcile] I1 heal cleared hold for program ${row.programId} / person ${row.personId} but the +1 release failed (see Shopify error alert).`,
+                );
+            }
+
+            await prisma.auditLog.create({
+                data: {
+                    actorId: 0, // system — no session behind a cron sweep
+                    action: "EDIT",
+                    tableName: "ProgramParticipant",
+                    affectedEntityId: row.programId,
+                    secondaryAffectedEntity: row.personId,
+                    oldData: {
+                        status: "ACTIVE",
+                        inventoryHeldAt: row.inventoryHeldAt?.toISOString() ?? null,
+                        reason: "lifecycle-reconcile: enrollment I1 (stranded hold on ACTIVE)",
+                    },
+                    newData: { inventoryHeldAt: null, shopifyReleaseOk: shopifyOk },
+                },
+            });
+            healed++;
+        } catch (error) {
+            // Per-row isolation: one bad row never aborts the sweep.
+            logger.error(
+                `[lifecycle-reconcile] I1 heal failed for program ${row.programId} / person ${row.personId}:`,
+                error,
+            );
+        }
+    }
+    return healed;
+}
+
+/**
+ * Report one off-diagram row to the existing sysadmin/board channel — the SAME
+ * path Shopify write failures use (IntegrationErrorLog → System Status "Link
+ * Status" + admin/board email). Never throws.
+ */
+async function reportViolation(v: LifecycleViolation): Promise<void> {
+    await reportShopifyFailure(
+        "lifecycleReconcile",
+        new Error(`${v.model} ${v.key}: off-diagram — invariant ${v.invariant} violated (status ${v.status})`),
+        { model: v.model, key: v.key, status: v.status, invariant: v.invariant },
+        `A ${v.model} row is off its lifecycle diagram (invariant <strong>${v.invariant}</strong>) and needs a human to resolve — nothing was changed automatically.`,
+    );
+}
+
+/**
+ * The reconciler sweep (LIFECYCLE_ARCHITECTURE §4.2): heal the one safe,
+ * unambiguous case (enrollment I1), report every remaining violation, return a
+ * summary. Complementary to the order-driven `lib/finance/reconcile.ts` — this
+ * one is invariant-driven.
+ */
+export async function runLifecycleReconcile(): Promise<ReconcileSummary> {
+    // Heal first, so the post-heal scan doesn't re-report a row we just fixed.
+    const healed = await healEnrollmentI1();
+
+    const { violations, scanned } = await scanLifecycleViolations();
+
+    let reported = 0;
+    for (const v of violations) {
+        try {
+            await reportViolation(v);
+            reported++;
+        } catch (error) {
+            // reportShopifyFailure never throws, but keep the sweep isolated regardless.
+            logger.error(`[lifecycle-reconcile] failed to report ${v.model} ${v.key}:`, error);
+        }
+    }
+
+    return { scanned, violations: healed + violations.length, healed, reported };
+}

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -201,7 +201,7 @@ export async function fetchStorefrontProductVariants(productUrl: string): Promis
  * (System Status > Link Status) and best-effort email admins/board. Never
  * throws — callers return false/null regardless of whether this succeeds.
  */
-async function reportShopifyFailure(
+export async function reportShopifyFailure(
     operation: string,
     error: unknown,
     context: Record<string, unknown>,

--- a/checkin-app/src/lib/systemStatusNav.ts
+++ b/checkin-app/src/lib/systemStatusNav.ts
@@ -12,6 +12,7 @@ export interface SystemStatusNavLink extends NavLink {
 export const SYSTEM_STATUS_NAV_LINKS: SystemStatusNavLink[] = [
   { name: "System Status", href: "/system-status/health", icon: "💚" },
   { name: "Link Status", href: "/system-status/links", icon: "🔗" },
+  { name: "Lifecycle", href: "/system-status/lifecycle", icon: "🔄" },
   { name: "Errors", href: "/system-status/errors", icon: "🚨" },
   { name: "Audit Log", href: "/system-status/audit-log", icon: "📜", sysadminOnly: true },
 ];


### PR DESCRIPTION
## What

Phase 4 — the invariant-driven lifecycle reconciler + its read-only System Status surface. The payoff for the `validate()` oracles the two lifecycle machines already export on `main` (`enrollmentState.ts`, `membership/lifecycle.ts`). Per LIFECYCLE_ARCHITECTURE §4.2 (reconciler) and §6.2 (runtime surface).

## Reconciler cron — `api/cron/lifecycle-reconcile`

`withCron` (same `Authorization: Bearer $CRON_SECRET` as the other crons). Scans **both** models with each machine's **own** `validate()` (no re-derived invariants):

- **Auto-heals the one safe, unambiguous case** — enrollment **I1** (`status=ACTIVE` with a stranded `inventoryHeldAt`: a Shopify `-1` the webhook took but died before releasing). Guarded CAS `updateMany` clears the hold, then `adjustProgramInventory(program, +1)` fires the missed release (doc §9, same helper `withdrawAndReleaseHold`/`activateProgramEnrollment` use). Each heal is audit-logged (actorId 0 = system).
- **Everything else is report-only** — pushed to the existing sysadmin/board channel (`reportShopifyFailure` → `IntegrationErrorLog` → System Status "Link Status" + admin/board email) for a human to resolve. Nothing ambiguous is auto-mutated.
- Per-row isolation (one bad row / failed Shopify call never aborts the sweep); Shopify leg non-fatal. Returns `{ scanned, violations, healed, reported }`.

Complementary to the order-driven `lib/finance/reconcile.ts` — this one is invariant-driven, covering the dual-write crash window the order path can't see.

## System Status surface (§6.2)

New "Lifecycle" tab (board/sysadmin): a live, read-only count/list of current off-diagram rows across both models, from the **same** `validate()` — so the board sees drift without waiting for the cron email.

## Files

- **added** `src/lib/lifecycleDrift.ts` (shared `scanLifecycleViolations` + `runLifecycleReconcile`), `api/cron/lifecycle-reconcile/route.ts`, `api/system-status/lifecycle/route.ts`, `system-status/lifecycle/page.tsx`, `components/admin/LifecycleDriftPanel.tsx`, integration test.
- **edited** `shopify.ts` (export `reportShopifyFailure` — reuse, not reinvent, the notify path), `systemStatusNav.ts` (nav tab), `pageRegistry.ts`, `authzRegistry.test.ts` (negative-authz entry).

## Deferred to Phase 4b

The other §6.2 surfaces — a `classify` badge in the per-row ops views, and the SQL `lifecycle_state` view / generated column — are a separate follow-up.

## Tests

Integration (throwaway docker Postgres, `--runInBand`) — **4/4 pass**:
- I1 heals: row validates clean, `adjustProgramInventory` called `+1`, audit logged.
- non-I1 (membership `paidAt` on INTAKE): reported but **not** mutated.
- clean row → zero violations.
- System Status GET rejects anon (401) / plain user (403).

authzRegistry + pageRegistry drift guards pass.

## Reviewer notes

- **No machine/guard/schema/`reconcile.ts` touched** — new cron + read-only panel only. Verified via git status.
- Only shared-file edit is one `export` keyword on `reportShopifyFailure` (was private) to reuse the exact existing notification path rather than invent a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)