### PR TITLE
feat(profile): add "I am over 25" attestation to the profile page

### DIFF
--- a/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/profileAPI.integration.test.ts
@@ -154,5 +154,47 @@ describe('Profile API Integration Tests', () => {
             });
             expect(auditLogs.length).toBeGreaterThan(0);
         });
+
+        it('sets isDeclaredAdult and clears DoB when over25 is checked with no dob', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: testUserId } });
+
+            const req = new Request('http://localhost:4000/api/profile', {
+                method: 'PATCH',
+                body: JSON.stringify({ dob: null, over25: true })
+            });
+            const res = await PATCH(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(200);
+
+            const row = await prisma.person.findUnique({
+                where: { id: testUserId },
+                select: { dateOfBirth: true, isDeclaredAdult: true }
+            });
+            expect(row?.dateOfBirth).toBeNull();
+            expect(row?.isDeclaredAdult).toBe(true);
+        });
+
+        it('leaves DoB and the adult flag untouched on a notification-only PATCH', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: testUserId } });
+
+            // Seed a real DoB first so we can prove the guard preserves it.
+            await prisma.person.update({
+                where: { id: testUserId },
+                data: { dateOfBirth: new Date('1990-01-01'), isDeclaredAdult: false }
+            });
+
+            const req = new Request('http://localhost:4000/api/profile', {
+                method: 'PATCH',
+                body: JSON.stringify({ notificationSettings: { foo: true } })
+            });
+            const res = await PATCH(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(200);
+
+            const row = await prisma.person.findUnique({
+                where: { id: testUserId },
+                select: { dateOfBirth: true, isDeclaredAdult: true }
+            });
+            expect(row?.dateOfBirth).toEqual(new Date('1990-01-01'));
+            expect(row?.isDeclaredAdult).toBe(false);
+        });
     });
 });

--- a/checkin-app/src/app/api/profile/route.ts
+++ b/checkin-app/src/app/api/profile/route.ts
@@ -40,7 +40,7 @@ export const PATCH = withAuth(
             }
 
             const body = await req.json();
-            const { name, phone, dob, notificationSettings, emailSuppressed } = body;
+            const { name, phone, dob, over25, notificationSettings, emailSuppressed } = body;
 
             if (phone !== undefined && phone !== "" && !isValidPhone(phone)) {
                 return apiError(PHONE_ERROR, 400);
@@ -52,8 +52,12 @@ export const PATCH = withAuth(
                     name: name !== undefined ? name : undefined,
                     phone: phone !== undefined ? (phone === "" ? null : formatPhone(phone)) : undefined,
                     // #1165: a self-entered DoB for a 26+ member is stripped and the
-                    // over-25 flag set instead. Empty dob leaves the field unchanged.
-                    ...(dob ? normalizeAdultDob(dob) : {}),
+                    // over-25 flag set instead; with no DoB the over-25 checkbox owns
+                    // the flag. Only touched when the profile form submits age fields,
+                    // so notification-only PATCHes leave DoB/flag unchanged.
+                    ...(dob !== undefined || over25 !== undefined
+                        ? { ...normalizeAdultDob(dob || null), ...(dob ? {} : { isDeclaredAdult: !!over25 }) }
+                        : {}),
                     notificationSettings: notificationSettings !== undefined ? notificationSettings : undefined,
                     emailSuppressed: emailSuppressed !== undefined ? !!emailSuppressed : undefined,
                 },

--- a/checkin-app/src/app/profile/__tests__/page.test.tsx
+++ b/checkin-app/src/app/profile/__tests__/page.test.tsx
@@ -29,6 +29,42 @@ describe("ProfilePage", () => {
         expect(fetchMock).toHaveBeenCalledWith("/api/profile", expect.objectContaining({ method: "PATCH" }));
     });
 
+    it("prefills the over-25 attestation and posts it without a DoB", async () => {
+        setSession({ id: 3 });
+        const fetchMock = mockFetchJson({
+            "/api/profile": { profile: { name: "Pat Declared", email: "pat@example.com", phone: "555-3333", dateOfBirth: null, isDeclaredAdult: true } },
+        });
+        renderWithProviders(<ProfilePage />);
+
+        const over25 = await screen.findByLabelText("I am over 25");
+        expect(over25).toBeChecked();
+        // With the attestation on, the DoB field is hidden entirely.
+        expect(screen.queryByLabelText("Date of Birth")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Save Profile" }));
+
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Profile updated successfully!" })));
+        const [, patchOpts] = fetchMock.mock.calls.find(([, init]) => init?.method === "PATCH")!;
+        expect(JSON.parse(patchOpts!.body as string)).toMatchObject({ over25: true, dob: null });
+    });
+
+    it("checking over-25 clears and hides the DoB field", async () => {
+        setSession({ id: 4 });
+        const fetchMock = mockFetchJson({
+            "/api/profile": { profile: { name: "Sam Adult", email: "sam@example.com", phone: "555-4444", dateOfBirth: "1990-01-01" } },
+        });
+        renderWithProviders(<ProfilePage />);
+
+        expect(await screen.findByLabelText("Date of Birth")).toHaveValue("1990-01-01");
+        fireEvent.click(screen.getByLabelText("I am over 25"));
+        expect(screen.queryByLabelText("Date of Birth")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Save Profile" }));
+        await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Profile updated successfully!" })));
+        const [, patchOpts] = fetchMock.mock.calls.find(([, init]) => init?.method === "PATCH")!;
+        expect(JSON.parse(patchOpts!.body as string)).toMatchObject({ over25: true, dob: null });
+    });
+
     it("locks the form as read-only for a youth", async () => {
         setSession({ id: 2 });
         mockFetchJson({

--- a/checkin-app/src/app/profile/page.tsx
+++ b/checkin-app/src/app/profile/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { Anchor, Button, Card, Stack, Text, TextInput, Title } from '@mantine/core';
+import { Anchor, Button, Card, Checkbox, Stack, Text, TextInput, Title } from '@mantine/core';
 import { PageContainer } from '@/components/ui/PageContainer';
 import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
 import { notifications } from '@mantine/notifications';
@@ -22,7 +22,8 @@ export default function ProfilePage() {
     name: "",
     email: "",
     phone: "",
-    dob: ""
+    dob: "",
+    over25: false
   });
   const fetchProfile = useCallback(async () => {
     try {
@@ -33,7 +34,8 @@ export default function ProfilePage() {
           name: data.profile.name || "",
           email: data.profile.email || "",
           phone: data.profile.phone || "",
-          dob: data.profile.dateOfBirth ? new Date(data.profile.dateOfBirth).toISOString().split('T')[0] : ""
+          dob: data.profile.dateOfBirth ? new Date(data.profile.dateOfBirth).toISOString().split('T')[0] : "",
+          over25: !data.profile.dateOfBirth && !!data.profile.isDeclaredAdult
         });
       } else {
         setMessage({ text: "Failed to load profile.", tone: "error" });
@@ -65,7 +67,8 @@ export default function ProfilePage() {
         body: JSON.stringify({
           name: form.name,
           phone: form.phone,
-          dob: form.dob || null
+          dob: form.over25 ? null : (form.dob || null),
+          over25: form.over25
         })
       });
 
@@ -105,7 +108,15 @@ export default function ProfilePage() {
               <TextInput label="Email Address" value={form.email} disabled title="Email cannot be changed here." />
               <TextInput label="Full Name" required value={form.name} onChange={(e) => setForm({ ...form, name: e.currentTarget.value })} placeholder="e.g. Jane Doe" disabled={readOnly} />
               <TextInput type="tel" label="Phone Number" required value={form.phone} onChange={(e) => setForm({ ...form, phone: e.currentTarget.value })} placeholder="(555) 123-4567" disabled={readOnly} />
-              <TextInput type="date" label="Date of Birth" value={form.dob} onChange={(e) => setForm({ ...form, dob: e.currentTarget.value })} disabled={readOnly} />
+              <Checkbox
+                label="I am over 25"
+                checked={form.over25}
+                disabled={readOnly}
+                onChange={(e) => setForm({ ...form, over25: e.currentTarget.checked, dob: e.currentTarget.checked ? "" : form.dob })}
+              />
+              {!form.over25 && (
+                <TextInput type="date" label="Date of Birth" value={form.dob} onChange={(e) => setForm({ ...form, dob: e.currentTarget.value })} disabled={readOnly} />
+              )}
 
               <Text size="sm" c="dimmed">
                 Your address is managed on the <Anchor href="/my-household">Household</Anchor> page.


### PR DESCRIPTION
## What

The `/profile` page collected only a raw **Date of Birth**, with no way for an adult to declare "over 25" — unlike the other age-collecting flows, which all offer an over-25 attestation that sets `Person.isDeclaredAdult` instead of storing a DoB:

- First-time intake — `FirstTimeIntakePanel` ("I am over 25")
- My Household add/edit member ("Individual is over 25")
- Membership-ops participants editor ("Adult (25 or older)")

This brings `/profile` in line by adding the same attestation.

## Changes

- **`profile/page.tsx`** — an **"I am over 25"** checkbox (first-person wording, matching `FirstTimeIntakePanel`). Checking it clears and hides the DoB field; the box prefills from `!dateOfBirth && !!isDeclaredAdult` (the same derivation My Household uses).
- **`api/profile/route.ts`** (PATCH) — accepts `over25` and, when no DoB is supplied, sets `isDeclaredAdult` from it — mirroring the household routes and still routing any real DoB through the `normalizeAdultDob` (#1165) guard.
- **Guard:** DoB/flag are only touched when the form actually submits age fields (`dob !== undefined || over25 !== undefined`). This matters because `/communication` PATCHes this same route with *only* notification settings — those calls must not wipe a stored DoB.

## Why it's safe / reviewer notes

- `isDeclaredAdult` is `@sensitivity:internal` and the `GET /api/profile` registry view already grants `their_own:internal`, so the checkbox prefills correctly with **no security-registry change**.
- Youth path unchanged: a youth still sees their DoB read-only, the checkbox disabled, and no Save button.
- A 26+ adult who leaves their real DoB in the field still has it stripped to `isDeclaredAdult` by the existing `normalizeAdultDob` guard (#1165) — unchanged behavior.

## Tests

- Page tests: prefill + post the attestation without a DoB; checking over-25 clears/hides the DoB field.
- Integration tests: the `over25` path sets the flag and clears DoB; a notification-only PATCH leaves DoB/flag untouched (the guard).
- Full `test:ci` (2375 tests) + tsc + eslint green via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
