### PR TITLE
fix(security): honor ?filter=adults in people search so minors can't lead a program

### DIFF
--- a/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
@@ -32,6 +32,9 @@ describe('Sensitive route authorization', () => {
     let plainId: number;
     let searchTargetId: number;
     let personaId: number;
+    let adultId: number;
+    let minorId: number;
+    let declaredAdultId: number;
     const householdIds: number[] = [];
     const ENV_BEFORE = process.env.CHECKIN_ENV;
 
@@ -57,6 +60,33 @@ describe('Sensitive route authorization', () => {
         });
         personaId = persona.id;
         householdIds.push(persona.householdId);
+
+        // Age fixtures for ?filter=adults (the lead-mentor pickers). Relative to now so
+        // they never age past the boundary the way a hardcoded year would.
+        const yearsAgo = (n: number) => {
+            const d = new Date();
+            d.setFullYear(d.getFullYear() - n);
+            return d;
+        };
+        const adult = await prisma.person.create({
+            data: { name: `ZZAdult ${TAG}`, email: `adult-${TAG}@example.com`, dateOfBirth: yearsAgo(40), household: { create: { name: "Test HH" } } },
+        });
+        adultId = adult.id;
+        householdIds.push(adult.householdId);
+
+        const minor = await prisma.person.create({
+            data: { name: `ZZMinor ${TAG}`, email: `minor-${TAG}@example.com`, dateOfBirth: yearsAgo(10), household: { create: { name: "Test HH" } } },
+        });
+        minorId = minor.id;
+        householdIds.push(minor.householdId);
+
+        // No DoB, but a lead marked them 25+ — must survive the filter, or every
+        // null-DoB adult mentor vanishes from the picker.
+        const declared = await prisma.person.create({
+            data: { name: `ZZDeclared ${TAG}`, email: `declared-${TAG}@example.com`, dateOfBirth: null, isDeclaredAdult: true, household: { create: { name: "Test HH" } } },
+        });
+        declaredAdultId = declared.id;
+        householdIds.push(declared.householdId);
     });
 
     beforeEach(() => {
@@ -66,7 +96,7 @@ describe('Sensitive route authorization', () => {
 
     afterAll(async () => {
         process.env.CHECKIN_ENV = ENV_BEFORE;
-        await prisma.person.deleteMany({ where: { id: { in: [plainId, searchTargetId, personaId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [plainId, searchTargetId, personaId, adultId, minorId, declaredAdultId] } } });
         // The target's orgMembership row must go before its household (RESTRICT FK).
         await prisma.orgMembership.deleteMany({ where: { householdId: { in: householdIds } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
@@ -149,6 +179,40 @@ describe('Sensitive route authorization', () => {
             // only place that pins the contract; dropping it from the select must fail here.
             // Present for ops too (opsOnly strips only orgMembership on the household).
             expect(hit.household.householdMembers[0]).toHaveProperty('isHouseholdLead', false);
+        });
+
+        // ?filter=adults backs both lead-mentor pickers (program-ops/new and
+        // program-ops/programs/[id]). The param used to be read nowhere, so a minor
+        // could be picked as a program lead mentor.
+        describe('?filter=adults', () => {
+            const ids = async (u: string) => {
+                mockSession.mockResolvedValue({ user: { id: plainId, isBoardMember: true } });
+                const res = await SearchGet(req(u));
+                expect(res.status).toBe(200);
+                return (await res.json()).people.map((p: { id: number }) => p.id);
+            };
+
+            it('returns adults (by DoB and by isDeclaredAdult) and excludes minors', async () => {
+                const got = await ids(`http://localhost/api/people/search?q=ZZ&filter=adults`);
+                expect(got).toContain(adultId);
+                expect(got).toContain(declaredAdultId);
+                expect(got).not.toContain(minorId);
+            });
+
+            it('applies no age filter without the param, or with an unrecognized value', async () => {
+                expect(await ids(`http://localhost/api/people/search?q=ZZ`)).toContain(minorId);
+                expect(await ids(`http://localhost/api/people/search?q=ZZ&filter=everyone`)).toContain(minorId);
+            });
+
+            // Pins the hazard: `q` and `filter` are both ORs, so a naive second `OR:` key
+            // drops the name search. Both must apply — a matching minor stays out, and a
+            // non-matching adult does not leak in on the age leg alone.
+            it('applies BOTH q and the age filter', async () => {
+                const got = await ids(`http://localhost/api/people/search?q=ZZMinor&filter=adults`);
+                expect(got).not.toContain(minorId);
+                expect(got).not.toContain(adultId);
+                expect(got).not.toContain(declaredAdultId);
+            });
         });
     });
 

--- a/checkin-app/src/app/api/people/search/route.ts
+++ b/checkin-app/src/app/api/people/search/route.ts
@@ -15,19 +15,38 @@ export const GET = withAuth(
         try {
             const url = new URL(req.url);
             const q = url.searchParams.get('q') || '';
+            // Only `adults` is recognized; any other value (or none) filters by age not at all.
+            const adultsOnly = url.searchParams.get('filter') === 'adults';
 
             const eighteenYearsAgo = new Date();
             eighteenYearsAgo.setFullYear(eighteenYearsAgo.getFullYear() - 18);
 
             const people = await prisma.person.findMany({
+                // Both clauses below are ORs, so they go in an AND array rather than as
+                // two `OR:` keys — a second top-level OR would silently overwrite the
+                // first, and Prisma's recursive WhereInput accepts that without a type
+                // error. `?q=x&filter=adults` must apply both.
                 where: {
                     ...LIVE_PERSON,
-                    ...(q ? {
-                        OR: [
-                            { name: { contains: q, mode: 'insensitive' } },
-                            { email: { contains: q, mode: 'insensitive' } },
-                        ]
-                    } : {}),
+                    AND: [
+                        ...(q ? [{
+                            OR: [
+                                { name: { contains: q, mode: 'insensitive' as const } },
+                                { email: { contains: q, mode: 'insensitive' as const } },
+                            ]
+                        }] : []),
+                        // Adult = 18+. The isDeclaredAdult leg keeps members a lead marked
+                        // 25+ without a DoB (schema.prisma) in the picker; a null-DoB person
+                        // who was never declared adult is excluded, which is what a strict
+                        // 18+ rule means — the "mark 25+" control in the Details modal is
+                        // the affordance to fix that.
+                        ...(adultsOnly ? [{
+                            OR: [
+                                { dateOfBirth: { lte: eighteenYearsAgo } },
+                                { isDeclaredAdult: true },
+                            ]
+                        }] : []),
+                    ],
                 },
                 take: 200,
                 orderBy: { id: 'desc' },


### PR DESCRIPTION
## What

`GET /api/people/search` computed an 18-years-ago cutoff and never used it. The `filter` param was read nowhere in the file, so both lead-mentor pickers — which both request `&filter=adults` — listed every person in the directory, minors included:

- [program-ops/new/page.tsx:127](checkin-app/src/app/program-ops/new/page.tsx#L127) — the "Lead Mentor / Program Coordinator" `EntityPicker` on the create-program form
- [program-ops/programs/[id]/page.tsx:136](checkin-app/src/app/program-ops/programs/%5Bid%5D/page.tsx#L136) — `searchAdults`, whose own comment says "Lead-mentor picker searches adult members"

So a minor could be selected as a program lead mentor. The dead cutoff variable says the filter was intended and dropped in a refactor.

## Why this shape

Adult = 18 or older: `dateOfBirth <= 18 years ago OR isDeclaredAdult`.

The `isDeclaredAdult` leg is deliberate. Per `prisma/schema.prisma:85-87` it is set when a lead marks someone 25+ without recording a DoB; without that leg every null-DoB person vanishes from both pickers, including legitimate adult mentors. A null-DoB person who has *not* been declared adult is excluded — that is what a strict 18+ rule means, and the board already has the affordance to fix it (the "mark 25+" control in the participant Details modal, #1008).

An absent or unrecognized `filter` value behaves exactly as before. No other filter values were invented.

## Reviewer note — the hazard this hinges on

The name/email search is already an `OR`. A second top-level `OR:` key **silently overwrites the first** in an object literal, and Prisma's recursive `WhereInput` accepts that without a type error, so the route would search on the wrong condition while compiling clean. Both clauses therefore go in one `AND` array.

I verified this is not theoretical. Building the route the naive way (two `OR:` keys, no `AND`):

| Broken shape | `tsc --noEmit` | jest |
|---|---|---|
| Route change reverted entirely | — | **2 failed** — the minor is returned |
| Naive duplicate `OR:` keys, no `AND` | **exit 0 (green)** | **1 failed** — "applies BOTH q and the age filter" |

The combination assertion is the only thing that catches row 2. Without it the fix can silently drop the `q` search and still look green.

## Tests

Added a `?filter=adults` block to the existing `GET /api/people/search` suite in `authzRoutes.integration.test.ts`, with three new fixtures following the file's `TAG` pattern (all added to `afterAll` cleanup). Ages are computed relative to now, not hardcoded years, so they never drift past the boundary:

- `ZZAdult` — DoB 40y ago → returned
- `ZZMinor` — DoB 10y ago → NOT returned
- `ZZDeclared` — `dateOfBirth: null, isDeclaredAdult: true` → returned

Plus the combination case: `?q=ZZMinor&filter=adults` must apply both — the matching minor stays excluded, and the non-matching adults do not leak in on the age leg alone.

`npm run test:integration -- --testPathPatterns authzRoutes` → **17 passed** (3 new, 14 pre-existing unchanged). `npx tsc --noEmit` clean.

Ran against a throwaway Postgres (Homebrew fallback; Docker was down) migrated and seeded with `prisma/seed.ts`.

## Scope

Two files. Deliberately **not** touched:

- Nothing under `checkin-app/src/security/**` — this route stays on `withAuth`, no `handler()` / `defineRoute` migration, per the CI-enforced boundary-isolation rule in `AGENTS.md`. That belongs in its own app-code-free PR.
- `scripts/legacy-authz-routes.txt` (this route stays at line 119) and `scripts/migrated-routes.txt` — unchanged.
- The response projection (`formatted`, the `opsOnly` strip, the `household` shape) — a sibling change owns that hunk; this diff is confined to the `where` clause.
- The four other callers (`membership-ops/participants`, `.../merge`, `membership-ops/roles`, `facility-ops/print-badges`) deliberately want everyone and were left alone.

## Not done

No manual browser check — I did not load the create-program page to eyeball the picker. The integration test drives the real route handler against real Postgres, and I read both callers to confirm they send the literal `&filter=adults`, but the UI itself was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)