### PR TITLE
chore(logging): prefix bare console.error in client components

### DIFF
--- a/checkin-app/src/app/facility-ops/print-badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/page.tsx
@@ -48,7 +48,7 @@ export default function PrintBadgesPage() {
         setParticipants(data.people);
       }
     } catch (e) {
-      console.error(e);
+      console.error("Failed to search people for badges:", e);
     } finally {
       setLoading(false);
     }

--- a/checkin-app/src/app/facility-ops/trends/page.tsx
+++ b/checkin-app/src/app/facility-ops/trends/page.tsx
@@ -42,7 +42,7 @@ export default function ParticipationTrendsPage() {
           setPrograms(data.map((p: { id: number; name: string }) => ({ id: p.id, name: p.name })));
         }
       })
-      .catch(console.error);
+      .catch((err) => console.error("Failed to load programs for trends dropdown:", err));
   }, []);
 
   // Fetch trends data
@@ -58,7 +58,7 @@ export default function ParticipationTrendsPage() {
         setBuckets(data.buckets || []);
         setTotals(data.totals || null);
       })
-      .catch(console.error)
+      .catch((err) => console.error("Failed to load facility trends:", err))
       .finally(() => setLoading(false));
   }, [period, programId, ready]);
 

--- a/checkin-app/src/app/membership-audit/broken/page.tsx
+++ b/checkin-app/src/app/membership-audit/broken/page.tsx
@@ -24,7 +24,7 @@ export default function BrokenHouseholdsPage() {
       const data = await res.json();
       if (data.households) setHouseholds(data.households);
     } catch (err) {
-      console.error(err);
+      console.error("Failed to load broken households:", err);
     } finally {
       setLoading(false);
     }

--- a/checkin-app/src/app/membership-audit/compliance/page.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/page.tsx
@@ -122,7 +122,7 @@ export default function CompliancePage() {
           setError("Failed to load compliance data. Ensure you have the proper authorizations.");
         }
       } catch (e) {
-        console.error(e);
+        console.error("Failed to load compliance data:", e);
         setError("Network error loading compliance data.");
       } finally {
         setLoading(false);

--- a/checkin-app/src/app/membership-audit/emergency-contacts/page.tsx
+++ b/checkin-app/src/app/membership-audit/emergency-contacts/page.tsx
@@ -30,7 +30,7 @@ export default function MissingEmergencyContactsPage() {
         setError("Failed to load households. Ensure you have the proper authorizations.");
       }
     } catch (e) {
-      console.error(e);
+      console.error("Failed to load households missing contacts:", e);
       notifications.show({ color: "red", message: "Network error loading households.", autoClose: false });
     } finally {
       setLoading(false);

--- a/checkin-app/src/app/membership-audit/unclaimed/page.tsx
+++ b/checkin-app/src/app/membership-audit/unclaimed/page.tsx
@@ -20,7 +20,7 @@ export default function UnclaimedHouseholdsIndex() {
         const data = await res.json();
         if (data.households) setHouseholds(data.households);
       } catch (err) {
-        console.error(err);
+        console.error("Failed to load unclaimed households:", err);
       } finally {
         setLoading(false);
       }

--- a/checkin-app/src/app/membership-ops/roles/page.tsx
+++ b/checkin-app/src/app/membership-ops/roles/page.tsx
@@ -29,7 +29,7 @@ export default function RolesPage() {
       const data = await res.json();
       if (data.people) setPeople(data.people);
     } catch (err) {
-      console.error(err);
+      console.error("Failed to load roles:", err);
     } finally {
       setFetching(false);
     }

--- a/checkin-app/src/app/program-ops/events/page.tsx
+++ b/checkin-app/src/app/program-ops/events/page.tsx
@@ -30,7 +30,7 @@ export default function OneTimeEventsList() {
     fetch("/api/events")
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => setEvents(Array.isArray(data) ? data : []))
-      .catch((err) => console.error(err))
+      .catch((err) => console.error("Failed to load events:", err))
       .finally(() => setLoading(false));
   }, []);
 

--- a/checkin-app/src/app/program-ops/programs/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/page.tsx
@@ -64,7 +64,7 @@ export default function AdminProgramsIndex() {
         setLoading(false);
       })
       .catch(err => {
-        console.error(err);
+        console.error("Failed to load programs:", err);
         setLoading(false);
       });
   }, []);

--- a/checkin-app/src/app/safety/board-contacts/page.tsx
+++ b/checkin-app/src/app/safety/board-contacts/page.tsx
@@ -31,7 +31,7 @@ export default function BoardContactInfoPage() {
         setError("Failed to load board contacts. Ensure you have the proper authorizations.");
       }
     } catch (e) {
-      console.error(e);
+      console.error("Failed to load board contacts:", e);
       notifications.show({ color: "red", message: "Network error loading board contacts.", autoClose: false });
     } finally {
       setLoading(false);

--- a/checkin-app/src/app/safety/emergency-contacts/page.tsx
+++ b/checkin-app/src/app/safety/emergency-contacts/page.tsx
@@ -66,7 +66,7 @@ export default function EmergencyContactsPage() {
         setError("Failed to load emergency contacts. Ensure you have the proper authorizations.");
       }
     } catch (e) {
-      console.error(e);
+      console.error("Failed to load emergency contacts:", e);
       notifications.show({ color: "red", message: "Network error loading contacts.", autoClose: false });
     } finally {
       setLoading(false);

--- a/checkin-app/src/app/safety/pickup/page.tsx
+++ b/checkin-app/src/app/safety/pickup/page.tsx
@@ -33,7 +33,7 @@ export default function TrustedAdultPickupPage() {
         fetch("/api/trusted-adults/operational")
             .then((r) => r.json())
             .then((d) => setItems(d.trustedAdults ?? []))
-            .catch(console.error)
+            .catch((err) => console.error("Failed to load trusted adults for pickup:", err))
             .finally(() => setLoading(false));
     }, []);
 

--- a/checkin-app/src/components/TrustedAdultPanel.tsx
+++ b/checkin-app/src/components/TrustedAdultPanel.tsx
@@ -105,7 +105,7 @@ export default function TrustedAdultPanel() {
         fetch("/api/trusted-adults/mine")
             .then((r) => r.json())
             .then((d) => setItems(d.trustedAdults ?? []))
-            .catch(console.error)
+            .catch((err) => console.error("Failed to load your trusted adults:", err))
             .finally(() => setLoading(false));
     }, []);
 

--- a/checkin-app/src/components/admin/SystemHealthPanels.tsx
+++ b/checkin-app/src/components/admin/SystemHealthPanels.tsx
@@ -328,7 +328,7 @@ export function BadgeScanChart() {
           setStats(data.days);
         }
       })
-      .catch(console.error)
+      .catch((err) => console.error("Failed to load system health:", err))
       .finally(() => setLoading(false));
   }, []);
 

--- a/checkin-app/src/components/roles/RolesEditModal.tsx
+++ b/checkin-app/src/components/roles/RolesEditModal.tsx
@@ -104,7 +104,7 @@ export function RolesEditModal({ target, me, onClose, onSaved }: RolesEditModalP
         showNotification(data.error || "Failed to update roles", "error");
       }
     } catch (err) {
-      console.error(err);
+      console.error("Failed to update roles:", err);
       showNotification("Network error updating roles", "error");
     } finally {
       setSavingRoles(false);


### PR DESCRIPTION
PR-2 of the console-error cleanup plan.

## What
Adds a stable context prefix to 16 bare `console.error` calls across 15 client-component catch/`.catch` handlers. Each previously printed a bare `Error: <msg>` + stack with no indication of which fetch failed. `.catch(console.error)` sites are expanded to an arrow so the prefix has somewhere to go.

## Why
Prefixes make these catches (a) debuggable — you can see *which* load failed — and (b) allowlistable by a stable prefix in the jest-fail-on-console gate (#1341).

## Independence
- **No file overlap** with the two open gate PRs (#1340 runpaced-mock, #1341 jest-fail-on-console). Does **not** stack on them.
- The two files owned by #1341 — `attendance/current/page.tsx` and `membership-ops/participants/page.tsx` — are deliberately left **bare** here to avoid conflict. After this sweep they are the only remaining bare `console.error` sites in the repo (6 lines).
- None of the 16 sites fire in the test suite, so CI outcomes are unaffected.

## Scope
- Mechanical, string-arg-only change. No behavior change, no new tests, no refactor.
- The 11 silent-swallow sites (no user-facing fallback) still need real error UI — that is a separate later PR, out of scope here.

No sites skipped — all 16 matched the described pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)