### PR TITLE
fix(ui): show an error state on failed loads (safety pickup, audit broken/unclaimed)

### DIFF
--- a/checkin-app/src/app/membership-audit/broken/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-audit/broken/__tests__/page.test.tsx
@@ -1,0 +1,31 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+
+import { screen } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import BrokenHouseholdsPage from "../page";
+
+beforeEach(() => resetRtl());
+
+describe("membership-audit/broken page", () => {
+  it("shows the empty state when there are no broken households", async () => {
+    mockFetchJson({ "/api/admin/broken-households": { households: [] } });
+    renderWithProviders(<BrokenHouseholdsPage />);
+
+    expect(await screen.findByText("No broken households.")).toBeInTheDocument();
+  });
+
+  it("shows an error state (not a false all-clear) when the load fails", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = jest.fn(() => Promise.reject(new Error("boom"))) as unknown as typeof fetch;
+    renderWithProviders(<BrokenHouseholdsPage />);
+
+    expect(await screen.findByText("Couldn't load broken households.")).toBeInTheDocument();
+    expect(screen.queryByText("No broken households.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    spy.mockRestore();
+  });
+});

--- a/checkin-app/src/app/membership-audit/broken/page.tsx
+++ b/checkin-app/src/app/membership-audit/broken/page.tsx
@@ -12,6 +12,7 @@ type BrokenHousehold = { id: number; name: string; members: Member[] };
 export default function BrokenHouseholdsPage() {
   const [households, setHouseholds] = useState<BrokenHousehold[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [promoting, setPromoting] = useState<number | null>(null);
   // Per-household lead-assign result, shown in a card-local Alert. A page-corner
   // toast reads as "nothing happened" for a card far down; the card also doesn't
@@ -19,12 +20,14 @@ export default function BrokenHouseholdsPage() {
   const [notice, setNotice] = useState<Record<number, { ok: boolean; text: string }>>({});
 
   const fetchHouseholds = useCallback(async () => {
+    setError(false);
     try {
       const res = await fetch("/api/admin/broken-households");
       const data = await res.json();
       if (data.households) setHouseholds(data.households);
     } catch (err) {
       console.error("Failed to load broken households:", err);
+      setError(true);
     } finally {
       setLoading(false);
     }
@@ -69,7 +72,14 @@ export default function BrokenHouseholdsPage() {
       </Text>
 
       <Box>
-        {households.length > 0 ? (
+        {error ? (
+          <Alert color="red" title="Couldn't load broken households.">
+            The list didn&apos;t load, so this isn&apos;t an all-clear.
+            <Button mt="sm" size="xs" variant="white" color="red" onClick={fetchHouseholds}>
+              Retry
+            </Button>
+          </Alert>
+        ) : households.length > 0 ? (
           <Stack gap="sm">
             {households.map((h) => (
               <Card key={h.id} withBorder radius="md" padding="md">

--- a/checkin-app/src/app/membership-audit/unclaimed/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-audit/unclaimed/__tests__/page.test.tsx
@@ -1,0 +1,30 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+
+import { screen } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import UnclaimedHouseholdsIndex from "../page";
+
+beforeEach(() => resetRtl());
+
+describe("membership-audit/unclaimed page", () => {
+  it("shows the empty state when there are no unclaimed households", async () => {
+    mockFetchJson({ "/api/membership-audit/unclaimed-households": { households: [] } });
+    renderWithProviders(<UnclaimedHouseholdsIndex />);
+
+    expect(await screen.findByText("No unclaimed accounts.")).toBeInTheDocument();
+  });
+
+  it("shows an error state (not a false all-clear) when the load fails", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = jest.fn(() => Promise.reject(new Error("boom"))) as unknown as typeof fetch;
+    renderWithProviders(<UnclaimedHouseholdsIndex />);
+
+    expect(await screen.findByText("Couldn't load unclaimed households.")).toBeInTheDocument();
+    expect(screen.queryByText("No unclaimed accounts.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    spy.mockRestore();
+  });
+});

--- a/checkin-app/src/app/membership-audit/unclaimed/page.tsx
+++ b/checkin-app/src/app/membership-audit/unclaimed/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Box, Card, Stack, Text } from "@mantine/core";
+import { useState, useEffect, useCallback } from "react";
+import { Alert, Box, Button, Card, Stack, Text } from "@mantine/core";
 
 type UnclaimedHousehold = {
   id: number;
@@ -12,20 +12,26 @@ type UnclaimedHousehold = {
 export default function UnclaimedHouseholdsIndex() {
   const [households, setHouseholds] = useState<UnclaimedHousehold[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await fetch('/api/membership-audit/unclaimed-households');
+      const data = await res.json();
+      if (data.households) setHouseholds(data.households);
+    } catch (err) {
+      console.error("Failed to load unclaimed households:", err);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    (async () => {
-      try {
-        const res = await fetch('/api/membership-audit/unclaimed-households');
-        const data = await res.json();
-        if (data.households) setHouseholds(data.households);
-      } catch (err) {
-        console.error("Failed to load unclaimed households:", err);
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, []);
+    load();
+  }, [load]);
 
   return (
     <Stack>
@@ -34,7 +40,14 @@ export default function UnclaimedHouseholdsIndex() {
       </div>
 
       <Box>
-        {households.length > 0 ? (
+        {error ? (
+          <Alert color="red" title="Couldn't load unclaimed households.">
+            The list didn&apos;t load, so this isn&apos;t an all-clear.
+            <Button mt="sm" size="xs" variant="white" color="red" onClick={load}>
+              Retry
+            </Button>
+          </Alert>
+        ) : households.length > 0 ? (
           <Stack gap="sm">
             {households.map((h) => (
               <Card key={h.id} withBorder radius="md" padding="md">

--- a/checkin-app/src/app/safety/pickup/__tests__/page.test.tsx
+++ b/checkin-app/src/app/safety/pickup/__tests__/page.test.tsx
@@ -39,4 +39,15 @@ describe("safety/pickup page", () => {
 
     expect(await screen.findByText("No approved trusted adults to show.")).toBeInTheDocument();
   });
+
+  it("shows an error state (not a false empty) when the load fails", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = jest.fn(() => Promise.reject(new Error("boom"))) as unknown as typeof fetch;
+    renderWithProviders(<TrustedAdultPickupPage />);
+
+    expect(await screen.findByText("Couldn't load the pickup list.")).toBeInTheDocument();
+    expect(screen.queryByText("No approved trusted adults to show.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    spy.mockRestore();
+  });
 });

--- a/checkin-app/src/app/safety/pickup/page.tsx
+++ b/checkin-app/src/app/safety/pickup/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Card, Center, Group, Loader, Stack, Text, Title } from "@mantine/core";
+import { useCallback, useEffect, useState } from "react";
+import { Alert, Button, Card, Center, Group, Loader, Stack, Text, Title } from "@mantine/core";
 import { TrustedAdultContact } from "@/components/TrustedAdultContact";
 
 interface Review {
@@ -28,14 +28,26 @@ interface TrustedAdult {
 export default function TrustedAdultPickupPage() {
     const [items, setItems] = useState<TrustedAdult[]>([]);
     const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(false);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(false);
+        try {
+            const r = await fetch("/api/trusted-adults/operational");
+            const d = await r.json();
+            setItems(d.trustedAdults ?? []);
+        } catch (err) {
+            console.error("Failed to load trusted adults for pickup:", err);
+            setError(true);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
 
     useEffect(() => {
-        fetch("/api/trusted-adults/operational")
-            .then((r) => r.json())
-            .then((d) => setItems(d.trustedAdults ?? []))
-            .catch((err) => console.error("Failed to load trusted adults for pickup:", err))
-            .finally(() => setLoading(false));
-    }, []);
+        load();
+    }, [load]);
 
     if (loading) {
         return (
@@ -55,7 +67,16 @@ export default function TrustedAdultPickupPage() {
                 </Text>
             </div>
 
-            {items.length === 0 && <Text c="dimmed">No approved trusted adults to show.</Text>}
+            {error ? (
+                <Alert color="red" title="Couldn't load the pickup list.">
+                    The list of approved trusted adults didn&apos;t load. Don&apos;t treat this as an empty list.
+                    <Button mt="sm" size="xs" variant="white" color="red" onClick={load}>
+                        Retry
+                    </Button>
+                </Alert>
+            ) : (
+                items.length === 0 && <Text c="dimmed">No approved trusted adults to show.</Text>
+            )}
 
             {items.map((ta) => {
                 const latest = ta.reviews[0];


### PR DESCRIPTION
PR-5b of the console-error cleanup plan.

## The bug
Three pages loaded data in a `catch { console.error(...) }` that only **logged** the failure. On a failed load the list stayed `[]`, so the page fell through to its empty-state text — visually **indistinguishable from a genuine empty result**:

- `safety/pickup` — an empty pickup list reads as "no authorized adults." A safety-relevant false negative; highest priority.
- `membership-audit/broken` — `"No broken households."` shows on failure: a false all-clear on an audit screen.
- `membership-audit/unclaimed` — same shape, `"No unclaimed accounts."`

## The fix
Add an `error` state set in each load's catch, and render a red Mantine `Alert` with a **Retry** button (re-runs the existing fetch) **instead of** the empty-state text when errored. The existing prefixed `console.error(prefix, err)` line stays for debuggability. No page restructure, no other catches touched.

Tests: one per page — mock `fetch` to reject, assert the error Alert appears and the empty-state text does **not**. A local `console.error` spy keeps the live `jest-fail-on-console` gate green (the real failure is now surfaced in the UI, not allowlisted).

## Scope
Limited to the **3 genuine bugs** where a false-empty is misleading. The ~8 lower-stakes swallow sites (trends dropdown, programs/events lists, print-badges search, roles list, system-health panel, trusted-adult panel) are **deliberately deferred** — their prefixed logs already make failures debuggable and an empty admin list is low-harm.

Independent of PR-5a (tests) and any helper refactor. Does not touch `jest.setup.js` / `KNOWN_INTENTIONAL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)