### PR TITLE
docs(security): note presence-gated canAccessStaging 403 in PATCH /api/roles

### DIFF
--- a/checkin-app/src/app/api/roles/route.ts
+++ b/checkin-app/src/app/api/roles/route.ts
@@ -96,6 +96,13 @@ export const PATCH = withAuth(
                 }
             }
 
+            // ponytail: presence-gated, not change-gated — a non-sysadmin who echoes an
+            // unchanged canAccessStaging (e.g. false==false) still 403s, taking any valid
+            // role edits in the same request down with it. Fail-closed, and no client hits
+            // it: RolesEditModal only sends the key on a real sysadmin-driven change. If a
+            // whole-form client (mobile/bulk/rewrite) ever PATCHes the full object, move
+            // this check next to the in-tx change detection below (compare vs
+            // target.canAccessStaging) so a no-op echo is harmless.
             const settingStaging = canAccessStaging !== undefined;
             if (settingStaging && !actor.isSysadmin) {
                 return apiError("Only Sysadmins can modify staging access", 403);


### PR DESCRIPTION
Stacks on #1166. Comment-only (option A from the #1166 review) — **no logic change**.

### The behavior
`PATCH /api/roles` gates `canAccessStaging` (sysadmin-only) on the key's **presence** in the body, not on an actual change:

```js
const settingStaging = canAccessStaging !== undefined;
if (settingStaging && !actor.isSysadmin) {
    return apiError("Only Sysadmins can modify staging access", 403);
}
```

A non-sysadmin (e.g. a board member editing the 5 role flags) who echoes an **unchanged** `canAccessStaging` — `false` when it's already `false` — still 403s, and takes any valid role edits in the same request down with it. The error ("Only Sysadmins can modify staging access") is misleading when nothing about staging changed.

### Why comment, not fix
- **Fail-closed** — over-rejects, never under-rejects. Not exploitable.
- **Unreachable from the live client**: `RolesEditModal` only sends the key on a real, sysadmin-driven change, so board members never send it.

So this documents the presence-vs-change gap and the upgrade path (move the check next to the in-tx change detection if a whole-form client ever PATCHes the full object) rather than restructuring a fail-closed security gate no caller trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)