### PR TITLE
fix(ci): dispatch security-boundary isolation on merge_group

### DIFF
--- a/.github/workflows/security-boundary-isolation.yml
+++ b/.github/workflows/security-boundary-isolation.yml
@@ -27,16 +27,29 @@ on:
     # so this must exist on both main (every future rel/* cut inherits it)
     # and rel/1.0 (so current release-line PRs get checks).
     branches: [main, 'rel/**']
+  # If `isolation` is a REQUIRED check, the merge queue expects it on the
+  # merge_group ref too — without this trigger no run is dispatched, the
+  # context never reports, and the queue entry hangs forever. The isolation
+  # policy is a PR-shape concern (changed files vs base); the queued PRs are
+  # already reviewed and there's no pull_request base SHA here, so this event
+  # short-circuits to success below.
+  merge_group:
 
 jobs:
   isolation:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip on merge queue (already enforced on the PR)
+        if: github.event_name == 'merge_group'
+        run: echo "merge_group event — isolation already checked on the PR; nothing to do."
+
       - uses: actions/checkout@v5
+        if: github.event_name != 'merge_group'
         with:
           fetch-depth: 0
 
       - name: Check boundary changes ship alone
+        if: github.event_name != 'merge_group'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |


### PR DESCRIPTION
## What

Add a `merge_group` trigger to `.github/workflows/security-boundary-isolation.yml`, and short-circuit the `isolation` job to success on that event.

## Why

The merge queue was hanging on the `isolation` check.

- The merge queue fires a `merge_group` event.
- `ci.yml` handles it (`merge_group:` trigger). But `security-boundary-isolation.yml` triggered **`on: pull_request` only**.
- So when a PR entered the queue, no run was dispatched for this workflow, the required `isolation` context never posted a status, and the queue entry waited forever.

## The fix

- Add `merge_group:` to `on:` so a run is dispatched for the queue's merge-group ref.
- Guard the steps with `if: github.event_name != 'merge_group'` and add a first step that reports success on `merge_group`.

The isolation policy is a PR-shape concern (changed files vs. base). Queued PRs are already reviewed, and there is no `pull_request` base SHA in a merge group anyway, so passing trivially on `merge_group` is correct, not a bypass.

## Reviewer notes

- `flow-tests.yml` and `migration-safety.yml` have the same `pull_request`-only gap. If either is also a required merge-queue check, it needs the same guard. This PR fixes only `isolation` (the one observed hanging). Worth confirming the queue's required-checks list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
