### PR TITLE
ci: skip deploy build + Node CI for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,11 @@ jobs:
   # The Python kiosk client (client/**) has no Node CI, so a client-only change has
   # nothing to test — but skipping the workflow via `paths-ignore` left those required
   # checks permanently "pending" and blocked client-only PRs from ever merging.
+  # Docs/markdown-only changes (docs/ dirs, or any *.md) are treated the same way:
+  # they can't affect the build or the app tests, so there's nothing to build or run.
   #
-  # Fix: this job decides whether anything OUTSIDE client/** changed. The required jobs
+  # Fix: this job decides whether any real app code (not client/, not docs/markdown)
+  # changed. The required jobs
   # below ALWAYS run (so the required contexts always report a result) but skip their
   # actual work when only client/** changed. A skipped *workflow* deadlocks a required
   # check; a job that runs and reports success does not.
@@ -82,8 +85,9 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # Only a pull_request whose every changed file is under client/ may skip the
-          # Node CI. push-to-main and merge_group always run the full pipeline.
+          # Only a pull_request whose every changed file is skippable — client code
+          # (client/), a docs/ directory, or any *.md file — may skip the Node CI.
+          # push-to-main and merge_group always run the full pipeline.
           if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "Non-PR event ($EVENT_NAME) — running full CI."
             echo "app=true" >> "$GITHUB_OUTPUT"
@@ -91,12 +95,13 @@ jobs:
           fi
           changed="$(git diff --name-only "$PR_BASE_SHA...$PR_HEAD_SHA")"
           echo "Changed files:"; printf '%s\n' "$changed"
-          # grep -v exits 0 if ANY line is NOT under client/ → there's app work to do.
-          if printf '%s\n' "$changed" | grep -qvE '^client/'; then
-            echo "Non-client files changed — running full CI."
+          # grep -v exits 0 if ANY line is NOT skippable (client/, a docs/ dir, or
+          # *.md) → there's real app code to build and test.
+          if printf '%s\n' "$changed" | grep -qvE '(^client/|(^|/)docs/|\.md$)'; then
+            echo "App code changed — running full CI."
             echo "app=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Client-only change — skipping Node CI work (required checks still pass)."
+            echo "Docs- or client-only change — skipping Node CI work (required checks still pass)."
             echo "app=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Problem
The `changes` / **Detect changes** job in `.github/workflows/ci.yml` classified a PR as skippable only when *every* changed file was under `client/`. A docs-only PR (e.g. one file under `checkin-app/docs/designs/`) got `app=true` and ran the full pipeline — including **Deploy build (no deploy)**, which builds a Docker image and recently flaked on a `node:24-alpine` registry timeout. A docs change can't affect the build or the app tests.

## Change
Broaden the skippable set from `client/` only to **client code OR documentation**. A changed file is skippable if it matches any of:
- under `client/`
- inside any `docs/` directory (`docs/...` or `checkin-app/docs/...`)
- a Markdown file anywhere (`*.md`)

`app=true` iff at least one changed file is **not** skippable, so a PR mixing docs and real code still runs full CI.

The grep pattern was broadened to also match docs/markdown. Echo strings and the nearby comment now say "app code changed / docs- or client-only change" instead of "client-only"; the job-level comment block above `changes:` now notes docs/markdown are treated the same and why.

Single-file change to `ci.yml`. No downstream jobs touched: `unit-tests`, `integration-tests`, `deploy-build`, `s-read`, and the coverage gate already gate their work on `needs.changes.outputs.app == 'true'` and each has a "Skip notice" step for the non-true case (verified — all guarded), so a docs-only PR reports success without doing work automatically. No branch-protection / required-check names changed.

## Verification (real GNU grep, as in CI)
| Changed files | Result |
|---|---|
| `checkin-app/docs/designs/167-youth-enrollment-rules.md` | `app=false` |
| `checkin-app/src/foo.ts` | `app=true` |
| one `.md` + one `.ts` (mixed) | `app=true` |
| `client/kiosk.py` | `app=false` |
| `README.md` | `app=false` |

`grep -n "app=" .github/workflows/ci.yml` confirms both outputs still set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
