### PR TITLE
fix(ui): stop section-tab count pills from collapsing to empty capsules (#1155)

### DIFF
--- a/checkin-app/src/components/ui/ScrollableTabsList.tsx
+++ b/checkin-app/src/components/ui/ScrollableTabsList.tsx
@@ -20,7 +20,15 @@ interface ScrollableTabsListProps extends TabsListProps {
 export function ScrollableTabsList({ children, style, mb, ...props }: ScrollableTabsListProps) {
   return (
     <ScrollArea type="auto" scrollbarSize={6} mb={mb}>
-      <Tabs.List style={{ flexWrap: "nowrap", ...style }} {...props}>
+      {/*
+        min-width: max-content is what actually makes this scroll. nowrap alone only
+        stops wrapping — the flex row still shrinks to the ScrollArea's width, and the
+        first thing to collapse is the count Badge, whose `overflow: hidden` zeroes its
+        automatic minimum size (labels have `white-space: nowrap` and keep their
+        min-content floor). That rendered the tab pills as empty capsules below ~1150px
+        (#1155). With max-content the row overflows and the ScrollArea scrolls instead.
+      */}
+      <Tabs.List style={{ flexWrap: "nowrap", minWidth: "max-content", ...style }} {...props}>
         {children}
       </Tabs.List>
     </ScrollArea>

--- a/checkin-app/src/components/ui/__tests__/SectionTabs.test.tsx
+++ b/checkin-app/src/components/ui/__tests__/SectionTabs.test.tsx
@@ -80,3 +80,17 @@ describe("SectionTabs guarded onChange", () => {
     expect(push).not.toHaveBeenCalled();
   });
 });
+
+// #1155: without min-width:max-content the tab row shrinks to the ScrollArea instead of
+// overflowing it, and the count Badge (overflow:hidden, so its automatic minimum size is
+// 0) collapses to zero width — the pill renders as an empty capsule. jsdom does no
+// layout, so this asserts the style that prevents it rather than the resulting width.
+describe("SectionTabs tab row sizing", () => {
+  it("sizes the tab list to its content so count pills can't be squeezed to zero", () => {
+    confirmNav.mockReturnValue(true);
+    const { container } = renderTabs();
+    const list = container.querySelector(".mantine-Tabs-list") as HTMLElement;
+    expect(list.style.minWidth).toBe("max-content");
+    expect(list.style.flexWrap).toBe("nowrap");
+  });
+});


### PR DESCRIPTION
Fixes #1155.

## Root cause

Not a colour bug. The number is in the DOM with good contrast — it is being **clipped to zero width**.

`ScrollableTabsList` set `flexWrap: "nowrap"` but nothing to force the row to overflow its `ScrollArea`. `nowrap` only stops wrapping; the flex row still shrinks to the viewport width. In that squeeze the count `Badge` is the only child that can collapse — Mantine's Badge root sets `overflow: hidden`, which zeroes its automatic minimum size, while the tab labels have `white-space: nowrap` and keep their min-content floor.

The pill's background and padding still paint, so it reads as an **empty capsule** rather than a missing badge.

## Measurement

Rendered `MembershipOpsLayout` with real counts, dumped the markup, and measured it in headless Chrome against Mantine's actual stylesheet:

| viewport | badge label width | needs |
|---|---|---|
| 1400px | 5.8px | 6px |
| 1200px | 5.8px | 6px |
| **1100px** | **0px** | 6px |
| 900px | 0px | 6px |
| 768px | 0px | 6px |

Membership Ops trips first because it has the most tabs (7) and the longest labels — which is why **Applications** and **Background-check Review** were the two reported.

The `ScrollArea` also never actually scrolled. It was dead code; the tabs squeezed instead.

## Fix

```diff
-<Tabs.List style={{ flexWrap: "nowrap", ...style }} {...props}>
+<Tabs.List style={{ flexWrap: "nowrap", minWidth: "max-content", ...style }} {...props}>
```

Verified in the same harness: label holds 5.8px at 1400 / 1100 / 900 / 768 / 390px, and the viewport becomes genuinely scrollable below 1155px.

One line in the shared component covers every section-tab bar — all seven ops layouts and `SettingsTabs` route through it. `AttendanceTabs` uses a raw `Tabs.List` but renders no badges.

## Ruled out

The original suspicion was pill text matching pill fill. Computed every Badge fg/bg pair from Mantine's own resolver against the treehouse theme, light and dark. Nothing is same-on-same — the two reported pills measure **9.70:1** (gray) and **7.21:1** (green). The brand-token swap in #1129 was contrast-neutral (mantine `green` light 2.17:1 → `treehouseGreen` light 2.21:1).

Separate pre-existing finding, not addressed here: `variant="light"` badges run 1.75–2.9:1 in light mode (yellow worst, e.g. `Maybe {tally.maybe}` on My Programs → Attendance). Worth its own issue.

## Tests

jsdom performs no layout, so the regression test asserts the style that prevents the collapse rather than the resulting width. 94 tests pass across `SectionTabs` + all `membership-ops` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)