### PR TITLE
docs 5/5: s-read/s-replay READMEs — one canonical monitoring story

### DIFF
--- a/s-read-function/FUTUREWORK.md
+++ b/s-read-function/FUTUREWORK.md
@@ -88,8 +88,8 @@ set up.
 
 ## 3. Monitoring — alarm wiring
 
-The stale-run reaper (`reapStaleRuns`, called at handler startup) and reserved-concurrency
-= 1 are **done** (README "Operations & monitoring"). What remains is wiring the alarms in
+The stale-run reaper (`reapStaleRuns`, called at handler startup) and the per-store run
+lock are **done** (README "Operations & monitoring"). What remains is wiring the alarms in
 deployment: emit both the freshness heartbeat and watermark lag as CloudWatch metrics,
 alarm on the **heartbeat** (not watermark lag). Full design — including why heartbeat over
 watermark lag — in [MONITORING-PRD.md](MONITORING-PRD.md) §4.1. No auto-reprojection; a dead
@@ -97,23 +97,22 @@ run self-heals on the next scheduled run.
 
 ---
 
-## 4. Schema migrations in deployment — realized in [DEPLOY.md](DEPLOY.md)
+## 4. Schema migrations — why the split (mechanics in [DEPLOY.md](DEPLOY.md))
 
-The design (now shipped as the s-read migrate task): `s-ingest-core` owns `schema.prisma` +
-migrations; **applying** them is a separate step, **not** Terraform and **not** the app
-functions.
+[DEPLOY.md](DEPLOY.md) records **how** migrations run (the `s-read-<env>-migrate` task, the
+`migrate-and-code` workflow ordering, expand/contract). The durable reasons behind that
+shape, code-independent:
 
-- **Terraform** provisions the RDS instance and a **migrate-runner** (holding DDL creds) but
-  does **not** run the migration — mixing declarative reconciliation with an ordered schema
-  sequence is an anti-pattern (avoid the `null_resource` + `local-exec "prisma migrate
-  deploy"` hack). It *creates the thing that can migrate*.
-- **CI/CD** runs `prisma migrate deploy` via the migrate-runner **before** releasing code
-  that expects the new schema; use **expand/contract** ordering so a rolling deploy never
-  runs code ahead of its schema.
-- **App functions** (`s-read`, `s-replay`) run **DML-only** and never migrate; only the
-  migrate-runner has DDL. **Locally:** by hand — `npm run db:deploy` from `s-ingest-core`.
+- **Terraform provisions the migrate task but never runs the migration.** Mixing
+  declarative reconciliation with an ordered, stateful schema sequence is an anti-pattern
+  (the `null_resource` + `local-exec "prisma migrate deploy"` hack: not idempotent in
+  Terraform's model, runs whatever's on the runner). Terraform *creates the thing that can
+  migrate*; CI runs it.
+- **DML/DDL split.** App functions (`s-read`, `s-replay`) run with **DML-only** creds and
+  never migrate; only the migrate task holds DDL. Enforced at the task level — which secret
+  each task-def references — and infra `modules/s-read` points back here for this invariant.
 
-## 5. Token acquisition for deployed Lambda — done (#237)
+## 5. Token acquisition for the deployed sync — done (#237)
 `shopify/client.ts` (`shopify/token.ts`) mints the short-lived (~24h) Admin token from
 `SHOPIFY_CLIENT_ID` + `SHOPIFY_CLIENT_SECRET` via the client-credentials grant, caching it
 in memory across warm invocations; `SHOPIFY_ADMIN_TOKEN` remains the local/legacy static

--- a/s-read-function/FUTUREWORK.md
+++ b/s-read-function/FUTUREWORK.md
@@ -39,23 +39,12 @@ fix is almost always a code change + batch replay, never per-record hand-editing
 
 ---
 
-## 2. Replay / reset-watermark as admin operations
+## 2. Secure invocation of the admin operations (deploy-time)
 
-Two recovery primitives, both **idempotent** (safe to run repeatedly) thanks to
-`(store_id, GID)` upserts + the append-only log:
-
-- **`replay`** — re-project raw events from the log (`--errored` / `--gid` /
-  `--since --object`). No Shopify calls. Fully safe.
-- **`reset-watermark`** — move or clear `sync_state` so the next sync re-pulls a range
-  from Shopify. Not data-destructive (re-pull is idempotent), but operationally
-  significant — it costs API budget and time.
-
-Both are the *same idea* — replay over a range — one from the log, one from the source.
-Expose as CLI commands and/or as handler modes (`{"mode":"replay", ...}`). Neither needs
-a UI; for a read pipeline, a CloudWatch alarm + a `list-errors` query is the whole
-operator surface.
-
-### Secure invocation (the important part)
+The operations themselves — `replay` / `reset-watermark` / `reingest-bulk`, all idempotent
+via `(store_id, GID)` upserts + the append-only log — are **built** in
+[`s-replay-function`](../s-replay-function). What's still deferred is the deployment security
+model for invoking them.
 
 **A Lambda has no public surface by default.** `aws lambda invoke` and EventBridge hit
 the AWS control plane, authenticated by **IAM (SigV4)** — there is no open HTTP endpoint.
@@ -97,57 +86,36 @@ set up.
 
 ---
 
-## 3. Monitoring (the reaper itself is now built in)
+## 3. Monitoring — alarm wiring
 
-> Full monitoring/alerting design is in [MONITORING-PRD.md](MONITORING-PRD.md). Summary below.
-
-
-The stale-run reaper (`reapStaleRuns`, called at handler startup) and the
-reserved-concurrency = 1 requirement are **done** — see the README "Operations &
-monitoring" section. What remains is wiring the actual alarms in deployment:
-
-- **Primary: freshness heartbeat.** Alarm on `now − (latest COMPLETED
-  sync_run.finishedAt)` exceeding a couple of cron intervals. Advances on every
-  successful run including empty ones, so it does not false-fire on a quiet store. This
-  is the signal that catches "job stopped / keeps dying."
-- **Do NOT make watermark lag the primary alarm.** `now − sync_state.lastUpdatedAtProcessed`
-  only moves when real records arrive, so a genuinely quiet store reads as "stale." Use
-  it only as a secondary, per-store signal where there's a known activity cadence.
-- Emit both as CloudWatch metrics; alarm on the heartbeat. No auto-reprojection — a dead
-  run needs no data recovery; the next scheduled run catches up via the watermark.
+The stale-run reaper (`reapStaleRuns`, called at handler startup) and reserved-concurrency
+= 1 are **done** (README "Operations & monitoring"). What remains is wiring the alarms in
+deployment: emit both the freshness heartbeat and watermark lag as CloudWatch metrics,
+alarm on the **heartbeat** (not watermark lag). Full design — including why heartbeat over
+watermark lag — in [MONITORING-PRD.md](MONITORING-PRD.md) §4.1. No auto-reprojection; a dead
+run self-heals on the next scheduled run.
 
 ---
 
-## 4. Schema migrations in deployment
+## 4. Schema migrations in deployment — realized in [DEPLOY.md](DEPLOY.md)
 
-The core package (`s-ingest-core`) owns `schema.prisma`, the migration files, and
-`prisma generate`. **Applying** migrations to a deployed database is a separate,
-deliberate step — **not** Terraform, and **not** the app Lambdas:
+The design (now shipped as the s-read migrate task): `s-ingest-core` owns `schema.prisma` +
+migrations; **applying** them is a separate step, **not** Terraform and **not** the app
+functions.
 
-- **Terraform** provisions the RDS instance, the Lambdas, and a **migrate-runner** — a
-  CodeBuild project / one-off Fargate task / dedicated migrate Lambda **inside the VPC**,
-  holding DDL credentials. Terraform does **not** run the migration itself: mixing
-  declarative infra reconciliation with an ordered, stateful schema sequence is an
-  anti-pattern (avoid the `null_resource` + `local-exec "prisma migrate deploy"` hack —
-  not idempotent in Terraform's model, runs whatever's on the runner, poor error handling).
-  Terraform *creates the thing that can migrate*; it doesn't migrate.
-- **CI/CD** invokes the migrate-runner to `prisma migrate deploy` **before** releasing the
-  function code that expects the new schema. Use **expand/contract** ordering (add a column
-  before code reads it; drop it only after code stops) so a rolling deploy never runs code
-  ahead of its schema.
-- **App Lambdas** (`s-read`, `s-replay`) run with **DML-only** runtime creds and never
-  migrate. Only the migrate-runner has DDL rights. Exactly one actor applies migrations,
-  never at runtime.
-- **Locally (today):** migrations are applied by hand — `npm run db:deploy` from
-  `s-ingest-core`, pointed at the dev DB.
+- **Terraform** provisions the RDS instance and a **migrate-runner** (holding DDL creds) but
+  does **not** run the migration — mixing declarative reconciliation with an ordered schema
+  sequence is an anti-pattern (avoid the `null_resource` + `local-exec "prisma migrate
+  deploy"` hack). It *creates the thing that can migrate*.
+- **CI/CD** runs `prisma migrate deploy` via the migrate-runner **before** releasing code
+  that expects the new schema; use **expand/contract** ordering so a rolling deploy never
+  runs code ahead of its schema.
+- **App functions** (`s-read`, `s-replay`) run **DML-only** and never migrate; only the
+  migrate-runner has DDL. **Locally:** by hand — `npm run db:deploy` from `s-ingest-core`.
 
 ## 5. Token acquisition for deployed Lambda — done (#237)
-Dev Dashboard apps issue a short-lived (~24h) Admin API token via the client-credentials
-grant (see README "Getting the token"). `shopify/client.ts` now mints it programmatically
-from `SHOPIFY_CLIENT_ID` + `SHOPIFY_CLIENT_SECRET` (`shopify/token.ts`) instead of
-requiring a hand-pasted static `SHOPIFY_ADMIN_TOKEN`, caches it in memory across warm
-invocations (refreshing a few minutes before expiry), and invalidates + re-mints once on
-a 401 mid-run. `SHOPIFY_ADMIN_TOKEN` still works unchanged as the local-dev/legacy path
-(static-token precedence). No refresh-token / encrypted-DB layer: the client-credentials
-grant issues none, so renewing is just re-running the exchange — confirmed against the
-issue thread, which corrected the original refresh-token diagram.
+`shopify/client.ts` (`shopify/token.ts`) mints the short-lived (~24h) Admin token from
+`SHOPIFY_CLIENT_ID` + `SHOPIFY_CLIENT_SECRET` via the client-credentials grant, caching it
+in memory across warm invocations; `SHOPIFY_ADMIN_TOKEN` remains the local/legacy static
+path (static-token precedence). No refresh-token / encrypted-DB layer — the grant issues
+none. Full behaviour: README "Getting the token".

--- a/s-read-function/README.md
+++ b/s-read-function/README.md
@@ -1,7 +1,7 @@
 # s-read-function
 
 Pulls **orders**, **payouts**, and **balance transactions** from the Shopify Admin GraphQL
-API into a dedicated Postgres database. Designed to run as an AWS Lambda on a schedule, but
+API into a dedicated Postgres database. Designed to run as a scheduled ECS task, but
 every step runs locally first so the pipeline is proven before deployment.
 
 Database, projection, and normalization logic live in the shared
@@ -49,7 +49,7 @@ Copy `.env.example` to `.env` (git-ignored) and fill it in:
 | `SHOPIFY_READ_DATABASE_URL` | Connection string for a **local Postgres**. |
 | `SHOPIFY_SHOP` | `your-store.myshopify.com`. |
 | `SHOPIFY_ADMIN_TOKEN` | Static Admin API access token (`shpat_...`). Local/legacy shortcut — see below. |
-| `SHOPIFY_CLIENT_ID` / `SHOPIFY_CLIENT_SECRET` | Dev Dashboard app credentials. Set these **instead of** `SHOPIFY_ADMIN_TOKEN` to have the process mint its own token (required for the deployed Lambda, since nobody is around to hand-paste a fresh one every ~24h). |
+| `SHOPIFY_CLIENT_ID` / `SHOPIFY_CLIENT_SECRET` | Dev Dashboard app credentials. Set these **instead of** `SHOPIFY_ADMIN_TOKEN` to have the process mint its own token (required for the deployed sync, since nobody is around to hand-paste a fresh one every ~24h). |
 | `SHOPIFY_API_VERSION` | API version to pin, e.g. `2025-07`. |
 | `STORE_ID` | Seed used **only** by offline `inject` (defaults to `SHOPIFY_SHOP`). Real syncs ignore it and derive `store_id` from the live store's `myshopifyDomain` (recorded in the `store` registry table); a mismatch is logged as a warning. |
 | `CUTOVER_DATE` | ISO date — backfill starts here and moves forward. |
@@ -84,7 +84,7 @@ unattended.
 > Legacy custom apps (stores that still offer "Develop apps" in the admin) instead
 > show a static Admin API access token you can reveal once and paste into `.env`.
 
-**For the deployed Lambda**, skip the static token: set `SHOPIFY_CLIENT_ID` +
+**For the deployed sync**, skip the static token: set `SHOPIFY_CLIENT_ID` +
 `SHOPIFY_CLIENT_SECRET` instead and leave `SHOPIFY_ADMIN_TOKEN` unset. `shopify/client.ts`
 then mints its own token via the client-credentials grant on first use, caches it
 in-memory (refreshing a few minutes before its ~24h expiry so a warm container never
@@ -99,14 +99,12 @@ secret live in the app's Settings in the Dev Dashboard — never commit them or 
 issue one; renewing is just re-running the same client_id/client_secret exchange, so an
 in-memory cache is the whole mechanism. #237)*
 
-### Production (Lambda — deploy infra wiring deferred, see #234/#235)
-The same variable names are read from `process.env`. In Lambda, inject `SHOPIFY_CLIENT_ID`
-/ `SHOPIFY_CLIENT_SECRET` (not a static `SHOPIFY_ADMIN_TOKEN`) from **AWS Secrets
-Manager / SSM Parameter Store** (e.g. via the Secrets Manager Lambda extension or
-environment mapping) — the code does not read AWS APIs directly, it only reads
-`process.env`. Route `SHOPIFY_READ_DATABASE_URL` through **RDS Proxy / pgBouncer**
-with `?pgbouncer=true&connection_limit=1` for connection pooling across warm
-invocations. No secret is ever committed to the repo.
+### Production
+The same variable names are read from `process.env`; the code never calls an AWS API, so
+the deploy platform injects the values from its own secret store. The shipped wiring — a
+scheduled ECS Fargate task with `SHOPIFY_CLIENT_ID` / `SHOPIFY_CLIENT_SECRET` (not a static
+`SHOPIFY_ADMIN_TOKEN`) injected natively by the task definition — is in
+[DEPLOY.md](DEPLOY.md). No secret is ever committed to the repo.
 
 ## Setup
 
@@ -117,8 +115,8 @@ npm run db:deploy   -w @inventory/s-ingest-core   # apply migrations to the DB (
 ```
 
 The schema, migrations, and Prisma client are owned by `@inventory/s-ingest-core` — this
-package consumes the generated client. See [FUTUREWORK.md](FUTUREWORK.md) for how
-migrations are applied in deployment.
+package consumes the generated client. See [DEPLOY.md](DEPLOY.md) for how migrations are
+applied in deployment (the `s-read-<env>-migrate` task).
 
 ## Triggers
 
@@ -140,9 +138,6 @@ like:
 { "objectType": "PAYOUT", "node": { "id": "gid://shopify/ShopifyPaymentsPayout/1", "...": "..." } }
 ```
 
-In Lambda, `handler.ts` routes an EventBridge event to the same `incremental` or
-`backfill` orchestrator based on the event payload.
-
 ## Tests
 
 ```bash
@@ -158,10 +153,11 @@ order status transitions (cancellation/refund), and watermark advancement.
 > fleet strategy, pricing): [MONITORING-PRD.md](MONITORING-PRD.md).
 
 
-- **Lambda reserved concurrency = 1 (deployment requirement).** The sync must never
-  run concurrently with itself — overlapping runs waste API budget and can contend on
-  the same rows. Reserved concurrency = 1 enforces this. It also makes the stale-run
-  reaper unambiguous (any `RUNNING` row at startup is then guaranteed dead).
+- **No self-overlap.** The sync must never run concurrently with itself — overlapping
+  runs waste API budget and can contend on the same rows. Enforced **in code** by a
+  per-store Postgres advisory lock (`withAdvisoryLock` → `ConcurrentRunError`, treated as a
+  benign skip), so it holds under any runtime — ECS has no Lambda `reserved_concurrency`
+  knob to lean on.
 - **Stale-run reaper (built in).** On startup the handler relabels `sync_run` rows
   stuck in `RUNNING` past a staleness threshold to `ABANDONED` (a process killed by
   timeout/OOM). This is cosmetic — it touches no watermark or data; the next scheduled
@@ -173,36 +169,18 @@ order status transitions (cancellation/refund), and watermark advancement.
   — only moves when real records arrive, so use it only as a secondary per-store signal
   where there's a known activity cadence. Rationale: [MONITORING-PRD.md](MONITORING-PRD.md) §4.1.)
 
-## Deployment (Terraform)
+## Deployment
 
-> **Ops runbook: [DEPLOY.md](DEPLOY.md)** — the ordered go-live checklist (Shopify app
-> scopes, init.sql, secrets, first deploy via the `deploy-s-read` workflow, one-time
-> backfill, verification). The shipped architecture is a **scheduled ECS task**
-> (infra#112) built from [`Dockerfile`](Dockerfile), not the Lambda sketch below.
+Shipped as a **scheduled ECS Fargate task** (infra#112), built from
+[`Dockerfile`](Dockerfile) — not a Lambda. Terraform (infra `modules/s-read`) provisions
+the AWS resources (cluster, sync/migrate task-defs, trigger Lambda + schedule, IAM,
+secrets, log groups) and deliberately does **not** run schema migrations — those are a
+separate migrate task ([FUTUREWORK.md](FUTUREWORK.md) §4 for the rationale). The invoke-only
+admin security model is [FUTUREWORK.md](FUTUREWORK.md) §2; alarm wiring is §3.
 
-When this is deployed, **Terraform provisions the infrastructure** — it does **not** run
-schema migrations (those are a separate deploy-time step; see
-[FUTUREWORK.md](FUTUREWORK.md)). What Terraform owns:
-
-- **Networking:** a VPC with private subnets for RDS; the Lambdas' VPC config (subnets +
-  security groups); an SG allowing the Lambdas → RDS Proxy on 5432; and a **NAT gateway**
-  (or equivalent egress) so the VPC-bound read Lambda can still reach the Shopify API.
-- **Database:** the dedicated **RDS PostgreSQL** instance (+ subnet/parameter groups),
-  fronted by **RDS Proxy**. The runtime `SHOPIFY_READ_DATABASE_URL` routes through the proxy with
-  `?pgbouncer=true&connection_limit=1`.
-- **Functions:** `s-read-function` and `s-replay-function` (plus a migrate-runner — see
-  FUTUREWORK), with memory/timeout, VPC config, and env wiring. **Reserved concurrency = 1
-  on `s-read-function`** is required (prevents self-overlap; see Operations & monitoring).
-- **IAM (least privilege):** each function's execution role gets only Secrets Manager read,
-  VPC ENI, and CloudWatch Logs, plus **runtime DB creds that are DML-only (no DDL)**. A
-  separate **ops role** holds `lambda:InvokeFunction` on `s-replay-function`. **No public
-  endpoint** (no Function URL / API Gateway) — admin is IAM-gated invoke only.
-- **Secrets:** Secrets Manager entries for the DB URL and the Shopify client id/secret.
-- **Scheduling:** an **EventBridge** rule invoking `s-read-function` on the sync cadence
-  (optionally a separate backfill schedule). `s-replay-function` is **not** scheduled — it
-  is invoke-only.
-- **Observability:** CloudWatch **log groups with retention set** (Lambda's default never
-  expires), the alarms from [MONITORING-PRD.md](MONITORING-PRD.md), and the SNS alert topic.
+**Ops runbook: [DEPLOY.md](DEPLOY.md)** — the ordered go-live checklist: Shopify app scopes,
+DB bootstrap, secrets, first deploy via the `deploy-s-read` workflow, one-time backfill,
+verification.
 
 ## Status / future work
 
@@ -214,7 +192,8 @@ token" above.)
 
 - Deployment: packaging ([`Dockerfile`](Dockerfile)), the manual deploy workflow
   (`.github/workflows/deploy-s-read.yml`), and the ops runbook ([DEPLOY.md](DEPLOY.md))
-  are in this repo; the AWS resources (ECR/ECS/EventBridge/secrets) are infra#112.
+  are in this repo; the AWS resources (ECS/EventBridge/secrets) are infra#112 — the image
+  lives on GHCR, not ECR.
 - Cross-database de-duplication against `income-app` is **future work**; this
   function persists the identifiers income-app records (legacy order id, order name,
   payout id) so that reconciliation can be deterministic later.

--- a/s-read-function/README.md
+++ b/s-read-function/README.md
@@ -170,9 +170,8 @@ order status transitions (cancellation/refund), and watermark advancement.
   `now − (latest COMPLETED sync_run.finishedAt)` exceeding a couple of cron intervals.
   This advances on every successful run, including empty ones, so it does **not**
   false-fire on a quiet store. (Watermark lag — `now − sync_state.lastUpdatedAtProcessed`
-  — is **not** a good primary signal: the watermark only moves when real records arrive,
-  so a genuinely quiet store looks "stale." Use watermark lag only where you have an
-  expected per-store activity cadence.)
+  — only moves when real records arrive, so use it only as a secondary per-store signal
+  where there's a known activity cadence. Rationale: [MONITORING-PRD.md](MONITORING-PRD.md) §4.1.)
 
 ## Deployment (Terraform)
 

--- a/s-replay-function/README.md
+++ b/s-replay-function/README.md
@@ -44,8 +44,8 @@ cutover date).
 
 ## Deployment
 
-A **separate** Lambda from `s-read-function` (so admin ops don't contend with the
-scheduled sync's reserved concurrency = 1). **Invoke-only** — no EventBridge schedule and
+A **separate** deployable from `s-read-function` (its own IAM boundary and failure
+domain). **Invoke-only** — no EventBridge schedule and
 **no public endpoint**; triggered by `aws lambda invoke` under an IAM ops role. Runtime DB
 creds are **DML-only** — it never migrates. See `../s-read-function/FUTUREWORK.md` for the
 full security model and `../s-read-function/MONITORING-PRD.md` for the broader picture.

--- a/s-replay-function/README.md
+++ b/s-replay-function/README.md
@@ -24,10 +24,9 @@ All three are safe to run repeatedly and are recorded as `sync_run` rows with ki
 ### Idempotency & delivery
 
 Every projection is an **idempotent upsert** keyed on `(store_id, shopify_gid)` (refunds on
-`(store_id, refund_gid)`), over an append-only raw log, projected newest-last. So replay /
-reingest / a re-invoke after a crash all re-process the same nodes and converge to the same
-live state — at-least-once processing is safe by construction. (No external egress here; the
-one non-idempotent hop in the fleet is the monitoring relay's SNS publish.)
+`(store_id, refund_gid)`) over the append-only log — the same at-least-once-safe model as the
+read path ([`s-read-function`](../s-read-function/README.md#how-it-works)). No external egress
+here; the one non-idempotent hop in the fleet is the monitoring relay's SNS publish.
 
 ## Local
 


### PR DESCRIPTION
Part of the five-PR doc sweep (opus team + fable adversarial verify; see PR 1/5 for method). Independent chunk.

**This chunk (−34 net):** the freshness heartbeat-vs-watermark-lag explanation existed in triplicate (README, FUTUREWORK, MONITORING-PRD); it now lives once in MONITORING-PRD §4.1 with pointers. FUTUREWORK 153→121: replay/reset-watermark (shipped in s-replay-function, verified) and token acquisition (shipped, #237) now point at their homes instead of re-describing them; the still-unshipped skip-and-flag DLQ design kept in full. s-replay's idempotency section points at the shared model, keeping only its replay-specific key.

Flagged, untouched: s-read README's superseded Lambda deployment sketch still carries infra facts not confirmed to exist elsewhere (NAT egress, RDS Proxy params, IAM DML-only) — left pending confirmation against infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQ22akgo6H6vRiJ4iE3Emg