### PR TITLE
test(client): negative-path tests for error-fallback components

### DIFF
--- a/checkin-app/src/app/membership-audit/compliance/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/__tests__/page.test.tsx
@@ -1,0 +1,24 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import CompliancePage from "../page";
+
+beforeEach(() => resetRtl());
+
+describe("membership-audit/compliance page", () => {
+  it("renders the everyone-in-compliance empty state", async () => {
+    mockFetchJson({ "/api/membership-audit/compliance": {} });
+    renderWithProviders(<CompliancePage />);
+
+    expect(await screen.findByText(/Everyone is in compliance/)).toBeInTheDocument();
+  });
+
+  it("renders the network-error alert when the fetch rejects", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = jest.fn(() => Promise.reject(new Error("network down"))) as unknown as typeof fetch;
+    renderWithProviders(<CompliancePage />);
+
+    expect(await screen.findByText("Network error loading compliance data.")).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("Failed to load"), expect.anything());
+    spy.mockRestore();
+  });
+});

--- a/checkin-app/src/app/membership-audit/emergency-contacts/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-audit/emergency-contacts/__tests__/page.test.tsx
@@ -1,0 +1,31 @@
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
+
+import { screen, waitFor } from "@testing-library/react";
+import { notifications } from "@mantine/notifications";
+import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import MissingEmergencyContactsPage from "../page";
+
+beforeEach(() => resetRtl());
+
+describe("membership-audit/emergency-contacts page", () => {
+  it("renders the all-clear empty state", async () => {
+    mockFetchJson({ "/api/membership-audit/households-missing-contact": { households: [] } });
+    renderWithProviders(<MissingEmergencyContactsPage />);
+
+    expect(await screen.findByText(/Every active household has a valid emergency contact/)).toBeInTheDocument();
+  });
+
+  it("toasts a network-error notification when the fetch rejects", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = jest.fn(() => Promise.reject(new Error("network down"))) as unknown as typeof fetch;
+    renderWithProviders(<MissingEmergencyContactsPage />);
+
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red", message: "Network error loading households." }),
+      ),
+    );
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("Failed to load"), expect.anything());
+    spy.mockRestore();
+  });
+});

--- a/checkin-app/src/app/safety/board-contacts/__tests__/page.test.tsx
+++ b/checkin-app/src/app/safety/board-contacts/__tests__/page.test.tsx
@@ -2,8 +2,10 @@
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import { notifications } from "@mantine/notifications";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
 import BoardContactInfoPage from "../page";
 
@@ -30,5 +32,20 @@ describe("safety/board-contacts page", () => {
     renderWithProviders(<BoardContactInfoPage />);
 
     expect(await screen.findByText("No board members found.")).toBeInTheDocument();
+  });
+
+  it("toasts a network-error notification when the fetch rejects", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    setSession({ id: 1, isBoardMember: true });
+    global.fetch = jest.fn(() => Promise.reject(new Error("network down"))) as unknown as typeof fetch;
+    renderWithProviders(<BoardContactInfoPage />);
+
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red", message: "Network error loading board contacts." }),
+      ),
+    );
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("Failed to load"), expect.anything());
+    spy.mockRestore();
   });
 });

--- a/checkin-app/src/app/safety/emergency-contacts/__tests__/page.test.tsx
+++ b/checkin-app/src/app/safety/emergency-contacts/__tests__/page.test.tsx
@@ -2,8 +2,10 @@
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { notifications } from "@mantine/notifications";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
 import EmergencyContactsPage from "../page";
 
@@ -68,5 +70,20 @@ describe("safety/emergency-contacts page", () => {
     renderWithProviders(<EmergencyContactsPage />);
 
     expect(await screen.findByText(/Failed to load emergency contacts/)).toBeInTheDocument();
+  });
+
+  it("toasts a network-error notification when the fetch rejects", async () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    setSession({ id: 1, isSysadmin: true });
+    global.fetch = jest.fn(() => Promise.reject(new Error("network down"))) as unknown as typeof fetch;
+    renderWithProviders(<EmergencyContactsPage />);
+
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red", message: "Network error loading contacts." }),
+      ),
+    );
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("Failed to load"), expect.anything());
+    spy.mockRestore();
   });
 });

--- a/checkin-app/src/components/roles/__tests__/RolesEditModal.test.tsx
+++ b/checkin-app/src/components/roles/__tests__/RolesEditModal.test.tsx
@@ -197,4 +197,36 @@ describe("RolesEditModal", () => {
         expect(onSaved).not.toHaveBeenCalled();
         expect(onClose).not.toHaveBeenCalled();
     });
+
+    it("toasts a network error and reverts when the PATCH fetch rejects", async () => {
+        const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+        const onSaved = jest.fn();
+        const onClose = jest.fn();
+        renderWithProviders(<RolesEditModal target={jane} me={{ isBoardMember: true }} onClose={onClose} onSaved={onSaved} />);
+
+        fireEvent.click(screen.getByLabelText("Operations")); // grant
+        fireEvent.click(screen.getByLabelText("Keyholder")); // revoke (was checked)
+        fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        const call = (modals.openConfirmModal as jest.Mock).mock.calls[0][0];
+        // Reject the fetch itself (not ok:false) so the catch runs, not the else branch.
+        global.fetch = jest.fn(() => Promise.reject(new Error("network down"))) as unknown as typeof fetch;
+
+        await act(async () => {
+            await call.onConfirm();
+        });
+
+        await waitFor(() =>
+            expect(notifications.show).toHaveBeenCalledWith(
+                expect.objectContaining({ color: "red", message: "Network error updating roles" }),
+            ),
+        );
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining("Failed to update roles"), expect.anything());
+
+        // The catch (unlike the ok:false branch) does not revert; it only toasts.
+        // Neither success callback fires.
+        expect(onSaved).not.toHaveBeenCalled();
+        expect(onClose).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
 });


### PR DESCRIPTION
PR-5a of the console-error cleanup plan.

These 5 client components already show a user-facing error UI when their `fetch` rejects, but no test drove that catch branch. This adds fetch-reject cases asserting the fallback fires. **Test-only** — no component source changed.

Each negative-path test wraps a local `jest.spyOn(console, "error")` so the live `jest-fail-on-console` gate (in `jest.setup.js`) stays green — none of these catches' prefixes are in `KNOWN_INTENTIONAL`, and this PR deliberately does not touch the allowlist. Independent of PR-5b (source fixes) and any helper refactor.

## Sites covered
| Component | Fallback asserted |
|---|---|
| `safety/emergency-contacts/page.tsx` | `notifications.show` red "Network error loading contacts." |
| `safety/board-contacts/page.tsx` | `notifications.show` red "Network error loading board contacts." |
| `components/roles/RolesEditModal.tsx` | `showNotification` "Network error updating roles" (fetch rejects, not ok:false — drives the catch, not the else) |
| `membership-audit/compliance/page.tsx` | `setError` -> "Network error loading compliance data." Alert renders (new test file) |
| `membership-audit/emergency-contacts/page.tsx` | `notifications.show` red "Network error loading households." (new test file) |

Each test also asserts the catch logged its "Failed to load..."/"Failed to update..." prefix.

## Verify
Ran the 5 target suites narrowly-scoped -> 22 tests pass, including under the live console gate.

Nothing skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
