### PR TITLE
ci(release): a v<major>.<minor>.x release must be cut from rel/<major>.<minor>

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -67,6 +67,32 @@ env:
   APP_URL: https://ops.innovationtreehouse.org
 
 jobs:
+  # A release must ship from its OWN release line: v1.1.x may only be cut from
+  # rel/1.1. The version and the branch are two independent claims about "which
+  # line is this", and nothing previously made them agree — so v1.1.0 could be
+  # tagged on rel/1.0, or on main, and deploy to prod carrying a version number
+  # that lies about its lineage. That is worst exactly when it matters: during an
+  # incident, when the version string is what people reason about.
+  #
+  # Checks ANCESTRY, not `release.target_commitish`. That field can be a branch
+  # name OR a bare SHA, is chosen by whoever cut the release, and is re-taggable —
+  # containment in the branch is the property we actually care about.
+  #
+  # Runs before `validate` so a mis-cut release fails in seconds with one clear
+  # error, instead of burning a full CI pass in parallel first.
+  release-branch-match:
+    name: Release version matches its rel/ branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout released tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0   # ancestry check needs real history, not a shallow clone
+
+      - name: Assert the tag's line matches the branch containing it
+        run: ./scripts/release-branch-match.sh "${{ github.event.release.tag_name }}"
+
   # Re-run the FULL CI pipeline (lint, type-check, migration-drift, Jest, the
   # security contract tests, AND the deploy build + boot/smoke) against the exact
   # released tag. This is the H1 fix: a release tag can point at any commit, and
@@ -74,6 +100,7 @@ jobs:
   # the released code green from scratch before a human is even asked to approve.
   validate:
     name: Revalidate CI on the released tag
+    needs: [release-branch-match]   # never burn a CI pass on a mis-cut release
     uses: ./.github/workflows/ci.yml
     with:
       ref: ${{ github.event.release.tag_name }}
@@ -96,7 +123,10 @@ jobs:
 
   deploy:
     name: Build, migrate, roll out
-    needs: [validate]   # do not build/migrate/roll out unless the tag re-passed all of CI
+    # Both listed explicitly, not just [validate]: the branch gate is a release
+    # correctness property, and a refactor that changes what `validate` needs
+    # must not be able to drop it silently.
+    needs: [release-branch-match, validate]
     runs-on: ubuntu-24.04-arm  # native ARM64 — task defs require arm64 images
     environment:
       name: production

--- a/scripts/release-branch-match.sh
+++ b/scripts/release-branch-match.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Assert a release tag ships from its OWN release line: v1.1.x only from rel/1.1.
+#
+#   scripts/release-branch-match.sh <tag>        # e.g. v1.1.4
+#
+# WHY: the version and the branch are two independent claims about "which line is
+# this", and nothing otherwise makes them agree — so v1.1.0 could be tagged on
+# rel/1.0, or on main, and ship to prod carrying a version number that lies about
+# its lineage. That is worst exactly when it matters: during an incident, when
+# the version string is what people reason about.
+#
+# Checks ANCESTRY, deliberately not `release.target_commitish`: that field can be
+# a branch name OR a bare SHA, is chosen by whoever cut the release, and is
+# re-taggable. Containment in the branch is the property we actually care about.
+#
+# Lives in a script rather than inline in deploy-prod.yml so it can be tested —
+# see test-release-branch-match.sh. A release gate that has never been run
+# against a failing case is not a gate.
+set -euo pipefail
+
+TAG="${1:?usage: release-branch-match.sh <tag>}"
+REMOTE="${REMOTE:-origin}"
+
+# v1.1.4, v1.1.4-rc.1, v1.1.4+build -> major 1, minor 1 -> rel/1.1.
+# PATCH is deliberately NOT part of the branch name: a release LINE is
+# major.minor, and every patch on it ships from that same branch.
+if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+ ]]; then
+  echo "::error::Release tag '$TAG' is not vMAJOR.MINOR.PATCH — cannot derive its release line." >&2
+  exit 1
+fi
+MAJOR="${BASH_REMATCH[1]}" MINOR="${BASH_REMATCH[2]}"
+BRANCH="rel/${MAJOR}.${MINOR}"
+
+SHA="$(git rev-parse HEAD)"
+echo "tag ${TAG} -> expected line ${BRANCH} (commit ${SHA})"
+
+# Fetch just that one ref. A missing branch is a hard failure, never a skip:
+# "the release line does not exist" is precisely the mistake this catches — a
+# typo'd minor, a branch never cut, a branch deleted after the fact.
+if ! git fetch --no-tags --quiet "$REMOTE" \
+       "+refs/heads/${BRANCH}:refs/remotes/${REMOTE}/${BRANCH}" 2>/dev/null; then
+  echo "::error::${TAG} requires branch ${BRANCH}, which does not exist on ${REMOTE}. Cut it first, or fix the tag's version." >&2
+  exit 1
+fi
+
+# --is-ancestor counts a commit as an ancestor of itself, so a tag sitting ON the
+# branch tip passes. Anything not reachable from the branch fails.
+if ! git merge-base --is-ancestor "$SHA" "refs/remotes/${REMOTE}/${BRANCH}"; then
+  echo "::error::${TAG} (${SHA}) is not contained in ${BRANCH} — a v${MAJOR}.${MINOR}.x release must be cut from that branch." >&2
+  echo "Branches that DO contain this commit:" >&2
+  git branch -a --contains "$SHA" 2>/dev/null | sed 's/^/  /' >&2 || echo "  (none)" >&2
+  exit 1
+fi
+
+echo "OK: ${TAG} is contained in ${BRANCH}"

--- a/scripts/test-release-branch-match.sh
+++ b/scripts/test-release-branch-match.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Runnable check for release-branch-match.sh — real git, no network, no CI.
+#
+#   scripts/test-release-branch-match.sh
+#
+# Builds a throwaway repo with a bare "origin", two release lines and a main,
+# then drives every outcome the gate is supposed to have an opinion about. A
+# release gate whose failing paths have never been executed is not a gate.
+set -uo pipefail
+cd "$(dirname "$0")"
+GUARD="$PWD/release-branch-match.sh"
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+q() { git "$@" >/dev/null 2>&1; }
+
+# ── a bare origin + a working clone ──────────────────────────────────────────
+q init --bare "$T/origin.git"
+q clone "$T/origin.git" "$T/work"
+cd "$T/work"
+q config user.email t@example.com; q config user.name t
+
+commit() { echo "$1" > f; q add f; q commit -m "$1"; git rev-parse HEAD; }
+
+BASE=$(commit base)
+q push origin HEAD:refs/heads/main
+
+# rel/1.0 with a release on it
+q checkout -b rel/1.0
+R10=$(commit "on rel/1.0")
+q push origin rel/1.0
+
+# rel/1.1 forked from base, with its own commit
+q checkout -b rel/1.1 "$BASE"
+R11=$(commit "on rel/1.1")
+q push origin rel/1.1
+
+# a commit that lives only on main — no release line at all
+q checkout -b main-only "$BASE"
+MAINONLY=$(commit "main only")
+q push origin main-only:refs/heads/main --force
+
+run_at() { q checkout --detach "$1"; bash "$GUARD" "$2" 2>&1; }
+
+echo "1. a v1.1.x tag on rel/1.1 passes"
+out=$(run_at "$R11" v1.1.4); rc=$?
+[ $rc -eq 0 ] || { echo "$out"; fail "should have passed"; }
+grep -q "OK: v1.1.4 is contained in rel/1.1" <<<"$out" || { echo "$out"; fail "wrong success message"; }
+echo "   ✓ $(grep -o 'OK:.*' <<<"$out")"
+
+echo "2. the SAME commit tagged v1.0.x is REJECTED — this is the whole point"
+out=$(run_at "$R11" v1.0.4); rc=$?
+[ $rc -ne 0 ] || { echo "$out"; fail "a v1.0.x tag on rel/1.1 must fail"; }
+grep -q "is not contained in rel/1.0" <<<"$out" || { echo "$out"; fail "wrong rejection reason"; }
+grep -q "Branches that DO contain this commit" <<<"$out" || fail "should list the real branches"
+echo "   ✓ rejected, and reported where the commit actually lives"
+
+echo "3. a patch release on the same line passes (PATCH is not part of the branch)"
+out=$(run_at "$R11" v1.1.99); rc=$?
+[ $rc -eq 0 ] || { echo "$out"; fail "v1.1.99 should ship from rel/1.1"; }
+echo "   ✓ v1.1.99 -> rel/1.1"
+
+echo "4. a pre-release tag derives the same line"
+out=$(run_at "$R11" v1.1.0-rc.1); rc=$?
+[ $rc -eq 0 ] || { echo "$out"; fail "v1.1.0-rc.1 should ship from rel/1.1"; }
+echo "   ✓ v1.1.0-rc.1 -> rel/1.1"
+
+echo "5. an ancestor of the branch tip passes (tag need not be the tip)"
+out=$(run_at "$BASE" v1.1.0); rc=$?
+[ $rc -eq 0 ] || { echo "$out"; fail "an ancestor of rel/1.1 should pass"; }
+echo "   ✓ ancestry, not tip-equality"
+
+echo "6. a commit on no release line at all is rejected"
+out=$(run_at "$MAINONLY" v1.1.0); rc=$?
+[ $rc -ne 0 ] || { echo "$out"; fail "a main-only commit must not release"; }
+grep -q "is not contained in rel/1.1" <<<"$out" || { echo "$out"; fail "wrong reason"; }
+echo "   ✓ main-only commit refused"
+
+echo "7. a version whose release line was never cut is a hard failure, not a skip"
+out=$(run_at "$R11" v9.9.0); rc=$?
+[ $rc -ne 0 ] || { echo "$out"; fail "a nonexistent rel/9.9 must fail"; }
+grep -q "which does not exist" <<<"$out" || { echo "$out"; fail "wrong reason: $out"; }
+echo "   ✓ missing release line refused"
+
+echo "8. a malformed tag is refused before any git work"
+for bad in v1.1 1.1.0 release-1.1.0 v1..0; do
+  out=$(run_at "$R11" "$bad"); rc=$?
+  [ $rc -ne 0 ] || fail "tag '$bad' should be refused"
+  grep -q "is not vMAJOR.MINOR.PATCH" <<<"$out" || fail "tag '$bad' failed for the wrong reason"
+done
+echo "   ✓ v1.1 / 1.1.0 / release-1.1.0 / v1..0 all refused"
+
+echo "ALL CHECKS PASSED"


### PR DESCRIPTION
Requires a `v<major>.<minor>.x` release to be cut from `rel/<major>.<minor>` — `v1.1.*` only from `rel/1.1`.

## The gap

The version and the branch are **two independent claims** about which release line a build belongs to, and nothing made them agree. `v1.1.0` could be tagged on `rel/1.0`, or on `main`, and ship to prod carrying a version number that lies about its lineage — worst exactly when it matters, during an incident, when the version string is what people reason about.

## The check

Derives the line from the tag and requires the released commit to be **contained in that branch**:

| tag | derived line |
|---|---|
| `v1.1.4` | `rel/1.1` |
| `v1.1.99` | `rel/1.1` |
| `v1.1.0-rc.1` | `rel/1.1` |

`PATCH` is deliberately not part of the branch name — a release *line* is major.minor, and every patch on it ships from the same branch.

**Ancestry, not `release.target_commitish`.** That field can be a branch name *or* a bare SHA, is chosen by whoever cut the release, and is re-taggable. Containment is the property we actually care about, and `--is-ancestor` counts a commit as an ancestor of itself, so a tag on the branch tip passes.

**A missing release line is a hard failure, not a skip** — a typo'd minor or an uncut branch is exactly the mistake being caught. On rejection it prints the branches that *do* contain the commit, so the error says where the release actually came from rather than only that it was wrong.

## Placement

Runs **before** `validate`, so a mis-cut release fails in seconds instead of burning a full CI revalidation in parallel. `deploy` lists **both** needs explicitly rather than inheriting through `validate`, so a later refactor can't drop the gate silently:

```yaml
needs: [release-branch-match, validate]
```

## Testable, and tested

The logic lives in `scripts/release-branch-match.sh` rather than inline YAML so it can actually be run. `scripts/test-release-branch-match.sh` builds a throwaway repo with a bare origin and two release lines, then drives all eight outcomes — **no network, no CI**:

```
1. a v1.1.x tag on rel/1.1 passes
2. the SAME commit tagged v1.0.x is REJECTED — this is the whole point
3. a patch release on the same line passes (PATCH is not part of the branch)
4. a pre-release tag derives the same line
5. an ancestor of the branch tip passes (tag need not be the tip)
6. a commit on no release line at all is rejected
7. a version whose release line was never cut is a hard failure, not a skip
8. a malformed tag is refused before any git work
ALL CHECKS PASSED
```

Case 2 is the one that matters: the identical commit passes as `v1.1.4` and is refused as `v1.0.4`. A release gate whose failing paths have never been executed isn't a gate.

## Overlap with #1147

#1147 adds a `branch-guard` job to the same file, checking containment in **any** `rel/*`. This check is strictly stronger — containment in the *matching* line implies containment in some line — so the two should collapse into one job rather than both running. Whichever merges second should fold them; I'd keep this one and drop `branch-guard`, but that's a call for whoever merges. Textual conflict is limited to the `jobs:` block and the `needs:` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6TfaRtHA5C76d6A8yU4Nm
