### PR TITLE
security: drop stale isOperations structural cast in callerHoldsRole

### DIFF
--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -160,13 +160,7 @@ export function callerHoldsRole(
         case 'isBackgroundCheckReviewer':
             return auth.type === 'session' && auth.user.isBackgroundCheckReviewer;
         case 'isOperations':
-            // SessionUser (types/participant.ts) doesn't declare isOperations yet —
-            // that lands with the roles-foundation PR (which stamps the flag on the
-            // session). This boundary PR adds the role vocabulary alone, ahead of
-            // it; the structural cast reads the flag once it exists without
-            // widening this PR's diff outside src/security/** (isolation-enforced).
-            // Falls back to false (default-deny) until roles-foundation lands.
-            return auth.type === 'session' && !!(auth.user as { isOperations?: boolean }).isOperations;
+            return auth.type === 'session' && auth.user.isOperations;
         case 'certifier':
             return isCertifier(auth);
         case 'householdLead':


### PR DESCRIPTION
## What

Removes the now-stale comment block and structural cast in the `isOperations` case of `callerHoldsRole` (`checkin-app/src/security/access-resolvers.ts`), reading `auth.user.isOperations` directly like the sibling role cases.

## Why

PR #1114 added the `isOperations` role vocabulary ahead of roles-foundation (#1104). At that point `SessionUser` didn't declare the field, so the case read it through a local structural cast (`auth.user as { isOperations?: boolean }`) with a comment explaining the cast should be dropped once roles-foundation landed — #1114's own commit message called for exactly this cleanup.

#1104 has since merged: `SessionUser` (`checkin-app/src/types/participant.ts`) now declares `isOperations: boolean`, making the cast and its seven-line justification comment invalid. This PR completes the planned cleanup.

## Reviewer notes

- No behavior change — the cast read the same field, just untyped; default-deny fallback is no longer reachable since the field is required on `SessionUser`.
- Also audited the other comment #1114 left (the `VALID_ROLES` export justification in `core.ts`): still accurate — the ⊆-guard test it references landed at `checkin-app/src/__tests__/coreRoles.test.ts`. No other stale references found.
- Diff is confined to `src/security/**` per the security-boundary isolation rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)