### PR TITLE
fix(merge): resolve login identity (email+googleId+emailVerified) as one unit

### DIFF
--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -327,10 +327,10 @@ describe('AuditLog Integration Tests', () => {
 
         const req = new Request('http://localhost:4000/api/membership-ops/participants/merge', {
             method: 'POST',
-            // name/email differ between the two fixtures (real conflicts) — resolve
-            // both to "keep" so this audit-log assertion doesn't depend on the
-            // field-picker's validation, which is exercised by its own suite.
-            body: JSON.stringify({ keepId: keep.id, mergeId: merge.id, fieldChoices: { name: 'keep', email: 'keep' } }),
+            // name differs and both carry a login identity (email) — real conflicts.
+            // Resolve name + the identity unit to "keep" so this audit-log assertion
+            // doesn't depend on the field-picker's validation (its own suite covers that).
+            body: JSON.stringify({ keepId: keep.id, mergeId: merge.id, fieldChoices: { name: 'keep', identity: 'keep' } }),
         });
 
         const res = await mergeParticipants(req as never);

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -24,11 +24,12 @@ jest.mock("@/lib/shopifyRead/client", () => ({
 import { runMatchAudit } from "@/lib/finance/matchAudit";
 
 // Base fixture participants differ on name+email by design (realistic collision
-// data for the field-picker tests below), so a merge that doesn't care about that
-// conflict needs *some* resolution — default to "keep" for both; tests that
-// specifically exercise fieldChoices validation pass their own map (including
-// `{}` to deliberately hit the "missing choice" 400).
-function mergeReq(keepId: number, mergeId: number, fieldChoices: Record<string, string> = { name: "keep", email: "keep" }) {
+// data for the field-picker tests below). name is a per-field conflict and both
+// sides carry a login identity (an email), so a merge needs *some* resolution for
+// both — default to "keep" for name and the identity unit; tests that specifically
+// exercise fieldChoices validation pass their own map (including `{}` to
+// deliberately hit the "missing choice" 400).
+function mergeReq(keepId: number, mergeId: number, fieldChoices: Record<string, string> = { name: "keep", identity: "keep" }) {
     return new Request("http://localhost/api/membership-ops/participants/merge", {
         method: "POST",
         body: JSON.stringify({ keepId, mergeId, fieldChoices })
@@ -150,7 +151,7 @@ describe("Merge Participants API", () => {
         expect(log?.oldData).toMatchObject({ id: pMergeId, name: "Merge User", email: "merge@example.com" });
         const newData = log?.newData as { keepId: number; fieldChoices: Record<string, string>; moved: { visits: number; programParticipants: { migrated: number; left: number } } };
         expect(newData.keepId).toBe(pKeepId);
-        expect(newData.fieldChoices).toEqual({ name: "keep", email: "keep" });
+        expect(newData.fieldChoices).toEqual({ name: "keep", identity: "keep" });
         expect(newData.moved.visits).toBe(1);
         // Tallies use migrated/left, not the old `deleted` name.
         expect(newData.moved.programParticipants).toEqual({ migrated: 0, left: 0 });
@@ -453,15 +454,15 @@ describe("Merge Participants API", () => {
             expect(data.error).toContain("name");
         });
 
-        it("'merge' on email adopts the tombstone's email with no P2002 (clear-first ordering proven)", async () => {
-            const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep", email: "merge" }));
+        it("identity 'merge' adopts the tombstone's email with no P2002 (clear-first ordering proven)", async () => {
+            const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep", identity: "merge" }));
             expect(res.status).toBe(200);
             const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
             expect(kept?.email).toBe("merge@example.com");
         });
 
-        it("'keep' leaves the keeper's value", async () => {
-            const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep", email: "keep" }));
+        it("identity 'keep' leaves the keeper's value", async () => {
+            const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep", identity: "keep" }));
             expect(res.status).toBe(200);
             const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
             expect(kept?.email).toBe("keep@example.com");
@@ -469,22 +470,83 @@ describe("Merge Participants API", () => {
         });
     });
 
-    // Matrix 9 — see route.ts's null-strand guard comment: under the recompute-conflicts
-    // (never trust the client) + backfill-only-fills-empties design, a login identity
-    // that existed on EITHER side always survives onto the keeper (either it was already
-    // there, or backfill/choice adopts the other side's non-null value) — there is no
-    // client-reachable input that resolves both email and googleId to null while either
-    // side had one. That invariant IS the guard's job; this test proves it holds on the
-    // most adversarial-looking shape (both fields have real conflicts, and one choice
-    // points at the side that structurally can't be null).
+    // Matrix 9 — the login identity (email+googleId+emailVerified) resolves as ONE
+    // unit, so a merge can never strand it: picking either side keeps a whole,
+    // self-consistent identity. This proves it on the most adversarial shape — both
+    // sides carry a full email+googleId — where the OLD per-field design could have
+    // spliced keeper-email onto merge-googleId. Now `identity: "merge"` adopts the
+    // merge side wholesale.
     it("does not strand the login identity on a full email+googleId conflict", async () => {
         await prisma.person.update({ where: { id: pKeepId }, data: { googleId: "g-keep" } });
         await prisma.person.update({ where: { id: pMergeId }, data: { googleId: "g-merge" } });
-        const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep", email: "merge", googleId: "merge" }));
+        const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep", identity: "merge" }));
         expect(res.status).toBe(200);
         const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
         expect(kept?.email).toBe("merge@example.com");
         expect(kept?.googleId).toBe("g-merge");
+    });
+
+    // #1225 identity-unit: email/googleId/emailVerified resolve together, never split.
+    describe("login identity resolves as one unit (#1225)", () => {
+        it("both sides Google, identity 'merge': keeper takes merge's email+googleId+emailVerified together, no cross-side split", async () => {
+            const keepVerified = new Date("2026-01-01");
+            const mergeVerified = new Date("2026-05-05");
+            await prisma.person.update({ where: { id: pKeepId }, data: { googleId: "g-keep", emailVerified: keepVerified } });
+            await prisma.person.update({ where: { id: pMergeId }, data: { googleId: "g-merge", emailVerified: mergeVerified } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep", identity: "merge" }));
+            expect(res.status).toBe(200);
+
+            const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
+            // Every identity field came from the merge side — no field left over from the keeper.
+            expect(kept?.email).toBe("merge@example.com");
+            expect(kept?.googleId).toBe("g-merge");
+            expect(kept?.emailVerified?.getTime()).toBe(mergeVerified.getTime());
+            // The stale keeper stamp must NOT ride along on the swapped-in address.
+            expect(kept?.emailVerified?.getTime()).not.toBe(keepVerified.getTime());
+
+            // Tombstone carries no verified stamp for the sentinel address.
+            const tomb = await prisma.person.findUnique({ where: { id: pMergeId } });
+            expect(tomb?.emailVerified).toBeNull();
+        });
+
+        it("magic-link keeper (email, no googleId) + Google merge, identity 'merge': all three move as a unit", async () => {
+            const mergeVerified = new Date("2026-06-06");
+            // keeper: magic-link/imported — email + emailVerified, NO googleId.
+            await prisma.person.update({ where: { id: pKeepId }, data: { googleId: null, emailVerified: new Date("2026-02-02") } });
+            await prisma.person.update({ where: { id: pMergeId }, data: { googleId: "g-merge", emailVerified: mergeVerified } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep", identity: "merge" }));
+            expect(res.status).toBe(200);
+
+            const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
+            expect(kept?.email).toBe("merge@example.com");
+            expect(kept?.googleId).toBe("g-merge");
+            expect(kept?.emailVerified?.getTime()).toBe(mergeVerified.getTime());
+        });
+
+        it("one-sided: empty keeper auto-adopts the merge side's email+googleId+emailVerified as a unit", async () => {
+            const mergeVerified = new Date("2026-07-07");
+            await prisma.person.update({ where: { id: pKeepId }, data: { email: null, googleId: null, emailVerified: null } });
+            await prisma.person.update({ where: { id: pMergeId }, data: { googleId: "g-merge", emailVerified: mergeVerified } });
+
+            // No identity choice needed (keeper has none); name is still a conflict.
+            const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep" }));
+            expect(res.status).toBe(200);
+
+            const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
+            expect(kept?.email).toBe("merge@example.com");
+            expect(kept?.googleId).toBe("g-merge");
+            expect(kept?.emailVerified?.getTime()).toBe(mergeVerified.getTime());
+        });
+
+        it("400s when both sides have a login identity but fieldChoices.identity is missing", async () => {
+            // Base fixture: keeper and merge both have an email — an unavoidable identity conflict.
+            const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep" }));
+            expect(res.status).toBe(400);
+            const data = await res.json();
+            expect(data.error).toContain("identity");
+        });
     });
 
     // Matrix 10

--- a/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
@@ -40,6 +40,10 @@ export const GET = withAuth(
                         email: true,
                         phone: true,
                         googleId: true,
+                        // Lets the merge picker label which side's identity is
+                        // verified/controlled (the login identity resolves as one
+                        // unit — see ../route.ts). Kept explicit, not a bare include.
+                        emailVerified: true,
                         dateOfBirth: true,
                         mergedIntoId: true,
                         household: {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -7,11 +7,20 @@ import { apiError } from "@/lib/api-response";
 
 export const dynamic = 'force-dynamic';
 
-// Fields eligible for a conflict radio: both sides non-null and different.
+// Fields eligible for a per-field conflict radio: both sides non-null and different.
 // `image` auto-backfills only (never a radio, decision 4) so it's a separate list below.
-const CONFLICT_FIELDS = ['name', 'email', 'phone', 'googleId', 'dateOfBirth'] as const;
-// Single-sided auto-backfill fields (today's semantics) — the 5 conflict fields plus image.
+// The login identity (email + googleId + emailVerified) is deliberately NOT here:
+// those three are minted together at sign-in and are resolved as ONE unit under
+// the `identity` key (see resolveKeeperUpdate), never split field-by-field —
+// splitting could seat one side's email on the other's googleId, or graft a stale
+// emailVerified onto a swapped-in address nobody proved they control (#1225).
+const CONFLICT_FIELDS = ['name', 'phone', 'dateOfBirth'] as const;
+// Single-sided auto-backfill fields (today's semantics) — the 3 conflict fields plus image.
 const AUTO_BACKFILL_FIELDS = [...CONFLICT_FIELDS, 'image'] as const;
+// The wholesale-choice key the client sends for the login identity conflict.
+const IDENTITY_CHOICE_KEY = 'identity';
+// Every valid fieldChoices key: the per-field radios plus the identity unit.
+const VALID_CHOICE_KEYS = [...CONFLICT_FIELDS, IDENTITY_CHOICE_KEY] as const;
 
 /** Thrown when the tombstone CAS loses the race (concurrent/repeat merge) — caught below and mapped to a 409. */
 class AlreadyMergedError extends Error {}
@@ -27,10 +36,16 @@ function valuesConflict(a: unknown, b: unknown): boolean {
     return a !== b;
 }
 
+/** A login identity is present iff email OR googleId is non-empty. */
+function hasIdentity(p: { email: string | null; googleId: string | null }): boolean {
+    return !isEmpty(p.email) || !isEmpty(p.googleId);
+}
+
 /**
  * Build the keeper's `person.update` data from: single-sided auto-backfill,
- * radio-resolved true conflicts (name/email/phone/googleId/dateOfBirth), and
- * the newer-date auto-pick for the two compliance dates (never a radio).
+ * radio-resolved true conflicts (name/phone/dateOfBirth), the login identity
+ * resolved as ONE unit (email + googleId + emailVerified), and the newer-date
+ * auto-pick for the two compliance dates (never a radio).
  */
 function resolveKeeperUpdate(
     keep: Person,
@@ -50,6 +65,26 @@ function resolveKeeperUpdate(
             data[field] = mergeVal;
         }
     }
+
+    // Login identity — email/googleId/emailVerified are minted together at
+    // sign-in, so they move together or not at all. A record holds only one of
+    // each (all @unique), so the only coherent outcomes are "keep the keeper's
+    // whole identity" or "adopt the merge side's" — never a cross-side split
+    // that would seat an address nobody proved they control (#1225).
+    const keepHasIdentity = hasIdentity(keep);
+    const mergeHasIdentity = hasIdentity(merge);
+    const adoptMergeIdentity =
+        // Both sides have one (always a true conflict — unique constraints):
+        // client picks via the `identity` radio.
+        (keepHasIdentity && mergeHasIdentity && choices[IDENTITY_CHOICE_KEY] === 'merge') ||
+        // Empty keeper, merge side has one: adopt it (single-sided backfill).
+        (!keepHasIdentity && mergeHasIdentity);
+    if (adoptMergeIdentity) {
+        data.email = merge.email;
+        data.googleId = merge.googleId;
+        data.emailVerified = merge.emailVerified;
+    }
+    // Only-keeper-has-identity (or 'keep' choice, or neither side) -> no write.
 
     // Compliance dates: always take the newer one. Same human — an older check
     // is never the right survivor. Never a radio.
@@ -131,7 +166,7 @@ export const POST = withAuth(
             }
             const choices: Partial<Record<string, 'keep' | 'merge'>> = {};
             for (const [key, value] of Object.entries(rawChoices)) {
-                if (!(CONFLICT_FIELDS as readonly string[]).includes(key)) {
+                if (!(VALID_CHOICE_KEYS as readonly string[]).includes(key)) {
                     return apiError(`Unknown field choice: ${key}`, 400);
                 }
                 if (value !== 'keep' && value !== 'merge') {
@@ -143,6 +178,12 @@ export const POST = withAuth(
                 if (valuesConflict(keepParticipant[field], mergeParticipant[field]) && !choices[field]) {
                     return apiError(`Choose a value for ${field}`, 400);
                 }
+            }
+            // Both sides carry a login identity => an unavoidable conflict (unique
+            // constraints guarantee they differ); the client must pick which whole
+            // identity survives.
+            if (hasIdentity(keepParticipant) && hasIdentity(mergeParticipant) && !choices[IDENTITY_CHOICE_KEY]) {
+                return apiError(`Choose a value for ${IDENTITY_CHOICE_KEY}`, 400);
             }
 
             // ---- Resolve the keeper's final field values, then guard against stranding login ----
@@ -166,6 +207,9 @@ export const POST = withAuth(
                         mergedIntoId: keepId,
                         googleId: null,
                         email: `merged-${mergeId}@deleted.invalid`,
+                        // Null the verified stamp with the identity: no tombstone
+                        // row should carry a "verified" mark for the sentinel address.
+                        emailVerified: null,
                         phone: null,
                         isHouseholdLead: false,
                         // NOTE: name is NOT mangled — mergedIntoId carries the semantics;

--- a/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
@@ -95,7 +95,7 @@ describe("membership-ops/participants/merge page", () => {
         "/api/membership-ops/participants/merge",
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({ keepId: 1, mergeId: 2, fieldChoices: { name: "keep", email: "keep" } }),
+          body: JSON.stringify({ keepId: 1, mergeId: 2, fieldChoices: { name: "keep", identity: "keep" } }),
         }),
       ),
     );
@@ -296,12 +296,15 @@ describe("membership-ops/participants/merge page", () => {
     await selectBoth();
     await screen.findByText("Keep and augment");
 
-    // Alice/Bob differ on name+email; both share phone: null.
+    // Alice/Bob differ on name; both have an email so the login identity is a
+    // conflict too; both share phone: null and have no dateOfBirth.
     const picker = screen.getByText("Resolve conflicting fields").closest(".mantine-Card-root") as HTMLElement;
     expect(within(picker).getByText("Name")).toBeInTheDocument();
-    expect(within(picker).getByText("Email")).toBeInTheDocument();
-    expect(within(picker).queryByText("Phone")).not.toBeInTheDocument();
+    expect(within(picker).getByText("Login identity")).toBeInTheDocument();
+    // email/googleId are no longer their own radios — folded into "Login identity".
+    expect(within(picker).queryByText("Email")).not.toBeInTheDocument();
     expect(within(picker).queryByText("Google Account")).not.toBeInTheDocument();
+    expect(within(picker).queryByText("Phone")).not.toBeInTheDocument();
     expect(within(picker).queryByText("Date of Birth")).not.toBeInTheDocument();
   });
 
@@ -313,14 +316,15 @@ describe("membership-ops/participants/merge page", () => {
     await selectBoth();
     await screen.findByText("Keep and augment");
 
-    // Alice out-scores Bob (visits + googleId), so she's the default keeper.
+    // Alice out-scores Bob (visits + googleId), so she's the default keeper. The
+    // "keep" radio in each group shows the keeper's value (name + login identity).
     expect(screen.getByRole("radio", { name: "Alice Adams" })).toBeChecked();
-    expect(screen.getByRole("radio", { name: "alice@example.com" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /alice@example\.com · Google/ })).toBeChecked();
 
     fireEvent.click(screen.getByRole("button", { name: "Swap Kept / Merged" }));
 
     expect(screen.getByRole("radio", { name: "Bob Adams" })).toBeChecked();
-    expect(screen.getByRole("radio", { name: "bob@example.com" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /bob@example\.com · unverified/ })).toBeChecked();
   });
 
   // Matrix 21
@@ -331,8 +335,8 @@ describe("membership-ops/participants/merge page", () => {
     await selectBoth();
     await screen.findByText("Keep and augment");
 
-    // Pick the tombstone's (Bob's) email instead of the keeper's default.
-    fireEvent.click(screen.getByRole("radio", { name: "bob@example.com" }));
+    // Pick the tombstone's (Bob's) login identity instead of the keeper's default.
+    fireEvent.click(screen.getByRole("radio", { name: /bob@example\.com · unverified/ }));
 
     fireEvent.click(screen.getByRole("button", { name: "Proceed to Preview" }));
     await screen.findByText("Preview & Confirm Merge");
@@ -343,21 +347,23 @@ describe("membership-ops/participants/merge page", () => {
         "/api/membership-ops/participants/merge",
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({ keepId: 1, mergeId: 2, fieldChoices: { name: "keep", email: "merge" } }),
+          body: JSON.stringify({ keepId: 1, mergeId: 2, fieldChoices: { name: "keep", identity: "merge" } }),
         }),
       ),
     );
   });
 
   // Matrix 22
-  it("shows each side's own identity for a googleId conflict instead of 'Connected' on both", async () => {
+  it("shows each side's own login identity (email + Google + verified marker), not 'Connected'", async () => {
     const gia = {
       id: 60, name: "Gia Google", email: "gia@example.com", phone: null, googleId: "g-gia-000000",
+      emailVerified: "2026-01-01T00:00:00.000Z",
       _count: { visits: 5, rawBadgeLogs: 0, programParticipants: 0, programVolunteers: 0 },
       household: null,
     };
     const gary = {
       id: 61, name: "Gary Gmail", email: null, phone: null, googleId: "g-gary-111111",
+      emailVerified: null,
       _count: { visits: 0, rawBadgeLogs: 0, programParticipants: 0, programVolunteers: 0 },
       household: null,
     };
@@ -376,10 +382,11 @@ describe("membership-ops/participants/merge page", () => {
 
     await screen.findByText("Keep and augment");
     const picker = screen.getByText("Resolve conflicting fields").closest(".mantine-Card-root") as HTMLElement;
-    // Gia has an email, so her radio shows it; Gary has none, so his falls back
-    // to the googleId tail — neither says the uninformative "Connected".
-    expect(within(picker).getByText("gia@example.com")).toBeInTheDocument();
-    expect(within(picker).getByText("…111111")).toBeInTheDocument();
+    // Gia has a verified email; Gary has none, so his falls back to the googleId
+    // tail and shows unverified — neither says the uninformative "Connected".
+    expect(within(picker).getByText(/gia@example\.com · Google/)).toBeInTheDocument();
+    expect(within(picker).getByText(/· verified$/)).toBeInTheDocument();
+    expect(within(picker).getByText(/…111111 · unverified/)).toBeInTheDocument();
     expect(within(picker).queryByText("Connected")).not.toBeInTheDocument();
   });
 

--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -16,6 +16,7 @@ interface ParticipantMergeView {
   name?: string;
   phone?: string;
   googleId?: string;
+  emailVerified?: string | null;
   dateOfBirth?: string | null;
   mergedIntoId?: number | null;
   _count: { visits: number, rawBadgeLogs: number, programParticipants: number, programVolunteers: number };
@@ -23,17 +24,23 @@ interface ParticipantMergeView {
   [key: string]: unknown;
 }
 
-// The 5 fields eligible for a conflict radio — mirrors the server's CONFLICT_FIELDS
-// (route.ts). image/lastBackgroundCheck/lastWaiverSign always auto-resolve, never a radio.
-const CONFLICT_FIELDS = ["name", "email", "phone", "googleId", "dateOfBirth"] as const;
+// Per-field conflict radios — mirrors the server's CONFLICT_FIELDS (route.ts).
+// email/googleId/emailVerified are NOT here: they're the login identity, minted
+// together at sign-in and resolved as ONE unit under the `identity` key (never
+// split field-by-field). image/lastBackgroundCheck/lastWaiverSign auto-resolve.
+const CONFLICT_FIELDS = ["name", "phone", "dateOfBirth"] as const;
 type ConflictField = typeof CONFLICT_FIELDS[number];
 const FIELD_LABELS: Record<ConflictField, string> = {
-  name: "Name", email: "Email", phone: "Phone", googleId: "Google Account", dateOfBirth: "Date of Birth",
+  name: "Name", phone: "Phone", dateOfBirth: "Date of Birth",
 };
 
+// A login identity is present iff email OR googleId is set.
+function hasIdentity(p: { email?: string; googleId?: string }): boolean {
+  return !!p.email || !!p.googleId;
+}
+
 // googleId has no human-readable value of its own — a raw "Connected" label reads
-// identically for both sides of a conflict, so the radio can't tell the admin what
-// they're actually choosing between. Show the identity behind it instead: the
+// identically for both sides of a conflict. Show the identity behind it instead: the
 // person's own email (the account you'd recognize), falling back to the tail of
 // the googleId itself when there's no email to show.
 function googleIdIdentity(person: { email?: string; googleId?: string }): string {
@@ -42,13 +49,21 @@ function googleIdIdentity(person: { email?: string; googleId?: string }): string
   return "—";
 }
 
-function formatFieldValue(field: ConflictField, value: unknown, person: { email?: string; googleId?: string }): string {
+// One option in the "which login identity survives?" radio: the side's email, the
+// account behind its googleId, and whether that address is verified/controlled.
+function identityOptionLabel(p: { email?: string; googleId?: string; emailVerified?: string | null }): string {
+  const parts = [p.email || "no email"];
+  if (p.googleId) parts.push(`Google: ${googleIdIdentity(p)}`);
+  parts.push(p.emailVerified ? "verified" : "unverified");
+  return parts.join(" · ");
+}
+
+function formatFieldValue(field: ConflictField, value: unknown): string {
   if (field === "dateOfBirth" && typeof value === "string") {
     const d = new Date(value);
     return isNaN(d.getTime()) ? String(value) : d.toLocaleDateString();
   }
   if (field === "phone" && typeof value === "string") return formatPhone(value);
-  if (field === "googleId") return googleIdIdentity(person);
   return String(value ?? "—");
 }
 
@@ -92,10 +107,16 @@ export default function MergeParticipants() {
       })
     : [];
 
+  // Both sides carry a login identity => an unavoidable conflict (unique
+  // constraints guarantee they differ); the admin picks which whole identity survives.
+  const identityConflict = !!(keepParticipant && mergeParticipant
+    && hasIdentity(keepParticipant) && hasIdentity(mergeParticipant));
+
   useEffect(() => {
     if (!keepParticipant || !mergeParticipant) return;
     const defaults: Record<string, "keep" | "merge"> = {};
     for (const f of conflicts) defaults[f] = "keep";
+    if (identityConflict) defaults.identity = "keep";
     setFieldChoices(defaults);
     // Reset defaults only when the keeper flips (or analysis first lands) — not on
     // every keystroke the picker itself causes.
@@ -348,10 +369,23 @@ export default function MergeParticipants() {
                 {renderStats(analyzedB, keepId === analyzedB.id, analyzedB.id !== keepId ? isLeadWithOthers : false)}
               </SimpleGrid>
 
-              {conflicts.length > 0 && keepParticipant && mergeParticipant && (
+              {(conflicts.length > 0 || identityConflict) && keepParticipant && mergeParticipant && (
                 <Card withBorder radius="md" padding="lg">
                   <Title order={5} mb="sm">Resolve conflicting fields</Title>
                   <Stack gap="md">
+                    {identityConflict && (
+                      <Radio.Group
+                        label="Login identity"
+                        description="Email, Google sign-in, and verified status move together as one unit — picking a side replaces the kept record's whole login, so choosing an email-only side drops the other's Google sign-in."
+                        value={fieldChoices.identity ?? "keep"}
+                        onChange={(v) => setFieldChoices((prev) => ({ ...prev, identity: v as "keep" | "merge" }))}
+                      >
+                        <Stack mt="xs" gap="xs">
+                          <Radio value="keep" label={identityOptionLabel(keepParticipant)} />
+                          <Radio value="merge" label={identityOptionLabel(mergeParticipant)} />
+                        </Stack>
+                      </Radio.Group>
+                    )}
                     {conflicts.map((field) => {
                       const radioGroup = (
                         <Radio.Group
@@ -360,8 +394,8 @@ export default function MergeParticipants() {
                           onChange={(v) => setFieldChoices((prev) => ({ ...prev, [field]: v as "keep" | "merge" }))}
                         >
                           <Group mt="xs">
-                            <Radio value="keep" label={formatFieldValue(field, keepParticipant[field], keepParticipant)} />
-                            <Radio value="merge" label={formatFieldValue(field, mergeParticipant[field], mergeParticipant)} />
+                            <Radio value="keep" label={formatFieldValue(field, keepParticipant[field])} />
+                            <Radio value="merge" label={formatFieldValue(field, mergeParticipant[field])} />
                           </Group>
                         </Radio.Group>
                       );


### PR DESCRIPTION
> [!NOTE]
> **Not #1225.** Independent correctness bug found while working near the merge resolver — unrelated to that issue, just surfaced along the way. Does not close #1225.

## Bug
Participant merge resolved `email` and `googleId` as two independent conflict radios and never touched `emailVerified`. A merge could therefore produce a login identity impossible in normal ops:
- one side's `email` seated on the other side's `googleId`, or
- a swapped-in `email` carrying the keeper's stale `emailVerified` stamp.

Readers that trust `emailVerified` (`lib/impersonation.ts`, `lib/config.ts` staging gate, directory pills) then treat an address nobody proved they control as verified.

## Fix
Resolve `{email, googleId, emailVerified}` as ONE `identity` unit. A record holds only one of each (all `@unique`), so the only coherent outcomes are "keep the keeper's whole identity" or "adopt the merge side's" — never a cross-side split.

- **route.ts** — drop `email`/`googleId` from `CONFLICT_FIELDS`; add one `identity` key. Both sides carry an identity → client must send `fieldChoices.identity` (`keep`|`merge`); on `merge` (or empty-keeper backfill) write `email`+`googleId`+`emailVerified` together. Missing `identity` → 400. Tombstone CAS also nulls `emailVerified` so no tombstone wears a verified stamp for the `merged-*@deleted` sentinel. Login-strand guard kept as defense-in-depth.
- **analyze/route.ts** — select `emailVerified` (one field; explicit-select discipline preserved) so the UI can label the verified side.
- **page.tsx** — collapse the two email/Google radios into one "which login identity survives?" radio showing each side's email, Google account, and verified/unverified marker.

## Scope
Login identity only. `emailSuppressed`/`emailUndeliverableAt` left untouched (owned by a separate branch). `name`/`phone`/`dateOfBirth`/`image` handling unchanged. No schema change, no migration.

## Tests
- `tsc --noEmit`: clean
- Page unit (`page.test.tsx`): 17/17
- Integration (`--runInBand`, throwaway Postgres): full suite **1249/1249** — merge route + audit-log suites green, no collateral breakage
- New identity-unit integration cases: both-Google `merge` (asserts no cross-side split, tombstone stamp nulled), magic-link→Google, one-sided auto-adopt, missing-`identity` → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)