### PR TITLE
test(programs): assert the checkout-broken WHERE equals its JS predicate

### DIFF
--- a/checkin-app/src/lib/__tests__/programCheckout.test.ts
+++ b/checkin-app/src/lib/__tests__/programCheckout.test.ts
@@ -1,4 +1,4 @@
-import { isProgramCheckoutBroken } from "@/lib/programCheckout";
+import { isProgramCheckoutBroken, PROGRAM_CHECKOUT_BROKEN_WHERE } from "@/lib/programCheckout";
 
 describe("isProgramCheckoutBroken", () => {
   it("free program (no prices) is never broken", () => {
@@ -68,5 +68,70 @@ describe("isProgramCheckoutBroken", () => {
       shopifyVariantId: null,
       shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
     })).toBe(true);
+  });
+});
+
+// ── predicate ≡ WHERE ────────────────────────────────────────────────────────
+// The count query (nav todo-counts) runs PROGRAM_CHECKOUT_BROKEN_WHERE in
+// Postgres; the list/detail UI runs isProgramCheckoutBroken in JS. If they
+// disagree the badge count contradicts the list it links to, so assert them
+// equal over the whole matrix rather than trusting the two to be edited together.
+
+type Row = {
+  orgMemberPriceCents: number | null;
+  nonOrgMemberPriceCents: number | null;
+  shopifyVariantId: string | null;
+  shopifyOrgMemberVariantId: string | null;
+  shopifyNonOrgMemberVariantId: string | null;
+};
+
+/**
+ * Evaluate the subset of Prisma `where` grammar this fragment uses against a row,
+ * with SQL null semantics: `field: null` is IS NULL, and `{ gt: n }` on a NULL
+ * column is unknown → no match.
+ */
+function whereMatches(where: Record<string, unknown>, row: Row): boolean {
+  for (const [key, clause] of Object.entries(where)) {
+    if (key === "OR") {
+      if (!(clause as Record<string, unknown>[]).some((c) => whereMatches(c, row))) return false;
+      continue;
+    }
+    const value = (row as unknown as Record<string, unknown>)[key];
+    if (clause === null) {
+      if (value !== null && value !== undefined) return false;
+    } else if (clause && typeof clause === "object" && typeof (clause as { gt?: unknown }).gt === "number") {
+      const { gt } = clause as { gt: number };
+      if (typeof value !== "number" || !(value > gt)) return false;
+    } else {
+      throw new Error(`whereMatches: unhandled shape for ${key}: ${JSON.stringify(clause)}`);
+    }
+  }
+  return true;
+}
+
+describe("PROGRAM_CHECKOUT_BROKEN_WHERE agrees with isProgramCheckoutBroken", () => {
+  const PRICES = [null, 0, 5000];
+  const VARIANTS = [null, "gid-1"];
+
+  it("matches the predicate on every price × variant combination", () => {
+    for (const orgMemberPriceCents of PRICES) {
+      for (const nonOrgMemberPriceCents of PRICES) {
+        for (const shopifyVariantId of VARIANTS) {
+          for (const shopifyOrgMemberVariantId of VARIANTS) {
+            for (const shopifyNonOrgMemberVariantId of VARIANTS) {
+              const row: Row = {
+                orgMemberPriceCents, nonOrgMemberPriceCents, shopifyVariantId,
+                shopifyOrgMemberVariantId, shopifyNonOrgMemberVariantId,
+              };
+              const query = whereMatches(
+                PROGRAM_CHECKOUT_BROKEN_WHERE as Record<string, unknown>,
+                row,
+              );
+              expect({ row, broken: query }).toEqual({ row, broken: isProgramCheckoutBroken(row) });
+            }
+          }
+        }
+      }
+    }
   });
 });

--- a/checkin-app/src/lib/programCheckout.ts
+++ b/checkin-app/src/lib/programCheckout.ts
@@ -17,10 +17,11 @@ import type { Prisma } from "@/generated/prisma/client";
  * alone, or the full legacy pair. Legacy programs (no shopifyVariantId) keep
  * the original per-tier check.
  *
- * The JS predicate and the Prisma WHERE below MUST stay in lockstep: the count
- * query (nav/todo-counts) and the per-row/detail UI are the same condition on two
- * sides of the wire. Change one, change the other. programCheckout.test.ts guards
- * the predicate.
+ * The JS predicate and the Prisma WHERE below are the same condition on two sides
+ * of the wire — the count query (nav/todo-counts) and the per-row/detail UI.
+ * programCheckout.test.ts evaluates the WHERE in memory against the full price ×
+ * variant matrix and asserts it equals the predicate, so editing one half alone
+ * fails the suite.
  */
 type CheckoutFields = {
   orgMemberPriceCents?: number | null;


### PR DESCRIPTION
## What

`checkin-app/src/lib/programCheckout.ts` exports one condition twice:

- `isProgramCheckoutBroken(p)` — the JS predicate, used by the per-row / detail UI
- `PROGRAM_CHECKOUT_BROKEN_WHERE` — the `Prisma.ProgramWhereInput`, used by the nav todo-count query

Only the predicate had tests. A change to either half alone was invisible; the symptom in production is a nav badge count that disagrees with the list it links to.

This adds a matrix test that evaluates the Prisma `WHERE` in memory and asserts it equals the predicate row for row, and rewrites the file's doc comment to name the test as the enforcement instead of asking a human to remember the lockstep.

## How

`whereMatches` interprets the subset of the `where` grammar this fragment uses (`field: null`, `{ gt: n }`, `OR`) with SQL null semantics — `field: null` is `IS NULL`, and `{ gt: n }` against a NULL column is unknown, so no match. Anything else throws rather than silently passing.

The matrix covers all five fields the condition reads: `null` / `0` / priced for each price tier, and `null` / set for each of the three variant ids — 72 rows, including every combination the single-pool short-circuit (`shopifyVariantId` set covers both tiers) has to absorb.

Same shape as the two existing parity tests in this repo:

- `checkin-app/src/lib/programs/enrollmentState.test.ts` ("where agrees with has across the full matrix")
- `checkin-app/src/lib/membership/__tests__/lifecycle.test.ts`

Their `whereMatches` helpers are file-local and hardcoded to their own clause shapes (the membership one destructures `awaitingBgReview.where` by name), so neither is importable — this is a third, deliberately small one.

## StateSet: assessed, doesn't fit

Generating both halves from one spec via `defineStateSet` (`checkin-app/src/lib/lifecycle/stateSet.ts`) would be strictly better than a test — no drift possible, and the comment could be deleted rather than updated. It does not fit:

- its grammar is `statuses: string[]` plus `flags` (nullable-column presence) and `equals` (boolean-column value); it always emits `status: { in: [...] }`, and this condition has no status field at all
- the price gate is `> 0`, a numeric comparison. Presence (`{ not: null }`) would flag `price: 0` as broken — wrong; free tiers legitimately have no variant
- the fragment is an `OR` of two conjunctions with `shopifyVariantId: null` AND'ed over it; `defineStateSet` emits a flat conjunction

Making it fit means adding numeric-comparison and top-level-`OR` grammar to a shared client-safe primitive to serve one caller. Left alone.

## Verification

`npm test -- --testPathPatterns programCheckout` — 10 passed. `tsc --noEmit` clean.

Proved the test bites by breaking one side at a time and reverting:

- **WHERE only** (`gt: 0` → `gt: -1`, i.e. `gte: 0`): all 9 pre-existing predicate tests pass, only the new matrix test fails, on `orgMemberPriceCents: 0` — `broken: true` from the query vs `false` from the predicate. This is exactly the class of edit that was previously invisible.
- **Predicate only** (dropped the `shopifyVariantId` short-circuit): 2 failed, 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)