### PR TITLE
fix(household): keep intakeNotes to household leads

### DIFF
--- a/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
+++ b/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
@@ -114,6 +114,60 @@ describe("Participant PII minimization (M1, M2)", () => {
         expect(callArgs.include.household.include.householdMembers).toEqual({ select: HOUSEHOLD_PEER_SELECT });
     });
 
+    // Household.intakeNotes is the family's free-text note TO the board (tier
+    // 'pii', read by the BG-review queue). Household peers — including youth
+    // with their own logins — must not receive a note a parent wrote about
+    // them. Only the lead, who authored it and edits it on /my-household, does.
+    describe("GET /api/household intakeNotes is lead-only", () => {
+        const mockCaller = (caller: Record<string, unknown>) => {
+            mockSession.mockResolvedValue({ user: { id: 1 } });
+            (prisma.person.findUnique as jest.Mock).mockResolvedValue({
+                id: 1,
+                householdId: 10,
+                ...caller,
+                household: {
+                    id: 10,
+                    name: "Test Household",
+                    line1: "123 Main St",
+                    city: "Austin",
+                    state: "TX",
+                    postalCode: "78701",
+                    intakeNotes: "we are volunteer only; dad lost his job",
+                    orgMembership: null,
+                    householdMembers: [],
+                },
+            });
+        };
+
+        const get = async () => {
+            const req = new Request("http://localhost/api/household") as unknown as NextRequest;
+            const res = await householdGET(req);
+            expect(res.status).toBe(200);
+            return (await res.json()).household;
+        };
+
+        it("strips the note for a non-lead household member", async () => {
+            mockCaller({ isHouseholdLead: false, isSysadmin: false });
+            const household = await get();
+
+            expect(household.intakeNotes).toBeNull();
+            // The address is shared household data the family authored — a peer
+            // still gets it. Only the note is lead-gated.
+            expect(household.line1).toBe("123 Main St");
+            expect(household.postalCode).toBe("78701");
+        });
+
+        it("returns the note to a household lead", async () => {
+            mockCaller({ isHouseholdLead: true, isSysadmin: false });
+            expect((await get()).intakeNotes).toBe("we are volunteer only; dad lost his job");
+        });
+
+        it("returns the note to a sysadmin", async () => {
+            mockCaller({ isHouseholdLead: false, isSysadmin: true });
+            expect((await get()).intakeNotes).toBe("we are volunteer only; dad lost his job");
+        });
+    });
+
     it("GET /api/attendance (full access) does not leak email/googleId", async () => {
         // No session — admitted via a verified kiosk signature instead.
         mockPubKeys.mockReturnValue(["dummy-key"]);

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -31,7 +31,20 @@ export const GET = withAuth(
 
             if (!user) return apiError("User not found", 404);
 
-            return NextResponse.json({ household: user.household }, { status: 200 });
+            // intakeNotes is the family's free-text "anything else we should know?"
+            // note written BY the lead TO the board/BG reviewers — schema classifies
+            // it 'pii' for the reviewer queue, and guards against it reaching any
+            // other household-scoped view. Household peers (incl. youth with their
+            // own logins) have no business reading a note a parent wrote about them.
+            // Only the lead sees it, matching the lead-gated editor on /my-household
+            // and the 403 on PATCH /api/household/settings. Address stays: shared
+            // household data the family authored.
+            const canSeeNotes = user.isHouseholdLead || user.isSysadmin;
+            const household = user.household && !canSeeNotes
+                ? { ...user.household, intakeNotes: null }
+                : user.household;
+
+            return NextResponse.json({ household }, { status: 200 });
         } catch (error: unknown) {
             logger.error("Household GET Error:", error);
             return apiError("Internal Server Error", 500);


### PR DESCRIPTION
## What

`GET /api/household` loaded the caller's household with a bare `include` and returned the row wholesale, so **every authenticated household member** received `Household.intakeNotes` — the family's free-text "anything else we should know?" note.

That note is written **by the household lead, to the board**, and is read by the background-check review queue (`GET /api/membership/reviews`). It can plausibly carry financial-hardship, medical, or family-circumstance disclosures. The audience included youth, who have their own logins (see the youth guard at `src/app/api/profile/route.ts:37-39`, and the "including youth" note in `participantProjection.ts`).

This restricts `intakeNotes` to household leads (and sysadmins). **Address is unchanged for all members** — shared household data the family authored, and a household-scoped grant for it is precedented.

## Zero UI change

Nothing renders the note for non-leads today:

- Only frontend consumer is `src/app/my-household/page.tsx:127`, and the Textarea that displays it (~`:510`) sits inside a card gated `{household && viewerIsLead && (` (~`:492`).
- The write path already agrees: `src/app/api/household/settings/route.ts:41` returns 403 `"Only household leads can edit household settings"`.
- The other three callers of the route (`attendance/current`, `programs/[id]` x2) use the members list only.

Response shape is unchanged — `intakeNotes` becomes `null` rather than being omitted, and the client already does `?? ""`.

## Why the schema already said so

`prisma/schema.prisma` carries an explicit GUARD on `intakeNotes`:

> GUARD: no household-scoped pii token may ever be granted to a lead/keyholder-facing view that returns Household rows, or this narrative leaks

`intakeNotes` is tier `pii` **only** because BG reviewers hold `everyones:pii` on the review queue — it's a reviewer-facing classification, not a family-facing one. The address comment on the same model says the household's own view is "hand-shaped by the self-household routes". This is that route; the hand-shaping was missing.

This route is **not** registry-covered (`withAuth`, not `handler()`, absent from `scripts/migrated-routes.txt`), so it evaded the guard rather than satisfying it.

## Scope / boundary

Ordinary app code only — **no changes under `src/security/`**, no `schema.prisma` edit, no `migrated-routes.txt` entry. **No CODEOWNERS boundary review needed.**

The lead check reuses `isHouseholdLead`/`isSysadmin` scalars already present on the fetched row (the bare `include` returns all `Person` scalars), so there is **no extra query**. The condition mirrors `householdLeadship().canManage` in `src/lib/household/leads.ts` exactly; the helper isn't called because it would issue a second `findUnique` for data already in hand.

## Follow-up, deliberately not in this PR

Migrating this route onto `handler()` is the durable fix. Worth recording why it is not a drop-in replacement for this change: grants are `(scope, tier)` pairs, not per-model. Household peers need `their_households:pii` for each other's `Person.email`/`phone`, and that same token re-exposes `Household.intakeNotes` at the same tier. **A hand-shaped select is required either way** — `GET /api/trusted-adults/mine` already does exactly this (see the "Do not widen that select" note at `registry.ts:174-181`).

## Testing

- `tsc --noEmit` — clean.
- Jest, narrowed to `participantPiiMinimization|my-household|attendance/current|programs/[id]` — 6 suites, 112 tests, all pass (covers all four consumers of the route).
- Added three cases to the route's existing PII-minimization suite pinning non-lead -> `null`, lead -> note, sysadmin -> note, plus an assertion that the address still reaches a non-lead peer.
- Mutation-checked the new test: forcing `canSeeNotes = true` fails `strips the note for a non-lead household member`, so it pins the logic rather than passing vacuously.
- `check-route-coverage` — 0 errors (133 pre-existing advisory warnings, unchanged).

Integration tests were not run (no live DB in this worktree); the changed logic is covered by the mocked unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
