### PR TITLE
fix(auth): stop idle-logout — retry the pg client connect-timeout during Aurora resume

### DIFF
--- a/checkin-app/src/lib/__tests__/auroraResumeRetry.test.ts
+++ b/checkin-app/src/lib/__tests__/auroraResumeRetry.test.ts
@@ -74,12 +74,18 @@ describe("retryP1001UntilDeadline", () => {
 
 describe("isDbResumeError — acquisition-phase signatures only", () => {
     const { isDbResumeError } = jest.requireActual("@/lib/auroraResumeRetry");
-    it("matches P1001, P2024, and the pg pool connect-timeout message", () => {
+    it("matches P1001, P2024, and both pg connect-timeout messages", () => {
         expect(isDbResumeError({ code: "P1001" })).toBe(true);
         expect(isDbResumeError({ code: "P2024" })).toBe(true);
+        // pg pool: no free connection within connectionTimeoutMillis
         expect(isDbResumeError(new Error("timeout exceeded when trying to connect"))).toBe(true);
+        // pg client: socket still connecting when connectionTimeoutMillis fired —
+        // the regression that logged users out after idle (JWT_SESSION_ERROR).
+        expect(isDbResumeError(new Error("Connection terminated due to connection timeout"))).toBe(true);
     });
     it("rejects mid-query drops and unrelated errors (write-safety)", () => {
+        // A LIVE connection dropped mid-statement — the query may have run, so never retry.
+        // Must stay distinct from the "due to connection timeout" acquisition failure above.
         expect(isDbResumeError(new Error("Connection terminated unexpectedly"))).toBe(false);
         expect(isDbResumeError({ code: "P2002" })).toBe(false);
         expect(isDbResumeError(null)).toBe(false);

--- a/checkin-app/src/lib/auroraResumeRetry.ts
+++ b/checkin-app/src/lib/auroraResumeRetry.ts
@@ -45,12 +45,23 @@ const RESUME_RETRY_DELAY_MS = 2_000;
  * when trying to connect" message, not P1001, which is how the public
  * programs directory 500'd at ~30s (three sequential 10s pool timeouts)
  * instead of riding out the resume.
+ *
+ * "Connection terminated due to connection timeout" is the pg *client's* own
+ * connectionTimeoutMillis firing while the socket is still connecting — again a
+ * connection-ACQUISITION failure (the connection never established, the query
+ * never ran), distinct from a mid-query "connection terminated UNEXPECTEDLY"
+ * drop, which we still must not retry. Missing it meant the jwt-callback role
+ * re-sync (auth-options.ts) threw against a paused DB instead of riding out the
+ * resume, surfacing as NextAuth JWT_SESSION_ERROR — i.e. users bounced to
+ * sign-in ~15min (updateAge) into an idle-then-return, and flaky cold sign-in
+ * (adapter_error_getUserByAccount). Prod evidence: 2026-07-19/20.
  */
 export function isDbResumeError(error: unknown): boolean {
     const e = error as { code?: string; message?: string } | null;
     if (!e) return false;
     if (e.code === 'P1001' || e.code === 'P2024') return true;
-    return typeof e.message === 'string' && /timeout exceeded when trying to connect/i.test(e.message);
+    return typeof e.message === 'string'
+        && /timeout exceeded when trying to connect|connection terminated due to connection timeout/i.test(e.message);
 }
 
 /** Deadline-based sibling of withAuroraResumeRetry (exported for tests). */


### PR DESCRIPTION
## Symptom
Users are bounced to sign-in after **as little as ~20 minutes** idle — nowhere near the 8h session `maxAge`.

## Root cause (prod log evidence, 2026-07-19/20)
1. The JWT session refreshes at most every **15 min** (`updateAge`). The first request past that runs the `jwt` callback's role re-sync — a `prisma.person.findUnique`.
2. When the scale-to-zero Aurora cluster (min-capacity 0, auto-pause) has paused during the idle window, acquiring a connection fails with pg's **`Connection terminated due to connection timeout`** (the pg *client's* own `connectionTimeoutMillis` firing mid-connect).
3. `isDbResumeError` matched `P1001`, `P2024`, and the pool's `timeout exceeded when trying to connect` — but **not** that client message. So neither `withAuroraResumeRetry` (jwt path) nor the 45 s client-wide extension retried it.
4. It threw → NextAuth `[JWT_SESSION_ERROR]` → session invalid → **forced re-authentication**.

The same gap made cold sign-in flaky (`adapter_error_getUserByAccount` / `OAUTH_CALLBACK_HANDLER_ERROR`), since the adapter's DB reads hit the identical unretried error.

`/ecs/checkin-prod` shows `JWT_SESSION_ERROR "Connection terminated due to connection timeout"` clustered exactly on idle-return times through the evening.

## Fix
Add that message to `isDbResumeError`. It's a connection-**acquisition** failure (the connection never established, the query never ran), so it's safe to retry like the others — and stays distinct from a mid-query `connection terminated UNEXPECTEDLY` drop, which we still must not retry (the existing write-safety test pins that line). One matcher line fixes **both** the idle-logout and the flaky cold sign-in, because both flow through the retry paths.

## Verify
`auroraResumeRetry.test.ts` extended: both connect-timeout messages now match, `unexpectedly` still rejected. **8/8 pass locally** (node 24), eslint clean.

Companion PR targets **`rel/1.0`** so the running release gets the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
