### PR TITLE
test(lifecycle): sharpen status-literal scanner to flag only multi-status sets/combos (#1079)

### DIFF
--- a/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
+++ b/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
@@ -5,28 +5,43 @@ import { join, relative, sep } from 'node:path';
  * Status-literal allowlist drift guard (LIFECYCLE_ARCHITECTURE §5) — the lifecycle
  * analogue of EDGE_INCLUDE_ALLOWLIST / authzRegistry.test.ts.
  *
- * A raw `where: { status: <literal> }` on the ProgramParticipant or
- * OrgMembershipProcess models is a hand-encoded state-set that can silently drift
- * from the ONE definition in the machine module. This test scans src for every
- * such literal and asserts it appears ONLY in:
+ * A hand-encoded state-SET in a `where` on the ProgramParticipant or
+ * OrgMembershipProcess models can silently drift from the ONE definition in the
+ * machine module. This test scans src for every such set and asserts it appears
+ * ONLY in:
  *   - the definition modules (enrollmentState.ts, membership/lifecycle.ts,
  *     lib/lifecycle/*) — the single source of "what is legal"; or
- *   - the ALLOWLIST below: CAS transition-guard sites (which keep a literal `where`
- *     on purpose — they encode a *transition*, "from-state ∧ nothing-changed", not a
- *     state-set) plus a handful of read/query filters not yet migrated onto a
- *     StateSet.where.
+ *   - the ALLOWLIST below: sites that keep such a `where` on purpose — CAS
+ *     status+flag transition guards (from-state ∧ a lifecycle flag = a *transition*,
+ *     not a plain state-set) and a handful of multi-status read/query filters not
+ *     yet migrated onto a StateSet.where.
  *
- * A new raw `where: { status: … }` anywhere else fails CI, forcing the author to
- * either consume a StateSet or register here with a justification — exactly how a
- * new sensitive `include` must earn an EDGE_INCLUDE_ALLOWLIST entry.
+ * SHARPENED GRANULARITY (why this test only flags SETS, not lone literals):
+ *   The drift risk is a hand-listed *set of states* getting out of sync with the
+ *   machine. A single bare `status: 'ACTIVE'` read carries none of that risk — it is
+ *   pure indirection, trivially wrappable in a StateSet later with zero behavioural
+ *   change. Flagging every lone literal forced ~8 single-status reads into the
+ *   allowlist purely to absorb false-positives, burying the real signal. So a `where`
+ *   is flagged ONLY when its status clause is a genuine multi-status construct:
+ *     - a set filter: `status: { in: [...] }` or `status: { notIn: [...] }`, OR
+ *     - a `status: '<literal>'` appearing ALONGSIDE ≥1 lifecycle flag condition in the
+ *       same object (a status+flag CAS guard — from-state plus a flag it also sets).
+ *   A lone `status: 'X'` with no set and no flag is NOT flagged.
  *
- * The irreducibly-human call (is a new `where` a duplicate of a StateSet or a
+ * A new such construct anywhere else fails CI, forcing the author to either consume a
+ * StateSet or register here with a justification — exactly how a new sensitive
+ * `include` must earn an EDGE_INCLUDE_ALLOWLIST entry.
+ *
+ * The irreducibly-human call (is a new set a duplicate of a StateSet or a
  * legitimately-new transition guard?) is what the allowlist forces into review; a
  * person answers it. Everything above is machine-checked.
  *
  * Scope / precision (a deliberate, documented simplification):
  *   - Only `where:{…}` blocks are scanned — `data:`/`oldData:`/`newData:` writes and
  *     `p.status === '…'` comparisons are NOT state-set drift and are ignored.
+ *   - A set spelled with a canonical constant (`status: { in: [...IN_FLIGHT_RENEWAL] }`)
+ *     carries no bare literal, so it is INVISIBLE to this scanner by design — it already
+ *     consumes the one definition and cannot drift.
  *   - Distinctive OrgMembershipProcessStatus literals (INTAKE, PENDING_BG_REVIEW, …)
  *     are attributed unambiguously. The two SHARED literals `ACTIVE`/`PENDING` also
  *     appear in OrgMembershipStatus/RSVPStatus/etc, so they are counted only when a
@@ -54,6 +69,20 @@ const SHARED = new Set<string>(PP_LITERALS); // ACTIVE / PENDING — ambiguous a
 const OMP_DISTINCT = OMP_LITERALS.filter((l) => !SHARED.has(l));
 const ALL_LITERALS = [...new Set<string>([...PP_LITERALS, ...OMP_LITERALS])];
 
+// Lifecycle flag columns whose presence next to a bare status literal marks a
+// status+flag CAS guard (a *transition*, not a plain read). One list, checked as a
+// union — a flag "belongs" to a model only loosely, and a status+flag combo is a
+// transition regardless of which flag it pairs with.
+const LIFECYCLE_FLAGS = [
+    'inventoryHeldAt',
+    'paymentPlanDeniedAt',
+    'isPaymentPlanRequested', // ProgramParticipant
+    'contractSignedAt',
+    'bgConsentAt',
+    'bgClearedAt',
+    'paidAt', // OrgMembershipProcess
+] as const;
+
 // Always-allowed: the definition layer itself is where literals are supposed to live.
 function isDefinitionModule(rel: string): boolean {
     const p = rel.split(sep).join('/');
@@ -65,50 +94,48 @@ function isDefinitionModule(rel: string): boolean {
 }
 
 /**
- * Every non-definition source file that keeps a raw status `where` literal on one of
- * the two models, each with a justification. `T#` = the transition id from the state
- * machine docs. New entries need a real reason; a stale one (no literal left) also
- * fails, keeping the list honest.
+ * Every non-definition source file that keeps a genuine multi-status `where` construct
+ * (a set, or a status+flag CAS combo — see the sharpened match above) on one of the two
+ * models, each with a justification. `T#` = the transition id from the state machine
+ * docs. New entries need a real reason; a stale one (no such construct left) also fails,
+ * keeping the list honest.
+ *
+ * Note: lone single-status reads (a bare `status: 'ACTIVE'` filter) are NO LONGER flagged
+ * and therefore do NOT belong here — they are pure indirection with zero drift risk. This
+ * is why files like facility/trends, renewal-status, notifications, payment.ts, and
+ * orgMembership.ts (all single-status reads) are absent; likewise single-status CAS guards
+ * (activateEnrollment PENDING→ACTIVE, archive ARCHIVED→target) and sets spelled with a
+ * canonical constant (renewal's `{ in: [...IN_FLIGHT_RENEWAL] }`, which carries no bare
+ * literal and cannot drift).
  */
 const ALLOWLIST: Record<string, string> = {
-    // ── enrollment (ProgramParticipant) CAS transition guards ──
-    'lib/programs/activateEnrollment.ts': 'T4 activate CAS: where status=PENDING → ACTIVE (from-state guard).',
+    // ── enrollment (ProgramParticipant) status+flag CAS transition guards ──
     'app/api/programs/[id]/request-payment-plan/route.ts':
-        'T3/T3f apply CAS: where status=PENDING (+ held null / not-null) — encodes the apply transition.',
+        'T3/T3f apply CAS: where status=PENDING + inventoryHeldAt (null / not-null) — status+flag transition.',
     'app/api/finance-ops/payment-plans/route.ts': 'T5 approve CAS: where isPaymentPlanRequested,status=PENDING.',
     'app/api/finance-ops/payment-plans/refuse/route.ts': 'T6 deny CAS: where isPaymentPlanRequested,status=PENDING.',
     'app/api/finance-ops/payment-plans/manual-hold/route.ts':
         'T3m manual-hold CAS: where status=PENDING,inventoryHeldAt null,isPaymentPlanRequested.',
 
-    // ── membership (OrgMembershipProcess) CAS transition guards ──
+    // ── membership (OrgMembershipProcess) status+flag CAS guards / sets ──
     'app/api/finance-ops/membership-payment-plans/route.ts':
-        'Membership grant CAS + probe: where status=PENDING_PAYMENT (payable-renewal guard).',
-    'lib/membership/external.ts': 'advanceExternalIfComplete CAS (#7): where status=PENDING_EXTERNAL_ACTION.',
-    'lib/membership/renewal.ts': 'beginRenewal CAS (#4): where status=PENDING_RENEWAL → PENDING_EXTERNAL_ACTION.',
-    'lib/membership/archive.ts': 'unarchive CAS (#13): where status=ARCHIVED → restore target (idempotent).',
+        'Membership grant CAS: where status=PENDING_PAYMENT + isPaymentPlanRequested (payable-renewal guard).',
+    'lib/membership/external.ts':
+        'advanceExternalIfComplete CAS (#7): where status=PENDING_EXTERNAL_ACTION + contractSignedAt/bgClearedAt/bgConsentAt.',
     'lib/membership/personBgTriggers.ts':
-        'PERSON_BG create idempotency guard: where status in {PENDING_BG_REVIEW,BLOCKED}.',
+        'PERSON_BG create idempotency guard: where status in {PENDING_BG_REVIEW,BLOCKED} (set).',
 
     // ── invariant-driven reconciler (Phase 4) ──
     'lib/lifecycleDrift.ts':
         'I1 heal query: where status=ACTIVE,inventoryHeldAt not null — the off-diagram violation set itself (has no StateSet; it is precisely what validate() rejects).',
 
-    // ── read / query / probe filters (not yet migrated onto a StateSet.where) ──
-    'app/api/facility/trends/route.ts': 'Read query: count ACTIVE enrollments for the trends view.',
-    'app/api/membership-audit/compliance/route.ts': 'Read query: compliance count of PENDING_BG_CLEARANCE processes.',
+    // ── multi-status read / query filters (not yet migrated onto a StateSet.where) ──
     'app/api/membership-ops/applications/route.ts':
-        'Board application list: archived (ARCHIVED) vs live (notIn ACTIVE,ARCHIVED).',
-    'app/api/membership/renewal-status/route.ts': 'Member probe: this household’s RENEWAL at PENDING_RENEWAL.',
-    'app/api/nav/todo-counts/route.ts': 'Dashboard counts: PENDING enrollments + member-actionable membership statuses.',
-    'lib/finance/reconcile.ts': 'Reconciler lookups: pending/active order-to-row matching on both models.',
-    'lib/membership/notifications.ts': 'Read query: board BLOCKED-process count for the notifications badge.',
-    'lib/membership/payment.ts': 'Read query: this household’s PENDING_PAYMENT process before activate.',
-    'lib/membership/personBgSubmit.ts': 'Read query: the subject’s PERSON_BG process at PENDING_BG_REVIEW.',
-    'lib/orgMembership.ts': 'Read query: latest settled OrgMembershipProcess (status=ACTIVE) for the login horizon.',
-
-    // ── dev-only tooling ──
-    'app/api/dev/shopify/orders-paid/route.ts': 'Dev webhook simulator: finds PENDING enrollments to fake a paid order.',
-    'app/dev/shopify/page.tsx': 'Dev tool listing: PENDING enrollments + PENDING_PAYMENT processes.',
+        'Board application list: live view is a set — status notIn {ACTIVE,ARCHIVED}.',
+    'app/api/nav/todo-counts/route.ts':
+        'Dashboard counts: status+flag probes — {PENDING,isPaymentPlanRequested,inventoryHeldAt,paymentPlanDeniedAt} and {PENDING_PAYMENT,isPaymentPlanRequested}.',
+    'lib/finance/reconcile.ts':
+        'Reconciler paid-order set: where status in {ACTIVE,PENDING_BG_CLEARANCE} on OrgMembershipProcess.',
 };
 
 // ── scanner ──────────────────────────────────────────────────────────────────
@@ -126,8 +153,9 @@ function walk(dir: string, out: string[] = []): string[] {
 }
 
 /** Capture the object literal at/after `from`, skipping strings & comments so a
- *  brace inside them can't unbalance the scan. */
-function captureObject(s: string, from: number): string | null {
+ *  brace inside them can't unbalance the scan. Returns the text and the index just
+ *  past the closing brace (so a caller can look for a ternary else-branch). */
+function captureObject(s: string, from: number): { text: string; end: number } | null {
     let i = s.indexOf('{', from);
     if (i < 0) return null;
     const start = i;
@@ -157,10 +185,24 @@ function captureObject(s: string, from: number): string | null {
         if (c === '{') depth++;
         else if (c === '}') {
             depth--;
-            if (depth === 0) return s.slice(start, i + 1);
+            if (depth === 0) return { text: s.slice(start, i + 1), end: i + 1 };
         }
     }
     return null;
+}
+
+/** The full filter for a `where:` match, INCLUDING a ternary else-branch. For
+ *  `where: c ? { A } : { B }` we must see both branches — otherwise a set in the
+ *  else-branch (e.g. `{ status: { notIn: [...] } }`) is invisible and the true
+ *  multi-status filter goes unflagged. A `where` object is never followed by `:`,
+ *  so a `: {` immediately after the first object unambiguously marks the else-branch. */
+function captureWhere(s: string, from: number): string | null {
+    const first = captureObject(s, from);
+    if (!first) return null;
+    const m = /^\s*:\s*(?=\{)/.exec(s.slice(first.end));
+    if (!m) return first.text;
+    const second = captureObject(s, first.end + m[0].length);
+    return second ? `${first.text}\n${second.text}` : first.text;
 }
 
 // `where: {`  or  `where: cond ? {`  (a ternary whose first branch is the filter)
@@ -178,22 +220,32 @@ function scan(): Set<string> {
         WHERE_RE.lastIndex = 0;
         let wm: RegExpExecArray | null;
         while ((wm = WHERE_RE.exec(src))) {
-            const body = captureObject(src, wm.index);
+            const body = captureWhere(src, wm.index);
             if (!body) continue;
             const pre = src.slice(Math.max(0, wm.index - 240), wm.index);
             const isPP = /\bprogramParticipant\b/.test(pre);
             const isOMP = /\borgMembershipProcess\b/.test(pre);
+            // A lifecycle flag condition anywhere in this same `where` object turns a
+            // bare status literal into a status+flag CAS combo.
+            const bodyHasFlag = LIFECYCLE_FLAGS.some((f) => new RegExp(`\\b${f}\\b`).test(body));
             STATUS_VAL_RE.lastIndex = 0;
             let vm: RegExpExecArray | null;
             while ((vm = STATUS_VAL_RE.exec(body))) {
                 const expr = vm[1];
+                // A genuine multi-status SET: { in: [...] } / { notIn: [...] }. A bare
+                // literal, or a single { not: 'X' } exclusion, is not a set.
+                const isSet = expr[0] === '{' && /\b(?:in|notIn)\s*:/.test(expr);
                 for (const lit of ALL_LITERALS) {
                     if (!new RegExp(`['"]${lit}['"]`).test(expr)) continue;
                     const inScope =
                         (OMP_DISTINCT as readonly string[]).includes(lit) || // unambiguous OMP literal
                         (isPP && (PP_LITERALS as readonly string[]).includes(lit)) ||
                         (isOMP && (OMP_LITERALS as readonly string[]).includes(lit));
-                    if (inScope) hits.add(rel.split(sep).join('/'));
+                    if (!inScope) continue;
+                    // Sharpened: only a real state-SET, or a status literal sitting
+                    // alongside a lifecycle flag (a status+flag CAS combo), carries
+                    // drift risk. A lone bare status literal is pure indirection.
+                    if (isSet || bodyHasFlag) hits.add(rel.split(sep).join('/'));
                 }
             }
         }


### PR DESCRIPTION
## What

Sharpen the lifecycle **status-literal allowlist drift guard** (`lifecycleStatusLiteralAllowlist.test.ts`) so it flags only genuine multi-status state-sets, not every lone bare status literal. **Test-file-only** — no route/guard/machine/`fromWhere`/schema change.

## Why

The scanner flagged ANY `status: 'X'` literal in a `where` on `ProgramParticipant`/`OrgMembershipProcess`. A lone single-status read carries zero drift risk — it's pure indirection, trivially wrappable in a `StateSet` later. So ~8 single-status reads sat in the `ALLOWLIST` only to absorb scanner false-positives, burying the real signal (which is a hand-listed *set* of states drifting from the one machine definition).

## Sharpened match rule

A `where` is flagged ONLY when its status clause is a genuine multi-status construct:
- `status: { in: [...] }` or `status: { notIn: [...] }` (a set), OR
- `status: '<literal>'` alongside ≥1 lifecycle flag in the same object — union `{inventoryHeldAt, paymentPlanDeniedAt, isPaymentPlanRequested, contractSignedAt, bgConsentAt, bgClearedAt, paidAt}` (a status+flag CAS combo).

A lone bare `status: 'X'` (no set, no flag) is no longer flagged.

## Extra scanner fix — ternary else-branch

`captureObject` now returns its end index and a new `captureWhere` also scans the else-branch of `where: c ? {A} : {B}`. Without it, `membership-ops/applications`' real `notIn {ACTIVE,ARCHIVED}` set (in the else-branch) was invisible — the scanner only ever saw the first branch's bare `ARCHIVED`. Needed to keep that genuine set flagged.

## Allowlist changes

**Dropped (12)** — now unflagged:
- Single-status reads: `facility/trends`, `membership-audit/compliance`, `renewal-status`, `notifications`, `payment.ts`, `personBgSubmit.ts`, `orgMembership.ts`, both `dev/shopify` tools.
- Single-status CAS guards whose WHERE carries no set or flag: `activateEnrollment` (`PENDING→ACTIVE`), `archive` (`ARCHIVED→target`), and `renewal` (its sets use the `IN_FLIGHT_RENEWAL` constant — no bare literal, invisible to the scanner and already drift-proof). Only the *allowlist entries* were removed; no guard code touched.

**Kept (11):** the 4 PP status+flag CAS guards, `membership-payment-plans` + `external.ts` OMP guards, `personBgTriggers`/`applications`/`reconcile` sets, `nav/todo-counts` status+flag probes, `lifecycleDrift`. Refreshed the vague `todo-counts`/`reconcile` justifications to name their actual trigger.

## Verification

- Both assertions pass: `no unexpected` and `no stale allowlist entry`.
- Set-still-caught check: temporarily added `orgMembershipProcess.findMany({ where:{ status:{ in:['INTAKE','ACTIVE'] } } })` → flagged as unexpected; removed → green.

## Reviewer note

`#1080` is separately migrating CAS guards to a `fromWhere` emitter. Any merge conflict would land on this one test file and be trivial. The three CAS-guard entries dropped here become moot under that migration anyway.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #1079
