### PR TITLE
fix(programs): reconcile Shopify inventory on manual comp-add (#625)

### DIFF
--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -339,6 +339,91 @@ describe('Program Participants API Integration Tests', () => {
              expect((await forceRes.json()).enrollment.status).toBe('ACTIVE'); // admin comp
         });
 
+        // A board/sysadmin comp seats a participant with NO Shopify
+        // checkout, so unlike a paid PENDING enrollment nothing ever fires
+        // Shopify's own sale-time -1. The comp path must reconcile it (-1),
+        // exactly like a paid sale and like scholarship apply — else the
+        // storefront keeps showing the taken seat as available (oversell).
+        it('comp-add decrements Shopify inventory (-1) for a capped Shopify program', async () => {
+            const prevCheckinEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local'; // arms the adjustProgramInventory mock (logs the delta)
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            const shopifyProgram = await prisma.program.create({
+                data: { name: 'Comp Shopify Partic API Test', enrollmentStatus: 'OPEN', maxParticipants: 5, orgMemberPriceCents: 1000, shopifyVariantId: 'dev-mock-variant-comp-partic' },
+            });
+            try {
+                (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+                const res = await POST(
+                    // CHECKIN_ENV=local arms the keyless-kiosk fallback — send a cookie so
+                    // the request isn't hijacked as `kiosk` before the session gate runs.
+                    new Request(`http://localhost:4000/api/programs/${shopifyProgram.id}/participants`, {
+                        method: 'POST',
+                        headers: { cookie: 'session=test' },
+                        body: JSON.stringify({ participantId: otherId, override: true }), // external admin comp
+                    }) as unknown as import("next/server").NextRequest,
+                    createParams(shopifyProgram.id) as unknown as never,
+                );
+                expect(res.status).toBe(200);
+                const data = await res.json();
+                expect(data.enrollment.status).toBe('ACTIVE'); // comp
+                expect(data.warning).toBeUndefined();
+                // The comp took a seat out of the Shopify pool: relative -1 on the variant.
+                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by -1 for variants: dev-mock-variant-comp-partic'));
+                // Comp is ACTIVE and NOT a hold: I1/I2/I3 keep inventoryHeldAt PENDING-only.
+                const row = await prisma.programParticipant.findUnique({
+                    where: { programId_personId: { programId: shopifyProgram.id, personId: otherId } },
+                });
+                expect(row?.inventoryHeldAt).toBeNull();
+            } finally {
+                logSpy.mockRestore();
+                process.env.CHECKIN_ENV = prevCheckinEnv;
+                await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
+                await prisma.program.delete({ where: { id: shopifyProgram.id } });
+            }
+        });
+
+        // Mirror the scholarship / cap-edit Shopify-failure discipline: the DB
+        // change stands, the failure is surfaced as a warning (adjustProgramInventory
+        // has already logged + emailed sysadmins), and the board reconciles. A comp
+        // that half-commits (enrollment rolled back) would be worse than the original gap.
+        //
+        // Real failure, no mock: with the Shopify mock OFF (env not `local`) and no
+        // SHOPIFY_STORE_DOMAIN/credentials configured, adjustProgramInventory returns
+        // false at its credential guard (before any network) — the exact non-fatal
+        // failure the warning branch handles.
+        it('comp-add keeps the enrollment and warns when the Shopify decrement fails', async () => {
+            const prevCheckinEnv = process.env.CHECKIN_ENV;
+            const prevDomain = process.env.SHOPIFY_STORE_DOMAIN;
+            delete process.env.CHECKIN_ENV;       // mock off → real adjust path
+            delete process.env.SHOPIFY_STORE_DOMAIN; // no creds → returns false (no network)
+            const shopifyProgram = await prisma.program.create({
+                data: { name: 'Comp Shopify Fail Partic API Test', enrollmentStatus: 'OPEN', maxParticipants: 5, orgMemberPriceCents: 1000, shopifyVariantId: 'dev-mock-variant-comp-fail' },
+            });
+            try {
+                (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+                const res = await POST(
+                    new Request(`http://localhost:4000/api/programs/${shopifyProgram.id}/participants`, {
+                        method: 'POST',
+                        body: JSON.stringify({ participantId: otherId, override: true }),
+                    }) as unknown as import("next/server").NextRequest,
+                    createParams(shopifyProgram.id) as unknown as never,
+                );
+                expect(res.status).toBe(200);
+                expect((await res.json()).warning).toMatch(/out of sync/i);
+                // No half-commit: the comp enrollment still exists (ACTIVE).
+                const row = await prisma.programParticipant.findUnique({
+                    where: { programId_personId: { programId: shopifyProgram.id, personId: otherId } },
+                });
+                expect(row?.status).toBe('ACTIVE');
+            } finally {
+                process.env.CHECKIN_ENV = prevCheckinEnv;
+                if (prevDomain === undefined) delete process.env.SHOPIFY_STORE_DOMAIN;
+                else process.env.SHOPIFY_STORE_DOMAIN = prevDomain;
+                await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
+                await prisma.program.delete({ where: { id: shopifyProgram.id } });
+            }
+        });
+
         it('should return 409 (not 500) when enrolling the same participant twice', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: leadId } });
 

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
 import { lockProgramAndCheckCapacity, ProgramCapacityError, withdrawAndReleaseHold } from "@/lib/program/capacity";
 import { checkProgramAge } from "@/lib/programAge";
+import { adjustProgramInventory } from "@/lib/shopify";
 import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
@@ -146,7 +147,38 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         // Trigger notification
         await sendNotification(participantId, 'PROGRAM_ENROLLMENT', { programName: currentProgram.name });
 
-        return NextResponse.json({ success: true, enrollment });
+        // A board/sysadmin comp (external admin, confirmed override) seats a
+        // participant WITHOUT a Shopify checkout, so unlike a normal PENDING
+        // enrollment nothing ever fires Shopify's own sale-time -1. Reconcile it
+        // here: -1 on the pool, exactly like a paid sale and like scholarship
+        // apply (request-payment-plan -1). Without it the roster takes a seat
+        // the storefront still shows as available (oversell).
+        //
+        // A comp is ACTIVE, so it deliberately does NOT use the inventoryHeldAt
+        // hold-ledger: invariants I1/I2/I3 (enrollmentState.ts) make a held seat
+        // PENDING-and-scholarship only, and the lifecycle reconciler auto-heals
+        // an ACTIVE+held row by releasing +1 — which would silently undo this
+        // decrement. A comp is a permanent consumption like a paid seat, and
+        // like a paid seat it is not auto-restocked on withdrawal (that stays a
+        // manual Shopify action, same as a refund). Uncapped programs track no
+        // inventory (inventory_management=null), so only capped programs adjust;
+        // adjustProgramInventory additionally no-ops when no variant is wired.
+        let warning: string | undefined;
+        if (isExternalAdmin && override && currentProgram.maxParticipants !== null) {
+            // Enrollment already committed above; on Shopify failure keep it and
+            // warn (adjustProgramInventory has logged + emailed sysadmins),
+            // mirroring the cap-edit and withdraw siblings. There is no stamp to
+            // roll back — deleting the just-created comp would be the worse
+            // half-commit.
+            const ok = await adjustProgramInventory(currentProgram, -1);
+            if (!ok) {
+                warning = "Participant added, but the Shopify inventory decrement failed. Capacity may be out of sync — check System Status > Link Status.";
+            }
+        }
+
+        const responseObj: Record<string, unknown> = { success: true, enrollment };
+        if (warning) responseObj.warning = warning;
+        return NextResponse.json(responseObj);
     } catch (error) {
         if (error instanceof ProgramCapacityError) {
             return NextResponse.json({ error: "Program has reached maximum capacity.", requiresOverride: true }, { status: 400 });


### PR DESCRIPTION
## What

A board/sysadmin comp (external-admin confirmed override in `POST /api/programs/[id]/participants`) creates an ACTIVE `ProgramParticipant` with **no Shopify checkout**, so nothing ever fired Shopify's sale-time `-1`. The roster took a seat the storefront still showed as available → oversell / silent roster↔Shopify divergence.

Comp-add now calls `adjustProgramInventory(program, -1)` for capped programs, plus an integration test for both the decrement and the failure path.

## Seat semantic (why `-1`, not `max+1`)

Derived from the existing consumed-seat contract, not invented:

- **Scholarship apply fires `-1`** for a seat consumed without a Shopify sale (`request-payment-plan/route.ts`). A comp is structurally identical: seat consumed, no checkout.
- A real storefront **sale decrements Shopify itself**; comp skips checkout, so the app must do the `-1` the sale would have.
- `maxParticipants` is only ever moved by an explicit cap edit, and the override deliberately overfills **without** raising the cap (intent-lock comment in the route). Bumping max would expand capacity the comp isn't meant to expand.

## Why NOT the `inventoryHeldAt` hold-ledger

A comp is ACTIVE. Invariants **I1/I2/I3** (`enrollmentState.ts`, `docs/designs/LIFECYCLE.md`) make a held seat PENDING-and-scholarship only, and the lifecycle reconciler **auto-heals `ACTIVE`+held by releasing `+1`** — which would silently undo the decrement. So the comp is modeled like a **paid sale**: `-1` at add, no stamp, and (like a paid seat) **not auto-restocked on withdrawal** — restocking stays a manual Shopify action, same as a refund. This matches current behavior: withdrawing a paid ACTIVE participant already doesn't restock (`withdrawAndReleaseHold` only `+1`s on `inventoryHeldAt`).

## Shopify-failure handling

Mirrors the cap-edit and withdraw siblings: the enrollment stands and a non-fatal `warning` is surfaced (`adjustProgramInventory` already logs + emails sysadmins). No stamp exists to roll back; deleting the just-created comp would be the worse half-commit.

## Scope notes for the reviewer

- Gated on `maxParticipants !== null`: uncapped programs create variants with `inventory_management: null` (no tracking), and `adjustProgramInventory` additionally no-ops with no variant wired.
- The capped↔uncapped **warn-only transition** in the program-edit route is a related but separate sub-gap — deliberately untouched here.
- Crash window between enrollment commit and the Shopify call matches the existing tolerance (LIFECYCLE.md defers the transactional outbox).

## Tests

`npm run test:integration -- --testPathPatterns programsParticipantsAPI` → **19 passed / 0 failed**:
- comp-add fires `-1` for a capped Shopify program (mock-mode delta assertion), row stays `inventoryHeldAt: null`
- real credential-guard Shopify failure keeps the ACTIVE enrollment + returns the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
