### PR TITLE
UI audit: sign-in rebuild, tool-cert de-dup, off-palette sweep, drift guard

### DIFF
--- a/checkin-app/src/__tests__/offPaletteColorAllowlist.test.ts
+++ b/checkin-app/src/__tests__/offPaletteColorAllowlist.test.ts
@@ -1,0 +1,153 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+/**
+ * Off-palette color drift guard (UI-AUDIT.md / UI-AUDIT-verdicts.md) — mirrors
+ * `lifecycleStatusLiteralAllowlist.test.ts`'s scanner-with-allowlist pattern: a `walk()`
+ * that skips `node_modules`/`generated`/`__tests__`, a brace-aware capture of the RHS of
+ * every `color` assignment, a hand-maintained ALLOWLIST, and — critically — two
+ * assertions: no new unlisted hit, and no stale allowlist entry.
+ *
+ * Scope (the "off-palette color sweep" PR): decorative/status colors that drifted off the
+ * brand palette (green/blue/teal/cyan/grape/orange/pink/indigo). `red`/`yellow` are
+ * deliberately OUTSIDE the banned set — repainting the near-universal destructive/warning
+ * convention (Deny/Delete buttons, validation Alerts) is an org-level design decision this
+ * PR explicitly does not make (97 `red` + 25 `yellow` instances, almost all destructive/
+ * error UI). See the PR description for the full rationale.
+ *
+ * Matches all three shapes the color audit found:
+ *   - JSX prop:       `color="grape"`
+ *   - object literal: `color: 'grape'`               (e.g. a ROLE_META-shaped status map)
+ *   - ternary/expr:    `color={cond ? 'grape' : 'blue'}` (brace-captured, so both branches
+ *                       of a nested ternary are visible to the regex even though it's a
+ *                       single capture)
+ * A new off-palette color anywhere else fails CI, forcing the author to either use a brand
+ * token (`treehouseGreen`/`treehousePurple`/`gray`) or register a justified ALLOWLIST entry.
+ */
+
+const SRC = join(__dirname, '..');
+
+const BANNED = ['green', 'blue', 'teal', 'cyan', 'grape', 'orange', 'pink', 'indigo'] as const;
+const BANNED_RE = new RegExp(`['"](${BANNED.join('|')})['"]`);
+
+/**
+ * Every file that keeps a genuine off-palette `color` value on purpose, with a justification.
+ * Note: `components/ToolLevelBadge.tsx` (the regulated Shop Safety Rules cert palette) needs
+ * NO entry here — like the red/yellow safety alerts, it never uses a `color=`/`color:` prop
+ * at all (its dot/bg/fg are raw hex via `styles`), so it's already outside the scanned set;
+ * listing it would trip the stale-entry check below.
+ */
+const ALLOWLIST: Record<string, string> = {
+    'components/AppFrame.tsx': 'DEV badge + header border (orange), dev-instance-gated — never shown in prod.',
+    'components/admin/SystemHealthPanels.tsx':
+        'Latency good/warn/bad status triad (green leg) — mirrors the yellow/red siblings and the SVG threshold colors; repainting only the green leg would desync it from both.',
+};
+
+// ── scanner (mirrors lifecycleStatusLiteralAllowlist.test.ts's walk/captureObject) ──────
+
+function walk(dir: string, out: string[] = []): string[] {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, e.name);
+        if (e.isDirectory()) {
+            if (!['node_modules', 'generated', '__tests__'].includes(e.name)) walk(full, out);
+        } else if (/\.tsx?$/.test(e.name) && !/\.test\.tsx?$/.test(e.name)) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+/** Capture the brace-balanced expression starting at/after `from`, skipping strings &
+ *  comments so a brace inside them can't unbalance the scan (e.g. a ternary's string
+ *  literals, or a nested object). Same mechanics as the lifecycle guard's captureObject. */
+function captureObject(s: string, from: number): { text: string; end: number } | null {
+    let i = s.indexOf('{', from);
+    if (i < 0) return null;
+    const start = i;
+    let depth = 0;
+    for (; i < s.length; i++) {
+        const c = s[i];
+        const d = s[i + 1];
+        if (c === '/' && d === '/') {
+            i = s.indexOf('\n', i);
+            if (i < 0) i = s.length;
+            continue;
+        }
+        if (c === '/' && d === '*') {
+            i = s.indexOf('*/', i + 2);
+            i = i < 0 ? s.length : i + 1;
+            continue;
+        }
+        if (c === "'" || c === '"' || c === '`') {
+            const q = c;
+            i++;
+            while (i < s.length && s[i] !== q) {
+                if (s[i] === '\\') i++;
+                i++;
+            }
+            continue;
+        }
+        if (c === '{') depth++;
+        else if (c === '}') {
+            depth--;
+            if (depth === 0) return { text: s.slice(start, i + 1), end: i + 1 };
+        }
+    }
+    return null;
+}
+
+// `color` followed by `=` (JSX prop) or `:` (object literal / ROLE_META-shaped map).
+const COLOR_RE = /\bcolor\s*[:=]\s*/g;
+
+/** Capture the RHS of a `color` assignment: a quoted literal, or (if it opens with `{`) the
+ *  brace-balanced expression — which is what makes a ternary's OFF branch visible too. */
+function captureColorValue(src: string, afterMatch: number): string | null {
+    const c = src[afterMatch];
+    if (c === '"' || c === "'" || c === '`') {
+        const q = c;
+        let j = afterMatch + 1;
+        while (j < src.length && src[j] !== q) {
+            if (src[j] === '\\') j++;
+            j++;
+        }
+        return src.slice(afterMatch, j + 1);
+    }
+    if (c === '{') {
+        const cap = captureObject(src, afterMatch);
+        return cap ? cap.text : null;
+    }
+    return null;
+}
+
+/** Files with a `color` value containing an off-palette literal (any of the three shapes). */
+function scan(): Set<string> {
+    const hits = new Set<string>();
+    for (const file of walk(SRC)) {
+        const src = readFileSync(file, 'utf8');
+        const rel = relative(SRC, file).split(sep).join('/');
+        COLOR_RE.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = COLOR_RE.exec(src))) {
+            const rhs = captureColorValue(src, m.index + m[0].length);
+            if (rhs && BANNED_RE.test(rhs)) hits.add(rel);
+        }
+    }
+    return hits;
+}
+
+describe('off-palette color allowlist drift guard', () => {
+    const flagged = scan();
+    const known = new Set(Object.keys(ALLOWLIST));
+
+    it('no unlisted off-palette color (green/blue/teal/cyan/grape/orange/pink/indigo)', () => {
+        const unexpected = [...flagged].filter((f) => !known.has(f)).sort();
+        // A new hit here must be repainted to a brand token (treehouseGreen / treehousePurple /
+        // gray) or registered in ALLOWLIST with a justification — see the file header.
+        expect(unexpected).toEqual([]);
+    });
+
+    it('has no stale allowlist entry (a listed file no longer keeps an off-palette color)', () => {
+        const stale = [...known].filter((f) => !flagged.has(f)).sort();
+        expect(stale).toEqual([]);
+    });
+});

--- a/checkin-app/src/app/attendance/certifications/page.tsx
+++ b/checkin-app/src/app/attendance/certifications/page.tsx
@@ -173,7 +173,7 @@ function KioskCertificationsInner() {
           <Group align="center" wrap="wrap">
             <Group align="center" wrap="wrap">
               <Title order={1} fz="clamp(1.5rem, 4vw, 2rem)">Live Certifications</Title>
-              <Badge color={limitToPresent ? 'teal' : 'gray'} variant="light" size="lg">
+              <Badge color="gray" variant="light" size="lg">
                 {limitToPresent ? `${participants.length} People Present` : `${participants.length} Total Members`}
               </Badge>
             </Group>

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -356,7 +356,7 @@ function KioskDisplayInner() {
                 Check Me In
               </Button>
             ) : (
-              <Alert color="teal" ta="center">You are currently checked in!</Alert>
+              <Alert ta="center">You are currently checked in!</Alert>
             )}
           </Box>
         )}

--- a/checkin-app/src/app/attendance/manual/page.tsx
+++ b/checkin-app/src/app/attendance/manual/page.tsx
@@ -67,7 +67,7 @@ export default function ManualAttendance() {
       if (!res.ok) {
         setError(data.error || "Failed to record manual visit.");
       } else {
-        notifications.show({ color: "green", message: "Visit recorded successfully." });
+        notifications.show({ message: "Visit recorded successfully." });
         setArrived("");
         setDeparted("");
         // Building occupancy badges (attendance nav) count this new visit — refresh them.

--- a/checkin-app/src/app/facility-ops/print-badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/page.tsx
@@ -157,10 +157,10 @@ export default function PrintBadgesPage() {
       header: 'Roles',
       render: (p) => (
         <Group gap={4}>
-          {p.isBoardMember && <Badge size="xs" color="blue">BOARD</Badge>}
-          {p.isKeyholder && <Badge size="xs" color="orange">KEYHOLDER</Badge>}
+          {p.isBoardMember && <Badge size="xs" color="treehousePurple">BOARD</Badge>}
+          {p.isKeyholder && <Badge size="xs" color="treehousePurple">KEYHOLDER</Badge>}
           {!p.isBoardMember && !p.isKeyholder && p.isMember && (
-            <Badge size="xs" color="green">MEMBER</Badge>
+            <Badge size="xs">MEMBER</Badge>
           )}
         </Group>
       ),
@@ -183,7 +183,7 @@ export default function PrintBadgesPage() {
         <Button onClick={() => generate('badge')} disabled={selectedIds.size === 0 || isGenerating} loading={isGenerating}>
           Generate Badge ({selectedIds.size})
         </Button>
-        <Button color="grape" onClick={() => generate('sticker')} disabled={selectedIds.size === 0 || isGenerating} loading={isGenerating}>
+        <Button color="treehousePurple" onClick={() => generate('sticker')} disabled={selectedIds.size === 0 || isGenerating} loading={isGenerating}>
           Generate Sticker ({selectedIds.size})
         </Button>
       </Group>

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -44,7 +44,7 @@ type RowNoticeState = { id: number; text: string; tone: AlertTone } | null;
 const RowNotice = ({ notice, id, onClose }: { notice: RowNoticeState; id: number; onClose: () => void }) => {
   if (notice?.id !== id) return null;
   return (
-    <Alert py={4} px="xs" color={notice.tone === 'success' ? 'green' : 'red'} variant="light" withCloseButton onClose={onClose}>
+    <Alert py={4} px="xs" color={notice.tone === 'success' ? 'treehouseGreen' : 'red'} variant="light" withCloseButton onClose={onClose}>
       {notice.text}
     </Alert>
   );
@@ -171,7 +171,7 @@ export default function AdminVisitsPage() {
         })
       });
       if (res.ok) {
-        notifications.show({ color: "green", message: "Visit updated successfully." });
+        notifications.show({ message: "Visit updated successfully." });
         setEditingVisitId(null);
         fetchVisits();
       } else {
@@ -200,7 +200,7 @@ export default function AdminVisitsPage() {
         body: JSON.stringify({ visitId: id })
       });
       if (res.ok) {
-        notifications.show({ color: "green", message: "Visit deleted." });
+        notifications.show({ message: "Visit deleted." });
         fetchVisits();
       } else {
         const data = await res.json().catch(() => ({}));
@@ -261,7 +261,7 @@ export default function AdminVisitsPage() {
                     <Table.Td>
                       <Stack gap={6}>
                         <Group gap="xs" wrap="nowrap">
-                          <Button size="xs" fz={15} color="green" onClick={() => handleSaveEdit(v.id)}>Save</Button>
+                          <Button size="xs" fz={15} onClick={() => handleSaveEdit(v.id)}>Save</Button>
                           <Button size="xs" fz={15} variant="default" onClick={() => setEditingVisitId(null)}>Cancel</Button>
                         </Group>
                         <RowNotice notice={rowNotice} id={v.id} onClose={() => setRowNotice(null)} />

--- a/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
@@ -114,7 +114,7 @@ export default function MembershipPaymentPlansPage() {
       if (res.ok) {
         setRequests(prev => prev.filter(r => r.id !== processId));
         notifyNavRefresh();
-        notifications.show({ color: 'green', message: 'Scholarship / payment plan denied.' });
+        notifications.show({ message: 'Scholarship / payment plan denied.' });
       } else {
         const data = await res.json();
         if (res.status === 409) {
@@ -169,7 +169,7 @@ export default function MembershipPaymentPlansPage() {
           <Button size="xs" fz={15} color="red" variant="light" onClick={() => handleDeny(req.id)}>
             Deny
           </Button>
-          <Button size="xs" fz={15} color="green" variant="light" onClick={() => handleApprove(req.id)}>
+          <Button size="xs" fz={15} variant="light" onClick={() => handleApprove(req.id)}>
             Approve &amp; Activate
           </Button>
         </Group>
@@ -216,7 +216,7 @@ export default function MembershipPaymentPlansPage() {
         />
         <Group justify="flex-end">
           <Button variant="default" onClick={closeConfirmApprove}>Cancel</Button>
-          <Button color="green" onClick={confirmApprove} disabled={!reason.trim()}>Approve &amp; Activate</Button>
+          <Button onClick={confirmApprove} disabled={!reason.trim()}>Approve &amp; Activate</Button>
         </Group>
       </Modal>
 

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -89,7 +89,7 @@ export default function PendingParticipantsPage() {
       if (res.ok) {
         setRequests(prev => prev.filter(r => !(r.programId === programId && r.personId === participantId)));
         notifyNavRefresh();
-        notifications.show({ color: 'green', message: 'Scholarship / payment plan approved.' });
+        notifications.show({ message: 'Scholarship / payment plan approved.' });
       } else {
         const data = await res.json();
         if (data.error === "No pending payment-plan request") {
@@ -128,7 +128,7 @@ export default function PendingParticipantsPage() {
       if (res.ok) {
         setRequests(prev => prev.filter(r => !(r.programId === programId && r.personId === participantId)));
         notifyNavRefresh();
-        notifications.show({ color: 'green', message: 'Scholarship / payment plan refused.' });
+        notifications.show({ message: 'Scholarship / payment plan refused.' });
       } else {
         const data = await res.json();
         if (data.error === "No pending payment-plan request") {
@@ -176,7 +176,7 @@ export default function PendingParticipantsPage() {
           <Group gap="xs">
             <Text fw={500}>{req.program.name}</Text>
             {landsNextYear(req.program.startAt, cutoff) && (
-              <Badge size="sm" color="orange" variant="light">Next year</Badge>
+              <Badge size="sm" color="treehousePurple" variant="light">Next year</Badge>
             )}
           </Group>
           <Text size="sm" c="dimmed">
@@ -210,7 +210,7 @@ export default function PendingParticipantsPage() {
             Refuse
           </Button>
           <Button
-            size="xs" fz={15} color="green" variant="light"
+            size="xs" fz={15} variant="light"
             disabled={ownHousehold(req)}
             title={ownHousehold(req) ? "You can't approve your own household's plan — a sysadmin must." : undefined}
             onClick={() => handleApprove(req.programId, req.personId)}
@@ -251,7 +251,7 @@ export default function PendingParticipantsPage() {
         </Text>
         <Group justify="flex-end">
           <Button variant="default" onClick={closeConfirmApprove}>Cancel</Button>
-          <Button color="green" onClick={confirmApprove}>Approve &amp; Mark Active</Button>
+          <Button onClick={confirmApprove}>Approve &amp; Mark Active</Button>
         </Group>
       </Modal>
 

--- a/checkin-app/src/app/finance-ops/payments/__tests__/page.test.tsx
+++ b/checkin-app/src/app/finance-ops/payments/__tests__/page.test.tsx
@@ -180,19 +180,22 @@ describe("finance-ops/payments — sync status", () => {
 
             expect(lastMessage()).toMatch(/still running/i);
             // Nothing went wrong — the sync started and is proceeding, we just stopped
-            // watching. Plain success shape; the sentence carries "check back later".
-            expect(lastShown()).toMatchObject({ color: "green" });
+            // watching. Plain success shape: no color override, so it inherits the
+            // theme's treehouseGreen (the off-palette sweep made success implicit
+            // rather than a literal 'green' — see offPaletteColorAllowlist.test.ts).
+            expect(lastShown().color).toBeUndefined();
             expect(lastShown().autoClose).not.toBe(false);
         } finally {
             jest.useRealTimers();
         }
     });
 
-    it("only ever speaks the app's red/green notification vocabulary", async () => {
+    it("only ever speaks the app's red/theme-primary notification vocabulary", async () => {
         // The app has no warning tier: every notifications.show() in checkin-app is red
-        // (error) or green (success). This page briefly invented `yellow` for the two
-        // ambiguous outcomes, which read as a new severity that nothing else uses — and
-        // the two disagreed with each other on whether they persisted.
+        // (error, explicit) or the theme's treehouseGreen (success — implicit, no color
+        // override; see the off-palette sweep). This page briefly invented `yellow` for
+        // the two ambiguous outcomes, which read as a new severity that nothing else
+        // uses — and the two disagreed with each other on whether they persisted.
         jest.useFakeTimers();
         try {
             mockSync([{ status: 500, body: {} }]);
@@ -201,7 +204,7 @@ describe("finance-ops/payments — sync status", () => {
 
             const colors = shown.mock.calls.map(([c]) => c.color);
             expect(colors.length).toBeGreaterThan(0);
-            expect(colors.every((c) => c === "red" || c === "green")).toBe(true);
+            expect(colors.every((c) => c === "red" || c === undefined)).toBe(true);
         } finally {
             jest.useRealTimers();
         }

--- a/checkin-app/src/app/finance-ops/payments/page.tsx
+++ b/checkin-app/src/app/finance-ops/payments/page.tsx
@@ -136,7 +136,7 @@ export default function PaymentProblemsPage() {
       if (res.ok) {
         await fetchRows();
         notifyNavRefresh();
-        notifications.show({ color: 'green', message: action === 'resolve' ? 'Payment problem resolved.' : 'Payment problem acknowledged.' });
+        notifications.show({ message: action === 'resolve' ? 'Payment problem resolved.' : 'Payment problem acknowledged.' });
       } else {
         const data = await res.json();
         notifications.show({ color: 'red', message: data.error || "Failed to update.", autoClose: false });
@@ -165,7 +165,7 @@ export default function PaymentProblemsPage() {
         notifications.show({ color: 'red', message: data.error || "Failed to start the Shopify sync.", autoClose: false });
         return;
       }
-      notifications.show({ color: 'green', message: 'Shopify sync started…' });
+      notifications.show({ message: 'Shopify sync started…' });
 
       for (let i = 0; i < POLL_MAX_ATTEMPTS; i++) {
         await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
@@ -194,7 +194,7 @@ export default function PaymentProblemsPage() {
         const { status } = res.run;
         await fetchRows();
         if (status === 'COMPLETED') {
-          notifications.show({ color: 'green', message: 'Shopify sync finished. Live payment amounts are up to date.' });
+          notifications.show({ message: 'Shopify sync finished. Live payment amounts are up to date.' });
         } else {
           notifications.show({
             color: 'red',
@@ -211,7 +211,6 @@ export default function PaymentProblemsPage() {
       // the sentence carries the "check back later", not a colour the app never uses
       // for anything else.
       notifications.show({
-        color: 'green',
         message: 'Shopify sync is still running. Reload the page in a few minutes to see the result.',
       });
     } catch {
@@ -302,7 +301,7 @@ export default function PaymentProblemsPage() {
               Acknowledge
             </Button>
           )}
-          <Button size="xs" fz={15} color="green" variant="light" onClick={() => handleResolve(row)}>
+          <Button size="xs" fz={15} variant="light" onClick={() => handleResolve(row)}>
             Resolve
           </Button>
         </Group>
@@ -365,7 +364,7 @@ export default function PaymentProblemsPage() {
         />
         <Group justify="flex-end">
           <Button variant="default" onClick={closeResolve}>Cancel</Button>
-          <Button color="green" onClick={confirmResolve}>Resolve</Button>
+          <Button onClick={confirmResolve}>Resolve</Button>
         </Group>
       </Modal>
     </Stack>

--- a/checkin-app/src/app/finance-ops/shopify-holds/page.tsx
+++ b/checkin-app/src/app/finance-ops/shopify-holds/page.tsx
@@ -84,7 +84,7 @@ export default function ShopifyHoldsPage() {
       if (res.ok) {
         drop(programId, participantId);
         notifyNavRefresh();
-        notifications.show({ color: 'green', message: successMsg });
+        notifications.show({ message: successMsg });
       } else {
         const data = await res.json();
         notifications.show({ color: 'red', message: data.error || "Action failed.", autoClose: 4000 });
@@ -145,7 +145,7 @@ export default function ShopifyHoldsPage() {
           >
             Approve (override)
           </Button>
-          <Button size="xs" fz={15} color="blue" onClick={() => openFor(r, 'hold')}>
+          <Button size="xs" fz={15} color="treehousePurple" onClick={() => openFor(r, 'hold')}>
             Confirm manual hold
           </Button>
         </Group>
@@ -188,7 +188,7 @@ export default function ShopifyHoldsPage() {
         </Text>
         <Group justify="flex-end">
           <Button variant="default" onClick={closeHold}>Cancel</Button>
-          <Button color="blue" onClick={() => { closeHold(); post('/api/finance-ops/payment-plans/manual-hold', 'Manual hold recorded — request moved to the payment-plan queue.'); }}>
+          <Button color="treehousePurple" onClick={() => { closeHold(); post('/api/finance-ops/payment-plans/manual-hold', 'Manual hold recorded — request moved to the payment-plan queue.'); }}>
             I&apos;ve removed the seat — confirm
           </Button>
         </Group>

--- a/checkin-app/src/app/globals.css
+++ b/checkin-app/src/app/globals.css
@@ -10,11 +10,6 @@ body {
   margin: 0;
 }
 
-/* Glass buttons are real <button>s; show a pointer on hover like a link. */
-.glass-button {
-  cursor: pointer;
-}
-
 /* Kiosk display runs unattended on a Raspberry Pi — never show a pointer there. */
 .kiosk-mode,
 .kiosk-mode * {

--- a/checkin-app/src/app/membership-audit/broken/page.tsx
+++ b/checkin-app/src/app/membership-audit/broken/page.tsx
@@ -44,7 +44,7 @@ export default function BrokenHouseholdsPage() {
         body: JSON.stringify({ participantId }),
       });
       if (res.ok) {
-        notifications.show({ color: "green", message: "Lead assigned." });
+        notifications.show({ message: "Lead assigned." });
         fetchHouseholds();
         notifyNavRefresh();
       } else {
@@ -75,7 +75,7 @@ export default function BrokenHouseholdsPage() {
               <Card key={h.id} withBorder radius="md" padding="md">
                 <Text fw={600} mb="xs">{h.name}</Text>
                 {notice[h.id] && (
-                  <Alert color={notice[h.id].ok ? "green" : "red"} variant="light" mb="xs" withCloseButton
+                  <Alert color={notice[h.id].ok ? "treehouseGreen" : "red"} variant="light" mb="xs" withCloseButton
                     onClose={() => setNotice((n) => { const next = { ...n }; delete next[h.id]; return next; })}>
                     {notice[h.id].text}
                   </Alert>

--- a/checkin-app/src/app/membership-audit/compliance/page.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/page.tsx
@@ -25,7 +25,7 @@ type PersonRow = {
 
 // Reason tag -> human label + badge color. Keys mirror the endpoint's tags.
 const REASON: Record<string, { label: string; color: string }> = {
-  STALE_BG: { label: "Background check expired", color: "orange" },
+  STALE_BG: { label: "Background check expired", color: "treehousePurple" },
   REVOKED: { label: "Revoked", color: "red" },
   DENIED: { label: "Denied", color: "red" },
   STUCK_BG_CLEARANCE: { label: "Stuck at BG clearance", color: "yellow" },
@@ -97,7 +97,7 @@ export default function CompliancePage() {
       });
       if (res.ok) {
         setSubmittedIds((s) => new Set(s).add(personId));
-        notifications.show({ color: "green", message: "Submitted for background-check review." });
+        notifications.show({ message: "Submitted for background-check review." });
       } else {
         const data = await res.json().catch(() => ({}));
         notifications.show({ color: "red", message: data.error || "Could not submit for review." });
@@ -201,11 +201,11 @@ export default function CompliancePage() {
       <PersonSection
         title="Background check needed"
         description="Program-attached people 18 or older with no current background check. Warn-only — nothing is blocked. Once an external check exists, submit it below for two-reviewer approval."
-        color="orange"
+        color="treehousePurple"
         people={peopleNeedingBgCheck}
         renderAction={(p) =>
           submittedIds.has(p.personId) ? (
-            <Badge color="green" variant="light">Submitted for review</Badge>
+            <Badge variant="light">Submitted for review</Badge>
           ) : (
             <Button size="xs" variant="light" loading={busyId === p.personId} disabled={busyId === p.personId} onClick={() => submitBg(p.personId)}>
               Record external check &amp; submit
@@ -217,7 +217,7 @@ export default function CompliancePage() {
       <PersonSection
         title="Missing date of birth"
         description="Program-attached people with no recorded age. Confirm their date of birth before a background check can be assessed."
-        color="grape"
+        color="treehousePurple"
         people={peopleMissingDob}
       />
     </Stack>

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -117,7 +117,7 @@ function ApplicationsBoard() {
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: "Updated." });
+        notifications.show({ message: "Updated." });
         await load(showArchived);
         notifyNavRefresh();
       } else {
@@ -142,7 +142,7 @@ function ApplicationsBoard() {
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: action === "reset" ? "Sent back for re-review." : "Overridden to payment." });
+        notifications.show({ message: action === "reset" ? "Sent back for re-review." : "Overridden to payment." });
         await load(showArchived);
         notifyNavRefresh();
       } else if (data.code === "wrong_phase") {
@@ -170,7 +170,7 @@ function ApplicationsBoard() {
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: "Application archived." });
+        notifications.show({ message: "Application archived." });
         await load(showArchived);
         notifyNavRefresh();
       } else {
@@ -214,7 +214,7 @@ function ApplicationsBoard() {
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: "Application unarchived." });
+        notifications.show({ message: "Application unarchived." });
         await load(showArchived);
         notifyNavRefresh();
       } else {
@@ -239,7 +239,7 @@ function ApplicationsBoard() {
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: "Certified — membership activated." });
+        notifications.show({ message: "Certified — membership activated." });
         await load(showArchived);
         notifyNavRefresh();
       } else if (data.code === "wrong_phase") {
@@ -389,7 +389,7 @@ function ApplicationsBoard() {
               {r.status === "PENDING_PAYMENT" && (
                 <Group mt="md" gap="md" wrap="wrap" align="center">
                   <Text size="sm" c="dimmed">Awaiting payment.</Text>
-                  <Button size="xs" fz={15} color="green" disabled={busyId === r.id || ownHousehold(r)} onClick={() => handleCertify(r.id)}>
+                  <Button size="xs" fz={15} disabled={busyId === r.id || ownHousehold(r)} onClick={() => handleCertify(r.id)}>
                     Certify payment plan → {r.bgClearedAt ? "activate" : "(holds for background check)"}
                   </Button>
                   {ownHousehold(r) && (
@@ -415,7 +415,7 @@ function ApplicationsBoard() {
                     <Button size="xs" fz={15} variant="default" disabled={busyId === r.id || ownHousehold(r)} onClick={() => override(r.id, "reset")}>
                       Reset for re-review
                     </Button>
-                    <Button size="xs" fz={15} color="green" disabled={busyId === r.id || ownHousehold(r)} onClick={() => override(r.id, "approve")}>
+                    <Button size="xs" fz={15} disabled={busyId === r.id || ownHousehold(r)} onClick={() => override(r.id, "approve")}>
                       Override → {r.paidAt ? "activate" : "payment"}
                     </Button>
                   </Group>
@@ -431,7 +431,7 @@ function ApplicationsBoard() {
 
               <Group justify="flex-end" mt="md">
                 {showArchived ? (
-                  <Button size="xs" fz={15} color="green" disabled={busyId === r.id} onClick={() => unarchive(r.id)}>
+                  <Button size="xs" fz={15} disabled={busyId === r.id} onClick={() => unarchive(r.id)}>
                     Unarchive
                   </Button>
                 ) : (
@@ -467,7 +467,7 @@ function ApplicationsBoard() {
         />
         <Group justify="flex-end">
           <Button variant="default" onClick={closeCertify}>Cancel</Button>
-          <Button color="green" onClick={confirmCertify} disabled={!certifyReason.trim()}>Certify</Button>
+          <Button onClick={confirmCertify} disabled={!certifyReason.trim()}>Certify</Button>
         </Group>
       </Modal>
     </Stack>

--- a/checkin-app/src/app/membership-ops/households/[id]/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/[id]/page.tsx
@@ -89,7 +89,7 @@ export default function HouseholdDetailPage({ params }: { params: Promise<{ id: 
         {status === "DENIED" ? (
           <Badge color="red">Denied</Badge>
         ) : status === "ACTIVE" ? (
-          <Badge color="green">Member</Badge>
+          <Badge>Member</Badge>
         ) : (
           <Badge color="gray">Not a member</Badge>
         )}
@@ -121,7 +121,7 @@ export default function HouseholdDetailPage({ params }: { params: Promise<{ id: 
                       <Badge
                         key={e.program.id}
                         variant="light"
-                        color={e.status === "ACTIVE" ? "green" : "yellow"}
+                        color={e.status === "ACTIVE" ? "treehouseGreen" : "yellow"}
                         style={{ cursor: "pointer" }}
                         onClick={() => router.push(`/program-ops/programs/${e.program.id}`)}
                       >

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -74,7 +74,7 @@ export default function AdminHouseholdsPage() {
 
       if (res.ok) {
         fetchHouseholds();
-        notifications.show({ color: 'green', message: currentActive ? 'Membership revoked.' : 'Membership granted.' });
+        notifications.show({ message: currentActive ? 'Membership revoked.' : 'Membership granted.' });
       } else {
         notifications.show({ color: 'red', message: 'Failed to update membership.', autoClose: false });
       }
@@ -96,7 +96,7 @@ export default function AdminHouseholdsPage() {
 
       if (res.ok) {
         fetchHouseholds();
-        notifications.show({ color: 'green', message: 'Granted for the coming year.' });
+        notifications.show({ message: 'Granted for the coming year.' });
       } else {
         const data = await res.json().catch(() => ({}));
         notifications.show({ color: 'red', message: data.error || 'Failed to grant for the coming year.', autoClose: false });
@@ -142,7 +142,7 @@ export default function AdminHouseholdsPage() {
 
       if (res.ok) {
         fetchHouseholds();
-        notifications.show({ color: 'green', message: deny ? 'Membership denied — members can no longer log in.' : 'Membership restored.' });
+        notifications.show({ message: deny ? 'Membership denied — members can no longer log in.' : 'Membership restored.' });
       } else {
         const data = await res.json().catch(() => ({}));
         notifications.show({ color: 'red', message: data.error || 'Failed to update membership.', autoClose: false });
@@ -305,7 +305,7 @@ export default function AdminHouseholdsPage() {
                         <Button
                           size="xs" fz={15}
                           variant="light"
-                          color="blue"
+                          color="treehousePurple"
                           onClick={() => setDenied(household.id, false)}
                         >
                           Restore Access
@@ -315,7 +315,7 @@ export default function AdminHouseholdsPage() {
                           <Button
                             size="xs" fz={15}
                             variant="light"
-                            color={hasActiveMembership ? 'red' : 'green'}
+                            color={hasActiveMembership ? 'red' : 'treehouseGreen'}
                             disabled={ownGrantBlocked || (!hasActiveMembership && isStaffHousehold)}
                             title={
                               !hasActiveMembership && isStaffHousehold
@@ -349,7 +349,6 @@ export default function AdminHouseholdsPage() {
                       <Button
                         size="xs" fz={15}
                         variant="light"
-                        color="green"
                         disabled={settledForComingYear}
                         title={settledForComingYear ? "This household is already set for the coming year." : undefined}
                         onClick={() => handleGrantForComingYear(household.id)}
@@ -416,7 +415,7 @@ export default function AdminHouseholdsPage() {
         />
         <Group justify="flex-end">
           <Button variant="default" onClick={closeGrantComingYear}>Cancel</Button>
-          <Button color="green" onClick={confirmGrantForComingYear} disabled={!grantReason.trim()}>Grant</Button>
+          <Button onClick={confirmGrantForComingYear} disabled={!grantReason.trim()}>Grant</Button>
         </Group>
       </Modal>
     </Stack>

--- a/checkin-app/src/app/membership-ops/participants/import/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/import/page.tsx
@@ -33,8 +33,8 @@ type ImportResult = { success?: boolean; message?: string; errors?: string[] };
 
 const STATUS_META: Record<RowStatus | "all", { label: string; icon: string; color: string }> = {
   all: { label: "All", icon: "📋", color: "gray" },
-  ready: { label: "New", icon: "✅", color: "green" },
-  update: { label: "Update", icon: "🔄", color: "blue" },
+  ready: { label: "New", icon: "✅", color: "treehouseGreen" },
+  update: { label: "Update", icon: "🔄", color: "treehousePurple" },
   warning: { label: "Warning", icon: "⚠️", color: "yellow" },
   error: { label: "Error", icon: "❌", color: "red" },
 };
@@ -130,7 +130,7 @@ export default function BulkImportParticipants() {
             chance to review everything before anything is imported.
           </Text>
 
-          <Alert color="blue" variant="light" title="Instructions">
+          <Alert color="treehousePurple" variant="light" title="Instructions">
             <List type="ordered" spacing="xs">
               <List.Item>Download the import template provided below.</List.Item>
               <List.Item>Fill in the participant data. <strong>First Name</strong> and <strong>Last Name</strong> are required.</List.Item>
@@ -257,7 +257,7 @@ export default function BulkImportParticipants() {
       {/* Step 3: Import Result */}
       {importResult && (
         <Stack>
-          <Alert color={importResult.success ? 'green' : 'red'} title={importResult.success ? "✅ Import Successful" : "❌ Import Failed"}>
+          <Alert color={importResult.success ? 'treehouseGreen' : 'red'} title={importResult.success ? "✅ Import Successful" : "❌ Import Failed"}>
             <Text>{importResult.message}</Text>
             {importResult.errors && importResult.errors.length > 0 && (
               <Box mt="md">

--- a/checkin-app/src/app/membership-ops/participants/new/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/page.tsx
@@ -98,7 +98,7 @@ function NewParticipantForm() {
       const data = await res.json().catch(() => ({}));
 
       if (res.ok) {
-        notifications.show({ color: "green", message: `Participant ${name || data.participant.email || 'created'} successfully!` });
+        notifications.show({ message: `Participant ${name || data.participant.email || 'created'} successfully!` });
         setName("");
         setEmail("");
         setParentEmail("");
@@ -211,7 +211,7 @@ function NewParticipantForm() {
               />
             )}
 
-            <Button type="submit" color="green" disabled={submitDisabled} loading={saving} mt="sm">
+            <Button type="submit" disabled={submitDisabled} loading={saving} mt="sm">
               Create Participant
             </Button>
           </Stack>

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -297,7 +297,7 @@ export default function AdminParticipantsIndex() {
         </div>
         <Group>
           <Button variant="light" onClick={() => router.push('/membership-ops/participants/import')}>Bulk Import</Button>
-          <Button color="green" onClick={() => router.push('/membership-ops/participants/new')}>+ New Person</Button>
+          <Button onClick={() => router.push('/membership-ops/participants/new')}>+ New Person</Button>
         </Group>
       </Group>
 
@@ -432,7 +432,7 @@ export default function AdminParticipantsIndex() {
             <Group justify="flex-end" mt="lg">
               <Button type="button" variant="default" onClick={closeAssign} disabled={assigning}>Cancel</Button>
               {canSubmitAssign && (
-                <Button type="submit" color="green" disabled={assigning} loading={assigning}>
+                <Button type="submit" disabled={assigning} loading={assigning}>
                   {householdId ? "Add to Household" : (selectedParticipant?.household ? "Pull from household and start a new one" : "Create New Household")}
                 </Button>
               )}

--- a/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
@@ -51,7 +51,7 @@ describe("membership-ops/review page", () => {
         }),
       ),
     );
-    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Attestation recorded — thank you." })));
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Attestation recorded — thank you." })));
   });
 
   it("shows the forbidden card when the queue endpoint returns 403", async () => {

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -70,7 +70,7 @@ export default function MembershipReviewPage() {
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: result === "APPROVE" ? "Attestation recorded — thank you." : "Recorded. The board has been notified." });
+        notifications.show({ message: result === "APPROVE" ? "Attestation recorded — thank you." : "Recorded. The board has been notified." });
         await load();
         notifyNavRefresh();
       } else if (data.code === "already_attested") {
@@ -170,7 +170,7 @@ export default function MembershipReviewPage() {
               />
 
               <Group gap="sm" wrap="wrap" mt="md">
-                <Button color="green" disabled={busyId === item.id} loading={busyId === item.id} onClick={() => submit(item.id, "APPROVE")}>
+                <Button disabled={busyId === item.id} loading={busyId === item.id} onClick={() => submit(item.id, "APPROVE")}>
                   Attest — check is clean
                 </Button>
                 <Button color="red" variant="light" disabled={busyId === item.id || !reviewNotes[item.id]?.trim()} onClick={() => submit(item.id, "REJECT")}>
@@ -179,7 +179,7 @@ export default function MembershipReviewPage() {
               </Group>
 
               {message?.processId === item.id && (
-                <Alert color={message.tone === "success" ? "green" : "red"} variant="light" mt="md">
+                <Alert color={message.tone === "success" ? "treehouseGreen" : "red"} variant="light" mt="md">
                   {message.text}
                 </Alert>
               )}

--- a/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
+++ b/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
@@ -50,7 +50,7 @@ export default function VolunteerMembershipsPage() {
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
         setNewEmail("");
-        if (data.warning) { flash(data.warning, "warning"); } else { notifications.show({ color: "green", message: "Designation added." }); }
+        if (data.warning) { flash(data.warning, "warning"); } else { notifications.show({ message: "Designation added." }); }
         await load();
       } else flash(data.error || "Could not add.");
     } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }

--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -274,7 +274,7 @@ describe("membership page", () => {
     });
     renderWithProviders(<MembershipPage />);
 
-    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Thanks — your signature was received." })));
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Thanks — your signature was received." })));
     expect(window.location.search).toBe("");
   });
 
@@ -290,7 +290,7 @@ describe("membership page", () => {
     });
     renderWithProviders(<MembershipPage />);
 
-    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: expect.stringContaining("Signature received — finalizing.") })));
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining("Signature received — finalizing.") })));
   });
 
   it("falls back to a finalizing message when the sync request itself errors", async () => {
@@ -309,7 +309,7 @@ describe("membership page", () => {
     global.fetch = fetchMock as unknown as typeof fetch;
     renderWithProviders(<MembershipPage />);
 
-    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: expect.stringContaining("Signature received — finalizing.") })));
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining("Signature received — finalizing.") })));
   });
 
   // ── PENDING_PAYMENT dues fetch branches ──────────────────────────────────────

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -94,7 +94,7 @@ function ExternalTask({ done, title, doneText, doneExtra, children }: { done: bo
   return (
     <Card withBorder radius="md" padding="md" bg={done ? "var(--mantine-color-green-light)" : undefined}>
       <Group align="flex-start" wrap="nowrap">
-        <ThemeIcon color={done ? "green" : "gray"} radius="xl" size="md" variant={done ? "filled" : "light"}>
+        <ThemeIcon color={done ? "treehouseGreen" : "gray"} radius="xl" size="md" variant={done ? "filled" : "light"}>
           {done ? "✓" : "•"}
         </ThemeIcon>
         <Box style={{ flex: 1 }}>
@@ -275,7 +275,6 @@ export default function MembershipPage() {
       }
       await load();
       notifications.show({
-        color: "green",
         message: signedNow
           ? "Thanks — your signature was received."
           : "Signature received — finalizing. If it doesn't update shortly, use “Refresh status”.",
@@ -558,7 +557,7 @@ export default function MembershipPage() {
       });
       if (res.ok) {
         setPlanRequested(true);
-        notifications.show({ color: "green", message: "Requested! The Scholarship Review Team will follow up." });
+        notifications.show({ message: "Requested! The Scholarship Review Team will follow up." });
       } else {
         const data = await res.json().catch(() => ({}));
         notifications.show({ color: "red", message: data.error || "Could not request a payment plan.", autoClose: false });
@@ -699,7 +698,7 @@ export default function MembershipPage() {
             Did anything change — new members, address, phone, or email?{" "}
             <Anchor component={Link} href="/my-household">Update your household details first</Anchor>.
           </Text>
-          <Button color="green" disabled={saving} loading={saving} onClick={renew}>Renew now</Button>
+          <Button disabled={saving} loading={saving} onClick={renew}>Renew now</Button>
         </Card>
       ) : isRenewal && inStatus === "RENEWAL_PENDING_BG" ? (
         <Card withBorder radius="md" padding="xl" maw={640}>
@@ -807,14 +806,14 @@ export default function MembershipPage() {
                   {/* Local echo of the page-top banner: intake is a long card, so
                       the top AlertBanner posts off-screen next to these buttons. */}
                   {message && (
-                    <Alert color={message.tone === "error" ? "red" : "green"} variant="light">
+                    <Alert color={message.tone === "error" ? "red" : "treehouseGreen"} variant="light">
                       {message.text}
                     </Alert>
                   )}
 
                   <Group gap="md" wrap="wrap">
                     <Button variant="default" disabled={saving} loading={saving} onClick={save}>Save progress</Button>
-                    <Button color="green" disabled={saving} loading={saving} onClick={submit}>Submit &amp; continue</Button>
+                    <Button disabled={saving} loading={saving} onClick={submit}>Submit &amp; continue</Button>
                   </Group>
                 </Stack>
               </Card>
@@ -837,7 +836,7 @@ export default function MembershipPage() {
                         automatically once it&apos;s signed. Have your insurance details handy — the
                         agreement asks for your provider and policy number.
                       </Text>
-                      <Button color="green" disabled={saving} loading={saving} onClick={startSigning}>
+                      <Button disabled={saving} loading={saving} onClick={startSigning}>
                         {state.external?.contractStarted ? "Resume signing →" : "Sign your membership agreement →"}
                       </Button>
                     </Stack>
@@ -916,11 +915,11 @@ export default function MembershipPage() {
                         </Anchor>
                       </Stack>
                     ) : payment.checkoutUrl ? (
-                      <Button component="a" href={payment.checkoutUrl} target="_blank" rel="noopener noreferrer" color="green" mt="md" onClick={handlePayClick}>
+                      <Button component="a" href={payment.checkoutUrl} target="_blank" rel="noopener noreferrer" mt="md" onClick={handlePayClick}>
                         Pay here with Shopify →
                       </Button>
                     ) : isLocalInstance ? (
-                      <Button color="green" mt="md" disabled={saving} onClick={settleMockPayment}>
+                      <Button mt="md" disabled={saving} onClick={settleMockPayment}>
                         Pay now (local mock) →
                       </Button>
                     ) : (
@@ -934,7 +933,7 @@ export default function MembershipPage() {
                       </Text>
                       <Group justify="flex-end" mt="md">
                         <Button variant="default" onClick={closeConfirmPlan}>Cancel</Button>
-                        <Button color="green" onClick={requestPaymentPlan}>Send request</Button>
+                        <Button onClick={requestPaymentPlan}>Send request</Button>
                       </Group>
                     </Modal>
                     {planRequested ? (
@@ -951,7 +950,7 @@ export default function MembershipPage() {
                       </Button>
                     )}
                     {!state.external?.bgCleared && (
-                      <Alert color="blue" variant="light" mt="md">
+                      <Alert color="treehousePurple" variant="light" mt="md">
                         Your background check is being reviewed in the background — you can pay now.
                         Your membership activates as soon as both the payment and the check are done.
                       </Alert>

--- a/checkin-app/src/app/my-activities/events/page.tsx
+++ b/checkin-app/src/app/my-activities/events/page.tsx
@@ -38,7 +38,7 @@ function groupByEvent(events: EventData[]): EventData[][] {
 }
 
 const RSVP_OPTIONS: { status: RsvpStatus; label: string; color: string }[] = [
-  { status: 'ATTENDING', label: 'Yes', color: 'green' },
+  { status: 'ATTENDING', label: 'Yes', color: 'treehouseGreen' },
   { status: 'MAYBE', label: 'Maybe', color: 'yellow' },
   { status: 'NOT_ATTENDING', label: 'No', color: 'red' },
 ];
@@ -141,7 +141,7 @@ export default function ParticipantEventsDashboard() {
                       <Text size="sm" c="dimmed">📅 {startStr} – {endStr}</Text>
                     </div>
                     {rows.some((r) => r.isVolunteer) && (
-                      <Badge color="grape" variant="light" style={{ flexShrink: 0 }}>Volunteer</Badge>
+                      <Badge color="treehousePurple" variant="light" style={{ flexShrink: 0 }}>Volunteer</Badge>
                     )}
                   </Group>
 

--- a/checkin-app/src/app/my-activities/programs/page.tsx
+++ b/checkin-app/src/app/my-activities/programs/page.tsx
@@ -23,13 +23,15 @@ type UserProgram = {
 };
 
 // Payment pill: ACTIVE (paid/free) shows nothing; a still-owed enrollment is
-// either the household's to pay (green, actionable) or waiting on finance to
+// either the household's to pay (theme-primary, actionable) or waiting on finance to
 // approve a payment plan (gray, not actionable — don't imply it's settled).
+// ponytail: "Payment due" reads more like a warning than a success state — mechanical
+// off-palette-sweep target is theme-primary green; a maintainer may prefer gray/yellow here.
 function paymentPill(status: string, planRequested: boolean) {
   if (status === 'ACTIVE') return null;
   return planRequested
     ? <Badge color="gray" variant="filled">Awaiting finance approval</Badge>
-    : <Badge color="green" variant="filled">Payment due</Badge>;
+    : <Badge variant="filled">Payment due</Badge>;
 }
 
 export default function MyProgramsDashboard() {

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -417,7 +417,7 @@ describe("HouseholdPage", () => {
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith("/api/household/emergency-contacts/2", expect.objectContaining({ method: "DELETE" })),
     );
-    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Emergency contact removed." })));
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Emergency contact removed." })));
     await waitFor(() => expect(screen.queryByText("Jess Friend")).not.toBeInTheDocument());
 
     const editButtons = screen.getAllByRole("button", { name: "Edit" });
@@ -432,7 +432,7 @@ describe("HouseholdPage", () => {
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith("/api/household/emergency-contacts/1", expect.objectContaining({ method: "PATCH" })),
     );
-    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Emergency contact updated." })));
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Emergency contact updated." })));
   });
 
   it("shows a dismissible contact server error, and validates/cancels the contact form", async () => {

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -39,7 +39,7 @@ function validateHouseholdMemberFields(f: { name: string; email: string; dob: st
 function ageBadge(p: HouseholdMember): { label: string; color: string; variant: string } {
   if (p.dateOfBirth) {
     const age = calculateAge(p.dateOfBirth);
-    return age < 18 ? { label: `Age (${age})`, color: 'blue', variant: 'light' } : { label: 'Adult', color: 'gray', variant: 'light' };
+    return age < 18 ? { label: `Age (${age})`, color: 'treehousePurple', variant: 'light' } : { label: 'Adult', color: 'gray', variant: 'light' };
   }
   if (p.isDeclaredAdult) return { label: 'Adult', color: 'gray', variant: 'light' };
   return { label: 'Age Unavailable', color: 'red', variant: 'filled' };
@@ -70,7 +70,7 @@ export default function HouseholdPage() {
   // decided by `message.includes('success')`).
   // Successes toast in the corner (no layout shift); errors/warnings stay in
   // the page banner where they can't be missed.
-  const ok = (text: string) => notifications.show({ color: "green", message: text });
+  const ok = (text: string) => notifications.show({ message: text });
   const err = (text: string) => setMessage({ text, tone: "error" });
   const warn = (text: string) => setMessage({ text, tone: "warning" });
   const [addingHouseholdMember, setAddingHouseholdMember] = useState(false);
@@ -192,7 +192,7 @@ export default function HouseholdPage() {
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: editing ? "Emergency contact updated." : "Emergency contact added." });
+        notifications.show({ message: editing ? "Emergency contact updated." : "Emergency contact added." });
         setContactForm(blankContactForm);
         setShowContactForm(false);
         fetchContacts();
@@ -213,7 +213,7 @@ export default function HouseholdPage() {
       const res = await fetch(`/api/household/emergency-contacts/${id}`, { method: 'DELETE' });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: "Emergency contact removed." });
+        notifications.show({ message: "Emergency contact removed." });
         fetchContacts();
         notifyNavRefresh();
       } else {
@@ -366,21 +366,21 @@ export default function HouseholdPage() {
             // joined gets the join prompt; an ACTIVE member with nothing due gets
             // the plain member badge.
             (renewalDue || household.orgMembership?.status === 'REVOKED') ? (
-              <Alert color="blue" mb="lg">
+              <Alert color="treehousePurple" mb="lg">
                 <Group justify="space-between" align="center" wrap="wrap">
                   <Text c="dimmed">Renew your membership now!</Text>
                   {viewerIsLead && <Button size="xs" fz={15} onClick={() => router.push('/membership')}>Renew!</Button>}
                 </Group>
               </Alert>
             ) : household.orgMembership?.status === 'ACTIVE' ? (
-              <Alert color="green" mb="lg">
+              <Alert mb="lg">
                 <Group gap="xs" wrap="wrap">
                   <Text fw={600}>✓ Member{household.orgMembership.memberSince ? ` since ${new Date(household.orgMembership.memberSince).getFullYear()}` : ''}</Text>
-                  {household.orgMembership.isVolunteer && <Badge color="green" variant="light">Volunteer-only family</Badge>}
+                  {household.orgMembership.isVolunteer && <Badge variant="light">Volunteer-only family</Badge>}
                 </Group>
               </Alert>
             ) : (
-              <Alert color="blue" mb="lg">
+              <Alert color="treehousePurple" mb="lg">
                 <Group justify="space-between" align="center" wrap="wrap">
                   <Text c="dimmed">Your household isn&apos;t a member yet.</Text>
                   {viewerIsLead && <Button size="xs" fz={15} onClick={() => router.push('/membership')}>Join the Treehouse!</Button>}
@@ -424,7 +424,7 @@ export default function HouseholdPage() {
                               <Checkbox label="Household Lead" checked={editForm.isLead} onChange={(e) => setEditForm({ ...editForm, isLead: e.currentTarget.checked })} />
                             )}
                             <Group gap="xs">
-                              <Button type="submit" size="xs" fz={15} color="green">Save</Button>
+                              <Button type="submit" size="xs" fz={15}>Save</Button>
                               <Button type="button" size="xs" fz={15} variant="default" onClick={() => { setEditingHouseholdMemberId(null); setEditErrors({}); }}>Cancel</Button>
                             </Group>
                           </Stack>
@@ -440,7 +440,7 @@ export default function HouseholdPage() {
                           {p.allergies && <Text size="sm" c="dimmed" style={{ wordBreak: 'break-word' }}>Allergies: {p.allergies}</Text>}
                           {leadMissingPhone && <Badge color="red" variant="filled" mt="xs">TODO: Add phone number</Badge>}
                           <Group gap="xs" mt="sm">
-                            {householdMemberIsLead && <Badge color="grape" variant="light">Household Lead</Badge>}
+                            {householdMemberIsLead && <Badge color="treehousePurple" variant="light">Household Lead</Badge>}
                             {!householdMemberIsLead && isAdult && viewerIsLead && (
                               <Button size="compact-xs" variant="light" onClick={() => handleMakeLead(p.id)}>Make Lead</Button>
                             )}
@@ -480,7 +480,7 @@ export default function HouseholdPage() {
                       <TextInput type="tel" label="Phone (optional)" value={householdMemberForm.phone} error={householdMemberErrors.phone} onChange={(e) => { setHouseholdMemberForm({ ...householdMemberForm, phone: e.currentTarget.value }); setHouseholdMemberErrors({ ...householdMemberErrors, phone: undefined }); }} />
                       <TextInput label="Allergies (optional)" value={householdMemberForm.allergies} onChange={(e) => setHouseholdMemberForm({ ...householdMemberForm, allergies: e.currentTarget.value })} />
                       <Group grow>
-                        <Button type="submit" color="green">Save / Invite</Button>
+                        <Button type="submit">Save / Invite</Button>
                         <Button type="button" variant="default" onClick={() => { setAddingHouseholdMember(false); setHouseholdMemberErrors({}); }}>Cancel</Button>
                       </Group>
                     </Stack>
@@ -514,7 +514,7 @@ export default function HouseholdPage() {
                 onChange={(e) => setNotes(e.currentTarget.value)}
               />
             </Stack>
-            <Button onClick={handleSaveSettings} disabled={savingSettings} loading={savingSettings} color="green" fullWidth mt="md">
+            <Button onClick={handleSaveSettings} disabled={savingSettings} loading={savingSettings} fullWidth mt="md">
               Save household details
             </Button>
           </Card>
@@ -588,7 +588,7 @@ export default function HouseholdPage() {
                         <TextInput label="Relationship (optional)" value={contactForm.relationship} onChange={(e) => setContactForm({ ...contactForm, relationship: e.currentTarget.value })} placeholder="Aunt, Neighbor…" />
                       </SimpleGrid>
                       <Group gap="xs">
-                        <Button type="submit" size="xs" fz={15} color="green" loading={savingContact}>{contactForm.id !== null ? "Save Contact" : "Add Contact"}</Button>
+                        <Button type="submit" size="xs" fz={15} loading={savingContact}>{contactForm.id !== null ? "Save Contact" : "Add Contact"}</Button>
                         <Button type="button" size="xs" fz={15} variant="default" onClick={() => { setShowContactForm(false); setContactForm(blankContactForm); setContactError(""); setContactErrors({}); }}>Cancel</Button>
                       </Group>
                     </Stack>

--- a/checkin-app/src/app/my-programs/attendance/page.tsx
+++ b/checkin-app/src/app/my-programs/attendance/page.tsx
@@ -66,7 +66,7 @@ function RsvpRow({ label, tally }: { label: string; tally: RsvpTally }) {
     <Group justify="space-between" wrap="nowrap" mt={4}>
       <Text size="xs" c="dimmed" w={90}>{label}</Text>
       <Group gap="xs" wrap="nowrap">
-        <Badge color="green" variant="light">Yes {tally.yes}</Badge>
+        <Badge variant="light">Yes {tally.yes}</Badge>
         <Badge color="yellow" variant="light">Maybe {tally.maybe}</Badge>
         <Badge color="red" variant="light">No {tally.no}</Badge>
       </Group>

--- a/checkin-app/src/app/my-programs/conflicts/page.tsx
+++ b/checkin-app/src/app/my-programs/conflicts/page.tsx
@@ -32,7 +32,7 @@ export default function ConflictsPage() {
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: "Duplicate visit deleted." });
+        notifications.show({ message: "Duplicate visit deleted." });
         refresh();
         notifyNavRefresh();
       } else {

--- a/checkin-app/src/app/page.tsx
+++ b/checkin-app/src/app/page.tsx
@@ -18,6 +18,7 @@ import {
 import {
   IconAlertTriangle,
   IconAddressBook,
+  IconScan,
   IconUrgent,
 } from '@tabler/icons-react';
 import { notifications } from "@mantine/notifications";
@@ -187,15 +188,15 @@ export default function Home() {
                   <Button
                     size="lg"
                     fullWidth
-                    color={isCheckedIn ? 'red' : 'green'}
+                    color={isCheckedIn ? 'red' : 'treehouseGreen'}
                     onClick={handleToggleCheckin}
                     loading={loading}
                   >
                     {isCheckedIn ? 'Check Out' : 'Check In'}
                   </Button>
                 ) : (
-                  <Alert color="gray" variant="light" ta="center">
-                    📛 Please use the kiosk badge scanner to check in and out.
+                  <Alert color="gray" variant="light" ta="center" icon={<IconScan size={18} />}>
+                    Please use the kiosk badge scanner to check in and out.
                   </Alert>
                 ))}
 
@@ -229,7 +230,6 @@ export default function Home() {
               </Text>
 
               <Button
-                color="green"
                 size="md"
                 onClick={() => router.push('/programs')}
                 style={{ maxWidth: 300, width: '100%' }}

--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -70,7 +70,7 @@ export default function ProfilePage() {
       });
 
       if (res.ok) {
-        notifications.show({ color: "green", message: "Profile updated successfully!" });
+        notifications.show({ message: "Profile updated successfully!" });
       } else {
         const data = await res.json().catch(() => ({}));
         setMessage({ text: data.error || "Failed to update profile.", tone: "error" });

--- a/checkin-app/src/app/program-ops/new/page.tsx
+++ b/checkin-app/src/app/program-ops/new/page.tsx
@@ -209,7 +209,7 @@ export default function CreateProgramPage() {
             )}
 
             <Group justify="flex-end">
-              <Button type="submit" color="green" disabled={saving || !name.trim() || !leadMentorId || !maxParticipants || datesInvalid} loading={saving}>
+              <Button type="submit" disabled={saving || !name.trim() || !leadMentorId || !maxParticipants || datesInvalid} loading={saving}>
                 Create Program
               </Button>
             </Group>

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -52,8 +52,8 @@ export type ParticipantOption = { id: number; name: string | null; email: string
 const PHASE_BADGE: Record<string, { label: string; color: string }> = {
   PLANNING: { label: 'Planning', color: 'gray' },
   UPCOMING: { label: 'Upcoming', color: 'yellow' },
-  RUNNING: { label: 'Running', color: 'cyan' },
-  FINISHED: { label: 'Finished', color: 'teal' },
+  RUNNING: { label: 'Running', color: 'treehousePurple' },
+  FINISHED: { label: 'Finished', color: 'gray' },
 };
 
 export default function ProgramDetailsPage({ params }: { params: Promise<{ id: string }> }) {
@@ -160,7 +160,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
         })
       });
       if (res.ok) {
-        notifications.show({ color: "green", message: "Saved." });
+        notifications.show({ message: "Saved." });
         notifyNavRefresh();
         fetchProgram();
       } else {
@@ -188,7 +188,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: "Shopify identifiers saved." });
+        notifications.show({ message: "Shopify identifiers saved." });
         notifyNavRefresh();
         fetchProgram();
       } else {
@@ -207,7 +207,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
       const res = await fetch(`/api/programs/${id}/sync-shopify`, { method: 'POST' });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        notifications.show({ color: "green", message: "Shopify checkout configured." });
+        notifications.show({ message: "Shopify checkout configured." });
         notifyNavRefresh();
         fetchProgram();
       } else {
@@ -323,7 +323,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                     </Stack>
                   </Alert>
                 ) : program.shopifyProductId && (
-                  <Alert color="green" variant="light">✓ Pre-configured for Shopify Checkout (Product ID: {program.shopifyProductId})</Alert>
+                  <Alert variant="light">✓ Pre-configured for Shopify Checkout (Product ID: {program.shopifyProductId})</Alert>
                 )}
 
                 {isSysAdminOrBoard && (
@@ -425,7 +425,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
 
                 {saveError && <Alert color="red" variant="light">{saveError}</Alert>}
                 <Group gap="sm">
-                  <Button type="submit" color="green" disabled={saving || !leadMentorIdInput} loading={saving}>
+                  <Button type="submit" disabled={saving || !leadMentorIdInput} loading={saving}>
                     Save Settings
                   </Button>
                 </Group>

--- a/checkin-app/src/app/program-ops/programs/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/page.tsx
@@ -107,7 +107,7 @@ export default function AdminProgramsIndex() {
     {
       header: "Enrollment",
       render: (p) => (
-        <Badge color={p.enrollmentStatus === "OPEN" ? "green" : "gray"} variant="light">
+        <Badge color={p.enrollmentStatus === "OPEN" ? "treehouseGreen" : "gray"} variant="light">
           {p.enrollmentStatus === "OPEN" ? "Open" : "Closed"}
         </Badge>
       ),
@@ -128,7 +128,7 @@ export default function AdminProgramsIndex() {
     {
       header: "Access",
       render: (p) => (
-        <Badge color={p.orgMemberOnly ? 'grape' : 'blue'} variant="light">
+        <Badge color={p.orgMemberOnly ? 'treehousePurple' : 'gray'} variant="light">
           {p.orgMemberOnly ? 'Treehouse Members Only' : 'Public'}
         </Badge>
       ),
@@ -149,7 +149,7 @@ export default function AdminProgramsIndex() {
     <Stack>
       <Group justify="space-between" align="flex-start" wrap="wrap">
         <Text c="dimmed">Manage recurring programs and curriculum tracks.</Text>
-        <Button color="green" onClick={() => router.push('/program-ops/new')}>
+        <Button onClick={() => router.push('/program-ops/new')}>
           + New Program
         </Button>
       </Group>

--- a/checkin-app/src/app/program-ops/sessions/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/__tests__/page.test.tsx
@@ -103,7 +103,7 @@ describe("EventAdminPage", () => {
         expect(screen.getByText("Attending")).toBeInTheDocument();
 
         fireEvent.click(screen.getByRole("button", { name: "Confirm Attendance" }));
-        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Attendance confirmed successfully!" })));
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Attendance confirmed successfully!" })));
 
         fireEvent.click(screen.getAllByRole("button", { name: "Manual Edit" })[0]);
         expect(await screen.findByText(/Manual Edit:/)).toBeInTheDocument();
@@ -127,7 +127,7 @@ describe("EventAdminPage", () => {
         expect(screen.getByLabelText(/Apply to Series/)).toBeInTheDocument();
 
         fireEvent.click(screen.getByRole("button", { name: "Save Time Changes" }));
-        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Event time updated successfully!" })));
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Event time updated successfully!" })));
 
         fireEvent.click(screen.getByRole("button", { name: "Edit Date / Time" }));
         fireEvent.click(screen.getByRole("button", { name: "Cancel Event(s)" }));
@@ -162,7 +162,7 @@ describe("EventAdminPage", () => {
 
         expect(await screen.findByText(/by Unknown/)).toBeInTheDocument();
         fireEvent.click(screen.getByRole("button", { name: "Re-confirm" }));
-        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Attendance confirmed successfully!" })));
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Attendance confirmed successfully!" })));
     });
 
     it("confirm attendance: shows the server error, then a network-error message", async () => {

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -47,7 +47,7 @@ type EventData = {
 };
 
 const RSVP_BADGE: Record<RSVPStatus, { label: string; color: string }> = {
-  ATTENDING: { label: 'Attending', color: 'green' },
+  ATTENDING: { label: 'Attending', color: 'treehouseGreen' },
   MAYBE: { label: 'Maybe', color: 'yellow' },
   NOT_ATTENDING: { label: 'Not attending', color: 'red' },
   NO_RESPONSE: { label: 'No response', color: 'gray' },
@@ -128,7 +128,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
           router.push('/my-programs');
           return;
         }
-        notifications.show({ color: "green", message: "Attendance confirmed successfully!" });
+        notifications.show({ message: "Attendance confirmed successfully!" });
         fetchEvent();
       } else {
         const data = await res.json().catch(() => ({}));
@@ -154,7 +154,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
         body: JSON.stringify({ action: 'editTime', startAt: startIso, endAt: endIso, applyToFuture })
       });
       if (res.ok) {
-        notifications.show({ color: "green", message: "Event time updated successfully!" });
+        notifications.show({ message: "Event time updated successfully!" });
         setEditMode(false);
         fetchEvent();
       } else {
@@ -311,7 +311,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
                     <Text size="xs" c="dimmed">{member.person.email}</Text>
                   </Table.Td>
                   <Table.Td>
-                    <Badge color={member.role === 'Participant' ? 'cyan' : 'yellow'} variant="light">{member.role}</Badge>
+                    <Badge color={member.role === 'Participant' ? 'treehousePurple' : 'yellow'} variant="light">{member.role}</Badge>
                   </Table.Td>
                   <Table.Td>
                     <Group justify="space-between" wrap="nowrap">
@@ -384,7 +384,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
                       <Text size="xs" c="dimmed">{member.person.email}</Text>
                     </Table.Td>
                     <Table.Td>
-                      <Badge color={member.role === 'Participant' ? 'cyan' : 'yellow'} variant="light">{member.role}</Badge>
+                      <Badge color={member.role === 'Participant' ? 'treehousePurple' : 'yellow'} variant="light">{member.role}</Badge>
                     </Table.Td>
                     <Table.Td>
                       <Badge color={badge.color} variant="light">{badge.label}</Badge>
@@ -449,7 +449,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
               )}
             </Group>
             {attendanceNotice && (
-              <Alert color={attendanceNotice.ok ? 'green' : 'red'} variant="light" mt="md" withCloseButton onClose={() => setAttendanceNotice(null)}>
+              <Alert color={attendanceNotice.ok ? 'treehouseGreen' : 'red'} variant="light" mt="md" withCloseButton onClose={() => setAttendanceNotice(null)}>
                 {attendanceNotice.msg}
               </Alert>
             )}
@@ -466,7 +466,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
             <Title order={4} mb="lg">Manage Event</Title>
 
             {timeNotice && (
-              <Alert color={timeNotice.ok ? 'green' : 'red'} variant="light" mb="lg" withCloseButton onClose={() => setTimeNotice(null)}>
+              <Alert color={timeNotice.ok ? 'treehouseGreen' : 'red'} variant="light" mb="lg" withCloseButton onClose={() => setTimeNotice(null)}>
                 {timeNotice.msg}
               </Alert>
             )}
@@ -494,7 +494,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
                 )}
 
                 <Group>
-                  <Button color="green" onClick={handleEditTime} disabled={actionLoading} loading={actionLoading}>Save Time Changes</Button>
+                  <Button onClick={handleEditTime} disabled={actionLoading} loading={actionLoading}>Save Time Changes</Button>
                   <Button color="red" variant="light" onClick={openConfirmCancel} disabled={actionLoading} loading={actionLoading}>Cancel Event(s)</Button>
                   <Button variant="default" onClick={() => setEditMode(false)} disabled={actionLoading} ml="auto">Nevermind</Button>
                 </Group>
@@ -547,7 +547,7 @@ export default function EventAdminPage({ params }: { params: Promise<{ id: strin
             </>
           )}
           {manualNotice && (
-            <Alert color={manualNotice.ok ? 'green' : 'red'} variant="light" withCloseButton onClose={() => setManualNotice(null)}>
+            <Alert color={manualNotice.ok ? 'treehouseGreen' : 'red'} variant="light" withCloseButton onClose={() => setManualNotice(null)}>
               {manualNotice.msg}
             </Alert>
           )}

--- a/checkin-app/src/app/program-ops/sessions/new/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/new/page.tsx
@@ -250,7 +250,7 @@ export function NewEventForm() {
             )}
           </Card>
 
-          <Button type="submit" color="green" disabled={saving} loading={saving} mt="sm">
+          <Button type="submit" disabled={saving} loading={saving} mt="sm">
             Create Event(s)
           </Button>
         </Stack>

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -227,7 +227,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
       }
 
       if (anyRequested) {
-        notifications.show({ color: "green", message: "Requested! Please check your email for communication from the Scholarship Review Team." });
+        notifications.show({ message: "Requested! Please check your email for communication from the Scholarship Review Team." });
         fetchProgram();
         notifyNavRefresh();
       }
@@ -316,7 +316,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
             body: JSON.stringify({ programId: program.id, participantIds: enrolledIds }),
           });
           if (payRes.ok) {
-            notifications.show({ color: "green", message: "Payment mocked (local) — enrollment activated." });
+            notifications.show({ message: "Payment mocked (local) — enrollment activated." });
           } else {
             notifications.show({ color: "red", autoClose: false, message: "Enrolled, but the mock payment failed — fire it from the Debug → Shopify tool." });
           }
@@ -343,7 +343,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
           window.location.href = buildShopifyCheckoutUrl(storeDomain, variantId, enrolledIds, id, discountCode);
           return; // spinner stays; page unloads on redirect
         } else {
-          notifications.show({ color: "green", message: enrolledIds.length > 1 ? `Successfully enrolled ${enrolledIds.length} members!` : "Successfully enrolled!" });
+          notifications.show({ message: enrolledIds.length > 1 ? `Successfully enrolled ${enrolledIds.length} members!` : "Successfully enrolled!" });
           setRequiresOverride(false);
           fetchProgram();
         }
@@ -410,7 +410,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
           <Title order={1}>{program.name}</Title>
           <Group>
             {canManage && (
-              <Button color="green" variant="light" onClick={() => router.push(`/program-ops/programs/${program.id}`)}>
+              <Button variant="light" onClick={() => router.push(`/program-ops/programs/${program.id}`)}>
                 Manage Program
               </Button>
             )}
@@ -478,7 +478,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
         )}
 
         {message && <Alert color="red" mb="lg">{message}</Alert>}
-        {successMessage && <Alert color="green" mb="lg">{successMessage}</Alert>}
+        {successMessage && <Alert mb="lg">{successMessage}</Alert>}
 
         <Center mt="xl">
           {!showEnrollmentSelection ? (

--- a/checkin-app/src/app/programs/page.tsx
+++ b/checkin-app/src/app/programs/page.tsx
@@ -96,7 +96,7 @@ export default function PublicProgramsDirectory() {
               checked={activeOnly}
               onChange={(e) => setActiveOnly(e.currentTarget.checked)}
             />
-            <Button component={Link} href="/program-ops/new" color="green" variant="light">
+            <Button component={Link} href="/program-ops/new" variant="light">
               + New Program
             </Button>
           </Group>
@@ -119,8 +119,8 @@ export default function PublicProgramsDirectory() {
                 <Group justify="space-between" align="flex-start" mb="sm">
                   <Title order={4}>{program.name}</Title>
                   <Group gap={4}>
-                    {isOwner && <Badge color="green">Yours</Badge>}
-                    {program.orgMemberOnly && <Badge color="grape" variant="light">Treehouse Members Only</Badge>}
+                    {isOwner && <Badge>Yours</Badge>}
+                    {program.orgMemberOnly && <Badge color="treehousePurple" variant="light">Treehouse Members Only</Badge>}
                     {program.phase === 'PLANNING' && <Badge color="yellow" variant="light">Planning</Badge>}
                     {program.enrollmentStatus === 'CLOSED' && <Badge color="red" variant="light">Closed</Badge>}
                   </Group>
@@ -159,7 +159,7 @@ export default function PublicProgramsDirectory() {
                     View details and enroll
                   </Button>
                   {canManage && (
-                    <Button component={Link} href={`/program-ops/programs/${program.id}`} variant="light" color="green">
+                    <Button component={Link} href={`/program-ops/programs/${program.id}`} variant="light">
                       Manage
                     </Button>
                   )}

--- a/checkin-app/src/app/safety/emergency-contacts/page.tsx
+++ b/checkin-app/src/app/safety/emergency-contacts/page.tsx
@@ -130,7 +130,7 @@ export default function EmergencyContactsPage() {
               <div>
                 <Group gap="xs" mb="xs">
                   <Text fw={600} fz="lg">{h.name || `Household #${h.id}`}</Text>
-                  {h.isPresent && <Badge color="cyan" variant="light">Present Now</Badge>}
+                  {h.isPresent && <Badge color="treehousePurple" variant="light">Present Now</Badge>}
                 </Group>
                 <Text size="sm" c="dimmed">Household members:</Text>
                 {h.householdMembers.length > 0 ? (

--- a/checkin-app/src/app/safety/trusted-adults/__tests__/page.test.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/__tests__/page.test.tsx
@@ -66,7 +66,7 @@ describe("safety/trusted-adults page", () => {
         }),
       ),
     );
-    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Recorded: APPROVED." })));
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Recorded: APPROVED." })));
   });
 
   it("redirects a caller without board/sysadmin role, and shows a loader while resolving", () => {
@@ -95,7 +95,7 @@ describe("safety/trusted-adults page", () => {
         expect.objectContaining({ method: "POST", body: JSON.stringify({ reviewId: 9, decision: "DENY" }) }),
       ),
     );
-    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Recorded: DENIED." })));
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Recorded: DENIED." })));
 
     // Cancelling the modal must NOT fire a decision (the old window.prompt returned null,
     // which `?? ""` swallowed into an empty-note REQUEST_INFO).

--- a/checkin-app/src/app/safety/trusted-adults/page.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/page.tsx
@@ -80,9 +80,9 @@ const label = (s: string) => s.replace(/_/g, " ");
 // (decision-less) states. Null → a fresh disclosure or a plain withdraw+resubmit, where
 // the board needs no prior-decision context.
 const PRIOR_DECISION_META: Record<string, { text: string; color: string }> = {
-    APPROVE: { text: "Renewal", color: "blue" },
+    APPROVE: { text: "Renewal", color: "treehousePurple" },
     DENY: { text: "Previously denied", color: "red" },
-    REQUEST_INFO: { text: "Previously: more info requested", color: "orange" },
+    REQUEST_INFO: { text: "Previously: more info requested", color: "treehousePurple" },
 };
 
 function priorDecisionReview(reviews: Review[]): Review | null {
@@ -154,7 +154,7 @@ export default function AdminTrustedAdultsPage() {
                     setNotices((n) => ({ ...n, [reviewId]: { text: body.error ?? "Decision failed.", tone: "error" } }));
                 }
             } else {
-                notifications.show({ color: "green", message: `Recorded: ${label(body.status)}.` });
+                notifications.show({ message: `Recorded: ${label(body.status)}.` });
                 await load();
                 notifyNavRefresh();
             }
@@ -240,7 +240,7 @@ export default function AdminTrustedAdultsPage() {
                 const changeBadge = priorMeta
                     ? { text: priorMeta.text + (infoUpdated ? " — info updated" : ""), color: priorMeta.color }
                     : infoUpdated
-                        ? { text: "Info updated", color: "blue" }
+                        ? { text: "Info updated", color: "treehousePurple" }
                         : null;
                 // "Previously dispositioned" note the board sent to staff — only APPROVE sets a
                 // sharedNote. When present on a renewal, offer to re-use it (gated by a radio).
@@ -353,7 +353,6 @@ export default function AdminTrustedAdultsPage() {
                                             <span>
                                                 <Button
                                                     size="xs" fz={15}
-                                                    color="green"
                                                     loading={busyId === latest.id}
                                                     disabled={isSelf || !sharedVal.trim() || (needsChoice && !choice)}
                                                     onClick={() => decide(latest.id, "APPROVE", { sharedNote: sharedVal })}
@@ -397,7 +396,6 @@ export default function AdminTrustedAdultsPage() {
                                 <Button
                                     size="xs" fz={15}
                                     variant="subtle"
-                                    color="green"
                                     disabled={isSelf && !user?.isSysadmin}
                                     loading={busyId === latest.id}
                                     onClick={() => openPrompt({

--- a/checkin-app/src/app/settings/email/page.tsx
+++ b/checkin-app/src/app/settings/email/page.tsx
@@ -90,7 +90,7 @@ export default function EmailSettingsPage() {
           scholarshipNotifyEmail: notify || null,
         }),
       });
-      if (res.ok) { notifications.show({ color: "green", message: "Email settings saved." }); setUnlocked(false); await load(); }
+      if (res.ok) { notifications.show({ message: "Email settings saved." }); setUnlocked(false); await load(); }
       else { const d = await res.json().catch(() => ({})); setSaveNotice({ text: d.error || "Save failed.", err: true }); }
     } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }
     finally { setSaving(false); }
@@ -116,7 +116,7 @@ export default function EmailSettingsPage() {
             notices, board alerts). Leave blank to use the environment default sender.
           </Text>
 
-          <Alert color={wasSet ? "yellow" : "blue"} variant="light" mb="md">
+          <Alert color={wasSet ? "yellow" : "treehousePurple"} variant="light" mb="md">
             {wasSet ? (
               <Text size="sm">
                 ⚠️ The <strong>From</strong> address must be on a domain verified in Resend or all mail
@@ -174,7 +174,7 @@ export default function EmailSettingsPage() {
           </Stack>
 
           {saveNotice && (
-            <Alert mt="lg" color={saveNotice.err ? "red" : "green"} variant="light">
+            <Alert mt="lg" color={saveNotice.err ? "red" : "treehouseGreen"} variant="light">
               {saveNotice.text}
             </Alert>
           )}

--- a/checkin-app/src/app/settings/localization/page.tsx
+++ b/checkin-app/src/app/settings/localization/page.tsx
@@ -76,7 +76,7 @@ export default function LocalizationSettingsPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ timezone, locale }),
       });
-      if (res.ok) { notifications.show({ color: "green", message: "Settings saved." }); await load(); }
+      if (res.ok) { notifications.show({ message: "Settings saved." }); await load(); }
       else { const d = await res.json().catch(() => ({})); flash(d.error || "Save failed."); }
     } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }
     finally { setSaving(false); }

--- a/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
@@ -54,7 +54,7 @@ describe("MembershipSettingsPage", () => {
     expect(JSON.parse(putOpts!.body as string)).toEqual(expect.objectContaining({ normalDuesCents: 20000 }));
 
     await waitFor(() =>
-      expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Settings saved." })),
+      expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Settings saved." })),
     );
   });
 
@@ -98,7 +98,7 @@ describe("MembershipSettingsPage", () => {
     // The extracted id lands in the variant-ID field, with a reminder to Save.
     expect(await screen.findByDisplayValue("789789")).toBeInTheDocument();
     expect(notifications.show).toHaveBeenCalledWith(
-      expect.objectContaining({ color: "green", message: expect.stringMatching(/789789.*Save settings/) }),
+      expect.objectContaining({ message: expect.stringMatching(/789789.*Save settings/) }),
     );
 
     // The normal save persists both the URL and the extracted variant ID.

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -135,7 +135,7 @@ export default function MembershipSettingsPage() {
           ...(boundaryUnlocked || !boundaryWasSet ? { orgMembershipYearBoundary: boundary || null } : {}),
         }),
       });
-      if (res.ok) { notifications.show({ color: "green", message: "Settings saved." }); setBoundaryUnlocked(false); notifyNavRefresh(); await load(); }
+      if (res.ok) { notifications.show({ message: "Settings saved." }); setBoundaryUnlocked(false); notifyNavRefresh(); await load(); }
       else { const d = await res.json().catch(() => ({})); setSaveNotice({ text: d.error || "Save failed.", err: true }); }
     } catch { notifications.show({ color: "red", message: "Network error.", autoClose: false }); }
     finally { setSaving(false); }
@@ -158,7 +158,7 @@ export default function MembershipSettingsPage() {
       if (res.ok) {
         setVariantId(data.variantId);
         setFieldErrors((f) => ({ ...f, variantId: undefined }));
-        notifications.show({ color: "green", message: `Variant ${data.variantId} filled in — press Save settings to keep it.` });
+        notifications.show({ message: `Variant ${data.variantId} filled in — press Save settings to keep it.` });
       } else {
         setSaveNotice({ text: data.error || "Could not extract the variant.", err: true });
       }
@@ -324,7 +324,7 @@ export default function MembershipSettingsPage() {
             </Alert>
 
             {isDev && (
-              <Alert color="grape" variant="light" mt="md" title="Contract signing target (dev instance only)">
+              <Alert color="treehousePurple" variant="light" mt="md" title="Contract signing target (dev instance only)">
                 <Text size="sm" mb="sm">
                   🧪 Where membership contract signing requests go on <strong>this dev instance</strong>.
                   Prod always uses Zoho; this switch never exists there.
@@ -347,7 +347,7 @@ export default function MembershipSettingsPage() {
             )}
 
             {saveNotice && (
-              <Alert mt="lg" color={saveNotice.err ? "red" : "green"} variant="light">
+              <Alert mt="lg" color={saveNotice.err ? "red" : "treehouseGreen"} variant="light">
                 {saveNotice.text}
               </Alert>
             )}
@@ -371,7 +371,7 @@ export default function MembershipSettingsPage() {
               label="Also email each household a renewal reminder"
             />
             {renewalNotice && (
-              <Alert mt="md" mb="md" color={renewalNotice.err ? "red" : "green"} variant="light">
+              <Alert mt="md" mb="md" color={renewalNotice.err ? "red" : "treehouseGreen"} variant="light">
                 {renewalNotice.text}
               </Alert>
             )}

--- a/checkin-app/src/app/settings/shopify-webhook/page.tsx
+++ b/checkin-app/src/app/settings/shopify-webhook/page.tsx
@@ -93,7 +93,7 @@ export default function ShopifyWebhookSettingsPage() {
               <Code style={{ fontSize: "var(--mantine-font-size-sm)" }}>{status.webhookUrl}</Code>
               <CopyButton value={status.webhookUrl}>
                 {({ copied, copy }) => (
-                  <Button size="xs" variant="light" color={copied ? "teal" : undefined} onClick={copy}>
+                  <Button size="xs" variant="light" color={copied ? "treehousePurple" : undefined} onClick={copy}>
                     {copied ? "Copied" : "Copy"}
                   </Button>
                 )}

--- a/checkin-app/src/app/shop-ops/create/page.tsx
+++ b/checkin-app/src/app/shop-ops/create/page.tsx
@@ -41,7 +41,7 @@ export default function CreateToolPage() {
       });
 
       if (res.ok) {
-        notifications.show({ color: "green", message: "New tool added successfully!" });
+        notifications.show({ message: "New tool added successfully!" });
         setNewToolName("");
         setNewToolGuide("");
         loadTools();

--- a/checkin-app/src/app/shop-ops/manage/ToolManagementPanel.tsx
+++ b/checkin-app/src/app/shop-ops/manage/ToolManagementPanel.tsx
@@ -117,7 +117,7 @@ function GrantForm({
             />
           )}
           <Select label="Level" w={140} value={level} onChange={(v) => setLevel(v ?? "CERTIFIED")} allowDeselect={false} data={levelOptions} />
-          <Button type="submit" color="green" disabled={saving}>Grant</Button>
+          <Button type="submit" disabled={saving}>Grant</Button>
         </Group>
       </form>
 
@@ -127,7 +127,7 @@ function GrantForm({
         </Text>
         <Group grow>
           <Button variant="default" onClick={() => setConfirm(null)}>Cancel</Button>
-          <Button color="green" onClick={confirm_} disabled={saving} loading={saving}>Confirm</Button>
+          <Button onClick={confirm_} disabled={saving} loading={saving}>Confirm</Button>
         </Group>
       </Modal>
     </>
@@ -194,7 +194,7 @@ function ToolsTab({ tools, members, isAdmin, isCertifier, onToolsChange }: {
 
   return (
     <div>
-      {msg && <Alert color="cyan" mb="md">{msg}</Alert>}
+      {msg && <Alert color="treehousePurple" mb="md">{msg}</Alert>}
 
       <Group mb="md" align="center" wrap="wrap">
         <TextInput placeholder="Search tools..." value={search} onChange={e => setSearch(e.currentTarget.value)} style={{ flex: '1 1 220px' }} />
@@ -262,7 +262,7 @@ function ToolsTab({ tools, members, isAdmin, isCertifier, onToolsChange }: {
         <TextInput type="url" placeholder="https://..." value={editingGuide?.value ?? ''} onChange={e => editingGuide && setEditingGuide({ ...editingGuide, value: e.currentTarget.value })} mb="md" />
         <Group grow>
           <Button variant="default" onClick={() => setEditingGuide(null)}>Cancel</Button>
-          <Button color="green" onClick={saveGuide} disabled={savingGuide} loading={savingGuide}>Save</Button>
+          <Button onClick={saveGuide} disabled={savingGuide} loading={savingGuide}>Save</Button>
         </Group>
       </Modal>
     </div>

--- a/checkin-app/src/app/signin/__tests__/page.test.tsx
+++ b/checkin-app/src/app/signin/__tests__/page.test.tsx
@@ -3,8 +3,15 @@ jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 import { screen, fireEvent } from "@testing-library/react";
-import { signIn } from "next-auth/react";
-import { renderWithProviders, setSession, resetRtl, router } from "@/test-helpers/rtl";
+import { signIn, signOut } from "next-auth/react";
+import {
+    renderWithProviders,
+    setSession,
+    setSearchParams,
+    setCheckinEnv,
+    resetRtl,
+    router,
+} from "@/test-helpers/rtl";
 import SignInPage from "../page";
 
 beforeEach(() => resetRtl());
@@ -37,5 +44,38 @@ describe("SignInPage", () => {
         renderWithProviders(<SignInPage />);
 
         expect(screen.queryByRole("button", { name: /sign in with google/i })).not.toBeInTheDocument();
+    });
+
+    it("shows the wrong-account notice (via AlertBanner) and wires sign-out on a dev, non-org account", () => {
+        setCheckinEnv("dev");
+        setSession({ id: 1, email: "x@gmail.com", hd: "gmail.com" });
+        renderWithProviders(<SignInPage />);
+
+        expect(screen.getByText(/not managed by the/i)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /sign out/i }));
+        expect(signOut).toHaveBeenCalledWith({ callbackUrl: "/signin" });
+    });
+
+    it("shows the sign-in-didn't-complete notice (via AlertBanner) when signed in with an error param", () => {
+        setSession({ id: 1, name: "Ann Admin" });
+        setSearchParams("error=OAuthCallback");
+        renderWithProviders(<SignInPage />);
+
+        expect(screen.getByText(/didn't complete/i)).toBeInTheDocument();
+        expect(screen.getByText(/OAuthCallback/)).toBeInTheDocument();
+    });
+
+    it("renders the wordmark lowercase", () => {
+        renderWithProviders(<SignInPage />);
+
+        const wordmark = screen.getByRole("heading", { name: /checkmein/i });
+        expect(wordmark).toHaveStyle({ textTransform: "lowercase" });
+    });
+
+    it("(regression) shows the primary sign-in button when signed out and not on a local instance", () => {
+        renderWithProviders(<SignInPage />);
+
+        expect(screen.getByRole("button", { name: /sign in with google/i })).toBeInTheDocument();
     });
 });

--- a/checkin-app/src/app/signin/page.tsx
+++ b/checkin-app/src/app/signin/page.tsx
@@ -1,36 +1,20 @@
 "use client";
 
 import { Suspense, useEffect } from "react";
+import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession, signIn, signOut } from "next-auth/react";
+import { Box, Button, Card, Container, Stack, Text, Title } from "@mantine/core";
+import { AlertBanner } from "@/components/admin/AlertBanner";
 import { ORG_DOMAIN } from "@/lib/config";
 import { useCheckinEnv, useIsDevInstance, useIsLocalInstance } from "@/components/EnvProvider";
 import DevLoginPicker from "@/components/DevLoginPicker";
-
-// Layout for the glass hero (this page still uses the legacy glass-* utilities, not Mantine).
-// Inlined from the former page.module.css, which the Mantine migration removed.
-const mainStyle: React.CSSProperties = {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
-    minHeight: "calc(100vh - 70px)",
-    padding: "2rem 1rem",
-};
-const heroStyle: React.CSSProperties = {
-    maxWidth: 600,
-    width: "100%",
-    textAlign: "center",
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-};
 
 /**
  * Custom sign-in screen for the dev instance (replaces NextAuth's bare default page). The dev
  * middleware (DEV_INSTANCE_DESIGN.md §4) bounces every anonymous request here, and a signed-in but
  * non-org account lands here too (it can't pass the `hd` gate) — so this page covers both states.
- * Styled to match the real homepage hero.
+ * Mirrors the homepage's signed-out card (page.tsx) on Mantine primitives.
  */
 function SignInInner() {
     const router = useRouter();
@@ -64,131 +48,78 @@ function SignInInner() {
         }
     }, [status, wrongAccount, callbackUrl, router]);
 
-    return (
-        <main style={mainStyle}>
-            <div className="glass-container animate-float" style={heroStyle}>
-                <h1 className="text-gradient" style={{ fontSize: "3rem", margin: "0 0 0.5rem 0", fontFamily: "var(--mantine-font-family-headings)" }}>
-                    {isDevInstance ? "Welcome to Innovation Treehouse Dev" : "CheckMeIn"}
-                </h1>
-                <p style={{ color: "var(--color-text-muted)", fontSize: "1.1rem", marginBottom: "2rem" }}>
-                    {isDevInstance
-                        ? <>Log in with an <strong>@{ORG_DOMAIN}</strong> email below.</>
-                        : "The Innovation Treehouse check-in system."}
-                </p>
+    if (status === "loading") return null;
 
-                {wrongAccount ? (
-                    <div
-                        style={{
-                            width: "100%",
-                            maxWidth: 360,
-                            display: "flex",
-                            flexDirection: "column",
-                            alignItems: "center",
-                            gap: "1rem",
-                        }}
+    return (
+        <Container size="sm" py="xl">
+            <Card withBorder shadow="sm" radius="md" padding="xl">
+                <Stack align="center" gap="xs" mb="lg">
+                    <Box
+                        bg="white"
+                        px={6}
+                        py={2}
+                        style={{ borderRadius: "var(--mantine-radius-md)", display: "inline-flex", alignItems: "center" }}
                     >
-                        <div
-                            style={{
-                                width: "100%",
-                                padding: "1rem",
-                                background: "rgba(239, 68, 68, 0.12)",
-                                border: "1px solid rgba(239, 68, 68, 0.4)",
-                                borderRadius: 12,
-                                color: "#fca5a5",
-                                fontSize: "0.95rem",
-                            }}
-                        >
-                            Signed in as <strong>{session.user?.email}</strong>, but this Google account is not
-                            managed by the <code>@{ORG_DOMAIN}</code> Google Workspace — it may be a personal
-                            account or a forwarding alias. Sign out and use an actual{" "}
-                            <code>@{ORG_DOMAIN}</code> Workspace account to access the dev environment.
-                        </div>
-                        <button
-                            className="glass-button"
-                            onClick={() => signOut({ callbackUrl: "/signin" })}
-                            style={{
-                                width: "100%",
-                                background: "rgba(59, 130, 246, 0.2)",
-                                borderColor: "rgba(59, 130, 246, 0.4)",
-                            }}
-                        >
-                            Sign out &amp; use another account
-                        </button>
-                    </div>
-                ) : signedIn ? (
-                    <div
-                        style={{
-                            width: "100%",
-                            maxWidth: 360,
-                            display: "flex",
-                            flexDirection: "column",
-                            alignItems: "center",
-                            gap: "1rem",
-                        }}
-                    >
-                        {error && (
-                            <div
-                                style={{
-                                    width: "100%",
-                                    padding: "1rem",
-                                    background: "rgba(245, 158, 11, 0.12)",
-                                    border: "1px solid rgba(245, 158, 11, 0.4)",
-                                    borderRadius: 12,
-                                    color: "#fcd34d",
-                                    fontSize: "0.95rem",
-                                }}
-                            >
-                                That sign-in attempt didn&apos;t complete (code: <code>{error}</code>).
-                                You are still signed in as <strong>{session.user?.email}</strong>.
-                            </div>
-                        )}
-                        <a
-                            className="glass-button"
-                            href={callbackUrl}
-                            style={{
-                                width: "100%",
-                                background: "rgba(59, 130, 246, 0.2)",
-                                borderColor: "rgba(59, 130, 246, 0.4)",
-                            }}
-                        >
-                            Continue as {session.user?.name || session.user?.email}
-                        </a>
-                    </div>
-                ) : status === "loading" ? null : (
-                    <div
-                        style={{
-                            width: "100%",
-                            maxWidth: 360,
-                            display: "flex",
-                            flexDirection: "column",
-                            alignItems: "center",
-                            gap: "1.25rem",
-                        }}
-                    >
-                        {isLocalInstance ? (
-                            // LOCAL never calls Google (no Google identity on a laptop) — the offline
-                            // dev persona picker is the only login path. callbackUrl is honored so a
-                            // program-page "Sign in to enroll" returns to /programs/<id> after mint.
-                            <DevLoginPicker callbackUrl={callbackUrl} />
+                        <Image src="/brand/treehouse-logo-full.webp" alt="Innovation Treehouse" width={84} height={40} priority />
+                    </Box>
+                    <Title order={1} tt="lowercase">{isDevInstance ? "CMI-dev" : "CheckMeIn"}</Title>
+                    <Text c="dimmed">
+                        {isDevInstance ? (
+                            <>Log in with an <strong>@{ORG_DOMAIN}</strong> email below.</>
                         ) : (
-                            <button
-                                className="glass-button primary-button"
-                                onClick={() => signIn("google", { callbackUrl })}
-                                style={{
-                                    width: "100%",
-                                    padding: "1rem 2rem",
-                                    fontSize: "1.2rem",
-                                    background: "rgba(59, 130, 246, 0.2)",
-                                    borderColor: "rgba(59, 130, 246, 0.4)",
-                                }}
-                            >
-                                Sign in with Google
-                            </button>
+                            "The Innovation Treehouse check-in system."
                         )}
-                    </div>
-                )}
-            </div>
-        </main>
+                    </Text>
+                </Stack>
+
+                <Stack>
+                    {wrongAccount ? (
+                        <>
+                            <AlertBanner
+                                tone="error"
+                                message={
+                                    <>
+                                        Signed in as <strong>{session?.user?.email}</strong>, but this Google account is
+                                        not managed by the <code>@{ORG_DOMAIN}</code> Google Workspace — it may be a
+                                        personal account or a forwarding alias. Sign out and use an actual{" "}
+                                        <code>@{ORG_DOMAIN}</code> Workspace account to access the dev environment.
+                                    </>
+                                }
+                            />
+                            <Button fullWidth onClick={() => signOut({ callbackUrl: "/signin" })}>
+                                Sign out &amp; use another account
+                            </Button>
+                        </>
+                    ) : signedIn ? (
+                        <>
+                            {error && (
+                                <AlertBanner
+                                    tone="warning"
+                                    message={
+                                        <>
+                                            That sign-in attempt didn&apos;t complete (code: <code>{error}</code>).
+                                            You are still signed in as <strong>{session?.user?.email}</strong>.
+                                        </>
+                                    }
+                                />
+                            )}
+                            <Button component="a" href={callbackUrl} fullWidth>
+                                Continue as {session?.user?.name || session?.user?.email}
+                            </Button>
+                        </>
+                    ) : isLocalInstance ? (
+                        // LOCAL never calls Google (no Google identity on a laptop) — the offline
+                        // dev persona picker is the only login path. callbackUrl is honored so a
+                        // program-page "Sign in to enroll" returns to /programs/<id> after mint.
+                        <DevLoginPicker callbackUrl={callbackUrl} />
+                    ) : (
+                        <Button size="lg" fullWidth onClick={() => signIn("google", { callbackUrl })}>
+                            Sign in with Google
+                        </Button>
+                    )}
+                </Stack>
+            </Card>
+        </Container>
     );
 }
 

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -335,7 +335,7 @@ function AppFrameInner({ children }: { children: React.ReactNode }) {
                         // Green action + gray info badges go through the shared CountBadge
                         // (treehouseGreen/black and gray.2/gray-8 respectively). The gray solid
                         // fill is deliberate: on the dark purple sidebar a 'light' translucent
-                        // tint reads dark. The 'blue' household-in-building badge is a one-off
+                        // tint reads dark. The 'treehousePurple' household-in-building badge is a one-off
                         // info color CountBadge doesn't model, so it stays inline (filled + black
                         // text, same as before). NavLink forces section text white on the colored
                         // sidebar, so the dark label is pinned explicitly.

--- a/checkin-app/src/components/DbWakeNotice.tsx
+++ b/checkin-app/src/components/DbWakeNotice.tsx
@@ -71,9 +71,9 @@ export default function DbWakeNotice() {
     // Deliberately generic copy (no infrastructure specifics for end users);
     // the actual cause is the DB auto-pause resume — see the module docblock.
     return (
-        <Alert color="blue" variant="light" radius={0} title="Getting the system ready…">
+        <Alert color="treehousePurple" variant="light" radius={0} title="Getting the system ready…">
             <Group align="center" gap="sm" wrap="nowrap">
-                <Loader size="sm" color="blue" />
+                <Loader size="sm" color="treehousePurple" />
                 <Text size="sm">
                     The system is getting ready for you — this usually takes under a
                     minute, and the page will refresh automatically.

--- a/checkin-app/src/components/DevImpersonationBar.tsx
+++ b/checkin-app/src/components/DevImpersonationBar.tsx
@@ -76,7 +76,6 @@ function DevImpersonationBarInner() {
                         type="button"
                         onClick={returnToMe}
                         disabled={busy}
-                        className="glass-button"
                         style={{ padding: "0.25rem 0.75rem", cursor: busy ? "wait" : "pointer" }}
                     >
                         {busy ? "Returning…" : "Return to me"}

--- a/checkin-app/src/components/DevLoginPicker.tsx
+++ b/checkin-app/src/components/DevLoginPicker.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect } from "react";
 import { signIn } from "next-auth/react";
-import { Badge, Card, Center, Divider, Group, SimpleGrid, Stack, Text } from "@mantine/core";
+import { Card, Center, Divider, Group, SimpleGrid, Stack, Text } from "@mantine/core";
 import { useCheckinEnv } from "@/components/EnvProvider";
+import { RoleBadge } from "@/components/ui/RoleBadge";
 
 interface Persona {
   id: number;
@@ -60,17 +61,21 @@ export default function DevLoginPicker({ callbackUrl = "/" }: { callbackUrl?: st
     signIn("persona-mint", { personaId: String(personaId), mode: "impersonate", callbackUrl });
   };
 
-  const getRoleBadges = (p: Persona): { label: string; color: string }[] => {
-    const badges: { label: string; color: string }[] = [];
-    if (p.isSysadmin) badges.push({ label: "Sysadmin", color: "red" });
-    if (p.isBoardMember) badges.push({ label: "Board", color: "grape" });
-    if (p.isKeyholder) badges.push({ label: "Keyholder", color: "blue" });
-    if (p.isBackgroundCheckReviewer) badges.push({ label: "BG Reviewer", color: "teal" });
-    if (p.toolStatuses?.length > 0) badges.push({ label: "Certified", color: "green" });
-    if (p.householdId) badges.push({ label: "Household", color: "indigo" });
+  // The four participant-role badges render through the shared RoleBadge (its ROLE_META
+  // is the one source of truth for role colors). The three derived, non-role labels below
+  // (Certified/Household/Student) have no ROLE_META entry, so a fake `_`-prefixed role plus
+  // a label override renders them through the same component with the gray fallback.
+  const getRoleBadges = (p: Persona): { role: string; label?: string }[] => {
+    const badges: { role: string; label?: string }[] = [];
+    if (p.isSysadmin) badges.push({ role: "isSysadmin" });
+    if (p.isBoardMember) badges.push({ role: "isBoardMember" });
+    if (p.isKeyholder) badges.push({ role: "isKeyholder" });
+    if (p.isBackgroundCheckReviewer) badges.push({ role: "isBackgroundCheckReviewer" });
+    if (p.toolStatuses?.length > 0) badges.push({ role: "_certified", label: "Certified" });
+    if (p.householdId) badges.push({ role: "_household", label: "Household" });
     if (p.dateOfBirth && now !== null) {
       const age = Math.floor((now - new Date(p.dateOfBirth).getTime()) / (365.25 * 24 * 60 * 60 * 1000));
-      if (age < 18) badges.push({ label: `Student (${age})`, color: "pink" });
+      if (age < 18) badges.push({ role: "_student", label: `Student (${age})` });
     }
     return badges;
   };
@@ -115,9 +120,7 @@ export default function DevLoginPicker({ callbackUrl = "/" }: { callbackUrl?: st
             {getRoleBadges(p).length > 0 && (
               <Group gap={4} mt={4}>
                 {getRoleBadges(p).map((b) => (
-                  <Badge key={b.label} color={b.color} size="xs" variant="filled">
-                    {b.label}
-                  </Badge>
+                  <RoleBadge key={b.role} role={b.role} label={b.label} size="xs" />
                 ))}
               </Group>
             )}

--- a/checkin-app/src/components/TrustedAdultPanel.tsx
+++ b/checkin-app/src/components/TrustedAdultPanel.tsx
@@ -21,8 +21,8 @@ import { TrustedAdultContact } from "@/components/TrustedAdultContact";
 
 const STATUS_META: Record<string, { label: string; color: string }> = {
     PENDING_BOARD_REVIEW: { label: "Awaiting board review", color: "yellow" },
-    PENDING_SUBJECT_ACTION: { label: "Board needs more info — see email", color: "orange" },
-    APPROVED: { label: "Approved", color: "green" },
+    PENDING_SUBJECT_ACTION: { label: "Board needs more info — see email", color: "treehousePurple" },
+    APPROVED: { label: "Approved", color: "treehouseGreen" },
     DENIED: { label: "Denied", color: "red" },
     EXPIRED: { label: "Expired", color: "gray" },
     REVOKED: { label: "Withdrawn", color: "gray" },
@@ -270,7 +270,7 @@ export default function TrustedAdultPanel() {
                                         <Button size="xs" fz={15} variant="light" onClick={() => act(ta.id, "renew")}>
                                             Resubmit (same info)
                                         </Button>
-                                        <Button size="xs" fz={15} variant="light" color="blue" onClick={() => startResubmit(ta)}>
+                                        <Button size="xs" fz={15} variant="light" color="treehousePurple" onClick={() => startResubmit(ta)}>
                                             Submit with new info
                                         </Button>
                                     </>

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -123,7 +123,7 @@ export function AdminEditHouseholdModal({
         body: JSON.stringify({ participantId }),
       });
       if (res.ok) {
-        notifications.show({ color: "green", message: "Lead removed." });
+        notifications.show({ message: "Lead removed." });
         await loadHousehold();
       } else {
         const data = await res.json().catch(() => ({}));
@@ -187,7 +187,7 @@ export function AdminEditHouseholdModal({
       });
       if (res.ok) {
         const data = await res.json();
-        notifications.show({ color: "green", message: "Household updated." });
+        notifications.show({ message: "Household updated." });
         onSaved?.(data.household);
         onClose();
       } else {
@@ -313,7 +313,7 @@ export function AdminEditHouseholdModal({
               )}
             </Stack>
 
-            <Alert color="orange" mt="md">
+            <Alert color="treehousePurple" mt="md">
               You&apos;re editing <strong>{displayName}</strong>, a household you&apos;re not a member of. This
               uses your administrative privileges and is recorded in the audit log.
             </Alert>
@@ -321,7 +321,7 @@ export function AdminEditHouseholdModal({
               <Button variant="default" onClick={requestClose} disabled={saving}>
                 Cancel
               </Button>
-              <Button color="orange" onClick={handleSave} loading={saving} disabled={phoneInvalid}>
+              <Button color="treehousePurple" onClick={handleSave} loading={saving} disabled={phoneInvalid}>
                 Save Changes — As Admin
               </Button>
             </Group>

--- a/checkin-app/src/components/admin/AlertBanner.tsx
+++ b/checkin-app/src/components/admin/AlertBanner.tsx
@@ -5,14 +5,14 @@ export type AlertTone = "success" | "error" | "info" | "warning";
 const TONE_COLOR: Record<AlertTone, string> = {
   success: "green",
   error: "red",
-  info: "cyan",
+  info: "treehousePurple",
   warning: "yellow",
 };
 
 export interface AlertBannerProps {
   /** The message to show. Falsy → renders nothing (replaces the `{message && …}` guard). */
   message: React.ReactNode;
-  /** Severity → Mantine color (success=green, error=red, info=cyan, warning=yellow). */
+  /** Severity → Mantine color (success=green, error=red, info=treehousePurple, warning=yellow). */
   tone?: AlertTone;
   title?: string;
   mb?: string | number;
@@ -21,10 +21,10 @@ export interface AlertBannerProps {
 }
 
 /**
- * Shared success/error status banner for admin pages. Replaces the per-page
- * `{message && <Alert color={isError ? 'red' : 'green'}>…</Alert>}` blocks (which had drifted
- * across green/red/cyan/yellow and a `message.includes('success')` heuristic) with one tone→color
- * mapping and a built-in empty-message guard.
+ * Shared success/error status banner for admin pages. Replaces the old per-page inline
+ * isError-ternary Alert blocks (which had drifted across several stock Mantine colors and a
+ * `message.includes('success')` heuristic) with one tone→color mapping and a built-in
+ * empty-message guard.
  */
 export function AlertBanner({ message, tone = "info", title, mb, mt, onClose }: AlertBannerProps) {
   if (!message) return null;

--- a/checkin-app/src/components/admin/LinkStatusPanel.tsx
+++ b/checkin-app/src/components/admin/LinkStatusPanel.tsx
@@ -85,7 +85,7 @@ export function LinkStatusPanel() {
               <Group gap="xs">
                 <Badge color={e.resolvedAt ? "gray" : "red"}>{e.source}</Badge>
                 {e.resolvedAt && (
-                  <Badge color="green" variant="light">
+                  <Badge variant="light">
                     Resolved
                   </Badge>
                 )}

--- a/checkin-app/src/components/admin/MatchAuditPanel.tsx
+++ b/checkin-app/src/components/admin/MatchAuditPanel.tsx
@@ -52,7 +52,7 @@ export function MatchAuditPanel() {
         memberships: prev.memberships.map((m) => body.kind === 'membership' && m.processId === body.processId ? { ...m, bucket: 'TRACKED_EXCEPTION' as const } : m),
         enrollments: prev.enrollments.map((e) => body.kind === 'enrollment' && e.programId === body.programId && e.personId === body.personId ? { ...e, bucket: 'TRACKED_EXCEPTION' as const } : e),
       });
-      notifications.show({ color: 'green', message: 'Gap tracked as a payment problem.' });
+      notifications.show({ message: 'Gap tracked as a payment problem.' });
     } catch {
       notifications.show({ color: 'red', autoClose: false, message: 'Network error tracking this gap.' });
     } finally {
@@ -167,7 +167,7 @@ export function MatchAuditPanel() {
 
           <Group mt="md" gap="xs">
             {gapCount === 0
-              ? <Badge color="green">No gaps</Badge>
+              ? <Badge>No gaps</Badge>
               : <Badge color="red">{gapCount} gap(s)</Badge>}
             {count('Orders matched', matched.orders)}
             {count('Tracked as exceptions', matched.tracked)}

--- a/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
@@ -102,7 +102,7 @@ describe("AdminEditHouseholdModal", () => {
       expect.objectContaining({ name: "Smith Fam", line1: "2 Main St", city: "Round Rock", postalCode: "78664" }),
     );
 
-    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green" })));
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Household updated." })));
     expect(onSaved).toHaveBeenCalledWith(expect.objectContaining({ name: "Smith Fam" }));
     expect(onClose).toHaveBeenCalled();
   });
@@ -200,7 +200,7 @@ describe("AdminEditHouseholdModal", () => {
         expect.objectContaining({ method: "DELETE", body: JSON.stringify({ participantId: 1 }) }),
       ),
     );
-    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "green", message: "Lead removed." })));
+    await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Lead removed." })));
 
     // Now down to a single lead: the last remaining Remove-lead button is disabled
     // and the "must keep at least one lead" copy shows.

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -103,11 +103,11 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
     }
     case '/attendance': {
       const mine = counts.buildingHousehold;
-      const blue = (n: number, label: string): NavBadge[] =>
-        n > 0 ? [{ count: n, color: 'blue', label }] : [];
+      const info = (n: number, label: string): NavBadge[] =>
+        n > 0 ? [{ count: n, color: 'treehousePurple', label }] : [];
       return [
-        // Blue not green: informational (who's here), not an action to take.
-        ...blue(mine, `${mine} from your household currently in the building`),
+        // Purple not green: informational (who's here), not an action to take.
+        ...info(mine, `${mine} from your household currently in the building`),
         ...gray(counts.building, `${counts.building} people currently in the building`),
       ];
     }

--- a/checkin-app/src/components/ui/RoleBadge.tsx
+++ b/checkin-app/src/components/ui/RoleBadge.tsx
@@ -5,28 +5,33 @@ import { Badge, type BadgeProps } from '@mantine/core';
 /**
  * Centralized role / certification badge. Replaces the per-page inline-styled badges that
  * were duplicated across the admin, shop, and household pages. Add new roles to ROLE_META.
+ *
+ * Tool-CERTIFICATION colors (BASIC/DOF/CERTIFIED/INSTRUCTOR/MAY_CERTIFY_OTHERS) live solely in
+ * ToolLevelBadge (the regulated Safety Rules palette) — do not re-add them here. The
+ * `ParticipantRole` union below makes that a compile error, not just a convention.
  */
 type RoleMeta = { label: string; color: string };
 
-const ROLE_META: Record<string, RoleMeta> = {
-  // Participant roles
+export type ParticipantRole =
+  | 'isSysadmin'
+  | 'isBoardMember'
+  | 'isKeyholder'
+  | 'isBackgroundCheckReviewer'
+  | 'isOperations'
+  | 'coreVolunteer';
+
+export const ROLE_META: Record<ParticipantRole, RoleMeta> = {
   isSysadmin: { label: 'Sysadmin', color: 'red' },
-  isBoardMember: { label: 'Board', color: 'grape' },
-  isKeyholder: { label: 'Keyholder', color: 'blue' },
-  isBackgroundCheckReviewer: { label: 'BG Reviewer', color: 'indigo' },
-  isOperations: { label: 'Operations', color: 'teal' },
-  coreVolunteer: { label: 'Core Volunteer', color: 'pink' },
-  // Tool certification levels
-  BASIC: { label: 'Basic', color: 'gray' },
-  DOF: { label: 'DOF', color: 'yellow' },
-  CERTIFIED: { label: 'Certified', color: 'blue' },
-  INSTRUCTOR: { label: 'Instructor', color: 'green' },
-  MAY_CERTIFY_OTHERS: { label: 'Certifier', color: 'green' },
+  isBoardMember: { label: 'Board', color: 'treehousePurple' },
+  isKeyholder: { label: 'Keyholder', color: 'treehousePurple' },
+  isBackgroundCheckReviewer: { label: 'BG Reviewer', color: 'treehousePurple' },
+  isOperations: { label: 'Operations', color: 'treehousePurple' },
+  coreVolunteer: { label: 'Core Volunteer', color: 'treehousePurple' },
 };
 
 /** The display label for a role/certification key — same lookup RoleBadge renders, for callers that need plain text (e.g. a confirm-modal delta summary). */
 export function roleLabel(role: string): string {
-  return ROLE_META[role]?.label ?? role;
+  return (ROLE_META as Record<string, RoleMeta>)[role]?.label ?? role;
 }
 
 export function RoleBadge({
@@ -34,7 +39,7 @@ export function RoleBadge({
   label,
   ...badgeProps
 }: { role: string; label?: string } & Omit<BadgeProps, 'color' | 'children'>) {
-  const meta = ROLE_META[role];
+  const meta = (ROLE_META as Record<string, RoleMeta>)[role];
   return (
     <Badge color={meta?.color ?? 'gray'} variant="light" {...badgeProps}>
       {label ?? meta?.label ?? role}

--- a/checkin-app/src/components/ui/SectionTabs.tsx
+++ b/checkin-app/src/components/ui/SectionTabs.tsx
@@ -13,7 +13,7 @@ import { useConfirmNav } from "@/components/UnsavedChangesProvider";
  *
  * Auth/loading gates stay in each layout (different hooks, different copy).
  */
-export type SectionTabLink = { name: string; href: string; icon?: string };
+export type SectionTabLink = { name: string; href: string; icon?: React.ReactNode };
 
 interface SectionTabsProps {
   links: readonly SectionTabLink[];
@@ -49,7 +49,7 @@ export function SectionTabs({ links, prefixMatch = false, badgeFor, mb }: Sectio
           <Tabs.Tab
             key={link.href}
             value={link.href}
-            leftSection={link.icon ? <span>{link.icon}</span> : undefined}
+            leftSection={link.icon}
             rightSection={badgeFor?.(link.href)}
           >
             {link.name}

--- a/checkin-app/src/components/ui/__tests__/RoleBadge.test.tsx
+++ b/checkin-app/src/components/ui/__tests__/RoleBadge.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import { ROLE_META, RoleBadge } from "@/components/ui/RoleBadge";
+
+const TOOL_LEVEL_KEYS = ["BASIC", "DOF", "CERTIFIED", "INSTRUCTOR", "MAY_CERTIFY_OTHERS"];
+
+const renderBadge = (ui: React.ReactElement) => render(<MantineProvider>{ui}</MantineProvider>);
+
+describe("ROLE_META", () => {
+  it("holds none of the ToolLevel keys — those belong solely to ToolLevelBadge", () => {
+    for (const key of TOOL_LEVEL_KEYS) {
+      expect(Object.keys(ROLE_META)).not.toContain(key);
+    }
+  });
+
+  it("every color is a brand-sanctioned value (treehousePurple, or red for the distinct sysadmin badge)", () => {
+    for (const meta of Object.values(ROLE_META)) {
+      expect(["treehousePurple", "red"]).toContain(meta.color);
+    }
+  });
+});
+
+describe("RoleBadge", () => {
+  it("renders the label for a known participant role", () => {
+    renderBadge(<RoleBadge role="isKeyholder" />);
+    expect(screen.getByText("Keyholder")).toBeInTheDocument();
+  });
+
+  it("falls back to gray + the raw/override label for an unknown role", () => {
+    renderBadge(<RoleBadge role="_certified" label="Certified" />);
+    const badge = screen.getByText("Certified");
+    expect(badge).toBeInTheDocument();
+  });
+
+  it("falls back to the raw role string when no label override is given", () => {
+    renderBadge(<RoleBadge role="_mystery" />);
+    expect(screen.getByText("_mystery")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Implements the validated UI audit (external audit → code validation with a full color inventory → reviewed spec → build). **Stacked on #1104** (both touch `RoleBadge`; #1104's new teal `isOperations` badge is recolored to the palette here).

- **Sign-in was actually broken**: the page referenced five glass-era CSS classes that no longer exist anywhere and rendered as unstyled text. Rebuilt on Mantine mirroring the home page's signed-out card — all nine auth/query-param states preserved verbatim (open-redirect guard included), notices through `AlertBanner`, lowercase wordmark, brand-default buttons. Dead CSS deleted.
- **Tool-cert colors de-duplicated**: `RoleBadge` carried the five `ToolLevel` keys with *wrong* colors versus the Safety-Rules-regulated `ToolLevelBadge` (e.g. BASIC gray-instead-of-red). Deleted — zero call sites passed them — and a closed `ParticipantRole` union makes re-adding a compile error. `DevLoginPicker`'s fourth hand-rolled role color map folded onto `RoleBadge`.
- **Off-palette sweep** (~45 files): stock `green/blue/teal/cyan/grape/orange/pink/indigo` → theme primary / `treehousePurple` / gray per the audited inventory. **Red/yellow destructive and error conventions are deliberately untouched** — the audit's "only two red/yellow instances" framing was off by two orders of magnitude (97+25, overwhelmingly Deny/Delete buttons and error alerts); repainting destructive UI is an org-level decision this PR does not make. Kept: `ToolLevelBadge` (regulated), DEV markers, the SystemHealthPanels latency triad.
- **Drift guard**: a scanner-with-allowlist test in the house pattern (lifecycle-guard mechanics) that catches JSX props, object literals, *and* ternaries — the shapes the audit's proposed regex lint would have missed — with a 2-entry allowlist and stale-entry check; plus a ROLE_META-no-ToolLevel assertion.

Out of scope, stated: red/yellow repaint, `/dev/*` and print-PDF hex (CSS vars don't resolve in the PDF path), P3 items (negative-margin refactor, focus ring, table migration — 20 files, its own initiative).

Verified: bare-exit tsc, CI-exact lint, 235 suites / 2127 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe