### PR TITLE
fix(audit): correct drifted audit-log tableName/entity metadata

### DIFF
--- a/checkin-app/src/app/__tests__/adminAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminAuditAPI.integration.test.ts
@@ -53,7 +53,7 @@ describe('Admin Audit API Integration Tests', () => {
                 actorId: adminId,
                 action: 'CREATE',
                 affectedEntityId: commonId,
-                tableName: 'Participant',
+                tableName: 'Person',
                 newData: { email: 'common-audit-api-test@example.com' }
             }
         });
@@ -116,7 +116,7 @@ describe('Admin Audit API Integration Tests', () => {
         it('should filter by action and entity and page server-side', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
 
-             const url = 'http://localhost:4000/api/system-status/audit-log?action=CREATE&table=Participant&page=1';
+             const url = 'http://localhost:4000/api/system-status/audit-log?action=CREATE&table=Person&page=1';
              const req = new Request(url, { method: 'GET' });
              const res = await GET(req as unknown as import("next/server").NextRequest);
              expect(res.status).toBe(200);
@@ -126,7 +126,7 @@ describe('Admin Audit API Integration Tests', () => {
              // Every returned row must satisfy both filters.
              for (const log of data.logs) {
                  expect(log.action).toBe('CREATE');
-                 expect(log.tableName).toBe('Participant');
+                 expect(log.tableName).toBe('Person');
              }
         });
     });

--- a/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
@@ -106,7 +106,7 @@ describe('Admin Participant Household API Integration Tests', () => {
 
             // The move MUST be audited with the acting admin and the prior→new
             // household — the route's only record of who reassigned the person.
-            const log = await expectAuditRow(prisma, { action: 'EDIT', tableName: 'Participant', affectedEntityId: testParticipantId });
+            const log = await expectAuditRow(prisma, { action: 'EDIT', tableName: 'Person', affectedEntityId: testParticipantId });
             expect(log.actorId).toBe(testAdminId);
             expect(auditJson(log.oldData).householdId).toBe(priorHouseholdId);
             expect(auditJson(log.newData).householdId).toBe(testHouseholdId);

--- a/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
@@ -285,7 +285,7 @@ describe('Admin Participants API Integration Tests', () => {
             // PII edits MUST leave an audit trail naming the acting admin and the
             // before/after of the field — a regression dropping the actor or the
             // log fails right here.
-            const log = await expectAuditRow(prisma, { action: 'EDIT', tableName: 'Participant', affectedEntityId: editUser.id });
+            const log = await expectAuditRow(prisma, { action: 'EDIT', tableName: 'Person', affectedEntityId: editUser.id });
             expect(log.actorId).toBe(testAdminId);
             expect(auditJson(log.oldData).name).toBe('Original Name');
             expect(auditJson(log.newData).name).toBe('Updated Name');

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -254,7 +254,7 @@ describe('AuditLog Integration Tests', () => {
     });
 
     it('should generate an AuditLog when an Admin edits participant PII', async () => {
-        await prisma.auditLog.deleteMany({ where: { tableName: 'Participant' } });
+        await prisma.auditLog.deleteMany({ where: { tableName: 'Person' } });
 
         const req = new Request(`http://localhost:4000/api/membership-ops/participants/${testParticipantId}`, {
             method: 'PUT',
@@ -265,7 +265,7 @@ describe('AuditLog Integration Tests', () => {
         expect(res.status).toBe(200);
 
         const logs = await prisma.auditLog.findMany({
-            where: { tableName: 'Participant', affectedEntityId: testParticipantId }
+            where: { tableName: 'Person', affectedEntityId: testParticipantId }
         });
         expect(logs).toHaveLength(1);
         expect(logs[0].action).toBe('EDIT');
@@ -275,7 +275,7 @@ describe('AuditLog Integration Tests', () => {
     });
 
     it('should generate an AuditLog when an Admin reassigns a participant household', async () => {
-        await prisma.auditLog.deleteMany({ where: { tableName: 'Participant' } });
+        await prisma.auditLog.deleteMany({ where: { tableName: 'Person' } });
 
         const newHousehold = await prisma.household.create({ data: { name: 'Audit Target Household' } });
 
@@ -288,7 +288,7 @@ describe('AuditLog Integration Tests', () => {
         expect(res.status).toBe(200);
 
         const logs = await prisma.auditLog.findMany({
-            where: { tableName: 'Participant', affectedEntityId: testParticipantId }
+            where: { tableName: 'Person', affectedEntityId: testParticipantId }
         });
         expect(logs).toHaveLength(1);
         expect(logs[0].action).toBe('EDIT');

--- a/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdLeadAPI.integration.test.ts
@@ -190,7 +190,7 @@ describe('Household Lead API Integration Tests', () => {
 
             // Verify Audit Trail is populated
             const auditLogs = await prisma.auditLog.findMany({
-                where: { actorId: testLeadId, action: 'CREATE', tableName: 'Person', secondaryAffectedEntity: testAdultId }
+                where: { actorId: testLeadId, action: 'CREATE', tableName: 'Person', affectedEntityId: testAdultId }
             });
             expect(auditLogs.length).toBeGreaterThan(0);
         });

--- a/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
@@ -190,7 +190,7 @@ describe('Household Member API Integration Tests', () => {
 
             // Verify Audit Trail is populated
             const auditLogs = await prisma.auditLog.findMany({
-                where: { actorId: testLeadId, action: 'EDIT', tableName: 'Participant', affectedEntityId: testMemberId }
+                where: { actorId: testLeadId, action: 'EDIT', tableName: 'Person', affectedEntityId: testMemberId }
             });
             expect(auditLogs.length).toBeGreaterThan(0);
         });

--- a/checkin-app/src/app/__tests__/lifecycleReconcile.integration.test.ts
+++ b/checkin-app/src/app/__tests__/lifecycleReconcile.integration.test.ts
@@ -58,7 +58,7 @@ describe('lifecycle reconciler — invariant-driven sweep over a real DB', () =>
     afterAll(async () => {
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.orgMembershipProcess.deleteMany({ where: { id: { in: processIds } } });
-        await prisma.auditLog.deleteMany({ where: { tableName: 'ProgramParticipant', affectedEntityId: programId } });
+        await prisma.auditLog.deleteMany({ where: { tableName: 'ProgramParticipant', secondaryAffectedEntity: programId } });
         await prisma.program.delete({ where: { id: programId } });
         const person = await prisma.person.findUnique({ where: { id: selfId }, select: { householdId: true } });
         await prisma.person.delete({ where: { id: selfId } });
@@ -101,7 +101,7 @@ describe('lifecycle reconciler — invariant-driven sweep over a real DB', () =>
 
         // Audit trail for the heal.
         const audit = await prisma.auditLog.findFirst({
-            where: { tableName: 'ProgramParticipant', affectedEntityId: programId, secondaryAffectedEntity: selfId, action: 'EDIT' },
+            where: { tableName: 'ProgramParticipant', affectedEntityId: selfId, secondaryAffectedEntity: programId, action: 'EDIT' },
         });
         expect(audit).not.toBeNull();
 

--- a/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
@@ -150,7 +150,7 @@ describe('Profile API Integration Tests', () => {
 
             // Verify Audit Trail is populated
             const auditLogs = await prisma.auditLog.findMany({
-                where: { actorId: testUserId, action: 'EDIT', tableName: 'Participant', affectedEntityId: testUserId }
+                where: { actorId: testUserId, action: 'EDIT', tableName: 'Person', affectedEntityId: testUserId }
             });
             expect(auditLogs.length).toBeGreaterThan(0);
         });

--- a/checkin-app/src/app/api/household/lead/route.ts
+++ b/checkin-app/src/app/api/household/lead/route.ts
@@ -51,8 +51,8 @@ export const POST = withAuth(
                     actorId: userId,
                     action: "CREATE",
                     tableName: "Person",
-                    affectedEntityId: targetHouseholdId,
-                    secondaryAffectedEntity: participantId,
+                    affectedEntityId: participantId,
+                    secondaryAffectedEntity: targetHouseholdId,
                     newData: { ...newLead, isHouseholdLead: true }
                 }
             });
@@ -125,8 +125,8 @@ export const DELETE = withAuth(
                     actorId: userId,
                     action: "DELETE",
                     tableName: "Person",
-                    affectedEntityId: targetHouseholdId,
-                    secondaryAffectedEntity: participantId,
+                    affectedEntityId: participantId,
+                    secondaryAffectedEntity: targetHouseholdId,
                     oldData: { householdId: targetHouseholdId, personId: participantId, isHouseholdLead: true }
                 }
             });

--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -81,8 +81,8 @@ export const PATCH = withAuth(
                                     actorId: userId,
                                     action: "CREATE",
                                     tableName: "Person",
-                                    affectedEntityId: householdId,
-                                    secondaryAffectedEntity: participantId
+                                    affectedEntityId: participantId,
+                                    secondaryAffectedEntity: householdId
                                 }
                             });
                         } catch (e) {
@@ -103,8 +103,8 @@ export const PATCH = withAuth(
                                     actorId: userId,
                                     action: "DELETE",
                                     tableName: "Person",
-                                    affectedEntityId: householdId,
-                                    secondaryAffectedEntity: participantId
+                                    affectedEntityId: participantId,
+                                    secondaryAffectedEntity: householdId
                                 }
                             });
                         }
@@ -115,7 +115,7 @@ export const PATCH = withAuth(
                     data: {
                         actorId: userId,
                         action: "EDIT",
-                        tableName: "Participant",
+                        tableName: "Person",
                         affectedEntityId: targetHouseholdMember.id,
                         newData: updatedHouseholdMember
                     }

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -117,7 +117,7 @@ export const PATCH = withAuth(
                     data: {
                         actorId: userId,
                         action: "EDIT",
-                        tableName: "Participant",
+                        tableName: "Person",
                         affectedEntityId: member.id,
                         newData: { householdId, email: member.email, name: member.name }
                     }

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/household/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/household/route.ts
@@ -75,7 +75,7 @@ export const POST = withAuth<{ params: Promise<{ id: string }> }>(
             data: {
                 actorId: auth.user.id,
                 action: "EDIT",
-                tableName: "Participant",
+                tableName: "Person",
                 affectedEntityId: participantId,
                 oldData: { householdId: participant.householdId },
                 newData: { householdId: targetHouseholdId, createNew: Boolean(createNew) },

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
@@ -66,7 +66,7 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
             data: {
                 actorId: auth.user.id,
                 action: "EDIT",
-                tableName: "Participant",
+                tableName: "Person",
                 affectedEntityId: id,
                 oldData: prior ?? undefined,
                 newData: updateData,

--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -68,7 +68,7 @@ export const PATCH = withAuth(
                 data: {
                     actorId: userId,
                     action: "EDIT",
-                    tableName: "Participant",
+                    tableName: "Person",
                     affectedEntityId: userId,
                     newData: updatedProfile,
                 }

--- a/checkin-app/src/lib/lifecycleDrift.ts
+++ b/checkin-app/src/lib/lifecycleDrift.ts
@@ -160,8 +160,8 @@ async function healEnrollmentI1(): Promise<number> {
                     actorId: 0, // system — no session behind a cron sweep
                     action: "EDIT",
                     tableName: "ProgramParticipant",
-                    affectedEntityId: row.programId,
-                    secondaryAffectedEntity: row.personId,
+                    affectedEntityId: row.personId,
+                    secondaryAffectedEntity: row.programId,
                     oldData: {
                         status: "ACTIVE",
                         inventoryHeldAt: row.inventoryHeldAt?.toISOString() ?? null,


### PR DESCRIPTION
## What

Fixes 7 audit-log writes whose recorded metadata (`tableName`, `affectedEntityId`) had drifted from the row actually mutated. A reader filtering the audit log by `tableName`/`affectedEntityId` would miss these changes or attribute them to the wrong table/entity.

Found by sweeping every `auditLog.create` call site in the app (no shared audit helper — each `tableName` is a hand-passed string, so every call site is risk surface).

### Fixes

1. **`tableName: "Participant"` → `"Person"`** on 5 handlers — the `Participant` model was renamed to `Person`, so `"Participant"` names a table that no longer exists; all 5 mutate `prisma.person`:
   - `membership-ops/participants/[id]/route.ts`
   - `membership-ops/participants/[id]/household/route.ts`
   - `profile/route.ts`
   - `household/route.ts`
   - `household/member/route.ts`
2. **Household-lead grant/revoke** (`household/lead` ×2, `household/member` ×2) — the mutated column is `Person.isHouseholdLead`, but `affectedEntityId` held the `householdId`. Swapped so the person is `affectedEntityId` and the household is `secondaryAffectedEntity`, matching `tableName: "Person"`.
3. **`lifecycleDrift` ProgramParticipant heal** — `affectedEntityId`/`secondaryAffectedEntity` were reversed (program-primary) vs every sibling `ProgramParticipant` audit row and the `matchAudit` reader (person-primary). Now `affectedEntityId=personId, secondaryAffectedEntity=programId`.

## Why

Audit metadata that names the wrong table/entity silently breaks any downstream filter, report, or reconciliation keyed on those fields (e.g. `matchAudit`).

## Notes for reviewer

- Test oracles that asserted the old (wrong) values were updated to match: `profileAPI`, `householdMemberAPI`, `householdLeadAPI`, `adminParticipants`, `adminParticipantHouseholdAPI`, `auditLog`, `lifecycleReconcile`, `adminAuditAPI`.
- **Deliberately not changed:** the trusted-adult `audit()` helper logs `tableName: "TrustedAdult"` even for `TrustedAdultReview` status changes. This is an intentional per-disclosure audit anchor encoded in dedicated tests, and `newData` is free-form JSON repo-wide (not required to be columns of `tableName`), so it's a design choice, not drift.
- The dev-only `zoho-import` tool still passes `"Participant"` — out of scope for this app-audit-write sweep.
- Changes are literal/int-value swaps only; oracles traced by hand. Integration tests not run in-session (need a Postgres per the worktree recipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)