### PR TITLE
match audit: a BLOCKED process is not a claim (paid-while-blocked bucketed MATCHED)

### DIFF
--- a/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
+++ b/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
@@ -103,7 +103,7 @@ const ALLOWLIST: Record<string, string> = {
     'app/api/finance-ops/s-read/match-audit/track/route.ts':
         'Track-button staleness probes: claim re-check excluding ARCHIVED before promoting a gap — human-per-row, mirrors the matchAudit entry.',
     'lib/finance/matchAudit.ts':
-        'Audit read queries: activation sweep (ACTIVE/PENDING_BG_CLEARANCE + ACTIVE participants) and the claim lookup excluding ARCHIVED — report-only, mirrors the reconcile.ts entry.',
+        'Audit read queries: activation sweep (ACTIVE/PENDING_BG_CLEARANCE + ACTIVE participants) and the claim lookup excluding ARCHIVED/BLOCKED — report-only, mirrors the reconcile.ts entry.',
     'lib/finance/reconcile.ts': 'Reconciler lookups: pending/active order-to-row matching on both models.',
     'lib/membership/notifications.ts': 'Read query: board BLOCKED-process count for the notifications badge.',
     'lib/membership/payment.ts': 'Read query: this household’s PENDING_PAYMENT process before activate.',

--- a/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
@@ -154,10 +154,19 @@ describe('order buckets (Shopify → activation)', () => {
         expect(r.orders[0].bucket).toBe('MATCHED');
     });
 
-    it('an ARCHIVED process is not a claim — the lookup excludes it in the where', async () => {
+    it('neither an ARCHIVED nor a BLOCKED process is a claim — the lookup excludes both in the where', async () => {
         await runMatchAudit();
         const claimWhere = (prismaMock.orgMembershipProcess.findMany.mock.calls[0][0] as { where: { status: unknown } }).where;
-        expect(claimWhere.status).toEqual({ not: 'ARCHIVED' });
+        expect(claimWhere.status).toEqual({ notIn: ['ARCHIVED', 'BLOCKED'] });
+    });
+
+    it('paid-while-blocked: claim excluded, the open exception (processId-attributed) buckets it TRACKED_EXCEPTION', async () => {
+        mirrorMock.ordersForVariants.mockResolvedValue([paidOrder('911')]);
+        // The BLOCKED process's PAID_WHILE_BLOCKED exception is open and carries processId;
+        // the claim lookup's notIn keeps the BLOCKED process itself out of the claim set.
+        prismaMock.paymentException.findMany.mockResolvedValue([{ shopifyOrderId: '911', processId: 55, programId: null }]);
+        const r = await runMatchAudit();
+        expect(r.orders[0].bucket).toBe('TRACKED_EXCEPTION');
     });
 
     it('a kind-attributed exception covers only ITS half: tracked membership + untracked program → UNCLAIMED_PAID naming the program', async () => {

--- a/checkin-app/src/lib/finance/matchAudit.ts
+++ b/checkin-app/src/lib/finance/matchAudit.ts
@@ -157,9 +157,15 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
     // AND program lines, and "the membership process claimed this order" says
     // nothing about the program half. An ARCHIVED process is not a claim — the
     // application was abandoned, so its money is exactly the unclaimed kind.
+    // A BLOCKED process is not a claim either: activate()'s BLOCKED branch (see
+    // membership/payment.ts) stores paidAt + shopifyOrderId on a still-BLOCKED
+    // process — money in, NO access granted, refund owed — so counting it as a
+    // claim would bucket the order MATCHED and hide the exact case this audit
+    // hunts. Excluded, the open PAID_WHILE_BLOCKED exception (which carries
+    // processId) buckets it TRACKED_EXCEPTION instead.
     const [claimedProcs, claimedEnrolls, trackedExceptions] = await Promise.all([
         prisma.orgMembershipProcess.findMany({
-            where: { shopifyOrderId: { in: orderIds }, status: { not: "ARCHIVED" } },
+            where: { shopifyOrderId: { in: orderIds }, status: { notIn: ["ARCHIVED", "BLOCKED"] } },
             select: { shopifyOrderId: true },
         }),
         prisma.programParticipant.findMany({ where: { shopifyOrderId: { in: orderIds } }, select: { shopifyOrderId: true, programId: true } }),


### PR DESCRIPTION
The one surviving delta from an independent second review of #1082 (fresh reviewer, blinded from the first review's findings and the companion stack — 15 findings, 13 of which were already fixed by #1084/#1085/#1087 or your follow-up commits; the UNCLAIMED_UNPAID visibility one you fixed in 3a94c23a in parallel).

**The gap**: `activate()`'s BLOCKED branch stores `paidAt` + `shopifyOrderId` on a still-BLOCKED process — money in, no access granted, refund owed, `PAID_WHILE_BLOCKED` exception open. The claim lookup excluded only ARCHIVED, so that order bucketed **MATCHED**: the flagship bucket hiding the flagship money-in-no-access case.

**The fix**: claim lookup excludes BLOCKED alongside ARCHIVED. With the claim gone, the open processId-attributed exception buckets the order TRACKED_EXCEPTION (correct — the exception queue owns it); after resolution/refund it falls to UNCLAIMED_UNPAID. Where-shape test updated, new paid-while-blocked bucket test, allowlist justification refreshed.

Verified: tsc clean (after `prisma generate` for your new exception kinds), eslint clean, matchAudit + lifecycle-guard suites 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe