### PR TITLE
feat(membership): BG reviewers can attest a completion date other than today (rel/1.0)

### DIFF
--- a/checkin-app/prisma/migrations/20260720170000_bg_attestation_proposed_check_date/migration.sql
+++ b/checkin-app/prisma/migrations/20260720170000_bg_attestation_proposed_check_date/migration.sql
@@ -1,0 +1,5 @@
+-- The check-completion date a reviewer attests to, when they backdate the check
+-- via the review UI. Null (the default for every existing row) = "as of today",
+-- i.e. the check is stamped at clearance time — the pre-feature behavior. Purely
+-- additive: a nullable column with no default and no backfill.
+ALTER TABLE "BackgroundCheckAttestation" ADD COLUMN "proposedCheckDate" TIMESTAMP(3);

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -488,6 +488,12 @@ model BackgroundCheckAttestation {
   note            String?
   /// @sensitivity:internal
   isMarkedVolunteer Boolean           @default(false)
+  /// The check-completion date this reviewer attests to. Null = "as of today"
+  /// (the check is stamped at clearance time). When a reviewer backdates via the
+  /// review UI, BOTH reviewers' attestations must carry the SAME date — the
+  /// second reviewer attests to the first's proposed date (see review.ts › attest).
+  /// @sensitivity:internal
+  proposedCheckDate DateTime?
   /// @sensitivity:public
   createdAt       DateTime          @default(now())
 

--- a/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipReviewAPI.integration.test.ts
@@ -137,6 +137,59 @@ describe('Membership BG review API', () => {
         expect(advance?.actorId).toBe(rev2);
     });
 
+    it('backdated check: BOTH reviewers must attest the same date, and it stamps lastBackgroundCheck to that date', async () => {
+        const proc = await makeApplicantProcess('Backdate');
+
+        // Reviewer 1 attests a past completion date.
+        as(rev1, { isBackgroundCheckReviewer: true });
+        const r1 = await ATTEST(req({ processId: proc.processId, result: 'APPROVE', checkDate: '2026-01-15' }) as never);
+        expect(r1.status).toBe(200);
+
+        // Reviewer 2 approving AS-OF-TODAY (no date) is refused with the required date.
+        as(rev2, { isBackgroundCheckReviewer: true });
+        const noDate = await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
+        expect(noDate.status).toBe(409);
+        const mm = await noDate.json();
+        expect(mm.code).toBe('date_mismatch');
+        expect(mm.requiredCheckDate).toBe('2026-01-15');
+
+        // A DIFFERENT date is refused too — the mismatched attempt records no attestation.
+        const wrongDate = await ATTEST(req({ processId: proc.processId, result: 'APPROVE', checkDate: '2026-02-01' }) as never);
+        expect(wrongDate.status).toBe(409);
+
+        // Attesting the SAME date clears the check and stamps THAT date (not today).
+        const ok = await ATTEST(req({ processId: proc.processId, result: 'APPROVE', checkDate: '2026-01-15' }) as never);
+        expect(ok.status).toBe(200);
+        expect((await ok.json()).outcome.status).toBe('PENDING_PAYMENT');
+        const parent = await prisma.person.findFirst({ where: { householdId: proc.householdId, isHouseholdLead: true } });
+        expect(parent?.lastBackgroundCheck?.toISOString().slice(0, 10)).toBe('2026-01-15');
+
+        // The clearance audit records the attested check date.
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: proc.processId } });
+        expect(audits.some((a) => JSON.stringify(normalizeAuditData(a.newData)).includes('"checkDate":"2026-01-15"'))).toBe(true);
+    });
+
+    it('an as-of-today clear (no custom date) stamps today, unchanged behavior', async () => {
+        const proc = await makeApplicantProcess('Today');
+        as(rev1, { isBackgroundCheckReviewer: true });
+        await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
+        as(rev2, { isBackgroundCheckReviewer: true });
+        const ok = await ATTEST(req({ processId: proc.processId, result: 'APPROVE' }) as never);
+        expect(ok.status).toBe(200);
+        const parent = await prisma.person.findFirst({ where: { householdId: proc.householdId, isHouseholdLead: true } });
+        expect(parent?.lastBackgroundCheck?.toISOString().slice(0, 10)).toBe(new Date().toISOString().slice(0, 10));
+    });
+
+    it('rejects a future check date with 400 before any attestation is recorded', async () => {
+        const proc = await makeApplicantProcess('FutureDate');
+        as(rev1, { isBackgroundCheckReviewer: true });
+        const future = new Date(Date.now() + 2 * 86400000).toISOString().slice(0, 10);
+        const res = await ATTEST(req({ processId: proc.processId, result: 'APPROVE', checkDate: future }) as never);
+        expect(res.status).toBe(400);
+        const count = await prisma.backgroundCheckAttestation.count({ where: { processId: proc.processId } });
+        expect(count).toBe(0);
+    });
+
     it('applies volunteer status from a pre-designation (Gmail dot-insensitive), without a checkbox', async () => {
         // Gmail drops dots, so vol.parent... matches the dotless designation. Non-Gmail
         // domains keep dots significant (see volunteerMatch.test.ts) — that's the fix.

--- a/checkin-app/src/app/api/membership/reviews/route.ts
+++ b/checkin-app/src/app/api/membership/reviews/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { handler, unauthorized } from "@/security/handler";
 import { eligibleReviewProcessIds, attest, ReviewError } from "@/lib/membership/review";
+import { parseCheckDate } from "@/lib/membership/bgCheckDate";
 import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
@@ -15,6 +16,7 @@ const STATUS_FOR: Record<ReviewError["code"], number> = {
     same_household_applicant: 403,
     same_household_reviewer: 403,
     already_attested: 409,
+    date_mismatch: 409,
 };
 
 /**
@@ -75,7 +77,7 @@ export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
 // Board members are implicit reviewers (see canReviewBackgroundChecks); attest() re-checks.
 export const POST = withAuth({ roles: ["isBackgroundCheckReviewer", "isBoardMember"] }, async (req, auth) => {
     if (auth.type !== "session") return apiError("Unauthorized", 401);
-    let body: { processId?: number; result?: "APPROVE" | "REJECT"; isMarkedVolunteer?: boolean; note?: string };
+    let body: { processId?: number; result?: "APPROVE" | "REJECT"; isMarkedVolunteer?: boolean; note?: string; checkDate?: string };
     try {
         body = await req.json();
     } catch {
@@ -88,12 +90,20 @@ export const POST = withAuth({ roles: ["isBackgroundCheckReviewer", "isBoardMemb
     if (body.result === "REJECT" && !note) {
         return apiError("A note explaining the denial is required", 400);
     }
+    const parsed = parseCheckDate(body.checkDate);
+    if ("error" in parsed) return apiError(parsed.error, 400);
     try {
-        const outcome = await attest(auth.user.id, body.processId, { result: body.result, isMarkedVolunteer: body.isMarkedVolunteer, note: note || undefined });
+        const outcome = await attest(auth.user.id, body.processId, { result: body.result, isMarkedVolunteer: body.isMarkedVolunteer, note: note || undefined, checkDate: parsed.date });
         return NextResponse.json({ outcome });
     } catch (error) {
         if (error instanceof ReviewError) {
-            return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_FOR[error.code] });
+            // date_mismatch carries the date the first reviewer already attested to
+            // (null = as-of-today), so the UI can require the second reviewer to
+            // confirm that exact date.
+            return NextResponse.json(
+                { error: error.message, code: error.code, ...(error.code === "date_mismatch" ? { requiredCheckDate: error.requiredCheckDate ?? null } : {}) },
+                { status: STATUS_FOR[error.code] },
+            );
         }
         logger.error("Attestation error:", error);
         return apiError("Internal Server Error", 500);

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
-import { Alert, Button, Card, Checkbox, Container, Group, Stack, Text, Textarea, Title } from "@mantine/core";
+import { Alert, Button, Card, Checkbox, Container, Group, Modal, Stack, Switch, Text, Textarea, TextInput, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { type AlertTone } from "@/components/admin/AlertBanner";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
@@ -33,6 +33,15 @@ export default function MembershipReviewPage() {
   const [busyId, setBusyId] = useState<number | null>(null);
   const [volunteer, setVolunteer] = useState<Record<number, boolean>>({});
   const [reviewNotes, setReviewNotes] = useState<Record<number, string>>({});
+  // Optional "check completed on a different date" per row — the slider gate + the
+  // picked YYYY-MM-DD. Off by default → the check is stamped as of clearance time.
+  const [customDateOn, setCustomDateOn] = useState<Record<number, boolean>>({});
+  const [customDate, setCustomDate] = useState<Record<number, string>>({});
+  // Confirmation modal: the attestation about to be submitted for `processId`,
+  // carrying the exact completion date being attested (null = as of today).
+  const [confirm, setConfirm] = useState<{ processId: number; date: string | null } | null>(null);
+  const [confirmBusy, setConfirmBusy] = useState(false);
+  const today = new Date().toISOString().slice(0, 10);
   // Tagged with the acting row's processId so the result renders in that card, not off-screen at page top.
   const [message, setMessage] = useState<{ processId: number; text: string; tone: AlertTone } | undefined>();
 
@@ -58,32 +67,71 @@ export default function MembershipReviewPage() {
     else if (sessionStatus === "unauthenticated") setLoading(false);
   }, [sessionStatus, load]);
 
-  const submit = async (processId: number, result: "APPROVE" | "REJECT") => {
-    if (result === "REJECT" && !reviewNotes[processId]?.trim()) return;
+  // Submit one attestation. Returns { mismatch } ONLY when the server reports a
+  // date_mismatch (value = the date the first reviewer attested to, null = today),
+  // so the caller can open the modal to make this reviewer confirm that date.
+  const finishAttest = async (
+    processId: number,
+    result: "APPROVE" | "REJECT",
+    checkDate: string | null,
+  ): Promise<{ mismatch?: string | null }> => {
     setBusyId(processId);
     setMessage(undefined);
     try {
       const res = await fetch("/api/membership/reviews", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ processId, result, isMarkedVolunteer: !!volunteer[processId], note: reviewNotes[processId]?.trim() || undefined }),
+        body: JSON.stringify({ processId, result, isMarkedVolunteer: !!volunteer[processId], note: reviewNotes[processId]?.trim() || undefined, checkDate: checkDate || undefined }),
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
         notifications.show({ message: result === "APPROVE" ? "Attestation recorded — thank you." : "Recorded. The board has been notified." });
         await load();
         notifyNavRefresh();
-      } else if (data.code === "already_attested") {
+        return {};
+      }
+      if (data.code === "date_mismatch") return { mismatch: data.requiredCheckDate ?? null };
+      if (data.code === "already_attested") {
         notifications.show({ color: "red", message: data.error || "Already attested.", autoClose: 4000 });
         await load();
-      } else {
-        setMessage({ processId, text: data.error || "Could not record your attestation.", tone: "error" });
+        return {};
       }
+      setMessage({ processId, text: data.error || "Could not record your attestation.", tone: "error" });
+      return {};
     } catch {
       notifications.show({ color: "red", message: "Network error.", autoClose: false });
+      return {};
     } finally {
       setBusyId(null);
     }
+  };
+
+  // Approve: a custom date always goes through the confirmation modal first. Without
+  // one, submit as-of-today — and if the server says the FIRST reviewer already
+  // attested a specific date, open the modal so this (second) reviewer confirms it.
+  const onApprove = async (processId: number) => {
+    if (customDateOn[processId] && customDate[processId]) {
+      setConfirm({ processId, date: customDate[processId] });
+      return;
+    }
+    const { mismatch } = await finishAttest(processId, "APPROVE", null);
+    if (mismatch !== undefined) setConfirm({ processId, date: mismatch });
+  };
+
+  const reject = (processId: number) => {
+    if (!reviewNotes[processId]?.trim()) return;
+    void finishAttest(processId, "REJECT", null);
+  };
+
+  const confirmApprove = async () => {
+    if (!confirm) return;
+    setConfirmBusy(true);
+    const { mismatch } = await finishAttest(confirm.processId, "APPROVE", confirm.date);
+    setConfirmBusy(false);
+    // Still mismatched → the required date differs from what was just confirmed;
+    // retarget the modal to the date the first reviewer actually attested to.
+    if (mismatch !== undefined) setConfirm({ processId: confirm.processId, date: mismatch });
+    else setConfirm(null);
   };
 
   if (sessionStatus === "loading" || loading) {
@@ -169,11 +217,37 @@ export default function MembershipReviewPage() {
                 minRows={2}
               />
 
+              {/* Optional backdating. Off → the check is stamped as of clearance.
+                  On → a completion date the reviewer attests to; a confirmation
+                  modal (on Approve) makes them attest to it, and the SECOND reviewer
+                  must attest to the SAME date (enforced server-side). */}
+              <Switch
+                mt="md"
+                checked={!!customDateOn[item.id]}
+                onChange={(e) => { const on = e.currentTarget.checked; setCustomDateOn((s) => ({ ...s, [item.id]: on })); }}
+                label="This background check was completed on a different date"
+              />
+              {customDateOn[item.id] && (
+                <TextInput
+                  type="date"
+                  mt="xs"
+                  max={today}
+                  label="Completion date"
+                  description="Both reviewers must attest to this date. You'll confirm it before approving."
+                  value={customDate[item.id] ?? ""}
+                  onChange={(e) => { const v = e.currentTarget.value; setCustomDate((s) => ({ ...s, [item.id]: v })); }}
+                />
+              )}
+
               <Group gap="sm" wrap="wrap" mt="md">
-                <Button disabled={busyId === item.id} loading={busyId === item.id} onClick={() => submit(item.id, "APPROVE")}>
+                <Button
+                  disabled={busyId === item.id || (!!customDateOn[item.id] && !customDate[item.id])}
+                  loading={busyId === item.id}
+                  onClick={() => onApprove(item.id)}
+                >
                   Attest — check is clean
                 </Button>
-                <Button color="red" variant="light" disabled={busyId === item.id || !reviewNotes[item.id]?.trim()} onClick={() => submit(item.id, "REJECT")}>
+                <Button color="red" variant="light" disabled={busyId === item.id || !reviewNotes[item.id]?.trim()} onClick={() => reject(item.id)}>
                   Reject
                 </Button>
               </Group>
@@ -188,6 +262,33 @@ export default function MembershipReviewPage() {
           })}
         </Stack>
       )}
+
+      {/* Date attestation confirmation. Opened when a reviewer sets a custom date,
+          or when the server requires the second reviewer to confirm the first's
+          date. Confirming records THIS reviewer's attestation to that exact date. */}
+      <Modal
+        opened={!!confirm}
+        onClose={() => { if (!confirmBusy) setConfirm(null); }}
+        title="Confirm the background-check date"
+        centered
+      >
+        <Text>
+          {confirm?.date ? (
+            <>You are attesting that this background check was <strong>completed on {confirm.date}</strong> and that it is clean.</>
+          ) : (
+            <>The first reviewer attested this check <strong>as of today</strong>. Confirm you attest to today&apos;s date and a clean check.</>
+          )}
+        </Text>
+        <Text size="sm" c="dimmed" mt="sm">
+          Both reviewers must attest to the same date. This is recorded as your attestation.
+        </Text>
+        <Group justify="flex-end" mt="lg">
+          <Button variant="default" onClick={() => setConfirm(null)} disabled={confirmBusy}>Cancel</Button>
+          <Button onClick={confirmApprove} loading={confirmBusy}>
+            Attest — check is clean{confirm?.date ? ` (${confirm.date})` : ""}
+          </Button>
+        </Group>
+      </Modal>
     </Container>
   );
 }

--- a/checkin-app/src/lib/membership/__tests__/bgCheckDate.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/bgCheckDate.test.ts
@@ -1,0 +1,61 @@
+import { attestedDay, sameAttestedDay, parseCheckDate } from "@/lib/membership/bgCheckDate";
+
+describe("bgCheckDate", () => {
+    describe("attestedDay", () => {
+        it("null/undefined → null (as of today)", () => {
+            expect(attestedDay(null)).toBeNull();
+            expect(attestedDay(undefined)).toBeNull();
+        });
+        it("a date → its UTC calendar day", () => {
+            expect(attestedDay(new Date("2026-03-14T00:00:00.000Z"))).toBe("2026-03-14");
+            // time-of-day is dropped
+            expect(attestedDay(new Date("2026-03-14T23:59:59.000Z"))).toBe("2026-03-14");
+        });
+    });
+
+    describe("sameAttestedDay", () => {
+        it("both null agree (both attest as of today)", () => {
+            expect(sameAttestedDay(null, null)).toBe(true);
+        });
+        it("null vs a date disagree — the second reviewer can't add a date the first didn't", () => {
+            expect(sameAttestedDay(null, new Date("2026-03-14T00:00:00Z"))).toBe(false);
+            expect(sameAttestedDay(new Date("2026-03-14T00:00:00Z"), null)).toBe(false);
+        });
+        it("same calendar day agrees regardless of time-of-day", () => {
+            expect(sameAttestedDay(new Date("2026-03-14T00:00:00Z"), new Date("2026-03-14T18:30:00Z"))).toBe(true);
+        });
+        it("different days disagree", () => {
+            expect(sameAttestedDay(new Date("2026-03-14T00:00:00Z"), new Date("2026-03-15T00:00:00Z"))).toBe(false);
+        });
+    });
+
+    describe("parseCheckDate", () => {
+        const now = new Date("2026-07-20T12:00:00.000Z");
+        it("absent → null (default, as of today)", () => {
+            expect(parseCheckDate(undefined, now)).toEqual({ date: null });
+            expect(parseCheckDate(null, now)).toEqual({ date: null });
+            expect(parseCheckDate("", now)).toEqual({ date: null });
+        });
+        it("a valid past date → UTC-midnight Date", () => {
+            const r = parseCheckDate("2026-03-14", now);
+            expect("date" in r && r.date?.toISOString()).toBe("2026-03-14T00:00:00.000Z");
+        });
+        it("today is allowed", () => {
+            const r = parseCheckDate("2026-07-20", now);
+            expect("date" in r && r.date?.toISOString()).toBe("2026-07-20T00:00:00.000Z");
+        });
+        it("a future date is rejected", () => {
+            expect(parseCheckDate("2026-07-21", now)).toEqual({ error: "The check date cannot be in the future" });
+        });
+        it("malformed input is rejected", () => {
+            expect("error" in parseCheckDate("03/14/2026", now)).toBe(true);
+            expect("error" in parseCheckDate("2026-3-4", now)).toBe(true);
+            expect("error" in parseCheckDate(20260314, now)).toBe(true);
+        });
+        it("a well-formed but impossible date is rejected (V8 would silently roll it over)", () => {
+            expect("error" in parseCheckDate("2026-02-30", now)).toBe(true); // → Mar 2 without the round-trip guard
+            expect("error" in parseCheckDate("2026-13-01", now)).toBe(true);
+            expect("error" in parseCheckDate("2026-07-00", now)).toBe(true);
+        });
+    });
+});

--- a/checkin-app/src/lib/membership/bgCheckDate.ts
+++ b/checkin-app/src/lib/membership/bgCheckDate.ts
@@ -1,0 +1,39 @@
+/**
+ * The completion date a background-check reviewer attests to, when they backdate a
+ * check via the review UI (Person.lastBackgroundCheck is otherwise stamped as of
+ * clearance time). One source of truth for the date's grammar, shared by the API
+ * route (parsing/validation) and the review service (equality between the two
+ * reviewers' attestations). Pure — unit-tested without a DB.
+ *
+ * The attestation is a CALENDAR DAY, never a time: the UI supplies a bare
+ * "YYYY-MM-DD" and it is stored at UTC midnight, and two attestations agree iff
+ * they name the same UTC day (or both are null = "as of today").
+ */
+
+/** UTC "YYYY-MM-DD" for a stored date, or null for "as of today". */
+export function attestedDay(d: Date | null | undefined): string | null {
+    return d ? d.toISOString().slice(0, 10) : null;
+}
+
+/** Two attestations agree iff both are null or name the same UTC day. */
+export function sameAttestedDay(a: Date | null | undefined, b: Date | null | undefined): boolean {
+    return attestedDay(a) === attestedDay(b);
+}
+
+/**
+ * Parse the optional backdated completion date from the review UI's native date
+ * input into a UTC-midnight Date. Returns { date: null } when absent (the default,
+ * "as of today"), { error } for a malformed or future date (a check cannot have
+ * been completed in the future), else { date }.
+ */
+export function parseCheckDate(raw: unknown, now: Date = new Date()): { date: Date | null } | { error: string } {
+    if (raw === undefined || raw === null || raw === "") return { date: null };
+    if (typeof raw !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(raw)) return { error: "checkDate must be a YYYY-MM-DD date" };
+    const date = new Date(`${raw}T00:00:00.000Z`);
+    // Number.isNaN alone is not enough: V8 SILENTLY rolls impossible days over
+    // (Feb 30 → Mar 2), so a well-formed-but-invalid date would be accepted and
+    // shifted. Round-trip the parsed day back to the input to reject those.
+    if (Number.isNaN(date.getTime()) || attestedDay(date) !== raw) return { error: "checkDate is not a valid date" };
+    if (raw > now.toISOString().slice(0, 10)) return { error: "The check date cannot be in the future" };
+    return { date };
+}

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -12,6 +12,7 @@ import { hasHouseholdConflict, sharesHousehold } from "@/lib/conflictOfInterest"
 import { type DbClient, type TxClient } from "@/lib/db-client";
 import { awaitingBgReview } from "@/lib/membership/lifecycle";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import { attestedDay, sameAttestedDay } from "@/lib/membership/bgCheckDate";
 
 /**
  * Background-check review — now a PARALLEL track, not a blocking phase.
@@ -58,8 +59,13 @@ export class ReviewError extends Error {
             | "wrong_phase"
             | "same_household_applicant"
             | "same_household_reviewer"
-            | "already_attested",
+            | "already_attested"
+            | "date_mismatch",
         message: string,
+        // date_mismatch only: the date the FIRST reviewer already attested to (ISO
+        // "YYYY-MM-DD"), or null when they attested "as of today". The API surfaces
+        // it so the second reviewer's UI can require them to attest to the SAME date.
+        public readonly requiredCheckDate?: string | null,
     ) {
         super(message);
         this.name = "ReviewError";
@@ -196,8 +202,11 @@ export async function reviewQueueCounts(reviewerId: number): Promise<{ canActOn:
 export async function attest(
     reviewerId: number,
     processId: number,
-    input: { result: "APPROVE" | "REJECT"; isMarkedVolunteer?: boolean; note?: string },
+    input: { result: "APPROVE" | "REJECT"; isMarkedVolunteer?: boolean; note?: string; checkDate?: Date | null },
 ) {
+    // The completion date this reviewer attests to (null = as-of-today). Only an
+    // APPROVE carries one; a REJECT never backdates anything.
+    const attestedDate = input.result === "APPROVE" ? (input.checkDate ?? null) : null;
     const reviewer = await loadReviewer(reviewerId);
     if (!reviewer || !canReviewBackgroundChecks(reviewer)) throw new ReviewError("not_reviewer", "You are not a background-check reviewer.");
 
@@ -224,8 +233,29 @@ export async function attest(
         if (process.attestations.some((a) => a.reviewerId === reviewerId)) throw new ReviewError("already_attested", "You have already reviewed this application.");
         if (process.attestations.some((a) => sharesHousehold(reviewer.householdId, a.reviewer.householdId))) throw new ReviewError("same_household_reviewer", "Another reviewer from your household has already reviewed this application.");
 
+        // Both reviewers must attest to the SAME completion date. When a prior
+        // APPROVE exists (this attestation is the clearing one), the incoming date
+        // must match it — the second reviewer attests to the first's proposed date,
+        // not a date of their own. A mismatch is refused with the required date so
+        // the UI can walk the second reviewer through confirming it. (An awaiting
+        // process only ever holds APPROVE attestations — any REJECT has already
+        // moved it to BLOCKED — so the first APPROVE is the one to match.)
+        if (input.result === "APPROVE") {
+            const priorApprove = process.attestations.find((a) => a.result === "APPROVE");
+            if (priorApprove && !sameAttestedDay(attestedDate, priorApprove.proposedCheckDate)) {
+                const required = attestedDay(priorApprove.proposedCheckDate);
+                throw new ReviewError(
+                    "date_mismatch",
+                    required
+                        ? `The first reviewer attested this check was completed on ${required}. You must attest to that same date.`
+                        : "The first reviewer attested this check as of today. To approve, attest as of today too (turn off the custom date).",
+                    required,
+                );
+            }
+        }
+
         await tx.backgroundCheckAttestation.create({
-            data: { processId, reviewerId, result: input.result, isMarkedVolunteer: !!input.isMarkedVolunteer, note: input.note ?? null },
+            data: { processId, reviewerId, result: input.result, isMarkedVolunteer: !!input.isMarkedVolunteer, note: input.note ?? null, proposedCheckDate: attestedDate },
         });
 
         if (input.result === "REJECT") {
@@ -281,15 +311,24 @@ async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: nu
     });
     if (!process) throw new ReviewError("not_found", "Application not found.");
 
+    // The completion date the reviewers attested to. attest() guarantees both
+    // APPROVE attestations carry the SAME proposedCheckDate, so any non-null one is
+    // the agreed date; null everywhere = "as of today" (clearance time), the
+    // pre-feature behavior. bgClearedAt/stageEnteredAt stay `now` — the CLEARANCE
+    // happened now; only the check's own date is backdated. A board force-clear
+    // (overrideBlocked) with no reviewer date falls through to `now` too.
+    const checkDate =
+        process.attestations.find((a) => a.result === "APPROVE" && a.proposedCheckDate)?.proposedCheckDate ?? new Date();
+
     // PERSON_BG: subject-scoped. Stamp ONLY the subject person and resolve — there is
     // no household membership to activate/pay, so skip the payment/activation
     // convergence entirely, and do NOT touch the household-lead blanket stamp (that's
     // the household path below, whose lead-stamp change is Phase 5).
     if (process.subjectPersonId) {
         const now = new Date();
-        await tx.person.update({ where: { id: process.subjectPersonId }, data: { lastBackgroundCheck: now } });
+        await tx.person.update({ where: { id: process.subjectPersonId }, data: { lastBackgroundCheck: checkDate } });
         await tx.orgMembershipProcess.update({ where: { id: processId }, data: { bgClearedAt: now, status: "ACTIVE", stageEnteredAt: now } });
-        await audit(tx, actorId, processId, { status: process.status }, { status: "ACTIVE", bgCleared: true, subjectPersonId: process.subjectPersonId });
+        await audit(tx, actorId, processId, { status: process.status }, { status: "ACTIVE", bgCleared: true, subjectPersonId: process.subjectPersonId, checkDate: attestedDay(checkDate) });
         return { activated: false, householdId: null, isInitial: false };
     }
 
@@ -300,9 +339,11 @@ async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: nu
     const now = new Date();
     const paid = !!process.paidAt;
 
-    // Stamp the guardians' (household leads') lastBackgroundCheck. Expiry is derived from this
-    // plus BoardSettings.bgRecheckMonths at read time (see householdBgIsFresh) — not stored.
-    await tx.person.updateMany({ where: { householdId, isHouseholdLead: true }, data: { lastBackgroundCheck: now } });
+    // Stamp the guardians' (household leads') lastBackgroundCheck with the attested
+    // completion date (checkDate above; `now` unless backdated). Expiry is derived
+    // from this plus BoardSettings.bgRecheckMonths at read time (see householdBgIsFresh)
+    // — not stored — so a backdated check correctly expires earlier.
+    await tx.person.updateMany({ where: { householdId, isHouseholdLead: true }, data: { lastBackgroundCheck: checkDate } });
     await applyVolunteerStatus(tx, process.orgMembershipId!, householdId, process.attestations.some((a) => a.isMarkedVolunteer));
 
     await tx.orgMembershipProcess.update({
@@ -313,7 +354,7 @@ async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: nu
         await tx.orgMembership.update({ where: { id: process.orgMembershipId! }, data: { status: "ACTIVE" } });
     }
 
-    await audit(tx, actorId, processId, { status: process.status }, { status: paid ? "ACTIVE" : "PENDING_PAYMENT", bgCleared: true });
+    await audit(tx, actorId, processId, { status: process.status }, { status: paid ? "ACTIVE" : "PENDING_PAYMENT", bgCleared: true, checkDate: attestedDay(checkDate) });
     return { activated: paid, householdId, isInitial: process.kind === "INITIAL" };
 }
 

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -104,6 +104,7 @@ export const classifications = {
         result: 'internal',
         note: 'internal',
         isMarkedVolunteer: 'internal',
+        proposedCheckDate: 'internal',
         createdAt: 'public',
     },
     VolunteerDesignation: {


### PR DESCRIPTION
## Problem
The two-reviewer background-check attestation flow stamps `Person.lastBackgroundCheck` with **today** at clearance (`review.ts › clearBackgroundCheck`). A check actually completed earlier (an external check dated last month, a paper check) can only be recorded through the ops participant-edit back door — which bypasses the two-reviewer attestation entirely. **There is no first-class way for a reviewer to attest a completion date other than today.** This adds one.

## What this does
- **Opt-in slider** on `/membership-ops/review`: a `Switch` per application ("This background check was completed on a different date"). Off by default → unchanged as-of-today behavior. On → a native `<input type="date">` (max = today).
- **Modal confirmation**: approving with a custom date opens a confirmation modal to explicitly attest to that date.
- **Both reviewers must attest to the same date**: the second reviewer's attestation must match the first's proposed date, enforced server-side. A mismatch returns `409 date_mismatch` carrying the required date, and the UI walks the second reviewer through confirming it. Neither reviewer can unilaterally introduce a date the other didn't attest to.
- **Clearance** stamps `lastBackgroundCheck` with the agreed date; `bgClearedAt` / audit-event timestamps stay `now` (only the *check's own date* is backdated, so bg-expiry math correctly treats it as older). The clearance audit records the attested date.

## Data
`BackgroundCheckAttestation.proposedCheckDate` — nullable, `@sensitivity:internal`, null = as-of-today. **Additive migration** (no `NOT NULL`, no default, no backfill; expand-only per the migration-safety checklist). Deliberately kept **out of `src/security`** — the second reviewer learns the required date from the POST response, not a stripped model field, so the boundary-isolation gate doesn't apply.

## Tests
- `lib/membership/bgCheckDate.test.ts` — pure date grammar: parse/validate/equality, incl. rejecting **future** dates and **impossible** dates (V8 silently rolls `2026-02-30` → Mar 2 without the round-trip guard). Verified locally.
- `membershipReviewAPI.integration.test.ts` — the attestation-flow enforcement: reviewer 1 backdates → reviewer 2 must match (mismatch 409 with the required date) → same date clears and stamps it; as-of-today path unchanged; future date rejected 400 before any attestation is recorded.

## Companion
This targets **`rel/1.0`** as the companion to **#1169** (main) — the same change; the touched files are byte-identical across the two branches, so it was a clean cherry-pick.

> Note: local `tsc`/jest weren't runnable in this environment (dev deps not installed); CI validates the full typecheck + suites. The pure date logic was verified with a standalone node harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
