### PR TITLE
programs: disable announce emails on the release line (#1153 mitigation)

### DIFF
--- a/checkin-app/src/app/__tests__/programAnnounceNotification.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAnnounceNotification.integration.test.ts
@@ -2,12 +2,15 @@
  * @jest-environment node
  */
 /**
- * Integration tests for the "new program announced" notification trigger.
+ * #1153 rel/1.0 mitigation: program-announce emails are disabled entirely on
+ * this release line (the PATCH route's announce-edge call to
+ * notifyNewProgramAnnounced was removed — see src/app/api/programs/[id]/route.ts).
+ * The full fix (opt-in toggle + covered-member audience + paced fan-out) lands
+ * on main and reaches this line at the next release cut.
  *
- * The PATCH route fires notifyNewProgramAnnounced ONLY on the transition INTO
- * (phase=UPCOMING && enrollmentStatus=OPEN) — see src/app/api/programs/[id]/route.ts.
- * These guard: it fires on the edge, does NOT re-fire while already announced,
- * and does NOT fire when only one of the two conditions flips.
+ * This suite pins the mitigation: notifyNewProgramAnnounced must never be
+ * called by the PATCH route, regardless of the phase/enrollmentStatus edge
+ * that used to trigger it.
  */
 
 import { PATCH } from '@/app/api/programs/[id]/route';
@@ -34,7 +37,7 @@ const patch = (id: number, body: Record<string, unknown>) =>
         { params: Promise.resolve({ id: String(id) }) },
     );
 
-describe('New-program announce notification trigger', () => {
+describe('New-program announce notification — disabled on rel/1.0 (#1153 mitigation)', () => {
     let adminId: number;
     let leadId: number;
 
@@ -70,7 +73,7 @@ describe('New-program announce notification trigger', () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
     });
 
-    it('fires once when a program crosses INTO UPCOMING + OPEN', async () => {
+    it('does NOT fire when a program crosses INTO UPCOMING + OPEN (the old trigger edge)', async () => {
         const name = `${PROGRAM_NAME_TAG} cross`;
         const program = await prisma.program.create({
             data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' },
@@ -78,39 +81,16 @@ describe('New-program announce notification trigger', () => {
 
         const res = await patch(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' });
         expect(res.status).toBe(200);
-        expect(mockNotify).toHaveBeenCalledTimes(1);
-        expect(mockNotify).toHaveBeenCalledWith(name);
+        expect(mockNotify).not.toHaveBeenCalled();
     });
 
-    it('does NOT re-fire on a later edit while already UPCOMING + OPEN', async () => {
+    it('does NOT fire on a later edit while already UPCOMING + OPEN', async () => {
         const name = `${PROGRAM_NAME_TAG} already`;
         const program = await prisma.program.create({
             data: { name, leadMentorId: leadId, phase: 'UPCOMING', enrollmentStatus: 'OPEN' },
         });
 
         const res = await patch(program.id, { name: `${name} renamed` });
-        expect(res.status).toBe(200);
-        expect(mockNotify).not.toHaveBeenCalled();
-    });
-
-    it('does NOT fire when only phase flips to UPCOMING (enrollment still CLOSED)', async () => {
-        const name = `${PROGRAM_NAME_TAG} phaseonly`;
-        const program = await prisma.program.create({
-            data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' },
-        });
-
-        const res = await patch(program.id, { phase: 'UPCOMING' });
-        expect(res.status).toBe(200);
-        expect(mockNotify).not.toHaveBeenCalled();
-    });
-
-    it('does NOT fire when only enrollment flips to OPEN (phase still PLANNING)', async () => {
-        const name = `${PROGRAM_NAME_TAG} enrollonly`;
-        const program = await prisma.program.create({
-            data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' },
-        });
-
-        const res = await patch(program.id, { enrollmentStatus: 'OPEN' });
         expect(res.status).toBe(200);
         expect(mockNotify).not.toHaveBeenCalled();
     });

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -4,7 +4,6 @@ import { withAuth, authenticateRequest } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { handler, notFound, forbidden, badRequest } from "@/security/handler";
 import { isActiveOrgMember, isActiveOrgMemberThrough, programCoverageDate } from "@/lib/orgMembership";
-import { notifyNewProgramAnnounced } from "@/lib/notifications";
 import { adjustProgramInventory } from "@/lib/shopify";
 import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
@@ -212,14 +211,6 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
                 newData: updatedProgram
             }
         });
-
-        // Announce only on the transition INTO (UPCOMING && OPEN) — not on every
-        // save while already there, and not when only one of the two is set.
-        const wasAnnounced = currentProgram.phase === 'UPCOMING' && currentProgram.enrollmentStatus === 'OPEN';
-        const nowAnnounced = updatedProgram.phase === 'UPCOMING' && updatedProgram.enrollmentStatus === 'OPEN';
-        if (!wasAnnounced && nowAnnounced) {
-            await notifyNewProgramAnnounced(updatedProgram.name);
-        }
 
         // Shopify is the source of truth for program capacity (product decision
         // 2026-07-06): cap edits propagate as relative inventory adjustments.


### PR DESCRIPTION
Minimal release-line mitigation — program-announce emails are OFF entirely here. There is no opt-in toggle on rel/1.0; the PATCH route's announce-edge call (`notifyNewProgramAnnounced` on a program crossing INTO UPCOMING + OPEN) has been removed outright.

The full fix (opt-in `announceOnOpen` toggle + covered-member audience + 5/sec paced fan-out, #1153/#1154) lands on main in #1158 and reaches the release line at the next release cut.

## Expected: no CI checks on this PR
This repo's CI triggers only on PRs targeting `main`, so this rel/1.0 PR will show no checks — that's expected, not a failure. Correctness rides on:
- local full gates run against this exact diff (below), and
- release-time full-CI revalidation on the tag (deploy-prod's validate job) before this line ships.

## Changes
- `src/app/api/programs/[id]/route.ts`: removed the `wasAnnounced`/`nowAnnounced` announce-edge block and the now-unused `notifyNewProgramAnnounced` import. `notifyNewProgramAnnounced` itself is left in place in `src/lib/notifications.ts` (unused but present — deleting it would drag its unit tests along for no benefit on this line).
- `src/app/__tests__/programAnnounceNotification.integration.test.ts`: the suite existed solely to test the removed trigger. Consolidated its 4 cases down to 2 that pin the mitigation invariant — `notifyNewProgramAnnounced` is never called by the PATCH route, on the classic UPCOMING+OPEN edge or on a later no-op edit. The other two original cases (phase-only / enrollment-only) were redundant once the trigger path is gone entirely (every case now proves the same "never called" fact for the same reason), so they were dropped rather than kept as no-signal duplicates.

## Gates (all from `checkin-app/`, run locally against this diff)
- `npx prisma generate` — clean
- `npx tsc --noEmit` — clean
- `npm run lint` (`--max-warnings 0`) — clean
- `npm run test:ci` — 249 suites / 2245 tests passing
- `INTEGRATION_DB=1 npm run test:integration` — 127 suites / 1193 tests passing

Refs #1153, #1154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe