### PR TITLE
fix(security): project merge/analyze to what the merge picker reads

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -341,6 +341,53 @@ describe("Merge Participants API", () => {
         expect(analyzeRes.status).toBe(409);
     });
 
+    it("analyze projects only what the merge picker reads — no raw Person/Household rows", async () => {
+        // The fixture must actually SET the sensitive fields, or the negative
+        // assertions below pass vacuously and pin nothing.
+        await prisma.household.update({
+            where: { id: householdId },
+            data: { intakeNotes: "family notes, not for the merge screen", line1: "1 Secret Ln" }
+        });
+        await prisma.person.update({
+            where: { id: pKeepId },
+            data: { allergies: "peanuts", googleId: "google-keep-1", dateOfBirth: new Date("2001-02-03") }
+        });
+        await prisma.person.update({
+            where: { id: pMergeId },
+            data: { allergies: "latex", googleId: "google-merge-2", dateOfBirth: new Date("2002-03-04") }
+        });
+        await prisma.visit.create({ data: { personId: pKeepId, arrivedAt: new Date() } });
+
+        const res = await analyzeGET(analyzeReq(pKeepId, pMergeId));
+        expect(res.status).toBe(200);
+        const { participants } = await res.json();
+        const hit = participants[0];
+        expect(hit.id).toBe(pKeepId);
+
+        // Stripped: nothing on this screen reads any of these.
+        expect(hit.allergies).toBeUndefined();
+        expect(hit.notificationSettings).toBeUndefined();
+        expect(hit.lastBackgroundCheck).toBeUndefined();
+        expect(hit.household.intakeNotes).toBeUndefined();
+        expect(hit.household.line1).toBeUndefined();
+        const member = hit.household.householdMembers.find((m: { id: number }) => m.id === pMergeId);
+        expect(member.googleId).toBeUndefined();
+        expect(member.dateOfBirth).toBeUndefined();
+        expect(member.email).toBeUndefined();
+        expect(member.allergies).toBeUndefined();
+
+        // Surviving: the conflict picker's inputs and the keep/merge score.
+        expect(hit.googleId).toBe("google-keep-1");
+        expect(hit.dateOfBirth).toBeTruthy();
+        expect(hit.name).toBe("Keep User");
+        expect(hit.email).toBe("keep@example.com");
+        expect(member).toHaveProperty("isHouseholdLead");
+        expect(member.name).toBe("Merge User");
+        expect(hit.household.name).toBe("Merge Test Household");
+        expect(hit._count.visits).toBe(1);
+        expect(hit._count.programParticipants).toBe(0);
+    });
+
     // Matrix 6
     it("concurrent double-merge: exactly one CAS wins, the other 409s and rolls back", async () => {
         const keep2 = await prisma.person.create({ data: { name: "Keep Two", householdId } });

--- a/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
@@ -21,10 +21,34 @@ export const GET = withAuth(
             const getParticipant = async (id: number) => {
                 const p = await prisma.person.findUnique({
                     where: { id },
-                    include: {
+                    // Explicit select, not a bare include — an include returns the whole
+                    // Person row (allergies, notificationSettings, emailVerified,
+                    // lastBackgroundCheck, waiverSignedBy, ...) plus the whole Household
+                    // (intakeNotes, line1/city/state/postalCode), and a plain
+                    // `householdMembers: true` returns full Person rows one level down for
+                    // people who aren't even being merged.
+                    // googleId/dateOfBirth ARE deliberately kept on the two merge subjects:
+                    // they're 2 of the 5 CONFLICT_FIELDS the merge field-picker compares
+                    // (see ../route.ts), and googleIdIdentity() renders the account behind a
+                    // googleId conflict. Stripping them silently breaks the picker.
+                    // Household members get only id/name/isHouseholdLead — all the merge page
+                    // renders (name, "(This)" self-marker, [Lead] marker, isLeadWithOthers
+                    // guard and others-count).
+                    select: {
+                        id: true,
+                        name: true,
+                        email: true,
+                        phone: true,
+                        googleId: true,
+                        dateOfBirth: true,
+                        mergedIntoId: true,
                         household: {
-                            include: {
-                                householdMembers: true
+                            select: {
+                                id: true,
+                                name: true,
+                                householdMembers: {
+                                    select: { id: true, name: true, isHouseholdLead: true }
+                                }
                             }
                         },
                         _count: {


### PR DESCRIPTION
## What

`GET /api/membership-ops/participants/merge/analyze` returned two **raw `Person` rows** plus a raw `Household` and **every household member as a full `Person` row** — no projection at all.

That shipped, per `src/security/generated/classifications.ts`:

- both merge subjects: `allergies`, `notificationSettings` (**personal**), `emailVerified`, `waiverSignedBy`, `emailUndeliverableAt`, `lastWaiverSign`, `lastBackgroundCheck` (**internal**), `image`, …
- the whole household: `intakeNotes` (**pii**) and `line1`/`line2`/`city`/`state`/`postalCode` (**internal**)
- **every household member**, complete: `googleId` (pii), `allergies`, `dateOfBirth`, `notificationSettings` (personal) and every internal flag — for people who aren't even being merged

Replaced the bare `include` with an explicit `select` covering exactly what the sole consumer reads.

## Why this is hygiene, not an incident

The route is legacy authz (`withAuth`, gated `isSysadmin`/`isBoardMember`). That audience is high-trust, so this is **data minimization, not a privilege breach**. Same shape as `62dd6d80` ("keep intakeNotes to household leads") and the in-flight `people/search` fix, whose comment is the model this one follows.

## What survives, and why

Sole caller is `src/app/membership-ops/participants/merge/page.tsx:128`. The new `select` is exactly its verified field usage:

| Kept | Read by |
|---|---|
| `name`, `email`, `phone`, `googleId`, `dateOfBirth` | the 5 `CONFLICT_FIELDS` radios (`page.tsx:28`, mirroring `../route.ts:12`) |
| `id`, `mergedIntoId` | client type; route 409s on it |
| `_count.{visits, rawBadgeLogs, programParticipants, programVolunteers}` | keep/merge recommendation score, `page.tsx:76-84` |
| `household.{id, name}` | `page.tsx:261` |
| `household.householdMembers[].{id, name, isHouseholdLead}` | `page.tsx:265-266` + `isLeadWithOthers` guard, `:309-310` |

**`googleId` and `dateOfBirth` are deliberately retained** on the two merge subjects — unlike `people/search`, this endpoint genuinely needs them: the conflict picker compares them and `googleIdIdentity()` (`page.tsx:39-43`) renders the identity behind a `googleId` conflict. Stripping them silently breaks the field picker. A comment on the route says so, so the next person doesn't "tidy" them away.

## Reviewer notes

- **`tsc` cannot catch a wrong projection here.** `ParticipantMergeView` has an `[key: string]: unknown` index signature (`page.tsx:23`), so the page compiles green against any response shape. The integration coverage is the only real net.
- No `LIVE_PERSON` filter added — `livePersonDriftGuard.test.ts:50-66` documents at length why `merge/analyze` is deliberately exempt (`findUnique` returns at most one row picked by key, so it can never leak a tombstone into a list or count). Adding it would contradict a written boundary decision.
- Not migrated to `handler()`/`defineRoute`; still a line in `legacy-authz-routes.txt`. **No file under `checkin-app/src/security/` or `checkin-app/scripts/` is in this diff** (verified) — per `AGENTS.md` boundary isolation, that must ship separately.
- `household._count.householdMembers` (optional on the client type, unread) deliberately NOT added.
- Page-test mocks already carried only `{id, name, householdMembers:[{id, isHouseholdLead}]}` — no stripped field present, nothing to trim.

## Verification

Added an analyze projection case to the existing merge integration suite, pinning the shape in both directions. Fixtures now actually SET household `intakeNotes` + `line1` and per-person `allergies`/`googleId`/`dateOfBirth` (test-local, to keep a two-sided `googleId` out of the existing conflict-resolution cases) — otherwise the negative assertions would pass vacuously and pin nothing.

| Run | Result |
|---|---|
| `test:integration --testPathPatterns "participants/merge"` | **26 passed** |
| `test:integration --testPathPatterns "authzRoleRejection"` (deny path, unedited) | **116 passed** |
| `npm test --testPathPatterns "participants/merge"` (page suite) | **17 passed** |
| `npx tsc --noEmit` | exit 0 |

**Revert sanity-check ran:** stashing the route change fails the new case — `Expected: undefined / Received: "peanuts"` at `hit.allergies`, 1 failed / 25 passed. Restored, re-verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
