### PR TITLE
feat(programs): announce exactly once — announcedAt + shared trigger helper

### DIFF
--- a/checkin-app/prisma/migrations/20260721120000_program_announced_at/migration.sql
+++ b/checkin-app/prisma/migrations/20260721120000_program_announced_at/migration.sql
@@ -1,0 +1,3 @@
+-- Additive, nullable: once-per-lifetime announce marker. NULL = never announced;
+-- existing rows stay NULL and simply won't re-announce (they already fired or never will).
+ALTER TABLE "Program" ADD COLUMN "announcedAt" TIMESTAMP(3);

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -835,6 +835,11 @@ model Program {
   /// Default false — no program announces unless a leader enables it.
   /// @sensitivity:public
   announceOnOpen                 Boolean          @default(false)
+  /// Once-per-lifetime announce marker: set by the conditional claim in
+  /// lib/programAnnounce.ts when the announce blast fires. Never reset — a
+  /// program that announced once never auto-announces again.
+  /// @sensitivity:internal
+  announcedAt                    DateTime?
   /// @sensitivity:public
   minAge                         Int?
   /// @sensitivity:public

--- a/checkin-app/src/app/__tests__/programAnnounceNotification.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAnnounceNotification.integration.test.ts
@@ -4,16 +4,19 @@
 /**
  * Integration tests for the "new program announced" notification trigger.
  *
- * The PATCH route fires notifyNewProgramAnnounced ONLY on the transition INTO
- * (phase=UPCOMING && enrollmentStatus=OPEN) — see src/app/api/programs/[id]/route.ts.
- * These guard: it fires on the edge, does NOT re-fire while already announced,
- * and does NOT fire when only one of the two conditions flips.
+ * Both program-edit PATCH routes fire notifyNewProgramAnnounced through
+ * maybeAnnounceOnOpen (src/lib/programAnnounce.ts): ONLY on the transition INTO
+ * (phase=UPCOMING && enrollmentStatus=OPEN), and at most once per program
+ * lifetime (the announcedAt claim). These guard: it fires on the edge, does NOT
+ * re-fire (already-open edit, close-and-reopen, stale-pre-state race), does NOT
+ * fire when only one of the two conditions flips, and audits the blast.
  */
 
 import { PATCH } from '@/app/api/programs/[id]/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import { notifyNewProgramAnnounced } from '@/lib/notifications';
+import { maybeAnnounceOnOpen } from '@/lib/programAnnounce';
 
 jest.mock('next-auth/next', () => ({
     getServerSession: jest.fn(),
@@ -126,5 +129,66 @@ describe('New-program announce notification trigger', () => {
         const res = await patch(program.id, { enrollmentStatus: 'OPEN' });
         expect(res.status).toBe(200);
         expect(mockNotify).not.toHaveBeenCalled();
+    });
+
+    // #1164 review F2/F3/F6: announcedAt is a once-per-program-lifetime claim.
+    describe('once-per-lifetime announcedAt claim', () => {
+        it('sets announcedAt on the first fire, and closing + reopening enrollment does NOT re-fire (F2)', async () => {
+            const name = `${PROGRAM_NAME_TAG} reopen`;
+            const program = await prisma.program.create({
+                data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED', announceOnOpen: true },
+            });
+
+            expect((await patch(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' })).status).toBe(200);
+            expect(mockNotify).toHaveBeenCalledTimes(1);
+
+            const announced = await prisma.program.findUnique({ where: { id: program.id } });
+            expect(announced?.announcedAt).not.toBeNull();
+
+            // Close, then reopen — the old row-compare logic would fire again here.
+            expect((await patch(program.id, { enrollmentStatus: 'CLOSED' })).status).toBe(200);
+            expect((await patch(program.id, { enrollmentStatus: 'OPEN' })).status).toBe(200);
+            expect(mockNotify).toHaveBeenCalledTimes(1);
+
+            // announcedAt unchanged by the reopen.
+            const after = await prisma.program.findUnique({ where: { id: program.id } });
+            expect(after?.announcedAt).toEqual(announced?.announcedAt);
+        });
+
+        it('two callers with the same stale pre-state send only once (F3 — conditional-write contract)', async () => {
+            const name = `${PROGRAM_NAME_TAG} race`;
+            const program = await prisma.program.create({
+                data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED', announceOnOpen: true },
+            });
+            const after = await prisma.program.update({
+                where: { id: program.id },
+                data: { phase: 'UPCOMING', enrollmentStatus: 'OPEN' },
+            });
+
+            // Both calls hold the SAME pre-update snapshot — exactly what two
+            // concurrent PATCHes observe. Only the updateMany claim may win once.
+            await maybeAnnounceOnOpen({ programId: program.id, before: program, after, actorId: adminId });
+            await maybeAnnounceOnOpen({ programId: program.id, before: program, after, actorId: adminId });
+
+            expect(mockNotify).toHaveBeenCalledTimes(1);
+        });
+
+        it('writes an AuditLog row for the blast with the triggering actor (F6)', async () => {
+            const name = `${PROGRAM_NAME_TAG} audit`;
+            const program = await prisma.program.create({
+                data: { name, leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED', announceOnOpen: true },
+            });
+
+            expect((await patch(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' })).status).toBe(200);
+
+            const rows = await prisma.auditLog.findMany({
+                where: { tableName: 'Program', affectedEntityId: program.id, actorId: adminId },
+            });
+            const blastRows = rows.filter(
+                (r) => (r.newData as { event?: string } | null)?.event === 'PROGRAM_ANNOUNCE_BLAST',
+            );
+            expect(blastRows).toHaveLength(1);
+            expect((blastRows[0].newData as { announcedAt?: string }).announcedAt).toBeDefined();
+        });
     });
 });

--- a/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
@@ -406,5 +406,32 @@ describe('Program Settings API Integration Tests', () => {
             expect(res.status).toBe(200);
             expect(mockNotify).not.toHaveBeenCalled();
         });
+
+        // #1164 review F2/F6: the announcedAt claim is once-per-lifetime and the
+        // blast is audited — same helper as programs/[id], asserted here so the
+        // settings surface can't regress independently.
+        it('does NOT re-fire after closing and reopening enrollment, and audits the one blast (F2/F6)', async () => {
+            const program = await prisma.program.create({
+                data: { name: 'Settings API Test announce reopen', leadMentorId: leadId, phase: 'PLANNING', enrollmentStatus: 'CLOSED', announceOnOpen: true }
+            });
+
+            expect((await patchSettings(program.id, { phase: 'UPCOMING', enrollmentStatus: 'OPEN' })).status).toBe(200);
+            expect(mockNotify).toHaveBeenCalledTimes(1);
+
+            expect((await patchSettings(program.id, { enrollmentStatus: 'CLOSED' })).status).toBe(200);
+            expect((await patchSettings(program.id, { enrollmentStatus: 'OPEN' })).status).toBe(200);
+            expect(mockNotify).toHaveBeenCalledTimes(1);
+
+            const persisted = await prisma.program.findUnique({ where: { id: program.id } });
+            expect(persisted?.announcedAt).not.toBeNull();
+
+            const rows = await prisma.auditLog.findMany({
+                where: { tableName: 'Program', affectedEntityId: program.id, actorId: adminId },
+            });
+            const blastRows = rows.filter(
+                (r) => (r.newData as { event?: string } | null)?.event === 'PROGRAM_ANNOUNCE_BLAST',
+            );
+            expect(blastRows).toHaveLength(1);
+        });
     });
 });

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -4,7 +4,7 @@ import { withAuth, authenticateRequest } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { handler, notFound, forbidden, badRequest } from "@/security/handler";
 import { isActiveOrgMember, isActiveOrgMemberThrough, programCoverageDate } from "@/lib/orgMembership";
-import { notifyNewProgramAnnounced } from "@/lib/notifications";
+import { maybeAnnounceOnOpen } from "@/lib/programAnnounce";
 import { adjustProgramInventory } from "@/lib/shopify";
 import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
@@ -214,21 +214,14 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
             }
         });
 
-        // Announce only on the transition INTO (UPCOMING && OPEN) — not on every
-        // save while already there, and not when only one of the two is set.
-        const wasAnnounced = currentProgram.phase === 'UPCOMING' && currentProgram.enrollmentStatus === 'OPEN';
-        const nowAnnounced = updatedProgram.phase === 'UPCOMING' && updatedProgram.enrollmentStatus === 'OPEN';
-        if (!wasAnnounced && nowAnnounced) {
-            if (updatedProgram.announceOnOpen) {
-                // Fire-and-forget: paced send is ~(recipients/5) seconds — must not block
-                // the PATCH response. notifyNewProgramAnnounced swallows its own errors;
-                // .catch is belt-and-suspenders, matching the best-effort idiom.
-                void notifyNewProgramAnnounced(updatedProgram).catch((e) =>
-                    logger.error("notifyNewProgramAnnounced failed:", e));
-            } else {
-                logger.info(`[announce] Program ${updatedProgram.id} reached UPCOMING+OPEN; announceOnOpen off — skipping.`);
-            }
-        }
+        // Announce trigger — transition rule, once-per-lifetime claim, audit row,
+        // and fire-without-await all live in the helper. Never throws.
+        await maybeAnnounceOnOpen({
+            programId: updatedProgram.id,
+            before: currentProgram,
+            after: updatedProgram,
+            actorId: auth.user.id,
+        });
 
         // Shopify is the source of truth for program capacity (product decision
         // 2026-07-06): cap edits propagate as relative inventory adjustments.

--- a/checkin-app/src/app/api/programs/[id]/settings/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/settings/route.ts
@@ -5,7 +5,7 @@ import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
 import { LIVE_PERSON } from "@/lib/person/filters";
 import { validateProgramAgeBounds } from "@/lib/programAge";
-import { notifyNewProgramAnnounced } from "@/lib/notifications";
+import { maybeAnnounceOnOpen } from "@/lib/programAnnounce";
 import { ProgramPhase, EnrollmentStatus } from "@/generated/prisma/client";
 
 export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promise<{ id: string }> }) => {
@@ -126,31 +126,15 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
             }
         });
 
-        // Announce only on the transition INTO (UPCOMING && OPEN) — not on every
-        // save while already there, and not when only one of the two is set.
-        // ponytail: duplicated verbatim from programs/[id] PATCH rather than
-        // extracted — the extraction travels with the announcedAt idempotency
-        // follow-up (#1164 review, findings 2/3/6/7), which rewrites this block.
-        // Own try/catch: the program update + audit log above are committed — a
-        // synchronous throw here (e.g. a partially mocked notifications module)
-        // must not turn a successful write into a 500 (#1164 review, finding 1).
-        try {
-            const wasAnnounced = currentProgram.phase === 'UPCOMING' && currentProgram.enrollmentStatus === 'OPEN';
-            const nowAnnounced = updatedProgram.phase === 'UPCOMING' && updatedProgram.enrollmentStatus === 'OPEN';
-            if (!wasAnnounced && nowAnnounced) {
-                if (updatedProgram.announceOnOpen) {
-                    // Fire-and-forget: paced send is ~(recipients/5) seconds — must not block
-                    // the PATCH response. notifyNewProgramAnnounced swallows its own errors;
-                    // .catch is belt-and-suspenders, matching the best-effort idiom.
-                    void notifyNewProgramAnnounced(updatedProgram).catch((e) =>
-                        logger.error("notifyNewProgramAnnounced failed:", e));
-                } else {
-                    logger.info(`[announce] Program ${updatedProgram.id} reached UPCOMING+OPEN; announceOnOpen off — skipping.`);
-                }
-            }
-        } catch (announceError) {
-            logger.error("announce trigger failed:", announceError);
-        }
+        // Announce trigger — transition rule, once-per-lifetime claim, audit row,
+        // and fire-without-await all live in the helper. Never throws (the F1
+        // committed-write-cant-500 guarantee moved into the helper's own try/catch).
+        await maybeAnnounceOnOpen({
+            programId,
+            before: currentProgram,
+            after: updatedProgram,
+            actorId: currentUserId,
+        });
 
         return NextResponse.json({ success: true, program: updatedProgram });
     } catch (error) {

--- a/checkin-app/src/lib/notifications.ts
+++ b/checkin-app/src/lib/notifications.ts
@@ -78,9 +78,10 @@ export async function sendNotification(userId: number, eventType: NotificationEv
  * covers the program's FULL DURATION (#1061 rule, reused verbatim), respecting each
  * person's notifyNewPrograms / email prefs (default ON). Paced at 5/sec (#1154).
  *
- * The announceOnOpen opt-in gate lives at the CALL SITES — programs/[id] PATCH and
- * programs/[id]/settings PATCH both fire this on the transition into UPCOMING+OPEN —
- * this only runs when a leader has enabled it. Best-effort: fire-and-forget from the route.
+ * The single gate is maybeAnnounceOnOpen in @/lib/programAnnounce — it owns the
+ * announceOnOpen opt-in, the transition rule, and the once-per-lifetime announcedAt
+ * claim, and both program-edit PATCH routes call it. This only runs after that gate
+ * has fired. Best-effort: fire-and-forget from the helper.
  */
 export async function notifyNewProgramAnnounced(
     program: { name: string; startAt: Date | null; endAt: Date | null },

--- a/checkin-app/src/lib/programAnnounce.ts
+++ b/checkin-app/src/lib/programAnnounce.ts
@@ -1,0 +1,83 @@
+import { logger } from "@/lib/logger";
+import prisma from "@/lib/prisma";
+import { notifyNewProgramAnnounced } from "@/lib/notifications";
+import type { EnrollmentStatus, ProgramPhase } from "@/generated/prisma/client";
+
+// Deliberately NOT in @/lib/notifications: the announce suites mock that module
+// with a single-export factory, and a helper living there would come back
+// undefined in every one of them (#1164 review, finding 7).
+
+type AnnounceState = {
+    phase: ProgramPhase;
+    enrollmentStatus: EnrollmentStatus;
+};
+
+type AnnouncedProgram = AnnounceState & {
+    announceOnOpen: boolean;
+    name: string;
+    startAt: Date | null;
+    endAt: Date | null;
+};
+
+/**
+ * Single gate for the "new program announced" email blast (#1153/#1158) —
+ * called by both program-edit PATCH routes after their update commits.
+ *
+ * Fires only on the transition INTO (UPCOMING && OPEN) with announceOnOpen on,
+ * and at most ONCE per program lifetime: the announcedAt claim is a conditional
+ * write, so concurrent PATCHes — or closing and reopening enrollment — can't
+ * re-send the full-membership blast. announcedAt is never reset by design.
+ *
+ * Never throws: the program update has already committed when this runs, and a
+ * failed announce must not turn that committed write into a 500.
+ */
+export async function maybeAnnounceOnOpen({ programId, before, after, actorId }: {
+    programId: number;
+    before: AnnounceState;
+    after: AnnouncedProgram;
+    actorId: number;
+}): Promise<void> {
+    try {
+        const wasOpen = before.phase === 'UPCOMING' && before.enrollmentStatus === 'OPEN';
+        const nowOpen = after.phase === 'UPCOMING' && after.enrollmentStatus === 'OPEN';
+        if (wasOpen || !nowOpen) return;
+
+        if (!after.announceOnOpen) {
+            logger.info(`[announce] Program ${programId} reached UPCOMING+OPEN; announceOnOpen off — skipping.`);
+            return;
+        }
+
+        // Once-per-lifetime claim. The conditional write wins races: two callers
+        // that both read a stale "never announced" row land here, but only one
+        // gets count === 1.
+        const announcedAt = new Date();
+        const claim = await prisma.program.updateMany({
+            where: { id: programId, announcedAt: null },
+            data: { announcedAt },
+        });
+        if (claim.count !== 1) {
+            logger.info(`[announce] Program ${programId} was already announced — skipping.`);
+            return;
+        }
+
+        // The routes' own audit rows record the field edit; this one records that
+        // a full-membership email blast was triggered, by whom, when.
+        await prisma.auditLog.create({
+            data: {
+                actorId,
+                action: 'EDIT',
+                tableName: 'Program',
+                affectedEntityId: programId,
+                newData: { event: 'PROGRAM_ANNOUNCE_BLAST', announcedAt: announcedAt.toISOString() },
+            },
+        });
+
+        // Fire-without-await: paced send is ~(recipients/5) seconds — must not
+        // block the PATCH response. notifyNewProgramAnnounced swallows its own
+        // errors; .catch is belt-and-suspenders.
+        void notifyNewProgramAnnounced(after).catch((e) =>
+            logger.error("notifyNewProgramAnnounced failed:", e));
+    } catch (error) {
+        logger.error(`[announce] maybeAnnounceOnOpen failed for program ${programId}:`, error);
+    }
+}

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -205,6 +205,7 @@ export const classifications = {
         enrollmentStatus: 'public',
         orgMemberOnly: 'public',
         announceOnOpen: 'public',
+        announcedAt: 'internal',
         minAge: 'public',
         maxAge: 'public',
         maxParticipants: 'public',


### PR DESCRIPTION
Follow-up to #1164 (now merged, along with #1158). Rebased onto `main` — the diff is this PR's single commit.

Closes review findings **F2, F3, F6, F7** from [jee7s's review on #1164](https://github.com/innovationtreehouse/checkin/pull/1164).

## The design

One new nullable column, one new module, net deletion in both routes.

### F2 — nothing recorded that a program was ever announced
`Program.announcedAt DateTime?` (migration `20260721120000_program_announced_at`, additive-only, no backfill). Semantics are deliberate and match the review: **once per program lifetime**. A program that announced once never auto-announces again, even on a genuine close-and-reopen. Existing rows stay `NULL` — a live program already sitting at UPCOMING+OPEN doesn't blast on its next unrelated edit; it only announces if it crosses the edge again, once. No reset surface (none found in product docs).

### F3 — read-then-write race double-sends
The trigger claims idempotency with a conditional write:
```ts
prisma.program.updateMany({ where: { id, announcedAt: null }, data: { announcedAt: new Date() } })
```
Two concurrent PATCHes (or one on each endpoint) both observe a stale "never announced" pre-state and both reach the trigger — only the caller whose `count === 1` proceeds to audit + send.

### F6 — the blast wasn't audited
The claim winner writes its own `AuditLog` row (`action: EDIT`, `tableName: Program`, `newData: { event: 'PROGRAM_ANNOUNCE_BLAST', announcedAt }`) with the triggering `actorId` — separate from the field-edit audit row, so "who emailed the whole membership, when" is a query, not an inference from a phase diff.

### F7 — transition rule duplicated across routes
Both `programs/[id]` PATCH and `programs/[id]/settings` PATCH now call one helper: `maybeAnnounceOnOpen` in **new module `src/lib/programAnnounce.ts`**. Deliberately NOT in `@/lib/notifications` — the announce suites mock that module, and a helper there comes back `undefined` (the exact trap the review's F7 documents). The helper owns the transition rule (INTO UPCOMING+OPEN only), the `announceOnOpen` opt-in with the log-and-skip breadcrumb, the claim, the audit row, and the fire-without-await paced send. It wraps its own body — it can never throw a committed program update into a 500, which **subsumes #1164's F1 fixup try/catch** (that block is replaced by the helper call; the guarantee moved into the helper, not dropped).

#1164's fixup commit is fully reconciled: F5's up-front validation and the F8/F9/F10/F11/F12 test hardening are all kept; the fixup's announce-block try/catch and the F4 doc-comment wording are superseded by the helper and the new single-gate comment in `notifications.ts`.

## Tests

All #1164 transition + fixup cases green, plus new:
- **fires once, close + reopen does NOT re-fire** — asserted through both endpoints (`programAnnounceNotification` for `programs/[id]`, `programsSettingsAPI` for settings); `announcedAt` set and unchanged by the reopen
- **stale-pre-state double-call sends once** — helper invoked twice with the identical pre-update snapshot two concurrent PATCHes would hold; one send. (A true `Promise.all` race isn't attempted — integration tests share one DB and it would be flaky; the `updateMany` conditional-write contract plus this case is the coverage.)
- **AuditLog blast row exists with the right actor**, exactly one after fire + reopen

## Gates (from `checkin-app/`)

- `npx tsc --noEmit` — clean
- `npm run lint` (`--max-warnings 0`) — clean
- Integration, scoped `programAnnounce|programsSettingsAPI` against a fresh throwaway Postgres:
  ```
  Test Suites: 3 passed, 3 total
  Tests:       30 passed, 30 total
  ```
  (#1164's 24 + its fixup's F5/F8 + this PR's 4)
- `npx prisma migrate deploy` on a fresh DB — all migrations apply cleanly, including the new one
- migration-safety checklist: additive nullable single-statement (no txn wrap needed), no rename, the claim filters on the PK so no new index, `@sensitivity:internal` + regenerated `classifications.ts` committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)