### PR TITLE
ci(staging): fail fast on a deterministic copy-task error

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -319,13 +319,32 @@ jobs:
               --query 'events[].message' --output text | tr '\t' '\n' || echo "(could not fetch logs)"
             echo "--- end copy task logs ---"
 
-            [ "$EXIT_CODE" = "0" ] && break
-            echo "Copy task failed (exit $EXIT_CODE) — DB may be resuming from auto-pause; retrying in 20s"
-            sleep 20
+            # Retry only what a retry can clear. The entrypoint runs under
+            # `set -e`, so a failing psql IS the container's exit status:
+            #   2        connection went bad — the Aurora auto-pause resume this
+            #            loop exists for.
+            #   None     no exit code reported: placement or image-pull failure.
+            #   1 / 3    deterministic. 3 is a SQL error under ON_ERROR_STOP; 1 is
+            #            the entrypoint's own FATAL asserts (STG_DB outside the
+            #            checkin_stg* namespace, target database missing,
+            #            classification row-count floor). Re-running reproduces
+            #            them exactly — infra #150's first staging deploy burned
+            #            5 attempts on an identical exit 3.
+            case "$EXIT_CODE" in
+              0) break ;;
+              2 | None | null | "")
+                echo "Copy task exit $EXIT_CODE — connection/placement failure (Aurora may be resuming); retrying in 20s"
+                sleep 20
+                ;;
+              *)
+                echo "Copy task exit $EXIT_CODE is deterministic — not retrying."
+                break
+                ;;
+            esac
           done
 
           if [ "$EXIT_CODE" != "0" ]; then
-            echo "::error::Staging DB copy failed after 5 attempts (exit $EXIT_CODE) — see copy task logs above"
+            echo "::error::Staging DB copy failed (exit $EXIT_CODE) after $attempt attempt(s) — see the copy task logs above"
             exit 1
           fi
 


### PR DESCRIPTION
Follow-up to the failed first staging deploy ([run 29887601414](https://github.com/innovationtreehouse/checkin/actions/runs/29887601414)), paired with infra #150.

## The problem

The copy step retried **every** non-zero exit five times, always announcing the same cause:

```
Copy task failed (exit 3) — DB may be resuming from auto-pause; retrying in 20s
```

Exit 3 is not an auto-pause. The run spent ~6 minutes reproducing an identical deterministic failure and then reported a cause that wasn't the cause — which is worse than the delay, because the message actively misdirects whoever reads the log.

## The fix

Retry only what a retry can clear. The copy entrypoint runs under `set -e`, so a failing `psql` **is** the container's exit status:

| exit | meaning | action |
|---|---|---|
| `0` | success | break |
| `2` | connection went bad — the Aurora auto-pause resume this loop exists for | **retry** |
| `None` | no exit code reported — placement / image-pull failure | **retry** |
| `3` | SQL error under `ON_ERROR_STOP` | **fail fast** |
| `1` | entrypoint FATAL asserts — `STG_DB` outside `checkin_stg*`, target database missing, classification row-count floor | **fail fast** |

The retry branch keeps its 20s backoff and now says *"connection/placement failure (Aurora may be resuming)"* — describing the class rather than asserting a diagnosis. The deterministic branch breaks immediately, and the final error reports the actual attempt count instead of a hardcoded "after 5 attempts".

## Verification

The decision logic exercised standalone across every case:

```
exit=0    -> success after 1
exit=2    -> gave up after 5 attempts (retried)
exit=3    -> FAIL FAST after 1 attempt(s)
exit=1    -> FAIL FAST after 1 attempt(s)
exit=None -> gave up after 5 attempts (retried)
exit=      -> gave up after 5 attempts (retried)
```

Workflow YAML parses; the extracted `run` block is `bash -n` clean. The full path can't be exercised without an AWS-backed run.

## Sequencing — this does not help the current failure on its own

`deploy-staging.yml` executes from the **pushed `rel/` branch**, so a change on `main` has no effect on `rel/1.0` until it's promoted there.

Order that actually unblocks staging:

1. **infra #150** (merge + apply) — grants `logs:GetLogEvents` on `/ecs/checkin-stg-copy` so the copy's real error becomes visible. That is what diagnoses exit 3.
2. This PR, promoted to `rel/1.0`, so the next failure fails in ~1 minute with an honest message.

Happy to fold this into the pending `rel/1.0` cherry-pick PR (#1181 / #1182 / #1188) rather than sending it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6TfaRtHA5C76d6A8yU4Nm
