### PR TITLE
security(route): migrate GET /api/safety/board-contacts onto handler()

### DIFF
--- a/checkin-app/scripts/migrated-routes.txt
+++ b/checkin-app/scripts/migrated-routes.txt
@@ -7,3 +7,4 @@
 GET /api/profile
 GET /api/programs/[id]
 GET /api/directory/board
+GET /api/safety/board-contacts

--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -110,7 +110,6 @@ const AUTHZ_TESTED = new Set<string>([
     // POST deny-path (401 anon / 403 non-board) in authzRoleRejection.integration.test.ts.
     'programs/[id]/sync-shopify',
     'roles',
-    'safety/board-contacts',
     'safety/emergency-contacts',
     'safety/trusted-adults/decision',
     'safety/trusted-adults/override',

--- a/checkin-app/src/app/api/safety/board-contacts/route.ts
+++ b/checkin-app/src/app/api/safety/board-contacts/route.ts
@@ -1,23 +1,21 @@
-import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { withAuth } from "@/lib/auth";
-import { logBackendError } from "@/lib/logger";
-import { apiError } from "@/lib/api-response";
+import { handler } from "@/security/handler";
 import { LIVE_PERSON } from "@/lib/person/filters";
 
-export const GET = withAuth(
-    { roles: ['isSysadmin', 'isBoardMember', 'isKeyholder'] },
-    async () => {
-        try {
-            const members = await prisma.person.findMany({
-                where: { isBoardMember: true, ...LIVE_PERSON },
-                select: { id: true, name: true, phone: true, email: true },
-                orderBy: { name: "asc" },
-            });
-            return NextResponse.json({ members });
-        } catch (error) {
-            await logBackendError(error, "GET /api/safety/board-contacts");
-            return apiError("Internal Server Error fetching board contacts.", 500);
-        }
-    }
-);
+// Emergency board contact sheet for the front desk. Keyholders receive email +
+// phone here — deliberate and owner-confirmed, declared as the registry's
+// 'keyholders:pii' grant rather than hand-rolled in this query. The select
+// stays tight as defense in depth: dateOfBirth and googleId must never enter
+// this response even for a sysadmin caller whose view would grant them.
+//
+// LIVE_PERSON is load-bearing: a merged-away board member keeps its row as a
+// tombstone, and without the filter it would reappear on the front-desk
+// contact sheet with email + phone. Human-facing list, so it filters.
+export const GET = handler('GET /api/safety/board-contacts', async () => {
+    const members = await prisma.person.findMany({
+        where: { isBoardMember: true, ...LIVE_PERSON },
+        select: { id: true, name: true, phone: true, email: true },
+        orderBy: { name: "asc" },
+    });
+    return { Person: members };
+});


### PR DESCRIPTION
Stacked on #1120 — **base is `claude/board-contacts-registry-grant`, not `main`.** Merge #1120 first. Both branches now sit on current main (`8a880dfe`). PR 2 of 3.

## What changed

Three files, no boundary code:

| File | Change |
|---|---|
| `src/app/api/safety/board-contacts/route.ts` | Rewritten on `handler()`; drops hand-rolled `withAuth` + `NextResponse.json` |
| `scripts/migrated-routes.txt` | Adds the endpoint |
| `src/__tests__/authzRegistry.test.ts` | Drops the now-stale `AUTHZ_TESTED` entry |

## Why

#1120 declared this route's policy in the registry — `envelope: 'members'`, `returns: ['Person']`, a keyholder view granting `keyholders:pii`, and the `keyholders` binding on `Person`. That entry is **inert**: the route was still hand-rolled, so nothing enforced the declared policy. This PR makes it live.

Role gating moves entirely to the registry's `authorize` (`{ anyRole: ['isSysadmin', 'isBoardMember', 'isKeyholder'] }`); field exposure comes from `orderedView`. No inline role check remains.

The keyholder email + phone exposure is **intended and owner-confirmed** — it is the front-desk emergency contact sheet, not a leak. The select stays tight (`id, name, phone, email`) as defense in depth so `dateOfBirth`/`googleId` never enter the response even for a sysadmin caller whose view would grant them.

## Reviewer notes

**Wire shape is unchanged.** The handler returns bag key `Person` (not `members`) so the stripper matches by model name; `envelope: 'members'` then re-wraps the single-key bag as `{ members: [...] }` — byte-identical to the old response. The existing page test passes **unedited**, which is the regression signal for this.

**`...LIVE_PERSON` is carried through the rewrite — please confirm it survives any future rebase.** `lib/person/filters.ts` landed on main (#1103) after this stack's original base, so the first version of this rewrite silently dropped it. A merged-away Person is a tombstone whose row survives forever, so without the filter a merged board member reappears on the front-desk contact sheet **with email and phone**. No compiler error — just a ghost in the list. This is a human-facing list, so it filters, per `livePersonDriftGuard`'s sweep-vs-display rule. Verified by negative control: removing the spread fails the guard naming this exact file; restoring it passes.

**Accepted regression:** the removed try/catch called `logBackendError`. `handler()` catches internally and only `console.error`s before an opaque 500, so persistent error logging is lost. This matches every already-migrated route (`directory/board`, `shop/certifications` GET). No wrapper was invented to preserve it.

**The `AUTHZ_TESTED` removal is the correct fix, not an exclusion.** That guard walks `src/app/api` for routes carrying a `roles:` gate and asserts no entry points at a route that is no longer role-gated. After migration this route has none. The deny-path integration case at `authzRoleRejection.integration.test.ts:201` is **kept** — handler admission still returns 401 unauthenticated / 403 otherwise, and it is now the coverage proving the migration preserved the boundary.

## Verification

Run against the current base (post-rebase onto #1120 on main):

| Check | Result |
|---|---|
| `livePersonDriftGuard.test.ts` | pass |
| `npm test` (page, authzRegistry, routeAuthDrift, scopeValidators, drift guard) | 6 suites, 439 tests pass; page test unedited |
| `npx tsc --noEmit` | 0 errors |
| `npm run check-route-coverage` | 0 errors, 132 warnings |
| `npm run test:integration` (policy.contract, authzRoleRejection) | 2 suites, 149 tests pass |

Integration tests ran against a real Postgres (throwaway local cluster, `INTEGRATION_DB=1`, `--runInBand`). `policy.contract.integration.test.ts` iterates `allRoutes()` × every role in `orderedView`, so the keyholder view on this endpoint was exercised through the real stripper — that is what proves keyholders still receive email/phone and nothing undeclared leaks. That run predates the final rebase; the route body is unchanged since, but a reviewer wanting belt-and-braces can re-run it.

Local gotcha, not a code issue: `tsc` may report a phantom `TS2307` from a stale `.next/dev/types/validator.ts` referencing `settings/roles/page.js` after switching branches across #1104. `rm -rf .next` clears it.

## Note on the deprecated role flags

This route filters `isBoardMember: true`. As of #1104 the `isSysadmin`/`isBoardMember`/`isKeyholder` booleans are `@deprecated legacy mirror column`s derived from the new `PersonRole` table. They still exist, and both main's pre-migration version of this route and the already-migrated `directory/board` sibling use the same shape, so this PR follows the current pattern rather than introducing drift. Migrating these call sites off the mirror columns is its own future sweep.

## Out of scope

PR 3 deletes the duplicate `GET /api/directory/board` (zero callers) — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)