### PR TITLE
docs: a documentation standard built on a domain rules register (proposal)

### DIFF
--- a/docs/DOCUMENTATION_STANDARD.md
+++ b/docs/DOCUMENTATION_STANDARD.md
@@ -26,7 +26,7 @@ domain rules — and gives everything else a shorter life.
 | `docs/rules/` | Board and operations decisions; invariants new work must not violate | **Permanent, edited by later changes** |
 | `docs/ops/` | How to run, deploy, test, and mock things | Long-lived, edited as tooling changes |
 | `docs/security/` | Security policy and boundary rules | Long-lived |
-| `docs/generated/` | Machine-derived artifacts, drift-tested | Regenerated, never hand-edited |
+| `checkin-app/docs/generated/` | Machine-derived artifacts, drift-tested | Regenerated, never hand-edited |
 | `docs/backlog/` | Journey inventory and gap tracking | Long-lived |
 | `docs/in-design/` | Proposals and designs being worked right now | **Deleted at merge** |
 
@@ -66,9 +66,9 @@ empty ones in advance.
 Decisions the board or operations have made about how things work, and
 invariants that later work must not violate.
 
-**Not:** implementation mechanism, state-machine structure (already generated
-and drift-tested under `docs/generated/`), rollout sequencing, or anything a
-reader could derive by reading the code.
+**Not:** implementation mechanism, state-machine structure (already generated and
+drift-tested under `checkin-app/docs/generated/`), rollout sequencing, or
+anything a reader could derive by reading the code.
 
 ### 3.2 Format
 
@@ -78,13 +78,19 @@ so a reviewer can judge a diff against it without opening code:
 ```markdown
 ## Membership application
 
-- An intake note holds the application at background-check review. Payment does
-  not open until two reviewers have read the note — a family that writes
-  "treat us as a volunteer household" must have dues settled before paying.
+- An intake note holds the application at background-check review, so reviewers
+  read it before dues are settled — a family writing "treat us as a volunteer
+  household" must not pay first. A household that already holds a still-valid
+  background clearance is exempt and goes straight to payment.
 
 - Membership activates only after background-check clearance. Payment arriving
   first does not activate; clearance arriving first does not activate.
 ```
+
+Note what the first rule spends a whole clause on: the **exemption**. An earlier
+draft of this document stated it without the clearance carve-out, which would
+have marked shipped, correct code as a violation. State the guards and carve-outs
+the code actually has, or the register does damage rather than none.
 
 **Write rules as constraints, not descriptions.** If the sentence does not let a
 reviewer tell whether a change violates it, rewrite the sentence.
@@ -98,6 +104,17 @@ linked to a diff and stays accurate on its own.
 **No line-number citations.** They rot within weeks and pull the register toward
 implementation when what a reviewer needs is the rule. A bare file path is the
 most a "where this bites" pointer should carry, and most rules need none.
+
+**Never state an over-broad rule.** A rule that claims more than the code does is
+worse than no rule: it marks correct behaviour as a violation, and the likely
+response is someone "fixing" working code to comply. When in doubt, state the
+narrower version, or leave it out and raise it.
+
+**An unratified policy is a candidate, not a rule.** Code sometimes carries a
+decision that was never actually decided — a `POLICY (flag for veto)` comment, a
+choice made to unblock a PR and never confirmed. Writing it here converts an open
+question into a stated invariant nobody agreed to. Take it to the owner or the
+board first; record it only once it is answered.
 
 ### 3.3 How much belongs
 

--- a/docs/DOCUMENTATION_STANDARD.md
+++ b/docs/DOCUMENTATION_STANDARD.md
@@ -1,0 +1,203 @@
+# Documentation standard
+
+**Status: PROPOSED — for review. Becomes the standard on merge.**
+How documentation in this repo is organised, written, and retired. Read this
+before writing or moving any doc.
+
+---
+
+## 1. Why this exists
+
+Documentation organised by *what change produced it* tells you whether a change
+landed. It does not tell you **what is true now** — so a rule only gets written
+down if it happened to be large enough to warrant its own doc, and a doc
+describing a shipped change silently decays into a wrong statement of current
+behaviour.
+
+This standard adds one register that is maintained rather than frozen — the
+domain rules — and gives everything else a shorter life.
+
+---
+
+## 2. Document classes
+
+| Where | What | Lifetime |
+|---|---|---|
+| `docs/rules/` | Board and operations decisions; invariants new work must not violate | **Permanent, edited by later changes** |
+| `docs/ops/` | How to run, deploy, test, and mock things | Long-lived, edited as tooling changes |
+| `docs/security/` | Security policy and boundary rules | Long-lived |
+| `docs/generated/` | Machine-derived artifacts, drift-tested | Regenerated, never hand-edited |
+| `docs/backlog/` | Journey inventory and gap tracking | Long-lived |
+| `docs/in-design/` | Proposals and designs being worked right now | **Deleted at merge** |
+
+Most of these are edited over time — ops docs follow the tooling, security
+policy evolves, the backlog is maintained continuously. What sets `docs/rules/`
+apart is *what triggers* the edit.
+
+A doc in any other class changes when **the thing it describes** changes: new
+mock, new deploy step, new gap found. That is ordinary upkeep, and it falls on
+whoever touches that thing.
+
+`docs/rules/` changes when **any work in its domain** establishes, alters, or
+retires a rule — even work that has nothing to do with documentation. That makes
+it the one class carrying an obligation outward onto unrelated changes, which is
+why the extract step in §4 exists at all.
+
+---
+
+## 3. `docs/rules/` — the domain register
+
+One file per domain, named for the domain and not for any feature:
+
+| File | Covers |
+|---|---|
+| `membership.md` | org membership: application, review, dues, renewal, lapse |
+| `programs.md` | programs and enrollment: eligibility, capacity, pricing, scholarships |
+| `people-households.md` | households, leads, guardianship, youth/adult status |
+| `finance-payments.md` | payment, refunds, exceptions, reconciliation obligations |
+| `attendance-checkin.md` | check-in, kiosk, visits, hours |
+| `tools-certification.md` | tool levels, certification, shop access |
+
+Add a file when a domain genuinely accumulates standing rules. Do not create
+empty ones in advance.
+
+### 3.1 What belongs
+
+Decisions the board or operations have made about how things work, and
+invariants that later work must not violate.
+
+**Not:** implementation mechanism, state-machine structure (already generated
+and drift-tested under `docs/generated/`), rollout sequencing, or anything a
+reader could derive by reading the code.
+
+### 3.2 Format
+
+Grouped under short headings, one rule per bullet, written in business language
+so a reviewer can judge a diff against it without opening code:
+
+```markdown
+## Membership application
+
+- An intake note holds the application at background-check review. Payment does
+  not open until two reviewers have read the note — a family that writes
+  "treat us as a volunteer household" must have dues settled before paying.
+
+- Membership activates only after background-check clearance. Payment arriving
+  first does not activate; clearance arriving first does not activate.
+```
+
+**Write rules as constraints, not descriptions.** If the sentence does not let a
+reviewer tell whether a change violates it, rewrite the sentence.
+"Payment does not open until reviewers have read the note" is checkable.
+"The intake system supports notes" is not.
+
+**No PR numbers, issue numbers, or dates.** These files say what is true, not
+how it came to be. Change history lives in git and in the PR record, where it is
+linked to a diff and stays accurate on its own.
+
+**No line-number citations.** They rot within weeks and pull the register toward
+implementation when what a reviewer needs is the rule. A bare file path is the
+most a "where this bites" pointer should carry, and most rules need none.
+
+### 3.3 How much belongs
+
+Enough but not too much. A domain has however many rules it has — some will be
+genuinely denser than others, and an arbitrary page count would either be
+ignored or cut real rules to meet it.
+
+Test each line, not the file:
+
+- **Could a change violate it?** If you cannot picture the PR that gets this
+  wrong, it is background, not a rule. Cut it.
+- **Would a reader derive it from the code anyway?** Then it is mechanism. Cut it.
+- **Does it duplicate a line already here?** Merge them.
+
+Test the file by whether it still gets read. If reviewers start skimming it, the
+register has stopped working — and the cause is nearly always mechanism that
+crept in, not a domain that genuinely has too many rules. Look for that first.
+Splitting the file hides the symptom without fixing it.
+
+---
+
+## 4. Working docs — `docs/in-design/`
+
+A doc written while designing or building something is welcome and useful. Edit
+it freely and skip the status ceremony — the folder it sits in already says it
+is unfinished.
+
+**Where it lives:** `docs/in-design/<name>.md`. One folder, so anyone can see
+what is currently being worked at a glance, and so nothing unfinished is mistaken
+for settled.
+
+Not `docs/backlog/` — that is an inventory of what exists and what does not,
+maintained over time; mixing disposable per-change docs into it defeats both
+purposes. Not the `docs/` root — that is for settled, permanent material.
+
+Anything sitting in `docs/in-design/` is by definition not yet true. Do not cite
+it as ground truth in another design, and do not implement against it without
+checking whether it landed.
+
+At merge:
+
+```
+extract   whatever standing rules the work established, into docs/rules/<domain>.md
+delete    the working doc
+```
+
+How many is however many there are — often none, sometimes one, occasionally
+several. Ask of each candidate the §3.3 question: *could a later change violate
+this?* If yes it is a rule and it goes in, however many that turns out to be. If
+no, leave it out, even if that empties the list.
+
+The failure to avoid is treating this as a quota — hunting for rules to justify
+the step, or stopping once a couple are written while a real one goes unrecorded.
+
+**Extracting nothing is a normal outcome.** Most changes do not establish new
+rules. Delete the working doc and add nothing.
+
+If a working doc turns out to be operational reference rather than feature
+design — how to run a mock, how an environment behaves — move it to `docs/ops/`
+instead of deleting it. It stays true and has no home in the rules register.
+
+A doc describing finished work that has nothing durable to say is sprawl. Delete
+it.
+
+---
+
+## 5. Enforcement
+
+**PR review, not tests.** A reviewer reads the domain rules for the area a
+change touches and catches a violation before it merges.
+
+To give reviewers something concrete to check, a working doc or design should
+name the domain rules it relies on or intends to change. A change that alters a
+rule says so explicitly rather than leaving the reviewer to notice.
+
+**Known limitation.** Nothing catches an *omitted* rule. A change that
+establishes a new invariant without writing it down leaves no trace a test or
+lint could find. The mitigation is that `docs/rules/` stays worth reading during
+review — see §3.3. This standard does not claim to close that gap mechanically,
+and no test should be built to pretend otherwise.
+
+---
+
+## 6. Guidance for agents
+
+1. **Before changing behaviour in a domain, read `docs/rules/<domain>.md`.** If
+   your change contradicts a rule there, that is a decision for the board or the
+   owner — raise it, do not quietly proceed.
+2. **A working doc is fine while building — put it in `docs/in-design/`.** No
+   `Status:` header ceremony; the folder carries that meaning.
+3. **Never cite a doc in `docs/in-design/` as ground truth.** It describes
+   something that is not yet true. Check whether it landed before building on it.
+4. **At merge, extract and delete.** Move the standing rules into the domain
+   doc; delete the working doc. Extracting nothing is normal.
+5. **Never put PR numbers, issue numbers, or dates in `docs/rules/`.**
+6. **Never put line-number citations in `docs/rules/`.**
+7. **Write rules as constraints.** A reviewer must be able to recognise a
+   violation from the sentence alone.
+8. **Do not add mechanism to a rules file.** Structure belongs in the generated
+   artifacts; how the code achieves something belongs in the code.
+9. **Do not create empty domain files** in anticipation of future rules.
+10. **Prefer cutting to adding.** Every line should be a rule a change could
+    violate; anything else dilutes the ones that matter.

--- a/docs/DOCUMENTATION_STANDARD.md
+++ b/docs/DOCUMENTATION_STANDARD.md
@@ -184,27 +184,27 @@ Splitting the file hides the symptom without fixing it.
 
 ### 3.5 Where the policies live
 
-The governing policies are **not in this repo**. They are held by the owner at
-`/Volumes/Untitled/Scratchpad/Policies` — outside version control and readable
-only on that machine.
+**The governing policies live on Google Drive.** That is the canonical source —
+what the board adopts and amends, and what a citation ultimately refers to.
+Anyone with Drive access can verify a policy-tier rule against the policy it
+names, which is what makes this tier meaningful rather than decorative.
 
-This has a consequence worth stating plainly: **a reviewer cannot verify a policy
-citation.** They can see that a rule claims policy authority and which policy it
-names, but not that the cited article says what the rule says. The register makes
-the claim auditable, not verified.
+A markdown **export** of the policies is also kept on the owner's machine at
+`/Volumes/Untitled/Scratchpad/Policies`, so agents can read them without Drive
+access. Treat it accordingly:
 
-That is the reason for the naming discipline in §3.2. A citation by policy name
-and article is meaningful to anyone holding the policy, in any format, at any
-time. A citation by path or page is meaningful only to the one machine that has
-the file open right now.
+- **It is a convenience copy, not the source.** Where the export and Drive
+  disagree, Drive wins.
+- **It can be stale.** A policy amended on Drive does not update the export.
+  Before promoting a rule to the policy tier off the export alone, confirm the
+  article still reads that way on Drive.
+- **Never cite the export path.** It exists on one machine and is derived.
 
-Two consequences for practice:
-
-- **Only someone with the policy corpus can classify a rule as policy-tier.**
-  Everyone else writes it as procedure and flags it for reclassification.
-- **If the policies are ever published**, this section is where the pointer goes.
-  Publishing them would turn every policy-tier rule from auditable into
-  verifiable, which is the single biggest available improvement to this register.
+This is why §3.2 cites by policy name and article rather than by any locator. The
+name and section are the one identifier stable across Drive, the export, and
+whatever format either is rendered in. A Drive URL is no better than a path:
+it rots on reorganisation and is permission-gated. Name the policy and its
+article; a reader with access can find it in seconds.
 
 ---
 

--- a/docs/DOCUMENTATION_STANDARD.md
+++ b/docs/DOCUMENTATION_STANDARD.md
@@ -189,22 +189,15 @@ what the board adopts and amends, and what a citation ultimately refers to.
 Anyone with Drive access can verify a policy-tier rule against the policy it
 names, which is what makes this tier meaningful rather than decorative.
 
-A markdown **export** of the policies is also kept on the owner's machine at
-`/Volumes/Untitled/Scratchpad/Policies`, so agents can read them without Drive
-access. Treat it accordingly:
-
-- **It is a convenience copy, not the source.** Where the export and Drive
-  disagree, Drive wins.
-- **It can be stale.** A policy amended on Drive does not update the export.
-  Before promoting a rule to the policy tier off the export alone, confirm the
-  article still reads that way on Drive.
-- **Never cite the export path.** It exists on one machine and is derived.
-
 This is why §3.2 cites by policy name and article rather than by any locator. The
-name and section are the one identifier stable across Drive, the export, and
-whatever format either is rendered in. A Drive URL is no better than a path:
-it rots on reorganisation and is permission-gated. Name the policy and its
-article; a reader with access can find it in seconds.
+name and section are the one identifier stable across Drive and whatever format
+a policy is rendered in. A Drive URL is no better than a filesystem path: it rots
+on reorganisation and is permission-gated. Name the policy and its article; a
+reader with access can find it in seconds.
+
+Verify against Drive, not against any local or cached copy of a policy — a copy
+predating an amendment would enshrine a superseded rule behind a citation that
+still looks correct.
 
 ---
 

--- a/docs/DOCUMENTATION_STANDARD.md
+++ b/docs/DOCUMENTATION_STANDARD.md
@@ -70,27 +70,75 @@ invariants that later work must not violate.
 drift-tested under `checkin-app/docs/generated/`), rollout sequencing, or
 anything a reader could derive by reading the code.
 
-### 3.2 Format
+### 3.2 Two tiers — policy first, then procedure
+
+Not every rule has the same authority, and a reviewer needs to know which kind
+they are looking at. Each domain file is split in two, **policy first**:
+
+**Policy** — the rule exists because the board or the organisation adopted a
+policy. The code implements it; it does not define it. **Cite the governing
+policy.** A change that violates one of these is not a design disagreement to be
+settled in review: the policy has to change first, which is a board action. A
+reviewer's correct response is to stop and escalate, not to weigh trade-offs.
+
+**Procedure** — everything else. Working agreements about how this system
+behaves: conventions, operational choices, invariants the team settled on
+because something had to be decided. Real rules that later work must not
+casually violate, but they can be renegotiated by the people doing the work,
+in a PR, without going to the board.
+
+Order matters. Policy goes above procedure in every file so the
+highest-authority constraints are read first and cannot be lost in a list.
+
+**Citing a policy.** Name the policy and its **structural location** — article,
+section, subsection, clause, whichever that policy actually uses. `Background
+Check Policy §2`, `Bylaws Art. IV §3(b)`, `Financial Controls Policy §5.2`.
+
+**Never cite a page number.** A page is an artifact of rendering: it moves when
+the document is reformatted, differs between PDF and print, and does not exist
+at all in some formats. The structural reference is part of the policy's own
+text and survives everything except an actual amendment — at which point the
+citation *should* break, because the rule may have changed.
+
+**Never cite a filesystem path.** The policy corpus lives outside this repo (see
+§3.5), so a path dangles for everyone but its owner and rots the way line numbers
+do. The policy's name plus its section is what survives a reorganisation.
+
+If a policy has no internal numbering to cite, say so explicitly ("*Volunteer
+Policy* — unnumbered") rather than inventing a locator or falling back to a
+page. That gap is worth surfacing: it usually means the policy needs structure.
+
+**Do not promote a rule to the policy tier to give it weight.** If you cannot
+name the policy it comes from, it is procedure. A rule that merely *feels*
+official is the same defect as an unratified policy written as settled.
+
+### 3.3 Format
 
 Grouped under short headings, one rule per bullet, written in business language
 so a reviewer can judge a diff against it without opening code:
 
 ```markdown
-## Membership application
+## Policy
+
+- Membership activates only after background-check clearance. Payment arriving
+  first does not activate; clearance arriving first does not activate.
+  — *Background Check Policy §2*
+
+## Procedure
 
 - An intake note holds the application at background-check review, so reviewers
   read it before dues are settled — a family writing "treat us as a volunteer
   household" must not pay first. A household that already holds a still-valid
   background clearance is exempt and goes straight to payment.
-
-- Membership activates only after background-check clearance. Payment arriving
-  first does not activate; clearance arriving first does not activate.
 ```
 
-Note what the first rule spends a whole clause on: the **exemption**. An earlier
+Note what the second rule spends a whole clause on: the **exemption**. An earlier
 draft of this document stated it without the clearance carve-out, which would
 have marked shipped, correct code as a violation. State the guards and carve-outs
 the code actually has, or the register does damage rather than none.
+
+(The tier split above is illustrative. Which of these is actually
+policy-backed is settled during the migration, against the real policy corpus.)
 
 **Write rules as constraints, not descriptions.** If the sentence does not let a
 reviewer tell whether a change violates it, rewrite the sentence.
@@ -116,7 +164,7 @@ choice made to unblock a PR and never confirmed. Writing it here converts an ope
 question into a stated invariant nobody agreed to. Take it to the owner or the
 board first; record it only once it is answered.
 
-### 3.3 How much belongs
+### 3.4 How much belongs
 
 Enough but not too much. A domain has however many rules it has — some will be
 genuinely denser than others, and an arbitrary page count would either be
@@ -133,6 +181,30 @@ Test the file by whether it still gets read. If reviewers start skimming it, the
 register has stopped working — and the cause is nearly always mechanism that
 crept in, not a domain that genuinely has too many rules. Look for that first.
 Splitting the file hides the symptom without fixing it.
+
+### 3.5 Where the policies live
+
+The governing policies are **not in this repo**. They are held by the owner at
+`/Volumes/Untitled/Scratchpad/Policies` — outside version control and readable
+only on that machine.
+
+This has a consequence worth stating plainly: **a reviewer cannot verify a policy
+citation.** They can see that a rule claims policy authority and which policy it
+names, but not that the cited article says what the rule says. The register makes
+the claim auditable, not verified.
+
+That is the reason for the naming discipline in §3.2. A citation by policy name
+and article is meaningful to anyone holding the policy, in any format, at any
+time. A citation by path or page is meaningful only to the one machine that has
+the file open right now.
+
+Two consequences for practice:
+
+- **Only someone with the policy corpus can classify a rule as policy-tier.**
+  Everyone else writes it as procedure and flags it for reclassification.
+- **If the policies are ever published**, this section is where the pointer goes.
+  Publishing them would turn every policy-tier rule from auditable into
+  verifiable, which is the single biggest available improvement to this register.
 
 ---
 
@@ -162,7 +234,7 @@ delete    the working doc
 ```
 
 How many is however many there are — often none, sometimes one, occasionally
-several. Ask of each candidate the §3.3 question: *could a later change violate
+several. Ask of each candidate the §3.4 question: *could a later change violate
 this?* If yes it is a rule and it goes in, however many that turns out to be. If
 no, leave it out, even if that empties the list.
 
@@ -193,7 +265,7 @@ rule says so explicitly rather than leaving the reviewer to notice.
 **Known limitation.** Nothing catches an *omitted* rule. A change that
 establishes a new invariant without writing it down leaves no trace a test or
 lint could find. The mitigation is that `docs/rules/` stays worth reading during
-review — see §3.3. This standard does not claim to close that gap mechanically,
+review — see §3.4. This standard does not claim to close that gap mechanically,
 and no test should be built to pretend otherwise.
 
 ---
@@ -202,19 +274,23 @@ and no test should be built to pretend otherwise.
 
 1. **Before changing behaviour in a domain, read `docs/rules/<domain>.md`.** If
    your change contradicts a rule there, that is a decision for the board or the
-   owner — raise it, do not quietly proceed.
-2. **A working doc is fine while building — put it in `docs/in-design/`.** No
+   owner — raise it, do not quietly proceed. A **Policy**-tier rule is not
+   negotiable in a PR at all: stop and escalate.
+2. **Never promote a rule to the Policy tier without naming the policy**, and
+   never cite one by page number or filesystem path — name plus article,
+   section, or subsection only.
+3. **A working doc is fine while building — put it in `docs/in-design/`.** No
    `Status:` header ceremony; the folder carries that meaning.
-3. **Never cite a doc in `docs/in-design/` as ground truth.** It describes
+4. **Never cite a doc in `docs/in-design/` as ground truth.** It describes
    something that is not yet true. Check whether it landed before building on it.
-4. **At merge, extract and delete.** Move the standing rules into the domain
+5. **At merge, extract and delete.** Move the standing rules into the domain
    doc; delete the working doc. Extracting nothing is normal.
-5. **Never put PR numbers, issue numbers, or dates in `docs/rules/`.**
-6. **Never put line-number citations in `docs/rules/`.**
-7. **Write rules as constraints.** A reviewer must be able to recognise a
+6. **Never put PR numbers, issue numbers, or dates in `docs/rules/`.**
+7. **Never put line-number citations in `docs/rules/`.**
+8. **Write rules as constraints.** A reviewer must be able to recognise a
    violation from the sentence alone.
-8. **Do not add mechanism to a rules file.** Structure belongs in the generated
+9. **Do not add mechanism to a rules file.** Structure belongs in the generated
    artifacts; how the code achieves something belongs in the code.
-9. **Do not create empty domain files** in anticipation of future rules.
-10. **Prefer cutting to adding.** Every line should be a rule a change could
+10. **Do not create empty domain files** in anticipation of future rules.
+11. **Prefer cutting to adding.** Every line should be a rule a change could
     violate; anything else dilutes the ones that matter.

--- a/docs/in-design/DOCUMENTATION_MIGRATION.md
+++ b/docs/in-design/DOCUMENTATION_MIGRATION.md
@@ -1,0 +1,292 @@
+# Documentation migration — getting the corpus to the standard
+
+**Status: WORKING DOC — delete when complete.**
+One-time plan for moving the existing ~43 docs and ~1,028 merged PRs' worth of
+undocumented decisions into the shape defined by `DOCUMENTATION_STANDARD.md`.
+This file is scaffolding: it follows its own rule and gets deleted when the work
+lands.
+
+---
+
+## 1. Evidence
+
+### 1.1 Rules ship without a home
+
+Two examples surfaced during a single design review:
+
+- **The intake-note hold.** An applicant note holds the membership application
+  at background-check review; payment does not open until reviewers have read
+  it, so a family writing "treat us as a volunteer household" has dues settled
+  before they pay. Stated only in a code comment in
+  `checkin-app/src/lib/membership/external.ts`, a parenthetical inside the
+  lifecycle transition table, and one aside in `docs/backlog/CUJS.md`.
+
+- **The member-pricing coverage window.** Member program pricing requires the
+  membership to be valid through the program's whole run, not merely active
+  today. Stated only in a JSDoc block in
+  `checkin-app/src/lib/orgMembership.ts` — where it is explicitly tagged as a
+  policy call awaiting a veto, and has sat there since.
+
+Neither was skipped through carelessness. There was no file either one belonged
+in. A design doc proposing to change both cited the lifecycle doc (mechanics)
+and a pricing doc that is itself an unbuilt proposal, and found nothing factual
+to check itself against.
+
+### 1.2 The cost is already measured
+
+An existing PR-history analysis distilled 861 merged PRs (#249–1168) and
+labelled each with the upstream cause that produced it. **192 of them — a
+little over a fifth — trace to the `SPEC` stage**, which decomposes as:
+
+| Cause | PRs | What it means |
+|---|---|---|
+| `scope-miss` | 87 | a rule existed but was not considered |
+| `domain-knowledge-gap` | 63 | a rule nobody had written down |
+| `auth-unclear` | 26 | an access or approval rule left undecided |
+
+A second analysis, run independently to answer a different question, agrees:
+19% of technical fixes trace to spec gaps, money paths worst (reconciliation,
+43%), and of 229 `feat:` PRs only 24% were real features — the plurality were
+business misses.
+
+Roughly one PR in five exists because a rule was not written down anywhere a
+person or an agent would look. That is the quantified case for a rules register,
+and it is why §3 mines this history rather than starting from a blank page.
+
+### 1.3 Sprawl
+
+One doc per change means the corpus grows with the PR count and is never pruned.
+Docs describing finished work sit next to live proposals, and a reader cannot
+tell which files are worth opening without opening all of them.
+
+---
+
+## 2. Step 1 — seed two rules files
+
+Create `docs/rules/membership.md` and `docs/rules/programs.md` from what is
+already known, before any mining. Sources:
+
+- the two rules in §1.1
+- `checkin-app/docs/designs/HOUSEHOLD_LEAD_MODEL.md` — a rules doc wearing a
+  design-doc hat; its content promotes directly
+- `checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md` — a domain rules doc
+  named after one feature; capacity and scholarship policy folds into
+  `programs.md`
+- `docs/backlog/CUJS.md` journey A1, which already states several membership
+  rules inline
+
+Cut aggressively. Two short files that get read beat six thorough ones that do
+not. This step also validates the format before the mining step produces volume.
+
+---
+
+## 3. Step 2 — mine the full PR history for standing rules
+
+**Goal:** recover the decisions that shipped over ~1,028 merged PRs and were
+never written anywhere durable. This is the bulk of the value and the only step
+that cannot be done incrementally later.
+
+### 3.1 Reuse the existing corpora
+
+Do not re-fetch from scratch. Two corpora already exist, built for different
+questions. Both are useful; neither is checked into this repo.
+
+**Primary — the `pr-mining` corpus.** An owner-local working directory holding a
+complete, distilled, cause-labelled analysis:
+
+- **861 PRs (#249–1168), 100% distilled.** `raw/pr-NNNN.json` is the exported
+  PR; `distilled/pr-NNNN.md` is a per-PR summary with YAML frontmatter
+  (`claimed_type`, `actual_nature`, `epoch`, `upstream_causes`, `confidence`)
+  plus prose sections for *What it actually did*, *Root cause*, *Upstream cause
+  analysis*, and *Evidence*.
+- `labels.tsv` — one row per PR with cause families and stages already joined.
+- `cause-map.tsv` — open-coded phrase → family, so a taxonomy change is a pure
+  join and needs no re-LLM pass.
+- `scripts/` — the five-phase pipeline (fetch → split → distill → parse →
+  label), every stage idempotent and resumable.
+- `REPORT.md` — the synthesis; `README.md` — how to reproduce or continue.
+
+This corpus is the right substrate because the distillation already answers the
+question this sweep asks. Its `SPEC` stage *is* the "a rule was never written
+down" bucket.
+
+**Secondary — the in-repo `analysis/` branch.** Branch
+`claude/github-issues-analysis-plan-31f6d4` (commit `0107a949`, unpushed) holds
+`pr_facts.jsonl` for 952 PRs and an owner-reviewed 24-category classification
+built to answer a different question (what fraction of features were real).
+Useful as a cross-check on anything the primary sweep surfaces; not the driver.
+
+**Coverage gap to close before the sweep:** PRs **#1169 and later** (80 merged
+since the last export). Fetchable with the existing pipeline, which skips work
+already on disk.
+
+PRs **#1–248** are deliberately out of scope. They predate the corpus and are
+not worth the fetch.
+
+**Three practical notes.** The corpus is owner-local and lives on one machine —
+it is a private *input*, and the domain rules it produces are the shared
+*output*; nothing about the sweep should assume another developer can see it.
+It is not a git repository, and `git init` is worth doing first so a
+long-running sweep is resumable and auditable. Its `README.md` still says to run
+from `~/Software/Checkin/pr-mining/`, which is stale since the repos moved —
+fix the path while you are in there.
+
+### 3.2 Filter to rule-bearing PRs
+
+Most PRs establish no rule. The distilled corpus makes the filter a query rather
+than a judgement call — select on stage and family in `labels.tsv`:
+
+| Stage | Family | PRs | Why it bears a rule |
+|---|---|---|---|
+| SPEC | `scope-miss` | 87 | a rule existed but was not considered |
+| SPEC | `domain-knowledge-gap` | 63 | a rule nobody had written down |
+| SPEC | `auth-unclear` | 26 | an access or approval rule left undecided |
+| PROCESS | `data-model-misfit` | 30 | the model and the policy disagreed |
+
+That is the sweep: roughly **200 PRs**, not 1,028. Read each one's *Upstream
+cause analysis* section — the rule is usually stated there in plain language
+already.
+
+Then check two secondary signals:
+
+- **`half-wired-feature`** (242 PRs, the largest family) — mostly genuine build
+  gaps, but a subset are a rule applied on one path and not its siblings. Sample
+  rather than read all of them.
+- **Churn clusters** — repeated work in one area usually means an unstated rule
+  everyone kept guessing at. `REPORT.md` names the ones already found.
+
+Deprioritise entirely: `missing-test-coverage` (219), `pattern-not-followed`
+(191), `process-tooling-friction`, `test-infra-reliability`, `none-clean-work`.
+These are process and craft findings — real, but they belong in a retrospective,
+not in a rules register.
+
+### 3.3 Extract, then discard the source
+
+For each rule-bearing PR, write one candidate rule as a constraint in business
+language. Then **drop the PR reference.** The output of this step is rules, not
+provenance. Per the standard, no PR number, issue number, or date survives into
+`docs/rules/`.
+
+Keep the working extraction list (candidate rule + originating PR) in scratch
+during the sweep so duplicates can be spotted — then throw it away. Do not check
+it in.
+
+### 3.4 Dedupe and cut
+
+The raw extraction will be far larger than what should ship. Expect to discard
+most of it:
+
+- Collapse restatements of the same rule into one line.
+- Drop anything that is mechanism, not policy.
+- Drop anything a reader would derive from the code.
+- Drop rules that are no longer true — verify against current `main`, not
+  against the PR that introduced them.
+
+**Judge by the §3.3 test in the standard, not by length:** keep a line only if a
+later change could violate it. A sweep over hundreds of PRs will over-produce —
+if a domain comes out with dozens of rules, it has almost certainly captured
+mechanism rather than policy, so re-apply the test before accepting the volume.
+Splitting the file is not the fix.
+
+### 3.5 Owner review
+
+The register states board and operations decisions. A rule inferred from a PR
+diff is a *candidate* decision until the owner confirms it. Present each domain
+file for review before it merges; some candidates will turn out to be
+accidents-of-implementation rather than decisions, and those must not be
+enshrined as rules.
+
+---
+
+## 4. Step 3 — update AGENTS.md
+
+- Point the docs map at `docs/rules/` first, as the place to read before
+  changing behaviour in a domain.
+- Reference `DOCUMENTATION_STANDARD.md` for the working-doc lifecycle and the
+  format rules.
+- Resolve the CUJS ambiguity: two files share the name `CUJS.md`
+  (`docs/designs/CUJS.md`, 98 lines, role-based; `docs/backlog/CUJS.md`,
+  276 lines, per-step with status). The docs map currently points at the thinner
+  one. Merge or delete one.
+
+---
+
+## 5. Step 4 — empty out the `designs/` directories
+
+Both `docs/designs/` and `checkin-app/docs/designs/` conflate three things with
+different lifetimes. Every file goes to one of three places, and **the `designs/`
+directories are then deleted** — which also avoids a `designs/` vs `in-design/`
+name collision.
+
+**→ `docs/in-design/`** — unbuilt proposals. These are working docs by another
+name: `SHOPIFY_MEMBER_SEGMENT_PRICING.md`, `KIOSK_RESILIENCE.md`,
+`MEMBERSHIP_SYNC.md`, `PROGRAM_INSTANCE_RESTRUCTURE.md`,
+`resilient-load-swr.md`, and the numbered set (`167-`, `354-`, `975-`, `1149_`,
+`1224_`, `1256_`, `1333-`). They keep their normal lifecycle from here: extract
+and delete when they land, delete outright when abandoned.
+
+**→ `docs/ops/`** — operational reference that stays true and has no rules-file
+home: `DEV_INSTANCE_DESIGN.md`, `DEV_DASHBOARD_DESIGN.md`,
+`BG_CHECK_DEV_MOCK.md`, `ZOHO_SIGN_DEV_MOCK.md`, `SHOPIFY_DEV_STORE_WEBHOOK.md`,
+`SHOPIFY_LIVE_TESTS.md`, `S_READ_DIAGNOSTICS.md`. `LIFECYCLE.md` goes here too —
+it documents how the generated artifacts and drift guards work, which is
+mechanism, not policy.
+
+**→ extract, then delete** — shipped feature docs: `HOUSEHOLD_LEAD_MODEL.md`
+(promotes into `people-households.md`), `INDEX_PAGE_SCOPING.md`,
+`MY_PROGRAMS_SCOPING.md`, `PRODUCTION_PLAN.md`, `ARCHITECT_IDEAS_o46.md`,
+`DESIGN.md`, `INDEX_PAGE_SCOPING.md`, `MY_PROGRAMS_SCOPING.md`. Check each for
+standing rules first; most will yield none.
+
+**Unresolved, decide during the sweep:** `CUJS.md` (both copies — see step 3),
+`UNFINISHED.md` (a deferred-decision ledger; arguably belongs in `in-design/`,
+arguably its own thing).
+
+**Leave alone entirely:** `docs/security/`, `docs/generated/`, `docs/backlog/`,
+`checkin-app/docs/VOCABULARY.md`, and the deploy/migration docs under
+`checkin-app/docs/`.
+
+---
+
+## 6. Step 5 — fix the root-vs-app split
+
+`docs/` at the repo root and `checkin-app/docs/` both hold app design docs, and
+the line is violated in both directions (`MEMBERSHIP_SYNC.md` is app design at
+the root; `LIFECYCLE.md` is app mechanics under `checkin-app/`).
+
+Proposed rule: repo root holds product, policy, and cross-cutting process;
+`checkin-app/docs/` holds app-implementation reference. Mechanical once agreed —
+do it last, after the rules register exists, so nothing moves twice.
+
+---
+
+## 7. Done when
+
+- `docs/rules/` holds the domain files, each owner-reviewed, every line a rule a
+  change could violate.
+- AGENTS.md points at the register and at `DOCUMENTATION_STANDARD.md`.
+- No `Status: SHIPPED` feature docs remain outside `docs/ops/`.
+- `docs/designs/` and `checkin-app/docs/designs/` no longer exist.
+- Only one `CUJS.md`.
+- This file is deleted.
+
+---
+
+## 8. Open questions
+
+1. **Domain list.** Are the six in the standard the right cut, or do membership
+   and finance-payments collapse into one?
+2. **Who owns a rules file?** CODEOWNERS on `docs/rules/` would route rule
+   changes to the board or owner automatically. Worth it, or too heavy?
+
+**Decided:**
+
+- **Working docs live with the change, in its PR** — not in `docs/backlog/`,
+  which is an inventory rather than a staging area. Recorded in the standard.
+- **No epoch cutoff on the mine.** The epoch boundary (2026-07-03) marks the
+  start of production, not a break in what is true. Rules established before it
+  remain valid; only the *character* of PRs changed, from major-refactoring work
+  to fixes found against a live app. Mine the whole corpus.
+- **No #1–248 backfill.** Out of scope; the corpus starts at #249.
+- **Corpus stays local.** `pr-mining` is an owner-local input; only the rules it
+  produces are shared. Revisit only if a second sweep needs to reproduce this one.

--- a/docs/in-design/DOCUMENTATION_MIGRATION.md
+++ b/docs/in-design/DOCUMENTATION_MIGRATION.md
@@ -95,6 +95,11 @@ Its content is guardianship and household leadership, which belongs in
 `membership.md` would violate "named for the domain, not for any feature."
 It is handled once, in step 4, and `people-households.md` is created there.
 
+Draft both files with the **Policy / Procedure** split from standard §3.2, even
+if the Policy section starts empty — the shape is part of what this step
+validates, and an empty Policy heading is an honest signal that nothing has been
+traced to a policy yet.
+
 Cut aggressively. Two short files that get read beat six thorough ones that do
 not. This step also validates the format before the mining step produces volume.
 
@@ -216,7 +221,52 @@ if a domain comes out with dozens of rules, it has almost certainly captured
 mechanism rather than policy, so re-apply the test before accepting the volume.
 Splitting the file is not the fix.
 
-### 3.5 Owner review
+### 3.5 Classify each rule: policy or procedure
+
+Standard §3.2 splits every domain file into a **Policy** section above a
+**Procedure** section. The mine cannot make that call on its own — a PR diff
+shows what the code does, never whether a board policy required it.
+
+So the sweep produces everything as **procedure by default**, and a separate
+pass promotes what is genuinely policy-backed:
+
+1. Draft every mined rule under Procedure. Never guess at policy authority; an
+   unsupported promotion is the same defect as writing an unratified policy as
+   settled.
+2. Flag candidates — anything touching dues, background checks, eligibility and
+   age gates, refunds, volunteer status, or access and certification is likely
+   to have a policy behind it. These are the ones worth checking.
+3. The owner checks each candidate against the policy corpus (§3.6) and either
+   promotes it with a citation by **policy name and article/section** — never a
+   page, never a path — or leaves it as procedure.
+
+Expect this to reclassify a meaningful share of the membership and finance
+rules, and almost none of the attendance or tooling ones.
+
+**A rule can also be neither.** If a candidate turns out to contradict the
+policy it supposedly implements, that is not a documentation finding — it is a
+compliance finding, and it goes to the owner directly rather than into any file.
+
+### 3.6 The policy corpus
+
+The governing policies are held by the owner at
+`/Volumes/Untitled/Scratchpad/Policies` — outside this repo, outside version
+control, readable only on that machine. Same custody model as the PR corpus
+(§3.1): a private **input** whose **output** is the citations in `docs/rules/`.
+
+Consequences for this step:
+
+- **Only the owner can run §3.5's promotion pass.** Everyone else drafts under
+  Procedure and flags.
+- **Reviewers can never verify a citation**, only see the claim and which policy
+  it names. Making the register auditable is the goal here; verifiable is out of
+  reach until the policies are published.
+- **The citation format is what makes this survivable.** Name plus
+  article/section stays meaningful to anyone holding the policy, in any format,
+  on any machine. A page number or a path would be meaningful only on the
+  owner's disk, today.
+
+### 3.7 Owner review
 
 The register states board and operations decisions. A rule inferred from a PR
 diff is a *candidate* decision until the owner confirms it. Present each domain
@@ -328,6 +378,11 @@ do it last, after the rules register exists, so nothing moves twice.
 
 - `docs/rules/` holds the domain files, each owner-reviewed, every line a rule a
   change could violate.
+- **Every domain file carries the Policy / Procedure split**, policy above
+  procedure, and every policy-tier rule cites a policy by name and
+  article/section — no page numbers, no filesystem paths.
+- **Any contradiction found between code and policy has been raised with the
+  owner**, not silently recorded as a rule.
 - AGENTS.md points at the register and at `DOCUMENTATION_STANDARD.md`.
 - No `Status: SHIPPED` feature docs remain outside `docs/ops/`.
 - `docs/designs/` and `checkin-app/docs/designs/` no longer exist.

--- a/docs/in-design/DOCUMENTATION_MIGRATION.md
+++ b/docs/in-design/DOCUMENTATION_MIGRATION.md
@@ -1,7 +1,7 @@
 # Documentation migration — getting the corpus to the standard
 
 **Status: WORKING DOC — delete when complete.**
-One-time plan for moving the existing ~43 docs and ~1,028 merged PRs' worth of
+One-time plan for moving the existing ~43 docs, and the years of
 undocumented decisions into the shape defined by `DOCUMENTATION_STANDARD.md`.
 This file is scaffolding: it follows its own rule and gets deleted when the work
 lands.
@@ -15,17 +15,19 @@ lands.
 Two examples surfaced during a single design review:
 
 - **The intake-note hold.** An applicant note holds the membership application
-  at background-check review; payment does not open until reviewers have read
-  it, so a family writing "treat us as a volunteer household" has dues settled
-  before they pay. Stated only in a code comment in
+  at background-check review so reviewers read it before dues are settled —
+  unless the household already holds a still-valid background clearance, which
+  takes the direct path to payment. Stated only in a code comment in
   `checkin-app/src/lib/membership/external.ts`, a parenthetical inside the
   lifecycle transition table, and one aside in `docs/backlog/CUJS.md`.
 
 - **The member-pricing coverage window.** Member program pricing requires the
-  membership to be valid through the program's whole run, not merely active
-  today. Stated only in a JSDoc block in
-  `checkin-app/src/lib/orgMembership.ts` — where it is explicitly tagged as a
-  policy call awaiting a veto, and has sat there since.
+  membership to cover the program's end date, not merely be active today; a
+  program with no end date requires coverage only through its start. Stated only
+  in a JSDoc block in `checkin-app/src/lib/orgMembership.ts` — which tags it
+  `POLICY (flag for veto)`, so it is an open question that has been shipping as
+  behaviour, not a settled decision. It cannot be written into `docs/rules/`
+  until the owner answers it.
 
 Neither was skipped through carelessness. There was no file either one belonged
 in. A design doc proposing to change both cited the lifecycle doc (mechanics)
@@ -34,24 +36,37 @@ to check itself against.
 
 ### 1.2 The cost is already measured
 
-An existing PR-history analysis distilled 861 merged PRs (#249–1168) and
-labelled each with the upstream cause that produced it. **192 of them — a
-little over a fifth — trace to the `SPEC` stage**, which decomposes as:
+An existing PR-history analysis distilled **941 PRs (#249–1372)** and labelled
+each with the upstream cause that produced it. **216 of them — just under a
+quarter — carry a `SPEC`-stage cause:**
 
 | Cause | PRs | What it means |
 |---|---|---|
-| `scope-miss` | 87 | a rule existed but was not considered |
-| `domain-knowledge-gap` | 63 | a rule nobody had written down |
-| `auth-unclear` | 26 | an access or approval rule left undecided |
+| `scope-miss` | 116 | a rule existed but was not considered |
+| `domain-knowledge-gap` | 82 | a rule nobody had written down |
+| `auth-unclear` | 31 | an access or approval rule left undecided |
 
-A second analysis, run independently to answer a different question, agrees:
-19% of technical fixes trace to spec gaps, money paths worst (reconciliation,
-43%), and of 229 `feat:` PRs only 24% were real features — the plurality were
-business misses.
+These columns **overlap** — a PR can carry several causes, so they sum to more
+than 216. The 216 is the deduplicated union and is the figure to quote. Adding
+`data-model-misfit` (34) brings the rule-bearing set to **243**.
 
-Roughly one PR in five exists because a rule was not written down anywhere a
-person or an agent would look. That is the quantified case for a rules register,
-and it is why §3 mines this history rather than starting from a blank page.
+Two counting caveats, so the figure is not overclaimed:
+
+- The corpus counts **all** PRs in range, not merged ones. Merged-only over
+  #249–1372 is 885 (816 up to #1168, 69 after). The cause labels are what the
+  argument rests on, and those are per-PR regardless of outcome — but "941
+  merged PRs" would be wrong.
+- The labels come from an LLM distillation pass, owner-reviewed in aggregate but
+  not line-by-line. Treat 216 as well-founded, not exact.
+
+A second analysis, run independently to answer a different question, points the
+same way: 19% of technical fixes trace to spec gaps, money paths worst
+(reconciliation, 43%), and of 229 `feat:` PRs only 24% were real features — the
+plurality were business misses.
+
+Roughly one PR in four carries a cause that means a rule was not written down
+anywhere a person or an agent would look. That is the quantified case for a
+rules register, and why §3 mines this history rather than starting blank.
 
 ### 1.3 Sprawl
 
@@ -66,14 +81,19 @@ tell which files are worth opening without opening all of them.
 Create `docs/rules/membership.md` and `docs/rules/programs.md` from what is
 already known, before any mining. Sources:
 
-- the two rules in §1.1
-- `checkin-app/docs/designs/HOUSEHOLD_LEAD_MODEL.md` — a rules doc wearing a
-  design-doc hat; its content promotes directly
+- the intake-note hold from §1.1. The member-pricing window is **not** seeded —
+  it is tagged `POLICY (flag for veto)` and needs an owner answer first.
 - `checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md` — a domain rules doc
   named after one feature; capacity and scholarship policy folds into
   `programs.md`
 - `docs/backlog/CUJS.md` journey A1, which already states several membership
   rules inline
+
+`checkin-app/docs/designs/HOUSEHOLD_LEAD_MODEL.md` is **not** a source here.
+Its content is guardianship and household leadership, which belongs in
+`people-households.md`, not in either seeded file — forcing it into
+`membership.md` would violate "named for the domain, not for any feature."
+It is handled once, in step 4, and `people-households.md` is created there.
 
 Cut aggressively. Two short files that get read beat six thorough ones that do
 not. This step also validates the format before the mining step produces volume.
@@ -82,7 +102,7 @@ not. This step also validates the format before the mining step produces volume.
 
 ## 3. Step 2 — mine the full PR history for standing rules
 
-**Goal:** recover the decisions that shipped over ~1,028 merged PRs and were
+**Goal:** recover the decisions that shipped across the repo's history and were
 never written anywhere durable. This is the bulk of the value and the only step
 that cannot be done incrementally later.
 
@@ -94,7 +114,8 @@ questions. Both are useful; neither is checked into this repo.
 **Primary — the `pr-mining` corpus.** An owner-local working directory holding a
 complete, distilled, cause-labelled analysis:
 
-- **861 PRs (#249–1168), 100% distilled.** `raw/pr-NNNN.json` is the exported
+- **941 PRs (#249–1372), 100% distilled** — all PRs in range, merged or not.
+  `raw/pr-NNNN.json` is the exported
   PR; `distilled/pr-NNNN.md` is a per-PR summary with YAML frontmatter
   (`claimed_type`, `actual_nature`, `epoch`, `upstream_causes`, `confidence`)
   plus prose sections for *What it actually did*, *Root cause*, *Upstream cause
@@ -116,20 +137,23 @@ down" bucket.
 built to answer a different question (what fraction of features were real).
 Useful as a cross-check on anything the primary sweep surfaces; not the driver.
 
-**Coverage gap to close before the sweep:** PRs **#1169 and later** (80 merged
-since the last export). Fetchable with the existing pipeline, which skips work
-already on disk.
+**Coverage is current** through #1372; the corpus was topped up and re-labelled.
 
 PRs **#1–248** are deliberately out of scope. They predate the corpus and are
 not worth the fetch.
 
-**Three practical notes.** The corpus is owner-local and lives on one machine —
-it is a private *input*, and the domain rules it produces are the shared
-*output*; nothing about the sweep should assume another developer can see it.
-It is not a git repository, and `git init` is worth doing first so a
-long-running sweep is resumable and auditable. Its `README.md` still says to run
-from `~/Software/Checkin/pr-mining/`, which is stale since the repos moved —
-fix the path while you are in there.
+**Reachability — read this before planning around the corpus.** It is
+**owner-local by decision** (§8), lives on one machine, and is not in any repo.
+No other developer or agent can open it, and the `~/Software/Checkin/pr-mining/`
+path in its own `README.md` is stale since the repos moved. The same applies to
+the secondary `analysis/` branch, whose commit is unpushed.
+
+That is deliberate: the corpus is a private **input**; the domain rules it
+produces are the shared **output**. Nobody should be blocked waiting for access.
+But it does mean **only the owner can execute step 2** — if this step needs to
+move to someone else, publishing the corpus becomes a prerequisite, not a
+detail. `git init` inside it is worth doing regardless, so a long sweep is
+resumable and auditable.
 
 ### 3.2 Filter to rule-bearing PRs
 
@@ -138,25 +162,29 @@ than a judgement call — select on stage and family in `labels.tsv`:
 
 | Stage | Family | PRs | Why it bears a rule |
 |---|---|---|---|
-| SPEC | `scope-miss` | 87 | a rule existed but was not considered |
-| SPEC | `domain-knowledge-gap` | 63 | a rule nobody had written down |
-| SPEC | `auth-unclear` | 26 | an access or approval rule left undecided |
-| PROCESS | `data-model-misfit` | 30 | the model and the policy disagreed |
+| SPEC | `scope-miss` | 116 | a rule existed but was not considered |
+| SPEC | `domain-knowledge-gap` | 82 | a rule nobody had written down |
+| SPEC | `auth-unclear` | 31 | an access or approval rule left undecided |
+| PROCESS | `data-model-misfit` | 34 | the model and the policy disagreed |
 
-That is the sweep: roughly **200 PRs**, not 1,028. Read each one's *Upstream
-cause analysis* section — the rule is usually stated there in plain language
-already.
+Families overlap, so do not add the column. The deduplicated set is **243 PRs**
+of 941 — that is the sweep. Read each one's *Upstream cause analysis* section;
+the rule is usually stated there in plain language already.
+
+```bash
+awk -F'\t' 'NR>1 && $5 ~ /scope-miss|domain-knowledge-gap|auth-unclear|data-model-misfit/{print $1}' labels.tsv | sort -un
+```
 
 Then check two secondary signals:
 
-- **`half-wired-feature`** (242 PRs, the largest family) — mostly genuine build
+- **`half-wired-feature`** (263 PRs, the largest family) — mostly genuine build
   gaps, but a subset are a rule applied on one path and not its siblings. Sample
   rather than read all of them.
 - **Churn clusters** — repeated work in one area usually means an unstated rule
   everyone kept guessing at. `REPORT.md` names the ones already found.
 
-Deprioritise entirely: `missing-test-coverage` (219), `pattern-not-followed`
-(191), `process-tooling-friction`, `test-infra-reliability`, `none-clean-work`.
+Deprioritise entirely: `missing-test-coverage` (238), `pattern-not-followed`
+(205), `process-tooling-friction`, `test-infra-reliability`, `none-clean-work`.
 These are process and craft findings — real, but they belong in a retrospective,
 not in a rules register.
 
@@ -233,18 +261,54 @@ it documents how the generated artifacts and drift guards work, which is
 mechanism, not policy.
 
 **→ extract, then delete** — shipped feature docs: `HOUSEHOLD_LEAD_MODEL.md`
-(promotes into `people-households.md`), `INDEX_PAGE_SCOPING.md`,
-`MY_PROGRAMS_SCOPING.md`, `PRODUCTION_PLAN.md`, `ARCHITECT_IDEAS_o46.md`,
-`DESIGN.md`, `INDEX_PAGE_SCOPING.md`, `MY_PROGRAMS_SCOPING.md`. Check each for
+(promotes into `people-households.md`, created here), `INDEX_PAGE_SCOPING.md`,
+`MY_PROGRAMS_SCOPING.md`, `ARCHITECT_IDEAS_o46.md`, `DESIGN.md`. Check each for
 standing rules first; most will yield none.
+
+**`PRODUCTION_PLAN.md` moves to `docs/ops/` — do not delete it.** Despite the
+name it is the live "Production Launch Runbook" for ops.innovationtreehouse.org:
+an ordered cutover checklist with open items (trust-policy verification,
+release-gate roster, ECR/ECS task-definition names). Extraction yields no rules,
+so the extract-and-delete bucket would destroy the only deploy/rollback runbook.
+The ops-bucket definition already covers it.
 
 **Unresolved, decide during the sweep:** `CUJS.md` (both copies — see step 3),
 `UNFINISHED.md` (a deferred-decision ledger; arguably belongs in `in-design/`,
 arguably its own thing).
 
-**Leave alone entirely:** `docs/security/`, `docs/generated/`, `docs/backlog/`,
-`checkin-app/docs/VOCABULARY.md`, and the deploy/migration docs under
-`checkin-app/docs/`.
+**Leave alone entirely:** `docs/security/`, `checkin-app/docs/generated/`,
+`docs/backlog/`, `checkin-app/docs/VOCABULARY.md`, and the deploy/migration docs
+under `checkin-app/docs/`.
+
+### 5.1 Reference sweep — do this BEFORE any move or delete
+
+Deleting or moving a doc that other files cite leaves dead pointers. There are
+currently **63 references to `docs/designs/…`** across `checkin-app/src`,
+`.github/`, `README.md`, and `AGENTS.md` — README front-page links and the
+AGENTS.md instruction to read `DEV_INSTANCE_DESIGN.md` before touching auth/env
+among them.
+
+```bash
+grep -rn "docs/designs/" checkin-app/src .github README.md AGENTS.md docs
+```
+
+Every hit is updated to the new path, or removed if its target is being deleted.
+The sweep is part of the same change as the move — never a follow-up.
+
+**One reference is not a plain text edit.**
+`checkin-app/src/lib/lifecycle/artifacts.ts:115` bakes the literal string
+`Generated from the machine's TRANSITIONS (docs/designs/LIFECYCLE.md)` into the
+generated artifacts, and `artifactsDrift.test.ts` asserts byte-equality against
+them. So moving `LIFECYCLE.md` requires, in one commit:
+
+1. update the literal in `artifacts.ts`,
+2. re-run `npm run generate:lifecycle-artifacts`,
+3. commit the regenerated files with it.
+
+Edit the string without regenerating and CI goes red on a confusing docs-path
+diff; skip the edit and the drift-tested, "do not hand-edit" artifacts ship a
+path that no longer exists — the one document class the standard calls
+machine-verified would be provably wrong.
 
 ---
 
@@ -267,6 +331,11 @@ do it last, after the rules register exists, so nothing moves twice.
 - AGENTS.md points at the register and at `DOCUMENTATION_STANDARD.md`.
 - No `Status: SHIPPED` feature docs remain outside `docs/ops/`.
 - `docs/designs/` and `checkin-app/docs/designs/` no longer exist.
+- **`grep -rn "docs/designs/" checkin-app/src .github README.md AGENTS.md docs`
+  returns nothing.**
+- **`npm run generate:lifecycle-artifacts` produces no diff**, and
+  `artifactsDrift.test.ts` passes.
+- **`PRODUCTION_PLAN.md` is in `docs/ops/`**, not deleted.
 - Only one `CUJS.md`.
 - This file is deleted.
 

--- a/docs/in-design/DOCUMENTATION_MIGRATION.md
+++ b/docs/in-design/DOCUMENTATION_MIGRATION.md
@@ -249,22 +249,19 @@ compliance finding, and it goes to the owner directly rather than into any file.
 
 ### 3.6 The policy corpus
 
-Canonical policies are on **Google Drive** (standard §3.5). A markdown export
-sits at `/Volumes/Untitled/Scratchpad/Policies` so agents can read them without
-Drive access — derived, possibly stale, never the authority.
+Canonical policies are on **Google Drive** (standard §3.5).
 
 Consequences for this step:
 
-- **Promote off Drive, not off the export.** The export is fine for finding
-  candidates and drafting a citation; confirm the article on Drive before a rule
-  lands in the Policy tier. An export predating an amendment would enshrine a
-  superseded rule with a citation that looks correct.
+- **Confirm on Drive before promoting.** A local or cached copy is fine for
+  finding candidates and drafting; the citation is only sound once checked
+  against Drive. A copy predating an amendment would enshrine a superseded rule
+  behind a citation that looks correct.
 - **Citations stay verifiable.** Anyone with Drive access can check a
   policy-tier rule against the policy it names — unlike the PR corpus (§3.1),
   this input is not owner-only, so the tier carries real weight.
-- **Cite name plus article/section only.** Not a page, not the export path, not
-  a Drive URL. It is the one identifier stable across Drive, the export, and
-  any rendering of either.
+- **Cite name plus article/section only.** Not a page, not a path, not a Drive
+  URL.
 
 ### 3.7 Owner review
 

--- a/docs/in-design/DOCUMENTATION_MIGRATION.md
+++ b/docs/in-design/DOCUMENTATION_MIGRATION.md
@@ -249,22 +249,22 @@ compliance finding, and it goes to the owner directly rather than into any file.
 
 ### 3.6 The policy corpus
 
-The governing policies are held by the owner at
-`/Volumes/Untitled/Scratchpad/Policies` — outside this repo, outside version
-control, readable only on that machine. Same custody model as the PR corpus
-(§3.1): a private **input** whose **output** is the citations in `docs/rules/`.
+Canonical policies are on **Google Drive** (standard §3.5). A markdown export
+sits at `/Volumes/Untitled/Scratchpad/Policies` so agents can read them without
+Drive access — derived, possibly stale, never the authority.
 
 Consequences for this step:
 
-- **Only the owner can run §3.5's promotion pass.** Everyone else drafts under
-  Procedure and flags.
-- **Reviewers can never verify a citation**, only see the claim and which policy
-  it names. Making the register auditable is the goal here; verifiable is out of
-  reach until the policies are published.
-- **The citation format is what makes this survivable.** Name plus
-  article/section stays meaningful to anyone holding the policy, in any format,
-  on any machine. A page number or a path would be meaningful only on the
-  owner's disk, today.
+- **Promote off Drive, not off the export.** The export is fine for finding
+  candidates and drafting a citation; confirm the article on Drive before a rule
+  lands in the Policy tier. An export predating an amendment would enshrine a
+  superseded rule with a citation that looks correct.
+- **Citations stay verifiable.** Anyone with Drive access can check a
+  policy-tier rule against the policy it names — unlike the PR corpus (§3.1),
+  this input is not owner-only, so the tier carries real weight.
+- **Cite name plus article/section only.** Not a page, not the export path, not
+  a Drive URL. It is the one identifier stable across Drive, the export, and
+  any rendering of either.
 
 ### 3.7 Owner review
 


### PR DESCRIPTION
## What

Two documents, both proposals. No code, no schema, nothing built.

- **`docs/DOCUMENTATION_STANDARD.md`** — the permanent standard. Document classes and what triggers each one's edits; `docs/rules/` as a maintained register of board and operations decisions; `docs/in-design/` for in-flight work with a delete-at-merge lifecycle; enforcement by PR review rather than tests.
- **`docs/in-design/DOCUMENTATION_MIGRATION.md`** — the working plan to get the existing corpus there. It deletes itself when complete, which is the standard practicing its own rule.

## Why

Reviewing [#1370](https://github.com/innovationtreehouse/checkin/pull/1370) surfaced a design proposing to change two shipped rules while citing neither — because neither had a home:

- **The intake-note payment hold.** An applicant note holds the application at BG review so dues settle before payment. Stated only in a code comment in `src/lib/membership/external.ts`, a parenthetical in the transition table, and one aside in `docs/backlog/CUJS.md`.
- **The member-pricing coverage window.** Member program pricing requires validity through the program's whole run, not merely ACTIVE today. Stated only in a JSDoc in `src/lib/orgMembership.ts`, tagged `POLICY (flag for veto)` and still sitting there.

Neither was skipped carelessly. There was no file either belonged in. The design cited `LIFECYCLE.md` (mechanics) and `SHOPIFY_MEMBER_SEGMENT_PRICING.md` (itself an unbuilt proposal), and found nothing factual to check against.

An existing PR-history analysis quantifies the pattern: **192 of 861 distilled PRs trace to SPEC-stage causes** — `scope-miss` (87), `domain-knowledge-gap` (63), `auth-unclear` (26). Roughly one PR in five exists because a rule was never written where anyone would look.

## The diagnosis

Docs today are organised by *what change produced them*, so a rule is only recorded if it was large enough to warrant its own doc, and a `Status: SHIPPED` doc is a record that decays into a wrong statement of current behaviour. `docs/rules/` is the one class that later changes are obliged to edit — that asymmetry is the whole proposal.

## Notes for reviewers

- **Enforcement is deliberately human.** Nothing catches an *omitted* rule; no test or lint can see a rule that was never written. The standard says so plainly and says not to build a test that pretends otherwise. If you think that is the wrong call, that is the thing to argue about.
- **No counts anywhere.** Earlier drafts said "a page per domain" and "extract the 2–3 rules." Both were replaced with a per-line test — *could a later change violate this?* — because fabricated numbers get read as quotas.
- **Migration §5 deletes both `designs/` directories**, sorting their contents into `in-design/`, `ops/`, or extract-and-delete. `LIFECYCLE.md` goes to `ops/`: it documents mechanism, which is exactly why citing it as a rules source did not help.
- **`CUJS.md` and `UNFINISHED.md` are flagged unresolved** rather than guessed at.
- Open questions are in migration §8, including whether the six proposed domains are the right cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)