### PR TITLE
security(route): migrate GET /api/safety/board-contacts onto handler()

### DIFF
--- a/checkin-app/scripts/migrated-routes.txt
+++ b/checkin-app/scripts/migrated-routes.txt
@@ -7,3 +7,4 @@
 GET /api/profile
 GET /api/programs/[id]
 GET /api/directory/board
+GET /api/safety/board-contacts

--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -110,7 +110,6 @@ const AUTHZ_TESTED = new Set<string>([
     // POST deny-path (401 anon / 403 non-board) in authzRoleRejection.integration.test.ts.
     'programs/[id]/sync-shopify',
     'roles',
-    'safety/board-contacts',
     'safety/emergency-contacts',
     'safety/trusted-adults/decision',
     'safety/trusted-adults/override',

--- a/checkin-app/src/app/api/safety/board-contacts/route.ts
+++ b/checkin-app/src/app/api/safety/board-contacts/route.ts
@@ -1,23 +1,21 @@
-import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { withAuth } from "@/lib/auth";
-import { logBackendError } from "@/lib/logger";
-import { apiError } from "@/lib/api-response";
+import { handler } from "@/security/handler";
 import { LIVE_PERSON } from "@/lib/person/filters";
 
-export const GET = withAuth(
-    { roles: ['isSysadmin', 'isBoardMember', 'isKeyholder'] },
-    async () => {
-        try {
-            const members = await prisma.person.findMany({
-                where: { isBoardMember: true, ...LIVE_PERSON },
-                select: { id: true, name: true, phone: true, email: true },
-                orderBy: { name: "asc" },
-            });
-            return NextResponse.json({ members });
-        } catch (error) {
-            await logBackendError(error, "GET /api/safety/board-contacts");
-            return apiError("Internal Server Error fetching board contacts.", 500);
-        }
-    }
-);
+// Emergency board contact sheet for the front desk. Keyholders receive email +
+// phone here — deliberate and owner-confirmed, declared as the registry's
+// 'keyholders:pii' grant rather than hand-rolled in this query. The select
+// stays tight as defense in depth: dateOfBirth and googleId must never enter
+// this response even for a sysadmin caller whose view would grant them.
+//
+// LIVE_PERSON is load-bearing: a merged-away board member keeps its row as a
+// tombstone, and without the filter it would reappear on the front-desk
+// contact sheet with email + phone. Human-facing list, so it filters.
+export const GET = handler('GET /api/safety/board-contacts', async () => {
+    const members = await prisma.person.findMany({
+        where: { isBoardMember: true, ...LIVE_PERSON },
+        select: { id: true, name: true, phone: true, email: true },
+        orderBy: { name: "asc" },
+    });
+    return { Person: members };
+});


### PR DESCRIPTION
Replaces #1121, which was closed after the original stack collapsed — #1121 had been merged into the boundary branch instead of #1120 landing on main first, so all three PRs are being rebuilt sequentially against main.

Migrates `GET /api/safety/board-contacts` onto `handler()`, consuming the `keyholders:pii` registry grant that landed in #1120.

## Contents

- `src/app/api/safety/board-contacts/route.ts` — route body moves under `handler('GET /api/safety/board-contacts')`
- `scripts/migrated-routes.txt` — route added to the migrated list
- `src/__tests__/authzRegistry.test.ts` — drops the now-stale unmigrated-route entry

## Notes

- Based on `65ab248e`, so the registry entry from #1120 is present — `handler()` resolves the endpoint rather than 500ing.
- `LIVE_PERSON` is retained in the query's `where`. Re-checked against main's current drift guard (`84448bc4`, class 3 join-table sites), which this branch now includes; the route is a direct `person.findMany`, not a class-3 site.

Local: `authzRegistry`, `livePersonDriftGuard`, `routeAuthDrift`, `scopeBindingsEquivalence`, `scopeValidators` — 6 suites, 439 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)