### PR TITLE
fix(security-lint): split orphan-registry — warn with no route file, error on a stale verb

### DIFF
--- a/checkin-app/scripts/__tests__/check-route-coverage.test.ts
+++ b/checkin-app/scripts/__tests__/check-route-coverage.test.ts
@@ -1,4 +1,8 @@
-import { findBareIncludeLegs, findUnregisteredBareIncludeLegs } from "../check-route-coverage";
+import {
+    findBareIncludeLegs,
+    findOrphanRegistryEntries,
+    findUnregisteredBareIncludeLegs,
+} from "../check-route-coverage";
 
 const names = (src: string) => findBareIncludeLegs(src).map(l => l.name);
 
@@ -72,5 +76,35 @@ describe("findUnregisteredBareIncludeLegs", () => {
 
     it("stays silent on a file that exports no verbs", () => {
         expect(findUnregisteredBareIncludeLegs(BODY, [], "/api/thing", new Set())).toEqual([]);
+    });
+});
+
+describe("findOrphanRegistryEntries", () => {
+    const orphans = (registered: string[], methods: string[], paths: string[]) =>
+        findOrphanRegistryEntries(registered, new Set(methods), new Set(paths));
+
+    it("stays silent when a route method serves the entry", () => {
+        expect(orphans(["GET /api/thing"], ["GET /api/thing"], ["/api/thing"])).toEqual([]);
+    });
+
+    // Severity is the register-first contract: a --strict run only fails on
+    // 'error', so an entry whose route file has not landed must be a 'warn'.
+    it("warns when no route file exists yet — the register-first state", () => {
+        const found = orphans(["PATCH /api/thing/[id]"], [], []);
+        expect(found).toHaveLength(1);
+        expect(found[0].severity).toBe("warn");
+        expect(found[0].rule).toBe("orphan-registry");
+        expect(found[0].message).toContain("PATCH /api/thing/[id]");
+        expect(found[0].message).toContain("register-first");
+    });
+
+    // The other half of the split: policy claims a verb the live file no longer
+    // serves. Inert it is not — the ratchet must keep blocking here.
+    it("errors when the route file exists but no longer exports the verb", () => {
+        const found = orphans(["PATCH /api/thing/[id]"], ["GET /api/thing/[id]"], ["/api/thing/[id]"]);
+        expect(found).toHaveLength(1);
+        expect(found[0].severity).toBe("error");
+        expect(found[0].message).toContain("stale");
+        expect(found[0].message).toContain("exports no PATCH");
     });
 });

--- a/checkin-app/scripts/check-route-coverage.ts
+++ b/checkin-app/scripts/check-route-coverage.ts
@@ -109,7 +109,7 @@ export function findUnregisteredBareIncludeLegs(
     return findBareIncludeLegs(content);
 }
 
-interface Finding {
+export interface Finding {
     severity: 'error' | 'warn';
     rule: string;
     file: string;
@@ -119,6 +119,33 @@ interface Finding {
 const findings: Finding[] = [];
 function report(severity: Finding['severity'], rule: string, file: string, message: string, line?: number) {
     findings.push({ severity, rule, file, line, message });
+}
+
+/** Registry entries no route method serves, split by which half is missing.
+ *  No route FILE is the sanctioned register-first state — inert, nothing serves
+ *  the endpoint — so it warns. A file that exists but no longer exports the verb
+ *  is live policy/code drift, so it blocks. */
+export function findOrphanRegistryEntries(
+    registered: Iterable<string>,
+    routeMethods: ReadonlySet<string>,
+    routePaths: ReadonlySet<string>,
+): Finding[] {
+    return Array.from(registered)
+        .filter(key => !routeMethods.has(key))
+        .map(key => {
+            const [method, routePath] = key.split(' ');
+            const stale = routePaths.has(routePath);
+            return {
+                severity: stale ? ('error' as const) : ('warn' as const),
+                rule: 'orphan-registry',
+                file: 'src/security/registry.ts',
+                message: stale
+                    ? `registry entry ${key} is stale — ${routePath} has a route file, but it ` +
+                      `exports no ${method}. Drop the entry, or restore the export.`
+                    : `registry entry ${key} has no route file at ${routePath} — the ` +
+                      `register-first state while its route PR is pending.`,
+            };
+        });
 }
 
 function loadMigratedRoutes(): Set<string> {
@@ -224,8 +251,10 @@ function main() {
     const routeFiles = findRouteFiles(API_DIR);
 
     const allRouteEndpoints = new Set<string>();
+    const allRoutePaths = new Set<string>();
     for (const file of routeFiles) {
         const endpointPath = fileToEndpointPath(file);
+        allRoutePaths.add(endpointPath);
         const content = fs.readFileSync(file, 'utf-8');
         const verbs = extractExportedVerbs(content);
 
@@ -282,12 +311,7 @@ function main() {
         }
     }
 
-    for (const key of registered) {
-        if (!allRouteEndpoints.has(key)) {
-            report('error', 'orphan-registry', 'src/security/registry.ts',
-                `registry entry ${key} has no corresponding route file`);
-        }
-    }
+    findings.push(...findOrphanRegistryEntries(registered, allRouteEndpoints, allRoutePaths));
 
     // Keep the ratchet honest: a baseline entry whose route no longer exists
     // (deleted or migrated) must be pruned, or a later re-creation of the same


### PR DESCRIPTION
`check-route-coverage` currently makes the repo's own documented register-first flow impossible. This splits one rule so the flow works, without giving up the enforcement that rule actually buys.

## The deadlock

Two hard errors in the same checker contradict each other for a genuinely **new** endpoint:

- `new-route-old-authz` — a route method in neither the registry nor the frozen `legacy-authz-routes.txt` baseline is an error.
- `orphan-registry` — a registry entry with no corresponding route file is an error.

AGENTS.md and `security-boundary-isolation.yml` both state the sanctioned flow: *"land the registry entry in its own PR first (a `defineRoute` for an endpoint nothing serves yet is inert), then land the route handler in the feature PR."* That is impossible as written. The register-first PR trips `orphan-registry` on its own CI, and merging it anyway would red-line `main` for everyone until the route landed.

Nobody has hit this before because every prior register-first wave (#1137, #1209–#1215) registered routes that **already existed** on `main` — "inert" there meant *registered but not yet on `handler()`*, never *no route file*. #1357 is the first genuinely new endpoint, and it is stuck: its unit job dies here before jest runs.

## The fix

`orphan-registry` splits on which half is missing:

| Situation | Severity | Why |
|---|---|---|
| No route **file** at the path | `warn` | The register-first state. Inert by construction — nothing serves the endpoint, so no policy is live. |
| File exists but exports no such **verb** | `error` | Real policy/code drift: a registered grant whose handler was removed. |

The first blocked a documented workflow. The second is the case worth blocking, and it stays blocked.

A blanket downgrade would have buried that second case as one warning among 176, where nobody would ever see it. Splitting keeps the ratchet exactly where it still bites.

This also brings the rule in line with its sibling: `stale-legacy-baseline` — a frozen-baseline entry whose route no longer exists — is *already* only a warning, and its own comment argues it is the more dangerous direction. `orphan-registry` being a hard error was the outlier.

## Verified against the real tree, not just unit tests

Run inside a worktree carrying the #1357 registry entries:

| Setup | Result |
|---|---|
| Registry entries, no route file, old checker | exit 1 — 2 × `✗ orphan-registry` |
| Registry entries, no route file, this checker | **exit 0** — 2 × `⚠ … register-first state while its route PR is pending` |
| \+ #1357's real route file | **exit 0** — zero `orphan-registry`, drops to the normal `unmigrated` warning |
| Route file with `export const DELETE` renamed away | **exit 1** — `✗ … is stale — has a route file, but it exports no DELETE` |
| Control: route file present, entries absent | exit 1 — `✗ new-route-old-authz` ×2 |

So the deadlock reproduces in both directions and the stale arm blocks for real, not only in the unit test.

`check-route-coverage -- --strict` on this branch exits **0** (0 errors / 174 warnings), which also confirms no entry on `main` is currently in the new `stale` state.

Unit coverage pins all three arms — served, no-file, and file-without-verb — asserting on the distinguishing message text so the two cases can't silently collapse back together.

## Sequencing — corrected

An earlier revision of this description claimed #1395 depended on this PR. **It does not**, and the correction is thpr's (#1395 review).

Two reasons, both verified:

1. CI never arms `--strict`. Root `package.json` runs `npm -w checkin-app run check-route-coverage`, so the workflow's `-- --strict` expands into a second `npm run` and is swallowed as an npm config (`npm warn Unknown cli config "--strict"` appears in every unit job). The checker therefore runs advisory and exits 0 on `orphan-registry`.
2. `new-route-old-authz` blocks *even in advisory mode* by design — header rule 6, and the log line `(2 new-route-old-authz error(s) block even in advisory mode)`. That, not `orphan-registry`, is what reds #1357.

So #1395 unblocks #1357 by itself, and this PR is **orthogonal to both**.

What it is instead: the prerequisite for ever arming `--strict`. Today `orphan-registry` is a latent trap — the moment someone fixes the `--strict` plumbing, the documented register-first flow starts hard-failing and merging an inert entry would red-line `main`. This makes the rule correct *before* that happens, and keeps the case worth blocking (a registered verb whose handler was deleted) blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
