### PR TITLE
fix(facility): let board members reach the visit-edit UI (AT13, #1259)

### DIFF
--- a/checkin-app/src/app/facility-ops/visits/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/visits/__tests__/page.test.tsx
@@ -5,7 +5,7 @@ jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
 import { screen, fireEvent, waitFor, within } from "@testing-library/react";
-import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import { renderWithProviders, mockFetchJson, setSession, resetRtl, router } from "@/test-helpers/rtl";
 import { notifications } from "@mantine/notifications";
 import AdminVisitsPage from "../page";
 
@@ -27,6 +27,27 @@ describe("facility-ops/visits page", () => {
     expect(screen.getByText("Open Gym")).toBeInTheDocument();
     expect(screen.getByText("Open Facility")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  // The page must gate on the same roles the PATCH/DELETE /api/facility/visits
+  // route allows (['isSysadmin', 'isBoardMember']) — UI and API agree on who
+  // may edit/delete a visit.
+  it("admits a board member (matches the API's edit/delete grant)", async () => {
+    setSession({ id: 3, isBoardMember: true });
+    mockFetchJson({ "/api/facility/visits": { visits } });
+    renderWithProviders(<AdminVisitsPage />);
+
+    expect(await screen.findByText("Val Volunteer")).toBeInTheDocument();
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it("redirects a non-privileged user (denied like the API)", async () => {
+    setSession({ id: 4 });
+    mockFetchJson({ "/api/facility/visits": { visits } });
+    renderWithProviders(<AdminVisitsPage />);
+
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/"));
+    expect(screen.queryByText("Val Volunteer")).not.toBeInTheDocument();
   });
 
   it("re-sorts rows when a sortable header is clicked", async () => {

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -63,7 +63,7 @@ const sortValue = (v: Visit, key: SortKey): string | number => {
 };
 
 export default function AdminVisitsPage() {
-  const { ready, loading: authLoading } = useRequireRole(['isSysadmin']);
+  const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
 
   const [loading, setLoading] = useState(true);
   const [visits, setVisits] = useState<Visit[]>([]);


### PR DESCRIPTION
## What

Widen the `/facility-ops/visits` page role gate from `['isSysadmin']` to `['isSysadmin', 'isBoardMember']`, so board members can reach the UI for a privilege the API already grants them.

## Why (AT13 / #1259)

`PATCH`/`DELETE /api/facility/visits` are gated `['isSysadmin', 'isBoardMember']` — board members can already correct or delete visit records via the API. But the page itself gated `useRequireRole(['isSysadmin'])`, so a board member had write access with **no UI page** to reach it. UI and API disagreed on who may edit/delete a visit.

## Direction: widen the UI (not narrow the API)

Evidence the API's board-allowance is intentional, and the page gate was the outlier:

- **API** (`src/app/api/facility/visits/route.ts`): `GET`, `PATCH`, and `DELETE` all gate `['isSysadmin', 'isBoardMember']` — the whole route is consistently board-allowed, not one stray verb.
- **Parent layout** (`src/app/facility-ops/layout.tsx`): `FacilityLayout` gates `['isSysadmin', 'isBoardMember']`. Board members already reach the Facility Ops tabs; sibling pages (badges, trends) add no inner sysadmin-only gate.
- **Nav registry** (`src/components/pageRegistry.ts`): `/facility-ops/visits` is `visible: BOARD`.

Security-over-grant case ruled out — the fix makes the UI consistent, it does not redesign the permission model (a separate attendance-correction design covers that).

## Changes

- `src/app/facility-ops/visits/page.tsx` — one-line gate widen.
- `src/app/facility-ops/visits/__tests__/page.test.tsx` — +2 tests: a board member is admitted; a non-privileged user is redirected to `/`.

## Test

Ran the page suite scoped to this one file: 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Closes #1259
