### PR TITLE
track button for #1082: human-per-row gap → PaymentException promotion

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -79,6 +79,9 @@ const AUTHZ_TESTED = new Set<string>([
     // GET deny-path (401 anon / 403 non-board) in s-read/match-audit/__tests__/route.test.ts,
     // which also asserts a denied request never runs the audit.
     'finance-ops/s-read/match-audit',
+    // POST deny-path (401 anon / 403 non-board) in s-read/match-audit/track/__tests__/route.test.ts,
+    // which also asserts a denied request never raises a PaymentException.
+    'finance-ops/s-read/match-audit/track',
     'kioskdisplay/certifications',
     'membership-audit/compliance',
     // POST deny-path (403 non-board) in personBgManualSubmit.integration.test.ts.

--- a/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
+++ b/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
@@ -96,6 +96,8 @@ const ALLOWLIST: Record<string, string> = {
         'Board application list: archived (ARCHIVED) vs live (notIn ACTIVE,ARCHIVED).',
     'app/api/membership/renewal-status/route.ts': 'Member probe: this household’s RENEWAL at PENDING_RENEWAL.',
     'app/api/nav/todo-counts/route.ts': 'Dashboard counts: PENDING enrollments + member-actionable membership statuses.',
+    'app/api/finance-ops/s-read/match-audit/track/route.ts':
+        'Track-button staleness probes: claim re-check excluding ARCHIVED before promoting a gap — human-per-row, mirrors the matchAudit entry.',
     'lib/finance/matchAudit.ts':
         'Audit read queries: activation sweep (ACTIVE/PENDING_BG_CLEARANCE + ACTIVE participants) and the claim lookup excluding ARCHIVED — report-only, mirrors the reconcile.ts entry.',
     'lib/finance/reconcile.ts': 'Reconciler lookups: pending/active order-to-row matching on both models.',

--- a/checkin-app/src/app/api/finance-ops/s-read/match-audit/track/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/match-audit/track/__tests__/route.test.ts
@@ -1,0 +1,259 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for POST /api/finance-ops/s-read/match-audit/track — the deny paths
+ * (401 anon / 403 non-board through the REAL withAuth, asserting no exception is
+ * ever raised) and the per-kind re-validation: each kind re-derives its gap
+ * condition from raw Prisma columns / mirror presence, so a stale panel (a row
+ * already resolved since the audit ran) is rejected with 409, not tracked. The
+ * dedup behavior of raisePaymentException itself is reconcile.ts's tested
+ * concern — here we only assert the route forwards to it (or doesn't).
+ */
+import { POST } from '../route';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+const prismaMock = {
+    orgMembershipProcess: { findFirst: jest.fn(), findUnique: jest.fn() },
+    programParticipant: { findFirst: jest.fn(), findUnique: jest.fn() },
+};
+jest.mock('@/lib/prisma', () => ({
+    __esModule: true,
+    default: {
+        orgMembershipProcess: {
+            findFirst: (...a: unknown[]) => prismaMock.orgMembershipProcess.findFirst(...a),
+            findUnique: (...a: unknown[]) => prismaMock.orgMembershipProcess.findUnique(...a),
+        },
+        programParticipant: {
+            findFirst: (...a: unknown[]) => prismaMock.programParticipant.findFirst(...a),
+            findUnique: (...a: unknown[]) => prismaMock.programParticipant.findUnique(...a),
+        },
+    },
+}));
+
+const mirrorMock = {
+    isConfigured: jest.fn(),
+    ordersByLegacyIds: jest.fn(),
+    orderLegacyIdsPresent: jest.fn(),
+};
+jest.mock('@/lib/shopifyRead/client', () => ({
+    isConfigured: () => mirrorMock.isConfigured(),
+    ordersByLegacyIds: (...a: unknown[]) => mirrorMock.ordersByLegacyIds(...a),
+    orderLegacyIdsPresent: (...a: unknown[]) => mirrorMock.orderLegacyIdsPresent(...a),
+}));
+
+// Keep the real isPaid (a pure predicate the tests need correct), spy only on
+// raisePaymentException — the write path this route must never hit on a deny
+// or stale-row rejection.
+const raisePaymentExceptionMock = jest.fn();
+jest.mock('@/lib/finance/reconcile', () => ({
+    ...jest.requireActual('@/lib/finance/reconcile'),
+    raisePaymentException: (...a: unknown[]) => raisePaymentExceptionMock(...a),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockSession = require('next-auth/next').getServerSession;
+
+const req = (body: unknown) =>
+    new Request('http://localhost/api/finance-ops/s-read/match-audit/track', {
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+const asBoard = () => mockSession.mockResolvedValue({ user: { id: 5, isBoardMember: true } });
+
+const paidOrder = (legacyId: string, over: Partial<Record<string, unknown>> = {}) => ({
+    legacyId,
+    financialStatus: 'PAID',
+    cancelledAt: null,
+    totalRefundedCents: 0,
+    ...over,
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mirrorMock.isConfigured.mockReturnValue(true);
+    mirrorMock.ordersByLegacyIds.mockResolvedValue([]);
+    mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set());
+    prismaMock.orgMembershipProcess.findFirst.mockResolvedValue(null);
+    prismaMock.orgMembershipProcess.findUnique.mockResolvedValue(null);
+    prismaMock.programParticipant.findFirst.mockResolvedValue(null);
+    prismaMock.programParticipant.findUnique.mockResolvedValue(null);
+});
+
+it('401 when unauthenticated, without raising anything', async () => {
+    mockSession.mockResolvedValue(null);
+    const res = await POST(req({ kind: 'order', shopifyOrderId: '900' }));
+    expect(res.status).toBe(401);
+    expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    expect(prismaMock.orgMembershipProcess.findFirst).not.toHaveBeenCalled();
+});
+
+it('403 for a signed-in member without board or sysadmin role, without raising anything', async () => {
+    mockSession.mockResolvedValue({ user: { id: 5, isSysadmin: false, isBoardMember: false } });
+    const res = await POST(req({ kind: 'order', shopifyOrderId: '900' }));
+    expect(res.status).toBe(403);
+    expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+});
+
+it('503 when the mirror is unwired', async () => {
+    asBoard();
+    mirrorMock.isConfigured.mockReturnValue(false);
+    const res = await POST(req({ kind: 'order', shopifyOrderId: '900' }));
+    expect(res.status).toBe(503);
+    expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+});
+
+describe('bad body', () => {
+    beforeEach(asBoard);
+
+    it('400 when kind is missing or unrecognised', async () => {
+        expect((await POST(req({}))).status).toBe(400);
+        expect((await POST(req({ kind: 'bogus' }))).status).toBe(400);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('400 when a membership processId is not numeric', async () => {
+        const res = await POST(req({ kind: 'membership', processId: 'abc' }));
+        expect(res.status).toBe(400);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('kind: order', () => {
+    beforeEach(asBoard);
+
+    it('paid, unclaimed → 200 tracked, raises UNMATCHED_ORDER keyed by shopifyOrderId', async () => {
+        mirrorMock.ordersByLegacyIds.mockResolvedValue([paidOrder('900')]);
+        const res = await POST(req({ kind: 'order', shopifyOrderId: '900' }));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ tracked: true });
+        expect(raisePaymentExceptionMock).toHaveBeenCalledWith('UNMATCHED_ORDER', { shopifyOrderId: '900' });
+    });
+
+    it('409 when the order is no longer paid (refunded since the audit) — not raised', async () => {
+        mirrorMock.ordersByLegacyIds.mockResolvedValue([paidOrder('901', { financialStatus: 'REFUNDED', totalRefundedCents: 5000 })]);
+        const res = await POST(req({ kind: 'order', shopifyOrderId: '901' }));
+        expect(res.status).toBe(409);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('409 when a membership process has since claimed the order — not raised', async () => {
+        mirrorMock.ordersByLegacyIds.mockResolvedValue([paidOrder('902')]);
+        prismaMock.orgMembershipProcess.findFirst.mockResolvedValue({ id: 1 });
+        const res = await POST(req({ kind: 'order', shopifyOrderId: '902' }));
+        expect(res.status).toBe(409);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('409 when a program enrollment has since claimed the order — not raised', async () => {
+        mirrorMock.ordersByLegacyIds.mockResolvedValue([paidOrder('903')]);
+        prismaMock.programParticipant.findFirst.mockResolvedValue({ programId: 7 });
+        const res = await POST(req({ kind: 'order', shopifyOrderId: '903' }));
+        expect(res.status).toBe(409);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('409 when the order is not found in the mirror at all', async () => {
+        mirrorMock.ordersByLegacyIds.mockResolvedValue([]);
+        const res = await POST(req({ kind: 'order', shopifyOrderId: '904' }));
+        expect(res.status).toBe(409);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('idempotent repeat click: 200 both times, simply forwards to raisePaymentException each time', async () => {
+        mirrorMock.ordersByLegacyIds.mockResolvedValue([paidOrder('905')]);
+        const first = await POST(req({ kind: 'order', shopifyOrderId: '905' }));
+        const second = await POST(req({ kind: 'order', shopifyOrderId: '905' }));
+        expect(first.status).toBe(200);
+        expect(second.status).toBe(200);
+        expect(raisePaymentExceptionMock).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('kind: membership', () => {
+    beforeEach(asBoard);
+
+    it('active, no order, no certification → 200 tracked, raises ACTIVE_WITHOUT_PAYMENT keyed by processId', async () => {
+        prismaMock.orgMembershipProcess.findUnique.mockResolvedValue({
+            status: 'ACTIVE', kind: 'INITIAL', shopifyOrderId: null, certifiedById: null,
+        });
+        const res = await POST(req({ kind: 'membership', processId: 42 }));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ tracked: true });
+        expect(raisePaymentExceptionMock).toHaveBeenCalledWith('ACTIVE_WITHOUT_PAYMENT', { processId: 42 });
+    });
+
+    it('409 when since certified', async () => {
+        prismaMock.orgMembershipProcess.findUnique.mockResolvedValue({
+            status: 'ACTIVE', kind: 'INITIAL', shopifyOrderId: null, certifiedById: 7,
+        });
+        const res = await POST(req({ kind: 'membership', processId: 42 }));
+        expect(res.status).toBe(409);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('409 when the order is now present in the mirror', async () => {
+        prismaMock.orgMembershipProcess.findUnique.mockResolvedValue({
+            status: 'ACTIVE', kind: 'INITIAL', shopifyOrderId: '800', certifiedById: null,
+        });
+        mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set(['800']));
+        const res = await POST(req({ kind: 'membership', processId: 42 }));
+        expect(res.status).toBe(409);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('409 for a process outside the audit-swept status/kind population', async () => {
+        prismaMock.orgMembershipProcess.findUnique.mockResolvedValue({
+            status: 'PENDING_PAYMENT', kind: 'INITIAL', shopifyOrderId: null, certifiedById: null,
+        });
+        const res = await POST(req({ kind: 'membership', processId: 42 }));
+        expect(res.status).toBe(409);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('404 when the process no longer exists', async () => {
+        const res = await POST(req({ kind: 'membership', processId: 42 }));
+        expect(res.status).toBe(404);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('kind: enrollment', () => {
+    beforeEach(asBoard);
+
+    it('active, no order, no scholarship stamp → 200 tracked, raises ACTIVE_WITHOUT_PAYMENT keyed by (programId, personId)', async () => {
+        prismaMock.programParticipant.findUnique.mockResolvedValue({
+            status: 'ACTIVE', shopifyOrderId: null, wasOrgMemberAtApproval: null,
+        });
+        const res = await POST(req({ kind: 'enrollment', programId: 7, personId: 9 }));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ tracked: true });
+        expect(raisePaymentExceptionMock).toHaveBeenCalledWith('ACTIVE_WITHOUT_PAYMENT', { programId: 7, personId: 9 });
+    });
+
+    it('409 when since scholarship-approved', async () => {
+        prismaMock.programParticipant.findUnique.mockResolvedValue({
+            status: 'ACTIVE', shopifyOrderId: null, wasOrgMemberAtApproval: true,
+        });
+        const res = await POST(req({ kind: 'enrollment', programId: 7, personId: 9 }));
+        expect(res.status).toBe(409);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('409 when no longer ACTIVE', async () => {
+        prismaMock.programParticipant.findUnique.mockResolvedValue({
+            status: 'PENDING', shopifyOrderId: null, wasOrgMemberAtApproval: null,
+        });
+        const res = await POST(req({ kind: 'enrollment', programId: 7, personId: 9 }));
+        expect(res.status).toBe(409);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('404 when the enrollment no longer exists', async () => {
+        const res = await POST(req({ kind: 'enrollment', programId: 7, personId: 9 }));
+        expect(res.status).toBe(404);
+        expect(raisePaymentExceptionMock).not.toHaveBeenCalled();
+    });
+});

--- a/checkin-app/src/app/api/finance-ops/s-read/match-audit/track/route.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/match-audit/track/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import prisma from "@/lib/prisma";
+import * as mirror from "@/lib/shopifyRead/client";
+import { isPaid, raisePaymentException } from "@/lib/finance/reconcile";
+
+/**
+ * POST /api/finance-ops/s-read/match-audit/track — promote ONE match-audit gap
+ * row (MatchAuditPanel's "Track" button) to a tracked PaymentException. Human-
+ * per-row only: nothing here is auto-raised.
+ *
+ * Same board/sysadmin gate + mirror-503 shape as the sibling GET — the panel
+ * that surfaces these rows is itself mirror-gated (its GET 503s when unwired),
+ * so a track request only ever reaches here after a successful audit.
+ *
+ * The gap predicate is re-run server-side from the raw Prisma columns (status,
+ * kind, shopifyOrderId, certifiedById, wasOrgMemberAtApproval, mirror presence)
+ * — NEVER from a bucket enum value — so a stale panel (a row already
+ * activated/certified/refunded/scholarship-approved since the audit ran)
+ * cannot mint an exception. This keeps the route independent of whatever
+ * bucket set matchAudit.ts happens to have (see that file's P2 buckets):
+ * the only two gaps this route ever promotes are the ones that re-derive true
+ * below, regardless of bucket name.
+ */
+
+export type TrackBody =
+    | { kind: "order"; shopifyOrderId: string }
+    | { kind: "membership"; processId: number }
+    | { kind: "enrollment"; programId: number; personId: number };
+
+function parseTrackBody(raw: unknown): TrackBody | null {
+    if (!raw || typeof raw !== "object") return null;
+    const b = raw as Record<string, unknown>;
+    if (b.kind === "order") {
+        return typeof b.shopifyOrderId === "string" && b.shopifyOrderId
+            ? { kind: "order", shopifyOrderId: b.shopifyOrderId }
+            : null;
+    }
+    if (b.kind === "membership") {
+        const processId = parseInt(b.processId as string, 10);
+        return Number.isNaN(processId) ? null : { kind: "membership", processId };
+    }
+    if (b.kind === "enrollment") {
+        const programId = parseInt(b.programId as string, 10);
+        const personId = parseInt(b.personId as string, 10);
+        return Number.isNaN(programId) || Number.isNaN(personId) ? null : { kind: "enrollment", programId, personId };
+    }
+    return null;
+}
+
+async function trackOrder(shopifyOrderId: string): Promise<NextResponse> {
+    // Staleness guards — the since-resolved cases for a paid-unclaimed order are:
+    // it got activated, or it got refunded/cancelled.
+    const [order] = await mirror.ordersByLegacyIds([shopifyOrderId]);
+    if (!order) return apiError("Order not found in the mirror", 409);
+    if (!isPaid(order)) return apiError("Order is no longer paid — refunded or cancelled since the audit", 409);
+    // Since-activated: a non-archived membership process or ANY enrollment now carries this order.
+    // ponytail: skip the variant re-check here — the panel only surfaces variant-matched
+    // orders and the caller is board-gated, so re-deriving the whole membership+program
+    // variant set per click (a second sweep) buys only defense against a forged id, not
+    // against the real "since-resolved" cases (activated / refunded), which the checks
+    // here cover. Add the variant intersection if a non-board surface ever calls this.
+    const claimedProc = await prisma.orgMembershipProcess.findFirst({
+        where: { shopifyOrderId, status: { not: "ARCHIVED" } },
+        select: { id: true },
+    });
+    const claimedEnroll = await prisma.programParticipant.findFirst({
+        where: { shopifyOrderId },
+        select: { programId: true },
+    });
+    if (claimedProc || claimedEnroll) return apiError("Order has since been claimed by an activation", 409);
+    await raisePaymentException("UNMATCHED_ORDER", { shopifyOrderId });
+    return NextResponse.json({ tracked: true });
+}
+
+async function trackMembership(processId: number): Promise<NextResponse> {
+    const p = await prisma.orgMembershipProcess.findUnique({
+        where: { id: processId },
+        select: { status: true, kind: true, shopifyOrderId: true, certifiedById: true },
+    });
+    if (!p) return apiError("Membership process not found", 404);
+    // Only the population the audit sweeps: ACTIVE/PENDING_BG_CLEARANCE, INITIAL/RENEWAL.
+    const swept = (p.status === "ACTIVE" || p.status === "PENDING_BG_CLEARANCE") && (p.kind === "INITIAL" || p.kind === "RENEWAL");
+    if (!swept) return apiError("Not an active membership activation", 409);
+    const gap = p.shopifyOrderId
+        ? !(await mirror.orderLegacyIdsPresent([p.shopifyOrderId])).has(p.shopifyOrderId) // ORDER_NOT_IN_MIRROR
+        : p.certifiedById == null; // NO_PAYMENT_BASIS (certified => MANUAL, not a gap)
+    if (!gap) return apiError("Membership is no longer a gap (matched or certified since the audit)", 409);
+    // ponytail: for the null-order kinds the @@unique(kind, shopifyOrderId) index does
+    // NOT dedup (NULLs are distinct — no NULLS NOT DISTINCT), so two *concurrent*
+    // clicks on the same row could create two ACTIVE_WITHOUT_PAYMENT rows.
+    // raisePaymentException's app-level findFirst guards the real case (sequential
+    // human clicks). Ceiling: a partial unique index with NULLS NOT DISTINCT would
+    // close the race — deferred, it needs a migration and P3 ships none.
+    await raisePaymentException("ACTIVE_WITHOUT_PAYMENT", { processId });
+    return NextResponse.json({ tracked: true });
+}
+
+async function trackEnrollment(programId: number, personId: number): Promise<NextResponse> {
+    const e = await prisma.programParticipant.findUnique({
+        where: { programId_personId: { programId, personId } }, // @@id([programId, personId]) — schema.prisma
+        select: { status: true, shopifyOrderId: true, wasOrgMemberAtApproval: true },
+    });
+    if (!e) return apiError("Enrollment not found", 404);
+    if (e.status !== "ACTIVE") return apiError("Not an active enrollment", 409); // audit sweeps status ACTIVE only
+    const gap = e.shopifyOrderId
+        ? !(await mirror.orderLegacyIdsPresent([e.shopifyOrderId])).has(e.shopifyOrderId) // ORDER_NOT_IN_MIRROR
+        : e.wasOrgMemberAtApproval == null; // NO_PAYMENT_BASIS (scholarship => not a gap)
+    if (!gap) return apiError("Enrollment is no longer a gap (matched or scholarship-approved since the audit)", 409);
+    // ponytail: for the null-order kinds the @@unique(kind, shopifyOrderId) index does
+    // NOT dedup (NULLs are distinct — no NULLS NOT DISTINCT), so two *concurrent*
+    // clicks on the same row could create two ACTIVE_WITHOUT_PAYMENT rows.
+    // raisePaymentException's app-level findFirst guards the real case (sequential
+    // human clicks). Ceiling: a partial unique index with NULLS NOT DISTINCT would
+    // close the race — deferred, it needs a migration and P3 ships none.
+    await raisePaymentException("ACTIVE_WITHOUT_PAYMENT", { programId, personId });
+    return NextResponse.json({ tracked: true });
+}
+
+export const POST = withAuth(
+    { roles: ["isSysadmin", "isBoardMember"] },
+    async (req: NextRequest, auth) => {
+        if (auth.type !== "session") {
+            return apiError("Unauthorized", 401);
+        }
+        if (!mirror.isConfigured()) {
+            return apiError("The Shopify mirror is not wired in this environment", 503);
+        }
+
+        let raw: unknown;
+        try {
+            raw = await req.json();
+        } catch {
+            return apiError("Invalid JSON", 400);
+        }
+        const body = parseTrackBody(raw);
+        if (!body) return apiError("Invalid track request body", 400);
+
+        try {
+            if (body.kind === "order") return await trackOrder(body.shopifyOrderId);
+            if (body.kind === "membership") return await trackMembership(body.processId);
+            return await trackEnrollment(body.programId, body.personId);
+        } catch (error) {
+            logger.error("Failed to track match-audit gap:", error);
+            return apiError("Failed to track the gap", 500);
+        }
+    },
+);

--- a/checkin-app/src/components/admin/MatchAuditPanel.tsx
+++ b/checkin-app/src/components/admin/MatchAuditPanel.tsx
@@ -2,11 +2,13 @@
 
 import { useMemo, useState } from "react";
 import { Alert, Badge, Button, Card, Group, Table, Text, Title } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
 import { formatCents } from "@inventory/money";
-// Type-only import: erased at compile time, so the server module's prisma
+// Type-only imports: erased at compile time, so the server modules' prisma
 // imports never reach the client bundle — and a server-side reshape is a
 // compile error here instead of a silent drift.
 import type { MatchAuditResult } from "@/lib/finance/matchAudit";
+import type { TrackBody } from "@/app/api/finance-ops/s-read/match-audit/track/route";
 
 /**
  * Board-facing Shopify ↔ activation match audit (lib/finance/matchAudit.ts via
@@ -25,6 +27,38 @@ export function MatchAuditPanel() {
   const [result, setResult] = useState<MatchAuditResult | null>(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [tracking, setTracking] = useState<Set<string>>(new Set());
+
+  // Optimistic local bucket flip → TRACKED_EXCEPTION. Deliberately NOT a re-run of
+  // the audit: a re-run re-sweeps the whole mirror and wakes the scale-to-zero
+  // cluster (infra#129) for what is a one-row state change. The next real "Run
+  // match audit" reconciles from the DB (matchAudit.ts's tracked lookup) anyway.
+  const track = async (key: string, body: TrackBody) => {
+    setTracking((s) => new Set(s).add(key));
+    try {
+      const res = await fetch('/api/finance-ops/s-read/match-audit/track', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        notifications.show({ color: 'red', autoClose: false, message: data.error || 'Failed to track this gap.' });
+        return;
+      }
+      // Flip the matching row's bucket in-place; the memo re-buckets it out of the
+      // gap table and into the tracked count.
+      setResult((prev) => prev && {
+        ...prev,
+        orders: prev.orders.map((o) => body.kind === 'order' && o.orderLegacyId === body.shopifyOrderId ? { ...o, bucket: 'TRACKED_EXCEPTION' as const } : o),
+        memberships: prev.memberships.map((m) => body.kind === 'membership' && m.processId === body.processId ? { ...m, bucket: 'TRACKED_EXCEPTION' as const } : m),
+        enrollments: prev.enrollments.map((e) => body.kind === 'enrollment' && e.programId === body.programId && e.personId === body.personId ? { ...e, bucket: 'TRACKED_EXCEPTION' as const } : e),
+      });
+      notifications.show({ color: 'green', message: 'Gap tracked as a payment problem.' });
+    } catch {
+      notifications.show({ color: 'red', autoClose: false, message: 'Network error tracking this gap.' });
+    } finally {
+      setTracking((s) => { const n = new Set(s); n.delete(key); return n; });
+    }
+  };
 
   const run = async () => {
     setRunning(true);
@@ -72,6 +106,7 @@ export function MatchAuditPanel() {
       else if (m.bucket === 'MANUAL_CERTIFIED') groups.manual.push(m);
       else if (m.bucket === 'ORDER_REVERSED') groups.reversedMemberships.push(m);
       else if (m.bucket === 'PRE_MIRROR') preMirrorCount++;
+      else if (m.bucket === 'TRACKED_EXCEPTION') matchedCounts.tracked++;
       else matchedCounts.memberships++; // ORDER_MATCHED
     }
     for (const e of result?.enrollments ?? []) {
@@ -80,6 +115,7 @@ export function MatchAuditPanel() {
       else if (e.bucket === 'ADMIN_COMPED') groups.comped.push(e);
       else if (e.bucket === 'ORDER_REVERSED') groups.reversedEnrollments.push(e);
       else if (e.bucket === 'PRE_MIRROR') preMirrorCount++;
+      else if (e.bucket === 'TRACKED_EXCEPTION') matchedCounts.tracked++;
       else matchedCounts.enrollments++; // ORDER_MATCHED
     }
     return { ...groups, preMirrorCount };
@@ -147,7 +183,7 @@ export function MatchAuditPanel() {
               <Table striped withTableBorder mt="xs">
                 <Table.Thead>
                   <Table.Tr>
-                    <Table.Th>Order</Table.Th><Table.Th>Email</Table.Th><Table.Th>Total</Table.Th><Table.Th>Expected</Table.Th><Table.Th>Codes</Table.Th>
+                    <Table.Th>Order</Table.Th><Table.Th>Email</Table.Th><Table.Th>Total</Table.Th><Table.Th>Expected</Table.Th><Table.Th>Codes</Table.Th><Table.Th>Action</Table.Th>
                   </Table.Tr>
                 </Table.Thead>
                 <Table.Tbody>
@@ -158,6 +194,14 @@ export function MatchAuditPanel() {
                       <Table.Td>{formatCents(o.totalCents)}</Table.Td>
                       <Table.Td>{o.expected.join(', ')}</Table.Td>
                       <Table.Td>{(o.discountCodes ?? []).join(', ')}</Table.Td>
+                      <Table.Td>
+                        <Button size="xs" variant="light"
+                          loading={tracking.has(o.orderLegacyId ?? '')}
+                          disabled={!o.orderLegacyId || tracking.has(o.orderLegacyId ?? '')}
+                          onClick={() => track(o.orderLegacyId!, { kind: 'order', shopifyOrderId: o.orderLegacyId! })}>
+                          Track
+                        </Button>
+                      </Table.Td>
                     </Table.Tr>
                   ))}
                 </Table.Tbody>
@@ -171,7 +215,7 @@ export function MatchAuditPanel() {
               <Table striped withTableBorder mt="xs">
                 <Table.Thead>
                   <Table.Tr>
-                    <Table.Th>What</Table.Th><Table.Th>Who</Table.Th><Table.Th>Problem</Table.Th>
+                    <Table.Th>What</Table.Th><Table.Th>Who</Table.Th><Table.Th>Problem</Table.Th><Table.Th>Action</Table.Th>
                   </Table.Tr>
                 </Table.Thead>
                 <Table.Tbody>
@@ -184,6 +228,18 @@ export function MatchAuditPanel() {
                         : m.bucket === 'NO_PROCESS' ? 'Active membership with no INITIAL/RENEWAL process'
                         : `Order ${m.shopifyOrderId} not in the mirror`
                       }</Table.Td>
+                      <Table.Td>
+                        {/* NO_PROCESS rows have no processId — no entity to key a PaymentException
+                            on, so no Track button (out of scope for this PR; see matchAudit.ts). */}
+                        {m.processId != null && (
+                          <Button size="xs" variant="light"
+                            loading={tracking.has(`m-${m.processId}`)}
+                            disabled={tracking.has(`m-${m.processId}`)}
+                            onClick={() => track(`m-${m.processId}`, { kind: 'membership', processId: m.processId! })}>
+                            Track
+                          </Button>
+                        )}
+                      </Table.Td>
                     </Table.Tr>
                   ))}
                   {enrollmentGaps.map((e) => (
@@ -191,6 +247,14 @@ export function MatchAuditPanel() {
                       <Table.Td>{e.programName}</Table.Td>
                       <Table.Td>{e.personName}</Table.Td>
                       <Table.Td>{e.bucket === 'NO_PAYMENT_BASIS' ? 'No order and no scholarship approval' : `Order ${e.shopifyOrderId} not in the mirror`}</Table.Td>
+                      <Table.Td>
+                        <Button size="xs" variant="light"
+                          loading={tracking.has(`e-${e.programId}-${e.personId}`)}
+                          disabled={tracking.has(`e-${e.programId}-${e.personId}`)}
+                          onClick={() => track(`e-${e.programId}-${e.personId}`, { kind: 'enrollment', programId: e.programId, personId: e.personId })}>
+                          Track
+                        </Button>
+                      </Table.Td>
                     </Table.Tr>
                   ))}
                 </Table.Tbody>

--- a/checkin-app/src/components/admin/__tests__/MatchAuditPanel.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/MatchAuditPanel.test.tsx
@@ -1,10 +1,11 @@
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
 import { MatchAuditPanel } from "../MatchAuditPanel";
 
 beforeEach(() => resetRtl());
 
 const AUDIT_URL = "/api/finance-ops/s-read/match-audit";
+const TRACK_URL = "/api/finance-ops/s-read/match-audit/track";
 
 describe("MatchAuditPanel", () => {
   it("does not run until clicked, then separates gaps from legitimate manual rows", async () => {
@@ -113,5 +114,75 @@ describe("MatchAuditPanel", () => {
     renderWithProviders(<MatchAuditPanel />);
     fireEvent.click(screen.getByRole("button", { name: /Run match audit/ }));
     expect(await screen.findByText(/failed to run/)).toBeInTheDocument();
+  });
+
+  it("renders a Track button on each gap row; clicking one posts to the track endpoint, drops the row from the gap table, and lowers the gap count", async () => {
+    // TRACK_URL registered first: it is a substring superset of AUDIT_URL, and
+    // mockFetchJson matches the first key found in the request URL.
+    const fetchMock = mockFetchJson({
+      [TRACK_URL]: { tracked: true },
+      [AUDIT_URL]: {
+        configured: true,
+        configuredVariants: 3,
+        variantCoverage: { lines: 6, withVariant: 6 },
+        orders: [
+          { bucket: "UNCLAIMED_PAID", orderLegacyId: "2", name: "#2", customerEmail: "b@x.com", financialStatus: "PAID", totalCents: 7500, discountCodes: [], expected: ["membership"] },
+        ],
+        memberships: [
+          { bucket: "NO_PAYMENT_BASIS", processId: 4, membershipId: null, householdName: "The Wrens", shopifyOrderId: null, certifiedByName: null },
+        ],
+        enrollments: [],
+      },
+    });
+    renderWithProviders(<MatchAuditPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /Run match audit/ }));
+    expect(await screen.findByText("2 gap(s)")).toBeInTheDocument();
+
+    const trackButtons = screen.getAllByRole("button", { name: "Track" });
+    expect(trackButtons).toHaveLength(2); // the order gap row + the membership gap row
+    fireEvent.click(trackButtons[0]); // the order row (#2)
+
+    expect(await screen.findByText("1 gap(s)")).toBeInTheDocument();
+    expect(screen.queryByText("#2")).not.toBeInTheDocument();
+
+    const trackCall = fetchMock.mock.calls.find(([url]) => url.toString().includes(TRACK_URL));
+    expect(trackCall).toBeDefined();
+    expect(trackCall![1]).toEqual(expect.objectContaining({ method: "POST" }));
+    expect(JSON.parse(trackCall![1]!.body as string)).toEqual({ kind: "order", shopifyOrderId: "2" });
+  });
+
+  it("keeps a gap row when the track request is rejected (stale row, 409)", async () => {
+    const auditResult = {
+      configured: true,
+      configuredVariants: 3,
+      variantCoverage: { lines: 6, withVariant: 6 },
+      orders: [
+        { bucket: "UNCLAIMED_PAID", orderLegacyId: "2", name: "#2", customerEmail: "b@x.com", financialStatus: "PAID", totalCents: 7500, discountCodes: [], expected: ["membership"] },
+      ],
+      memberships: [],
+      enrollments: [],
+    };
+    // Bespoke fetch stub (mockFetchJson always 200s a matched route): the audit GET
+    // succeeds, the track POST 409s — same shape as the "explains an unwired
+    // mirror" 503 test above.
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes(TRACK_URL)) {
+        return { ok: false, status: 409, json: async () => ({ error: "stale" }), text: async () => "" } as Response;
+      }
+      return { ok: true, status: 200, json: async () => auditResult, text: async () => "" } as Response;
+    }) as unknown as typeof fetch;
+
+    renderWithProviders(<MatchAuditPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /Run match audit/ }));
+    expect(await screen.findByText("#2")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Track" }));
+
+    // Row stays — RTL doesn't mount the Mantine notifications portal by default,
+    // so assert on the row surviving rather than the toast text.
+    await waitFor(() => expect((global.fetch as jest.Mock).mock.calls.length).toBe(2));
+    expect(screen.getByText("#2")).toBeInTheDocument();
+    expect(screen.getByText("1 gap(s)")).toBeInTheDocument();
   });
 });

--- a/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
@@ -386,3 +386,88 @@ describe('enrollment buckets', () => {
         });
     });
 });
+
+describe('tracked-exception override (P3 gap → exception promotion)', () => {
+    const proc = (id: number, over: Partial<Record<string, unknown>> = {}) => ({
+        id,
+        shopifyOrderId: null,
+        certifiedById: null,
+        orgMembership: { household: { name: `House ${id}` } },
+        ...over,
+    });
+    const enroll = (personId: number, over: Partial<Record<string, unknown>> = {}) => ({
+        programId: 7,
+        personId,
+        shopifyOrderId: null,
+        wasOrgMemberAtApproval: null,
+        program: { name: 'Robotics' },
+        person: { name: `Kid ${personId}` },
+        ...over,
+    });
+    // Distinguishes the three paymentException.findMany call sites (order-side
+    // trackedExceptions, membership tracked lookup, enrollment tracked lookup) by
+    // their where-clause shape, since all three share one jest.fn().
+    const isMembershipLookup = (where: Record<string, unknown>) => 'processId' in where;
+    const isEnrollmentLookup = (where: Record<string, unknown>) => 'programId' in where && !('shopifyOrderId' in where);
+
+    it('a NO_PAYMENT_BASIS membership with an open exception on its processId → TRACKED_EXCEPTION, not a gap', async () => {
+        prismaMock.orgMembershipProcess.findMany
+            .mockResolvedValueOnce([]) // claim lookup
+            .mockResolvedValueOnce([proc(1)]);
+        prismaMock.paymentException.findMany.mockImplementation(async ({ where }: { where: Record<string, unknown> }) =>
+            isMembershipLookup(where) ? [{ processId: 1 }] : [],
+        );
+        const r = await runMatchAudit();
+        expect(r.memberships[0].bucket).toBe('TRACKED_EXCEPTION');
+    });
+
+    it('a NO_PAYMENT_BASIS enrollment with an open exception on its (programId, personId) → TRACKED_EXCEPTION, not a gap', async () => {
+        prismaMock.programParticipant.findMany
+            .mockResolvedValueOnce([]) // claim lookup
+            .mockResolvedValueOnce([enroll(3)]);
+        prismaMock.paymentException.findMany.mockImplementation(async ({ where }: { where: Record<string, unknown> }) =>
+            isEnrollmentLookup(where) ? [{ programId: 7, personId: 3 }] : [],
+        );
+        const r = await runMatchAudit();
+        expect(r.enrollments[0].bucket).toBe('TRACKED_EXCEPTION');
+    });
+
+    it('the tracked lookups exclude RESOLVED exceptions by construction (a RESOLVED row must not flip the bucket)', async () => {
+        prismaMock.orgMembershipProcess.findMany
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([proc(1)]);
+        prismaMock.programParticipant.findMany
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([enroll(3)]);
+        await runMatchAudit();
+        const calls = prismaMock.paymentException.findMany.mock.calls as [{ where: Record<string, unknown> }][];
+        const membershipCall = calls.find(([{ where }]) => isMembershipLookup(where));
+        const enrollmentCall = calls.find(([{ where }]) => isEnrollmentLookup(where));
+        expect(membershipCall![0].where.status).toEqual({ not: 'RESOLVED' });
+        expect(enrollmentCall![0].where.status).toEqual({ not: 'RESOLVED' });
+    });
+
+    it('a stray open exception on a MANUAL_CERTIFIED row is not overridden — the override is gap-only', async () => {
+        prismaMock.orgMembershipProcess.findMany
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([proc(1, { certifiedById: 42 })]); // MANUAL_CERTIFIED, not a gap
+        prismaMock.person.findMany.mockResolvedValue([{ id: 42, name: 'Board Bob' }]);
+        prismaMock.paymentException.findMany.mockImplementation(async ({ where }: { where: Record<string, unknown> }) =>
+            isMembershipLookup(where) ? [{ processId: 1 }] : [],
+        );
+        const r = await runMatchAudit();
+        expect(r.memberships[0].bucket).toBe('MANUAL_CERTIFIED');
+    });
+
+    it('a stray open exception on an ORDER_MATCHED enrollment is not overridden — the override is gap-only', async () => {
+        prismaMock.programParticipant.findMany
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([enroll(3, { shopifyOrderId: '700' })]); // ORDER_MATCHED, not a gap
+        mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set(['700']));
+        prismaMock.paymentException.findMany.mockImplementation(async ({ where }: { where: Record<string, unknown> }) =>
+            isEnrollmentLookup(where) ? [{ programId: 7, personId: 3 }] : [],
+        );
+        const r = await runMatchAudit();
+        expect(r.enrollments[0].bucket).toBe('ORDER_MATCHED');
+    });
+});

--- a/checkin-app/src/lib/finance/matchAudit.ts
+++ b/checkin-app/src/lib/finance/matchAudit.ts
@@ -62,7 +62,10 @@ export type MembershipBucket =
     | "PRE_MIRROR"
     | "ORDER_REVERSED"
     | "NO_PROCESS"
-    | "NO_PAYMENT_BASIS";
+    | "NO_PAYMENT_BASIS"
+    // Not claimed, but an open/acknowledged PaymentException already tracks it
+    // (the Track button on the panel raises one) — parity with the order side.
+    | "TRACKED_EXCEPTION";
 
 export type EnrollmentBucket =
     | "ORDER_MATCHED"
@@ -71,7 +74,8 @@ export type EnrollmentBucket =
     | "ORDER_NOT_IN_MIRROR"
     | "PRE_MIRROR"
     | "ORDER_REVERSED"
-    | "NO_PAYMENT_BASIS";
+    | "NO_PAYMENT_BASIS"
+    | "TRACKED_EXCEPTION";
 
 export interface AuditMembershipRow {
     bucket: MembershipBucket;
@@ -354,19 +358,48 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
         ...enrolls.map((e) => e.shopifyOrderId),
     ].filter((v): v is string => !!v);
     const uniqueActivationIds = [...new Set(activationOrderIds)];
-    const [inMirror, mirrorOrders, minReal] = await Promise.all([
+
+    // Tracked-exception lookups for the two P3-trackable gap buckets
+    // (NO_PAYMENT_BASIS / ORDER_NOT_IN_MIRROR): batched IN-lists over the swept
+    // ids, run in the same round-trip as the mirror presence lookup below.
+    const procIds = procs.map((p) => p.id);
+    const enrollProgramIds = [...new Set(enrolls.map((e) => e.programId))];
+    const enrollPersonIds = [...new Set(enrolls.map((e) => e.personId))];
+    const [inMirror, mirrorOrders, minReal, trackedProcRows, trackedEnrollRows] = await Promise.all([
         mirror.orderLegacyIdsPresent(uniqueActivationIds), // test=false authoritative present set
         mirror.ordersByLegacyIds(uniqueActivationIds),      // full rows, for reversal state only
         mirror.minRealOrderLegacyId(),
+        procIds.length
+            ? prisma.paymentException.findMany({
+                  where: { status: { not: "RESOLVED" }, processId: { in: procIds } },
+                  select: { processId: true },
+              })
+            : Promise.resolve([]),
+        // Composite key: Prisma can't tuple-IN, so IN×IN over-fetches, then filter to
+        // exact (programId, personId) pairs via a Set — same over-approximate-then-filter
+        // shape the order side's trackedExceptions lookup uses, above.
+        enrollProgramIds.length && enrollPersonIds.length
+            ? prisma.paymentException.findMany({
+                  where: { status: { not: "RESOLVED" }, programId: { in: enrollProgramIds }, personId: { in: enrollPersonIds } },
+                  select: { programId: true, personId: true },
+              })
+            : Promise.resolve([]),
     ]);
+    // No `kind` filter — parity with the order-side tracked lookup, which keys purely
+    // on order + `status != RESOLVED`. Any open exception carrying this processId (or
+    // this programId:personId) means the board is already tracking this activation.
+    // It only ever overrides a row that is otherwise a gap (below), so a stray
+    // order-linked exception on an ORDER_MATCHED row can't hide it.
+    const trackedProcs = new Set(trackedProcRows.map((r) => r.processId));
+    const trackedEnrolls = new Set(trackedEnrollRows.map((r) => `${r.programId}:${r.personId}`));
     // Reversal is only meaningful for orders that ARE present (test=false gated by inMirror below),
     // so a test order that ordersByLegacyIds returns can never become a payment basis here.
     const reversedIds = new Set(mirrorOrders.filter((o) => o.legacyId && isReversed(o)).map((o) => o.legacyId!));
     // Recorded id below the mirror's low-water mark = pre-mirror history, informational not a gap.
     const isPreMirror = (id: string) => minReal != null && /^\d+$/.test(id) && BigInt(id) < minReal;
 
-    const membershipRows: AuditMembershipRow[] = procs.map((p) => ({
-        bucket: p.shopifyOrderId
+    const membershipRows: AuditMembershipRow[] = procs.map((p) => {
+        const raw: MembershipBucket = p.shopifyOrderId
             ? !inMirror.has(p.shopifyOrderId)
                 ? (isPreMirror(p.shopifyOrderId) ? "PRE_MIRROR" : "ORDER_NOT_IN_MIRROR")
                 : reversedIds.has(p.shopifyOrderId)
@@ -374,13 +407,22 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
                     : "ORDER_MATCHED"
             : p.certifiedById != null
                 ? "MANUAL_CERTIFIED"
-                : "NO_PAYMENT_BASIS",
-        processId: p.id,
-        membershipId: null,
-        householdName: p.orgMembership?.household?.name ?? null,
-        shopifyOrderId: p.shopifyOrderId,
-        certifiedByName: p.certifiedById != null ? (personName.get(p.certifiedById) ?? `person ${p.certifiedById}`) : null,
-    }));
+                : "NO_PAYMENT_BASIS";
+        // Override only the two trackable gaps — literal bucket names, so a P2
+        // bucket this PR doesn't know about is never touched (see file header).
+        const bucket: MembershipBucket =
+            (raw === "NO_PAYMENT_BASIS" || raw === "ORDER_NOT_IN_MIRROR") && trackedProcs.has(p.id)
+                ? "TRACKED_EXCEPTION"
+                : raw;
+        return {
+            bucket,
+            processId: p.id,
+            membershipId: null,
+            householdName: p.orgMembership?.household?.name ?? null,
+            shopifyOrderId: p.shopifyOrderId,
+            certifiedByName: p.certifiedById != null ? (personName.get(p.certifiedById) ?? `person ${p.certifiedById}`) : null,
+        };
+    });
 
     const noProcessRows: AuditMembershipRow[] = noProcessMemberships.map((m) => ({
         bucket: "NO_PROCESS",
@@ -391,8 +433,8 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
         certifiedByName: null,
     }));
 
-    const enrollmentRows: AuditEnrollmentRow[] = enrolls.map((e) => ({
-        bucket: e.shopifyOrderId
+    const enrollmentRows: AuditEnrollmentRow[] = enrolls.map((e) => {
+        const raw: EnrollmentBucket = e.shopifyOrderId
             ? !inMirror.has(e.shopifyOrderId)
                 ? (isPreMirror(e.shopifyOrderId) ? "PRE_MIRROR" : "ORDER_NOT_IN_MIRROR")
                 : reversedIds.has(e.shopifyOrderId)
@@ -402,14 +444,21 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
                 ? "SCHOLARSHIP_APPROVED"
                 : createdActive(e)
                     ? "ADMIN_COMPED"
-                    : "NO_PAYMENT_BASIS",
-        programId: e.programId,
-        programName: e.program.name,
-        personId: e.personId,
-        personName: e.person.name,
-        shopifyOrderId: e.shopifyOrderId,
-        compedByName: createdActive(e) ? (personName.get(compActorId(e)!) ?? null) : null,
-    }));
+                    : "NO_PAYMENT_BASIS";
+        const bucket: EnrollmentBucket =
+            (raw === "NO_PAYMENT_BASIS" || raw === "ORDER_NOT_IN_MIRROR") && trackedEnrolls.has(`${e.programId}:${e.personId}`)
+                ? "TRACKED_EXCEPTION"
+                : raw;
+        return {
+            bucket,
+            programId: e.programId,
+            programName: e.program.name,
+            personId: e.personId,
+            personName: e.person.name,
+            shopifyOrderId: e.shopifyOrderId,
+            compedByName: createdActive(e) ? (personName.get(compActorId(e)!) ?? null) : null,
+        };
+    });
 
     return {
         configured: true,


### PR DESCRIPTION
Third, **independently decline-able** companion to #1082 (stacked on #1085; #1082 review comment Q7). Deliberately built so declining it costs nothing — single purpose, no schema, no migration, no auto-raising.

- **POST `/api/finance-ops/s-read/match-audit/track`**: promotes ONE gap row, on a human click. Order gaps → `UNMATCHED_ORDER`; activation gaps → `ACTIVE_WITHOUT_PAYMENT` — both kinds already exist, with board-alert copy that has waited for a producer since the reconciler shipped.
- **Stale panels can't mint exceptions**: the gap predicate re-derives server-side from raw columns (never from a bucket name) — since-activated, since-certified, since-refunded, since-scholarship-approved all 409 with the reason.
- **Promoted gaps stop re-reporting**: the audit's activation sweeps gain entity-keyed tracked-awareness (open exceptions by processId / programId+personId → `TRACKED_EXCEPTION`), mirroring the order side. This also resolves the page contradiction — a tracked gap becomes a row in the exceptions table directly above the panel.
- **Dedup honesty**: order-keyed raises dedup on the `@@unique(kind, shopifyOrderId)` index; null-order raises rely on `raisePaymentException`'s app-level guard, and the NULLs-distinct concurrent-click ceiling is documented at both raise sites (closing it needs a partial unique index — a migration this PR deliberately does not ship).
- **Auth scaffolding**: real-`withAuth` deny tests (401/403 create nothing), `AUTHZ_TESTED` registry entry, 26 route tests + RTL click-to-track and 409-survival cases. Lifecycle-guard allowlist entry for the route's staleness probes (caught by the guard pre-push, working as designed).

Verified: tsc clean (bare exit), eslint clean, 90 tests green across matchAudit / panel / both routes / authzRegistry / lifecycle guard / shopifyRead client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe