### PR TITLE
security: migrate GET /api/household to handler(), keep intakeNotes to leads

### DIFF
--- a/checkin-app/scripts/migrated-routes.txt
+++ b/checkin-app/scripts/migrated-routes.txt
@@ -7,3 +7,4 @@
 GET /api/profile
 GET /api/programs/[id]
 GET /api/directory/board
+GET /api/household

--- a/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdAPI.integration.test.ts
@@ -50,7 +50,7 @@ describe('Household API Integration Tests', () => {
 
         // Setup mock database records
         const household = await prisma.household.create({
-            data: { name: 'Lead User Household', line1: '123 Main' }
+            data: { name: 'Lead User Household', line1: '123 Main', intakeNotes: 'Private note to the board.' }
         });
         householdId = household.id;
 
@@ -129,7 +129,7 @@ describe('Household API Integration Tests', () => {
 
         it('should return household info if the user belongs to one', async () => {
             (getServerSession as jest.Mock).mockResolvedValue({
-                user: { id: testUserId }
+                user: { id: testUserId, householdId, householdLead: true }
             });
 
             const req = new Request('http://localhost:4000/api/household', { method: 'GET' });
@@ -140,6 +140,48 @@ describe('Household API Integration Tests', () => {
             expect(data.household).toBeDefined();
             expect(data.household.id).toBe(householdId);
             expect(data.household.householdMembers.length).toBeGreaterThanOrEqual(2);
+        });
+
+        // The lead authored intakeNotes for the board, so the lead still reads it
+        // back (the my-household Textarea prefills from this response).
+        it('gives a household lead the address, peer contact details, and intakeNotes', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testUserId, householdId, householdLead: true }
+            });
+
+            const req = new Request('http://localhost:4000/api/household', { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.household.line1).toBe('123 Main');
+            expect(data.household.intakeNotes).toBe('Private note to the board.');
+            const peer = data.household.householdMembers.find((m: { id: number }) => m.id === testMemberId);
+            expect(peer.email).toBe('member-user-household-api-test@example.com');
+        });
+
+        // The leak this route's migration closed: intakeNotes is 'pii', and the
+        // their_households:pii token the view needs for peer email/phone would
+        // otherwise hand the lead's private note to the board to every household
+        // member with a login — including youth. Kept out by the handler, not a
+        // token (see the registry comment). The address is shared family data and
+        // deliberately stays.
+        it('a non-lead household member does not receive intakeNotes', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testMemberId, householdId }
+            });
+
+            const req = new Request('http://localhost:4000/api/household', { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.household.id).toBe(householdId);
+            expect(data.household.intakeNotes).toBeUndefined();
+            // Still a full household view otherwise.
+            expect(data.household.line1).toBe('123 Main');
+            const peer = data.household.householdMembers.find((m: { id: number }) => m.id === testUserId);
+            expect(peer.email).toBe('lead-user-household-api-test@example.com');
         });
     });
 

--- a/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
+++ b/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
@@ -24,11 +24,17 @@ jest.mock("@/lib/verify-kiosk", () => ({
     verifyKioskSignature: jest.fn(),
 }));
 jest.mock("@/lib/logger", () => ({ logBackendError: jest.fn() }));
+// GET /api/household now runs through the security handler(), whose
+// buildCallerContext prefetches the caller's programs/events before the route
+// body executes. Those all resolve empty here — this caller leads nothing.
 jest.mock("@/lib/prisma", () => ({
     __esModule: true,
     default: {
-        person: { findUnique: jest.fn() },
+        person: { findUnique: jest.fn(), findMany: jest.fn().mockResolvedValue([]) },
         visit: { findMany: jest.fn() },
+        program: { findMany: jest.fn().mockResolvedValue([]) },
+        programVolunteer: { findMany: jest.fn().mockResolvedValue([]) },
+        event: { findMany: jest.fn().mockResolvedValue([]) },
     },
 }));
 
@@ -45,7 +51,10 @@ beforeEach(() => {
 
 describe("Participant PII minimization (M1, M2)", () => {
     it("GET /api/household does not leak a peer's internal-tier fields", async () => {
-        mockSession.mockResolvedValue({ user: { id: 1 } });
+        // householdId is what the handler's `their_households` scope reads — a
+        // real session carries it, and without it the peer's own pii/personal
+        // fields would strip out for the wrong reason.
+        mockSession.mockResolvedValue({ user: { id: 1, householdId: 10 } });
 
         // Full raw row as it exists in the DB, including everything a household
         // peer must never see (M2). The mock applies whatever `select` the route
@@ -71,13 +80,13 @@ describe("Participant PII minimization (M1, M2)", () => {
         } as Record<string, unknown>;
 
         (prisma.person.findUnique as jest.Mock).mockImplementation((args) => {
-            const peerSelect = args.include.household.include.householdMembers.select as Record<string, boolean>;
+            const peerSelect = args.select.household.include.householdMembers.select as Record<string, boolean>;
             const projected = Object.fromEntries(
                 Object.keys(peerSelect).filter((k) => peerSelect[k]).map((k) => [k, rawPeer[k]])
             );
             return Promise.resolve({
-                id: 1,
-                householdId: 10,
+                isHouseholdLead: false,
+                isSysadmin: false,
                 household: {
                     id: 10,
                     name: "Test Household",
@@ -109,9 +118,12 @@ describe("Participant PII minimization (M1, M2)", () => {
         expect(peer.waiverSignedBy).toBeUndefined();
         expect(peer.notificationSettings).toBeUndefined();
 
-        // Pin the actual query shape, not just this test's mock.
+        // Pin the actual query shape, not just this test's mock. householdId is
+        // additive to HOUSEHOLD_PEER_SELECT (the scope key, see the route).
         const callArgs = (prisma.person.findUnique as jest.Mock).mock.calls[0][0];
-        expect(callArgs.include.household.include.householdMembers).toEqual({ select: HOUSEHOLD_PEER_SELECT });
+        expect(callArgs.select.household.include.householdMembers).toEqual({
+            select: { ...HOUSEHOLD_PEER_SELECT, householdId: true },
+        });
     });
 
     it("GET /api/attendance (full access) does not leak email/googleId", async () => {

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -9,35 +9,43 @@ import { isOrgAccount } from "@/lib/orgAccount";
 import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
 import { householdLeadship } from "@/lib/household/leads";
 import { apiError } from "@/lib/api-response";
+import { handler, notFound, unauthorized } from "@/security/handler";
 
-export const GET = withAuth(
-    {},
-    async (_req, auth) => {
-        try {
-            if (auth.type !== 'session') return apiError("Unauthorized", 401);
-            const userId = auth.user.id;
+export const GET = handler('GET /api/household', async ({ auth }) => {
+    if (auth.type !== 'session') throw unauthorized();
 
-            const user = await prisma.person.findUnique({
-                where: { id: userId },
+    const user = await prisma.person.findUnique({
+        where: { id: auth.user.id },
+        select: {
+            isHouseholdLead: true,
+            isSysadmin: true,
+            household: {
                 include: {
-                    household: {
-                        include: {
-                            householdMembers: { select: HOUSEHOLD_PEER_SELECT },
-                            orgMembership: true,
-                        }
-                    }
-                }
-            });
+                    // householdId is what Person's `their_households` scope binding
+                    // reads (scopeBindings.ts) — without it every peer row fails
+                    // closed and loses email/phone/dob/allergies.
+                    householdMembers: { select: { ...HOUSEHOLD_PEER_SELECT, householdId: true } },
+                    orgMembership: true,
+                },
+            },
+        },
+    });
 
-            if (!user) return apiError("User not found", 404);
+    if (!user) throw notFound("User not found");
+    if (!user.household) return { Household: null };
 
-            return NextResponse.json({ household: user.household }, { status: 200 });
-        } catch (error: unknown) {
-            logger.error("Household GET Error:", error);
-            return apiError("Internal Server Error", 500);
-        }
-    }
-);
+    // intakeNotes is the lead's freeform note TO the board (hardship, medical,
+    // family circumstance) and is 'pii' only because background-check reviewers
+    // must read it. The view's their_households:pii token — needed for peers'
+    // email/phone — would also hand it to every household member incl. youth,
+    // which is exactly the schema GUARD's case. Leads (and sysadmins) only; the
+    // my-household Textarea that renders it is already `viewerIsLead`-gated and
+    // the write path 403s non-leads. Do not move this into a token.
+    const { intakeNotes: _intakeNotes, ...withoutNotes } = user.household;
+    const canManage = user.isHouseholdLead || user.isSysadmin;
+
+    return { Household: canManage ? user.household : withoutNotes };
+});
 
 export const PATCH = withAuth(
     {},

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -190,6 +190,26 @@ defineRoute({
     ],
 });
 
+// The caller's own household. Household-scoped: every member (incl. youth) sees
+// the family's address (internal — the family authored it) and their peers'
+// contact details (pii — HOUSEHOLD_PEER_SELECT). That their_households:pii grant
+// nominally also covers Household.intakeNotes, the lead's private "anything else
+// we should know?" note TO the board — the exact case the schema GUARD on that
+// field names. It is kept out for non-leads by the handler, which drops the field
+// unless isHouseholdLead || isSysadmin, pinned by householdAPI.integration.test.ts
+// ("a non-lead household member does not receive intakeNotes"). Do not express
+// that split as a token — a token here is household-wide by construction.
+defineRoute({
+    endpoint: 'GET /api/household',
+    authorize: 'authenticated',
+    envelope: 'household',
+    // Bag: { Household } with householdMembers (Person) + orgMembership (OrgMembership).
+    returns: ['Household', 'Person', 'OrgMembership'],
+    orderedView: [
+        ['authenticated', ['their_households:pii', 'their_households:personal', 'their_households:internal', 'member', 'public']],
+    ],
+});
+
 // Board's trusted-adult review queue. Full visibility incl. familyContext
 // (internal — narrative band) and the board's internal decision notes.
 defineRoute({


### PR DESCRIPTION
Migrates the GET verb of `/api/household` onto the security policy layer's `handler()`, and closes a PII over-fetch on the same route.

## The leak

The GET loaded the caller's household with a bare `include` and returned the row wholesale, so **every authenticated household member received `Household.intakeNotes`** — including youth, who get real sessions (see the youth guard at `src/app/api/profile/route.ts:37-39`).

`intakeNotes` is the freeform "anything else we should know?" note written by the household lead **to the board** — plausibly financial-hardship, medical, or family-circumstance disclosures, possibly about a specific child. It is classified `pii` only because background-check reviewers hold `everyones:pii` on `GET /api/membership/reviews` and must read it. That is a reviewer-facing classification, not a family-facing one.

## Why the registry could not express this alone

Grants are `(scope, tier)` pairs, not per-model. Household peers legitimately need `their_households:pii` to see each other's `Person.email`/`phone` (`HOUSEHOLD_PEER_SELECT`) — and that exact token also exposes `Household.intakeNotes`, which is likewise `pii`. This is precisely the case the `GUARD:` comment on that field in `schema.prisma` names.

So the split lives in the handler: the field is dropped unless `isHouseholdLead || isSysadmin`. This follows the established `GET /api/trusted-adults/mine` precedent — a hand-shaped select kept narrow by the handler, pinned by an integration test, with a "do not express this as a token" note in the registry.

**Zero UI change.** The only frontend consumer (`my-household/page.tsx:127`) renders it in a Textarea inside a `viewerIsLead`-gated card, and the write path (`household/settings/route.ts:41`) already 403s non-leads.

**The address is deliberately unchanged** — visible to every household member. The family authored it, it is shared household data, and a household-scoped `internal` grant is precedented.

## Also fixed: a scope key that would have silently failed closed

Added `householdId` to the peer select. It is the field `Person`'s `their_households` binding reads (`scopeBindings.ts`); `HOUSEHOLD_PEER_SELECT` does not include it, so without this every peer row would fail closed and quietly lose `email`/`phone`/`dateOfBirth`/`allergies`. Caught by running the stripper, not by `tsc`.

## Scope

- **GET only. PATCH stays on `withAuth`** — `migrated-routes.txt` contains zero non-GET entries; the layer is GET-shaped in practice. This produces a tolerated `partially-migrated` **warning**, not an error: lint rule 3 (no direct `NextResponse.json`) only fires when every verb in the file is migrated (`check-route-coverage.ts` `fullyMigrated`), and CI runs the lint without `--strict`. The PATCH was deliberately not restructured to silence a warning.
- **Response shape `{ household: ... }` is preserved**, so all four frontend callers are untouched — `my-household/page.tsx`, `attendance/current/page.tsx`, `programs/[id]/page.tsx`.

## Verification

- `npx tsc --noEmit` — clean.
- `check-route-coverage` — **0 errors**, 133 warnings (unchanged count; the new `partially-migrated` warn for PATCH replaced the route's previous `unmigrated` warn).
- Full unit suite — 2114 passed, 233 suites, 0 failed.
- Security contract test (`policy.contract.integration.test.ts`) — 38 passed; it picks up `GET /api/household` and validates every visible field against the view.
- Household / trusted-adult / profile / programs integration suites — 242 passed, 30 suites.

New test pins the fix in `householdAPI.integration.test.ts`: a household **lead** receives `intakeNotes` + address + peer contact details, and **a non-lead household member does not receive `intakeNotes`** while still getting the address and peer email. Both callers hold the identical token, so the pair is non-vacuous — it isolates the handler-side strip.

`participantPiiMinimization.test.ts` was updated for the new query shape: its prisma mock predated `handler()`'s `buildCallerContext` prefetch, and its select-shape pin needed the `include` → `select` move plus the additive `householdId`.

## Note for reviewers

This trips **CODEOWNERS** — `src/security/registry.ts` and `scripts/migrated-routes.txt` are maintainer-gated. Per `docs/security/SECURITY-POLICY.md` that is expected, not a mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
