### PR TITLE
UI audit 2/3: RoleBadge stops duplicating the regulated tool-cert palette

### DIFF
--- a/checkin-app/src/components/DevLoginPicker.tsx
+++ b/checkin-app/src/components/DevLoginPicker.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect } from "react";
 import { signIn } from "next-auth/react";
-import { Badge, Card, Center, Divider, Group, SimpleGrid, Stack, Text } from "@mantine/core";
+import { Card, Center, Divider, Group, SimpleGrid, Stack, Text } from "@mantine/core";
 import { useCheckinEnv } from "@/components/EnvProvider";
+import { RoleBadge } from "@/components/ui/RoleBadge";
 
 interface Persona {
   id: number;
@@ -60,17 +61,21 @@ export default function DevLoginPicker({ callbackUrl = "/" }: { callbackUrl?: st
     signIn("persona-mint", { personaId: String(personaId), mode: "impersonate", callbackUrl });
   };
 
-  const getRoleBadges = (p: Persona): { label: string; color: string }[] => {
-    const badges: { label: string; color: string }[] = [];
-    if (p.isSysadmin) badges.push({ label: "Sysadmin", color: "red" });
-    if (p.isBoardMember) badges.push({ label: "Board", color: "grape" });
-    if (p.isKeyholder) badges.push({ label: "Keyholder", color: "blue" });
-    if (p.isBackgroundCheckReviewer) badges.push({ label: "BG Reviewer", color: "teal" });
-    if (p.toolStatuses?.length > 0) badges.push({ label: "Certified", color: "green" });
-    if (p.householdId) badges.push({ label: "Household", color: "indigo" });
+  // The four participant-role badges render through the shared RoleBadge (its ROLE_META
+  // is the one source of truth for role colors). The three derived, non-role labels below
+  // (Certified/Household/Student) have no ROLE_META entry, so a fake `_`-prefixed role plus
+  // a label override renders them through the same component with the gray fallback.
+  const getRoleBadges = (p: Persona): { role: string; label?: string }[] => {
+    const badges: { role: string; label?: string }[] = [];
+    if (p.isSysadmin) badges.push({ role: "isSysadmin" });
+    if (p.isBoardMember) badges.push({ role: "isBoardMember" });
+    if (p.isKeyholder) badges.push({ role: "isKeyholder" });
+    if (p.isBackgroundCheckReviewer) badges.push({ role: "isBackgroundCheckReviewer" });
+    if (p.toolStatuses?.length > 0) badges.push({ role: "_certified", label: "Certified" });
+    if (p.householdId) badges.push({ role: "_household", label: "Household" });
     if (p.dateOfBirth && now !== null) {
       const age = Math.floor((now - new Date(p.dateOfBirth).getTime()) / (365.25 * 24 * 60 * 60 * 1000));
-      if (age < 18) badges.push({ label: `Student (${age})`, color: "pink" });
+      if (age < 18) badges.push({ role: "_student", label: `Student (${age})` });
     }
     return badges;
   };
@@ -115,9 +120,7 @@ export default function DevLoginPicker({ callbackUrl = "/" }: { callbackUrl?: st
             {getRoleBadges(p).length > 0 && (
               <Group gap={4} mt={4}>
                 {getRoleBadges(p).map((b) => (
-                  <Badge key={b.label} color={b.color} size="xs" variant="filled">
-                    {b.label}
-                  </Badge>
+                  <RoleBadge key={b.role} role={b.role} label={b.label} size="xs" />
                 ))}
               </Group>
             )}

--- a/checkin-app/src/components/ui/RoleBadge.tsx
+++ b/checkin-app/src/components/ui/RoleBadge.tsx
@@ -5,28 +5,33 @@ import { Badge, type BadgeProps } from '@mantine/core';
 /**
  * Centralized role / certification badge. Replaces the per-page inline-styled badges that
  * were duplicated across the admin, shop, and household pages. Add new roles to ROLE_META.
+ *
+ * Tool-CERTIFICATION colors (BASIC/DOF/CERTIFIED/INSTRUCTOR/MAY_CERTIFY_OTHERS) live solely in
+ * ToolLevelBadge (the regulated Safety Rules palette) — do not re-add them here. The
+ * `ParticipantRole` union below makes that a compile error, not just a convention.
  */
 type RoleMeta = { label: string; color: string };
 
-const ROLE_META: Record<string, RoleMeta> = {
-  // Participant roles
+export type ParticipantRole =
+  | 'isSysadmin'
+  | 'isBoardMember'
+  | 'isKeyholder'
+  | 'isBackgroundCheckReviewer'
+  | 'isOperations'
+  | 'coreVolunteer';
+
+export const ROLE_META: Record<ParticipantRole, RoleMeta> = {
   isSysadmin: { label: 'Sysadmin', color: 'red' },
-  isBoardMember: { label: 'Board', color: 'grape' },
-  isKeyholder: { label: 'Keyholder', color: 'blue' },
-  isBackgroundCheckReviewer: { label: 'BG Reviewer', color: 'indigo' },
-  isOperations: { label: 'Operations', color: 'teal' },
-  coreVolunteer: { label: 'Core Volunteer', color: 'pink' },
-  // Tool certification levels
-  BASIC: { label: 'Basic', color: 'gray' },
-  DOF: { label: 'DOF', color: 'yellow' },
-  CERTIFIED: { label: 'Certified', color: 'blue' },
-  INSTRUCTOR: { label: 'Instructor', color: 'green' },
-  MAY_CERTIFY_OTHERS: { label: 'Certifier', color: 'green' },
+  isBoardMember: { label: 'Board', color: 'treehousePurple' },
+  isKeyholder: { label: 'Keyholder', color: 'treehousePurple' },
+  isBackgroundCheckReviewer: { label: 'BG Reviewer', color: 'treehousePurple' },
+  isOperations: { label: 'Operations', color: 'treehousePurple' },
+  coreVolunteer: { label: 'Core Volunteer', color: 'treehousePurple' },
 };
 
 /** The display label for a role/certification key — same lookup RoleBadge renders, for callers that need plain text (e.g. a confirm-modal delta summary). */
 export function roleLabel(role: string): string {
-  return ROLE_META[role]?.label ?? role;
+  return (ROLE_META as Record<string, RoleMeta>)[role]?.label ?? role;
 }
 
 export function RoleBadge({
@@ -34,7 +39,7 @@ export function RoleBadge({
   label,
   ...badgeProps
 }: { role: string; label?: string } & Omit<BadgeProps, 'color' | 'children'>) {
-  const meta = ROLE_META[role];
+  const meta = (ROLE_META as Record<string, RoleMeta>)[role];
   return (
     <Badge color={meta?.color ?? 'gray'} variant="light" {...badgeProps}>
       {label ?? meta?.label ?? role}

--- a/checkin-app/src/components/ui/__tests__/RoleBadge.test.tsx
+++ b/checkin-app/src/components/ui/__tests__/RoleBadge.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import { ROLE_META, RoleBadge } from "@/components/ui/RoleBadge";
+
+const TOOL_LEVEL_KEYS = ["BASIC", "DOF", "CERTIFIED", "INSTRUCTOR", "MAY_CERTIFY_OTHERS"];
+
+const renderBadge = (ui: React.ReactElement) => render(<MantineProvider>{ui}</MantineProvider>);
+
+describe("ROLE_META", () => {
+  it("holds none of the ToolLevel keys — those belong solely to ToolLevelBadge", () => {
+    for (const key of TOOL_LEVEL_KEYS) {
+      expect(Object.keys(ROLE_META)).not.toContain(key);
+    }
+  });
+
+  it("every color is a brand-sanctioned value (treehousePurple, or red for the distinct sysadmin badge)", () => {
+    for (const meta of Object.values(ROLE_META)) {
+      expect(["treehousePurple", "red"]).toContain(meta.color);
+    }
+  });
+});
+
+describe("RoleBadge", () => {
+  it("renders the label for a known participant role", () => {
+    renderBadge(<RoleBadge role="isKeyholder" />);
+    expect(screen.getByText("Keyholder")).toBeInTheDocument();
+  });
+
+  it("falls back to gray + the raw/override label for an unknown role", () => {
+    renderBadge(<RoleBadge role="_certified" label="Certified" />);
+    const badge = screen.getByText("Certified");
+    expect(badge).toBeInTheDocument();
+  });
+
+  it("falls back to the raw role string when no label override is given", () => {
+    renderBadge(<RoleBadge role="_mystery" />);
+    expect(screen.getByText("_mystery")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Second of three (splits #1106; stacks on 1/3). RoleBadge carried the five ToolLevel keys with colors contradicting the Safety-Rules-regulated ToolLevelBadge (BASIC gray-instead-of-red, CERTIFIED blue-instead-of-green…). Deleted — zero call sites passed them — and a closed ParticipantRole union makes re-adding a compile error, pinned by a new test. DevLoginPicker's fourth hand-rolled role→color map folded onto RoleBadge. 3 files; green standalone (2125 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe