### PR TITLE
fix(reconcile): flag volunteer-code use by non-volunteer families (DISCOUNT_UNAUTHORIZED)

### DIFF
--- a/checkin-app/prisma/migrations/20260717170000_discount_unauthorized_kind/migration.sql
+++ b/checkin-app/prisma/migrations/20260717170000_discount_unauthorized_kind/migration.sql
@@ -1,0 +1,6 @@
+-- New reconciler exception kind: a non-volunteer household redeemed the
+-- volunteer-rate discount code (the entitlement check #1074's variant gate
+-- dropped along with the amount gate). Additive enum value only — legal inside
+-- Prisma's migration transaction on Postgres 12+ (we run 15) because nothing in
+-- this migration uses the new value.
+ALTER TYPE "PaymentExceptionKind" ADD VALUE 'DISCOUNT_UNAUTHORIZED';

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -1144,6 +1144,7 @@ enum PaymentExceptionKind {
   REVERSED_BEFORE_ACTIVATION
   AMOUNT_MISMATCH
   ACTIVE_WITHOUT_PAYMENT
+  DISCOUNT_UNAUTHORIZED
 }
 
 enum PaymentExceptionSeverity {

--- a/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
@@ -89,11 +89,16 @@ async function makeApplicant(opts: {
     return { householdId: hh.id, processId: proc.id, membershipId: m.id };
 }
 
+// The board-configured volunteer-rate coupon (BoardSettings.volunteerDiscountCode).
+// Distinct from the "VOLUNTEER50" promo-style code other cases use, which must stay
+// unregistered-as-volunteer so they exercise the codes-are-Shopify's-business path.
+const VOLUNTEER_CODE = "VOLFAM";
+
 beforeAll(async () => {
     await prisma.boardSettings.upsert({
         where: { id: 1 },
-        create: { id: 1, normalDuesCents: 5000, volunteerDuesCents: 2000, shopifyNormalVariantId: MEMBERSHIP_VARIANT },
-        update: { normalDuesCents: 5000, volunteerDuesCents: 2000, shopifyNormalVariantId: MEMBERSHIP_VARIANT, shopifyReconcileCursorAt: null },
+        create: { id: 1, normalDuesCents: 5000, volunteerDuesCents: 2000, shopifyNormalVariantId: MEMBERSHIP_VARIANT, volunteerDiscountCode: VOLUNTEER_CODE },
+        update: { normalDuesCents: 5000, volunteerDuesCents: 2000, shopifyNormalVariantId: MEMBERSHIP_VARIANT, volunteerDiscountCode: VOLUNTEER_CODE, shopifyReconcileCursorAt: null },
     });
 });
 
@@ -177,6 +182,39 @@ describe("forward recovery", () => {
         expect(proc?.status).toBe("ACTIVE");
         expect(proc?.shopifyOrderId).toBe(oid);
         expect(await prisma.paymentException.count({ where: { kind: "AMOUNT_MISMATCH", processId } })).toBe(0);
+    });
+
+    it("raises DISCOUNT_UNAUTHORIZED and does not activate when a NON-volunteer family used the volunteer code", async () => {
+        // The #1074 regression: variant gate passes (real membership product), amounts
+        // are Shopify's business — but the family isn't entitled to the volunteer rate.
+        const email = `volcode-${TAG}@ex.com`;
+        const oid = `${TAG}-123`;
+        const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true, isVolunteer: false });
+        orderLineVariantIds.mockResolvedValue([MEMBERSHIP_VARIANT]);
+        ordersChangedSince.mockResolvedValue([
+            // Lowercase on the order — Shopify codes are case-insensitive.
+            order({ legacyId: oid, customerEmail: email, totalCents: 2000, discountCents: 3000, discountCodes: ["volfam"] }),
+        ]);
+        await runReconcile();
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: processId } }))?.status).toBe("PENDING_PAYMENT");
+        expect(await prisma.paymentException.count({ where: { kind: "DISCOUNT_UNAUTHORIZED", shopifyOrderId: oid } })).toBe(1);
+
+        // Idempotent: a second run does not duplicate the exception.
+        await runReconcile();
+        expect(await prisma.paymentException.count({ where: { kind: "DISCOUNT_UNAUTHORIZED", shopifyOrderId: oid } })).toBe(1);
+    });
+
+    it("activates a volunteer family using the volunteer code, no exception", async () => {
+        const email = `volok-${TAG}@ex.com`;
+        const oid = `${TAG}-124`;
+        const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true, isVolunteer: true });
+        orderLineVariantIds.mockResolvedValue([MEMBERSHIP_VARIANT]);
+        ordersChangedSince.mockResolvedValue([
+            order({ legacyId: oid, customerEmail: email, totalCents: 2000, discountCents: 3000, discountCodes: [VOLUNTEER_CODE] }),
+        ]);
+        await runReconcile();
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: processId } }))?.status).toBe("ACTIVE");
+        expect(await prisma.paymentException.count({ where: { processId } })).toBe(0);
     });
 
     it("raises NO_ITEM when a variant-mirrored order contains no membership product", async () => {
@@ -315,6 +353,18 @@ describe("reversal detection", () => {
         await runReconcile();
         expect((await prisma.orgMembershipProcess.findUnique({ where: { id: processId } }))?.status).toBe("ACTIVE");
         expect(await prisma.paymentException.count({ where: { kind: "AMOUNT_MISMATCH", processId } })).toBe(0);
+    });
+
+    it("raises DISCOUNT_UNAUTHORIZED on an already-ACTIVATED non-volunteer order that used the volunteer code", async () => {
+        // The webhook activated this in real time (order recorded on the process), so
+        // the forward pass never re-examines it — the reversal loop is the daily audit.
+        const oid = `${TAG}-204`;
+        const { processId } = await makeApplicant({ email: `revvol-${TAG}@ex.com`, status: "ACTIVE", paid: true, shopifyOrderId: oid, isVolunteer: false });
+        ordersByLegacyIds.mockResolvedValue([order({ legacyId: oid, financialStatus: "PAID", totalCents: 2000, discountCents: 3000, discountCodes: [VOLUNTEER_CODE] })]);
+        await runReconcile();
+        // Never auto-reverted — flagged for the board.
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: processId } }))?.status).toBe("ACTIVE");
+        expect(await prisma.paymentException.count({ where: { kind: "DISCOUNT_UNAUTHORIZED", processId } })).toBe(1);
     });
 
     it("raises CANCELLED for a cancelled order", async () => {

--- a/checkin-app/src/lib/finance/__tests__/volunteerCodeEntitlement.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/volunteerCodeEntitlement.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for usesVolunteerCodeUnentitled (lib/finance/reconcile.ts) — the
+ * volunteer-coupon entitlement predicate. The integration matrix drives it through
+ * runReconcile against a real DB, but that suite is not in the default jest run;
+ * this pins the predicate itself in default CI. Heavy reconcile deps are mocked
+ * away — the predicate is pure.
+ */
+import type { MirrorOrder } from "@/lib/shopifyRead/client";
+
+jest.mock("@/lib/prisma", () => ({ __esModule: true, default: {} }));
+jest.mock("@/lib/membership/payment", () => ({ activateByProcessId: jest.fn() }));
+jest.mock("@/lib/membership/boardAlerts", () => ({ notifyBoardPaymentException: jest.fn() }));
+jest.mock("@/lib/shopifyRead/client", () => ({}));
+
+import { usesVolunteerCodeUnentitled } from "../reconcile";
+
+const order = (discountCodes: string[]) => ({ discountCodes } as MirrorOrder);
+
+describe("usesVolunteerCodeUnentitled", () => {
+    it("flags a non-volunteer order carrying the volunteer code", () => {
+        expect(usesVolunteerCodeUnentitled(order(["VOLFAM"]), "VOLFAM", false)).toBe(true);
+    });
+
+    it("compares case-insensitively and ignores whitespace — Shopify codes are case-insensitive", () => {
+        expect(usesVolunteerCodeUnentitled(order(["volfam"]), "VolFam", false)).toBe(true);
+        expect(usesVolunteerCodeUnentitled(order([" VOLFAM "]), "volfam ", false)).toBe(true);
+    });
+
+    it("never flags a volunteer membership", () => {
+        expect(usesVolunteerCodeUnentitled(order(["VOLFAM"]), "VOLFAM", true)).toBe(false);
+    });
+
+    it("ignores other coupons — promos are Shopify's business, not checkin's", () => {
+        expect(usesVolunteerCodeUnentitled(order(["SUMMER26"]), "VOLFAM", false)).toBe(false);
+    });
+
+    it("an empty code list is never evidence (pre-#1048 rows mirror no codes)", () => {
+        expect(usesVolunteerCodeUnentitled(order([]), "VOLFAM", false)).toBe(false);
+    });
+
+    it("no-ops when the board has not configured a volunteer code (null or blank)", () => {
+        expect(usesVolunteerCodeUnentitled(order(["VOLFAM"]), null, false)).toBe(false);
+        expect(usesVolunteerCodeUnentitled(order(["VOLFAM"]), undefined, false)).toBe(false);
+        expect(usesVolunteerCodeUnentitled(order([""]), "  ", false)).toBe(false);
+    });
+});

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -36,7 +36,9 @@ import type { MirrorOrder } from "@/lib/shopifyRead/client";
  * those fall back to a discount-aware dues amount gate — see reconcileForwardMembership.)
  * Nothing is guessed: an attribute naming an unknown process, an ambiguous email
  * match, or an order with no membership item raises a problem for the board rather
- * than activating.
+ * than activating. One policy check rides on top of the variant gate: a
+ * non-volunteer family redeeming the board's volunteer discount code raises
+ * DISCOUNT_UNAUTHORIZED instead of activating (see usesVolunteerCodeUnentitled).
  */
 
 export type PaymentExceptionKind =
@@ -48,7 +50,8 @@ export type PaymentExceptionKind =
     | "CANCELLED"
     | "REVERSED_BEFORE_ACTIVATION"
     | "AMOUNT_MISMATCH"
-    | "ACTIVE_WITHOUT_PAYMENT";
+    | "ACTIVE_WITHOUT_PAYMENT"
+    | "DISCOUNT_UNAUTHORIZED";
 
 type Severity = "WARN" | "CRITICAL";
 
@@ -126,6 +129,27 @@ function isPaid(o: MirrorOrder): boolean {
 function isReversed(o: MirrorOrder): boolean {
     const s = (o.financialStatus ?? "").toUpperCase();
     return !!o.cancelledAt || o.totalRefundedCents > 0 || s === "REFUNDED" || s === "PARTIALLY_REFUNDED" || s === "VOIDED";
+}
+
+/**
+ * Volunteer-coupon entitlement check. Shopify owns the discount ARITHMETIC
+ * (variant-backed orders are never amount-gated); checkin owns the POLICY that
+ * only volunteer households may use the volunteer-rate code — the #1074 variant
+ * gate correctly stopped flagging couponed orders by amount, which also meant a
+ * non-volunteer family redeeming the volunteer code activated cleanly with no flag.
+ *
+ * True iff the order's mirrored coupon list carries the board-configured volunteer
+ * code (BoardSettings.volunteerDiscountCode — the same code the checkout link
+ * appends for volunteer households) while the membership is NOT volunteer. Compared
+ * case-insensitively (Shopify codes are). An EMPTY discountCodes list is never
+ * evidence of anything — rows synced before #1048 mirror no codes — so only a
+ * non-empty list can flag. Other codes (promos) are Shopify's business, not ours.
+ */
+export function usesVolunteerCodeUnentitled(order: MirrorOrder, volunteerCode: string | null | undefined, isVolunteer: boolean): boolean {
+    if (isVolunteer || !volunteerCode) return false;
+    const vc = volunteerCode.trim().toUpperCase();
+    if (!vc) return false;
+    return order.discountCodes.some((c) => c.trim().toUpperCase() === vc);
 }
 
 // ── forward pass (recover missed payments) ───────────────────────────────────
@@ -221,6 +245,7 @@ async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> 
             shopifyVolunteerVariantId: true,
             normalDuesCents: true,
             volunteerDuesCents: true,
+            volunteerDiscountCode: true,
         },
     });
     const membershipVariantIds = new Set(
@@ -232,6 +257,11 @@ async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> 
         ].filter((v): v is string => !!v),
     );
     const lineVariantIds = await mirror.orderLineVariantIds(order.orderGid);
+    // Both branches below need the membership's volunteer flag: the amount-gate
+    // fallback for expected dues, the coupon entitlement check for volunteerOnly.
+    const membership = proc.orgMembershipId
+        ? await prisma.orgMembership.findUnique({ where: { id: proc.orgMembershipId }, select: { isVolunteer: true } })
+        : null;
 
     if (lineVariantIds.length > 0) {
         // Post-#1048 order: variant ids are mirrored, so the item check is authoritative.
@@ -247,14 +277,22 @@ async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> 
         // impossible — fall back to the old dues amount gate, made discount-aware by
         // adding the coupon back so a couponed pre-backfill order compares its GROSS
         // figure to gross dues and no longer false-raises AMOUNT_MISMATCH.
-        const membership = proc.orgMembershipId
-            ? await prisma.orgMembership.findUnique({ where: { id: proc.orgMembershipId }, select: { isVolunteer: true } })
-            : null;
         const expected = membership?.isVolunteer ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
         if (expected > 0 && order.totalCents + order.discountCents + AMOUNT_TOLERANCE_CENTS < expected) {
             await raisePaymentException("AMOUNT_MISMATCH", { shopifyOrderId: order.legacyId, processId: proc.id });
             return true;
         }
+    }
+
+    // Coupon entitlement: the item gates above prove the order carries the membership
+    // product, but not that the family was ALLOWED the code that priced it. Volunteer
+    // code on a non-volunteer membership → tell the board, do NOT activate (parity
+    // with the NO_ITEM branch). Sits after both gates so a backfilled pre-#1048 row
+    // with codes is covered too; pre-backfill rows mirror [] and pass through unjudged.
+    if (usesVolunteerCodeUnentitled(order, settings?.volunteerDiscountCode, membership?.isVolunteer ?? false)) {
+        logger.warn(`[reconcile] volunteer discount code on non-volunteer order ${order.legacyId} (process ${proc.id})`);
+        await raisePaymentException("DISCOUNT_UNAUTHORIZED", { shopifyOrderId: order.legacyId, processId: proc.id });
+        return true;
     }
 
     // Recover: advance past the paid checkpoint. hasMembershipItem=true — the order
@@ -406,7 +444,10 @@ async function reconcileReversals(): Promise<number> {
     const disputed = await mirror.disputedOrderGids(orders.map((o) => o.orderGid));
 
     // Expected dues per membership (for the "order edited down below dues" case).
-    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 }, select: { normalDuesCents: true, volunteerDuesCents: true } });
+    const settings = await prisma.boardSettings.findUnique({
+        where: { id: 1 },
+        select: { normalDuesCents: true, volunteerDuesCents: true, volunteerDiscountCode: true },
+    });
     const memberIds = procs.map((p) => p.orgMembershipId).filter((v): v is number => v != null);
     const members = memberIds.length
         ? await prisma.orgMembership.findMany({ where: { id: { in: memberIds } }, select: { id: true, isVolunteer: true } })
@@ -425,6 +466,15 @@ async function reconcileReversals(): Promise<number> {
             // shortfall below GROSS dues counts. Keeps the "edited down" purpose intact.
             const expected = isVolunteerById.get(proc.orgMembershipId ?? -1) ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
             if (expected > 0 && o.totalCents + o.discountCents + AMOUNT_TOLERANCE_CENTS < expected) kind = "AMOUNT_MISMATCH";
+        }
+        if (!kind && usesVolunteerCodeUnentitled(o, settings?.volunteerDiscountCode, isVolunteerById.get(proc.orgMembershipId ?? -1) ?? false)) {
+            // Coupon entitlement, shared with the forward pass — and load-bearing here:
+            // orders the webhook activated in real time never reach the forward pass
+            // (already recorded on the process → early return), so this loop over
+            // activated memberships is the daily audit that catches a volunteer code
+            // a non-volunteer family redeemed. Order + volunteer flag already in hand.
+            logger.warn(`[reconcile] volunteer discount code on non-volunteer activated order ${proc.shopifyOrderId} (process ${proc.id})`);
+            kind = "DISCOUNT_UNAUTHORIZED";
         }
         if (kind) {
             await raisePaymentException(kind, { shopifyOrderId: proc.shopifyOrderId, processId: proc.id });

--- a/checkin-app/src/lib/membership/boardAlerts.ts
+++ b/checkin-app/src/lib/membership/boardAlerts.ts
@@ -34,6 +34,7 @@ const EXCEPTION_BLURB: Record<string, string> = {
     CANCELLED: "an active membership/enrollment's order was cancelled",
     REVERSED_BEFORE_ACTIVATION: "a payment was refunded/cancelled before the family was activated",
     AMOUNT_MISMATCH: "a payment does not cover the expected dues/price",
+    DISCOUNT_UNAUTHORIZED: "a non-volunteer household's membership order used the volunteer discount code",
     ACTIVE_WITHOUT_PAYMENT: "a membership/enrollment is active with no matching payment on file",
 };
 


### PR DESCRIPTION
## What

The daily Shopify reconciler now raises a `DISCOUNT_UNAUTHORIZED` payment exception when a **non-volunteer** family's membership order was priced with the board's **volunteer discount code** — and refuses to activate that order in forward recovery.

## Why

#1074 replaced the reconciler's dues amount gate with the variant-item gate. That was correct (the amount gate false-raised `AMOUNT_MISMATCH` on every legitimately couponed order), but it also dropped the one incidental catch the amount gate provided: a non-volunteer family redeeming the volunteer-rate coupon came in below normal dues and got flagged. After #1074 such an order activated cleanly with no signal to the board.

Principle: Shopify owns the discount **arithmetic** (variant-backed orders are never amount-gated); checkin owns the **policy** that only volunteer households may use the volunteer code.

## How

- `usesVolunteerCodeUnentitled(order, volunteerCode, isVolunteer)` in `lib/finance/reconcile.ts`: true iff the order's mirrored `discount_codes` (verbatim since #1048) carries `BoardSettings.volunteerDiscountCode` — compared case-insensitively, Shopify codes are — while the membership is not volunteer. An **empty** code list is never evidence (rows synced before #1048 mirror no codes), and **other** codes (promos) are ignored: their arithmetic is Shopify's business.
- **Forward pass**: the check rides on top of the membership-variant gate, before activation. Violation → `DISCOUNT_UNAUTHORIZED` (WARN, dashboard + red-dot; no email) and the process stays `PENDING_PAYMENT`, parity with the `NO_ITEM` branch.
- **Reversal pass**: the same predicate over already-activated orders. This half is load-bearing: orders the webhook activated in real time never reach the forward pass (already recorded on the process → early return), so the activated-membership loop is the only daily audit for them. Access is never auto-reverted — the board decides.
- New `PaymentExceptionKind` value + board-alert blurb. The payments dashboard renders kinds generically, so no UI change.

## Migration

`20260717170000_discount_unauthorized_kind` — a single additive `ALTER TYPE "PaymentExceptionKind" ADD VALUE`. Safe inside Prisma's migration transaction on PG 15 because nothing in the migration uses the new value. No table changes, no backfill, no drain-window hazard (old code never reads the new value).

## Out of scope (deliberate)

- No `DiscountCodeRule` registry / promo-code table, no expiry dates, no settings UI — scoped down to the volunteer entitlement check only. If the board later runs time-boxed promo codes and wants unknown-code detection, that's when a registry earns its table.
- The orders/paid webhook path is untouched — real-time activation keeps trusting Shopify; the reconciler is the audit backstop.
- No amount gate re-added on variant-backed orders.

## Tests

- New unit suite `volunteerCodeEntitlement.test.ts` pins the predicate in the **default** CI run (the integration matrix is not in the default run).
- 3 new cases in `reconcile.integration.test.ts` (run green against a throwaway PG 15, 20/20): non-volunteer + volunteer code (lowercase on the order) → flagged, stays `PENDING_PAYMENT`, idempotent across runs; volunteer + code → activates with no exception; already-activated non-volunteer order → flagged by the reversal audit, stays `ACTIVE`.
- Full default run: 227 suites / 2001 tests green. Migration applied clean via `prisma migrate deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)