### PR TITLE
feat(footer): show the tag alone when the build IS the tag

### DIFF
--- a/checkin-app/src/components/BuildInfoFooter.tsx
+++ b/checkin-app/src/components/BuildInfoFooter.tsx
@@ -12,7 +12,7 @@ const FULL_SHA =
 // Release tag (e.g. "v1.0.0"), set only by the prod deploy workflow. Empty on
 // dev/local builds -> the footer shows the hash alone.
 const RELEASE_TAG = process.env.NEXT_PUBLIC_RELEASE_TAG;
-// `git describe --tags --long --abbrev=7 --always`, e.g. "v1.0.8-0-ge790e17".
+// `git describe --tags --long --abbrev=7 --always`, e.g. "v1.0.8-2-g0123456".
 // Strictly more informative than the bare SHA — it carries the ancestor tag and
 // the distance from it — so it WINS over the tag/sha pair when present.
 const GIT_DESCRIBE = process.env.NEXT_PUBLIC_GIT_DESCRIBE;
@@ -20,9 +20,21 @@ const GIT_DESCRIBE = process.env.NEXT_PUBLIC_GIT_DESCRIBE;
 // NOT set by deploy-prod.yml (its ref IS the tag — see the Dockerfile comment).
 const GIT_BRANCH = process.env.NEXT_PUBLIC_GIT_BRANCH;
 
+// `--long` always appends "-<distance>-g<sha>", so an exact tag reads
+// "v1.0.8-0-ge790e17". At distance 0 the commit IS the tag: the count is
+// noise and the sha is redundant (it's already in the hover title), so render
+// the tag alone. Anchored at the end and requires a 0 distance — a tag whose
+// own name contains "-0-g" is untouched.
+const EXACT_TAG = /^(.+)-0-g[0-9a-f]+$/;
+
+function shortenExactTag(describe: string | undefined | null): string {
+  if (!describe) return "";
+  return describe.replace(EXACT_TAG, "$1");
+}
+
 /**
  * Human-facing build label, most informative form first:
- *   "<branch> <describe>"  — e.g. "rel/1.0 v1.0.8-0-ge790e17"
+ *   "<branch> <describe>"  — e.g. "rel/1.0 v1.0.8-2-g0123456"
  *   "<describe>"           — when the branch is unknown
  *   "<tag> <7-char sha>"   — pre-describe fallback, a tagged build
  *   "<7-char sha>"         — pre-describe fallback, untagged
@@ -38,7 +50,7 @@ export function buildLabel(
   describe?: string | null,
   branch?: string | null,
 ): string {
-  const version = describe || (sha ? (tag ? `${tag} ${sha.slice(0, 7)}` : sha.slice(0, 7)) : "");
+  const version = shortenExactTag(describe) || (sha ? (tag ? `${tag} ${sha.slice(0, 7)}` : sha.slice(0, 7)) : "");
   if (!version) return "dev";
   return branch ? `${branch} ${version}` : version;
 }

--- a/checkin-app/src/components/__tests__/BuildInfoFooter.test.tsx
+++ b/checkin-app/src/components/__tests__/BuildInfoFooter.test.tsx
@@ -42,13 +42,13 @@ describe("buildLabel", () => {
   });
 
   it("prefixes the branch when both branch and describe are set", () => {
-    expect(buildLabel("0123456", null, "v1.0.8-0-ge790e17", "rel/1.0")).toBe(
-      "rel/1.0 v1.0.8-0-ge790e17",
+    expect(buildLabel("0123456", null, "v1.0.8-2-g0123456", "rel/1.0")).toBe(
+      "rel/1.0 v1.0.8-2-g0123456",
     );
   });
 
   it("renders describe alone when the branch is unknown (nothing sets it yet)", () => {
-    expect(buildLabel("0123456", null, "v1.0.8-0-ge790e17")).toBe("v1.0.8-0-ge790e17");
+    expect(buildLabel("0123456", null, "v1.0.8-2-g0123456")).toBe("v1.0.8-2-g0123456");
   });
 
   it("falls back to tag+sha for an image built before describe existed", () => {
@@ -61,11 +61,34 @@ describe("buildLabel", () => {
 
   it("still labels a describe-only build when the sha is somehow unset", () => {
     // describe is self-contained; it should not require the sha var too.
-    expect(buildLabel(undefined, null, "v1.0.8-0-ge790e17")).toBe("v1.0.8-0-ge790e17");
+    expect(buildLabel(undefined, null, "v1.0.8-2-g0123456")).toBe("v1.0.8-2-g0123456");
   });
 
   it("branches the label even with no describe, using the fallback version", () => {
     expect(buildLabel("0123456789abcdef", "v1.0.0", null, "main")).toBe("main v1.0.0 0123456");
+  });
+
+  it("renders the tag ALONE when the commit is the tag (distance 0)", () => {
+    expect(buildLabel("e790e173", null, "v1.0.8-0-ge790e17")).toBe("v1.0.8");
+  });
+
+  it("keeps distance and hash when the commit is PAST the tag", () => {
+    expect(buildLabel("0123456", null, "v1.0.8-2-g0123456")).toBe("v1.0.8-2-g0123456");
+  });
+
+  it("still prefixes the branch on an exact tag", () => {
+    expect(buildLabel("e790e173", null, "v1.0.8-0-ge790e17", "rel/1.0")).toBe("rel/1.0 v1.0.8");
+  });
+
+  it("leaves a bare sha alone (no reachable tag, --always fallback)", () => {
+    expect(buildLabel("e790e173", null, "e790e17")).toBe("e790e17");
+  });
+
+  it("does not mangle a tag whose own name contains -0-g", () => {
+    // Only a trailing "-0-g<sha>" is the distance suffix; an interior one is
+    // part of the tag name and must survive.
+    expect(buildLabel("0123456", null, "v1.0.8-0-gamma-3-g0123456")).toBe("v1.0.8-0-gamma-3-g0123456");
+    expect(buildLabel("0123456", null, "v1.0.8-0-gamma-0-g0123456")).toBe("v1.0.8-0-gamma");
   });
 
   it("ignores the tag when there is no sha", () => {


### PR DESCRIPTION
Follow-on to #1181. On a release build the footer currently reads `v1.0.8-0-ge790e17` — but at distance 0 the commit **is** the tag, so the count is noise and the sha is redundant (it's already in the footer's hover title, `commit <full sha>`). Render just `v1.0.8`.

| build | before | after |
|---|---|---|
| exactly on a tag | `v1.0.8-0-ge790e17` | **`v1.0.8`** |
| 2 commits past a tag | `v1.0.8-2-g0123456` | `v1.0.8-2-g0123456` |
| on a branch, exact tag | `rel/1.0 v1.0.8-0-ge790e17` | **`rel/1.0 v1.0.8`** |
| no reachable tag (`--always`) | `e790e17` | `e790e17` |

Only the distance-0 case changes; that's the one where the extra 12 characters carry no information.

## The edge worth naming

The pattern is `/^(.+)-0-g[0-9a-f]+$/` — anchored at the end and requiring a **zero** distance, so a tag whose own name happens to contain `-0-g` isn't mangled. Two assertions pin it:

```
"v1.0.8-0-gamma-3-g0123456"  →  unchanged  (interior -0-g is part of the tag name)
"v1.0.8-0-gamma-0-g0123456"  →  "v1.0.8-0-gamma"  (only the trailing suffix is stripped)
```

`.+` is greedy, so the match binds to the last `-0-g`, which is the only one that can be the distance suffix.

## Three existing tests changed, deliberately

`prefixes the branch when both branch and describe are set`, `renders describe alone when the branch is unknown`, and `still labels a describe-only build when the sha is somehow unset` all used `v1.0.8-0-ge790e17` as a generic round-trip fixture and asserted it came back verbatim — which is exactly the behaviour this PR changes.

I retargeted those fixtures to a distance-2 describe rather than relaxing the assertions, so each still tests what it was written for (branch prefix / describe-alone / describe-without-sha) and still asserts an exact round-trip. No coverage was weakened to make this pass.

## Verification

- `npx jest src/components/__tests__/BuildInfoFooter.test.tsx` — **21/21**
- `eslint` clean
- `npx tsc --noEmit --pretty false` — 2 errors, both the `@aws-sdk/client-lambda` baseline from a local `node_modules` symlink; **none** attributable to this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6TfaRtHA5C76d6A8yU4Nm
