### PR TITLE
fix(notifications): real program-lead welcome email (#1220)

### DIFF
--- a/checkin-app/src/app/api/programs/route.ts
+++ b/checkin-app/src/app/api/programs/route.ts
@@ -238,7 +238,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         });
 
         if (newProgram.leadMentorId) {
-            await sendNotification(newProgram.leadMentorId, 'PROGRAM_ASSIGNMENT', { programName: newProgram.name });
+            await sendNotification(newProgram.leadMentorId, 'PROGRAM_ASSIGNMENT', { programName: newProgram.name, programId: newProgram.id });
         }
 
         const responseObj: Record<string, unknown> = { success: true, program: newProgram };

--- a/checkin-app/src/lib/__tests__/notifications.test.ts
+++ b/checkin-app/src/lib/__tests__/notifications.test.ts
@@ -52,6 +52,22 @@ describe('sendNotification return contract', () => {
         await expect(sendNotification(1, 'CHECKIN', {})).resolves.toBe(true);
         expect(mockSendEmail).not.toHaveBeenCalled();
     });
+
+    it('PROGRAM_ASSIGNMENT sends the welcome email with a manage link, not the generic "System Action" copy (#1220)', async () => {
+        mockFindUnique.mockResolvedValue({ email: 'lead@b.com', name: 'Lead', notificationSettings: {} });
+        mockSendEmail.mockResolvedValue(true);
+
+        await sendNotification(7, 'PROGRAM_ASSIGNMENT', { programName: 'FLL Team A', programId: 42 });
+
+        expect(mockSendEmail).toHaveBeenCalledTimes(1);
+        const [to, subject, html] = mockSendEmail.mock.calls[0];
+        expect(to).toBe('lead@b.com');
+        expect(subject).toBe('Your Innovation Treehouse Program has been Created!');
+        expect(html).not.toContain('System Action');
+        expect(html).toContain('FLL Team A');
+        expect(html).toContain('/program-ops/programs/42');
+        expect(html).toContain('href=');
+    });
 });
 
 describe('notifyNewProgramAnnounced opt-in filtering', () => {

--- a/checkin-app/src/lib/email-templates/program-assignment.ts
+++ b/checkin-app/src/lib/email-templates/program-assignment.ts
@@ -1,0 +1,21 @@
+import { escapeHtml, baseEmailLayout } from "./base";
+
+/**
+ * Welcome email sent to a program lead when their program is created/approved
+ * (#1220). Replaces the generic "System Action: PROGRAM_ASSIGNMENT" copy with a
+ * congratulatory message and a link to the program-management page.
+ */
+export function programAssignmentTemplate(args: { programName: string; manageUrl: string }): string {
+    const name = escapeHtml(args.programName);
+    // manageUrl is server-built from config.baseUrl() + a numeric id — not user input.
+    const url = escapeHtml(args.manageUrl);
+    return baseEmailLayout(`
+        <h2 style="color: #0f172a;">Your Innovation Treehouse Program has been Created!</h2>
+        <p>Congrats! Your program <strong>${name}</strong> has been approved and initialized by Innovation Treehouse.</p>
+        <p>You can manage it <a href="${url}">here</a>.</p>
+        <p>We recommend adding the first couple of events to the program, and then marking it open
+        for enrollment as soon as you can so our community can start signing up!</p>
+        <p>Thank you again for your commitment to teaching and fostering community with this upcoming program,</p>
+        <p>Sincerely,<br />Innovation Treehouse</p>
+    `);
+}

--- a/checkin-app/src/lib/notifications.ts
+++ b/checkin-app/src/lib/notifications.ts
@@ -5,6 +5,8 @@ import { formatTime, formatDate } from "./time";
 import { checkinReceiptTemplate } from "./email-templates/checkin";
 import { householdMemberTemplate } from "./email-templates/household";
 import { escapeHtml, type VisitSource } from "./email-templates/base";
+import { programAssignmentTemplate } from "./email-templates/program-assignment";
+import { config } from "./config";
 import { LIVE_PERSON } from "./person/filters";
 import {
     ACTIVE_ORG_MEMBER_PERSON_WHERE,
@@ -36,14 +38,24 @@ export async function sendNotification(userId: number, eventType: NotificationEv
         // No user / no address: nothing can ever be sent here — treat as done, not retryable.
         if (!user || !user.email) return true;
 
-        // Construct message based on type
+        // Construct message based on type. `html`, when set, is sent verbatim as the
+        // email body (already-safe HTML from a template); otherwise `message` is
+        // escaped and wrapped in a <p>.
         let message = "";
         let subject = "Treehouse Notification";
+        let html: string | null = null;
 
         switch (eventType) {
             case 'PROGRAM_ENROLLMENT':
                 subject = `Confirmed: Enrollment in ${payload.programName}`;
                 message = `Hi ${user.name}, you have been successfully enrolled in ${payload.programName}.`;
+                break;
+            case 'PROGRAM_ASSIGNMENT':
+                subject = 'Your Innovation Treehouse Program has been Created!';
+                html = programAssignmentTemplate({
+                    programName: String(payload.programName ?? 'your program'),
+                    manageUrl: `${config.baseUrl()}/program-ops/programs/${payload.programId}`,
+                });
                 break;
             case 'CHECKIN':
                 subject = `✅ Checked In — ${user.name}`;
@@ -64,7 +76,7 @@ export async function sendNotification(userId: number, eventType: NotificationEv
         // Email disabled: return true so a user who opted out isn't retried forever.
         if (!wantsEmail) return true;
 
-        const ok = await sendEmail(user.email, subject, `<p>${escapeHtml(message)}</p>`);
+        const ok = await sendEmail(user.email, subject, html ?? `<p>${escapeHtml(message)}</p>`);
         return ok;
 
     } catch (error) {


### PR DESCRIPTION
Closes #1220.

## Problem
Program leads received a notification on program creation, but `sendNotification` had no `case` for `PROGRAM_ASSIGNMENT`, so it fell through to the `default` branch — body `System Action: PROGRAM_ASSIGNMENT`, subject `Treehouse Notification`.

## Fix
- **`email-templates/program-assignment.ts`** (new) — welcome-email template using the shared `baseEmailLayout`, with the copy from the issue and a "manage it here" link.
- **`notifications.ts`** — added the `PROGRAM_ASSIGNMENT` case (real subject + templated HTML). `sendNotification` gains an optional pre-built `html` body path so this case renders a linked template instead of the escaped one-liner; the other cases are untouched.
- **`api/programs/route.ts`** — passes `programId` in the payload so the link targets `/program-ops/programs/<id>` (the lead's manage page). URL base from `config.baseUrl()`, matching `postEventEmails.ts`.
- **`notifications.test.ts`** — asserts the welcome subject, the manage link, program name, and that the body no longer contains "System Action".

## Verification
- `tsc --noEmit`: no new errors in touched files (remaining failures are pre-existing: missing generated Prisma client, `xlsx`, test `any`s).
- Targeted jest: 7/7 pass, including the new case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)