### PR TITLE
ci(staging): fail fast on a deterministic copy-task error (rel/1.0)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -319,13 +319,32 @@ jobs:
               --query 'events[].message' --output text | tr '\t' '\n' || echo "(could not fetch logs)"
             echo "--- end copy task logs ---"
 
-            [ "$EXIT_CODE" = "0" ] && break
-            echo "Copy task failed (exit $EXIT_CODE) — DB may be resuming from auto-pause; retrying in 20s"
-            sleep 20
+            # Retry only what a retry can clear. The entrypoint runs under
+            # `set -e`, so a failing psql IS the container's exit status:
+            #   2        connection went bad — the Aurora auto-pause resume this
+            #            loop exists for.
+            #   None     no exit code reported: placement or image-pull failure.
+            #   1 / 3    deterministic. 3 is a SQL error under ON_ERROR_STOP; 1 is
+            #            the entrypoint's own FATAL asserts (STG_DB outside the
+            #            checkin_stg* namespace, target database missing,
+            #            classification row-count floor). Re-running reproduces
+            #            them exactly — infra #150's first staging deploy burned
+            #            5 attempts on an identical exit 3.
+            case "$EXIT_CODE" in
+              0) break ;;
+              2 | None | null | "")
+                echo "Copy task exit $EXIT_CODE — connection/placement failure (Aurora may be resuming); retrying in 20s"
+                sleep 20
+                ;;
+              *)
+                echo "Copy task exit $EXIT_CODE is deterministic — not retrying."
+                break
+                ;;
+            esac
           done
 
           if [ "$EXIT_CODE" != "0" ]; then
-            echo "::error::Staging DB copy failed after 5 attempts (exit $EXIT_CODE) — see copy task logs above"
+            echo "::error::Staging DB copy failed (exit $EXIT_CODE) after $attempt attempt(s) — see the copy task logs above"
             exit 1
           fi
 


### PR DESCRIPTION
Same change as #1190, targeted at `rel/1.0`.

This is the branch where it actually matters: `deploy-staging.yml` executes from the **pushed `rel/` branch**, so #1190 landing on `main` does nothing for staging deploys until the fix is on the release line. Sent separately rather than waiting for a promotion.

Cherry-pick of #1190's commit (`d51441da`), applied clean — `rel/1.0`'s copy of the workflow is byte-identical to main's pre-fix state.

## What it changes

The copy step retried **every** non-zero exit five times, always announcing the same cause:

```
Copy task failed (exit 3) — DB may be resuming from auto-pause; retrying in 20s
```

The first real staging deploy ([run 29887601414](https://github.com/innovationtreehouse/checkin/actions/runs/29887601414)) exited 3 five times and spent ~6 minutes reproducing an identical deterministic failure — while reporting a cause that was not the cause.

| exit | meaning | action |
|---|---|---|
| `0` | success | break |
| `2` | connection went bad — the Aurora auto-pause resume this loop exists for | **retry** |
| `None` | no exit code reported — placement / image-pull failure | **retry** |
| `3` | SQL error under `ON_ERROR_STOP` | **fail fast** |
| `1` | entrypoint FATAL asserts — `STG_DB` outside `checkin_stg*`, target database missing, classification row-count floor | **fail fast** |

## Verification

- Diff is **identical** to #1190's, verified line-for-line rather than by eye.
- Workflow YAML parses; the extracted `run` block is `bash -n` clean.
- Decision logic exercised standalone (on #1190): `3` and `1` stop after one attempt, `2` and `None` still retry to five, `0` breaks immediately.

## Known gap, in this PR and in #1190

`deploy-staging.yml` has a **second** identical retry loop — the *Repoint app DML secret* step, which still carries `[ "$EXIT_CODE" = "0" ] && break` and *"failed after 5 attempts"*. It has the same defect and neither PR touches it, because both are scoped to be the same change.

That step runs the copy task with `REPOINT_ONLY=true`, whose failure modes are the same entrypoint asserts (exit 1 — notably the "target database does not exist" guard) plus `psql` connection errors. Worth the same treatment in a follow-up; say the word and I'll extend both PRs instead.

## Sequencing

This does **not** fix the current staging failure — it makes the next one fail in ~1 minute with an honest message. **infra #150** is what diagnoses exit 3, by granting `logs:GetLogEvents` on `/ecs/checkin-stg-copy` so the copy's real error reaches the workflow log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6TfaRtHA5C76d6A8yU4Nm
