### PR TITLE
fix(programs): fire the announce trigger from the settings PATCH too

### DIFF
--- a/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
@@ -10,14 +10,17 @@ import { PATCH } from '@/app/api/programs/[id]/settings/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import { notifyNewProgramAnnounced } from '@/lib/notifications';
+import { logger } from '@/lib/logger';
 // Mock NextAuth
 jest.mock('next-auth/next', () => ({
     getServerSession: jest.fn(),
 }));
 jest.mock('@/lib/notifications', () => ({
-    // The settings route's fire-without-await edge does
-    // `notifyNewProgramAnnounced(...).catch(...)` — the mock must resolve so
-    // `.catch` is defined (a bare jest.fn() returns undefined and throws).
+    // Keep the real module (sendNotification etc.) and stub only the announce
+    // fan-out. The fire-without-await edge does `notifyNewProgramAnnounced(...)
+    // .catch(...)` — the stub must resolve so `.catch` is defined (a bare
+    // jest.fn() returns undefined and throws).
+    ...jest.requireActual('@/lib/notifications'),
     notifyNewProgramAnnounced: jest.fn().mockResolvedValue(undefined),
 }));
 
@@ -84,12 +87,22 @@ describe('Program Settings API Integration Tests', () => {
     afterAll(async () => {
         const existingUserIds = [adminId, leadId, newLeadId, commonId].filter(id => id !== undefined);
 
+        // Participant cleanup mirrors the program sweep below — id-scoped alone
+        // would FK-block deletion if an announce-case program ever enrolls anyone.
+        await prisma.programParticipant.deleteMany({
+            where: { program: { name: { contains: 'Settings API Test' } } }
+        });
         if (targetProgramId) {
             await prisma.programParticipant.deleteMany({
                 where: { programId: targetProgramId }
             });
+            // Id anchor: survives even if a test renames the program out of the
+            // naming convention the sweep below depends on.
+            await prisma.program.deleteMany({
+                where: { id: targetProgramId }
+            });
         }
-        // Covers targetProgramId plus the per-test programs the announce cases create.
+        // Name sweep: the per-test programs the announce cases create.
         await prisma.program.deleteMany({
             where: { name: { contains: 'Settings API Test' } }
         });
@@ -283,6 +296,23 @@ describe('Program Settings API Integration Tests', () => {
              const res = await PATCH(req as unknown as import("next/server").NextRequest, createParams(targetProgramId) as unknown as never);
              expect(res.status).toBe(400);
         });
+
+        it('should reject bad announceOnOpen / phase / enrollmentStatus values with 400, not 500', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+             for (const body of [
+                 { announceOnOpen: 'yes' },
+                 { phase: 'upcoming' },          // enum values are uppercase
+                 { enrollmentStatus: 'ajar' },
+             ]) {
+                 const req = new Request(`http://localhost:4000/api/programs/${targetProgramId}/settings`, {
+                     method: 'PATCH',
+                     body: JSON.stringify(body)
+                 });
+                 const res = await PATCH(req as unknown as import("next/server").NextRequest, createParams(targetProgramId) as unknown as never);
+                 expect(res.status).toBe(400);
+             }
+        });
     });
 
     // The settings PATCH is the lead-mentor edit surface and accepts phase /
@@ -314,14 +344,37 @@ describe('Program Settings API Integration Tests', () => {
             expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({ name }));
         });
 
-        it('does NOT fire on the same crossing with announceOnOpen at its false default', async () => {
+        it('fires once when announceOnOpen is enabled in the same request as the transition', async () => {
+            // The realistic lead-mentor flow: tick the box and open enrollment in one save.
+            const name = 'Settings API Test announce same-request';
+            const program = await prisma.program.create({
+                data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' }
+            });
+
+            const res = await patchSettings(program.id, { announceOnOpen: true, phase: 'UPCOMING', enrollmentStatus: 'OPEN' });
+            expect(res.status).toBe(200);
+            expect(mockNotify).toHaveBeenCalledTimes(1);
+            expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({ name }));
+        });
+
+        it('does NOT fire on the same crossing with announceOnOpen at its false default (logs the skip)', async () => {
             const program = await prisma.program.create({
                 data: { name: 'Settings API Test announce default-off', leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' }
             });
 
-            const res = await patchSettings(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' });
-            expect(res.status).toBe(200);
-            expect(mockNotify).not.toHaveBeenCalled();
+            const infoSpy = jest.spyOn(logger, 'info');
+            try {
+                const res = await patchSettings(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' });
+                expect(res.status).toBe(200);
+                expect(mockNotify).not.toHaveBeenCalled();
+                // The skip leaves an audit breadcrumb — a silent no-send is the bug
+                // this trigger exists to avoid (#1164 review, finding 9).
+                expect(infoSpy).toHaveBeenCalledWith(
+                    expect.stringContaining(`Program ${program.id} reached UPCOMING+OPEN; announceOnOpen off`)
+                );
+            } finally {
+                infoSpy.mockRestore();
+            }
         });
 
         it('does NOT re-fire on a later edit while already UPCOMING + OPEN', async () => {

--- a/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
@@ -9,10 +9,19 @@
 import { PATCH } from '@/app/api/programs/[id]/settings/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
+import { notifyNewProgramAnnounced } from '@/lib/notifications';
 // Mock NextAuth
 jest.mock('next-auth/next', () => ({
     getServerSession: jest.fn(),
 }));
+jest.mock('@/lib/notifications', () => ({
+    // The settings route's fire-without-await edge does
+    // `notifyNewProgramAnnounced(...).catch(...)` — the mock must resolve so
+    // `.catch` is defined (a bare jest.fn() returns undefined and throws).
+    notifyNewProgramAnnounced: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockNotify = notifyNewProgramAnnounced as jest.Mock;
 describe('Program Settings API Integration Tests', () => {
     let adminId: number;
     let leadId: number;
@@ -79,10 +88,11 @@ describe('Program Settings API Integration Tests', () => {
             await prisma.programParticipant.deleteMany({
                 where: { programId: targetProgramId }
             });
-            await prisma.program.deleteMany({
-                where: { id: targetProgramId }
-            });
         }
+        // Covers targetProgramId plus the per-test programs the announce cases create.
+        await prisma.program.deleteMany({
+            where: { name: { contains: 'Settings API Test' } }
+        });
         
         if (existingUserIds.length > 0) {
             await prisma.auditLog.deleteMany({
@@ -272,6 +282,76 @@ describe('Program Settings API Integration Tests', () => {
              });
              const res = await PATCH(req as unknown as import("next/server").NextRequest, createParams(targetProgramId) as unknown as never);
              expect(res.status).toBe(400);
+        });
+    });
+
+    // The settings PATCH is the lead-mentor edit surface and accepts phase /
+    // enrollmentStatus / announceOnOpen, so it owns the same announce edge as
+    // programs/[id] PATCH — see programAnnounceNotification.integration.test.ts.
+    describe('announce trigger on PATCH /api/programs/[id]/settings', () => {
+        const patchSettings = async (id: number, body: Record<string, unknown>) => {
+            const req = new Request(`http://localhost:4000/api/programs/${id}/settings`, {
+                method: 'PATCH',
+                body: JSON.stringify(body)
+            });
+            return PATCH(req as unknown as import("next/server").NextRequest, createParams(id) as unknown as never);
+        };
+
+        beforeEach(() => {
+            mockNotify.mockClear();
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+        });
+
+        it('fires once when the settings PATCH crosses INTO UPCOMING + OPEN (announceOnOpen: true)', async () => {
+            const name = 'Settings API Test announce cross';
+            const program = await prisma.program.create({
+                data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED', announceOnOpen: true }
+            });
+
+            const res = await patchSettings(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' });
+            expect(res.status).toBe(200);
+            expect(mockNotify).toHaveBeenCalledTimes(1);
+            expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({ name }));
+        });
+
+        it('does NOT fire on the same crossing with announceOnOpen at its false default', async () => {
+            const program = await prisma.program.create({
+                data: { name: 'Settings API Test announce default-off', leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED' }
+            });
+
+            const res = await patchSettings(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' });
+            expect(res.status).toBe(200);
+            expect(mockNotify).not.toHaveBeenCalled();
+        });
+
+        it('does NOT re-fire on a later edit while already UPCOMING + OPEN', async () => {
+            const program = await prisma.program.create({
+                data: { name: 'Settings API Test announce already', leadMentorId: leadId, phase: 'UPCOMING', enrollmentStatus: 'OPEN', announceOnOpen: true }
+            });
+
+            const res = await patchSettings(program.id, { name: 'Settings API Test announce already renamed' });
+            expect(res.status).toBe(200);
+            expect(mockNotify).not.toHaveBeenCalled();
+        });
+
+        it('does NOT fire when only phase flips to UPCOMING (enrollment still CLOSED)', async () => {
+            const program = await prisma.program.create({
+                data: { name: 'Settings API Test announce phaseonly', leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED', announceOnOpen: true }
+            });
+
+            const res = await patchSettings(program.id, { phase: 'UPCOMING' });
+            expect(res.status).toBe(200);
+            expect(mockNotify).not.toHaveBeenCalled();
+        });
+
+        it('does NOT fire when only enrollment flips to OPEN (phase still PLANNING)', async () => {
+            const program = await prisma.program.create({
+                data: { name: 'Settings API Test announce enrollonly', leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED', announceOnOpen: true }
+            });
+
+            const res = await patchSettings(program.id, { enrollmentStatus: 'OPEN' });
+            expect(res.status).toBe(200);
+            expect(mockNotify).not.toHaveBeenCalled();
         });
     });
 });

--- a/checkin-app/src/app/api/programs/[id]/settings/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/settings/route.ts
@@ -6,6 +6,7 @@ import { apiError } from "@/lib/api-response";
 import { LIVE_PERSON } from "@/lib/person/filters";
 import { validateProgramAgeBounds } from "@/lib/programAge";
 import { notifyNewProgramAnnounced } from "@/lib/notifications";
+import { ProgramPhase, EnrollmentStatus } from "@/generated/prisma/client";
 
 export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
     if (auth.type !== 'session') return apiError("Unauthorized", 401);
@@ -48,6 +49,19 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
             maxParticipants,
             leadMentorNotificationSettings
         } = body;
+
+        // Validate the three announce-relevant fields up front: bad values would
+        // otherwise surface as Prisma validation errors → generic 500, and
+        // announceOnOpen now gates an email blast (#1164 review, finding 5).
+        if (announceOnOpen !== undefined && typeof announceOnOpen !== "boolean") {
+            return apiError("announceOnOpen must be a boolean", 400);
+        }
+        if (phase !== undefined && !Object.values(ProgramPhase).includes(phase)) {
+            return apiError("Invalid phase", 400);
+        }
+        if (enrollmentStatus !== undefined && !Object.values(EnrollmentStatus).includes(enrollmentStatus)) {
+            return apiError("Invalid enrollmentStatus", 400);
+        }
 
         // Age range sanity. Use effective values (body overrides current) so a
         // one-sided edit can't leave minAge > maxAge or exceed the 25+ ceiling.
@@ -115,20 +129,27 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
         // Announce only on the transition INTO (UPCOMING && OPEN) — not on every
         // save while already there, and not when only one of the two is set.
         // ponytail: duplicated verbatim from programs/[id] PATCH rather than
-        // extracted — a shared helper in @/lib/notifications would need mock
-        // plumbing in every suite that stubs that module, for six lines.
-        const wasAnnounced = currentProgram.phase === 'UPCOMING' && currentProgram.enrollmentStatus === 'OPEN';
-        const nowAnnounced = updatedProgram.phase === 'UPCOMING' && updatedProgram.enrollmentStatus === 'OPEN';
-        if (!wasAnnounced && nowAnnounced) {
-            if (updatedProgram.announceOnOpen) {
-                // Fire-and-forget: paced send is ~(recipients/5) seconds — must not block
-                // the PATCH response. notifyNewProgramAnnounced swallows its own errors;
-                // .catch is belt-and-suspenders, matching the best-effort idiom.
-                void notifyNewProgramAnnounced(updatedProgram).catch((e) =>
-                    logger.error("notifyNewProgramAnnounced failed:", e));
-            } else {
-                logger.info(`[announce] Program ${updatedProgram.id} reached UPCOMING+OPEN; announceOnOpen off — skipping.`);
+        // extracted — the extraction travels with the announcedAt idempotency
+        // follow-up (#1164 review, findings 2/3/6/7), which rewrites this block.
+        // Own try/catch: the program update + audit log above are committed — a
+        // synchronous throw here (e.g. a partially mocked notifications module)
+        // must not turn a successful write into a 500 (#1164 review, finding 1).
+        try {
+            const wasAnnounced = currentProgram.phase === 'UPCOMING' && currentProgram.enrollmentStatus === 'OPEN';
+            const nowAnnounced = updatedProgram.phase === 'UPCOMING' && updatedProgram.enrollmentStatus === 'OPEN';
+            if (!wasAnnounced && nowAnnounced) {
+                if (updatedProgram.announceOnOpen) {
+                    // Fire-and-forget: paced send is ~(recipients/5) seconds — must not block
+                    // the PATCH response. notifyNewProgramAnnounced swallows its own errors;
+                    // .catch is belt-and-suspenders, matching the best-effort idiom.
+                    void notifyNewProgramAnnounced(updatedProgram).catch((e) =>
+                        logger.error("notifyNewProgramAnnounced failed:", e));
+                } else {
+                    logger.info(`[announce] Program ${updatedProgram.id} reached UPCOMING+OPEN; announceOnOpen off — skipping.`);
+                }
             }
+        } catch (announceError) {
+            logger.error("announce trigger failed:", announceError);
         }
 
         return NextResponse.json({ success: true, program: updatedProgram });

--- a/checkin-app/src/app/api/programs/[id]/settings/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/settings/route.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
 import { LIVE_PERSON } from "@/lib/person/filters";
 import { validateProgramAgeBounds } from "@/lib/programAge";
+import { notifyNewProgramAnnounced } from "@/lib/notifications";
 
 export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
     if (auth.type !== 'session') return apiError("Unauthorized", 401);
@@ -110,6 +111,25 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
                 newData: updateData
             }
         });
+
+        // Announce only on the transition INTO (UPCOMING && OPEN) — not on every
+        // save while already there, and not when only one of the two is set.
+        // ponytail: duplicated verbatim from programs/[id] PATCH rather than
+        // extracted — a shared helper in @/lib/notifications would need mock
+        // plumbing in every suite that stubs that module, for six lines.
+        const wasAnnounced = currentProgram.phase === 'UPCOMING' && currentProgram.enrollmentStatus === 'OPEN';
+        const nowAnnounced = updatedProgram.phase === 'UPCOMING' && updatedProgram.enrollmentStatus === 'OPEN';
+        if (!wasAnnounced && nowAnnounced) {
+            if (updatedProgram.announceOnOpen) {
+                // Fire-and-forget: paced send is ~(recipients/5) seconds — must not block
+                // the PATCH response. notifyNewProgramAnnounced swallows its own errors;
+                // .catch is belt-and-suspenders, matching the best-effort idiom.
+                void notifyNewProgramAnnounced(updatedProgram).catch((e) =>
+                    logger.error("notifyNewProgramAnnounced failed:", e));
+            } else {
+                logger.info(`[announce] Program ${updatedProgram.id} reached UPCOMING+OPEN; announceOnOpen off — skipping.`);
+            }
+        }
 
         return NextResponse.json({ success: true, program: updatedProgram });
     } catch (error) {

--- a/checkin-app/src/lib/notifications.ts
+++ b/checkin-app/src/lib/notifications.ts
@@ -78,8 +78,9 @@ export async function sendNotification(userId: number, eventType: NotificationEv
  * covers the program's FULL DURATION (#1061 rule, reused verbatim), respecting each
  * person's notifyNewPrograms / email prefs (default ON). Paced at 5/sec (#1154).
  *
- * The announceOnOpen opt-in gate lives at the CALL SITE (programs/[id] PATCH) — this
- * only runs when a leader has enabled it. Best-effort: fire-and-forget from the route.
+ * The announceOnOpen opt-in gate lives at the CALL SITES — programs/[id] PATCH and
+ * programs/[id]/settings PATCH both fire this on the transition into UPCOMING+OPEN —
+ * this only runs when a leader has enabled it. Best-effort: fire-and-forget from the route.
  */
 export async function notifyNewProgramAnnounced(
     program: { name: string; startAt: Date | null; endAt: Date | null },


### PR DESCRIPTION
~~Stacked on #1158.~~ **Update:** #1158 squash-merged (`80bfefef`); this branch is rebased onto `main` (dropped the pre-squash stacked commit) and the diff is now exactly this PR's changes. Post-rebase gates re-run: tsc clean, lint clean, settings + announce integration suites 26/26.

Review disposition (12 findings): 1, 4, 5, 8–12 fixed in `97ba3cc1` (formerly `af82adc3`); 2, 3, 6, 7 travel together in an in-progress follow-up PR (`announcedAt` idempotency + race-safe claim + blast audit + helper extraction). Details in the comment thread.

## The gap

Two endpoints can edit a program; only one announced.

- `programs/[id]` PATCH — has the trigger.
- `programs/[id]/settings` PATCH (the lead-mentor surface) — accepts `phase`, `enrollmentStatus`, and as of #1158 `announceOnOpen`, writes all three, returns 200, and contains no announce code at all.

So a lead mentor who ticks the announce box and opens enrollment through the settings endpoint gets `announceOnOpen: true` back in the response body and no email is ever sent. Silent.

The missing trigger predates #1158. What #1158 changed is that the settings endpoint now accepts the toggle, which implies to any caller that it's a place where announcing is configured. No frontend calls it today — this is API-contract risk, not a live user bug.

The alternative fix — dropping `announceOnOpen` from the settings endpoint — is the shorter diff, but #1158 deliberately added the field there *and* added a passing round-trip test for it, so supporting it on the lead-mentor surface reads as intentional.

## The fix

Mirrored the trigger, semantics identical:

- fires only on the transition INTO (`UPCOMING` && `OPEN`) — not on every save while already there, not when only one of the two is set
- gated on `announceOnOpen`, log-and-skip when off
- fire-without-await (`void ... .catch(...)`) — the paced send is ~(recipients/5) seconds and must not block the response

Both sides of the edge were already in scope (the route loads `currentProgram` before its update), so no extra query.

**Duplicated rather than extracted.** A shared helper would have to live in `@/lib/notifications`, and both announce suites mock that module with a factory supplying only `notifyNewProgramAnnounced` — the helper would come back `undefined` and every mocking suite would need new plumbing. More plumbing than the six lines save. Marked with a `ponytail:` comment naming the reason.

## Tests

5 cases added to `programsSettingsAPI.integration.test.ts`, mirroring `programAnnounceNotification.integration.test.ts`: fires on the crossing with `announceOnOpen: true`; does not fire on the same crossing at the `false` default; does not re-fire while already UPCOMING+OPEN; does not fire on phase-only; does not fire on enrollment-only.

Verified non-vacuous — stashing the route change alone fails `fires once when the settings PATCH crosses INTO UPCOMING + OPEN` (`1 failed, 15 passed`), and it passes with the change.

Also widened that file's `afterAll` program cleanup from `id: targetProgramId` to delete by name — the new cases create their own programs and would otherwise leak and block the person deletes on FK.

## Gates

- `npx tsc --noEmit` — clean
- `npm run lint` — clean (`--max-warnings 0`)
- integration run scoped to `programsSettingsAPI|programAnnounce` — 3 suites, 24 tests, all passing

## Noted, not fixed

23 existing test files mock `@/lib/email` with a factory and don't supply `runPaced`. Pre-existing from #1158, none on this path. If any of them reach `fanOutEmails` it throws inside a try that swallows and logs — a silent zero-emails pass, not a loud failure. Worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
