### PR TITLE
refactor(api): route age-18 checks through canonical isYouth helper

### DIFF
--- a/checkin-app/src/app/api/people/search/route.ts
+++ b/checkin-app/src/app/api/people/search/route.ts
@@ -18,6 +18,9 @@ export const GET = withAuth(
             // Only `adults` is recognized; any other value (or none) filters by age not at all.
             const adultsOnly = url.searchParams.get('filter') === 'adults';
 
+            // DB-level 18-year boundary for the adults filter below. Mirrors the
+            // under-18 threshold in isYouth (lib/time.ts); kept inline because this
+            // is a Prisma `where` predicate, not an in-memory classification.
             const eighteenYearsAgo = new Date();
             eighteenYearsAgo.setFullYear(eighteenYearsAgo.getFullYear() - 18);
 

--- a/checkin-app/src/app/api/roles/route.ts
+++ b/checkin-app/src/app/api/roles/route.ts
@@ -12,6 +12,7 @@ import {
     LastBoardMemberError,
 } from "@/lib/roles";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import { isYouth } from "@/lib/time";
 
 const PERSON_SELECT = {
     id: true,
@@ -29,9 +30,6 @@ export const GET = withAuth(
     { roles: ['isSysadmin', 'isBoardMember'] },
     async () => {
         try {
-            const eighteenYearsAgo = new Date();
-            eighteenYearsAgo.setFullYear(eighteenYearsAgo.getFullYear() - 18);
-
             const rows = await prisma.person.findMany({
                 where: LIVE_PERSON,
                 select: {
@@ -51,7 +49,7 @@ export const GET = withAuth(
             const people = rows.map(({ dateOfBirth, roles, ...p }) => ({
                 ...p,
                 ...rolesToFlags(roles),
-                isYouth: dateOfBirth != null && dateOfBirth > eighteenYearsAgo,
+                isYouth: isYouth(dateOfBirth),
             }));
             return NextResponse.json({ people });
         } catch (error) {


### PR DESCRIPTION
## What

Two API routes reinvented an inline `eighteenYearsAgo` age-18 threshold instead of calling the canonical `isYouth(dob)` classifier in `@/lib/time`, whose doc says "use this everywhere instead of inline age checks."

- **`api/roles/route.ts`** — dropped the inline `eighteenYearsAgo` local; the GET youth flag is now `isYouth: isYouth(dateOfBirth)`.
- **`api/people/search/route.ts`** — left as-is by design. Its `eighteenYearsAgo` feeds a Prisma `where` predicate (`dateOfBirth: { lte: ... }`), a DB-level query filter, not an in-memory classification, so `isYouth` (which operates on a fetched value) does not drop in. Added a comment noting the boundary mirrors `isYouth`'s threshold.

## Why

Single source of truth for "youth" (under 18). Code-quality dedup, **not** a behavior change.

## Behavior preservation

- `isYouth(null)` returns `false` (adult), matching the prior `dateOfBirth != null && dateOfBirth > eighteenYearsAgo`.
- Exact-18th-birthday boundary: `calculateAge` returns 18 → `isYouth` false (adult); old inline `dob > eighteenYearsAgo` also false. They agree — no off-by-one introduced.

## Testing

- `tsc --noEmit` clean for both target files.
- `time.test.ts` unit suite — pass.
- Full integration suite (incl. `adminRolesAPI.integration.test.ts`, which asserts `isYouth` true for a 10-year-old and false for a 1990-DOB adult through the changed GET route) — 1245/1245 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)