### PR TITLE
UI audit 1/3: rebuild the broken sign-in page, delete dead glass CSS

### DIFF
--- a/checkin-app/src/app/globals.css
+++ b/checkin-app/src/app/globals.css
@@ -10,11 +10,6 @@ body {
   margin: 0;
 }
 
-/* Glass buttons are real <button>s; show a pointer on hover like a link. */
-.glass-button {
-  cursor: pointer;
-}
-
 /* Kiosk display runs unattended on a Raspberry Pi — never show a pointer there. */
 .kiosk-mode,
 .kiosk-mode * {

--- a/checkin-app/src/app/signin/__tests__/page.test.tsx
+++ b/checkin-app/src/app/signin/__tests__/page.test.tsx
@@ -3,8 +3,15 @@ jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 import { screen, fireEvent } from "@testing-library/react";
-import { signIn } from "next-auth/react";
-import { renderWithProviders, setSession, resetRtl, router } from "@/test-helpers/rtl";
+import { signIn, signOut } from "next-auth/react";
+import {
+    renderWithProviders,
+    setSession,
+    setSearchParams,
+    setCheckinEnv,
+    resetRtl,
+    router,
+} from "@/test-helpers/rtl";
 import SignInPage from "../page";
 
 beforeEach(() => resetRtl());
@@ -37,5 +44,38 @@ describe("SignInPage", () => {
         renderWithProviders(<SignInPage />);
 
         expect(screen.queryByRole("button", { name: /sign in with google/i })).not.toBeInTheDocument();
+    });
+
+    it("shows the wrong-account notice (via AlertBanner) and wires sign-out on a dev, non-org account", () => {
+        setCheckinEnv("dev");
+        setSession({ id: 1, email: "x@gmail.com", hd: "gmail.com" });
+        renderWithProviders(<SignInPage />);
+
+        expect(screen.getByText(/not managed by the/i)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /sign out/i }));
+        expect(signOut).toHaveBeenCalledWith({ callbackUrl: "/signin" });
+    });
+
+    it("shows the sign-in-didn't-complete notice (via AlertBanner) when signed in with an error param", () => {
+        setSession({ id: 1, name: "Ann Admin" });
+        setSearchParams("error=OAuthCallback");
+        renderWithProviders(<SignInPage />);
+
+        expect(screen.getByText(/didn't complete/i)).toBeInTheDocument();
+        expect(screen.getByText(/OAuthCallback/)).toBeInTheDocument();
+    });
+
+    it("renders the wordmark lowercase", () => {
+        renderWithProviders(<SignInPage />);
+
+        const wordmark = screen.getByRole("heading", { name: /checkmein/i });
+        expect(wordmark).toHaveStyle({ textTransform: "lowercase" });
+    });
+
+    it("(regression) shows the primary sign-in button when signed out and not on a local instance", () => {
+        renderWithProviders(<SignInPage />);
+
+        expect(screen.getByRole("button", { name: /sign in with google/i })).toBeInTheDocument();
     });
 });

--- a/checkin-app/src/app/signin/page.tsx
+++ b/checkin-app/src/app/signin/page.tsx
@@ -1,36 +1,20 @@
 "use client";
 
 import { Suspense, useEffect } from "react";
+import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession, signIn, signOut } from "next-auth/react";
+import { Box, Button, Card, Container, Stack, Text, Title } from "@mantine/core";
+import { AlertBanner } from "@/components/admin/AlertBanner";
 import { ORG_DOMAIN } from "@/lib/config";
 import { useCheckinEnv, useIsDevInstance, useIsLocalInstance } from "@/components/EnvProvider";
 import DevLoginPicker from "@/components/DevLoginPicker";
-
-// Layout for the glass hero (this page still uses the legacy glass-* utilities, not Mantine).
-// Inlined from the former page.module.css, which the Mantine migration removed.
-const mainStyle: React.CSSProperties = {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
-    minHeight: "calc(100vh - 70px)",
-    padding: "2rem 1rem",
-};
-const heroStyle: React.CSSProperties = {
-    maxWidth: 600,
-    width: "100%",
-    textAlign: "center",
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-};
 
 /**
  * Custom sign-in screen for the dev instance (replaces NextAuth's bare default page). The dev
  * middleware (DEV_INSTANCE_DESIGN.md §4) bounces every anonymous request here, and a signed-in but
  * non-org account lands here too (it can't pass the `hd` gate) — so this page covers both states.
- * Styled to match the real homepage hero.
+ * Mirrors the homepage's signed-out card (page.tsx) on Mantine primitives.
  */
 function SignInInner() {
     const router = useRouter();
@@ -64,131 +48,78 @@ function SignInInner() {
         }
     }, [status, wrongAccount, callbackUrl, router]);
 
-    return (
-        <main style={mainStyle}>
-            <div className="glass-container animate-float" style={heroStyle}>
-                <h1 className="text-gradient" style={{ fontSize: "3rem", margin: "0 0 0.5rem 0", fontFamily: "var(--mantine-font-family-headings)" }}>
-                    {isDevInstance ? "Welcome to Innovation Treehouse Dev" : "CheckMeIn"}
-                </h1>
-                <p style={{ color: "var(--color-text-muted)", fontSize: "1.1rem", marginBottom: "2rem" }}>
-                    {isDevInstance
-                        ? <>Log in with an <strong>@{ORG_DOMAIN}</strong> email below.</>
-                        : "The Innovation Treehouse check-in system."}
-                </p>
+    if (status === "loading") return null;
 
-                {wrongAccount ? (
-                    <div
-                        style={{
-                            width: "100%",
-                            maxWidth: 360,
-                            display: "flex",
-                            flexDirection: "column",
-                            alignItems: "center",
-                            gap: "1rem",
-                        }}
+    return (
+        <Container size="sm" py="xl">
+            <Card withBorder shadow="sm" radius="md" padding="xl">
+                <Stack align="center" gap="xs" mb="lg">
+                    <Box
+                        bg="white"
+                        px={6}
+                        py={2}
+                        style={{ borderRadius: "var(--mantine-radius-md)", display: "inline-flex", alignItems: "center" }}
                     >
-                        <div
-                            style={{
-                                width: "100%",
-                                padding: "1rem",
-                                background: "rgba(239, 68, 68, 0.12)",
-                                border: "1px solid rgba(239, 68, 68, 0.4)",
-                                borderRadius: 12,
-                                color: "#fca5a5",
-                                fontSize: "0.95rem",
-                            }}
-                        >
-                            Signed in as <strong>{session.user?.email}</strong>, but this Google account is not
-                            managed by the <code>@{ORG_DOMAIN}</code> Google Workspace — it may be a personal
-                            account or a forwarding alias. Sign out and use an actual{" "}
-                            <code>@{ORG_DOMAIN}</code> Workspace account to access the dev environment.
-                        </div>
-                        <button
-                            className="glass-button"
-                            onClick={() => signOut({ callbackUrl: "/signin" })}
-                            style={{
-                                width: "100%",
-                                background: "rgba(59, 130, 246, 0.2)",
-                                borderColor: "rgba(59, 130, 246, 0.4)",
-                            }}
-                        >
-                            Sign out &amp; use another account
-                        </button>
-                    </div>
-                ) : signedIn ? (
-                    <div
-                        style={{
-                            width: "100%",
-                            maxWidth: 360,
-                            display: "flex",
-                            flexDirection: "column",
-                            alignItems: "center",
-                            gap: "1rem",
-                        }}
-                    >
-                        {error && (
-                            <div
-                                style={{
-                                    width: "100%",
-                                    padding: "1rem",
-                                    background: "rgba(245, 158, 11, 0.12)",
-                                    border: "1px solid rgba(245, 158, 11, 0.4)",
-                                    borderRadius: 12,
-                                    color: "#fcd34d",
-                                    fontSize: "0.95rem",
-                                }}
-                            >
-                                That sign-in attempt didn&apos;t complete (code: <code>{error}</code>).
-                                You are still signed in as <strong>{session.user?.email}</strong>.
-                            </div>
-                        )}
-                        <a
-                            className="glass-button"
-                            href={callbackUrl}
-                            style={{
-                                width: "100%",
-                                background: "rgba(59, 130, 246, 0.2)",
-                                borderColor: "rgba(59, 130, 246, 0.4)",
-                            }}
-                        >
-                            Continue as {session.user?.name || session.user?.email}
-                        </a>
-                    </div>
-                ) : status === "loading" ? null : (
-                    <div
-                        style={{
-                            width: "100%",
-                            maxWidth: 360,
-                            display: "flex",
-                            flexDirection: "column",
-                            alignItems: "center",
-                            gap: "1.25rem",
-                        }}
-                    >
-                        {isLocalInstance ? (
-                            // LOCAL never calls Google (no Google identity on a laptop) — the offline
-                            // dev persona picker is the only login path. callbackUrl is honored so a
-                            // program-page "Sign in to enroll" returns to /programs/<id> after mint.
-                            <DevLoginPicker callbackUrl={callbackUrl} />
+                        <Image src="/brand/treehouse-logo-full.webp" alt="Innovation Treehouse" width={84} height={40} priority />
+                    </Box>
+                    <Title order={1} tt="lowercase">{isDevInstance ? "CMI-dev" : "CheckMeIn"}</Title>
+                    <Text c="dimmed">
+                        {isDevInstance ? (
+                            <>Log in with an <strong>@{ORG_DOMAIN}</strong> email below.</>
                         ) : (
-                            <button
-                                className="glass-button primary-button"
-                                onClick={() => signIn("google", { callbackUrl })}
-                                style={{
-                                    width: "100%",
-                                    padding: "1rem 2rem",
-                                    fontSize: "1.2rem",
-                                    background: "rgba(59, 130, 246, 0.2)",
-                                    borderColor: "rgba(59, 130, 246, 0.4)",
-                                }}
-                            >
-                                Sign in with Google
-                            </button>
+                            "The Innovation Treehouse check-in system."
                         )}
-                    </div>
-                )}
-            </div>
-        </main>
+                    </Text>
+                </Stack>
+
+                <Stack>
+                    {wrongAccount ? (
+                        <>
+                            <AlertBanner
+                                tone="error"
+                                message={
+                                    <>
+                                        Signed in as <strong>{session?.user?.email}</strong>, but this Google account is
+                                        not managed by the <code>@{ORG_DOMAIN}</code> Google Workspace — it may be a
+                                        personal account or a forwarding alias. Sign out and use an actual{" "}
+                                        <code>@{ORG_DOMAIN}</code> Workspace account to access the dev environment.
+                                    </>
+                                }
+                            />
+                            <Button fullWidth onClick={() => signOut({ callbackUrl: "/signin" })}>
+                                Sign out &amp; use another account
+                            </Button>
+                        </>
+                    ) : signedIn ? (
+                        <>
+                            {error && (
+                                <AlertBanner
+                                    tone="warning"
+                                    message={
+                                        <>
+                                            That sign-in attempt didn&apos;t complete (code: <code>{error}</code>).
+                                            You are still signed in as <strong>{session?.user?.email}</strong>.
+                                        </>
+                                    }
+                                />
+                            )}
+                            <Button component="a" href={callbackUrl} fullWidth>
+                                Continue as {session?.user?.name || session?.user?.email}
+                            </Button>
+                        </>
+                    ) : isLocalInstance ? (
+                        // LOCAL never calls Google (no Google identity on a laptop) — the offline
+                        // dev persona picker is the only login path. callbackUrl is honored so a
+                        // program-page "Sign in to enroll" returns to /programs/<id> after mint.
+                        <DevLoginPicker callbackUrl={callbackUrl} />
+                    ) : (
+                        <Button size="lg" fullWidth onClick={() => signIn("google", { callbackUrl })}>
+                            Sign in with Google
+                        </Button>
+                    )}
+                </Stack>
+            </Card>
+        </Container>
     );
 }
 

--- a/checkin-app/src/components/DevImpersonationBar.tsx
+++ b/checkin-app/src/components/DevImpersonationBar.tsx
@@ -76,7 +76,6 @@ function DevImpersonationBarInner() {
                         type="button"
                         onClick={returnToMe}
                         disabled={busy}
-                        className="glass-button"
                         style={{ padding: "0.25rem 0.75rem", cursor: busy ? "wait" : "pointer" }}
                     >
                         {busy ? "Returning…" : "Return to me"}


### PR DESCRIPTION
First of three PRs splitting #1106 (Jeff: too big as one). The sign-in page referenced five glass-era CSS classes that no longer exist and rendered as unstyled text in prod. Rebuilt on Mantine mirroring the home page's signed-out card — all nine auth/query-param states preserved verbatim (open-redirect guard included), notices via AlertBanner, lowercase wordmark, brand-default buttons. Dead CSS deleted including the DevImpersonationBar straggler. 4 files; tsc/lint/test:ci green standalone (2120 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe