### PR TITLE
fix(merge): tombstone email uses reserved .invalid domain, not checkme.in

### DIFF
--- a/checkin-app/prisma/migrations/20260724120000_merge_tombstone_invalid_domain/migration.sql
+++ b/checkin-app/prisma/migrations/20260724120000_merge_tombstone_invalid_domain/migration.sql
@@ -1,0 +1,9 @@
+-- Data-only backfill (no schema change): merge tombstones held a sentinel email at
+-- deleted.checkme.in — a REAL registrable domain (.in) the org does not control, so
+-- mail to it could be received by whoever owns checkme.in. Rewrite to the RFC 2606 /
+-- 6761 reserved .invalid TLD (guaranteed unregistrable, non-routable). id-keyed so the
+-- Person.email @unique constraint still holds. Nothing matches this sentinel for logic
+-- (tombstone detection is Person.mergedIntoId) — it's a pure placeholder.
+UPDATE "Person"
+SET email = 'merged-' || id || '@deleted.invalid'
+WHERE email LIKE 'merged-%@deleted.checkme.in';

--- a/checkin-app/src/__tests__/livePersonDriftGuard.test.ts
+++ b/checkin-app/src/__tests__/livePersonDriftGuard.test.ts
@@ -135,7 +135,7 @@ const ALLOWLIST: Record<string, string> = {
     'app/api/shop/certifications/route.ts': 'Scanner is textually blind to a VARIABLE-held where. The "All Assignments" grid — the only many-person list here — spells out `where: { person: LIVE_PERSON }` inline; the second findMany passes `whereClause`, whose two branches are `{ toolId, person: LIVE_PERSON }` (list) and `{ personId: targetUserId }` (one already-identified person). Both covered, neither visible in the captured argument object.',
 
     // ── dev-only tooling (no production / user-facing effect) ─────────────────
-    'app/api/auth/dev-personas/route.ts': 'Dev-only persona picker (config.isDevInstance() gated), scoped to `email: { endsWith: "@example.com" }` — a merge tombstone\'s email is always rewritten to merged-*@deleted.checkme.in (merge/route.ts step 1 CAS), so it can never match this domain filter.',
+    'app/api/auth/dev-personas/route.ts': 'Dev-only persona picker (config.isDevInstance() gated), scoped to `email: { endsWith: "@example.com" }` — a merge tombstone\'s email is always rewritten to merged-*@deleted.invalid (merge/route.ts step 1 CAS), so it can never match this domain filter.',
     'app/api/dev/shopify/orders-paid/route.ts': 'Dev-only mock-webhook firer (config.isDevInstance() gated). Both join reads pin `personId: { in: participantIds }` from the request body and are echoed back to the dev UI — no production or user-facing effect.',
     'lib/dev/seed-helpers.ts': 'Dev seed helper: picks an arbitrary sample of existing persons for local macro/demo flows. No production or user-facing effect.',
 };

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -59,12 +59,12 @@ describe("Merge Participants API", () => {
         householdId = hh.id;
 
         const actor = await prisma.person.create({
-            data: { name: "Board Actor", email: "actor@checkme.in", householdId: hh.id, isBoardMember: true }
+            data: { name: "Board Actor", email: "actor@example.com", householdId: hh.id, isBoardMember: true }
         });
         actorId = actor.id;
 
         mockGetServerSession.mockResolvedValue({
-            user: { id: actorId, email: "actor@checkme.in", isBoardMember: true }
+            user: { id: actorId, email: "actor@example.com", isBoardMember: true }
         });
 
         const pKeep = await prisma.person.create({
@@ -129,7 +129,7 @@ describe("Merge Participants API", () => {
 
         const merged = await prisma.person.findUnique({ where: { id: pMergeId } });
         expect(merged?.email).toContain("merged-");
-        expect(merged?.email).toContain("@deleted.checkme.in");
+        expect(merged?.email).toContain("@deleted.invalid");
         expect(merged?.phone).toBeNull();
         // decision 5: tombstone identity keeps its ORIGINAL name — no mangling.
         expect(merged?.name).toBe("Merge User");
@@ -203,7 +203,7 @@ describe("Merge Participants API", () => {
         const merged = await prisma.person.findUnique({ where: { id: pMergeId } });
         expect(merged?.googleId).toBeNull();
         expect(merged?.email).toContain("merged-");
-        expect(merged?.email).toContain("@deleted.checkme.in");
+        expect(merged?.email).toContain("@deleted.invalid");
     });
 
     // Matrix 1: unique collision, both directions, across every loop-guarded relation.

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -165,7 +165,7 @@ export const POST = withAuth(
                     data: {
                         mergedIntoId: keepId,
                         googleId: null,
-                        email: `merged-${mergeId}@deleted.checkme.in`,
+                        email: `merged-${mergeId}@deleted.invalid`,
                         phone: null,
                         isHouseholdLead: false,
                         // NOTE: name is NOT mangled — mergedIntoId carries the semantics;


### PR DESCRIPTION
## What

Merged-away `Person` tombstones rewrote their `email` to `merged-<id>@deleted.checkme.in`. `.in` is a **real registrable India TLD** the org does not control — mail addressed to a tombstone could be received by whoever owns `checkme.in`. We must not write addresses at a domain we don't control, even on dead records.

Switches the sentinel to the RFC 2606 / 6761 reserved `.invalid` TLD (guaranteed unregistrable, non-routable): `merged-<id>@deleted.invalid`.

## Why it's safe

- Pure placeholder. Tombstone detection is `Person.mergedIntoId` (`src/lib/person/filters.ts`) — **nothing matches the email string** for logic, so changing it is inert.
- Still `id`-keyed, so `Person.email @unique` holds.
- `.invalid` (not `@example.com`) preserves the `livePersonDriftGuard` exception that depends on merge tombstones never matching the dev-personas `@example.com` filter.
- CAS block: **only** the email string changed. `googleId`/`emailVerified`/`emailSuppressed` and the other CAS fields are untouched, so the adjacent `claude/merge-identity-unit` rebase stays trivial.

## Changes

- `merge/route.ts` — sentinel domain `deleted.checkme.in` → `deleted.invalid`.
- **New data-only migration** `20260724120000_merge_tombstone_invalid_domain/migration.sql` — hand-authored `UPDATE "Person" SET email = 'merged-' || id || '@deleted.invalid' WHERE email LIKE 'merged-%@deleted.checkme.in'`. No schema change, id-keyed, single statement.
- Merge integration assertions `@deleted.checkme.in` → `@deleted.invalid` (`toContain("merged-")` kept); test board-actor fixture moved off `checkme.in` to `example.com`.
- Drift-guard justification string updated to reference the new domain.

## Verification

- `checkme.in` grep-to-zero across `src`/`prisma` (only the migration's `WHERE`/comments reference it, which must, to match legacy rows).
- `tsc --noEmit` clean.
- Merge integration suite **26/26 pass** on Postgres; `migrate deploy` applied the new migration cleanly during test setup.
- migration-safety checklist: single-statement, data-only, no schema/rename/FK, timestamp sorts after `20260721120000_program_announced_at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)