### PR TITLE
perf(security): scope CallerContext prefetch to each route's derived ctxNeeds

### DIFF
--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -15,7 +15,7 @@
  */
 import prisma from '@/lib/prisma';
 import type { AuthResult } from '@/types/auth';
-import type { Authorize, Role } from './core';
+import type { Authorize, CtxNeeds, Role } from './core';
 import { LIVE_PERSON } from '@/lib/person/filters';
 
 export interface CallerContext {
@@ -39,7 +39,15 @@ export interface CallerContext {
     activeVisitorIds: Set<number>;
 }
 
-export async function buildCallerContext(auth: AuthResult): Promise<CallerContext> {
+/**
+ * Build the per-request context, fetching ONLY what `needs` says this route's
+ * policy can consume (see deriveCtxNeeds in core.ts). An unfetched field stays
+ * an empty set — strictly fewer scopes than a full fetch, and provably
+ * output-identical for any scope the route's tokens don't grant (the
+ * ctxNeeds equivalence test asserts this per registered route). Session-derived
+ * fields (selfId/householdId/isKeyholder) are always populated.
+ */
+export async function buildCallerContext(auth: AuthResult, needs: CtxNeeds): Promise<CallerContext> {
     const ctx: CallerContext = {
         selfId: undefined,
         householdId: undefined,
@@ -59,57 +67,69 @@ export async function buildCallerContext(auth: AuthResult): Promise<CallerContex
     ctx.householdId = auth.user.householdId;
     ctx.isKeyholder = auth.user.isKeyholder;
 
-    const ledPrograms = await prisma.program.findMany({
-        where: { leadMentorId: auth.user.id },
-        select: { id: true, participants: { select: { personId: true } } },
-    });
+    const [ledPrograms, coreVols, visits] = await Promise.all([
+        needs.programs
+            ? prisma.program.findMany({
+                  where: { leadMentorId: auth.user.id },
+                  select: { id: true, participants: { select: { personId: true } } },
+              })
+            : [],
+        needs.programs
+            ? prisma.programVolunteer.findMany({
+                  where: { personId: auth.user.id, isCore: true, person: LIVE_PERSON },
+                  select: {
+                      programId: true,
+                      program: { select: { participants: { select: { personId: true } } } },
+                  },
+              })
+            : [],
+        needs.activeVisitors && ctx.isKeyholder
+            ? prisma.visit.findMany({
+                  where: { departedAt: null },
+                  select: { personId: true },
+              })
+            : [],
+    ]);
+
     for (const p of ledPrograms) {
         ctx.programsLed.add(p.id);
         for (const pp of p.participants) ctx.participantIdsInScopePrograms.add(pp.personId);
     }
-
-    const coreVols = await prisma.programVolunteer.findMany({
-        where: { personId: auth.user.id, isCore: true, person: LIVE_PERSON },
-        select: {
-            programId: true,
-            program: { select: { participants: { select: { personId: true } } } },
-        },
-    });
     for (const v of coreVols) {
         ctx.programsCoreVolIn.add(v.programId);
         for (const pp of v.program.participants) ctx.participantIdsInScopePrograms.add(pp.personId);
     }
+    for (const v of visits) ctx.activeVisitorIds.add(v.personId);
 
-    // Households of the children in the caller's programs — for Trusted Adult
-    // pickup-note visibility (program leads see operational notes for the
-    // households whose kids they oversee).
-    if (ctx.participantIdsInScopePrograms.size) {
-        const members = await prisma.person.findMany({
-            where: { id: { in: [...ctx.participantIdsInScopePrograms] }, ...LIVE_PERSON },
-            select: { householdId: true },
-        });
-        for (const m of members) ctx.householdIdsInScopePrograms.add(m.householdId);
-    }
-
-    // Events belonging to the caller's programs — RSVP reaches a program only via
-    // eventId → Event.programId (RSVP has no programId column). Drives the
-    // 'their_program_participants' scope on RSVP rows.
     const scopePrograms = [...ctx.programsLed, ...ctx.programsCoreVolIn];
-    if (scopePrograms.length) {
-        const events = await prisma.event.findMany({
-            where: { programId: { in: scopePrograms } },
-            select: { id: true },
-        });
-        for (const e of events) ctx.eventIdsInScopePrograms.add(e.id);
-    }
-
-    if (ctx.isKeyholder) {
-        const visits = await prisma.visit.findMany({
-            where: { departedAt: null },
-            select: { personId: true },
-        });
-        for (const v of visits) ctx.activeVisitorIds.add(v.personId);
-    }
+    await Promise.all([
+        // Households of the children in the caller's programs — for Trusted Adult
+        // pickup-note visibility (program leads see operational notes for the
+        // households whose kids they oversee).
+        needs.programHouseholds && ctx.participantIdsInScopePrograms.size
+            ? prisma.person
+                  .findMany({
+                      where: { id: { in: [...ctx.participantIdsInScopePrograms] }, ...LIVE_PERSON },
+                      select: { householdId: true },
+                  })
+                  .then(members => {
+                      for (const m of members) ctx.householdIdsInScopePrograms.add(m.householdId);
+                  })
+            : undefined,
+        // Events belonging to the caller's programs — RSVP reaches a program only via
+        // eventId → Event.programId (RSVP has no programId column). Drives the
+        // 'their_program_participants' scope on RSVP rows.
+        needs.programEvents && scopePrograms.length
+            ? prisma.event
+                  .findMany({
+                      where: { programId: { in: scopePrograms } },
+                      select: { id: true },
+                  })
+                  .then(events => {
+                      for (const e of events) ctx.eventIdsInScopePrograms.add(e.id);
+                  })
+            : undefined,
+    ]);
 
     return ctx;
 }

--- a/checkin-app/src/security/core.ts
+++ b/checkin-app/src/security/core.ts
@@ -45,6 +45,7 @@
  */
 import { classifications, type Models, type FieldsOf } from './generated/classifications';
 import type { BusinessRole } from '@/types/auth';
+import { assertNever } from '@/lib/lifecycle/classify';
 
 export type { Models, FieldsOf };
 export { classifications };
@@ -188,7 +189,127 @@ export interface OutboundSpec {
     tiers: readonly ('public' | SensitiveTier)[];
 }
 
-const _routes = new Map<string, RouteSpec>();
+/**
+ * Which CallerContext prefetches a route can possibly consume — derived
+ * statically from its RouteSpec (authorize + orderedView roles + granted token
+ * scopes). buildCallerContext skips the DB queries behind any field not
+ * needed, so a route whose grants never consult program/visitor scopes pays
+ * zero context queries.
+ *
+ * Skipping is fail-closed by construction: an unfetched field is an empty
+ * set, which can only SHRINK scopesHeld — and a scope no view token grants
+ * can never flip fieldVisible anyway. The equivalence test
+ * (tests/security/ctxNeeds.test.ts) proves output-identity per registered
+ * route; the total switches below (assertNever) force this derivation to be
+ * revisited whenever a Scope/Role/Authorize variant is added.
+ */
+export interface CtxNeeds {
+    /** programsLed, programsCoreVolIn, participantIdsInScopePrograms */
+    programs: boolean;
+    /** householdIdsInScopePrograms (implies programs) */
+    programHouseholds: boolean;
+    /** eventIdsInScopePrograms (implies programs) */
+    programEvents: boolean;
+    /** activeVisitorIds (fetched only for keyholders) */
+    activeVisitors: boolean;
+}
+
+export const ALL_CTX_NEEDS: CtxNeeds = Object.freeze({
+    programs: true,
+    programHouseholds: true,
+    programEvents: true,
+    activeVisitors: true,
+});
+
+function scopeNeeds(scope: Scope): Partial<CtxNeeds> {
+    switch (scope) {
+        case 'everyones':
+        case 'their_own':
+        case 'their_households':
+        case 'keyholders':
+            // Resolved from the session alone — no prefetch.
+            return {};
+        case 'their_program_participants':
+            // participantIds AND (RSVP-only) eventIds both hang off this scope;
+            // the bag's models aren't statically known, so fetch both.
+            return { programs: true, programEvents: true };
+        case 'their_program_households':
+            return { programs: true, programHouseholds: true };
+        case 'all_current_visitors':
+            return { activeVisitors: true };
+        default:
+            return assertNever(scope);
+    }
+}
+
+function roleNeeds(role: Role): Partial<CtxNeeds> {
+    switch (role) {
+        case 'anyone':
+        case 'unauthenticated':
+        case 'authenticated':
+        case 'kiosk':
+        case 'isSysadmin':
+        case 'isBoardMember':
+        case 'isKeyholder':
+        case 'isBackgroundCheckReviewer':
+        case 'isOperations':
+        case 'certifier':
+        case 'householdLead':
+            // callerHoldsRole answers these from the session alone.
+            return {};
+        case 'programLeadMentor':
+        case 'programCoreVolunteer':
+            return { programs: true };
+        default:
+            return assertNever(role);
+    }
+}
+
+function authorizeNeeds(authorize: Authorize): Partial<CtxNeeds> {
+    if (typeof authorize !== 'string') return {}; // anyRole — session flags only
+    switch (authorize) {
+        case 'public':
+        case 'authenticated':
+        case 'self':
+        case 'certifier':
+        case 'household-lead':
+        case 'household-member':
+        case 'kiosk':
+            return {};
+        case 'program-lead-mentor':
+        case 'program-core-volunteer':
+            return { programs: true };
+        default:
+            return assertNever(authorize);
+    }
+}
+
+export function deriveCtxNeeds(spec: RouteSpec): CtxNeeds {
+    const needs: CtxNeeds = {
+        programs: false,
+        programHouseholds: false,
+        programEvents: false,
+        activeVisitors: false,
+    };
+    Object.assign(needs, authorizeNeeds(spec.authorize));
+    for (const [role, tokens] of spec.orderedView) {
+        Object.assign(needs, roleNeeds(role));
+        for (const tok of tokens) {
+            const parsed = parseToken(tok);
+            if (parsed !== null && typeof parsed === 'object') {
+                Object.assign(needs, scopeNeeds(parsed.scope));
+            }
+        }
+    }
+    return needs;
+}
+
+/** A RouteSpec as stored: ctxNeeds is DERIVED at registration, never authored. */
+export interface RegisteredRoute extends RouteSpec {
+    readonly ctxNeeds: CtxNeeds;
+}
+
+const _routes = new Map<string, RegisteredRoute>();
 const _outbounds = new Map<string, OutboundSpec>();
 
 export function defineRoute(spec: RouteSpec): RouteSpec {
@@ -210,7 +331,9 @@ export function defineRoute(spec: RouteSpec): RouteSpec {
             }
         }
     }
-    _routes.set(spec.endpoint, spec);
+    // Derived AFTER validation (deriveCtxNeeds assumes tokens parse). The spread
+    // order means an (illegally) author-supplied ctxNeeds is overwritten.
+    _routes.set(spec.endpoint, { ...spec, ctxNeeds: deriveCtxNeeds(spec) });
     return spec;
 }
 
@@ -227,7 +350,7 @@ export function defineOutbound(spec: OutboundSpec): OutboundSpec {
     return spec;
 }
 
-export function getRoute(endpoint: string): RouteSpec | undefined {
+export function getRoute(endpoint: string): RegisteredRoute | undefined {
     return _routes.get(endpoint);
 }
 
@@ -235,7 +358,7 @@ export function getOutbound(surface: string): OutboundSpec | undefined {
     return _outbounds.get(surface);
 }
 
-export function allRoutes(): IterableIterator<[string, RouteSpec]> {
+export function allRoutes(): IterableIterator<[string, RegisteredRoute]> {
     return _routes.entries();
 }
 

--- a/checkin-app/src/security/handler.ts
+++ b/checkin-app/src/security/handler.ts
@@ -3,8 +3,10 @@
  *
  * Flow:
  *   1. Look up the registry entry for endpointKey.
- *   2. Authenticate the request + build the per-request CallerContext (one
- *      DB-heavy prefetch: caller's programs, household, active visitors).
+ *   2. Authenticate the request + build the per-request CallerContext. The
+ *      prefetch is scoped to spec.ctxNeeds (derived from the route's grants
+ *      at registration) — a route whose policy never consults program or
+ *      visitor scopes pays zero context queries.
  *   3. Run the admission gate (`authorize`). 401/403 if it fails.
  *   4. Walk `orderedView` top-to-bottom; pick the first role the caller
  *      satisfies. Its tokens become the view.
@@ -71,7 +73,7 @@ export function handler<P extends Record<string, string> = Record<string, string
 
         const params = (ctx?.params ? await ctx.params : ({} as P)) ?? ({} as P);
         const auth = await authenticateRequest(req);
-        const callerCtx = await buildCallerContext(auth);
+        const callerCtx = await buildCallerContext(auth, spec.ctxNeeds);
 
         const { allowed } = await resolveAccess(spec.authorize, {
             auth,

--- a/checkin-app/tests/security/ctxNeeds.test.ts
+++ b/checkin-app/tests/security/ctxNeeds.test.ts
@@ -1,0 +1,302 @@
+/**
+ * ctxNeeds — the proof the scoped CallerContext prefetch is behavior-neutral.
+ *
+ * buildCallerContext now fetches only the fields a route's policy can consume
+ * (spec.ctxNeeds, derived in core.ts from authorize + orderedView roles +
+ * granted token scopes). Skipping a fetch leaves that field an EMPTY set, so
+ * this suite asserts, for EVERY registered route:
+ *
+ *   1. Admission (resolveAccess) is identical under a fully-populated context
+ *      vs the same context masked to the route's ctxNeeds.
+ *   2. The role walk (first orderedView role the caller holds — exactly the
+ *      handler's loop) picks the same role under both.
+ *   3. stripValue output is identical under both, for every view's token list
+ *      × every bound model × representative rows.
+ *
+ * (1)–(3) are the only three consumers of CallerContext (the user handler fn
+ * never sees it), so equality here IS output equality for the route.
+ *
+ * Masking — not re-fetching — mirrors the runtime exactly: an unfetched field
+ * and a masked field are both empty sets. Pure unit test, no DB.
+ *
+ * On a mismatch the DERIVATION is wrong — fix deriveCtxNeeds (core.ts), never
+ * this test. The total switches in core.ts (assertNever) separately force the
+ * derivation to be revisited when a Scope/Role/Authorize variant is added.
+ */
+import {
+    allRoutes,
+    deriveCtxNeeds,
+    ALL_CTX_NEEDS,
+    type CtxNeeds,
+    type Role,
+    type Token,
+} from '@/security/core';
+import {
+    callerHoldsRole,
+    resolveAccess,
+    type CallerContext,
+} from '@/security/access-resolvers';
+import { stripValue } from '@/security/stripper';
+import { SCOPE_BINDINGS } from '@/security/scopeBindings';
+import type { AuthResult } from '@/types/auth';
+import type { SessionUser } from '@/types/participant';
+// Side-effect import: registers every route via defineRoute() so allRoutes()
+// yields the real policy surface.
+import '@/security/registry';
+
+// ─── Personas: fully-populated contexts + matching AuthResults ────────────────
+
+function ctx(opts: Partial<CallerContext> = {}): CallerContext {
+    return {
+        selfId: undefined,
+        householdId: undefined,
+        isKeyholder: false,
+        isKiosk: false,
+        programsLed: new Set(),
+        programsCoreVolIn: new Set(),
+        participantIdsInScopePrograms: new Set(),
+        householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
+        activeVisitorIds: new Set(),
+        ...opts,
+    };
+}
+
+function sessionUser(over: Partial<SessionUser> & { id: number }): SessionUser {
+    return {
+        email: `p${over.id}@example.com`,
+        isSysadmin: false,
+        isBoardMember: false,
+        isKeyholder: false,
+        isBackgroundCheckReviewer: false,
+        isOperations: false,
+        ...over,
+    };
+}
+
+interface Persona {
+    auth: AuthResult;
+    full: CallerContext;
+}
+
+// Every persona's context is populated as if ALL fetches ran (the "full" side).
+// Program-scoped fields are non-empty even for personas that wouldn't earn them
+// from the DB — deliberately adversarial: if masking such a field ever changes
+// route output, the derivation missed a consumer.
+const PERSONAS: Record<string, Persona> = {
+    anonymous: { auth: { type: 'unauthenticated' }, full: ctx() },
+    kiosk: { auth: { type: 'kiosk' }, full: ctx({ isKiosk: true }) },
+    member: {
+        auth: { type: 'session', user: sessionUser({ id: 5, householdId: 2 }) },
+        full: ctx({ selfId: 5, householdId: 2 }),
+    },
+    householdLead: {
+        auth: {
+            type: 'session',
+            user: sessionUser({ id: 6, householdId: 2, householdLead: true }),
+        },
+        full: ctx({ selfId: 6, householdId: 2 }),
+    },
+    programLead: {
+        auth: { type: 'session', user: sessionUser({ id: 10, householdId: 4 }) },
+        full: ctx({
+            selfId: 10,
+            householdId: 4,
+            programsLed: new Set([100]),
+            participantIdsInScopePrograms: new Set([9, 5]),
+            householdIdsInScopePrograms: new Set([2]),
+            eventIdsInScopePrograms: new Set([200]),
+        }),
+    },
+    coreVolunteer: {
+        auth: { type: 'session', user: sessionUser({ id: 11, householdId: 5 }) },
+        full: ctx({
+            selfId: 11,
+            householdId: 5,
+            programsCoreVolIn: new Set([101]),
+            participantIdsInScopePrograms: new Set([9]),
+            householdIdsInScopePrograms: new Set([2]),
+            eventIdsInScopePrograms: new Set([201]),
+        }),
+    },
+    keyholder: {
+        auth: {
+            type: 'session',
+            user: sessionUser({ id: 12, householdId: 6, isKeyholder: true }),
+        },
+        full: ctx({
+            selfId: 12,
+            householdId: 6,
+            isKeyholder: true,
+            activeVisitorIds: new Set([9, 5]),
+        }),
+    },
+    certifier: {
+        auth: {
+            type: 'session',
+            user: sessionUser({
+                id: 15,
+                householdId: 9,
+                toolStatuses: [{ toolId: 1, level: 'MAY_CERTIFY_OTHERS' }],
+            }),
+        },
+        full: ctx({ selfId: 15, householdId: 9 }),
+    },
+    boardMember: {
+        auth: {
+            type: 'session',
+            user: sessionUser({ id: 13, householdId: 7, isBoardMember: true }),
+        },
+        full: ctx({ selfId: 13, householdId: 7 }),
+    },
+    sysadmin: {
+        auth: {
+            type: 'session',
+            user: sessionUser({ id: 14, householdId: 8, isSysadmin: true }),
+        },
+        full: ctx({ selfId: 14, householdId: 8 }),
+    },
+};
+
+/** The runtime effect of skipping a fetch: that field is an empty set. */
+function maskToNeeds(full: CallerContext, needs: CtxNeeds): CallerContext {
+    return {
+        ...full,
+        programsLed: needs.programs ? full.programsLed : new Set(),
+        programsCoreVolIn: needs.programs ? full.programsCoreVolIn : new Set(),
+        participantIdsInScopePrograms: needs.programs
+            ? full.participantIdsInScopePrograms
+            : new Set(),
+        householdIdsInScopePrograms: needs.programHouseholds
+            ? full.householdIdsInScopePrograms
+            : new Set(),
+        eventIdsInScopePrograms: needs.programEvents ? full.eventIdsInScopePrograms : new Set(),
+        activeVisitorIds: needs.activeVisitors ? full.activeVisitorIds : new Set(),
+    };
+}
+
+// Representative rows: each carries every field any binding matches on (same
+// shape as the S1 equivalence suite), so one row set exercises all models.
+const ROWS: Array<Record<string, unknown> | null> = [
+    null,
+    {},
+    { id: 1, name: 'X' },
+    // caller-5 own / in-program / active visitor
+    { id: 5, householdId: 2, participantId: 5, personId: 5, programId: 100, eventId: 200, userId: 5, actorId: 5, departedAt: null },
+    // program participant via coreVol program / active visitor
+    { id: 9, householdId: 2, participantId: 9, personId: 9, programId: 101, eventId: 201, userId: 9, actorId: 9, departedAt: null },
+    // another's / out-of-program / departed
+    { id: 7, householdId: 99, participantId: 7, personId: 7, programId: 88, eventId: 88, userId: 7, actorId: 7, departedAt: new Date(0) },
+    // lead's own program (Program row id 100)
+    { id: 100, householdId: 4, participantId: 10, personId: 10, programId: 100, eventId: 200, userId: 10, actorId: 10, departedAt: null },
+];
+
+const MODELS = [...Object.keys(SCOPE_BINDINGS), 'Fee', 'OrgMembershipProcess'];
+
+// Param sets: program-scoped routes key roles/admission on params.id.
+// 100 = programLead's program, 101 = coreVolunteer's, 999 = nobody's.
+const PARAM_SETS: Array<Record<string, string>> = [{}, { id: '100' }, { id: '101' }, { id: '999' }];
+
+/** Exactly the handler's orderedView walk. */
+function chooseRole(
+    orderedView: readonly (readonly [Role, readonly Token[]])[],
+    auth: AuthResult,
+    params: Record<string, string>,
+    callerCtx: CallerContext,
+): Role | undefined {
+    for (const [role] of orderedView) {
+        if (callerHoldsRole(role, auth, params, callerCtx)) return role;
+    }
+    return undefined;
+}
+
+describe('ctxNeeds — masked prefetch ≡ full prefetch for every registered route', () => {
+    const routes = [...allRoutes()];
+
+    it('has routes registered (side-effect import worked)', () => {
+        expect(routes.length).toBeGreaterThan(0);
+    });
+
+    it('stores the derivation on every registered spec', () => {
+        for (const [endpoint, spec] of routes) {
+            expect({ endpoint, needs: spec.ctxNeeds }).toEqual({
+                endpoint,
+                needs: deriveCtxNeeds(spec),
+            });
+        }
+    });
+
+    it('admission + role walk are identical under masked context', async () => {
+        for (const [endpoint, spec] of routes) {
+            for (const [pName, { auth, full }] of Object.entries(PERSONAS)) {
+                const masked = maskToNeeds(full, spec.ctxNeeds);
+                for (const params of PARAM_SETS) {
+                    const [a, b] = await Promise.all([
+                        resolveAccess(spec.authorize, { auth, params, callerContext: full }),
+                        resolveAccess(spec.authorize, { auth, params, callerContext: masked }),
+                    ]);
+                    expect({ endpoint, pName, params, allowed: b.allowed }).toEqual({
+                        endpoint, pName, params, allowed: a.allowed,
+                    });
+                    expect({
+                        endpoint, pName, params,
+                        role: chooseRole(spec.orderedView, auth, params, masked),
+                    }).toEqual({
+                        endpoint, pName, params,
+                        role: chooseRole(spec.orderedView, auth, params, full),
+                    });
+                }
+            }
+        }
+    });
+
+    it('stripValue output is identical under masked context (all views × models × rows)', () => {
+        const mismatches: string[] = [];
+        for (const [endpoint, spec] of routes) {
+            for (const [pName, { full }] of Object.entries(PERSONAS)) {
+                const masked = maskToNeeds(full, spec.ctxNeeds);
+                for (const [role, tokens] of spec.orderedView) {
+                    for (const model of MODELS) {
+                        for (const row of ROWS) {
+                            const a = stripValue(model, row, tokens, full);
+                            const b = stripValue(model, row, tokens, masked);
+                            if (JSON.stringify(a) !== JSON.stringify(b)) {
+                                mismatches.push(
+                                    `${endpoint} / ${pName} / view=${role} / ${model} / row=${JSON.stringify(row)}`,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        expect(mismatches).toEqual([]);
+    });
+});
+
+describe('deriveCtxNeeds — spot checks against the live registry', () => {
+    const byEndpoint = new Map([...allRoutes()]);
+
+    it('a self-scoped route needs no prefetch at all', () => {
+        expect(byEndpoint.get('GET /api/profile')?.ctxNeeds).toEqual({
+            programs: false,
+            programHouseholds: false,
+            programEvents: false,
+            activeVisitors: false,
+        });
+    });
+
+    it('the program roster route needs the program prefetches', () => {
+        expect(byEndpoint.get('GET /api/programs/[id]')?.ctxNeeds).toEqual({
+            programs: true,
+            programHouseholds: true,
+            programEvents: true,
+            activeVisitors: false,
+        });
+    });
+
+    it('ALL_CTX_NEEDS is the everything mask (masking with it is a no-op)', () => {
+        const full = PERSONAS.programLead.full;
+        expect(maskToNeeds(full, ALL_CTX_NEEDS)).toEqual(full);
+    });
+});


### PR DESCRIPTION
## What

`buildCallerContext` ran up to 5 sequential queries (led programs, core-vol programs, in-scope households, in-scope events, all open visits) on **every** `handler()` request — including routes whose policy never consults any of it. That standing cost was the perf argument for keeping new routes on `withAuth` instead of the audited registry path.

- `defineRoute` now derives **`CtxNeeds`** statically from the spec (authorize + orderedView roles + granted token scopes) and stores it on the registered spec. Derivation runs after token validation and overwrites any author-supplied value.
- `buildCallerContext(auth, needs)` fetches only the needed fields, in 2 parallel levels instead of 5 serial awaits.
- `handler()` passes `spec.ctxNeeds` — one-line runtime change.

## Effect

- Routes granting only session-derived scopes (`their_own` / `their_households` / `keyholders` / `everyones`) — admin/board, self, and household routes, i.e. the main `withAuth`→`handler()` migration targets — now pay **zero** context queries.
- Program-lead routes keep their queries, in 2 round trips instead of 5.
- The all-open-visits scan (previously ran for every keyholder request) now runs only on routes granting `all_current_visitors` — currently **none**.

## Why it's safe

Skipping a fetch is fail-closed by construction: an unfetched field is an empty set, which can only *shrink* `scopesHeld` — and a scope no view token grants can never flip `fieldVisible`.

Proven, not just argued:

- **`tests/security/ctxNeeds.test.ts`** — for every registered route × 10 personas × param sets, asserts admission (`resolveAccess`), the role walk, and `stripValue` output (every view × 20 models × representative rows) are identical under a fully-populated context vs one masked to the route's `ctxNeeds`. Personas are deliberately adversarial: program-scope sets are populated even for personas that wouldn't earn them from the DB, so a missed consumer would surface as a diff.
- **Drift guard** — `deriveCtxNeeds` is built from three *total* switches (`assertNever`), so adding a `Scope`, `Role`, or `Authorize` variant fails compile until the derivation handles it.
- The handler fn never sees `CallerContext` (its `HandlerContext` is `{req, auth, params, role}`), so admission, role walk, and stripper are provably the only consumers.

## Reviewer notes

- Boundary-only PR (core.ts, access-resolvers.ts, handler.ts + test) per the boundary-isolation rule — no app/feature code.
- `getRoute`/`allRoutes` now return `RegisteredRoute` (`RouteSpec` + derived `ctxNeeds`); existing consumers treat it as `RouteSpec`, no changes needed.
- Verified: tsc clean, security suites 548/548, full unit suite 2105/2105, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)