### PR TITLE
fix(safety): declared adults (DoB-stripped, #1165) still supervise in the two-deep calc

### DIFF
--- a/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
+++ b/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
@@ -105,7 +105,7 @@ describe("two-deep calc fails closed on unknown DOB (#300)", () => {
         id: 204, arrivedAt: new Date("2026-07-01T14:20:00Z"), departedAt: null, personId: 80,
         person: {
             id: 80, email: "nodob@example.com", name: "No Dob", isKeyholder: false,
-            dateOfBirth: null, householdId: 8, phone: null,
+            dateOfBirth: null, isDeclaredAdult: false, householdId: 8, phone: null,
             household: { id: 8, emergencyContacts: [] },
         },
         event: null,
@@ -119,5 +119,19 @@ describe("two-deep calc fails closed on unknown DOB (#300)", () => {
         // counted as youth, not volunteer, and flagged as youth on the wire
         expect(counts).toEqual({ keyholders: 1, volunteers: 0, youth: 2, total: 3 });
         expect(attendance[2].participant.isYouth).toBe(true);
+    });
+
+    it("a DoB-stripped declared adult (#1165) still supervises", async () => {
+        // Same shape, but the null-DoB visitor is a 26+ member whose DoB was
+        // deliberately deleted: isDeclaredAdult wins over the fail-closed default.
+        findMany.mockResolvedValue([...rows, {
+            ...nullDobRow,
+            person: { ...nullDobRow.person, isDeclaredAdult: true },
+        }]);
+        const { attendance, counts, safety } = await getFullAttendance({ kiosk: true });
+
+        expect(safety.isTwoDeepViolation).toBe(false);
+        expect(counts).toEqual({ keyholders: 1, volunteers: 1, youth: 1, total: 3 });
+        expect(attendance[2].participant.isYouth).toBe(false);
     });
 });

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -43,6 +43,9 @@ export async function getFullAttendance(opts: { kiosk?: boolean } = {}) {
                     // dateOfBirth is read on both paths (it computes isYouth / the
                     // counts) but only SHIPS on the privileged path.
                     dateOfBirth: true,
+                    // Adults 26+ have their DoB deliberately stripped (#1165) and
+                    // carry this flag instead — the safety calc must honor it.
+                    isDeclaredAdult: true,
                     householdId: true,
                     phone: true,
                     household: kiosk ? false : {
@@ -68,11 +71,15 @@ export async function getFullAttendance(opts: { kiosk?: boolean } = {}) {
     });
 
     // Pre-compute isYouth once per visit to avoid repeated calculations.
-    // unknownIs:'youth' — this map feeds the two-deep safety calc, so an
-    // unknown DOB must fail closed (never count as a supervising adult), #300.
+    // This map feeds the two-deep safety calc: a declared adult (null DoB is
+    // the NORMAL state for 26+, #1165) counts as an adult; only a truly
+    // unknown person — no DoB, not declared — fails closed as youth (#300),
+    // never as a supervising adult.
     const youthMap = new Map<number, boolean>();
     for (const v of activeVisits) {
-        youthMap.set(v.id, isYouth(v.person.dateOfBirth, { unknownIs: 'youth' }));
+        youthMap.set(v.id, v.person.isDeclaredAdult
+            ? false
+            : isYouth(v.person.dateOfBirth, { unknownIs: 'youth' }));
     }
 
     const keyholderVisits = activeVisits.filter(v => v.person.isKeyholder);


### PR DESCRIPTION
Follow-up to #1353, which merged just before its amendment landed on the branch (race with re-review): the merged version treats **every** null-DoB visitor as youth in the two-deep calc. Since #1326 deliberately nulls `dateOfBirth` for all 26+ members (setting `isDeclaredAdult`), null DoB is now the *normal* adult state — so on current main every DoB-stripped adult is classified youth: `adultVisits` collapses, `isTwoDeepViolation` fires with adults present, and the kiosk badges adults as youth.

This is the amendment (cherry-picked `96af2bae` from the #1353 branch): the safety classification honors the flag — `isDeclaredAdult` ⇒ adult; only a *truly* unknown person (no DoB **and** not declared) fails closed as youth, exactly the #300 intent. `isDeclaredAdult` is added to the select only; both wire paths build the participant DTO field-by-field, so nothing new ships. New test: a DoB-stripped declared adult in the youth's household supervises (no violation, counted as volunteer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBeNiBRHhV7anXNQSWCTMv