### PR TITLE
security(boundary): declare the board-contacts keyholder PII grant

### DIFF
--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -136,6 +136,37 @@ defineRoute({
     ],
 });
 
+// Emergency board contact sheet for the front desk. Board email + phone to
+// keyholders is DELIBERATE and owner-confirmed: a keyholder on shift needs to
+// reach a board member, and this is the sheet they reach for. That makes the
+// 'pii' grant an operational one exactly as core.ts describes it ("routinely
+// grantable to operational roles: program leads, keyholders"), not a leak.
+// Declared here so the recurring audit finding on this route resolves to
+// policy instead of being re-litigated each sweep — same move as
+// GET /api/shop/certifications below.
+//
+// Written as 'keyholders:pii' (bound flag-only on Person) rather than
+// 'everyones:pii' so the grant reads as what it is. Both resolve identically
+// under this route's role gate; the token is the audit signal.
+//
+// The route's Prisma select stays tight (id/name/email/phone) as defense in
+// depth: dateOfBirth and googleId are 'personal'/'pii' on Person and must
+// never enter this response even for sysadmin.
+//
+// INERT until the route migrates to handler() in the follow-up PR.
+defineRoute({
+    endpoint: 'GET /api/safety/board-contacts',
+    authorize: { anyRole: ['isSysadmin', 'isBoardMember', 'isKeyholder'] },
+    envelope: 'members',
+    // Bag: { Person }.
+    returns: ['Person'],
+    orderedView: [
+        ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
+        ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
+        ['isKeyholder',   ['keyholders:pii', 'member', 'public']],
+    ],
+});
+
 // Board's in-flight membership applications. Exposes every applicant household's
 // PII (parents + children names/emails), so only isSysadmin/board may see it, and
 // the field grant is explicit per role.

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -153,7 +153,9 @@ defineRoute({
 // depth: dateOfBirth and googleId are 'personal'/'pii' on Person and must
 // never enter this response even for sysadmin.
 //
-// INERT until the route migrates to handler() in the follow-up PR.
+// Landed registry-first, ahead of the route's handler() migration, per the
+// AGENTS.md boundary-isolation rule: an unused defineRoute is inert, so the
+// grant is reviewable on its own before anything serves it.
 defineRoute({
     endpoint: 'GET /api/safety/board-contacts',
     authorize: { anyRole: ['isSysadmin', 'isBoardMember', 'isKeyholder'] },

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -35,6 +35,11 @@ export const SCOPE_BINDINGS = {
         their_own: { field: 'id', eqCtx: 'selfId' },
         their_households: { field: 'householdId', eqCtx: 'householdId' },
         their_program_participants: { field: 'id', inCtx: 'participantIdsInScopePrograms' },
+        // Global front-desk grant, unconditional per row (mirrors TrustedAdult).
+        // Only GET /api/safety/board-contacts grants keyholders:* on Person, and
+        // that route returns board members only. Any future Person view granting
+        // a keyholders:* token is a policy decision, not an inherited one.
+        keyholders: { flag: 'isKeyholder' },
         all_current_visitors: {
             all: [{ flag: 'isKeyholder' }, { field: 'id', inCtx: 'activeVisitorIds' }],
         },

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -270,6 +270,14 @@ function eq(a: Set<string>, b: Set<string>): boolean {
  * coverage validator passes — runtime-inert (no route grants their_own:internal
  * on AuditLog). On a row whose actorId === selfId the table therefore adds
  * their_own where the snapshot did not. That is the one expected diff.
+ *
+ * Person.keyholders: the switch's Person case had no keyholders grant, so it
+ * yields no 'keyholders'. Person was later bound `keyholders: { flag }` — an
+ * unconditional per-row grant mirroring TrustedAdult — so that
+ * GET /api/safety/board-contacts can hand keyholders the board's email/phone
+ * via a 'keyholders:pii' token instead of a blanket 'everyones:pii'. On any
+ * object row, a keyholder caller therefore holds 'keyholders' where the
+ * snapshot did not. That is the second expected diff.
  */
 function expectedFromSnapshot(
     model: string,
@@ -285,6 +293,9 @@ function expectedFromSnapshot(
         row.actorId === callerCtx.selfId
     ) {
         expected.add('their_own');
+    }
+    if (model === 'Person' && row && typeof row === 'object' && callerCtx.isKeyholder) {
+        expected.add('keyholders');
     }
     return expected;
 }


### PR DESCRIPTION
**Boundary-only PR (1 of 3).** No app code — `src/security/` + its contract test only.

## What

`GET /api/safety/board-contacts` returns board members' `email` + `phone` (both `pii` on `Person`) to `isKeyholder` callers.

That exposure is **intended and owner-confirmed**: it is the emergency contact sheet the front desk uses — a keyholder on shift needs to reach a board member. It is not a leak, and nothing is narrowed here.

The problem was that the intent was *undeclared*, so it re-tripped every audit sweep. This declares it in the registry — the same move already made for `GET /api/shop/certifications`.

## Changes

| File | Change |
|---|---|
| `src/security/registry.ts` | `defineRoute` for `GET /api/safety/board-contacts` |
| `src/security/scopeBindings.ts` | bind `keyholders` on `Person` (flag-only) |
| `tests/security/scopeBindingsEquivalence.test.ts` | documented expected delta |

**Why `keyholders:pii` and not `everyones:pii`.** Both resolve identically under this route's role gate; the token is the audit signal, so it reads as what it actually is — a front-desk operational grant, matching `core.ts`'s own description of the `pii` tier ("routinely grantable to operational roles: program leads, keyholders").

**Why the `Person` binding is required, not cosmetic.** `Person` had no `keyholders` binding, and `makeScopesHeld` only adds scopes present in the binding table — so `keyholders:pii` would resolve to nothing and silently strip `email`/`phone`. `tests/security/scopeValidators.test.ts` (`validateRouteGrants`) is the gate that proves the token resolves on a returned model.

**Why the equivalence test changes.** `scopeBindingsEquivalence.test.ts` compares `SCOPE_BINDINGS` against a frozen snapshot of the deleted imperative switch. That snapshot has no `Person` keyholders case, so the new binding legitimately diverges. Encoded as an explicit expected delta in `expectedFromSnapshot`, following the existing `AuditLog.their_own` precedent. **The frozen `referenceScopesHeld` oracle is untouched** — its value is being an independent snapshot.

## Reviewer notes

- `envelope: 'members'` is load-bearing: it reproduces the current wire shape `{ members: [...] }` that `src/app/safety/board-contacts/page.tsx:26` already reads, so the follow-up route PR needs no frontend change.
- The `defineRoute` entry is **inert** until the route migrates to `handler()`. The route is still hand-rolled `withAuth` on this branch and keeps its `roles:` gate, so its `AUTHZ_TESTED` entry is unchanged.
- The `Person.keyholders` binding is unconditional per row (mirrors `TrustedAdult`). Only this route grants `keyholders:*` on `Person`, and it returns board members only. Any future `Person` view granting a `keyholders:*` token is a fresh policy decision, not an inherited one.
- The route's Prisma select stays tight (`id`/`name`/`email`/`phone`) as defense in depth: `dateOfBirth` and `googleId` are `personal`/`pii` on `Person` and must never enter this response even for sysadmin.

## Follow-ups (separate PRs)

- **PR 2** — rewrite the route on `handler()`, add the `scripts/migrated-routes.txt` line, drop the `AUTHZ_TESTED` entry.
- **PR 3** — delete the duplicate `GET /api/directory/board` (zero callers).

## Verification

All run locally, foreground:

| Command | Result |
|---|---|
| unit: `scopeValidators` + `scopeBindingsEquivalence` + `authzRegistry` | 4 suites / 19 tests **pass** |
| `npx tsc --noEmit` | clean |
| `npm run check-route-coverage` | **0 errors**, 133 pre-existing warnings |
| integration: `policy.contract` (`--runInBand`) | 1 suite / 40 tests **pass** |

`policy.contract.integration.test.ts` is the one that mattered here: it imports the route module for every registry entry, so it exercised the still-hand-rolled `safety/board-contacts` and asserted every visible field has a grantable tier. Ran against a throwaway Postgres 16 with migrations applied — confirmed green, not assumed.

`src/__tests__/authzRegistry.test.ts` passes **unchanged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
