### PR TITLE
fix(lifecycle): emit fromWhere from TRANSITIONS so CAS guards stop re-hand-coding their from-state (#1080)

### DIFF
--- a/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
+++ b/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
@@ -109,21 +109,20 @@ function isDefinitionModule(rel: string): boolean {
  * literal and cannot drift).
  */
 const ALLOWLIST: Record<string, string> = {
-    // ── enrollment (ProgramParticipant) status+flag CAS transition guards ──
-    'app/api/programs/[id]/request-payment-plan/route.ts':
-        'T3/T3f apply CAS: where status=PENDING + inventoryHeldAt (null / not-null) — status+flag transition.',
-    'app/api/finance-ops/payment-plans/route.ts': 'T5 approve CAS: where isPaymentPlanRequested,status=PENDING.',
-    'app/api/finance-ops/payment-plans/refuse/route.ts': 'T6 deny CAS: where isPaymentPlanRequested,status=PENDING.',
-    'app/api/finance-ops/payment-plans/manual-hold/route.ts':
-        'T3m manual-hold CAS: where status=PENDING,inventoryHeldAt null,isPaymentPlanRequested.',
+    // ── CAS transition guards now source their from-state status from the definition (#1080) ──
+    // The enrollment guards (activateEnrollment, request-payment-plan, payment-plans
+    // approve/refuse/manual-hold) and the membership advanceExternal/beginRenewal/unarchive/
+    // membership-payment-plans guards spread `...fromWhere(<from>)` instead of a raw `status:`
+    // literal, so they carry NO bare status literal and no longer appear here — the guard↔table
+    // parity test (guardFromStateParity.test.ts) is what keeps them honest now. (renewal's
+    // beginRenewalForUser read is a LONE single-status literal, which the sharpened scanner no
+    // longer flags either, so it isn't listed.)
 
-    // ── membership (OrgMembershipProcess) status+flag CAS guards / sets ──
-    'app/api/finance-ops/membership-payment-plans/route.ts':
-        'Membership grant CAS: where status=PENDING_PAYMENT + isPaymentPlanRequested (payable-renewal guard).',
-    'lib/membership/external.ts':
-        'advanceExternalIfComplete CAS (#7): where status=PENDING_EXTERNAL_ACTION + contractSignedAt/bgClearedAt/bgConsentAt.',
+    // Not a transition from-state: the PERSON_BG edge is ∅→PENDING_BG_REVIEW (no from-row).
+    // An idempotency EXISTENCE SET (already open/blocked → skip), broader than any one
+    // from-state, so it stays a literal set rather than misrepresent it via fromWhere.
     'lib/membership/personBgTriggers.ts':
-        'PERSON_BG create idempotency guard: where status in {PENDING_BG_REVIEW,BLOCKED} (set).',
+        'PERSON_BG create idempotency existence set: where status in {PENDING_BG_REVIEW,BLOCKED}.',
 
     // ── invariant-driven reconciler (Phase 4) ──
     'lib/lifecycleDrift.ts':

--- a/checkin-app/src/app/api/finance-ops/membership-payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/membership-payment-plans/route.ts
@@ -5,12 +5,14 @@ import { withAuth } from "@/lib/auth";
 import { handler } from "@/security/handler";
 import { apiError } from "@/lib/api-response";
 import { certifyPaymentPlan, PaymentError } from "@/lib/membership/payment";
+import { fromWhere } from "@/lib/membership/lifecycle";
 
 export const GET = handler('GET /api/finance-ops/membership-payment-plans', async () => {
     const requests = await prisma.orgMembershipProcess.findMany({
+        // Queue read = the PENDING_PAYMENT from-state the POST acts on; status from the definition (#1080).
         where: {
             isPaymentPlanRequested: true,
-            status: 'PENDING_PAYMENT',
+            ...fromWhere('PENDING_PAYMENT'),
         },
         include: {
             orgMembership: { include: { household: true } },
@@ -45,7 +47,8 @@ export const POST = withAuth(
             // approving a stale/nonexistent request is a no-op error, mirroring the
             // GET queue's filter.
             const process = await prisma.orgMembershipProcess.findFirst({
-                where: { id: processId, isPaymentPlanRequested: true, status: 'PENDING_PAYMENT' },
+                // Approve probe: from-state status from the definition (#1080); isPaymentPlanRequested stays literal.
+                where: { id: processId, isPaymentPlanRequested: true, ...fromWhere('PENDING_PAYMENT') },
                 select: { id: true },
             });
             if (!process) {

--- a/checkin-app/src/app/api/finance-ops/payment-plans/manual-hold/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/manual-hold/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
+import { fromWhere } from "@/lib/programs/enrollmentState";
 
 // Board manual-hold confirmation for a PENDING_HOLD_FAILED row (the apply-time
 // Shopify -1 failed, so { status: PENDING, inventoryHeldAt: null,
@@ -38,7 +39,8 @@ export const POST = withAuth(
             // concurrent approve/deny/manual-hold that already moved it 409s
             // instead of double-stamping.
             const { count } = await prisma.programParticipant.updateMany({
-                where: { programId, personId: participantId, status: 'PENDING', inventoryHeldAt: null, isPaymentPlanRequested: true },
+                // T3m manual-hold CAS: from-state status from the definition (#1080); held/req narrowing stays literal.
+                where: { programId, personId: participantId, ...fromWhere('PENDING_HOLD_FAILED'), inventoryHeldAt: null, isPaymentPlanRequested: true },
                 data,
             });
 

--- a/checkin-app/src/app/api/finance-ops/payment-plans/refuse/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/refuse/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
+import { fromWhere } from "@/lib/programs/enrollmentState";
 
 // Denies a pending scholarship / payment-plan request — the sibling of
 // POST /api/finance-ops/payment-plans (approve) this branch previously lacked.
@@ -43,7 +44,8 @@ export const POST = withAuth(
             // true->false guard: a double-refuse (already false) 409s instead of
             // re-stamping paymentPlanDeniedAt.
             const { count } = await prisma.programParticipant.updateMany({
-                where: { programId, personId: participantId, isPaymentPlanRequested: true, status: 'PENDING' },
+                // T6 deny CAS: from-state status from the definition (#1080); isPaymentPlanRequested stays literal.
+                where: { programId, personId: participantId, isPaymentPlanRequested: true, ...fromWhere('PENDING_HELD') },
                 data,
             });
 

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -6,7 +6,7 @@ import { handler } from "@/security/handler";
 import { apiError } from "@/lib/api-response";
 import { isActiveOrgMember, ACTIVE_ORG_MEMBER_INCLUDE } from "@/lib/orgMembership";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
-import { STATES } from "@/lib/programs/enrollmentState";
+import { STATES, fromWhere } from "@/lib/programs/enrollmentState";
 
 // Two DISJOINT board queues over PENDING + isPaymentPlanRequested rows, split on
 // whether a Shopify seat is actually held (inventoryHeldAt):
@@ -93,7 +93,8 @@ export const POST = withAuth(
             // Scope to the pending request so approving a non-pending/nonexistent
             // request is a no-op error, mirroring the GET queue's filter.
             const { count } = await prisma.programParticipant.updateMany({
-                where: { programId, personId: participantId, isPaymentPlanRequested: true, status: 'PENDING' },
+                // T5 approve CAS: from-state status from the definition (#1080); isPaymentPlanRequested stays literal.
+                where: { programId, personId: participantId, isPaymentPlanRequested: true, ...fromWhere('PENDING_HELD') },
                 data
             });
 

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
 import { adjustProgramInventory } from "@/lib/shopify";
+import { fromWhere } from "@/lib/programs/enrollmentState";
 
 export const POST = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
     if (auth.type !== 'session') return apiError("Unauthorized", 401);
@@ -84,12 +85,14 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         // to null) would match branch 1, re-stamp the hold, fire a second -1,
         // and reopen a resolved scholarship.
         const holdResult = await prisma.programParticipant.updateMany({
-            where: { programId, personId: participantId, status: 'PENDING', inventoryHeldAt: null },
+            // T3 apply CAS from-state (PENDING_UNPAID); flag narrowing stays literal (#1080).
+            where: { programId, personId: participantId, ...fromWhere('PENDING_UNPAID'), inventoryHeldAt: null },
             data: { isPaymentPlanRequested: true, inventoryHeldAt: new Date(), paymentPlanDeniedAt: null },
         });
         if (holdResult.count === 0) {
             await prisma.programParticipant.updateMany({
-                where: { programId, personId: participantId, status: 'PENDING', inventoryHeldAt: { not: null } },
+                // T3 re-apply CAS from-state (PENDING_HELD_DENIED); status clause shared with UNPAID.
+                where: { programId, personId: participantId, ...fromWhere('PENDING_HELD_DENIED'), inventoryHeldAt: { not: null } },
                 data: { isPaymentPlanRequested: true, paymentPlanDeniedAt: null },
             });
         }

--- a/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
+++ b/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
@@ -1,0 +1,129 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+    TRANSITIONS as ENROLL_TX,
+    STATES as ENROLL_STATES,
+    fromWhere as enrollFromWhere,
+    type FromStateName as EnrollFrom,
+} from '../../programs/enrollmentState';
+import {
+    TRANSITIONS as MEMB_TX,
+    ALL_STATUSES as MEMB_STATES,
+    fromWhere as membFromWhere,
+    type ProcessStatus,
+} from '../../membership/lifecycle';
+
+/**
+ * CAS guard ↔ TRANSITIONS from-state parity (#1080) — the real drift-closer.
+ *
+ * `TRANSITIONS` used to carry `guardSite` as a doc string only; each of the ~10 CAS
+ * guards re-hand-wrote `where: { status: <FROM> }`, and nothing checked that literal
+ * against the table. A status rename/split could desync a guard from its declared
+ * transition silently.
+ *
+ * Now every migratable guard spreads `...fromWhere(<fromState>)`, sourcing its
+ * from-state `status` clause from the ONE definition. This test pins that link:
+ *
+ *   1. `fromWhere(from)` emits exactly the from-state's identifying `status` clause.
+ *   2. Each guard's declared from-state is a real node in that machine's TRANSITIONS,
+ *      and (for forward guards) the declared `from → to` edge exists in the table.
+ *   3. Migrated guards actually consume `fromWhere(<from>)` in source; guards left
+ *      literal (documented) still carry their literal, and its status agrees with
+ *      the definition.
+ *
+ * Because a status rename flows through the enum-parity line → the local union →
+ * `fromWhere` → every spreading guard at once, a guard can no longer drift from the
+ * table by construction; this test guards the pieces that aren't purely structural.
+ */
+
+const SRC = join(__dirname, '../../..'); // .../src
+
+type GuardSite = {
+    /** Source file, relative to src/. */
+    file: string;
+    machine: 'enrollment' | 'membership';
+    /** The from-state the guard's CAS names (a state in that machine). */
+    from: string;
+    /** Forward transition the guard drives, as [from, to]; omit for a reverse/entry
+     *  guard whose from-state has no outgoing table edge (e.g. unarchive from ARCHIVED). */
+    edge?: [string, string];
+    /** 'spread' = migrated onto fromWhere; 'literal' = intentionally kept literal. */
+    mode: 'spread' | 'literal';
+};
+
+const GUARDS: GuardSite[] = [
+    // ── enrollment (ProgramParticipant) ──
+    { file: 'lib/programs/activateEnrollment.ts', machine: 'enrollment', from: 'PENDING_UNPAID', edge: ['PENDING_UNPAID', 'ACTIVE'], mode: 'spread' },
+    { file: 'app/api/programs/[id]/request-payment-plan/route.ts', machine: 'enrollment', from: 'PENDING_UNPAID', edge: ['PENDING_UNPAID', 'PENDING_HELD'], mode: 'spread' },
+    { file: 'app/api/programs/[id]/request-payment-plan/route.ts', machine: 'enrollment', from: 'PENDING_HELD_DENIED', edge: ['PENDING_HELD_DENIED', 'PENDING_HELD'], mode: 'spread' },
+    { file: 'app/api/finance-ops/payment-plans/route.ts', machine: 'enrollment', from: 'PENDING_HELD', edge: ['PENDING_HELD', 'ACTIVE'], mode: 'spread' },
+    { file: 'app/api/finance-ops/payment-plans/refuse/route.ts', machine: 'enrollment', from: 'PENDING_HELD', edge: ['PENDING_HELD', 'PENDING_HELD_DENIED'], mode: 'spread' },
+    { file: 'app/api/finance-ops/payment-plans/manual-hold/route.ts', machine: 'enrollment', from: 'PENDING_HOLD_FAILED', edge: ['PENDING_HOLD_FAILED', 'PENDING_HELD'], mode: 'spread' },
+
+    // ── membership (OrgMembershipProcess) ──
+    { file: 'lib/membership/external.ts', machine: 'membership', from: 'PENDING_EXTERNAL_ACTION', edge: ['PENDING_EXTERNAL_ACTION', 'PENDING_PAYMENT'], mode: 'spread' },
+    { file: 'lib/membership/renewal.ts', machine: 'membership', from: 'PENDING_RENEWAL', edge: ['PENDING_RENEWAL', 'PENDING_EXTERNAL_ACTION'], mode: 'spread' },
+    { file: 'lib/membership/archive.ts', machine: 'membership', from: 'ARCHIVED', mode: 'spread' }, // unarchive: reverse of #13, no ARCHIVED→ edge
+    { file: 'app/api/finance-ops/membership-payment-plans/route.ts', machine: 'membership', from: 'PENDING_PAYMENT', edge: ['PENDING_PAYMENT', 'ACTIVE'], mode: 'spread' },
+
+    // ── left literal on purpose (documented) ──
+    // personBgTriggers is an idempotency EXISTENCE set (∅→PENDING_BG_REVIEW is the edge;
+    // the guard's {in:[PENDING_BG_REVIEW,BLOCKED]} is broader than any from-state).
+];
+
+const read = (file: string) => readFileSync(join(SRC, file), 'utf8');
+
+function fromWhereOf(g: GuardSite) {
+    return g.machine === 'enrollment' ? enrollFromWhere(g.from as EnrollFrom) : membFromWhere(g.from as ProcessStatus);
+}
+
+/** Recompute the expected identifying status clause independently of fromWhere, so a
+ *  bug in fromWhere itself can't make the test tautological. Enrollment maps a
+ *  from-state name to its status via STATES; membership's name IS the status. */
+function expectedStatusWhere(g: GuardSite) {
+    const statuses = g.machine === 'enrollment' ? ENROLL_STATES[g.from as EnrollFrom].statuses : [g.from];
+    return statuses.length === 1 ? { status: statuses[0] } : { status: { in: [...statuses] } };
+}
+
+describe('CAS guard ↔ TRANSITIONS from-state parity (#1080)', () => {
+    it('fromWhere emits exactly the from-state identifying status clause', () => {
+        for (const g of GUARDS) {
+            expect(fromWhereOf(g)).toEqual(expectedStatusWhere(g));
+        }
+    });
+
+    it('every guard from-state is a real node in its machine', () => {
+        for (const g of GUARDS) {
+            const states: readonly string[] = g.machine === 'enrollment' ? Object.keys(ENROLL_STATES) : MEMB_STATES;
+            expect(states).toContain(g.from);
+        }
+    });
+
+    it('every declared forward edge exists in the machine TRANSITIONS table', () => {
+        for (const g of GUARDS) {
+            if (!g.edge) continue;
+            const tx = g.machine === 'enrollment' ? ENROLL_TX : MEMB_TX;
+            const [from, to] = g.edge;
+            const found = tx.some((t) => t.from === from && t.to === to);
+            expect({ site: g.file, edge: g.edge, found }).toEqual({ site: g.file, edge: g.edge, found: true });
+        }
+    });
+
+    it('migrated guards consume fromWhere(<from>) for their from-state', () => {
+        for (const g of GUARDS) {
+            if (g.mode !== 'spread') continue;
+            const src = read(g.file);
+            const re = new RegExp(`fromWhere\\(\\s*['"]${g.from}['"]\\s*\\)`);
+            expect({ site: g.file, from: g.from, spreads: re.test(src) }).toEqual({ site: g.file, from: g.from, spreads: true });
+        }
+    });
+
+    it('the personBg idempotency guard is left literal, and its states are valid', () => {
+        const src = read('lib/membership/personBgTriggers.ts');
+        // still a raw {in:[…]} literal (NOT fromWhere) — documented as an existence set
+        expect(/status:\s*\{\s*in:\s*\[\s*"PENDING_BG_REVIEW",\s*"BLOCKED"\s*\]/.test(src)).toBe(true);
+        expect(src).not.toMatch(/fromWhere\(/);
+        for (const s of ['PENDING_BG_REVIEW', 'BLOCKED']) expect(MEMB_STATES).toContain(s);
+    });
+});

--- a/checkin-app/src/lib/lifecycle/index.ts
+++ b/checkin-app/src/lib/lifecycle/index.ts
@@ -8,7 +8,7 @@
  * caller-supplied generic params; the enum-parity check is type-only at build
  * and value-based only in tests.
  */
-export { defineStateSet, type StateSet, type FlagRule } from './stateSet';
+export { defineStateSet, fromStatusWhere, type StateSet, type FlagRule } from './stateSet';
 export { assertNever, defineValidator, type Invariant } from './classify';
 export {
     type Transition,

--- a/checkin-app/src/lib/lifecycle/stateSet.ts
+++ b/checkin-app/src/lib/lifecycle/stateSet.ts
@@ -19,6 +19,29 @@ export type StateSet<Row, Where> = {
 };
 
 /**
+ * Emit the identifying STATUS `where` clause for a from-state: a scalar
+ * `{ status: X }` for a single status, `{ status: { in: [...] } }` for many.
+ *
+ * This is the from-state drift-closer (#1080). A CAS transition guard's from-clause
+ * is `from-state ∧ nothing-else-moved`; the ONLY part that a status rename/split
+ * changes is the `status:` literal. Sourcing THAT from the definition (each machine
+ * wraps this as `fromWhere(edge)`) — instead of hand-writing it per guard — is what
+ * keeps the ~10 CAS guards in sync with the TRANSITIONS table. The guard keeps its
+ * transition-specific flag narrowing (`inventoryHeldAt`, `isPaymentPlanRequested`, …)
+ * literal: those are not statuses and cannot drift with a status rename.
+ *
+ * Client-safe: the caller supplies the Prisma `Where` type param; the value is an
+ * inert object literal (no `@/generated/prisma` value reaches the client bundle).
+ * The scalar/`in` split mirrors what the guards already hand-write, so a migrated
+ * guard's runtime query is byte-for-byte identical.
+ */
+export function fromStatusWhere<Where>(statuses: readonly string[]): Where {
+    return (statuses.length === 1
+        ? { status: statuses[0] }
+        : { status: { in: [...statuses] } }) as Where;
+}
+
+/**
  * A field-rule map: field name → required boolean. Reused for both `flags`
  * (presence of a nullable column) and `equals` (value of a boolean column) —
  * see `defineStateSet`. The two differ only in how the boolean maps to `where`.

--- a/checkin-app/src/lib/membership/archive.ts
+++ b/checkin-app/src/lib/membership/archive.ts
@@ -2,6 +2,7 @@ import { Prisma, type OrgMembershipProcessStatus } from "@/generated/prisma/clie
 import prisma from "@/lib/prisma";
 import { ReviewError } from "@/lib/membership/review";
 import { normalizeAuditData } from "@/lib/auditPayload";
+import { fromWhere } from "@/lib/membership/lifecycle";
 
 /**
  * Board disposal of an abandoned application. Transitions the process to the
@@ -83,7 +84,8 @@ export async function unarchiveApplication(processId: number, actorId: number) {
             // pre-check, but only the winner's updateMany flips it (count === 1) — so
             // the audit row is written exactly once. Mirrors beginRenewal/markContractSigned.
             const { count } = await tx.orgMembershipProcess.updateMany({
-                where: { id: processId, status: "ARCHIVED" },
+                // #13 unarchive CAS from-state (ARCHIVED) from the definition (#1080).
+                where: { id: processId, ...fromWhere("ARCHIVED") },
                 data: { status: target, stageEnteredAt: new Date() },
             });
             if (count !== 1) return;

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -7,6 +7,7 @@ import { zohoSign } from "@/lib/membership/contract/zohoProvider";
 import { signingMockActive } from "@/lib/membership/contract/signingTarget";
 import { loadAgreementPdf, stampWatermark, AGREEMENT_FILENAME, AgreementUnavailableError } from "@/lib/membership/contract/agreementDocument";
 import { latestPendingExternal } from "@/lib/membership/phases";
+import { fromWhere } from "@/lib/membership/lifecycle";
 
 /**
  * EXTERNAL-phase service — the actions an applicant completes after intake:
@@ -113,7 +114,8 @@ export async function advanceExternalIfComplete(processId: number) {
         const { count } = await tx.orgMembershipProcess.updateMany({
             where: {
                 id: processId,
-                status: "PENDING_EXTERNAL_ACTION",
+                // #7 advance CAS from-state from the definition (#1080); the contract/BG narrowing stays literal.
+                ...fromWhere("PENDING_EXTERNAL_ACTION"),
                 contractSignedAt: { not: null },
                 OR: [{ bgClearedAt: { not: null } }, { bgConsentAt: { not: null } }],
             },

--- a/checkin-app/src/lib/membership/lifecycle.ts
+++ b/checkin-app/src/lib/membership/lifecycle.ts
@@ -20,6 +20,7 @@
 import type { Prisma, OrgMembershipProcessStatus, OrgMembershipProcessKind } from "@/generated/prisma/client";
 import {
     type StateSet,
+    fromStatusWhere,
     assertNever,
     defineValidator,
     type Invariant,
@@ -172,6 +173,25 @@ export const settledThisCycleWhere = (windowStart: Date): Where => ({
     status: { in: ["ACTIVE", "ARCHIVED"] },
     stageEnteredAt: { gte: windowStart },
 });
+
+// ── fromWhere (§5 CAS from-state, #1080) ───────────────────────────────────────
+
+/**
+ * Emit the `status` clause a CAS transition guard names for its from-state. For this
+ * machine the from-state name IS the status, so the emit is direct — the value is what
+ * closes the drift gap (#1080): a status rename/split changes the enum (compile-caught
+ * by the union-parity line) and this one emitter, and every guard that spreads
+ * `...fromWhere(<status>)` moves with it, instead of ~6 hand-written `status:` literals
+ * desyncing silently from the TRANSITIONS table.
+ *
+ * Status only: the guard keeps its transition-specific clauses (`contractSignedAt`,
+ * the BG-consent `OR`, `isPaymentPlanRequested`) literal — not statuses, don't drift,
+ * and several guards check a strict subset of the from-state. The scalar shape matches
+ * the guards' hand-written `status: "X"`, so the migrated query is byte-for-byte identical.
+ */
+export function fromWhere(from: ProcessStatus): Where {
+    return fromStatusWhere<Where>([from]);
+}
 
 // ── classify / validate (LIFECYCLE_ARCHITECTURE §3.2) ──────────────────────────
 

--- a/checkin-app/src/lib/membership/personBgTriggers.ts
+++ b/checkin-app/src/lib/membership/personBgTriggers.ts
@@ -46,6 +46,11 @@ export async function openPersonBg(personId: number, asOf: Date, threshold: Date
         });
         if (!person) return null;
         if (personBgVerdict(person, asOf, threshold) !== "NEEDED") return null; // (b)
+        // Left literal on purpose (#1080): this is NOT a transition from-state — the
+        // PERSON_BG edge is ∅→PENDING_BG_REVIEW (no from-row). This `{in:…}` is an
+        // idempotency EXISTENCE set ("a PERSON_BG is already open or blocked for this
+        // person → skip"), broader than any single from-state, so it can't be sourced
+        // from `fromWhere` without misrepresenting it.
         const existing = await tx.orgMembershipProcess.findFirst({
             where: { kind: "PERSON_BG", subjectPersonId: personId, status: { in: ["PENDING_BG_REVIEW", "BLOCKED"] } },
             select: { id: true },

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -4,7 +4,7 @@ import { logger } from "@/lib/logger";
 import { emailHouseholdLeads } from "@/lib/emailRecipients";
 import { config } from "@/lib/config";
 import { certifyPaymentPlan, PaymentError } from "./payment";
-import { IN_FLIGHT_RENEWAL, grantableRenewalWhere, settledThisCycleWhere } from "@/lib/membership/lifecycle";
+import { IN_FLIGHT_RENEWAL, grantableRenewalWhere, settledThisCycleWhere, fromWhere } from "@/lib/membership/lifecycle";
 
 /**
  * Annual renewal. A common membership-year boundary (BoardSettings) drives every
@@ -206,7 +206,8 @@ export async function beginRenewal(processId: number) {
     // here, but only the winner's updateMany flips it (count === 1) — so the audit
     // row is written exactly once. Mirrors external.ts markContractSigned.
     const { count } = await prisma.orgMembershipProcess.updateMany({
-        where: { id: processId, status: "PENDING_RENEWAL" },
+        // #4 beginRenewal CAS from-state from the definition (#1080).
+        where: { id: processId, ...fromWhere("PENDING_RENEWAL") },
         data: { status: "PENDING_EXTERNAL_ACTION", stageEnteredAt: new Date(), ...(clearNow ? { bgClearedAt: new Date() } : {}) },
     });
     if (count === 1) {

--- a/checkin-app/src/lib/programs/activateEnrollment.ts
+++ b/checkin-app/src/lib/programs/activateEnrollment.ts
@@ -1,6 +1,7 @@
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { adjustProgramInventory } from "@/lib/shopify";
+import { fromWhere } from "@/lib/programs/enrollmentState";
 
 /**
  * Activate paid program enrollments — the single choke point the Shopify
@@ -59,7 +60,8 @@ export async function activateProgramEnrollment(input: ActivateEnrollmentInput):
 
         // Guarded PENDING → ACTIVE so a redelivery / re-run can't inflate the count.
         const activated = await prisma.programParticipant.updateMany({
-            where: { programId, personId, status: "PENDING" },
+            // T4 activate CAS from-state (any PENDING; sourced from the definition, #1080).
+            where: { programId, personId, ...fromWhere("PENDING_UNPAID") },
             data: { status: "ACTIVE", pendingSince: null, shopifyOrderId },
         });
         activatedCount += activated.count;

--- a/checkin-app/src/lib/programs/enrollmentState.ts
+++ b/checkin-app/src/lib/programs/enrollmentState.ts
@@ -14,6 +14,7 @@
  */
 import {
     defineStateSet,
+    fromStatusWhere,
     assertNever,
     defineValidator,
     type Invariant,
@@ -104,6 +105,30 @@ export const STATES = {
         flags: { inventoryHeldAt: false },
     }),
 } as const;
+
+// ---- fromWhere (§5 CAS from-state, #1080) -----------------------------------
+
+/** The named present-row states — the keys of STATES, i.e. every state a CAS
+ *  guard can transition FROM. */
+export type FromStateName = keyof typeof STATES;
+
+/**
+ * Emit the `status` clause a CAS transition guard names for its from-state, sourced
+ * from STATES so a status rename/split flows into every guard that spreads it
+ * (#1080). All enrollment PENDING_* states share `status:'PENDING'`; ACTIVE is its
+ * own status — the scalar shape matches what the guards hand-write, so the migrated
+ * query is byte-for-byte identical.
+ *
+ * It emits ONLY the status: the guard keeps its transition-specific flag narrowing
+ * (`inventoryHeldAt`, `isPaymentPlanRequested`, `paymentPlanDeniedAt`) literal — those
+ * are not statuses and don't drift on a status rename, and several guards check a
+ * strict SUBSET of the from-state's defining flags (e.g. T4 activate checks only
+ * `status`; T5 approve keeps `isPaymentPlanRequested`), so over-emitting them would
+ * over-constrain the CAS. Never includes the transition's mutation (that lives in `data`).
+ */
+export function fromWhere(from: FromStateName): Where {
+    return fromStatusWhere<Where>(STATES[from].statuses);
+}
 
 // ---- classify (§3 table, total switch) --------------------------------------
 


### PR DESCRIPTION
Closes #1080.

## The gap
`TRANSITIONS` was inert — it carried `guardSite` as a doc string only, and the ~10 CAS transition guards each hand-wrote `where: { status: <FROM> }`. The definition module emitted state-set `where`s but never a transition's **from-state** `where`, so a status rename/split changed every CAS `where` by hand and nothing checked a guard's from-clause against the table.

## What changed

**D1 — `fromWhere` emitter (status-only).** Shared `fromStatusWhere(statuses)` in `lib/lifecycle/stateSet.ts` emits the identifying `status` clause (`{ status: X }` scalar, or `{ status: { in:[…] } }`). Each machine wraps it as `fromWhere(from)`: enrollment maps a from-state name → its status via `STATES`; membership's name **is** the status.

Status-only by design: the only part of a CAS from-clause that drifts on a status rename/split is the `status:` literal. The flag narrowing (`inventoryHeldAt` / `isPaymentPlanRequested` / contract+BG `OR`) is transition-specific, doesn't drift with the enum, and several guards check a strict **subset** of their from-state's defining flags (T4 checks only status; T5 keeps `isPaymentPlanRequested`; T3m keeps held+req) — so over-emitting flags would over-constrain the CAS. Client-safe (type-only Prisma).

**D2 — guards consume `fromWhere` (query byte-for-byte identical).** Migrated: `activateEnrollment`, `request-payment-plan` (both branches), `payment-plans` approve/refuse/manual-hold, membership `external` (advance), `renewal` (beginRenewal), `archive` (unarchive), `membership-payment-plans` (GET queue + POST probe). Only the **source** of the from-state `status` changes — no change to CAS atomicity, `FOR UPDATE`, `delete()`, P2002 handling, or any `data:` mutation.

Left literal + documented:
- `personBgTriggers` — `{in:[PENDING_BG_REVIEW,BLOCKED]}` is an idempotency **existence** set, not a transition from-state (the PERSON_BG edge is `∅→PENDING_BG_REVIEW`). Sourcing from `fromWhere` would misrepresent it.
- `renewal.ts` `beginRenewalForUser` — a `PENDING_RENEWAL` read probe, not a CAS.

**D3 — guard↔TRANSITIONS parity test.** New `guardFromStateParity.test.ts` pins each guard's from-state to `fromWhere` and to a real node/edge in `TRANSITIONS`, so a status rename/split can no longer desync a guard from the table. The 8 fully-migrated files drop from `lifecycleStatusLiteralAllowlist` (the stale-entry check enforces the drop).

## Verification
- `tsc --noEmit` clean.
- Lifecycle unit + parity + allowlist: 5 suites / 38 tests green.
- Concurrency/integration gate, `--runInBand` against a throwaway Postgres — **12 suites / 103 tests, all green, unchanged**: programsParticipantsConcurrency, programPaymentPlansAPI, cronPendingParticipants, enrollmentStateOracle, membership {ExternalConcurrency, ReviewAPI, ReviewConcurrency, PaymentPlansAPI, RenewalAPI, BulkRenewalAPI}, intakeConcurrency, renewalConcurrency.

## Reviewer notes
- The intended invariant: every migrated guard's resulting Prisma `where` is identical to before — this re-sources the literal, it does not change the query.
- Design docs (`LIFECYCLE_ARCHITECTURE` §2/§5, the two state-machine docs) intentionally untouched — orchestrator owns them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)