### PR TITLE
cherry-pick to rel/1.0: build footer (#1181, #1188) + release-line guard (#1182)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -68,6 +68,22 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ steps.vars.outputs.sha }}
+          # Full history + tags: `git describe` below needs them. The default
+          # shallow clone has neither, and describe degrades SILENTLY to a bare
+          # SHA rather than failing, so a missing fetch-depth shows up only as a
+          # footer that quietly stopped carrying its version.
+          fetch-depth: 0
+
+      - name: Resolve build describe
+        id: describe
+        run: |
+          set -euo pipefail
+          # --long so an exact tag still reports its distance ("-0-g"), keeping
+          # the shape identical for tagged and untagged builds; --always so a
+          # repo with no reachable tag yields the SHA instead of failing the run.
+          DESCRIBE=$(git describe --tags --long --abbrev=7 --always)
+          echo "describe=$DESCRIBE" >> "$GITHUB_OUTPUT"
+          echo "build describe: $DESCRIBE"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6
@@ -92,6 +108,7 @@ jobs:
           # ECS task defs require (runtime_platform.cpu_architecture = ARM64).
           docker build \
             --build-arg NEXT_PUBLIC_GIT_SHA="${{ steps.vars.outputs.sha }}" \
+            --build-arg NEXT_PUBLIC_GIT_DESCRIBE="${{ steps.describe.outputs.describe }}" \
             --build-arg NEXT_PUBLIC_GIT_BRANCH="main" \
             -f checkin-app/Dockerfile \
             -t "$IMAGE" .

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,10 +4,11 @@ name: Deploy prod
 # published in this repo. Mirrors deploy-dev.yml step-for-step (build an ARM64
 # image, run DB migrations, roll out the ECS service) with these differences:
 #   - trigger: a published GitHub release instead of a merge to main
-#   - guard 1: the released commit must live on a rel/* release branch — see
-#              the `branch-guard` job. Prod ships only from release branches;
-#              a release cut from main (or any other ref) fails fast here,
-#              before any CI or human approval is spent on it.
+#   - guard 1: the released commit must live on the rel/* branch matching its
+#              own version — see the `release-branch-match` job. Prod ships
+#              only from release branches; a release cut from main (or any
+#              other ref) fails fast here, before any CI or human approval is
+#              spent on it.
 #   - guard 2: RE-RUNS the entire CI pipeline (tests + the deploy build/smoke)
 #              against the released tag — see the `validate` job. A release can
 #              be cut from any commit ON a rel/* branch, and stale or partial
@@ -73,47 +74,40 @@ env:
   APP_URL: https://ops.innovationtreehouse.org
 
 jobs:
-  # Prod publishes come only from release branches. The released tag's commit
-  # must be contained in some rel/* branch — not "target_commitish says rel/*"
-  # (that field can name a branch OR be a bare SHA and is trivially spoofable
-  # by re-tagging), but actual ancestry against the fetched rel/* refs. Runs
-  # first and cheap so an off-branch release dies with one clear error before
-  # any CI minutes or reviewer attention are spent.
-  branch-guard:
-    name: Release must come from rel/*
+  # A release must ship from its OWN release line: v1.1.x may only be cut from
+  # rel/1.1. Supersedes the old branch-guard job (any rel/* branch) — matching
+  # the specific line implies containment in some rel/* line, so running both
+  # was redundant.
+  #
+  # Checks ANCESTRY, not `release.target_commitish`. That field can be a branch
+  # name OR a bare SHA, is chosen by whoever cut the release, and is re-taggable —
+  # containment in the branch is the property we actually care about.
+  #
+  # Runs before `validate` so a mis-cut release fails in seconds with one clear
+  # error, instead of burning a full CI pass in parallel first.
+  release-branch-match:
+    name: Release version matches its rel/ branch
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout released tag (full history)
+      - name: Checkout released tag
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
-          fetch-depth: 0
-      - name: Verify the released commit is on a rel/* branch
-        run: |
-          set -euo pipefail
-          # fetch-depth: 0 already brings all branches; this explicit fetch
-          # pins the guard's correctness to itself rather than to checkout's
-          # default refspec staying that way.
-          git fetch --quiet origin '+refs/heads/rel/*:refs/remotes/origin/rel/*'
-          SHA=$(git rev-parse HEAD)
-          CONTAINING=$(git branch -r --contains "$SHA" --list 'origin/rel/*' | sed 's/^ *//')
-          if [ -z "$CONTAINING" ]; then
-            echo "::error::Release ${{ github.event.release.tag_name }} points at $SHA, which is not on any rel/* branch. Prod publishes come only from release branches — fast-forward or cut one (e.g. git push origin <sha>:refs/heads/rel/1.2) and re-publish."
-            exit 1
-          fi
-          echo "Release commit $SHA is contained in:"
-          echo "$CONTAINING"
+          fetch-depth: 0   # ancestry check needs real history, not a shallow clone
+
+      - name: Assert the tag's line matches the branch containing it
+        run: ./scripts/release-branch-match.sh "${{ github.event.release.tag_name }}"
 
   # Re-run the FULL CI pipeline (lint, type-check, migration-drift, Jest, the
   # security contract tests, AND the deploy build + boot/smoke) against the exact
   # released tag. This is the H1 fix: a release tag can point at any commit, and
   # we no longer trust whatever check status happened to exist there — we prove
   # the released code green from scratch before a human is even asked to approve.
-  # Needs branch-guard so an off-branch release fails with ONE error instead of
-  # burning a full CI pass in parallel with the rejection.
+  # Needs release-branch-match so a mis-cut release fails with ONE error
+  # instead of burning a full CI pass in parallel with the rejection.
   validate:
     name: Revalidate CI on the released tag
-    needs: [branch-guard]
+    needs: [release-branch-match]   # never burn a CI pass on a mis-cut release
     uses: ./.github/workflows/ci.yml
     with:
       ref: ${{ github.event.release.tag_name }}
@@ -136,9 +130,10 @@ jobs:
 
   deploy:
     name: Build, migrate, roll out
-    # branch-guard is transitively required via validate; listed explicitly so
-    # the prod gate never silently loosens if validate's needs are refactored.
-    needs: [branch-guard, validate]   # rel/* origin proven AND the tag re-passed all of CI
+    # Both listed explicitly, not just [validate]: the branch gate is a release
+    # correctness property, and a refactor that changes what `validate` needs
+    # must not be able to drop it silently.
+    needs: [release-branch-match, validate]
     runs-on: ubuntu-24.04-arm  # native ARM64 — task defs require arm64 images
     environment:
       name: production

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -148,6 +148,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
+          # Full history + tags for `git describe` below (see deploy-dev.yml's
+          # note: a shallow clone degrades describe to a bare SHA silently).
+          fetch-depth: 0
 
       - name: Resolve released commit
         id: vars
@@ -158,6 +161,11 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHA:0:7}" >> "$GITHUB_OUTPUT"
           echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          # On a release this normally reads "<tag>-0-g<sha>" — the -0- is the
+          # point: it proves the deployed commit IS the tag, not a descendant.
+          DESCRIBE=$(git describe --tags --long --abbrev=7 --always)
+          echo "describe=$DESCRIBE" >> "$GITHUB_OUTPUT"
+          echo "build describe: $DESCRIBE"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6
@@ -196,6 +204,7 @@ jobs:
           # branch part and shows "<tag> <sha7>", which is what prod wants anyway.
           docker build \
             --build-arg NEXT_PUBLIC_GIT_SHA="${{ steps.vars.outputs.sha }}" \
+            --build-arg NEXT_PUBLIC_GIT_DESCRIBE="${{ steps.vars.outputs.describe }}" \
             --build-arg NEXT_PUBLIC_RELEASE_TAG="${{ steps.vars.outputs.tag }}" \
             -f checkin-app/Dockerfile \
             -t "$IMAGE" -t "$IMAGE_TAGGED" .

--- a/checkin-app/Dockerfile
+++ b/checkin-app/Dockerfile
@@ -34,6 +34,15 @@ ENV NEXT_PUBLIC_GIT_SHA=${NEXT_PUBLIC_GIT_SHA}
 # "<tag> <sha>" on prod. Empty on dev/local builds -> footer shows the hash alone.
 ARG NEXT_PUBLIC_RELEASE_TAG
 ENV NEXT_PUBLIC_RELEASE_TAG=${NEXT_PUBLIC_RELEASE_TAG}
+# `git describe --tags --long --abbrev=7 --always` of the built commit, e.g.
+# "v1.0.8-0-ge790e17" — the tag it descends from, how many commits past it, and
+# the commit itself. Answers "what is running" in one string for a build that is
+# NOT itself a release: a bare SHA can't tell you it is 2 commits past v1.0.7,
+# and the release tag alone is empty on every non-prod build. Requires the deploy
+# workflow to check out with fetch-depth: 0 (a shallow clone has no tags, and
+# describe silently degrades to the bare SHA).
+ARG NEXT_PUBLIC_GIT_DESCRIBE
+ENV NEXT_PUBLIC_GIT_DESCRIBE=${NEXT_PUBLIC_GIT_DESCRIBE}
 # Branch, passed by deploy-dev.yml (main) and deploy-staging.yml (the rel/*
 # branch being deployed) -> footer shows "<branch> <sha>" on those envs. NOT
 # passed by deploy-prod.yml: on prod, github.ref_name IS the tag, so passing it

--- a/checkin-app/src/components/BuildInfoFooter.tsx
+++ b/checkin-app/src/components/BuildInfoFooter.tsx
@@ -12,7 +12,7 @@ const FULL_SHA =
 // Release tag (e.g. "v1.0.0"), set only by the prod deploy workflow. Empty on
 // dev/local builds -> the footer shows the hash alone.
 const RELEASE_TAG = process.env.NEXT_PUBLIC_RELEASE_TAG;
-// `git describe --tags --long --abbrev=7 --always`, e.g. "v1.0.8-0-ge790e17".
+// `git describe --tags --long --abbrev=7 --always`, e.g. "v1.0.8-2-g0123456".
 // Strictly more informative than the bare SHA — it carries the ancestor tag and
 // the distance from it — so it WINS over the tag/sha pair when present.
 const GIT_DESCRIBE = process.env.NEXT_PUBLIC_GIT_DESCRIBE;
@@ -20,9 +20,21 @@ const GIT_DESCRIBE = process.env.NEXT_PUBLIC_GIT_DESCRIBE;
 // NOT set by deploy-prod.yml (its ref IS the tag — see the Dockerfile comment).
 const GIT_BRANCH = process.env.NEXT_PUBLIC_GIT_BRANCH;
 
+// `--long` always appends "-<distance>-g<sha>", so an exact tag reads
+// "v1.0.8-0-ge790e17". At distance 0 the commit IS the tag: the count is
+// noise and the sha is redundant (it's already in the hover title), so render
+// the tag alone. Anchored at the end and requires a 0 distance — a tag whose
+// own name contains "-0-g" is untouched.
+const EXACT_TAG = /^(.+)-0-g[0-9a-f]+$/;
+
+function shortenExactTag(describe: string | undefined | null): string {
+  if (!describe) return "";
+  return describe.replace(EXACT_TAG, "$1");
+}
+
 /**
  * Human-facing build label, most informative form first:
- *   "<branch> <describe>"  — e.g. "rel/1.0 v1.0.8-0-ge790e17"
+ *   "<branch> <describe>"  — e.g. "rel/1.0 v1.0.8-2-g0123456"
  *   "<describe>"           — when the branch is unknown
  *   "<tag> <7-char sha>"   — pre-describe fallback, a tagged build
  *   "<7-char sha>"         — pre-describe fallback, untagged
@@ -38,7 +50,7 @@ export function buildLabel(
   describe?: string | null,
   branch?: string | null,
 ): string {
-  const version = describe || (sha ? (tag ? `${tag} ${sha.slice(0, 7)}` : sha.slice(0, 7)) : "");
+  const version = shortenExactTag(describe) || (sha ? (tag ? `${tag} ${sha.slice(0, 7)}` : sha.slice(0, 7)) : "");
   if (!version) return "dev";
   return branch ? `${branch} ${version}` : version;
 }

--- a/checkin-app/src/components/BuildInfoFooter.tsx
+++ b/checkin-app/src/components/BuildInfoFooter.tsx
@@ -12,26 +12,39 @@ const FULL_SHA =
 // Release tag (e.g. "v1.0.0"), set only by the prod deploy workflow. Empty on
 // dev/local builds -> the footer shows the hash alone.
 const RELEASE_TAG = process.env.NEXT_PUBLIC_RELEASE_TAG;
+// `git describe --tags --long --abbrev=7 --always`, e.g. "v1.0.8-0-ge790e17".
+// Strictly more informative than the bare SHA — it carries the ancestor tag and
+// the distance from it — so it WINS over the tag/sha pair when present.
+const GIT_DESCRIBE = process.env.NEXT_PUBLIC_GIT_DESCRIBE;
 // Branch (e.g. "main", "rel/1.2"), set by deploy-dev.yml and deploy-staging.yml.
 // NOT set by deploy-prod.yml (its ref IS the tag — see the Dockerfile comment).
 const GIT_BRANCH = process.env.NEXT_PUBLIC_GIT_BRANCH;
 
 /**
- * Human-facing build label: "<branch> <tag> <7-char sha>", omitting whichever
- * of branch/tag are unset, or "dev" when there is no sha at all.
+ * Human-facing build label, most informative form first:
+ *   "<branch> <describe>"  — e.g. "rel/1.0 v1.0.8-0-ge790e17"
+ *   "<describe>"           — when the branch is unknown
+ *   "<tag> <7-char sha>"   — pre-describe fallback, a tagged build
+ *   "<7-char sha>"         — pre-describe fallback, untagged
+ *   "dev"                  — nothing was stamped at all
+ *
+ * The fallbacks are not dead code: an image built before this change, or any
+ * build whose checkout was shallow (describe needs tags), still renders a
+ * sensible label rather than "dev".
  */
 export function buildLabel(
   sha: string | undefined | null,
   tag?: string | null,
+  describe?: string | null,
   branch?: string | null,
 ): string {
-  if (!sha) return "dev";
-  const short = sha.slice(0, 7);
-  return [branch, tag, short].filter(Boolean).join(" ");
+  const version = describe || (sha ? (tag ? `${tag} ${sha.slice(0, 7)}` : sha.slice(0, 7)) : "");
+  if (!version) return "dev";
+  return branch ? `${branch} ${version}` : version;
 }
 
 export function BuildInfoFooter() {
-  const label = buildLabel(FULL_SHA, RELEASE_TAG, GIT_BRANCH);
+  const label = buildLabel(FULL_SHA, RELEASE_TAG, GIT_DESCRIBE, GIT_BRANCH);
   return (
     <Text
       component="div"

--- a/checkin-app/src/components/__tests__/BuildInfoFooter.test.tsx
+++ b/checkin-app/src/components/__tests__/BuildInfoFooter.test.tsx
@@ -42,13 +42,13 @@ describe("buildLabel", () => {
   });
 
   it("prefixes the branch when both branch and describe are set", () => {
-    expect(buildLabel("0123456", null, "v1.0.8-0-ge790e17", "rel/1.0")).toBe(
-      "rel/1.0 v1.0.8-0-ge790e17",
+    expect(buildLabel("0123456", null, "v1.0.8-2-g0123456", "rel/1.0")).toBe(
+      "rel/1.0 v1.0.8-2-g0123456",
     );
   });
 
   it("renders describe alone when the branch is unknown (nothing sets it yet)", () => {
-    expect(buildLabel("0123456", null, "v1.0.8-0-ge790e17")).toBe("v1.0.8-0-ge790e17");
+    expect(buildLabel("0123456", null, "v1.0.8-2-g0123456")).toBe("v1.0.8-2-g0123456");
   });
 
   it("falls back to tag+sha for an image built before describe existed", () => {
@@ -61,11 +61,34 @@ describe("buildLabel", () => {
 
   it("still labels a describe-only build when the sha is somehow unset", () => {
     // describe is self-contained; it should not require the sha var too.
-    expect(buildLabel(undefined, null, "v1.0.8-0-ge790e17")).toBe("v1.0.8-0-ge790e17");
+    expect(buildLabel(undefined, null, "v1.0.8-2-g0123456")).toBe("v1.0.8-2-g0123456");
   });
 
   it("branches the label even with no describe, using the fallback version", () => {
     expect(buildLabel("0123456789abcdef", "v1.0.0", null, "main")).toBe("main v1.0.0 0123456");
+  });
+
+  it("renders the tag ALONE when the commit is the tag (distance 0)", () => {
+    expect(buildLabel("e790e173", null, "v1.0.8-0-ge790e17")).toBe("v1.0.8");
+  });
+
+  it("keeps distance and hash when the commit is PAST the tag", () => {
+    expect(buildLabel("0123456", null, "v1.0.8-2-g0123456")).toBe("v1.0.8-2-g0123456");
+  });
+
+  it("still prefixes the branch on an exact tag", () => {
+    expect(buildLabel("e790e173", null, "v1.0.8-0-ge790e17", "rel/1.0")).toBe("rel/1.0 v1.0.8");
+  });
+
+  it("leaves a bare sha alone (no reachable tag, --always fallback)", () => {
+    expect(buildLabel("e790e173", null, "e790e17")).toBe("e790e17");
+  });
+
+  it("does not mangle a tag whose own name contains -0-g", () => {
+    // Only a trailing "-0-g<sha>" is the distance suffix; an interior one is
+    // part of the tag name and must survive.
+    expect(buildLabel("0123456", null, "v1.0.8-0-gamma-3-g0123456")).toBe("v1.0.8-0-gamma-3-g0123456");
+    expect(buildLabel("0123456", null, "v1.0.8-0-gamma-0-g0123456")).toBe("v1.0.8-0-gamma");
   });
 
   it("ignores the tag when there is no sha", () => {

--- a/checkin-app/src/components/__tests__/BuildInfoFooter.test.tsx
+++ b/checkin-app/src/components/__tests__/BuildInfoFooter.test.tsx
@@ -35,6 +35,39 @@ describe("buildLabel", () => {
     );
   });
 
+  it("prefers describe over the tag+sha pair — it carries strictly more", () => {
+    expect(
+      buildLabel("0123456789abcdef0123456789abcdef01234567", "v1.0.0", "v1.0.8-2-g0123456"),
+    ).toBe("v1.0.8-2-g0123456");
+  });
+
+  it("prefixes the branch when both branch and describe are set", () => {
+    expect(buildLabel("0123456", null, "v1.0.8-0-ge790e17", "rel/1.0")).toBe(
+      "rel/1.0 v1.0.8-0-ge790e17",
+    );
+  });
+
+  it("renders describe alone when the branch is unknown (nothing sets it yet)", () => {
+    expect(buildLabel("0123456", null, "v1.0.8-0-ge790e17")).toBe("v1.0.8-0-ge790e17");
+  });
+
+  it("falls back to tag+sha for an image built before describe existed", () => {
+    // A running image predating this change has no NEXT_PUBLIC_GIT_DESCRIBE.
+    // It must keep its old label, not regress to "dev".
+    expect(buildLabel("0123456789abcdef0123456789abcdef01234567", "v1.0.0", undefined)).toBe(
+      "v1.0.0 0123456",
+    );
+  });
+
+  it("still labels a describe-only build when the sha is somehow unset", () => {
+    // describe is self-contained; it should not require the sha var too.
+    expect(buildLabel(undefined, null, "v1.0.8-0-ge790e17")).toBe("v1.0.8-0-ge790e17");
+  });
+
+  it("branches the label even with no describe, using the fallback version", () => {
+    expect(buildLabel("0123456789abcdef", "v1.0.0", null, "main")).toBe("main v1.0.0 0123456");
+  });
+
   it("ignores the tag when there is no sha", () => {
     expect(buildLabel(undefined, "v1.0.0")).toBe("dev");
   });
@@ -42,23 +75,23 @@ describe("buildLabel", () => {
   const SHA = "0123456789abcdef0123456789abcdef01234567";
 
   it("branch only: prefixes the branch, no tag", () => {
-    expect(buildLabel(SHA, undefined, "rel/1.2")).toBe("rel/1.2 0123456");
+    expect(buildLabel(SHA, undefined, undefined, "rel/1.2")).toBe("rel/1.2 0123456");
   });
 
   it("tag only: prefixes the tag, no branch", () => {
-    expect(buildLabel(SHA, "v1.0.0", undefined)).toBe("v1.0.0 0123456");
+    expect(buildLabel(SHA, "v1.0.0", undefined, undefined)).toBe("v1.0.0 0123456");
   });
 
   it("both branch and tag: branch then tag then sha", () => {
-    expect(buildLabel(SHA, "v1.0.0", "rel/1.2")).toBe("rel/1.2 v1.0.0 0123456");
+    expect(buildLabel(SHA, "v1.0.0", undefined, "rel/1.2")).toBe("rel/1.2 v1.0.0 0123456");
   });
 
   it("neither branch nor tag: sha alone", () => {
-    expect(buildLabel(SHA, undefined, undefined)).toBe("0123456");
+    expect(buildLabel(SHA, undefined, undefined, undefined)).toBe("0123456");
   });
 
   it("ignores branch when there is no sha", () => {
-    expect(buildLabel(undefined, undefined, "main")).toBe("dev");
+    expect(buildLabel(undefined, undefined, undefined, "main")).toBe("dev");
   });
 });
 

--- a/scripts/release-branch-match.sh
+++ b/scripts/release-branch-match.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Assert a release tag ships from its OWN release line: v1.1.x only from rel/1.1.
+#
+#   scripts/release-branch-match.sh <tag>        # e.g. v1.1.4
+#
+# WHY: the version and the branch are two independent claims about "which line is
+# this", and nothing otherwise makes them agree — so v1.1.0 could be tagged on
+# rel/1.0, or on main, and ship to prod carrying a version number that lies about
+# its lineage. That is worst exactly when it matters: during an incident, when
+# the version string is what people reason about.
+#
+# Checks ANCESTRY, deliberately not `release.target_commitish`: that field can be
+# a branch name OR a bare SHA, is chosen by whoever cut the release, and is
+# re-taggable. Containment in the branch is the property we actually care about.
+#
+# Lives in a script rather than inline in deploy-prod.yml so it can be tested —
+# see test-release-branch-match.sh. A release gate that has never been run
+# against a failing case is not a gate.
+set -euo pipefail
+
+TAG="${1:?usage: release-branch-match.sh <tag>}"
+REMOTE="${REMOTE:-origin}"
+
+# v1.1.4, v1.1.4-rc.1, v1.1.4+build -> major 1, minor 1 -> rel/1.1.
+# PATCH is deliberately NOT part of the branch name: a release LINE is
+# major.minor, and every patch on it ships from that same branch.
+if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+ ]]; then
+  echo "::error::Release tag '$TAG' is not vMAJOR.MINOR.PATCH — cannot derive its release line." >&2
+  exit 1
+fi
+MAJOR="${BASH_REMATCH[1]}" MINOR="${BASH_REMATCH[2]}"
+BRANCH="rel/${MAJOR}.${MINOR}"
+
+SHA="$(git rev-parse HEAD)"
+echo "tag ${TAG} -> expected line ${BRANCH} (commit ${SHA})"
+
+# Fetch just that one ref. A missing branch is a hard failure, never a skip:
+# "the release line does not exist" is precisely the mistake this catches — a
+# typo'd minor, a branch never cut, a branch deleted after the fact.
+if ! git fetch --no-tags --quiet "$REMOTE" \
+       "+refs/heads/${BRANCH}:refs/remotes/${REMOTE}/${BRANCH}" 2>/dev/null; then
+  echo "::error::${TAG} requires branch ${BRANCH}, which does not exist on ${REMOTE}. Cut it first, or fix the tag's version." >&2
+  exit 1
+fi
+
+# --is-ancestor counts a commit as an ancestor of itself, so a tag sitting ON the
+# branch tip passes. Anything not reachable from the branch fails.
+if ! git merge-base --is-ancestor "$SHA" "refs/remotes/${REMOTE}/${BRANCH}"; then
+  echo "::error::${TAG} (${SHA}) is not contained in ${BRANCH} — a v${MAJOR}.${MINOR}.x release must be cut from that branch." >&2
+  echo "Branches that DO contain this commit:" >&2
+  git branch -a --contains "$SHA" 2>/dev/null | sed 's/^/  /' >&2 || echo "  (none)" >&2
+  exit 1
+fi
+
+echo "OK: ${TAG} is contained in ${BRANCH}"

--- a/scripts/test-release-branch-match.sh
+++ b/scripts/test-release-branch-match.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Runnable check for release-branch-match.sh — real git, no network, no CI.
+#
+#   scripts/test-release-branch-match.sh
+#
+# Builds a throwaway repo with a bare "origin", two release lines and a main,
+# then drives every outcome the gate is supposed to have an opinion about. A
+# release gate whose failing paths have never been executed is not a gate.
+set -uo pipefail
+cd "$(dirname "$0")"
+GUARD="$PWD/release-branch-match.sh"
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+q() { git "$@" >/dev/null 2>&1; }
+
+# ── a bare origin + a working clone ──────────────────────────────────────────
+q init --bare "$T/origin.git"
+q clone "$T/origin.git" "$T/work"
+cd "$T/work"
+q config user.email t@example.com; q config user.name t
+
+commit() { echo "$1" > f; q add f; q commit -m "$1"; git rev-parse HEAD; }
+
+BASE=$(commit base)
+q push origin HEAD:refs/heads/main
+
+# rel/1.0 with a release on it
+q checkout -b rel/1.0
+R10=$(commit "on rel/1.0")
+q push origin rel/1.0
+
+# rel/1.1 forked from base, with its own commit
+q checkout -b rel/1.1 "$BASE"
+R11=$(commit "on rel/1.1")
+q push origin rel/1.1
+
+# a commit that lives only on main — no release line at all
+q checkout -b main-only "$BASE"
+MAINONLY=$(commit "main only")
+q push origin main-only:refs/heads/main --force
+
+run_at() { q checkout --detach "$1"; bash "$GUARD" "$2" 2>&1; }
+
+echo "1. a v1.1.x tag on rel/1.1 passes"
+out=$(run_at "$R11" v1.1.4); rc=$?
+[ $rc -eq 0 ] || { echo "$out"; fail "should have passed"; }
+grep -q "OK: v1.1.4 is contained in rel/1.1" <<<"$out" || { echo "$out"; fail "wrong success message"; }
+echo "   ✓ $(grep -o 'OK:.*' <<<"$out")"
+
+echo "2. the SAME commit tagged v1.0.x is REJECTED — this is the whole point"
+out=$(run_at "$R11" v1.0.4); rc=$?
+[ $rc -ne 0 ] || { echo "$out"; fail "a v1.0.x tag on rel/1.1 must fail"; }
+grep -q "is not contained in rel/1.0" <<<"$out" || { echo "$out"; fail "wrong rejection reason"; }
+grep -q "Branches that DO contain this commit" <<<"$out" || fail "should list the real branches"
+echo "   ✓ rejected, and reported where the commit actually lives"
+
+echo "3. a patch release on the same line passes (PATCH is not part of the branch)"
+out=$(run_at "$R11" v1.1.99); rc=$?
+[ $rc -eq 0 ] || { echo "$out"; fail "v1.1.99 should ship from rel/1.1"; }
+echo "   ✓ v1.1.99 -> rel/1.1"
+
+echo "4. a pre-release tag derives the same line"
+out=$(run_at "$R11" v1.1.0-rc.1); rc=$?
+[ $rc -eq 0 ] || { echo "$out"; fail "v1.1.0-rc.1 should ship from rel/1.1"; }
+echo "   ✓ v1.1.0-rc.1 -> rel/1.1"
+
+echo "5. an ancestor of the branch tip passes (tag need not be the tip)"
+out=$(run_at "$BASE" v1.1.0); rc=$?
+[ $rc -eq 0 ] || { echo "$out"; fail "an ancestor of rel/1.1 should pass"; }
+echo "   ✓ ancestry, not tip-equality"
+
+echo "6. a commit on no release line at all is rejected"
+out=$(run_at "$MAINONLY" v1.1.0); rc=$?
+[ $rc -ne 0 ] || { echo "$out"; fail "a main-only commit must not release"; }
+grep -q "is not contained in rel/1.1" <<<"$out" || { echo "$out"; fail "wrong reason"; }
+echo "   ✓ main-only commit refused"
+
+echo "7. a version whose release line was never cut is a hard failure, not a skip"
+out=$(run_at "$R11" v9.9.0); rc=$?
+[ $rc -ne 0 ] || { echo "$out"; fail "a nonexistent rel/9.9 must fail"; }
+grep -q "which does not exist" <<<"$out" || { echo "$out"; fail "wrong reason: $out"; }
+echo "   ✓ missing release line refused"
+
+echo "8. a malformed tag is refused before any git work"
+for bad in v1.1 1.1.0 release-1.1.0 v1..0; do
+  out=$(run_at "$R11" "$bad"); rc=$?
+  [ $rc -ne 0 ] || fail "tag '$bad' should be refused"
+  grep -q "is not vMAJOR.MINOR.PATCH" <<<"$out" || fail "tag '$bad' failed for the wrong reason"
+done
+echo "   ✓ v1.1 / 1.1.0 / release-1.1.0 / v1..0 all refused"
+
+echo "ALL CHECKS PASSED"


### PR DESCRIPTION
Cherry-picks #1181, #1182 and #1188 onto the 1.0 release line, in merge order. All three applied **clean** — no conflicts.

| commit | PR | |
|---|---|---|
| `bf164f2f` | #1181 | footer stamps `git describe` + branch |
| `6da6da2b` | #1182 | a `v<major>.<minor>.x` release must be cut from `rel/<major>.<minor>` |
| `fbd920c5` | #1188 | show the tag alone when the build **is** the tag |

## Why these matter on `rel/1.0` specifically

**#1182 is the one with teeth here.** `rel/1.0` is a release line, so this is the branch whose tags the guard governs: cutting `v1.1.0` from it will now fail fast instead of shipping a version number that lies about its lineage.

**#1181 + #1188** give the release line a footer that says what is actually running. On a tagged build that is now just `v1.0.8`; on a branch build, `rel/1.0 v1.0.8-2-g0123456`.

## What I verified rather than assumed

I expected two conflicts and got neither, so I checked the results directly instead of trusting the clean apply:

**#1182's guard collapse landed correctly.** It deletes #1147's `branch-guard` in favour of `release-branch-match`, and `rel/1.0` received `branch-guard` via the #1185 promotion — so a mis-apply here would leave a dangling `needs:` and a syntactically broken workflow. Parsed job graph:

```
release-branch-match   needs: None
validate               needs: ['release-branch-match']
deploy                 needs: ['release-branch-match', 'validate']
```

`branch-guard` is gone, every `needs:` resolves to a job that exists, and `deploy` still names the guard explicitly rather than inheriting it through `validate`.

**#1188's fixture rewrites applied over #1181's tests.** Those two touch the same test file and #1188 retargets fixtures #1181 introduced — **21/21 pass**.

**`fetch-depth: 0` survived on every checkout preceding a `git describe`** (`deploy-dev.yml:75`, `deploy-prod.yml:148`) plus the ancestry check's own (`deploy-prod.yml:96`). A shallow clone degrades `git describe` *silently* to a bare SHA, so losing this in a pick would not fail — it would just quietly stop stamping versions.

## Verification

- `./scripts/test-release-branch-match.sh` — **ALL CHECKS PASSED** (8/8), including the case that matters: the same commit passes as `v1.1.4` and is refused as `v1.0.4`
- `npx jest .../BuildInfoFooter.test.tsx` — **21/21**
- `npx tsc --noEmit --pretty false` — 2 errors, both the `@aws-sdk/client-lambda` baseline from a local `node_modules` symlink; **none** from this branch
- All three deploy workflow YAMLs parse

## Note

Independent of #1191 (fail-fast on the staging copy task), which also targets `rel/1.0` but touches only `deploy-staging.yml` — no overlap with these three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6TfaRtHA5C76d6A8yU4Nm
