### PR TITLE
fix(finance-ops): restrict all tabs to board members only (#1083)

### DIFF
--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -40,6 +40,7 @@ describe('Program payment-plan routes', () => {
     let programId: number;
     let mentorId: number;
     let boardId: number;
+    let board2Id: number;
     let boardKinId: number;
     let selfId: number;
     let otherId: number;
@@ -64,6 +65,15 @@ describe('Program payment-plan routes', () => {
         });
         boardId = board.id;
         householdIds.push(board.householdId);
+
+        // A second board member in a DIFFERENT household — the non-conflicted
+        // approver, and (since #1083 gated sysadmins out of finance-ops) the
+        // remedy when the first board member has a household conflict.
+        const board2 = await prisma.person.create({
+            data: { name: 'PP Board Two', email: `board2-${TAG}@example.com`, isBoardMember: true, household: { create: { name: "Test HH2" } } },
+        });
+        board2Id = board2.id;
+        householdIds.push(board2.householdId);
 
         // A household-mate of the board member — the conflict-of-interest target.
         const boardKin = await prisma.person.create({
@@ -105,7 +115,7 @@ describe('Program payment-plan routes', () => {
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.program.delete({ where: { id: programId } });
         await prisma.person.deleteMany({
-            where: { id: { in: [mentorId, boardId, boardKinId, selfId, otherId, noiseId, memberId] } },
+            where: { id: { in: [mentorId, boardId, board2Id, boardKinId, selfId, otherId, noiseId, memberId] } },
         });
         await prisma.orgMembership.deleteMany({ where: { householdId: { in: householdIds } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
@@ -319,7 +329,7 @@ describe('Program payment-plan routes', () => {
             expect(row?.wasOrgMemberAtApproval).toBe(false);
         });
 
-        it("refuses to approve a plan for the board member's OWN household (conflict of interest); sysadmin overrides", async () => {
+        it("refuses to approve a plan for the board member's OWN household (conflict of interest); another board member is the remedy", async () => {
             await enroll(boardKinId, { requested: true });
             mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
             const res = await PlansPost(nextReq('http://localhost', {
@@ -332,8 +342,21 @@ describe('Program payment-plan routes', () => {
             });
             expect(row?.status).toBe('PENDING'); // unchanged — nothing approved
 
-            // Sysadmin is the deliberate remedy.
+            // Sysadmins are gated out of finance-ops entirely (#1083), so they are
+            // no longer the COI remedy here — a non-conflicted board member is.
             mockSession.mockResolvedValue({ user: { id: boardId, isSysadmin: true } });
+            const denied = await PlansPost(nextReq('http://localhost', {
+                method: 'POST',
+                body: JSON.stringify({ programId, participantId: boardKinId }),
+            }));
+            expect(denied.status).toBe(403);
+            row = await prisma.programParticipant.findUnique({
+                where: { programId_personId: { programId, personId: boardKinId } },
+            });
+            expect(row?.status).toBe('PENDING'); // still unchanged
+
+            // A second board member, from a different household, has no conflict.
+            mockSession.mockResolvedValue({ user: { id: board2Id, isBoardMember: true } });
             const ok = await PlansPost(nextReq('http://localhost', {
                 method: 'POST',
                 body: JSON.stringify({ programId, participantId: boardKinId }),

--- a/checkin-app/src/app/api/finance-ops/membership-payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/membership-payment-plans/route.ts
@@ -24,7 +24,7 @@ export const GET = handler('GET /api/finance-ops/membership-payment-plans', asyn
 });
 
 export const POST = withAuth(
-    { roles: ['isSysadmin', 'isBoardMember'] },
+    { roles: ['isBoardMember'] },
     async (req, auth) => {
         try {
             const body = await req.json();

--- a/checkin-app/src/app/api/finance-ops/payment-plans/manual-hold/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/manual-hold/route.ts
@@ -20,7 +20,7 @@ import { apiError } from "@/lib/api-response";
 // confers no benefit on the applicant — it only records a seat the board already
 // removed, and the value-conferring approve step keeps its own CoI check.
 export const POST = withAuth(
-    { roles: ['isSysadmin', 'isBoardMember'] },
+    { roles: ['isBoardMember'] },
     async (req, auth) => {
         try {
             const body = await req.json();

--- a/checkin-app/src/app/api/finance-ops/payment-plans/refuse/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/refuse/route.ts
@@ -16,7 +16,7 @@ import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 // normal payment / grace-period expiry fires first (see
 // docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md).
 export const POST = withAuth(
-    { roles: ['isSysadmin', 'isBoardMember'] },
+    { roles: ['isBoardMember'] },
     async (req, auth) => {
         try {
             const body = await req.json();

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -50,7 +50,7 @@ export const GET = handler('GET /api/finance-ops/payment-plans', async ({ req })
 });
 
 export const POST = withAuth(
-    { roles: ['isSysadmin', 'isBoardMember'] },
+    { roles: ['isBoardMember'] },
     async (req, auth) => {
         try {
             const body = await req.json();

--- a/checkin-app/src/app/api/finance-ops/payments/[id]/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payments/[id]/route.ts
@@ -13,7 +13,7 @@ import { apiError } from "@/lib/api-response";
  * audit-logged since the actor is not the affected household.
  */
 export const PATCH = withAuth<{ params: Promise<{ id: string }> }>(
-    { roles: ['isSysadmin', 'isBoardMember'] },
+    { roles: ['isBoardMember'] },
     async (request: NextRequest, auth, { params }) => {
         if (auth.type !== 'session') {
             return apiError("Unauthorized", 401);

--- a/checkin-app/src/app/api/finance-ops/payments/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payments/route.ts
@@ -14,7 +14,7 @@ import { ordersByLegacyIds, type MirrorOrder } from "@/lib/shopifyRead/client";
  * yields no live block — the row still lists. See lib/shopifyRead/client.ts.
  */
 export const GET = withAuth(
-    { roles: ['isSysadmin', 'isBoardMember'] },
+    { roles: ['isBoardMember'] },
     async () => {
         const exceptions = await prisma.paymentException.findMany({
             where: { status: { in: ['OPEN', 'ACKNOWLEDGED'] } },

--- a/checkin-app/src/app/api/finance-ops/s-read/diagnose/route.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/diagnose/route.ts
@@ -93,7 +93,7 @@ function classifyMirrorError(err: unknown, dbName: string): { detail: string; co
 const skipped = (id: string): DiagStep => ({ id, ok: null, detail: "Skipped — an earlier step already failed." });
 
 export const GET = withAuth(
-    { roles: ['isSysadmin', 'isBoardMember'] },
+    { roles: ['isBoardMember'] },
     async (_req, auth) => {
         if (auth.type !== 'session') {
             return apiError("Unauthorized", 401);

--- a/checkin-app/src/app/api/finance-ops/s-read/sync/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/sync/__tests__/route.test.ts
@@ -74,6 +74,13 @@ describe('POST /api/finance-ops/s-read/sync', () => {
         expect(sendMock).not.toHaveBeenCalled();
     });
 
+    it('403 for a sysadmin — finance-ops is board-only (issue #1083)', async () => {
+        mockSession.mockResolvedValue({ user: { id: 5, isSysadmin: true, isBoardMember: false } });
+        const res = await POST(req());
+        expect(res.status).toBe(403);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
     it('invokes the configured trigger with a hardcoded incremental mode for a board member', async () => {
         mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
         const res = await POST(req());

--- a/checkin-app/src/app/api/finance-ops/s-read/sync/route.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/sync/route.ts
@@ -39,7 +39,7 @@ import { isConfigured, latestSyncRun } from "@/lib/shopifyRead/client";
  * GET on the same path reports the latest run's status — see below.
  */
 export const POST = withAuth(
-    { roles: ['isSysadmin', 'isBoardMember'] },
+    { roles: ['isBoardMember'] },
     async (_req, auth) => {
         if (auth.type !== 'session') {
             return apiError("Unauthorized", 401);
@@ -92,7 +92,7 @@ export const POST = withAuth(
  * value it does not recognise (s-read owns that enum and may extend it).
  */
 export const GET = withAuth(
-    { roles: ['isSysadmin', 'isBoardMember'] },
+    { roles: ['isBoardMember'] },
     async (_req, auth) => {
         if (auth.type !== 'session') {
             return apiError("Unauthorized", 401);

--- a/checkin-app/src/app/finance-ops/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/finance-ops/__tests__/layout.test.tsx
@@ -69,6 +69,15 @@ describe("FinanceOpsLayout role gate", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
+  it("redirects a sysadmin (finance-ops is board-only, issue #1083)", () => {
+    renderLayout("/finance-ops/payment-plan", {
+      data: { user: { id: 3, isSysadmin: true, isBoardMember: false } },
+      status: "authenticated",
+    });
+    expect(screen.queryByText(CHILD)).not.toBeInTheDocument();
+    expect(push).toHaveBeenCalledWith("/");
+  });
+
   it("redirects an authenticated user with none of the allowed roles", () => {
     renderLayout("/finance-ops/payment-plan", {
       data: { user: { id: 2 } },

--- a/checkin-app/src/app/finance-ops/layout.tsx
+++ b/checkin-app/src/app/finance-ops/layout.tsx
@@ -10,7 +10,7 @@ import { tabBadgeFor } from "@/components/navBadges";
 import { CountBadge } from "@/components/ui/CountBadge";
 
 export default function FinanceOpsLayout({ children }: { children: React.ReactNode }) {
-  const { loading, ready } = useRequireRole(["isSysadmin", "isBoardMember"]);
+  const { loading, ready } = useRequireRole(["isBoardMember"]);
   const counts = useTodoCounts(true);
 
   if (loading) {

--- a/checkin-app/src/app/finance-ops/payment-plan/__tests__/page.test.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/__tests__/page.test.tsx
@@ -22,7 +22,7 @@ const requests = [
 
 describe("finance-ops/payment-plan page", () => {
   it("loads and renders pending payment plan requests", async () => {
-    setSession({ id: 1, isSysadmin: true });
+    setSession({ id: 1, isBoardMember: true });
     mockFetchJson({ "/api/finance-ops/payment-plans": { ProgramParticipant: requests, BoardSettings: null } });
     renderWithProviders(<PendingParticipantsPage />);
 
@@ -33,7 +33,7 @@ describe("finance-ops/payment-plan page", () => {
   });
 
   it("approves a request and removes it from the list", async () => {
-    setSession({ id: 1, isSysadmin: true });
+    setSession({ id: 1, isBoardMember: true });
     const fetchMock = mockFetchJson({
       "/api/finance-ops/payment-plans": () => ({ ProgramParticipant: requests, BoardSettings: null }),
     });

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -139,7 +139,8 @@ const NAV_ITEMS: NavItem[] = [
     href: '/finance-ops',
     label: 'Finance Ops',
     icon: <IconCoin size={18} />,
-    visible: (u) => !!u?.isSysadmin || !!u?.isBoardMember,
+    // Finance Ops is board-only — sysadmin has no access (issue #1083).
+    visible: (u) => !!u?.isBoardMember,
   },
   {
     href: '/system-status',

--- a/checkin-app/src/components/__tests__/AppFrame.test.tsx
+++ b/checkin-app/src/components/__tests__/AppFrame.test.tsx
@@ -59,9 +59,17 @@ describe("AppFrame", () => {
     expect(screen.getByText("Membership Ops")).toBeInTheDocument();
     expect(screen.getByText("Membership Audit")).toBeInTheDocument();
     expect(screen.getByText("Program Ops")).toBeInTheDocument();
-    expect(screen.getByText("Finance Ops")).toBeInTheDocument();
+    // Finance Ops is board-only — a sysadmin does NOT see it (issue #1083).
+    expect(screen.queryByText("Finance Ops")).not.toBeInTheDocument();
     expect(screen.getByText("System Status")).toBeInTheDocument();
     expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("shows Finance Ops to a board member (board-only, issue #1083)", () => {
+    setSession({ id: 1, isBoardMember: true });
+    renderFrame();
+
+    expect(screen.getByText("Finance Ops")).toBeInTheDocument();
   });
 
   it("shows Shop Ops for a certifier without admin flags, and My Programs when leading a program", () => {

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -28,6 +28,8 @@ const HOUSEHOLD_LEAD: Visible = (u, signedIn) => signedIn && !!u?.householdLead;
 // Program lead mentors only — mirrors the staff "My Programs" nav gate.
 const LEADS_PROGRAM: Visible = (_u, signedIn, counts) => signedIn && leadsAnyProgram(counts);
 const BOARD: Visible = (u) => !!u?.isSysadmin || !!u?.isBoardMember;
+// Finance Ops is board-only — sysadmin has no access (issue #1083).
+const BOARD_ONLY: Visible = (u) => !!u?.isBoardMember;
 const SYSADMIN: Visible = (u) => !!u?.isSysadmin;
 const SAFETY: Visible = (u) => !!u?.isSysadmin || !!u?.isBoardMember || !!u?.isKeyholder;
 const SHOP: Visible = (u) =>
@@ -119,11 +121,11 @@ export const PAGES: PageEntry[] = [
   { href: '/program-ops/sessions/new', label: 'New Session', section: 'Program Ops', visible: BOARD },
 
   // Finance Ops — board
-  { href: '/finance-ops', label: 'Finance Ops', section: 'Finance Ops', visible: BOARD },
-  { href: '/finance-ops/payment-plan', label: 'Program Payment Plan', section: 'Finance Ops', visible: BOARD },
-  { href: '/finance-ops/membership-payment-plan', label: 'Membership Payment Plan', section: 'Finance Ops', visible: BOARD },
-  { href: '/finance-ops/shopify-holds', label: 'Shopify Hold Reconciliation', section: 'Finance Ops', keywords: 'seat hold failed inventory scholarship manual reconcile shopify', visible: BOARD },
-  { href: '/finance-ops/payments', label: 'Payment problems', section: 'Finance Ops', keywords: 'reconcile exception refund chargeback unmatched shopify', visible: BOARD },
+  { href: '/finance-ops', label: 'Finance Ops', section: 'Finance Ops', visible: BOARD_ONLY },
+  { href: '/finance-ops/payment-plan', label: 'Program Payment Plan', section: 'Finance Ops', visible: BOARD_ONLY },
+  { href: '/finance-ops/membership-payment-plan', label: 'Membership Payment Plan', section: 'Finance Ops', visible: BOARD_ONLY },
+  { href: '/finance-ops/shopify-holds', label: 'Shopify Hold Reconciliation', section: 'Finance Ops', keywords: 'seat hold failed inventory scholarship manual reconcile shopify', visible: BOARD_ONLY },
+  { href: '/finance-ops/payments', label: 'Payment problems', section: 'Finance Ops', keywords: 'reconcile exception refund chargeback unmatched shopify', visible: BOARD_ONLY },
 
   // System Status — board
   { href: '/system-status', label: 'System Status', section: 'System Status', visible: BOARD },


### PR DESCRIPTION
Closes #1083.

## What
Finance Ops was reachable by sysadmins as well as board members. This makes every finance-ops tab and its APIs **board-only** — sysadmins no longer have access.

## Changes
- **Access gates (real enforcement)**
  - `finance-ops/layout.tsx` → `useRequireRole(["isBoardMember"])`
  - 9 finance-ops API route gates → `roles: ['isBoardMember']` (payments, payments/[id], membership-payment-plans, payment-plans, manual-hold, refuse, s-read/diagnose, s-read/sync ×2)
- **Nav / discovery (hide dead links from sysadmins)**
  - `AppFrame.tsx` Finance Ops nav → `visible: (u) => !!u?.isBoardMember`
  - `pageRegistry.ts` → new `BOARD_ONLY` predicate on the 5 finance-ops entries
- **Tests locking intent**
  - layout: sysadmin redirected; board admitted
  - AppFrame: sysadmin doesn't see Finance Ops; board does
  - sync route: sysadmin → 403

## Reviewer notes
The `isSysadmin` conflict-of-interest params inside the payment-plan handlers (`certifyPaymentPlan`, `hasHouseholdConflict`) are intentionally left untouched. They run only *after* the board gate passes, so with sysadmins now gated out they are unreachable-but-harmless — no behavior change.

67 tests pass across the touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)