### PR TITLE
test(my-household): split the error-branch mega-test so it fits the 5s jest timeout

### DIFF
--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -470,59 +470,92 @@ describe("HouseholdPage", () => {
     expect(screen.queryByText("Duplicate contact.")).not.toBeInTheDocument();
   });
 
-  it("covers the remaining server-error and network-error branches (settings, contacts, member edit, lead)", async () => {
-    const household = { ...householdData, householdMembers: [...householdData.householdMembers, { id: 12, name: "Casey Smith", email: "", isDeclaredAdult: true }] };
+  // ── Remaining server-error and network-error branches, one write route per
+  //    test ───────────────────────────────────────────────────────────────────
+  // Casey is a promotable non-lead adult; two contacts on file so either row's
+  // Remove is enabled (the last valid contact's is not).
+  const failureHousehold = { ...householdData, householdMembers: [...householdData.householdMembers, { id: 12, name: "Casey Smith", email: "", isDeclaredAdult: true }] };
+  const failureLoadRules = [
+    { url: "/api/household/emergency-contacts", method: "GET", result: { ok: true, body: { contacts: [
+      { id: 9, name: "Old Contact", phone: "5125550000", email: null, relationship: null, priority: 1, invalid: false },
+      { id: 8, name: "Backup Contact", phone: "5125550001", email: null, relationship: null, priority: 2, invalid: false },
+    ] } } },
+    { url: "/api/household", method: "GET", result: { ok: true, body: { household: failureHousehold } } },
+  ];
+
+  /** Render the loaded page as its lead, with `rules` layered over the GET routes. */
+  async function renderWithFailingRoutes(rules: Parameters<typeof routedFetch>[0]) {
     setSession({ id: 10, email: "sam@example.com" });
-    let settingsAttempt = 0;
-    let deleteAttempt = 0;
-    let editAttempt = 0;
-    const fetchMock = routedFetch([
-      { url: "/api/household/emergency-contacts/9", method: "DELETE", result: () => (deleteAttempt++ === 0 ? { ok: false, status: 400, body: { error: "Contact not found." } } : { throws: true }) },
-      { url: "/api/household/emergency-contacts", method: "POST", result: { throws: true } },
-      { url: "/api/household/emergency-contacts", method: "GET", result: { ok: true, body: { contacts: [
-        { id: 9, name: "Old Contact", phone: "5125550000", email: null, relationship: null, priority: 1, invalid: false },
-        { id: 8, name: "Backup Contact", phone: "5125550001", email: null, relationship: null, priority: 2, invalid: false },
-      ] } } },
-      { url: "/api/household/settings", method: "PATCH", result: () => (settingsAttempt++ === 0 ? { ok: false, status: 400, body: {} } : { throws: true }) },
-      { url: "/api/household/member", method: "PATCH", result: () => (editAttempt++ === 0 ? { ok: false, status: 400, body: { error: "Update rejected." } } : { throws: true }) },
-      { url: "/api/household/lead", method: "POST", result: { throws: true } },
-      { url: "/api/household", method: "GET", result: { ok: true, body: { household } } },
-    ]);
+    const fetchMock = routedFetch([...rules, ...failureLoadRules]);
     renderWithProviders(<HouseholdPage />);
     await screen.findByRole("heading", { name: "Smith Household", level: 1 });
+    return fetchMock;
+  }
 
-    // Address settings: client validation error, then server failure, then network error.
+  it("surfaces client-validation, server, and network failures when saving the address", async () => {
+    let attempt = 0;
+    await renderWithFailingRoutes([
+      { url: "/api/household/settings", method: "PATCH", result: () => (attempt++ === 0 ? { ok: false, status: 400, body: {} } : { throws: true }) },
+    ]);
+
     fireEvent.change(screen.getByLabelText(/Street Address/), { target: { value: "" } });
     fireEvent.click(screen.getByRole("button", { name: "Save household details" }));
     expect(await screen.findByText("Street address is required.")).toBeInTheDocument();
+
     fireEvent.change(screen.getByLabelText(/Street Address/), { target: { value: "123 Main St" } });
     fireEvent.click(screen.getByRole("button", { name: "Save household details" }));
     expect(await screen.findByText("Failed to update some settings.")).toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: "Save household details" }));
     await waitFor(() => expectToast("Network error saving settings."));
+  });
 
-    // Emergency contact add: network error.
+  it("toasts a network failure when adding an emergency contact", async () => {
+    await renderWithFailingRoutes([
+      { url: "/api/household/emergency-contacts", method: "POST", result: { throws: true } },
+    ]);
+
     fireEvent.click(screen.getByRole("button", { name: "+ Add Contact" }));
     fireEvent.change(screen.getByLabelText("Contact Name"), { target: { value: "New Contact" } });
     fireEvent.change(screen.getByLabelText("Phone"), { target: { value: "5125559000" } });
     fireEvent.click(screen.getByRole("button", { name: "Add Contact" }));
-    await waitFor(() => expectToast("Network error saving emergency contact."));
 
-    // Emergency contact delete: server failure, then network error (same row both times).
+    await waitFor(() => expectToast("Network error saving emergency contact."));
+  });
+
+  it("surfaces server and network failures when removing an emergency contact", async () => {
+    let attempt = 0;
+    await renderWithFailingRoutes([
+      { url: "/api/household/emergency-contacts/9", method: "DELETE", result: () => (attempt++ === 0 ? { ok: false, status: 400, body: { error: "Contact not found." } } : { throws: true }) },
+    ]);
+
+    // Same row both times — the failed delete leaves it on the list.
     fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[0]);
     expect(await screen.findByText("Contact not found.")).toBeInTheDocument();
     fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[0]);
     await waitFor(() => expectToast("Network error removing emergency contact."));
+  });
 
-    // Household member edit: server failure, then network error.
+  it("surfaces server and network failures when editing a household member", async () => {
+    let attempt = 0;
+    await renderWithFailingRoutes([
+      { url: "/api/household/member", method: "PATCH", result: () => (attempt++ === 0 ? { ok: false, status: 400, body: { error: "Update rejected." } } : { throws: true }) },
+    ]);
+
     fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
     expect(await screen.findByText("Update rejected.")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
     await waitFor(() => expectToast("Network error updating household member."));
+  });
 
-    // Make Lead: network error.
+  it("toasts a network failure when promoting a household member to lead", async () => {
+    const fetchMock = await renderWithFailingRoutes([
+      { url: "/api/household/lead", method: "POST", result: { throws: true } },
+    ]);
+
     fireEvent.click(screen.getByRole("button", { name: "Make Lead" }));
+
     await waitFor(() => expectToast("Network error promoting household member."));
     expect(fetchMock).toHaveBeenCalledWith("/api/household/lead", expect.objectContaining({ method: "POST" }));
   });


### PR DESCRIPTION
`HouseholdPage › covers the remaining server-error and network-error branches (settings, contacts, member edit, lead)` fails on `main` with `Exceeded timeout of 5000 ms`. It reproduces in isolation, so it is not contention from a parallel run.

## Root cause

The test is not stuck — it is genuinely too big for the 5s default.

- No unmatched fetch URL, no missing `act()`, no swallowed rejection. Under `--testTimeout=60000` it passes first try, in ~9.0s.
- The time is spread evenly across ~25 interactions spanning four unrelated write routes, at ~300–350ms each. There is no single stall to fix.
- A CPU profile taken inside the test showed no hot spot. It is React dev-build element creation plus jsdom over a ~160-node tree, re-run on **every** `fireEvent` (controlled Mantine inputs re-render the whole page), with each following `*ByRole`/`*ByLabelText` re-walking that tree. Measured here: `fireEvent.change` ≈ 260ms, `getByRole(…, {name})` ≈ 90–280ms.

So the fix is to make the test smaller, not to raise the timeout. **No timeout was bumped.**

**This is not an app bug** — no app code changed.

## The change

Split the one mega-test into five, one write route each, behind a new `renderWithFailingRoutes()` helper that layers the failing route onto the two shared GET routes:

- address save — client-validation, server, then network failure
- add emergency contact — network failure
- remove emergency contact — server, then network failure
- edit household member — server, then network failure
- promote member to lead — network failure

Every error branch the original covered is still covered. Splitting also made the fixtures legible: the shared household and contact list are now named (`failureHousehold`, `failureLoadRules`) with a comment explaining why two contacts are on file — the last valid contact's Remove button is disabled, so a second one is needed for the remove-failure cases to be reachable at all. The three `let attempt = 0` counters that previously had to coexist in one scope are now one per test.

## Verification

- `src/app/my-household/__tests__/page.test.tsx`: **23/23 pass**; slowest new test 2.2s, down from 9.0s.
- `npx tsc --noEmit` clean, `npm run lint` clean.

Independent of the companion PR from `fix/membership-intake-test`, which fixes a second instance of the same pattern — different file, different directory, no shared helper touched (`rtl.tsx` and `jest.setup.js` are untouched by both). The two merge in either order; confirmed conflict-free by merging both into a scratch branch.

## Follow-up, not in this PR

Two tests in this same file are next in line on slow hardware — `"validates required fields, then adds a member…"` (4.1s) and `"edits a household member: cancels, validates…"` (4.2s). They pass today but have little margin against the 5s limit, and are worth splitting the same way if CI stays flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
