### PR TITLE
chore(lint): ban process.env.NODE_ENV reads in src

### DIFF
--- a/checkin-app/src/app/api/auth/dev-personas/route.ts
+++ b/checkin-app/src/app/api/auth/dev-personas/route.ts
@@ -28,9 +28,7 @@ const PERSONA_LIMIT = 50;
  * session is required (the logged-out picker is the initial login path).
  */
 export async function GET(request: Request) {
-    // Gate on CHECKIN_ENV only (via isDevInstance) — NOT NODE_ENV. The cloud dev instance is a
-    // prod build (NODE_ENV=production, CHECKIN_ENV=dev), so a NODE_ENV check would 404 the picker
-    // there. isDevInstance() already fails safe to prod. Mirrors the shared dev fence (guard.ts).
+    // isDevInstance() fails safe to prod; mirrors the shared dev fence (guard.ts).
     if (!config.isDevInstance()) {
         return apiError("Not available", 404);
     }
@@ -104,7 +102,6 @@ export async function GET(request: Request) {
  * a caller-supplied email, so it cannot target or collide with a real person.
  */
 export async function POST() {
-    // CHECKIN_ENV is the single fuse (NODE_ENV eliminated repo-wide, #951 review):
     // 'local' can only be true when explicitly set — unset/unknown fails safe to prod.
     if (config.checkinEnv() !== 'local') {
         return apiError("Not available", 404);

--- a/checkin-app/src/app/dev/sent-mail/page.tsx
+++ b/checkin-app/src/app/dev/sent-mail/page.tsx
@@ -14,9 +14,6 @@ export const metadata = {
     title: "Dev — Sent Mail",
 };
 
-// devToolsActive, NOT a NODE_ENV check: cloud-dev runs the same production
-// image as prod, so a NODE_ENV fuse 404'd this page on the dev instance itself
-// (the Debug nav item's landing tab). See config.devToolsActive.
 function devOnlyOrNotFound() {
     if (!config.devToolsActive()) notFound();
 }

--- a/checkin-app/src/components/DevLoginPicker.tsx
+++ b/checkin-app/src/components/DevLoginPicker.tsx
@@ -80,10 +80,8 @@ export default function DevLoginPicker({ callbackUrl = "/" }: { callbackUrl?: st
     return badges;
   };
 
-  // CHECKIN_ENV, not NODE_ENV: in a client bundle NODE_ENV is inlined at BUILD
-  // time, so the old check made the picker vanish in every production build —
-  // including a local `next build` — regardless of instance. checkinEnv comes
-  // from EnvProvider (server-resolved) and fails safe to 'prod' when unset.
+  // checkinEnv comes from EnvProvider (server-resolved) and fails safe to 'prod'
+  // when unset — a client bundle has no server env of its own to read.
   if (checkinEnv === 'prod') return null;
 
   if (loading) {

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -184,13 +184,10 @@ export const authOptions: NextAuthOptions = {
         // (Replaces the old local-only "Offline Login" provider — local mints are the
         // unauthenticated-caller case in evaluateMint.)
         //
-        // Registration gates on CHECKIN_ENV only (via isDevInstance) — NOT NODE_ENV. The cloud dev
-        // instance runs the prod image (NODE_ENV=production, CHECKIN_ENV=dev; see Dockerfile +
-        // deploy-dev.yml), so a NODE_ENV clause here (added by #280) unregistered the provider on
-        // the very instance impersonation is designed for, and every mint failed. isDevInstance()
-        // fails safe to prod (unset CHECKIN_ENV → 'prod'), matching the shared dev fence
-        // (lib/dev/guard.ts), and evaluateMint independently denies prod even if the provider
-        // somehow runs — both covered in auth-options-authorize.test.ts.
+        // Registration gates on isDevInstance(), which fails safe to prod (unset CHECKIN_ENV
+        // → 'prod'), matching the shared dev fence (lib/dev/guard.ts); evaluateMint
+        // independently denies prod even if the provider somehow runs — both covered in
+        // auth-options-authorize.test.ts.
         ...(config.isDevInstance() ? [
             CredentialsProvider({
                 id: PERSONA_MINT_PROVIDER_ID,

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -24,6 +24,12 @@ export type CheckinEnv = 'prod' | 'dev' | 'local';
 /** Verified Google Workspace hosted-domain (`hd`) allowed on the dev instance. */
 export const ORG_DOMAIN = 'innovationtreehouse.org';
 
+/**
+ * The single environment fuse. Every deployed instance — prod, cloud-dev, ops-stg —
+ * runs the same production image, so NODE_ENV is 'production' everywhere and cannot
+ * tell them apart: environment branches gate on this (through the config predicates
+ * below), never NODE_ENV. Enforced by the NODE_ENV ban in eslint.config.mjs.
+ */
 function readCheckinEnv(): CheckinEnv {
     const value = process.env.CHECKIN_ENV;
     // Anything unrecognized — including unset — fails safe to prod.
@@ -320,15 +326,10 @@ export const config = {
     // True on the cloud dev instance OR a local laptop (i.e. not prod). Server-only.
     isDevInstance: (): boolean => readCheckinEnv() !== 'prod',
     // Gate for the /dev tools + their capture paths (sent-mail inbox, email
-    // capture). The design docs paired isDevInstance() with a
-    // `NODE_ENV !== 'production'` build fuse (the persona-mint idiom), but every
-    // DEPLOYED instance — cloud-dev included — runs the same production image
-    // (checkin-app/Dockerfile sets NODE_ENV=production), so that clause made the
-    // tools 404 on the very instance they exist for. Prod safety rests on
-    // CHECKIN_ENV, which is server-only and FAILS SAFE to 'prod' for any
-    // unset/unrecognized value (readCheckinEnv); cloud-dev pages are additionally
-    // behind the org-member login gate. Use this — not a hand-rolled
-    // NODE_ENV check — to gate any future dev tool.
+    // capture) — use this to gate any future dev tool. Prod safety rests on
+    // CHECKIN_ENV alone, which is server-only and fails safe to 'prod' for any
+    // unset/unrecognized value; cloud-dev pages are additionally behind the
+    // org-member login gate.
     devToolsActive: (): boolean => readCheckinEnv() !== 'prod',
     // True only on a developer laptop. Gates offline credential login + keyless kiosk.
     isLocal: (): boolean => readCheckinEnv() === 'local',

--- a/checkin-app/src/lib/email.ts
+++ b/checkin-app/src/lib/email.ts
@@ -20,10 +20,9 @@ export async function sendEmail(to: string, subject: string, html: string): Prom
     if (!resend) {
         console.log(`[Email (no RESEND_API_KEY)] To: ${to} | Subject: ${subject}`);
         // Dev/local: capture the email so link/token flows are retrievable at /dev/sent-mail,
-        // and report success so gating callers follow the prod happy-path. Gated on
-        // devToolsActive (CHECKIN_ENV, fails safe to prod — NOT a NODE_ENV fuse, which is
-        // 'production' on every deployed instance incl. cloud-dev): a prod box that somehow
-        // lost its key still falls through to `return false` (fail loud, not fake success).
+        // and report success so gating callers follow the prod happy-path. devToolsActive
+        // fails safe to prod, so a prod box that somehow lost its key still falls through
+        // to `return false` (fail loud, not fake success).
         if (config.devToolsActive()) {
             return captureSentEmail(from, to, subject, html);
         }

--- a/checkin-app/src/lib/membership/contract/signingTarget.ts
+++ b/checkin-app/src/lib/membership/contract/signingTarget.ts
@@ -17,10 +17,6 @@ import prisma from "@/lib/prisma";
  * signing from the settings page without a redeploy.
  */
 export async function signingMockActive(): Promise<boolean> {
-    // CHECKIN_ENV only — NOT a NODE_ENV fuse: every deployed instance (cloud-dev
-    // included) runs the production image, so a NODE_ENV check would make the
-    // radio inert on the one instance it exists for (see #951 / devToolsActive).
-    // readCheckinEnv fails safe to 'prod' when unset/unrecognized.
     if (config.isProd()) return false;
     if (config.zohoMockActive()) return true; // no real creds on a non-prod instance
     if (config.checkinEnv() !== "dev") return false;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,19 @@ const bareConsoleErrorRules = [
   },
 ];
 
+// Every deployed instance — prod, cloud-dev, ops-stg — runs the same production
+// image, so NODE_ENV is 'production' everywhere and cannot tell them apart.
+// CHECKIN_ENV is the only fuse. Shared for the same replace-not-merge reason as
+// bareConsoleErrorRules.
+const nodeEnvRules = [
+  {
+    selector:
+      "MemberExpression[object.object.name='process'][object.property.name='env'][property.name='NODE_ENV']",
+    message:
+      "Environment branches gate on config.checkinEnv(), never NODE_ENV — every deployed instance runs the same production image. (Test-harness plumbing in src/lib/prisma.ts is the only exception.)",
+  },
+];
+
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
@@ -39,7 +52,13 @@ const eslintConfig = defineConfig([
   ]),
   {
     files: ["**/src/**/*.{ts,tsx}"],
-    rules: { "no-restricted-syntax": ["error", ...bareConsoleErrorRules] },
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...bareConsoleErrorRules,
+        ...nodeEnvRules,
+      ],
+    },
   },
   // API routes must log through @/lib/logger (console sink + logBackendError),
   // not raw console. Scoped to server routes only — client code can't use the
@@ -69,8 +88,21 @@ const eslintConfig = defineConfig([
             "Return errors via apiError(message, status[, details]) from @/lib/api-response, not a raw NextResponse.json({ error }).",
         },
         ...bareConsoleErrorRules,
+        ...nodeEnvRules,
       ],
     },
+  },
+  // NODE_ENV exemptions. prisma.ts reads it as test-harness/dev-server plumbing
+  // (pool sizing, adapter disposal, the dev global), not as an environment fuse;
+  // tests set and read it to exercise both builds. Both blocks re-spread the
+  // rules they still need, since flat config replaces the array.
+  {
+    files: ["**/src/lib/prisma.ts"],
+    rules: { "no-restricted-syntax": ["error", ...bareConsoleErrorRules] },
+  },
+  {
+    files: ["**/src/**/*.test.{ts,tsx}"],
+    rules: { "no-restricted-syntax": ["error", ...bareConsoleErrorRules] },
   },
 ]);
 


### PR DESCRIPTION
## What

Adds a `no-restricted-syntax` selector to `eslint.config.mjs` banning reads of `process.env.NODE_ENV` under `**/src/**`, and collapses the 20 comments that were the only prior enforcement of that rule down to one canonical statement.

## Why

Every deployed instance — prod, cloud-dev, ops-stg — runs the same production Docker image, so `NODE_ENV` is `production` everywhere and cannot distinguish them. `CHECKIN_ENV` is the only real fuse, and it fails safe to `'prod'` for any unset or unrecognized value (`readCheckinEnv()` in `checkin-app/src/lib/config.ts`).

This was enforced by convention alone, and it has already failed in production: a `NODE_ENV` clause added to `auth-options.ts` unregistered the persona-mint provider on the very instance impersonation exists for, and every mint failed. The fix that shipped for that outage was more comments. Nothing prevented a recurrence — now something does.

## The flat-config gotcha

ESLint flat config **replaces**, does not merge, a same-named rule across blocks. `no-restricted-syntax` was already set in two blocks: the src-wide one and `**/src/app/api/**/*.ts` (which re-spreads `bareConsoleErrorRules` for exactly this reason). The new selector is therefore defined as a shared `nodeEnvRules` const and spread into **both** — otherwise it would have been silently dead in `src/app/api/**`, which is where several of the env gates live.

## Exemptions

Scoped override blocks in the config rather than inline `eslint-disable` comments — the point of the change is that the rule lives in config, not in comments.

- `**/src/lib/prisma.ts` — the only 4 reads in non-test source (pool sizing, adapter disposal, the dev global). Test-harness and dev-server plumbing, not environment fuses.
- `**/src/**/*.test.{ts,tsx}` — tests under `src/**/__tests__/` **do** match the src-wide glob and legitimately set and read `NODE_ENV`. Verified empirically, not assumed.

Both exemption blocks re-spread `bareConsoleErrorRules` for the same replace-not-merge reason.

## Comment shrink

Canonical statement now sits at `readCheckinEnv()` in `checkin-app/src/lib/config.ts`. The other 7 non-test sites were trimmed to the part of the sentence that still carries information beyond the rule itself — fails-safe semantics, `evaluateMint`'s independent prod denial, fail-loud-not-fake-success, `EnvProvider` sourcing. Per AGENTS.md, the outage history moved out of the source and lives here in the PR instead.

## Verification

`npm run lint` from `checkin-app/` is clean on this tree.

Proved the rule actually fires by temporarily appending `if (process.env.NODE_ENV === "production") {}` to one plain src file and one api route (to confirm the api block isn't dead), then reverting:

```
checkin-app/src/app/api/auth/dev-personas/route.ts
  124:5  error  Environment branches gate on config.checkinEnv(), never NODE_ENV — every deployed instance runs the same production image. (Test-harness plumbing in src/lib/prisma.ts is the only exception.)  no-restricted-syntax

checkin-app/src/lib/email.ts
  81:5  error  Environment branches gate on config.checkinEnv(), never NODE_ENV — every deployed instance runs the same production image. (Test-harness plumbing in src/lib/prisma.ts is the only exception.)  no-restricted-syntax

✖ 2 problems (2 errors, 0 warnings)
```

## Notes for reviewers

- **Left deliberately:** 8 `NODE_ENV` mentions remain in test files (`config.test.ts`, `email.test.ts`, `auth-options-authorize.test.ts`, `signingTarget.test.ts`, `zohoProvider.test.ts`). Those are test names and regression-guard comments describing what each assertion covers — test intent, not source comments restating the rule. A few carry issue numbers in the test name; renaming them is cosmetic follow-up.
- **Not run:** the jest suite (comments + lint config only). `tsc --noEmit` was not clean in the worktree used here, but only with `Cannot find module '@/generated/prisma/client'` and its downstream implicit-any errors — `prisma generate` had not been run. Unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)