### PR TITLE
feat(home): brand-sourced hero copy; drop dead badge-scanner prompt

### DIFF
--- a/checkin-app/src/app/page.tsx
+++ b/checkin-app/src/app/page.tsx
@@ -21,6 +21,7 @@ import {
   IconUrgent,
 } from '@tabler/icons-react';
 import { notifications } from "@mantine/notifications";
+import { brand } from '@/brand';
 import DevLoginPicker from '@/components/DevLoginPicker';
 import { useIsDevInstance, useIsLocalInstance } from '@/components/EnvProvider';
 import JoinTreehouseBanner from '@/components/JoinTreehouseBanner';
@@ -138,9 +139,11 @@ export default function Home() {
     <Container size="sm" py="xl">
       <Card withBorder shadow="sm" radius="md" padding="xl">
         <Stack align="center" gap="xs" mb="lg">
-          <Title order={1} tt="lowercase">{isDevInstance ? 'CMI-dev' : 'CheckMeIn'}</Title>
-          <Text c="dimmed" size="lg">
-            The next-generation facility check-in system.
+          <Title order={1} ta="center">
+            {isDevInstance ? `${brand.home.title} (dev)` : brand.home.title}
+          </Title>
+          <Text c="dimmed" size="lg" ta="center">
+            {brand.home.subtitle}
           </Text>
         </Stack>
 
@@ -182,22 +185,17 @@ export default function Home() {
               )}
 
               {/* Check-in Toggle Button — in production, only privileged users can self-check-in from the web */}
-              {isCheckedIn !== null &&
-                (canSelfCheckin ? (
-                  <Button
-                    size="lg"
-                    fullWidth
-                    color={isCheckedIn ? 'red' : 'treehouseGreen'}
-                    onClick={handleToggleCheckin}
-                    loading={loading}
-                  >
-                    {isCheckedIn ? 'Check Out' : 'Check In'}
-                  </Button>
-                ) : (
-                  <Alert color="gray" variant="light" ta="center">
-                    📛 Please use the kiosk badge scanner to check in and out.
-                  </Alert>
-                ))}
+              {isCheckedIn !== null && canSelfCheckin && (
+                <Button
+                  size="lg"
+                  fullWidth
+                  color={isCheckedIn ? 'red' : 'treehouseGreen'}
+                  onClick={handleToggleCheckin}
+                  loading={loading}
+                >
+                  {isCheckedIn ? 'Check Out' : 'Check In'}
+                </Button>
+              )}
 
               {/* Board Directory Button for Keyholders/Admins */}
               {isPrivileged && (

--- a/checkin-app/src/brand/base.ts
+++ b/checkin-app/src/brand/base.ts
@@ -26,6 +26,7 @@ export const baseTheme = createTheme({
 export const baseBrand: Brand = {
   id: 'base',
   appName: 'CheckMeIn',
+  home: { title: 'CheckMeIn', subtitle: 'the program and attendance system for your community' },
   theme: baseTheme,
   fontVariables: '',
   logo: null,

--- a/checkin-app/src/brand/treehouse.ts
+++ b/checkin-app/src/brand/treehouse.ts
@@ -34,6 +34,7 @@ export const treehouseBrand: Brand = {
   ...baseBrand,
   id: 'treehouse',
   appName: 'CheckMeIn',
+  home: { title: 'Innovation Treehouse Operations', subtitle: 'the program and attendance system for our community' },
   fontVariables,
   // Trademarked brand collateral — see /TRADEMARKS.md. The source-code license does NOT grant
   // a license to use the Innovation Treehouse logo/marks; replace when reusing for another org.

--- a/checkin-app/src/brand/types.ts
+++ b/checkin-app/src/brand/types.ts
@@ -14,6 +14,8 @@ export interface Brand {
   id: string;
   /** Wordmark text, shown when there is no `logo`. */
   appName: string;
+  /** Home page hero copy. Kept per-brand so the base/unbranded build carries no trademark. */
+  home: { title: string; subtitle: string };
   /** Mantine theme — base structural theme extended per brand via mergeThemeOverrides. */
   theme: MantineThemeOverride;
   /** className exposing the brand's --font-* CSS vars on <body>; '' = system fonts. */


### PR DESCRIPTION
## What

Two homepage changes:

1. **Removed the "📛 Please use the kiosk badge scanner to check in and out." alert.** It rendered for every non-privileged signed-in user, in the slot where a check-in control would otherwise be. In practice it meant something only to the original devs who expected the homepage to drive check-in; to everyone else it was a dead-end message. The check-in button now renders *only* for users who can self-check-in — non-privileged users see nothing in that slot.

2. **New hero copy:** title "Innovation Treehouse Operations", subtitle "the program and attendance system for our community".

## Why the hero copy lives in the brand config

The obvious approach — hardcoding the new title/subtitle in `page.tsx` — would ship the string **"Innovation Treehouse Operations"** in the unbranded `base` build too. That conflicts with:

- **`TRADEMARKS.md`**, which designates `NEXT_PUBLIC_BRAND=base` as the explicit opt-out for forks/other orgs and requires removing Innovation Treehouse brand collateral; and
- the brand-swap design rule in `src/brand/types.ts`: *"nothing in the pages/components hardcodes a brand — adding an org is one new Brand object."*

So instead this adds a `home: { title, subtitle }` field to the `Brand` interface:
- **treehouse** brand → the Innovation Treehouse copy;
- **base** brand → neutral fallback (`"CheckMeIn"` / "…for your community"), carrying no trademark.

`page.tsx` reads `brand.home.*` (dev instances still append `(dev)`).

## Reviewer notes

- Also dropped the `tt="lowercase"` transform on the title since the new title is proper-case, and centered both lines.
- The `base`-brand subtitle wording ("…for **your** community" vs. treehouse's "…for **our** community") was my choice — easy to tweak.
- Verified: `tsc --noEmit` clean on touched files; `src/brand/__tests__/theme.test.ts` passes 6/6; pre-commit `test:ci` hook ran clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)