### PR TITLE
fix(membership-audit): decide "claimed" from the Account row, not Person.googleId

### DIFF
--- a/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminUnclaimedHouseholdsAPI.integration.test.ts
@@ -58,12 +58,20 @@ describe('Admin Unclaimed Households API Integration Tests', () => {
             data: { isHouseholdLead: true }
         });
 
-        // 2. Lead HAS a googleId -> claimed, even though a student member never signs in.
+        // 2. Lead HAS signed in -> claimed, even though a student member never signs in.
         // This is the case that must NOT appear: a claimed lead covers the household.
+        // Seeded the way a real sign-in leaves it for an imported member: an Account
+        // row and NO googleId (NextAuth email-links to the existing Person, which never
+        // backfills googleId). Seeding googleId here instead is what hid the bug where
+        // every imported household stayed listed forever — don't put it back.
         const claimed = await prisma.household.create({ data: { name: 'Unclaimed API Test HH Claimed' } });
         testClaimedHouseholdId = claimed.id;
         const claimedLead = await prisma.person.create({
-            data: { email: 'member2-unclaimed-api-test@example.com', name: 'Claimed Lead', householdId: testClaimedHouseholdId, googleId: 'unclaimed-test-google-id' }
+            data: {
+                email: 'member2-unclaimed-api-test@example.com', name: 'Claimed Lead',
+                householdId: testClaimedHouseholdId, googleId: null,
+                accounts: { create: { type: 'oauth', provider: 'google', providerAccountId: 'unclaimed-test-google-id' } },
+            }
         });
         await prisma.person.update({
             where: { id: claimedLead.id },

--- a/checkin-app/src/lib/household/filters.ts
+++ b/checkin-app/src/lib/household/filters.ts
@@ -19,12 +19,22 @@ export const BROKEN_HOUSEHOLD_WHERE: Prisma.HouseholdWhereInput = {
  *      with Google yet (a claimed lead covers the whole household).
  *   2. Broken: no lead at all — no email requirement (may have no contactable member).
  * The audit list route and the nav count MUST use this same predicate or they drift.
+ *
+ * "Signed in" is the Account row, NOT `Person.googleId`. googleId is only written on
+ * the new-user path (auth-options createUser, off the Google profile); an imported
+ * Person matched by email links via allowDangerousEmailAccountLinking, which writes
+ * only an Account and never backfills googleId. Keying off googleId therefore left
+ * every imported household — exactly the population this list chases — permanently
+ * unclaimed no matter how many times its lead signed in. Account covers both paths
+ * (createUser is followed by linkAccount) and survives a participant merge, which
+ * reassigns Account.userId unconditionally while googleId only moves if the conflict
+ * picker chose it.
  */
 export const UNCLAIMED_OR_BROKEN_HOUSEHOLD_WHERE: Prisma.HouseholdWhereInput = {
     OR: [
         {
             householdMembers: { some: { isHouseholdLead: true, email: { not: null } } },
-            NOT: { householdMembers: { some: { isHouseholdLead: true, googleId: { not: null } } } },
+            NOT: { householdMembers: { some: { isHouseholdLead: true, accounts: { some: { provider: "google" } } } } },
         },
         BROKEN_HOUSEHOLD_WHERE,
     ],


### PR DESCRIPTION
Fixes #1175.

## The bug

"Claimed" was read off `Person.googleId`. That column is only ever written on the
**new-user** path — the Google `profile()` callback feeding `createUser`
(`auth-options.ts:176` → `:85`).

An imported Person signs in through a different path: `getUserByEmail` → `linkAccount`
under `allowDangerousEmailAccountLinking: true`. That writes an `Account` row and never
backfills `googleId` (`linkAccount` maps only Account columns; `updateUser` doesn't
accept `googleId`; there is no `signIn` callback and no backfill anywhere).

Net effect: **every imported household — exactly the population this list exists to
chase — stayed listed forever**, no matter how many times its lead signed in. Confirmed
in prod against known-claimed households.

## The fix

One predicate, in the shared `filters.ts` both consumers already import, so the list and
the badge can't diverge:

```diff
-NOT: { householdMembers: { some: { isHouseholdLead: true, googleId: { not: null } } } },
+NOT: { householdMembers: { some: { isHouseholdLead: true, accounts: { some: { provider: "google" } } } } },
```

`Account` is the actual record of "has signed in":
- Covers **both** paths — `createUser` is followed by `linkAccount`, so every signed-in
  Person has one. `googleId` is a strict subset.
- **No migration, no backfill** — corrects already-linked history on the next query.
- **Survives a merge** — `merge/route.ts:273` reassigns `Account.userId` unconditionally,
  while `googleId` only moves if the conflict picker chose it. Keying off Account is
  strictly more correct here too.

`BROKEN_HOUSEHOLD_WHERE` (no lead at all) is untouched.

## Why the suite was green

`adminUnclaimedHouseholdsAPI.integration.test.ts` seeded the claimed household with a
literal `googleId: 'unclaimed-test-google-id'` — a state no real sign-in produces on an
imported Person. It now seeds an `Account` row with `googleId: null`, the shape an actual
email-linked sign-in leaves behind, so the old predicate would fail this test.

## Verification

- `tsc --noEmit` — clean (0 errors, after `prisma generate`; the checked-in generated
  client was stale in my worktree).
- `eslint` — clean on both files.
- The integration test **could not be run locally** — no Postgres on this box
  (`pg_isready` → no response) and `*.integration.test.ts` is gated behind
  `npm run test:integration`. It needs a CI run to confirm.

## Not addressed here

Neither surface self-refreshes: the list page fetches once on mount with no interval and
no `NAV_COUNTS_EVENT` listener; the badge refetches only on mount or a local mutation
event. A household becomes claimed in the *member's* browser, so nothing signals the
board member's tab. Post-merge, both still need a page reload to reflect a claim. Noted
in #1175 as a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6TfaRtHA5C76d6A8yU4Nm
