### PR TITLE
review fixes for #1082: per-kind claims, cursor-tie replay, consistent mirror filters

### DIFF
--- a/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
+++ b/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
@@ -96,6 +96,8 @@ const ALLOWLIST: Record<string, string> = {
         'Board application list: archived (ARCHIVED) vs live (notIn ACTIVE,ARCHIVED).',
     'app/api/membership/renewal-status/route.ts': 'Member probe: this household’s RENEWAL at PENDING_RENEWAL.',
     'app/api/nav/todo-counts/route.ts': 'Dashboard counts: PENDING enrollments + member-actionable membership statuses.',
+    'lib/finance/matchAudit.ts':
+        'Audit read queries: activation sweep (ACTIVE/PENDING_BG_CLEARANCE + ACTIVE participants) and the claim lookup excluding ARCHIVED — report-only, mirrors the reconcile.ts entry.',
     'lib/finance/reconcile.ts': 'Reconciler lookups: pending/active order-to-row matching on both models.',
     'lib/membership/notifications.ts': 'Read query: board BLOCKED-process count for the notifications badge.',
     'lib/membership/payment.ts': 'Read query: this household’s PENDING_PAYMENT process before activate.',

--- a/checkin-app/src/app/api/finance-ops/s-read/match-audit/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/match-audit/__tests__/route.test.ts
@@ -24,6 +24,7 @@ const req = () => new Request('http://localhost/api/finance-ops/s-read/match-aud
 const HEALTHY = {
     configured: true,
     variantCoverage: { lines: 4, withVariant: 4 },
+    configuredVariants: 3,
     orders: [],
     memberships: [],
     enrollments: [],

--- a/checkin-app/src/components/admin/MatchAuditPanel.tsx
+++ b/checkin-app/src/components/admin/MatchAuditPanel.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Alert, Badge, Button, Card, Group, Table, Text, Title } from "@mantine/core";
+import { formatCents } from "@inventory/money";
+// Type-only import: erased at compile time, so the server module's prisma
+// imports never reach the client bundle — and a server-side reshape is a
+// compile error here instead of a silent drift.
+import type { MatchAuditResult } from "@/lib/finance/matchAudit";
 
 /**
  * Board-facing Shopify ↔ activation match audit (lib/finance/matchAudit.ts via
@@ -15,40 +20,6 @@ import { Alert, Badge, Button, Card, Group, Table, Text, Title } from "@mantine/
  * listed too — they are legitimate, but "who certified what" is exactly what an
  * auditor is here to see.
  */
-
-// Mirror of lib/finance/matchAudit.ts result types (client copy, house pattern).
-type AuditOrderRow = {
-  bucket: 'MATCHED' | 'TRACKED_EXCEPTION' | 'UNCLAIMED_PAID' | 'UNCLAIMED_UNPAID';
-  orderLegacyId: string | null;
-  name: string | null;
-  customerEmail: string | null;
-  financialStatus: string | null;
-  totalCents: number;
-  expected: string[];
-};
-type AuditMembershipRow = {
-  bucket: 'ORDER_MATCHED' | 'MANUAL_CERTIFIED' | 'ORDER_NOT_IN_MIRROR' | 'NO_PAYMENT_BASIS';
-  processId: number;
-  householdName: string | null;
-  shopifyOrderId: string | null;
-  certifiedByName: string | null;
-};
-type AuditEnrollmentRow = {
-  bucket: 'ORDER_MATCHED' | 'SCHOLARSHIP_APPROVED' | 'ORDER_NOT_IN_MIRROR' | 'NO_PAYMENT_BASIS';
-  programId: number;
-  programName: string;
-  personId: number;
-  personName: string | null;
-  shopifyOrderId: string | null;
-};
-type MatchAuditResult = {
-  variantCoverage: { lines: number; withVariant: number };
-  orders: AuditOrderRow[];
-  memberships: AuditMembershipRow[];
-  enrollments: AuditEnrollmentRow[];
-};
-
-const dollars = (cents: number) => `$${(cents / 100).toFixed(2)}`;
 
 export function MatchAuditPanel() {
   const [result, setResult] = useState<MatchAuditResult | null>(null);
@@ -75,11 +46,35 @@ export function MatchAuditPanel() {
     }
   };
 
-  const unclaimedPaid = result?.orders.filter((o) => o.bucket === 'UNCLAIMED_PAID') ?? [];
-  const membershipGaps = result?.memberships.filter((m) => m.bucket === 'NO_PAYMENT_BASIS' || m.bucket === 'ORDER_NOT_IN_MIRROR') ?? [];
-  const enrollmentGaps = result?.enrollments.filter((e) => e.bucket === 'NO_PAYMENT_BASIS' || e.bucket === 'ORDER_NOT_IN_MIRROR') ?? [];
-  const manual = result?.memberships.filter((m) => m.bucket === 'MANUAL_CERTIFIED') ?? [];
-  const scholarships = result?.enrollments.filter((e) => e.bucket === 'SCHOLARSHIP_APPROVED') ?? [];
+  // One memoized pass per result: this panel re-renders on every keystroke in
+  // the page's resolve-exception modal, and the audit arrays can be large.
+  const { unclaimedPaid, membershipGaps, enrollmentGaps, manual, scholarships, matched } = useMemo(() => {
+    const matchedCounts = { orders: 0, tracked: 0, memberships: 0, enrollments: 0 };
+    const groups = {
+      unclaimedPaid: [] as NonNullable<typeof result>['orders'],
+      membershipGaps: [] as NonNullable<typeof result>['memberships'],
+      enrollmentGaps: [] as NonNullable<typeof result>['enrollments'],
+      manual: [] as NonNullable<typeof result>['memberships'],
+      scholarships: [] as NonNullable<typeof result>['enrollments'],
+      matched: matchedCounts,
+    };
+    for (const o of result?.orders ?? []) {
+      if (o.bucket === 'UNCLAIMED_PAID') groups.unclaimedPaid.push(o);
+      else if (o.bucket === 'MATCHED') matchedCounts.orders++;
+      else if (o.bucket === 'TRACKED_EXCEPTION') matchedCounts.tracked++;
+    }
+    for (const m of result?.memberships ?? []) {
+      if (m.bucket === 'NO_PAYMENT_BASIS' || m.bucket === 'ORDER_NOT_IN_MIRROR') groups.membershipGaps.push(m);
+      else if (m.bucket === 'MANUAL_CERTIFIED') groups.manual.push(m);
+      else matchedCounts.memberships++;
+    }
+    for (const e of result?.enrollments ?? []) {
+      if (e.bucket === 'NO_PAYMENT_BASIS' || e.bucket === 'ORDER_NOT_IN_MIRROR') groups.enrollmentGaps.push(e);
+      else if (e.bucket === 'SCHOLARSHIP_APPROVED') groups.scholarships.push(e);
+      else matchedCounts.enrollments++;
+    }
+    return groups;
+  }, [result]);
   const gapCount = unclaimedPaid.length + membershipGaps.length + enrollmentGaps.length;
 
   const count = (label: string, n: number) => (
@@ -102,10 +97,24 @@ export function MatchAuditPanel() {
 
       {result && (
         <>
+          {result.configuredVariants === 0 && (
+            <Alert color="red" mt="md">
+              No membership or program variant ids are configured in checkin, so nothing tells this audit
+              which orders should reconcile — the order side below is empty because it is <b>blind</b>, not
+              because it is clean. Set the variant ids in Board Settings / on the programs first.
+            </Alert>
+          )}
           {result.variantCoverage.withVariant === 0 && result.variantCoverage.lines > 0 && (
             <Alert color="red" mt="md">
               The mirror has {result.variantCoverage.lines} order lines but none carry a variant id — it predates
               variant mirroring. The order side of this audit is blind until an s-read <b>backfill</b> sync runs.
+            </Alert>
+          )}
+          {result.variantCoverage.withVariant > 0 && result.variantCoverage.withVariant < result.variantCoverage.lines && (
+            <Alert color="yellow" mt="md">
+              {result.variantCoverage.lines - result.variantCoverage.withVariant} of {result.variantCoverage.lines} mirror
+              order lines still have no variant id (a backfill is incomplete or predates variant mirroring for part of
+              history). Orders made of only those lines are <b>absent</b> from this report, not shown as gaps.
             </Alert>
           )}
 
@@ -113,10 +122,10 @@ export function MatchAuditPanel() {
             {gapCount === 0
               ? <Badge color="green">No gaps</Badge>
               : <Badge color="red">{gapCount} gap(s)</Badge>}
-            {count('Orders matched', result.orders.filter((o) => o.bucket === 'MATCHED').length)}
-            {count('Tracked as exceptions', result.orders.filter((o) => o.bucket === 'TRACKED_EXCEPTION').length)}
-            {count('Memberships matched', result.memberships.filter((m) => m.bucket === 'ORDER_MATCHED').length)}
-            {count('Enrollments matched', result.enrollments.filter((e) => e.bucket === 'ORDER_MATCHED').length)}
+            {count('Orders matched', matched.orders)}
+            {count('Tracked as exceptions', matched.tracked)}
+            {count('Memberships matched', matched.memberships)}
+            {count('Enrollments matched', matched.enrollments)}
             {count('Board-certified', manual.length)}
             {count('Scholarships', scholarships.length)}
           </Group>
@@ -135,7 +144,7 @@ export function MatchAuditPanel() {
                     <Table.Tr key={o.orderLegacyId ?? `row-${i}`}>
                       <Table.Td>{o.name ?? o.orderLegacyId}</Table.Td>
                       <Table.Td>{o.customerEmail}</Table.Td>
-                      <Table.Td>{dollars(o.totalCents)}</Table.Td>
+                      <Table.Td>{formatCents(o.totalCents)}</Table.Td>
                       <Table.Td>{o.expected.join(', ')}</Table.Td>
                     </Table.Tr>
                   ))}

--- a/checkin-app/src/components/admin/__tests__/MatchAuditPanel.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/MatchAuditPanel.test.tsx
@@ -10,6 +10,8 @@ describe("MatchAuditPanel", () => {
   it("does not run until clicked, then separates gaps from legitimate manual rows", async () => {
     mockFetchJson({
       [AUDIT_URL]: {
+        configured: true,
+        configuredVariants: 3,
         variantCoverage: { lines: 6, withVariant: 6 },
         orders: [
           { bucket: "MATCHED", orderLegacyId: "1", name: "#1", customerEmail: "a@x.com", financialStatus: "PAID", totalCents: 5000, expected: ["membership"] },
@@ -45,7 +47,7 @@ describe("MatchAuditPanel", () => {
 
   it("shows a clean badge when nothing is wrong", async () => {
     mockFetchJson({
-      [AUDIT_URL]: { variantCoverage: { lines: 6, withVariant: 6 }, orders: [], memberships: [], enrollments: [] },
+      [AUDIT_URL]: { configured: true, configuredVariants: 3, variantCoverage: { lines: 6, withVariant: 6 }, orders: [], memberships: [], enrollments: [] },
     });
     renderWithProviders(<MatchAuditPanel />);
     fireEvent.click(screen.getByRole("button", { name: /Run match audit/ }));
@@ -54,15 +56,45 @@ describe("MatchAuditPanel", () => {
 
   it("calls out a variant-blind mirror instead of reporting a falsely clean audit", async () => {
     mockFetchJson({
-      [AUDIT_URL]: { variantCoverage: { lines: 9, withVariant: 0 }, orders: [], memberships: [], enrollments: [] },
+      [AUDIT_URL]: { configured: true, configuredVariants: 3, variantCoverage: { lines: 9, withVariant: 0 }, orders: [], memberships: [], enrollments: [] },
     });
     renderWithProviders(<MatchAuditPanel />);
     fireEvent.click(screen.getByRole("button", { name: /Run match audit/ }));
     expect(await screen.findByText(/predates variant mirroring/)).toBeInTheDocument();
   });
 
-  it("explains an unwired mirror on 503", async () => {
-    mockFetchJson({}); // unmatched URL → non-ok
+  it("calls out partially-backfilled variant coverage — absent orders, not gaps", async () => {
+    mockFetchJson({
+      [AUDIT_URL]: { configured: true, configuredVariants: 3, variantCoverage: { lines: 10, withVariant: 4 }, orders: [], memberships: [], enrollments: [] },
+    });
+    renderWithProviders(<MatchAuditPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /Run match audit/ }));
+    expect(await screen.findByText(/6 of 10 mirror order lines still have no variant id/)).toBeInTheDocument();
+  });
+
+  it("calls out an unconfigured variant set instead of reporting a falsely clean audit", async () => {
+    mockFetchJson({
+      [AUDIT_URL]: { configured: true, configuredVariants: 0, variantCoverage: { lines: 6, withVariant: 6 }, orders: [], memberships: [], enrollments: [] },
+    });
+    renderWithProviders(<MatchAuditPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /Run match audit/ }));
+    expect(await screen.findByText(/No membership or program variant ids are configured/)).toBeInTheDocument();
+  });
+
+  it("explains an unwired mirror on a real 503", async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+      text: async () => "",
+    })) as unknown as typeof fetch;
+    renderWithProviders(<MatchAuditPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /Run match audit/ }));
+    expect(await screen.findByText(/not wired in this environment/)).toBeInTheDocument();
+  });
+
+  it("shows the generic failure message on any other error", async () => {
+    mockFetchJson({}); // unmatched URL → 404, the generic catch path
     renderWithProviders(<MatchAuditPanel />);
     fireEvent.click(screen.getByRole("button", { name: /Run match audit/ }));
     expect(await screen.findByText(/failed to run/)).toBeInTheDocument();

--- a/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
@@ -122,6 +122,40 @@ describe('order buckets (Shopify → activation)', () => {
         const r = await runMatchAudit();
         expect(r.orders.map((o) => o.bucket)).toEqual(['UNCLAIMED_UNPAID', 'UNCLAIMED_UNPAID']);
     });
+
+    it('splits a multi-item checkout per kind: membership claimed, program half not → UNCLAIMED_PAID naming only the gap', async () => {
+        mirrorMock.ordersForVariants.mockResolvedValue([paidOrder('905', { matchedVariantIds: ['111', '222'] })]);
+        prismaMock.orgMembershipProcess.findMany
+            .mockResolvedValueOnce([{ shopifyOrderId: '905' }]) // claims the MEMBERSHIP half only
+            .mockResolvedValueOnce([]);
+        const r = await runMatchAudit();
+        expect(r.orders[0].bucket).toBe('UNCLAIMED_PAID');
+        expect(r.orders[0].expected).toEqual(['program: Robotics']);
+    });
+
+    it('a program enrollment claims its own program half → MATCHED', async () => {
+        mirrorMock.ordersForVariants.mockResolvedValue([paidOrder('906', { matchedVariantIds: ['222'] })]);
+        prismaMock.programParticipant.findMany
+            .mockResolvedValueOnce([{ shopifyOrderId: '906', programId: 7 }]) // claim lookup
+            .mockResolvedValueOnce([]); // activation sweep
+        const r = await runMatchAudit();
+        expect(r.orders[0].bucket).toBe('MATCHED');
+    });
+
+    it('an ARCHIVED process is not a claim — the lookup excludes it in the where', async () => {
+        await runMatchAudit();
+        const claimWhere = (prismaMock.orgMembershipProcess.findMany.mock.calls[0][0] as { where: { status: unknown } }).where;
+        expect(claimWhere.status).toEqual({ not: 'ARCHIVED' });
+    });
+
+    it('a fully-claimed order stays MATCHED even when refunded (claim precedence — reversal-pass territory)', async () => {
+        mirrorMock.ordersForVariants.mockResolvedValue([paidOrder('907', { totalRefundedCents: 5000, financialStatus: 'REFUNDED' })]);
+        prismaMock.orgMembershipProcess.findMany
+            .mockResolvedValueOnce([{ shopifyOrderId: '907' }])
+            .mockResolvedValueOnce([]);
+        const r = await runMatchAudit();
+        expect(r.orders[0].bucket).toBe('MATCHED');
+    });
 });
 
 describe('membership buckets (activation → Shopify)', () => {

--- a/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
@@ -148,6 +148,21 @@ describe('order buckets (Shopify → activation)', () => {
         expect(claimWhere.status).toEqual({ not: 'ARCHIVED' });
     });
 
+    it('a kind-attributed exception covers only ITS half: tracked membership + untracked program → UNCLAIMED_PAID naming the program', async () => {
+        mirrorMock.ordersForVariants.mockResolvedValue([paidOrder('908', { matchedVariantIds: ['111', '222'] })]);
+        prismaMock.paymentException.findMany.mockResolvedValue([{ shopifyOrderId: '908', processId: 55, programId: null }]);
+        const r = await runMatchAudit();
+        expect(r.orders[0].bucket).toBe('UNCLAIMED_PAID');
+        expect(r.orders[0].expected).toEqual(['program: Robotics']);
+    });
+
+    it('an order-level exception (no process/program attribution) covers the whole order → TRACKED_EXCEPTION', async () => {
+        mirrorMock.ordersForVariants.mockResolvedValue([paidOrder('909', { matchedVariantIds: ['111', '222'] })]);
+        prismaMock.paymentException.findMany.mockResolvedValue([{ shopifyOrderId: '909', processId: null, programId: null }]);
+        const r = await runMatchAudit();
+        expect(r.orders[0].bucket).toBe('TRACKED_EXCEPTION');
+    });
+
     it('a fully-claimed order stays MATCHED even when refunded (claim precedence — reversal-pass territory)', async () => {
         mirrorMock.ordersForVariants.mockResolvedValue([paidOrder('907', { totalRefundedCents: 5000, financialStatus: 'REFUNDED' })]);
         prismaMock.orgMembershipProcess.findMany

--- a/checkin-app/src/lib/finance/matchAudit.ts
+++ b/checkin-app/src/lib/finance/matchAudit.ts
@@ -1,5 +1,5 @@
 import prisma from "@/lib/prisma";
-import { config, DEV_MOCK_MEMBERSHIP_VARIANT_ID } from "@/lib/config";
+import { isPaid, membershipVariantIdSet } from "@/lib/finance/reconcile";
 import * as mirror from "@/lib/shopifyRead/client";
 
 /**
@@ -80,41 +80,38 @@ export interface MatchAuditResult {
      * of an empty (falsely clean) report.
      */
     variantCoverage: { lines: number; withVariant: number };
+    /**
+     * How many membership/program variant ids the app is configured with. 0 means
+     * the order side of the audit is vacuous for a DIFFERENT reason than backfill:
+     * nothing tells us which orders should reconcile. The UI must distinguish this
+     * from a genuinely clean report.
+     */
+    configuredVariants: number;
     orders: AuditOrderRow[];
     memberships: AuditMembershipRow[];
     enrollments: AuditEnrollmentRow[];
 }
 
-/** Same money-in predicate the reconciler uses (reconcile.ts isPaid). */
-function isPaid(o: { financialStatus: string | null; cancelledAt: Date | null; totalRefundedCents: number }): boolean {
-    const s = (o.financialStatus ?? "").toUpperCase();
-    return (s === "PAID" || s === "PARTIALLY_PAID") && !o.cancelledAt && o.totalRefundedCents === 0;
-}
-
 export async function runMatchAudit(): Promise<MatchAuditResult> {
     if (!mirror.isConfigured()) {
-        return { configured: false, variantCoverage: { lines: 0, withVariant: 0 }, orders: [], memberships: [], enrollments: [] };
+        return { configured: false, variantCoverage: { lines: 0, withVariant: 0 }, configuredVariants: 0, orders: [], memberships: [], enrollments: [] };
     }
 
     // ── the "should reconcile" variant set ────────────────────────────────────
-    const settings = await prisma.boardSettings.findUnique({
-        where: { id: 1 },
-        select: { orgMembershipVariantId: true, shopifyNormalVariantId: true, shopifyVolunteerVariantId: true },
-    });
-    const programs = await prisma.program.findMany({
-        select: { id: true, name: true, shopifyVariantId: true, shopifyOrgMemberVariantId: true, shopifyNonOrgMemberVariantId: true },
-    });
+    const [settings, programs, variantCoverage] = await Promise.all([
+        prisma.boardSettings.findUnique({
+            where: { id: 1 },
+            select: { orgMembershipVariantId: true, shopifyNormalVariantId: true, shopifyVolunteerVariantId: true },
+        }),
+        prisma.program.findMany({
+            select: { id: true, name: true, shopifyVariantId: true, shopifyOrgMemberVariantId: true, shopifyNonOrgMemberVariantId: true },
+        }),
+        mirror.lineVariantStats(),
+    ]);
 
-    // Same set the reconciler's item gate builds (reconcile.ts, #1074), dev-mock
-    // variant included so a mock-active local env audits its own test orders.
-    const membershipVariants = new Set(
-        [
-            settings?.orgMembershipVariantId,
-            settings?.shopifyNormalVariantId,
-            settings?.shopifyVolunteerVariantId,
-            config.shopifyMockActive() ? DEV_MOCK_MEMBERSHIP_VARIANT_ID : null,
-        ].filter((v): v is string => !!v),
-    );
+    // The same set the reconciler's item gate uses — shared, not copied, so the
+    // two can't drift (#1074 was exactly that drift).
+    const membershipVariants = membershipVariantIdSet(settings ?? null);
     const programByVariant = new Map<string, { id: number; name: string }>();
     for (const p of programs) {
         for (const v of [p.shopifyVariantId, p.shopifyOrgMemberVariantId, p.shopifyNonOrgMemberVariantId]) {
@@ -123,29 +120,57 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
     }
     const allVariants = [...membershipVariants, ...programByVariant.keys()];
 
-    const variantCoverage = await mirror.lineVariantStats();
-
     // ── Shopify → activation: every reconcilable order accounted for ──────────
     const orders = await mirror.ordersForVariants(allVariants);
     const orderIds = orders.map((o) => o.legacyId).filter((v): v is string => !!v);
 
+    // Claims are per-KIND, not per-order: a single checkout can carry membership
+    // AND program lines, and "the membership process claimed this order" says
+    // nothing about the program half. An ARCHIVED process is not a claim — the
+    // application was abandoned, so its money is exactly the unclaimed kind.
     const [claimedProcs, claimedEnrolls, trackedExceptions] = await Promise.all([
-        prisma.orgMembershipProcess.findMany({ where: { shopifyOrderId: { in: orderIds } }, select: { shopifyOrderId: true } }),
-        prisma.programParticipant.findMany({ where: { shopifyOrderId: { in: orderIds } }, select: { shopifyOrderId: true } }),
+        prisma.orgMembershipProcess.findMany({
+            where: { shopifyOrderId: { in: orderIds }, status: { not: "ARCHIVED" } },
+            select: { shopifyOrderId: true },
+        }),
+        prisma.programParticipant.findMany({ where: { shopifyOrderId: { in: orderIds } }, select: { shopifyOrderId: true, programId: true } }),
         prisma.paymentException.findMany({
             where: { shopifyOrderId: { in: orderIds }, status: { not: "RESOLVED" } },
             select: { shopifyOrderId: true },
         }),
     ]);
-    const claimed = new Set([...claimedProcs, ...claimedEnrolls].map((r) => r.shopifyOrderId));
+    const membershipClaimed = new Set(claimedProcs.map((r) => r.shopifyOrderId));
+    const programsClaimed = new Map<string, Set<number>>();
+    for (const r of claimedEnrolls) {
+        if (!r.shopifyOrderId) continue;
+        const set = programsClaimed.get(r.shopifyOrderId) ?? new Set<number>();
+        set.add(r.programId);
+        programsClaimed.set(r.shopifyOrderId, set);
+    }
     const tracked = new Set(trackedExceptions.map((r) => r.shopifyOrderId));
 
     const orderRows: AuditOrderRow[] = orders.map((o) => {
-        const expected = (o.matchedVariantIds ?? []).map((v) =>
-            membershipVariants.has(v) ? "membership" : `program: ${programByVariant.get(v)?.name ?? v}`,
-        );
+        // What each matched variant should have produced, and whether it did.
+        const unclaimed: string[] = [];
+        const expected: string[] = [];
+        for (const v of new Set(o.matchedVariantIds ?? [])) {
+            if (membershipVariants.has(v)) {
+                if (!expected.includes("membership")) {
+                    expected.push("membership");
+                    if (!(o.legacyId && membershipClaimed.has(o.legacyId))) unclaimed.push("membership");
+                }
+            } else {
+                const program = programByVariant.get(v);
+                const label = `program: ${program?.name ?? v}`;
+                if (!expected.includes(label)) {
+                    expected.push(label);
+                    const claimedSet = o.legacyId ? programsClaimed.get(o.legacyId) : undefined;
+                    if (!(program && claimedSet?.has(program.id))) unclaimed.push(label);
+                }
+            }
+        }
         const bucket: OrderBucket =
-            o.legacyId && claimed.has(o.legacyId)
+            unclaimed.length === 0
                 ? "MATCHED"
                 : o.legacyId && tracked.has(o.legacyId)
                   ? "TRACKED_EXCEPTION"
@@ -159,39 +184,43 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
             customerEmail: o.customerEmail,
             financialStatus: o.financialStatus,
             totalCents: o.totalCents,
-            expected: [...new Set(expected)],
+            // MATCHED rows list everything the order bought; gap rows list only
+            // what is still missing, so a half-claimed checkout names its gap.
+            expected: unclaimed.length > 0 ? unclaimed : expected,
         };
     });
 
     // ── activation → Shopify: every activation has a payment basis ────────────
     // INITIAL/RENEWAL only: PERSON_BG processes carry no payment by design, so
     // including them would flood NO_PAYMENT_BASIS with false positives.
-    const procs = await prisma.orgMembershipProcess.findMany({
-        where: { status: { in: ["ACTIVE", "PENDING_BG_CLEARANCE"] }, kind: { in: ["INITIAL", "RENEWAL"] } },
-        select: {
-            id: true,
-            shopifyOrderId: true,
-            certifiedById: true,
-            orgMembership: { select: { household: { select: { name: true } } } },
-        },
-    });
+    const [procs, enrolls] = await Promise.all([
+        prisma.orgMembershipProcess.findMany({
+            where: { status: { in: ["ACTIVE", "PENDING_BG_CLEARANCE"] }, kind: { in: ["INITIAL", "RENEWAL"] } },
+            select: {
+                id: true,
+                shopifyOrderId: true,
+                certifiedById: true,
+                orgMembership: { select: { household: { select: { name: true } } } },
+            },
+        }),
+        prisma.programParticipant.findMany({
+            where: { status: "ACTIVE" },
+            select: {
+                programId: true,
+                personId: true,
+                shopifyOrderId: true,
+                wasOrgMemberAtApproval: true,
+                program: { select: { name: true } },
+                person: { select: { name: true } },
+            },
+        }),
+    ]);
     // certifiedById has no Prisma relation — resolve the names in one batch.
     const certifierIds = [...new Set(procs.map((p) => p.certifiedById).filter((v): v is number => v != null))];
     const certifiers = certifierIds.length
         ? await prisma.person.findMany({ where: { id: { in: certifierIds } }, select: { id: true, name: true } })
         : [];
     const certifierName = new Map(certifiers.map((c) => [c.id, c.name]));
-    const enrolls = await prisma.programParticipant.findMany({
-        where: { status: "ACTIVE" },
-        select: {
-            programId: true,
-            personId: true,
-            shopifyOrderId: true,
-            wasOrgMemberAtApproval: true,
-            program: { select: { name: true } },
-            person: { select: { name: true } },
-        },
-    });
 
     const activationOrderIds = [
         ...procs.map((p) => p.shopifyOrderId),
@@ -204,7 +233,7 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
             ? inMirror.has(p.shopifyOrderId)
                 ? "ORDER_MATCHED"
                 : "ORDER_NOT_IN_MIRROR"
-            : p.certifiedById
+            : p.certifiedById != null
               ? "MANUAL_CERTIFIED"
               : "NO_PAYMENT_BASIS",
         processId: p.id,
@@ -228,5 +257,5 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
         shopifyOrderId: e.shopifyOrderId,
     }));
 
-    return { configured: true, variantCoverage, orders: orderRows, memberships: membershipRows, enrollments: enrollmentRows };
+    return { configured: true, variantCoverage, configuredVariants: allVariants.length, orders: orderRows, memberships: membershipRows, enrollments: enrollmentRows };
 }

--- a/checkin-app/src/lib/finance/matchAudit.ts
+++ b/checkin-app/src/lib/finance/matchAudit.ts
@@ -136,7 +136,7 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
         prisma.programParticipant.findMany({ where: { shopifyOrderId: { in: orderIds } }, select: { shopifyOrderId: true, programId: true } }),
         prisma.paymentException.findMany({
             where: { shopifyOrderId: { in: orderIds }, status: { not: "RESOLVED" } },
-            select: { shopifyOrderId: true },
+            select: { shopifyOrderId: true, processId: true, programId: true },
         }),
     ]);
     const membershipClaimed = new Set(claimedProcs.map((r) => r.shopifyOrderId));
@@ -147,17 +147,40 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
         set.add(r.programId);
         programsClaimed.set(r.shopifyOrderId, set);
     }
-    const tracked = new Set(trackedExceptions.map((r) => r.shopifyOrderId));
+    // Tracking is per-kind too: an exception carrying processId covers the
+    // MEMBERSHIP half, programId covers THAT program, and an order-level
+    // exception (neither set, e.g. UNMATCHED_ORDER) covers the whole order.
+    // Without this, one tracked half hides the other half's untracked gap.
+    const trackedOrderLevel = new Set<string>();
+    const trackedMembership = new Set<string>();
+    const trackedPrograms = new Map<string, Set<number>>();
+    for (const r of trackedExceptions) {
+        if (!r.shopifyOrderId) continue;
+        if (r.processId == null && r.programId == null) trackedOrderLevel.add(r.shopifyOrderId);
+        if (r.processId != null) trackedMembership.add(r.shopifyOrderId);
+        if (r.programId != null) {
+            const set = trackedPrograms.get(r.shopifyOrderId) ?? new Set<number>();
+            set.add(r.programId);
+            trackedPrograms.set(r.shopifyOrderId, set);
+        }
+    }
 
     const orderRows: AuditOrderRow[] = orders.map((o) => {
         // What each matched variant should have produced, and whether it did.
+        // A kind is ACCOUNTED when claimed or covered by an unresolved exception;
+        // UNACCOUNTED kinds are the real gap.
         const unclaimed: string[] = [];
+        const unaccounted: string[] = [];
         const expected: string[] = [];
+        const orderTracked = !!o.legacyId && trackedOrderLevel.has(o.legacyId);
         for (const v of new Set(o.matchedVariantIds ?? [])) {
             if (membershipVariants.has(v)) {
                 if (!expected.includes("membership")) {
                     expected.push("membership");
-                    if (!(o.legacyId && membershipClaimed.has(o.legacyId))) unclaimed.push("membership");
+                    if (!(o.legacyId && membershipClaimed.has(o.legacyId))) {
+                        unclaimed.push("membership");
+                        if (!orderTracked && !(o.legacyId && trackedMembership.has(o.legacyId))) unaccounted.push("membership");
+                    }
                 }
             } else {
                 const program = programByVariant.get(v);
@@ -165,14 +188,18 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
                 if (!expected.includes(label)) {
                     expected.push(label);
                     const claimedSet = o.legacyId ? programsClaimed.get(o.legacyId) : undefined;
-                    if (!(program && claimedSet?.has(program.id))) unclaimed.push(label);
+                    if (!(program && claimedSet?.has(program.id))) {
+                        unclaimed.push(label);
+                        const trackedSet = o.legacyId ? trackedPrograms.get(o.legacyId) : undefined;
+                        if (!orderTracked && !(program && trackedSet?.has(program.id))) unaccounted.push(label);
+                    }
                 }
             }
         }
         const bucket: OrderBucket =
             unclaimed.length === 0
                 ? "MATCHED"
-                : o.legacyId && tracked.has(o.legacyId)
+                : unaccounted.length === 0
                   ? "TRACKED_EXCEPTION"
                   : isPaid(o)
                     ? "UNCLAIMED_PAID"
@@ -185,8 +212,9 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
             financialStatus: o.financialStatus,
             totalCents: o.totalCents,
             // MATCHED rows list everything the order bought; gap rows list only
-            // what is still missing, so a half-claimed checkout names its gap.
-            expected: unclaimed.length > 0 ? unclaimed : expected,
+            // the UNACCOUNTED half (a tracked half is the exception queue's
+            // problem, not this row's), so a half-claimed checkout names its gap.
+            expected: unaccounted.length > 0 ? unaccounted : unclaimed.length > 0 ? unclaimed : expected,
         };
     });
 

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -116,10 +116,36 @@ export async function raisePaymentException(kind: PaymentExceptionKind, ref: Exc
 
 // ── predicates over a mirror order ───────────────────────────────────────────
 
-/** Shopify displayFinancialStatus that means "money is in" and not reversed. */
-function isPaid(o: MirrorOrder): boolean {
+/**
+ * Shopify displayFinancialStatus that means "money is in" and not reversed.
+ * Exported: matchAudit.ts must apply the SAME predicate, or the audit and the
+ * reconciler disagree about which orders count as paid.
+ */
+export function isPaid(o: Pick<MirrorOrder, "financialStatus" | "cancelledAt" | "totalRefundedCents">): boolean {
     const s = (o.financialStatus ?? "").toUpperCase();
     return (s === "PAID" || s === "PARTIALLY_PAID") && !o.cancelledAt && o.totalRefundedCents === 0;
+}
+
+/**
+ * The membership variant-id set (BoardSettings variants + the dev-mock variant
+ * when the Shopify mock is active) — the ONE "is this line a membership?" rule.
+ * Exported so matchAudit.ts consumes the same set as the #1074 item gate; a
+ * variant added here but missed in a private copy would silently VANISH from
+ * the audit (filtered out in SQL), not show as a gap.
+ */
+export function membershipVariantIdSet(settings: {
+    orgMembershipVariantId: string | null;
+    shopifyNormalVariantId: string | null;
+    shopifyVolunteerVariantId: string | null;
+} | null): Set<string> {
+    return new Set(
+        [
+            settings?.orgMembershipVariantId,
+            settings?.shopifyNormalVariantId,
+            settings?.shopifyVolunteerVariantId,
+            config.shopifyMockActive() ? DEV_MOCK_MEMBERSHIP_VARIANT_ID : null,
+        ].filter((v): v is string => !!v),
+    );
 }
 
 /** Any sign the money came back out. */
@@ -223,14 +249,7 @@ async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> 
             volunteerDuesCents: true,
         },
     });
-    const membershipVariantIds = new Set(
-        [
-            settings?.orgMembershipVariantId,
-            settings?.shopifyNormalVariantId,
-            settings?.shopifyVolunteerVariantId,
-            config.shopifyMockActive() ? DEV_MOCK_MEMBERSHIP_VARIANT_ID : null,
-        ].filter((v): v is string => !!v),
-    );
+    const membershipVariantIds = membershipVariantIdSet(settings ?? null);
     const lineVariantIds = await mirror.orderLineVariantIds(order.orderGid);
 
     if (lineVariantIds.length > 0) {
@@ -476,6 +495,14 @@ export async function runReconcile(): Promise<ReconcileResult> {
         } catch (e) {
             logger.error(`[reconcile] forward pass failed for order ${order.legacyId ?? order.orderGid}:`, e);
             cursorFrozen = true;
+            // The watermark may ALREADY sit at this order's updatedAt — an earlier
+            // order in the batch with the same timestamp succeeded and advanced it.
+            // ordersChangedSince compares with a strict `updated_at >`, so leaving
+            // the cursor there would skip this order forever. Pull it back below
+            // the failed order so the next run re-fetches it.
+            if (order.updatedAt && newCursor && newCursor >= order.updatedAt) {
+                newCursor = new Date(order.updatedAt.getTime() - 1);
+            }
         }
         if (!cursorFrozen && order.updatedAt && (!newCursor || order.updatedAt > newCursor)) newCursor = order.updatedAt;
     }

--- a/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
+++ b/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
@@ -148,15 +148,21 @@ describe('match-audit reads', () => {
         expect(queryMock).not.toHaveBeenCalled();
     });
 
-    it('lineVariantStats counts only live lines', async () => {
+    it('lineVariantStats counts only live lines of real (non-test) orders', async () => {
         queryMock.mockResolvedValue({ rows: [{ lines: 5, withVariant: 2 }] });
         expect(await freshClient().lineVariantStats()).toEqual({ lines: 5, withVariant: 2 });
         expect(sqlOf(0)).toContain('removed = false');
+        // Same test-order rule as ordersForVariants: test lines must not count as
+        // variant coverage, or they'd mask an unbackfilled real mirror.
+        expect(sqlOf(0)).toContain('test = false');
+        expect(sqlOf(0)).toContain('JOIN shop_order');
     });
 
-    it('orderLegacyIdsPresent returns the found ids as a set', async () => {
+    it('orderLegacyIdsPresent returns the found ids as a set, ignoring test orders', async () => {
         queryMock.mockResolvedValue({ rows: [{ legacyId: '900' }] });
         expect(await freshClient().orderLegacyIdsPresent(['900', '901'])).toEqual(new Set(['900']));
+        // A test-mode order must not serve as an activation's payment basis.
+        expect(sqlOf(0)).toContain('test = false');
     });
 });
 

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -246,8 +246,13 @@ export async function lineVariantStats(): Promise<{ lines: number; withVariant: 
     const p = getPool();
     if (!p) throw new Error("shopify_read mirror is not configured");
     const rows = await p.query<{ lines: number; withVariant: number }>(
-        `SELECT count(*)::int AS "lines", count(variant_legacy_id)::int AS "withVariant"
-         FROM shop_order_line WHERE removed = false`,
+        // Joined to shop_order for the same `test = false` rule as ordersForVariants:
+        // lines of test orders must not count as coverage, or a handful of test
+        // orders synced post-backfill would mask a still-unbackfilled real mirror.
+        `SELECT count(*)::int AS "lines", count(l.variant_legacy_id)::int AS "withVariant"
+         FROM shop_order_line l
+         JOIN shop_order o ON o.shopify_gid = l.order_gid
+         WHERE l.removed = false AND o.test = false`,
     );
     return rows.rows[0];
 }
@@ -287,18 +292,23 @@ export async function ordersForVariants(variantIds: string[]): Promise<MirrorAud
          WHERE test = false
            AND EXISTS (SELECT 1 FROM shop_order_line l
                         WHERE l.order_gid = shop_order.shopify_gid AND l.removed = false
-                          AND l.variant_legacy_id = ANY($1::text[]))`,
+                          AND l.variant_legacy_id = ANY($1::text[]))
+         ORDER BY legacy_id NULLS LAST`,
         [variantIds],
     );
     return rows.rows;
 }
 
-/** Which of the given numeric order ids exist in the mirror at all. */
+/**
+ * Which of the given numeric order ids exist in the mirror as REAL orders.
+ * `test = false` matches every other read here: a test-mode order must not
+ * serve as the payment basis that turns an activation "ORDER_MATCHED".
+ */
 export async function orderLegacyIdsPresent(legacyIds: string[]): Promise<Set<string>> {
     const p = getPool();
     if (!p || legacyIds.length === 0) return new Set();
     const rows = await p.query<{ legacyId: string }>(
-        `SELECT legacy_id AS "legacyId" FROM shop_order WHERE legacy_id = ANY($1::text[])`,
+        `SELECT legacy_id AS "legacyId" FROM shop_order WHERE test = false AND legacy_id = ANY($1::text[])`,
         [legacyIds],
     );
     return new Set(rows.rows.map((r) => r.legacyId));


### PR DESCRIPTION
Mechanical fixes for the findings of the #1082 code review (full write-up is a review comment on #1082). Targets the PR branch, so merging this folds the fixes into #1082 before it lands on main.

**Unblocks CI**: `lifecycleStatusLiteralAllowlist` was red on the PR branch — `lib/finance/matchAudit.ts` is now registered (same read-query precedent as `reconcile.ts`).

**Audit correctness**
- Claims are per-KIND: a checkout with membership + program lines is `MATCHED` only when every matched kind has a claimant; gap rows list only the missing half (was: either claim marked the whole order matched, hiding the other half).
- `ARCHIVED` processes no longer count as claims (paid-then-abandoned money is unclaimed, not matched).
- `runMatchAudit` reports `configuredVariants`; the panel calls out an unconfigured variant set and partially-backfilled variant coverage instead of rendering a falsely clean "No gaps".

**Reconciler cursor**
- On a forward-pass failure the watermark is pulled below the failed order's `updatedAt`: `ordersChangedSince` compares with strict `>`, so a throw that tied the watermark's timestamp was skipped forever despite the freeze.

**Mirror reads**
- `lineVariantStats` and `orderLegacyIdsPresent` now apply the same `test = false` rule as `ordersForVariants`; `ordersForVariants` gains a deterministic `ORDER BY`.

**Dedup / drift guards**
- `isPaid` and the membership-variant set are exported from `reconcile.ts` and shared (ends the third inline copy; the webhook route's copy is left for a follow-up to keep the blast radius small).
- Panel types are an erasable `import type` from the server module (the hand-mirror omitted `configured`); money renders via `formatCents`; bucket grouping is one memoized pass.

**Tests**: real 503 panel test (the old one drove a 404 through the generic catch), split-claim, ARCHIVED-exclusion where-shape, claimed-but-refunded precedence pin, partial/unconfigured coverage warnings. Deliberately NOT fixed here (design calls left on #1082): reverse-direction paid/variant validation, comp-enrollment classification, direct-ACTIVE membership sweep, freeze alerting/escape hatch, PII/registry question.

Verified: tsc clean, eslint clean, full unit suite 2027/2027 (PR branch: 1 failing / 2019).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe