### PR TITLE
feat(events): include programs a person leads in "My Upcoming Events"

### DIFF
--- a/checkin-app/src/app/__tests__/eventMineAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventMineAPI.integration.test.ts
@@ -16,10 +16,13 @@ jest.mock('next-auth/next', () => ({
 describe('My Events API Integration Tests', () => {
     let testUserId: number;
     let testVolunteerId: number;
+    let testLeadId: number;
     let testProgram1Id: number;
     let testProgram2Id: number;
+    let testProgram3Id: number;
     let testEventUpcoming1Id: number;
     let testEventUpcoming2Id: number;
+    let testEventUpcoming3Id: number;
     let testEventPastId: number;
 
     beforeAll(async () => {
@@ -54,6 +57,11 @@ describe('My Events API Integration Tests', () => {
         });
         testVolunteerId = volunteer.id;
 
+        const lead = await prisma.person.create({
+            data: { email: 'lead-mine-events-test@example.com', name: 'Lead Mine Test', household: { create: { name: "Test HH" } } }
+        });
+        testLeadId = lead.id;
+
         const program1 = await prisma.program.create({
             data: {
                 name: 'Mine Test Program 1',
@@ -73,6 +81,18 @@ describe('My Events API Integration Tests', () => {
             }
         });
         testProgram2Id = program2.id;
+
+        // Program 3 has a lead mentor and no enrollments/volunteers.
+        const program3 = await prisma.program.create({
+            data: {
+                name: 'Mine Test Program 3',
+                maxParticipants: 10,
+                minAge: 5,
+                maxAge: 18,
+                leadMentorId: testLeadId,
+            }
+        });
+        testProgram3Id = program3.id;
 
         // User is enrolled in Program 1
         await prisma.programParticipant.create({
@@ -128,6 +148,17 @@ describe('My Events API Integration Tests', () => {
         });
         testEventUpcoming2Id = event2.id;
 
+        // Event for Program 3 (upcoming) — only the lead mentor is tied to it
+        const event3 = await prisma.event.create({
+            data: {
+                name: 'Mine Test Event Upcoming 3',
+                programId: testProgram3Id,
+                startAt: futureStart2,
+                endAt: new Date(futureStart2.getTime() + 1 * 60 * 60 * 1000)
+            }
+        });
+        testEventUpcoming3Id = event3.id;
+
         // RSVP for the user on event 1
         await prisma.rSVP.create({
             data: {
@@ -141,28 +172,28 @@ describe('My Events API Integration Tests', () => {
     afterAll(async () => {
         // Clean up
         await prisma.rSVP.deleteMany({
-            where: { personId: { in: [testUserId, testVolunteerId] } }
+            where: { personId: { in: [testUserId, testVolunteerId, testLeadId] } }
         });
         await prisma.event.deleteMany({
-            where: { id: { in: [testEventUpcoming1Id, testEventUpcoming2Id, testEventPastId] } }
+            where: { id: { in: [testEventUpcoming1Id, testEventUpcoming2Id, testEventUpcoming3Id, testEventPastId] } }
         });
         await prisma.programParticipant.deleteMany({
-            where: { programId: { in: [testProgram1Id, testProgram2Id] } }
+            where: { programId: { in: [testProgram1Id, testProgram2Id, testProgram3Id] } }
         });
         await prisma.programVolunteer.deleteMany({
-            where: { programId: { in: [testProgram1Id, testProgram2Id] } }
+            where: { programId: { in: [testProgram1Id, testProgram2Id, testProgram3Id] } }
         });
         await prisma.program.deleteMany({
-            where: { id: { in: [testProgram1Id, testProgram2Id] } }
+            where: { id: { in: [testProgram1Id, testProgram2Id, testProgram3Id] } }
         });
         // RESTRICT: delete participants before their (auto-created) households.
         const householdIds = (await prisma.person.findMany({
-            where: { id: { in: [testUserId, testVolunteerId] } },
+            where: { id: { in: [testUserId, testVolunteerId, testLeadId] } },
             select: { householdId: true }
         })).map(p => p.householdId);
 
         await prisma.person.deleteMany({
-            where: { id: { in: [testUserId, testVolunteerId] } }
+            where: { id: { in: [testUserId, testVolunteerId, testLeadId] } }
         });
         await prisma.household.deleteMany({
             where: { id: { in: householdIds } }
@@ -206,6 +237,20 @@ describe('My Events API Integration Tests', () => {
             expect(data.length).toBe(1); // Only the upcoming event for Program 2
             
             expect(data[0].name).toBe('Mine Test Event Upcoming 2');
+        });
+
+        it('should return upcoming events for programs the person leads', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testLeadId }
+            });
+            const res = await GET(new Request('http://localhost') as unknown as import("next/server").NextRequest) as Response;
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.length).toBe(1);
+            expect(data[0].name).toBe('Mine Test Event Upcoming 3');
+            expect(data[0].isLead).toBe(true);
+            expect(data[0].isVolunteer).toBe(false);
         });
 
         it('should not return past events', async () => {

--- a/checkin-app/src/app/api/events/[id]/rsvp/__tests__/rsvpHouseholdLead.test.ts
+++ b/checkin-app/src/app/api/events/[id]/rsvp/__tests__/rsvpHouseholdLead.test.ts
@@ -58,6 +58,31 @@ it('forbids a non-lead from RSVPing for someone else', async () => {
     expect(mockRsvpUpsert).not.toHaveBeenCalled();
 });
 
+it("lets a program's lead mentor RSVP to that program's event", async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: 7 } });
+    // Neither enrolled nor a listed volunteer — the lead-mentor tie is the only one.
+    mockEventFindUnique.mockResolvedValue({
+        id: 5, programId: 3, endAt: new Date(Date.now() + 3600_000), program: { id: 3, leadMentorId: 7 },
+    });
+
+    const res = await PATCH(body({ status: 'ATTENDING' }), { params });
+
+    expect(res.status).toBe(200);
+    expect(mockRsvpUpsert.mock.calls[0][0].create.personId).toBe(7);
+});
+
+it('forbids RSVPing to a program event with no tie to the program', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: 7 } });
+    mockEventFindUnique.mockResolvedValue({
+        id: 5, programId: 3, endAt: new Date(Date.now() + 3600_000), program: { id: 3, leadMentorId: 99 },
+    });
+
+    const res = await PATCH(body({ status: 'ATTENDING' }), { params });
+
+    expect(res.status).toBe(403);
+    expect(mockRsvpUpsert).not.toHaveBeenCalled();
+});
+
 it('forbids a lead from RSVPing for someone outside their household', async () => {
     (getServerSession as jest.Mock).mockResolvedValue({ user: { id: 1, householdId: 10, householdLead: true } });
     mockParticipantFindMany.mockResolvedValue([{ id: 1, name: 'Lead' }, { id: 2, name: 'Kid' }]);

--- a/checkin-app/src/app/api/events/[id]/rsvp/route.ts
+++ b/checkin-app/src/app/api/events/[id]/rsvp/route.ts
@@ -68,7 +68,9 @@ export const PATCH = withAuth({}, async (req, auth, { params }: { params: Promis
                 }
             });
 
-            if (!isEnrolled && !isVolunteer) {
+            const isLead = event.program?.leadMentorId === currentUserId;
+
+            if (!isEnrolled && !isVolunteer && !isLead) {
                 return apiError("Forbidden: You are not a participant of this program", 403);
             }
         }

--- a/checkin-app/src/app/api/events/mine/route.ts
+++ b/checkin-app/src/app/api/events/mine/route.ts
@@ -17,8 +17,8 @@ export const GET = withAuth({}, async (_req, auth) => {
         const householdMemberIds = householdMembers.map(m => m.id);
         const householdMemberById = new Map(householdMembers.map(m => [m.id, m]));
 
-        // Which household members are tied to which programs (enrolled or volunteering).
-        const [enrolled, volunteers] = await Promise.all([
+        // Which household members are tied to which programs (enrolled, volunteering, or leading).
+        const [enrolled, volunteers, ledPrograms] = await Promise.all([
             prisma.programParticipant.findMany({
                 where: { personId: { in: householdMemberIds } },
                 select: { personId: true, programId: true }
@@ -26,18 +26,24 @@ export const GET = withAuth({}, async (_req, auth) => {
             prisma.programVolunteer.findMany({
                 where: { personId: { in: householdMemberIds } },
                 select: { personId: true, programId: true }
+            }),
+            prisma.program.findMany({
+                where: { leadMentorId: { in: householdMemberIds } },
+                select: { id: true, leadMentorId: true }
             })
         ]);
+        const led = ledPrograms.map(p => ({ personId: p.leadMentorId as number, programId: p.id }));
 
         const programParticipants = new Map<number, Set<number>>();
-        for (const { programId, personId } of [...enrolled, ...volunteers]) {
+        for (const { programId, personId } of [...enrolled, ...volunteers, ...led]) {
             let set = programParticipants.get(programId);
             if (!set) programParticipants.set(programId, (set = new Set()));
             set.add(personId);
         }
 
-        // (person, program) pairs where the household member volunteers, not enrolls.
+        // (person, program) pairs where the household member staffs the program rather than enrolling.
         const volunteerKeys = new Set(volunteers.map(v => `${v.personId}:${v.programId}`));
+        const leadKeys = new Set(led.map(l => `${l.personId}:${l.programId}`));
 
         const events = await prisma.event.findMany({
             where: {
@@ -70,7 +76,8 @@ export const GET = withAuth({}, async (_req, auth) => {
                     program: ev.program,
                     participant: householdMemberById.get(pid),
                     rsvp: ev.rsvps.find((r: typeof ev.rsvps[number]) => r.personId === pid)?.status ?? null,
-                    isVolunteer: volunteerKeys.has(`${pid}:${ev.programId}`)
+                    isVolunteer: volunteerKeys.has(`${pid}:${ev.programId}`),
+                    isLead: leadKeys.has(`${pid}:${ev.programId}`)
                 }));
         });
 

--- a/checkin-app/src/app/my-activities/events/page.tsx
+++ b/checkin-app/src/app/my-activities/events/page.tsx
@@ -24,6 +24,7 @@ type EventData = {
   participant: { id: number; name: string | null };
   rsvp: RsvpStatus | null;
   isVolunteer: boolean;
+  isLead: boolean;
 };
 
 // Group (event, member) rows into one bucket per event, preserving first-seen order.
@@ -114,7 +115,7 @@ export default function ParticipantEventsDashboard() {
         <Card withBorder radius="md" padding="xl" ta="center">
           <Title order={3}>No Upcoming Events</Title>
           <Text c="dimmed" mt="sm">
-            You have no scheduled events for the programs you are enrolled in.
+            You have no scheduled events for the programs you take part in.
           </Text>
           <Group justify="center" mt="lg">
             <Button component={Link} href="/programs" variant="light">Browse Programs</Button>
@@ -140,9 +141,14 @@ export default function ParticipantEventsDashboard() {
                       <Title order={4}>{ev.name}</Title>
                       <Text size="sm" c="dimmed">📅 {startStr} – {endStr}</Text>
                     </div>
-                    {rows.some((r) => r.isVolunteer) && (
-                      <Badge color="grape" variant="light" style={{ flexShrink: 0 }}>Volunteer</Badge>
-                    )}
+                    <Group gap={4} wrap="nowrap" style={{ flexShrink: 0 }}>
+                      {rows.some((r) => r.isLead) && (
+                        <Badge color="indigo" variant="light">Lead Mentor</Badge>
+                      )}
+                      {rows.some((r) => r.isVolunteer) && (
+                        <Badge color="grape" variant="light">Volunteer</Badge>
+                      )}
+                    </Group>
                   </Group>
 
                   {ev.description && (


### PR DESCRIPTION
Fixes #1376

## What

`GET /api/events/mine` derived a person's programs from `ProgramParticipant` and `ProgramVolunteer` only. Enrollees and volunteers saw their program's events; **lead mentors did not** — neither in their own "My Upcoming Events" nor in a household lead's view of that member (both views come from this one endpoint via `activityMembers`).

- `api/events/mine/route.ts` — third query on `Program.leadMentorId`, merged into the same person→program tie map. Rows now carry `isLead` alongside `isVolunteer`.
- `api/events/[id]/rsvp/route.ts` — the RSVP gate checked the same two ties, so a lead mentor RSVPing to their own program's event got `403 Forbidden: You are not a participant of this program`. Accept the lead-mentor tie there too. No extra query — the route already includes `program`.
- `my-activities/events/page.tsx` — "Lead Mentor" badge rendered next to the existing Volunteer badge; empty-state copy widened from "programs you are enrolled in" to "programs you take part in".

## Why the RSVP route is in the same PR

Surfacing the events without it would ship a card whose Yes/Maybe/No buttons 403 for exactly the people the issue is about. Same root cause — one definition of "tied to this program" that omitted the lead — so it is fixed in both places it was spelled out.

## Reviewer notes

- Someone who is both lead mentor and a listed volunteer of a program gets **both** badges. Deliberate: each tie is real, and collapsing them would need a precedence rule nobody has asked for.
- "Lead Mentor" is the existing UI term (`programs/[id]/page.tsx`), not a new vocabulary item — the lead is deliberately *not* labelled "Volunteer".
- Route is `withAuth`, not `handler()` — no security-registry surface touched.

## Tests

- `rsvpHouseholdLead.test.ts` — new: lead mentor may RSVP to their program's event; a person with no tie to the program still gets 403.
- `eventMineAPI.integration.test.ts` — new: Program 3 has a lead mentor and no enrollments/volunteers; its event comes back with `isLead: true`, `isVolunteer: false`.
- Scoped unit run → 16 passed. Full integration run → 1254 passed. `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
