### PR TITLE
docs(agents): wire AGENTS.md into every agent + add concise comment policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,9 @@
+# Jules Security Sentinel Log
+
+> **Start with [AGENTS.md](../AGENTS.md)** — the shared, canonical orientation
+> for all agents in this repo. This file is Jules's running log of security
+> learnings, not general instructions; keep it cross-consistent with AGENTS.md.
+
 ## 2024-05-24 - [Timing Attack in Webhook Verification]
 **Vulnerability:** Found a timing attack vulnerability in `src/app/api/webhooks/shopify/route.ts` where the HMAC signature from Shopify (`headerSignature`) was being compared to the expected signature (`generatedSignature`) using a standard string equality operator (`!==`).
 **Learning:** Standard string comparisons fail early as soon as a mismatching character is found. This "fail-fast" behavior leaks timing information to an attacker, theoretically allowing them to guess the correct HMAC character by character and forge a valid Shopify webhook signature to bypass payment verification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,29 @@ After a `git merge`/`rebase`/`cherry-pick` (or any external write) touches a
 file you're about to edit, re-Read it first — it counts as modified since your
 last Read.
 
+## Comments
+
+A code comment describes what the code below it does and why it exists **now**,
+in the present tense. Keep it short — usually one line. Prefer making the code
+self-explanatory (better names, smaller functions) over explaining it.
+
+- **No history in comments.** Don't narrate how the code got here: no "used
+  to…", "previously…", "changed because…", "workaround for the old…", bug/PR
+  numbers, TODO-from-2023, or a log of past attempts. That context belongs in
+  the PR description and commit message, where it's linked to the diff and
+  reviewable — not stranded in the source where it rots.
+- **A "why" comment is fine when the reason is non-obvious and still true** —
+  an ordering constraint, an external-API quirk, a security invariant. State
+  the constraint, not the story of discovering it.
+- **Delete stale comments when you touch the code.** A comment that no longer
+  matches the code is worse than none.
+- If a comment needs multiple paragraphs to make sense, that's usually a signal
+  the code or its name should change instead.
+
+Design rationale, regressions-to-learn-from, and past approaches live in
+`docs/` and PR history — not in code comments. (This file's own flow-test
+section is an example: the failure stories sit in docs, not in the source.)
+
 ## Test classes
 
 There are **three** classes of tests. Run all commands from `checkin-app/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+Claude Code loads this file automatically at the start of every session. The
+real agent orientation for this repo lives in **AGENTS.md** (the shared
+instructions for all agents) — it's imported below so every Claude session,
+including subagents, picks it up. Keep the guidance in AGENTS.md; this file is
+just the loader.
+
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,10 @@
 # Agent Instructions & Guidelines
 
+> **Start with [AGENTS.md](AGENTS.md)** — the shared, canonical orientation for
+> all agents in this repo (repo layout, test classes, docs map, and the
+> commenting strategy). The rules below are Gemini-specific additions on top of
+> it. Keep the two cross-consistent.
+
 ## Code Quality & Linting
 - **NEVER fix lint errors by disabling the linter.** Do not use `// eslint-disable-next-line`, `/* eslint-disable */`, `@ts-expect-error`, or `@ts-ignore` to suppress errors.
 - **NEVER fix TypeScript errors by using `any` coercions.** Always properly type variables, parameters, and return signatures. If a type isn't immediately obvious, define an interface or use `unknown` and perform proper type narrowing.


### PR DESCRIPTION
## Why

Two problems with agent guidance in this repo:

1. **AGENTS.md wasn't actually being read by Claude.** Claude Code auto-loads `CLAUDE.md`, not `AGENTS.md`, and there was no `CLAUDE.md` (or symlink) — so the intended shared orientation was silently ignored by every Claude session.
2. **No commenting guidance existed anywhere**, which showed up as multi-line comments reading like a history of tech debt rather than a short description of what/why a function exists.

## What

- **`CLAUDE.md`** (new) — a thin loader that imports AGENTS.md via `@AGENTS.md`, so every Claude session (including subagents) picks it up. AGENTS.md stays the single source of truth.
- **`AGENTS.md`** — new **Comments** section: a comment describes what/why the code exists *now*; history, bug/PR numbers, and past attempts belong in PR descriptions and commit messages, not source. "Why" comments are fine when the reason is non-obvious and still true.
- **`GEMINI.md`** / **`.jules/sentinel.md`** — pointers back to AGENTS.md as the canonical shared instructions, satisfying AGENTS.md's own cross-consistency rule.

Docs-only; no app/code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)