### PR TITLE
fix(merge): carry emailSuppressed with the surviving email (#1225 failure #2)

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -470,6 +470,33 @@ describe("Merge Participants API", () => {
         });
     });
 
+    // #1225 failure #2: emailSuppressed is an opt-out tied to a specific address.
+    // The login identity resolves as one unit, so suppression must ride with
+    // whichever side's address wins — not stay stuck on the keeper's own.
+    it("carries emailSuppressed with the identity when 'merge' wins", async () => {
+        await prisma.person.update({ where: { id: pKeepId }, data: { emailSuppressed: false } });
+        await prisma.person.update({ where: { id: pMergeId }, data: { emailSuppressed: true } });
+
+        const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep", identity: "merge" }));
+        expect(res.status).toBe(200);
+        const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
+        expect(kept?.email).toBe("merge@example.com");
+        expect(kept?.emailSuppressed).toBe(true); // opt-out rode in with address B
+    });
+
+    it("backfills emailSuppressed with the identity when the keeper had no identity of its own", async () => {
+        await prisma.person.update({ where: { id: pKeepId }, data: { email: null, emailSuppressed: false } });
+        await prisma.person.update({ where: { id: pMergeId }, data: { emailSuppressed: true } });
+
+        // name is the base-fixture conflict; the merge-side identity is backfilled
+        // (keeper empty), so no `identity` radio is needed.
+        const res = await POST(mergeReq(pKeepId, pMergeId, { name: "keep" }));
+        expect(res.status).toBe(200);
+        const kept = await prisma.person.findUnique({ where: { id: pKeepId } });
+        expect(kept?.email).toBe("merge@example.com");
+        expect(kept?.emailSuppressed).toBe(true);
+    });
+
     // Matrix 9 — the login identity (email+googleId+emailVerified) resolves as ONE
     // unit, so a merge can never strand it: picking either side keeps a whole,
     // self-consistent identity. This proves it on the most adversarial shape — both

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -83,8 +83,11 @@ function resolveKeeperUpdate(
         data.email = merge.email;
         data.googleId = merge.googleId;
         data.emailVerified = merge.emailVerified;
+        // #1225: suppression is tied to the address, so it rides in with it.
+        data.emailSuppressed = merge.emailSuppressed;
     }
-    // Only-keeper-has-identity (or 'keep' choice, or neither side) -> no write.
+    // Only-keeper-has-identity (or 'keep' choice, or neither side) -> no write:
+    // the keeper's address stands, and so does its own emailSuppressed.
 
     // Compliance dates: always take the newer one. Same human — an older check
     // is never the right survivor. Never a radio.


### PR DESCRIPTION
## What

`Person.emailSuppressed` is an outreach opt-out **tied to a specific email address**. The person/record merge route adopts the tombstone's login identity but never carried `emailSuppressed` with it. So when the keeper adopts the tombstone's email, it kept its *own* `emailSuppressed` — which described a different address.

Net effect: merging in an address that was unsubscribed silently **re-subscribes** it (or the reverse — wrongly silences a fresh address).

## Fix

In `resolveKeeperUpdate` (`checkin-app/src/app/api/membership-ops/participants/merge/route.ts`), the login identity (email + googleId + emailVerified) already resolves as **one unit** — the keeper either keeps its whole identity or adopts the merge side's wholesale. This PR makes `emailSuppressed` ride along inside that same `adoptMergeIdentity` branch:

- Merge-side identity is adopted (via the `identity` radio, or single-sided backfill when the keeper had none) → `data.emailSuppressed = merge.emailSuppressed`.
- Keeper's identity stands (or neither side has one) → no write; keeper's own `emailSuppressed` stays.

Suppression tracks whichever address survives.

## Scope

- **Only** `emailSuppressed`. No schema change, no migration. Folds cleanly into the existing identity-unit resolution — one line + comment.

## Tests

Two new integration cases in `route.integration.test.ts`:
1. Keeper `emailSuppressed=false`, tombstone `emailSuppressed=true`, `identity` choice `merge` → keeper ends with the tombstone's email **and** `emailSuppressed=true`.
2. Empty-keeper backfill: keeper has no identity, tombstone suppressed → keeper adopts identity + suppression.

**Result:** scoped integration run (`--runInBand`) → **32 passed, 32 total**. `tsc --noEmit` clean.

## Reviewer note

Rebased onto latest `origin/main`, which had refactored this function to resolve the login identity as a single unit (previously the email choice was a per-field radio). The fix was re-homed into the identity block accordingly; the two tests now drive the `identity` choice key rather than the removed `email` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
