### PR TITLE
fix(security): stop GET /api/programs leaking a personal-tier column

### DIFF
--- a/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
@@ -9,6 +9,7 @@
 import { GET, POST } from '@/app/api/programs/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
+import { classifications } from '@/security/generated/classifications';
 // Mock NextAuth
 jest.mock('next-auth/next', () => ({
     getServerSession: jest.fn(),
@@ -64,7 +65,7 @@ describe('Programs API Integration Tests', () => {
         // Create mock programs
         await prisma.program.createMany({
             data: [
-                { name: 'Public API Test Program', phase: 'RUNNING', orgMemberOnly: false, minAge: 10, maxAge: 18 },
+                { name: 'Public API Test Program', phase: 'RUNNING', orgMemberOnly: false, minAge: 10, maxAge: 18, leadMentorNotificationSettings: { notifyRsvp: true } },
                 { name: 'Draft API Test Program', phase: 'PLANNING', orgMemberOnly: false, leadMentorId: leadId },
                 { name: 'Member Only API Test Program', phase: 'RUNNING', orgMemberOnly: true }
             ]
@@ -132,6 +133,38 @@ describe('Programs API Integration Tests', () => {
 
              expect(draft).toBeDefined(); // Revealed because admin
              expect(orgMemberOnly).toBeDefined(); // Revealed because admin
+        });
+
+        // The catalog is deliberately anonymous-readable, so the projection — not a
+        // route gate — is what keeps `personal`-tier data off the wire. Both the
+        // cached anonymous path and the live session path must ship public columns only.
+        //
+        // Expected keys are DERIVED from the generated classifications rather than
+        // listed here: the route's PUBLIC_PROGRAM_SELECT is a hand-maintained copy of
+        // policy data, so a hardcoded list would rot in lockstep with it. Adding a
+        // non-public column to Program now fails this test instead of leaking.
+        it.each([
+            ['anonymous', null],
+            ['admin session', { user: { id: undefined as number | undefined, isSysadmin: true } }],
+        ])('exposes only public-tier Program columns (%s)', async (_label, session) => {
+             if (session) session.user.id = adminId;
+             (getServerSession as jest.Mock).mockResolvedValue(session);
+
+             const req = new Request('http://localhost:4000/api/programs', { method: 'GET' });
+             const res = await GET(req as unknown as import("next/server").NextRequest);
+             expect(res.status).toBe(200);
+
+             const programs = await res.json();
+             const publicActive = programs.find((p: { name?: string }) => p.name === 'Public API Test Program');
+
+             const publicColumns = Object.entries(classifications.Program)
+                 .filter(([, tier]) => tier === 'public')
+                 .map(([field]) => field);
+
+             expect(publicActive).toBeDefined();
+             expect(publicColumns).not.toHaveLength(0); // guard: a broken import would vacuously pass
+             expect(Object.keys(publicActive).sort()).toEqual([...publicColumns, '_count'].sort());
+             expect(publicActive._count).toEqual({ participants: 0, volunteers: 0, events: 0 });
         });
     });
 

--- a/checkin-app/src/app/api/programs/route.ts
+++ b/checkin-app/src/app/api/programs/route.ts
@@ -10,6 +10,32 @@ import { apiError } from "@/lib/api-response";
 import { staleWhileRevalidate } from "@/lib/staleCache";
 import { validateProgramAgeBounds } from "@/lib/programAge";
 
+// Public catalog projection: every Program column whose `/// @sensitivity:` tier
+// is `public` per src/security/generated/classifications.ts, in schema order.
+// Deliberately omits `leadMentorNotificationSettings` (tier `personal`) — GET is
+// anonymous-readable and its rows are shared through a 60s cache, so a bare
+// findMany shipped that column to every signed-out visitor. Keep this in sync
+// with the classifications Program block when columns are added.
+const PUBLIC_PROGRAM_SELECT = {
+    id: true,
+    name: true,
+    leadMentorId: true,
+    startAt: true,
+    endAt: true,
+    phase: true,
+    enrollmentStatus: true,
+    orgMemberOnly: true,
+    minAge: true,
+    maxAge: true,
+    maxParticipants: true,
+    orgMemberPriceCents: true,
+    nonOrgMemberPriceCents: true,
+    shopifyProductId: true,
+    shopifyOrgMemberVariantId: true,
+    shopifyNonOrgMemberVariantId: true,
+    shopifyVariantId: true,
+} as const;
+
 // GET is the PUBLIC program catalog — anonymous callers legitimately get the
 // non-draft, non-orgMemberOnly list (asserted by programsAPI.integration.test.ts),
 // so it can't move to withAuth (which 401s anonymous). getOptionalSessionUser
@@ -75,7 +101,8 @@ export async function GET(req: Request) {
         const fetchPrograms = () => prisma.program.findMany({
             where: andClauses.length > 0 ? { AND: andClauses } : undefined,
             orderBy: { startAt: 'asc' },
-            include: {
+            select: {
+                ...PUBLIC_PROGRAM_SELECT,
                 _count: {
                     select: {
                         participants: true,
@@ -102,6 +129,7 @@ export async function GET(req: Request) {
                 () => prisma.program.findMany({
                     where: andClauses.length > 0 ? { AND: andClauses } : undefined,
                     orderBy: { startAt: 'asc' },
+                    select: PUBLIC_PROGRAM_SELECT,
                 }),
             );
             const counts = await Promise.race([


### PR DESCRIPTION
## What

`GET /api/programs` — the deliberately-public program catalog — ran both of its `findMany` calls with no `select`, so every scalar on `Program` shipped to the caller. That included `leadMentorNotificationSettings`, tier `personal` per `src/security/generated/classifications.ts` (schema annotation at `prisma/schema.prisma:756`).

The anonymous path made it worse: those rows sit in a 60s shared `staleWhileRevalidate` entry, so one fetch served the column to every signed-out visitor until the entry expired.

Fix is an explicit projection on both queries:

```ts
const PUBLIC_PROGRAM_SELECT = {
    id: true, name: true, leadMentorId: true, startAt: true, endAt: true,
    phase: true, enrollmentStatus: true, orgMemberOnly: true, minAge: true,
    maxAge: true, maxParticipants: true, orgMemberPriceCents: true,
    nonOrgMemberPriceCents: true, shopifyProductId: true,
    shopifyOrgMemberVariantId: true, shopifyNonOrgMemberVariantId: true,
    shopifyVariantId: true,
} as const;
```

All 17 `public`-tier columns, in schema order. Only omission is `leadMentorNotificationSettings`. The third query on this route (`counts`) already had a `select` and is untouched.

## Why not a route gate

Anonymous access here is intentional and asserted by `programsAPI.integration.test.ts`. The sibling detail route `GET /api/programs/[id]` is already registered with `authorize: 'public'` and grants `['anyone', ['public']]` — anonymous gets public-tier only. The list route just bypassed the registry entirely. This brings its exposure in line without changing who can call it.

## Reviewer notes

**Response shape is unchanged apart from the dropped key.** `_count` keeps its shape and position. Frontend consumers were grepped before settling the column list — `src/app/programs`, `facility-ops/trends`, `program-ops/programs`, `program-ops/sessions/new` — and between them they read `id, name, startAt, endAt, phase, enrollmentStatus, orgMemberOnly, leadMentorId, _count.{participants,volunteers,events}`. All retained. Repo-wide, the only readers of `leadMentorNotificationSettings` are the `[id]` PATCH and `[id]/settings` routes, which write it.

**The const is a known stopgap.** It is a hand-maintained copy of policy data living outside the policy layer, so it rots the moment a new non-public column is added to `Program`. The regression test therefore derives its expected key set from `classifications.Program` rather than hardcoding one:

```ts
const publicColumns = Object.entries(classifications.Program)
    .filter(([, tier]) => tier === 'public').map(([field]) => field);

expect(publicColumns).not.toHaveLength(0); // guard: a broken import would vacuously pass
expect(Object.keys(publicActive).sort()).toEqual([...publicColumns, '_count'].sort());
```

Adding a `personal`/`pii` column to `Program` now fails this test instead of leaking. The non-empty guard is deliberate — without it, a bad import or a renamed model key makes the filter return `[]` and the assertion passes against an empty response, which is the exact silent-green failure this test exists to prevent.

**The real fix is migrating to `handler()`**, so visibility derives from the schema tiers at runtime instead of a snapshot. That touches `src/security/registry.ts` and `scripts/migrated-routes.txt`, both CODEOWNERS-gated, so it ships separately. Deliberately out of scope here: no changes to `src/security/**` or `prisma/schema.prisma`.

One thing that migration will need to handle: `handler()` strips at response time, so the cached rows would still hold the personal column in process memory even though it never reaches the wire. The `select` on the cached query is worth keeping as defence in depth regardless.

## Verification

- Integration, scoped to `programs|program` — 20 suites, 175 tests passed.
- CI-style, scoped to `security|routeAuth|pageRegistry` — 16 suites, 547 tests passed.
- `tsc --noEmit` clean, eslint clean, `prisma generate` produced no diff in `src/security/generated/`.

**Negative control.** Reverted the projection and reran:

```
✓ should return only public, active programs for unauthenticated users
✓ should return drafts if the authenticated user is the lead mentor
✓ should return all programs including drafts and member-only for admins
✕ exposes only public-tier Program columns (anonymous)
✕ exposes only public-tier Program columns (admin session)
+   "leadMentorNotificationSettings",
```

Both paths fail and name the leaked column. Worth noting the three pre-existing GET tests pass in that run — they never would have caught this, which is why an audit found it and CI did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
