### PR TITLE
fix(security): revive the CODEOWNERS gate — re-anchor paths, correct owner handle (#1132)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,28 +6,33 @@
 # DO NOT remove paths from this file without understanding which guarantee
 # you are weakening. See docs/SECURITY-POLICY.md.
 
+# NOTE: paths were root-anchored from Sprint 1 (#140) while the app lives
+# under /checkin-app — root-anchored patterns matched NOTHING, so none of
+# these gates were active until the prefix fix below (2026-07-19).
+
 # Schema annotations — the source of truth for field sensitivity.
-/prisma/schema.prisma                 @dkay
+/checkin-app/prisma/schema.prisma                 @dkaygithub
 
 # The policy layer itself.
-/src/security/                        @dkay
+/checkin-app/src/security/                        @dkaygithub
 
 # Authentication & session machinery.
-/src/lib/auth.ts                      @dkay
-/src/lib/auth-options.ts              @dkay
+/checkin-app/src/lib/auth.ts                      @dkaygithub
+/checkin-app/src/lib/auth-options.ts              @dkaygithub
 
 # Contract tests that enforce the policy in CI.
-/tests/security/                      @dkay
+/checkin-app/tests/security/                      @dkaygithub
 
 # CODEOWNERS itself and CI workflows — without protecting these, the rest
 # can be quietly disabled in a PR you'd never see.
-/.github/                             @dkay
+/.github/                             @dkaygithub
 
 # The CI lint and the codegen — bypass routes if changed.
-/scripts/check-route-coverage.ts      @dkay
-/scripts/security-generator.js        @dkay
-/scripts/migrated-routes.txt          @dkay
-/scripts/tsconfig.json                @dkay
+/checkin-app/scripts/check-route-coverage.ts      @dkaygithub
+/checkin-app/scripts/security-generator.js        @dkaygithub
+/checkin-app/scripts/migrated-routes.txt          @dkaygithub
+/checkin-app/scripts/legacy-authz-routes.txt      @dkaygithub
+/checkin-app/scripts/tsconfig.json                @dkaygithub
 
 # Git hooks.
-/.husky/                              @dkay
+/.husky/                              @dkaygithub

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,28 +11,28 @@
 # these gates were active until the prefix fix below (2026-07-19).
 
 # Schema annotations — the source of truth for field sensitivity.
-/checkin-app/prisma/schema.prisma                 @dkaygithub
+/checkin-app/prisma/schema.prisma                 @dkaygithub @jee7s @thpr
 
 # The policy layer itself.
-/checkin-app/src/security/                        @dkaygithub
+/checkin-app/src/security/                        @dkaygithub @jee7s @thpr
 
 # Authentication & session machinery.
-/checkin-app/src/lib/auth.ts                      @dkaygithub
-/checkin-app/src/lib/auth-options.ts              @dkaygithub
+/checkin-app/src/lib/auth.ts                      @dkaygithub @jee7s @thpr
+/checkin-app/src/lib/auth-options.ts              @dkaygithub @jee7s @thpr
 
 # Contract tests that enforce the policy in CI.
-/checkin-app/tests/security/                      @dkaygithub
+/checkin-app/tests/security/                      @dkaygithub @jee7s @thpr
 
 # CODEOWNERS itself and CI workflows — without protecting these, the rest
 # can be quietly disabled in a PR you'd never see.
-/.github/                             @dkaygithub
+/.github/                             @dkaygithub @jee7s @thpr
 
 # The CI lint and the codegen — bypass routes if changed.
-/checkin-app/scripts/check-route-coverage.ts      @dkaygithub
-/checkin-app/scripts/security-generator.js        @dkaygithub
-/checkin-app/scripts/migrated-routes.txt          @dkaygithub
-/checkin-app/scripts/legacy-authz-routes.txt      @dkaygithub
-/checkin-app/scripts/tsconfig.json                @dkaygithub
+/checkin-app/scripts/check-route-coverage.ts      @dkaygithub @jee7s @thpr
+/checkin-app/scripts/security-generator.js        @dkaygithub @jee7s @thpr
+/checkin-app/scripts/migrated-routes.txt          @dkaygithub @jee7s @thpr
+/checkin-app/scripts/legacy-authz-routes.txt      @dkaygithub @jee7s @thpr
+/checkin-app/scripts/tsconfig.json                @dkaygithub @jee7s @thpr
 
 # Git hooks.
-/.husky/                              @dkaygithub
+/.husky/                              @dkaygithub @jee7s @thpr


### PR DESCRIPTION
## What

Code half of **#1132**, split out of #1135 per review feedback. The CODEOWNERS security gate has been inert since Sprint 1 (#140) — two independent, each-sufficient failures fixed here:

1. **Dead paths**: patterns were root-anchored (`/src/security/`, `/prisma/schema.prisma`, `/tests/security/`, `/scripts/*`) while the app lives under `checkin-app/` — they matched **0 tracked files**. Only `/.github/` and `/.husky/` were path-live. All re-anchored under `/checkin-app/`.
2. **Wrong owner**: `@dkay` is a real but unrelated GitHub account (not a collaborator), so every line failed GitHub's validator ("Unknown owner"). Corrected to `@dkaygithub` — verified an **admin collaborator** via API.

Also adds `/checkin-app/scripts/legacy-authz-routes.txt` (the authz ratchet baseline from #1135) — a harmless dead pattern until that PR lands, then load-bearing. No ordering constraint between the two PRs.

## Not in this PR (repo settings, post-merge)

- `require_code_owner_reviews: true` on `main` — the third failure from #1132. Must flip **after** this merges: flipping while the broken `@dkay` handle is on main leaves the gate inert or wedges `/.github/`-touching PRs (including this one).
- Adding `isolation` to required status checks (#1133).

## Evidence

#1132's behavioral proof stands: PRs #1120/#1128 modified `checkin-app/src/security/` with no code-owner review requested. After this + the settings flip, that can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)