### PR TITLE
security(boundary): register PATCH/DELETE /api/attendance/manual/[id] (registry-first)

### DIFF
--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -33,13 +33,15 @@ defineRoute({
 });
 
 // Self-correction of the caller's OWN visit: PATCH edits the times, DELETE
-// tombstones the row. Ownership is the admission gate — the route 404s any id
-// that is not the caller's own live row — and their_own (Visit.personId) is the
-// per-row backstop. The grant stops at 'personal' (arrivedAt/departedAt); the
-// 'internal' tombstone fields stay stripped.
+// tombstones the row. `[id]` is a Visit id, NOT a person id, so 'self' cannot
+// express the gate — it compares the id param against auth.user.id. Ownership
+// is enforced in the route body, which 404s any id that is not the caller's own
+// live row; their_own (Visit.personId) is the per-row field backstop. The grant
+// stops at 'personal' (arrivedAt/departedAt); 'internal' tombstone fields stay
+// stripped.
 defineRoute({
     endpoint: 'PATCH /api/attendance/manual/[id]',
-    authorize: 'self',
+    authorize: 'authenticated',
     envelope: 'visit',
     // Bag: { Visit }.
     returns: ['Visit'],
@@ -50,7 +52,7 @@ defineRoute({
 
 defineRoute({
     endpoint: 'DELETE /api/attendance/manual/[id]',
-    authorize: 'self',
+    authorize: 'authenticated',
     // No bag — the response is { success, flagged }, no model data.
     envelope: null,
     orderedView: [

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -32,6 +32,32 @@ defineRoute({
     ],
 });
 
+// Self-correction of the caller's OWN visit: PATCH edits the times, DELETE
+// tombstones the row. Ownership is the admission gate — the route 404s any id
+// that is not the caller's own live row — and their_own (Visit.personId) is the
+// per-row backstop. The grant stops at 'personal' (arrivedAt/departedAt); the
+// 'internal' tombstone fields stay stripped.
+defineRoute({
+    endpoint: 'PATCH /api/attendance/manual/[id]',
+    authorize: 'self',
+    envelope: 'visit',
+    // Bag: { Visit }.
+    returns: ['Visit'],
+    orderedView: [
+        ['authenticated', ['their_own:personal', 'member', 'public']],
+    ],
+});
+
+defineRoute({
+    endpoint: 'DELETE /api/attendance/manual/[id]',
+    authorize: 'self',
+    // No bag — the response is { success, flagged }, no model data.
+    envelope: null,
+    orderedView: [
+        ['authenticated', ['their_own:personal', 'member', 'public']],
+    ],
+});
+
 defineRoute({
     endpoint: 'GET /api/programs/[id]',
     authorize: 'public',

--- a/checkin-app/tests/security/registryAuthz.integration.test.ts
+++ b/checkin-app/tests/security/registryAuthz.integration.test.ts
@@ -23,6 +23,8 @@
 // this is an integration test that needs the real client to seed personas.
 jest.unmock('@/lib/prisma');
 
+import * as fs from 'fs';
+import * as path from 'path';
 import { allRoutes, type Authorize } from '@/security/core';
 import type { BusinessRole } from '@/types/auth';
 import type { SessionUser } from '@/types/participant';
@@ -72,6 +74,14 @@ const PLANS: RoutePlan[] = Array.from(allRoutes()).map(([endpoint, spec]) => {
 
 function importPathFor(routePath: string): string {
     return `@/app${routePath}/route`;
+}
+
+/** A registry entry may legally precede its route file (register-first: an
+ *  unused defineRoute is inert). Cases that drive the handler are skipped until
+ *  the file lands; a file that exists and then fails to import still throws. */
+function routeFileExists(routePath: string): boolean {
+    const base = path.resolve(__dirname, `../../src/app${routePath}/route`);
+    return ['.ts', '.tsx'].some(ext => fs.existsSync(base + ext));
 }
 
 describe('Registry route admission gates', () => {
@@ -154,21 +164,31 @@ describe('Registry route admission gates', () => {
         return verb(new Request(url, { method: plan.method }), ctx);
     }
 
+    // Guards the skip below: a wrong path would resolve every route as absent
+    // and skip the whole file green.
+    it('resolves route files on disk', () => {
+        expect(PLANS.filter(p => routeFileExists(p.routePath)).length).toBeGreaterThan(0);
+    });
+
     for (const plan of PLANS) {
         describe(plan.endpoint, () => {
+            // Every case using this drives the real handler, so it waits for the
+            // route file. The gate check below is static and always runs.
+            const itServed = routeFileExists(plan.routePath) ? it : it.skip;
+
             it('has a handled authorize gate (route not silently skipped)', () => {
                 expect(plan.gate).not.toBe('unhandled');
             });
 
             // ── unauthenticated ───────────────────────────────────────────────
             if (plan.gate === 'public') {
-                it('admits an unauthenticated caller (public route)', async () => {
+                itServed('admits an unauthenticated caller (public route)', async () => {
                     mockSession.mockResolvedValue(null);
                     const res = await call(plan);
                     expect(res.status).toBeLessThan(400);
                 });
             } else {
-                it('rejects an unauthenticated caller with 401', async () => {
+                itServed('rejects an unauthenticated caller with 401', async () => {
                     mockSession.mockResolvedValue(null);
                     expect((await call(plan)).status).toBe(401);
                 });
@@ -177,21 +197,21 @@ describe('Registry route admission gates', () => {
             // ── authenticated but under-privileged ───────────────────────────
             if (plan.gate === 'anyRole') {
                 const roles = (plan.requiredRoles ?? []).join(' | ');
-                it(`rejects an authenticated caller holding none of [${roles}] with 403`, async () => {
+                itServed(`rejects an authenticated caller holding none of [${roles}] with 403`, async () => {
                     // plainUser carries every role flag = false → holds none.
                     mockSession.mockResolvedValue({ user: plainUser });
                     expect((await call(plan)).status).toBe(403);
                 });
             }
             if (plan.gate === 'certifier') {
-                it('rejects an authenticated non-certifier (and non-admin) with 403', async () => {
+                itServed('rejects an authenticated non-certifier (and non-admin) with 403', async () => {
                     // plainUser holds no toolStatuses and no admin flag.
                     mockSession.mockResolvedValue({ user: plainUser });
                     expect((await call(plan)).status).toBe(403);
                 });
             }
             if (plan.gate === 'program-scoped') {
-                it('rejects an authenticated caller who is not a lead of this program with 403', async () => {
+                itServed('rejects an authenticated caller who is not a lead of this program with 403', async () => {
                     // plainUser leads no program and is not sysadmin/board.
                     mockSession.mockResolvedValue({ user: plainUser });
                     expect((await call(plan)).status).toBe(403);
@@ -203,7 +223,8 @@ describe('Registry route admission gates', () => {
             // scoping for those is covered by policy.contract + route tests.
 
             // ── allowed (sanity) ─────────────────────────────────────────────
-            it('admits an allowed caller (2xx)', async () => {
+            const admitted = plan.method === 'GET' ? '2xx' : 'not 401/403';
+            itServed(`admits an allowed caller (${admitted})`, async () => {
                 if (plan.gate === 'public') {
                     mockSession.mockResolvedValue(null);
                 } else if (plan.gate === 'anyRole') {
@@ -223,7 +244,11 @@ describe('Registry route admission gates', () => {
                     mockSession.mockResolvedValue({ user: plainUser });
                 }
                 const res = await call(plan);
-                expect(res.status).toBeLessThan(400);
+                // A write verb can't be driven with an empty body and no owned
+                // row, so admission is all that's assertable: a 400 from
+                // validation or a 404 from an ownership check both cleared authz.
+                if (plan.method === 'GET') expect(res.status).toBeLessThan(400);
+                else expect([401, 403]).not.toContain(res.status);
             });
         });
     }


### PR DESCRIPTION
Registry entries for the two self-correction routes #1357 adds, landed registry-first per the boundary isolation rule. Boundary files only — no app code.

**Depends on #1394.** Until that merges, `check-route-coverage --strict` hard-errors `orphan-registry` on these entries (the route file does not exist on `main` yet), so this PR's own unit job stays red. #1394 makes that case a warning while keeping a hard error for the genuinely stale case. Merge order: **#1394 → this → #1357**.

## The entries

Both are self-scoped writes on the caller's own `Visit`. Ownership is the admission gate — the route resolves the visit by id and 404s anything that is not the caller's own live row, with no existence oracle — and `their_own` (bound to `Visit.personId`) is the per-row backstop.

- **`PATCH`** edits the times and returns the visit: `envelope: 'visit'`, `returns: ['Visit']`.
- **`DELETE`** tombstones the row and returns `{ success, flagged }` — no model data, so no `returns`.

The grant stops at `their_own:personal`. `arrivedAt`/`departedAt` are the only `personal`-tier columns and the member authored them; `deletedAt`/`deletedById` are `internal` and stay stripped.

Both routes keep `withAuth` and are **not** migrated to `handler()`. Registered-but-unmigrated is an established state here — a dozen existing entries are absent from `migrated-routes.txt` — and it matches the sibling `POST /api/attendance/manual`.

Each field was checked against `security/core.ts` rather than assumed: `Envelope` is `string | null` with no closed vocabulary, so `'visit'` is correct because it matches the actual JSON key the route returns; `returns` is optional and `validateRouteGrants` skips an empty one; the `their_own:personal` token is statically typed, so `tsc` enforces it rather than a runtime parse. `returns: ['Visit']` on PATCH is load-bearing, not decoration — it is what makes `their_own` resolvable, and dropping it would silently remove this entry from `delivery.test.ts` coverage.

`DELETE`'s grant is inert today (it returns no model data). Kept for symmetry with `PATCH` so the two entries don't disagree for a future reader — say the word if you'd rather it carry an empty token list.

## Test change (`tests/security/registryAuthz.integration.test.ts`)

This suite generates its cases from the registry and dynamically imports each route's module, so **without this change the PR would go red on integration** — the module does not exist yet in the register-first state.

Worse, it would not have self-healed when #1357 landed. These are the **first non-GET entries in the registry** (all 14 existing are GET), and the "allowed caller" sanity case drives the endpoint with an empty `Request` against a seeded program id: `PATCH` would hit `req.json()` → 400, `DELETE` would hit the ownership check → 404. Both would fail `expect(res.status).toBeLessThan(400)`. That is a trap for every future write route, not just these two.

Two narrow changes:

- **Route-file-absent** — cases that drive the handler use `it.skip` until the file lands. `call()` is untouched, so a file that exists and then fails to import still throws loudly. The static `has a handled authorize gate` case still runs unconditionally, so a register-first entry with an unhandled `authorize` is still caught.
- **The 2xx sanity, for non-GET only** — asserts the response is **not 401/403** rather than `< 400`. A 400 from validation or a 404 from an ownership check both prove the caller cleared authz, which is what that assertion exists to show. Skipping it outright would have dropped the only "an allowed caller actually gets in" signal for every future write route. GET keeps `< 400` unchanged.

Plus a 3-line meta-guard asserting at least one plan resolves on disk — without it, a wrong `__dirname` offset would skip every case and the whole file would pass green.

## Verification

`tsc --noEmit --pretty false` clean (only the 2 pre-existing `@aws-sdk/client-lambda` errors), `npm run lint` exit 0, `npm test -- --testPathPatterns security` exit 0 (17 suites / 619 tests, including this entry's `delivery` coverage).

**Not run: `registryAuthz.integration.test.ts` itself** — no Postgres available in my environment. It compiles and lints, but neither the skip behaviour nor the reworked assertion has been observed executing; CI's `integration-tests` job is the first real exercise. The path arithmetic *was* verified directly (a throwaway unit test from the same directory resolved `/api/profile` → true and `/api/attendance/manual/[id]` → false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
