### PR TITLE
fix(safety): unknown DOB fails closed in the two-deep calc

### DIFF
--- a/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
+++ b/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
@@ -95,3 +95,29 @@ describe("getFullAttendance() — privileged caller (unchanged)", () => {
         expect(JSON.stringify(attendance)).not.toContain("@example.com");
     });
 });
+
+describe("two-deep calc fails closed on unknown DOB (#300)", () => {
+    // Youth (hh 8) + real adult (hh 6) + null-DOB visitor in the youth's
+    // household. Under the old null→adult default the null-DOB visitor
+    // "accompanied" the youth AND made adultVisits.length 2 — masking the
+    // violation on both prongs.
+    const nullDobRow = {
+        id: 204, arrivedAt: new Date("2026-07-01T14:20:00Z"), departedAt: null, personId: 80,
+        person: {
+            id: 80, email: "nodob@example.com", name: "No Dob", isKeyholder: false,
+            dateOfBirth: null, householdId: 8, phone: null,
+            household: { id: 8, emergencyContacts: [] },
+        },
+        event: null,
+    };
+
+    it("unknown DOB is never a supervising adult and cannot mask a violation", async () => {
+        findMany.mockResolvedValue([...rows, nullDobRow]);
+        const { attendance, counts, safety } = await getFullAttendance({ kiosk: true });
+
+        expect(safety.isTwoDeepViolation).toBe(true);
+        // counted as youth, not volunteer, and flagged as youth on the wire
+        expect(counts).toEqual({ keyholders: 1, volunteers: 0, youth: 2, total: 3 });
+        expect(attendance[2].participant.isYouth).toBe(true);
+    });
+});

--- a/checkin-app/src/lib/__tests__/time.test.ts
+++ b/checkin-app/src/lib/__tests__/time.test.ts
@@ -1,4 +1,24 @@
-import { formatDate, formatTime, formatDateTime, formatVisitRange, APP_TIMEZONE, toDatetimeLocal, fromDatetimeLocal } from '../time';
+import { formatDate, formatTime, formatDateTime, formatVisitRange, APP_TIMEZONE, toDatetimeLocal, fromDatetimeLocal, isYouth } from '../time';
+
+describe('isYouth', () => {
+  it('classifies by age when DOB is known', () => {
+    expect(isYouth(new Date('2020-01-01'))).toBe(true);
+    expect(isYouth(new Date('1980-01-01'))).toBe(false);
+  });
+
+  it('unknown DOB defaults to adult (UI/household-lead contract)', () => {
+    expect(isYouth(null)).toBe(false);
+    expect(isYouth(undefined)).toBe(false);
+    expect(isYouth('', { unknownIs: 'adult' })).toBe(false);
+  });
+
+  it('unknown DOB fails closed when the caller opts in (#300)', () => {
+    expect(isYouth(null, { unknownIs: 'youth' })).toBe(true);
+    expect(isYouth(undefined, { unknownIs: 'youth' })).toBe(true);
+    // known DOB is never overridden by the option
+    expect(isYouth(new Date('1980-01-01'), { unknownIs: 'youth' })).toBe(false);
+  });
+});
 
 describe('datetime-local helpers', () => {
   it('round-trips a datetime-local value', () => {

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -67,10 +67,12 @@ export async function getFullAttendance(opts: { kiosk?: boolean } = {}) {
         orderBy: { arrivedAt: "desc" },
     });
 
-    // Pre-compute isYouth once per visit to avoid repeated calculations
+    // Pre-compute isYouth once per visit to avoid repeated calculations.
+    // unknownIs:'youth' — this map feeds the two-deep safety calc, so an
+    // unknown DOB must fail closed (never count as a supervising adult), #300.
     const youthMap = new Map<number, boolean>();
     for (const v of activeVisits) {
-        youthMap.set(v.id, isYouth(v.person.dateOfBirth));
+        youthMap.set(v.id, isYouth(v.person.dateOfBirth, { unknownIs: 'youth' }));
     }
 
     const keyholderVisits = activeVisits.filter(v => v.person.isKeyholder);

--- a/checkin-app/src/lib/time.ts
+++ b/checkin-app/src/lib/time.ts
@@ -107,8 +107,16 @@ export function calculateAge(dob: Date | string, asOf: Date | string = new Date(
 /**
  * Returns true if the person with the given DOB is under 18 years old (youth).
  * Canonical implementation — use this everywhere instead of inline age checks.
+ *
+ * Unknown (null/undefined) DOB resolves to `unknownIs`, default 'adult': UI and
+ * household-lead callers rely on that (a null-DOB member stays promotable to
+ * lead, blank forms don't show youth fields). Safety checks must pass
+ * `{ unknownIs: 'youth' }` so missing data fails closed (#300).
  */
-export function isYouth(dob: Date | string | null | undefined): boolean {
-    if (!dob) return false;
+export function isYouth(
+    dob: Date | string | null | undefined,
+    opts?: { unknownIs?: 'youth' | 'adult' },
+): boolean {
+    if (!dob) return (opts?.unknownIs ?? 'adult') === 'youth';
     return calculateAge(dob) < 18;
 }


### PR DESCRIPTION
Fixes #300 — `isYouth(null)` defaults to adult, which failed **open** in the two-deep safety calc: an unknown-DOB visitor counted as a supervising adult and dropped out of `unaccompaniedYouth`, masking `isTwoDeepViolation` on both prongs.

Implements option (b) from the issue (context-scoped default), updated for the minor→youth rename:

- `lib/time.ts` — `isYouth(dob, opts?: { unknownIs?: 'youth' | 'adult' })`, default `'adult'`. Every existing caller keeps today's behavior, including the documented household-lead contract (`lib/household/leads.ts`: null-DOB stays promotable) and the blank new-participant form.
- `lib/getFullAttendance.ts` — the `youthMap` feeding the safety calc opts into `unknownIs: 'youth'`: missing data fails closed, a null-DOB visitor is never a supervising adult.

**Visible side effects, intended:** null-DOB visitors now count as `youth` (not `volunteers`) in the attendance counts and badge as youth on the board; two-deep warnings can newly fire at moments previously masked by an unknown-DOB "adult". That is the fix working — and it surfaces missing DOBs where someone will correct them.

Tests: `isYouth` unknown-DOB contract both ways (default unchanged, opt-in fails closed, known DOB never overridden); a `getFullAttendance` case where a null-DOB visitor in the youth's household flipped the violation from masked to reported. Full unit suite green locally (the two `finance-ops/s-read` suite failures are the pre-existing local `@aws-sdk/client-lambda` install gap, identical on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBeNiBRHhV7anXNQSWCTMv
