### PR TITLE
fix(membership): hold every actor to the conflict-of-interest check, sysadmin included

### DIFF
--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -182,19 +182,21 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         expect((audit!.newData as { status: string }).status).toBe('ACTIVE');
     });
 
-    it("refuses to grant the actor's OWN household (conflict of interest); sysadmin overrides", async () => {
+    it("refuses to grant the actor's OWN household (conflict of interest), sysadmin included", async () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
         const res = await post({ householdId: boardHouseholdId, active: true });
         expect(res.status).toBe(403);
         const before = await prisma.orgMembership.findUnique({ where: { householdId: boardHouseholdId } });
         expect(before?.status ?? 'NONE').not.toBe('ACTIVE'); // not granted
 
-        // Sysadmin is the deliberate remedy.
-        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isSysadmin: true } });
-        const ok = await post({ householdId: boardHouseholdId, active: true });
-        expect(ok.status).toBe(200);
-        const after = await prisma.orgMembership.findUnique({ where: { householdId: boardHouseholdId } });
-        expect(after?.status).toBe('ACTIVE');
+        // Holding sysadmin — alone or alongside board — buys no way through.
+        for (const roles of [{ isSysadmin: true }, { isBoardMember: true, isSysadmin: true }]) {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, ...roles } });
+            const denied = await post({ householdId: boardHouseholdId, active: true });
+            expect(denied.status).toBe(403);
+            const after = await prisma.orgMembership.findUnique({ where: { householdId: boardHouseholdId } });
+            expect(after?.status ?? 'NONE').not.toBe('ACTIVE');
+        }
     });
 
     it('coming-year grant: no in-flight renewal → 409, no mutation', async () => {
@@ -255,19 +257,22 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         expect(process?.paidAt).not.toBeNull();
     });
 
-    it("refuses coming-year grant for the actor's OWN household (conflict of interest); sysadmin overrides", async () => {
+    it("refuses coming-year grant for the actor's OWN household (conflict of interest), sysadmin included", async () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
         const res = await post({ householdId: boardHouseholdId, comingYear: true, reason: 'Renewal grant test' });
         expect(res.status).toBe(403);
         const stillPending = await prisma.orgMembershipProcess.findUnique({ where: { id: boardProcessId } });
         expect(stillPending?.status).toBe('PENDING_PAYMENT');
 
-        // Sysadmin is the deliberate remedy — same renewal, now grantable.
-        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isSysadmin: true } });
-        const ok = await post({ householdId: boardHouseholdId, comingYear: true, reason: 'Renewal grant test' });
-        expect(ok.status).toBe(200);
-        const settled = await prisma.orgMembershipProcess.findUnique({ where: { id: boardProcessId } });
-        expect(settled?.status).toBe('ACTIVE');
+        // The comingYear branch reaches the same guard through grantRenewalPayment →
+        // certifyPaymentPlan, so sysadmin gets no separate door here either.
+        for (const roles of [{ isSysadmin: true }, { isBoardMember: true, isSysadmin: true }]) {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, ...roles } });
+            const denied = await post({ householdId: boardHouseholdId, comingYear: true, reason: 'Renewal grant test' });
+            expect(denied.status).toBe(403);
+            const unsettled = await prisma.orgMembershipProcess.findUnique({ where: { id: boardProcessId } });
+            expect(unsettled?.status).toBe('PENDING_PAYMENT');
+        }
     });
 
     it('coming-year grant: missing reason → 400, no mutation', async () => {

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -321,7 +321,7 @@ describe('background check is non-blocking', () => {
         expect(await statusOf(processId)).toBe('PENDING_BG_REVIEW'); // held for the note
     });
 
-    it('conflict of interest: a certifier in the applicant household is blocked; sysadmin overrides', async () => {
+    it('conflict of interest: a certifier in the applicant household is blocked, sysadmin flag or not', async () => {
         const { processId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
         await markContractSigned(processId);
         await markBgConsent(processId, revA);
@@ -331,12 +331,14 @@ describe('background check is non-blocking', () => {
         await expect(certifyPaymentPlan(processId, leadId)).rejects.toMatchObject({ code: 'forbidden' });
         expect(await statusOf(processId)).toBe('PENDING_PAYMENT'); // unchanged — nothing certified
 
-        // Sysadmin is the deliberate remedy and bypasses the guard.
-        await certifyPaymentPlan(processId, leadId, { isSysadmin: true });
-        expect(await statusOf(processId)).toBe('PENDING_BG_CLEARANCE'); // paid; still needs the check
+        // Promoting that same lead to sysadmin does not buy a way through: the guard
+        // reads the household relationship, not the actor's roles.
+        await prisma.person.update({ where: { id: leadId }, data: { isSysadmin: true } });
+        await expect(certifyPaymentPlan(processId, leadId)).rejects.toMatchObject({ code: 'forbidden' });
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
     });
 
-    it('conflict of interest: overrideBlocked by the applicant household is blocked; sysadmin overrides', async () => {
+    it('conflict of interest: overrideBlocked by the applicant household is blocked, sysadmin flag or not', async () => {
         const { processId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
         await markContractSigned(processId);
         await markBgConsent(processId, revA);
@@ -347,9 +349,12 @@ describe('background check is non-blocking', () => {
         await expect(overrideBlocked(processId, leadId, 'approve')).rejects.toMatchObject({ code: 'same_household_applicant' });
         expect(await statusOf(processId)).toBe('BLOCKED'); // unchanged
 
-        // Sysadmin bypasses; the force-clear lands the process back on the payment track.
-        await overrideBlocked(processId, leadId, 'approve', { isSysadmin: true });
-        expect(await statusOf(processId)).not.toBe('BLOCKED');
+        // A sysadmin is still the applicant's own household → still refused. This is the
+        // asymmetry that mattered: attest() never let them vote on their own family's
+        // check, so the stronger force-clear must not either.
+        await prisma.person.update({ where: { id: leadId }, data: { isSysadmin: true } });
+        await expect(overrideBlocked(processId, leadId, 'approve')).rejects.toMatchObject({ code: 'same_household_applicant' });
+        expect(await statusOf(processId)).toBe('BLOCKED');
     });
 
     it('renewal with a still-valid background check: bgClearedAt stamped, signature opens payment, paying activates (not stuck)', async () => {

--- a/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
@@ -275,7 +275,7 @@ describe('Membership payment-plan routes', () => {
             await prisma.person.delete({ where: { id: boardKin.id } });
         });
 
-        it('a sysadmin may deny their own household (COI bypass)', async () => {
+        it('a board+sysadmin may NOT deny their own household either', async () => {
             const own = await makeProc('DenySysadmin', { requested: true });
             const sysKin = await prisma.person.create({
                 data: { name: 'Sys Kin', email: `sys-kin-${own.processId}-${TAG}@example.com`, isBoardMember: true, householdId: own.householdId },
@@ -283,9 +283,9 @@ describe('Membership payment-plan routes', () => {
             mockSession.mockResolvedValue({ user: { id: sysKin.id, isBoardMember: true, isSysadmin: true } });
 
             const res = await DenyPost(denyReq({ processId: own.processId }));
-            expect(res.status).toBe(200);
+            expect(res.status).toBe(403);
             const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: own.processId } });
-            expect(proc?.isPaymentPlanRequested).toBe(false);
+            expect(proc?.isPaymentPlanRequested).toBe(true); // flag NOT flipped by the refused deny
 
             await prisma.person.delete({ where: { id: sysKin.id } }); // keep it out of the board-member fallback set
         });

--- a/checkin-app/src/app/api/finance-ops/membership-payment-plans/refuse/route.ts
+++ b/checkin-app/src/app/api/finance-ops/membership-payment-plans/refuse/route.ts
@@ -48,11 +48,11 @@ export const POST = withAuth(
                 return apiError("Membership application not found", 404);
             }
 
-            // Conflict of interest: mirrors certifyPaymentPlan (approve) — a board
-            // member may not deny their OWN household's request either. Sysadmin bypasses.
+            // Conflict of interest: mirrors certifyPaymentPlan (approve) — no actor may
+            // deny their OWN household's request either. No role bypasses this.
             if (auth.type === 'session') {
-                if (await hasHouseholdConflict(prisma, auth.user.id, process.orgMembership?.householdId, { isSysadmin: auth.user.isSysadmin === true })) {
-                    return apiError("You cannot deny your own household's payment plan — a sysadmin must.", 403);
+                if (await hasHouseholdConflict(prisma, auth.user.id, process.orgMembership?.householdId)) {
+                    return apiError("You cannot deny your own household's payment plan — someone outside your household must.", 403);
                 }
             }
 

--- a/checkin-app/src/app/api/finance-ops/membership-payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/membership-payment-plans/route.ts
@@ -58,7 +58,7 @@ export const POST = withAuth(
             // Reuse the membership activation path: certifies the plan and activates
             // without a Shopify payment (holding for background clearance if not yet
             // cleared). Then clear the request flag so it drops off the queue.
-            await certifyPaymentPlan(processId, auth.user.id, { isSysadmin: auth.user.isSysadmin === true, reason });
+            await certifyPaymentPlan(processId, auth.user.id, { reason });
             await prisma.orgMembershipProcess.update({
                 where: { id: processId },
                 data: { isPaymentPlanRequested: false },

--- a/checkin-app/src/app/api/finance-ops/payment-plans/refuse/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/refuse/route.ts
@@ -28,12 +28,12 @@ export const POST = withAuth(
                 return apiError("programId and participantId are required", 400);
             }
 
-            // Conflict of interest: mirrors approve — a board member may not refuse
-            // their OWN household's request either. Sysadmin bypasses.
+            // Conflict of interest: mirrors approve — no actor may refuse their OWN
+            // household's request either. No role bypasses this.
             if (auth.type === 'session') {
                 const target = await prisma.person.findUnique({ where: { id: participantId }, select: { householdId: true } });
-                if (await hasHouseholdConflict(prisma, auth.user.id, target?.householdId, { isSysadmin: auth.user.isSysadmin === true })) {
-                    return apiError("You cannot refuse your own household's payment plan — a sysadmin must.", 403);
+                if (await hasHouseholdConflict(prisma, auth.user.id, target?.householdId)) {
+                    return apiError("You cannot refuse your own household's payment plan — someone outside your household must.", 403);
                 }
             }
 

--- a/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payment-plans/route.ts
@@ -62,13 +62,13 @@ export const POST = withAuth(
                 return apiError("programId and participantId are required", 400);
             }
 
-            // Conflict of interest: a board member may not approve their OWN household's
-            // program payment plan (activate an enrollment without payment for their own
-            // family). Sysadmin bypasses.
+            // Conflict of interest: no actor may approve their OWN household's program
+            // payment plan (activate an enrollment without payment for their own
+            // family). No role bypasses this.
             if (auth.type === 'session') {
                 const target = await prisma.person.findUnique({ where: { id: participantId }, select: { householdId: true } });
-                if (await hasHouseholdConflict(prisma, auth.user.id, target?.householdId, { isSysadmin: auth.user.isSysadmin === true })) {
-                    return apiError("You cannot approve your own household's payment plan — a sysadmin must.", 403);
+                if (await hasHouseholdConflict(prisma, auth.user.id, target?.householdId)) {
+                    return apiError("You cannot approve your own household's payment plan — someone outside your household must.", 403);
                 }
             }
 

--- a/checkin-app/src/app/api/membership-ops/applications/certify-payment/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/certify-payment/route.ts
@@ -23,7 +23,7 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
     const reason = typeof body.reason === "string" ? body.reason.trim() : "";
     if (!reason) return apiError("A reason is required to certify a payment", 400);
     try {
-        const process = await certifyPaymentPlan(body.processId, auth.user.id, { isSysadmin: auth.user.isSysadmin === true, reason });
+        const process = await certifyPaymentPlan(body.processId, auth.user.id, { reason });
         return NextResponse.json({ process });
     } catch (error) {
         if (error instanceof PaymentError) {

--- a/checkin-app/src/app/api/membership-ops/applications/review-override/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/review-override/route.ts
@@ -25,9 +25,7 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
         return apiError("processId and action (reset|approve) are required", 400);
     }
     try {
-        const outcome = await overrideBlocked(body.processId, auth.user.id, body.action, {
-            isSysadmin: auth.user.isSysadmin === true,
-        });
+        const outcome = await overrideBlocked(body.processId, auth.user.id, body.action);
         return NextResponse.json({ outcome });
     } catch (error) {
         if (error instanceof ReviewError) {

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -282,7 +282,6 @@ export const POST = withAuth(
                 try {
                     const process = await grantRenewalPayment(householdId, {
                         actorId: auth.user.id,
-                        isSysadmin: auth.user.isSysadmin === true,
                         reason: trimmedReason,
                     });
                     return NextResponse.json({ success: true, process });
@@ -296,12 +295,12 @@ export const POST = withAuth(
             }
 
             if (active) {
-                // Conflict of interest: a board member may not grant their OWN household
-                // ACTIVE membership — that bypasses payment AND the background check for
-                // their own family. Sysadmin bypasses. (Mirrors the deny branch's
+                // Conflict of interest: no actor may grant their OWN household ACTIVE
+                // membership — that bypasses payment AND the background check for their
+                // own family. No role bypasses this. (Mirrors the deny branch's
                 // board-member protection, and certifyPaymentPlan's guard.)
-                if (auth.type === 'session' && await hasHouseholdConflict(prisma, auth.user.id, householdId, { isSysadmin: auth.user.isSysadmin === true })) {
-                    return apiError("You cannot activate your own household's membership — a sysadmin must.", 403);
+                if (auth.type === 'session' && await hasHouseholdConflict(prisma, auth.user.id, householdId)) {
+                    return apiError("You cannot activate your own household's membership — someone outside your household must.", 403);
                 }
                 const membership = await prisma.orgMembership.upsert({
                     where: { householdId },

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -38,10 +38,10 @@ type PaymentPlanRequest = {
 
 export default function PendingParticipantsPage() {
   const { user: me, ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
-  // Conflict of interest: a board member may not approve their OWN household member's
-  // plan (mirrors the server guard). Sysadmin keeps the button. UX only — server enforces.
+  // Conflict of interest: no actor may approve their OWN household member's plan
+  // (mirrors the server guard). UX only — server enforces.
   const ownHousehold = (req: PaymentPlanRequest) =>
-    me?.isSysadmin !== true && sharesHousehold(me?.householdId, req.person.householdId);
+    sharesHousehold(me?.householdId, req.person.householdId);
 
   const [requests, setRequests] = useState<PaymentPlanRequest[]>([]);
   const [cutoff, setCutoff] = useState<string | null>(null);
@@ -204,7 +204,7 @@ export default function PendingParticipantsPage() {
           <Button
             size="xs" fz={15} color="red" variant="light"
             disabled={ownHousehold(req)}
-            title={ownHousehold(req) ? "You can't refuse your own household's plan — a sysadmin must." : undefined}
+            title={ownHousehold(req) ? "You can't refuse your own household's plan — someone outside your household must." : undefined}
             onClick={() => handleRefuse(req.programId, req.personId)}
           >
             Refuse
@@ -212,7 +212,7 @@ export default function PendingParticipantsPage() {
           <Button
             size="xs" fz={15} variant="light"
             disabled={ownHousehold(req)}
-            title={ownHousehold(req) ? "You can't approve your own household's plan — a sysadmin must." : undefined}
+            title={ownHousehold(req) ? "You can't approve your own household's plan — someone outside your household must." : undefined}
             onClick={() => handleApprove(req.programId, req.personId)}
           >
             Approve &amp; Mark Active

--- a/checkin-app/src/app/finance-ops/shopify-holds/page.tsx
+++ b/checkin-app/src/app/finance-ops/shopify-holds/page.tsx
@@ -30,11 +30,11 @@ type Target = { programId: number; participantId: number } | null;
 
 export default function ShopifyHoldsPage() {
   const { user: me, ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
-  // Conflict of interest mirrors the scholarship queue: a board member may not
-  // approve/deny their OWN household's request (server enforces; this is UX). It
-  // does NOT gate the manual-hold action — that confers no benefit.
+  // Conflict of interest mirrors the scholarship queue: no actor may approve/deny
+  // their OWN household's request (server enforces; this is UX). It does NOT gate
+  // the manual-hold action — that confers no benefit.
   const ownHousehold = (row: HoldFailedRow) =>
-    me?.isSysadmin !== true && sharesHousehold(me?.householdId, row.person.householdId);
+    sharesHousehold(me?.householdId, row.person.householdId);
 
   const [rows, setRows] = useState<HoldFailedRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -132,7 +132,7 @@ export default function ShopifyHoldsPage() {
           <Button
             size="xs" fz={15} color="red" variant="subtle"
             disabled={ownHousehold(r)}
-            title={ownHousehold(r) ? "You can't deny your own household's plan — a sysadmin must." : undefined}
+            title={ownHousehold(r) ? "You can't deny your own household's plan — someone outside your household must." : undefined}
             onClick={() => openFor(r, 'deny')}
           >
             Deny (override)
@@ -140,7 +140,7 @@ export default function ShopifyHoldsPage() {
           <Button
             size="xs" fz={15} color="red" variant="subtle"
             disabled={ownHousehold(r)}
-            title={ownHousehold(r) ? "You can't approve your own household's plan — a sysadmin must." : undefined}
+            title={ownHousehold(r) ? "You can't approve your own household's plan — someone outside your household must." : undefined}
             onClick={() => openFor(r, 'approve')}
           >
             Approve (override)

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -73,12 +73,11 @@ export default function AdminMembershipPage() {
 function ApplicationsBoard() {
   const { data: session } = useSession();
   const me = session?.user;
-  // Conflict of interest: a board member may not certify/override their OWN household's
-  // application (mirrors the server guards in certifyPaymentPlan/overrideBlocked). Sysadmin
-  // is the deliberate remedy and keeps the buttons. The disabled state is UX only — the
-  // server is the real enforcement.
+  // Conflict of interest: no actor may certify/override their OWN household's
+  // application (mirrors the server guards in certifyPaymentPlan/overrideBlocked).
+  // The disabled state is UX only — the server is the real enforcement.
   const ownHousehold = (r: ProcessRow) =>
-    me?.isSysadmin !== true && sharesHousehold(me?.householdId, r.orgMembership?.householdId);
+    sharesHousehold(me?.householdId, r.orgMembership?.householdId);
   const [rows, setRows] = useState<ProcessRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<number | null>(null);

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -392,7 +392,7 @@ function ApplicationsBoard() {
                     Certify payment plan → {r.bgClearedAt ? "activate" : "(holds for background check)"}
                   </Button>
                   {ownHousehold(r) && (
-                    <Text size="xs" c="dimmed">You can&apos;t certify your own household&apos;s application — another board member (or a sysadmin) must.</Text>
+                    <Text size="xs" c="dimmed">You can&apos;t certify your own household&apos;s application — someone outside your household must.</Text>
                   )}
                 </Group>
               )}
@@ -419,7 +419,7 @@ function ApplicationsBoard() {
                     </Button>
                   </Group>
                   {ownHousehold(r) && (
-                    <Text size="xs" c="dimmed" mt="sm">You can&apos;t override your own household&apos;s application — another board member (or a sysadmin) must.</Text>
+                    <Text size="xs" c="dimmed" mt="sm">You can&apos;t override your own household&apos;s application — someone outside your household must.</Text>
                   )}
                 </Alert>
               )}

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -215,13 +215,12 @@ export default function AdminHouseholdsPage() {
               const hasActiveMembership = status === "ACTIVE";
               const isDenied = status === "DENIED";
               const hasBoardMember = household.householdMembers?.some((p) => p.isBoardMember) ?? false;
-              // Conflict of interest: a board member may not GRANT their own household
-              // membership (bypasses payment + background check). Sysadmin keeps the button.
-              // Mirrors the server guard; disabled state is UX only. Revoke stays allowed.
-              // A board member may not grant their own household (bypasses payment + BG).
+              // Conflict of interest: no actor may GRANT their own household membership
+              // (bypasses payment + background check). Mirrors the server guard; disabled
+              // state is UX only. Revoke stays allowed.
               // Grant Membership only offers on non-members; the coming-year override applies
               // to existing members too, so it needs the conflict regardless of current status.
-              const ownHouseholdConflict = me?.isSysadmin !== true && sharesHousehold(me?.householdId, household.id);
+              const ownHouseholdConflict = sharesHousehold(me?.householdId, household.id);
               const ownGrantBlocked = !hasActiveMembership && ownHouseholdConflict;
               const hasBrokenEmail = household.householdMembers?.some((p) => p.emailUndeliverableAt) ?? false;
               // Staff households (@innovationtreehouse.org) aren't program families: block
@@ -321,7 +320,7 @@ export default function AdminHouseholdsPage() {
                               !hasActiveMembership && isStaffHousehold
                                 ? "Staff households can't be granted membership."
                                 : ownGrantBlocked
-                                  ? "You can't grant your own household's membership — a sysadmin must."
+                                  ? "You can't grant your own household's membership — someone outside your household must."
                                   : undefined
                             }
                             onClick={() => toggleMembership(household.id, hasActiveMembership)}

--- a/checkin-app/src/lib/__tests__/conflictOfInterest.test.ts
+++ b/checkin-app/src/lib/__tests__/conflictOfInterest.test.ts
@@ -15,8 +15,8 @@ describe("sharesHousehold", () => {
 });
 
 describe("hasHouseholdConflict", () => {
-    const db = (actorHouseholdId: number | null) =>
-        ({ person: { findUnique: jest.fn().mockResolvedValue(actorHouseholdId == null ? null : { householdId: actorHouseholdId }) } }) as unknown as DbClient;
+    const db = (actorHouseholdId: number | null, actorRow: Record<string, unknown> = {}) =>
+        ({ person: { findUnique: jest.fn().mockResolvedValue(actorHouseholdId == null ? null : { householdId: actorHouseholdId, ...actorRow }) } }) as unknown as DbClient;
 
     it("conflict when the actor shares the subject's household", async () => {
         expect(await hasHouseholdConflict(db(3), 1, 3)).toBe(true);
@@ -26,8 +26,9 @@ describe("hasHouseholdConflict", () => {
         expect(await hasHouseholdConflict(db(4), 1, 3)).toBe(false);
     });
 
-    it("takes no role argument — there is no way for a caller to opt out of the rule", () => {
-        expect(hasHouseholdConflict).toHaveLength(3); // db, actorId, subjectHouseholdId
+    it("still conflicts when the actor holds every privileged role", async () => {
+        const privileged = { isSysadmin: true, isBoardMember: true, isBackgroundCheckReviewer: true, isKeyholder: true };
+        expect(await hasHouseholdConflict(db(3, privileged), 1, 3)).toBe(true);
     });
 
     it("no conflict when the subject has no household to conflict with", async () => {

--- a/checkin-app/src/lib/__tests__/conflictOfInterest.test.ts
+++ b/checkin-app/src/lib/__tests__/conflictOfInterest.test.ts
@@ -26,10 +26,8 @@ describe("hasHouseholdConflict", () => {
         expect(await hasHouseholdConflict(db(4), 1, 3)).toBe(false);
     });
 
-    it("sysadmin always bypasses — no conflict, and no DB read", async () => {
-        const client = db(3); // same household as subject → would conflict without the bypass
-        expect(await hasHouseholdConflict(client, 1, 3, { isSysadmin: true })).toBe(false);
-        expect((client.person.findUnique as jest.Mock)).not.toHaveBeenCalled();
+    it("takes no role argument — there is no way for a caller to opt out of the rule", () => {
+        expect(hasHouseholdConflict).toHaveLength(3); // db, actorId, subjectHouseholdId
     });
 
     it("no conflict when the subject has no household to conflict with", async () => {

--- a/checkin-app/src/lib/conflictOfInterest.ts
+++ b/checkin-app/src/lib/conflictOfInterest.ts
@@ -6,16 +6,21 @@ import type { DbClient } from "@/lib/db-client";
  * The policy is uniform across the app: an actor may not approve, certify, clear,
  * or grant something for their OWN household — approving your own family is the
  * same abuse whether it's a background-check review, membership dues, a program
- * payment plan, or a direct membership grant. A sysadmin is the deliberate remedy
- * everywhere and bypasses the gate.
+ * payment plan, or a direct membership grant.
+ *
+ * No role is exempt. `isSysadmin` is an application role with no counterpart in the
+ * org's policy corpus, so it cannot stand in for the non-conflicted board member the
+ * policy requires — a sysadmin who is also board is bound by this rule like anyone
+ * else. Don't add a role-shaped parameter here; a break-glass path needs its own
+ * audited, multi-actor mechanism, not a flag that silently returns false.
  *
  * Two entry points, because callers differ in what they already hold:
  *   - sharesHousehold(a, b): pure predicate for callers that already have both
  *     household ids loaded (attest's already-loaded reviewer, isTrustedAdultConflict,
  *     the UI gating its buttons off the same rule so client and server can't drift).
- *   - hasHouseholdConflict(db, actorId, subjectHouseholdId, opts): resolves the
- *     actor's household itself + applies the sysadmin bypass, for callers that only
- *     hold an actor id (the service/route guards).
+ *   - hasHouseholdConflict(db, actorId, subjectHouseholdId): resolves the actor's
+ *     household itself, for callers that only hold an actor id (the service/route
+ *     guards).
  *
  * What is deliberately NOT here: resolving the SUBJECT's household. That varies per
  * caller (a person, an OrgMembership, an OrgMembershipProcess, or a raw householdId
@@ -35,16 +40,13 @@ export function sharesHousehold(
 /**
  * Whether `actorId` has a household conflict with a subject in `subjectHouseholdId`.
  * Resolves the actor's household so callers don't re-roll the same findUnique.
- * Returns false (no conflict) when opts.isSysadmin — the escape hatch every gate
- * grants a sysadmin — or when the subject has no household to conflict with.
+ * Returns false (no conflict) only when the subject has no household to conflict with.
  */
 export async function hasHouseholdConflict(
     db: DbClient,
     actorId: number,
     subjectHouseholdId: number | null | undefined,
-    opts?: { isSysadmin?: boolean },
 ): Promise<boolean> {
-    if (opts?.isSysadmin) return false;
     if (subjectHouseholdId == null) return false;
     const actor = await db.person.findUnique({ where: { id: actorId }, select: { householdId: true } });
     return sharesHousehold(actor?.householdId, subjectHouseholdId);

--- a/checkin-app/src/lib/membership/lifecycle.ts
+++ b/checkin-app/src/lib/membership/lifecycle.ts
@@ -152,7 +152,7 @@ export const awaitingBgReview: StateSet<AwaitingBgRow, Where> = {
  * settles to PENDING_BG_CLEARANCE, while a cleared one settles to ACTIVE — activate()
  * makes that split, BG is never bypassed. Both the list route's `renewalGrantable`
  * probe and `grantRenewalPayment`'s row lookup use this ONE fragment; the COI check
- * inside certifyPaymentPlan stays on top.
+ * inside certifyPaymentPlan stays on top for every actor.
  */
 export const grantableRenewalWhere: Where = {
     kind: "RENEWAL",

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -243,7 +243,7 @@ export async function activate(
 }
 
 /** Board override: certify a payment plan and activate without a Shopify payment. */
-export async function certifyPaymentPlan(processId: number, actorId: number, opts?: { isSysadmin?: boolean; reason?: string }) {
+export async function certifyPaymentPlan(processId: number, actorId: number, opts?: { reason?: string }) {
     // Unlike the webhook path, a board certify is a deliberate action — reject
     // (not silently no-op) when the process isn't actually awaiting payment, so
     // certifying an already-ACTIVE or still-in-review grant surfaces a 409
@@ -253,11 +253,11 @@ export async function certifyPaymentPlan(processId: number, actorId: number, opt
     if (!process) throw new PaymentError("not_found", "Application not found.");
     if (process.status !== "PENDING_PAYMENT") throw new PaymentError("wrong_phase", "This application is not awaiting payment.");
 
-    // Conflict of interest: a board member may not certify (mark paid + activate) their
-    // OWN household's membership — else they could activate their family without paying
-    // dues. Sysadmin bypasses.
-    if (await hasHouseholdConflict(prisma, actorId, process.orgMembership?.householdId, { isSysadmin: opts?.isSysadmin })) {
-        throw new PaymentError("forbidden", "You cannot certify your own household's membership — a sysadmin must.");
+    // Conflict of interest: no actor may certify (mark paid + activate) their OWN
+    // household's membership — else they could activate their family without paying
+    // dues. No role bypasses this.
+    if (await hasHouseholdConflict(prisma, actorId, process.orgMembership?.householdId)) {
+        throw new PaymentError("forbidden", "You cannot certify your own household's membership — someone outside your household must.");
     }
     return activate(processId, { via: "certified", actorId, reason: opts?.reason });
 }

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -342,7 +342,7 @@ export async function householdBgIsFresh(householdId: number, boundary: Date, re
  */
 export async function grantRenewalPayment(
     householdId: number,
-    actor: { actorId: number; isSysadmin: boolean; reason: string },
+    actor: { actorId: number; reason: string },
 ): Promise<import("@/generated/prisma/client").OrgMembershipProcess> {
     // Share the "payable renewal" predicate with the list route's renewalGrantable
     // probe (fix #3, grantableRenewalWhere): kind=RENEWAL, PENDING_PAYMENT — NOT
@@ -355,9 +355,9 @@ export async function grantRenewalPayment(
     });
     if (!process) throw new PaymentError("wrong_phase", "No renewal is awaiting payment.");
 
-    // COI is enforced INSIDE certifyPaymentPlan (single source): a board member
-    // certifying their own household throws PaymentError('forbidden'); sysadmin bypasses.
-    await certifyPaymentPlan(process.id, actor.actorId, { isSysadmin: actor.isSysadmin, reason: actor.reason });
+    // COI is enforced INSIDE certifyPaymentPlan (single source): certifying your own
+    // household throws PaymentError('forbidden'), whatever roles you hold.
+    await certifyPaymentPlan(process.id, actor.actorId, { reason: actor.reason });
 
     // Supplementary audit marker (traceability) — the PENDING_PAYMENT→ACTIVE
     // transition itself is already audited inside activate().

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -349,7 +349,7 @@ export async function applyVolunteerStatus(db: DbClient, orgMembershipId: number
 }
 
 /** Board override on a BLOCKED application: reset for re-review, or force-clear the check. */
-export async function overrideBlocked(processId: number, actorId: number, action: "reset" | "approve", opts?: { isSysadmin?: boolean }) {
+export async function overrideBlocked(processId: number, actorId: number, action: "reset" | "approve") {
     const process = await prisma.orgMembershipProcess.findUnique({
         where: { id: processId },
         include: { orgMembership: { select: { household: { select: { intakeNotes: true } } } } },
@@ -357,12 +357,12 @@ export async function overrideBlocked(processId: number, actorId: number, action
     if (!process) throw new ReviewError("not_found", "Application not found.");
     if (process.status !== "BLOCKED") throw new ReviewError("wrong_phase", "This application is not blocked.");
 
-    // Conflict of interest: a board member may not override their OWN household's blocked
+    // Conflict of interest: no actor may override their OWN household's blocked
     // application — else they could force-clear their family's failed background check, the
-    // very thing attest()'s same-household gate forbids. Sysadmin bypasses (opts.isSysadmin).
+    // very thing attest()'s same-household gate forbids. No role bypasses this.
     const applicantHouseholdId = await applicantHousehold(prisma, process);
-    if (await hasHouseholdConflict(prisma, actorId, applicantHouseholdId, { isSysadmin: opts?.isSysadmin })) {
-        throw new ReviewError("same_household_applicant", "You cannot override your own household's application — a sysadmin must.");
+    if (await hasHouseholdConflict(prisma, actorId, applicantHouseholdId)) {
+        throw new ReviewError("same_household_applicant", "You cannot override your own household's application — someone outside your household must.");
     }
 
     if (action === "reset") {


### PR DESCRIPTION
We want to ensure that systems and processes relying on two-party control among board members are not accidentally bypassed by a board member who is also a sysadmin. `hasHouseholdConflict` is the shared guard behind every self-approval check, and it returned `false` immediately whenever a caller passed `isSysadmin` — so a board member holding that flag could decide their own household's case: force-clear a blocked background check, activate a membership with no payment, grant membership outright, or approve and refuse a payment plan. A non-board sysadmin could do the same on the three surfaces whose gate accepts `isSysadmin` in place of `isBoardMember`. This PR deletes the bypass from the primitive, so no actor is exempt regardless of the roles they hold. The `opts` parameter is removed rather than ignored, which turns every stale caller into a compile error and leaves no role-shaped hole to pass `true` into — and `tsc` used exactly that to surface an eighth decision path the issue had not inventoried.

The strongest argument for doing this at the primitive is an asymmetry inside our own code, independent of policy: `attest()` requires `isBackgroundCheckReviewer || isBoardMember` and has never had a sysadmin bypass on its same-household guard, so a bare sysadmin could not cast one of two votes on their own family's background check — yet `overrideBlocked` let them force-clear it outright, the strictly more powerful action. The bypass was inverted relative to the danger. **One consequence reviewers should weigh:** with no escape valve, a case whose only eligible deciders all live in the subject household can no longer be decided at all until the board adds a non-conflicted person. That is now a visible 403 instead of a silent bypass, and is the gap the planned admin auditing / break-glass mechanism is meant to fill — deliberately out of scope here.

Decision: remove the bypass outright (question 1 on the issue), not narrow the route gates (question 3). A non-board sysadmin can still act on *other* households' cases; only the self-approval path closes.

Fixes #1390

---

<details>
<summary><b>Appendix</b></summary>

### The eight decision paths (7 route files)

| Route | Gate | Reached the guard via |
|---|---|---|
| `POST /api/membership-ops/applications/review-override` | sysadmin **or** board | `overrideBlocked` |
| `POST /api/membership-ops/applications/certify-payment` | sysadmin **or** board | `certifyPaymentPlan` |
| `POST /api/membership-ops/households` (`active`) | sysadmin **or** board | inline guard |
| `POST /api/membership-ops/households` (`comingYear`) | sysadmin **or** board | `grantRenewalPayment` → `certifyPaymentPlan` |
| `POST /api/finance-ops/payment-plans` | board only | inline guard |
| `POST /api/finance-ops/payment-plans/refuse` | board only | inline guard |
| `POST /api/finance-ops/membership-payment-plans/refuse` | board only | inline guard |
| `POST /api/finance-ops/membership-payment-plans` | board only | `certifyPaymentPlan` ← **found by `tsc`, not by grep** |

The last row is the one the issue missed: it calls `certifyPaymentPlan` directly, so it never appeared in a `hasHouseholdConflict` search. Deleting the parameter is what caught it.

### Also updated, so client and server can't drift

Four UI mirrors dropped `me?.isSysadmin !== true &&` from their own-household predicate (`membership-ops/applications`, `membership-ops/households`, `finance-ops/payment-plan`, `finance-ops/shopify-holds`). Without this the client would keep offering a button the server now refuses. User-facing copy changed from "a sysadmin must" to "someone outside your household must", which is what is now true.

### Tests

Five tests asserted the bypass as correct behavior and now assert refusal; the route-level ones exercise `{isBoardMember: true, isSysadmin: true}` explicitly. In `membershipBgNonBlocking` the applicant's own household lead is promoted to sysadmin mid-test and still cannot certify or force-clear. That test sets only `isSysadmin`, not `isBoardMember` — the suite has "email all board members" fallbacks that a stray board member would inflate.

### Validation

`tsc --noEmit` clean. `npm run test:ci`: 2393 passed, 3 failed — all three pre-existing, confirmed by stashing this branch and re-running the same suites on clean `main` for an identical result (3 failed / 92 passed, same test names). Two are 5s render timeouts (`program-ops/programs/[id]`, `my-household`); one is a jsdom "navigation not implemented" error from `window.location.href` in `membership/page.tsx:525`. None are files this PR touches. Integration tests were not run locally (shared dev DB); they typecheck and CI covers them.

### Deliberately out of scope

`trusted-adult/service.ts` → `overrideReview` has a structurally identical bypass (`if (!opts?.isSysadmin)` around `isTrustedAdultConflict`, same "a sysadmin must" message). Different primitive, different approval regime, not covered by the #1390 decision — worth its own issue and PR.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
