### PR TITLE
fix(security): tighten over-granted admin views to public-only (#1137 findings 4/5)

### DIFF
--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -327,9 +327,11 @@ defineRoute({
 // ─── handler() conversion lands in its feature PR — AGENTS.md boundary rule ─
 
 // Standalone (one-time) events list — admin surface. The handler selects only
-// public-tier Event columns (id/name/startAt/endAt/description); the full
-// everyones band is the standard admin view so a later select widening is
-// still policy-covered rather than silently leaking.
+// public-tier Event columns only (id/name/startAt/endAt/description). Declared
+// public-only ON PURPOSE: the response is exact, not aspirational. If the select
+// later grows to an internal field (attendanceConfirmedAt/ById, postEventEmailSent)
+// the strip fails closed and forces a boundary PR + CODEOWNERS review, instead of
+// the field shipping silently under a pre-granted band.
 defineRoute({
     endpoint: 'GET /api/events',
     authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
@@ -337,8 +339,8 @@ defineRoute({
     // Bag: { Event } — bare-array response (envelope null + single-key bag).
     returns: ['Event'],
     orderedView: [
-        ['isSysadmin',    ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
-        ['isBoardMember', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
+        ['isSysadmin',    ['public']],
+        ['isBoardMember', ['public']],
     ],
 });
 
@@ -372,7 +374,10 @@ defineRoute({
 
 // App-localization singleton (timezone/locale) — sysadmin-only surface,
 // wholly public-tier data; the gate is about who may see admin settings
-// screens, not the fields.
+// screens, not the fields. Declared public-only ON PURPOSE: AppSettings is the
+// natural home for a future integration key / webhook secret, and a public-only
+// view makes that field fail closed (forcing a boundary PR) instead of shipping
+// to sysadmin through an entry nobody revisited.
 defineRoute({
     endpoint: 'GET /api/admin/settings/localization',
     authorize: { anyRole: ['isSysadmin'] },
@@ -380,7 +385,7 @@ defineRoute({
     // Bag: { AppSettings } (singleton row).
     returns: ['AppSettings'],
     orderedView: [
-        ['isSysadmin', ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
+        ['isSysadmin', ['public']],
     ],
 });
 


### PR DESCRIPTION
## What

Registry-only fix for two of the wave-1 boundary entries (PR #1137), addressing review findings **4** and **5**. Stacked on `sec/registry-wave1`.

Both `GET /api/events` and `GET /api/admin/settings/localization` declared the full everyones band (`everyones:pii/personal/internal, member, public`) while their handlers select only public-tier columns. As the reviewer noted, that's the inverse of what the isolation rule is for: widening the select to an internal field (`Event.attendanceConfirmedAt/ById`, `postEventEmailSent`; or a future integration key on the `AppSettings` singleton) would ship it with **no boundary PR and no CODEOWNERS review**, because the policy already permits it.

This declares both views `['public']` so a future select-widening **fails closed** and forces a boundary change — matching #1137's own "views are exact, not aspirational" claim.

| Endpoint | Before | After |
|---|---|---|
| `GET /api/events` | full everyones band | `['public']` |
| `GET /api/admin/settings/localization` | full everyones band | `['public']` |

## Scope

- Registry-only; no handler touched (isolation rule holds).
- The over-granted rationale comments are retracted and replaced with the fail-closed reasoning.

## Verified

- `tsc --noEmit`: clean (pre-existing `@aws-sdk/client-lambda` errors in finance-ops routes are unrelated).
- `ctxNeeds` mocked suite: 7/7 — a public-only view needs no caller context, and masked≡full still holds. No hardcoded expectation exists for these two endpoints.

## Not in scope

Findings 1 (`profile/visits` select must include `personId`) and 10 (view-delivery test) land in the `profile/visits` conversion PR, where the handler actually flips to `handler()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)