### PR TITLE
feat(membership): state the "outside your family" rule wherever we ask for an emergency contact (#1371) [rel/1.1]

### DIFF
--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -734,9 +734,6 @@ export default function MembershipPage() {
                       errors={{ line1: fieldErrors.address, city: fieldErrors.addrCity, state: fieldErrors.addrState, postalCode: fieldErrors.addrZip }}
                       onErrorClear={(f) => clearErr(f === "line1" ? "address" : f === "city" ? "addrCity" : f === "state" ? "addrState" : "addrZip")}
                     />
-                    <Text c="dimmed" size="sm" mt="md" mb="xs">
-                      Someone we can call in an emergency — must be an adult outside your household.
-                    </Text>
                     <EmergencyContactForm
                       emName={emName} setEmName={setEmName}
                       emPhone={emPhone} setEmPhone={setEmPhone}

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -6,6 +6,7 @@ import { useRequireRole } from '@/hooks/useRequireRole';
 import { Alert, Badge, Button, Card, Checkbox, Group, Paper, SimpleGrid, Stack, Text, Textarea, TextInput, Title, Tooltip } from '@mantine/core';
 import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
 import { PageContainer } from '@/components/ui/PageContainer';
+import EmergencyContactNotice from '@/components/ui/EmergencyContactNotice';
 import { calculateAge } from '@/lib/time';
 import TrustedAdultPanel from '@/components/TrustedAdultPanel';
 import { notifications } from '@mantine/notifications';
@@ -527,8 +528,9 @@ export default function HouseholdPage() {
                   {!showContactForm && <Button size="compact-xs" variant="light" onClick={startAddContact}>+ Add Contact</Button>}
                 </Group>
                 <Text size="sm" c="dimmed" mb="sm">
-                  At least one is required. Each must be someone <strong>outside</strong> this household.
+                  At least one is required.
                 </Text>
+                <EmergencyContactNotice mb="sm" />
 
                 {contactError && (
                   <Alert color="red" variant="light" mb="sm" withCloseButton onClose={() => setContactError("")}>{contactError}</Alert>

--- a/checkin-app/src/components/OnboardingGate.tsx
+++ b/checkin-app/src/components/OnboardingGate.tsx
@@ -7,6 +7,7 @@ import { notifications } from '@mantine/notifications';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { isValidEmail } from '@/lib/emergencyContacts/identity';
 import { isValidPhone, PHONE_ERROR } from '@/lib/phone';
+import EmergencyContactNotice from '@/components/ui/EmergencyContactNotice';
 import {
   Alert,
   Box,
@@ -154,10 +155,11 @@ export default function OnboardingGate({ children }: { children: React.ReactNode
                 <Title order={5} mb="xs">
                   Household Emergency Contact
                 </Title>
-                <Text size="sm" c="dimmed" mb="md">
+                <Text size="sm" c="dimmed" mb="sm">
                   As a household lead, you must designate an emergency contact for your household
                   members.
                 </Text>
+                <EmergencyContactNotice mb="md" />
                 <Stack>
                   <TextInput
                     label="Contact Name"

--- a/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
+++ b/checkin-app/src/components/admin/AdminEditHouseholdModal.tsx
@@ -7,6 +7,7 @@ import { modals } from "@mantine/modals";
 import { pickAddress, type StructuredAddress } from "@/lib/address";
 import { isValidPhone, PHONE_ERROR } from "@/lib/phone";
 import { isYouth } from "@/lib/time";
+import EmergencyContactNotice from "@/components/ui/EmergencyContactNotice";
 
 // Per-household lead cap (issue #269). Server enforces it atomically in
 // lib/household/leads.ts (MAX_HOUSEHOLD_LEADS); hardcoded here — that module
@@ -278,6 +279,7 @@ export function AdminEditHouseholdModal({
               <TextInput label="State" maxLength={2} value={form.state} onChange={(e) => update({ state: e.currentTarget.value })} placeholder="TX" />
               <TextInput label="ZIP" value={form.postalCode} onChange={(e) => update({ postalCode: e.currentTarget.value })} placeholder="78701" />
             </SimpleGrid>
+            <EmergencyContactNotice />
             <SimpleGrid cols={{ base: 1, sm: 2 }}>
               <TextInput
                 label="Emergency Contact Name"

--- a/checkin-app/src/components/membership/EmergencyContactForm.tsx
+++ b/checkin-app/src/components/membership/EmergencyContactForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SimpleGrid, TextInput } from "@mantine/core";
+import EmergencyContactNotice from "@/components/ui/EmergencyContactNotice";
 
 export default function EmergencyContactForm({
   emName, setEmName,
@@ -16,10 +17,13 @@ export default function EmergencyContactForm({
   clearErr: (key: string) => void;
 }) {
   return (
-    <SimpleGrid cols={{ base: 1, sm: 2 }} mt="md">
-      <TextInput withAsterisk label="Emergency contact name" value={emName} error={errors.emName} onChange={(e) => { setEmName(e.currentTarget.value); clearErr("emName"); }} />
-      <TextInput withAsterisk label="Emergency contact phone" value={emPhone} error={errors.emPhone} onChange={(e) => { setEmPhone(e.currentTarget.value); clearErr("emPhone"); }} />
-      <TextInput type="email" label="Emergency contact email (optional)" value={emEmail} error={errors.emEmail} onChange={(e) => { setEmEmail(e.currentTarget.value); clearErr("emEmail"); }} />
-    </SimpleGrid>
+    <>
+      <EmergencyContactNotice mt="md" />
+      <SimpleGrid cols={{ base: 1, sm: 2 }} mt="sm">
+        <TextInput withAsterisk label="Emergency contact name" value={emName} error={errors.emName} onChange={(e) => { setEmName(e.currentTarget.value); clearErr("emName"); }} />
+        <TextInput withAsterisk label="Emergency contact phone" value={emPhone} error={errors.emPhone} onChange={(e) => { setEmPhone(e.currentTarget.value); clearErr("emPhone"); }} />
+        <TextInput type="email" label="Emergency contact email (optional)" value={emEmail} error={errors.emEmail} onChange={(e) => { setEmEmail(e.currentTarget.value); clearErr("emEmail"); }} />
+      </SimpleGrid>
+    </>
   );
 }

--- a/checkin-app/src/components/ui/EmergencyContactNotice.tsx
+++ b/checkin-app/src/components/ui/EmergencyContactNotice.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Alert, type AlertProps, Text } from "@mantine/core";
+import { IconUsersGroup } from "@tabler/icons-react";
+
+/**
+ * The single place the "not someone in your own family" rule is stated to users.
+ *
+ * The rule is enforced server-side (EmergencyContactError, code "is_member"), but
+ * nothing on the way in said so — applicants only discovered it by being rejected
+ * after filling the form out. Every surface that *collects* an emergency contact
+ * renders this up front instead.
+ *
+ * Keep the copy here and nowhere else so the collection surfaces can't drift apart.
+ * Accepts any AlertProps (mt/mb/color/...) for spacing at each call site.
+ */
+export default function EmergencyContactNotice(props: Omit<AlertProps, "children" | "icon">) {
+  return (
+    <Alert variant="light" color="blue" icon={<IconUsersGroup size={20} />} {...props}>
+      <Text fw={700}>Must be someone outside of your family.</Text>
+      <Text size="sm" mt={2}>
+        Pick an adult who doesn&apos;t live in your household — a neighbor, a friend, or a
+        relative in another home — so we can always reach someone if your family can&apos;t
+        be found.
+      </Text>
+    </Alert>
+  );
+}

--- a/checkin-app/src/components/ui/__tests__/EmergencyContactNotice.test.tsx
+++ b/checkin-app/src/components/ui/__tests__/EmergencyContactNotice.test.tsx
@@ -1,0 +1,31 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test-helpers/rtl";
+import EmergencyContactNotice from "@/components/ui/EmergencyContactNotice";
+import EmergencyContactForm from "@/components/membership/EmergencyContactForm";
+
+const NOTICE = "Must be someone outside of your family.";
+
+describe("EmergencyContactNotice", () => {
+  it("states the outside-the-family rule", () => {
+    renderWithProviders(<EmergencyContactNotice />);
+    expect(screen.getByText(NOTICE)).toBeInTheDocument();
+  });
+
+  // The rule is enforced server-side (EmergencyContactError, code "is_member").
+  // Applicants used to only meet it as a rejection, so every surface that collects
+  // a contact has to state it up front — the shared form is two of those surfaces
+  // (membership intake + first-time program intake) and must not lose it.
+  it("ships with the shared emergency-contact form", () => {
+    renderWithProviders(
+      <EmergencyContactForm
+        emName="" setEmName={() => {}}
+        emPhone="" setEmPhone={() => {}}
+        emEmail="" setEmEmail={() => {}}
+        errors={{}}
+        clearErr={() => {}}
+      />,
+    );
+    expect(screen.getByText(NOTICE)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Emergency contact name/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Brings #1371 onto the 1.1 release line.

Its parent is exactly `rel/1.1`'s head (`10ac47f4`, the v1.1.0 commit), so this is a **fast-forward of the same commit** rather than a re-picked duplicate — the diff here is #1371 and nothing else. Keeping the original SHA avoids an add/add conflict on the new `EmergencyContactNotice.tsx` if this line ever merges from `main`.

UI copy only — 7 files, no schema, no migration, no API change. Adds one shared `EmergencyContactNotice` to every surface that collects an emergency contact, stating a rule the server already enforces (`EmergencyContactError`, code `is_member`).

**Not live until a v1.1.1 is cut.** v1.1.0 already deployed to prod at `10ac47f4` (run 30323396149, success), so prod does not have this yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier