### PR TITLE
feat(security): legacy-authz ratchet — no new routes outside the registry; revive CODEOWNERS gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,33 +6,28 @@
 # DO NOT remove paths from this file without understanding which guarantee
 # you are weakening. See docs/SECURITY-POLICY.md.
 
-# NOTE: paths were root-anchored from Sprint 1 (#140) while the app lives
-# under /checkin-app — root-anchored patterns matched NOTHING, so none of
-# these gates were active until the prefix fix below (2026-07-19).
-
 # Schema annotations — the source of truth for field sensitivity.
-/checkin-app/prisma/schema.prisma                 @dkaygithub
+/prisma/schema.prisma                 @dkay
 
 # The policy layer itself.
-/checkin-app/src/security/                        @dkaygithub
+/src/security/                        @dkay
 
 # Authentication & session machinery.
-/checkin-app/src/lib/auth.ts                      @dkaygithub
-/checkin-app/src/lib/auth-options.ts              @dkaygithub
+/src/lib/auth.ts                      @dkay
+/src/lib/auth-options.ts              @dkay
 
 # Contract tests that enforce the policy in CI.
-/checkin-app/tests/security/                      @dkaygithub
+/tests/security/                      @dkay
 
 # CODEOWNERS itself and CI workflows — without protecting these, the rest
 # can be quietly disabled in a PR you'd never see.
-/.github/                             @dkaygithub
+/.github/                             @dkay
 
 # The CI lint and the codegen — bypass routes if changed.
-/checkin-app/scripts/check-route-coverage.ts      @dkaygithub
-/checkin-app/scripts/security-generator.js        @dkaygithub
-/checkin-app/scripts/migrated-routes.txt          @dkaygithub
-/checkin-app/scripts/legacy-authz-routes.txt      @dkaygithub
-/checkin-app/scripts/tsconfig.json                @dkaygithub
+/scripts/check-route-coverage.ts      @dkay
+/scripts/security-generator.js        @dkay
+/scripts/migrated-routes.txt          @dkay
+/scripts/tsconfig.json                @dkay
 
 # Git hooks.
-/.husky/                              @dkaygithub
+/.husky/                              @dkay

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,28 +6,33 @@
 # DO NOT remove paths from this file without understanding which guarantee
 # you are weakening. See docs/SECURITY-POLICY.md.
 
+# NOTE: paths were root-anchored from Sprint 1 (#140) while the app lives
+# under /checkin-app — root-anchored patterns matched NOTHING, so none of
+# these gates were active until the prefix fix below (2026-07-19).
+
 # Schema annotations — the source of truth for field sensitivity.
-/prisma/schema.prisma                 @dkay
+/checkin-app/prisma/schema.prisma                 @dkaygithub
 
 # The policy layer itself.
-/src/security/                        @dkay
+/checkin-app/src/security/                        @dkaygithub
 
 # Authentication & session machinery.
-/src/lib/auth.ts                      @dkay
-/src/lib/auth-options.ts              @dkay
+/checkin-app/src/lib/auth.ts                      @dkaygithub
+/checkin-app/src/lib/auth-options.ts              @dkaygithub
 
 # Contract tests that enforce the policy in CI.
-/tests/security/                      @dkay
+/checkin-app/tests/security/                      @dkaygithub
 
 # CODEOWNERS itself and CI workflows — without protecting these, the rest
 # can be quietly disabled in a PR you'd never see.
-/.github/                             @dkay
+/.github/                             @dkaygithub
 
 # The CI lint and the codegen — bypass routes if changed.
-/scripts/check-route-coverage.ts      @dkay
-/scripts/security-generator.js        @dkay
-/scripts/migrated-routes.txt          @dkay
-/scripts/tsconfig.json                @dkay
+/checkin-app/scripts/check-route-coverage.ts      @dkaygithub
+/checkin-app/scripts/security-generator.js        @dkaygithub
+/checkin-app/scripts/migrated-routes.txt          @dkaygithub
+/checkin-app/scripts/legacy-authz-routes.txt      @dkaygithub
+/checkin-app/scripts/tsconfig.json                @dkaygithub
 
 # Git hooks.
-/.husky/                              @dkay
+/.husky/                              @dkaygithub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,11 @@ jobs:
 
       - name: Check route coverage (security policy lint)
         if: needs.changes.outputs.app == 'true'
-        run: npm run check-route-coverage
+        # --strict: errors fail the build (0 errors at flip time; warnings never
+        # fail). The new-route-old-authz ratchet would block even without
+        # --strict, but strict also arms direct-json / third-party-fetch /
+        # registry-drift as real gates.
+        run: npm run check-route-coverage -- --strict
 
       # Full unit tier with coverage, no DB (sibling Jest-side contract).
       # SKIP_COVERAGE_THRESHOLD=1 disables jest.config.js's coverageThreshold

--- a/checkin-app/scripts/check-route-coverage.ts
+++ b/checkin-app/scripts/check-route-coverage.ts
@@ -8,6 +8,9 @@
  *   3. Migrated routes (listed in scripts/migrated-routes.txt) must NOT call NextResponse.json / Response.json directly.
  *   4. Calls to third-party hosts (shopify.com, myshopify.com, resend.com, SHOPIFY_STORE_DOMAIN) live only in src/lib/shopify.ts and src/lib/email.ts.
  *   5. src/security/generated/classifications.ts is up to date with prisma/schema.prisma.
+ *   6. RATCHET (blocking even in advisory mode): every exported route method is
+ *      either in src/security/registry.ts or in the frozen legacy baseline
+ *      (scripts/legacy-authz-routes.txt) — no NEW route can ship on old authz.
  *
  * Uses string/regex parsing — fast, no AST library to load. Trade-off: a
  * sufficiently-obfuscated bypass slips past, but this lint is one layer
@@ -55,6 +58,28 @@ function report(severity: Finding['severity'], rule: string, file: string, messa
 function loadMigratedRoutes(): Set<string> {
     const file = path.join(REPO_ROOT, 'scripts/migrated-routes.txt');
     if (!fs.existsSync(file)) return new Set();
+    return new Set(
+        fs.readFileSync(file, 'utf-8')
+            .split('\n')
+            .map(l => l.trim())
+            .filter(l => l && !l.startsWith('#')),
+    );
+}
+
+/**
+ * The legacy-authz ratchet baseline: route method keys that predate the
+ * registry and are allowed to keep withAuth/withKiosk/withCron/bespoke authz.
+ * Frozen; may only shrink (see the file header). A key in NEITHER the
+ * registry NOR this file is a NEW route on old authz → hard error, blocking
+ * even in advisory mode.
+ */
+function loadLegacyAuthzRoutes(): Set<string> {
+    const file = path.join(REPO_ROOT, 'scripts/legacy-authz-routes.txt');
+    if (!fs.existsSync(file)) {
+        report('error', 'new-route-old-authz', file,
+            'scripts/legacy-authz-routes.txt missing — the legacy-authz ratchet cannot run');
+        return new Set();
+    }
     return new Set(
         fs.readFileSync(file, 'utf-8')
             .split('\n')
@@ -128,6 +153,7 @@ function checkGeneratedFileFresh() {
 
 function main() {
     const migrated = loadMigratedRoutes();
+    const legacyAuthz = loadLegacyAuthzRoutes();
     const { routes: registered } = loadRegisteredEndpoints();
     const routeFiles = findRouteFiles(API_DIR);
 
@@ -144,6 +170,15 @@ function main() {
             if (migrated.has(key)) migratedVerbs.push(verb);
             if (migrated.has(key) && !registered.has(key)) {
                 report('error', 'missing-registry', file, `migrated route ${key} not in registry`);
+            }
+            // The legacy-authz ratchet: a route method in neither the registry
+            // nor the frozen baseline is NEW surface on old authz. New routes
+            // go through defineRoute() + handler() — see legacy-authz-routes.txt.
+            if (!registered.has(key) && !legacyAuthz.has(key)) {
+                report('error', 'new-route-old-authz', file,
+                    `${key} is not in the security registry and not in the frozen ` +
+                    `legacy baseline (scripts/legacy-authz-routes.txt). New routes must ` +
+                    `use defineRoute() + handler() from @/security.`);
             }
         }
 
@@ -176,6 +211,20 @@ function main() {
         }
     }
 
+    // Keep the ratchet honest: a baseline entry whose route no longer exists
+    // (deleted or migrated) must be pruned, or a later re-creation of the same
+    // METHOD+path would silently inherit its old-authz allowance.
+    for (const key of legacyAuthz) {
+        if (!allRouteEndpoints.has(key)) {
+            report('warn', 'stale-legacy-baseline', 'scripts/legacy-authz-routes.txt',
+                `baseline entry ${key} has no corresponding route method — remove the line`);
+        }
+        if (registered.has(key)) {
+            report('warn', 'stale-legacy-baseline', 'scripts/legacy-authz-routes.txt',
+                `baseline entry ${key} is now in the security registry — remove the line`);
+        }
+    }
+
     const allTs = walkTsFiles(SRC_DIR);
     for (const file of allTs) {
         if (ALLOWED_THIRD_PARTY_FETCH_FILES.has(file)) continue;
@@ -204,9 +253,16 @@ function main() {
     console.log(`${errors.length} error(s), ${warnings.length} warning(s)`);
 
     if (errors.length > 0) {
-        if (ADVISORY_MODE) {
+        // The legacy-authz ratchet blocks unconditionally — advisory mode was
+        // the migration on-ramp for EXISTING routes, and grandfathering is the
+        // baseline file's job. A new route on old authz has no advisory tier.
+        const ratchet = errors.filter(f => f.rule === 'new-route-old-authz');
+        if (ADVISORY_MODE && ratchet.length === 0) {
             console.log('(advisory mode — exiting 0; pass --strict to fail the build)');
             process.exit(0);
+        }
+        if (ADVISORY_MODE) {
+            console.log(`(${ratchet.length} new-route-old-authz error(s) block even in advisory mode)`);
         }
         process.exit(1);
     }

--- a/checkin-app/scripts/legacy-authz-routes.txt
+++ b/checkin-app/scripts/legacy-authz-routes.txt
@@ -1,0 +1,178 @@
+# RATCHET — routes that predate the security registry (@/security/handler).
+#
+# Every route method key here still uses legacy authorization (withAuth /
+# withKiosk / withCron / bespoke verify) instead of defineRoute() + handler().
+# The CI lint (scripts/check-route-coverage.ts, rule `new-route-old-authz`)
+# fails any exported route method that is in NEITHER src/security/registry.ts
+# NOR this file — so a NEW route cannot ship on old authz.
+#
+# This list may only SHRINK:
+#   - migrating a route to handler(): delete its line here (and add the
+#     registry entry + scripts/migrated-routes.txt line).
+#   - deleting a route: delete its line here.
+#   - ADDING a line requires CODEOWNERS sign-off and is an explicit decision
+#     to ship new surface outside the audited policy layer. Don't.
+#
+# Frozen 2026-07-19 from the live route tree (161 method keys).
+# Comment lines and blank lines are ignored.
+GET /api/admin/broken-households
+GET /api/admin/settings/localization
+PUT /api/admin/settings/localization
+POST /api/attendance/manual
+GET /api/attendance
+POST /api/attendance
+DELETE /api/attendance
+GET /api/auth/dev-personas
+POST /api/auth/dev-personas
+GET /api/cron/lifecycle-reconcile
+GET /api/cron/membership-renewals
+GET /api/cron/nightly
+GET /api/cron/pending-participants
+GET /api/cron/person-bg-annual
+GET /api/cron/post-event
+GET /api/cron/reconcile-shopify
+GET /api/cron/scholarship-grace-expiry
+GET /api/cron/trusted-adult-expiry
+POST /api/dev/bg-consent/complete
+POST /api/dev/shopify/orders-paid
+POST /api/dev/zoho-sign/complete
+POST /api/events/[id]/attendance
+PATCH /api/events/[id]
+PATCH /api/events/[id]/rsvp
+GET /api/events/mine
+GET /api/events
+POST /api/events
+GET /api/facility/badges
+GET /api/facility/trends
+GET /api/facility/visits
+PATCH /api/facility/visits
+DELETE /api/facility/visits
+POST /api/finance-ops/membership-payment-plans/refuse
+POST /api/finance-ops/membership-payment-plans
+POST /api/finance-ops/payment-plans/manual-hold
+POST /api/finance-ops/payment-plans/refuse
+POST /api/finance-ops/payment-plans
+PATCH /api/finance-ops/payments/[id]
+GET /api/finance-ops/payments
+GET /api/finance-ops/s-read/diagnose
+GET /api/finance-ops/s-read/match-audit
+POST /api/finance-ops/s-read/match-audit/track
+GET /api/finance-ops/s-read/sync
+POST /api/finance-ops/s-read/sync
+GET /api/health/db
+GET /api/health
+PATCH /api/household/emergency-contacts/[contactId]
+DELETE /api/household/emergency-contacts/[contactId]
+GET /api/household/emergency-contacts
+POST /api/household/emergency-contacts
+GET /api/household/intake
+POST /api/household/intake
+POST /api/household/lead
+DELETE /api/household/lead
+PATCH /api/household/member
+GET /api/household
+PATCH /api/household
+PATCH /api/household/settings
+GET /api/household/visits
+GET /api/kioskdisplay/certifications
+GET /api/membership-audit/compliance
+GET /api/membership-audit/households-missing-contact
+POST /api/membership-audit/person-bg
+GET /api/membership-audit/unclaimed-households
+POST /api/membership-ops/applications/archive
+POST /api/membership-ops/applications/certify-payment
+POST /api/membership-ops/applications/external
+POST /api/membership-ops/applications/review-override
+POST /api/membership-ops/applications/unarchive
+POST /api/membership-ops/contacts
+PATCH /api/membership-ops/households/[id]
+GET /api/membership-ops/households
+POST /api/membership-ops/households
+POST /api/membership-ops/participants/[id]/household
+PUT /api/membership-ops/participants/[id]
+POST /api/membership-ops/participants/import/preview
+POST /api/membership-ops/participants/import
+GET /api/membership-ops/participants/merge/analyze
+POST /api/membership-ops/participants/merge
+POST /api/membership-ops/participants
+POST /api/membership/bg-consent
+POST /api/membership/contract/sign
+POST /api/membership/contract/sync
+PATCH /api/membership/intake
+POST /api/membership/intake/submit
+GET /api/membership/payment
+POST /api/membership/renew
+GET /api/membership/renewal-status
+POST /api/membership/request-payment-plan
+POST /api/membership/reviews
+GET /api/membership
+POST /api/membership
+POST /api/my-programs/conflicts/resolve
+GET /api/my-programs/conflicts
+GET /api/nav/todo-counts
+GET /api/notifications
+POST /api/outreach/process-batch
+POST /api/outreach/send
+GET /api/outreach/status
+POST /api/outreach/status
+POST /api/outreach/test-send
+GET /api/people/search
+GET /api/profile/onboarding-status
+POST /api/profile/onboarding
+PATCH /api/profile
+GET /api/profile/visits
+POST /api/programs/[id]/discount-code
+POST /api/programs/[id]/participants
+DELETE /api/programs/[id]/participants
+POST /api/programs/[id]/publish
+POST /api/programs/[id]/request-payment-plan
+PATCH /api/programs/[id]
+PATCH /api/programs/[id]/settings
+POST /api/programs/[id]/sync-shopify
+POST /api/programs/[id]/volunteers
+PATCH /api/programs/[id]/volunteers
+DELETE /api/programs/[id]/volunteers
+GET /api/programs/mine
+GET /api/programs
+POST /api/programs
+GET /api/roles
+PATCH /api/roles
+GET /api/safety/emergency-contacts
+POST /api/safety/trusted-adults/decision
+POST /api/safety/trusted-adults/override
+POST /api/scan
+GET /api/settings/email
+PUT /api/settings/email
+POST /api/settings/membership/bulk-open-renewals
+POST /api/settings/membership/extract-variant
+GET /api/settings/membership
+PUT /api/settings/membership
+GET /api/settings/membership/volunteer-designations
+POST /api/settings/membership/volunteer-designations
+DELETE /api/settings/membership/volunteer-designations
+GET /api/settings/outreach
+PUT /api/settings/outreach
+GET /api/settings/shopify-webhook
+POST /api/shop/certifications
+PATCH /api/shop/tools/[id]
+GET /api/shop/tools
+POST /api/shop/tools
+GET /api/system-status/audit-log
+GET /api/system-status/config-health
+GET /api/system-status/errors
+GET /api/system-status/health
+GET /api/system-status/kiosk-version
+GET /api/system-status/lifecycle
+PATCH /api/system-status/links/[id]
+GET /api/system-status/links
+POST /api/trusted-adults/[id]/hide
+POST /api/trusted-adults/[id]/renew
+POST /api/trusted-adults/[id]/resubmit
+POST /api/trusted-adults/[id]/withdraw
+POST /api/trusted-adults
+GET /api/unsubscribe
+POST /api/unsubscribe
+POST /api/webhooks/resend
+POST /api/webhooks/shopify/reversals
+POST /api/webhooks/shopify
+POST /api/webhooks/zoho


### PR DESCRIPTION
## What

Makes `defineRoute()` + `handler()` the only way to ship a **new** API route.

1. **`scripts/legacy-authz-routes.txt`** — frozen baseline of the 161 route method keys that predate the registry (139 `withAuth`, 9 `withCron`, 1 `withKiosk`, 12 bespoke: webhooks/HMAC, signed unsubscribe, health, dev-personas, 2 manual-session reads). Shrink-only by contract: migrating or deleting a route removes its line; **adding** a line is an explicit decision to ship surface outside the audited policy layer (CODEOWNERS-gated once #1136 + the #1132 settings flip land).
2. **Lint rule `new-route-old-authz`** (scripts/check-route-coverage.ts, check #6) — any exported route method in neither `src/security/registry.ts` nor the baseline is a hard error, **blocking even in advisory mode** (grandfathering is the baseline's job; a new route on old authz has no advisory tier). Stale baseline entries warn so a deleted route can't be resurrected on old authz. A missing baseline file is itself an error, so the ratchet can't be deleted to bypass it.
3. **CI runs the lint `--strict`** — 0 errors on the tree at flip time, so this lands green; warnings (137 unmigrated / 2 partially-migrated) are unaffected. Strict also arms `direct-json` / `third-party-fetch` / registry-drift as real gates. The lint step is inside **Run Tests (unit)**, already a required status check, so violations mechanically block merge.

CODEOWNERS revival split out to **#1136** per review feedback.

## Verified

- `npm run check-route-coverage -- --strict` → exit 0 on the clean tree.
- Synthetic `withAuth` route (`src/app/api/__ratchet_test__/route.ts`) → `new-route-old-authz` error, exit 1 in **both** advisory and strict modes; clean again after removal.
- Baseline generated with the lint's own verb-extraction regex against the live route tree; 161 keys = 175 exported methods − 14 registry entries, matching the audit exactly.

## Post-merge (repo settings, not code — #1132 / #1133)

- Enable `require_code_owner_reviews: true` on `main` after #1136 merges (#1132).
- Add the `isolation` job (Security boundary isolation) to required status checks (#1133) — pin the exact context string from a recent run first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
