### PR TITLE
test(ci): fail jest on unexpected console.error, with an allowlist

### DIFF
--- a/checkin-app/jest.setup.js
+++ b/checkin-app/jest.setup.js
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import '@testing-library/jest-dom'
+import failOnConsole from 'jest-fail-on-console'
 
 // Integration tier (A+B): point THIS worker at its own cloned database before
 // any test module loads @/lib/prisma. integrationGlobalSetup.js created one DB
@@ -140,4 +141,66 @@ jest.mock('@/lib/prisma', () => {
     __esModule: true,
     default: new Proxy({}, handler),
   };
+});
+
+// ---------------------------------------------------------------------------
+// Fail any test that logs an UNEXPECTED console.error.
+//
+// Jest only fails on a failed assertion or an uncaught throw, so before this a
+// new error could stack-trace into the log and every check still passed green.
+// jest-fail-on-console flips that: an unallowlisted console.error throws and
+// turns the test red. Runs for BOTH tiers (setupFilesAfterEnv covers unit and
+// integration).
+//
+// KNOWN_INTENTIONAL is the allowlist: console.error messages that fire on
+// purpose — catch-block/service logs whose negative path a test deliberately
+// exercises while asserting only the HTTP status/DB outcome, plus React/jsdom
+// test-env noise. Each entry is anchored to the log's FIXED prefix (not `.*`)
+// so a genuinely new, different error still slips past and fails the test.
+//
+// Rules for adding an entry:
+//   1. Only incidental logs — the error is a side effect of the path under
+//      test, NOT the thing the test is checking.
+//   2. Match a stable, specific prefix. Never a broad `.*` that would swallow
+//      unrelated future errors.
+//   3. If a flagged error is actually a REAL bug (something logging where it
+//      shouldn't), FIX it — do not allowlist it. (The runPaced mock-drift found
+//      while building this list was fixed, not allowlisted.)
+// The 9 suites that jest.spyOn(console,...) still suppress their own messages
+// before they reach this guard — left as-is on purpose.
+const KNOWN_INTENTIONAL = [
+  // React / jsdom test-environment noise (emitted via console.error).
+  /Not implemented: navigation/,          // jsdom: window.location navigation
+  /not wrapped in act\(/,                  // React state update outside act()
+  /In HTML, .+ cannot be a (child|descendant) of/, // React DOM-nesting validation
+  /cannot contain a nested/,               // React DOM-nesting validation (alt phrasing)
+  // Bracketed service log namespaces (incidental negative-path logs).
+  /^\[Shopify/,                            // [Shopify], [Shopify Error], [Shopify API Error]
+  /^\[s-read diagnose\]/,                  // shopify-read diagnostics probes
+  /^\[enroll\]/,                           // program enroll compensation logs
+  /^\[CRON\]/,                             // cron job per-item failure logs
+  // Prefixed catch-block/service logs (incidental negative-path logs).
+  /^Failed to fetch household:/,
+  /^Failed to fetch attendance:/,
+  /^Search error:/,
+  /^resolveHouseholdRecipients failed:/,
+  /^Renewal begin error:/,
+  /^Match audit failed:/,
+  /^Failed to trigger s-read sync:/,
+  /^Failed to read the s-read sync status:/,
+  /^Failed to obtain Shopify access token:/,
+  /^Participants page action failed:/,     // membership-ops/participants/page.tsx catches
+  /^Attendance action failed:/,            // attendance/current/page.tsx catches
+  /^Failed to update event:/,
+  /^Zoho webhook received but ZOHO_WEBHOOK_SECRET is not configured\./,
+  /^Zoho status sync failed for process/,
+  /^Shopify webhook signature mismatch\./,
+  /^Failed to check out visit/,            // cron nightly per-visit failure injection
+  /^Error in pass \d+ for row/,            // finance reconcile bad-row negative path
+];
+
+failOnConsole({
+  shouldFailOnError: true,
+  shouldFailOnWarn: false, // errors only this pass; warn (React act() noise) deferred
+  allowMessage: (msg) => KNOWN_INTENTIONAL.some((re) => re.test(msg)),
 });

--- a/checkin-app/package.json
+++ b/checkin-app/package.json
@@ -73,6 +73,7 @@
     "eslint-config-next": "16.1.6",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.2.0",
+    "jest-fail-on-console": "^3.3.4",
     "jest-junit": "^17.0.0",
     "node-mocks-http": "^1.17.2",
     "prisma": "7.8.0",

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -230,7 +230,7 @@ function KioskDisplayInner() {
       if (res.ok) refreshAttendance();
       else notifications.show({ color: "red", message: isSelf ? "Failed to check out." : "Failed to force checkout.", autoClose: false });
     } catch (e) {
-      console.error(e);
+      console.error("Attendance action failed:", e);
       notifications.show({ color: "red", message: "Network error.", autoClose: false });
     } finally {
       setCheckingOut(null);
@@ -267,7 +267,7 @@ function KioskDisplayInner() {
         }
       }
     } catch (e) {
-      console.error(e);
+      console.error("Attendance action failed:", e);
       notifications.show({ color: "red", message: "Network error.", autoClose: false });
     } finally {
       setCheckingInId(null);

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -92,7 +92,7 @@ export default function AdminParticipantsIndex() {
         setResults(data.people);
       }
     } catch (err) {
-      console.error(err);
+      console.error("Participants page action failed:", err);
     } finally {
       setLoading(false);
     }
@@ -163,7 +163,7 @@ export default function AdminParticipantsIndex() {
         showNotification(data.error || "Failed to assign household", "error");
       }
     } catch (err) {
-      console.error(err);
+      console.error("Participants page action failed:", err);
       showNotification("Network error", "error");
     } finally {
       setAssigning(false);
@@ -191,7 +191,7 @@ export default function AdminParticipantsIndex() {
         showNotification(data.error || "Failed to update person", "error");
       }
     } catch (err) {
-      console.error(err);
+      console.error("Participants page action failed:", err);
       showNotification("Network error", "error");
     } finally {
       setSavingDetails(false);
@@ -226,7 +226,7 @@ export default function AdminParticipantsIndex() {
         showNotification(data.error || "Failed to add contact", "error");
       }
     } catch (err) {
-      console.error(err);
+      console.error("Participants page action failed:", err);
       showNotification("Network error", "error");
     } finally {
       setAddContactSaving(false);

--- a/checkin-app/src/lib/__tests__/notifications.test.ts
+++ b/checkin-app/src/lib/__tests__/notifications.test.ts
@@ -71,7 +71,16 @@ describe('sendNotification return contract', () => {
 });
 
 describe('notifyNewProgramAnnounced opt-in filtering', () => {
-    beforeEach(() => jest.clearAllMocks());
+    // clearAllMocks() wipes call data but NOT implementations, so the
+    // mockRejectedValue('boom') set in the sendNotification describe above would
+    // leak in and make these sends reject — recording the calls these tests
+    // assert on while incidentally logging "Failed to send new-program
+    // notifications:". Reset sendEmail to succeed: these tests exercise the
+    // recipient-filtering logic, not the send failure path.
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockSendEmail.mockResolvedValue(true);
+    });
 
     const program = { name: 'Robotics', startAt: null, endAt: new Date('2026-12-01') };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "eslint-config-next": "16.1.6",
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.2.0",
+        "jest-fail-on-console": "^3.3.4",
         "jest-junit": "^17.0.0",
         "node-mocks-http": "^1.17.2",
         "prisma": "7.8.0",
@@ -11631,6 +11632,19 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jest-fail-on-console": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-3.3.4.tgz",
+      "integrity": "sha512-ckcABlg7ZLy83RRVOE1YvJMF1thgVPozVp+DjnE36Z1CaIbTrSeSR2AU4de/SEpfFgp2qK62EHXfm47N74zMuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "yarn": "1.x"
+      },
+      "peerDependencies": {
+        "@jest/globals": ">=27.5.1"
+      }
     },
     "node_modules/jest-haste-map": {
       "version": "30.3.0",


### PR DESCRIPTION
> ✅ **#1340 is merged; this branch is rebased on top of it.** Dependency satisfied — the `runPaced` mock fix is in `main`, so the integration tier no longer trips the gate. No special merge ordering needed anymore.

## What
Jest only failed on assertions or uncaught throws, so a new `console.error` could stack-trace into the log while every check stayed green. This wires [`jest-fail-on-console`](https://www.npmjs.com/package/jest-fail-on-console) in `jest.setup.js` (both tiers via `setupFilesAfterEnv`) so an **unallowlisted** `console.error` turns the test red.

`KNOWN_INTENTIONAL` allowlists the messages that fire on purpose — incidental catch-block/service logs whose negative path a test deliberately exercises, plus React/jsdom test-env noise — each anchored to the log's **fixed prefix** (not `.*`) so a genuinely new error still fails. Built empirically from real unit + integration runs: 25 regex entries covering ~60 distinct messages. The 9 suites that already `jest.spyOn(console,…)` are left as-is.

## Fixes the gate surfaced (fixed, not allowlisted)
- **Bare `console.error(err)` catches** in `membership-ops/participants` and `attendance/current` pages given a stable prefix, so they carry context and are allowlistable by more than a fixture string.
- **`notifications.test.ts` mock leak** — a rejecting `sendEmail` mock leaked across describes via `clearAllMocks` (which does not reset implementations), silently no-op'ing the sends the filtering tests assert on. Reset it to resolve.
- **`runPaced` mock-drift** (the bigger one) shipped in **#1340**: 16 integration suites stubbed `@/lib/email` with a partial factory omitting `runPaced`, so email fan-out silently threw and was swallowed. Split out for isolated review, now merged.

## Verification
Rebased on current `main`; both tiers green with the gate active: unit **252 suites / 2373 tests**, integration **128 / 1249**, 0 gate failures, 0 `runPaced` remnants. `tsc --noEmit` clean.

## Follow-up
Warn-gating is off this pass (`shouldFailOnWarn: false`) to defer React `act()` noise — flip it once that's cleaned up. A separate research task is auditing the remaining bare `console.error` sites with no negative-path coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)