### PR TITLE
review fix-up for #1095: no-email base, COI check, transactional audit, contract-true UI

### DIFF
--- a/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
+++ b/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
@@ -187,7 +187,7 @@ request actually transitioned (no duplicate mail on a no-op re-POST).
 | Program approve | `POST /api/finance-ops/payment-plans` | — | **no automatic email** |
 | Program deny | `POST /api/finance-ops/payment-plans/refuse` | — | **no automatic email** |
 | Membership approve (certify) | `POST /api/finance-ops/membership-payment-plans` | — | **no automatic email** |
-| Membership deny | — | **does not exist** | — |
+| Membership deny | `POST /api/finance-ops/membership-payment-plans/refuse` | — | **no automatic email** |
 | Manual-hold | `…/payment-plans/manual-hold` | — | **no email** |
 
 **2. Approve/deny are silent by design.** Board decisions — program approve, program deny,
@@ -201,10 +201,18 @@ sends nothing when it fires — both silences are deliberate, not gaps.
 **all board members** (the board *is* the review team until configured). Set on
 **Settings → Email** (distinct from `scholarshipDenialGraceDays`, set on Settings → Membership).
 
-**4. Membership-deny asymmetry.** The program side has approve **and** deny; the membership
-side has **only approve** — there is no membership-deny route. Now that neither approve nor
-deny sends automatic email either way, this asymmetry only matters for the manual process:
-the board has no dedicated membership-deny action to hang a manual communication step off of.
+**4. Membership deny — action parity, still silent.** The membership side now has both
+approve **and** deny (`POST /api/finance-ops/membership-payment-plans/refuse`), matching the
+program side's set of board actions. Denial clears `isPaymentPlanRequested` back to `false`;
+the process **stays `PENDING_PAYMENT`** and the household returns to normal "pay your dues to
+activate". Like every other board decision (item 2) it sends **no automatic email** — the
+Scholarship Review Team communicates the outcome manually; the deny action just gives them a
+dedicated control to drop the request off the queue. It differs from the program deny only in
+what it touches: membership reserves no Shopify seat on request and has no grace-expiry cron
+(grace is program-only), so there is no seat to release and no `paymentPlanDeniedAt` to stamp
+— `OrgMembershipProcess` has no such column and needs none, the cleared flag is the whole of
+denial state. The transactional `isPaymentPlanRequested: true → false` guard (mirroring the
+approve probe) makes a no-op re-deny a 409.
 
 ## 6. Related
 

--- a/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
+++ b/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
@@ -185,7 +185,7 @@ actually transitioned (no duplicate mail on a no-op re-POST).
 | Program deny | `POST /api/finance-ops/payment-plans/refuse` | — | ✅ status + grace deadline | ✅ per-recipient |
 | Membership request | `POST /api/membership/request-payment-plan` | ✅ | ✅ ack (leads only) | ack ungated |
 | Membership approve | `POST /api/finance-ops/membership-payment-plans` | — | ✅ status | ✅ per-recipient |
-| Membership deny | — | **does not exist** | — | — |
+| Membership deny | `POST /api/finance-ops/membership-payment-plans/refuse` | — | ✅ status (no grace line) | ✅ per-recipient |
 | Manual-hold | `…/payment-plans/manual-hold` | — | **no email** | — |
 
 **2. Preference + default-ON rationale.** `Person.notificationSettings.emailScholarshipUpdates`,
@@ -199,9 +199,20 @@ the Communication page.
 **all board members** (the board *is* the review team until configured). Set on
 **Settings → Email** (distinct from `scholarshipDenialGraceDays`, set on Settings → Membership).
 
-**4. Membership-deny asymmetry.** The program side has approve **and** deny; the membership
-side has **only approve** — there is no membership-deny route, so no membership denial
-email exists. This mirrors the code and is intentional, not an omission to "fix" here.
+**4. Membership deny — parity with the program side (asymmetry closed).** The membership
+side now has both approve **and** deny (`POST /api/finance-ops/membership-payment-plans/refuse`),
+matching the program side. Denial clears `isPaymentPlanRequested` back to `false`; the
+process **stays `PENDING_PAYMENT`** and the household returns to normal "pay your dues to
+activate". It differs from the program deny in two ways, both because membership has no
+held seat and no grace-expiry cron (grace is program-only):
+- **No Shopify operation and no grace deadline** — membership reserves no seat on request,
+  so there is nothing to release and no `paymentPlanDeniedAt + graceDays` release date to
+  promise. `OrgMembershipProcess` has no `paymentPlanDeniedAt` column and needs none — the
+  cleared flag is the whole of denial state (no re-apply-clears-denial step to model).
+- **Status email minus the seat/grace lines** — same gated `sendScholarshipStatus`
+  (default-ON), copy states the plan was declined and that dues can still be paid normally.
+The transactional `isPaymentPlanRequested: true → false` guard (mirroring the approve
+probe) makes a no-op re-deny a 409 that sends no email.
 
 **5. Two flagged-NOT-built holes:**
 - The **grace-expiry cron** (`scholarship-grace-expiry/route.ts`) auto-withdraws a denied

--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -63,6 +63,8 @@ const AUTHZ_TESTED = new Set<string>([
     'finance-ops/payment-plans/manual-hold',
     // POST deny-path (401 anon / 403 non-board) in membershipPaymentPlansAPI.integration.test.ts.
     'finance-ops/membership-payment-plans',
+    // POST deny-path (401 anon / 403 non-board) in membershipPaymentPlansAPI.integration.test.ts.
+    'finance-ops/membership-payment-plans/refuse',
     'admin/settings/localization',
     'events',
     'facility/badges',

--- a/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
@@ -3,9 +3,10 @@
  */
 /**
  * Integration tests for the membership payment-plan routes:
- *   GET  /api/finance-ops/membership-payment-plans     (board-only queue)
- *   POST /api/finance-ops/membership-payment-plans      (board approves -> certify/activate)
- *   POST /api/membership/request-payment-plan           (request, with IDOR guard)
+ *   GET  /api/finance-ops/membership-payment-plans        (board-only queue)
+ *   POST /api/finance-ops/membership-payment-plans         (board approves -> certify/activate)
+ *   POST /api/finance-ops/membership-payment-plans/refuse  (board denies -> clear flag, stay PENDING_PAYMENT)
+ *   POST /api/membership/request-payment-plan              (request, with IDOR guard)
  *
  * Covers auth rejections (401/403), validation (400/404), the wrong-phase gate
  * (409 off PENDING_PAYMENT), the IDOR path (an unrelated authenticated user
@@ -13,6 +14,7 @@
  * (flag set on request; certify -> ACTIVE + flag cleared + audit on approve).
  */
 import { GET as PlansGet, POST as PlansPost } from '@/app/api/finance-ops/membership-payment-plans/route';
+import { POST as DenyPost } from '@/app/api/finance-ops/membership-payment-plans/refuse/route';
 import { POST as RequestPost } from '@/app/api/membership/request-payment-plan/route';
 import prisma from '@/lib/prisma';
 
@@ -197,6 +199,59 @@ describe('Membership payment-plan routes', () => {
         });
     });
 
+    describe('POST /api/finance-ops/membership-payment-plans/refuse (deny)', () => {
+        const denyReq = (body: unknown) => new Request('http://localhost/api/finance-ops/membership-payment-plans/refuse', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        }) as unknown as import('next/server').NextRequest;
+
+        it('401 without a session', async () => {
+            mockSession.mockResolvedValue(null);
+            expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(401);
+        });
+
+        it('403 for a non-board user', async () => {
+            mockSession.mockResolvedValue({ user: { id: otherId } });
+            expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(403);
+        });
+
+        it('400 when processId is missing', async () => {
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            expect((await DenyPost(denyReq({}))).status).toBe(400);
+        });
+
+        it('409 when there is no pending request for the process', async () => {
+            const cleared = await makeProc('DenyCleared', { requested: false });
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            expect((await DenyPost(denyReq({ processId: cleared.processId }))).status).toBe(409);
+        });
+
+        it('board denial clears the flag, keeps the process PENDING_PAYMENT, and writes an audit row', async () => {
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            const res = await DenyPost(denyReq({ processId: leadProcessId }));
+            expect(res.status).toBe(200);
+
+            const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: leadProcessId } });
+            expect(proc?.isPaymentPlanRequested).toBe(false);
+            expect(proc?.status).toBe('PENDING_PAYMENT'); // stays awaiting payment — no seat, no grace, pay-to-activate
+            expect(proc?.certifiedById).toBeNull(); // denial never certifies/activates
+
+            const membership = await prisma.orgMembership.findUnique({ where: { id: leadMembershipId } });
+            expect(membership?.status).toBe('NONE'); // untouched by denial
+
+            const audits = await prisma.auditLog.findMany({
+                where: { tableName: 'OrgMembershipProcess', affectedEntityId: leadProcessId, actorId: boardId },
+            });
+            expect(audits.some(a => (a.newData as { paymentPlanDenied?: boolean })?.paymentPlanDenied === true)).toBe(true);
+        });
+
+        it('a re-deny of an already-denied (flag false) process is a 409 no-op', async () => {
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(200);
+            expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(409);
+        });
+    });
+
     describe('POST /api/membership/request-payment-plan', () => {
         it('401 without a session', async () => {
             mockSession.mockResolvedValue(null);
@@ -287,6 +342,22 @@ describe('Membership payment-plan routes', () => {
             const res = await PlansPost(nextReq('http://localhost', { method: 'POST', body: JSON.stringify({ processId: leadProcessId, reason: 'Board approved scholarship' }) }));
             expect(res.status).toBe(200);
 
+            expect(__getSentEmails()).toHaveLength(0);
+        });
+
+        // Deny is silent like approve (item 2): no automatic applicant email —
+        // the board communicates the outcome manually. leadProcessId's household
+        // lead exists (a would-be recipient), yet nothing is sent.
+        it('deny sends no automatic email', async () => {
+            const denyReq = new Request('http://localhost/api/finance-ops/membership-payment-plans/refuse', {
+                method: 'POST',
+                body: JSON.stringify({ processId: leadProcessId }),
+            }) as unknown as import('next/server').NextRequest;
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+            __clearSentEmails();
+            const res = await DenyPost(denyReq);
+            expect(res.status).toBe(200);
             expect(__getSentEmails()).toHaveLength(0);
         });
     });

--- a/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
@@ -251,6 +251,43 @@ describe('Membership payment-plan routes', () => {
             expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(200);
             expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(409);
         });
+
+        it('404 when the process does not exist', async () => {
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            expect((await DenyPost(denyReq({ processId: 999999999 }))).status).toBe(404);
+        });
+
+        it('403 (conflict of interest) when a board member denies their OWN household; the request is untouched', async () => {
+            const own = await makeProc('DenyCOI', { requested: true });
+            const boardKin = await prisma.person.create({
+                data: { name: 'Board Kin', email: `board-kin-${own.processId}-${TAG}@example.com`, isBoardMember: true, householdId: own.householdId },
+            });
+            mockSession.mockResolvedValue({ user: { id: boardKin.id, isBoardMember: true } });
+
+            const res = await DenyPost(denyReq({ processId: own.processId }));
+            expect(res.status).toBe(403);
+            const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: own.processId } });
+            expect(proc?.isPaymentPlanRequested).toBe(true); // flag NOT flipped by the refused deny
+
+            // Drop this extra board member so it doesn't inflate the "email all board
+            // members" review-team fallback that later count-based tests assert on.
+            await prisma.person.delete({ where: { id: boardKin.id } });
+        });
+
+        it('a sysadmin may deny their own household (COI bypass)', async () => {
+            const own = await makeProc('DenySysadmin', { requested: true });
+            const sysKin = await prisma.person.create({
+                data: { name: 'Sys Kin', email: `sys-kin-${own.processId}-${TAG}@example.com`, isBoardMember: true, householdId: own.householdId },
+            });
+            mockSession.mockResolvedValue({ user: { id: sysKin.id, isBoardMember: true, isSysadmin: true } });
+
+            const res = await DenyPost(denyReq({ processId: own.processId }));
+            expect(res.status).toBe(200);
+            const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: own.processId } });
+            expect(proc?.isPaymentPlanRequested).toBe(false);
+
+            await prisma.person.delete({ where: { id: sysKin.id } }); // keep it out of the board-member fallback set
+        });
     });
 
     describe('POST /api/membership/request-payment-plan', () => {

--- a/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
@@ -250,6 +250,38 @@ describe('Membership payment-plan routes', () => {
             expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(200);
             expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(409);
         });
+
+        it('403 (conflict of interest) when a board member denies their OWN household; the request is untouched', async () => {
+            const own = await makeProc('DenyCOI', { requested: true });
+            const boardKin = await prisma.person.create({
+                data: { name: 'Board Kin', email: `board-kin-${own.processId}-${TAG}@example.com`, isBoardMember: true, householdId: own.householdId },
+            });
+            mockSession.mockResolvedValue({ user: { id: boardKin.id, isBoardMember: true } });
+
+            const res = await DenyPost(denyReq({ processId: own.processId }));
+            expect(res.status).toBe(403);
+            const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: own.processId } });
+            expect(proc?.isPaymentPlanRequested).toBe(true); // flag NOT flipped by the refused deny
+
+            // Drop this extra board member so it doesn't inflate the "email all board
+            // members" review-team fallback that later count-based tests assert on.
+            await prisma.person.delete({ where: { id: boardKin.id } });
+        });
+
+        it('a sysadmin may deny their own household (COI bypass)', async () => {
+            const own = await makeProc('DenySysadmin', { requested: true });
+            const sysKin = await prisma.person.create({
+                data: { name: 'Sys Kin', email: `sys-kin-${own.processId}-${TAG}@example.com`, isBoardMember: true, householdId: own.householdId },
+            });
+            mockSession.mockResolvedValue({ user: { id: sysKin.id, isBoardMember: true, isSysadmin: true } });
+
+            const res = await DenyPost(denyReq({ processId: own.processId }));
+            expect(res.status).toBe(200);
+            const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: own.processId } });
+            expect(proc?.isPaymentPlanRequested).toBe(false);
+
+            await prisma.person.delete({ where: { id: sysKin.id } }); // keep it out of the board-member fallback set
+        });
     });
 
     describe('POST /api/membership/request-payment-plan', () => {

--- a/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
@@ -41,6 +41,12 @@ function requestReq(body: unknown) {
         body: JSON.stringify(body),
     }) as unknown as import('next/server').NextRequest;
 }
+function denyReq(body: unknown) {
+    return new Request('http://localhost/api/finance-ops/membership-payment-plans/refuse', {
+        method: 'POST',
+        body: JSON.stringify(body),
+    }) as unknown as import('next/server').NextRequest;
+}
 
 describe('Membership payment-plan routes', () => {
     let boardId: number;
@@ -200,11 +206,6 @@ describe('Membership payment-plan routes', () => {
     });
 
     describe('POST /api/finance-ops/membership-payment-plans/refuse (deny)', () => {
-        const denyReq = (body: unknown) => new Request('http://localhost/api/finance-ops/membership-payment-plans/refuse', {
-            method: 'POST',
-            body: JSON.stringify(body),
-        }) as unknown as import('next/server').NextRequest;
-
         it('401 without a session', async () => {
             mockSession.mockResolvedValue(null);
             expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(401);
@@ -345,22 +346,20 @@ describe('Membership payment-plan routes', () => {
             expect(__getSentEmails()).toHaveLength(0);
         });
 
-        const denyReq = (body: unknown) => new Request('http://localhost/api/finance-ops/membership-payment-plans/refuse', {
-            method: 'POST',
-            body: JSON.stringify(body),
-        }) as unknown as import('next/server').NextRequest;
-
-        it('deny sends the household a status email (no grace line), once', async () => {
-            const lead = await prisma.person.findUniqueOrThrow({ where: { id: leadId } });
+        // User decision: deny is deliberately silent — no automatic applicant email
+        // (the request ack, covered above, is the applicant's only automatic email;
+        // the board communicates a denial manually). Filtered to exclude a stray
+        // "Welcome to the Treehouse" send (another test's certify/activate) rather
+        // than asserting a bare zero total, so this can't be fooled by mock bleed.
+        it('deny sends no automatic email', async () => {
             mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
 
+            __clearSentEmails();
             const res = await DenyPost(denyReq({ processId: leadProcessId }));
             expect(res.status).toBe(200);
 
-            const sent = __getSentEmails();
-            const status = sent.filter((e) => e.subject === 'Update on your membership scholarship / payment-plan request');
-            expect(status).toEqual([expect.objectContaining({ to: lead.email })]);
-            expect(status[0].html).not.toMatch(/grace|deadline|released/i); // membership deny has no seat/grace lines
+            const sent = __getSentEmails().filter((e) => !e.subject.startsWith('Welcome to the Treehouse'));
+            expect(sent).toHaveLength(0);
         });
 
         it('a no-op re-deny (flag already false) sends zero emails', async () => {
@@ -372,10 +371,9 @@ describe('Membership payment-plan routes', () => {
             expect(__getSentEmails()).toHaveLength(0);
         });
 
-        it('deny status email is gated per-recipient: an opted-out lead is excluded, the other lead receives it', async () => {
+        it('deny sends no automatic email regardless of household notification settings', async () => {
             const fresh = await makeProc('DenyGate', { requested: true, withLead: true });
-            const defaultOn = await prisma.person.findUniqueOrThrow({ where: { id: fresh.personId! } });
-            const optedOut = await prisma.person.create({
+            await prisma.person.create({
                 data: {
                     email: `deny-gate-out-${TAG}@example.com`, name: 'OptOut', householdId: fresh.householdId,
                     isHouseholdLead: true, notificationSettings: { emailScholarshipUpdates: false },
@@ -383,14 +381,12 @@ describe('Membership payment-plan routes', () => {
             });
             mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
 
+            __clearSentEmails();
             const res = await DenyPost(denyReq({ processId: fresh.processId }));
             expect(res.status).toBe(200);
 
-            const to = __getSentEmails()
-                .filter((e) => e.subject === 'Update on your membership scholarship / payment-plan request')
-                .map((e) => e.to);
-            expect(to).toContain(defaultOn.email);
-            expect(to).not.toContain(optedOut.email);
+            const sent = __getSentEmails().filter((e) => !e.subject.startsWith('Welcome to the Treehouse'));
+            expect(sent).toHaveLength(0);
         });
     });
 });

--- a/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
@@ -3,9 +3,10 @@
  */
 /**
  * Integration tests for the membership payment-plan routes:
- *   GET  /api/finance-ops/membership-payment-plans     (board-only queue)
- *   POST /api/finance-ops/membership-payment-plans      (board approves -> certify/activate)
- *   POST /api/membership/request-payment-plan           (request, with IDOR guard)
+ *   GET  /api/finance-ops/membership-payment-plans        (board-only queue)
+ *   POST /api/finance-ops/membership-payment-plans         (board approves -> certify/activate)
+ *   POST /api/finance-ops/membership-payment-plans/refuse  (board denies -> clear flag, stay PENDING_PAYMENT)
+ *   POST /api/membership/request-payment-plan              (request, with IDOR guard)
  *
  * Covers auth rejections (401/403), validation (400/404), the wrong-phase gate
  * (409 off PENDING_PAYMENT), the IDOR path (an unrelated authenticated user
@@ -13,6 +14,7 @@
  * (flag set on request; certify -> ACTIVE + flag cleared + audit on approve).
  */
 import { GET as PlansGet, POST as PlansPost } from '@/app/api/finance-ops/membership-payment-plans/route';
+import { POST as DenyPost } from '@/app/api/finance-ops/membership-payment-plans/refuse/route';
 import { POST as RequestPost } from '@/app/api/membership/request-payment-plan/route';
 import prisma from '@/lib/prisma';
 
@@ -197,6 +199,59 @@ describe('Membership payment-plan routes', () => {
         });
     });
 
+    describe('POST /api/finance-ops/membership-payment-plans/refuse (deny)', () => {
+        const denyReq = (body: unknown) => new Request('http://localhost/api/finance-ops/membership-payment-plans/refuse', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        }) as unknown as import('next/server').NextRequest;
+
+        it('401 without a session', async () => {
+            mockSession.mockResolvedValue(null);
+            expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(401);
+        });
+
+        it('403 for a non-board user', async () => {
+            mockSession.mockResolvedValue({ user: { id: otherId } });
+            expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(403);
+        });
+
+        it('400 when processId is missing', async () => {
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            expect((await DenyPost(denyReq({}))).status).toBe(400);
+        });
+
+        it('409 when there is no pending request for the process', async () => {
+            const cleared = await makeProc('DenyCleared', { requested: false });
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            expect((await DenyPost(denyReq({ processId: cleared.processId }))).status).toBe(409);
+        });
+
+        it('board denial clears the flag, keeps the process PENDING_PAYMENT, and writes an audit row', async () => {
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            const res = await DenyPost(denyReq({ processId: leadProcessId }));
+            expect(res.status).toBe(200);
+
+            const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: leadProcessId } });
+            expect(proc?.isPaymentPlanRequested).toBe(false);
+            expect(proc?.status).toBe('PENDING_PAYMENT'); // stays awaiting payment — no seat, no grace, pay-to-activate
+            expect(proc?.certifiedById).toBeNull(); // denial never certifies/activates
+
+            const membership = await prisma.orgMembership.findUnique({ where: { id: leadMembershipId } });
+            expect(membership?.status).toBe('NONE'); // untouched by denial
+
+            const audits = await prisma.auditLog.findMany({
+                where: { tableName: 'OrgMembershipProcess', affectedEntityId: leadProcessId, actorId: boardId },
+            });
+            expect(audits.some(a => (a.newData as { paymentPlanDenied?: boolean })?.paymentPlanDenied === true)).toBe(true);
+        });
+
+        it('a re-deny of an already-denied (flag false) process is a 409 no-op', async () => {
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(200);
+            expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(409);
+        });
+    });
+
     describe('POST /api/membership/request-payment-plan', () => {
         it('401 without a session', async () => {
             mockSession.mockResolvedValue(null);
@@ -288,6 +343,54 @@ describe('Membership payment-plan routes', () => {
                 to: lead.email,
                 subject: 'Your membership scholarship / payment plan was approved',
             }));
+        });
+
+        const denyReq = (body: unknown) => new Request('http://localhost/api/finance-ops/membership-payment-plans/refuse', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        }) as unknown as import('next/server').NextRequest;
+
+        it('deny sends the household a status email (no grace line), once', async () => {
+            const lead = await prisma.person.findUniqueOrThrow({ where: { id: leadId } });
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+            const res = await DenyPost(denyReq({ processId: leadProcessId }));
+            expect(res.status).toBe(200);
+
+            const sent = __getSentEmails();
+            const status = sent.filter((e) => e.subject === 'Update on your membership scholarship / payment-plan request');
+            expect(status).toEqual([expect.objectContaining({ to: lead.email })]);
+            expect(status[0].html).not.toMatch(/grace|deadline|released/i); // membership deny has no seat/grace lines
+        });
+
+        it('a no-op re-deny (flag already false) sends zero emails', async () => {
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(200);
+            __clearSentEmails();
+            const res = await DenyPost(denyReq({ processId: leadProcessId }));
+            expect(res.status).toBe(409);
+            expect(__getSentEmails()).toHaveLength(0);
+        });
+
+        it('deny status email is gated per-recipient: an opted-out lead is excluded, the other lead receives it', async () => {
+            const fresh = await makeProc('DenyGate', { requested: true, withLead: true });
+            const defaultOn = await prisma.person.findUniqueOrThrow({ where: { id: fresh.personId! } });
+            const optedOut = await prisma.person.create({
+                data: {
+                    email: `deny-gate-out-${TAG}@example.com`, name: 'OptOut', householdId: fresh.householdId,
+                    isHouseholdLead: true, notificationSettings: { emailScholarshipUpdates: false },
+                },
+            });
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+            const res = await DenyPost(denyReq({ processId: fresh.processId }));
+            expect(res.status).toBe(200);
+
+            const to = __getSentEmails()
+                .filter((e) => e.subject === 'Update on your membership scholarship / payment-plan request')
+                .map((e) => e.to);
+            expect(to).toContain(defaultOn.email);
+            expect(to).not.toContain(optedOut.email);
         });
     });
 });

--- a/checkin-app/src/app/api/finance-ops/membership-payment-plans/refuse/route.ts
+++ b/checkin-app/src/app/api/finance-ops/membership-payment-plans/refuse/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { fromWhere } from "@/lib/membership/lifecycle";
+
+// Denies a pending membership scholarship / payment-plan request — the sibling
+// of POST /api/finance-ops/membership-payment-plans (approve) that membership
+// previously lacked, so a declined request had no board action and sat
+// PENDING_PAYMENT on the queue indefinitely. This gives the board a dedicated
+// deny control (docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md §5 item 4).
+//
+// Silent by design, like every other board decision (approve on both sides,
+// program deny): sends NO automatic applicant email — the Scholarship Review
+// Team communicates the outcome manually. Denial is purely clearing
+// isPaymentPlanRequested back to false: the process stays PENDING_PAYMENT and
+// the household returns to normal "pay your dues to activate". Membership holds
+// no Shopify seat and has no grace-expiry cron (grace is program-only), so there
+// is no seat to release and no paymentPlanDeniedAt to stamp — OrgMembershipProcess
+// has no such column and needs none; the cleared flag is the whole of denial state.
+export const POST = withAuth(
+    { roles: ['isBoardMember'] },
+    async (req, auth) => {
+        try {
+            const body = await req.json();
+            const processId = parseInt(body.processId, 10);
+
+            if (Number.isNaN(processId)) {
+                return apiError("processId is required", 400);
+            }
+            if (auth.type !== 'session') {
+                return apiError("Unauthorized", 401);
+            }
+
+            // Only act on a genuinely-requested, still-awaiting-payment process, so
+            // denying a stale/nonexistent request is a no-op error, mirroring the
+            // approve route's probe. Transactional true->false guard: a double-deny
+            // (already false) 409s instead of re-writing.
+            const data = { isPaymentPlanRequested: false };
+            const { count } = await prisma.orgMembershipProcess.updateMany({
+                // Deny CAS: from-state status from the definition (#1080); isPaymentPlanRequested stays literal.
+                where: { id: processId, isPaymentPlanRequested: true, ...fromWhere('PENDING_PAYMENT') },
+                data,
+            });
+
+            if (count === 0) {
+                return apiError("No pending payment-plan request", 409);
+            }
+
+            await prisma.auditLog.create({
+                data: {
+                    actorId: auth.user.id,
+                    action: "EDIT",
+                    tableName: "OrgMembershipProcess",
+                    affectedEntityId: processId,
+                    newData: { paymentPlanDenied: true, isPaymentPlanRequested: false },
+                },
+            });
+
+            return NextResponse.json({ success: true });
+        } catch (error) {
+            logger.error("Failed to refuse membership payment plan:", error);
+            return apiError("Failed to refuse payment plan", 500);
+        }
+    }
+);

--- a/checkin-app/src/app/api/finance-ops/membership-payment-plans/refuse/route.ts
+++ b/checkin-app/src/app/api/finance-ops/membership-payment-plans/refuse/route.ts
@@ -3,8 +3,8 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
+import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 import { fromWhere } from "@/lib/membership/lifecycle";
-import { resolveScholarshipRecipients, sendScholarshipStatus } from "@/lib/scholarshipEmails";
 
 // Denies a pending membership scholarship / payment-plan request — the sibling
 // of POST /api/finance-ops/membership-payment-plans (approve) that membership
@@ -21,60 +21,71 @@ import { resolveScholarshipRecipients, sendScholarshipStatus } from "@/lib/schol
 export const POST = withAuth(
     { roles: ['isBoardMember'] },
     async (req, auth) => {
+        let body;
         try {
-            const body = await req.json();
+            body = await req.json();
+        } catch {
+            return apiError("Invalid JSON", 400);
+        }
+
+        try {
             const processId = parseInt(body.processId, 10);
 
             if (Number.isNaN(processId)) {
                 return apiError("processId is required", 400);
             }
-            if (auth.type !== 'session') {
-                return apiError("Unauthorized", 401);
+
+            // Probe the process itself (not just the target household) so a
+            // nonexistent processId gets a real 404, mirroring the program refuse
+            // route's probe order.
+            const process = await prisma.orgMembershipProcess.findUnique({
+                where: { id: processId },
+                select: { orgMembership: { select: { householdId: true } } },
+            });
+            if (!process) {
+                return apiError("Membership application not found", 404);
+            }
+
+            // Conflict of interest: mirrors certifyPaymentPlan (approve) — a board
+            // member may not deny their OWN household's request either. Sysadmin bypasses.
+            if (auth.type === 'session') {
+                if (await hasHouseholdConflict(prisma, auth.user.id, process.orgMembership?.householdId, { isSysadmin: auth.user.isSysadmin === true })) {
+                    return apiError("You cannot deny your own household's payment plan — a sysadmin must.", 403);
+                }
             }
 
             // Only act on a genuinely-requested, still-awaiting-payment process, so
-            // denying a stale/nonexistent request is a no-op error, mirroring the
-            // approve route's probe. Transactional true->false guard: a double-deny
-            // (already false) 409s and sends no email.
-            const data = { isPaymentPlanRequested: false };
-            const { count } = await prisma.orgMembershipProcess.updateMany({
-                // Deny CAS: from-state status from the definition (#1080); isPaymentPlanRequested stays literal.
-                where: { id: processId, isPaymentPlanRequested: true, ...fromWhere('PENDING_PAYMENT') },
-                data,
+            // denying a stale/already-denied request 409s, mirroring the approve
+            // route's probe. Transactional true->false guard inside $transaction: the
+            // CAS and its audit row commit together, and a double-deny (already
+            // false) leaves count at 0 with no audit row written.
+            const count = await prisma.$transaction(async (tx) => {
+                const { count } = await tx.orgMembershipProcess.updateMany({
+                    // Deny CAS: from-state status from the definition (#1080); isPaymentPlanRequested stays literal.
+                    where: { id: processId, isPaymentPlanRequested: true, ...fromWhere('PENDING_PAYMENT') },
+                    data: { isPaymentPlanRequested: false },
+                });
+                if (count === 1 && auth.type === 'session') {
+                    await tx.auditLog.create({
+                        data: {
+                            actorId: auth.user.id,
+                            action: "EDIT",
+                            tableName: "OrgMembershipProcess",
+                            affectedEntityId: processId,
+                            newData: { paymentPlanDenied: true, isPaymentPlanRequested: false },
+                        },
+                    });
+                }
+                return count;
             });
 
             if (count === 0) {
                 return apiError("No pending payment-plan request", 409);
             }
 
-            await prisma.auditLog.create({
-                data: {
-                    actorId: auth.user.id,
-                    action: "EDIT",
-                    tableName: "OrgMembershipProcess",
-                    affectedEntityId: processId,
-                    newData: { paymentPlanDenied: true, isPaymentPlanRequested: false },
-                },
-            });
-
-            // Fire-and-forget status email after the transition commits (a failed send
-            // never fails the request). Mirrors program deny voice MINUS the seat/grace
-            // lines — membership holds no seat and has no grace deadline.
-            const process = await prisma.orgMembershipProcess.findUnique({
-                where: { id: processId },
-                select: { orgMembership: { select: { householdId: true } } },
-            });
-            const householdId = process?.orgMembership?.householdId;
-            if (householdId) {
-                const recipients = await resolveScholarshipRecipients(householdId); // no requester at deny time
-                await sendScholarshipStatus(
-                    recipients,
-                    "Update on your membership scholarship / payment-plan request",
-                    `<p>The Scholarship Review Team was unable to approve your household's scholarship / payment plan `
-                    + `for your Treehouse membership dues at this time.</p>`
-                    + `<p>You can still pay your dues normally to activate your membership.</p>`,
-                );
-            }
+            // Deny sends NO automatic email (notification contract: the request ack
+            // is the applicant's only automatic email; the board communicates the
+            // denial manually).
 
             return NextResponse.json({ success: true });
         } catch (error) {

--- a/checkin-app/src/app/api/finance-ops/membership-payment-plans/refuse/route.ts
+++ b/checkin-app/src/app/api/finance-ops/membership-payment-plans/refuse/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { fromWhere } from "@/lib/membership/lifecycle";
+import { resolveScholarshipRecipients, sendScholarshipStatus } from "@/lib/scholarshipEmails";
+
+// Denies a pending membership scholarship / payment-plan request — the sibling
+// of POST /api/finance-ops/membership-payment-plans (approve) that membership
+// previously lacked, so a declined request sat PENDING_PAYMENT forever with no
+// follow-up email (the request ack promises one). Closes the program/membership
+// deny asymmetry (docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md §5 item 4).
+//
+// Unlike the program deny, membership has NO held Shopify seat (dues are paid to
+// activate, no seat is reserved on request) and NO grace-expiry cron, so denial
+// is purely clearing isPaymentPlanRequested back to false: the process stays
+// PENDING_PAYMENT and the household returns to normal "pay your dues to activate".
+// There is no paymentPlanDeniedAt column on OrgMembershipProcess and none is
+// needed — the cleared flag is the whole of denial state.
+export const POST = withAuth(
+    { roles: ['isBoardMember'] },
+    async (req, auth) => {
+        try {
+            const body = await req.json();
+            const processId = parseInt(body.processId, 10);
+
+            if (Number.isNaN(processId)) {
+                return apiError("processId is required", 400);
+            }
+            if (auth.type !== 'session') {
+                return apiError("Unauthorized", 401);
+            }
+
+            // Only act on a genuinely-requested, still-awaiting-payment process, so
+            // denying a stale/nonexistent request is a no-op error, mirroring the
+            // approve route's probe. Transactional true->false guard: a double-deny
+            // (already false) 409s and sends no email.
+            const data = { isPaymentPlanRequested: false };
+            const { count } = await prisma.orgMembershipProcess.updateMany({
+                // Deny CAS: from-state status from the definition (#1080); isPaymentPlanRequested stays literal.
+                where: { id: processId, isPaymentPlanRequested: true, ...fromWhere('PENDING_PAYMENT') },
+                data,
+            });
+
+            if (count === 0) {
+                return apiError("No pending payment-plan request", 409);
+            }
+
+            await prisma.auditLog.create({
+                data: {
+                    actorId: auth.user.id,
+                    action: "EDIT",
+                    tableName: "OrgMembershipProcess",
+                    affectedEntityId: processId,
+                    newData: { paymentPlanDenied: true, isPaymentPlanRequested: false },
+                },
+            });
+
+            // Fire-and-forget status email after the transition commits (a failed send
+            // never fails the request). Mirrors program deny voice MINUS the seat/grace
+            // lines — membership holds no seat and has no grace deadline.
+            const process = await prisma.orgMembershipProcess.findUnique({
+                where: { id: processId },
+                select: { orgMembership: { select: { householdId: true } } },
+            });
+            const householdId = process?.orgMembership?.householdId;
+            if (householdId) {
+                const recipients = await resolveScholarshipRecipients(householdId); // no requester at deny time
+                await sendScholarshipStatus(
+                    recipients,
+                    "Update on your membership scholarship / payment-plan request",
+                    `<p>The Scholarship Review Team was unable to approve your household's scholarship / payment plan `
+                    + `for your Treehouse membership dues at this time.</p>`
+                    + `<p>You can still pay your dues normally to activate your membership.</p>`,
+                );
+            }
+
+            return NextResponse.json({ success: true });
+        } catch (error) {
+            logger.error("Failed to refuse membership payment plan:", error);
+            return apiError("Failed to refuse payment plan", 500);
+        }
+    }
+);

--- a/checkin-app/src/app/api/finance-ops/membership-payment-plans/refuse/route.ts
+++ b/checkin-app/src/app/api/finance-ops/membership-payment-plans/refuse/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
+import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 import { fromWhere } from "@/lib/membership/lifecycle";
 
 // Denies a pending membership scholarship / payment-plan request — the sibling
@@ -33,30 +34,49 @@ export const POST = withAuth(
                 return apiError("Unauthorized", 401);
             }
 
-            // Only act on a genuinely-requested, still-awaiting-payment process, so
-            // denying a stale/nonexistent request is a no-op error, mirroring the
-            // approve route's probe. Transactional true->false guard: a double-deny
-            // (already false) 409s instead of re-writing.
-            const data = { isPaymentPlanRequested: false };
-            const { count } = await prisma.orgMembershipProcess.updateMany({
-                // Deny CAS: from-state status from the definition (#1080); isPaymentPlanRequested stays literal.
-                where: { id: processId, isPaymentPlanRequested: true, ...fromWhere('PENDING_PAYMENT') },
-                data,
+            // Conflict of interest: a board member may not deny their OWN household's
+            // request. Sysadmin bypasses. Approve enforces this inside certifyPaymentPlan
+            // (payment.ts) and program refuse checks it at route level — mirror that here.
+            // A nonexistent process → null householdId → no conflict → falls through to the
+            // CAS below, which 409s (not 403), keeping "not found" distinct from "your own".
+            const target = await prisma.orgMembershipProcess.findUnique({
+                where: { id: processId },
+                select: { orgMembership: { select: { householdId: true } } },
             });
-
-            if (count === 0) {
-                return apiError("No pending payment-plan request", 409);
+            if (await hasHouseholdConflict(prisma, auth.user.id, target?.orgMembership?.householdId, { isSysadmin: auth.user.isSysadmin === true })) {
+                return apiError("You cannot deny your own household's payment plan — a sysadmin must.", 403);
             }
 
-            await prisma.auditLog.create({
-                data: {
-                    actorId: auth.user.id,
-                    action: "EDIT",
-                    tableName: "OrgMembershipProcess",
-                    affectedEntityId: processId,
-                    newData: { paymentPlanDenied: true, isPaymentPlanRequested: false },
-                },
+            const data = { isPaymentPlanRequested: false };
+
+            // CAS + audit atomically (archive.ts pattern): a crash between the flag
+            // flip and the audit write would otherwise leave a flag-flipped denial
+            // with no audit row and no way to retry (the guard is already false).
+            // Only act on a genuinely-requested, still-awaiting-payment process, so
+            // denying a stale/nonexistent request is a no-op 409, mirroring approve's
+            // probe. Transactional true->false guard: a double-deny (already false) 409s.
+            const denied = await prisma.$transaction(async (tx) => {
+                const { count } = await tx.orgMembershipProcess.updateMany({
+                    // Deny CAS: from-state status from the definition (#1080); isPaymentPlanRequested stays literal.
+                    where: { id: processId, isPaymentPlanRequested: true, ...fromWhere('PENDING_PAYMENT') },
+                    data,
+                });
+                if (count === 0) return false;
+                await tx.auditLog.create({
+                    data: {
+                        actorId: auth.user.id,
+                        action: "EDIT",
+                        tableName: "OrgMembershipProcess",
+                        affectedEntityId: processId,
+                        newData: { paymentPlanDenied: true, isPaymentPlanRequested: false },
+                    },
+                });
+                return true;
             });
+
+            if (!denied) {
+                return apiError("No pending payment-plan request", 409);
+            }
 
             return NextResponse.json({ success: true });
         } catch (error) {

--- a/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
@@ -33,6 +33,8 @@ export default function MembershipPaymentPlansPage() {
   const [confirmApproveOpened, { open: openConfirmApprove, close: closeConfirmApprove }] = useDisclosure(false);
   const [pendingApproval, setPendingApproval] = useState<number | null>(null);
   const [reason, setReason] = useState("");
+  const [confirmDenyOpened, { open: openConfirmDeny, close: closeConfirmDeny }] = useDisclosure(false);
+  const [pendingDenial, setPendingDenial] = useState<number | null>(null);
 
   const fetchRequests = useCallback(async () => {
     try {
@@ -94,6 +96,45 @@ export default function MembershipPaymentPlansPage() {
     await doApprove(processId, reasonToSend);
   };
 
+  const handleDeny = (processId: number) => {
+    setPendingDenial(processId);
+    openConfirmDeny();
+  };
+
+  const doDeny = async (processId: number) => {
+    try {
+      const res = await fetch('/api/finance-ops/membership-payment-plans/refuse', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ processId })
+      });
+
+      if (res.ok) {
+        setRequests(prev => prev.filter(r => r.id !== processId));
+        notifyNavRefresh();
+        notifications.show({ color: 'green', message: 'Scholarship / payment plan denied.' });
+      } else {
+        const data = await res.json();
+        if (data.error === "No pending payment-plan request") {
+          notifications.show({ color: 'red', message: data.error, autoClose: 4000 });
+          fetchRequests();
+        } else {
+          notifications.show({ color: 'red', message: data.error || "Failed to deny.", autoClose: false });
+        }
+      }
+    } catch {
+      notifications.show({ color: 'red', message: "Network error processing denial.", autoClose: false });
+    }
+  };
+
+  const confirmDeny = async () => {
+    if (pendingDenial === null) return;
+    closeConfirmDeny();
+    const processId = pendingDenial;
+    setPendingDenial(null);
+    await doDeny(processId);
+  };
+
   if (authLoading || loading) {
     return <PageLoader />;
   }
@@ -120,9 +161,14 @@ export default function MembershipPaymentPlansPage() {
       header: 'Actions',
       align: 'right',
       render: (req) => (
-        <Button size="xs" fz={15} color="green" variant="light" onClick={() => handleApprove(req.id)}>
-          Approve &amp; Activate
-        </Button>
+        <Group justify="flex-end" gap="xs" wrap="nowrap">
+          <Button size="xs" fz={15} color="red" variant="light" onClick={() => handleDeny(req.id)}>
+            Deny
+          </Button>
+          <Button size="xs" fz={15} color="green" variant="light" onClick={() => handleApprove(req.id)}>
+            Approve &amp; Activate
+          </Button>
+        </Group>
       ),
     },
   ];
@@ -167,6 +213,23 @@ export default function MembershipPaymentPlansPage() {
         <Group justify="flex-end">
           <Button variant="default" onClick={closeConfirmApprove}>Cancel</Button>
           <Button color="green" onClick={confirmApprove} disabled={!reason.trim()}>Approve &amp; Activate</Button>
+        </Group>
+      </Modal>
+
+      <Modal
+        opened={confirmDenyOpened}
+        onClose={closeConfirmDeny}
+        title={<Text span fw={700} fz="lg">Deny Scholarship / Payment Plan</Text>}
+        centered
+      >
+        <Text mb="lg">
+          Deny this request? The household stays awaiting payment and can still pay their dues
+          normally to activate, or re-request later. No automatic email is sent — notify the
+          household of the decision yourself.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmDeny}>Cancel</Button>
+          <Button color="red" onClick={confirmDeny}>Deny</Button>
         </Group>
       </Modal>
     </Stack>

--- a/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
@@ -33,6 +33,8 @@ export default function MembershipPaymentPlansPage() {
   const [confirmApproveOpened, { open: openConfirmApprove, close: closeConfirmApprove }] = useDisclosure(false);
   const [pendingApproval, setPendingApproval] = useState<number | null>(null);
   const [reason, setReason] = useState("");
+  const [confirmDenyOpened, { open: openConfirmDeny, close: closeConfirmDeny }] = useDisclosure(false);
+  const [pendingDenial, setPendingDenial] = useState<number | null>(null);
 
   const fetchRequests = useCallback(async () => {
     try {
@@ -94,6 +96,45 @@ export default function MembershipPaymentPlansPage() {
     await doApprove(processId, reasonToSend);
   };
 
+  const handleDeny = (processId: number) => {
+    setPendingDenial(processId);
+    openConfirmDeny();
+  };
+
+  const doDeny = async (processId: number) => {
+    try {
+      const res = await fetch('/api/finance-ops/membership-payment-plans/refuse', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ processId })
+      });
+
+      if (res.ok) {
+        setRequests(prev => prev.filter(r => r.id !== processId));
+        notifyNavRefresh();
+        notifications.show({ color: 'green', message: 'Scholarship / payment plan denied.' });
+      } else {
+        const data = await res.json();
+        if (data.error === "No pending payment-plan request") {
+          notifications.show({ color: 'red', message: data.error, autoClose: 4000 });
+          fetchRequests();
+        } else {
+          notifications.show({ color: 'red', message: data.error || "Failed to deny.", autoClose: false });
+        }
+      }
+    } catch {
+      notifications.show({ color: 'red', message: "Network error processing denial.", autoClose: false });
+    }
+  };
+
+  const confirmDeny = async () => {
+    if (pendingDenial === null) return;
+    closeConfirmDeny();
+    const processId = pendingDenial;
+    setPendingDenial(null);
+    await doDeny(processId);
+  };
+
   if (authLoading || loading) {
     return <PageLoader />;
   }
@@ -120,9 +161,14 @@ export default function MembershipPaymentPlansPage() {
       header: 'Actions',
       align: 'right',
       render: (req) => (
-        <Button size="xs" fz={15} color="green" variant="light" onClick={() => handleApprove(req.id)}>
-          Approve &amp; Activate
-        </Button>
+        <Group justify="flex-end" gap="xs" wrap="nowrap">
+          <Button size="xs" fz={15} color="red" variant="light" onClick={() => handleDeny(req.id)}>
+            Deny
+          </Button>
+          <Button size="xs" fz={15} color="green" variant="light" onClick={() => handleApprove(req.id)}>
+            Approve &amp; Activate
+          </Button>
+        </Group>
       ),
     },
   ];
@@ -167,6 +213,22 @@ export default function MembershipPaymentPlansPage() {
         <Group justify="flex-end">
           <Button variant="default" onClick={closeConfirmApprove}>Cancel</Button>
           <Button color="green" onClick={confirmApprove} disabled={!reason.trim()}>Approve &amp; Activate</Button>
+        </Group>
+      </Modal>
+
+      <Modal
+        opened={confirmDenyOpened}
+        onClose={closeConfirmDeny}
+        title={<Text span fw={700} fz="lg">Deny Scholarship / Payment Plan</Text>}
+        centered
+      >
+        <Text mb="lg">
+          Deny this request? The household stays awaiting payment and can still pay their dues
+          normally to activate, or re-request later. They&apos;ll be emailed that the request was declined.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeConfirmDeny}>Cancel</Button>
+          <Button color="red" onClick={confirmDeny}>Deny</Button>
         </Group>
       </Modal>
     </Stack>

--- a/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
@@ -35,6 +35,7 @@ export default function MembershipPaymentPlansPage() {
   const [reason, setReason] = useState("");
   const [confirmDenyOpened, { open: openConfirmDeny, close: closeConfirmDeny }] = useDisclosure(false);
   const [pendingDenial, setPendingDenial] = useState<number | null>(null);
+  const [denying, setDenying] = useState(false);
 
   const fetchRequests = useCallback(async () => {
     try {
@@ -102,6 +103,7 @@ export default function MembershipPaymentPlansPage() {
   };
 
   const doDeny = async (processId: number) => {
+    setDenying(true);
     try {
       const res = await fetch('/api/finance-ops/membership-payment-plans/refuse', {
         method: 'POST',
@@ -115,7 +117,7 @@ export default function MembershipPaymentPlansPage() {
         notifications.show({ color: 'green', message: 'Scholarship / payment plan denied.' });
       } else {
         const data = await res.json();
-        if (data.error === "No pending payment-plan request") {
+        if (res.status === 409) {
           notifications.show({ color: 'red', message: data.error, autoClose: 4000 });
           fetchRequests();
         } else {
@@ -124,15 +126,17 @@ export default function MembershipPaymentPlansPage() {
       }
     } catch {
       notifications.show({ color: 'red', message: "Network error processing denial.", autoClose: false });
+    } finally {
+      setDenying(false);
     }
   };
 
   const confirmDeny = async () => {
     if (pendingDenial === null) return;
-    closeConfirmDeny();
     const processId = pendingDenial;
-    setPendingDenial(null);
     await doDeny(processId);
+    setPendingDenial(null);
+    closeConfirmDeny();
   };
 
   if (authLoading || loading) {
@@ -224,11 +228,12 @@ export default function MembershipPaymentPlansPage() {
       >
         <Text mb="lg">
           Deny this request? The household stays awaiting payment and can still pay their dues
-          normally to activate, or re-request later. They&apos;ll be emailed that the request was declined.
+          normally to activate, or re-request later. No automatic email is sent — contact the
+          household to let them know.
         </Text>
         <Group justify="flex-end">
-          <Button variant="default" onClick={closeConfirmDeny}>Cancel</Button>
-          <Button color="red" onClick={confirmDeny}>Deny</Button>
+          <Button variant="default" onClick={closeConfirmDeny} disabled={denying}>Cancel</Button>
+          <Button color="red" onClick={confirmDeny} disabled={denying} loading={denying}>Deny</Button>
         </Group>
       </Modal>
     </Stack>

--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -989,4 +989,28 @@ describe("scholarship / payment-plan request", () => {
     expect(await screen.findByText(/requested — the Scholarship Review Team will follow up/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Request a scholarship or payment plan/ })).not.toBeInTheDocument();
   });
+
+  it("a state refetch with isPaymentPlanRequested:false reverts the button to requestable", async () => {
+    setSession({ id: 1 });
+    // Piggyback on the payment-holdoff visibility refetch (already exercised
+    // above) as the lever to force a second /api/membership load — the
+    // PENDING_PAYMENT card has no other user-facing refresh trigger.
+    sessionStorage.setItem("membership_awaiting_payment_1", String(Date.now()));
+    let requested = true;
+    mockFetchJson({
+      "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
+      "/api/membership": () => state({
+        process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT", isPaymentPlanRequested: requested },
+        external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
+      }),
+    });
+    renderWithProviders(<MembershipPage />);
+    expect(await screen.findByText(/requested — the Scholarship Review Team will follow up/)).toBeInTheDocument();
+
+    requested = false;
+    Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(await screen.findByRole("button", { name: /Request a scholarship or payment plan/ })).toBeInTheDocument();
+  });
 });

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -537,8 +537,14 @@ export default function MembershipPage() {
   // Ask the board's Scholarship Review Team for a payment plan on membership dues.
   // Mirrors the program-page request; the finance-ops Membership Payment Plan tab
   // picks it up and activates the membership on approval (no Shopify payment).
+  // Mirrors the server flag both ways (not just true->true) so a denial that
+  // clears isPaymentPlanRequested — surfaced on the next state refetch — reverts
+  // the button to requestable instead of latching "requested" forever. The
+  // request button's own optimistic setPlanRequested(true) after a successful
+  // POST (below) is untouched by this: it doesn't change `state`, so this effect
+  // doesn't re-run and clobber it.
   useEffect(() => {
-    if (state?.process?.isPaymentPlanRequested) setPlanRequested(true);
+    setPlanRequested(!!state?.process?.isPaymentPlanRequested);
   }, [state?.process?.isPaymentPlanRequested]);
 
   const requestPaymentPlan = async () => {

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -537,8 +537,11 @@ export default function MembershipPage() {
   // Ask the board's Scholarship Review Team for a payment plan on membership dues.
   // Mirrors the program-page request; the finance-ops Membership Payment Plan tab
   // picks it up and activates the membership on approval (no Shopify payment).
+  // Two-way sync to the server flag: a board deny clears isPaymentPlanRequested,
+  // so a one-way latch would leave a denied member stuck on "Requested!" after a
+  // refetch. The optimistic set in requestPaymentPlan still gives instant feedback.
   useEffect(() => {
-    if (state?.process?.isPaymentPlanRequested) setPlanRequested(true);
+    setPlanRequested(!!state?.process?.isPaymentPlanRequested);
   }, [state?.process?.isPaymentPlanRequested]);
 
   const requestPaymentPlan = async () => {

--- a/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
+++ b/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
@@ -66,6 +66,7 @@ const GUARDS: GuardSite[] = [
     { file: 'lib/membership/renewal.ts', machine: 'membership', from: 'PENDING_RENEWAL', edge: ['PENDING_RENEWAL', 'PENDING_EXTERNAL_ACTION'], mode: 'spread' },
     { file: 'lib/membership/archive.ts', machine: 'membership', from: 'ARCHIVED', mode: 'spread' }, // unarchive: reverse of #13, no ARCHIVED→ edge
     { file: 'app/api/finance-ops/membership-payment-plans/route.ts', machine: 'membership', from: 'PENDING_PAYMENT', edge: ['PENDING_PAYMENT', 'ACTIVE'], mode: 'spread' },
+    { file: 'app/api/finance-ops/membership-payment-plans/refuse/route.ts', machine: 'membership', from: 'PENDING_PAYMENT', mode: 'spread' }, // deny: clears the flag only, no status edge (stays PENDING_PAYMENT)
 
     // ── left literal on purpose (documented) ──
     // personBgTriggers is an idempotency EXISTENCE set (∅→PENDING_BG_REVIEW is the edge;

--- a/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
+++ b/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
@@ -66,6 +66,7 @@ const GUARDS: GuardSite[] = [
     { file: 'lib/membership/renewal.ts', machine: 'membership', from: 'PENDING_RENEWAL', edge: ['PENDING_RENEWAL', 'PENDING_EXTERNAL_ACTION'], mode: 'spread' },
     { file: 'lib/membership/archive.ts', machine: 'membership', from: 'ARCHIVED', mode: 'spread' }, // unarchive: reverse of #13, no ARCHIVED→ edge
     { file: 'app/api/finance-ops/membership-payment-plans/route.ts', machine: 'membership', from: 'PENDING_PAYMENT', edge: ['PENDING_PAYMENT', 'ACTIVE'], mode: 'spread' },
+    { file: 'app/api/finance-ops/membership-payment-plans/refuse/route.ts', machine: 'membership', from: 'PENDING_PAYMENT', mode: 'spread' }, // deny: flag-only, no status edge
 
     // ── left literal on purpose (documented) ──
     // personBgTriggers is an idempotency EXISTENCE set (∅→PENDING_BG_REVIEW is the edge;


### PR DESCRIPTION
The fix-up offered in the #1095 review — merge this into your branch and #1095 becomes stackable on current #1093. Every item from the review comment is addressed:

- **Current base merged in**: the scope reduction (`sendScholarshipStatus` deleted; applicant gets exactly one automatic email) and the design-doc §5 rewrite are reconciled — the deny route now sends **nothing**, and the doc's membership-deny row reads "no automatic email" with the asymmetry note rewritten as closed-but-silent.
- **COI**: `hasHouseholdConflict` before the CAS (sysadmin bypass), matching approve's enforcement in `certifyPaymentPlan` and the program refuse route — plus a real 404 for a nonexistent processId.
- **Atomicity**: the flag-clear CAS and its audit row commit in one `$transaction` (archive.ts pattern) — no more unauditable denials on a crash between them.
- **Tests**: deny-email tests flipped to zero-email negative assertions (welcome-subject-filtered, same shape as #1096); the new CAS guard registered in `guardFromStateParity` (flag-only, no status edge, archive.ts shape); `denyReq` hoisted. The certify test is left to #1096.
- **UI**: modal now says "No automatic email is sent — contact the household to let them know"; in-flight guard on the confirm Deny button (double-click can't paint a false failure); 409 detected by status code, not error-string matching.
- **Member page**: the `planRequested` one-way latch is fixed — a state refetch after your denial reverts the button to requestable (test added via the visibility-refetch path).

Verified: bare-exit tsc 0, eslint clean, guardFromStateParity + membership page suites 73/73 locally; integration runtime in CI. Deliberately untouched: `doApprove`'s identical error-string pattern (predates this PR), the certify test (#1096 owns it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe