### PR TITLE
merge hotfix: unique-identity ordering, named errors, full pre-image audit

### DIFF
--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -338,7 +338,7 @@ describe('AuditLog Integration Tests', () => {
         const logs = await prisma.auditLog.findMany({
             where: {
                 action: 'DELETE',
-                tableName: 'Participant',
+                tableName: 'Person',
                 affectedEntityId: keep.id,
                 secondaryAffectedEntity: merge.id,
             },

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -128,13 +128,61 @@ describe("Merge Participants API", () => {
         expect(res.status).toBe(200);
 
         const log = await prisma.auditLog.findFirst({
-            where: { tableName: "Participant", affectedEntityId: pKeepId, secondaryAffectedEntity: pMergeId }
+            where: { tableName: "Person", affectedEntityId: pKeepId, secondaryAffectedEntity: pMergeId }
         });
         expect(log).not.toBeNull();
         expect(log?.actorId).toBe(actorId);
         const newData = log?.newData as { keepId: number; moved: { visits: number } };
         expect(newData.keepId).toBe(pKeepId);
         expect(newData.moved.visits).toBe(1);
+
+        // Full pre-image of the merged-away Person: every field the merge
+        // rewrites (tombstone) or moves (backfill), captured before either update.
+        const oldData = log?.oldData as Record<string, unknown>;
+        expect(Object.keys(oldData).sort()).toEqual([
+            "dateOfBirth", "email", "googleId", "householdId", "id", "image",
+            "isHouseholdLead", "lastBackgroundCheck", "lastWaiverSign", "name", "phone",
+        ].sort());
+        expect(oldData.id).toBe(pMergeId);
+        expect(oldData.email).toBe("merge@example.com");
+        expect(oldData.phone).toBe("123-456-7890");
+    });
+
+    it("should succeed when the MERGED side holds googleId+email and the keeper holds neither (prod P2002 repro)", async () => {
+        // This is the exact prod failure: the keeper backfill used to copy
+        // googleId/email onto the keeper BEFORE the tombstone cleared them off
+        // the merge-side row, tripping the @unique constraint and surfacing as
+        // a generic 500. Reordering (tombstone first) fixes it.
+        // Keeper starts with no email/googleId of its own (beforeEach gives it one
+        // by default) so the backfill actually has something to copy.
+        await prisma.person.update({
+            where: { id: pKeepId },
+            data: { email: null, googleId: null }
+        });
+        await prisma.person.update({
+            where: { id: pMergeId },
+            data: { googleId: "google-conflict-id", email: "conflict@example.com" }
+        });
+
+        const req = new Request("http://localhost/api/membership-ops/participants/merge", {
+            method: "POST",
+            body: JSON.stringify({ keepId: pKeepId, mergeId: pMergeId })
+        }) as unknown as import('next/server').NextRequest;
+
+        const res = await POST(req);
+        const data = await res.json();
+        if (res.status !== 200) console.error('Merge error:', data);
+        expect(res.status).toBe(200);
+        expect(data.success).toBe(true);
+
+        const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
+        expect(kept?.googleId).toBe("google-conflict-id");
+        expect(kept?.email).toBe("conflict@example.com");
+
+        const merged = await prisma.person.findUnique({ where: { id: pMergeId } });
+        expect(merged?.googleId).toBeNull();
+        expect(merged?.email).toContain("merged-");
+        expect(merged?.email).toContain("@deleted.checkme.in");
     });
 
     it("relinks one row and deletes the loser when keep AND merge both have a conflicting programParticipant + feePayment", async () => {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -171,9 +171,9 @@ describe("Merge Participants API", () => {
 
         const res = await POST(req);
         const data = await res.json();
-        if (res.status !== 200) console.error('Merge error:', data);
-        expect(res.status).toBe(200);
-        expect(data.success).toBe(true);
+        // Assert on the pair together so a failure's diff shows the response
+        // body (was a console.error; folded into the assertion instead).
+        expect({ status: res.status, data }).toEqual({ status: 200, data: { success: true } });
 
         const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
         expect(kept?.googleId).toBe("google-conflict-id");

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -66,6 +66,29 @@ export const POST = withAuth(
                     }
                 }
 
+                // Clear the merged person's unique identity fields FIRST, before
+                // backfilling those same values onto the keeper below. Postgres
+                // checks non-deferrable unique constraints per-statement, so
+                // clearing mergeId's googleId/email in this statement means the
+                // keeper's backfill statement (same values, captured pre-tx) no
+                // longer collides with it. Reordering these two was the fix for
+                // the P2002 that produced the prod 500 (a1).
+                //
+                // householdId stays pointing at the old household: every
+                // participant must belong to a household, and merged-away
+                // records are tombstoned rather than deleted. Leadership is
+                // cleared (a1): the tombstone is no longer a lead of anything.
+                await tx.person.update({
+                    where: { id: mergeId },
+                    data: {
+                        googleId: null,
+                        email: `merged-${mergeId}@deleted.checkme.in`,
+                        phone: null,
+                        name: `${mergeParticipant.name || 'Unknown'} (Merged into ${keepId})`,
+                        isHouseholdLead: false,
+                    }
+                });
+
                 if (Object.keys(updates).length > 0) {
                     await tx.person.update({
                         where: { id: keepId },
@@ -163,34 +186,30 @@ export const POST = withAuth(
                     }
                 }
 
-                // householdId stays pointing at the old household: every
-                // participant must belong to a household, and merged-away
-                // records are tombstoned rather than deleted. Leadership is
-                // cleared (a1): the tombstone is no longer a lead of anything.
-                await tx.person.update({
-                    where: { id: mergeId },
-                    data: {
-                        googleId: null,
-                        email: `merged-${mergeId}@deleted.checkme.in`,
-                        phone: null,
-                        name: `${mergeParticipant.name || 'Unknown'} (Merged into ${keepId})`,
-                        isHouseholdLead: false,
-                    }
-                });
-
                 // ponytail: audit only — undo is unimplemented; merge is still irreversible.
                 if (auth.type === 'session') {
                     await tx.auditLog.create({
                         data: {
                             actorId: auth.user.id,
                             action: "DELETE",
-                            tableName: "Participant",
+                            tableName: "Person",
                             affectedEntityId: keepId,
                             secondaryAffectedEntity: mergeId,
+                            // Full pre-image of every field the merge rewrites (tombstone)
+                            // or moves (backfill) on the merged-away Person, captured
+                            // before either update ran.
                             oldData: {
                                 id: mergeParticipant.id,
-                                name: mergeParticipant.name,
+                                googleId: mergeParticipant.googleId,
                                 email: mergeParticipant.email,
+                                phone: mergeParticipant.phone,
+                                name: mergeParticipant.name,
+                                dateOfBirth: mergeParticipant.dateOfBirth,
+                                image: mergeParticipant.image,
+                                lastWaiverSign: mergeParticipant.lastWaiverSign,
+                                lastBackgroundCheck: mergeParticipant.lastBackgroundCheck,
+                                isHouseholdLead: mergeParticipant.isHouseholdLead,
+                                householdId: mergeParticipant.householdId,
                             },
                             newData: { keepId, moved },
                         }
@@ -200,8 +219,30 @@ export const POST = withAuth(
 
             return NextResponse.json({ success: true });
         } catch (error: unknown) {
+            const field = prismaUniqueConflictField(error);
+            if (field) {
+                const label = field === 'googleId' ? 'the Google identity'
+                    : field === 'email' ? 'the email address'
+                    : field === 'phone' ? 'the phone number'
+                    : `the ${field} field`;
+                return apiError(`Merge conflict: ${label} is already attached to another record.`, 409);
+            }
             await logBackendError(error, "POST /api/membership-ops/participants/merge");
-            return apiError("Failed to merge participants", 500);
+            return apiError("Failed to merge participants — check server logs for details.", 500);
         }
     }
 );
+
+// Prisma known-request errors carry a string `code` and, for P2002, a
+// `meta.target` naming the colliding column(s). Duck-typed so we don't pull
+// in the generated Prisma namespace just for one check. Returns the first
+// colliding field name, or undefined if this isn't a P2002.
+function prismaUniqueConflictField(error: unknown): string | undefined {
+    if (typeof error !== 'object' || error === null || (error as { code?: unknown }).code !== 'P2002') {
+        return undefined;
+    }
+    const target = (error as { meta?: { target?: string[] | string } }).meta?.target;
+    if (Array.isArray(target)) return target[0];
+    if (typeof target === 'string') return target;
+    return 'unique';
+}


### PR DESCRIPTION
PR-A of the merge-tool work — the minimal fix that unblocks the merge Jeff attempted in prod. The redesign (field-by-field selection, no-deletion, relation disposition) follows as its own PR.

- **The 500, root-caused and fixed**: the transaction backfilled the merged person's `googleId`/`email` onto the keeper *before* the tombstone update cleared them — both columns are `@unique`, so any duplicate carrying the Google login (the normal duplicate-person case) hit P2002 and the catch-all "Failed to merge participants". The tombstone-clear now runs first; Postgres checks non-deferrable uniques per statement, so clear-then-apply in one transaction is safe.
- **Errors are named now**: P2002 → 409 telling the board which identity collided ("the Google identity", "the email address", …); the residual catch-all points at server logs instead of shrugging.
- **Audit row records the full pre-image** of the merged person (all rewritten/moved fields, captured pre-transaction) instead of id/name/email — with no-deletion coming in PR-B, this is the recovery record. Stale `tableName: "Participant"` → `"Person"` (the one reader discovers table names dynamically; the two hardcoded test assertions updated).
- **Tested against a real Postgres locally** (15/15): includes the exact prod repro (merge-side holds the login identity), with causality proven — un-reordering the transaction makes the new test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe