### PR TITLE
promote: security boundary -> rel/1.0 (isolated, stacked on the remainder)

### DIFF
--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -9,6 +9,7 @@
 import { GET, PATCH } from '@/app/api/programs/[id]/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
+import { ORG_DOMAIN } from '@/lib/config';
 // Mock NextAuth
 jest.mock('next-auth/next', () => ({
     getServerSession: jest.fn(),
@@ -271,6 +272,89 @@ describe('Individual Program API Integration Tests', () => {
              const data = await res.json();
              expect(Array.isArray(data.participants)).toBe(true);
              expect(data.participants.some((p: { personId: number }) => p.personId === enrolledId)).toBe(true);
+        });
+    });
+
+    // ── ops-stg ACCESS GATE regression (the defect that killed the prior staging
+    // design) ─────────────────────────────────────────────────────────────────
+    // GET /api/programs/[id] is registered `authorize: 'public'` (security/registry.ts)
+    // and returns real enrolled participants' names/household/emergency-contact data —
+    // exactly the surface an anonymous `curl` against a copy of PRODUCTION data must
+    // never reach. `authorize: 'public'` unconditionally admits every caller regardless
+    // of session state, so the gate has to be enforced ahead of that check
+    // (resolveAccess in security/access-resolvers.ts), not only in authenticateRequest —
+    // this describe is that regression test, run against the REAL route (handler() ->
+    // registry -> resolveAccess -> stripBag), not a mock of the gate.
+    describe('GET /api/programs/[id] — ops-stg access gate (regression: authorize:"public" must not bypass staging)', () => {
+        const CHECKIN_ENV_BEFORE = process.env.CHECKIN_ENV;
+
+        beforeEach(() => {
+            process.env.CHECKIN_ENV = 'stg';
+        });
+
+        afterAll(() => {
+            if (CHECKIN_ENV_BEFORE === undefined) delete process.env.CHECKIN_ENV;
+            else process.env.CHECKIN_ENV = CHECKIN_ENV_BEFORE;
+        });
+
+        it('DENIES an anonymous caller — the regression case for the defect that shipped real minors\' data to curl', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue(null);
+
+            const req = new Request(`http://localhost:4000/api/programs/${publicProgramId}`, { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest, createParams(publicProgramId) as unknown as never);
+
+            expect(res.status).not.toBe(200);
+            expect(res.status).toBe(401);
+            // Belt-and-suspenders: even if the status assertion above were wrong, the
+            // roster identity must never appear in the body.
+            const text = await res.text();
+            expect(text).not.toContain(ENROLLED_NAME);
+        });
+
+        it('DENIES an authenticated non-org caller with canAccessStaging unset (false)', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId, hd: 'gmail.com', emailVerified: true, canAccessStaging: false } });
+
+            const req = new Request(`http://localhost:4000/api/programs/${publicProgramId}`, { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest, createParams(publicProgramId) as unknown as never);
+
+            expect(res.status).toBe(401);
+        });
+
+        it('DENIES an authenticated non-org caller whose emailVerified is false, even with the right hd', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId, hd: ORG_DOMAIN, emailVerified: false } });
+
+            const req = new Request(`http://localhost:4000/api/programs/${publicProgramId}`, { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest, createParams(publicProgramId) as unknown as never);
+
+            expect(res.status).toBe(401);
+        });
+
+        it('ALLOWS an authenticated non-org caller with canAccessStaging=true (the sysadmin-settable escape hatch)', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId, hd: 'gmail.com', emailVerified: true, canAccessStaging: true } });
+
+            const req = new Request(`http://localhost:4000/api/programs/${publicProgramId}`, { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest, createParams(publicProgramId) as unknown as never);
+
+            expect(res.status).toBe(200);
+        });
+
+        it('ALLOWS a verified org member', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId, hd: ORG_DOMAIN, emailVerified: true } });
+
+            const req = new Request(`http://localhost:4000/api/programs/${publicProgramId}`, { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest, createParams(publicProgramId) as unknown as never);
+
+            expect(res.status).toBe(200);
+        });
+
+        it('is inert outside staging (CHECKIN_ENV not stg): the same anonymous request that gets denied above still succeeds', async () => {
+            process.env.CHECKIN_ENV = 'prod';
+            (getServerSession as jest.Mock).mockResolvedValue(null);
+
+            const req = new Request(`http://localhost:4000/api/programs/${publicProgramId}`, { method: 'GET' });
+            const res = await GET(req as unknown as import("next/server").NextRequest, createParams(publicProgramId) as unknown as never);
+
+            expect(res.status).toBe(200);
         });
     });
 

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -14,6 +14,7 @@
  * IMPORTANT: This file is CODEOWNERS-gated.
  */
 import prisma from '@/lib/prisma';
+import { config, isStagingAccessAllowed } from '@/lib/config';
 import type { AuthResult } from '@/types/auth';
 import type { Authorize, CtxNeeds, Role } from './core';
 import { LIVE_PERSON } from '@/lib/person/filters';
@@ -207,12 +208,33 @@ export interface ResolverContext {
  * Admission gate — the per-route `authorize` check. Returns whether the
  * caller is even allowed to *invoke* the endpoint (401/403 if not). View
  * resolution (orderedView) is downstream.
+ *
+ * ops-stg ACCESS GATE, checked FIRST, ahead of every `authorize` branch below —
+ * including `'public'`. This is the surface that made the pre-gate design
+ * dangerous: `authenticateRequest` (lib/auth.ts) already downgrades a
+ * non-org/non-flagged caller to `unauthenticated` on staging, but
+ * `authorize: 'public'` unconditionally returns `{ allowed: true }` regardless
+ * of `auth` — so without this check, an anonymous `curl` of
+ * `GET /api/programs/[id]` (registered `authorize: 'public'`, returning real
+ * enrolled minors' names/household/emergency contacts) would sail straight
+ * through on a copy of prod data. Re-derives the predicate independently
+ * (not just `auth.type !== 'unauthenticated'`) as belt-and-suspenders: even if
+ * a future caller ever constructs an `AuthResult` without going through
+ * `authenticateRequest`, this still fails closed on its own.
  */
 export async function resolveAccess(
     authorize: Authorize,
     ctx: ResolverContext,
 ): Promise<{ allowed: boolean }> {
     const { auth, params, callerContext } = ctx;
+
+    if (config.isStaging()) {
+        const claims = auth.type === 'session' ? auth.user : null;
+        if (!isStagingAccessAllowed(claims)) {
+            return { allowed: false };
+        }
+    }
+
     const isAdmin = auth.type === 'session' && (auth.user.isSysadmin || auth.user.isBoardMember);
 
     if (typeof authorize === 'string') {

--- a/checkin-app/tests/security/resolveAccess.test.ts
+++ b/checkin-app/tests/security/resolveAccess.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for the admission gate (resolveAccess). Pure: no DB, no HTTP.
+ * Focus on the 'self' case binding to the resource id param — a latent IDOR
+ * guard, so it must fail closed on a present-but-mismatched id.
+ */
+import { resolveAccess, type ResolverContext } from '@/security/access-resolvers';
+import type { AuthResult } from '@/types/auth';
+
+const session = (id: number): AuthResult => ({
+    type: 'session',
+    user: {
+        id,
+        email: 'u@x.test',
+        isSysadmin: false,
+        isBoardMember: false,
+        isKeyholder: false,
+        isBackgroundCheckReviewer: false,
+        isOperations: false,
+    },
+});
+
+const rctx = (
+    auth: AuthResult,
+    params: Record<string, string> = {},
+    callerOverrides: Partial<ResolverContext['callerContext']> = {},
+): ResolverContext => ({
+    auth,
+    params,
+    callerContext: {
+        selfId: auth.type === 'session' ? auth.user.id : undefined,
+        householdId: undefined,
+        isKeyholder: false,
+        isKiosk: false,
+        programsLed: new Set(),
+        programsCoreVolIn: new Set(),
+        participantIdsInScopePrograms: new Set(),
+        householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
+        activeVisitorIds: new Set(),
+        ...callerOverrides,
+    },
+});
+
+describe("resolveAccess 'self'", () => {
+    test('no id param + session → allowed (handler scopes itself, e.g. GET /api/profile)', async () => {
+        expect((await resolveAccess('self', rctx(session(42)))).allowed).toBe(true);
+    });
+
+    test('matching id param → allowed', async () => {
+        expect((await resolveAccess('self', rctx(session(42), { id: '42' }))).allowed).toBe(true);
+    });
+
+    test('mismatched id param → denied (IDOR fail-closed)', async () => {
+        expect((await resolveAccess('self', rctx(session(42), { id: '43' }))).allowed).toBe(false);
+    });
+
+    test('non-numeric id param → denied', async () => {
+        expect((await resolveAccess('self', rctx(session(42), { id: 'abc' }))).allowed).toBe(false);
+    });
+
+    test('no session → denied', async () => {
+        expect((await resolveAccess('self', rctx({ type: 'unauthenticated' }, { id: '42' }))).allowed).toBe(false);
+    });
+});
+
+// The branches below are real authorize values (access-resolvers.ts switch) but no
+// route in the current registry uses them, so registryAuthz marks them 'unhandled'
+// and never drives them through resolveAccess. Cover each one allowed + denied here.
+
+describe("resolveAccess 'program-lead-mentor'", () => {
+    test('caller leads the program in the id param → allowed', async () => {
+        expect(
+            (await resolveAccess('program-lead-mentor', rctx(session(1), { id: '5' }, { programsLed: new Set([5]) }))).allowed,
+        ).toBe(true);
+    });
+
+    test('admin who does not lead it → allowed (admin bypass)', async () => {
+        const admin = session(1);
+        if (admin.type === 'session') admin.user.isSysadmin = true;
+        expect((await resolveAccess('program-lead-mentor', rctx(admin, { id: '5' }))).allowed).toBe(true);
+    });
+
+    test('caller does not lead the program and is not admin → denied', async () => {
+        expect((await resolveAccess('program-lead-mentor', rctx(session(1), { id: '5' }))).allowed).toBe(false);
+    });
+
+    test('non-numeric id → denied', async () => {
+        expect(
+            (await resolveAccess('program-lead-mentor', rctx(session(1), { id: 'abc' }, { programsLed: new Set([5]) }))).allowed,
+        ).toBe(false);
+    });
+});
+
+describe("resolveAccess 'program-core-volunteer'", () => {
+    test('caller is a core volunteer of the program in the id param → allowed', async () => {
+        expect(
+            (await resolveAccess('program-core-volunteer', rctx(session(1), { id: '5' }, { programsCoreVolIn: new Set([5]) }))).allowed,
+        ).toBe(true);
+    });
+
+    test('caller is not a core volunteer and not admin → denied', async () => {
+        expect((await resolveAccess('program-core-volunteer', rctx(session(1), { id: '5' }))).allowed).toBe(false);
+    });
+});
+
+describe("resolveAccess 'household-lead'", () => {
+    test('caller is a household lead → allowed', async () => {
+        const lead = session(1);
+        if (lead.type === 'session') lead.user.householdLead = true;
+        expect((await resolveAccess('household-lead', rctx(lead))).allowed).toBe(true);
+    });
+
+    test('authenticated caller who is not a lead (and not admin) → denied', async () => {
+        expect((await resolveAccess('household-lead', rctx(session(1)))).allowed).toBe(false);
+    });
+
+    test('no session → denied', async () => {
+        expect((await resolveAccess('household-lead', rctx({ type: 'unauthenticated' }))).allowed).toBe(false);
+    });
+});
+
+describe("resolveAccess 'certifier'", () => {
+    const certifier = (id: number): AuthResult => ({
+        type: 'session',
+        user: {
+            id,
+            email: 'c@x.test',
+            isSysadmin: false,
+            isBoardMember: false,
+            isKeyholder: false,
+            isBackgroundCheckReviewer: false,
+            isOperations: false,
+            toolStatuses: [{ toolId: 1, level: 'MAY_CERTIFY_OTHERS' }],
+        },
+    });
+
+    test('caller holding a MAY_CERTIFY_OTHERS toolStatus → allowed', async () => {
+        expect((await resolveAccess('certifier', rctx(certifier(1)))).allowed).toBe(true);
+    });
+
+    test('admin who is not a certifier → allowed (admin bypass)', async () => {
+        const admin = session(1);
+        if (admin.type === 'session') admin.user.isSysadmin = true;
+        expect((await resolveAccess('certifier', rctx(admin))).allowed).toBe(true);
+    });
+
+    test('authenticated caller with only a CERTIFIED (not MAY_CERTIFY_OTHERS) status → denied', async () => {
+        const u = session(1);
+        if (u.type === 'session') u.user.toolStatuses = [{ toolId: 1, level: 'CERTIFIED' }];
+        expect((await resolveAccess('certifier', rctx(u))).allowed).toBe(false);
+    });
+
+    test('plain authenticated caller (no toolStatuses) → denied', async () => {
+        expect((await resolveAccess('certifier', rctx(session(1)))).allowed).toBe(false);
+    });
+
+    test('no session → denied', async () => {
+        expect((await resolveAccess('certifier', rctx({ type: 'unauthenticated' }))).allowed).toBe(false);
+    });
+});
+
+describe("resolveAccess 'kiosk'", () => {
+    test('kiosk caller → allowed', async () => {
+        expect((await resolveAccess('kiosk', rctx({ type: 'kiosk' }))).allowed).toBe(true);
+    });
+
+    test('a normal session (not kiosk) → denied', async () => {
+        expect((await resolveAccess('kiosk', rctx(session(1)))).allowed).toBe(false);
+    });
+});
+
+/**
+ * ops-stg ACCESS GATE — the regression coverage for the defect that killed the prior
+ * staging design. `authorize: 'public'` (case above, line ~220 in access-resolvers.ts)
+ * unconditionally returns `{ allowed: true }`, which is exactly right in every normal
+ * environment but is precisely the surface that would ship real minors' data to an
+ * anonymous `curl` of `GET /api/programs/[id]` on ops-stg. The gate must be checked
+ * BEFORE the `authorize` switch, for every authorize value, not only session-gated ones.
+ */
+describe("resolveAccess — ops-stg access gate (checked ahead of every `authorize` branch)", () => {
+    const ORIGINAL_ENV = process.env.CHECKIN_ENV;
+    beforeEach(() => { process.env.CHECKIN_ENV = 'stg'; });
+    afterEach(() => {
+        if (ORIGINAL_ENV === undefined) delete process.env.CHECKIN_ENV;
+        else process.env.CHECKIN_ENV = ORIGINAL_ENV;
+    });
+
+    const orgMember = (): AuthResult => ({
+        type: 'session',
+        user: {
+            id: 1, email: 'org@innovationtreehouse.org',
+            isSysadmin: false, isBoardMember: false, isKeyholder: false,
+            isBackgroundCheckReviewer: false, isOperations: false,
+            hd: 'innovationtreehouse.org', emailVerified: true,
+        },
+    });
+    const nonOrg = (canAccessStaging: boolean): AuthResult => ({
+        type: 'session',
+        user: {
+            id: 2, email: 'stranger@gmail.com',
+            isSysadmin: false, isBoardMember: false, isKeyholder: false,
+            isBackgroundCheckReviewer: false, isOperations: false,
+            hd: 'gmail.com', emailVerified: true, canAccessStaging,
+        },
+    });
+
+    test("'public' + anonymous (unauthenticated) → DENIED — the regression case", async () => {
+        expect((await resolveAccess('public', rctx({ type: 'unauthenticated' }))).allowed).toBe(false);
+    });
+
+    test("'public' + kiosk → DENIED (a kiosk carries no org/flag claims either)", async () => {
+        expect((await resolveAccess('public', rctx({ type: 'kiosk' }))).allowed).toBe(false);
+    });
+
+    test("'public' + verified org member → allowed", async () => {
+        expect((await resolveAccess('public', rctx(orgMember()))).allowed).toBe(true);
+    });
+
+    test("'public' + non-org, canAccessStaging false → denied", async () => {
+        expect((await resolveAccess('public', rctx(nonOrg(false)))).allowed).toBe(false);
+    });
+
+    test("'public' + non-org, canAccessStaging true → allowed (the sysadmin-settable escape hatch)", async () => {
+        expect((await resolveAccess('public', rctx(nonOrg(true)))).allowed).toBe(true);
+    });
+
+    test("a route-level admin bypass (e.g. isSysadmin) still cannot skip the staging gate", async () => {
+        const admin = nonOrg(false);
+        if (admin.type === 'session') admin.user.isSysadmin = true;
+        // 'program-lead-mentor' grants isAdmin a bypass past ITS OWN check — but the
+        // staging gate runs first and denies before that bypass is ever consulted.
+        expect((await resolveAccess('program-lead-mentor', rctx(admin, { id: '5' }))).allowed).toBe(false);
+    });
+
+    test('is inert outside staging: the same anonymous public request is allowed once CHECKIN_ENV is not stg', async () => {
+        process.env.CHECKIN_ENV = 'prod';
+        expect((await resolveAccess('public', rctx({ type: 'unauthenticated' }))).allowed).toBe(true);
+    });
+});


### PR DESCRIPTION
The security-boundary half of the `main` → `rel/1.0` promotion, split out so a change to the data policy isn't buried inside a 44-file promotion diff — which is exactly what `security-boundary-isolation.yml` exists to prevent:

> a change to the boundary … must land in its own PR: a widening or narrowing of what data leaves the server should never be buried inside a feature diff

## Contents — 2 commits, 5 files

| | |
|---|---|
| #1162 | `fix(security)`: teach `SCOPABLE_FIELDS` about `personId`, resolve the models it unmasks — `scopeBindings.ts`, `scopes.ts` |
| #1168 | `feat(security)`: staging gate at the `resolveAccess` boundary — `access-resolvers.ts` |

Everything else in the diff is a test (`resolveAccess.test.ts`, `programsIdAPI.integration.test.ts`), which the isolation rule explicitly permits alongside a boundary file.

## Stacked on #1185 — merge that first

Based on `promote/rel-1.0-remainder`, not `rel/1.0` directly. That is deliberate and load-bearing in two ways:

- **It compiles.** `access-resolvers.ts` imports `isStagingAccessAllowed` from `@/lib/config`, which arrives with #1166 in the remainder PR. Based on `rel/1.0` it would not build.
- **It's genuinely isolated.** Based on `rel/1.0` the diff would also show the whole remainder, defeating the split. Cherry-picking onto `rel/1.0` also conflicts add/add on `resolveAccess.test.ts`, whose current version #1166 rewrites.

**After #1185 merges**, GitHub retargets this to `rel/1.0` and the diff stays these 5 files. If that retarget doesn't happen cleanly, reset onto `rel/1.0` and replay the two commits rather than merging `rel/1.0` in — #1185 will have been squashed, so a merge-back conflicts add/add on every shared file.

## Verification

`tsc --noEmit` 0 errors · **541 tests / 7 suites** in `tests/security` · isolation check: the only non-test files are the three under `src/security/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6TfaRtHA5C76d6A8yU4Nm
