### PR TITLE
rel/1.0: staging smoke window + staging banner (cherry-pick)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -524,8 +524,13 @@ jobs:
           set -euo pipefail
           # Real probe of the deployed service (mirrors deploy-prod.yml). The
           # app answers 200 or an auth redirect; retries cover target
-          # registration + first boot after scale-up.
-          for i in $(seq 1 12); do
+          # registration + first boot after scale-up. 10 minutes, measured, not
+          # guessed: on run 29925037763 task-start -> waker rule promote took
+          # 4m22s and the old 2-minute window expired 68s before the promote —
+          # a succeeded deploy reported as failed. The 503s during the wait are
+          # the ops-stg-waker's holding page; each probe also drives the
+          # waker's health poll, so keep the 10s cadence.
+          for i in $(seq 1 60); do
             CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$APP_URL" || echo 000)
             echo "attempt $i: $APP_URL -> HTTP $CODE"
             case "$CODE" in

--- a/checkin-app/src/app/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/__tests__/layout.test.tsx
@@ -15,6 +15,10 @@ jest.mock("@/components/DevImpersonationBar", () => ({
   __esModule: true,
   default: () => null,
 }));
+jest.mock("@/components/StagingBar", () => ({
+  __esModule: true,
+  default: () => null,
+}));
 jest.mock("@/components/DevDashboard", () => ({
   __esModule: true,
   default: () => null,

--- a/checkin-app/src/app/layout.tsx
+++ b/checkin-app/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Notifications } from '@mantine/notifications';
 import AuthProvider from '@/components/AuthProvider';
 import { EnvProvider } from '@/components/EnvProvider';
 import DevImpersonationBar from '@/components/DevImpersonationBar';
+import StagingBar from '@/components/StagingBar';
 import DevDashboard from '@/components/DevDashboard';
 import OnboardingGate from '@/components/OnboardingGate';
 import RenewalBanner from '@/components/RenewalBanner';
@@ -40,9 +41,10 @@ export default function RootLayout({
         <MantineProvider theme={brand.theme} defaultColorScheme="auto">
           <ModalsProvider>
             <Notifications />
-            <EnvProvider value={{ checkinEnv: config.checkinEnv(), shopifyStoreDomain: config.shopifyStoreDomain() }}>
+            <EnvProvider value={{ checkinEnv: config.checkinEnv(), shopifyStoreDomain: config.shopifyStoreDomain(), isStaging: config.isStaging() }}>
               <AuthProvider>
                 <OnboardingGate>
+                  <StagingBar />
                   <DevImpersonationBar />
                   <UnsavedChangesProvider>
                     <AppFrame>

--- a/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
@@ -26,7 +26,7 @@ import AdminMembershipPage from "../page";
 // reconciling, losing the page's already-fetched rows state.
 const rewrapped = () => (
     <MantineProvider>
-        <EnvProvider value={{ checkinEnv: "prod", shopifyStoreDomain: null }}>
+        <EnvProvider value={{ checkinEnv: "prod", shopifyStoreDomain: null, isStaging: false }}>
             <AdminMembershipPage />
         </EnvProvider>
     </MantineProvider>

--- a/checkin-app/src/components/EnvProvider.tsx
+++ b/checkin-app/src/components/EnvProvider.tsx
@@ -16,9 +16,11 @@ type EnvContextValue = {
     checkinEnv: CheckinEnv;
     /** Public …myshopify.com domain from SHOPIFY_STORE_DOMAIN, or null when unconfigured. */
     shopifyStoreDomain: string | null;
+    /** True on ops-stg. Separate from checkinEnv, which staging deliberately collapses to 'prod' (see config.isStaging). */
+    isStaging: boolean;
 };
 
-const CheckinEnvContext = createContext<EnvContextValue>({ checkinEnv: 'prod', shopifyStoreDomain: null });
+const CheckinEnvContext = createContext<EnvContextValue>({ checkinEnv: 'prod', shopifyStoreDomain: null, isStaging: false });
 
 export function EnvProvider({
     value,
@@ -42,6 +44,11 @@ export function useIsDevInstance(): boolean {
 /** True only on a developer laptop — gates offline credential login UI. */
 export function useIsLocalInstance(): boolean {
     return useContext(CheckinEnvContext).checkinEnv === 'local';
+}
+
+/** True on ops-stg — gates the staging banner. NOT a mock gate; staging keeps checkinEnv 'prod'. */
+export function useIsStagingInstance(): boolean {
+    return useContext(CheckinEnvContext).isStaging;
 }
 
 /**

--- a/checkin-app/src/components/StagingBar.tsx
+++ b/checkin-app/src/components/StagingBar.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { useIsStagingInstance } from "@/components/EnvProvider";
+
+/**
+ * Persistent staging-instance bar — the ops-stg counterpart of DevImpersonationBar's
+ * dev banner, in amber so the two environments cannot be mistaken for each other.
+ * Shown to everyone (staging holds a scrubbed prod copy; even the /signin page
+ * should say which instance this is), not just signed-in users.
+ */
+export default function StagingBar() {
+    return (
+        <Suspense fallback={null}>
+            <StagingBarInner />
+        </Suspense>
+    );
+}
+
+function StagingBarInner() {
+    const isStaging = useIsStagingInstance();
+    const searchParams = useSearchParams();
+
+    // Same kiosk-strip rule as DevImpersonationBar/AppFrame: kiosk views are full-screen.
+    const isKioskMode = searchParams.get("mode") === "kiosk" || !!searchParams.get("sig");
+    if (!isStaging || isKioskMode) return null;
+
+    return (
+        <div
+            style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.75rem",
+                padding: "0.5rem 1rem",
+                background: "rgba(245, 158, 11, 0.15)",
+                borderBottom: "1px solid rgba(245, 158, 11, 0.4)",
+                fontSize: "0.85rem",
+            }}
+        >
+            <span style={{ fontWeight: 600 }}>
+                🚧 Staging instance — scrubbed copy of production data; changes here are discarded on the next reseed
+            </span>
+        </div>
+    );
+}

--- a/checkin-app/src/components/__tests__/StagingBar.test.tsx
+++ b/checkin-app/src/components/__tests__/StagingBar.test.tsx
@@ -1,0 +1,31 @@
+import { screen } from "@testing-library/react";
+import StagingBar from "../StagingBar";
+import { renderWithProviders, resetRtl, setStagingInstance } from "@/test-helpers/rtl";
+
+let search = "";
+jest.mock("next/navigation", () => ({
+    useSearchParams: () => new URLSearchParams(search),
+}));
+
+beforeEach(() => {
+    resetRtl();
+    search = "";
+});
+
+it("renders the staging banner on the staging instance", () => {
+    setStagingInstance(true);
+    renderWithProviders(<StagingBar />);
+    expect(screen.getByText(/Staging instance/)).toBeInTheDocument();
+});
+
+it("renders nothing outside staging", () => {
+    renderWithProviders(<StagingBar />);
+    expect(screen.queryByText(/Staging instance/)).not.toBeInTheDocument();
+});
+
+it("renders nothing in kiosk mode, like the dev bar", () => {
+    setStagingInstance(true);
+    search = "mode=kiosk";
+    renderWithProviders(<StagingBar />);
+    expect(screen.queryByText(/Staging instance/)).not.toBeInTheDocument();
+});

--- a/checkin-app/src/test-helpers/rtl.tsx
+++ b/checkin-app/src/test-helpers/rtl.tsx
@@ -58,6 +58,7 @@ if (typeof window !== "undefined") {
 // setShopifyStoreDomain / setCheckinEnv; resetRtl restores the prod defaults.
 let checkinEnv: CheckinEnv = "prod";
 let shopifyStoreDomain: string | null = null;
+let isStaging = false;
 
 /** Set the mocked CHECKIN_ENV seen by useCheckinEnv/useIsLocalInstance. */
 export function setCheckinEnv(env: CheckinEnv) {
@@ -67,12 +68,16 @@ export function setCheckinEnv(env: CheckinEnv) {
 export function setShopifyStoreDomain(domain: string | null) {
     shopifyStoreDomain = domain;
 }
+/** Set the mocked ops-stg flag seen by useIsStagingInstance. */
+export function setStagingInstance(v: boolean) {
+    isStaging = v;
+}
 
 /** Render `ui` wrapped in the providers a page/component tree needs. */
 export function renderWithProviders(ui: ReactElement, options?: RenderOptions) {
     return render(
         <MantineProvider>
-            <EnvProvider value={{ checkinEnv, shopifyStoreDomain }}>{ui}</EnvProvider>
+            <EnvProvider value={{ checkinEnv, shopifyStoreDomain, isStaging }}>{ui}</EnvProvider>
         </MantineProvider>,
         options,
     );
@@ -130,6 +135,7 @@ export function resetRtl() {
     session = { data: null, status: "unauthenticated" };
     checkinEnv = "prod";
     shopifyStoreDomain = null;
+    isStaging = false;
 }
 
 // ── fetch stub ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Cherry-pick of both commits from the main PR (staging deploys and serves from this branch): the measured 10-minute smoke window and the amber staging-instance banner. See the main PR for full rationale and the run-29925037763 timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQ22akgo6H6vRiJ4iE3Emg