### PR TITLE
ci: run PR checks against rel/* base branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main
+      # pull_request triggers evaluate against the BASE branch's workflow
+      # file, so this must exist on both main (every future rel/* cut
+      # inherits it) and rel/1.0 (so current release-line PRs get checks).
+      - 'rel/**'
   merge_group:
   # Callable so the prod release flow can RE-RUN the full pipeline (tests + the
   # deploy build/smoke) against the exact released tag before shipping — see

--- a/.github/workflows/flow-tests.yml
+++ b/.github/workflows/flow-tests.yml
@@ -5,7 +5,10 @@ name: Flow tests
 
 on:
   pull_request:
-    branches: [main]
+    # pull_request triggers evaluate against the BASE branch's workflow file,
+    # so this must exist on both main (every future rel/* cut inherits it)
+    # and rel/1.0 (so current release-line PRs get checks).
+    branches: [main, 'rel/**']
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -31,7 +31,10 @@ name: Migration safety (populated DB)
 # same conditions, as before.
 on:
   pull_request:
-    branches: [main]
+    # pull_request triggers evaluate against the BASE branch's workflow file,
+    # so this must exist on both main (every future rel/* cut inherits it)
+    # and rel/1.0 (so current release-line PRs get checks).
+    branches: [main, 'rel/**']
     paths:
       - 'checkin-app/prisma/migrations/**'
       # The mirror chain gets the history-invariants job below (the populated-DB

--- a/.github/workflows/security-boundary-isolation.yml
+++ b/.github/workflows/security-boundary-isolation.yml
@@ -23,7 +23,10 @@ name: Security boundary isolation
 # inert), then land the route handler in the feature PR.
 on:
   pull_request:
-    branches: [main]
+    # pull_request triggers evaluate against the BASE branch's workflow file,
+    # so this must exist on both main (every future rel/* cut inherits it)
+    # and rel/1.0 (so current release-line PRs get checks).
+    branches: [main, 'rel/**']
 
 jobs:
   isolation:


### PR DESCRIPTION
## Summary

Companion to #1160 (same change, targeting `main`). Cherry-pick of the same commit (`3303e3ea`) onto `rel/1.0` — trees were identical at cut time, so it applied cleanly with no conflicts.

CI, flow tests, migration safety, and the security boundary isolation check only fired `pull_request` for PRs targeting `main` — so PRs based on `rel/1.0` (e.g. #1159) showed zero checks. This adds `rel/**` alongside `main` in each affected workflow's `pull_request.branches` filter.

**Key fact:** `pull_request` triggers evaluate against the workflow file on the PR's **base** branch, not the head. That's why this needs to land on **both** `main` (#1160 — every future `rel/*` cut inherits it) and `rel/1.0` directly (this PR — so PRs already open against the current release line pick it up without waiting for the next cut).

## Chicken-and-egg (expected)

This PR itself will show **no checks** in its own PR view: GitHub reads `rel/1.0`'s *current* workflow files to decide what to run against a PR based on `rel/1.0`, and those files don't have this change yet — it isn't merged. That's expected, not a bug. Once this merges, `rel/1.0` gets the trigger and subsequent PRs against it pick up full CI automatically.

**#1159** (`programs: disable announce emails on the release line`, base `rel/1.0`, currently open) is the PR this unblocks. It won't retroactively gain checks just because this merges — GitHub evaluates the trigger at event time, not retroactively — so it likely needs a re-push (empty commit or rebase) or a close/reopen to fire a fresh `pull_request` event after this lands.

## What changed / what didn't

Same inventory as #1160 — see that PR body for the full per-workflow table. Only `ci.yml`, `flow-tests.yml`, `migration-safety.yml`, and `security-boundary-isolation.yml` had a `branches: [main]`-style filter; all four got `rel/**` added, nothing else touched (paths filters, comments, formatting preserved). No workflow here deploys or pushes state on `pull_request` — verified across all ten workflow files.

## Validation

`python3 -c "import yaml; yaml.safe_load(open(f))"` passed on all four edited files. No functional way to test that the trigger actually fires from this environment — that can only be confirmed live, after merge, by watching whether #1159 (or a fresh PR against `rel/1.0`) gets checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFHNwTRstb6KrgCqPA7iTe