### PR TITLE
fix(security): stop shipping minors' personal-tier data to the kiosk

### DIFF
--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -51,13 +51,20 @@ export async function GET(req: NextRequest) {
             return apiError("Unauthorized", 401);
         }
 
-        const { attendance, counts, safety } = await getFullAttendance();
+        // The kiosk is an unattended device in a public room and re-broadcasts this
+        // payload into an iframe with a wildcard postMessage target origin
+        // (client/client.py). It gets a display-only roster: no dateOfBirth
+        // (personal), no phone (pii), no emergency contacts (personal) — none of
+        // which it renders. A signed-in keyholder/board/sysadmin still gets the
+        // full payload: that grant is deliberate (registry.ts `keyholders:personal`,
+        // for pickup/emergency lookups) and unchanged here.
+        const { attendance, counts, safety } = await getFullAttendance({ kiosk: isKiosk });
 
         // Determine access level
         const isAdmin = isKiosk || user?.isSysadmin || user?.isBoardMember || user?.isKeyholder;
 
         if (isAdmin) {
-            // Full access: return all visits + counts
+            // Full roster access: all visits + counts (kiosk gets the reduced rows above)
             return NextResponse.json({
                 access: "full",
                 attendance,

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -24,6 +24,9 @@ type Person = {
   name?: string | null;
   isKeyholder: boolean;
   isSysadmin: boolean;
+  // Server-computed youth classification. The kiosk payload carries this INSTEAD of
+  // dateOfBirth (personal tier); privileged payloads carry both.
+  isYouth?: boolean;
   dateOfBirth?: string | null;
   householdId?: number | null;
   phone?: string | null;
@@ -76,16 +79,20 @@ function KioskDisplayInner() {
   const counts = data?.counts || { keyholders: 0, volunteers: 0, youth: 0, total: 0 };
   const safety = data?.safety || { isLastKeyholder: false, isTwoDeepViolation: false };
 
+  // Prefer the server-computed flag (the only youth signal the kiosk payload carries),
+  // fall back to the birth date the privileged payload still ships.
+  const visitIsYouth = (v: Visit) => v.participant.isYouth ?? isYouth(v.participant.dateOfBirth);
+
   const fullAttendance = isFull ? (data as FullResponse).attendance : [];
   const keyholderList = fullAttendance.filter(v => v.participant.isKeyholder);
-  const volunteerList = fullAttendance.filter(v => !v.participant.isKeyholder && !isYouth(v.participant.dateOfBirth));
-  const youthList = fullAttendance.filter(v => isYouth(v.participant.dateOfBirth));
+  const volunteerList = fullAttendance.filter(v => !v.participant.isKeyholder && !visitIsYouth(v));
+  const youthList = fullAttendance.filter(v => visitIsYouth(v));
 
   const limitedHousehold = !isFull && data ? (data as LimitedResponse).household : [];
   const limitedSelf = !isFull && data ? (data as LimitedResponse).self : null;
   const householdKeyholders = limitedHousehold.filter(v => v.participant.isKeyholder);
-  const householdVolunteers = limitedHousehold.filter(v => !v.participant.isKeyholder && !isYouth(v.participant.dateOfBirth));
-  const householdYouth = limitedHousehold.filter(v => isYouth(v.participant.dateOfBirth));
+  const householdVolunteers = limitedHousehold.filter(v => !v.participant.isKeyholder && !visitIsYouth(v));
+  const householdYouth = limitedHousehold.filter(v => visitIsYouth(v));
 
   const isCheckedIn = isFull
     ? fullAttendance.some(v => v.participant.id === (session?.user as SessionUser)?.id)

--- a/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
+++ b/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The kiosk is an unattended device that re-broadcasts this payload into an iframe
+ * with a wildcard postMessage origin (client/client.py), so its roster must carry no
+ * `personal`/`pii` field. The privileged (keyholder/board/sysadmin) roster keeps them
+ * — that grant is deliberate (registry.ts `keyholders:personal`, pickup/emergency).
+ */
+const findMany = jest.fn();
+jest.mock("@/lib/prisma", () => ({ __esModule: true, default: { visit: { findMany: (...a: unknown[]) => findMany(...a) } } }));
+
+import { getFullAttendance } from "@/lib/getFullAttendance";
+
+const rows = [
+    {
+        id: 201, arrivedAt: new Date("2026-07-01T14:00:00Z"), departedAt: null, personId: 50,
+        person: {
+            id: 50, email: "karen@example.com", name: "Karen Keyholder", isKeyholder: true,
+            dateOfBirth: new Date("1985-01-01"), householdId: 6, phone: "5551234567",
+            household: { id: 6, emergencyContacts: [{ id: 1, name: "Con One", phone: "5559990001", relationship: "Aunt" }] },
+        },
+        event: { id: 9, program: { id: 3, name: "Robotics", price: 100 } },
+    },
+    {
+        id: 203, arrivedAt: new Date("2026-07-01T14:10:00Z"), departedAt: null, personId: 70,
+        person: {
+            id: 70, email: "stu@example.com", name: null, isKeyholder: false,
+            dateOfBirth: new Date("2012-01-01"), householdId: 8, phone: "5557654321",
+            household: { id: 8, emergencyContacts: [{ id: 2, name: "Con Two", phone: "5559990002", relationship: null }] },
+        },
+        event: null,
+    },
+];
+
+beforeEach(() => {
+    findMany.mockReset();
+    findMany.mockResolvedValue(rows);
+});
+
+describe("getFullAttendance({ kiosk: true })", () => {
+    it("ships no dateOfBirth, phone, householdId or emergency contacts", async () => {
+        const { attendance } = await getFullAttendance({ kiosk: true });
+
+        const wire = JSON.stringify(attendance);
+        expect(wire).not.toMatch(/dateOfBirth|phone|emergencyContacts|householdId/);
+        // The contact values themselves, not just the keys.
+        expect(wire).not.toContain("5551234567");
+        expect(wire).not.toContain("Con One");
+
+        expect(attendance[0]).toEqual({
+            id: 201,
+            arrivedAt: rows[0].arrivedAt,
+            participant: { id: 50, name: "Karen Keyholder", isKeyholder: true, isYouth: false },
+            event: { program: { id: 3, name: "Robotics" } },
+        });
+    });
+
+    it("still gives the display what it renders: name fallback, youth split, program badge", async () => {
+        const { attendance, counts, safety } = await getFullAttendance({ kiosk: true });
+
+        // name-or-email-prefix resolved server-side; raw address never ships
+        expect(attendance[1].participant.name).toBe("stu");
+        expect(JSON.stringify(attendance)).not.toContain("@example.com");
+        // youth column still populates without dateOfBirth
+        expect(attendance[1].participant.isYouth).toBe(true);
+        expect(attendance[0].event).toEqual({ program: { id: 3, name: "Robotics" } });
+        expect(attendance[1].event).toBeNull();
+        // aggregates are identical either way
+        expect(counts).toEqual({ keyholders: 1, volunteers: 0, youth: 1, total: 2 });
+        expect(safety).toEqual({ isLastKeyholder: true, isTwoDeepViolation: true });
+    });
+
+    it("does not even fetch the emergency contacts", async () => {
+        await getFullAttendance({ kiosk: true });
+        expect(findMany.mock.calls[0][0].include.person.select.household).toBe(false);
+    });
+});
+
+describe("getFullAttendance() — privileged caller (unchanged)", () => {
+    it("keeps dateOfBirth, phone and the household emergency contacts", async () => {
+        const { attendance } = await getFullAttendance();
+
+        expect(attendance[0].participant).toMatchObject({
+            id: 50,
+            name: "Karen Keyholder",
+            isKeyholder: true,
+            dateOfBirth: rows[0].person.dateOfBirth,
+            householdId: 6,
+            phone: "5551234567",
+            household: { id: 6, emergencyContacts: [{ id: 1, name: "Con One", phone: "5559990001", relationship: "Aunt" }] },
+        });
+        expect(findMany.mock.calls[0][0].include.person.select.household).toMatchObject({ select: { id: true } });
+    });
+
+    it("never ships the raw email on either path", async () => {
+        const { attendance } = await getFullAttendance();
+        expect(JSON.stringify(attendance)).not.toContain("@example.com");
+    });
+});

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -1,7 +1,32 @@
 import prisma from "@/lib/prisma";
 import { isYouth } from "@/lib/time";
 
-export async function getFullAttendance() {
+/**
+ * Current-attendance feed.
+ *
+ * Two payload shapes, chosen by caller type:
+ *
+ * - Default (a signed-in privileged human — keyholder/board/sysadmin): the full
+ *   roster including `dateOfBirth`, `phone` and the household's emergency
+ *   contacts. That is the deliberate pickup/safety grant behind the keyholder
+ *   view (`registry.ts` grants `keyholders:personal`), rendered by the
+ *   emergency-contact modal on /attendance/current.
+ *
+ * - `{ kiosk: true }` (a signature-verified kiosk): a display-only roster —
+ *   id, display name, isKeyholder, isYouth, arrival time and the program badge.
+ *   The kiosk is an UNATTENDED device in a public room, and it forwards whatever
+ *   it receives into an iframe with a wildcard postMessage origin
+ *   (`client/client.py`), so no `personal`/`pii` field may reach it. It renders
+ *   none of them: phone and the emergency-contact modal are both gated on
+ *   `!isKioskMode` in /attendance/current/page.tsx. Emergency contacts aren't
+ *   even fetched on this path. Same minimization as the sibling kiosk
+ *   certifications grid (#329).
+ *
+ * `counts`/`safety` are identical either way — they are aggregates.
+ */
+export async function getFullAttendance(opts: { kiosk?: boolean } = {}) {
+    const kiosk = opts.kiosk === true;
+
     const activeVisits = await prisma.visit.findMany({
         where: { departedAt: null },
         include: {
@@ -14,10 +39,12 @@ export async function getFullAttendance() {
                     email: true,
                     name: true,
                     isKeyholder: true,
+                    // dateOfBirth is read on both paths (it computes isYouth / the
+                    // counts) but only SHIPS on the privileged path.
                     dateOfBirth: true,
                     householdId: true,
                     phone: true,
-                    household: {
+                    household: kiosk ? false : {
                         select: {
                             id: true,
                             // Only valid (non-member, complete) contacts, primary first.
@@ -71,19 +98,42 @@ export async function getFullAttendance() {
     // server-side, so `name` is always populated and the raw address never ships.
     // Strip the raw included `person` (carries email) out of the spread and re-emit
     // a sanitized DTO under the unchanged wire key `participant` (API contract).
-    const attendance = activeVisits.map(({ person, ...v }) => ({
-        ...v,
-        participant: {
-            id: person.id,
-            name: person.name?.trim() || person.email?.split("@")[0] || null,
-            isKeyholder: person.isKeyholder,
-            dateOfBirth: person.dateOfBirth,
-            householdId: person.householdId,
-            phone: person.phone,
-            household: person.household,
-        },
-    }));
+    const attendance = activeVisits.map(({ person, ...v }) => {
+        const displayName = person.name?.trim() || person.email?.split("@")[0] || null;
+
+        if (kiosk) {
+            // Display-only projection — see the header comment. The visit row itself
+            // is rebuilt field by field rather than spread, so nothing new added to
+            // Visit/Program later leaks onto the kiosk by default.
+            return {
+                id: v.id,
+                arrivedAt: v.arrivedAt,
+                participant: {
+                    id: person.id,
+                    name: displayName,
+                    isKeyholder: person.isKeyholder,
+                    // The kiosk splits the board into keyholder/volunteer/youth
+                    // columns. It gets the classification, not the birth date.
+                    isYouth: youthMap.get(v.id)!,
+                },
+                event: v.event ? { program: v.event.program ? { id: v.event.program.id, name: v.event.program.name } : null } : null,
+            };
+        }
+
+        return {
+            ...v,
+            participant: {
+                id: person.id,
+                name: displayName,
+                isKeyholder: person.isKeyholder,
+                isYouth: youthMap.get(v.id)!,
+                dateOfBirth: person.dateOfBirth,
+                householdId: person.householdId,
+                phone: person.phone,
+                household: person.household,
+            },
+        };
+    });
 
     return { attendance, counts, safety };
 }
-


### PR DESCRIPTION
## What

`GET /api/attendance` folded the kiosk into the privileged branch (`route.ts:57`), so a signature-verified kiosk received the **full** roster for every person currently in the building:

- `dateOfBirth` — tier **personal** (the present population includes youth; `isYouth` is computed from this exact field)
- `phone` — tier **pii**
- `household.emergencyContacts { name, phone, relationship }` — tier **personal**

The kiosk is an unattended device in a public room, and it re-broadcasts whatever it receives into an iframe with a **wildcard** `postMessage` target origin (`client/client.py:315`).

No registered route in `src/security/registry.ts` grants the `kiosk` role a single token. That is the leak this closes.

## How

`getFullAttendance` now takes `{ kiosk }` and projects a display-only roster for that caller:

```jsonc
{ "id": 201, "arrivedAt": "...",
  "participant": { "id": 50, "name": "Karen", "isKeyholder": true, "isYouth": false },
  "event": { "program": { "id": 3, "name": "Robotics" } } }
```

- Emergency contacts aren't fetched at all on that path (`household: kiosk ? false : {...}`) rather than fetched and discarded.
- The visit row is rebuilt field by field instead of spread, so nothing later added to `Visit`/`Program` leaks onto the kiosk by default.
- Same minimization as the sibling kiosk certifications grid (#329), which resolves a display name server-side and drops the raw email.

`counts` and `safety` are unchanged for both callers — they're aggregates.

## What is deliberately NOT changed

**The keyholder/board/sysadmin payload is byte-identical to before.** That grant is precedented and intentional — `registry.ts:224` gives `isKeyholder` a `keyholders:personal` for exactly this pickup/safety purpose, and the keyholder web view at `attendance/current/page.tsx:508` genuinely renders emergency contacts. The limited/non-admin branch (`route.ts:71-83`) was already correctly self/household-scoped and is untouched.

## Reviewer notes

**1. One change outside the obvious blast radius.** The kiosk *did* need `dateOfBirth` — but only to derive the keyholder/volunteer/youth column split (`page.tsx:81-82`). Cutting it with no substitute would have silently dumped every youth into the Volunteers column. So the kiosk now receives a server-computed `isYouth` boolean instead of the birth date, and `page.tsx` gained a 3-line helper:

```ts
const visitIsYouth = (v: Visit) => v.participant.isYouth ?? isYouth(v.participant.dateOfBirth);
```

The `??` fallback keeps the privileged payload and every existing client fixture working. This is the only client-side edit.

**2. Evidence the kiosk needs nothing else** (verified in `client/`, not assumed):
- `client.py:159,331` — the iframe is the app's own kiosk page (`?mode=kiosk`), i.e. `attendance/current/page.tsx` with `isKioskMode` set.
- `client.py:315` forwards only `attendance`/`counts`/`safety`; the wrapper page itself reads just `data.counts.total` (blackout-on-empty) and `data.html`.
- In kiosk mode the page renders: display name via `getKioskDisplayNames`, arrival time, program badge, three column counts, two safety alerts. Phone is gated `!isKioskMode && ...` (`page.tsx:305`); the emergency-contact modal is gated on `canSeeNames`, also `!isKioskMode` (`page.tsx:280`) — the kiosk can never open it.

**3. This is a stopgap; the registry is the real enforcement.** The route is legacy: unregistered, absent from `scripts/migrated-routes.txt`, with its own kiosk-signature plumbing (403 on bad signature, not 401). The durable fix is registering it and migrating to `handler()`, so the stripper enforces the cut and `tests/security/policy.contract.test.ts` becomes a permanent oracle. That could not ship here — the boundary-isolation rule (`AGENTS.md:114`, CI-enforced) requires the registry entry to land in its own PR first. A follow-up is in flight for that entry; it has two genuine open questions (`Authorize` is single-valued but this endpoint admits kiosk **or** authenticated; and the bespoke `{access, attendance, counts, safety, signedRequest}` envelope may not be describable as-is). Worth deciding in the same conversation as this review.

**4. Separate concern, not fixed here:** `client/client.py:315` still posts to `"*"` rather than the app origin. With the payload reduced it no longer leaks personal-tier data, but any co-resident frame still receives the roster.

**5. No security-boundary files touched** — `src/security/**` is CODEOWNERS-gated and out of scope for this PR.

## Testing

- New `src/lib/__tests__/getFullAttendance.test.ts` — 5 tests: kiosk wire carries no `dateOfBirth`/`phone`/`householdId`/`emergencyContacts` (asserted on keys *and* on the contact values themselves), `household: false` in the query args, name fallback + youth split + program badge all survive, counts/safety identical across both paths, privileged payload retains all three fields.
- `npm run test:ci -- "src/app/attendance"` → 5 suites / 35 tests pass, including `attendance/current/__tests__/page.test.tsx`, which pins the emergency-contact rendering at `:453`/`:470` — the regression that mattered most.
- Full `npm run test:ci` → **234 suites / 2119 tests pass**.
- `npx tsc --noEmit` → clean.
- Integration tests not run (no DB spun up in this worktree). `attendanceAPI.integration.test.ts`'s kiosk cases only assert 401/403 and are unaffected by the payload change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)