### PR TITLE
outreach engine: templated renewal/join emails, ledger-drain delivery, unsubscribe

### DIFF
--- a/checkin-app/prisma/migrations/20260718194028_outreach_engine/migration.sql
+++ b/checkin-app/prisma/migrations/20260718194028_outreach_engine/migration.sql
@@ -1,0 +1,40 @@
+-- AlterTable
+ALTER TABLE "BoardSettings" ADD COLUMN     "outreachOpeningBody" TEXT,
+ADD COLUMN     "outreachOpeningSubject" TEXT,
+ADD COLUMN     "outreachReminderBody" TEXT,
+ADD COLUMN     "outreachReminderSubject" TEXT;
+
+-- AlterTable
+ALTER TABLE "Person" ADD COLUMN     "emailSuppressed" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "BulkSend" (
+    "id" SERIAL NOT NULL,
+    "emailType" TEXT NOT NULL,
+    "audience" TEXT NOT NULL,
+    "senderId" INTEGER NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "BulkSend_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BulkSendItem" (
+    "id" SERIAL NOT NULL,
+    "bulkSendId" INTEGER NOT NULL,
+    "personId" INTEGER NOT NULL,
+    "email" TEXT NOT NULL,
+    "variant" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "sentAt" TIMESTAMP(3),
+    "error" TEXT,
+
+    CONSTRAINT "BulkSendItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BulkSendItem_bulkSendId_status_idx" ON "BulkSendItem"("bulkSendId", "status");
+
+-- AddForeignKey
+ALTER TABLE "BulkSendItem" ADD CONSTRAINT "BulkSendItem_bulkSendId_fkey" FOREIGN KEY ("bulkSendId") REFERENCES "BulkSend"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -99,6 +99,14 @@ model Person {
   /// @sensitivity:personal
   notificationSettings Json?
 
+  /// Self- or board-set suppression of outreach (join-invitation) email to this
+  /// person. Set via the unsubscribe link (join-variant only) or the member's own
+  /// communication-page toggle. Renew-variant outreach ignores this — see
+  /// lib/outreach/recipients.ts. 'personal' (not 'internal'): the member reads/writes
+  /// their own via their_own:personal; board/ops see it on the directory pill via
+  /// everyones:personal. @sensitivity:personal
+  emailSuppressed Boolean @default(false)
+
   /// @sensitivity:public
   householdId Int
   household   Household @relation(fields: [householdId], references: [id])
@@ -450,6 +458,10 @@ model OrgMembershipProcess {
   certifiedById         Int?
   /// @sensitivity:internal
   certificationNote     String?
+  /// Write-never as of the outreach engine (PR-2): the renewal sweep and the go-live
+  /// bulk-open button no longer email, so nothing stamps this anymore. Kept (not
+  /// dropped) because dropping a column is a destructive migration for no benefit —
+  /// see lib/outreach for the only remaining send surface.
   /// @sensitivity:internal
   renewalReminderSentAt DateTime?
   /// @sensitivity:internal
@@ -551,6 +563,17 @@ model BoardSettings {
   /// this is configured).
   /// @sensitivity:internal
   scholarshipNotifyEmail     String?
+  /// Opening-of-renewals campaign template (settings/outreach). Board/sysadmin/ops
+  /// editable; four tokens only ({{name}} {{deadline}} {{actionWord}} {{actionLink}}),
+  /// validated on save. @sensitivity:internal
+  outreachOpeningSubject     String?
+  /// @sensitivity:internal
+  outreachOpeningBody        String?
+  /// Reminder campaign template (settings/outreach). Same token set as
+  /// outreachOpeningSubject/Body. @sensitivity:internal
+  outreachReminderSubject    String?
+  /// @sensitivity:internal
+  outreachReminderBody       String?
   /// @sensitivity:internal
   shopifyOrgMembershipProductId String?
   /// @sensitivity:internal
@@ -1252,4 +1275,60 @@ model PaymentException {
   // the reconciler upserts on this key instead of duplicating each run.
   @@unique([kind, shopifyOrderId])
   @@index([status, severity])
+}
+
+/// One manual outreach campaign send (settings/outreach). The recipient snapshot
+/// is captured into BulkSendItem rows at create time; there is no background
+/// job — the browser drains `queued` items via /api/outreach/process-batch until
+/// none remain. This row (+ its items) IS the send log / last-sent panel data.
+/// Counts are computed from items (groupBy status), never denormalized here.
+model BulkSend {
+  /// @sensitivity:internal
+  id          Int       @id @default(autoincrement())
+  /// "opening" | "reminder"
+  /// @sensitivity:internal
+  emailType   String
+  /// "a" | "b" | "c" — the audience preset chosen at send time.
+  /// @sensitivity:internal
+  audience    String
+  /// Person.id who fired the send.
+  /// @sensitivity:internal
+  senderId    Int
+  /// @sensitivity:internal
+  startedAt   DateTime  @default(now())
+  /// Set when a batch finds zero `queued` items remaining.
+  /// @sensitivity:internal
+  completedAt DateTime?
+  items       BulkSendItem[]
+}
+
+/// One recipient row of a BulkSend — the per-item idempotency key for the
+/// client-driven drain (a guarded `updateMany where status='queued'` claim means
+/// a re-POST of an already-processed batch claims and sends nothing).
+model BulkSendItem {
+  /// @sensitivity:internal
+  id         Int       @id @default(autoincrement())
+  /// @sensitivity:internal
+  bulkSendId Int
+  bulkSend   BulkSend  @relation(fields: [bulkSendId], references: [id])
+  /// @sensitivity:internal
+  personId   Int
+  /// Captured at snapshot time (not re-read from Person at send time). Tagged
+  /// `internal` rather than `pii` as a DELIBERATE call, FLAGGED FOR REVIEW: this
+  /// row is only ever read by board/ops on the admin send panel, never serialized
+  /// through a member-facing bag — same admin-ledger tier as the rest of this model.
+  /// @sensitivity:internal
+  email      String
+  /// "join" | "renew"
+  /// @sensitivity:internal
+  variant    String
+  /// "queued" | "sent" | "failed" | "skipped_unsubscribed"
+  /// @sensitivity:internal
+  status     String
+  /// @sensitivity:internal
+  sentAt     DateTime?
+  /// @sensitivity:internal
+  error      String?
+
+  @@index([bulkSendId, status])
 }

--- a/checkin-app/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
@@ -74,11 +74,11 @@ describe('Bulk renewal migration', () => {
         expect(res.status).toBe(403);
     });
 
-    it('a board member opens PENDING_RENEWAL for all active members, idempotently, no email by default', async () => {
+    it('a board member opens PENDING_RENEWAL for all active members, idempotently, never emailing (PR-2)', async () => {
         (sendEmail as jest.Mock).mockClear();
         asBoard(boardId);
 
-        const res = await BULK(jsonReq({ sendReminders: false }));
+        const res = await BULK(jsonReq());
         expect(res.status).toBe(200);
         const data = await res.json();
         expect(data.success).toBe(true);
@@ -91,7 +91,7 @@ describe('Bulk renewal migration', () => {
         expect(sendEmail as jest.Mock).not.toHaveBeenCalled();
 
         // Idempotent: a second press opens nothing new.
-        const second = await BULK(jsonReq({ sendReminders: false }));
+        const second = await BULK(jsonReq());
         expect((await second.json()).opened).toBe(0);
         const count = await prisma.orgMembershipProcess.count({ where: { orgMembershipId: mA } });
         expect(count).toBe(1);
@@ -99,7 +99,7 @@ describe('Bulk renewal migration', () => {
 
     it('a isSysadmin may also trigger it', async () => {
         asSysadmin(sysId);
-        const res = await BULK(jsonReq({ sendReminders: false }));
+        const res = await BULK(jsonReq());
         expect(res.status).toBe(200);
         const data = await res.json();
         expect(data.success).toBe(true);

--- a/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
@@ -222,7 +222,7 @@ describe('Membership Intake API', () => {
         const householdId = owner.householdId!;
         const membership = await prisma.orgMembership.findUniqueOrThrow({ where: { householdId } });
 
-        const proc = await createRenewalProcess(membership.id, householdId, new Date(), { remind: false, boundary: new Date() });
+        const proc = await createRenewalProcess(membership.id);
         expect(proc).not.toBeNull();
 
         const createLog = await expectAuditRow(prisma, { action: 'CREATE', tableName: 'OrgMembershipProcess', affectedEntityId: proc!.id });

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -102,13 +102,11 @@ describe('Membership renewal', () => {
         expect(res.opened).toBe(0);
     });
 
-    it('opens a PENDING_RENEWAL process within the window, once', async () => {
+    it('opens a PENDING_RENEWAL process within the window, once, without emailing (PR-2: the machine never emails)', async () => {
         await setBoundary(new Date(Date.UTC(2000, 7, 1))); // Aug 1
         const m = await makeActiveMembership('Due', null, `due-lead-${TAG}@example.com`);
         const now = new Date(Date.UTC(2026, 6, 1)); // Jul 1 — within 2 months before Aug 1
 
-        // sendEmail is mocked (top of file), so the reminder is recorded on the spy,
-        // not devSentEmail. Clear it so the assertion sees only this scenario's sweep.
         const { sendEmail } = jest.requireMock('@/lib/email') as { sendEmail: jest.Mock };
         sendEmail.mockClear();
 
@@ -118,8 +116,8 @@ describe('Membership renewal', () => {
         expect(proc?.status).toBe('PENDING_RENEWAL');
         expect(proc?.kind).toBe('RENEWAL');
 
-        // Opening the renewal also reminds the household lead by email.
-        expect(sendEmail).toHaveBeenCalledWith(m.leadEmail, 'Time to renew your Treehouse membership', expect.any(String));
+        // The sweep no longer reminds — the settings/outreach page is the only send surface.
+        expect(sendEmail).not.toHaveBeenCalled();
 
         const second = await runRenewalSweep(now);
         const count = await prisma.orgMembershipProcess.count({ where: { orgMembershipId: m.orgMembershipId } });

--- a/checkin-app/src/app/__tests__/renewalConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/renewalConcurrency.integration.test.ts
@@ -6,13 +6,17 @@
  * openRenewalsForAllActive (admin button) both check-then-act through the shared
  * createRenewalProcess, and neither serializes the read+create. Across instances
  * two overlapping runs each read zero open processes and both reach the INSERT —
- * which would mint duplicate PENDING_RENEWAL rows (duplicate household reminders +
- * a dangling process beginRenewalForUser never advances). We drive that losing
- * branch directly: two concurrent createRenewalProcess calls (the read-guard
- * already passed). The partial unique index `membership_one_inflight_renewal` is
- * the guarantee — the loser's INSERT hits P2002, which createRenewalProcess
- * catches and turns into a clean no-op (returns null, no second audit row, no
- * second reminder). Drop the index and the second INSERT succeeds → this fails.
+ * which would mint duplicate PENDING_RENEWAL rows (and a dangling process
+ * beginRenewalForUser never advances). We drive that losing branch directly: two
+ * concurrent createRenewalProcess calls (the read-guard already passed). The
+ * partial unique index `membership_one_inflight_renewal` is the guarantee — the
+ * loser's INSERT hits P2002, which createRenewalProcess catches and turns into a
+ * clean no-op (returns null, no second audit row). Drop the index and the second
+ * INSERT succeeds → this fails.
+ *
+ * The machine never emails (PR-2, outreach engine) — createRenewalProcess no
+ * longer reminds, so this test no longer asserts a send; sendEmail is mocked only
+ * as a blanket guard against any accidental real network call.
  */
 
 import { createRenewalProcess } from '@/lib/membership/renewal';
@@ -36,12 +40,10 @@ async function wipe() {
 
 describe('renewal opening concurrency', () => {
     let orgMembershipId = 0;
-    let householdId = 0;
 
     beforeAll(async () => {
         await wipe();
         const hh = await prisma.household.create({ data: { name: `Family ${TAG}` } });
-        householdId = hh.id;
         const lead = await prisma.person.create({ data: { name: 'Lead', email: `lead-${TAG}@ex.com`, householdId: hh.id } });
         await prisma.person.update({ where: { id: lead.id }, data: { isHouseholdLead: true } });
         orgMembershipId = (await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'ACTIVE' } })).id;
@@ -49,12 +51,10 @@ describe('renewal opening concurrency', () => {
 
     afterAll(wipe);
 
-    it('two concurrent createRenewalProcess calls yield exactly one in-flight RENEWAL and one reminder', async () => {
-        const now = new Date();
-        const boundary = new Date();
+    it('two concurrent createRenewalProcess calls yield exactly one in-flight RENEWAL', async () => {
         const results = await Promise.all([
-            createRenewalProcess(orgMembershipId, householdId, now, { remind: true, boundary }),
-            createRenewalProcess(orgMembershipId, householdId, now, { remind: true, boundary }),
+            createRenewalProcess(orgMembershipId),
+            createRenewalProcess(orgMembershipId),
         ]);
 
         // Exactly one create won; the other lost the race and no-op'd (null).
@@ -67,8 +67,8 @@ describe('renewal opening concurrency', () => {
         });
         expect(inflight).toHaveLength(1); // the loser's P2002 no-op'd, not a second process
 
-        // One lead → reminder sent exactly once (the duplicate send is skipped).
-        expect(sendEmail).toHaveBeenCalledTimes(1);
+        // The machine never emails — no reminder fires either way.
+        expect(sendEmail).not.toHaveBeenCalled();
 
         // Exactly one CREATE audit row for the winning process — no orphan from the loser.
         const created = await prisma.auditLog.count({

--- a/checkin-app/src/app/api/outreach/__tests__/ledger.integration.test.ts
+++ b/checkin-app/src/app/api/outreach/__tests__/ledger.integration.test.ts
@@ -221,6 +221,29 @@ describe('outreach ledger (send / process-batch / status)', () => {
         expect(finalBulkSend.completedAt).not.toBeNull();
     });
 
+    it('retry 409s when another send is already in flight (protects the one-in-flight invariant)', async () => {
+        await makeNonMemberLead('RetryGuard', `retryguard-${TAG}@example.com`);
+        asBoard(boardId);
+
+        // Send A: force a failure so it completes with a failed item (0 queued → completedAt set).
+        (sendEmail as jest.Mock).mockResolvedValue(false);
+        const aRes = await SEND(req('POST', { emailType: 'opening', audience: 'c' }));
+        const a = await aRes.json();
+        await PROCESS_BATCH(req('POST', { bulkSendId: a.bulkSend.id }));
+        expect((await prisma.bulkSend.findUniqueOrThrow({ where: { id: a.bulkSend.id } })).completedAt).not.toBeNull();
+
+        // Send B: created after A completed, left un-drained so it is genuinely in flight.
+        (sendEmail as jest.Mock).mockResolvedValue(true);
+        const bRes = await SEND(req('POST', { emailType: 'reminder', audience: 'c' }));
+        expect(bRes.status).toBe(201);
+
+        // Retrying A would reopen a second in-flight row — reject it, and don't re-queue A's failures.
+        const retry = await STATUS_POST(req('POST', { action: 'retry', bulkSendId: a.bulkSend.id }));
+        expect(retry.status).toBe(409);
+        expect((await prisma.bulkSend.findUniqueOrThrow({ where: { id: a.bulkSend.id } })).completedAt).not.toBeNull();
+        expect(await prisma.bulkSendItem.count({ where: { bulkSendId: a.bulkSend.id, status: 'failed' } })).toBe(1);
+    });
+
     it('no double-send: two concurrent process-batch calls on the same send never send an item twice', async () => {
         for (let i = 0; i < 8; i++) {
             await makeNonMemberLead(`Race${i}`, `race${i}-${TAG}@example.com`);
@@ -252,6 +275,33 @@ describe('outreach ledger (send / process-batch / status)', () => {
         expect(third.status).toBe(404); // already completedAt-set — nothing left to drain
     });
 
+    it('drain honors an unsubscribe that landed AFTER the snapshot: no email, item marked skipped_unsubscribed', async () => {
+        const hh = await makeNonMemberLead('LateUnsub', `lateunsub-${TAG}@example.com`);
+        const person = await prisma.person.findFirstOrThrow({ where: { householdId: hh.id } });
+        asBoard(boardId);
+
+        const createRes = await SEND(req('POST', { emailType: 'opening', audience: 'c' }));
+        const created = await createRes.json();
+        const bulkSendId = created.bulkSend.id;
+        // Snapshot froze this recipient as queued (join variant, not yet suppressed).
+        const item = await prisma.bulkSendItem.findFirstOrThrow({ where: { bulkSendId, personId: person.id } });
+        expect(item.status).toBe('queued');
+        expect(item.variant).toBe('join');
+
+        // Unsubscribe click arrives between snapshot and drain.
+        await prisma.person.update({ where: { id: person.id }, data: { emailSuppressed: true } });
+
+        let remaining = created.counts.queued;
+        let guard = 0;
+        while (remaining > 0 && guard++ < 5) {
+            remaining = (await (await PROCESS_BATCH(req('POST', { bulkSendId }))).json()).remaining;
+        }
+
+        const drained = await prisma.bulkSendItem.findUniqueOrThrow({ where: { id: item.id } });
+        expect(drained.status).toBe('skipped_unsubscribed');
+        expect((sendEmail as jest.Mock).mock.calls.some(([to]) => to === `lateunsub-${TAG}@example.com`)).toBe(false);
+    });
+
     it('test-send renders both variants and sends them to the caller', async () => {
         asBoard(boardId, `tester-${TAG}@example.com`);
         const res = await TEST_SEND(req('POST', {
@@ -267,5 +317,10 @@ describe('outreach ledger (send / process-batch / status)', () => {
         expect(bodies.some((h) => h.includes('please renew'))).toBe(true);
         // Join variant carries the unsubscribe footer, renew does not.
         expect(bodies.filter((h) => h.includes('Unsubscribe from invitations'))).toHaveLength(1);
+        // ...but it is an INERT placeholder (href="#") — a test render must never mint a live,
+        // signed unsubscribe token that would opt the tester out when they click to verify it.
+        const joinBody = bodies.find((h) => h.includes('Unsubscribe from invitations'))!;
+        expect(joinBody).toContain('href="#"');
+        expect(joinBody).not.toContain('/api/unsubscribe');
     });
 });

--- a/checkin-app/src/app/api/outreach/__tests__/ledger.integration.test.ts
+++ b/checkin-app/src/app/api/outreach/__tests__/ledger.integration.test.ts
@@ -18,6 +18,22 @@ import { sendEmail } from '@/lib/email';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
 jest.mock('@/lib/email', () => ({ sendEmail: jest.fn() }));
+// process-batch's join-variant unsubscribe footer (unsubscribeToken.ts hmacKey) reads
+// config.nextAuthSecret(), which throws when unset — fine locally (the gitignored .env
+// supplies it) but CI has no .env. Same partial-mock pattern as auth-options-jwt.test.ts:
+// preserve every other config read (render.ts's baseUrl(), etc.) via requireActual and
+// stub only the secret.
+jest.mock('@/lib/config', () => {
+    const actual = jest.requireActual('@/lib/config');
+    return {
+        __esModule: true,
+        ...actual,
+        config: {
+            ...actual.config,
+            nextAuthSecret: jest.fn(() => 'test-secret'),
+        },
+    };
+});
 
 const TAG = 'outreach-ledger-test';
 const BOUNDARY = new Date(Date.UTC(2000, 7, 1)); // Aug 1

--- a/checkin-app/src/app/api/outreach/__tests__/ledger.integration.test.ts
+++ b/checkin-app/src/app/api/outreach/__tests__/ledger.integration.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the client-driven chunked drain: create (snapshot + 409 guard),
+ * process-batch (claim + send + no-double-send), resume, retry-failed, and test-send.
+ * Recipient-preset semantics (a/b/c, settled, in-flight, suppression, tombstoning) are
+ * covered exhaustively in recipients.integration.test.ts — this file only needs enough
+ * real recipients to drive the ledger's own lifecycle.
+ */
+import { POST as SEND } from '@/app/api/outreach/send/route';
+import { POST as PROCESS_BATCH } from '@/app/api/outreach/process-batch/route';
+import { GET as STATUS_GET, POST as STATUS_POST } from '@/app/api/outreach/status/route';
+import { POST as TEST_SEND } from '@/app/api/outreach/test-send/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import { sendEmail } from '@/lib/email';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/email', () => ({ sendEmail: jest.fn() }));
+
+const TAG = 'outreach-ledger-test';
+const BOUNDARY = new Date(Date.UTC(2000, 7, 1)); // Aug 1
+
+function asBoard(id: number, email = `board-${TAG}@example.com`) {
+    (getServerSession as jest.Mock).mockResolvedValue({
+        user: { id, email, isBoardMember: true, isSysadmin: false, isOperations: false },
+    });
+}
+function asPlain(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, isBoardMember: false, isSysadmin: false, isOperations: false } });
+}
+
+function req(method: string, body?: unknown) {
+    return new Request('http://localhost:4000/x', { method, ...(body !== undefined ? { body: JSON.stringify(body) } : {}) }) as never;
+}
+
+async function setBoundary(date: Date | null) {
+    await prisma.boardSettings.upsert({
+        where: { id: 1 },
+        create: { id: 1, normalDuesCents: 0, volunteerDuesCents: 0, orgMembershipYearBoundary: date },
+        update: { orgMembershipYearBoundary: date },
+    });
+}
+
+async function makeNonMemberLead(label: string, email: string) {
+    const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
+    await prisma.person.create({ data: { name: label, email, householdId: hh.id, isHouseholdLead: true } });
+    return hh;
+}
+
+async function wipeHouseholds() {
+    const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+    const ids = hhs.map((h) => h.id);
+    if (ids.length) {
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: ids } } });
+    }
+}
+
+async function wipeLedger() {
+    await prisma.bulkSendItem.deleteMany({});
+    await prisma.bulkSend.deleteMany({});
+}
+
+describe('outreach ledger (send / process-batch / status)', () => {
+    let prevBoundary: Date | null = null;
+    let boardId: number;
+
+    beforeAll(async () => {
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevBoundary = existing?.orgMembershipYearBoundary ?? null;
+    });
+
+    afterAll(async () => {
+        await wipeLedger();
+        await wipeHouseholds();
+        await setBoundary(prevBoundary);
+        await prisma.$disconnect();
+    });
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        (sendEmail as jest.Mock).mockResolvedValue(true);
+        await wipeLedger();
+        // Audience 'c' is "every live household lead with an email" — without re-wiping
+        // households between tests, an earlier test's fixtures would still be in scope
+        // for a later test's snapshot (and could blow past BATCH_SIZE, changing which
+        // items land in the first batch). The board fixture is recreated below.
+        await wipeHouseholds();
+        const boardHh = await prisma.household.create({ data: { name: `Board ${TAG}` } });
+        boardId = (await prisma.person.create({ data: { name: 'Board', email: `boardperson-${TAG}@example.com`, householdId: boardHh.id, isBoardMember: true } })).id;
+        await setBoundary(BOUNDARY);
+    });
+
+    it('is forbidden for a plain (non-board/sysadmin/operations) user', async () => {
+        asPlain(999999);
+        const res = await SEND(req('POST', { emailType: 'opening', audience: 'c' }));
+        expect(res.status).toBe(403);
+    });
+
+    it('blocks create-send with a clear error when the boundary is unset', async () => {
+        await setBoundary(null);
+        asBoard(boardId);
+        const res = await SEND(req('POST', { emailType: 'opening', audience: 'c' }));
+        expect(res.status).toBe(400);
+        const data = await res.json();
+        expect(data.error).toMatch(/boundary/i);
+    });
+
+    it('create -> batch -> complete: drains every queued item and sets completedAt', async () => {
+        await makeNonMemberLead('Lifecycle1', `lifecycle1-${TAG}@example.com`);
+        await makeNonMemberLead('Lifecycle2', `lifecycle2-${TAG}@example.com`);
+        asBoard(boardId);
+
+        const createRes = await SEND(req('POST', { emailType: 'opening', audience: 'c' }));
+        expect(createRes.status).toBe(201);
+        const created = await createRes.json();
+        expect(created.counts.queued).toBeGreaterThanOrEqual(2);
+        const bulkSendId = created.bulkSend.id;
+
+        let remaining = created.counts.queued;
+        let guard = 0;
+        while (remaining > 0 && guard++ < 10) {
+            const res = await PROCESS_BATCH(req('POST', { bulkSendId }));
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            remaining = data.remaining;
+        }
+        expect(remaining).toBe(0);
+
+        const bulkSend = await prisma.bulkSend.findUniqueOrThrow({ where: { id: bulkSendId } });
+        expect(bulkSend.completedAt).not.toBeNull();
+        const items = await prisma.bulkSendItem.findMany({ where: { bulkSendId } });
+        expect(items.every((i) => i.status === 'sent')).toBe(true);
+        expect(sendEmail).toHaveBeenCalledTimes(items.length);
+    });
+
+    it('409s a concurrent create while one send is already in flight', async () => {
+        await makeNonMemberLead('Conflict1', `conflict1-${TAG}@example.com`);
+        asBoard(boardId);
+
+        const first = await SEND(req('POST', { emailType: 'opening', audience: 'c' }));
+        expect(first.status).toBe(201);
+
+        const second = await SEND(req('POST', { emailType: 'reminder', audience: 'c' }));
+        expect(second.status).toBe(409);
+    });
+
+    it('resume: a partially-drained send (more recipients than one batch) stays in-flight, and a second process-batch call (what Resume does) finishes it', async () => {
+        // BATCH_SIZE is 40 — 45 recipients guarantees the first call claims only 40,
+        // leaving the send genuinely in-flight (simulating a closed tab mid-drain)
+        // without needing to fake anything about the route itself.
+        const RECIPIENT_COUNT = 45;
+        for (let i = 0; i < RECIPIENT_COUNT; i++) {
+            await makeNonMemberLead(`Resume${i}`, `resume${i}-${TAG}@example.com`);
+        }
+        asBoard(boardId);
+
+        const createRes = await SEND(req('POST', { emailType: 'opening', audience: 'c' }));
+        const created = await createRes.json();
+        expect(created.counts.queued).toBeGreaterThanOrEqual(RECIPIENT_COUNT);
+        const bulkSendId = created.bulkSend.id;
+
+        const first = await PROCESS_BATCH(req('POST', { bulkSendId }));
+        const firstData = await first.json();
+        expect(firstData.processed).toBe(40);
+        expect(firstData.remaining).toBeGreaterThan(0); // genuinely still in-flight
+
+        const statusRes = await STATUS_GET(req('GET'));
+        const status = await statusRes.json();
+        expect(status.inFlight).not.toBeNull();
+        expect(status.inFlight.id).toBe(bulkSendId);
+        expect(status.inFlight.counts.sent).toBe(40);
+        expect(status.inFlight.counts.queued).toBe(firstData.remaining);
+
+        // Reopening the panel and hitting process-batch again — no special "resume"
+        // endpoint, just the same call the drain loop always makes — finishes it.
+        let remaining = firstData.remaining;
+        let guard = 0;
+        while (remaining > 0 && guard++ < 5) {
+            const res = await PROCESS_BATCH(req('POST', { bulkSendId }));
+            remaining = (await res.json()).remaining;
+        }
+        expect(remaining).toBe(0);
+
+        const finalStatus = await (await STATUS_GET(req('GET'))).json();
+        expect(finalStatus.inFlight).toBeNull();
+        expect(finalStatus.lastCompleted.id).toBe(bulkSendId);
+        expect(finalStatus.lastCompleted.counts.sent).toBeGreaterThanOrEqual(RECIPIENT_COUNT);
+    });
+
+    it('retry-failed re-queues failed items and lets the drain finish them', async () => {
+        await makeNonMemberLead('Failing', `failing-${TAG}@example.com`);
+        await makeNonMemberLead('Passing', `passing-${TAG}@example.com`);
+        asBoard(boardId);
+
+        (sendEmail as jest.Mock).mockImplementation(async (to: string) => !to.startsWith('failing-'));
+
+        const createRes = await SEND(req('POST', { emailType: 'opening', audience: 'c' }));
+        const created = await createRes.json();
+        const bulkSendId = created.bulkSend.id;
+
+        await PROCESS_BATCH(req('POST', { bulkSendId }));
+        const midway = await prisma.bulkSendItem.findMany({ where: { bulkSendId } });
+        expect(midway.some((i) => i.status === 'failed')).toBe(true);
+        const completedAfterFirstDrain = await prisma.bulkSend.findUniqueOrThrow({ where: { id: bulkSendId } });
+        expect(completedAfterFirstDrain.completedAt).not.toBeNull(); // 0 queued remain (1 sent, 1 failed)
+
+        (sendEmail as jest.Mock).mockResolvedValue(true); // "fix" the problem before retrying
+        const retryRes = await STATUS_POST(req('POST', { action: 'retry', bulkSendId }));
+        expect(retryRes.status).toBe(200);
+        const retryData = await retryRes.json();
+        expect(retryData.bulkSend.completedAt).toBeNull(); // reopened
+
+        await PROCESS_BATCH(req('POST', { bulkSendId }));
+        const final = await prisma.bulkSendItem.findMany({ where: { bulkSendId } });
+        expect(final.every((i) => i.status === 'sent')).toBe(true);
+        const finalBulkSend = await prisma.bulkSend.findUniqueOrThrow({ where: { id: bulkSendId } });
+        expect(finalBulkSend.completedAt).not.toBeNull();
+    });
+
+    it('no double-send: two concurrent process-batch calls on the same send never send an item twice', async () => {
+        for (let i = 0; i < 8; i++) {
+            await makeNonMemberLead(`Race${i}`, `race${i}-${TAG}@example.com`);
+        }
+        asBoard(boardId);
+
+        const createRes = await SEND(req('POST', { emailType: 'opening', audience: 'c' }));
+        const created = await createRes.json();
+        const bulkSendId = created.bulkSend.id;
+        const totalQueued = created.counts.queued;
+
+        const [a, b] = await Promise.all([
+            PROCESS_BATCH(req('POST', { bulkSendId })),
+            PROCESS_BATCH(req('POST', { bulkSendId })),
+        ]);
+        expect(a.status).toBe(200);
+        expect(b.status).toBe(200);
+        const [aData, bData] = await Promise.all([a.json(), b.json()]);
+
+        // Every queued item was claimed by exactly one of the two overlapping calls —
+        // never both (the guarded per-item claim), and never neither (nothing left queued).
+        expect(aData.processed + bData.processed).toBe(totalQueued);
+        expect(sendEmail).toHaveBeenCalledTimes(totalQueued);
+        const remaining = await prisma.bulkSendItem.count({ where: { bulkSendId, status: 'queued' } });
+        expect(remaining).toBe(0);
+
+        // A further re-POST (the "already-processed batch" case) claims and sends nothing.
+        const third = await PROCESS_BATCH(req('POST', { bulkSendId }));
+        expect(third.status).toBe(404); // already completedAt-set — nothing left to drain
+    });
+
+    it('test-send renders both variants and sends them to the caller', async () => {
+        asBoard(boardId, `tester-${TAG}@example.com`);
+        const res = await TEST_SEND(req('POST', {
+            subject: 'Renew by {{deadline}}',
+            body: 'Hi {{name}}, please {{actionWord}} at {{actionLink}}.',
+        }));
+        expect(res.status).toBe(200);
+        expect(sendEmail).toHaveBeenCalledTimes(2);
+        const calls = (sendEmail as jest.Mock).mock.calls;
+        expect(calls.every(([to]) => to === `tester-${TAG}@example.com`)).toBe(true);
+        const bodies = calls.map(([, , html]) => html as string);
+        expect(bodies.some((h) => h.includes('please join'))).toBe(true);
+        expect(bodies.some((h) => h.includes('please renew'))).toBe(true);
+        // Join variant carries the unsubscribe footer, renew does not.
+        expect(bodies.filter((h) => h.includes('Unsubscribe from invitations'))).toHaveLength(1);
+    });
+});

--- a/checkin-app/src/app/api/outreach/__tests__/recipients.integration.test.ts
+++ b/checkin-app/src/app/api/outreach/__tests__/recipients.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the recipient snapshot (lib/outreach/recipients.ts) — the
+ * presets, the settled/in-flight predicates, suppression, dedup, tombstoning, and
+ * the "leads without email" count. Runs against a real Postgres (localhost:5433,
+ * INTEGRATION_DB=1) because the whole point is to exercise the real Prisma query
+ * shape, not a mocked approximation of it.
+ */
+import prisma from '@/lib/prisma';
+import { computeRecipientSnapshot } from '@/lib/outreach/recipients';
+
+const TAG = 'outreach-recipients-test';
+const BOUNDARY = new Date(Date.UTC(2000, 7, 1)); // Aug 1 (year is irrelevant — nextBoundary rolls it forward)
+const IN_SEASON_NOW = new Date(Date.UTC(2026, 6, 15)); // Jul 15 — inside the 2-month renewal window before Aug 1
+const OFF_SEASON_NOW = new Date(Date.UTC(2026, 0, 15)); // Jan 15 — well outside the window
+
+async function setBoundary(date: Date | null) {
+    await prisma.boardSettings.upsert({
+        where: { id: 1 },
+        create: { id: 1, normalDuesCents: 0, volunteerDuesCents: 0, orgMembershipYearBoundary: date },
+        update: { orgMembershipYearBoundary: date },
+    });
+}
+
+async function wipe() {
+    const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+    const ids = hhs.map((h) => h.id);
+    if (ids.length) {
+        await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: ids } } });
+    }
+}
+
+async function makeHousehold(label: string) {
+    return prisma.household.create({ data: { name: `${label} ${TAG}` } });
+}
+
+async function makeLead(householdId: number, email: string | null, opts: { emailSuppressed?: boolean; mergedIntoId?: number } = {}) {
+    const p = await prisma.person.create({
+        data: { name: label(email), email, householdId, isHouseholdLead: true, emailSuppressed: !!opts.emailSuppressed },
+    });
+    if (opts.mergedIntoId) {
+        await prisma.person.update({ where: { id: p.id }, data: { mergedIntoId: opts.mergedIntoId } });
+    }
+    return p;
+}
+function label(email: string | null) { return email ?? 'no-email'; }
+
+describe('outreach recipient snapshot', () => {
+    let prevBoundary: Date | null = null;
+
+    beforeAll(async () => {
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevBoundary = existing?.orgMembershipYearBoundary ?? null;
+        await wipe();
+    });
+
+    afterAll(async () => {
+        await wipe();
+        await setBoundary(prevBoundary);
+        await prisma.$disconnect();
+    });
+
+    it('preset (a): non-member is join, unsettled member is renew, both included', async () => {
+        await setBoundary(BOUNDARY);
+        const nonMemberHh = await makeHousehold('NonMember');
+        await makeLead(nonMemberHh.id, `nonmember-${TAG}@example.com`);
+
+        const memberHh = await makeHousehold('UnsettledMember');
+        await prisma.orgMembership.create({ data: { householdId: memberHh.id, status: 'ACTIVE' } });
+        await makeLead(memberHh.id, `unsettled-${TAG}@example.com`);
+
+        const snap = await computeRecipientSnapshot('a', IN_SEASON_NOW);
+        const nonMemberItem = snap.items.find((i) => i.email === `nonmember-${TAG}@example.com`);
+        const memberItem = snap.items.find((i) => i.email === `unsettled-${TAG}@example.com`);
+        expect(nonMemberItem?.variant).toBe('join');
+        expect(nonMemberItem?.status).toBe('queued');
+        expect(memberItem?.variant).toBe('renew');
+        expect(memberItem?.status).toBe('queued');
+    });
+
+    it('preset (a) excludes a settled member IN-SEASON, but includes them OFF-SEASON (nobody is settled)', async () => {
+        await setBoundary(BOUNDARY);
+        const hh = await makeHousehold('Settled');
+        const membership = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
+        const email = `settled-${TAG}@example.com`;
+        await makeLead(hh.id, email);
+        // A terminal ACTIVE RENEWAL stamped inside the in-season window — "settled for the coming cycle".
+        await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: membership.id, kind: 'RENEWAL', status: 'ACTIVE', stageEnteredAt: IN_SEASON_NOW },
+        });
+
+        const inSeason = await computeRecipientSnapshot('a', IN_SEASON_NOW);
+        expect(inSeason.items.find((i) => i.email === email)).toBeUndefined();
+
+        const offSeason = await computeRecipientSnapshot('a', OFF_SEASON_NOW);
+        expect(offSeason.items.find((i) => i.email === email)?.variant).toBe('renew');
+    });
+
+    it('preset (b) additionally excludes in-flight RENEWAL and in-flight INITIAL households; preset (a) still includes them', async () => {
+        await setBoundary(BOUNDARY);
+
+        const renewingHh = await makeHousehold('InFlightRenewal');
+        const membership = await prisma.orgMembership.create({ data: { householdId: renewingHh.id, status: 'ACTIVE' } });
+        const renewingEmail = `inflight-renewal-${TAG}@example.com`;
+        await makeLead(renewingHh.id, renewingEmail);
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: membership.id, kind: 'RENEWAL', status: 'PENDING_RENEWAL' } });
+
+        const applyingHh = await makeHousehold('InFlightInitial');
+        const applyingMembership = await prisma.orgMembership.create({ data: { householdId: applyingHh.id, status: 'NONE' } });
+        const applyingEmail = `inflight-initial-${TAG}@example.com`;
+        await makeLead(applyingHh.id, applyingEmail);
+        await prisma.orgMembershipProcess.create({ data: { orgMembershipId: applyingMembership.id, kind: 'INITIAL', status: 'INTAKE' } });
+
+        const a = await computeRecipientSnapshot('a', IN_SEASON_NOW);
+        expect(a.items.find((i) => i.email === renewingEmail)).toBeDefined();
+        expect(a.items.find((i) => i.email === applyingEmail)).toBeDefined();
+
+        const b = await computeRecipientSnapshot('b', IN_SEASON_NOW);
+        expect(b.items.find((i) => i.email === renewingEmail)).toBeUndefined();
+        expect(b.items.find((i) => i.email === applyingEmail)).toBeUndefined();
+    });
+
+    it('preset (c) is everyone — no settled/in-flight filtering', async () => {
+        await setBoundary(BOUNDARY);
+        const hh = await makeHousehold('SettledForC');
+        const membership = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
+        const email = `settled-c-${TAG}@example.com`;
+        await makeLead(hh.id, email);
+        await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: membership.id, kind: 'RENEWAL', status: 'ACTIVE', stageEnteredAt: IN_SEASON_NOW },
+        });
+
+        const c = await computeRecipientSnapshot('c', IN_SEASON_NOW);
+        expect(c.items.find((i) => i.email === email)).toBeDefined();
+    });
+
+    it('suppressed JOIN lead is recorded skipped_unsubscribed; suppressed RENEW lead is still queued', async () => {
+        await setBoundary(BOUNDARY);
+
+        const nonMemberHh = await makeHousehold('SuppressedJoin');
+        const joinEmail = `suppressed-join-${TAG}@example.com`;
+        await makeLead(nonMemberHh.id, joinEmail, { emailSuppressed: true });
+
+        const memberHh = await makeHousehold('SuppressedRenew');
+        await prisma.orgMembership.create({ data: { householdId: memberHh.id, status: 'ACTIVE' } });
+        const renewEmail = `suppressed-renew-${TAG}@example.com`;
+        await makeLead(memberHh.id, renewEmail, { emailSuppressed: true });
+
+        const snap = await computeRecipientSnapshot('a', IN_SEASON_NOW);
+        const joinItem = snap.items.find((i) => i.email === joinEmail);
+        const renewItem = snap.items.find((i) => i.email === renewEmail);
+        expect(joinItem?.variant).toBe('join');
+        expect(joinItem?.status).toBe('skipped_unsubscribed');
+        expect(renewItem?.variant).toBe('renew');
+        expect(renewItem?.status).toBe('queued'); // renew is never suppressed
+    });
+
+    it('excludes a tombstoned (merged-away) lead', async () => {
+        await setBoundary(BOUNDARY);
+        const survivorHh = await makeHousehold('MergeSurvivor');
+        const survivor = await makeLead(survivorHh.id, `survivor-${TAG}@example.com`);
+
+        const tombstonedHh = await makeHousehold('MergeTombstone');
+        const tombstonedEmail = `tombstoned-${TAG}@example.com`;
+        await makeLead(tombstonedHh.id, tombstonedEmail, { mergedIntoId: survivor.id });
+
+        const snap = await computeRecipientSnapshot('a', IN_SEASON_NOW);
+        expect(snap.items.find((i) => i.email === tombstonedEmail)).toBeUndefined();
+    });
+
+    // No standalone "two leads share an email" case: Person.email is @unique at the DB
+    // level AND auto-lowercased at write (lib/prismaEmailNormalize.ts) — two distinct
+    // Person rows literally cannot carry the same lowercased email, so this scenario
+    // can't be constructed against the real schema (resolveHouseholdRecipients's
+    // identical dedupe, emailRecipients.ts:31-38, is untested for the same reason). The
+    // dedup in recipients.ts stays as defense-in-depth matching that precedent.
+
+    it('counts a lead without an email in leadsWithoutEmail, and gives them no item', async () => {
+        await setBoundary(BOUNDARY);
+        const hh = await makeHousehold('NoEmailLead');
+        await makeLead(hh.id, null);
+
+        const before = await computeRecipientSnapshot('a', IN_SEASON_NOW);
+        // Add one more no-email lead and confirm the count increments by exactly one —
+        // avoids a brittle absolute-count assertion (other suites' fixtures may exist).
+        const hh2 = await makeHousehold('NoEmailLead2');
+        await makeLead(hh2.id, null);
+        const after = await computeRecipientSnapshot('a', IN_SEASON_NOW);
+        expect(after.leadsWithoutEmail).toBe(before.leadsWithoutEmail + 1);
+        expect(after.items.some((i) => i.email === undefined as never)).toBe(false);
+    });
+});

--- a/checkin-app/src/app/api/outreach/__tests__/settingsOutreach.integration.test.ts
+++ b/checkin-app/src/app/api/outreach/__tests__/settingsOutreach.integration.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for GET/PUT /api/settings/outreach — the four template columns,
+ * role gating (board/sysadmin/operations, NOT settings/email's narrower board/sysadmin),
+ * and validate-on-save unknown-token rejection.
+ */
+import { GET, PUT } from '@/app/api/settings/outreach/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+
+function asRole(id: number, role: 'isBoardMember' | 'isSysadmin' | 'isOperations') {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, [role]: true } });
+}
+function asPlain(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id } });
+}
+function req(method: string, body?: unknown) {
+    return new Request('http://localhost:4000/x', { method, ...(body !== undefined ? { body: JSON.stringify(body) } : {}) }) as never;
+}
+
+describe('GET/PUT /api/settings/outreach', () => {
+    const prevValues = { outreachOpeningSubject: null as string | null, outreachOpeningBody: null as string | null, outreachReminderSubject: null as string | null, outreachReminderBody: null as string | null };
+
+    beforeAll(async () => {
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        if (existing) {
+            prevValues.outreachOpeningSubject = existing.outreachOpeningSubject;
+            prevValues.outreachOpeningBody = existing.outreachOpeningBody;
+            prevValues.outreachReminderSubject = existing.outreachReminderSubject;
+            prevValues.outreachReminderBody = existing.outreachReminderBody;
+        }
+    });
+
+    afterAll(async () => {
+        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, ...prevValues }, update: prevValues });
+        await prisma.$disconnect();
+    });
+
+    it('rejects an unprivileged (non-board/sysadmin/operations) caller', async () => {
+        asPlain(1);
+        expect((await GET(req('GET'))).status).toBe(403);
+        expect((await PUT(req('PUT', { outreachOpeningSubject: 'x' }))).status).toBe(403);
+    });
+
+    it('operations may read and write (unlike settings/email)', async () => {
+        asRole(1, 'isOperations');
+        expect((await GET(req('GET'))).status).toBe(200);
+        const res = await PUT(req('PUT', { outreachOpeningSubject: 'Renew by {{deadline}}' }));
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.settings.outreachOpeningSubject).toBe('Renew by {{deadline}}');
+    });
+
+    it('saves all four fields and round-trips them on GET', async () => {
+        asRole(2, 'isBoardMember');
+        const body = {
+            outreachOpeningSubject: 'Time to {{actionWord}}',
+            outreachOpeningBody: 'Hi {{name}}, {{actionLink}}',
+            outreachReminderSubject: 'Reminder: {{actionWord}} by {{deadline}}',
+            outreachReminderBody: 'Hi {{name}}, a friendly reminder.',
+        };
+        const putRes = await PUT(req('PUT', body));
+        expect(putRes.status).toBe(200);
+
+        const getRes = await GET(req('GET'));
+        const data = await getRes.json();
+        expect(data.settings).toEqual(expect.objectContaining(body));
+    });
+
+    it('rejects the WHOLE update with a 400 when any field carries an unknown token', async () => {
+        asRole(3, 'isSysadmin');
+        // Snapshot before, to prove the bad update didn't partially apply.
+        const before = await (await GET(req('GET'))).json();
+
+        const res = await PUT(req('PUT', {
+            outreachOpeningSubject: 'Fine',
+            outreachOpeningBody: 'Uses an unsupported {{unsubscribeUrl}} token',
+        }));
+        expect(res.status).toBe(400);
+        const data = await res.json();
+        expect(data.error).toMatch(/unsubscribeUrl/);
+
+        const after = await (await GET(req('GET'))).json();
+        expect(after.settings).toEqual(before.settings); // whole update rejected, nothing persisted
+    });
+
+    it('writes an audit log row on save', async () => {
+        asRole(4, 'isBoardMember');
+        const before = await prisma.auditLog.count({ where: { tableName: 'BoardSettings', action: 'EDIT' } });
+        await PUT(req('PUT', { outreachReminderSubject: 'Audited change' }));
+        const after = await prisma.auditLog.count({ where: { tableName: 'BoardSettings', action: 'EDIT' } });
+        expect(after).toBe(before + 1);
+    });
+});

--- a/checkin-app/src/app/api/outreach/process-batch/route.ts
+++ b/checkin-app/src/app/api/outreach/process-batch/route.ts
@@ -60,7 +60,14 @@ export const POST = withAuth({ roles: ROLES }, async (req) => {
         const claim = await prisma.bulkSendItem.updateMany({ where: { id: item.id, status: "queued" }, data: { status: "sending" } });
         if (claim.count === 0) continue; // already claimed elsewhere — skip, don't send
 
-        const person = await prisma.person.findUnique({ where: { id: item.personId }, select: { name: true } });
+        const person = await prisma.person.findUnique({ where: { id: item.personId }, select: { name: true, emailSuppressed: true } });
+        // Honor an unsubscribe that landed AFTER the snapshot was frozen: the drain resumes
+        // arbitrarily later (survives deploys), so re-check suppression at send time. Join-only,
+        // recorded (not dropped) as the same status the snapshot path uses — spec §2.4.
+        if (item.variant === "join" && person?.emailSuppressed) {
+            await prisma.bulkSendItem.update({ where: { id: item.id }, data: { status: "skipped_unsubscribed" } });
+            continue;
+        }
         const { subject, html } = renderOutreachEmail(template.subject, template.body, {
             name: person?.name ?? "",
             variant: item.variant as OutreachVariant,

--- a/checkin-app/src/app/api/outreach/process-batch/route.ts
+++ b/checkin-app/src/app/api/outreach/process-batch/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { sendEmail } from "@/lib/email";
+import { renderOutreachEmail, resolveBoundary, loadTemplate, BoundaryNotSetError, type EmailType, type OutreachVariant } from "@/lib/outreach/render";
+import type { BusinessRole } from "@/types/auth";
+
+export const dynamic = "force-dynamic";
+
+const ROLES: BusinessRole[] = ["isBoardMember", "isSysadmin", "isOperations"];
+const BATCH_SIZE = 40; // within the spec's ~25-50/round
+
+/**
+ * POST /api/outreach/process-batch — claim and drain one batch of a BulkSend's `queued`
+ * items. The browser calls this in a loop until `remaining` is 0 (see the send panel).
+ *
+ * No double-send: each candidate item is claimed with a guarded `updateMany where
+ * id=<id> AND status='queued'` BEFORE it is sent — the claim must land before sendEmail,
+ * not after, because the ledger can only prevent a double *write*, not a double *send*, if
+ * the guard ran afterward. A losing claim (count 0, e.g. a retried/duplicate POST racing
+ * another in-flight process-batch call for the same item) is simply skipped.
+ *
+ * ponytail: the claim writes a transient "sending" status — not one of the four the design
+ * doc names (queued/sent/failed/skipped_unsubscribed) — as the atomic marker, since Prisma's
+ * updateMany can't return which rows it touched. A crash in the narrow window between claim
+ * and finalize could strand a single item in "sending" (not resumable by count-of-queued or
+ * retry-failed); add a stale-"sending" reaper if that's ever observed in practice.
+ */
+export const POST = withAuth({ roles: ROLES }, async (req) => {
+    let body: { bulkSendId?: number } = {};
+    try {
+        body = await req.json();
+    } catch {
+        // empty body is fine — falls back to the current in-flight send below
+    }
+
+    const bulkSend = body.bulkSendId
+        ? await prisma.bulkSend.findUnique({ where: { id: body.bulkSendId } })
+        : await prisma.bulkSend.findFirst({ where: { completedAt: null }, orderBy: { id: "desc" } });
+    if (!bulkSend || bulkSend.completedAt) return apiError("No in-flight send.", 404);
+
+    let boundary;
+    try {
+        boundary = await resolveBoundary(new Date());
+    } catch (e) {
+        if (e instanceof BoundaryNotSetError) return apiError(e.message, 400);
+        throw e;
+    }
+    const template = await loadTemplate(bulkSend.emailType as EmailType);
+
+    const candidates = await prisma.bulkSendItem.findMany({
+        where: { bulkSendId: bulkSend.id, status: "queued" },
+        orderBy: { id: "asc" },
+        take: BATCH_SIZE,
+    });
+
+    let processed = 0;
+    for (const item of candidates) {
+        const claim = await prisma.bulkSendItem.updateMany({ where: { id: item.id, status: "queued" }, data: { status: "sending" } });
+        if (claim.count === 0) continue; // already claimed elsewhere — skip, don't send
+
+        const person = await prisma.person.findUnique({ where: { id: item.personId }, select: { name: true } });
+        const { subject, html } = renderOutreachEmail(template.subject, template.body, {
+            name: person?.name ?? "",
+            variant: item.variant as OutreachVariant,
+            boundary,
+            personId: item.variant === "join" ? item.personId : undefined,
+        });
+
+        const ok = await sendEmail(item.email, subject, html);
+        await prisma.bulkSendItem.update({
+            where: { id: item.id },
+            data: ok ? { status: "sent", sentAt: new Date() } : { status: "failed", error: "sendEmail failed" },
+        });
+        processed++;
+    }
+
+    const remaining = await prisma.bulkSendItem.count({ where: { bulkSendId: bulkSend.id, status: "queued" } });
+    if (remaining === 0) {
+        await prisma.bulkSend.update({ where: { id: bulkSend.id }, data: { completedAt: new Date() } });
+    }
+
+    return NextResponse.json({ bulkSendId: bulkSend.id, processed, remaining });
+});

--- a/checkin-app/src/app/api/outreach/send/route.ts
+++ b/checkin-app/src/app/api/outreach/send/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@/generated/prisma/client";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { computeRecipientSnapshot, type Audience } from "@/lib/outreach/recipients";
+import { resolveBoundary, BoundaryNotSetError } from "@/lib/outreach/render";
+import type { BusinessRole } from "@/types/auth";
+
+export const dynamic = "force-dynamic";
+
+const ROLES: BusinessRole[] = ["isBoardMember", "isSysadmin", "isOperations"];
+const EMAIL_TYPES = new Set(["opening", "reminder"]);
+const AUDIENCES = new Set(["a", "b", "c"]);
+
+/** One in-flight BulkSend at a time — the create-then-drain guard (see recipients.ts /
+ * process-batch for the rest of the flow). Thrown inside the transaction below and mapped
+ * to 409 by the catch. */
+class ConcurrentSendError extends Error {}
+
+/**
+ * POST /api/outreach/send — create a campaign send. Computes the recipient snapshot (§2.2)
+ * and writes it as BulkSendItem rows (queued / skipped_unsubscribed) under a brand-new
+ * BulkSend. Returns the pre-send counts so the page can show a confirm dialog before the
+ * browser starts draining via /api/outreach/process-batch. No email is sent here.
+ *
+ * Concurrency: a Serializable transaction wraps the "is anything else in flight" check and
+ * the insert, so two overlapping creates can't both pass the check — Postgres aborts the
+ * loser with a serialization failure (P2034), mapped to 409 here, same as the read-then-act
+ * 409 a plain check-then-insert would only approximate.
+ */
+export const POST = withAuth({ roles: ROLES }, async (req, auth) => {
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
+
+    let body: { emailType?: string; audience?: string };
+    try {
+        body = await req.json();
+    } catch {
+        return apiError("Invalid JSON", 400);
+    }
+    const emailType = body.emailType;
+    const audience = body.audience;
+    if (!emailType || !EMAIL_TYPES.has(emailType)) return apiError('emailType must be "opening" or "reminder"', 400);
+    if (!audience || !AUDIENCES.has(audience)) return apiError('audience must be "a", "b", or "c"', 400);
+
+    try {
+        await resolveBoundary(new Date());
+    } catch (e) {
+        if (e instanceof BoundaryNotSetError) return apiError(e.message, 400);
+        throw e;
+    }
+
+    const snapshot = await computeRecipientSnapshot(audience as Audience);
+    let queued = 0;
+    let skippedUnsubscribed = 0;
+    for (const item of snapshot.items) {
+        if (item.status === "queued") queued++;
+        else skippedUnsubscribed++;
+    }
+
+    try {
+        const bulkSend = await prisma.$transaction(
+            async (tx) => {
+                const inFlight = await tx.bulkSend.findFirst({ where: { completedAt: null }, select: { id: true } });
+                if (inFlight) throw new ConcurrentSendError();
+                return tx.bulkSend.create({
+                    data: {
+                        emailType,
+                        audience,
+                        senderId: auth.user.id,
+                        // Nothing to drain — a send to zero recipients is trivially complete.
+                        completedAt: snapshot.items.length === 0 ? new Date() : null,
+                        items: { createMany: { data: snapshot.items } },
+                    },
+                });
+            },
+            { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        );
+
+        return NextResponse.json(
+            {
+                bulkSend,
+                counts: {
+                    queued,
+                    skippedUnsubscribed,
+                    leadsWithoutEmail: snapshot.leadsWithoutEmail,
+                    total: snapshot.items.length,
+                },
+            },
+            { status: 201 },
+        );
+    } catch (e) {
+        if (e instanceof ConcurrentSendError) return apiError("A send is already in progress.", 409);
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2034") {
+            return apiError("A send is already in progress.", 409);
+        }
+        throw e;
+    }
+});

--- a/checkin-app/src/app/api/outreach/status/route.ts
+++ b/checkin-app/src/app/api/outreach/status/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import type { BusinessRole } from "@/types/auth";
+import type { BulkSend } from "@/generated/prisma/client";
+
+export const dynamic = "force-dynamic";
+
+const ROLES: BusinessRole[] = ["isBoardMember", "isSysadmin", "isOperations"];
+const STATUSES = ["queued", "sent", "failed", "skipped_unsubscribed", "sending"] as const;
+
+async function countsFor(bulkSendId: number) {
+    const groups = await prisma.bulkSendItem.groupBy({ by: ["status"], where: { bulkSendId }, _count: { _all: true } });
+    const counts: Record<(typeof STATUSES)[number], number> = { queued: 0, sent: 0, failed: 0, skipped_unsubscribed: 0, sending: 0 };
+    let total = 0;
+    for (const g of groups) {
+        if ((STATUSES as readonly string[]).includes(g.status)) counts[g.status as (typeof STATUSES)[number]] = g._count._all;
+        total += g._count._all;
+    }
+    return { ...counts, total };
+}
+
+async function summarize(bulkSend: BulkSend) {
+    return { ...bulkSend, counts: await countsFor(bulkSend.id) };
+}
+
+/** GET /api/outreach/status — the send panel's data: the current in-flight send (if any,
+ * so the page can offer Resume) and the last completed send (the "last sent" log line). */
+export const GET = withAuth({ roles: ROLES }, async () => {
+    const inFlight = await prisma.bulkSend.findFirst({ where: { completedAt: null }, orderBy: { id: "desc" } });
+    const lastCompleted = await prisma.bulkSend.findFirst({ where: { completedAt: { not: null } }, orderBy: { id: "desc" } });
+
+    return NextResponse.json({
+        inFlight: inFlight ? await summarize(inFlight) : null,
+        lastCompleted: lastCompleted ? await summarize(lastCompleted) : null,
+    });
+});
+
+/** POST /api/outreach/status — `{ action: "retry", bulkSendId }` re-queues that send's
+ * `failed` items (status failed → queued) and reopens it for draining if it had completed. */
+export const POST = withAuth({ roles: ROLES }, async (req) => {
+    let body: { action?: string; bulkSendId?: number };
+    try {
+        body = await req.json();
+    } catch {
+        return apiError("Invalid JSON", 400);
+    }
+    if (body.action !== "retry" || !body.bulkSendId) return apiError('Body must be { action: "retry", bulkSendId }', 400);
+
+    const bulkSend = await prisma.bulkSend.findUnique({ where: { id: body.bulkSendId } });
+    if (!bulkSend) return apiError("Send not found", 404);
+
+    await prisma.bulkSendItem.updateMany({ where: { bulkSendId: bulkSend.id, status: "failed" }, data: { status: "queued", error: null } });
+    const reopened = bulkSend.completedAt
+        ? await prisma.bulkSend.update({ where: { id: bulkSend.id }, data: { completedAt: null } })
+        : bulkSend;
+
+    return NextResponse.json({ bulkSend: await summarize(reopened) });
+});

--- a/checkin-app/src/app/api/outreach/status/route.ts
+++ b/checkin-app/src/app/api/outreach/status/route.ts
@@ -51,6 +51,15 @@ export const POST = withAuth({ roles: ROLES }, async (req) => {
     const bulkSend = await prisma.bulkSend.findUnique({ where: { id: body.bulkSendId } });
     if (!bulkSend) return apiError("Send not found", 404);
 
+    // Reopening a completed send must not create a second in-flight row: two rows with
+    // completedAt: null break the one-in-flight invariant (send/route.ts 409s every new
+    // campaign, and process-batch's no-id fallback drains whichever is newest). Plain check —
+    // the create path guards under Serializable, but this reopen's exposure is far narrower.
+    if (bulkSend.completedAt) {
+        const other = await prisma.bulkSend.findFirst({ where: { completedAt: null }, select: { id: true } });
+        if (other) return apiError("A send is already in progress.", 409);
+    }
+
     await prisma.bulkSendItem.updateMany({ where: { bulkSendId: bulkSend.id, status: "failed" }, data: { status: "queued", error: null } });
     const reopened = bulkSend.completedAt
         ? await prisma.bulkSend.update({ where: { id: bulkSend.id }, data: { completedAt: null } })

--- a/checkin-app/src/app/api/outreach/test-send/route.ts
+++ b/checkin-app/src/app/api/outreach/test-send/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { sendEmail } from "@/lib/email";
+import { renderOutreachEmail, resolveBoundary, BoundaryNotSetError } from "@/lib/outreach/render";
+import { findUnknownTokens } from "@/lib/outreach/tokens";
+import type { BusinessRole } from "@/types/auth";
+
+export const dynamic = "force-dynamic";
+
+const ROLES: BusinessRole[] = ["isBoardMember", "isSysadmin", "isOperations"];
+const SAMPLE_NAME = "Jordan Rivera";
+
+/**
+ * POST /api/outreach/test-send — renders BOTH variants of whatever template is currently in
+ * the editor (unsaved-or-saved — the body carries the live text, not a saved-column read)
+ * and sends both to the caller's own address. Sample data: name "Jordan Rivera", the real
+ * next boundary, each variant's real actionWord/actionLink/unsubscribe-footer behavior.
+ */
+export const POST = withAuth({ roles: ROLES }, async (req, auth) => {
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
+    const to = auth.user.email;
+    if (!to) return apiError("Your account has no email on file.", 400);
+
+    let body: { subject?: string; body?: string };
+    try {
+        body = await req.json();
+    } catch {
+        return apiError("Invalid JSON", 400);
+    }
+    const subjectTemplate = body.subject ?? "";
+    const bodyTemplate = body.body ?? "";
+    const unknown = [...findUnknownTokens(subjectTemplate), ...findUnknownTokens(bodyTemplate)];
+    if (unknown.length) return apiError(`Unknown token {{${unknown[0]}}}`, 400);
+
+    let boundary;
+    try {
+        boundary = await resolveBoundary(new Date());
+    } catch (e) {
+        if (e instanceof BoundaryNotSetError) return apiError(e.message, 400);
+        throw e;
+    }
+
+    for (const variant of ["join", "renew"] as const) {
+        const { subject, html } = renderOutreachEmail(subjectTemplate, bodyTemplate, {
+            name: SAMPLE_NAME,
+            variant,
+            boundary,
+            personId: variant === "join" ? auth.user.id : undefined,
+        });
+        await sendEmail(to, `[Test - ${variant}] ${subject}`, html);
+    }
+
+    return NextResponse.json({ success: true });
+});

--- a/checkin-app/src/app/api/outreach/test-send/route.ts
+++ b/checkin-app/src/app/api/outreach/test-send/route.ts
@@ -46,9 +46,12 @@ export const POST = withAuth({ roles: ROLES }, async (req, auth) => {
             name: SAMPLE_NAME,
             variant,
             boundary,
-            personId: variant === "join" ? auth.user.id : undefined,
+            // No personId: a test render must not mint a working unsubscribe token for the tester
+            // (who would opt themselves out by clicking through to verify the link). Mirror the
+            // client preview's inert footer (settings/outreach/page.tsx) so test and preview match.
         });
-        await sendEmail(to, `[Test - ${variant}] ${subject}`, html);
+        const testHtml = html + (variant === "join" ? '<p><a href="#">Unsubscribe from invitations</a></p>' : "");
+        await sendEmail(to, `[Test - ${variant}] ${subject}`, testHtml);
     }
 
     return NextResponse.json({ success: true });

--- a/checkin-app/src/app/api/people/search/route.ts
+++ b/checkin-app/src/app/api/people/search/route.ts
@@ -55,6 +55,7 @@ export const GET = withAuth(
                 lastBackgroundCheck: p.lastBackgroundCheck,
                 isMember: personRecordIsActiveOrgMember(p),
                 ...rolesToFlags(p.roles),
+                emailSuppressed: p.emailSuppressed,
                 household: p.household,
             }));
 

--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -39,7 +39,7 @@ export const PATCH = withAuth(
             }
 
             const body = await req.json();
-            const { name, phone, dob, notificationSettings } = body;
+            const { name, phone, dob, notificationSettings, emailSuppressed } = body;
 
             if (phone !== undefined && phone !== "" && !isValidPhone(phone)) {
                 return apiError(PHONE_ERROR, 400);
@@ -52,6 +52,7 @@ export const PATCH = withAuth(
                     phone: phone !== undefined ? (phone === "" ? null : formatPhone(phone)) : undefined,
                     dateOfBirth: dob ? new Date(dob) : undefined,
                     notificationSettings: notificationSettings !== undefined ? notificationSettings : undefined,
+                    emailSuppressed: emailSuppressed !== undefined ? !!emailSuppressed : undefined,
                 },
                 select: {
                     name: true,
@@ -59,6 +60,7 @@ export const PATCH = withAuth(
                     phone: true,
                     dateOfBirth: true,
                     notificationSettings: true,
+                    emailSuppressed: true,
                 }
             });
 

--- a/checkin-app/src/app/api/settings/membership/bulk-open-renewals/route.ts
+++ b/checkin-app/src/app/api/settings/membership/bulk-open-renewals/route.ts
@@ -9,17 +9,11 @@ export const dynamic = "force-dynamic";
  * POST /api/settings/membership/bulk-open-renewals — go-live action.
  * Opens a renewal cycle (PENDING_RENEWAL) for every active membership not already
  * mid-renewal. Board members or sysadmins may trigger it; it is a deliberate,
- * manual one-time action (nothing opens automatically).
- * Body: { sendReminders?: boolean } (default false — avoids a mass email blast).
+ * manual one-time action (nothing opens automatically). Never emails — this button
+ * only opens processes; the settings/outreach page is the only send surface.
  */
-export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
+export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (_req, auth) => {
     if (auth.type !== "session") return apiError("Unauthorized", 401);
-    let body: { sendReminders?: boolean } = {};
-    try {
-        body = await req.json();
-    } catch {
-        /* empty body is fine */
-    }
-    const result = await openRenewalsForAllActive(new Date(), { sendReminders: !!body.sendReminders });
+    const result = await openRenewalsForAllActive();
     return NextResponse.json({ success: true, ...result });
 });

--- a/checkin-app/src/app/api/settings/outreach/route.ts
+++ b/checkin-app/src/app/api/settings/outreach/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { apiError } from "@/lib/api-response";
+import { findUnknownTokens } from "@/lib/outreach/tokens";
+import { nextBoundary } from "@/lib/membership/renewal";
+import type { BusinessRole } from "@/types/auth";
+
+export const dynamic = "force-dynamic";
+
+const ROLES: BusinessRole[] = ["isBoardMember", "isSysadmin", "isOperations"];
+
+const SELECT = {
+    outreachOpeningSubject: true,
+    outreachOpeningBody: true,
+    outreachReminderSubject: true,
+    outreachReminderBody: true,
+} as const;
+
+type Field = keyof typeof SELECT;
+const FIELDS = Object.keys(SELECT) as Field[];
+
+/**
+ * GET /api/settings/outreach — the four outreach template columns, plus the current
+ * membership-year boundary's next occurrence (read-only, for the live preview's
+ * {{deadline}} — computed server-side so the client never has to re-derive nextBoundary()
+ * and pull prisma into the bundle, see settings/membership/page.tsx's currentBoundaryLabel
+ * for the workaround this avoids). Null when the boundary isn't configured yet.
+ */
+export const GET = withAuth({ roles: ROLES }, async () => {
+    const settings = await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1 }, update: {}, select: SELECT });
+    const boundarySetting = await prisma.boardSettings.findUnique({ where: { id: 1 }, select: { orgMembershipYearBoundary: true } });
+    const nextDeadline = boundarySetting?.orgMembershipYearBoundary
+        ? nextBoundary(boundarySetting.orgMembershipYearBoundary, new Date()).toISOString().slice(0, 10)
+        : null;
+    return NextResponse.json({ settings, nextDeadline });
+});
+
+/**
+ * PUT /api/settings/outreach — sets the four outreach template columns. Deliberately
+ * separate from /api/settings/email (which drives every outbound email's From/Reply-To —
+ * operations must never touch that): this route only ever writes these four columns and is
+ * open to isOperations. Validate-on-save: any `{{token}}` outside {name, deadline,
+ * actionWord, actionLink} rejects the WHOLE update (400), same shape as settings/email's
+ * header validation.
+ */
+export const PUT = withAuth({ roles: ROLES }, async (req, auth) => {
+    if (auth.type !== "session") return apiError("Unauthorized", 401);
+    let body: Partial<Record<Field, string | null>>;
+    try {
+        body = await req.json();
+    } catch {
+        return apiError("Invalid JSON", 400);
+    }
+
+    const data: Record<string, string | null> = {};
+    for (const field of FIELDS) {
+        if (body[field] === undefined) continue;
+        const value = (body[field] ?? "").toString();
+        const unknown = findUnknownTokens(value);
+        if (unknown.length) {
+            return apiError(`Unknown token {{${unknown[0]}}} in ${field} — only {{name}}, {{deadline}}, {{actionWord}}, {{actionLink}} are allowed.`, 400);
+        }
+        data[field] = value.trim() ? value : null;
+    }
+
+    const settings = await prisma.boardSettings.upsert({
+        where: { id: 1 },
+        create: { id: 1, ...data },
+        update: data,
+        select: SELECT,
+    });
+
+    await prisma.auditLog.create({
+        data: { actorId: auth.user.id, action: "EDIT", tableName: "BoardSettings", affectedEntityId: 1, newData: data },
+    });
+
+    return NextResponse.json({ settings });
+});

--- a/checkin-app/src/app/api/unsubscribe/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/unsubscribe/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests for /api/unsubscribe — GET must never flip the flag (mail scanners and
+ * link-preview bots prefetch GET links), only POST does. Prisma is mocked (this route's
+ * own logic — token verify + which prisma call each verb makes — is what's under test;
+ * the real DB write is covered end-to-end by the integration suites elsewhere).
+ */
+import { GET, POST } from '../route';
+import { sign } from '@/lib/outreach/unsubscribeToken';
+
+const mockFindUnique = jest.fn();
+const mockUpdate = jest.fn();
+jest.mock('@/lib/prisma', () => ({
+    __esModule: true,
+    default: {
+        person: {
+            findUnique: (...args: unknown[]) => mockFindUnique(...args),
+            update: (...args: unknown[]) => mockUpdate(...args),
+        },
+    },
+}));
+
+const prevSecret = process.env.NEXTAUTH_SECRET;
+beforeAll(() => { process.env.NEXTAUTH_SECRET = 'unit-test-nextauth-secret'; });
+afterAll(() => {
+    if (prevSecret === undefined) delete process.env.NEXTAUTH_SECRET; else process.env.NEXTAUTH_SECRET = prevSecret;
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+function url(personId: number, sig: string) {
+    return `http://localhost:4000/api/unsubscribe?p=${personId}&sig=${encodeURIComponent(sig)}`;
+}
+
+describe('GET /api/unsubscribe', () => {
+    it('renders a confirm page and does NOT flip the flag', async () => {
+        mockFindUnique.mockResolvedValue({ email: 'member@example.com' });
+        const sig = sign(42);
+        const res = await GET(new Request(url(42, sig)));
+        expect(res.status).toBe(200);
+        const html = await res.text();
+        expect(html).toContain('Stop membership invitation emails');
+        expect(html).toContain('member@example.com');
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('bad signature -> neutral "expired or invalid" page, no flip, no lookup', async () => {
+        const res = await GET(new Request(url(42, 'not-the-real-signature')));
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('expired or invalid');
+        expect(mockFindUnique).not.toHaveBeenCalled();
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('missing params -> neutral page', async () => {
+        const res = await GET(new Request('http://localhost:4000/api/unsubscribe'));
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('expired or invalid');
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('unknown person id (valid signature, no such row) -> neutral page, no info leak', async () => {
+        mockFindUnique.mockResolvedValue(null);
+        const res = await GET(new Request(url(999, sign(999))));
+        expect(await res.text()).toContain('expired or invalid');
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+});
+
+describe('POST /api/unsubscribe', () => {
+    it('flips emailSuppressed with a valid token', async () => {
+        mockFindUnique.mockResolvedValue({ id: 42 });
+        mockUpdate.mockResolvedValue({ id: 42, emailSuppressed: true });
+        const sig = sign(42);
+        const res = await POST(new Request(url(42, sig), { method: 'POST' }));
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain("You're unsubscribed");
+        expect(mockUpdate).toHaveBeenCalledWith({ where: { id: 42 }, data: { emailSuppressed: true } });
+    });
+
+    it('bad signature -> neutral page, does not flip', async () => {
+        const res = await POST(new Request(url(42, 'garbage'), { method: 'POST' }));
+        expect(await res.text()).toContain('expired or invalid');
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent — a second POST on an already-suppressed person still succeeds', async () => {
+        mockFindUnique.mockResolvedValue({ id: 42 });
+        mockUpdate.mockResolvedValue({ id: 42, emailSuppressed: true });
+        const sig = sign(42);
+        const first = await POST(new Request(url(42, sig), { method: 'POST' }));
+        const second = await POST(new Request(url(42, sig), { method: 'POST' }));
+        expect(first.status).toBe(200);
+        expect(second.status).toBe(200);
+        expect(mockUpdate).toHaveBeenCalledTimes(2);
+    });
+});

--- a/checkin-app/src/app/api/unsubscribe/route.ts
+++ b/checkin-app/src/app/api/unsubscribe/route.ts
@@ -1,0 +1,71 @@
+import prisma from "@/lib/prisma";
+import { verify } from "@/lib/outreach/unsubscribeToken";
+import { escapeHtml } from "@/lib/email-templates/base";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * /api/unsubscribe — public, session-less, self-verifying via the signed token (the
+ * withCron/withWebhook/withKiosk family — see unsubscribeToken.ts). No withAuth, no
+ * registry entry: `middleware.ts` already leaves `/api/*` ungated, and this route enforces
+ * itself.
+ *
+ * GET renders a confirm page and does NOT flip the flag — mail scanners and link-preview
+ * bots prefetch GET links, so flipping here would mass-unsubscribe people who never clicked
+ * anything. POST (the confirm button's target) flips it. Bad/missing/tampered token → a
+ * neutral "expired or invalid" page on GET, 400 on POST — no information leak either way.
+ */
+
+// Plain Response (not NextResponse) — this is a bare HTML page, not a Next-specific
+// concern (cookies/rewrites), and the constructor form of NextResponse isn't used
+// anywhere else in this codebase.
+function page(body: string): Response {
+    return new Response(
+        `<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>Unsubscribe</title></head>` +
+            `<body style="font-family: sans-serif; max-width: 480px; margin: 15vh auto 0; padding: 0 24px; text-align: center;">${body}</body></html>`,
+        { status: 200, headers: { "Content-Type": "text/html; charset=utf-8" } },
+    );
+}
+
+function invalidPage(): Response {
+    return page(`<h1>Link expired or invalid</h1><p>This unsubscribe link is no longer valid.</p>`);
+}
+
+function parseParams(req: Request): { personId: number; sig: string } | null {
+    const url = new URL(req.url);
+    const p = url.searchParams.get("p");
+    const sig = url.searchParams.get("sig");
+    if (!p || !sig) return null;
+    const personId = Number.parseInt(p, 10);
+    if (!Number.isInteger(personId)) return null;
+    return { personId, sig };
+}
+
+export async function GET(req: Request) {
+    const parsed = parseParams(req);
+    if (!parsed || !verify(parsed.personId, parsed.sig)) return invalidPage();
+
+    const person = await prisma.person.findUnique({ where: { id: parsed.personId }, select: { email: true } });
+    if (!person) return invalidPage();
+
+    const actionUrl = `/api/unsubscribe?p=${parsed.personId}&sig=${encodeURIComponent(parsed.sig)}`;
+    return page(`
+        <h1>Stop membership invitation emails?</h1>
+        <p>Stop membership invitation emails to ${escapeHtml(person.email ?? "")}?</p>
+        <form method="POST" action="${actionUrl}">
+            <button type="submit" style="font-size: 1rem; padding: 8px 20px; cursor: pointer;">Unsubscribe</button>
+        </form>
+    `);
+}
+
+export async function POST(req: Request) {
+    const parsed = parseParams(req);
+    if (!parsed || !verify(parsed.personId, parsed.sig)) return invalidPage();
+
+    const person = await prisma.person.findUnique({ where: { id: parsed.personId }, select: { id: true } });
+    if (!person) return invalidPage();
+
+    // Idempotent — already-suppressed is fine, no separate branch needed.
+    await prisma.person.update({ where: { id: parsed.personId }, data: { emailSuppressed: true } });
+    return page(`<h1>You're unsubscribed.</h1><p>You won't receive further membership invitation emails.</p>`);
+}

--- a/checkin-app/src/app/communication/__tests__/page.test.tsx
+++ b/checkin-app/src/app/communication/__tests__/page.test.tsx
@@ -30,4 +30,38 @@ describe("CommunicationPage", () => {
 
         expect(await screen.findByLabelText("Email me when I check in or out")).toBeDisabled();
     });
+
+    it("persists the outreach-suppression toggle immediately", async () => {
+        setSession({ id: 1, email: "a@example.com" });
+        const fetchMock = mockFetchJson({
+            "/api/profile": { profile: { notificationSettings: {}, emailSuppressed: false } },
+        });
+        renderWithProviders(<CommunicationPage />);
+
+        const suppress = await screen.findByLabelText("Don't email me membership join/renewal invitations");
+        expect(suppress).not.toBeChecked();
+
+        fireEvent.click(suppress);
+        await waitFor(() => expect(suppress).toBeChecked());
+        expect(fetchMock).toHaveBeenCalledWith(
+            "/api/profile",
+            expect.objectContaining({ method: "PATCH", body: JSON.stringify({ emailSuppressed: true }) }),
+        );
+    });
+
+    it("reverts the outreach-suppression toggle if the save fails", async () => {
+        setSession({ id: 1, email: "a@example.com" });
+        mockFetchJson({ "/api/profile": { profile: { notificationSettings: {}, emailSuppressed: false } } });
+        renderWithProviders(<CommunicationPage />);
+
+        const suppress = await screen.findByLabelText("Don't email me membership join/renewal invitations");
+        expect(suppress).not.toBeChecked();
+
+        global.fetch = jest.fn(() => Promise.reject(new Error("net"))) as unknown as typeof fetch;
+        fireEvent.click(suppress);
+        expect(suppress).toBeChecked(); // optimistic flip
+
+        await waitFor(() => expect(suppress).not.toBeChecked()); // reverted
+        expect(await screen.findByText("Failed to update settings.")).toBeInTheDocument();
+    });
 });

--- a/checkin-app/src/app/communication/page.tsx
+++ b/checkin-app/src/app/communication/page.tsx
@@ -27,6 +27,7 @@ export default function CommunicationPage() {
     emailDependentCheckins: false,
     notifyNewPrograms: true
   });
+  const [emailSuppressed, setEmailSuppressed] = useState(false);
 
   const fetchSettings = useCallback(async () => {
     try {
@@ -39,6 +40,7 @@ export default function CommunicationPage() {
           emailDependentCheckins: s.emailDependentCheckins || false,
           notifyNewPrograms: s.notifyNewPrograms !== undefined ? s.notifyNewPrograms : true
         });
+        setEmailSuppressed(!!data.profile.emailSuppressed);
       } else {
         setMessage("Failed to load settings.");
       }
@@ -77,6 +79,25 @@ export default function CommunicationPage() {
     }
   };
 
+  // Same immediate-persist / revert-on-failure pattern as the checkboxes above, for the
+  // one field that isn't inside notificationSettings.
+  const persistSuppression = async (value: boolean) => {
+    const prev = emailSuppressed;
+    setEmailSuppressed(value);
+    setMessage("");
+    try {
+      const res = await fetch('/api/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ emailSuppressed: value })
+      });
+      if (!res.ok) throw new Error();
+    } catch {
+      setEmailSuppressed(prev);
+      setMessage("Failed to update settings.");
+    }
+  };
+
   if (loading || status === "loading") {
     return <PageLoader />;
   }
@@ -105,6 +126,14 @@ export default function CommunicationPage() {
               />
             </Tooltip>
           ))}
+        </Stack>
+
+        <Stack mt="lg">
+          <Checkbox
+            checked={emailSuppressed}
+            onChange={(e) => persistSuppression(e.currentTarget.checked)}
+            label="Don't email me membership join/renewal invitations"
+          />
         </Stack>
 
         {message && <Alert color="red" mt="md">{message}</Alert>}

--- a/checkin-app/src/app/membership-ops/participants/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/__tests__/page.test.tsx
@@ -291,4 +291,17 @@ describe("AdminParticipantsIndex", () => {
         expect(await screen.findByText(/Edit Household Info —/)).toBeInTheDocument();
         await waitFor(() => expect(screen.queryByText("Edit Person")).not.toBeInTheDocument());
     });
+
+    it("shows an Unsubscribed pill for a suppressed row, and not for others", async () => {
+        mockFetchJson({
+            "/api/people/search": { people: [{ ...alice, emailSuppressed: true }, { ...dave, emailSuppressed: false }] },
+        });
+        renderWithProviders(<AdminParticipantsIndex />);
+
+        const aliceRow = (await screen.findByText("Alice A")).closest("tr")!;
+        expect(within(aliceRow).getByText("Unsubscribed")).toBeInTheDocument();
+
+        const daveRow = screen.getByText("Dave D").closest("tr")!;
+        expect(within(daveRow).queryByText("Unsubscribed")).not.toBeInTheDocument();
+    });
 });

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Alert, Box, Button, Card, Group, Modal, Paper, Stack, Switch, Table, Text, TextInput, UnstyledButton } from "@mantine/core";
+import { Alert, Badge, Box, Button, Card, Group, Modal, Paper, Stack, Switch, Table, Text, TextInput, UnstyledButton } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { IconChevronDown, IconChevronUp, IconSelector } from "@tabler/icons-react";
 import { EntityPicker } from "@/components/admin/EntityPicker";
@@ -31,6 +31,7 @@ type PersonRow = {
   isKeyholder?: boolean;
   isBackgroundCheckReviewer?: boolean;
   isOperations?: boolean;
+  emailSuppressed?: boolean;
 };
 
 export default function AdminParticipantsIndex() {
@@ -242,7 +243,12 @@ export default function AdminParticipantsIndex() {
                     <Table.Tr key={p.id}>
                       <Table.Td c="dimmed">{p.id}</Table.Td>
                       <Table.Td fw={600}>{p.name}</Table.Td>
-                      <Table.Td>{p.email || <Text span c="dimmed">No email</Text>}</Table.Td>
+                      <Table.Td>
+                        <Group gap={6} wrap="nowrap">
+                          {p.email || <Text span c="dimmed">No email</Text>}
+                          {p.emailSuppressed && <Badge size="xs" color="gray" variant="light">Unsubscribed</Badge>}
+                        </Group>
+                      </Table.Td>
                       <Table.Td>{p.household?.name || <Text span c="dimmed">No household</Text>}</Table.Td>
                       <Table.Td>
                         <Group gap={4} wrap="wrap">

--- a/checkin-app/src/app/settings/layout.tsx
+++ b/checkin-app/src/app/settings/layout.tsx
@@ -6,10 +6,14 @@ import { useEffect } from "react";
 import { Center, Loader, Stack, Text } from "@mantine/core";
 import { PageContainer } from "@/components/ui/PageContainer";
 
-type SettingsUser = { isSysadmin?: boolean; isBoardMember?: boolean };
+type SettingsUser = { isSysadmin?: boolean; isBoardMember?: boolean; isOperations?: boolean };
 
-// Settings is isSysadmin/board only. Gate here since these pages were moved out of
+// Settings is isSysadmin/board/operations. Gate here since these pages were moved out of
 // /admin: the membership settings page self-gates nothing and relied on the admin layout.
+// Operations only actually has a real destination today (settings/outreach) — every other
+// settings page carries its own stricter useRequireRole(['isSysadmin','isBoardMember']) that
+// bounces an operations session straight back out, the same layered pattern that already
+// keeps board members off the sysadmin-only localization tab.
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
   const { data: session, status } = useSession();
   const router = useRouter();
@@ -19,7 +23,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
       router.push("/");
     } else if (status === "authenticated") {
       const user = session?.user as SettingsUser;
-      if (!user?.isSysadmin && !user?.isBoardMember) router.push("/");
+      if (!user?.isSysadmin && !user?.isBoardMember && !user?.isOperations) router.push("/");
     }
   }, [status, session, router]);
 
@@ -35,7 +39,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
   }
 
   const user = session?.user as SettingsUser;
-  if (!session || (!user?.isSysadmin && !user?.isBoardMember)) {
+  if (!session || (!user?.isSysadmin && !user?.isBoardMember && !user?.isOperations)) {
     return null;
   }
 

--- a/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
@@ -231,7 +231,7 @@ describe("MembershipSettingsPage", () => {
     );
   });
 
-  it("opens renewals for all active members after confirming, with reminders toggled on", async () => {
+  it("opens renewals for all active members after confirming (never emails — PR-2)", async () => {
     setSession({ id: 1, isSysadmin: true });
     const fetchMock = mockFetchJson({
       "/api/settings/membership/bulk-open-renewals": { opened: 12, skipped: 3 },
@@ -240,7 +240,8 @@ describe("MembershipSettingsPage", () => {
     renderWithProviders(<MembershipSettingsPage />);
     await screen.findByDisplayValue("150.00");
 
-    fireEvent.click(screen.getByLabelText("Also email each household a renewal reminder"));
+    expect(screen.queryByLabelText("Also email each household a renewal reminder")).not.toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: "Open renewals for all active members" }));
     const modal = await screen.findByRole("dialog", { name: "Open Renewals For All Active Members" });
     fireEvent.click(within(modal).getByRole("button", { name: "Open Renewals" }));
@@ -248,7 +249,7 @@ describe("MembershipSettingsPage", () => {
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
         "/api/settings/membership/bulk-open-renewals",
-        expect.objectContaining({ method: "POST", body: JSON.stringify({ sendReminders: true }) }),
+        expect.objectContaining({ method: "POST" }),
       ),
     );
     expect(await screen.findByText("Opened 12 renewal(s); 3 already in progress.")).toBeInTheDocument();

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -55,7 +55,6 @@ export default function MembershipSettingsPage() {
   // separate save flow — wire it if it grows edits.
   const [initial, setInitial] = useState<Record<string, string> | null>(null);
 
-  const [bulkReminders, setBulkReminders] = useState(false);
   const [confirmOpenRenewalsOpened, { open: openConfirmOpenRenewals, close: closeConfirmOpenRenewals }] = useDisclosure(false);
 
   const [loading, setLoading] = useState(true);
@@ -171,11 +170,7 @@ export default function MembershipSettingsPage() {
     setSaving(true);
     setRenewalNotice(null);
     try {
-      const res = await fetch("/api/settings/membership/bulk-open-renewals", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sendReminders: bulkReminders }),
-      });
+      const res = await fetch("/api/settings/membership/bulk-open-renewals", { method: "POST" });
       const data = await res.json().catch(() => ({}));
       if (res.ok) setRenewalNotice({ text: `Opened ${data.opened} renewal(s); ${data.skipped} already in progress.`, err: false });
       else setRenewalNotice({ text: data.error || "Failed.", err: true });
@@ -364,12 +359,6 @@ export default function MembershipSettingsPage() {
               they renew for the upcoming year. Press this once, after your existing members are
               imported (board or isSysadmin).
             </Text>
-            <Checkbox
-              my="sm"
-              checked={bulkReminders}
-              onChange={(e) => setBulkReminders(e.currentTarget.checked)}
-              label="Also email each household a renewal reminder"
-            />
             {renewalNotice && (
               <Alert mt="md" mb="md" color={renewalNotice.err ? "red" : "green"} variant="light">
                 {renewalNotice.text}

--- a/checkin-app/src/app/settings/outreach/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/outreach/__tests__/page.test.tsx
@@ -49,9 +49,10 @@ describe("OutreachSettingsPage", () => {
     await screen.findByDisplayValue("Time to {{actionWord}}");
     expect(screen.getAllByDisplayValue(/Hi \{\{name\}\}/)).toHaveLength(2);
 
-    // Live preview substitutes the tokens for both variants (join/renew).
-    expect(screen.getByText(/please join by 2026-08-01/)).toBeInTheDocument();
-    expect(screen.getByText(/please renew by 2026-08-01/)).toBeInTheDocument();
+    // Live preview substitutes the tokens for both variants (join/renew). The body renders in a
+    // scriptless sandboxed iframe (XSS hardening), so assert against its srcDoc, not the DOM text.
+    expect(screen.getByTitle("Opening of renewals: join preview").getAttribute("srcdoc")).toMatch(/please join by 2026-08-01/);
+    expect(screen.getByTitle("Opening of renewals: renew preview").getAttribute("srcdoc")).toMatch(/please renew by 2026-08-01/);
   });
 
   it("live preview updates as the board types", async () => {

--- a/checkin-app/src/app/settings/outreach/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/outreach/__tests__/page.test.tsx
@@ -1,0 +1,152 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { renderWithProviders, setSession, resetRtl } from "@/test-helpers/rtl";
+import OutreachSettingsPage from "../page";
+
+const SETTINGS = {
+  outreachOpeningSubject: "Time to {{actionWord}}",
+  outreachOpeningBody: "Hi {{name}}, please {{actionWord}} by {{deadline}} at {{actionLink}}.",
+  outreachReminderSubject: "Reminder: {{actionWord}}",
+  outreachReminderBody: "Hi {{name}}, a reminder.",
+};
+const EMPTY_STATUS = { inFlight: null, lastCompleted: null };
+
+type Route = { status?: number; body: unknown };
+function router(routes: Record<string, Partial<Record<string, Route>> | Route>) {
+  const fn = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    const key = Object.keys(routes).find((k) => url.includes(k));
+    let entry = key !== undefined ? routes[key] : undefined;
+    if (entry && "body" in entry === false) entry = (entry as Partial<Record<string, Route>>)[method];
+    const route = entry as Route | undefined;
+    const body = route?.body ?? {};
+    const status = route?.status ?? (route ? 200 : 404);
+    return { ok: status < 400, status, json: async () => body, text: async () => JSON.stringify(body) } as Response;
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+beforeEach(() => {
+  resetRtl();
+  setSession({ id: 1, isBoardMember: true });
+});
+
+describe("OutreachSettingsPage", () => {
+  it("loads the four fields and renders a live dual-variant preview", async () => {
+    router({
+      "/api/settings/outreach": { body: { settings: SETTINGS, nextDeadline: "2026-08-01" } },
+      "/api/outreach/status": { body: EMPTY_STATUS },
+    });
+    renderWithProviders(<OutreachSettingsPage />);
+
+    await screen.findByDisplayValue("Time to {{actionWord}}");
+    expect(screen.getAllByDisplayValue(/Hi \{\{name\}\}/)).toHaveLength(2);
+
+    // Live preview substitutes the tokens for both variants (join/renew).
+    expect(screen.getByText(/please join by 2026-08-01/)).toBeInTheDocument();
+    expect(screen.getByText(/please renew by 2026-08-01/)).toBeInTheDocument();
+  });
+
+  it("live preview updates as the board types", async () => {
+    router({
+      "/api/settings/outreach": { body: { settings: SETTINGS, nextDeadline: "2026-08-01" } },
+      "/api/outreach/status": { body: EMPTY_STATUS },
+    });
+    renderWithProviders(<OutreachSettingsPage />);
+    await screen.findByDisplayValue("Time to {{actionWord}}");
+
+    const subjectInputs = screen.getAllByLabelText("Subject");
+    fireEvent.change(subjectInputs[0], { target: { value: "Brand new subject {{actionWord}}" } });
+
+    expect(await screen.findByText("Brand new subject join")).toBeInTheDocument();
+    expect(screen.getByText("Brand new subject renew")).toBeInTheDocument();
+  });
+
+  it("sends a test email for a template", async () => {
+    const fetchMock = router({
+      "/api/settings/outreach": { body: { settings: SETTINGS, nextDeadline: "2026-08-01" } },
+      "/api/outreach/status": { body: EMPTY_STATUS },
+      "/api/outreach/test-send": { body: { success: true } },
+    });
+    renderWithProviders(<OutreachSettingsPage />);
+    await screen.findByDisplayValue("Time to {{actionWord}}");
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Send test to me/ })[0]);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/outreach/test-send", expect.objectContaining({ method: "POST" })));
+  });
+
+  it("rejects saving an unknown token with a visible error", async () => {
+    router({
+      "/api/settings/outreach": { GET: { body: { settings: SETTINGS, nextDeadline: "2026-08-01" } }, PUT: { status: 400, body: { error: "Unknown token {{bogus}} in outreachOpeningSubject" } } },
+      "/api/outreach/status": { body: EMPTY_STATUS },
+    });
+    renderWithProviders(<OutreachSettingsPage />);
+    await screen.findByDisplayValue("Time to {{actionWord}}");
+
+    const subjectInputs = screen.getAllByLabelText("Subject");
+    fireEvent.change(subjectInputs[0], { target: { value: "{{bogus}}" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save templates" }));
+
+    expect(await screen.findByText(/Unknown token \{\{bogus\}\}/)).toBeInTheDocument();
+  });
+
+  it("send panel: confirm dialog shows counts, then draining reaches 100%", async () => {
+    router({
+      "/api/settings/outreach": { body: { settings: SETTINGS, nextDeadline: "2026-08-01" } },
+      "/api/outreach/status": { body: EMPTY_STATUS },
+      "/api/outreach/send": { body: { bulkSend: { id: 1 }, counts: { queued: 10, skippedUnsubscribed: 2, leadsWithoutEmail: 1, total: 10 } } },
+      "/api/outreach/process-batch": { body: { bulkSendId: 1, processed: 10, remaining: 0 } },
+    });
+    renderWithProviders(<OutreachSettingsPage />);
+    await screen.findByDisplayValue("Time to {{actionWord}}");
+
+    fireEvent.click(screen.getByRole("button", { name: "Send Opening-of-renewals campaign" }));
+
+    const modal = await screen.findByRole("dialog", { name: "Confirm send" });
+    expect(within(modal).getByText(/10/)).toBeInTheDocument();
+    expect(within(modal).getByText(/2 more are skipped/)).toBeInTheDocument();
+
+    fireEvent.click(within(modal).getByRole("button", { name: "Send now" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Confirm send" })).not.toBeInTheDocument());
+  });
+
+  it("offers Resume for an in-flight send reported by status", async () => {
+    router({
+      "/api/settings/outreach": { body: { settings: SETTINGS, nextDeadline: "2026-08-01" } },
+      "/api/outreach/status": {
+        body: {
+          inFlight: { id: 5, emailType: "opening", audience: "a", startedAt: new Date().toISOString(), completedAt: null, counts: { queued: 3, sent: 7, failed: 0, skipped_unsubscribed: 0, sending: 0, total: 10 } },
+          lastCompleted: null,
+        },
+      },
+    });
+    renderWithProviders(<OutreachSettingsPage />);
+
+    expect(await screen.findByRole("button", { name: "Resume send" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Send Opening-of-renewals campaign/ })).not.toBeInTheDocument();
+  });
+
+  it("shows a Retry-failed button when the last completed send had failures", async () => {
+    router({
+      "/api/settings/outreach": { body: { settings: SETTINGS, nextDeadline: "2026-08-01" } },
+      "/api/outreach/status": {
+        body: {
+          inFlight: null,
+          lastCompleted: { id: 9, emailType: "reminder", audience: "c", startedAt: new Date().toISOString(), completedAt: new Date().toISOString(), counts: { queued: 0, sent: 8, failed: 2, skipped_unsubscribed: 0, sending: 0, total: 10 } },
+        },
+      },
+    });
+    renderWithProviders(<OutreachSettingsPage />);
+
+    expect(await screen.findByRole("button", { name: /Retry 2 failed/ })).toBeInTheDocument();
+  });
+});

--- a/checkin-app/src/app/settings/outreach/page.tsx
+++ b/checkin-app/src/app/settings/outreach/page.tsx
@@ -1,0 +1,436 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Alert, Badge, Button, Card, Center, Group, Loader, Modal, Progress, Radio, Stack, Text, Textarea, TextInput, Title,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
+import { SettingsTabs } from "@/components/admin/SettingsTabs";
+import { useRequireRole } from "@/hooks/useRequireRole";
+import { useUnsavedGuard, shallowEqual } from "@/components/UnsavedChangesProvider";
+import { substituteTokens } from "@/lib/outreach/tokens";
+
+type TemplateKey = "opening" | "reminder";
+
+interface Settings {
+  outreachOpeningSubject: string | null;
+  outreachOpeningBody: string | null;
+  outreachReminderSubject: string | null;
+  outreachReminderBody: string | null;
+}
+
+interface Counts {
+  queued: number;
+  sent: number;
+  failed: number;
+  skipped_unsubscribed: number;
+  sending: number;
+  total: number;
+}
+
+interface BulkSendSummary {
+  id: number;
+  emailType: string;
+  audience: string;
+  startedAt: string;
+  completedAt: string | null;
+  counts: Counts;
+}
+
+const SAMPLE_NAME = "Jordan Rivera";
+const TEMPLATE_LABEL: Record<TemplateKey, string> = { opening: "Opening of renewals", reminder: "Reminder" };
+const AUDIENCE_LABEL: Record<string, string> = {
+  a: "Unsettled members + non-members (default)",
+  b: "Same as (a), excluding in-flight renewals/applications",
+  c: "Everyone (all live leads with an email)",
+};
+
+export default function OutreachSettingsPage() {
+  const { ready, loading: authLoading } = useRequireRole(["isBoardMember", "isSysadmin", "isOperations"]);
+
+  const [loading, setLoading] = useState(true);
+  const [opening, setOpening] = useState({ subject: "", body: "" });
+  const [reminder, setReminder] = useState({ subject: "", body: "" });
+  const [initial, setInitial] = useState<{ opening: { subject: string; body: string }; reminder: { subject: string; body: string } } | null>(null);
+  const [nextDeadline, setNextDeadline] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveNotice, setSaveNotice] = useState<{ text: string; err: boolean } | null>(null);
+  const [testSending, setTestSending] = useState<TemplateKey | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/settings/outreach");
+      if (res.ok) {
+        const data = (await res.json()) as { settings: Settings; nextDeadline: string | null };
+        const snap = {
+          opening: { subject: data.settings.outreachOpeningSubject ?? "", body: data.settings.outreachOpeningBody ?? "" },
+          reminder: { subject: data.settings.outreachReminderSubject ?? "", body: data.settings.outreachReminderBody ?? "" },
+        };
+        setOpening(snap.opening);
+        setReminder(snap.reminder);
+        setInitial(snap);
+        setNextDeadline(data.nextDeadline);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (ready) load();
+  }, [ready, load]);
+
+  const isDirty = !!initial && !shallowEqual(
+    { os: initial.opening.subject, ob: initial.opening.body, rs: initial.reminder.subject, rb: initial.reminder.body },
+    { os: opening.subject, ob: opening.body, rs: reminder.subject, rb: reminder.body },
+  );
+  useUnsavedGuard(isDirty);
+
+  const saveSettings = async () => {
+    setSaveNotice(null);
+    setSaving(true);
+    try {
+      const res = await fetch("/api/settings/outreach", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          outreachOpeningSubject: opening.subject,
+          outreachOpeningBody: opening.body,
+          outreachReminderSubject: reminder.subject,
+          outreachReminderBody: reminder.body,
+        }),
+      });
+      if (res.ok) {
+        notifications.show({ color: "green", message: "Outreach templates saved." });
+        await load();
+      } else {
+        const d = await res.json().catch(() => ({}));
+        setSaveNotice({ text: d.error || "Save failed.", err: true });
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const sendTest = async (key: TemplateKey) => {
+    const t = key === "opening" ? opening : reminder;
+    setTestSending(key);
+    try {
+      const res = await fetch("/api/outreach/test-send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ subject: t.subject, body: t.body }),
+      });
+      const d = await res.json().catch(() => ({}));
+      if (res.ok) notifications.show({ color: "green", message: "Test email sent (both variants) to your address." });
+      else notifications.show({ color: "red", message: d.error || "Test send failed.", autoClose: false });
+    } catch {
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
+    } finally {
+      setTestSending(null);
+    }
+  };
+
+  if (authLoading) return <Center mih="60vh"><Loader /></Center>;
+  if (!ready) return null; // redirect to / is in flight
+
+  return (
+    <Stack>
+      <SettingsTabs active="outreach" />
+
+      {loading ? (
+        <Center py="xl"><Loader /></Center>
+      ) : (
+        <>
+          {nextDeadline === null && (
+            <Alert color="red" variant="light">
+              The membership-year boundary is not set (Settings → Membership). <code>{"{{deadline}}"}</code> has
+              nothing to render — sending (test or campaign) is blocked until it is configured.
+            </Alert>
+          )}
+
+          <TemplateCard
+            title={TEMPLATE_LABEL.opening}
+            value={opening}
+            onChange={setOpening}
+            deadline={nextDeadline}
+            testSending={testSending === "opening"}
+            onSendTest={() => sendTest("opening")}
+          />
+          <TemplateCard
+            title={TEMPLATE_LABEL.reminder}
+            value={reminder}
+            onChange={setReminder}
+            deadline={nextDeadline}
+            testSending={testSending === "reminder"}
+            onSendTest={() => sendTest("reminder")}
+          />
+
+          {saveNotice && <Alert color={saveNotice.err ? "red" : "green"} variant="light">{saveNotice.text}</Alert>}
+          <Group>
+            <Button disabled={saving} loading={saving} onClick={saveSettings}>Save templates</Button>
+          </Group>
+
+          <SendPanel deadlineSet={nextDeadline !== null} />
+        </>
+      )}
+    </Stack>
+  );
+}
+
+function TemplateCard({
+  title, value, onChange, deadline, testSending, onSendTest,
+}: {
+  title: string;
+  value: { subject: string; body: string };
+  onChange: (v: { subject: string; body: string }) => void;
+  deadline: string | null;
+  testSending: boolean;
+  onSendTest: () => void;
+}) {
+  const deadlineText = deadline ?? "(boundary not set)";
+  const preview = (variant: "join" | "renew") =>
+    substituteTokens(value.body, {
+      name: SAMPLE_NAME,
+      deadline: deadlineText,
+      actionWord: variant === "renew" ? "renew" : "join",
+      actionLink: "/membership",
+    }) + (variant === "join" ? '<p><a href="#">Unsubscribe from invitations</a></p>' : "");
+  const previewSubject = (variant: "join" | "renew") =>
+    substituteTokens(value.subject, {
+      name: SAMPLE_NAME,
+      deadline: deadlineText,
+      actionWord: variant === "renew" ? "renew" : "join",
+      actionLink: "/membership",
+    });
+
+  return (
+    <Card withBorder radius="md" padding="lg">
+      <Title order={3} mb="xs">{title}</Title>
+      <Text c="dimmed" size="sm" mb="md">
+        Tokens: <code>{"{{name}}"}</code> <code>{"{{deadline}}"}</code> <code>{"{{actionWord}}"}</code> <code>{"{{actionLink}}"}</code>.
+        {" "}The action link always points at <code>/membership</code>, for both members and non-members.
+      </Text>
+
+      <Stack gap="sm">
+        <TextInput
+          label="Subject"
+          value={value.subject}
+          onChange={(e) => onChange({ ...value, subject: e.currentTarget.value })}
+        />
+        <Textarea
+          label="Body (HTML)"
+          minRows={6}
+          autosize
+          value={value.body}
+          onChange={(e) => onChange({ ...value, body: e.currentTarget.value })}
+        />
+      </Stack>
+
+      <Group mt="md" grow align="flex-start">
+        {(["join", "renew"] as const).map((variant) => (
+          <Card key={variant} withBorder padding="sm" radius="sm">
+            <Badge size="sm" mb="xs" variant="light">{variant === "join" ? "Join (non-member preview)" : "Renew (member preview)"}</Badge>
+            <Text fw={600} size="sm" mb={4}>{previewSubject(variant)}</Text>
+            <div style={{ fontSize: 13 }} dangerouslySetInnerHTML={{ __html: preview(variant) }} />
+          </Card>
+        ))}
+      </Group>
+
+      <Button mt="md" variant="light" loading={testSending} onClick={onSendTest}>
+        Send test to me (both variants)
+      </Button>
+    </Card>
+  );
+}
+
+function SendPanel({ deadlineSet }: { deadlineSet: boolean }) {
+  const [audience, setAudience] = useState<"a" | "b" | "c">("a");
+  const [panelLoading, setPanelLoading] = useState(true);
+  const [inFlight, setInFlight] = useState<BulkSendSummary | null>(null);
+  const [lastCompleted, setLastCompleted] = useState<BulkSendSummary | null>(null);
+  const [draining, setDraining] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [confirm, setConfirm] = useState<{ emailType: TemplateKey; bulkSendId: number; counts: { queued: number; skippedUnsubscribed: number; leadsWithoutEmail: number } } | null>(null);
+  const [confirmOpened, { open: openConfirm, close: closeConfirm }] = useDisclosure(false);
+  const [starting, setStarting] = useState<TemplateKey | null>(null);
+
+  const refreshStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/outreach/status");
+      if (res.ok) {
+        const data = (await res.json()) as { inFlight: BulkSendSummary | null; lastCompleted: BulkSendSummary | null };
+        setInFlight(data.inFlight);
+        setLastCompleted(data.lastCompleted);
+      }
+    } finally {
+      setPanelLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { refreshStatus(); }, [refreshStatus]);
+
+  const drain = async (bulkSendId: number) => {
+    setDraining(true);
+    setSendError(null);
+    try {
+      for (;;) {
+        const res = await fetch("/api/outreach/process-batch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bulkSendId }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) { setSendError(data.error || "Send failed mid-batch."); break; }
+        await refreshStatus();
+        if (data.remaining === 0 || data.processed === 0) break;
+      }
+    } finally {
+      setDraining(false);
+    }
+  };
+
+  const startSend = async (emailType: TemplateKey) => {
+    setSendError(null);
+    setStarting(emailType);
+    try {
+      const res = await fetch("/api/outreach/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ emailType, audience }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.status === 409) { setSendError(data.error || "A send is already in progress."); await refreshStatus(); return; }
+      if (!res.ok) { setSendError(data.error || "Failed to start send."); return; }
+      setConfirm({
+        emailType,
+        bulkSendId: data.bulkSend.id,
+        counts: { queued: data.counts.queued, skippedUnsubscribed: data.counts.skippedUnsubscribed, leadsWithoutEmail: data.counts.leadsWithoutEmail },
+      });
+      openConfirm();
+    } catch {
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
+    } finally {
+      setStarting(null);
+    }
+  };
+
+  const confirmSend = async () => {
+    if (!confirm) return;
+    closeConfirm();
+    const id = confirm.bulkSendId;
+    setConfirm(null);
+    await drain(id);
+  };
+
+  const retryFailed = async (bulkSendId: number) => {
+    setSendError(null);
+    const res = await fetch("/api/outreach/status", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "retry", bulkSendId }),
+    });
+    if (res.ok) {
+      await refreshStatus();
+      await drain(bulkSendId);
+    } else {
+      const d = await res.json().catch(() => ({}));
+      setSendError(d.error || "Retry failed.");
+    }
+  };
+
+  const progress = (c: Counts) => (c.total === 0 ? 100 : Math.round(((c.sent + c.failed + c.skipped_unsubscribed) / c.total) * 100));
+
+  return (
+    <Card withBorder radius="md" padding="lg" style={{ borderColor: "var(--mantine-color-yellow-5)" }}>
+      <Title order={3} mb="xs">Send a campaign</Title>
+      <Text c="dimmed" size="sm" mb="md">
+        One email per live household lead with an email; the copy resolves join vs. renew from
+        current membership. Sending is manual — nothing here runs on a schedule.
+      </Text>
+
+      {panelLoading ? (
+        <Center py="md"><Loader size="sm" /></Center>
+      ) : inFlight ? (
+        <Stack>
+          <Alert color="blue" variant="light">
+            A {TEMPLATE_LABEL[inFlight.emailType as TemplateKey] ?? inFlight.emailType} send (audience {inFlight.audience}) is
+            in progress — {inFlight.counts.sent + inFlight.counts.failed + inFlight.counts.skipped_unsubscribed} of{" "}
+            {inFlight.counts.total} done.
+          </Alert>
+          <Progress value={progress(inFlight.counts)} animated={draining} />
+          <Group>
+            <Button loading={draining} onClick={() => drain(inFlight.id)}>Resume send</Button>
+            {inFlight.counts.failed > 0 && (
+              <Button variant="light" color="orange" loading={draining} onClick={() => retryFailed(inFlight.id)}>
+                Retry {inFlight.counts.failed} failed
+              </Button>
+            )}
+          </Group>
+        </Stack>
+      ) : (
+        <Stack>
+          <Radio.Group label="Audience" value={audience} onChange={(v) => setAudience(v as "a" | "b" | "c")}>
+            <Stack gap={4} mt="xs">
+              {(["a", "b", "c"] as const).map((key) => (
+                <Radio key={key} value={key} label={AUDIENCE_LABEL[key]} />
+              ))}
+            </Stack>
+          </Radio.Group>
+          <Text size="xs" c="dimmed">
+            Off-season, no member has yet &quot;settled&quot; for the coming cycle — presets (a) and (b) count
+            every current member until the renewal window opens.
+          </Text>
+
+          <Group>
+            <Button disabled={!deadlineSet} loading={starting === "opening"} onClick={() => startSend("opening")}>
+              Send Opening-of-renewals campaign
+            </Button>
+            <Button disabled={!deadlineSet} loading={starting === "reminder"} onClick={() => startSend("reminder")}>
+              Send Reminder campaign
+            </Button>
+          </Group>
+
+          {lastCompleted && (
+            <Text size="sm" c="dimmed">
+              Last sent: {TEMPLATE_LABEL[lastCompleted.emailType as TemplateKey] ?? lastCompleted.emailType} (audience{" "}
+              {lastCompleted.audience}) — {lastCompleted.counts.sent} sent, {lastCompleted.counts.failed} failed,{" "}
+              {lastCompleted.counts.skipped_unsubscribed} skipped (unsubscribed), on{" "}
+              {lastCompleted.completedAt ? new Date(lastCompleted.completedAt).toLocaleString() : ""}.
+              {lastCompleted.counts.failed > 0 && (
+                <>
+                  {" "}
+                  <Button size="compact-xs" variant="light" color="orange" onClick={() => retryFailed(lastCompleted.id)}>
+                    Retry {lastCompleted.counts.failed} failed
+                  </Button>
+                </>
+              )}
+            </Text>
+          )}
+        </Stack>
+      )}
+
+      {sendError && <Alert color="red" variant="light" mt="md">{sendError}</Alert>}
+
+      <Modal opened={confirmOpened} onClose={closeConfirm} title="Confirm send" centered>
+        {confirm && (
+          <Stack>
+            <Text>
+              This will send to <strong>{confirm.counts.queued}</strong> recipient(s).{" "}
+              {confirm.counts.skippedUnsubscribed > 0 && <>{confirm.counts.skippedUnsubscribed} more are skipped (unsubscribed). </>}
+              {confirm.counts.leadsWithoutEmail > 0 && <>{confirm.counts.leadsWithoutEmail} household lead(s) have no email on file and are not counted.</>}
+            </Text>
+            <Group justify="flex-end">
+              <Button variant="default" onClick={closeConfirm}>Cancel</Button>
+              <Button onClick={confirmSend}>Send now</Button>
+            </Group>
+          </Stack>
+        )}
+      </Modal>
+    </Card>
+  );
+}

--- a/checkin-app/src/app/settings/outreach/page.tsx
+++ b/checkin-app/src/app/settings/outreach/page.tsx
@@ -236,7 +236,16 @@ function TemplateCard({
           <Card key={variant} withBorder padding="sm" radius="sm">
             <Badge size="sm" mb="xs" variant="light">{variant === "join" ? "Join (non-member preview)" : "Renew (member preview)"}</Badge>
             <Text fw={600} size="sm" mb={4}>{previewSubject(variant)}</Text>
-            <div style={{ fontSize: 13 }} dangerouslySetInnerHTML={{ __html: preview(variant) }} />
+            {/* Template body is operator-authored HTML (PUT is open to isOperations). Render it in a
+                scriptless sandboxed iframe so an <img onerror> can't run in a board/sysadmin session
+                that opens this same-origin admin page — sandbox="" blocks scripts while still showing
+                the markup a mail client would. */}
+            <iframe
+              title={`${title}: ${variant} preview`}
+              sandbox=""
+              srcDoc={`<style>body{margin:0;font:13px system-ui,sans-serif}</style>${preview(variant)}`}
+              style={{ border: 0, width: "100%", height: 160 }}
+            />
           </Card>
         ))}
       </Group>

--- a/checkin-app/src/components/admin/SettingsTabs.tsx
+++ b/checkin-app/src/components/admin/SettingsTabs.tsx
@@ -9,12 +9,13 @@ import { useTodoCounts } from "@/hooks/useTodoCounts";
 import { settingsMisconfigBadge } from "@/components/navBadges";
 import { CountBadge } from "@/components/ui/CountBadge";
 
-export type SettingsTab = "membership" | "localization" | "email" | "shopify-webhook";
+export type SettingsTab = "membership" | "localization" | "email" | "shopify-webhook" | "outreach";
 
 // sysadminOnly tabs are hidden from board members (the /settings layout admits both).
 const TABS: { value: SettingsTab; label: string; href: string; sysadminOnly?: boolean }[] = [
   { value: "membership", label: "Membership Settings", href: "/settings/membership" },
   { value: "email", label: "Email", href: "/settings/email" },
+  { value: "outreach", label: "Outreach", href: "/settings/outreach" },
   { value: "shopify-webhook", label: "Shopify Webhook", href: "/settings/shopify-webhook" },
   { value: "localization", label: "Localization", href: "/settings/localization", sysadminOnly: true },
 ];

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -12,6 +12,7 @@ export type RegistryUser = {
   isSysadmin?: boolean;
   isBoardMember?: boolean;
   isKeyholder?: boolean;
+  isOperations?: boolean;
   householdLead?: boolean;
   toolStatuses?: Array<{ level: string }>;
 };
@@ -28,6 +29,8 @@ const HOUSEHOLD_LEAD: Visible = (u, signedIn) => signedIn && !!u?.householdLead;
 // Program lead mentors only — mirrors the staff "My Programs" nav gate.
 const LEADS_PROGRAM: Visible = (_u, signedIn, counts) => signedIn && leadsAnyProgram(counts);
 const BOARD: Visible = (u) => !!u?.isSysadmin || !!u?.isBoardMember;
+// Outreach is the one settings/* page operations can also reach (see settings/layout.tsx).
+const BOARD_OR_OPS: Visible = (u) => !!u?.isSysadmin || !!u?.isBoardMember || !!u?.isOperations;
 // Finance Ops is board-only — sysadmin has no access (issue #1083).
 const BOARD_ONLY: Visible = (u) => !!u?.isBoardMember;
 const SYSADMIN: Visible = (u) => !!u?.isSysadmin;
@@ -140,6 +143,7 @@ export const PAGES: PageEntry[] = [
   { href: '/settings/membership', label: 'Membership Settings', section: 'Settings', visible: BOARD },
   { href: '/settings/localization', label: 'Localization', section: 'Settings', visible: SYSADMIN },
   { href: '/settings/email', label: 'Email Settings', section: 'Settings', keywords: 'sender from reply-to identity', visible: BOARD },
+  { href: '/settings/outreach', label: 'Outreach', section: 'Settings', keywords: 'renewal join campaign email template bulk send reminder opening', visible: BOARD_OR_OPS },
   { href: '/settings/shopify-webhook', label: 'Shopify Webhook', section: 'Settings', keywords: 'orders paid delivery test notification signature secret payment', visible: BOARD },
 ];
 

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -1,8 +1,6 @@
 import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
-import { emailHouseholdLeads } from "@/lib/emailRecipients";
-import { config } from "@/lib/config";
 import { certifyPaymentPlan, PaymentError } from "./payment";
 import { IN_FLIGHT_RENEWAL, grantableRenewalWhere, settledThisCycleWhere, fromWhere } from "@/lib/membership/lifecycle";
 import { LIVE_PERSON } from "@/lib/person/filters";
@@ -142,9 +140,9 @@ export async function runRenewalSweep(now: Date) {
         // cycle — a member who finished renewal early, or the admin "Grant for coming
         // year" override, both leave a terminal (ACTIVE/ARCHIVED) RENEWAL with
         // stageEnteredAt in this window. Without the second clause a completed renewal
-        // gets re-opened + re-reminded, since terminal rows aren't in-flight.
+        // gets re-opened, since terminal rows aren't in-flight.
         select: {
-            id: true, householdId: true,
+            id: true,
             processes: {
                 where: {
                     kind: "RENEWAL",
@@ -163,7 +161,7 @@ export async function runRenewalSweep(now: Date) {
     let skipped = 0;
     for (const m of memberships) {
         if (m.processes.length > 0) { skipped++; continue; } // already opened this cycle
-        const p = await createRenewalProcess(m.id, m.householdId, now, { remind: true, boundary });
+        const p = await createRenewalProcess(m.id);
         if (p) opened++; else skipped++; // null = concurrent run beat us to it
     }
 
@@ -220,18 +218,23 @@ export async function beginRenewal(processId: number) {
 }
 
 /**
- * Create one PENDING_RENEWAL process (+ audit, optional reminder), or no-op if one
- * is already in flight. The callers' check-then-act is NOT atomic, so this function
- * serializes its own check+insert by locking the parent Membership row (SELECT ...
- * FOR UPDATE): a concurrent sweep/admin-button/double-click blocks until the winner
- * commits, then sees the winner's in-flight process and returns null — no duplicate
- * audit row, no duplicate household reminder. This holds in every environment, not
- * just one provisioned via `migrate deploy` (the partial unique index
- * `membership_one_inflight_renewal` is migration-only — `prisma db push` and the
- * integration test DBs don't have it). The index stays as defense-in-depth and the
- * P2002 catch as a backstop. Returns null when this call lost the race.
+ * Create one PENDING_RENEWAL process (+ audit), or no-op if one is already in flight.
+ * The callers' check-then-act is NOT atomic, so this function serializes its own
+ * check+insert by locking the parent Membership row (SELECT ... FOR UPDATE): a
+ * concurrent sweep/admin-button/double-click blocks until the winner commits, then
+ * sees the winner's in-flight process and returns null — no duplicate audit row.
+ * This holds in every environment, not just one provisioned via `migrate deploy`
+ * (the partial unique index `membership_one_inflight_renewal` is migration-only —
+ * `prisma db push` and the integration test DBs don't have it). The index stays as
+ * defense-in-depth and the P2002 catch as a backstop. Returns null when this call
+ * lost the race.
+ *
+ * Never emails — the machine (sweep, go-live button) never sends a reminder; the
+ * settings/outreach page is the only send surface (see lib/outreach). householdId/now/
+ * boundary dropped from the signature (#PR-2) along with the reminder they only existed
+ * to feed — renewalReminderSentAt is now write-never (column kept, see its schema doc).
  */
-export async function createRenewalProcess(orgMembershipId: number, householdId: number, now: Date, opts: { remind: boolean; boundary: Date }) {
+export async function createRenewalProcess(orgMembershipId: number) {
     let process;
     try {
         process = await prisma.$transaction(async (tx) => {
@@ -243,7 +246,7 @@ export async function createRenewalProcess(orgMembershipId: number, householdId:
             });
             if (existing) return null; // someone else already opened the renewal
             const created = await tx.orgMembershipProcess.create({
-                data: { orgMembershipId, kind: "RENEWAL", status: "PENDING_RENEWAL", renewalReminderSentAt: opts.remind ? now : null },
+                data: { orgMembershipId, kind: "RENEWAL", status: "PENDING_RENEWAL" },
             });
             await tx.auditLog.create({
                 data: { actorId: SYSTEM_ACTOR, action: "CREATE", tableName: "OrgMembershipProcess", affectedEntityId: created.id, newData: { kind: "RENEWAL", status: "PENDING_RENEWAL" } },
@@ -261,25 +264,18 @@ export async function createRenewalProcess(orgMembershipId: number, householdId:
         logger.info("Renewal already in flight for membership %d — concurrent open, skipping", orgMembershipId);
         return null;
     }
-    if (opts.remind) await remindHousehold(householdId, opts.boundary);
     return process;
 }
 
 /**
  * Go-live migration: open a renewal cycle for EVERY active membership that isn't
- * already mid-renewal, ignoring the date window. Reminders are opt-in (default
- * off) to avoid an unexpected mass email blast on the button press — the board
- * can send them deliberately or let the normal cron remind on schedule.
+ * already mid-renewal, ignoring the date window. Never emails — see createRenewalProcess.
  */
-export async function openRenewalsForAllActive(now: Date, opts: { sendReminders?: boolean } = {}) {
-    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, now) : now;
-
+export async function openRenewalsForAllActive() {
     const memberships = await prisma.orgMembership.findMany({
         where: { status: "ACTIVE" },
         select: {
             id: true,
-            householdId: true,
             processes: { where: { kind: "RENEWAL", status: { in: [...IN_FLIGHT_RENEWAL] } }, select: { id: true } },
         },
     });
@@ -288,7 +284,7 @@ export async function openRenewalsForAllActive(now: Date, opts: { sendReminders?
     let skipped = 0;
     for (const m of memberships) {
         if (m.processes.length > 0) { skipped++; continue; }
-        const p = await createRenewalProcess(m.id, m.householdId, now, { remind: !!opts.sendReminders, boundary });
+        const p = await createRenewalProcess(m.id);
         if (p) opened++; else skipped++; // null = concurrent run beat us to it
     }
     return { opened, skipped };
@@ -368,15 +364,4 @@ export async function grantRenewalPayment(
     });
 
     return prisma.orgMembershipProcess.findUniqueOrThrow({ where: { id: process.id } });
-}
-
-async function remindHousehold(householdId: number, boundary: Date) {
-    const base = config.baseUrl();
-    const due = boundary.toISOString().slice(0, 10);
-    await emailHouseholdLeads(
-        householdId,
-        "Time to renew your Treehouse membership",
-        `<p>Your household membership is up for renewal by ${due}. Please sign in to renew: <a href="${base}/membership">${base}/membership</a></p>`,
-        "Renewal reminder failed:",
-    );
 }

--- a/checkin-app/src/lib/outreach/__tests__/render.test.ts
+++ b/checkin-app/src/lib/outreach/__tests__/render.test.ts
@@ -1,0 +1,58 @@
+import { renderOutreachEmail } from '@/lib/outreach/render';
+
+describe('renderOutreachEmail', () => {
+    const prevSecret = process.env.NEXTAUTH_SECRET;
+    const prevUrl = process.env.NEXTAUTH_URL;
+    const boundary = new Date(Date.UTC(2026, 7, 1)); // Aug 1 2026
+
+    beforeAll(() => {
+        process.env.NEXTAUTH_SECRET = 'unit-test-nextauth-secret';
+        process.env.NEXTAUTH_URL = 'http://localhost:4000';
+    });
+    afterAll(() => {
+        if (prevSecret === undefined) delete process.env.NEXTAUTH_SECRET; else process.env.NEXTAUTH_SECRET = prevSecret;
+        if (prevUrl === undefined) delete process.env.NEXTAUTH_URL; else process.env.NEXTAUTH_URL = prevUrl;
+    });
+
+    it('renders {{deadline}} as YYYY-MM-DD from the resolved boundary', () => {
+        const { subject } = renderOutreachEmail('Renew by {{deadline}}', 'body', { name: 'A', variant: 'renew', boundary });
+        expect(subject).toBe('Renew by 2026-08-01');
+    });
+
+    it('escapes {{name}} — an XSS payload in the name renders as text', () => {
+        const { html } = renderOutreachEmail('s', 'Hello {{name}}', {
+            name: '<script>alert(1)</script>', variant: 'join', boundary, personId: 1,
+        });
+        expect(html).not.toContain('<script>');
+        expect(html).toContain('&lt;script&gt;');
+    });
+
+    it('actionWord is "renew" for the renew variant and "join" for join', () => {
+        const renew = renderOutreachEmail('{{actionWord}}', 'b', { name: 'A', variant: 'renew', boundary });
+        const join = renderOutreachEmail('{{actionWord}}', 'b', { name: 'A', variant: 'join', boundary, personId: 1 });
+        expect(renew.subject).toBe('renew');
+        expect(join.subject).toBe('join');
+    });
+
+    it('actionLink is /membership for BOTH variants', () => {
+        const renew = renderOutreachEmail('s', '{{actionLink}}', { name: 'A', variant: 'renew', boundary });
+        const join = renderOutreachEmail('s', '{{actionLink}}', { name: 'A', variant: 'join', boundary, personId: 1 });
+        // Renew has no footer, so its body IS the rendered actionLink, verbatim.
+        expect(renew.html).toBe('http://localhost:4000/membership');
+        // Join gets the same actionLink, plus its footer appended after it.
+        expect(join.html.startsWith('http://localhost:4000/membership')).toBe(true);
+    });
+
+    it('appends the unsubscribe footer to the JOIN variant only, when a personId is given', () => {
+        const join = renderOutreachEmail('s', 'body', { name: 'A', variant: 'join', boundary, personId: 99 });
+        const renew = renderOutreachEmail('s', 'body', { name: 'A', variant: 'renew', boundary, personId: 99 });
+        expect(join.html).toContain('Unsubscribe from invitations');
+        expect(join.html).toContain('/api/unsubscribe?p=99&sig=');
+        expect(renew.html).not.toContain('Unsubscribe from invitations');
+    });
+
+    it('omits the footer for a join render with no personId (e.g. a preview with no real recipient)', () => {
+        const { html } = renderOutreachEmail('s', 'body', { name: 'A', variant: 'join', boundary });
+        expect(html).not.toContain('Unsubscribe from invitations');
+    });
+});

--- a/checkin-app/src/lib/outreach/__tests__/tokens.test.ts
+++ b/checkin-app/src/lib/outreach/__tests__/tokens.test.ts
@@ -1,0 +1,56 @@
+import { findUnknownTokens, substituteTokens } from '@/lib/outreach/tokens';
+
+describe('findUnknownTokens', () => {
+    it('accepts every legal token and reports none', () => {
+        expect(findUnknownTokens('{{name}} {{deadline}} {{actionWord}} {{actionLink}}')).toEqual([]);
+    });
+
+    it('tolerates surrounding whitespace inside the braces', () => {
+        expect(findUnknownTokens('{{ name }} {{  deadline  }}')).toEqual([]);
+    });
+
+    it('reports an unknown token name', () => {
+        expect(findUnknownTokens('Click {{unsubscribeUrl}} now')).toEqual(['unsubscribeUrl']);
+    });
+
+    it('dedupes a repeated unknown token', () => {
+        expect(findUnknownTokens('{{foo}} and {{foo}} again')).toEqual(['foo']);
+    });
+
+    it('reports every distinct unknown token', () => {
+        expect(findUnknownTokens('{{foo}} {{bar}} {{name}}').sort()).toEqual(['bar', 'foo']);
+    });
+
+    it('is empty for plain text with no tokens', () => {
+        expect(findUnknownTokens('Just a plain sentence.')).toEqual([]);
+    });
+});
+
+describe('substituteTokens', () => {
+    const ctx = { name: 'Jordan Rivera', deadline: '2026-08-01', actionWord: 'renew', actionLink: '/membership' };
+
+    it('substitutes every legal token', () => {
+        expect(substituteTokens('{{name}}: {{deadline}} / {{actionWord}} / {{actionLink}}', ctx))
+            .toBe('Jordan Rivera: 2026-08-01 / renew / /membership');
+    });
+
+    it('HTML-escapes {{name}} — an XSS payload renders as text, not markup', () => {
+        const evil = { ...ctx, name: '<img src=x onerror=alert(1)>' };
+        const out = substituteTokens('Hello {{name}}', evil);
+        expect(out).not.toContain('<img');
+        expect(out).toBe('Hello &lt;img src=x onerror=alert(1)&gt;');
+    });
+
+    it('does not escape deadline/actionWord/actionLink (server-controlled, not user text)', () => {
+        const out = substituteTokens('{{actionLink}}', { ...ctx, actionLink: '/membership?a=1&b=2' });
+        expect(out).toBe('/membership?a=1&b=2');
+    });
+
+    it('leaves an unknown token literally in place (save-time validation is what blocks it)', () => {
+        expect(substituteTokens('{{name}} {{bogus}}', ctx)).toBe('Jordan Rivera {{bogus}}');
+    });
+
+    it('substitutes repeated occurrences of the same token', () => {
+        expect(substituteTokens('{{name}}, again {{name}}!', ctx)).toBe('Jordan Rivera, again Jordan Rivera!');
+    });
+});

--- a/checkin-app/src/lib/outreach/__tests__/unsubscribeToken.test.ts
+++ b/checkin-app/src/lib/outreach/__tests__/unsubscribeToken.test.ts
@@ -1,0 +1,48 @@
+import { sign, verify } from '@/lib/outreach/unsubscribeToken';
+
+// NEXTAUTH_SECRET is required by config.nextAuthSecret(); tests set it directly rather
+// than relying on .env so this suite is self-contained.
+describe('outreach unsubscribe token (HMAC sign/verify)', () => {
+    const prevSecret = process.env.NEXTAUTH_SECRET;
+
+    beforeAll(() => { process.env.NEXTAUTH_SECRET = 'unit-test-nextauth-secret'; });
+    afterAll(() => {
+        if (prevSecret === undefined) delete process.env.NEXTAUTH_SECRET;
+        else process.env.NEXTAUTH_SECRET = prevSecret;
+    });
+
+    it('verifies a signature it just signed', () => {
+        const token = sign(42);
+        expect(verify(42, token)).toBe(true);
+    });
+
+    it('is deterministic for the same id', () => {
+        expect(sign(7)).toBe(sign(7));
+    });
+
+    it('differs across ids', () => {
+        expect(sign(1)).not.toBe(sign(2));
+    });
+
+    it('rejects a signature checked against the wrong id', () => {
+        const token = sign(42);
+        expect(verify(43, token)).toBe(false);
+    });
+
+    it('rejects a tampered signature', () => {
+        const token = sign(42);
+        const tampered = token.slice(0, -1) + (token.at(-1) === 'a' ? 'b' : 'a');
+        expect(verify(42, tampered)).toBe(false);
+    });
+
+    it('rejects null/undefined/empty tokens without throwing', () => {
+        expect(verify(42, null)).toBe(false);
+        expect(verify(42, undefined)).toBe(false);
+        expect(verify(42, '')).toBe(false);
+    });
+
+    it('rejects a token of a completely different length without throwing', () => {
+        expect(verify(42, 'x')).toBe(false);
+        expect(verify(42, 'x'.repeat(500))).toBe(false);
+    });
+});

--- a/checkin-app/src/lib/outreach/recipients.ts
+++ b/checkin-app/src/lib/outreach/recipients.ts
@@ -1,0 +1,117 @@
+import prisma from "@/lib/prisma";
+import { LIVE_PERSON } from "@/lib/person/filters";
+import { renewalSeasonWindow } from "@/lib/membership/renewal";
+import { IN_FLIGHT_RENEWAL, IN_FLIGHT_INITIAL } from "@/lib/membership/lifecycle";
+import { personRecordIsActiveOrgMember } from "@/lib/orgMembership";
+import type { OrgMembershipProcessStatus } from "@/generated/prisma/client";
+
+export type Audience = "a" | "b" | "c";
+export type OutreachVariant = "join" | "renew";
+export type ItemStatus = "queued" | "skipped_unsubscribed";
+
+export interface RecipientSnapshotItem {
+    personId: number;
+    email: string;
+    variant: OutreachVariant;
+    status: ItemStatus;
+}
+
+export interface RecipientSnapshot {
+    items: RecipientSnapshotItem[];
+    /** isHouseholdLead && LIVE_PERSON && email == null, in the chosen audience's base
+     * population — informational only, these leads get no item. */
+    leadsWithoutEmail: number;
+}
+
+// Off-season / boundary-unset sentinel: `stageEnteredAt >= maxDate` matches nothing, so
+// "settled" is false for everyone (mirrors membershipValidThrough, orgMembership.ts:95).
+const MAX_DATE = new Date(8.64e15);
+
+const IN_FLIGHT_STATUSES = new Set<OrgMembershipProcessStatus>([...IN_FLIGHT_RENEWAL, ...IN_FLIGHT_INITIAL]);
+
+/** Compute the recipient snapshot for one audience preset (see spec §2.2). One query for the
+ * candidate leads (with just enough of their household's membership to decide settled/
+ * in-flight/variant in JS — no per-row N+1), one query for the without-email count. */
+export async function computeRecipientSnapshot(audience: Audience, now = new Date()): Promise<RecipientSnapshot> {
+    const window = await renewalSeasonWindow(now);
+    const windowStart = window?.windowStart ?? MAX_DATE;
+
+    const [leadsWithoutEmail, leads] = await Promise.all([
+        prisma.person.count({ where: { isHouseholdLead: true, email: null, ...LIVE_PERSON } }),
+        prisma.person.findMany({
+            where: { isHouseholdLead: true, email: { not: null }, ...LIVE_PERSON },
+            select: {
+                id: true,
+                email: true,
+                emailSuppressed: true,
+                household: {
+                    select: {
+                        orgMembership: {
+                            select: {
+                                status: true,
+                                // Only the processes relevant to settled/in-flight decisions —
+                                // computed ONCE per snapshot, not re-queried per household.
+                                processes: {
+                                    where: {
+                                        OR: [
+                                            { status: "ACTIVE", stageEnteredAt: { gte: windowStart } },
+                                            { status: { in: [...IN_FLIGHT_STATUSES] } },
+                                        ],
+                                    },
+                                    select: { status: true, stageEnteredAt: true },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }),
+    ]);
+
+    const byEmail = new Map<string, { personId: number; email: string; variant: OutreachVariant; emailSuppressed: boolean }>();
+
+    for (const lead of leads) {
+        if (!lead.email) continue; // narrows for TS; the where already excludes this
+        const membership = lead.household.orgMembership;
+        const isMember = membership?.status === "ACTIVE";
+
+        if (audience !== "c") {
+            const settled = (membership?.processes ?? []).some(
+                (p) => p.status === "ACTIVE" && p.stageEnteredAt != null && p.stageEnteredAt.getTime() >= windowStart.getTime(),
+            );
+            if (isMember && settled) continue; // excluded from both (a) and (b)
+
+            if (audience === "b") {
+                const inFlight = (membership?.processes ?? []).some((p) => IN_FLIGHT_STATUSES.has(p.status));
+                if (inFlight) continue;
+            }
+        }
+
+        const variant: OutreachVariant = personRecordIsActiveOrgMember({ household: { orgMembership: membership ?? null } })
+            ? "renew"
+            : "join";
+
+        const key = lead.email.toLowerCase();
+        const existing = byEmail.get(key);
+        // Dedup by lowercased email (mirrors resolveHouseholdRecipients, emailRecipients.ts:31-38).
+        // Person.email is @unique + auto-lowercased at write (prismaEmailNormalize.ts), so two
+        // DISTINCT Person rows can't actually collide here today — this is defense-in-depth
+        // matching that precedent, not a reachable case against the current schema. If any
+        // duplicate resolves to a member, the renew variant wins for the merged item.
+        if (!existing || (variant === "renew" && existing.variant !== "renew")) {
+            byEmail.set(key, { personId: lead.id, email: lead.email, variant, emailSuppressed: lead.emailSuppressed });
+        }
+    }
+
+    const items: RecipientSnapshotItem[] = [...byEmail.values()].map((r) => ({
+        personId: r.personId,
+        email: r.email,
+        variant: r.variant,
+        // Suppression is join-variant-only (binding decision, spec §2.4): renew recipients
+        // are never dropped, and a suppressed join recipient is recorded (not silently
+        // dropped) so the count/ledger stays honest.
+        status: r.variant === "join" && r.emailSuppressed ? "skipped_unsubscribed" : "queued",
+    }));
+
+    return { items, leadsWithoutEmail };
+}

--- a/checkin-app/src/lib/outreach/render.ts
+++ b/checkin-app/src/lib/outreach/render.ts
@@ -1,0 +1,88 @@
+import prisma from "@/lib/prisma";
+import { config } from "@/lib/config";
+import { nextBoundary } from "@/lib/membership/renewal";
+import { substituteTokens, findUnknownTokens } from "@/lib/outreach/tokens";
+import { sign } from "@/lib/outreach/unsubscribeToken";
+
+export { findUnknownTokens };
+
+export type OutreachVariant = "join" | "renew";
+export type EmailType = "opening" | "reminder";
+
+/** The board's current subject/body for one campaign template (BoardSettings singleton). */
+export async function loadTemplate(emailType: EmailType): Promise<{ subject: string; body: string }> {
+    const settings = await prisma.boardSettings.findUnique({
+        where: { id: 1 },
+        select: {
+            outreachOpeningSubject: true,
+            outreachOpeningBody: true,
+            outreachReminderSubject: true,
+            outreachReminderBody: true,
+        },
+    });
+    return emailType === "opening"
+        ? { subject: settings?.outreachOpeningSubject ?? "", body: settings?.outreachOpeningBody ?? "" }
+        : { subject: settings?.outreachReminderSubject ?? "", body: settings?.outreachReminderBody ?? "" };
+}
+
+/** Thrown by {@link resolveBoundary} when the board hasn't configured the membership-year
+ * boundary. `{{deadline}}` has nothing to render, so create-send blocks on this, surfacing
+ * one clear error in the confirm dialog rather than a per-item failure mid-drain. */
+export class BoundaryNotSetError extends Error {
+    constructor() {
+        super("Set the membership-year boundary (Settings → Membership) before sending.");
+        this.name = "BoundaryNotSetError";
+    }
+}
+
+/** The next occurrence of the board's configured membership-year boundary, or throws. */
+export async function resolveBoundary(now: Date): Promise<Date> {
+    const settings = await prisma.boardSettings.findUnique({
+        where: { id: 1 },
+        select: { orgMembershipYearBoundary: true },
+    });
+    if (!settings?.orgMembershipYearBoundary) throw new BoundaryNotSetError();
+    return nextBoundary(settings.orgMembershipYearBoundary, now);
+}
+
+export interface RenderContext {
+    name: string;
+    variant: OutreachVariant;
+    /** Resolved via {@link resolveBoundary} — computed ONCE per send, not per item. */
+    boundary: Date;
+    /** Needed to build the join-variant unsubscribe footer link. Omit for a preview/test
+     * render that has no real recipient (falls back to no footer). */
+    personId?: number;
+}
+
+/**
+ * Render one recipient's subject+html from the board's template. `{{actionLink}}` is
+ * `/membership` for BOTH variants (see spec §2.3 pin justification) — only
+ * `{{actionWord}}` differs. The join variant gets an unsubscribe footer appended AFTER
+ * token substitution (so the footer link itself is never subject to token rewriting);
+ * renew carries no footer (renewal emails don't offer to unsubscribe from invitations).
+ */
+export function renderOutreachEmail(
+    subjectTemplate: string,
+    bodyTemplate: string,
+    ctx: RenderContext,
+): { subject: string; html: string } {
+    const tokenCtx = {
+        name: ctx.name,
+        deadline: ctx.boundary.toISOString().slice(0, 10),
+        actionWord: ctx.variant === "renew" ? "renew" : "join",
+        actionLink: `${config.baseUrl()}/membership`,
+    };
+    const subject = substituteTokens(subjectTemplate, tokenCtx);
+    let html = substituteTokens(bodyTemplate, tokenCtx);
+    if (ctx.variant === "join" && ctx.personId != null) {
+        html += unsubscribeFooter(ctx.personId);
+    }
+    return { subject, html };
+}
+
+function unsubscribeFooter(personId: number): string {
+    const sig = sign(personId);
+    const url = `${config.baseUrl()}/api/unsubscribe?p=${personId}&sig=${encodeURIComponent(sig)}`;
+    return `<p><a href="${url}">Unsubscribe from invitations</a></p>`;
+}

--- a/checkin-app/src/lib/outreach/tokens.ts
+++ b/checkin-app/src/lib/outreach/tokens.ts
@@ -1,0 +1,44 @@
+import { escapeHtml } from "@/lib/email-templates/base";
+
+/**
+ * Token substitution shared by the server-side render path (lib/outreach/render.ts)
+ * and the settings/outreach page's live client preview. Dependency-free (just
+ * escapeHtml, itself dependency-free) so it is safe to import from a "use client"
+ * component without pulling prisma/crypto into the browser bundle — the ONE source
+ * of substitution logic means the preview can never drift from what actually sends.
+ */
+
+export const ALLOWED_TOKENS = ["name", "deadline", "actionWord", "actionLink"] as const;
+const ALLOWED_TOKEN_SET = new Set<string>(ALLOWED_TOKENS);
+
+const TOKEN_RE = /\{\{\s*(\w+)\s*\}\}/g;
+
+/** Every `{{token}}` name in `text` that is not one of the four legal tokens. */
+export function findUnknownTokens(text: string): string[] {
+    const found = new Set<string>();
+    for (const m of text.matchAll(TOKEN_RE)) {
+        if (!ALLOWED_TOKEN_SET.has(m[1])) found.add(m[1]);
+    }
+    return [...found];
+}
+
+export interface TokenContext {
+    /** Pre-escaped or plain — substituteTokens escapes name itself, so pass raw. */
+    name: string;
+    deadline: string;
+    actionWord: string;
+    actionLink: string;
+}
+
+/** Replace the four legal tokens; `{{name}}` is HTML-escaped, the rest are plain strings the caller controls. */
+export function substituteTokens(template: string, ctx: TokenContext): string {
+    return template.replace(TOKEN_RE, (whole, name: string) => {
+        switch (name) {
+            case "name": return escapeHtml(ctx.name);
+            case "deadline": return ctx.deadline;
+            case "actionWord": return ctx.actionWord;
+            case "actionLink": return ctx.actionLink;
+            default: return whole; // unknown token — left as-is; save-time validation rejects these
+        }
+    });
+}

--- a/checkin-app/src/lib/outreach/unsubscribeToken.ts
+++ b/checkin-app/src/lib/outreach/unsubscribeToken.ts
@@ -1,0 +1,36 @@
+import crypto from "crypto";
+import { config } from "@/lib/config";
+
+/**
+ * Signed, session-less unsubscribe token: HMAC-SHA256 over the bare personId, keyed off
+ * NEXTAUTH_SECRET. Mirrors the Shopify webhook HMAC (src/app/api/webhooks/shopify/route.ts)
+ * and cronAuth's length-safe compare — NOT verify-kiosk.ts's Ed25519 scheme, which is
+ * asymmetric and the wrong model for a server-generated-and-verified token.
+ *
+ * The URL carries both the id and the signature (`?p=<id>&sig=<hmac>`) rather than trusting
+ * a bare id: verify() recomputes sign(id) and timing-safe compares it against the provided
+ * sig, so a tampered id fails unless the attacker also forges its signature.
+ */
+
+function hmacKey(): Buffer {
+    // Derive a distinct key from NEXTAUTH_SECRET rather than using it directly, so this
+    // token family can't be replayed against/confused with any other NEXTAUTH_SECRET-keyed use.
+    return crypto.createHash("sha256").update(`outreach-unsubscribe:${config.nextAuthSecret()}`).digest();
+}
+
+/** The signature for a given personId. */
+export function sign(personId: number): string {
+    return crypto.createHmac("sha256", hmacKey()).update(String(personId)).digest("base64url");
+}
+
+/** Timing-safe check that `token` is the signature for `personId`. */
+export function verify(personId: number, token: string | null | undefined): boolean {
+    if (!token) return false;
+    const expected = sign(personId);
+    // Hash both sides to a fixed length before comparing (same idiom as cronAuth.ts /
+    // the Shopify webhook verify) so timingSafeEqual never throws on a mismatched-length
+    // input and no length information leaks.
+    const a = crypto.createHash("sha256").update(token).digest();
+    const b = crypto.createHash("sha256").update(expected).digest();
+    return crypto.timingSafeEqual(a, b);
+}

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -17,6 +17,7 @@ export const classifications = {
         lastBackgroundCheck: 'internal',
         emailUndeliverableAt: 'internal',
         notificationSettings: 'personal',
+        emailSuppressed: 'personal',
         householdId: 'public',
         isHouseholdLead: 'public',
         mergedIntoId: 'internal',
@@ -124,6 +125,10 @@ export const classifications = {
         emailFromAddress: 'public',
         emailReplyToAddress: 'public',
         scholarshipNotifyEmail: 'internal',
+        outreachOpeningSubject: 'internal',
+        outreachOpeningBody: 'internal',
+        outreachReminderSubject: 'internal',
+        outreachReminderBody: 'internal',
         shopifyOrgMembershipProductId: 'internal',
         shopifyNormalVariantId: 'internal',
         shopifyVolunteerVariantId: 'internal',
@@ -360,6 +365,24 @@ export const classifications = {
         resolutionNote: 'personal',
         detectedAt: 'internal',
     },
+    BulkSend: {
+        id: 'internal',
+        emailType: 'internal',
+        audience: 'internal',
+        senderId: 'internal',
+        startedAt: 'internal',
+        completedAt: 'internal',
+    },
+    BulkSendItem: {
+        id: 'internal',
+        bulkSendId: 'internal',
+        personId: 'internal',
+        email: 'internal',
+        variant: 'internal',
+        status: 'internal',
+        sentAt: 'internal',
+        error: 'internal',
+    },
 } as const;
 
 export const relations = {
@@ -510,6 +533,12 @@ export const relations = {
     DevSentEmail: {
     },
     PaymentException: {
+    },
+    BulkSend: {
+        items: { model: 'BulkSendItem', isList: true },
+    },
+    BulkSendItem: {
+        bulkSend: { model: 'BulkSend', isList: false },
     },
 } as const;
 

--- a/checkin-app/tests/security/routeAuthDrift.test.ts
+++ b/checkin-app/tests/security/routeAuthDrift.test.ts
@@ -58,6 +58,14 @@ const ALLOWLIST = new Set<string>([
     // getOptionalSessionUser doesn't apply. Abuse is bounded by IP + email rate
     // limits inside the handler (see the "email-bomb / DB-spam target" comment).
     'programs/[id]/public-register/route.ts',
+    // Session-less, self-verifying via a signed HMAC token in the URL (?p=&sig=),
+    // NOT a shared-secret family like withCron/withWebhook/withKiosk (no header,
+    // no config-held secret to check) — see lib/outreach/unsubscribeToken.ts. GET
+    // must not flip the flag (mail scanners prefetch GET links) and POST verifies
+    // the token itself, so neither handler fits withAuth/withCron/withWebhook/
+    // withKiosk, and it's genuinely public so getOptionalSessionUser doesn't apply
+    // either. Bad/missing/tampered tokens get a neutral page, no info leak.
+    'unsubscribe/route.ts',
 ]);
 
 const HTTP_METHODS = 'GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS';


### PR DESCRIPTION
PR-2 — the final piece of the interviewed outreach/RBAC series (interview → adversarial challenge → reviewed opus spec → sonnet build → architect review).

**⚠️ Contains #1103's commits until it merges**: this branch is #1104's + #1103's branches merged (both are hard dependencies — `isOperations` and `LIVE_PERSON`). Merge order: #1101→#1102→#1103, #1104, then this — at which point this PR's diff collapses to just the outreach work. The assumed #1103 SHA (6d03626) was verified unchanged at ship time; if #1103 moves before merging, I reconcile.

- **Two templated emails** (Opening of renewals + Reminder) with `{{name}}/{{deadline}}/{{actionWord}}/{{actionLink}}` and per-recipient join-vs-renew; a new Settings → Outreach page (board + sysadmin + operations) with live both-variant preview, send-test-to-me, unknown-token rejection, and a hard block when the membership-year boundary is unset.
- **Delivery that survives deploys**: no cron, no background job — a client-driven chunked drain over a per-recipient ledger. Recipients are snapshotted at create (audience presets: unsettled+non-members / also-skip-in-flight / everyone — with the off-season "nobody is settled" behavior stated in the UI copy next to the count); each item is claimed (`queued→sending`) *before* `sendEmail` for at-most-once delivery under concurrent batch calls; abandoned sends resume; failures retry; one in-flight send at a time is a Serializable-transaction guarantee. The ledger doubles as the last-sent panel.
- **Unsubscribe (join variant only)**: HMAC-signed token; GET shows a confirmation page only — mail scanners prefetch GETs — POST flips the suppression flag; members re-enable from the communication page; an "unsubscribed" pill in the directory keeps exclusions legible. Renew recipients are never suppressed.
- **The machine stops emailing about renewals**: the cron's remind path and the bulk-open button's `sendReminders` option are gone (process opening unchanged) — the outreach page is the only send surface, per the manual-communication model.
- One additive migration; every new scalar sensitivity-tagged; no `src/security` policy edits.

Verified: bare-exit tsc, CI-exact lint, **2178 unit + 1166 integration** green locally against a real Postgres — including the concurrent no-double-send race, resume-after-abandon, preset semantics in and out of season, and the GET-doesn't-flip unsubscribe cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe