### PR TITLE
security: drop GET /api/directory/board registry entry (boundary PR)

### DIFF
--- a/checkin-app/src/app/__tests__/safetyBoardContactsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/safetyBoardContactsAPI.integration.test.ts
@@ -2,15 +2,21 @@
  * @jest-environment node
  */
 /**
- * Regression guard for GET /api/directory/board.
+ * Regression guard for GET /api/safety/board-contacts.
  *
- * Pins the field set leaving the board directory. The endpoint must NEVER ship
- * pii (`dob`, `googleId`) regardless of caller — this is enforced twice: the
- * route's explicit Prisma `select` (defense in depth) AND the outbound stripper.
- * Reverting the `select` makes the board-member assertions fail, which is the
- * point: this test guards the leak.
+ * Pins the field set leaving the emergency board contact sheet. Two distinct
+ * properties, and they pull in opposite directions:
+ *
+ *  - Keyholders DO receive email + phone. That is the registry's
+ *    'keyholders:pii' grant — deliberate and owner-confirmed, because a
+ *    keyholder on shift needs to reach a board member and this is the sheet
+ *    they reach for.
+ *  - `dateOfBirth` and `googleId` must NEVER ship, for ANY caller, sysadmin
+ *    and board included. Enforced twice: the route's tight Prisma `select`
+ *    (defense in depth) AND the outbound stripper. Widening the `select`
+ *    makes these assertions fail, which is the point.
  */
-import { GET } from '@/app/api/directory/board/route';
+import { GET } from '@/app/api/safety/board-contacts/route';
 import prisma from '@/lib/prisma';
 
 jest.mock('next-auth/next', () => ({
@@ -20,13 +26,13 @@ jest.mock('next-auth/next', () => ({
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockSession = require('next-auth/next').getServerSession;
 
-const TAG = 'directory-board-test';
+const TAG = 'safety-board-contacts-test';
 
 function req() {
-    return new Request('http://localhost/api/directory/board') as unknown as import('next/server').NextRequest;
+    return new Request('http://localhost/api/safety/board-contacts') as unknown as import('next/server').NextRequest;
 }
 
-describe('GET /api/directory/board', () => {
+describe('GET /api/safety/board-contacts', () => {
     let boardId: number;
     let keyholderId: number;
     const householdIds: number[] = [];
@@ -72,36 +78,40 @@ describe('GET /api/directory/board', () => {
 
         const res = await GET(req());
         expect(res.status).toBe(200);
-        const { boardMembers } = await res.json();
+        const { members } = await res.json();
 
-        expect(Array.isArray(boardMembers)).toBe(true);
-        const seeded = boardMembers.find((r: { id: number }) => r.id === boardId);
+        expect(Array.isArray(members)).toBe(true);
+        const seeded = members.find((r: { id: number }) => r.id === boardId);
         expect(seeded).toBeDefined();
         // Board legitimately sees contact fields...
         expect(seeded.email).toBe(`board-${TAG}@example.com`);
         expect(seeded.phone).toBe('555-0001');
-        // ...but pii must never ship, for any row.
-        for (const row of boardMembers) {
+        // ...but dob/googleId must never ship, for any row.
+        for (const row of members) {
             expect(row).not.toHaveProperty('dateOfBirth');
             expect(row).not.toHaveProperty('googleId');
         }
     });
 
-    it('a isKeyholder gets only public/member fields — no email/phone/dob/googleId', async () => {
+    it('a isKeyholder gets email and phone — the owner-confirmed emergency-contact grant', async () => {
         mockSession.mockResolvedValue({ user: { id: keyholderId, isKeyholder: true } });
 
         const res = await GET(req());
         expect(res.status).toBe(200);
-        const { boardMembers } = await res.json();
+        const { members } = await res.json();
 
-        const seeded = boardMembers.find((r: { id: number }) => r.id === boardId);
+        const seeded = members.find((r: { id: number }) => r.id === boardId);
         expect(seeded).toBeDefined();
         // Public fields survive.
         expect(seeded.name).toBe(`Board ${TAG}`);
-        // Stripper clears contact pii for keyholders.
-        for (const row of boardMembers) {
-            expect(row).not.toHaveProperty('email');
-            expect(row).not.toHaveProperty('phone');
+        // Contact pii reaches keyholders BY DESIGN: the registry's
+        // 'keyholders:pii' grant on this route. A keyholder on shift must be
+        // able to phone a board member. If this assertion ever flips to
+        // not.toHaveProperty, the emergency sheet has silently gone blank.
+        expect(seeded.email).toBe(`board-${TAG}@example.com`);
+        expect(seeded.phone).toBe('555-0001');
+        // dob/googleId stay out for keyholders too.
+        for (const row of members) {
             expect(row).not.toHaveProperty('dateOfBirth');
             expect(row).not.toHaveProperty('googleId');
         }

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -123,19 +123,6 @@ defineRoute({
     ],
 });
 
-defineRoute({
-    endpoint: 'GET /api/directory/board',
-    authorize: { anyRole: ['isSysadmin', 'isBoardMember', 'isKeyholder'] },
-    envelope: 'boardMembers',
-    // Bag: { Person }.
-    returns: ['Person'],
-    orderedView: [
-        ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
-        ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
-        ['isKeyholder',   ['member', 'public']],
-    ],
-});
-
 // Emergency board contact sheet for the front desk. Board email + phone to
 // keyholders is DELIBERATE and owner-confirmed: a keyholder on shift needs to
 // reach a board member, and this is the sheet they reach for. That makes the


### PR DESCRIPTION
Boundary PR. Removes one registry entry and re-homes one regression test. No app code.

## Why

`GET /api/directory/board` duplicates `GET /api/safety/board-contacts` — identical Prisma query, same role gate — and has **zero callers**. No page, hook, or component fetches it. It is a pilot route from the security-layer rollout and is being retired.

## Why the entry goes first

Retiring the route takes two PRs, and the order is **entry-first, route-file-second** — the reverse of the usual sequence.

`tests/security/registryAuthz.integration.test.ts` builds its plans from `allRoutes()` and does a bare `await import(...)` in `call()` with **no `try`/`catch`**, unlike `policy.contract.integration.test.ts:67-71` which wraps it. So a registry entry whose route file is gone does not degrade gracefully there — it hard-fails with `Could not locate module @/app/api/directory/board/route`. Deleting the route file first would break CI. Dropping the entry first does not: the endpoint simply stops appearing in `allRoutes()`.

## The intermediate state is deliberate

After this merges, the route file exists on main with no registry entry, so `handler()` answers it with a 500. That is acceptable **only** because nothing calls it. `check-route-coverage` emits exactly one advisory warning for this (rule 1, `missing-registry`); the lint runs without `--strict` in `.github/workflows/ci.yml:208`, so it does not fail the build. Not silenced here on purpose.

## The test re-home

The existing `directoryBoardAPI.integration.test.ts` asserted a 200 from the now-unregistered route, so it had to move in this same PR or CI goes red. It is re-homed onto the surviving endpoint rather than dropped, and pins both halves of that route's policy:

- keyholders **DO** receive `email` and `phone` — the registry's owner-confirmed `keyholders:pii` grant for the emergency contact sheet;
- `dateOfBirth` and `googleId` never ship, for any caller, sysadmin and board included.

## Isolation

`registry.ts` is the only non-test file; the two test paths are companions via `*/__tests__/*`.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean, zero output |
| `tests/security/routeAuthDrift.test.ts` + `scopeValidators` | 447 passed |
| `check-route-coverage` | 1 error / 138 warnings, advisory exit 0 — the single error is the expected `directory/board` `missing-registry` |
| `registryAuthz.integration` | **passes**, 54 → 50 tests; `directory/board` no longer appears in the plan set |
| `policy.contract.integration` | passes |
| `safetyBoardContactsAPI.integration` (re-homed) | passes |

Integration tests ran `--runInBand` against a throwaway Postgres 16 with `prisma migrate deploy`.

Note: `registryAuthz` passes on `main` as well — the breakage it guards against only materializes if the route file is deleted while the entry is still registered, which is precisely the ordering this PR avoids.

## Follow-up

PR #1123 (`claude/directory-board-delete`) is still open and carries a contaminated multi-PR diff. It gets rebuilt as the follow-up: delete `src/app/api/directory/board/route.ts` and drop its `scripts/migrated-routes.txt` line, which also clears the advisory warning above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)