### PR TITLE
chore(lint): enforce type-only Prisma imports in client-safe lifecycle modules

### DIFF
--- a/checkin-app/src/lib/lifecycle/stateSet.ts
+++ b/checkin-app/src/lib/lifecycle/stateSet.ts
@@ -3,10 +3,10 @@
  * BOTH a client-safe runtime predicate (`has`) AND a server Prisma `where`
  * fragment from ONE spec, so the two can never drift apart.
  *
- * Client-safety (see lifecycle/README intent): this file value-imports NOTHING.
- * The Prisma `where` type is a caller-supplied generic param (`Where`), so no
- * `@/generated/prisma` value ever reaches the client bundle. The `where` value
- * is a plain object literal — inert data, no Prisma runtime dependency.
+ * Client-safe: a Prisma value here would pull the generated client into a page
+ * bundle, so the `where` type is a caller-supplied generic (`Where`) and the
+ * value a plain object literal. Enforced by `no-restricted-imports` in
+ * `eslint.config.mjs` — `import type` only.
  */
 
 export type StateSet<Row, Where> = {

--- a/checkin-app/src/lib/membership/lifecycle.ts
+++ b/checkin-app/src/lib/membership/lifecycle.ts
@@ -10,12 +10,12 @@
  * `FOR UPDATE` lock, conditional `updateMany`, and partial-unique-index +
  * P2002 catch is unchanged and merely *fed* the status set it names.
  *
- * CLIENT-SAFETY (docs/designs/LIFECYCLE.md) — CRITICAL, pages import
- * this file: NOTHING here value-imports `@/generated/prisma`. `Prisma` and the
- * enums are `import type` only (erased at build); predicates take booleans, not
- * `Date | null`; the `where` fragments are plain object literals typed via the
- * generic. The enum-parity assertion is compile-time here (type-only) and
- * value-based only in the test.
+ * Client-safe — pages import this file, and a Prisma value here would pull the
+ * generated client into a page bundle. `no-restricted-imports` in
+ * `eslint.config.mjs` allows `@/generated/prisma` only as `import type`.
+ * Predicates therefore take booleans, not `Date | null`; the `where` fragments
+ * are plain object literals typed via the generic; enum parity is compile-time
+ * here and value-based only in the test.
  */
 import type { Prisma, OrgMembershipProcessStatus, OrgMembershipProcessKind } from "@/generated/prisma/client";
 import {

--- a/checkin-app/src/lib/programs/enrollmentState.ts
+++ b/checkin-app/src/lib/programs/enrollmentState.ts
@@ -6,10 +6,10 @@
  * `where`/predicate the existing compare-and-set guards already hand-write; it
  * never executes a transition. Postgres stays the runtime authority.
  *
- * Client-safe (docs/designs/LIFECYCLE.md): value-imports NOTHING from
- * `@/generated/prisma`. The status union is a local string-literal type checked
- * against the Prisma enum by a TYPE-ONLY parity line; the `where` fragments are
- * typed via `import type { Prisma }` (erased at build).
+ * Client-safe — a Prisma value here would pull the generated client into a page
+ * bundle. `no-restricted-imports` in `eslint.config.mjs` allows
+ * `@/generated/prisma` only as `import type`, so the status union is a local
+ * string-literal type checked against the Prisma enum by a TYPE-ONLY parity line.
  */
 import {
     defineStateSet,
@@ -21,7 +21,6 @@ import {
     type Expect,
     type Equal,
 } from '@/lib/lifecycle';
-// Type-only: erased at build, so no Prisma value reaches the client bundle.
 import type { Prisma, ProgramParticipantStatus as PrismaStatus } from '@/generated/prisma/client';
 
 /** Local status union — the trunk `status` column. `UNENROLLED` (∅/no row) is

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,19 @@ const nodeEnvRules = [
   },
 ];
 
+// The lifecycle modules are imported by client components, so a Prisma VALUE
+// reaching them drags the generated client into a page bundle. Types are erased
+// at build, so `import type` stays legal. The regex covers the `@/` alias and any
+// relative path to the same directory.
+const noPrismaValueImport = [
+  {
+    regex: "(^@/|/)generated/prisma(/|$)",
+    message:
+      "Client-safe module: use `import type` for @/generated/prisma — a value import pulls the Prisma client into the page bundle.",
+    allowTypeImports: true,
+  },
+];
+
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
@@ -66,6 +79,23 @@ const eslintConfig = defineConfig([
   {
     files: ["**/src/app/api/**/*.ts"],
     rules: { "no-console": "warn" },
+  },
+  {
+    // Lifecycle definitions are shared server/client, so they stay Prisma-free at
+    // runtime. Tests are excluded: they are not the client bundle and may value-
+    // import the generated enum (see lifecycle/enumParity.ts).
+    files: [
+      "**/src/lib/lifecycle/**/*.ts",
+      "**/src/lib/membership/lifecycle.ts",
+      "**/src/lib/programs/enrollmentState.ts",
+    ],
+    ignores: ["**/__tests__/**", "**/*.test.ts"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        { patterns: noPrismaValueImport },
+      ],
+    },
   },
   {
     // P3-1: error responses must go through apiError() (@/lib/api-response) so the


### PR DESCRIPTION
## What

Adds an ESLint `@typescript-eslint/no-restricted-imports` rule (with `allowTypeImports: true`) banning **value** imports of `@/generated/prisma` from the client-safe lifecycle modules, and shrinks the three header comments that previously carried the rule as prose.

## Why

`src/lib/lifecycle/stateSet.ts`, `src/lib/membership/lifecycle.ts`, and `src/lib/programs/enrollmentState.ts` each declared in a header comment that nothing in them may value-import the generated Prisma client — these modules are imported by client components, so a Prisma value drags the generated client into a page bundle.

Nothing enforced it. A Prisma enum is a runtime **value**, so a single plain `import { OrgMembershipProcessStatus } from '@/generated/prisma/client'` compiles, type-checks, passes every test, and ships the regression silently. `src/lib/lifecycle/enumParity.ts` exists purely to avoid needing such an import — the constraint is load-bearing enough to be machine-checked.

## Scope

`src/lib/lifecycle/**/*.ts` + `src/lib/membership/lifecycle.ts` + `src/lib/programs/enrollmentState.ts`, with `**/__tests__/**` and `**/*.test.ts` ignored.

The broader directory scope is safe: every file in `src/lib/lifecycle/` (`artifacts.ts`, `classify.ts`, `enumParity.ts`, `generate.ts`, `index.ts`, `machineSpecs.ts`, `stateSet.ts`, `transitions.ts`) was checked and none imports `@/generated/prisma` at all — value or type. `enumParity.ts` imports nothing whatsoever; `generate.ts` is a node-only CLI that imports only sibling modules.

Tests are exempt deliberately: `enumParity.ts` documents that `assertEnumParity` is *meant* to be called from a test with a value-imported Prisma enum ("tests aren't the client bundle"). Linting that shut would break the design it protects.

## Implementation notes

- Only `@/generated/prisma/client` is actually imported anywhere in the repo (46 sites), but the pattern covers the bare `@/generated/prisma` path too.
- Uses `regex` rather than a glob group so a **relative-path bypass** is also caught: `@/*` maps to `./src/*`, so `../../generated/prisma/client` from `src/lib/lifecycle/` resolves identically and a bare-specifier glob would miss it. Pattern: `(^@/|/)generated/prisma(/|$)`.
- Flat-config replacement hazard checked: no existing block sets `no-restricted-imports`. The new block co-matches only the src-wide `no-restricted-syntax` block, a different rule name, so nothing is dropped. Follows the file's shared-const pattern (`noPrismaValueImport`, alongside `bareConsoleErrorRules`).

## Verification

`npm run lint` is clean before and after — which also proves `import type` stays legal, since all three files use it today.

Temporarily converting `import type` to a plain `import` in two files (one via the `@/` alias, one via a relative path) fires the rule:

```
checkin-app/src/lib/membership/lifecycle.ts
  20:1  error  '@/generated/prisma/client' import is restricted from being used by a pattern. Client-safe module: use `import type` for @/generated/prisma — a value import pulls the Prisma client into the page bundle  @typescript-eslint/no-restricted-imports

checkin-app/src/lib/programs/enrollmentState.ts
  25:1  error  '../../generated/prisma/client' import is restricted from being used by a pattern. Client-safe module: use `import type` for @/generated/prisma — a value import pulls the Prisma client into the page bundle  @typescript-eslint/no-restricted-imports

✖ 2 problems (2 errors, 0 warnings)
```

And the bare subpath plus the directory glob, via a file that imports nothing today:

```
checkin-app/src/lib/lifecycle/stateSet.ts
  119:1  error  '@/generated/prisma' import is restricted from being used by a pattern. …
```

All temporary edits reverted. Lint-only change; no test suite was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)