### PR TITLE
fix(enroll): collapse activate's two-step flip into one atomic write (I1)

### DIFF
--- a/checkin-app/src/app/__tests__/activateEnrollmentRedelivery.integration.test.ts
+++ b/checkin-app/src/app/__tests__/activateEnrollmentRedelivery.integration.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Focused regression for the T4 activate collapse (PROGRAM_ENROLLMENT_STATE_MACHINE §7).
+ *
+ * activateProgramEnrollment used to do the PENDING→ACTIVE status flip and the
+ * hold release as TWO bare updateManys; between them the row was committed as
+ * ACTIVE-with-held — an I1 violation, and a crash-window that stranded a −1 that
+ * never came back. The flip and the release are now ONE atomic updateMany
+ * (status:ACTIVE + inventoryHeldAt:null together), so that intermediate never
+ * exists.
+ *
+ * This asserts the post-condition (ACTIVE, held null, validates clean — no I1),
+ * that the compensating Shopify +1 is exactly right for a held row, and that a
+ * webhook REDELIVERY (a second call) is a no-op: no double-activate, no double
+ * +1 — the single status:'PENDING' guard matches 0 rows the second time.
+ *
+ * adjustProgramInventory is mocked so the +1 call count is asserted directly.
+ */
+import { activateProgramEnrollment } from '@/lib/programs/activateEnrollment';
+import prisma from '@/lib/prisma';
+import { toRow, classify, validate } from '@/lib/programs/enrollmentState';
+import { adjustProgramInventory } from '@/lib/shopify';
+
+jest.mock('@/lib/shopify', () => ({
+    adjustProgramInventory: jest.fn().mockResolvedValue(true),
+}));
+const mockAdjust = adjustProgramInventory as jest.Mock;
+
+const TAG = 'activate-redelivery-test';
+
+describe('activateProgramEnrollment — atomic collapse + redelivery no-op', () => {
+    let programId: number;
+    let personId: number;
+
+    beforeAll(async () => {
+        const person = await prisma.person.create({
+            data: { name: 'Redelivery Self', email: `self-${TAG}@example.com`, household: { create: { name: 'HH' } } },
+        });
+        personId = person.id;
+        // Single-pool (shopifyVariantId present) → the legacy two-pool sibling mirror is skipped.
+        const program = await prisma.program.create({
+            data: { name: `Redelivery Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyVariantId: 'dev-mock-variant-redeliv' },
+        });
+        programId = program.id;
+    });
+
+    afterAll(async () => {
+        await prisma.programParticipant.deleteMany({ where: { programId } });
+        await prisma.program.delete({ where: { id: programId } });
+        const p = await prisma.person.findUniqueOrThrow({ where: { id: personId }, select: { householdId: true } });
+        await prisma.person.delete({ where: { id: personId } });
+        await prisma.household.delete({ where: { id: p.householdId } });
+    });
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('activates a held PENDING row → ACTIVE + held null (clean, no I1), +1 fired once; redelivery is a no-op', async () => {
+        // Seed PENDING_HELD (a seat held): the −1 landed at apply time.
+        await prisma.programParticipant.upsert({
+            where: { programId_personId: { programId, personId } },
+            update: { status: 'PENDING', isPaymentPlanRequested: true, inventoryHeldAt: new Date(), paymentPlanDeniedAt: null, pendingSince: new Date() },
+            create: { programId, personId, status: 'PENDING', isPaymentPlanRequested: true, inventoryHeldAt: new Date(), pendingSince: new Date() },
+        });
+
+        // First activation (the paid webhook).
+        const first = await activateProgramEnrollment({
+            programId, personIds: [personId], shopifyOrderId: 'order-redeliv-1', hasProgramItem: true, purchasedOrgMember: null,
+        });
+        expect(first).toEqual({ activatedCount: 1, releasedHoldCount: 1 });
+
+        // Post-condition: ACTIVE with the hold released in the SAME write — never ACTIVE+held.
+        const db = await prisma.programParticipant.findUniqueOrThrow({ where: { programId_personId: { programId, personId } } });
+        expect(db.status).toBe('ACTIVE');
+        expect(db.inventoryHeldAt).toBeNull(); // raw column cleared in the atomic flip
+        const row = toRow(db);
+        expect(classify(row)).toBe('ACTIVE');
+        expect(validate(row)).toBeNull(); // no I1
+
+        // Exactly one compensating +1 for the one released hold.
+        expect(mockAdjust).toHaveBeenCalledTimes(1);
+        expect(mockAdjust).toHaveBeenCalledWith(expect.anything(), 1);
+
+        mockAdjust.mockClear();
+
+        // Redelivery: same order arrives again. Guard finds the row already ACTIVE.
+        const second = await activateProgramEnrollment({
+            programId, personIds: [personId], shopifyOrderId: 'order-redeliv-1', hasProgramItem: true, purchasedOrgMember: null,
+        });
+        expect(second).toEqual({ activatedCount: 0, releasedHoldCount: 0 }); // no double-activate, no double-release
+        expect(mockAdjust).not.toHaveBeenCalled();                            // no double +1
+
+        // Row unchanged: still ACTIVE, still clean.
+        const db2 = await prisma.programParticipant.findUniqueOrThrow({ where: { programId_personId: { programId, personId } } });
+        expect(db2.status).toBe('ACTIVE');
+        expect(db2.inventoryHeldAt).toBeNull();
+        expect(validate(toRow(db2))).toBeNull();
+    });
+});

--- a/checkin-app/src/lib/programs/activateEnrollment.ts
+++ b/checkin-app/src/lib/programs/activateEnrollment.ts
@@ -58,24 +58,23 @@ export async function activateProgramEnrollment(input: ActivateEnrollmentInput):
             continue;
         }
 
-        // Guarded PENDING → ACTIVE so a redelivery / re-run can't inflate the count.
+        // Guarded PENDING → ACTIVE in ONE atomic write: status flip AND hold release
+        // together, so the row is never committed as ACTIVE-with-held (invariant I1 —
+        // the crash window that stranded a −1 that never came back). The single
+        // status:'PENDING' guard makes this idempotent: a webhook redelivery / reconciler
+        // re-run finds the row already ACTIVE → matches 0 rows → no double-activate, and
+        // (since the flip and the release are the same write) no double-release either.
         const activated = await prisma.programParticipant.updateMany({
             // T4 activate CAS from-state (any PENDING; sourced from the definition, #1080).
             where: { programId, personId, ...fromWhere("PENDING_UNPAID") },
-            data: { status: "ACTIVE", pendingSince: null, shopifyOrderId },
+            data: { status: "ACTIVE", pendingSince: null, shopifyOrderId, inventoryHeldAt: null },
         });
         activatedCount += activated.count;
         if (activated.count > 0) logger.info(`[enroll] Marked participant ${personId} ACTIVE for program ${programId}`);
 
-        // Release a scholarship hold if one was set (compensates the sale's auto-decrement),
-        // guarded (NOT NULL → NULL) so a retry can't release twice.
-        if (existing.inventoryHeldAt) {
-            const release = await prisma.programParticipant.updateMany({
-                where: { programId, personId, inventoryHeldAt: { not: null } },
-                data: { inventoryHeldAt: null },
-            });
-            releasedHoldCount += release.count;
-        }
+        // A hold was released iff THIS activation flipped a row that had one set (the pre-read
+        // held stamp + a real 0→1 flip). The compensating Shopify +1 stays a separate call below.
+        if (existing.inventoryHeldAt && activated.count > 0) releasedHoldCount += 1;
     }
 
     // Compensating +1 for every hold released, in one call. Never fatal.


### PR DESCRIPTION
## What

`activateProgramEnrollment` performed a state transition as **two bare, non-transactional `updateMany`s**:

1. `where {status:'PENDING'}` → `data {status:'ACTIVE', pendingSince:null, shopifyOrderId}`
2. `if (existing.inventoryHeldAt)` → `where {inventoryHeldAt:{not:null}}` → `data {inventoryHeldAt:null}`

Between #1 and #2 the row is committed as **ACTIVE + `inventoryHeldAt` set** — an **I1 violation** (`ACTIVE ⟹ held null`, per `PROGRAM_ENROLLMENT_STATE_MACHINE.md` §4). A crash between the two strands it there: a Shopify `−1` that never comes back → permanent over-decrement. It was the lone state-transition in the app not done as a single atomic flip.

This collapses both into ONE write:

```ts
const activated = await prisma.programParticipant.updateMany({
    where: { programId, personId, status: "PENDING" },
    data: { status: "ACTIVE", pendingSince: null, shopifyOrderId, inventoryHeldAt: null },
});
```

## Why it's safe

- `inventoryHeldAt:null` is now part of the same atomic flip → the ACTIVE+held intermediate never exists.
- `releasedHoldCount` is still derived from the pre-read `existing.inventoryHeldAt` **AND** a real `0→1` flip (`activated.count > 0`); the compensating Shopify `+1` (`adjustProgramInventory`) stays a separate best-effort call — that DB↔Shopify dual-write is irreducible.
- **Idempotent:** the single `status:'PENDING'` guard means a webhook redelivery / reconciler re-run finds the row already ACTIVE → matches 0 rows → no double-activate, and (flip and release being the same write) no double-release.
- Matches the membership machine, which was already atomic (FOR UPDATE + single-update flips). Phase-4 I1 reconciler untouched (still covers any legacy/other-source I1 row).

## Scope

Only `activateEnrollment.ts` changes. No CAS/guard semantics, Shopify call, FOR UPDATE locks, or schema touched.

Verified no illegal intermediate elsewhere:
- `request-payment-plan/route.ts` — `status` stays PENDING; intermediates are legal (`PENDING_HELD`, and the `−1`-fail rollback → `PENDING_HOLD_FAILED`, a compensating write).
- `participants/merge/route.ts` — all `programParticipant` writes are inside `$transaction` (atomic).

## Tests

New focused integration test `activateEnrollmentRedelivery.integration.test.ts`: after activate the row is `ACTIVE` with `inventoryHeldAt=null` (validates clean, no I1), `+1` fired once for a held row, and a **second activate (redelivery) is a no-op** (no double-activate, no double `+1`).

Hard-gate suites green, unchanged: `programsParticipantsConcurrency`, `programPaymentPlansAPI`, `cronPendingParticipants`, `enrollmentStateOracle`. **5 suites, 54 tests pass;** `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)