### PR TITLE
fix(security): drop raw email from the last-keyholder kiosk warning

### DIFF
--- a/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
+++ b/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The last-keyholder warning is rendered on the kiosk screen. `Person.email` is
+ * tier `pii`, so a person with no `name` must degrade to the email local-part —
+ * never the full address (#329).
+ */
+import type { Person } from "@/generated/prisma/client";
+import type { DbClient } from "@/lib/db-client";
+import { processCheckout } from "@/lib/scan-service";
+
+jest.mock("@/lib/prisma", () => ({ __esModule: true, default: {} }));
+jest.mock("@/lib/notifications", () => ({ sendCheckinNotifications: jest.fn() }));
+
+const keyholder = { id: 1, isKeyholder: true } as Person;
+
+/** Tx-shaped fake (no `$transaction`, so isRootClient() is false). */
+function fakeDb(remaining: Array<{ name: string | null; email: string | null }>): DbClient {
+    return {
+        visit: {
+            count: jest.fn().mockResolvedValue(0), // no other keyholders present
+            findMany: jest.fn().mockResolvedValue(
+                remaining.map((person, i) => ({ id: 100 + i, person }))
+            ),
+        },
+        rawBadgeLog: { findMany: jest.fn().mockResolvedValue([]) }, // no double-badge confirm
+    } as unknown as DbClient;
+}
+
+async function warningFor(remaining: Array<{ name: string | null; email: string | null }>) {
+    const res = await processCheckout(keyholder, 42, "kiosk", fakeDb(remaining));
+    expect(res.status).toBe(400);
+    return (await res.json()) as { error: string; type: string };
+}
+
+it("renders a nameless person as the email local-part, not the address", async () => {
+    const body = await warningFor([{ name: null, email: "jane.doe@example.com" }]);
+
+    expect(body.type).toBe("warning");
+    expect(body.error).toContain("jane.doe");
+    expect(body.error).not.toContain("@");
+    expect(body.error).not.toContain("example.com");
+});
+
+it("prefers the name when set, and mixes both without leaking", async () => {
+    const body = await warningFor([
+        { name: "Alex Rivera", email: "arivera@example.com" },
+        { name: "   ", email: "blank.name@example.com" },
+    ]);
+
+    expect(body.error).toContain("Alex Rivera, blank.name");
+    expect(body.error).not.toContain("@");
+});
+
+it("omits a person with neither name nor email rather than rendering an empty slot", async () => {
+    const body = await warningFor([
+        { name: null, email: null },
+        { name: null, email: "solo@example.com" },
+    ]);
+
+    expect(body.error).toContain("solo");
+    expect(body.error).not.toMatch(/, ,|:\n, /);
+});

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -104,7 +104,13 @@ export async function processCheckout(
                 }
 
                 if (!confirmForceClose) {
-                    const names = remainingUsers.map(u => u.person.name || u.person.email).join(", ");
+                    // Never render the raw address (tier `pii`) on the kiosk screen (#329):
+                    // fall back to the email local-part, same as getFullAttendance /
+                    // kioskdisplay/certifications.
+                    const names = remainingUsers
+                        .map(u => u.person.name?.trim() || u.person.email?.split("@")[0] || "")
+                        .filter(Boolean)
+                        .join(", ");
                     return apiJson({
                         error: `Warning! You are the last isKeyholder, but others are here:\n${names}\n\nBadge again within 10 seconds to confirm you've checked them and close the facility.`,
                         type: "warning" as const


### PR DESCRIPTION
## What

`processCheckout` built the "you are the last keyholder, but others are here" warning as:

```ts
const names = remainingUsers.map(u => u.person.name || u.person.email).join(", ");
```

A present person with no `name` set therefore had their **full email address** rendered into a banner on the kiosk screen, and returned in the 400 response body. `Person.email` is tier `pii` per `src/security/generated/classifications.ts`.

This falls back to the email local-part instead.

```diff
-const names = remainingUsers.map(u => u.person.name || u.person.email).join(", ");
+// Never render the raw address (tier `pii`) on the kiosk screen (#329):
+// fall back to the email local-part, same as getFullAttendance /
+// kioskdisplay/certifications.
+const names = remainingUsers
+    .map(u => u.person.name?.trim() || u.person.email?.split("@")[0] || "")
+    .filter(Boolean)
+    .join(", ");
```

## Why this shape

Not a new invention — it reuses the existing #329 fallback that every other display path already uses:

- `src/lib/getFullAttendance.ts:78`
- `src/app/api/kioskdisplay/certifications/route.ts:56`

Left inline rather than extracted into a shared helper: the three sites have different shapes (DTO field, `""` default, joined string), so extracting would mean editing two files outside this fix's scope for what is a `??`-chain. Worth revisiting if a fourth site needs the identical shape.

One behaviour change beyond the neighbours: `.filter(Boolean)` drops a person with neither name nor email. The old code would have joined a `null` into the string.

## Tests

New `src/lib/__tests__/scanServiceKeyholderWarning.test.ts` — 3 cases against a fake tx client, no DB needed:

- nameless person renders as local-part, response body contains no `@` and no domain
- `name` still wins when set; a whitespace-only name falls through to local-part
- person with neither field is omitted rather than leaving an empty slot

The first case fails against the pre-fix code. Both the new file and the existing `scanRoute` suite pass (3/3 and 4/4).

## Reviewer notes

- **No files under `src/security/**` are touched** — that boundary is CODEOWNERS-gated and ships separately (see the Security section of `AGENTS.md`).
- Scope is this one leak. Surrounding checkout / facility-close logic is untouched.
- `npx tsc --noEmit` is dirty in my worktree with `Cannot find module '@/generated/prisma/client'` — that's just `prisma generate` not having run there, pre-existing and unrelated to this diff. CI generates the client, so it should be clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
