### PR TITLE
feat(programs): surface freed-seat notice + Shopify warnings on roster add/remove

### DIFF
--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -779,7 +779,11 @@ describe('Program Participants API Integration Tests', () => {
                     createParams(shopifyProgram.id) as unknown as never,
                 );
                 expect(res.status).toBe(200);
-                expect((await res.json()).warning).toBeUndefined();
+                const withdrawData = await res.json();
+                expect(withdrawData.warning).toBeUndefined();
+                // Scholarship release path already fires +1 (released:true); it is
+                // NOT the manual-restock notice case.
+                expect(withdrawData.notice).toBeUndefined();
                 expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by 1 for variant: dev-mock-variant-withdraw-partic'));
 
                 const row = await prisma.programParticipant.findUnique({
@@ -808,6 +812,108 @@ describe('Program Participants API Integration Tests', () => {
                 process.env.CHECKIN_ENV = prevCheckinEnv;
                 await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
                 await prisma.program.delete({ where: { id: shopifyProgram.id } });
+            }
+        });
+
+        // Removing an ACTIVE seat frees the room but does NOT auto-restock
+        // Shopify (paid/comped seats are only put back on sale by a human). The
+        // route returns an advisory `notice` and fires NO +1 — the staffer
+        // decides whether to restock.
+        it('advises (notice) on ACTIVE removal from a capped Shopify program, and does NOT +1', async () => {
+            const prevCheckinEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local'; // arms the adjustProgramInventory mock (logs the delta)
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            const shopifyProgram = await prisma.program.create({
+                data: { name: 'Notice Shopify Partic API Test', enrollmentStatus: 'OPEN', maxParticipants: 5, shopifyVariantId: 'dev-mock-variant-notice-partic' },
+            });
+            try {
+                await prisma.programParticipant.create({
+                    data: { programId: shopifyProgram.id, personId: commonId, status: 'ACTIVE' },
+                });
+                (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } }); // self-removal
+
+                const res = await DELETE(
+                    new Request(`http://localhost:4000/api/programs/${shopifyProgram.id}/participants`, {
+                        method: 'DELETE',
+                        headers: { cookie: 'session=test' },
+                        body: JSON.stringify({ participantId: commonId }),
+                    }) as unknown as import("next/server").NextRequest,
+                    createParams(shopifyProgram.id) as unknown as never,
+                );
+                expect(res.status).toBe(200);
+                const data = await res.json();
+                expect(data.notice).toMatch(/NOT put back on sale automatically/i);
+                expect(data.warning).toBeUndefined();
+                // Freed seat is NOT auto-restocked: no positive-delta Shopify call.
+                expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by 1'));
+            } finally {
+                logSpy.mockRestore();
+                process.env.CHECKIN_ENV = prevCheckinEnv;
+                await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
+                await prisma.program.delete({ where: { id: shopifyProgram.id } });
+            }
+        });
+
+        // A PENDING non-scholarship row never took a seat, so removing it frees
+        // nothing and carries no notice.
+        it('does NOT advise (no notice) when removing a PENDING participant with no hold', async () => {
+            const shopifyProgram = await prisma.program.create({
+                data: { name: 'Notice Pending Partic API Test', enrollmentStatus: 'OPEN', maxParticipants: 5, shopifyVariantId: 'dev-mock-variant-notice-pending' },
+            });
+            try {
+                await prisma.programParticipant.create({
+                    data: { programId: shopifyProgram.id, personId: commonId, status: 'PENDING' },
+                });
+                (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } }); // self-removal
+
+                const res = await DELETE(
+                    new Request(`http://localhost:4000/api/programs/${shopifyProgram.id}/participants`, {
+                        method: 'DELETE',
+                        body: JSON.stringify({ participantId: commonId }),
+                    }) as unknown as import("next/server").NextRequest,
+                    createParams(shopifyProgram.id) as unknown as never,
+                );
+                expect(res.status).toBe(200);
+                const data = await res.json();
+                expect(data.notice).toBeUndefined();
+            } finally {
+                await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
+                await prisma.program.delete({ where: { id: shopifyProgram.id } });
+            }
+        });
+
+        // Uncapped programs track no inventory (inventory_management=null), so an
+        // ACTIVE removal there frees no tracked seat — no notice, no Shopify call.
+        it('does NOT advise (no notice) on ACTIVE removal from an UNCAPPED program', async () => {
+            const prevCheckinEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local';
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            const uncappedProgram = await prisma.program.create({
+                data: { name: 'Notice Uncapped Partic API Test', enrollmentStatus: 'OPEN', maxParticipants: null, shopifyVariantId: 'dev-mock-variant-notice-uncapped' },
+            });
+            try {
+                await prisma.programParticipant.create({
+                    data: { programId: uncappedProgram.id, personId: commonId, status: 'ACTIVE' },
+                });
+                (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } }); // self-removal
+
+                const res = await DELETE(
+                    new Request(`http://localhost:4000/api/programs/${uncappedProgram.id}/participants`, {
+                        method: 'DELETE',
+                        headers: { cookie: 'session=test' },
+                        body: JSON.stringify({ participantId: commonId }),
+                    }) as unknown as import("next/server").NextRequest,
+                    createParams(uncappedProgram.id) as unknown as never,
+                );
+                expect(res.status).toBe(200);
+                const data = await res.json();
+                expect(data.notice).toBeUndefined();
+                expect(logSpy).not.toHaveBeenCalled();
+            } finally {
+                logSpy.mockRestore();
+                process.env.CHECKIN_ENV = prevCheckinEnv;
+                await prisma.programParticipant.deleteMany({ where: { programId: uncappedProgram.id } });
+                await prisma.program.delete({ where: { id: uncappedProgram.id } });
             }
         });
     });

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -284,6 +284,13 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
         if (released && !shopifyOk) {
             responseObj.warning = "Participant removed, but the Shopify inventory release failed. Capacity may be out of sync — check System Status > Link Status.";
         }
+
+        // Advise a manual Shopify restock only when an ACTIVE removal freed a
+        // tracked seat; `released` already handles the PENDING hold path (+1).
+        const hasShopifyVariant = !!(currentProgram.shopifyVariantId || currentProgram.shopifyOrgMemberVariantId || currentProgram.shopifyNonOrgMemberVariantId);
+        if (!released && enrollment.status === 'ACTIVE' && currentProgram.maxParticipants !== null && hasShopifyVariant) {
+            responseObj.notice = "Seat freed. This enrollment held a seat in Shopify; it was NOT put back on sale automatically. If you want it available for a paying family, add +1 to this program's inventory in Shopify.";
+        }
         return NextResponse.json(responseObj);
     } catch (error) {
         // P2025 = row to delete not found. Benign double-submit (participant

--- a/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
@@ -9,6 +9,14 @@ import { calculateAge, formatDateTime } from '@/lib/time';
 import { formatPhone } from '@/lib/phone';
 import type { ProgramDetail, ParticipantOption } from './page';
 
+// Roster mutation routes answer with these advisory fields. A non-JSON body
+// (session-expiry HTML redirect, proxy error page) must not throw and skip the
+// roster refetch, so parse failures degrade to an empty object.
+type ApiFeedback = { notice?: string; warning?: string; error?: string };
+async function readJson(res: Response): Promise<ApiFeedback> {
+  try { return await res.json(); } catch { return {}; }
+}
+
 type ProgramRosterTabProps = {
   programId: string;
   program: Pick<ProgramDetail, 'volunteers' | 'participants' | 'startAt' | 'minAge' | 'maxAge'>;
@@ -36,16 +44,16 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, fetchP
   // Roster mutations must never fail silently: a rejected remove (403 from a
   // caller who isn't this program's lead, a 400, a 500) is otherwise
   // indistinguishable from a successful one — the row just stays put.
-  const mutate = async (path: string, init: RequestInit): Promise<boolean> => {
+  const mutate = async (path: string, init: RequestInit): Promise<ApiFeedback | null> => {
     try {
       const res = await fetch(path, { headers: { 'Content-Type': 'application/json' }, ...init });
-      if (res.ok) return true;
-      const data = await res.json().catch(() => ({}));
+      const data = await readJson(res);
+      if (res.ok) return data;
       notifications.show({ color: 'red', message: data.error || `Request failed (${res.status}).`, autoClose: 6000 });
     } catch {
       notifications.show({ color: 'red', message: 'Network error — please try again.', autoClose: 6000 });
     }
-    return false;
+    return null;
   };
 
   // Volunteer + participant pickers both search this program's eligible members.
@@ -116,9 +124,12 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, fetchP
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ participantId: parseInt(newPartId), override: true })
       });
-      if (res.ok) { setNewPartId(""); setPartLabel(""); fetchProgram(); }
+      const data = await readJson(res);
+      if (res.ok) {
+        if (data.warning) notifications.show({ color: 'yellow', message: data.warning, autoClose: false });
+        setNewPartId(""); setPartLabel(""); fetchProgram();
+      }
       else {
-        const data = await res.json();
         if (res.status === 409) {
           // Race: benign double-submit / stale view — already enrolled.
           notifications.show({ color: "red", message: data.error || "Participant is already enrolled in this program.", autoClose: 4000 });
@@ -143,8 +154,12 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, fetchP
     closeConfirmRemovePart();
     const participantId = pendingRemovePartId;
     setPendingRemovePartId(null);
-    const ok = await mutate(`/api/programs/${programId}/participants`, { method: 'DELETE', body: JSON.stringify({ participantId }) });
-    if (ok) fetchProgram();
+    const data = await mutate(`/api/programs/${programId}/participants`, { method: 'DELETE', body: JSON.stringify({ participantId }) });
+    if (data) {
+      if (data.notice) notifications.show({ color: 'blue', message: data.notice, autoClose: false });
+      if (data.warning) notifications.show({ color: 'yellow', message: data.warning, autoClose: false });
+      fetchProgram();
+    }
   };
 
   return (

--- a/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
@@ -568,6 +568,45 @@ describe("ProgramDetailsPage", () => {
     );
   });
 
+  it("surfaces a DELETE notice/warning as a notification, but stays quiet on a bare success", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const responses = [
+      { notice: "Seat freed. Add +1 in Shopify." },
+      { warning: "Shopify inventory release failed." },
+      { success: true },
+    ];
+    let call = 0;
+    routedFetch([
+      { url: "/api/programs/1", method: "GET", result: { ok: true, body: programData } },
+      { url: "/api/programs/1/participants", method: "DELETE", result: () => ({ ok: true, body: responses[call++] }) },
+    ]);
+    renderPage();
+    await screen.findByRole("heading", { name: "Robotics Club", level: 1 });
+    fireEvent.click(screen.getByRole("tab", { name: "Roster" }));
+    await screen.findByText(/Alice Kid/);
+
+    // 1st remove -> notice (blue)
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[1]);
+    fireEvent.click(within(await screen.findByRole("dialog", { name: "Remove Participant" })).getByRole("button", { name: "Remove" }));
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "blue", message: "Seat freed. Add +1 in Shopify." })),
+    );
+
+    // 2nd remove -> warning (yellow)
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[1]);
+    fireEvent.click(within(await screen.findByRole("dialog", { name: "Remove Participant" })).getByRole("button", { name: "Remove" }));
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ color: "yellow", message: "Shopify inventory release failed." })),
+    );
+
+    // 3rd remove -> bare success, no further notification
+    const before = (notifications.show as jest.Mock).mock.calls.length;
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[1]);
+    fireEvent.click(within(await screen.findByRole("dialog", { name: "Remove Participant" })).getByRole("button", { name: "Remove" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Remove Participant" })).not.toBeInTheDocument());
+    expect((notifications.show as jest.Mock).mock.calls.length).toBe(before);
+  });
+
   it("shows past-confirmed and future events distinctly, and can schedule a new session", async () => {
     const eventsProgram = {
       ...programData,


### PR DESCRIPTION
## Problem

Program capacity models the physical room. A board comp consumes a Shopify seat (`-1`), and removing an ACTIVE enrollment does **not** auto-restock Shopify — a human decides whether to put the freed seat back on sale, by hand. But the program-ops roster UI **discarded the API response** on both add and remove, so:

- the comp-add `-1`-failure `warning` (already returned by POST) never reached anyone;
- the scholarship-hold-release-failure `warning` (already returned by DELETE) never reached anyone;
- a removed ACTIVE seat gave **no signal at all** that it is now freed and needs a manual Shopify restock decision.

## Change

**Backend** — `participants/route.ts` DELETE: add an advisory `notice` when an ACTIVE removal frees a tracked seat, i.e. all of: no scholarship hold released (`released === false`), `enrollment.status === 'ACTIVE'`, capped program (`maxParticipants !== null`), and a Shopify variant is wired. Purely derived from the row + program — **no auto-`+1`, no schema column, no Shopify call on removal**. The existing `released && !shopifyOk` warning is unchanged; both fields may appear together.

**Frontend** — `ProgramRosterTab.tsx`: surface `notice` (blue) + `warning` (yellow) on remove, and `warning` (yellow) on add, instead of dropping the response. Both are **sticky** (`autoClose: false`) — they prompt a manual Shopify action / flag an out-of-sync state, matching this page's existing load-error notification.

## Tests

- Integration (`programsParticipantsAPI.integration.test.ts`): ACTIVE removal from a capped Shopify-wired program → `notice`, no `+1`; PENDING no-hold removal → no `notice`; ACTIVE removal from an uncapped program → no `notice`, no Shopify call; plus asserting the existing scholarship-withdraw (`released:true`, `+1`) does **not** also get a `notice`.
- Frontend (`page.test.tsx`): a DELETE response with `notice` / with `warning` fires `notifications.show`; a bare `{success:true}` does not.

## Verify

- `npx tsc --noEmit` clean
- frontend `page.test.tsx` 23/23
- integration `programsParticipantsAPI` PASS

Closes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)