### PR TITLE
security: ProgramSlackAuth pending-route binding opt-out (boundary PR)

### DIFF
--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -162,6 +162,17 @@ export const OPT_OUT_PENDING_ROUTE = new Set<string>([
     // served via withAuth on finance-ops/payments; a household-facing "your payment
     // problem" route is plausible later, and that is when this earns a real binding.
     'PaymentException',
+    // Same shape as PaymentException above: the model (ProgramSlackAuth — the
+    // isolated Slack-bot-token table, group-slack-sync PR1) ships schema-only,
+    // fully inert, with no route yet. `programId` makes it isScopable(); its
+    // `updatedAt`/`updatedById` internal-tier fields make it "sensitive" by the
+    // coverage check even though the actual secret (`botToken`) is tier `secret`
+    // and thus never reaches a GET select regardless (security/core.ts's stripper
+    // drops `secret` unconditionally — see spec §9). GET /api/settings/sync-status
+    // is the model's real reader; its registry entry lands in the boundary PR
+    // (spec §7.4/§12 PR3), which is when this earns a real SCOPE_BINDINGS row and
+    // leaves this queue.
+    'ProgramSlackAuth',
 ]);
 
 /**


### PR DESCRIPTION
One line + comment in `scopeBindings.ts`: queue `ProgramSlackAuth` (the isolated Slack-bot-token table arriving with #1156) in `OPT_OUT_PENDING_ROUTE`, exactly like the existing `PaymentException` entry — schema-only model, no reader route yet, real binding lands with the sync-status route's boundary PR (the feature's PR3).

Why a separate PR: hand-authored `src/security/**` changes ship alone (AGENTS.md boundary rule). #1156 currently carries this same line and its isolation check is expected-red until this merges; then its diff collapses and isolation goes green — the #1114→#1104 pattern.

Validators verified green on main with the entry present (no stale-model coupling); tsc/lint/test:ci all clean on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe