### PR TITLE
fix(settings): gate signing-target on CHECKIN_ENV=dev, not not-prod

### DIFF
--- a/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
@@ -5,7 +5,7 @@ jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
 import { screen, fireEvent, waitFor, within } from "@testing-library/react";
-import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import { renderWithProviders, mockFetchJson, setSession, setCheckinEnv, resetRtl } from "@/test-helpers/rtl";
 import { notifications } from "@mantine/notifications";
 import MembershipSettingsPage from "../page";
 
@@ -229,6 +229,29 @@ describe("MembershipSettingsPage", () => {
     await waitFor(() =>
       expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "red", message: "Network error." })),
     );
+  });
+
+  // The signing-target radio is a CHECKIN_ENV=dev knob: the API 400s devSigningTarget on
+  // any other env, and one rejected field rejects the whole PUT — so sending it on 'local'
+  // made every membership setting unsaveable. tsc can't see this (both predicates are
+  // boolean), so the env gate needs a real assertion on the PUT body.
+  it.each([
+    ["local" as const, false],
+    ["dev" as const, true],
+  ])("on CHECKIN_ENV=%s, sends devSigningTarget: %s", async (env, expected) => {
+    setCheckinEnv(env);
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({ "/api/settings/membership": { settings: SETTINGS } });
+    renderWithProviders(<MembershipSettingsPage />);
+    await screen.findByDisplayValue("150.00");
+
+    // The radio itself is only rendered on a real dev instance.
+    expect(!!screen.queryByText(/Contract signing target/)).toBe(expected);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/settings/membership", expect.objectContaining({ method: "PUT" })));
+    const [, putOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PUT")!;
+    expect("devSigningTarget" in JSON.parse(putOpts!.body as string)).toBe(expected);
   });
 
   it("opens renewals for all active members after confirming (never emails — PR-2)", async () => {

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -6,7 +6,7 @@ import { useDisclosure } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
 import { SettingsTabs } from "@/components/admin/SettingsTabs";
 import { useUnsavedGuard, shallowEqual } from "@/components/UnsavedChangesProvider";
-import { useIsDevInstance } from "@/components/EnvProvider";
+import { useCheckinEnv } from "@/components/EnvProvider";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 
 interface Settings {
@@ -46,7 +46,9 @@ export default function MembershipSettingsPage() {
   const [extracting, setExtracting] = useState(false);
   const [discountCode, setDiscountCode] = useState("");
   // Dev-instance-only: where contract signing requests go ('zoho' | 'debug').
-  const isDev = useIsDevInstance();
+  // Strictly CHECKIN_ENV=dev, not useIsDevInstance()'s not-prod: the API rejects
+  // devSigningTarget on any other env, and one rejected field 400s the whole PUT.
+  const isDev = useCheckinEnv() === "dev";
   const [signingTarget, setSigningTarget] = useState("zoho");
 
   // Snapshot of the dues-form values as last loaded/saved; isDirty compares it to


### PR DESCRIPTION
## The bug

Every membership setting was unsaveable on any `CHECKIN_ENV=local` instance. Observed live as `PUT /api/settings/membership 400`, with `BoardSettings.bgRecheckMonths` stuck at 0 — which sends every renewal back for a fresh background review.

Client and server disagreed on what "dev" means.

The page gated the dev-only `devSigningTarget` field on `useIsDevInstance()`, which is `checkinEnv !== 'prod'` — **true on `local`**. The API accepts that field only when `checkinEnv() === "dev"`. So on a local instance the page always sent it and the server always rejected it. Because one invalid field rejects the whole body (documented at `route.ts:22-25`), that took down every unrelated setting in the same request: `normalDuesCents`, `volunteerDuesCents`, `orgMembershipYearBoundary`, `orgMembershipVariantId`, `bgRecheckMonths`, `scholarshipDenialGraceDays`.

Pre-existing; unrelated to any in-flight UI work.

## The server is the correct side

`devSigningTarget` is genuinely meaningful only on `dev`. `signingMockActive()` never reads the column outside it — on `local` there are no real Zoho creds, so `zohoMockActive()` short-circuits and the mock is already on:

```ts
if (config.isProd()) return false;
if (config.zohoMockActive()) return true;   // local stops here
if (config.checkinEnv() !== "dev") return false;
```

The radio is inert on `local`. The page should not render it or send it. Server check left alone.

## The fix

```diff
-const isDev = useIsDevInstance();
+const isDev = useCheckinEnv() === "dev";
```

One predicate, fixing both the send and the radio render. Kept the name `isDev` — it now means what it says, and renaming would have churned two more call sites for no gain. Added a comment recording why it can't be `useIsDevInstance()`, since the next person will be tempted.

`useIsDevInstance()` itself is **unchanged**. Its not-prod semantics are correct for its other 6 consumers (`app/page.tsx`, `signin/page.tsx`, `dev/layout.tsx`, `DevImpersonationBar`, `DevDashboard`, `AppFrame`), all verified untouched by grep.

## Test

`tsc` is blind here — both predicates are `boolean`, so the mismatch type-checks clean. The regression test asserts the PUT body omits `devSigningTarget` under `checkinEnv: 'local'` and includes it under `'dev'`, plus the radio's presence in each.

I confirmed it isn't vacuous: reverting the predicate to `!== "prod"` fails the `local` case and passes `dev`. Restored, 16/16 green.

`npx tsc --noEmit` needed `npx prisma generate` first (this worktree had no generated client, cascading ~550 bogus errors). After generating, the only remaining 8 are `Cannot find module 'xlsx'` / `'@aws-sdk/client-lambda'` in untouched files — incomplete `node_modules`, not code. Zero in either changed file.

## Follow-up, not fixed here

The all-or-nothing rejection is what turned an inert radio into "board settings are unsaveable". That behaviour is intentional for dues — an invalid amount must not silently collapse to zero — but it makes every env-gated field a latent full-form outage, gated only on a client predicate `tsc` can't check. Filed as #1130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
