### PR TITLE
feat(privacy): delete DoB for all adults (26+) (#1165)

### DIFF
--- a/checkin-app/prisma/migrations/20260724120000_purge_adult_dob/migration.sql
+++ b/checkin-app/prisma/migrations/20260724120000_purge_adult_dob/migration.sql
@@ -1,0 +1,17 @@
+-- #1165: delete DoB for all adults (26+).
+--
+-- No age-gated program can target anyone over 25 (MAX_PROGRAM_AGE in
+-- lib/programAge.ts), so an exact date of birth for a 26+ person is dead weight on
+-- Person.dateOfBirth — our most-sensitive (@sensitivity:personal) field. Strip it
+-- and set isDeclaredAdult so age gates, the people picker and the household UI
+-- still classify them as an adult (all already honor the flag).
+--
+-- Data-only backfill: no schema change. This is a deliberate, one-time deletion of
+-- live data (the whole point of the issue), NOT an accidental data-loss migration.
+-- Tombstoned (merged) rows are included — privacy applies to dead records too.
+-- The nightly cron re-runs the same statement for anyone who crosses 26 afterward.
+UPDATE "Person"
+SET "dateOfBirth" = NULL,
+    "isDeclaredAdult" = true
+WHERE "dateOfBirth" IS NOT NULL
+  AND "dateOfBirth" <= (CURRENT_DATE - INTERVAL '26 years');

--- a/checkin-app/src/app/api/cron/nightly/route.ts
+++ b/checkin-app/src/app/api/cron/nightly/route.ts
@@ -68,12 +68,28 @@ export const GET = withCron(async () => {
         // 2. Process all pending post-event emails immediately, regardless of 1-hour delay
         const emailResult = await processPostEventEmails({ forceImmediate: true });
 
-        return NextResponse.json({ 
-            success: true, 
+        // 3. #1165: delete DoB for anyone who has crossed 26 since the last run. No
+        // age-gated program can target anyone over 25 (MAX_PROGRAM_AGE), so a DoB for
+        // a 26+ person is dead weight on our most-sensitive field. Strip it and set the
+        // declared-adult flag so age gates / search / UI still see them as an adult.
+        // The #1165 backfill migration did the one-time sweep; this keeps it clean as
+        // members age in. Raw SQL so age is judged in the DB, tombstones included.
+        const adultDobPurged = await prisma.$executeRaw`
+            UPDATE "Person"
+            SET "dateOfBirth" = NULL, "isDeclaredAdult" = true
+            WHERE "dateOfBirth" IS NOT NULL
+              AND "dateOfBirth" <= (CURRENT_DATE - INTERVAL '26 years')`;
+        if (adultDobPurged > 0) {
+            logger.info(`Nightly cron: purged DoB for ${adultDobPurged} member(s) now over 25 (#1165).`);
+        }
+
+        return NextResponse.json({
+            success: true,
             facilityClose: {
                 checkedOutCount,
                 boardNotified
             },
-            postEvents: emailResult
+            postEvents: emailResult,
+            adultDobPurged
         });
 });

--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -7,6 +7,7 @@ import { reconcileAndWarn } from "@/lib/emergencyContacts/service";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
 import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
 import { householdLeadship } from "@/lib/household/leads";
+import { normalizeAdultDob } from "@/lib/person/adultDob";
 import { apiError } from "@/lib/api-response";
 
 export const PATCH = withAuth(
@@ -51,10 +52,12 @@ export const PATCH = withAuth(
                     data: {
                         name: name !== undefined ? name : undefined,
                         email: email !== undefined ? (email === "" ? null : email.toLowerCase()) : undefined,
-                        dateOfBirth: dob !== undefined ? (dob === "" ? null : new Date(dob + "T12:00:00Z")) : undefined,
                         phone: phone !== undefined ? (phone === "" ? null : formatPhone(phone)) : undefined,
-                        // A real DoB supersedes the 25+ flag; otherwise honor the checkbox.
-                        isDeclaredAdult: over25 !== undefined ? (dob ? false : !!over25) : undefined,
+                        // #1165: a real sub-26 DoB is kept and supersedes the 25+ flag; a
+                        // 26+ DoB is stripped and forces the flag on; an empty DoB honors
+                        // the checkbox. `undefined` dob leaves the field unchanged.
+                        ...(dob !== undefined ? normalizeAdultDob(dob === "" ? null : dob + "T12:00:00Z") : {}),
+                        ...(over25 !== undefined && !dob ? { isDeclaredAdult: !!over25 } : {}),
                         allergies: allergies !== undefined ? (allergies === "" ? null : allergies) : undefined,
                     },
                     select: HOUSEHOLD_PEER_SELECT,

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -8,6 +8,7 @@ import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
 import { isOrgAccount } from "@/lib/orgAccount";
 import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
 import { householdLeadship } from "@/lib/household/leads";
+import { normalizeAdultDob } from "@/lib/person/adultDob";
 import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
@@ -104,9 +105,11 @@ export const PATCH = withAuth(
                     data: {
                         name: memberName,
                         ...(memberEmail && { email: memberEmail.toLowerCase() }),
-                        dateOfBirth: memberDob ? new Date(memberDob) : null,
+                        // #1165: strip DoB + declare adult when the entered date is 26+.
+                        // When no DoB is given, the over-25 checkbox owns the flag.
+                        ...normalizeAdultDob(memberDob || null),
                         ...(memberPhone && { phone: formatPhone(memberPhone) }),
-                        isDeclaredAdult: !memberDob && !!memberOver25,
+                        ...(memberDob ? {} : { isDeclaredAdult: !!memberOver25 }),
                         allergies: memberAllergies || null,
                         householdId,
                     },

--- a/checkin-app/src/app/api/membership-ops/participants/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth";
 import { logBackendError } from "@/lib/logger";
 import { addHouseholdLead, HouseholdLeadLimitError } from "@/lib/household/leads";
 import { isValidEmail } from "@/lib/emergencyContacts/identity";
+import { normalizeAdultDob } from "@/lib/person/adultDob";
 import { apiError } from "@/lib/api-response";
 
 export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (req, auth) => {
@@ -80,7 +81,8 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                 data: {
                     name,
                     ...(email && { email }),
-                    dateOfBirth: dob ? new Date(dob).toISOString() : null,
+                    // #1165: 26+ participants are stored declared-adult with no DoB.
+                    ...normalizeAdultDob(dob),
                     householdId: householdIdToAssign
                 }
             });
@@ -90,7 +92,8 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                 data: {
                     name,
                     ...(email && { email }),
-                    dateOfBirth: dob ? new Date(dob).toISOString() : null,
+                    // #1165: 26+ participants are stored declared-adult with no DoB.
+                    ...normalizeAdultDob(dob),
                     household: {
                         create: { name: lastName ? `${lastName} Household` : "Household" }
                     }

--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -5,6 +5,7 @@ import { withAuth } from "@/lib/auth";
 import { handler, notFound, unauthorized } from "@/security/handler";
 import { isValidPhone, formatPhone, PHONE_ERROR } from "@/lib/phone";
 import { isYouth } from "@/lib/time";
+import { normalizeAdultDob } from "@/lib/person/adultDob";
 import { apiError } from "@/lib/api-response";
 
 export const GET = handler('GET /api/profile', async ({ auth }) => {
@@ -50,7 +51,9 @@ export const PATCH = withAuth(
                 data: {
                     name: name !== undefined ? name : undefined,
                     phone: phone !== undefined ? (phone === "" ? null : formatPhone(phone)) : undefined,
-                    dateOfBirth: dob ? new Date(dob) : undefined,
+                    // #1165: a self-entered DoB for a 26+ member is stripped and the
+                    // over-25 flag set instead. Empty dob leaves the field unchanged.
+                    ...(dob ? normalizeAdultDob(dob) : {}),
                     notificationSettings: notificationSettings !== undefined ? notificationSettings : undefined,
                     emailSuppressed: emailSuppressed !== undefined ? !!emailSuppressed : undefined,
                 },

--- a/checkin-app/src/lib/person/__tests__/adultDob.test.ts
+++ b/checkin-app/src/lib/person/__tests__/adultDob.test.ts
@@ -1,0 +1,30 @@
+import { normalizeAdultDob } from "@/lib/person/adultDob";
+
+// #1165: no DoB above the program-age ceiling (25). The boundary is the whole point.
+describe("normalizeAdultDob", () => {
+  const yearsAgo = (n: number) => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() - n);
+    // step off the birthday so age math is unambiguous mid-year
+    d.setDate(d.getDate() - 1);
+    return d;
+  };
+
+  it("clears the date and leaves the flag alone for empty input", () => {
+    expect(normalizeAdultDob(null)).toEqual({ dateOfBirth: null });
+    expect(normalizeAdultDob(undefined)).toEqual({ dateOfBirth: null });
+    expect(normalizeAdultDob("")).toEqual({ dateOfBirth: null });
+  });
+
+  it("keeps a real DoB and un-declares for age <= 25", () => {
+    const dob = yearsAgo(25);
+    expect(normalizeAdultDob(dob)).toEqual({ dateOfBirth: dob, isDeclaredAdult: false });
+    const teen = yearsAgo(14);
+    expect(normalizeAdultDob(teen)).toEqual({ dateOfBirth: teen, isDeclaredAdult: false });
+  });
+
+  it("strips the DoB and declares adult for age > 25", () => {
+    expect(normalizeAdultDob(yearsAgo(26))).toEqual({ dateOfBirth: null, isDeclaredAdult: true });
+    expect(normalizeAdultDob(yearsAgo(40))).toEqual({ dateOfBirth: null, isDeclaredAdult: true });
+  });
+});

--- a/checkin-app/src/lib/person/adultDob.ts
+++ b/checkin-app/src/lib/person/adultDob.ts
@@ -1,0 +1,31 @@
+import { calculateAge } from "@/lib/time";
+import { MAX_PROGRAM_AGE } from "@/lib/programAge";
+
+/**
+ * Normalize a DoB write so we never store a date of birth for someone over the
+ * program-age ceiling (issue #1165 — "delete DoB for all adults").
+ *
+ * No age-gated program can target anyone over MAX_PROGRAM_AGE (25), so an exact
+ * DoB for a 26+ person is dead weight on the most-sensitive field we hold. Strip
+ * it and set isDeclaredAdult instead, so age gates, the people picker and the
+ * household UI still classify them as an adult (all already honor the flag).
+ *
+ * Rules:
+ *   - empty / null DoB       -> clear the date, leave isDeclaredAdult to the caller
+ *                               (the "over 25" checkbox owns the flag in that case)
+ *   - DoB implies age > 25   -> clear the date, set isDeclaredAdult = true
+ *   - DoB implies age <= 25   -> keep the date, set isDeclaredAdult = false
+ *                               (a real sub-26 DoB is authoritative, supersedes the flag)
+ *
+ * Route EVERY interactive path that persists Person.dateOfBirth through this. The
+ * nightly cron + the #1165 backfill migration are the safety net for rows that
+ * slip past (e.g. bulk import); this is the write-time guard so it can't creep back.
+ */
+export function normalizeAdultDob(
+  dob: Date | string | null | undefined,
+): { dateOfBirth: Date | null; isDeclaredAdult?: boolean } {
+  if (dob === null || dob === undefined || dob === "") return { dateOfBirth: null };
+  const d = new Date(dob);
+  if (calculateAge(d) > MAX_PROGRAM_AGE) return { dateOfBirth: null, isDeclaredAdult: true };
+  return { dateOfBirth: d, isDeclaredAdult: false };
+}


### PR DESCRIPTION
Closes #1165.

## Why
No age-gated program can target anyone over 25 (`MAX_PROGRAM_AGE` in `lib/programAge.ts`), so an exact date of birth for a **26+** person is dead weight on `Person.dateOfBirth` — our most-sensitive (`@sensitivity:personal`) field. This deletes it and marks the person `isDeclaredAdult` instead, which age gates, the people picker and the household UI already honor.

## Threshold: 26+, not 18+
18-25-year-olds can legitimately sit inside a youth program cap (`maxAge` up to 25), so their exact DoB still enforces gating. 26+ can't be in any age-gated program, so their DoB is pure privacy debt. Deleting 26+ is functionally lossless; deleting 18-25 would break gating.

## What changed
- **`lib/person/adultDob.ts`** — `normalizeAdultDob(dob)`, the single policy seam:
  - `age > 25` -> strip DoB, set `isDeclaredAdult: true`
  - real sub-26 DoB -> keep it, `isDeclaredAdult: false` (a real DoB supersedes the flag)
  - empty/null -> clear the date, leave the flag to the caller (the "over 25" checkbox owns it there)
- **Write-time strip** wired into the 4 interactive DoB-write routes: `profile`, `household`, `household/member`, `membership-ops` participant create.
- **`20260724120000_purge_adult_dob`** — one-time backfill of existing rows (tombstoned/merged rows included; privacy covers dead records).
- **`cron/nightly`** — same `UPDATE` runs nightly so members who cross 26 self-heal within a day.
- Unit check on the 25/26/null boundaries.

## Reviewer notes
- **Rolling-deploy safe**: data-only, no schema change, no `NOT NULL`. `null DoB + declared-adult` is a pre-existing state old code already handles, so it is fine during the drain window.
- **Bulk CSV import** is deliberately not strip-wired — it is slated for rewrite, and the nightly cron sweeps its rows within 24h. Called out in code with a note.
- `tsc --noEmit` clean; `adultDob` unit check green. The migration/integration suite needs a DB (worktree has none) — run `npm run test:integration -- household` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)