### PR TITLE
fix(programs): stack card actions so labels don't truncate (#1218)

### DIFF
--- a/checkin-app/src/app/programs/page.tsx
+++ b/checkin-app/src/app/programs/page.tsx
@@ -154,7 +154,7 @@ export default function PublicProgramsDirectory() {
                   </Card>
                 )}
 
-                <Group grow>
+                <Stack gap="xs">
                   <Button component={Link} href={`/programs/${program.id}`} variant="light">
                     View details and enroll
                   </Button>
@@ -163,7 +163,7 @@ export default function PublicProgramsDirectory() {
                       Manage
                     </Button>
                   )}
-                </Group>
+                </Stack>
               </Card>
             );
           })}


### PR DESCRIPTION
## Problem

Fixes #1218. On the public programs directory (`/programs`), a program leader saw the primary button's label truncated to **"View details and e"** next to the **Manage** button.

The two card actions were wrapped in a Mantine `<Group grow>`, which splits the card width equally between children. With both buttons present, the longer "View details and enroll" label didn't fit its half and got clipped.

## Fix

Swap `<Group grow>` for `<Stack gap="xs">`, so the actions stack vertically and each button spans the full card width. Non-manager viewers (single button) are unaffected visually.

## Testing

- programs page tests: 4 suites / 12 pass (existing link-name/href assertions unchanged).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)