### PR TITLE
merge page: unclip the participant search results

### DIFF
--- a/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
@@ -54,6 +54,29 @@ describe("membership-ops/participants/merge page", () => {
     expect(screen.getByRole("button", { name: "Proceed to Preview" })).toBeInTheDocument();
   });
 
+  it("renders multiple search results fully, not clipped to a sliver", async () => {
+    // Regression test for the merge page's search dropdown being clipped by an
+    // ancestor Card's default overflow:hidden (only a sliver of the first result
+    // was visible). All results must render, not just the first.
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({
+      "/api/people/search?q=Sam": {
+        people: [
+          { id: 50, name: "Sam One", email: "sam1@example.com" },
+          { id: 51, name: "Sam Two", email: "sam2@example.com" },
+          { id: 52, name: "Sam Three", email: "sam3@example.com" },
+        ],
+      },
+    });
+    renderWithProviders(<MergeParticipants />);
+
+    fireEvent.change(screen.getAllByPlaceholderText("Search by name or email...")[0], { target: { value: "Sam" } });
+
+    expect(await screen.findByText("Sam One", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Sam Two", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Sam Three", { exact: false })).toBeInTheDocument();
+  });
+
   it("previews and confirms the merge", async () => {
     setSession({ id: 1, isSysadmin: true });
     const fetchMock = mockRoutes();

--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -151,7 +151,7 @@ export default function MergeParticipants() {
             placeholder="Search by name or email..."
           />
           {results.length > 0 && (
-            <Paper withBorder shadow="md" radius="sm" pos="absolute" left={0} right={0} style={{ zIndex: 10, maxHeight: 250, overflowY: "auto" }}>
+            <Paper withBorder shadow="md" radius="sm" pos="absolute" left={0} right={0} style={{ zIndex: 10, maxHeight: 320, overflowY: "auto" }}>
               {results.map((r) => (
                 <Box key={r.id} p="sm" style={{ cursor: "pointer", borderBottom: "1px solid var(--mantine-color-default-border)" }} onClick={() => setSelected(r)}>
                   <Text>{r.name || "Unnamed"} <Text component="span" size="xs" c="dimmed">(ID: {r.id})</Text></Text>
@@ -254,7 +254,9 @@ export default function MergeParticipants() {
 
       {!previewMode ? (
         <>
-          <Card withBorder radius="md" padding="lg">
+          {/* overflow: visible overrides Mantine's Card default (overflow: hidden), which
+              otherwise clips the search results dropdown below to a sliver — see renderSearch. */}
+          <Card withBorder radius="md" padding="lg" style={{ overflow: "visible" }}>
             <Group align="flex-start" gap="xl" grow>
               {renderSearch("Participant 1", searchA, setSearchA, resultsA, pA, setPA)}
               {renderSearch("Participant 2", searchB, setSearchB, resultsB, pB, setPB)}


### PR DESCRIPTION
First of the merge-tool fixes from prod dogfooding: typing in either participant search box showed only the first pixels of the results list.

**Root cause**: Mantine's `Card` hardcodes `overflow: hidden` in its base class (no prop opt-out), and the results dropdown is an absolutely-positioned `Paper` whose static position falls past the card's bottom edge — everything below the padding line got clipped. Fix: inline `overflow: visible` on the one outer card wrapping both search columns, and results `maxHeight` 250→320 so 6-8 rows show before scrolling. Regression test asserts three mocked results render simultaneously.

**Deliberately NOT in this PR — the missing nav link**: it's hidden on purpose. `membershipOpsNav.ts` carries a hold comment documenting the merge API's blind-delete-on-collision data loss (higher tool cert destroyed, ACTIVE enrollment reverted, payment metadata dropped). Re-linking now would re-expose that. The link returns with the merge redesign already in flight (field-by-field keep selection, no data deletion, tombstone provenance) — which also fixes the P2002 500 Jeff hit (keeper backfill of unique googleId/email before the merged row is cleared).

Verified: tsc bare-exit 0, eslint clean, 12 suites / 97 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe