### PR TITLE
ci: run PR checks against rel/* base branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main
+      # pull_request triggers evaluate against the BASE branch's workflow
+      # file, so this must exist on both main (every future rel/* cut
+      # inherits it) and rel/1.0 (so current release-line PRs get checks).
+      - 'rel/**'
   merge_group:
   # Callable so the prod release flow can RE-RUN the full pipeline (tests + the
   # deploy build/smoke) against the exact released tag before shipping — see

--- a/.github/workflows/flow-tests.yml
+++ b/.github/workflows/flow-tests.yml
@@ -5,7 +5,10 @@ name: Flow tests
 
 on:
   pull_request:
-    branches: [main]
+    # pull_request triggers evaluate against the BASE branch's workflow file,
+    # so this must exist on both main (every future rel/* cut inherits it)
+    # and rel/1.0 (so current release-line PRs get checks).
+    branches: [main, 'rel/**']
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -31,7 +31,10 @@ name: Migration safety (populated DB)
 # same conditions, as before.
 on:
   pull_request:
-    branches: [main]
+    # pull_request triggers evaluate against the BASE branch's workflow file,
+    # so this must exist on both main (every future rel/* cut inherits it)
+    # and rel/1.0 (so current release-line PRs get checks).
+    branches: [main, 'rel/**']
     paths:
       - 'checkin-app/prisma/migrations/**'
       # The mirror chain gets the history-invariants job below (the populated-DB

--- a/.github/workflows/security-boundary-isolation.yml
+++ b/.github/workflows/security-boundary-isolation.yml
@@ -23,7 +23,10 @@ name: Security boundary isolation
 # inert), then land the route handler in the feature PR.
 on:
   pull_request:
-    branches: [main]
+    # pull_request triggers evaluate against the BASE branch's workflow file,
+    # so this must exist on both main (every future rel/* cut inherits it)
+    # and rel/1.0 (so current release-line PRs get checks).
+    branches: [main, 'rel/**']
 
 jobs:
   isolation:


### PR DESCRIPTION
## Summary

CI, flow tests, migration safety, and the security boundary isolation check only fire `pull_request` for PRs targeting `main` — release-line PRs (base `rel/1.0`, e.g. #1159) show zero checks. This adds `rel/**` alongside `main` in each affected workflow's `pull_request.branches` filter.

**Key fact:** `pull_request` triggers evaluate against the workflow file on the PR's **base** branch, not the head. So this change has to land on **both** `main` (so every future `rel/*` cut inherits it from day one) and `rel/1.0` (so PRs already open against the current release line pick it up). This PR targets `main`; a paired PR targets `rel/1.0` directly (cherry-pick of this same commit) — see that PR for the chicken-and-egg note on why it itself will show no checks until it merges.

## What changed / what didn't

| Workflow | `pull_request` trigger | Change |
|---|---|---|
| `ci.yml` | `branches: [main]` (list form) | added `rel/**` |
| `flow-tests.yml` | `branches: [main]` | added `rel/**` |
| `migration-safety.yml` | `branches: [main]` + `paths:` filter | added `rel/**`, paths filter untouched |
| `security-boundary-isolation.yml` | `branches: [main]` | added `rel/**` |
| `db-reconcile-dev.yml` | `workflow_dispatch` only | no `pull_request` trigger — untouched |
| `deploy-dev.yml` | `workflow_run` (branches: [main], event == push) | not a PR trigger — untouched |
| `deploy-prod.yml` | `release: published` | not a PR trigger — untouched |
| `deploy-s-read.yml` | `workflow_dispatch` / `workflow_call` | not a PR trigger — untouched |
| `jules.yml` | `issues` / `issue_comment` | not a PR trigger — untouched |
| `shopify-live.yml` | `schedule` / `workflow_dispatch` (explicitly "never part of PR CI") | not a PR trigger — untouched |

Verified none of the four edited workflows push/deploy state on `pull_request` — all builds (`docker build`, the deploy-build smoke test) stay local, nothing is pushed to a registry or rolled out to ECS from a PR run. Only real deploys (`deploy-dev.yml`, `deploy-prod.yml`) are gated on push-to-main / release-published / manual dispatch, none of which this PR touches.

Also checked open PR #1147 (adds a PR-target-label workflow): that workflow triggers on all PRs with no branch filter, so it needs no changes here and this PR doesn't conflict with it — confirmed no such file exists yet in this tree (still unmerged).

## Validation

`python3 -c "import yaml; yaml.safe_load(open(f))"` passed on all four edited files. This is a trigger-condition change with no functional way to exercise locally — I can't verify GitHub Actions actually fires on a rel/* base PR from this environment; that needs a live PR against rel/1.0 after merge (see the companion PR to rel/1.0 and the #1159 note there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe