### PR TITLE
test(membership): split the intake mega-test so it fits the 5s jest timeout

### DIFF
--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -811,8 +811,8 @@ describe("membership page", () => {
           household: { name: null, emergencyContactName: "Aunt Jo", emergencyContactPhone: "512-555-1234", emergencyContactEmail: null, line1: "1 Treehouse Ln", line2: null, city: "Austin", state: "TX", postalCode: "78701" },
           primaryParent: { id: 1, name: "Pat Parent", email: "pat@example.com", dob: "1980-01-01", allergies: null },
           // Sam has every field null except name/id — exercises the `sec.x ?? ""`
-          // fallback side of hydrate() (the "fills every intake field" test below
-          // already exercises the truthy side with a fully-populated secondary).
+          // fallback side of hydrate() (the "fills every second parent / guardian
+          // field" test below covers the truthy side).
           secondaryParent: { id: 9, name: "Sam Secondary", email: null, dob: null, allergies: null },
           children: [
             { id: 5, name: "Kid A", email: null, dob: "2015-01-01", allergies: "peanuts" },
@@ -834,8 +834,10 @@ describe("membership page", () => {
     expect(screen.queryByText("No children added yet.")).not.toBeInTheDocument();
   });
 
-  // ── Every intake onChange handler + addChild/updateChild/removeChild ─────
-  it("fills every intake field, adds/removes children, and saves with a secondary parent", async () => {
+  // Renders the intake step and exposes the body of the PATCH a "Save progress"
+  // sends. The payload is the only place to read the filled form back: save()
+  // re-hydrates every field from the response, which carries an empty prefill.
+  async function renderIntakeStep() {
     setSession({ id: 1 });
     const fetchMock = mockFetchJson({
       "/api/membership/intake": { state: state({ process: { id: 1, kind: "INITIAL", status: "INTAKE" } }), rejections: [] },
@@ -843,6 +845,21 @@ describe("membership page", () => {
     });
     renderWithProviders(<MembershipPage />);
     await screen.findByText("Your household");
+
+    const savedPayload = async () => {
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith("/api/membership/intake", expect.objectContaining({ method: "PATCH" })),
+      );
+      const call = fetchMock.mock.calls.find(([u, init]) => u === "/api/membership/intake" && (init as RequestInit)?.method === "PATCH")!;
+      return JSON.parse((call[1] as RequestInit).body as string);
+    };
+    return { fetchMock, savedPayload };
+  }
+
+  // ── Every intake onChange handler + addChild/updateChild/removeChild, one
+  //    form section per test ─────────────────────────────────────────────────
+  it("fills every household and primary-parent intake field and saves them", async () => {
+    const { savedPayload } = await renderIntakeStep();
 
     fireEvent.change(screen.getByPlaceholderText("123 Main St"), { target: { value: "1 Treehouse Ln" } });
     fireEvent.change(screen.getByPlaceholderText("Apt 4B"), { target: { value: "Unit 2" } });
@@ -856,41 +873,63 @@ describe("membership page", () => {
     fireEvent.change(screen.getByLabelText("Date of birth"), { target: { value: "1980-01-01" } });
     fireEvent.change(screen.getByLabelText("Allergies (optional)"), { target: { value: "none" } });
 
+    fireEvent.click(screen.getByRole("button", { name: "Save progress" }));
+
+    const body = await savedPayload();
+    expect(body.household).toMatchObject({
+      line1: "1 Treehouse Ln", line2: "Unit 2", city: "Austin", state: "TX", postalCode: "78701",
+      emergencyContactName: "Aunt Jo", emergencyContactPhone: "512-555-1234", emergencyContactEmail: "jo@example.com",
+    });
+    expect(body.primaryParent).toMatchObject({ name: "Pat Parent", dob: "1980-01-01", allergies: "none" });
+    expect(body.secondaryParent).toBeNull();
+  });
+
+  it("fills every second parent / guardian field and saves them", async () => {
+    const { savedPayload } = await renderIntakeStep();
+
     fireEvent.click(screen.getByLabelText("Add a second parent / guardian"));
     fireEvent.change(screen.getAllByLabelText("Full name", { exact: false })[1], { target: { value: "Sam Secondary" } });
-    fireEvent.change(screen.getAllByLabelText("Email (optional)")[0], { target: { value: "sam@example.com" } });
+    fireEvent.change(screen.getByLabelText("Email (optional)"), { target: { value: "sam@example.com" } });
     fireEvent.change(screen.getAllByLabelText("Date of birth")[1], { target: { value: "1982-02-02" } });
     fireEvent.change(screen.getAllByLabelText("Allergies (optional)")[1], { target: { value: "peanuts" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save progress" }));
+
+    const body = await savedPayload();
+    expect(body.secondaryParent).toMatchObject({ name: "Sam Secondary", email: "sam@example.com", dob: "1982-02-02", allergies: "peanuts" });
+  });
+
+  it("adds and removes children, saving only the ones left", async () => {
+    const { savedPayload } = await renderIntakeStep();
 
     fireEvent.click(screen.getByRole("button", { name: "+ Add child" }));
     fireEvent.click(screen.getByRole("button", { name: "+ Add child" }));
     expect(screen.getByText("Child 1")).toBeInTheDocument();
     expect(screen.getByText("Child 2")).toBeInTheDocument();
 
-    fireEvent.change(screen.getAllByLabelText("Full name", { exact: false })[2], { target: { value: "Kid One" } });
-    fireEvent.change(screen.getAllByLabelText("Date of birth")[2], { target: { value: "2015-01-01" } });
-    fireEvent.change(screen.getAllByLabelText("Email (optional)")[1], { target: { value: "kid1@example.com" } });
-    fireEvent.change(screen.getAllByLabelText("Allergies (optional)")[2], { target: { value: "bees" } });
-    fireEvent.change(screen.getAllByLabelText("Full name", { exact: false })[3], { target: { value: "Kid Two" } });
+    fireEvent.change(screen.getAllByLabelText("Full name", { exact: false })[1], { target: { value: "Kid One" } });
+    fireEvent.change(screen.getAllByLabelText("Date of birth")[1], { target: { value: "2015-01-01" } });
+    fireEvent.change(screen.getAllByLabelText("Email (optional)")[0], { target: { value: "kid1@example.com" } });
+    fireEvent.change(screen.getAllByLabelText("Allergies (optional)")[1], { target: { value: "bees" } });
+    fireEvent.change(screen.getAllByLabelText("Full name", { exact: false })[2], { target: { value: "Kid Two" } });
 
     fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[1]);
     expect(screen.queryByText("Child 2")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Save progress" }));
 
-    await waitFor(() =>
-      expect(fetchMock).toHaveBeenCalledWith("/api/membership/intake", expect.objectContaining({ method: "PATCH" })),
-    );
-    const call = fetchMock.mock.calls.find(([u, init]) => u === "/api/membership/intake" && (init as RequestInit)?.method === "PATCH")!;
-    const body = JSON.parse((call[1] as RequestInit).body as string);
-    expect(body.household.city).toBe("Austin");
-    expect(body.secondaryParent.name).toBe("Sam Secondary");
+    const body = await savedPayload();
     expect(body.children).toHaveLength(1);
-    expect(body.children[0].name).toBe("Kid One");
+    expect(body.children[0]).toMatchObject({ name: "Kid One", dob: "2015-01-01", email: "kid1@example.com", allergies: "bees" });
+  });
+
+  it("leaves the Home link's navigation unblocked", async () => {
+    await renderIntakeStep();
 
     // onNavigate on the Home link — no UnsavedChangesProvider is mounted in this
     // harness, so confirmNav() is the always-true no-op and preventDefault is skipped.
-    fireEvent.click(screen.getByRole("link", { name: "← Home" }));
+    const home = screen.getByRole("link", { name: "← Home" });
+    expect(fireEvent.click(home)).toBe(true);
   });
 
   it("omits blank secondary-parent and child fields from the saved payload", async () => {

--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -853,7 +853,7 @@ describe("membership page", () => {
       const call = fetchMock.mock.calls.find(([u, init]) => u === "/api/membership/intake" && (init as RequestInit)?.method === "PATCH")!;
       return JSON.parse((call[1] as RequestInit).body as string);
     };
-    return { fetchMock, savedPayload };
+    return { savedPayload };
   }
 
   // ── Every intake onChange handler + addChild/updateChild/removeChild, one
@@ -943,7 +943,9 @@ describe("membership page", () => {
 
     // Only the secondary parent's name and a child's name are filled — leaves
     // email/dob/allergies blank on both, exercising the `|| undefined`/`|| null`
-    // fallback side of buildPayload() (the previous test covers the truthy side).
+    // fallback side of buildPayload() (the "fills every second parent /
+    // guardian field" and "adds and removes children" tests above cover the
+    // truthy side).
     fireEvent.click(screen.getByLabelText("Add a second parent / guardian"));
     fireEvent.change(screen.getAllByLabelText("Full name", { exact: false })[1], { target: { value: "Sam Secondary" } });
 


### PR DESCRIPTION
`membership page › fills every intake field, adds/removes children, and saves with a secondary parent` fails on `main` with `Exceeded timeout of 5000 ms`. It reproduces in isolation, so it is not contention from a parallel run.

## Root cause

The test is not stuck — it is genuinely too big for the 5s default.

- No unmatched fetch URL, no missing `act()`, no swallowed rejection. Under `--testTimeout=60000` it passes first try, in ~10.5s.
- Step-by-step instrumentation showed the time spread evenly across ~30 interactions at ~300–350ms each. There is no single stall to fix.
- A CPU profile taken inside the test showed no hot spot. It is React dev-build element creation plus jsdom over a ~160-node tree, re-run on **every** `fireEvent` (the intake form's controlled Mantine inputs re-render the whole page), with each following `*ByRole`/`*ByLabelText` re-walking that tree. Measured here: `fireEvent.change` ≈ 260ms, `getByRole(…, {name})` ≈ 90–280ms.

So the fix is to make the test smaller, not to raise the timeout. **No timeout was bumped.**

**This is not an app bug** — no app code changed.

## The change

Split the one mega-test into four, by form section, behind a new `renderIntakeStep()` helper that also reads back the body of the PATCH that "Save progress" sends:

- fills every household and primary-parent field and saves them
- fills every second parent / guardian field and saves them
- adds and removes children, saving only the ones left
- leaves the Home link's navigation unblocked

Coverage is preserved: every intake `onChange` handler, `addChild`/`updateChild`/`removeChild`, and the `onNavigate` handler are all still exercised. Assertions got **stronger** on the way through — the payload checks are now `toMatchObject` over whole objects rather than one field each, and the Home-link case now asserts `fireEvent.click(...) === true` (i.e. `preventDefault` was not called) instead of just clicking and moving on.

A neighbouring comment that referred to the old test by name was updated to point at its replacement.

## Verification

- `src/app/membership/__tests__/page.test.tsx`: **57/57 pass**; slowest new test 3.5s, down from 10.5s.
- `npx tsc --noEmit` clean, `npm run lint` clean.

Independent of the companion PR from `fix/my-household-error-branches-test`, which fixes a second instance of the same pattern — different file, different directory, no shared helper touched (`rtl.tsx` and `jest.setup.js` are untouched by both). The two merge in either order; confirmed conflict-free by merging both into a scratch branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
