### PR TITLE
test(finance-ops): cover membership-deny COI guard + 404 (stacks on #1097)

### DIFF
--- a/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
@@ -251,6 +251,43 @@ describe('Membership payment-plan routes', () => {
             expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(200);
             expect((await DenyPost(denyReq({ processId: leadProcessId }))).status).toBe(409);
         });
+
+        it('404 when the process does not exist', async () => {
+            mockSession.mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+            expect((await DenyPost(denyReq({ processId: 999999999 }))).status).toBe(404);
+        });
+
+        it('403 (conflict of interest) when a board member denies their OWN household; the request is untouched', async () => {
+            const own = await makeProc('DenyCOI', { requested: true });
+            const boardKin = await prisma.person.create({
+                data: { name: 'Board Kin', email: `board-kin-${own.processId}-${TAG}@example.com`, isBoardMember: true, householdId: own.householdId },
+            });
+            mockSession.mockResolvedValue({ user: { id: boardKin.id, isBoardMember: true } });
+
+            const res = await DenyPost(denyReq({ processId: own.processId }));
+            expect(res.status).toBe(403);
+            const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: own.processId } });
+            expect(proc?.isPaymentPlanRequested).toBe(true); // flag NOT flipped by the refused deny
+
+            // Drop this extra board member so it doesn't inflate the "email all board
+            // members" review-team fallback that later count-based tests assert on.
+            await prisma.person.delete({ where: { id: boardKin.id } });
+        });
+
+        it('a sysadmin may deny their own household (COI bypass)', async () => {
+            const own = await makeProc('DenySysadmin', { requested: true });
+            const sysKin = await prisma.person.create({
+                data: { name: 'Sys Kin', email: `sys-kin-${own.processId}-${TAG}@example.com`, isBoardMember: true, householdId: own.householdId },
+            });
+            mockSession.mockResolvedValue({ user: { id: sysKin.id, isBoardMember: true, isSysadmin: true } });
+
+            const res = await DenyPost(denyReq({ processId: own.processId }));
+            expect(res.status).toBe(200);
+            const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: own.processId } });
+            expect(proc?.isPaymentPlanRequested).toBe(false);
+
+            await prisma.person.delete({ where: { id: sysKin.id } }); // keep it out of the board-member fallback set
+        });
     });
 
     describe('POST /api/membership/request-payment-plan', () => {


### PR DESCRIPTION
Stacks on #1097 (`claude/pr1095-fixes`).

#1097 added conflict-of-interest enforcement (`hasHouseholdConflict`, sysadmin bypass) and a real **404** for a nonexistent `processId` to the membership deny route — solid changes, but shipped with **no tests exercising either path**. This adds that coverage (the only gap I found comparing #1097 against my own branch).

## Added
- **404** when the process does not exist.
- **403 conflict-of-interest** when a board member denies their **own** household — and asserts the pending flag is **not** flipped by the refused deny (guards against a partial-effect regression).
- **Sysadmin COI bypass**: a sysadmin may deny their own household (200, flag cleared).

## Note on test hygiene
The two COI cases create an extra in-household board member. Each **deletes it after asserting** — otherwise it leaks into the "email all board members" review-team fallback and inflates the request-email count assertion elsewhere in the suite (a real cross-test pollution I hit while writing these).

## Verified
- `tsc` clean (only the pre-existing `@aws-sdk/client-lambda` missing-dep noise), eslint clean.
- Membership integration suite: my 3 new tests green; whole suite green except the pre-existing `certify (approve) sends no automatic email` (the activation welcome-email failure #1096 owns — unchanged by this PR).

Once #1097 merges into #1095's branch, this rides along.