### PR TITLE
fix(security): teach SCOPABLE_FIELDS about personId, resolve the models it unmasks

### DIFF
--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -154,7 +154,7 @@ export const ROW_SCOPE_KEY: Record<string, string> = {
 export const OPT_OUT_PENDING_ROUTE = new Set<string>([
     'OrgMembershipProcess', // board/admin today; a household-facing status route is plausible
     'BackgroundCheckAttestation', // bind their_own at migration, keep notes `internal`
-    'Corporation', // has leads→participantId; a corp-lead view is plausible
+    'Corporation', // has leads→personId; a corp-lead view is plausible
     'VolunteerDesignation', // has createdById; confirm whether a self view is warranted
     // Lands ahead of the model itself (#1031, the Shopify payment reconciler), so the
     // boundary change ships alone and reviewable — inert until that PR adds the model
@@ -162,6 +162,25 @@ export const OPT_OUT_PENDING_ROUTE = new Set<string>([
     // served via withAuth on finance-ops/payments; a household-facing "your payment
     // problem" route is plausible later, and that is when this earns a real binding.
     'PaymentException',
+    // Surfaced by the personId fix to SCOPABLE_FIELDS (the Participant→Person rename
+    // left `participantId` in that list, so every personId-only model silently took
+    // the "un-scopable, admin-only by construction" exemption instead of being made
+    // to declare itself here). Both below are that backlog, not new models.
+    //
+    // Read today only by GET/PATCH /api/roles (withAuth isSysadmin|isBoardMember) and,
+    // as a derived boolean set via rolesToFlags, by GET /api/people/search (board/
+    // sysadmin/ops) — the rows themselves are never serialized into a member-facing
+    // bag. auth-options.ts also reads them, but that is session assembly, not a served
+    // response. A self-facing "your roles/permissions" view is the plausible future
+    // reader; that is when this earns `their_own: { field: 'personId', eqCtx: 'selfId' }`.
+    'PersonRole',
+    // Admin outreach ledger: read only by GET /api/outreach/status and the
+    // process-batch drain job, both withAuth board/sysadmin/operations. The model's
+    // own schema comment makes the same call for its `email` field ("only ever read
+    // by board/ops on the admin send panel, never serialized through a member-facing
+    // bag"). If a self-serve "emails we sent you" / suppression-audit view ever ships,
+    // it earns `their_own: { field: 'personId', eqCtx: 'selfId' }`.
+    'BulkSendItem',
 ]);
 
 /**

--- a/checkin-app/src/security/scopes.ts
+++ b/checkin-app/src/security/scopes.ts
@@ -158,7 +158,7 @@ function allMatches(scopeMap: Partial<Record<Scope, Match>>): Match[] {
 const SCOPABLE_FIELDS = new Set([
     'householdId',
     'programId',
-    'participantId',
+    'personId',
     'userId',
     'actorId',
     'createdById',


### PR DESCRIPTION
## What

One word in `checkin-app/src/security/scopes.ts`:

```diff
 const SCOPABLE_FIELDS = new Set([
     'householdId',
     'programId',
-    'participantId',
+    'personId',
     'userId',
     'actorId',
     'createdById',
 ]);
```

…plus the two `OPT_OUT_PENDING_ROUTE` entries that change forces, and one stale-comment fix.

## Why

The Participant → Person model rename shipped on main; person FKs are now `personId`. `participantId` was left behind in `SCOPABLE_FIELDS` and is dead:

- `grep -c "participantId" checkin-app/prisma/schema.prisma` → **0**
- `grep -c "participantId:" checkin-app/src/security/generated/classifications.ts` → **0**
- `grep -c "personId:" .../classifications.ts` → **12**

`isScopable(model, classifications)` is what decides whether `validateBindings`' coverage check demands a decision for a sensitive model:

```ts
if (!isScopable(model, classifications)) { console.info(...admin-only by construction...); continue; }
if (pendingRoute.has(model)) continue;
errors.push(`${model} is sensitive and scopable but has no binding ...`);
```

With no person FK in the list, every sensitive model whose only actor FK is `personId` silently took the *"un-scopable, admin-only by construction"* exemption instead of being made to declare a `SCOPE_BINDINGS` row or sit in `OPT_OUT_PENDING_ROUTE`. The forgotten-model catcher was blind to exactly the person-scoped models it exists to catch.

This is a **pre-existing gap**, found while reviewing #1156/#1157 but not introduced by them. Fixed on its own branch off `main`.

### `participantId` removed, not kept

619 `participantId` hits remain under `checkin-app/src` — every one is an API wire key or React prop (`JSON.stringify({ participantId })`, `handleMakeLead(participantId: number)`), never a Prisma field name. `isScopable` only ever reads keys out of the generated classification map, so those could never make it live. Removed.

## The models it unmasks

Only **two** actually surfaced, not the seven a naive "sensitive + carries `personId`" scan suggests. `ToolStatus`, `FeePayment`, `RSVP`, `RawBadgeLog` and `Visit` are already bound in `SCOPE_BINDINGS`, and the coverage loop skips bound models *before* `isScopable` runs — so they were never silently exempt. The gate now **verifies** that rather than assuming it.

The two that were genuinely exempt, each resolved with per-model judgement:

| Model | Verdict | Reasoning |
|---|---|---|
| `PersonRole` | `OPT_OUT_PENDING_ROUTE` | Read only by `GET`/`PATCH /api/roles` (`withAuth { roles: ['isSysadmin','isBoardMember'] }`) and — as a derived boolean set via `rolesToFlags`, never as raw rows — by `GET /api/people/search` (board/sysadmin/ops). `auth-options.ts` also reads it, but that is session assembly, not a served response. |
| `BulkSendItem` | `OPT_OUT_PENDING_ROUTE` | Read only by `GET/POST /api/outreach/status` and the `process-batch` drain job, both `withAuth` board/sysadmin/operations. The model's own schema comment already makes this exact call for its `email` field: *"only ever read by board/ops on the admin send panel, never serialized through a member-facing bag."* |

Neither has a household- or self-facing reader today, so neither can be given an honest binding — a `their_own` on `personId` would grant a scope no route ever requests, which is its own species of wrong. Each entry's comment names the future route that would earn it a real binding (a self-facing "your roles/permissions" view; a self-serve "emails we sent you" / suppression audit).

No validator was weakened and no blanket exemption was added.

Also corrects a stale `leads→participantId` comment on the `Corporation` opt-out entry (the field is `CorporationLead.personId`).

## Reviewer notes

- **Both files are CODEOWNERS-gated** (`scopes.ts`, `scopeBindings.ts`).
- **#1156's `SyncState`** carries `personId` and will need this same per-model decision once it merges. Deliberately not added here — it arrives with that PR and is that stack's call.
- The gate was confirmed to actually bite: before the opt-out entries were added, `validateBindings(SCOPE_BINDINGS, classifications, OPT_OUT_PENDING_ROUTE)` returned exactly those two errors and `scopeValidators.test.ts` went red. That red was the point.
- No behavior change at runtime — `SCOPABLE_FIELDS` feeds only the CI validator, never `makeScopesHeld`/`evalMatch`. Zero effect on what any route returns.

## Verification

Run from `checkin-app/`:

- `npx prisma generate` — regenerated client + classifications are byte-identical, not in the diff
- `npx tsc --noEmit` — exit 0
- `npm run lint` — clean (`--max-warnings 0`)
- `npm run test:ci` — 249 suites / 2245 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
