### PR TITLE
lint(security): flag bare `include: { rel: true }` on unregistered routes

### DIFF
--- a/checkin-app/scripts/__tests__/check-route-coverage.test.ts
+++ b/checkin-app/scripts/__tests__/check-route-coverage.test.ts
@@ -1,0 +1,76 @@
+import { findBareIncludeLegs, findUnregisteredBareIncludeLegs } from "../check-route-coverage";
+
+const names = (src: string) => findBareIncludeLegs(src).map(l => l.name);
+
+describe("findBareIncludeLegs", () => {
+    it("flags a bare-true leg directly inside include", () => {
+        expect(names(`prisma.person.findMany({ include: { rel: true } })`)).toEqual(["rel"]);
+    });
+
+    it("ignores a fully-projected query with no include at all", () => {
+        expect(names(`prisma.person.findMany({ select: { rel: { select: { id: true } } } })`)).toEqual([]);
+    });
+
+    it("ignores a bare-true leg inside select — that is how you narrow a query", () => {
+        expect(names(`select: { id: true, name: true, isHouseholdLead: true }`)).toEqual([]);
+    });
+
+    it("ignores _count, which returns integers rather than rows", () => {
+        expect(names(`include: { _count: { select: { visits: true } } }`)).toEqual([]);
+    });
+
+    // The case that actually pins the block-kind tracking: one include block
+    // containing a nested-block leg, a nested include, and a nested select.
+    it("tracks the nearest enclosing block through nesting", () => {
+        const src = `
+            include: {
+                household: {
+                    include: {
+                        householdMembers: true,
+                    },
+                    select: { id: true, name: true },
+                },
+                _count: { select: { visits: true } },
+                orgMembership: true,
+            }
+        `;
+        expect(names(src)).toEqual(["householdMembers", "orgMembership"]);
+    });
+
+    it("reports the line of the offending leg", () => {
+        expect(findBareIncludeLegs("a\nb\ninclude: {\n  rel: true,\n}")).toEqual([{ name: "rel", line: 4 }]);
+    });
+
+    it("does not let braces in a blanked comment skew the brace stack", () => {
+        const src = `
+            select: {
+                // include: { leaked: true
+                id: true,
+            }
+        `;
+        expect(names(src)).toEqual([]);
+    });
+
+    it("does not match true legs mid-identifier", () => {
+        expect(names(`include: { a_rel: true }`)).toEqual(["a_rel"]);
+        expect(names(`include: { x.rel: true }`)).toEqual([]);
+    });
+});
+
+describe("findUnregisteredBareIncludeLegs", () => {
+    const BODY = `export async function GET() { return prisma.p.findMany({ include: { rel: true } }) }`;
+
+    it("flags the leg when no verb of the route is registered", () => {
+        const legs = findUnregisteredBareIncludeLegs(BODY, ["GET"], "/api/thing", new Set());
+        expect(legs.map(l => l.name)).toEqual(["rel"]);
+    });
+
+    it("stays silent on a registered route — handler()'s stripper covers it", () => {
+        const registered = new Set(["GET /api/thing"]);
+        expect(findUnregisteredBareIncludeLegs(BODY, ["GET"], "/api/thing", registered)).toEqual([]);
+    });
+
+    it("stays silent on a file that exports no verbs", () => {
+        expect(findUnregisteredBareIncludeLegs(BODY, [], "/api/thing", new Set())).toEqual([]);
+    });
+});

--- a/checkin-app/scripts/check-route-coverage.ts
+++ b/checkin-app/scripts/check-route-coverage.ts
@@ -11,6 +11,9 @@
  *   6. RATCHET (blocking even in advisory mode): every exported route method is
  *      either in src/security/registry.ts or in the frozen legacy baseline
  *      (scripts/legacy-authz-routes.txt) — no NEW route can ship on old authz.
+ *   7. Routes with NO registered verb must not use bare `include: { rel: true }`
+ *      — with no handler() response stripper in front of them, every column of
+ *      the related model reaches the wire (see 62dd6d80, GET /api/household).
  *
  * Uses string/regex parsing — fast, no AST library to load. Trade-off: a
  * sufficiently-obfuscated bypass slips past, but this lint is one layer
@@ -42,6 +45,69 @@ const ALLOWED_THIRD_PARTY_FETCH_FILES = new Set<string>([
 const THIRD_PARTY_HOST_RE = /(shopify\.com|myshopify\.com|resend\.com|SHOPIFY_STORE_DOMAIN)/;
 const VERB_EXPORT_RE = /export\s+(?:const|async\s+function|function)\s+(GET|POST|PUT|PATCH|DELETE)\b/g;
 const JSON_CALL_RE = /\b(NextResponse|Response)\.json\s*\(/;
+
+/**
+ * Rule 7 parser. A `x: true` leg inside `select: {}` is how you NARROW a query
+ * and is everywhere; the same leg inside `include: {}` pulls whole rows. So the
+ * only thing that matters is the NEAREST enclosing block kind, tracked through
+ * nested braces — the dangerous shape is routinely nested inside a safe one:
+ *
+ *   include: { household: { include: { householdMembers: true },   // <- flagged
+ *                           select:  { id: true } } }              // <- not
+ *
+ * `_count` legs are exempt: `_count: { select: {...} }` returns integers.
+ *
+ * ponytail: brace counting, not an AST (see the header's no-AST trade-off).
+ * Known ceiling — an unbalanced `{` inside a string literal would skew the
+ * stack. `${...}` interpolation is balanced so it self-corrects; comments are
+ * blanked below. Reach for an AST only if that ceiling is actually hit.
+ */
+const BLOCK_KEY_RE = /([A-Za-z_$][A-Za-z0-9_$]*)\s*:\s*$/;
+const BARE_TRUE_LEG_RE = /([A-Za-z_$][A-Za-z0-9_$]*)\s*:\s*true\b/y;
+
+/** Blank out comment bodies, preserving offsets and line count. Line comments
+ *  only when the `//` starts the line, so `'https://…'` survives intact. */
+function blankComments(src: string): string {
+    return src
+        .replace(/\/\*[\s\S]*?\*\//g, c => c.replace(/[^\n]/g, ' '))
+        .replace(/^[ \t]*\/\/[^\n]*/gm, c => ' '.repeat(c.length));
+}
+
+export function findBareIncludeLegs(source: string): { name: string; line: number }[] {
+    const src = blankComments(source);
+    const hits: { name: string; line: number }[] = [];
+    const stack: string[] = [];
+    let line = 1;
+    for (let i = 0; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '\n') { line++; continue; }
+        if (ch === '{') {
+            const m = BLOCK_KEY_RE.exec(src.slice(Math.max(0, i - 200), i));
+            stack.push(m ? m[1] : '');
+            continue;
+        }
+        if (ch === '}') { stack.pop(); continue; }
+        if (stack[stack.length - 1] !== 'include') continue;
+        if (i > 0 && /[A-Za-z0-9_$.]/.test(src[i - 1])) continue; // mid-identifier
+        BARE_TRUE_LEG_RE.lastIndex = i;
+        const leg = BARE_TRUE_LEG_RE.exec(src);
+        if (!leg) continue;
+        if (leg[1] !== '_count') hits.push({ name: leg[1], line });
+        i = BARE_TRUE_LEG_RE.lastIndex - 1;
+    }
+    return hits;
+}
+
+/** Rule 7's gate: registered verbs go through handler(), whose response stripper
+ *  enforces the tier policy regardless of what the query fetched — a bare
+ *  `household: true` there is safe. A route with NO registered verb has no
+ *  stripper, so whatever the include pulled reaches the wire as-is. */
+export function findUnregisteredBareIncludeLegs(
+    content: string, verbs: string[], endpointPath: string, registered: Set<string>,
+): { name: string; line: number }[] {
+    if (verbs.length === 0 || verbs.some(v => registered.has(`${v} ${endpointPath}`))) return [];
+    return findBareIncludeLegs(content);
+}
 
 interface Finding {
     severity: 'error' | 'warn';
@@ -194,6 +260,18 @@ function main() {
             });
         }
 
+        // Rule 7. ponytail: warn, not error — there are pre-existing hits and CI
+        // runs this with --strict, so error would break main on contact. Flip to
+        // 'error' once the hit list reaches zero; that is this one word and no new
+        // machinery (deliberately NOT a third baseline file — the warn severity IS
+        // the grandfathering, and every scripts/*.txt is CODEOWNERS-gated).
+        for (const leg of findUnregisteredBareIncludeLegs(content, verbs, endpointPath, registered)) {
+            report('warn', 'bare-include-relation', file,
+                `bare 'include: { ${leg.name}: true }' on an unregistered route returns every ` +
+                `column of ${leg.name} — use an explicit select, or migrate to handler()`,
+                leg.line);
+        }
+
         if (verbs.length > 0 && migratedVerbs.length === 0) {
             report('warn', 'unmigrated', file,
                 `route ${verbs.join('/')} ${endpointPath} has not yet been migrated to handler()`);
@@ -269,4 +347,6 @@ function main() {
     process.exit(0);
 }
 
-main();
+// Guarded so the rule-7 parser above can be imported by its test without
+// running the whole lint (and its process.exit) on import.
+if (require.main === module) main();


### PR DESCRIPTION
## Why

Three PII over-exposure bugs this month came from one shape: a route does `include: { relation: true }` and returns the row without projecting, so every column of the related model reaches the wire.

- `62dd6d80` — `GET /api/household`, `intakeNotes` to every household member
- the in-flight `people/search` fix
- the in-flight `merge/analyze` fix

A one-time manual sweep decays. A lint rule does not, and it puts the cheapest escape route at "migrate this to `handler()`" — which shrinks `legacy-authz-routes.txt` in the direction its own header says it may move (currently 161 legacy method keys vs 16 registered entries).

## What changed

New rule 7 in `scripts/check-route-coverage.ts`: for each route file, if **none** of its exported verbs are in the security registry, flag every bare-`true` relation leg directly inside an `include: { ... }` block.

Registered verbs are immune and deliberately not flagged — `handler()`'s response stripper enforces the tier policy regardless of what the query fetched. `finance-ops/membership-payment-plans/route.ts:18` has a bare `household: true` and is perfectly safe for exactly that reason. The exposure only exists for routes still on legacy authz.

### The discriminator

Block kind, not the leg. A `field: true` inside `select: { ... }` is how you narrow a query and is everywhere; the same leg inside `include: { ... }` pulls whole rows. The parser tracks the **nearest enclosing block** through nested braces, because the dangerous shape routinely nests inside a safe one:

```ts
include: {
    household: {                                  // nested-block leg — not flagged
        include: { householdMembers: true },      // FLAGGED
        select: { id: true, name: true },         // select legs — not flagged
    },
    _count: { select: { visits: true } },         // exempt: returns integers, not rows
}
```

Still string/regex level — no AST library, per the file header's documented trade-off. Comments are blanked first (offset- and line-preserving) so braces inside them can't skew the stack; line comments only when the `//` starts the line, so `'https://…'` survives intact. The known ceiling is called out in a `ponytail:` comment: an unbalanced `{` inside a string literal would skew the stack (`${...}` interpolation is balanced, so it self-corrects).

`main()` is now behind `if (require.main === module)` so the parser can be imported by its test without running the whole lint and its `process.exit`.

## Severity: warn, not error

CI runs this script with `--strict` (`.github/workflows/ci.yml:212`), where any **error** fails the build. There are 36 pre-existing legs across 17 files, so shipping this as an error would break `main` on contact. Warnings never fail, in either mode.

A `ponytail:` comment records the intended flip to `error` once the hit list reaches zero — one word, no new machinery. **No new baseline/allowlist file**: the warn severity *is* the grandfathering, a third ratchet file is machinery this doesn't need, and every `scripts/*.txt` is CODEOWNERS-gated.

## Verification

| Command | Exit |
|---|---|
| `npm run check-route-coverage` | **0** |
| `npm run check-route-coverage -- --strict` | **0** |

Summary line: `0 error(s), 175 warning(s)`. Both invocations tested explicitly — a rule that accidentally blocks CI would be worse than no rule.

New test `scripts/__tests__/check-route-coverage.test.ts`, 11/11 passing. Covers: bare leg inside `include` → flagged; the same body fully projected → clean; a bare leg inside `select` → clean; `_count: { select: {...} }` → clean; a registered route with `include: { rel: true }` → clean; line-number reporting; braces inside a comment; mid-identifier non-matching. The nested case (an `include` containing both a nested `include` and a nested `select`) is the one that actually pins the parser.

### False-positive class verified clean, by name

- `finance-ops/membership-payment-plans/route.ts` — absent (registered)
- `profile/route.ts`, `programs/[id]/route.ts` — absent (registered)
- `roles/route.ts` — absent (select-only)
- `membership-ops/households/route.ts` — its `householdMembers` leg uses an explicit `select` and is **not** flagged. Its line 59 `orgMembership: true` *is* — a separate genuine bare leg, sibling of the select-using one, directly inside the `include: {` opened at line 46. Verified by reading the source; not a parser artifact.

## Notes for the reviewer

**`shop/certifications/route.ts` does not flag, by design.** Its `GET` is registered via `handler()`; only `POST` is `withAuth`. The rule gates at file level — one registered verb exempts the file — so its two `tool: true` legs, both inside the registered GET, are genuinely stripper-covered. Per-verb granularity would need attributing each query to its enclosing exported function; that's a different rule and more machinery. Flagging it here would be a false positive.

**No routes are fixed in this PR.** The rule's job is to surface the list. Two hits already have chips in flight (`merge/analyze`, `people/search`); the rest are follow-up work.

**Boundary check:** `.github/workflows/security-boundary-isolation.yml`'s `is_boundary()` (lines 45-52) covers only `checkin-app/src/security/*` (excluding `generated/`) and `checkin-app/scripts/security-generator.js`. This file matches neither, so the isolation workflow will **not** force it to ship alone. It **is** CODEOWNERS-gated (`@dkaygithub @jee7s @thpr`), so maintainer approval is expected.

Untouched: `legacy-authz-routes.txt`, `migrated-routes.txt`, everything under `src/security/**`, and every flagged route.

## Hit list for triage

| File | Legs |
|---|---|
| `membership-ops/participants/merge/route.ts` | 17 — `programParticipants`, `programVolunteers`, `rsvps`, `toolStatuses`, `feePayments`, `bgAttestations`, `corporationLeads`, `corporationMembers` (×2 blocks), `householdMembers` |
| `programs/[id]/request-payment-plan/route.ts` | `person`, `program` |
| `cron/scholarship-grace-expiry/route.ts` | `program`, `person` |
| `cron/pending-participants/route.ts` | `person`, `program` |
| `membership-ops/participants/[id]/route.ts` | `household` |
| `membership-ops/participants/[id]/household/route.ts` | `household` |
| `membership-ops/participants/merge/analyze/route.ts` | `householdMembers` _(chip in flight)_ |
| `membership-ops/households/route.ts` | `orgMembership` |
| `membership-audit/unclaimed-households/route.ts` | `householdMembers` |
| `people/search/route.ts` | `orgMembership` _(chip in flight)_ |
| `household/route.ts` | `orgMembership` |
| `attendance/route.ts` | `person` |
| `cron/nightly/route.ts` | `person` |
| `events/[id]/attendance/route.ts` | `program` |
| `events/[id]/rsvp/route.ts` | `program` |
| `programs/[id]/publish/route.ts` | `events` |
| `dev/bg-consent/complete/route.ts` | `processes` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)