### PR TITLE
test(integration): add runPaced to partial email mocks (fix test-only false-green)

### DIFF
--- a/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
@@ -38,7 +38,7 @@ import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 
 const TAG = 'authz-ownership-test';
 

--- a/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
@@ -68,7 +68,7 @@ import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 
 const TAG = 'authz-rolereject-test';
 

--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -6,6 +6,7 @@ import prisma from '@/lib/prisma';
 import { sendEmail } from '@/lib/email';
 
 jest.mock('@/lib/email', () => ({
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
     sendEmail: jest.fn().mockResolvedValue(true)
 }));
 

--- a/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronPostEventAPI.integration.test.ts
@@ -3,6 +3,7 @@ import { sendEmail } from "@/lib/email";
 import { GET } from "../api/cron/post-event/route";
 
 jest.mock("@/lib/email", () => ({
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
     sendEmail: jest.fn().mockResolvedValue(true)
 }));
 

--- a/checkin-app/src/app/__tests__/eventCancelNotification.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelNotification.integration.test.ts
@@ -18,7 +18,7 @@ import { getServerSession } from 'next-auth/next';
 import { sendEmail } from '@/lib/email';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 
 const TAG = 'cancel-notify-test';
 const HOUR = 60 * 60 * 1000;

--- a/checkin-app/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBulkRenewalAPI.integration.test.ts
@@ -11,7 +11,7 @@ import { getServerSession } from 'next-auth/next';
 import { sendEmail } from '@/lib/email';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 
 const TAG = 'bulk-renewal-test';
 

--- a/checkin-app/src/app/__tests__/membershipContractSync.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipContractSync.integration.test.ts
@@ -20,7 +20,7 @@ import { getServerSession } from 'next-auth/next';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
 // Advancing to PENDING_PAYMENT pings reviewers; don't hit Resend in tests.
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 // Mock the whole Zoho client so no real OAuth/HTTP happens. Only getAccessToken +
 // getRequestStatus are exercised by syncContractStatus; the rest are stubs.
 jest.mock('@/lib/membership/contract/zohoClient', () => ({

--- a/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -15,7 +15,7 @@ import { getServerSession } from 'next-auth/next';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
 // Advancing to PENDING_BG_REVIEW pings reviewers; don't hit Resend in tests.
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 
 const TAG = 'membership-external-test';
 const SECRET = 'zoho-test-secret';

--- a/checkin-app/src/app/__tests__/membershipExternalConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalConcurrency.integration.test.ts
@@ -16,7 +16,7 @@ import { normalizeAuditData } from '@/lib/auditPayload';
 import { notifyReviewers } from '@/lib/membership/review';
 import prisma from '@/lib/prisma';
 
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 // Bare stubs, deliberately NOT a requireActual spread: review.ts sits on an
 // import cycle (review → payment → personBgTriggers → renewal → review), so an
 // eager requireActual inside this factory re-enters review.ts mid-init and

--- a/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipIntakeAPI.integration.test.ts
@@ -16,7 +16,7 @@ import { expectAuditRow, auditJson } from '@/test-helpers/expectAuditRow';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
 // beginRenewal -> notifyReviewers sends email when re-review is needed; mock it out.
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 
 const TAG = 'membership-intake-test';
 

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -12,7 +12,7 @@ import { attest } from '@/lib/membership/review';
 import { markBgConsent, markContractSigned } from '@/lib/membership/external';
 import prisma from '@/lib/prisma';
 
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 
 const TAG = 'renewal-test';
 const CRON_SECRET = 'cron-test-secret';

--- a/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
+++ b/checkin-app/src/app/__tests__/notificationsCheckin.integration.test.ts
@@ -4,6 +4,7 @@ import { sendCheckinNotifications } from "@/lib/notifications";
 import { sendEmail } from "@/lib/email";
 
 jest.mock("@/lib/email", () => ({
+    runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
     sendEmail: jest.fn().mockResolvedValue(true)
 }));
 

--- a/checkin-app/src/app/__tests__/personBgManualSubmit.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgManualSubmit.integration.test.ts
@@ -25,7 +25,7 @@ import { sendEmail } from '@/lib/email';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
 // The reviewer ping is exercised (notifyReviewers) but must not hit Resend.
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 const sendEmailMock = sendEmail as jest.Mock;
 
 const TAG = 'person-bg-submit-test';

--- a/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
@@ -16,7 +16,7 @@ import { activate } from '@/lib/membership/payment';
 import prisma from '@/lib/prisma';
 
 // Congrats/reviewer pings must not hit Resend.
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
 
 const TAG = 'person-bg-trigger-test';
 const RECHECK_MONTHS = 12;

--- a/checkin-app/src/app/__tests__/renewalConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/renewalConcurrency.integration.test.ts
@@ -23,7 +23,7 @@ import { createRenewalProcess } from '@/lib/membership/renewal';
 import prisma from '@/lib/prisma';
 
 const sendEmail = jest.fn().mockResolvedValue(true);
-jest.mock('@/lib/email', () => ({ sendEmail: (...a: unknown[]) => sendEmail(...a) }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: (...a: unknown[]) => sendEmail(...a) }));
 
 const TAG = 'renewal-concurrency-test';
 

--- a/checkin-app/src/app/api/outreach/__tests__/ledger.integration.test.ts
+++ b/checkin-app/src/app/api/outreach/__tests__/ledger.integration.test.ts
@@ -17,7 +17,7 @@ import { getServerSession } from 'next-auth/next';
 import { sendEmail } from '@/lib/email';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
-jest.mock('@/lib/email', () => ({ sendEmail: jest.fn() }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn() }));
 // process-batch's join-variant unsubscribe footer (unsubscribeToken.ts hmacKey) reads
 // config.nextAuthSecret(), which throws when unset — fine locally (the gitignored .env
 // supplies it) but CI has no .env. Same partial-mock pattern as auth-options-jwt.test.ts:


### PR DESCRIPTION
## What

16 integration suites mock `@/lib/email` with an inline **partial** factory that lists only `sendEmail` and omits `runPaced`:

```js
jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
```

`runPaced` is a real export of `src/lib/email.ts`, called by `emailRecipients.fanOutEmails`. Any code path that fans out email hits the missing mock and throws `TypeError: (0, _email.runPaced) is not a function`. The caller's try/catch swallows it and logs, so the test **still passes** while the email side-effect never runs — a test-only false-green.

Confirmed firing on 3 paths before this fix:
- `Congrats email failed` → `sendCongrats` (membership/payment.ts) via activate
- `Payment-open notice failed` → `notifyPaymentOpen` (membership/review.ts)
- `Board trusted-adult ping failed` → `notifyBoard` (trusted-adult/service.ts)

Prod is unaffected — `runPaced` exists there.

## Fix

Add the `runPaced` stub already used by 6 sibling suites (membershipPaymentAPI / trustedAdultAPI / membershipReviewAPI etc.) to each partial factory, preserving every existing `sendEmail` stub verbatim:

```js
runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
```

Suites using bare `jest.mock('@/lib/email')` (no factory) are untouched — they already pick up the full manual mock at `src/lib/__mocks__/email.ts`.

## Verification

- `npm run test:integration`: **128 suites / 1245 tests pass**
- `grep -c "runPaced is not a function"` on the run log → **0** (was firing on 3 paths)
- 3 swallowed-error log lines → **0**
- `npx tsc --noEmit` → clean

## Note for reviewer

Pre-existing bug on `main`, unrelated to any feature work. 16 test files only, no source/prod changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)