### PR TITLE
feat(footer): stamp the build with git describe, and the branch when known

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -68,6 +68,22 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ steps.vars.outputs.sha }}
+          # Full history + tags: `git describe` below needs them. The default
+          # shallow clone has neither, and describe degrades SILENTLY to a bare
+          # SHA rather than failing, so a missing fetch-depth shows up only as a
+          # footer that quietly stopped carrying its version.
+          fetch-depth: 0
+
+      - name: Resolve build describe
+        id: describe
+        run: |
+          set -euo pipefail
+          # --long so an exact tag still reports its distance ("-0-g"), keeping
+          # the shape identical for tagged and untagged builds; --always so a
+          # repo with no reachable tag yields the SHA instead of failing the run.
+          DESCRIBE=$(git describe --tags --long --abbrev=7 --always)
+          echo "describe=$DESCRIBE" >> "$GITHUB_OUTPUT"
+          echo "build describe: $DESCRIBE"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6
@@ -92,6 +108,7 @@ jobs:
           # ECS task defs require (runtime_platform.cpu_architecture = ARM64).
           docker build \
             --build-arg NEXT_PUBLIC_GIT_SHA="${{ steps.vars.outputs.sha }}" \
+            --build-arg NEXT_PUBLIC_GIT_DESCRIBE="${{ steps.describe.outputs.describe }}" \
             -f checkin-app/Dockerfile \
             -t "$IMAGE" .
           docker push "$IMAGE"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -106,6 +106,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
+          # Full history + tags for `git describe` below (see deploy-dev.yml's
+          # note: a shallow clone degrades describe to a bare SHA silently).
+          fetch-depth: 0
 
       - name: Resolve released commit
         id: vars
@@ -116,6 +119,11 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHA:0:7}" >> "$GITHUB_OUTPUT"
           echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          # On a release this normally reads "<tag>-0-g<sha>" — the -0- is the
+          # point: it proves the deployed commit IS the tag, not a descendant.
+          DESCRIBE=$(git describe --tags --long --abbrev=7 --always)
+          echo "describe=$DESCRIBE" >> "$GITHUB_OUTPUT"
+          echo "build describe: $DESCRIBE"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6
@@ -144,6 +152,7 @@ jobs:
           # deploy-dev.yml (the release-scrub found this job would die here).
           docker build \
             --build-arg NEXT_PUBLIC_GIT_SHA="${{ steps.vars.outputs.sha }}" \
+            --build-arg NEXT_PUBLIC_GIT_DESCRIBE="${{ steps.vars.outputs.describe }}" \
             --build-arg NEXT_PUBLIC_RELEASE_TAG="${{ steps.vars.outputs.tag }}" \
             -f checkin-app/Dockerfile \
             -t "$IMAGE" -t "$IMAGE_TAGGED" .

--- a/checkin-app/Dockerfile
+++ b/checkin-app/Dockerfile
@@ -34,6 +34,15 @@ ENV NEXT_PUBLIC_GIT_SHA=${NEXT_PUBLIC_GIT_SHA}
 # "<tag> <sha>" on prod. Empty on dev/local builds -> footer shows the hash alone.
 ARG NEXT_PUBLIC_RELEASE_TAG
 ENV NEXT_PUBLIC_RELEASE_TAG=${NEXT_PUBLIC_RELEASE_TAG}
+# `git describe --tags --long --abbrev=7 --always` of the built commit, e.g.
+# "v1.0.8-0-ge790e17" — the tag it descends from, how many commits past it, and
+# the commit itself. Answers "what is running" in one string for a build that is
+# NOT itself a release: a bare SHA can't tell you it is 2 commits past v1.0.7,
+# and the release tag alone is empty on every non-prod build. Requires the deploy
+# workflow to check out with fetch-depth: 0 (a shallow clone has no tags, and
+# describe silently degrades to the bare SHA).
+ARG NEXT_PUBLIC_GIT_DESCRIBE
+ENV NEXT_PUBLIC_GIT_DESCRIBE=${NEXT_PUBLIC_GIT_DESCRIBE}
 # Needed for GitHub to build the image, overwritten by secrets in AWS at run time.
 # (next build imports auth-options.ts, which requires these to exist; the values
 # are never used — every route is dynamic — and never reach the runner stage.)

--- a/checkin-app/src/components/BuildInfoFooter.tsx
+++ b/checkin-app/src/components/BuildInfoFooter.tsx
@@ -12,19 +12,41 @@ const FULL_SHA =
 // Release tag (e.g. "v1.0.0"), set only by the prod deploy workflow. Empty on
 // dev/local builds -> the footer shows the hash alone.
 const RELEASE_TAG = process.env.NEXT_PUBLIC_RELEASE_TAG;
+// `git describe --tags --long --abbrev=7 --always`, e.g. "v1.0.8-0-ge790e17".
+// Strictly more informative than the bare SHA — it carries the ancestor tag and
+// the distance from it — so it WINS over the tag/sha pair when present.
+const GIT_DESCRIBE = process.env.NEXT_PUBLIC_GIT_DESCRIBE;
+// Branch the image was built from. Read defensively: nothing sets this yet on
+// main. It is deliberately NOT introduced here — the staging deploy PR adds the
+// build arg, and this reads it the moment that lands, with no further change.
+// Until then it is undefined and the label is simply the describe string.
+const GIT_BRANCH = process.env.NEXT_PUBLIC_GIT_BRANCH;
 
 /**
- * Human-facing build label: "<tag> <7-char sha>" on a tagged prod build,
- * the 7-char SHA alone otherwise, or "dev" when unbuilt.
+ * Human-facing build label, most informative form first:
+ *   "<branch> <describe>"  — e.g. "rel/1.0 v1.0.8-0-ge790e17"
+ *   "<describe>"           — when the branch is unknown
+ *   "<tag> <7-char sha>"   — pre-describe fallback, a tagged build
+ *   "<7-char sha>"         — pre-describe fallback, untagged
+ *   "dev"                  — nothing was stamped at all
+ *
+ * The fallbacks are not dead code: an image built before this change, or any
+ * build whose checkout was shallow (describe needs tags), still renders a
+ * sensible label rather than "dev".
  */
-export function buildLabel(sha: string | undefined | null, tag?: string | null): string {
-  if (!sha) return "dev";
-  const short = sha.slice(0, 7);
-  return tag ? `${tag} ${short}` : short;
+export function buildLabel(
+  sha: string | undefined | null,
+  tag?: string | null,
+  describe?: string | null,
+  branch?: string | null,
+): string {
+  const version = describe || (sha ? (tag ? `${tag} ${sha.slice(0, 7)}` : sha.slice(0, 7)) : "");
+  if (!version) return "dev";
+  return branch ? `${branch} ${version}` : version;
 }
 
 export function BuildInfoFooter() {
-  const label = buildLabel(FULL_SHA, RELEASE_TAG);
+  const label = buildLabel(FULL_SHA, RELEASE_TAG, GIT_DESCRIBE, GIT_BRANCH);
   return (
     <Text
       component="div"

--- a/checkin-app/src/components/__tests__/BuildInfoFooter.test.tsx
+++ b/checkin-app/src/components/__tests__/BuildInfoFooter.test.tsx
@@ -35,6 +35,39 @@ describe("buildLabel", () => {
     );
   });
 
+  it("prefers describe over the tag+sha pair — it carries strictly more", () => {
+    expect(
+      buildLabel("0123456789abcdef0123456789abcdef01234567", "v1.0.0", "v1.0.8-2-g0123456"),
+    ).toBe("v1.0.8-2-g0123456");
+  });
+
+  it("prefixes the branch when both branch and describe are set", () => {
+    expect(buildLabel("0123456", null, "v1.0.8-0-ge790e17", "rel/1.0")).toBe(
+      "rel/1.0 v1.0.8-0-ge790e17",
+    );
+  });
+
+  it("renders describe alone when the branch is unknown (nothing sets it yet)", () => {
+    expect(buildLabel("0123456", null, "v1.0.8-0-ge790e17")).toBe("v1.0.8-0-ge790e17");
+  });
+
+  it("falls back to tag+sha for an image built before describe existed", () => {
+    // A running image predating this change has no NEXT_PUBLIC_GIT_DESCRIBE.
+    // It must keep its old label, not regress to "dev".
+    expect(buildLabel("0123456789abcdef0123456789abcdef01234567", "v1.0.0", undefined)).toBe(
+      "v1.0.0 0123456",
+    );
+  });
+
+  it("still labels a describe-only build when the sha is somehow unset", () => {
+    // describe is self-contained; it should not require the sha var too.
+    expect(buildLabel(undefined, null, "v1.0.8-0-ge790e17")).toBe("v1.0.8-0-ge790e17");
+  });
+
+  it("branches the label even with no describe, using the fallback version", () => {
+    expect(buildLabel("0123456789abcdef", "v1.0.0", null, "main")).toBe("main v1.0.0 0123456");
+  });
+
   it("ignores the tag when there is no sha", () => {
     expect(buildLabel(undefined, "v1.0.0")).toBe("dev");
   });


### PR DESCRIPTION
Makes the footer answer the question people actually ask of a non-release build: **what is running, relative to the last release?**

Today it renders `v1.0.0 abc1234` on a release and `abc1234` on everything else. A bare SHA can't tell you it's two commits past `v1.0.7`.

## What it stamps

`git describe --tags --long --abbrev=7 --always` → **`v1.0.8-2-g0123456`** — the tag it descends from, the distance from it, and the commit.

- **`--long`** keeps the shape identical for an exact tag (`v1.0.8-0-ge790e17`). The `-0-` is itself worth having on a release: it proves the deployed commit **is** the tag, not a descendant of it.
- **`--always`** degrades to the bare SHA rather than failing a deploy when no tag is reachable.
- **`--abbrev=7`** matches the 7 chars the footer already used, instead of git's variable default.

## Branch prefix, without touching #1167

The label prefixes the branch when known → `rel/1.0 v1.0.8-0-ge790e17`.

This PR **does not introduce `NEXT_PUBLIC_GIT_BRANCH`** — #1167 adds that build arg. The footer reads it defensively, so it starts rendering the branch the moment #1167 lands, with **no change here and no edit to that PR**. Until then the label is the describe string alone.

## The part that's easy to lose

Both deploy workflows now check out with **`fetch-depth: 0`**. That's load-bearing: a shallow clone has no tags, and `git describe` degrades **silently** to a bare SHA rather than failing. Dropping it wouldn't break a build — it would just quietly stop stamping the version. Called out in a comment at both sites for that reason.

## Backward compatibility

`buildLabel` keeps its tag+sha and bare-sha branches instead of requiring describe. Not dead code: an image built before this change, or any build whose checkout was shallow, still renders a sensible label rather than regressing to `dev`. Precedence is describe → tag+sha → sha → `dev`.

## Verification

**11/11** in `BuildInfoFooter.test.tsx` (6 new: describe-wins precedence, branch prefix, describe-without-branch, the pre-describe fallback, describe-without-sha, and branch-with-fallback-version). `eslint` clean, `tsc --noEmit` 0 errors, both workflow YAMLs parse.

## Conflict note

Textually conflicts with **#1167** on `Dockerfile`, `deploy-dev.yml`, `deploy-prod.yml` and `BuildInfoFooter.tsx` — both add build args in the same places. The resolutions are all "keep both": #1167's `NEXT_PUBLIC_GIT_BRANCH` alongside this `NEXT_PUBLIC_GIT_DESCRIBE`. Whichever merges second takes the fixups; no behavioural disagreement between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6TfaRtHA5C76d6A8yU4Nm
