### PR TITLE
fix(membership): thank returning households for renewing, don't welcome them

### DIFF
--- a/checkin-app/flow-tests/membership-activation-fanout.flow.test.ts
+++ b/checkin-app/flow-tests/membership-activation-fanout.flow.test.ts
@@ -57,8 +57,10 @@ import { loginAs, api } from "./helpers";
 
 type State = { process: { id: number; status: string } | null; membershipStatus: string | null };
 
-// payment.ts › sendCongrats — the one and only activation email. Kept in sync by hand;
-// if the copy changes, this literal must change with it (that's the point — it pins the send).
+// payment.ts › sendCongrats — the one and only activation email, in its INITIAL
+// wording (this journey activates a brand-new membership; a RENEWAL is thanked for
+// renewing instead). Kept in sync by hand; if the copy changes, this literal must
+// change with it (that's the point — it pins the send).
 const CONGRATS_SUBJECT = "Welcome to the Treehouse — your membership is active!";
 const APPLICANT_EMAIL = "parent.family@example.com";
 

--- a/checkin-app/src/lib/membership/__tests__/payment.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/payment.test.ts
@@ -8,6 +8,9 @@
  *   - no membership variant in the order -> NOT activated, no paidAt, board alerted (notifyBoardPaidReject).
  *   - membership variant present         -> activates as before (status ACTIVE, membership ACTIVE).
  *   - a "certified" (board) activation never had an order to check, so it's exempt regardless.
+ *
+ * Also covers the activation email's INITIAL/RENEWAL split: a renewing household
+ * is thanked for renewing, not welcomed as if it were new.
  */
 import { activate, activateByProcessId } from '@/lib/membership/payment';
 
@@ -27,11 +30,14 @@ jest.mock('@/lib/prisma', () => {
 jest.mock('@/lib/email', () => ({ sendEmail: jest.fn().mockResolvedValue(true) }));
 jest.mock('@/lib/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn() } }));
 jest.mock('@/lib/membership/boardAlerts', () => ({ notifyBoardPaidReject: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('@/lib/emailRecipients', () => ({ emailHouseholdLeads: jest.fn().mockResolvedValue(undefined) }));
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const prisma = require('@/lib/prisma').default;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { notifyBoardPaidReject } = require('@/lib/membership/boardAlerts');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { emailHouseholdLeads } = require('@/lib/emailRecipients');
 
 const PROCESS_ID = 5;
 const MEMBERSHIP_ID = 9;
@@ -75,6 +81,31 @@ it('activates a PENDING_PAYMENT process when the order contains the membership i
         expect.objectContaining({ where: { id: MEMBERSHIP_ID }, data: { status: 'ACTIVE' } }),
     );
     expect(notifyBoardPaidReject).not.toHaveBeenCalled();
+});
+
+it('welcomes an INITIAL household on activation', async () => {
+    prisma.orgMembershipProcess.findUnique.mockResolvedValue({
+        id: PROCESS_ID, kind: 'INITIAL', status: 'PENDING_PAYMENT', paidAt: null, bgClearedAt: new Date(), orgMembershipId: MEMBERSHIP_ID,
+    });
+
+    await activateByProcessId(PROCESS_ID, 'order-3', true);
+
+    const [, subject, body] = emailHouseholdLeads.mock.calls[0];
+    expect(subject).toBe('Welcome to the Treehouse — your membership is active!');
+    expect(body).toContain('Welcome to the Innovation Treehouse community');
+});
+
+it('thanks a RENEWAL household for renewing instead of welcoming it', async () => {
+    prisma.orgMembershipProcess.findUnique.mockResolvedValue({
+        id: PROCESS_ID, kind: 'RENEWAL', status: 'PENDING_PAYMENT', paidAt: null, bgClearedAt: new Date(), orgMembershipId: MEMBERSHIP_ID,
+    });
+
+    await activateByProcessId(PROCESS_ID, 'order-4', true);
+
+    const [, subject, body] = emailHouseholdLeads.mock.calls[0];
+    expect(subject).toBe('Thank you for renewing — your Treehouse membership is active!');
+    expect(subject).not.toContain('Welcome');
+    expect(body).toContain('Thank you for renewing');
 });
 
 it('a certified (board) activation is exempt from the membership-item check', async () => {

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -233,7 +233,7 @@ export async function activate(
     // Side effects outside the transaction: a slow/failed send must not roll back
     // the write, and only the call that actually recorded the change emits one.
     if (result.kind === "active") {
-        await sendCongrats(result.householdId);
+        await sendCongrats(result.householdId, result.isInitial);
         // Trigger C: a brand-new (INITIAL) member just activated (bg cleared before
         // payment landed) — open PERSON_BG for the household's program-attached adults.
         if (result.isInitial) await openPersonBgForNewMember(result.householdId, new Date());
@@ -267,13 +267,23 @@ export async function activateByProcessId(processId: number, shopifyOrderId: str
     return activate(processId, { via: "payment", shopifyOrderId, hasMembershipItem });
 }
 
-/** Send the one "welcome — your membership is active" email to a household's leads. */
-export async function sendCongrats(householdId: number) {
+/**
+ * Send the one "your membership is active" email to a household's leads. A
+ * renewal gets thanked for renewing — welcoming a family that has been here for
+ * years reads as if we don't know them.
+ */
+export async function sendCongrats(householdId: number, isInitial: boolean) {
     const base = config.baseUrl();
+    const subject = isInitial
+        ? "Welcome to the Treehouse — your membership is active!"
+        : "Thank you for renewing — your Treehouse membership is active!";
+    const lead = isInitial
+        ? "Congratulations! Your household membership is now active. Welcome to the Innovation Treehouse community."
+        : "Thank you for renewing! Your household membership is active again — we're glad to have your family back at the Innovation Treehouse.";
     await emailHouseholdLeads(
         householdId,
-        "Welcome to the Treehouse — your membership is active!",
-        `<p>Congratulations! Your household membership is now active. Welcome to the Innovation Treehouse community.</p><p><a href="${base}">Visit your dashboard</a></p>`,
+        subject,
+        `<p>${lead}</p><p><a href="${base}">Visit your dashboard</a></p>`,
         "Congrats email failed:",
     );
 }

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -249,7 +249,7 @@ export async function attest(
     // Side effects outside the transaction (a slow/failed send must not roll it back).
     if ("activated" in result) {
         if (result.activated) {
-            await sendCongrats(result.householdId!);
+            await sendCongrats(result.householdId!, result.isInitial);
             // Trigger C: a brand-new (INITIAL) member just activated — open PERSON_BG
             // for any program-attached ≥18 person in the household (as-of activation).
             if (result.isInitial) await openPersonBgForNewMember(result.householdId!, new Date());
@@ -397,7 +397,7 @@ export async function overrideBlocked(processId: number, actorId: number, action
         return clearBackgroundCheck(tx, processId, actorId);
     });
     if (activated) {
-        await sendCongrats(householdId!);
+        await sendCongrats(householdId!, isInitial);
         // Trigger C: a board force-clear can be the first activation of a brand-new
         // (INITIAL) member — open PERSON_BG for the household's program-attached adults.
         if (isInitial) await openPersonBgForNewMember(householdId!, new Date());


### PR DESCRIPTION
Fixes #1375

## What

`sendCongrats` — the single activation email sent when a membership flips ACTIVE — had one hardcoded copy:

> **Welcome to the Treehouse — your membership is active!**
> Congratulations! Your household membership is now active. Welcome to the Innovation Treehouse community.

A household **renewing** its membership got that same new-member welcome. As the issue puts it, it should be a thank you for renewing.

## Why this shape

The fix is a branch inside `sendCongrats`, not new plumbing: all three activation call sites already carry `isInitial` (`process.kind === "INITIAL"`) for the Trigger-C PERSON_BG fan-out, so the kind just needed threading one level down.

- `payment.ts` › `activate()` — Shopify webhook + board payment-plan certify
- `review.ts` › `attest()` — second reviewer clears the background check
- `review.ts` › board force-clear override

RENEWAL now sends:

> **Thank you for renewing — your Treehouse membership is active!**
> Thank you for renewing! Your household membership is active again — we're glad to have your family back at the Innovation Treehouse.

INITIAL copy is unchanged.

## Reviewer notes

- `PERSON_BG` never reaches `sendCongrats` (it has no household and no payment step), so the two-way INITIAL/RENEWAL split covers every caller.
- The activation flow test (`membership-activation-fanout.flow.test.ts`) pins the congrats subject by literal. That journey activates a brand-new membership, so the literal is still correct — only its comment changed, to say the constant is the INITIAL wording.
- `membershipPaymentPlansAPI.integration.test.ts` filters activation emails with `subject.startsWith('Welcome to the Treehouse')`. Its fixtures are `kind: 'INITIAL'`, so the filter still matches.

## Testing

- `npx tsc --noEmit` — clean
- Membership unit scope — 35 suites / 352 tests pass, including two new cases in `payment.test.ts` pinning the INITIAL and RENEWAL subject + body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)