### PR TITLE
ci: dump a task's entire log stream, not its oldest 200 events (rel/1.0)

### DIFF
--- a/.github/workflows/db-reconcile-dev.yml
+++ b/.github/workflows/db-reconcile-dev.yml
@@ -135,11 +135,7 @@ jobs:
           # Surface the container's own output either way, same as deploy-dev.
           TASK_ID="${TASK_ARN##*/}"
           echo "--- reconcile container logs (/ecs/checkin-migrate-dev) ---"
-          aws logs get-log-events \
-            --log-group-name /ecs/checkin-migrate-dev \
-            --log-stream-name "ecs/checkin-migrate/$TASK_ID" \
-            --start-from-head --limit 200 \
-            --query 'events[].message' --output text | tr '\t' '\n' || echo "(could not fetch logs)"
+          ./scripts/dump-task-logs.sh /ecs/checkin-migrate-dev "ecs/checkin-migrate/$TASK_ID"
           echo "--- end reconcile container logs ---"
 
           if [ "$EXIT_CODE" != "0" ]; then

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -183,11 +183,7 @@ jobs:
           # undiagnosed for a day.
           TASK_ID="${TASK_ARN##*/}"
           echo "--- migrate container logs (/ecs/checkin-migrate-dev) ---"
-          aws logs get-log-events \
-            --log-group-name /ecs/checkin-migrate-dev \
-            --log-stream-name "ecs/checkin-migrate/$TASK_ID" \
-            --start-from-head --limit 200 \
-            --query 'events[].message' --output text | tr '\t' '\n' || echo "(could not fetch logs)"
+          ./scripts/dump-task-logs.sh /ecs/checkin-migrate-dev "ecs/checkin-migrate/$TASK_ID"
           echo "--- end migrate container logs ---"
 
           if [ "$EXIT_CODE" != "0" ]; then

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -272,11 +272,7 @@ jobs:
           # undiagnosed for a day (mirrors deploy-dev.yml).
           TASK_ID="${TASK_ARN##*/}"
           echo "--- migrate container logs (/ecs/checkin-migrate-prod) ---"
-          aws logs get-log-events \
-            --log-group-name /ecs/checkin-migrate-prod \
-            --log-stream-name "ecs/checkin-migrate/$TASK_ID" \
-            --start-from-head --limit 200 \
-            --query 'events[].message' --output text | tr '\t' '\n' || echo "(could not fetch logs)"
+          ./scripts/dump-task-logs.sh /ecs/checkin-migrate-prod "ecs/checkin-migrate/$TASK_ID"
           echo "--- end migrate container logs ---"
 
           if [ "$EXIT_CODE" != "0" ]; then

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -312,11 +312,7 @@ jobs:
             # undiagnosed for a day (same reasoning as deploy-dev.yml's migrate step).
             TASK_ID="${TASK_ARN##*/}"
             echo "--- copy task logs (/ecs/$COPY_TASK_FAMILY), attempt $attempt ---"
-            aws logs get-log-events \
-              --log-group-name "/ecs/$COPY_TASK_FAMILY" \
-              --log-stream-name "ecs/checkin-stg-copy/$TASK_ID" \
-              --start-from-head --limit 200 \
-              --query 'events[].message' --output text | tr '\t' '\n' || echo "(could not fetch logs)"
+            ./scripts/dump-task-logs.sh "/ecs/$COPY_TASK_FAMILY" "ecs/checkin-stg-copy/$TASK_ID"
             echo "--- end copy task logs ---"
 
             # Retry only what a retry can clear. The entrypoint runs under
@@ -412,11 +408,7 @@ jobs:
 
             TASK_ID="${TASK_ARN##*/}"
             echo "--- $label logs (/ecs/checkin-migrate-stg) ---"
-            aws logs get-log-events \
-              --log-group-name /ecs/checkin-migrate-stg \
-              --log-stream-name "ecs/checkin-migrate/$TASK_ID" \
-              --start-from-head --limit 200 \
-              --query 'events[].message' --output text | tr '\t' '\n' || echo "(could not fetch logs)"
+            ./scripts/dump-task-logs.sh /ecs/checkin-migrate-stg "ecs/checkin-migrate/$TASK_ID"
             echo "--- end $label logs ---"
 
             if [ "$EXIT_CODE" != "0" ]; then
@@ -482,11 +474,7 @@ jobs:
 
             TASK_ID="${TASK_ARN##*/}"
             echo "--- repoint task logs (/ecs/$COPY_TASK_FAMILY), attempt $attempt ---"
-            aws logs get-log-events \
-              --log-group-name "/ecs/$COPY_TASK_FAMILY" \
-              --log-stream-name "ecs/checkin-stg-copy/$TASK_ID" \
-              --start-from-head --limit 200 \
-              --query 'events[].message' --output text | tr '\t' '\n' || echo "(could not fetch logs)"
+            ./scripts/dump-task-logs.sh "/ecs/$COPY_TASK_FAMILY" "ecs/checkin-stg-copy/$TASK_ID"
             echo "--- end repoint task logs ---"
 
             [ "$EXIT_CODE" = "0" ] && break

--- a/scripts/dump-task-logs.sh
+++ b/scripts/dump-task-logs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Print a stopped ECS task's ENTIRE CloudWatch stream.
+#
+#   scripts/dump-task-logs.sh <log-group> <log-stream>
+#
+# Replaces `aws logs get-log-events --start-from-head --limit 200`, which showed
+# the OLDEST 200 events. A failing task's error is at the END, so for anything
+# chatty the window closed before reaching it — a staging DB copy spent its 200
+# on `pg_dump | psql` COPY lines and the real error was never printed
+# (checkin run 29890662528).
+#
+# get-log-events returns at most 1MB/10k events per call and a nextForwardToken
+# that STOPS ADVANCING at the end of the stream — that repeat is the documented
+# end-of-stream signal, and paging on it is the only way to guarantee the tail.
+#
+# Best-effort by contract: every failure path prints a marker and returns 0, so
+# a logging problem can never fail a deploy that otherwise succeeded.
+set -uo pipefail
+
+GROUP="${1:?usage: dump-task-logs.sh <log-group> <log-stream>}"
+STREAM="${2:?usage: dump-task-logs.sh <log-group> <log-stream>}"
+MAX_PAGES="${MAX_LOG_PAGES:-50}"
+
+token=""; prev=""; page=0
+while [ "$page" -lt "$MAX_PAGES" ]; do
+    page=$((page + 1))
+    if [ -z "$token" ]; then
+        out=$(aws logs get-log-events --log-group-name "$GROUP" --log-stream-name "$STREAM" \
+                --start-from-head --limit 10000 --output json 2>&1)
+    else
+        out=$(aws logs get-log-events --log-group-name "$GROUP" --log-stream-name "$STREAM" \
+                --start-from-head --limit 10000 --next-token "$token" --output json 2>&1)
+    fi
+    if [ $? -ne 0 ]; then
+        # Page 1 failing means no logs at all; a later page means we already
+        # printed most of it — say which, rather than implying nothing was read.
+        [ "$page" = 1 ] && echo "(could not fetch logs)" || echo "(log fetch failed at page $page — output above is partial)"
+        exit 0
+    fi
+    printf '%s' "$out" | jq -r '.events[].message' 2>/dev/null || echo "(could not parse log page $page)"
+    token=$(printf '%s' "$out" | jq -r '.nextForwardToken // empty' 2>/dev/null)
+    [ -z "$token" ] && break
+    [ "$token" = "$prev" ] && break
+    prev="$token"
+done
+
+[ "$page" -ge "$MAX_PAGES" ] && echo "(log dump truncated at $MAX_PAGES pages — raise MAX_LOG_PAGES if this is real output and not a loop)"
+exit 0

--- a/scripts/test-dump-task-logs.sh
+++ b/scripts/test-dump-task-logs.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Runnable check for dump-task-logs.sh — stubbed `aws`, no network.
+#
+#   scripts/test-dump-task-logs.sh
+#
+# The bug this guards: the old fetch printed the OLDEST 200 events, so a chatty
+# task's real error (always last) never appeared. These cases pin that the whole
+# stream is printed, in order, and that paging terminates.
+set -uo pipefail
+cd "$(dirname "$0")"
+SCRIPT="$PWD/dump-task-logs.sh"
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+mkdir -p "$T/bin"; export PATH="$T/bin:$PATH"
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Stub: 3 pages of 2 events, then a repeated token (end-of-stream signal).
+cat > "$T/bin/aws" <<'EOF'
+#!/usr/bin/env bash
+tok=""
+for ((i=0;i<$#;i++)); do :; done
+args=("$@")
+for ((i=0;i<${#args[@]};i++)); do [ "${args[$i]}" = "--next-token" ] && tok="${args[$((i+1))]}"; done
+case "$FAKE_MODE:$tok" in
+  fail:*)      echo "AccessDenied" >&2; exit 254 ;;
+  failp2:t1)   echo "Throttled" >&2; exit 254 ;;
+esac
+case "$tok" in
+  "")   echo '{"events":[{"message":"line1"},{"message":"line2"}],"nextForwardToken":"t1"}' ;;
+  t1)   echo '{"events":[{"message":"line3"},{"message":"line4"}],"nextForwardToken":"t2"}' ;;
+  t2)   echo '{"events":[{"message":"ERROR: the real failure"}],"nextForwardToken":"t2"}' ;;
+esac
+EOF
+chmod +x "$T/bin/aws"
+
+echo "1. prints the ENTIRE stream, in order, including the final page"
+out=$(FAKE_MODE=ok "$SCRIPT" grp strm)
+n=$(grep -c . <<<"$out")
+[ "$n" = "5" ] || { echo "$out"; fail "expected 5 lines, got $n"; }
+[ "$(head -1 <<<"$out")" = "line1" ] || fail "first line wrong"
+grep -q "ERROR: the real failure" <<<"$out" || fail "the LAST page was not printed — this is the original bug"
+echo "   ✓ 5 lines, oldest first, final-page error present"
+
+echo "2. terminates on the repeated forward token (no infinite paging)"
+timeout 10 env FAKE_MODE=ok "$SCRIPT" grp strm >/dev/null || fail "did not terminate"
+echo "   ✓ returned promptly"
+
+echo "3. a total fetch failure is best-effort, not fatal"
+out=$(FAKE_MODE=fail "$SCRIPT" grp strm); rc=$?
+[ $rc -eq 0 ] || fail "must exit 0 so logging never fails a deploy (got $rc)"
+grep -q "could not fetch logs" <<<"$out" || { echo "$out"; fail "no marker"; }
+echo "   ✓ exit 0 with a marker"
+
+echo "4. a mid-stream failure says the output is partial"
+out=$(FAKE_MODE=failp2 "$SCRIPT" grp strm); rc=$?
+[ $rc -eq 0 ] || fail "must exit 0 (got $rc)"
+grep -q "line1" <<<"$out" || fail "should keep what it already read"
+grep -q "partial" <<<"$out" || { echo "$out"; fail "should flag partial output"; }
+echo "   ✓ keeps partial output and says so"
+
+echo "5. the page cap is enforced and announced"
+cat > "$T/bin/aws" <<'EOF'
+#!/usr/bin/env bash
+n=$RANDOM
+echo "{\"events\":[{\"message\":\"x\"}],\"nextForwardToken\":\"t$n\"}"
+EOF
+chmod +x "$T/bin/aws"
+out=$(MAX_LOG_PAGES=3 "$SCRIPT" grp strm)
+grep -q "truncated at 3 pages" <<<"$out" || { echo "$out"; fail "cap not announced"; }
+echo "   ✓ never-repeating token stops at the cap"
+
+echo "ALL CHECKS PASSED"


### PR DESCRIPTION
Same change as #1195, targeted at `rel/1.0` — the branch where it actually takes effect, since `deploy-staging.yml` executes from the pushed `rel/` branch.

Cherry-pick of `e16dbecd`, applied clean. Diff verified **identical** to #1195's, line for line.

## Why

Every ECS log dump fetched the **oldest** 200 events (`--start-from-head --limit 200`). A failing task's error is at the **end**. Staging run [29890662528](https://github.com/innovationtreehouse/checkin/actions/runs/29890662528) had log access from infra #150 and still couldn't be diagnosed — the copy task burned its 200 events on `pg_dump | psql` output and cut off mid-`setval`, before the error.

`scripts/dump-task-logs.sh` pages until `nextForwardToken` stops advancing, so the tail is always reached. Best-effort by contract: every failure path prints a marker and exits 0, so logging can never fail an otherwise-good deploy; a mid-stream failure keeps what it read and says it's partial. Page cap (`MAX_LOG_PAGES`, default 50) prevents a runaway.

Replaces **all six** call sites — `deploy-staging` (copy/migrate/repoint), `deploy-dev`, `deploy-prod`, `db-reconcile-dev` — so one implementation replaces six copies of the same invocation.

## Verification

- `./scripts/test-dump-task-logs.sh` — **ALL CHECKS PASSED** (5/5), including that the final page is printed, which is the original bug
- All workflow YAML parses; no raw `get-log-events` left in any workflow
- Diff byte-identical to #1195

## Sequencing

This is the one that unblocks diagnosis. With it on `rel/1.0`, the next staging run prints the copy task's real error instead of restore noise — which is what finally explains the `exit 3` we've now hit twice.

Order: merge this → re-run staging (`workflow_dispatch` from `rel/1.0`, or the next merge) → read the actual failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6TfaRtHA5C76d6A8yU4Nm
