### PR TITLE
feat(security): register GET /api/events (public-only view, inert)

### DIFF
--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -323,6 +323,26 @@ defineRoute({
     ],
 });
 
+// Standalone (one-time) events list — admin surface. Registered ahead of its
+// handler() conversion (inert until then; AGENTS.md boundary-isolation rule).
+// The handler selects only public-tier Event columns (id/name/startAt/endAt/
+// description). Declared public-only ON PURPOSE: the response is exact, not
+// aspirational. If the select later grows to an internal field
+// (attendanceConfirmedAt/ById, postEventEmailSent) the strip fails closed and
+// forces a boundary PR + CODEOWNERS review, instead of the field shipping
+// silently under a pre-granted band.
+defineRoute({
+    endpoint: 'GET /api/events',
+    authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
+    envelope: null,
+    // Bag: { Event } — bare-array response (envelope null + single-key bag).
+    returns: ['Event'],
+    orderedView: [
+        ['isSysadmin',    ['public']],
+        ['isBoardMember', ['public']],
+    ],
+});
+
 // ─── Outbound surfaces ─────────────────────────────────────────────────────
 
 defineOutbound({


### PR DESCRIPTION
## What

First of the wave-1 read routes, re-cut as a **small registry-only PR to `main`** — replacing the 10-routes-in-one boundary batch (#1137) with one route per PR, per the request to keep these small and land them directly on `main`.

Adds a single `defineRoute` entry for `GET /api/events`. The handler stays on `withAuth`, so the entry is **inert** (the stripper isn't wired until the handler's `handler()` conversion lands in its own follow-up PR).

## View

Declared **public-only** (`['public']`) deliberately — the handler selects only public-tier `Event` columns (id/name/startAt/endAt/description), so the declared view is exact, not aspirational. If the select later grows to an internal field (`attendanceConfirmedAt/ById`, `postEventEmailSent`), the strip **fails closed** and forces a boundary + CODEOWNERS review rather than shipping silently under a pre-granted band. This folds in #1137 review findings 4/5 at the point of registration.

## Verified

- `tsc --noEmit`: clean (registry/security).
- Mocked security suites (`ctxNeeds`, `authzRegistry`, `scopeBindingsEquivalence`): **12/12**.
- Boundary-isolation: `registry.ts` only.
- Built in an isolated git worktree off fresh `origin/main`.

## Sequencing

Remaining wave-1 routes (facility, profile-visits, settings, system-status) follow as their own small registry-only PRs to `main`. Each route's `handler()` conversion is a separate follow-up PR once its entry lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)