### PR TITLE
fix(programs): opt-in announce + covered-member audience + paced fan-out (#1153, #1154)

### DIFF
--- a/checkin-app/prisma/migrations/20260719120000_program_announce_on_open/migration.sql
+++ b/checkin-app/prisma/migrations/20260719120000_program_announce_on_open/migration.sql
@@ -1,0 +1,2 @@
+-- Additive, NOT NULL with a default so existing rows backfill to false (#1153 opt-in).
+ALTER TABLE "Program" ADD COLUMN "announceOnOpen" BOOLEAN NOT NULL DEFAULT false;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -819,6 +819,10 @@ model Program {
   enrollmentStatus               EnrollmentStatus @default(CLOSED)
   /// @sensitivity:public
   orgMemberOnly                  Boolean          @default(false)
+  /// Opt-in (#1153): when true, reaching UPCOMING+OPEN emails covered members once.
+  /// Default false — no program announces unless a leader enables it.
+  /// @sensitivity:public
+  announceOnOpen                 Boolean          @default(false)
   /// @sensitivity:public
   minAge                         Int?
   /// @sensitivity:public

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -20,7 +20,10 @@ import { beginRenewal } from '@/lib/membership/renewal';
 import prisma from '@/lib/prisma';
 import { sendEmail } from '@/lib/email';
 
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({
+    sendEmail: jest.fn().mockResolvedValue(true),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
 
 const TAG = 'bg-nonblocking-test';
 

--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -17,7 +17,10 @@ import { getServerSession } from 'next-auth/next';
 import { sendEmail } from '@/lib/email';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({
+    sendEmail: jest.fn().mockResolvedValue(true),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
 
 const TAG = 'payment-test';
 const WEBHOOK_SECRET = 'shopify-test-secret';

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -14,7 +14,10 @@ import { getServerSession } from 'next-auth/next';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
 // Don't hit Resend during tests — the reviewer ping is exercised, not actually sent.
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({
+    sendEmail: jest.fn().mockResolvedValue(true),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
 
 const TAG = 'review-test';
 

--- a/checkin-app/src/app/__tests__/membershipReviewConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewConcurrency.integration.test.ts
@@ -13,7 +13,10 @@ import { attest, ReviewError } from '@/lib/membership/review';
 import { normalizeAuditData } from '@/lib/auditPayload';
 import prisma from '@/lib/prisma';
 
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({
+    sendEmail: jest.fn().mockResolvedValue(true),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
 
 const TAG = 'review-concurrency-test';
 

--- a/checkin-app/src/app/__tests__/programAnnounceNotification.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAnnounceNotification.integration.test.ts
@@ -19,7 +19,9 @@ jest.mock('next-auth/next', () => ({
     getServerSession: jest.fn(),
 }));
 jest.mock('@/lib/notifications', () => ({
-    notifyNewProgramAnnounced: jest.fn(),
+    // route.ts's fire-without-await edge does `notifyNewProgramAnnounced(...).catch(...)`
+    // (#1154 belt-and-suspenders) — the mock must resolve so `.catch` is defined.
+    notifyNewProgramAnnounced: jest.fn().mockResolvedValue(undefined),
 }));
 
 const PROGRAM_NAME_TAG = 'Announce Notify Test Program';
@@ -70,22 +72,33 @@ describe('New-program announce notification trigger', () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
     });
 
-    it('fires once when a program crosses INTO UPCOMING + OPEN', async () => {
+    it('fires once when a program crosses INTO UPCOMING + OPEN (announceOnOpen: true)', async () => {
         const name = `${PROGRAM_NAME_TAG} cross`;
+        const program = await prisma.program.create({
+            data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED', announceOnOpen: true },
+        });
+
+        const res = await patch(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' });
+        expect(res.status).toBe(200);
+        expect(mockNotify).toHaveBeenCalledTimes(1);
+        expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({ name }));
+    });
+
+    it('does NOT fire when crossing INTO UPCOMING + OPEN with announceOnOpen left at its false default', async () => {
+        const name = `${PROGRAM_NAME_TAG} default-off`;
         const program = await prisma.program.create({
             data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' },
         });
 
         const res = await patch(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' });
         expect(res.status).toBe(200);
-        expect(mockNotify).toHaveBeenCalledTimes(1);
-        expect(mockNotify).toHaveBeenCalledWith(name);
+        expect(mockNotify).not.toHaveBeenCalled();
     });
 
     it('does NOT re-fire on a later edit while already UPCOMING + OPEN', async () => {
         const name = `${PROGRAM_NAME_TAG} already`;
         const program = await prisma.program.create({
-            data: { name, leadMentorId: leadId, phase: 'UPCOMING', enrollmentStatus: 'OPEN' },
+            data: { name, leadMentorId: leadId, phase: 'UPCOMING', enrollmentStatus: 'OPEN', announceOnOpen: true },
         });
 
         const res = await patch(program.id, { name: `${name} renamed` });
@@ -96,7 +109,7 @@ describe('New-program announce notification trigger', () => {
     it('does NOT fire when only phase flips to UPCOMING (enrollment still CLOSED)', async () => {
         const name = `${PROGRAM_NAME_TAG} phaseonly`;
         const program = await prisma.program.create({
-            data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' },
+            data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED', announceOnOpen: true },
         });
 
         const res = await patch(program.id, { phase: 'UPCOMING' });
@@ -107,7 +120,7 @@ describe('New-program announce notification trigger', () => {
     it('does NOT fire when only enrollment flips to OPEN (phase still PLANNING)', async () => {
         const name = `${PROGRAM_NAME_TAG} enrollonly`;
         const program = await prisma.program.create({
-            data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' },
+            data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED', announceOnOpen: true },
         });
 
         const res = await patch(program.id, { enrollmentStatus: 'OPEN' });

--- a/checkin-app/src/app/__tests__/programAnnounceRecipients.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAnnounceRecipients.integration.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for notifyNewProgramAnnounced's recipient set — the #1153
+ * covered-member audience (isActiveOrgMemberThrough / #1061 "full duration" rule),
+ * independent of the PATCH route's announceOnOpen toggle gate (covered by
+ * programAnnounceNotification.integration.test.ts). Calls notifyNewProgramAnnounced
+ * directly, skipping the route.
+ */
+
+jest.mock('@/lib/email', () => ({
+    sendEmail: jest.fn().mockResolvedValue(true),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
+
+import { notifyNewProgramAnnounced } from '@/lib/notifications';
+import { sendEmail } from '@/lib/email';
+import prisma from '@/lib/prisma';
+
+const mockSendEmail = sendEmail as jest.Mock;
+const TAG = 'announce-recip-test';
+
+describe('notifyNewProgramAnnounced recipient set (#1153 covered-member audience)', () => {
+    let tombstoneHouseholdId: number, tombstoneTargetId: number;
+
+    async function wipe() {
+        const hhs = await prisma.household.findMany({
+            where: { OR: [{ name: { contains: TAG } }, { householdMembers: { some: { email: { contains: TAG } } } }] },
+            select: { id: true },
+        });
+        const ids = hhs.map((h) => h.id);
+        if (ids.length) {
+            await prisma.orgMembershipProcess.deleteMany({ where: { orgMembership: { householdId: { in: ids } } } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.person.deleteMany({ where: { householdId: { in: ids } } });
+            await prisma.household.deleteMany({ where: { id: { in: ids } } });
+        }
+        await prisma.person.deleteMany({ where: { email: { contains: TAG } } });
+    }
+
+    beforeAll(async () => {
+        await wipe();
+
+        // Covered: ACTIVE-membership household, default prefs -> included.
+        await prisma.person.create({
+            data: {
+                email: `covered-${TAG}@example.com`, name: 'Covered',
+                household: { create: { name: `Covered HH ${TAG}`, orgMembership: { create: { status: 'ACTIVE', memberSince: new Date() } } } },
+            },
+        });
+
+        // Uncovered: no orgMembership at all -> fails ACTIVE_ORG_MEMBER_PERSON_WHERE.
+        await prisma.person.create({
+            data: { email: `uncovered-${TAG}@example.com`, name: 'Uncovered', household: { create: { name: `Uncovered HH ${TAG}` } } },
+        });
+
+        // Opted-out: covered household, but notifyNewPrograms:false.
+        await prisma.person.create({
+            data: {
+                email: `optedout-${TAG}@example.com`, name: 'OptedOut',
+                notificationSettings: { notifyNewPrograms: false },
+                household: { create: { name: `OptedOut HH ${TAG}`, orgMembership: { create: { status: 'ACTIVE', memberSince: new Date() } } } },
+            },
+        });
+
+        // Tombstone: covered household, but mergedIntoId set -> excluded by LIVE_PERSON.
+        // The live merge target stays covered and included.
+        const tombstoneTarget = await prisma.person.create({
+            data: {
+                email: `tombstone-target-${TAG}@example.com`, name: 'TombstoneTarget',
+                household: { create: { name: `Tombstone HH ${TAG}`, orgMembership: { create: { status: 'ACTIVE', memberSince: new Date() } } } },
+            },
+            select: { id: true, householdId: true },
+        });
+        tombstoneTargetId = tombstoneTarget.id;
+        tombstoneHouseholdId = tombstoneTarget.householdId;
+        await prisma.person.create({
+            data: { email: `tombstone-${TAG}@example.com`, name: 'Tombstone', householdId: tombstoneHouseholdId, mergedIntoId: tombstoneTargetId },
+        });
+    });
+
+    afterAll(async () => {
+        await wipe();
+    });
+
+    beforeEach(() => {
+        mockSendEmail.mockClear();
+    });
+
+    it('includes covered+opted-in live members, excludes uncovered/opted-out/tombstoned, with no date boundary configured', async () => {
+        await notifyNewProgramAnnounced({ name: 'Robotics Recip Test', startAt: null, endAt: new Date('2026-12-01') });
+
+        const recipients = mockSendEmail.mock.calls.map((c) => c[0]);
+        expect(recipients).toContain(`covered-${TAG}@example.com`);
+        expect(recipients).toContain(`tombstone-target-${TAG}@example.com`);
+        expect(recipients).not.toContain(`uncovered-${TAG}@example.com`);
+        expect(recipients).not.toContain(`optedout-${TAG}@example.com`);
+        expect(recipients).not.toContain(`tombstone-${TAG}@example.com`);
+    });
+
+    // #1061 "full duration" gate: a covered household with NO settled renewal is only
+    // valid through the current membership-year boundary. One boundary config (Aug 1,
+    // via BoardSettings row 1, absent by default in the integration DB) exercises both
+    // sides: a program ending after the boundary excludes the household, a program
+    // ending before it includes the SAME household.
+    describe('expired-at-midyear boundary', () => {
+        let prevBoardSettings: { orgMembershipYearBoundary: Date | null; bgRecheckMonths: number } | null = null;
+        const AUG1 = new Date(Date.UTC(2020, 7, 1)); // only month/day matter to nextBoundary()
+
+        beforeAll(async () => {
+            const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+            prevBoardSettings = existing
+                ? { orgMembershipYearBoundary: existing.orgMembershipYearBoundary, bgRecheckMonths: existing.bgRecheckMonths }
+                : null;
+            await prisma.boardSettings.upsert({
+                where: { id: 1 },
+                create: { id: 1, orgMembershipYearBoundary: AUG1 },
+                update: { orgMembershipYearBoundary: AUG1 },
+            });
+        });
+
+        afterAll(async () => {
+            if (prevBoardSettings) {
+                await prisma.boardSettings.update({ where: { id: 1 }, data: prevBoardSettings });
+            } else {
+                await prisma.boardSettings.delete({ where: { id: 1 } }).catch(() => {});
+            }
+        });
+
+        it('excludes the covered household when the program ends AFTER the boundary (unrenewed)', async () => {
+            await notifyNewProgramAnnounced({ name: 'Robotics Past Boundary', startAt: null, endAt: new Date('2026-12-01') });
+            const recipients = mockSendEmail.mock.calls.map((c) => c[0]);
+            expect(recipients).not.toContain(`covered-${TAG}@example.com`);
+        });
+
+        it('includes the SAME covered household when the program ends BEFORE the boundary', async () => {
+            await notifyNewProgramAnnounced({ name: 'Robotics Before Boundary', startAt: null, endAt: new Date('2026-07-25') });
+            const recipients = mockSendEmail.mock.calls.map((c) => c[0]);
+            expect(recipients).toContain(`covered-${TAG}@example.com`);
+        });
+    });
+});

--- a/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
@@ -139,6 +139,33 @@ describe('Program Settings API Integration Tests', () => {
              expect(data.program.minAge).toBe(15);
         });
 
+        // #1153: the announce toggle is a lead-mentor setting — the existing gate
+        // (line ~28-33) already allows lead mentors, no new role needed.
+        it('should allow the lead mentor to flip announceOnOpen (persists round-trip)', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: leadId } });
+
+             const onReq = new Request(`http://localhost:4000/api/programs/${targetProgramId}/settings`, {
+                 method: 'PATCH',
+                 body: JSON.stringify({ announceOnOpen: true })
+             });
+             const onRes = await PATCH(onReq as unknown as import("next/server").NextRequest, createParams(targetProgramId) as unknown as never);
+             expect(onRes.status).toBe(200);
+             const onData = await onRes.json();
+             expect(onData.program.announceOnOpen).toBe(true);
+
+             const persisted = await prisma.program.findUnique({ where: { id: targetProgramId } });
+             expect(persisted?.announceOnOpen).toBe(true);
+
+             const offReq = new Request(`http://localhost:4000/api/programs/${targetProgramId}/settings`, {
+                 method: 'PATCH',
+                 body: JSON.stringify({ announceOnOpen: false })
+             });
+             const offRes = await PATCH(offReq as unknown as import("next/server").NextRequest, createParams(targetProgramId) as unknown as never);
+             expect(offRes.status).toBe(200);
+             const offData = await offRes.json();
+             expect(offData.program.announceOnOpen).toBe(false);
+        });
+
         it('should block the lead mentor from reassigning the leadMentorId', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: leadId } });
 

--- a/checkin-app/src/app/__tests__/trustedAdultAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultAPI.integration.test.ts
@@ -20,7 +20,10 @@ import { getServerSession } from 'next-auth/next';
 import { expectAuditRow, auditJson } from '@/test-helpers/expectAuditRow';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({
+    sendEmail: jest.fn().mockResolvedValue(true),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
 
 const TAG = 'trustedadult-api-test';
 const SHARED = 'Grandma may pick up the kids.';

--- a/checkin-app/src/app/__tests__/trustedAdultAtomicity.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultAtomicity.integration.test.ts
@@ -24,7 +24,10 @@ import {
 import prisma from '@/lib/prisma';
 
 const sendEmail = jest.fn().mockResolvedValue(true);
-jest.mock('@/lib/email', () => ({ sendEmail: (...a: unknown[]) => sendEmail(...a) }));
+jest.mock('@/lib/email', () => ({
+    sendEmail: (...a: unknown[]) => sendEmail(...a),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
 
 const TAG = 'trustedadult-atomicity-test';
 

--- a/checkin-app/src/app/__tests__/trustedAdultConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultConcurrency.integration.test.ts
@@ -23,7 +23,10 @@ import { normalizeAuditData } from '@/lib/auditPayload';
 import prisma from '@/lib/prisma';
 
 const sendEmail = jest.fn().mockResolvedValue(true);
-jest.mock('@/lib/email', () => ({ sendEmail: (...a: unknown[]) => sendEmail(...a) }));
+jest.mock('@/lib/email', () => ({
+    sendEmail: (...a: unknown[]) => sendEmail(...a),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
 
 const TAG = 'trustedadult-concurrency-test';
 const SHARED = 'Grandma may pick up the kids.';

--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -22,7 +22,10 @@ import {
 import prisma from '@/lib/prisma';
 
 const sendEmail = jest.fn().mockResolvedValue(true);
-jest.mock('@/lib/email', () => ({ sendEmail: (...a: unknown[]) => sendEmail(...a) }));
+jest.mock('@/lib/email', () => ({
+    sendEmail: (...a: unknown[]) => sendEmail(...a),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
 
 const TAG = 'trustedadult-test';
 const SHARED = 'Grandma may pick up the kids.';

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -156,7 +156,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
 
         const body = await req.json();
         let { leadMentorId } = body;
-        const { name, startAt, endAt, orgMemberOnly, phase, enrollmentStatus, minAge, maxAge, maxParticipants, leadMentorNotificationSettings, memberPrice, nonMemberPrice, shopifyProductId, shopifyVariantId, shopifyOrgMemberVariantId, shopifyNonOrgMemberVariantId } = body;
+        const { name, startAt, endAt, orgMemberOnly, announceOnOpen, phase, enrollmentStatus, minAge, maxAge, maxParticipants, leadMentorNotificationSettings, memberPrice, nonMemberPrice, shopifyProductId, shopifyVariantId, shopifyOrgMemberVariantId, shopifyNonOrgMemberVariantId } = body;
 
         if (body.hasOwnProperty('leadMentorId')) {
             if (!leadMentorId) {
@@ -179,6 +179,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
             ...(startAt !== undefined && { startAt: startAt ? new Date(startAt) : null }),
             ...(endAt !== undefined && { endAt: endAt ? new Date(endAt) : null }),
             ...(orgMemberOnly !== undefined && { orgMemberOnly }),
+            ...(announceOnOpen !== undefined && { announceOnOpen }),
             ...(phase !== undefined && { phase }),
             ...(enrollmentStatus !== undefined && { enrollmentStatus }),
             ...(minAge !== undefined && { minAge }),
@@ -218,7 +219,15 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
         const wasAnnounced = currentProgram.phase === 'UPCOMING' && currentProgram.enrollmentStatus === 'OPEN';
         const nowAnnounced = updatedProgram.phase === 'UPCOMING' && updatedProgram.enrollmentStatus === 'OPEN';
         if (!wasAnnounced && nowAnnounced) {
-            await notifyNewProgramAnnounced(updatedProgram.name);
+            if (updatedProgram.announceOnOpen) {
+                // Fire-and-forget: paced send is ~(recipients/5) seconds — must not block
+                // the PATCH response. notifyNewProgramAnnounced swallows its own errors;
+                // .catch is belt-and-suspenders, matching the best-effort idiom.
+                void notifyNewProgramAnnounced(updatedProgram).catch((e) =>
+                    logger.error("notifyNewProgramAnnounced failed:", e));
+            } else {
+                logger.info(`[announce] Program ${updatedProgram.id} reached UPCOMING+OPEN; announceOnOpen off — skipping.`);
+            }
         }
 
         // Shopify is the source of truth for program capacity (product decision

--- a/checkin-app/src/app/api/programs/[id]/settings/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/settings/route.ts
@@ -41,6 +41,7 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
             phase,
             enrollmentStatus,
             orgMemberOnly,
+            announceOnOpen,
             minAge,
             maxAge,
             maxParticipants,
@@ -77,6 +78,7 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         if (phase !== undefined) updateData.phase = phase;
         if (enrollmentStatus !== undefined) updateData.enrollmentStatus = enrollmentStatus;
         if (orgMemberOnly !== undefined) updateData.orgMemberOnly = orgMemberOnly;
+        if (announceOnOpen !== undefined) updateData.announceOnOpen = announceOnOpen;
         if (minAge !== undefined) updateData.minAge = minAge;
         if (maxAge !== undefined) updateData.maxAge = maxAge;
         if (maxParticipants !== undefined) updateData.maxParticipants = maxParticipants;

--- a/checkin-app/src/app/api/programs/route.ts
+++ b/checkin-app/src/app/api/programs/route.ts
@@ -26,6 +26,7 @@ const PUBLIC_PROGRAM_SELECT = {
     phase: true,
     enrollmentStatus: true,
     orgMemberOnly: true,
+    announceOnOpen: true,
     minAge: true,
     maxAge: true,
     maxParticipants: true,

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -26,6 +26,7 @@ export type ProgramDetail = {
   maxAge: number | null;
   maxParticipants: number | null;
   orgMemberOnly: boolean;
+  announceOnOpen: boolean;
   participants: {
     personId: number;
     status: string;
@@ -72,6 +73,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
   const [phase, setPhase] = useState("PLANNING");
   const [enrollmentStatus, setEnrollmentStatus] = useState("CLOSED");
   const [orgMemberOnly, setMemberOnly] = useState(false);
+  const [announceOnOpen, setAnnounceOnOpen] = useState(false);
   const [leadMentorIdInput, setLeadMentorIdInput] = useState("");
   const [memberPrice, setMemberPrice] = useState("");
   const [nonMemberPrice, setNonMemberPrice] = useState("");
@@ -107,6 +109,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
         setPhase(data.phase || "PLANNING");
         setEnrollmentStatus(data.enrollmentStatus || "CLOSED");
         setMemberOnly(Boolean(data.orgMemberOnly));
+        setAnnounceOnOpen(Boolean(data.announceOnOpen));
         setLeadMentorIdInput(data.leadMentorId !== null ? String(data.leadMentorId) : "");
         setMemberPrice(data.orgMemberPriceCents !== null ? String(data.orgMemberPriceCents / 100) : "");
         setNonMemberPrice(data.nonOrgMemberPriceCents !== null ? String(data.nonOrgMemberPriceCents / 100) : "");
@@ -153,7 +156,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
           minAge: minAge ? parseInt(minAge) : null,
           maxAge: maxAge ? parseInt(maxAge) : null,
           maxParticipants: maxParticipants ? parseInt(maxParticipants) : null,
-          phase, enrollmentStatus, orgMemberOnly,
+          phase, enrollmentStatus, orgMemberOnly, announceOnOpen,
           leadMentorId: leadMentorIdInput ? parseInt(leadMentorIdInput) : null,
           memberPrice: memberPrice || null,
           nonMemberPrice: nonMemberPrice || null,
@@ -407,6 +410,13 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                 )}
 
                 <Checkbox checked={orgMemberOnly} onChange={e => setMemberOnly(e.currentTarget.checked)} label="Treehouse Members-Only Program" />
+
+                <Checkbox
+                  checked={announceOnOpen}
+                  onChange={e => setAnnounceOnOpen(e.currentTarget.checked)}
+                  label="Announce to members when enrollment opens"
+                  description="Off by default. When on, reaching Upcoming + Open emails members whose membership covers this program's dates (once)."
+                />
 
                 <SimpleGrid cols={{ base: 1, sm: 2 }}>
                   <Select label="Program Phase" value={phase} onChange={v => setPhase(v ?? 'PLANNING')} allowDeselect={false}

--- a/checkin-app/src/lib/__mocks__/email.ts
+++ b/checkin-app/src/lib/__mocks__/email.ts
@@ -31,3 +31,10 @@ export function __getSentEmails(): RecordedEmail[] {
 export function __clearSentEmails(): void {
     sent.length = 0;
 }
+
+// emailRecipients.ts's fanOutEmails routes through runPaced (#1154) — a synchronous
+// passthrough here keeps this mock timer-free, matching every other runPaced mock
+// in the suite (notifications.test.ts, the announce integration tests).
+export async function runPaced<T>(tasks: Array<() => Promise<T>>): Promise<T[]> {
+    return Promise.all(tasks.map((t) => t()));
+}

--- a/checkin-app/src/lib/__tests__/email.test.ts
+++ b/checkin-app/src/lib/__tests__/email.test.ts
@@ -18,6 +18,7 @@ jest.mock('../emailIdentity', () => ({
 }));
 
 import { sendEmail } from '../email';
+import { runPaced } from '../email';
 
 // process.env.NODE_ENV is typed read-only; tests need to vary it at runtime
 const setNodeEnv = (value: string | undefined) => {
@@ -231,5 +232,46 @@ describe('sendEmail send-failure contract (Resend configured)', () => {
         expect((error as Error).message).toBe('network down');
         expect(context).toEqual({ to: 'bounced@test.com', subject: 'Subject' });
         expect(JSON.stringify(context)).not.toContain(html);
+    });
+});
+
+describe('runPaced pacing', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('runs 12 thunks in chunks of 5/5/2 with 2 gaps, preserving order', async () => {
+        const started: number[] = [];
+        const tasks = Array.from({ length: 12 }, (_, i) => async () => {
+            started.push(i);
+            return i;
+        });
+        const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
+        const resultsPromise = runPaced(tasks);
+
+        // Before advancing any timers, only the first chunk (5) has run.
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(started).toEqual([0, 1, 2, 3, 4]);
+
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(started).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(started).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+        const results = await resultsPromise;
+        expect(results).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+        // Exactly 2 gaps (between chunk 1→2 and chunk 2→3); no gap after the last chunk.
+        expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1000);
+
+        setTimeoutSpy.mockRestore();
     });
 });

--- a/checkin-app/src/lib/__tests__/notifications.test.ts
+++ b/checkin-app/src/lib/__tests__/notifications.test.ts
@@ -1,14 +1,24 @@
 import { sendNotification, notifyNewProgramAnnounced } from '../notifications';
 import { sendEmail } from '../email';
+import { isActiveOrgMemberThrough } from '../orgMembership';
 import prisma from '../prisma';
 
-jest.mock('../email', () => ({ sendEmail: jest.fn() }));
+jest.mock('../email', () => ({
+    sendEmail: jest.fn(),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
+jest.mock('../orgMembership', () => ({
+    ACTIVE_ORG_MEMBER_PERSON_WHERE: {},
+    programCoverageDate: () => new Date('2026-12-01'),
+    isActiveOrgMemberThrough: jest.fn(),
+}));
 jest.mock('../prisma', () => ({
     __esModule: true,
     default: { person: { findUnique: jest.fn(), findMany: jest.fn() } },
 }));
 
 const mockSendEmail = sendEmail as jest.Mock;
+const mockIsActiveOrgMemberThrough = isActiveOrgMemberThrough as jest.Mock;
 const mockFindUnique = (prisma as unknown as { person: { findUnique: jest.Mock } }).person.findUnique;
 const mockFindMany = (prisma as unknown as { person: { findMany: jest.Mock } }).person.findMany;
 
@@ -47,19 +57,38 @@ describe('sendNotification return contract', () => {
 describe('notifyNewProgramAnnounced opt-in filtering', () => {
     beforeEach(() => jest.clearAllMocks());
 
-    it('emails only users not opted out, defaulting ON', async () => {
+    const program = { name: 'Robotics', startAt: null, endAt: new Date('2026-12-01') };
+
+    it('emails only prefs-passing users, defaulting ON, when coverage passes for all', async () => {
         mockFindMany.mockResolvedValue([
-            { email: 'in@b.com', name: 'In', notificationSettings: { notifyNewPrograms: true } },
-            { email: 'def@b.com', name: 'Def', notificationSettings: {} },            // default ON
-            { email: 'null@b.com', name: 'Null', notificationSettings: null },        // default ON
-            { email: 'out@b.com', name: 'Out', notificationSettings: { notifyNewPrograms: false } },
-            { email: 'noemail@b.com', name: 'NoE', notificationSettings: { email: false } },
-            { email: '', name: 'Empty', notificationSettings: {} },                   // empty address
+            { id: 1, email: 'in@b.com', name: 'In', notificationSettings: { notifyNewPrograms: true } },
+            { id: 2, email: 'def@b.com', name: 'Def', notificationSettings: {} },            // default ON
+            { id: 3, email: 'null@b.com', name: 'Null', notificationSettings: null },        // default ON
+            { id: 4, email: 'out@b.com', name: 'Out', notificationSettings: { notifyNewPrograms: false } },
+            { id: 5, email: 'noemail@b.com', name: 'NoE', notificationSettings: { email: false } },
+            { id: 6, email: '', name: 'Empty', notificationSettings: {} },                   // empty address
         ]);
-        await notifyNewProgramAnnounced('Robotics');
+        mockIsActiveOrgMemberThrough.mockResolvedValue(true);
+
+        await notifyNewProgramAnnounced(program);
 
         expect(mockSendEmail).toHaveBeenCalledTimes(3);
         const recipients = mockSendEmail.mock.calls.map(c => c[0]);
         expect(recipients).toEqual(['in@b.com', 'def@b.com', 'null@b.com']);
+    });
+
+    it('excludes a prefs-passing person whose coverage does not extend through the program (the #1061 gate)', async () => {
+        mockFindMany.mockResolvedValue([
+            { id: 1, email: 'covered@b.com', name: 'Covered', notificationSettings: {} },
+            { id: 2, email: 'uncovered@b.com', name: 'Uncovered', notificationSettings: {} },
+        ]);
+        mockIsActiveOrgMemberThrough.mockImplementation((id: number) => Promise.resolve(id !== 2));
+
+        await notifyNewProgramAnnounced(program);
+
+        expect(mockSendEmail).toHaveBeenCalledTimes(1);
+        const recipients = mockSendEmail.mock.calls.map(c => c[0]);
+        expect(recipients).toEqual(['covered@b.com']);
+        expect(mockIsActiveOrgMemberThrough).toHaveBeenCalledWith(2, new Date('2026-12-01'));
     });
 });

--- a/checkin-app/src/lib/email.ts
+++ b/checkin-app/src/lib/email.ts
@@ -55,3 +55,25 @@ export async function sendEmail(to: string, subject: string, html: string): Prom
         return false;
     }
 }
+
+/**
+ * Run async tasks in chunks, pausing `gapMs` between chunks — a crude client-side
+ * rate limiter for provider fan-out (#1154, chunks of 5 @ 1/s). Best-effort: assumes
+ * each task already swallows its own errors (sendEmail resolves false, never rejects),
+ * so nothing is caught here. Order of results matches order of tasks.
+ */
+export async function runPaced<T>(
+    tasks: Array<() => Promise<T>>,
+    chunkSize = 5,
+    gapMs = 1000,
+): Promise<T[]> {
+    const results: T[] = [];
+    for (let i = 0; i < tasks.length; i += chunkSize) {
+        const chunk = tasks.slice(i, i + chunkSize);
+        results.push(...await Promise.all(chunk.map((t) => t())));
+        if (i + chunkSize < tasks.length) {
+            await new Promise((r) => setTimeout(r, gapMs));
+        }
+    }
+    return results;
+}

--- a/checkin-app/src/lib/emailRecipients.ts
+++ b/checkin-app/src/lib/emailRecipients.ts
@@ -1,5 +1,5 @@
 import prisma from "@/lib/prisma";
-import { sendEmail } from "@/lib/email";
+import { sendEmail, runPaced } from "@/lib/email";
 import { logger } from "@/lib/logger";
 import { LIVE_PERSON } from "@/lib/person/filters";
 
@@ -52,7 +52,7 @@ export async function resolveHouseholdRecipients(
  * nothing left to catch here.
  */
 function fanOutEmails(emails: string[], subject: string, html: string): Promise<boolean[]> {
-    return Promise.all(emails.map((email) => sendEmail(email, subject, html)));
+    return runPaced(emails.map((email) => () => sendEmail(email, subject, html)));
 }
 
 /** Email every lead of a household. Resolve + fan-out; all errors logged and swallowed. */

--- a/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
@@ -12,7 +12,10 @@ import prisma from "@/lib/prisma";
 import { runReconcile, raiseReversalByOrderId } from "@/lib/finance/reconcile";
 import type { MirrorOrder } from "@/lib/shopifyRead/client";
 
-jest.mock("@/lib/email", () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock("@/lib/email", () => ({
+    sendEmail: jest.fn().mockResolvedValue(true),
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
+}));
 
 // Mocked mirror — each test sets what the read helpers return. Only the DB-backed
 // reads are stubbed; orderAttr stays REAL (it's a pure parse of the mirrored

--- a/checkin-app/src/lib/notifications.ts
+++ b/checkin-app/src/lib/notifications.ts
@@ -1,10 +1,16 @@
 import prisma from "./prisma";
 import { sendEmail } from "./email";
+import { runPaced } from "./email";
 import { formatTime, formatDate } from "./time";
 import { checkinReceiptTemplate } from "./email-templates/checkin";
 import { householdMemberTemplate } from "./email-templates/household";
 import { escapeHtml, type VisitSource } from "./email-templates/base";
 import { LIVE_PERSON } from "./person/filters";
+import {
+    ACTIVE_ORG_MEMBER_PERSON_WHERE,
+    isActiveOrgMemberThrough,
+    programCoverageDate,
+} from "./orgMembership";
 
 /**
  * Service to handle sending notifications to users via their defined preferences.
@@ -68,30 +74,46 @@ export async function sendNotification(userId: number, eventType: NotificationEv
 }
 
 /**
- * Broadcast a "new program announced" email to every user opted into
- * notifyNewPrograms. Fired when a program first becomes BOTH phase=UPCOMING and
- * enrollmentStatus=OPEN. Respects the global `email` opt-out too. Both prefs
- * default ON — only an explicit `false` opts out.
+ * Broadcast a "new program announced" email to members whose household membership
+ * covers the program's FULL DURATION (#1061 rule, reused verbatim), respecting each
+ * person's notifyNewPrograms / email prefs (default ON). Paced at 5/sec (#1154).
+ *
+ * The announceOnOpen opt-in gate lives at the CALL SITE (programs/[id] PATCH) — this
+ * only runs when a leader has enabled it. Best-effort: fire-and-forget from the route.
  */
-export async function notifyNewProgramAnnounced(programName: string): Promise<void> {
+export async function notifyNewProgramAnnounced(
+    program: { name: string; startAt: Date | null; endAt: Date | null },
+): Promise<void> {
     try {
-        // ponytail: full scan of users-with-email, filtered in JS. This fires at
-        // most once per program (the UPCOMING+OPEN edge), so a table scan is fine;
-        // switch to a JSON-path where-filter if the person table grows large.
+        const coverageDate = programCoverageDate(program);
+
+        // Narrow to LIVE persons with an address in an ACTIVE-membership household
+        // (canonical ACTIVE_ORG_MEMBER_PERSON_WHERE). Class-1 person.findMany with
+        // LIVE_PERSON — drift guard stays green, no allowlist (human-facing).
         const users = await prisma.person.findMany({
-            where: { email: { not: null }, ...LIVE_PERSON },
-            select: { email: true, name: true, notificationSettings: true },
+            where: { email: { not: null }, ...LIVE_PERSON, ...ACTIVE_ORG_MEMBER_PERSON_WHERE },
+            select: { id: true, email: true, name: true, notificationSettings: true },
         });
 
-        const subject = `New program: ${programName}`;
-        await Promise.all(users.map(u => {
-            if (!u.email) return;
+        const subject = `New program: ${program.name}`;
+        const tasks: Array<() => Promise<boolean>> = [];
+        for (const u of users) {
+            if (!u.email) continue;
             const s = u.notificationSettings as unknown as Record<string, boolean> | null;
-            if (s?.notifyNewPrograms === false) return; // opted out of this notice
-            if (s?.email === false) return;             // opted out of all email
-            const message = `Hi ${u.name}, a new program "${programName}" is now open for enrollment.`;
-            return sendEmail(u.email, subject, `<p>${escapeHtml(message)}</p>`);
-        }));
+            if (s?.notifyNewPrograms === false) continue; // opted out of this notice
+            if (s?.email === false) continue;              // opted out of all email
+            // ponytail: reuse isActiveOrgMemberThrough verbatim (#1061 — one definition of
+            // "covered for the program year"). N indexed reads over the active-member set;
+            // fires once per program, fire-and-forget — fine. If the member base grows,
+            // dedupe the horizon per householdId via membershipValidThrough.
+            if (!(await isActiveOrgMemberThrough(u.id, coverageDate))) continue;
+            const email = u.email;
+            const name = u.name;
+            const message = `Hi ${name}, a new program "${program.name}" is now open for enrollment.`;
+            tasks.push(() => sendEmail(email, subject, `<p>${escapeHtml(message)}</p>`));
+        }
+
+        await runPaced(tasks);
     } catch (error) {
         console.error("Failed to send new-program notifications:", error);
     }

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -203,6 +203,7 @@ export const classifications = {
         phase: 'public',
         enrollmentStatus: 'public',
         orgMemberOnly: 'public',
+        announceOnOpen: 'public',
         minAge: 'public',
         maxAge: 'public',
         maxParticipants: 'public',


### PR DESCRIPTION
## ⚠️ Behavior change (read before merging)

**Every program that previously auto-announced on reaching UPCOMING + OPEN will now be silent by default.** Leaders must tick the new "Announce to members when enrollment opens" checkbox (Program editor → General tab) to re-enable the announce email for that program. Existing programs get `announceOnOpen = false` on migration — nothing sends until a lead mentor opts in.

## What changed

**#1153 — opt-in + covered-member audience**
- New `Program.announceOnOpen` boolean, default `false` (Jeff's call — no program announces unless a leader turns it on).
- The announce email now goes only to members whose household membership covers the **program's full duration** — reuses the existing #1061 predicate (`isActiveOrgMemberThrough` in `lib/orgMembership.ts`), one definition, not two.
- Toggle is a lead-mentor setting; no new roles (existing gates on `/api/programs/[id]` and `/api/programs/[id]/settings` already allow lead mentors).

**#1154 — paced fan-out**
- New `runPaced()` in `lib/email.ts`: runs tasks in chunks of 5, 1s between chunks.
- `emailRecipients.ts`'s `fanOutEmails` (used by `emailHouseholdLeads`/`emailBoardMembers`) now routes through it — shared by both the announce path and existing fan-outs, for free.
- The announce path fires **without awaiting** from the PATCH route (a big recipient list × 5/sec would otherwise block the PATCH response for tens of seconds); `notifyNewProgramAnnounced` swallows its own errors, `.catch` is belt-and-suspenders.

## Files touched
- `prisma/schema.prisma` + migration `20260719120000_program_announce_on_open` (single additive `ALTER TABLE ... ADD COLUMN`)
- `src/security/generated/classifications.ts` (regenerated)
- `src/lib/notifications.ts` (`notifyNewProgramAnnounced` now takes the program row, applies the coverage gate, sends paced)
- `src/lib/email.ts` (`runPaced`)
- `src/lib/emailRecipients.ts` (`fanOutEmails` → `runPaced`)
- `src/app/api/programs/[id]/route.ts` (toggle persists; fire-without-await gated on `announceOnOpen`)
- `src/app/api/programs/[id]/settings/route.ts` (toggle persists via the lead-mentor settings surface)
- `src/app/api/programs/route.ts` (public catalog `PUBLIC_PROGRAM_SELECT` mirror updated — not in the original spec, needed to keep the anonymous-catalog projection test green)
- `src/app/program-ops/programs/[id]/page.tsx` (new checkbox on the General tab)

## Tests
- Unit: `src/lib/__tests__/email.test.ts` (new `runPaced` pacing suite, fake timers), `src/lib/__tests__/notifications.test.ts` (opt-in filtering + coverage gate)
- Integration: `programAnnounceNotification.integration.test.ts` (toggle gates the fire), new `programAnnounceRecipients.integration.test.ts` (covered/uncovered/opted-out/tombstoned + the #1061 midyear-boundary case), `programsSettingsAPI.integration.test.ts` (lead-mentor round-trip)
- Drift guard (`livePersonDriftGuard.test.ts`) stays green — no allowlist entry needed.

## Gates (all from `checkin-app/`)
- `npx prisma generate` — clean
- `npx tsc --noEmit` — clean
- `npm run lint` (`--max-warnings 0`) — clean
- `npm run test:ci` — 249 suites / 2247 tests passing
- `INTEGRATION_DB=1 npm run test:integration` — 128 suites / 1200 tests passing

Refs #1153. Fixes #1153. Refs #1154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe