### PR TITLE
docs(agents): issue workflow — assignment means active work, PRs carry the claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,23 +121,31 @@ issue's assignee are the claim-state machine. An assignment means exactly one
 thing: someone is actively working the issue *right now* — never leave one
 standing as a soft reservation, and never trust it as the only signal.
 
-- **Pick up**: choose an open issue that is unassigned **and** has no open
-  linked PR (check `closingIssuesReferences` on open PRs, or the issue's
-  Development panel). Assignment is dropped when a PR opens, so "unassigned"
-  alone does not mean free. Then assign yourself and set Status →
-  **In progress**.
+- **Pick up**: choose an open issue that is unassigned **and** has no open PR
+  claiming it. That check is two-pronged, because design PRs don't create a
+  closing link: (1) `closingIssuesReferences` on open PRs / the issue's
+  Development panel (implementation PRs), and (2) open PRs whose title/body
+  mention `#NNN` and carry a design doc for it. Assignment is dropped when a
+  PR opens, so "unassigned" alone does not mean free. Then assign yourself and
+  set Status → **In progress**.
 - **Re-verify before building**: issue bodies go stale — renames, moved files,
   callers added since filing. Re-run the blast-radius search against current
   `main` before implementing, and comment corrections on the issue (see #300:
   filed against `isMinor`/3 callers, fixed as `isYouth`/10 callers).
-- **PR open** (an initial design or an implementation, same rule): body carries
-  `Fixes #NNN` — confirm the link registered via `closingIssuesReferences` —
-  set Status → **In review**, and **unassign the issue**. The next action
-  belongs to reviewers, not the author; a standing assignment would claim work
-  that isn't happening. The open linked PR is what marks the issue as taken.
-- **Merge**: nothing manual. The closing keyword closes the issue, and the
-  project's built-in workflows (Item closed / Pull request merged) set Status
-  → Done.
+- **PR open**: set Status → **In review** and **unassign the issue**. The next
+  action belongs to reviewers, not the author; a standing assignment would
+  claim work that isn't happening. The open PR is what marks the issue as
+  taken. How the PR references the issue depends on what it is:
+  - **Implementation PR**: a closing keyword — `Fixes #NNN`, `Closes #NNN`,
+    or `Resolves #NNN` (all three work) — and confirm the link registered via
+    `closingIssuesReferences`.
+  - **Design-doc PR**: reference the issue WITHOUT a closing keyword (plain
+    `#NNN`, "Design for #NNN"). A closing link here would auto-close the
+    issue when the doc merges, with nothing implemented.
+- **Merge**: an implementation PR needs nothing manual — the closing keyword
+  closes the issue and the project's built-in workflows (Item closed / Pull
+  request merged) set Status → Done. A merged design-doc PR leaves the issue
+  open: set Status back to **Ready** for implementation pickup.
 
 Project-field writes need the `project` token scope; if GraphQL returns
 INSUFFICIENT_SCOPES, have the user run `gh auth refresh -s project`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,34 @@ external integrations (Zoho/Shopify/Averity); use the board/admin manual-action
 routes to advance flows those would otherwise gate. Real journeys are catalogued
 in `docs/designs/CUJS.md` — start there when choosing what to cover.
 
+## Issue workflow (org project 1)
+
+Org **project 1** is the canonical triage surface; its Status field plus the
+issue's assignee are the claim-state machine. An assignment means exactly one
+thing: someone is actively working the issue *right now* — never leave one
+standing as a soft reservation, and never trust it as the only signal.
+
+- **Pick up**: choose an open issue that is unassigned **and** has no open
+  linked PR (check `closingIssuesReferences` on open PRs, or the issue's
+  Development panel). Assignment is dropped when a PR opens, so "unassigned"
+  alone does not mean free. Then assign yourself and set Status →
+  **In progress**.
+- **Re-verify before building**: issue bodies go stale — renames, moved files,
+  callers added since filing. Re-run the blast-radius search against current
+  `main` before implementing, and comment corrections on the issue (see #300:
+  filed against `isMinor`/3 callers, fixed as `isYouth`/10 callers).
+- **PR open** (an initial design or an implementation, same rule): body carries
+  `Fixes #NNN` — confirm the link registered via `closingIssuesReferences` —
+  set Status → **In review**, and **unassign the issue**. The next action
+  belongs to reviewers, not the author; a standing assignment would claim work
+  that isn't happening. The open linked PR is what marks the issue as taken.
+- **Merge**: nothing manual. The closing keyword closes the issue, and the
+  project's built-in workflows (Item closed / Pull request merged) set Status
+  → Done.
+
+Project-field writes need the `project` token scope; if GraphQL returns
+INSUFFICIENT_SCOPES, have the user run `gh auth refresh -s project`.
+
 ## Docs map
 
 Read these before changing the relevant area — start here, then follow links.


### PR DESCRIPTION
Adds an **Issue workflow (org project 1)** section to AGENTS.md so agents follow the lifecycle exercised on #300 / #1353:

- **Pick up**: unassigned **and** no open linked PR (assignment is dropped at PR-open, so unassigned alone ≠ free) → assign + Status **In progress**.
- **Re-verify** stale issue bodies against current `main` before building (the #300 lesson: filed against `isMinor`/3 callers, fixed as `isYouth`/10).
- **PR open** (design or implementation): `Fixes #NNN` (verify `closingIssuesReferences`), Status **In review**, **unassign** — the next action belongs to reviewers, and a standing assignment would hold a claim that is no longer true; the linked PR is what marks the issue taken.
- **Merge**: closing keyword + the project's built-in workflows handle close + Done; nothing manual.

Also notes the `project` token-scope gotcha for project-field writes.

GEMINI.md and .jules/sentinel.md already defer to AGENTS.md as canonical, so no sibling edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBeNiBRHhV7anXNQSWCTMv