### PR TITLE
test(prisma): pin the app pool's scale-to-zero and hang-guard options

### DIFF
--- a/checkin-app/src/lib/__tests__/prisma.test.ts
+++ b/checkin-app/src/lib/__tests__/prisma.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Pins the app pool's constructor options. Every one of these regresses
+ * silently — nothing throws, no other test goes red: a non-zero `min` or an
+ * unbounded idle keeps the shared Aurora cluster from ever auto-pausing, and
+ * the missing timeout/keepAlive only ever shows up as a hang.
+ *
+ * jest.setup.js mocks `@/lib/prisma` for the unit tier, so the real module is
+ * pulled in with requireActual. `pg` and the Prisma client are mocked so
+ * loading it builds the options object without opening a connection.
+ */
+// Keeps the consts below out of the global scope tsc gives an import-free test
+// file, where they'd collide with same-named consts in other such files.
+export {};
+
+const poolCtor = jest.fn();
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation((opts: unknown) => {
+        poolCtor(opts);
+        return { query: jest.fn(), on: jest.fn(), end: jest.fn() };
+    }),
+}));
+
+jest.mock('@prisma/adapter-pg', () => ({ PrismaPg: jest.fn() }));
+
+jest.mock('@/generated/prisma/client', () => ({
+    PrismaClient: jest.fn().mockImplementation(() => ({
+        $extends() {
+            return this;
+        },
+    })),
+    Prisma: { defineExtension: (ext: unknown) => ext },
+}));
+
+let opts: Record<string, unknown>;
+
+beforeAll(() => {
+    jest.isolateModules(() => {
+        jest.requireActual('@/lib/prisma');
+    });
+    opts = poolCtor.mock.calls[0][0];
+});
+
+describe('app pool options', () => {
+    it('holds no idle connections, so the Aurora cluster can auto-pause', () => {
+        expect(opts.min).toBe(0);
+        expect(opts.idleTimeoutMillis).toBeGreaterThan(0);
+        // 0 disables reaping in pg-pool, which reads as "no idle timeout" —
+        // the same failure as min > 0, so keep the ceiling explicit.
+        expect(opts.idleTimeoutMillis).toBeLessThanOrEqual(60_000);
+    });
+
+    it('fails fast instead of hanging when the pool cannot get a connection', () => {
+        // pg has NO default here: without it an exhausted or unresponsive
+        // server blocks a connection attempt forever, with no error.
+        expect(opts.connectionTimeoutMillis).toBeGreaterThan(0);
+    });
+
+    it('probes dead peers, so an abandoned lock holder gets reaped', () => {
+        // Off by default in pg. A connection whose peer died abruptly while
+        // holding pg_advisory_xact_lock looks alive to Postgres forever, and
+        // every later query needing that lock hangs.
+        expect(opts.keepAlive).toBe(true);
+    });
+});


### PR DESCRIPTION
## What

Adds `checkin-app/src/lib/__tests__/prisma.test.ts` — a unit test asserting the constructor options of the app's own `pg` pool in `checkin-app/src/lib/prisma.ts`.

Asserted:

| Option | Assertion | Why it's load-bearing |
|---|---|---|
| `min` | `=== 0` | Scale-to-zero: Aurora only auto-pauses after ~5 min with zero connections. |
| `idleTimeoutMillis` | `> 0` and `<= 60_000` | Same invariant — `0` disables reaping in pg-pool, which is the "never pauses" failure by another name. |
| `connectionTimeoutMillis` | `> 0` | pg has **no default**; without it an exhausted/unresponsive server blocks a connection attempt forever, with no error. |
| `keepAlive` | `=== true` | Off by default in pg. A peer that died abruptly while holding `pg_advisory_xact_lock` looks alive to Postgres forever, and every later query needing that lock hangs. |

`max` is deliberately **not** asserted: it branches on `NODE_ENV === 'test'`, so under jest it's the test value (1), not the production 10.

## Why

Two `pg` pools carry this invariant. The s-read mirror pool (`src/lib/shopifyRead/client.ts`) has had the assertion since #1030 — see `shopifyRead/__tests__/client.test.ts` "honours the scale-to-zero pool invariant". The app's own pool, the one every request goes through, had none.

That's the wrong way round: the unguarded pool has the larger blast radius and the quieter failure. Nothing throws, no test goes red, no page breaks — the shared Aurora cluster simply never auto-pauses and bills continuously. Same for the two hang guards: their absence only ever shows up as a stall.

## How it gets at the real module (reviewer note)

`jest.setup.js` globally mocks `@/lib/prisma` for the unit tier, so a plain import gets the mock and never runs the `new Pool(...)` we want to inspect. The test instead:

1. mocks `pg` so the `Pool` constructor records its options object,
2. mocks `@prisma/adapter-pg` and `@/generated/prisma/client` (the latter needs a `Prisma.defineExtension` stub, or `prismaEmailNormalize` throws at import time),
3. loads the real module with `jest.requireActual('@/lib/prisma')` inside `jest.isolateModules` — `requireActual` un-mocks only that module, so its dependencies still resolve to the mocks above.

Net effect: the module's import-time side effects run far enough to build the pool options, without opening a connection or constructing a real `PrismaClient`. No production code changed — the mock approach worked, so nothing had to be extracted out of `prisma.ts`.

The `export {}` at the top keeps the file module-scoped; without it, tsc treats an import-free test file as a global script and its top-level `poolCtor` collides with the identically-named const in the mirror-pool test.

## Verification

```
PASS src/lib/__tests__/prisma.test.ts
  app pool options
    ✓ holds no idle connections, so the Aurora cluster can auto-pause
    ✓ fails fast instead of hanging when the pool cannot get a connection
    ✓ probes dead peers, so an abandoned lock holder gets reaped

Tests: 3 passed, 3 total
```

Confirmed the test actually bites — temporarily flipped `min` to `1` in `prisma.ts`:

```
✕ holds no idle connections, so the Aurora cluster can auto-pause
    expect(received).toBe(expected) // Object.is equality
    Expected: 0
    Received: 1
```

then reverted (`git diff` clean; the diff here is the one new file).

## Pre-existing issue, not from this branch

`npx tsc --noEmit` reports `src/lib/shopifyRead/__tests__/client.test.ts(17,7): error TS2451: Cannot redeclare block-scoped variable 'poolCtor'`. This reproduces with the new file deleted, so it predates this change and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)