### PR TITLE
fix(membership-ops): page-level role guard on import, merge, and volunteer-memberships

### DIFF
--- a/checkin-app/src/app/membership-ops/participants/import/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/import/__tests__/page.test.tsx
@@ -72,4 +72,13 @@ describe("membership-ops/participants/import page", () => {
     );
     expect(await screen.findByText("Imported 1 participant.")).toBeInTheDocument();
   });
+
+  it("renders nothing for a background-check reviewer who navigates directly", () => {
+    setSession({ id: 9, isBackgroundCheckReviewer: true });
+    mockFetchJson({});
+    renderWithProviders(<BulkImportParticipants />);
+
+    expect(screen.queryByRole("button", { name: /Preview Import/ })).not.toBeInTheDocument();
+    expect(screen.queryByText("Bulk Import Participants")).not.toBeInTheDocument();
+  });
 });

--- a/checkin-app/src/app/membership-ops/participants/import/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/import/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import { Alert, Badge, Box, Button, Card, FileInput, Group, List, Stack, Table, Text, Title } from "@mantine/core";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { useRequireRole } from "@/hooks/useRequireRole";
+import { PageLoader } from "@/components/ui/PageLoader";
 
 type RowStatus = "ready" | "update" | "warning" | "error";
 
@@ -40,6 +42,7 @@ const STATUS_META: Record<RowStatus | "all", { label: string; icon: string; colo
 };
 
 export default function BulkImportParticipants() {
+  const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
   const [file, setFile] = useState<File | null>(null);
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
@@ -48,6 +51,14 @@ export default function BulkImportParticipants() {
   const [statusFilter, setStatusFilter] = useState<RowStatus | "all">("all");
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
   const [previewError, setPreviewError] = useState<string | null>(null);
+
+  if (authLoading) {
+    return <PageLoader />;
+  }
+
+  if (!ready) {
+    return null;
+  }
 
   const handleFileChange = (f: File | null) => {
     setFile(f);

--- a/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
@@ -418,4 +418,13 @@ describe("membership-ops/participants/merge page", () => {
     // text is locale/timezone-formatted (toLocaleDateString), so just count them.
     expect(within(alertBox).getAllByRole("radio")).toHaveLength(2);
   });
+
+  it("renders nothing for a background-check reviewer who navigates directly", () => {
+    setSession({ id: 9, isBackgroundCheckReviewer: true });
+    mockRoutes();
+    renderWithProviders(<MergeParticipants />);
+
+    expect(screen.queryByPlaceholderText("Search by name or email...")).not.toBeInTheDocument();
+    expect(screen.queryByText("Keep and augment")).not.toBeInTheDocument();
+  });
 });

--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -6,6 +6,8 @@ import { Alert, Box, Button, Card, Group, List, Paper, Radio, SimpleGrid, Stack,
 import { notifications } from "@mantine/notifications";
 import { AlertBanner } from "@/components/admin/AlertBanner";
 import { MergedBadge } from "@/components/ui/MergedBadge";
+import { useRequireRole } from "@/hooks/useRequireRole";
+import { PageLoader } from "@/components/ui/PageLoader";
 import { formatPhone } from "@/lib/phone";
 
 interface ParticipantMergeView {
@@ -51,6 +53,7 @@ function formatFieldValue(field: ConflictField, value: unknown, person: { email?
 }
 
 export default function MergeParticipants() {
+  const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
   const router = useRouter();
   const [searchA, setSearchA] = useState("");
   const [searchB, setSearchB] = useState("");
@@ -156,6 +159,14 @@ export default function MergeParticipants() {
       setPreviewMode(false);
     }
   }, [pA, pB]);
+
+  if (authLoading) {
+    return <PageLoader />;
+  }
+
+  if (!ready) {
+    return null;
+  }
 
   const handleMerge = async () => {
     setMerging(true);

--- a/checkin-app/src/app/membership-ops/volunteer-memberships/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/volunteer-memberships/__tests__/page.test.tsx
@@ -62,4 +62,14 @@ describe("membership-ops/volunteer-memberships page", () => {
       ),
     );
   });
+
+  it("renders nothing for a background-check reviewer who navigates directly", async () => {
+    setSession({ id: 9, isBackgroundCheckReviewer: true });
+    mockFetchJson({ "/api/settings/membership/volunteer-designations": designations });
+    renderWithProviders(<VolunteerMembershipsPage />);
+
+    // The load effect still fires before the guard's early return — let it settle.
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Add" })).not.toBeInTheDocument());
+    expect(screen.queryByText("Volunteer-only designated emails")).not.toBeInTheDocument();
+  });
 });

--- a/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
+++ b/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { Button, Card, Center, Group, Loader, Stack, Table, Text, TextInput, Title } from "@mantine/core";
 import { AlertBanner } from "@/components/admin/AlertBanner";
+import { useRequireRole } from "@/hooks/useRequireRole";
+import { PageLoader } from "@/components/ui/PageLoader";
 import { notifications } from "@mantine/notifications";
 import { isValidEmail } from "@/lib/emergencyContacts/identity";
 
@@ -13,6 +15,7 @@ interface Designation {
 }
 
 export default function VolunteerMembershipsPage() {
+  const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
   const [designations, setDesignations] = useState<Designation[]>([]);
   const [newEmail, setNewEmail] = useState("");
   const [loading, setLoading] = useState(true);
@@ -34,6 +37,14 @@ export default function VolunteerMembershipsPage() {
   }, []);
 
   useEffect(() => { load(); }, [load]);
+
+  if (authLoading) {
+    return <PageLoader />;
+  }
+
+  if (!ready) {
+    return null;
+  }
 
   const addDesignation = async () => {
     setEmailError(undefined);


### PR DESCRIPTION
## What

Adds the missing page-level `useRequireRole(['isSysadmin', 'isBoardMember'])` guard to three pages under `/membership-ops`:

- `participants/import/page.tsx` (bulk import)
- `participants/merge/page.tsx` (participant merge)
- `volunteer-memberships/page.tsx`

Plus one RTL test per page asserting a reviewer-only session does not render that page's primary write affordance.

## Why

The Membership Ops layout admits three roles:

```ts
useRequireRole(["isSysadmin", "isBoardMember", "isBackgroundCheckReviewer"])
```

Background-check reviewers are let in so they can reach the Review tab, which their notification emails link to. The nav link list is separately filtered so reviewers only *see* the Review tab — but these three pages had no role check of their own, so a reviewer navigating directly by URL rendered the full write UI.

This is UI-shell exposure, not a data breach: the backing routes under `src/app/api/membership-ops/**` are all correctly gated to `roles: ['isSysadmin','isBoardMember']`, so a reviewer's submit would 403. But handing a reviewer a working-looking bulk-import and merge form is wrong, and the layout's own comment claims "the admin tools below stay scoped to sysadmin/board and each page 403s independently" — which was only true of the APIs, not the pages. This makes it true of both.

Pre-existing gap on `main`; not part of #1111.

## Notes for the reviewer

- The pattern is copied verbatim from the sibling `participants/new/page.tsx` — same import, same hook call, same `authLoading → <PageLoader />` / `!ready → null` early returns. Returns are placed after all hooks and before the first handler const, so hook order is unchanged.
- The `loading: authLoading` alias matters: `merge` and `volunteer-memberships` both already have their own `loading` state.
- Every pre-existing test in the three affected test files already set `{ id: 1, isSysadmin: true }`, so the new guard broke none of them.
- The volunteer-memberships test needs `await waitFor` — that page's `load()` effect fires before the guard's early return, so a synchronous assertion left a dangling state update (`act(...)` warning). Noted in a comment at the call site.
- Deliberately untouched: `layout.tsx`, the nav filter, and every API route.

## Verification

- `npx tsc --noEmit` — clean
- Targeted jest run over the three `__tests__` dirs — 3 suites, 21 tests passed
- `eslint` on the three directories — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
