### PR TITLE
fix(perf): pause client polls when hidden/idle so scale-to-zero can sleep

### DIFF
--- a/checkin-app/src/app/attendance/certifications/page.tsx
+++ b/checkin-app/src/app/attendance/certifications/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { Alert, Badge, Box, Card, Center, Group, Loader, Text, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useAutoCycle } from "../../../hooks/useAutoCycle";
+import { usePolling } from "@/hooks/usePolling";
 import { getKioskDisplayNames } from "@/lib/kiosk-names";
 import { ToolLevelBadge, toToolLevel, toolLevelDot } from "@/components/ToolLevelBadge";
 
@@ -87,11 +88,10 @@ function KioskCertificationsInner() {
     }
   }, [searchParams, limitToPresent]);
 
-  useEffect(() => {
-    fetchData();
-    const interval = setInterval(fetchData, 10000);
-    return () => clearInterval(interval);
-  }, [fetchData]);
+  // Visibility gate only, NO idle-stop: this is an unattended wall display, so
+  // idle-stop would freeze it. It's also cookieless (kiosk signature, not a
+  // session), so it can't wake a slept env and can't defeat the overnight curfew.
+  usePolling(fetchData, 10000);
 
   const getColorForLevel = (level: ToolStatusLevel | undefined) =>
     level ? toolLevelDot(toToolLevel(level)) : "transparent";

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
+import { usePolling, POLL_IDLE_STOP_MS } from "@/hooks/usePolling";
 import { useDisclosure } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
 import {
@@ -114,39 +115,43 @@ function KioskDisplayInner() {
     if (canCheckInHousehold) fetchHousehold();
   }, [canCheckInHousehold, currentUserHouseholdId]);
 
-  useEffect(() => {
-    const fetchAttendance = async () => {
-      try {
-        const headers: Record<string, string> = {};
-        const sigParamsUrl = searchParams.get("sig");
-        const tsParamsUrl = searchParams.get("ts");
-        const nonceParamsUrl = searchParams.get("nonce");
-        if (sigParamsUrl && tsParamsUrl && nonceParamsUrl) {
-          headers["x-kiosk-signature"] = sigParamsUrl;
-          headers["x-kiosk-timestamp"] = tsParamsUrl;
-          headers["x-kiosk-nonce"] = nonceParamsUrl;
-        }
+  // A signed kiosk display (sig/ts/nonce present) is unattended, so it must not
+  // idle-stop — only the interactive staff view does. Either way the visibility
+  // gate applies; a cookieless kiosk poll can't wake a slept env anyway.
+  const isSignedKiosk = !!(searchParams.get("sig") && searchParams.get("ts") && searchParams.get("nonce"));
 
-        const res = await fetch("/api/attendance", { headers });
-        const json = await res.json().catch(() => ({}));
-        if (res.ok && (json.access === "full" || json.access === "limited")) {
-          setData(json);
-          setError(null);
-          if (json.signedRequest === true) setIsKioskMode(true);
-        } else if (!res.ok) {
-          setError(json.error || "Failed to load attendance");
-        }
-      } catch (error) {
-        console.error("Failed to fetch attendance:", error);
-        notifications.show({ color: "red", message: "Network error", autoClose: false });
-      } finally {
-        setLoading(false);
+  const fetchAttendance = useCallback(async () => {
+    try {
+      const headers: Record<string, string> = {};
+      const sigParamsUrl = searchParams.get("sig");
+      const tsParamsUrl = searchParams.get("ts");
+      const nonceParamsUrl = searchParams.get("nonce");
+      if (sigParamsUrl && tsParamsUrl && nonceParamsUrl) {
+        headers["x-kiosk-signature"] = sigParamsUrl;
+        headers["x-kiosk-timestamp"] = tsParamsUrl;
+        headers["x-kiosk-nonce"] = nonceParamsUrl;
       }
-    };
 
-    fetchAttendance();
-    const interval = setInterval(fetchAttendance, 60000);
+      const res = await fetch("/api/attendance", { headers });
+      const json = await res.json().catch(() => ({}));
+      if (res.ok && (json.access === "full" || json.access === "limited")) {
+        setData(json);
+        setError(null);
+        if (json.signedRequest === true) setIsKioskMode(true);
+      } else if (!res.ok) {
+        setError(json.error || "Failed to load attendance");
+      }
+    } catch (error) {
+      console.error("Failed to fetch attendance:", error);
+      notifications.show({ color: "red", message: "Network error", autoClose: false });
+    } finally {
+      setLoading(false);
+    }
+  }, [searchParams]);
 
+  usePolling(fetchAttendance, 60000, { idleStopMs: isSignedKiosk ? undefined : POLL_IDLE_STOP_MS });
+
+  useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       if (typeof event.data === "object" && event.data?.type === "refresh-attendance" && event.data.attendance) {
         setData({ access: "full", attendance: event.data.attendance, counts: event.data.counts, safety: event.data.safety });
@@ -157,12 +162,8 @@ function KioskDisplayInner() {
       }
     };
     window.addEventListener("message", handleMessage);
-
-    return () => {
-      clearInterval(interval);
-      window.removeEventListener("message", handleMessage);
-    };
-  }, [searchParams]);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [fetchAttendance]);
 
   useEffect(() => {
     const performSearch = async () => {

--- a/checkin-app/src/components/Notifications.tsx
+++ b/checkin-app/src/components/Notifications.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useCallback } from "react";
 import Link from "next/link";
 import { Button, Group } from "@mantine/core";
 import { CountBadge } from "@/components/ui/CountBadge";
+import { usePolling, POLL_IDLE_STOP_MS } from "@/hooks/usePolling";
 
 interface NotificationData {
   membership: { pendingReviews: number; blocked: number };
@@ -18,17 +19,15 @@ interface NotificationData {
 export default function Notifications() {
   const [data, setData] = useState<NotificationData | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    const fetchCounts = () =>
-      fetch("/api/notifications")
-        .then((res) => (res.ok ? res.json() : null))
-        .then((d) => { if (!cancelled && d) setData(d); })
-        .catch(() => { /* silent — indicators are best-effort */ });
-    fetchCounts();
-    const t = setInterval(fetchCounts, 60000);
-    return () => { cancelled = true; clearInterval(t); };
+  const fetchCounts = useCallback(() => {
+    fetch("/api/notifications")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((d) => { if (d) setData(d); })
+      .catch(() => { /* silent — indicators are best-effort */ });
   }, []);
+  // Mounted in the root layout, so it polls from every open tab. Pause when
+  // hidden and idle-stop so a forgotten tab stops pinning Aurora / re-waking prod.
+  usePolling(fetchCounts, 60000, { idleStopMs: POLL_IDLE_STOP_MS });
 
   const m = data?.membership;
   if (!m || m.blocked === 0) return null;

--- a/checkin-app/src/hooks/__tests__/usePolling.test.tsx
+++ b/checkin-app/src/hooks/__tests__/usePolling.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook } from "@testing-library/react";
+import { usePolling } from "../usePolling";
+
+function setVisibility(state: "visible" | "hidden") {
+    Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
+    document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("usePolling", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        setVisibility("visible");
+    });
+    afterEach(() => {
+        jest.useRealTimers();
+        setVisibility("visible");
+    });
+
+    it("fires once on mount then on the interval", () => {
+        const fn = jest.fn();
+        renderHook(() => usePolling(fn, 1000));
+        expect(fn).toHaveBeenCalledTimes(1); // immediate
+        act(() => { jest.advanceTimersByTime(3000); });
+        expect(fn).toHaveBeenCalledTimes(4);
+    });
+
+    it("pauses while hidden and fires once + resumes on re-show", () => {
+        const fn = jest.fn();
+        renderHook(() => usePolling(fn, 1000));
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        act(() => { setVisibility("hidden"); });
+        act(() => { jest.advanceTimersByTime(5000); });
+        expect(fn).toHaveBeenCalledTimes(1); // no ticks while hidden
+
+        act(() => { setVisibility("visible"); });
+        expect(fn).toHaveBeenCalledTimes(2); // fired once on re-show
+        act(() => { jest.advanceTimersByTime(2000); });
+        expect(fn).toHaveBeenCalledTimes(4); // interval resumed
+    });
+
+    it("idle-stops after idleStopMs, then resumes + fires once on activity", () => {
+        const fn = jest.fn();
+        renderHook(() => usePolling(fn, 1000, { idleStopMs: 10_000 }));
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        act(() => { jest.advanceTimersByTime(10_000); }); // 10 ticks, then idle-stop fires
+        const atStop = fn.mock.calls.length;
+        act(() => { jest.advanceTimersByTime(5000); });
+        expect(fn).toHaveBeenCalledTimes(atStop); // stopped — no more ticks
+
+        act(() => { window.dispatchEvent(new Event("pointerdown")); });
+        expect(fn).toHaveBeenCalledTimes(atStop + 1); // resumed + refreshed
+        act(() => { jest.advanceTimersByTime(2000); });
+        expect(fn).toHaveBeenCalledTimes(atStop + 3);
+    });
+
+    it("without idleStopMs it never idle-stops", () => {
+        const fn = jest.fn();
+        renderHook(() => usePolling(fn, 1000));
+        act(() => { jest.advanceTimersByTime(60_000); });
+        expect(fn.mock.calls.length).toBeGreaterThan(50);
+    });
+
+    it("stops all timers on unmount", () => {
+        const fn = jest.fn();
+        const { unmount } = renderHook(() => usePolling(fn, 1000, { idleStopMs: 10_000 }));
+        act(() => { jest.advanceTimersByTime(1000); });
+        const before = fn.mock.calls.length;
+        unmount();
+        act(() => { jest.advanceTimersByTime(10_000); });
+        expect(fn).toHaveBeenCalledTimes(before);
+    });
+});

--- a/checkin-app/src/hooks/usePolling.ts
+++ b/checkin-app/src/hooks/usePolling.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Interval poller that stops burning server/DB round-trips when nobody is looking.
+ *
+ * Both guards exist so checkin's scale-to-zero infra can actually sleep: a
+ * left-open tab polling a DB-backed route every N seconds pins Aurora awake
+ * (it pauses only after ~5 min with zero queries), and when the request carries
+ * a session cookie it also re-wakes a curfewed prod via the waker's cookie
+ * wake-gate — so the overnight teardown never sticks.
+ *
+ *   - pauseWhenHidden (default true): no ticks while the tab is hidden; on
+ *     re-show, fire once immediately (data went stale) then resume the interval.
+ *   - idleStopMs (opt-in): after this long with no user input, stop entirely;
+ *     the next interaction resumes and fires once. Leave UNSET for an unattended
+ *     display — a wall kiosk has no input and must not freeze.
+ *
+ * fn is kept in a ref, so passing a fresh closure each render does not reset the
+ * timers. SSR-safe: no-op until document/window exist.
+ */
+const ACTIVITY_EVENTS = ["pointerdown", "keydown", "mousemove", "scroll", "touchstart"] as const;
+
+export function usePolling(
+    fn: () => void,
+    intervalMs: number,
+    opts: { pauseWhenHidden?: boolean; idleStopMs?: number } = {},
+): void {
+    const { pauseWhenHidden = true, idleStopMs } = opts;
+    const fnRef = useRef(fn);
+    useEffect(() => { fnRef.current = fn; });
+
+    useEffect(() => {
+        if (typeof document === "undefined") return;
+
+        let interval: ReturnType<typeof setInterval> | null = null;
+        let idleTimer: ReturnType<typeof setTimeout> | null = null;
+        let idleStopped = false;
+
+        const tick = () => fnRef.current();
+
+        const start = (fireNow: boolean) => {
+            if (idleStopped) return;
+            if (pauseWhenHidden && document.visibilityState !== "visible") return;
+            if (fireNow) tick();
+            if (interval === null) interval = setInterval(tick, intervalMs);
+        };
+
+        const stop = () => {
+            if (interval !== null) {
+                clearInterval(interval);
+                interval = null;
+            }
+        };
+
+        const armIdle = () => {
+            if (idleStopMs === undefined) return;
+            if (idleTimer !== null) clearTimeout(idleTimer);
+            idleTimer = setTimeout(() => {
+                idleStopped = true;
+                stop();
+            }, idleStopMs);
+        };
+
+        const onActivity = () => {
+            if (idleStopped) {
+                idleStopped = false;
+                start(true); // resume + refresh
+            }
+            armIdle();
+        };
+
+        const onVisibility = () => {
+            if (document.visibilityState === "visible") start(true);
+            else stop();
+        };
+
+        start(true);
+        armIdle();
+
+        if (pauseWhenHidden) document.addEventListener("visibilitychange", onVisibility);
+        if (idleStopMs !== undefined) {
+            for (const e of ACTIVITY_EVENTS) window.addEventListener(e, onActivity, { passive: true });
+        }
+
+        return () => {
+            stop();
+            if (idleTimer !== null) clearTimeout(idleTimer);
+            if (pauseWhenHidden) document.removeEventListener("visibilitychange", onVisibility);
+            if (idleStopMs !== undefined) {
+                for (const e of ACTIVITY_EVENTS) window.removeEventListener(e, onActivity);
+            }
+        };
+    }, [intervalMs, pauseWhenHidden, idleStopMs]);
+}
+
+/** Default idle-stop for attended staff views. Tune if it proves too eager. */
+export const POLL_IDLE_STOP_MS = 10 * 60 * 1000;


### PR DESCRIPTION
## Problem
Left-open browser tabs polling DB-backed routes on a timer keep checkin's DB (and prod) from ever sleeping:

- Each poll queries Postgres, and Aurora Serverless v2 pauses only after **~5 min with zero queries** → a single background tab pins it awake indefinitely.
- The cookie-bearing polls are worse: the scale-to-zero **waker wakes on any cookie-bearing request** (`modules/scale-to-zero/lambda/handler.py`), so after the overnight curfew tears prod down, the very next 60s poll (carrying the session cookie) **re-wakes it** — the curfew never sticks. This is the mechanism behind "checkin-prod stayed up overnight" that the curfew-window widening (infra #142) alone can't fix.

Three offending loops: `Notifications` (root layout → every page, 60s → `/api/notifications`), `attendance/current` (60s → `/api/attendance`), `attendance/certifications` (10s → `/api/kioskdisplay/certifications`).

## Fix
New shared hook `usePolling(fn, intervalMs, { pauseWhenHidden = true, idleStopMs })`:
- **Visibility gate** (default on): no ticks while the tab is hidden; on re-show, fire once (data went stale) then resume.
- **Idle-stop** (opt-in): after `idleStopMs` with no user input, stop entirely; next interaction resumes + fires once.
- fn held in a ref (a fresh closure per render doesn't reset timers), SSR-safe, cleans up every timer/listener.

### Per-loop decisions
| Loop | Guard | Why |
|---|---|---|
| Notifications | visibility **+ idle-stop (10 min)** | On every page, cookie-bearing — the main curfew-defeater. |
| attendance/current | visibility **+ idle-stop**, *except signed-kiosk* | Interactive staff view idle-stops; a signed-kiosk instance (`sig/ts/nonce`) stays visibility-only so the **unattended display never freezes**. |
| attendance/certifications | **visibility only** | Unattended wall display (idle-stop would freeze it); cookieless kiosk, so it can't wake a slept env or defeat the curfew. |

The 1s wall-clock `setInterval` in certifications is untouched (not a fetch).

## Verification (node 24)
- New `usePolling` unit test: **5/5** (pause-on-hidden, fire-once-on-reshow, idle-stop, resume-on-activity, unmount cleanup).
- Existing `attendance/current` + `attendance/certifications` component tests: **pass** (34 tests total incl. the hook suite).
- eslint clean on all changed files; `tsc --noEmit` clean on all changed files.

## Follow-up
This targets `main` only. If the running release should get it too, it cherry-picks cleanly onto `rel/1.0` — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6TfaRtHA5C76d6A8yU4Nm