### PR TITLE
fix(security): reject youth as household lead server-side

### DIFF
--- a/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
@@ -18,6 +18,7 @@ describe('Household Lead API Integration Tests', () => {
     let testLeadId: number;
     let testAdultId: number;
     let testChildId: number;
+    let testYouthId: number;
     let testOtherLeadId: number;
     let testOtherMemberId: number;
     let householdId: number;
@@ -63,8 +64,11 @@ describe('Household Lead API Integration Tests', () => {
 
         await prisma.person.update({ where: { id: leadUser.id }, data: { isHouseholdLead: true } });
 
+        // Adult DOB (30 years ago) — promoting them to lead must succeed.
+        const adultDob = new Date();
+        adultDob.setFullYear(adultDob.getFullYear() - 30);
         const adultUser = await prisma.person.create({
-            data: { email: 'adult-lead-api-test@example.com', name: 'Adult User', householdId: household.id }
+            data: { email: 'adult-lead-api-test@example.com', name: 'Adult User', householdId: household.id, dateOfBirth: adultDob }
         });
         testAdultId = adultUser.id;
 
@@ -72,6 +76,14 @@ describe('Household Lead API Integration Tests', () => {
             data: { email: 'child-lead-api-test@example.com', name: 'Child User', householdId: household.id }
         });
         testChildId = childUser.id;
+
+        // Clearly a youth (DOB 10 years ago) — server must refuse promoting them to lead.
+        const youthDob = new Date();
+        youthDob.setFullYear(youthDob.getFullYear() - 10);
+        const youthUser = await prisma.person.create({
+            data: { email: 'youth-lead-api-test@example.com', name: 'Youth User', householdId: household.id, dateOfBirth: youthDob }
+        });
+        testYouthId = youthUser.id;
 
         const otherHousehold = await prisma.household.create({
             data: { name: 'Other Lead Test Household' }
@@ -92,7 +104,7 @@ describe('Household Lead API Integration Tests', () => {
     });
 
     afterAll(async () => {
-        const currentIds = [testLeadId, testAdultId, testChildId, testOtherLeadId, testOtherMemberId];
+        const currentIds = [testLeadId, testAdultId, testChildId, testYouthId, testOtherLeadId, testOtherMemberId];
         const validHouseholdIds = [householdId, otherHouseholdId];
 
         await prisma.orgMembership.deleteMany({
@@ -151,6 +163,27 @@ describe('Household Lead API Integration Tests', () => {
             expect(res.status).toBe(403);
             const data = await res.json();
             expect(data.error).toBe('Only household leads, board members, or sysadmins can promote members');
+        });
+
+        it('should reject promoting a youth to lead (server-side youth exclusion)', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: testLeadId } });
+
+            const req = new Request('http://localhost:4000/api/household/lead', {
+                method: 'POST',
+                body: JSON.stringify({ participantId: testYouthId })
+            });
+
+            const res = await POST(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(400);
+            const data = await res.json();
+            expect(data.error).toBe('A youth cannot be a household lead.');
+
+            // The youth must not have been flagged as a lead.
+            const notLead = await prisma.person.findFirst({
+                where: { id: testYouthId, householdId, isHouseholdLead: true },
+                select: { id: true }
+            });
+            expect(notLead).toBeNull();
         });
 
         it('should return successfully when user is already a lead', async () => {

--- a/checkin-app/src/app/api/household/lead/route.ts
+++ b/checkin-app/src/app/api/household/lead/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
-import { addHouseholdLead, removeHouseholdLead, HouseholdLeadLimitError } from "@/lib/household/leads";
+import { addHouseholdLead, removeHouseholdLead, HouseholdLeadLimitError, HouseholdLeadYouthError } from "@/lib/household/leads";
 import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth(
@@ -61,6 +61,9 @@ export const POST = withAuth(
 
         } catch (error: unknown) {
             if (error instanceof HouseholdLeadLimitError) {
+                return apiError(error.message, 400);
+            }
+            if (error instanceof HouseholdLeadYouthError) {
                 return apiError(error.message, 400);
             }
             logger.error("Household Lead POST Error:", error);

--- a/checkin-app/src/lib/household/leads.ts
+++ b/checkin-app/src/lib/household/leads.ts
@@ -1,6 +1,7 @@
 import { type DbClient, type TxClient, withTx } from "@/lib/db-client";
 import prisma from "@/lib/prisma";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import { isYouth } from "@/lib/time";
 
 /**
  * Shared household-lead ownership check (audit P1-2). Loads the person and
@@ -70,6 +71,20 @@ export class HouseholdLeadMismatchError extends Error {
 }
 
 /**
+ * Thrown by {@link addHouseholdLead} when the promotion target is a youth. The UI
+ * hides "Make Lead" for youth, but that's client-side only — this is the server
+ * enforcement so a direct POST can't flag a youth as a household lead. A null/unknown
+ * DOB is NOT a youth ({@link isYouth} returns false), matching the UI which shows the
+ * control for null-DOB members.
+ */
+export class HouseholdLeadYouthError extends Error {
+    constructor(public readonly householdId: number, public readonly personId: number) {
+        super("A youth cannot be a household lead.");
+        this.name = "HouseholdLeadYouthError";
+    }
+}
+
+/**
  * The count-then-flag core, run inside a transaction. Takes a row lock on the
  * household first so concurrent promotions are serialized: a second caller
  * blocks on the lock, then sees the updated count and is rejected — closing the
@@ -92,7 +107,7 @@ async function addHouseholdLeadTx(
 
     const person = await tx.person.findUnique({
         where: { id: participantId },
-        select: { isHouseholdLead: true, householdId: true },
+        select: { isHouseholdLead: true, householdId: true, dateOfBirth: true },
     });
     // Invariant: isHouseholdLead means "lead of their OWN household". Flagging a
     // person whose householdId != the counted/locked household would create a
@@ -102,6 +117,10 @@ async function addHouseholdLeadTx(
         throw new HouseholdLeadMismatchError(householdId, participantId);
     }
     if (person?.isHouseholdLead) return { created: false };
+    // Youth exclusion (server-side; UI also filters). null/unknown DOB is allowed.
+    if (person && isYouth(person.dateOfBirth)) {
+        throw new HouseholdLeadYouthError(householdId, participantId);
+    }
 
     const count = await tx.person.count({ where: { ...householdLeadsWhere(householdId), ...LIVE_PERSON } });
     if (count >= MAX_HOUSEHOLD_LEADS) {


### PR DESCRIPTION
## What

`addHouseholdLeadTx` (the transactional core of `POST /api/household/lead`) enforced the per-household cap of 2 and the household-match invariant, but **not age**. Youth exclusion was UI-only:

- `membership-audit/broken/page.tsx` — filters `!isYouth(dob)` before rendering "Make Lead"
- `AdminEditHouseholdModal.tsx` — same filter on its "Make lead" control

So a direct `POST /api/household/lead` could flag a youth as `isHouseholdLead`, bypassing both.

## Fix

- `addHouseholdLeadTx` now selects `dateOfBirth` and, after the existing mismatch/already-lead checks, throws a new exported `HouseholdLeadYouthError` when `isYouth(dateOfBirth)`.
- POST handler maps it to `apiError(msg, 400)`, mirroring the existing `HouseholdLeadLimitError` block.
- Check order: mismatch → already-lead → **youth** → cap. Youth is rejected even in a full household.

## Policy: null/unknown DOB is allowed

`isYouth(null) === false`, so a null-DOB member is treated as **not** youth and may be promoted — matching the UI, which shows the control for null-DOB members. Server behavior now consistent with the client.

## Scope

- Client-side youth filters **kept** (defense in depth).
- No change to the cap, the household-match logic, or the schema (`dateOfBirth` already exists — additive select field only).

## Tests

`householdLeadAPI.integration.test.ts`:
- youth (DOB 10y ago) → **400**, not flagged
- adult (real DOB 30y ago) → still promotes (existing success test, now with a real DOB)
- null-DOB member still passes the youth gate (cap test reaches the cap, proving it isn't youth-rejected)

Verified: `tsc --noEmit` clean; unit + `src/security` (42 passed); `householdLead*` integration against a throwaway Postgres (17 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)