### PR TITLE
docs(lifecycle): document the s-read payment backstop actor

### DIFF
--- a/checkin-app/docs/designs/LIFECYCLE.md
+++ b/checkin-app/docs/designs/LIFECYCLE.md
@@ -43,6 +43,27 @@ Dues + background-check + renewal. BG and payment are **parallel tracks** that c
 PERSON_BG`. `RENEWAL_PENDING_BG` is dead-but-guarded legacy (the reachability test asserts it's
 unreachable). Full diagram/table: `../generated/lifecycle/membership.md`.
 
+**Who fires the payment edge (`PENDING_PAYMENT → ACTIVE`).** The generated matrix records that
+the edge is *legal*, not who drives it. The recovery choke point is `activate()` (renewals route
+through it too — `grantRenewalPayment` is the board-only renewal path, actor `board/sysadmin`).
+Three actors reach `activate()`:
+1. **Shopify `orders/paid` webhook** (`app/api/webhooks/shopify/route.ts`) — the low-latency path,
+   activates in real time when the family pays.
+2. **Backup s-read reconciler** (`app/api/cron/reconcile-shopify` → `lib/finance/reconcile.ts`,
+   `runReconcile`) — the **guaranteed backstop for a missed webhook**. Daily at 09:15 UTC, ~15 min
+   behind s-read's 09:00 sync so it reads a fresh Shopify mirror. Forward pass: a paid order whose
+   family is still `PENDING_PAYMENT` is a dropped webhook → recover it via `activate()`. Idempotent
+   (`activate()` stores `shopifyOrderId` and short-circuits on `paidAt`). Reversal pass: refund /
+   chargeback / cancel on an already-activated order is raised to the board (never auto-reversed).
+   Daily-not-hourly is a scale-to-zero Aurora constraint (infra#129), not taste — the trade is a
+   missed webhook recovered in ~24h instead of ~1h. No-op when the mirror isn't wired
+   (`config.shopifyReadDatabaseUrl()` null).
+3. **Manual board action** (membership-ops) — the human override.
+
+This is distinct from `app/api/cron/lifecycle-reconcile` (see *Detection & healing*), which heals
+*off-diagram* rows; the s-read reconciler recovers *on-diagram* rows stuck at a checkpoint because
+an event never fired.
+
 ## Changing a machine — the rules
 1. **Add / rename a status** → update the definition module. `classify` is a total `switch`
    (`assertNever` default), so it won't compile until every status is handled; the enum-parity


### PR DESCRIPTION
## What

Adds a **"Who fires the payment edge"** subsection to the hand-written `checkin-app/docs/designs/LIFECYCLE.md` (Membership section). Doc-only, 21 lines added, no code.

## Why

The generated `docs/generated/lifecycle/membership.md` records that `PENDING_PAYMENT → ACTIVE` is a *legal* edge but — by design — not **who** drives it. The backup s-read reconciler that recovers a missed Shopify `orders/paid` webhook (advancing a family past the paid checkpoint) only existed as a prose comment on `app/api/cron/reconcile-shopify/route.ts`, so the payment-recovery safety net wasn't discoverable from the lifecycle design doc.

## What the new section covers

- The **three actors** that reach `activate()`: the `orders/paid` webhook (low-latency), the s-read reconciler (`cron/reconcile-shopify` → `lib/finance/reconcile.ts`, the guaranteed backstop), and manual board action.
- Backstop mechanics: daily 09:15 UTC (~15 min behind s-read's 09:00 sync), forward pass (missed webhook → `activate()`), reversal pass (refund/chargeback/cancel → raised to board, never auto-reversed), idempotency via `shopifyOrderId`/`paidAt`, no-op when the mirror isn't wired.
- The daily-not-hourly cadence as an **Aurora scale-to-zero constraint** (infra#129), with the ~24h-vs-~1h recovery trade.
- Distinction from `cron/lifecycle-reconcile`: that heals *off-diagram* rows; the s-read reconciler recovers *on-diagram* rows stuck at a checkpoint because an event never fired.
- Precision note: `grantRenewalPayment` is the board-only renewal edge; webhook and reconciler route renewals through the shared `activate()` choke point.

## Reviewer notes

- Generated `membership.md` is intentionally **untouched** — no `TRANSITIONS` edge changed, so the artifacts-drift test is unaffected.
- All mechanics quoted from existing source comments (`reconcile-shopify/route.ts`, `lib/finance/reconcile.ts`, `lib/membership/lifecycle.ts` TRANSITIONS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)