### PR TITLE
feat(households): board can add a second household lead from the edit modal

### DIFF
--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -48,6 +48,9 @@ export const GET = withAuth(
                         householdMembers: {
                             select: {
                                 id: true, name: true, email: true, isHouseholdLead: true, lastBackgroundCheck: true,
+                                // dateOfBirth: the Edit Info modal excludes youth from the
+                                // "Make lead" control (mirrors membership-audit/broken).
+                                dateOfBirth: true,
                                 // Program enrollments for the household detail view. Extra field the
                                 // Edit Info modal (same endpoint) simply ignores.
                                 programParticipants: {

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -6,13 +6,20 @@ import { notifications } from "@mantine/notifications";
 import { modals } from "@mantine/modals";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
 import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
+import { isYouth } from "@/lib/time";
+
+// Per-household lead cap (issue #269). Server enforces it atomically in
+// lib/household/leads.ts (MAX_HOUSEHOLD_LEADS); hardcoded here — that module
+// pulls in prisma and can't be imported into a client bundle. Mirrors the
+// last-lead guard below, also hardcoded client-side.
+const MAX_HOUSEHOLD_LEADS = 2;
 
 export type AdminHousehold = {
   id: number;
   name: string | null;
   emergencyContactName: string | null;
   emergencyContactPhone: string | null;
-  householdMembers?: Array<{ id: number; name: string | null; email: string | null }>;
+  householdMembers?: Array<{ id: number; name: string | null; email: string | null; dateOfBirth?: string | null }>;
   householdLeads?: Array<{ personId: number }>;
   orgMembership?: { memberSince: string | null; isVolunteer?: boolean } | null;
 } & Partial<StructuredAddress>;
@@ -64,6 +71,7 @@ export function AdminEditHouseholdModal({
   const [members, setMembers] = useState<NonNullable<AdminHousehold["householdMembers"]>>([]);
   const [leadIds, setLeadIds] = useState<number[]>([]);
   const [removingLead, setRemovingLead] = useState<number | null>(null);
+  const [promotingLead, setPromotingLead] = useState<number | null>(null);
   const [fieldErrors, setFieldErrors] = useState<{ memberSince?: string }>({});
   const [hasMembership, setHasMembership] = useState(false);
   // Modal-local notice for save-error / lead-remove results, so feedback lands
@@ -133,6 +141,30 @@ export function AdminEditHouseholdModal({
       notifications.show({ color: "red", message: "Network error.", autoClose: false });
     } finally {
       setRemovingLead(null);
+    }
+  };
+
+  const handleMakeLead = async (participantId: number) => {
+    if (leadIds.length >= MAX_HOUSEHOLD_LEADS) return; // cap also enforced server-side
+    setNotice(null);
+    setPromotingLead(participantId);
+    try {
+      const res = await fetch(`/api/household/lead`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ participantId }),
+      });
+      if (res.ok) {
+        notifications.show({ message: "Lead added." });
+        await loadHousehold();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setNotice({ color: "red", message: data.error || "Failed to add lead." });
+      }
+    } catch {
+      notifications.show({ color: "red", message: "Network error.", autoClose: false });
+    } finally {
+      setPromotingLead(null);
     }
   };
 
@@ -311,6 +343,34 @@ export function AdminEditHouseholdModal({
               {leadIds.length === 1 && (
                 <Text size="xs" c="dimmed">A household must keep at least one lead.</Text>
               )}
+
+              {/* Promote a non-lead member. Youth excluded (mirrors
+                  membership-audit/broken); cap of 2 hides the controls once full. */}
+              {leadIds.length < MAX_HOUSEHOLD_LEADS && (() => {
+                const promotable = members.filter((m) => !leadIds.includes(m.id) && !isYouth(m.dateOfBirth));
+                if (promotable.length === 0) return null;
+                return (
+                  <>
+                    <Text size="xs" c="dimmed" mt="xs">Add another lead:</Text>
+                    {promotable.map((m) => (
+                      <Group key={m.id} justify="space-between" wrap="nowrap">
+                        <div>
+                          <Text size="sm">{m.name || `#${m.id}`}</Text>
+                          {m.email && <Text size="xs" c="dimmed">{m.email}</Text>}
+                        </div>
+                        <Button
+                          size="xs"
+                          variant="light"
+                          loading={promotingLead === m.id}
+                          onClick={() => handleMakeLead(m.id)}
+                        >
+                          Make lead
+                        </Button>
+                      </Group>
+                    ))}
+                  </>
+                );
+              })()}
             </Stack>
 
             <Alert color="orange" mt="md">

--- a/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/AdminEditHouseholdModal.test.tsx
@@ -209,6 +209,47 @@ describe("AdminEditHouseholdModal", () => {
     expect(screen.getByText("A household must keep at least one lead.")).toBeInTheDocument();
   });
 
+  it("promotes a non-lead adult to lead, excluding youth and existing leads", async () => {
+    // One lead (adult), one promotable adult, one youth. Only the promotable
+    // adult gets a Make-lead button; youth is excluded, the lead has Remove.
+    const oneLady = {
+      ...household,
+      householdLeads: [{ personId: 1 }],
+      householdMembers: [
+        { id: 1, name: "Lead Adult", email: "lead@example.com", dateOfBirth: "1985-01-01" },
+        { id: 2, name: "Other Adult", email: "adult@example.com", dateOfBirth: "1990-01-01" },
+        { id: 3, name: "A Kid", email: null, dateOfBirth: "2015-01-01" },
+      ],
+    };
+    const promoted = { ...oneLady, householdLeads: [{ personId: 1 }, { personId: 2 }] };
+    mockFetchJson({
+      "/api/membership-ops/households?id=55": { household: oneLady },
+      "/api/household/lead": { ok: true },
+    });
+    renderWithProviders(<AdminEditHouseholdModal householdId={55} opened={true} onClose={jest.fn()} />);
+    await screen.findByDisplayValue("Smith Family");
+
+    const makeLeadButtons = screen.getAllByRole("button", { name: "Make lead" });
+    expect(makeLeadButtons).toHaveLength(1); // Other Adult only — not the youth, not the lead
+    expect(screen.getByText("Other Adult")).toBeInTheDocument();
+    expect(screen.queryByText("A Kid")).not.toBeInTheDocument();
+
+    // After a successful promote the reload shows both leads and no Make-lead button (cap of 2).
+    const fetchMock = mockFetchJson({
+      "/api/household/lead": { ok: true },
+      "/api/membership-ops/households?id=55": { household: promoted },
+    });
+    fireEvent.click(makeLeadButtons[0]);
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/household/lead",
+        expect.objectContaining({ method: "POST", body: JSON.stringify({ participantId: 2 }) }),
+      ),
+    );
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Make lead" })).not.toBeInTheDocument());
+  });
+
   it("shows a failure notification, and a network-error notification, when removing a lead", async () => {
     mockFetchJson({ "/api/membership-ops/households?id=55": { household } });
     renderWithProviders(<AdminEditHouseholdModal householdId={55} opened={true} onClose={jest.fn()} />);


### PR DESCRIPTION
## What

Adds a **Make lead** control to `AdminEditHouseholdModal`'s Household Leads section, so a board member / sysadmin can promote a second lead to **any** household from the households list.

## Why

The modal listed a household's leads with a **Remove** control but no way to **add** one. The only add-lead UI was:
- `/my-household` — self-serve, the member's **own** household only
- `membership-audit/broken` — only surfaces **zero-lead** households (falls off the list after the 1st lead, so it can't reach a 2nd)

The backend already supported it — `POST /api/household/lead` enforces the cap of 2 atomically (row-locked, TOCTOU-safe) — there was just no board-facing UI to reach it for an arbitrary household.

## Changes

- **`AdminEditHouseholdModal.tsx`** — new "Make lead" control: promotes any non-lead, non-youth member via the existing `POST /api/household/lead`; hidden once the household hits `MAX_HOUSEHOLD_LEADS` (2); reloads on success. Mirrors the existing Remove-lead handler.
- **`membership-ops/households/route.ts`** — added `dateOfBirth` to the household-detail member select so the modal can exclude youth (mirrors the youth filter in `membership-audit/broken`). Route is board/sysadmin gated.
- **modal test** — new case: promotes an adult, excludes youth + existing leads, POSTs the right `participantId`, section vanishes at cap 2.

## Reviewer notes

- **`MAX_HOUSEHOLD_LEADS = 2` is duplicated client-side** — the server module (`lib/household/leads.ts`) imports prisma and can't be pulled into the client bundle. Commented as such; mirrors the already-hardcoded last-lead guard in the same modal.
- **`dateOfBirth` is `@sensitivity:personal`** but this GET is board/sysadmin gated and the `membership-audit/broken` route already returns it. Full security suite (566 tests) passes with the addition.
- **Youth exclusion is UI-only**, matching the pre-existing behavior of `membership-audit/broken`. The server helper enforces cap + household-match but not age. Closing that server-side gap is tracked in a separate task.

## Verification

- `tsc --noEmit` clean
- modal unit tests 15/15
- security suite 566/566
- Skipped the households integration DB run — the route change is an additive select field with no exact-shape assertion depending on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)