### PR TITLE
security boundary: isOperations role vocabulary

### DIFF
--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -159,6 +159,14 @@ export function callerHoldsRole(
             return auth.type === 'session' && auth.user.isKeyholder;
         case 'isBackgroundCheckReviewer':
             return auth.type === 'session' && auth.user.isBackgroundCheckReviewer;
+        case 'isOperations':
+            // SessionUser (types/participant.ts) doesn't declare isOperations yet —
+            // that lands with the roles-foundation PR (which stamps the flag on the
+            // session). This boundary PR adds the role vocabulary alone, ahead of
+            // it; the structural cast reads the flag once it exists without
+            // widening this PR's diff outside src/security/** (isolation-enforced).
+            // Falls back to false (default-deny) until roles-foundation lands.
+            return auth.type === 'session' && !!(auth.user as { isOperations?: boolean }).isOperations;
         case 'certifier':
             return isCertifier(auth);
         case 'householdLead':

--- a/checkin-app/src/security/core.ts
+++ b/checkin-app/src/security/core.ts
@@ -79,6 +79,7 @@ export type Role =
     | 'isBoardMember'
     | 'isKeyholder'
     | 'isBackgroundCheckReviewer'
+    | 'isOperations'
     // Holds a MAY_CERTIFY_OTHERS toolStatus (a shop certifier). Not a Person
     // role boolean — derived from session.user.toolStatuses (see callerHoldsRole).
     | 'certifier'
@@ -96,7 +97,9 @@ const VALID_SCOPES = new Set<Scope>([
     'all_current_visitors',
 ]);
 const VALID_SENSITIVE_TIERS = new Set<SensitiveTier>(['pii', 'personal', 'internal']);
-const VALID_ROLES = new Set<Role>([
+// Exported so a guard test can assert BusinessRole (types/auth.ts) ⊆ VALID_ROLES —
+// the gap that let #1104 add isOperations to BusinessRole without adding it here.
+export const VALID_ROLES = new Set<Role>([
     'anyone',
     'unauthenticated',
     'authenticated',
@@ -105,6 +108,7 @@ const VALID_ROLES = new Set<Role>([
     'isBoardMember',
     'isKeyholder',
     'isBackgroundCheckReviewer',
+    'isOperations',
     'certifier',
     'householdLead',
     'programLeadMentor',


### PR DESCRIPTION
Boundary-isolation PR per the AGENTS.md rule (extracted from #1104, whose isolation check it unblocks): adds `isOperations` to the registry's `Role` union and `callerHoldsRole` (default-deny via a structural cast until the session flag lands with #1104 — rationale commented in place), and exports `VALID_ROLES` so the roles PR can carry a `BusinessRole ⊆ VALID_ROLES` guard test closing the exact drift class that created this gap. 13 lines, src/security only, no behavior change for any existing role. **Merge before #1104**; the roles branch then restores its guard test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe