### PR TITLE
chore(lint): ban bare console.error (error severity)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,26 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 
+// Bare error logs regress silently: console.error(err) and .catch(console.error)
+// emit a stack with no stable context prefix, so grepping prod logs for a
+// failure site turns up nothing. Require a literal prefix string —
+// console.error("Failed to X:", err) passes. Shared so the api-routes block
+// (which replaces, not merges, this rule for its files) stays a superset.
+const bareConsoleErrorRules = [
+  {
+    selector:
+      "CallExpression[callee.object.name='console'][callee.property.name='error'][arguments.length=1][arguments.0.type='Identifier']",
+    message:
+      'Do not log a bare error — add a stable context prefix: console.error("Failed to X:", err).',
+  },
+  {
+    selector:
+      "CallExpression[callee.property.name='catch'][arguments.0.object.name='console'][arguments.0.property.name='error']",
+    message:
+      'Do not pass console.error as a handler — wrap it: .catch((err) => console.error("Failed to X:", err)).',
+  },
+];
+
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
@@ -17,6 +37,10 @@ const eslintConfig = defineConfig([
     // Generated Prisma client — emitted by `prisma generate`, never linted.
     "**/src/generated/**",
   ]),
+  {
+    files: ["**/src/**/*.{ts,tsx}"],
+    rules: { "no-restricted-syntax": ["error", ...bareConsoleErrorRules] },
+  },
   // API routes must log through @/lib/logger (console sink + logBackendError),
   // not raw console. Scoped to server routes only — client code can't use the
   // prisma-backed sink. Broadening to all of src is a follow-up.
@@ -30,6 +54,10 @@ const eslintConfig = defineConfig([
     // NextResponse.json({ error }) / ({ error, details }) in the route surface.
     // Multi-key error bodies (e.g. { error, code }, { error, requiresOverride })
     // are intentional richer contracts and are NOT flagged.
+    //
+    // Flat config replaces (does not merge) a same-named rule, and api files
+    // also match the src-wide block above, so this array carries the shared
+    // bare-console-error rules too — otherwise this block would silence them.
     files: ["**/src/app/api/**/*.ts"],
     rules: {
       "no-restricted-syntax": [
@@ -40,6 +68,7 @@ const eslintConfig = defineConfig([
           message:
             "Return errors via apiError(message, status[, details]) from @/lib/api-response, not a raw NextResponse.json({ error }).",
         },
+        ...bareConsoleErrorRules,
       ],
     },
   },


### PR DESCRIPTION
**PR-3** of the console-error cleanup plan — a regression guard so new un-prefixed error logs can't land.

## What it does
Adds two `no-restricted-syntax` selectors (severity `error`), scoped to `**/src/**/*.{ts,tsx}`:

1. **Lone-identifier** — bans `console.error(err)` / `console.error(e)`:
   `CallExpression[callee.object.name='console'][callee.property.name='error'][arguments.length=1][arguments.0.type='Identifier']`
2. **Passed-reference** — bans `.catch(console.error)`:
   `CallExpression[callee.property.name='catch'][arguments.0.object.name='console'][arguments.0.property.name='error']`

The selectors are shared via a `bareConsoleErrorRules` const. Flat config **replaces** (does not merge) a same-named rule across config objects, and api routes also match the existing api-scoped `no-restricted-syntax` block (the `apiError` NextResponse rule) — so that block re-includes the shared rules to stay a superset. Without this, the api block would silently drop the bare-console ban on api files (and the reverse — a naive append would have clobbered `apiError`, tripping an unused-`eslint-disable` warning under `--max-warnings 0`).

## Intentionally still allowed
- `console.error("Failed to X:", err)` — string-literal prefix as arg 0 (a `Literal`, not an `Identifier`) passes. A stable context prefix survives.
- `logger.error(...)` — different `callee.object`, never matched.

## Merge gate — CLEARED ✅
Both dependency PRs that removed the 22 pre-existing bare sites have merged into `main`:
- #1341 — jest-fail-on-console gate (prefixed `attendance/current` + `membership-ops/participants`).
- The `claude/prefix-console-errors` sweep (PR-2) — prefixed the remaining client-component sites.

Rebased on current `main`. `npm run lint` (`eslint --max-warnings 0`) exits **0** — 0 errors, 0 warnings. Verified the ban fires on both a non-api (`src/lib`) and an api (`src/app/api`) path, and that the `apiError` rule still fires on api routes. Green — ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)