### PR TITLE
audit v2 for #1082: manual-class completeness, reversal/pre-mirror state, process-less memberships

### DIFF
--- a/checkin-app/src/components/admin/MatchAuditPanel.tsx
+++ b/checkin-app/src/components/admin/MatchAuditPanel.tsx
@@ -48,14 +48,18 @@ export function MatchAuditPanel() {
 
   // One memoized pass per result: this panel re-renders on every keystroke in
   // the page's resolve-exception modal, and the audit arrays can be large.
-  const { unclaimedPaid, membershipGaps, enrollmentGaps, manual, scholarships, matched } = useMemo(() => {
+  const { unclaimedPaid, membershipGaps, enrollmentGaps, manual, scholarships, comped, reversedMemberships, reversedEnrollments, preMirrorCount, matched } = useMemo(() => {
     const matchedCounts = { orders: 0, tracked: 0, memberships: 0, enrollments: 0 };
+    let preMirrorCount = 0;
     const groups = {
       unclaimedPaid: [] as NonNullable<typeof result>['orders'],
       membershipGaps: [] as NonNullable<typeof result>['memberships'],
       enrollmentGaps: [] as NonNullable<typeof result>['enrollments'],
       manual: [] as NonNullable<typeof result>['memberships'],
       scholarships: [] as NonNullable<typeof result>['enrollments'],
+      comped: [] as NonNullable<typeof result>['enrollments'],
+      reversedMemberships: [] as NonNullable<typeof result>['memberships'],
+      reversedEnrollments: [] as NonNullable<typeof result>['enrollments'],
       matched: matchedCounts,
     };
     for (const o of result?.orders ?? []) {
@@ -64,16 +68,21 @@ export function MatchAuditPanel() {
       else if (o.bucket === 'TRACKED_EXCEPTION') matchedCounts.tracked++;
     }
     for (const m of result?.memberships ?? []) {
-      if (m.bucket === 'NO_PAYMENT_BASIS' || m.bucket === 'ORDER_NOT_IN_MIRROR') groups.membershipGaps.push(m);
+      if (m.bucket === 'NO_PAYMENT_BASIS' || m.bucket === 'ORDER_NOT_IN_MIRROR' || m.bucket === 'NO_PROCESS') groups.membershipGaps.push(m);
       else if (m.bucket === 'MANUAL_CERTIFIED') groups.manual.push(m);
-      else matchedCounts.memberships++;
+      else if (m.bucket === 'ORDER_REVERSED') groups.reversedMemberships.push(m);
+      else if (m.bucket === 'PRE_MIRROR') preMirrorCount++;
+      else matchedCounts.memberships++; // ORDER_MATCHED
     }
     for (const e of result?.enrollments ?? []) {
       if (e.bucket === 'NO_PAYMENT_BASIS' || e.bucket === 'ORDER_NOT_IN_MIRROR') groups.enrollmentGaps.push(e);
       else if (e.bucket === 'SCHOLARSHIP_APPROVED') groups.scholarships.push(e);
-      else matchedCounts.enrollments++;
+      else if (e.bucket === 'ADMIN_COMPED') groups.comped.push(e);
+      else if (e.bucket === 'ORDER_REVERSED') groups.reversedEnrollments.push(e);
+      else if (e.bucket === 'PRE_MIRROR') preMirrorCount++;
+      else matchedCounts.enrollments++; // ORDER_MATCHED
     }
-    return groups;
+    return { ...groups, preMirrorCount };
   }, [result]);
   const gapCount = unclaimedPaid.length + membershipGaps.length + enrollmentGaps.length;
 
@@ -128,6 +137,8 @@ export function MatchAuditPanel() {
             {count('Enrollments matched', matched.enrollments)}
             {count('Board-certified', manual.length)}
             {count('Scholarships', scholarships.length)}
+            {count('Comped', comped.length)}
+            {preMirrorCount > 0 && count('Pre-mirror (before mirror history)', preMirrorCount)}
           </Group>
 
           {unclaimedPaid.length > 0 && (
@@ -136,7 +147,7 @@ export function MatchAuditPanel() {
               <Table striped withTableBorder mt="xs">
                 <Table.Thead>
                   <Table.Tr>
-                    <Table.Th>Order</Table.Th><Table.Th>Email</Table.Th><Table.Th>Total</Table.Th><Table.Th>Expected</Table.Th>
+                    <Table.Th>Order</Table.Th><Table.Th>Email</Table.Th><Table.Th>Total</Table.Th><Table.Th>Expected</Table.Th><Table.Th>Codes</Table.Th>
                   </Table.Tr>
                 </Table.Thead>
                 <Table.Tbody>
@@ -146,6 +157,7 @@ export function MatchAuditPanel() {
                       <Table.Td>{o.customerEmail}</Table.Td>
                       <Table.Td>{formatCents(o.totalCents)}</Table.Td>
                       <Table.Td>{o.expected.join(', ')}</Table.Td>
+                      <Table.Td>{(o.discountCodes ?? []).join(', ')}</Table.Td>
                     </Table.Tr>
                   ))}
                 </Table.Tbody>
@@ -164,10 +176,14 @@ export function MatchAuditPanel() {
                 </Table.Thead>
                 <Table.Tbody>
                   {membershipGaps.map((m) => (
-                    <Table.Tr key={`m-${m.processId}`}>
-                      <Table.Td>Membership process {m.processId}</Table.Td>
+                    <Table.Tr key={m.processId != null ? `m-${m.processId}` : `mm-${m.membershipId}`}>
+                      <Table.Td>{m.processId != null ? `Membership process ${m.processId}` : `Membership — ${m.householdName ?? m.membershipId}`}</Table.Td>
                       <Table.Td>{m.householdName}</Table.Td>
-                      <Table.Td>{m.bucket === 'NO_PAYMENT_BASIS' ? 'No order and no certification' : `Order ${m.shopifyOrderId} not in the mirror`}</Table.Td>
+                      <Table.Td>{
+                        m.bucket === 'NO_PAYMENT_BASIS' ? 'No order and no certification'
+                        : m.bucket === 'NO_PROCESS' ? 'Active membership with no INITIAL/RENEWAL process'
+                        : `Order ${m.shopifyOrderId} not in the mirror`
+                      }</Table.Td>
                     </Table.Tr>
                   ))}
                   {enrollmentGaps.map((e) => (
@@ -182,7 +198,7 @@ export function MatchAuditPanel() {
             </>
           )}
 
-          {(manual.length > 0 || scholarships.length > 0) && (
+          {(manual.length > 0 || scholarships.length > 0 || comped.length > 0) && (
             <>
               <Title order={5} mt="md">Manual — legitimate, listed for audit</Title>
               <Table striped withTableBorder mt="xs">
@@ -204,6 +220,34 @@ export function MatchAuditPanel() {
                       <Table.Td>{e.programName}</Table.Td>
                       <Table.Td>{e.personName}</Table.Td>
                       <Table.Td>Scholarship / payment plan approved</Table.Td>
+                    </Table.Tr>
+                  ))}
+                  {comped.map((e) => (
+                    <Table.Tr key={`comp-${e.programId}-${e.personId}`}>
+                      <Table.Td>{e.programName}</Table.Td>
+                      <Table.Td>{e.personName}</Table.Td>
+                      <Table.Td>Comped by {e.compedByName}</Table.Td>
+                    </Table.Tr>
+                  ))}
+                </Table.Tbody>
+              </Table>
+            </>
+          )}
+
+          {(reversedMemberships.length > 0 || reversedEnrollments.length > 0) && (
+            <>
+              <Title order={5} mt="md" c="yellow">Reversed after activation — already in the exceptions queue</Title>
+              <Table striped withTableBorder mt="xs">
+                <Table.Thead><Table.Tr><Table.Th>What</Table.Th><Table.Th>Who</Table.Th><Table.Th>Order</Table.Th></Table.Tr></Table.Thead>
+                <Table.Tbody>
+                  {reversedMemberships.map((m) => (
+                    <Table.Tr key={`rm-${m.processId}`}>
+                      <Table.Td>Membership process {m.processId}</Table.Td><Table.Td>{m.householdName}</Table.Td><Table.Td>{m.shopifyOrderId}</Table.Td>
+                    </Table.Tr>
+                  ))}
+                  {reversedEnrollments.map((e) => (
+                    <Table.Tr key={`re-${e.programId}-${e.personId}`}>
+                      <Table.Td>{e.programName}</Table.Td><Table.Td>{e.personName}</Table.Td><Table.Td>{e.shopifyOrderId}</Table.Td>
                     </Table.Tr>
                   ))}
                 </Table.Tbody>

--- a/checkin-app/src/components/admin/__tests__/MatchAuditPanel.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/MatchAuditPanel.test.tsx
@@ -14,15 +14,20 @@ describe("MatchAuditPanel", () => {
         configuredVariants: 3,
         variantCoverage: { lines: 6, withVariant: 6 },
         orders: [
-          { bucket: "MATCHED", orderLegacyId: "1", name: "#1", customerEmail: "a@x.com", financialStatus: "PAID", totalCents: 5000, expected: ["membership"] },
-          { bucket: "UNCLAIMED_PAID", orderLegacyId: "2", name: "#2", customerEmail: "b@x.com", financialStatus: "PAID", totalCents: 7500, expected: ["program: Robotics"] },
+          { bucket: "MATCHED", orderLegacyId: "1", name: "#1", customerEmail: "a@x.com", financialStatus: "PAID", totalCents: 5000, discountCodes: [], expected: ["membership"] },
+          { bucket: "UNCLAIMED_PAID", orderLegacyId: "2", name: "#2", customerEmail: "b@x.com", financialStatus: "PAID", totalCents: 7500, discountCodes: ["VOL50"], expected: ["program: Robotics"] },
         ],
         memberships: [
-          { bucket: "MANUAL_CERTIFIED", processId: 3, householdName: "The Larks", shopifyOrderId: null, certifiedByName: "Board Bob" },
-          { bucket: "NO_PAYMENT_BASIS", processId: 4, householdName: "The Wrens", shopifyOrderId: null, certifiedByName: null },
+          { bucket: "MANUAL_CERTIFIED", processId: 3, membershipId: null, householdName: "The Larks", shopifyOrderId: null, certifiedByName: "Board Bob" },
+          { bucket: "NO_PAYMENT_BASIS", processId: 4, membershipId: null, householdName: "The Wrens", shopifyOrderId: null, certifiedByName: null },
+          { bucket: "NO_PROCESS", processId: null, membershipId: 5, householdName: "The Finches", shopifyOrderId: null, certifiedByName: null },
+          { bucket: "ORDER_REVERSED", processId: 6, membershipId: null, householdName: "The Sparrows", shopifyOrderId: "801", certifiedByName: null },
         ],
         enrollments: [
-          { bucket: "SCHOLARSHIP_APPROVED", programId: 7, programName: "Robotics", personId: 9, personName: "Kid Nine", shopifyOrderId: null },
+          { bucket: "SCHOLARSHIP_APPROVED", programId: 7, programName: "Robotics", personId: 9, personName: "Kid Nine", shopifyOrderId: null, compedByName: null },
+          { bucket: "ADMIN_COMPED", programId: 7, programName: "Robotics", personId: 10, personName: "Kid Ten", shopifyOrderId: null, compedByName: "Admin Amy" },
+          { bucket: "ORDER_REVERSED", programId: 7, programName: "Robotics", personId: 11, personName: "Kid Eleven", shopifyOrderId: "701", compedByName: null },
+          { bucket: "PRE_MIRROR", programId: 7, programName: "Robotics", personId: 12, personName: "Kid Twelve", shopifyOrderId: "50", compedByName: null },
         ],
       },
     });
@@ -33,14 +38,24 @@ describe("MatchAuditPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Run match audit/ }));
 
-    // The two gap classes render as rows...
-    expect(await screen.findByText("2 gap(s)")).toBeInTheDocument();
+    // The gap classes render as rows — unclaimed paid, membership NO_PAYMENT_BASIS,
+    // and NO_PROCESS all count as gaps (3 gap(s)); reversed + pre-mirror do not.
+    expect(await screen.findByText("3 gap(s)")).toBeInTheDocument();
     expect(screen.getByText("#2")).toBeInTheDocument();
     expect(screen.getByText("program: Robotics")).toBeInTheDocument();
+    expect(screen.getByText("VOL50")).toBeInTheDocument();
     expect(screen.getByText("No order and no certification")).toBeInTheDocument();
-    // ...and the manual class is listed with WHO certified, not flagged as a gap.
+    expect(screen.getByText("Active membership with no INITIAL/RENEWAL process")).toBeInTheDocument();
+    // ...and the manual/scholarship/comped classes are listed with WHO, not flagged as gaps.
     expect(screen.getByText("Certified by Board Bob")).toBeInTheDocument();
     expect(screen.getByText("Scholarship / payment plan approved")).toBeInTheDocument();
+    expect(screen.getByText("Comped by Admin Amy")).toBeInTheDocument();
+    // Reversed rows render informationally, not as a gap.
+    expect(screen.getByText("Reversed after activation — already in the exceptions queue")).toBeInTheDocument();
+    expect(screen.getByText("Membership process 6")).toBeInTheDocument();
+    // Pre-mirror is a count only, no row.
+    expect(screen.getByText(/Pre-mirror \(before mirror history\)/)).toBeInTheDocument();
+    expect(screen.queryByText("Kid Twelve")).not.toBeInTheDocument();
     // Matched orders stay a count, never a table row.
     expect(screen.queryByText("#1")).not.toBeInTheDocument();
   });

--- a/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
@@ -16,6 +16,8 @@ const prismaMock = {
     programParticipant: { findMany: jest.fn() },
     paymentException: { findMany: jest.fn() },
     person: { findMany: jest.fn() },
+    auditLog: { findMany: jest.fn() },
+    orgMembership: { findMany: jest.fn() },
 };
 // The factories defer every dereference to call time (jest.mock is hoisted above
 // the consts, so touching them during factory evaluation would hit the TDZ).
@@ -28,6 +30,8 @@ jest.mock('@/lib/prisma', () => ({
         programParticipant: { findMany: (...a: unknown[]) => prismaMock.programParticipant.findMany(...a) },
         paymentException: { findMany: (...a: unknown[]) => prismaMock.paymentException.findMany(...a) },
         person: { findMany: (...a: unknown[]) => prismaMock.person.findMany(...a) },
+        auditLog: { findMany: (...a: unknown[]) => prismaMock.auditLog.findMany(...a) },
+        orgMembership: { findMany: (...a: unknown[]) => prismaMock.orgMembership.findMany(...a) },
     },
 }));
 
@@ -36,12 +40,16 @@ const mirrorMock = {
     lineVariantStats: jest.fn(),
     ordersForVariants: jest.fn(),
     orderLegacyIdsPresent: jest.fn(),
+    ordersByLegacyIds: jest.fn(),
+    minRealOrderLegacyId: jest.fn(),
 };
 jest.mock('@/lib/shopifyRead/client', () => ({
     isConfigured: () => mirrorMock.isConfigured(),
     lineVariantStats: () => mirrorMock.lineVariantStats(),
     ordersForVariants: (...a: unknown[]) => mirrorMock.ordersForVariants(...a),
     orderLegacyIdsPresent: (...a: unknown[]) => mirrorMock.orderLegacyIdsPresent(...a),
+    ordersByLegacyIds: (...a: unknown[]) => mirrorMock.ordersByLegacyIds(...a),
+    minRealOrderLegacyId: () => mirrorMock.minRealOrderLegacyId(),
 }));
 
 const paidOrder = (legacyId: string, over: Partial<Record<string, unknown>> = {}) => ({
@@ -74,6 +82,10 @@ beforeEach(() => {
     prismaMock.programParticipant.findMany.mockResolvedValue([]);
     prismaMock.paymentException.findMany.mockResolvedValue([]);
     prismaMock.person.findMany.mockResolvedValue([]);
+    prismaMock.auditLog.findMany.mockResolvedValue([]);
+    prismaMock.orgMembership.findMany.mockResolvedValue([]);
+    mirrorMock.ordersByLegacyIds.mockResolvedValue([]);
+    mirrorMock.minRealOrderLegacyId.mockResolvedValue(null);
 });
 
 it('reports configured:false without touching prisma or the mirror data when unwired', async () => {
@@ -210,6 +222,67 @@ describe('membership buckets (activation → Shopify)', () => {
         expect(sweep.where.kind).toEqual({ in: ['INITIAL', 'RENEWAL'] });
         expect(sweep.where.status).toEqual({ in: ['ACTIVE', 'PENDING_BG_CLEARANCE'] });
     });
+
+    it('reversed after activation → ORDER_REVERSED, not a fresh gap', async () => {
+        prismaMock.orgMembershipProcess.findMany
+            .mockResolvedValueOnce([]) // claim lookup
+            .mockResolvedValueOnce([proc(1, { shopifyOrderId: '800' })]);
+        mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set(['800']));
+        mirrorMock.ordersByLegacyIds.mockResolvedValue([
+            { legacyId: '800', financialStatus: 'REFUNDED', totalRefundedCents: 5000, cancelledAt: null },
+        ]);
+
+        const r = await runMatchAudit();
+        expect(r.memberships[0].bucket).toBe('ORDER_REVERSED');
+    });
+
+    it('an ACTIVE household membership with no INITIAL/RENEWAL process → NO_PROCESS gap', async () => {
+        prismaMock.orgMembership.findMany.mockResolvedValue([{ id: 5, household: { name: 'The Finches' } }]);
+
+        const r = await runMatchAudit();
+        expect(r.memberships).toContainEqual(
+            expect.objectContaining({ bucket: 'NO_PROCESS', processId: null, membershipId: 5, householdName: 'The Finches' }),
+        );
+    });
+
+    it('NO_PROCESS sweep asks for exactly the pinned where', async () => {
+        await runMatchAudit();
+        expect(prismaMock.orgMembership.findMany.mock.calls[0][0].where).toEqual({
+            status: 'ACTIVE',
+            processes: { none: { kind: { in: ['INITIAL', 'RENEWAL'] }, status: { not: 'ARCHIVED' } } },
+        });
+    });
+});
+
+describe('PRE_MIRROR vs ORDER_NOT_IN_MIRROR', () => {
+    const proc = (id: number, shopifyOrderId: string) => ({
+        id,
+        shopifyOrderId,
+        certifiedById: null,
+        orgMembership: { household: { name: `House ${id}` } },
+    });
+
+    it('an id below the mirror low-water mark is PRE_MIRROR; at/above it is a real gap', async () => {
+        prismaMock.orgMembershipProcess.findMany
+            .mockResolvedValueOnce([]) // claim lookup
+            .mockResolvedValueOnce([proc(1, '50'), proc(2, '200')]);
+        mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set());
+        mirrorMock.minRealOrderLegacyId.mockResolvedValue(BigInt(100));
+
+        const r = await runMatchAudit();
+        expect(r.memberships.map((m) => m.bucket)).toEqual(['PRE_MIRROR', 'ORDER_NOT_IN_MIRROR']);
+    });
+
+    it('an empty mirror (null low-water mark) never reclassifies — everything is a real gap', async () => {
+        prismaMock.orgMembershipProcess.findMany
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([proc(1, '50'), proc(2, '200')]);
+        mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set());
+        mirrorMock.minRealOrderLegacyId.mockResolvedValue(null);
+
+        const r = await runMatchAudit();
+        expect(r.memberships.map((m) => m.bucket)).toEqual(['ORDER_NOT_IN_MIRROR', 'ORDER_NOT_IN_MIRROR']);
+    });
 });
 
 describe('enrollment buckets', () => {
@@ -235,5 +308,81 @@ describe('enrollment buckets', () => {
 
         const r = await runMatchAudit();
         expect(r.enrollments.map((e) => e.bucket)).toEqual(['ORDER_MATCHED', 'SCHOLARSHIP_APPROVED', 'NO_PAYMENT_BASIS']);
+    });
+
+    it('reversed after activation → ORDER_REVERSED, not a fresh gap', async () => {
+        prismaMock.programParticipant.findMany
+            .mockResolvedValueOnce([]) // claim lookup
+            .mockResolvedValueOnce([enroll(1, { shopifyOrderId: '700' })]);
+        mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set(['700']));
+        mirrorMock.ordersByLegacyIds.mockResolvedValue([
+            { legacyId: '700', financialStatus: 'PAID', totalRefundedCents: 0, cancelledAt: new Date() },
+        ]);
+
+        const r = await runMatchAudit();
+        expect(r.enrollments[0].bucket).toBe('ORDER_REVERSED');
+    });
+
+    it('sweeps only payment-bearing programs — a free program never floods NO_PAYMENT_BASIS', async () => {
+        await runMatchAudit();
+        const sweep = prismaMock.programParticipant.findMany.mock.calls[1][0];
+        expect(sweep.where.status).toBe('ACTIVE');
+        expect(sweep.where.OR).toContainEqual({ shopifyOrderId: { not: null } });
+        expect(sweep.where.OR).toContainEqual({
+            program: {
+                OR: [
+                    { shopifyVariantId: { not: null } },
+                    { shopifyOrgMemberVariantId: { not: null } },
+                    { shopifyNonOrgMemberVariantId: { not: null } },
+                ],
+            },
+        });
+    });
+
+    describe('ADMIN_COMPED', () => {
+        it('an enrollment CREATED active with no order and no scholarship stamp → ADMIN_COMPED', async () => {
+            prismaMock.programParticipant.findMany
+                .mockResolvedValueOnce([]) // claim lookup
+                .mockResolvedValueOnce([enroll(3)]);
+            prismaMock.auditLog.findMany.mockResolvedValue([
+                { affectedEntityId: 3, secondaryAffectedEntity: 7, actorId: 42, newData: { status: 'ACTIVE' } },
+            ]);
+            prismaMock.person.findMany.mockResolvedValue([{ id: 42, name: 'Admin Amy' }]);
+
+            const r = await runMatchAudit();
+            expect(r.enrollments[0].bucket).toBe('ADMIN_COMPED');
+            expect(r.enrollments[0].compedByName).toBe('Admin Amy');
+        });
+
+        it('created PENDING (later flipped some other way) stays NO_PAYMENT_BASIS — proves the inference', async () => {
+            prismaMock.programParticipant.findMany
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([enroll(3)]);
+            prismaMock.auditLog.findMany.mockResolvedValue([
+                { affectedEntityId: 3, secondaryAffectedEntity: 7, actorId: 42, newData: { status: 'PENDING' } },
+            ]);
+
+            const r = await runMatchAudit();
+            expect(r.enrollments[0].bucket).toBe('NO_PAYMENT_BASIS');
+            expect(r.enrollments[0].compedByName).toBeNull();
+        });
+
+        it('looks up the CREATE audit row in one batched query with the pinned where', async () => {
+            prismaMock.programParticipant.findMany
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([enroll(3)]);
+            prismaMock.auditLog.findMany.mockResolvedValue([
+                { affectedEntityId: 3, secondaryAffectedEntity: 7, actorId: 42, newData: { status: 'ACTIVE' } },
+            ]);
+            prismaMock.person.findMany.mockResolvedValue([{ id: 42, name: 'Admin Amy' }]);
+
+            await runMatchAudit();
+            expect(prismaMock.auditLog.findMany).toHaveBeenCalledTimes(1);
+            const where = prismaMock.auditLog.findMany.mock.calls[0][0].where;
+            expect(where.tableName).toBe('ProgramParticipant');
+            expect(where.action).toBe('CREATE');
+            expect(where.affectedEntityId).toEqual({ in: [3] });
+            expect(where.secondaryAffectedEntity).toEqual({ in: [7] });
+        });
     });
 });

--- a/checkin-app/src/lib/finance/matchAudit.ts
+++ b/checkin-app/src/lib/finance/matchAudit.ts
@@ -1,6 +1,7 @@
 import prisma from "@/lib/prisma";
-import { isPaid, membershipVariantIdSet } from "@/lib/finance/reconcile";
+import { isPaid, isReversed, membershipVariantIdSet } from "@/lib/finance/reconcile";
 import * as mirror from "@/lib/shopifyRead/client";
+import { normalizeAuditData } from "@/lib/auditPayload";
 
 /**
  * Bidirectional Shopify ↔ activation match audit — the completeness check the
@@ -46,16 +47,38 @@ export interface AuditOrderRow {
     customerEmail: string | null;
     financialStatus: string | null;
     totalCents: number;
+    /** Order-level coupon codes (mirror shop_order.discount_codes, #1048). [] when un-couponed
+     *  or pre-#1048. Shown on UNCLAIMED_PAID rows only — a coupon can explain a sub-dues total the
+     *  auditor is eyeballing. Absence is NOT "no coupon" (see MirrorOrder.discountCodes). */
+    discountCodes: string[];
     /** Which membership/program the variant match points at, e.g. "membership", "program: Robotics". */
     expected: string[];
 }
 
-export type MembershipBucket = "ORDER_MATCHED" | "MANUAL_CERTIFIED" | "ORDER_NOT_IN_MIRROR" | "NO_PAYMENT_BASIS";
-export type EnrollmentBucket = "ORDER_MATCHED" | "SCHOLARSHIP_APPROVED" | "ORDER_NOT_IN_MIRROR" | "NO_PAYMENT_BASIS";
+export type MembershipBucket =
+    | "ORDER_MATCHED"
+    | "MANUAL_CERTIFIED"
+    | "ORDER_NOT_IN_MIRROR"
+    | "PRE_MIRROR"
+    | "ORDER_REVERSED"
+    | "NO_PROCESS"
+    | "NO_PAYMENT_BASIS";
+
+export type EnrollmentBucket =
+    | "ORDER_MATCHED"
+    | "SCHOLARSHIP_APPROVED"
+    | "ADMIN_COMPED"
+    | "ORDER_NOT_IN_MIRROR"
+    | "PRE_MIRROR"
+    | "ORDER_REVERSED"
+    | "NO_PAYMENT_BASIS";
 
 export interface AuditMembershipRow {
     bucket: MembershipBucket;
-    processId: number;
+    /** Null only for NO_PROCESS rows, which have no process (they are keyed by membershipId). */
+    processId: number | null;
+    /** Set for NO_PROCESS rows (the OrgMembership id); null for process-derived rows. */
+    membershipId: number | null;
     householdName: string | null;
     shopifyOrderId: string | null;
     /** Who certified, for the MANUAL_CERTIFIED rows — the "what is in audit as manual" answer. */
@@ -69,6 +92,8 @@ export interface AuditEnrollmentRow {
     personId: number;
     personName: string | null;
     shopifyOrderId: string | null;
+    /** Who comped it, for ADMIN_COMPED rows (the AuditLog CREATE row's actor). Null otherwise. */
+    compedByName: string | null;
 }
 
 export interface MatchAuditResult {
@@ -211,6 +236,7 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
             customerEmail: o.customerEmail,
             financialStatus: o.financialStatus,
             totalCents: o.totalCents,
+            discountCodes: o.discountCodes,
             // MATCHED rows list everything the order bought; gap rows list only
             // the UNACCOUNTED half (a tracked half is the exception queue's
             // problem, not this row's), so a half-claimed checkout names its gap.
@@ -221,7 +247,7 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
     // ── activation → Shopify: every activation has a payment basis ────────────
     // INITIAL/RENEWAL only: PERSON_BG processes carry no payment by design, so
     // including them would flood NO_PAYMENT_BASIS with false positives.
-    const [procs, enrolls] = await Promise.all([
+    const [procs, enrolls, noProcessMemberships] = await Promise.all([
         prisma.orgMembershipProcess.findMany({
             where: { status: { in: ["ACTIVE", "PENDING_BG_CLEARANCE"] }, kind: { in: ["INITIAL", "RENEWAL"] } },
             select: {
@@ -231,8 +257,24 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
                 orgMembership: { select: { household: { select: { name: true } } } },
             },
         }),
+        // Payment-bearing programs only: a FREE program sets initialStatus ACTIVE in the
+        // participants route, so sweeping every ACTIVE participant floods NO_PAYMENT_BASIS.
+        // "Carries payment" == has a Shopify variant id — the same "should reconcile" key the
+        // order side uses. An order-backed row stays swept even if its program later dropped its
+        // variant, so recorded money is always auditable. (No season-bounding: an old ACTIVE
+        // enrollment IS current.)
         prisma.programParticipant.findMany({
-            where: { status: "ACTIVE" },
+            where: {
+                status: "ACTIVE",
+                OR: [
+                    { shopifyOrderId: { not: null } },
+                    { program: { OR: [
+                        { shopifyVariantId: { not: null } },
+                        { shopifyOrgMemberVariantId: { not: null } },
+                        { shopifyNonOrgMemberVariantId: { not: null } },
+                    ] } },
+                ],
+            },
             select: {
                 programId: true,
                 personId: true,
@@ -242,48 +284,139 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
                 person: { select: { name: true } },
             },
         }),
+        // Item 5: an ACTIVE household membership with no INITIAL/RENEWAL process in any
+        // non-ARCHIVED status has no payment/approval track behind it at all — a real gap.
+        // Raw "ACTIVE" literal on the orgMembership delegate is guard-clean (the lifecycle
+        // literal guard only scans programParticipant/orgMembershipProcess) and matchAudit is
+        // allowlisted regardless. No season-bounding by design.
+        prisma.orgMembership.findMany({
+            where: {
+                status: "ACTIVE",
+                processes: { none: { kind: { in: ["INITIAL", "RENEWAL"] }, status: { not: "ARCHIVED" } } },
+            },
+            select: { id: true, household: { select: { name: true } } },
+        }),
     ]);
-    // certifiedById has no Prisma relation — resolve the names in one batch.
-    const certifierIds = [...new Set(procs.map((p) => p.certifiedById).filter((v): v is number => v != null))];
-    const certifiers = certifierIds.length
-        ? await prisma.person.findMany({ where: { id: { in: certifierIds } }, select: { id: true, name: true } })
-        : [];
-    const certifierName = new Map(certifiers.map((c) => [c.id, c.name]));
 
+    // ── item 2: admin-comped enrollments — the AuditLog CREATE row settles it ─
+    // Candidates are exactly the enrollments that would otherwise be NO_PAYMENT_BASIS:
+    // no order, no scholarship stamp.
+    const compCandidates = enrolls.filter((e) => !e.shopifyOrderId && e.wasOrgMemberAtApproval == null);
+    const candPersonIds = [...new Set(compCandidates.map((e) => e.personId))];
+    const candProgramIds = [...new Set(compCandidates.map((e) => e.programId))];
+    // ONE query, not N. Over-fetches cross (person,program) pairs; harmless — we only read exact
+    // `${personId}:${programId}` keys. Newest CREATE wins (re-enroll after a withdrawal DELETE).
+    const createRows = candPersonIds.length
+        ? await prisma.auditLog.findMany({
+              where: {
+                  tableName: "ProgramParticipant",
+                  action: "CREATE",
+                  affectedEntityId: { in: candPersonIds },
+                  secondaryAffectedEntity: { in: candProgramIds },
+              },
+              select: { affectedEntityId: true, secondaryAffectedEntity: true, actorId: true, newData: true },
+              orderBy: { id: "desc" },
+          })
+        : [];
+    const createByKey = new Map<string, { actorId: number; status: string | null }>();
+    for (const r of createRows) {
+        const key = `${r.affectedEntityId}:${r.secondaryAffectedEntity}`;
+        if (createByKey.has(key)) continue; // desc order → first is newest
+        const status = (normalizeAuditData(r.newData) as { status?: string } | null)?.status ?? null;
+        createByKey.set(key, { actorId: r.actorId, status });
+    }
+    // A payment-bearing (free programs already filtered) enrollment CREATED active = admin comp.
+    // ponytail: a household-merge (membership-ops/participants/merge) moves an enrollment to
+    // the surviving personId but the CREATE audit row still names the OLD personId, so a merged
+    // comp misses this lookup and falls to NO_PAYMENT_BASIS instead of ADMIN_COMPED. Safe
+    // direction (surfaces, never hides) and rare; re-key by merge history if it gets noisy.
+    const compActorId = (e: { personId: number; programId: number }) => createByKey.get(`${e.personId}:${e.programId}`)?.actorId;
+    const createdActive = (e: { personId: number; programId: number; shopifyOrderId: string | null; wasOrgMemberAtApproval: boolean | null }) =>
+        !e.shopifyOrderId && e.wasOrgMemberAtApproval == null && createByKey.get(`${e.personId}:${e.programId}`)?.status === "ACTIVE";
+
+    // certifiedById / comp actor ids have no Prisma relation — resolve every name in one batch.
+    const certifierIds = [...new Set(procs.map((p) => p.certifiedById).filter((v): v is number => v != null))];
+    const comperActorIds = compCandidates
+        .map((e) => (createByKey.get(`${e.personId}:${e.programId}`)?.status === "ACTIVE" ? compActorId(e) : null))
+        .filter((v): v is number => v != null);
+    const nameIds = [...new Set([...certifierIds, ...comperActorIds])];
+    const people = nameIds.length
+        ? await prisma.person.findMany({ where: { id: { in: nameIds } }, select: { id: true, name: true } })
+        : [];
+    const personName = new Map(people.map((p) => [p.id, p.name]));
+
+    // ── items 3 & 4: reversal state + the mirror's low-water mark ─────────────
+    // Out of scope (P3, not this pass): no re-validation that a mirrored order's
+    // lines actually contain the recorded process/enrollment's variant — presence
+    // in the mirror is enough for ORDER_MATCHED here.
     const activationOrderIds = [
         ...procs.map((p) => p.shopifyOrderId),
         ...enrolls.map((e) => e.shopifyOrderId),
     ].filter((v): v is string => !!v);
-    const inMirror = await mirror.orderLegacyIdsPresent([...new Set(activationOrderIds)]);
+    const uniqueActivationIds = [...new Set(activationOrderIds)];
+    const [inMirror, mirrorOrders, minReal] = await Promise.all([
+        mirror.orderLegacyIdsPresent(uniqueActivationIds), // test=false authoritative present set
+        mirror.ordersByLegacyIds(uniqueActivationIds),      // full rows, for reversal state only
+        mirror.minRealOrderLegacyId(),
+    ]);
+    // Reversal is only meaningful for orders that ARE present (test=false gated by inMirror below),
+    // so a test order that ordersByLegacyIds returns can never become a payment basis here.
+    const reversedIds = new Set(mirrorOrders.filter((o) => o.legacyId && isReversed(o)).map((o) => o.legacyId!));
+    // Recorded id below the mirror's low-water mark = pre-mirror history, informational not a gap.
+    const isPreMirror = (id: string) => minReal != null && /^\d+$/.test(id) && BigInt(id) < minReal;
 
     const membershipRows: AuditMembershipRow[] = procs.map((p) => ({
         bucket: p.shopifyOrderId
-            ? inMirror.has(p.shopifyOrderId)
-                ? "ORDER_MATCHED"
-                : "ORDER_NOT_IN_MIRROR"
+            ? !inMirror.has(p.shopifyOrderId)
+                ? (isPreMirror(p.shopifyOrderId) ? "PRE_MIRROR" : "ORDER_NOT_IN_MIRROR")
+                : reversedIds.has(p.shopifyOrderId)
+                    ? "ORDER_REVERSED"
+                    : "ORDER_MATCHED"
             : p.certifiedById != null
-              ? "MANUAL_CERTIFIED"
-              : "NO_PAYMENT_BASIS",
+                ? "MANUAL_CERTIFIED"
+                : "NO_PAYMENT_BASIS",
         processId: p.id,
+        membershipId: null,
         householdName: p.orgMembership?.household?.name ?? null,
         shopifyOrderId: p.shopifyOrderId,
-        certifiedByName: p.certifiedById != null ? (certifierName.get(p.certifiedById) ?? `person ${p.certifiedById}`) : null,
+        certifiedByName: p.certifiedById != null ? (personName.get(p.certifiedById) ?? `person ${p.certifiedById}`) : null,
+    }));
+
+    const noProcessRows: AuditMembershipRow[] = noProcessMemberships.map((m) => ({
+        bucket: "NO_PROCESS",
+        processId: null,
+        membershipId: m.id,
+        householdName: m.household?.name ?? null,
+        shopifyOrderId: null,
+        certifiedByName: null,
     }));
 
     const enrollmentRows: AuditEnrollmentRow[] = enrolls.map((e) => ({
         bucket: e.shopifyOrderId
-            ? inMirror.has(e.shopifyOrderId)
-                ? "ORDER_MATCHED"
-                : "ORDER_NOT_IN_MIRROR"
+            ? !inMirror.has(e.shopifyOrderId)
+                ? (isPreMirror(e.shopifyOrderId) ? "PRE_MIRROR" : "ORDER_NOT_IN_MIRROR")
+                : reversedIds.has(e.shopifyOrderId)
+                    ? "ORDER_REVERSED"
+                    : "ORDER_MATCHED"
             : e.wasOrgMemberAtApproval != null
-              ? "SCHOLARSHIP_APPROVED"
-              : "NO_PAYMENT_BASIS",
+                ? "SCHOLARSHIP_APPROVED"
+                : createdActive(e)
+                    ? "ADMIN_COMPED"
+                    : "NO_PAYMENT_BASIS",
         programId: e.programId,
         programName: e.program.name,
         personId: e.personId,
         personName: e.person.name,
         shopifyOrderId: e.shopifyOrderId,
+        compedByName: createdActive(e) ? (personName.get(compActorId(e)!) ?? null) : null,
     }));
 
-    return { configured: true, variantCoverage, configuredVariants: allVariants.length, orders: orderRows, memberships: membershipRows, enrollments: enrollmentRows };
+    return {
+        configured: true,
+        variantCoverage,
+        configuredVariants: allVariants.length,
+        orders: orderRows,
+        memberships: [...membershipRows, ...noProcessRows],
+        enrollments: enrollmentRows,
+    };
 }

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -148,8 +148,9 @@ export function membershipVariantIdSet(settings: {
     );
 }
 
-/** Any sign the money came back out. */
-function isReversed(o: MirrorOrder): boolean {
+/** Any sign the money came back out. Exported so matchAudit.ts marks reversed activations
+ *  with the SAME predicate the reversal pass raises exceptions on. */
+export function isReversed(o: Pick<MirrorOrder, "financialStatus" | "cancelledAt" | "totalRefundedCents">): boolean {
     const s = (o.financialStatus ?? "").toUpperCase();
     return !!o.cancelledAt || o.totalRefundedCents > 0 || s === "REFUNDED" || s === "PARTIALLY_REFUNDED" || s === "VOIDED";
 }

--- a/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
+++ b/checkin-app/src/lib/shopifyRead/__tests__/client.test.ts
@@ -143,6 +143,12 @@ describe('match-audit reads', () => {
         expect(queryMock.mock.calls[0][1]).toEqual([['111', '222']]);
     });
 
+    it('ordersForVariants projects discount_codes', async () => {
+        queryMock.mockResolvedValue({ rows: [] });
+        await freshClient().ordersForVariants(['111']);
+        expect(sqlOf(0)).toContain('discount_codes AS "discountCodes"');
+    });
+
     it('ordersForVariants short-circuits on an empty variant set without querying', async () => {
         expect(await freshClient().ordersForVariants([])).toEqual([]);
         expect(queryMock).not.toHaveBeenCalled();
@@ -163,6 +169,24 @@ describe('match-audit reads', () => {
         expect(await freshClient().orderLegacyIdsPresent(['900', '901'])).toEqual(new Set(['900']));
         // A test-mode order must not serve as an activation's payment basis.
         expect(sqlOf(0)).toContain('test = false');
+    });
+
+    it('minRealOrderLegacyId returns the mirror low-water mark', async () => {
+        queryMock.mockResolvedValue({ rows: [{ minLegacyId: '4200' }] });
+        expect(await freshClient().minRealOrderLegacyId()).toBe(BigInt(4200));
+        expect(sqlOf(0)).toContain('min(legacy_id::bigint)');
+        expect(sqlOf(0)).toContain('test = false');
+    });
+
+    it('minRealOrderLegacyId returns null for an empty mirror', async () => {
+        queryMock.mockResolvedValue({ rows: [{ minLegacyId: null }] });
+        expect(await freshClient().minRealOrderLegacyId()).toBeNull();
+    });
+
+    it('minRealOrderLegacyId returns null without opening a pool when unwired', async () => {
+        delete process.env.SHOPIFY_READ_DATABASE_URL;
+        expect(await freshClient().minRealOrderLegacyId()).toBeNull();
+        expect(poolCtor).not.toHaveBeenCalled();
     });
 });
 

--- a/checkin-app/src/lib/shopifyRead/client.ts
+++ b/checkin-app/src/lib/shopifyRead/client.ts
@@ -267,6 +267,8 @@ export interface MirrorAuditOrder {
     totalCents: number;
     totalRefundedCents: number;
     cancelledAt: Date | null;
+    /** Order-level coupon codes (shop_order.discount_codes text[] @default([]), #1048). */
+    discountCodes: string[];
     /** Which of the requested variant ids this order's lines matched. */
     matchedVariantIds: string[];
 }
@@ -283,6 +285,7 @@ export async function ordersForVariants(variantIds: string[]): Promise<MirrorAud
         `SELECT legacy_id AS "legacyId", name, customer_email AS "customerEmail",
                 financial_status AS "financialStatus", total_cents AS "totalCents",
                 total_refunded_cents AS "totalRefundedCents",
+                discount_codes AS "discountCodes",
                 cancelled_at AT TIME ZONE 'UTC' AS "cancelledAt",
                 (SELECT array_agg(DISTINCT l.variant_legacy_id)
                    FROM shop_order_line l
@@ -331,4 +334,23 @@ export async function disputedOrderGids(orderGids: string[]): Promise<Set<string
         [orderGids],
     );
     return new Set(rows.rows.map((r) => r.orderGid));
+}
+
+/**
+ * The smallest real (non-test) order legacy id in the mirror — the mirror's low-water mark.
+ * An activation whose recorded order id sits BELOW this predates the mirror's coverage and is
+ * unverifiable-by-design, not a gap. Null when the mirror holds no non-test orders (or is
+ * unwired) → the caller then treats every not-in-mirror id as a real gap.
+ * legacy_id is numeric-in-text; the ::bigint cast orders them numerically, ::text hands JS a
+ * string to BigInt-parse without node-pg's numeric coercion.
+ * ponytail: assumes every legacy_id parses as bigint — true for Shopify order ids.
+ */
+export async function minRealOrderLegacyId(): Promise<bigint | null> {
+    const p = getPool();
+    if (!p) return null;
+    const rows = await p.query<{ minLegacyId: string | null }>(
+        `SELECT min(legacy_id::bigint)::text AS "minLegacyId" FROM shop_order WHERE test = false`,
+    );
+    const v = rows.rows[0]?.minLegacyId;
+    return v == null ? null : BigInt(v);
 }


### PR DESCRIPTION
Second, **independently decline-able** companion to #1082 (stacked on #1084; full rationale in the #1082 review comment, questions Q2-Q4/Q6). Everything here is read-only reporting — no exceptions raised, no schema, no migrations.

- **Free-program flood fixed before it happened**: the enrollment sweep now covers only payment-bearing programs — without this, every free-program participant (created ACTIVE by design) would have landed in NO_PAYMENT_BASIS on the first real run. Order-backed rows stay swept even if their program later dropped its variant.
- **ADMIN_COMPED**: comps identified from the AuditLog CREATE row (created-ACTIVE on a payment-bearing program = admin comp), listed as a manual class with who comped — same posture as MANUAL_CERTIFIED. A household-merge re-keys personId and degrades the inference to NO_PAYMENT_BASIS: safe direction (surfaces, never hides), noted in a ponytail comment; the honest upgrade is a compedById column if the board finds this insufficient.
- **ORDER_REVERSED** (informational): activations whose mirrored order is refunded/cancelled/voided — via the existing ordersByLegacyIds + newly-exported isReversed, zero new SQL, gated behind the test=false present set so a test order can't be a payment basis. Not counted as a gap: the reversal exceptions queue owns these.
- **PRE_MIRROR**: recorded order ids below the mirror's min real legacy_id (new one-row min() query) classify as informational history instead of ORDER_NOT_IN_MIRROR — kills the predictable first-run noise wave for pre-mirror activations.
- **NO_PROCESS**: ACTIVE OrgMemberships with no INITIAL/RENEWAL process at all (the legacy CSV-import path upserts these) now appear as gaps — previously they were invisible even to NO_PAYMENT_BASIS, despite being the likeliest real ACTIVE_WITHOUT_PAYMENT population.
- **Discount codes** on UNCLAIMED_PAID rows (already mirrored by #1048) — coupon eyeballing for the board without building the deferred DiscountCodeRule registry.

Deliberately NOT here: variant re-validation of matched orders, season-bounding (an old ACTIVE process IS current membership), any PaymentException raising (that's the separate track-button PR), pagination.

Verified: tsc clean (bare exit), eslint clean, all touched suites green (matchAudit 25, shopifyRead client 21, panel RTL 7, route 5, lifecycle guard 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe