### PR TITLE
fix(programs): never pre-check a participant on the enrollment page

### DIFF
--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -31,6 +31,12 @@ function renderPage() {
     return renderWithProviders(<ProgramEnrollmentPage params={params} />);
 }
 
+// Nobody is ever pre-checked, so every enrolling test picks its participants the
+// way a household does. findByLabelText waits out the in-flight household fetch.
+async function selectMember(name: string) {
+    fireEvent.click(await screen.findByLabelText(name));
+}
+
 const household = {
     household: {
         householdMembers: [
@@ -80,6 +86,7 @@ describe("ProgramEnrollmentPage", () => {
         expect(screen.getByText("(Enrolled)")).toBeInTheDocument();
         expect(screen.getByText("(Too young)")).toBeInTheDocument();
 
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
         await waitFor(() =>
             expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Successfully enrolled!" })),
@@ -135,9 +142,11 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.change(screen.getByLabelText(/Emergency contact phone/), { target: { value: "5125550000" } });
         fireEvent.click(screen.getByRole("button", { name: "Save & continue to enroll" }));
 
-        // Back to member-select with the now-enrollable child preselected.
+        // Back to member-select with the now-enrollable child selectable — but
+        // still unchecked, so enrolling them stays a deliberate act.
         await screen.findByText("Which of your household wants to enroll?");
-        expect(await screen.findByLabelText("New Kid")).toBeChecked();
+        expect(await screen.findByLabelText("New Kid")).not.toBeChecked();
+        await selectMember("New Kid");
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
         await waitFor(() =>
             expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Successfully enrolled!" })),
@@ -197,10 +206,12 @@ describe("ProgramEnrollmentPage", () => {
         expect(screen.getByText("(Adult)")).toBeInTheDocument();
         expect(screen.queryByText("(DOB missing)")).not.toBeInTheDocument();
         // PENDING enrollment is a RESUMABLE state, not a dead end: labeled as
-        // payment-pending, preselected, with the enroll button available — NOT
-        // the misleading household-setup affordance.
+        // payment-pending and selectable, with the enroll button available — NOT
+        // the misleading household-setup affordance. Resuming payment is still an
+        // explicit click, so the row is not pre-checked.
         expect(screen.getByText("(Payment pending — select to finish payment)")).toBeInTheDocument();
-        expect(screen.getByLabelText("Only Kid")).toBeChecked();
+        expect(screen.getByLabelText("Only Kid")).not.toBeChecked();
+        expect(screen.getByLabelText("Only Kid")).toBeEnabled();
         expect(screen.queryByRole("button", { name: "Finish setting up your household to enroll" })).not.toBeInTheDocument();
         expect(screen.getByRole("button", { name: "Complete Enrollment" })).toBeInTheDocument();
     });
@@ -219,6 +230,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
         // No chargeable variant → persistent error, and NO enrollment is created.
         await waitFor(() =>
@@ -284,6 +296,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/i }));
         await waitFor(() =>
             expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringMatching(/Requested! Please check your email/) })),
@@ -310,6 +323,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/i }));
         expect(await screen.findByText("Already pending.")).toBeInTheDocument();
     });
@@ -329,6 +343,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/i }));
         expect(await screen.findByText(/failed to alert the Scholarship Review Team/)).toBeInTheDocument();
     });
@@ -341,6 +356,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
+        await selectMember("Kid One");
         global.fetch = jest.fn().mockRejectedValue(new Error("down"));
         fireEvent.click(screen.getByRole("button", { name: /request a scholarship or payment plan/i }));
         await waitFor(() =>
@@ -360,6 +376,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
+        await selectMember("Kid One");
         fireEvent.click(screen.getByLabelText("Too Young"));
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
         await waitFor(() =>
@@ -382,6 +399,7 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Robotics Club");
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
         await waitFor(() =>
             expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Successfully enrolled!" })),
@@ -407,6 +425,7 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Robotics Club");
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
 
         expect(await screen.findByText("Warning: Enrollment rules not met.")).toBeInTheDocument();
@@ -425,6 +444,7 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
+        await selectMember("Kid One");
         global.fetch = jest.fn().mockRejectedValue(new Error("down"));
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
         await waitFor(() =>
@@ -445,6 +465,7 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Robotics Club");
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
 
         expect(await screen.findByText("Redirecting to Shopify for secure payment...")).toBeInTheDocument();
@@ -469,6 +490,7 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Robotics Club");
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
 
         expect(await screen.findByText("Redirecting to Shopify for secure payment...")).toBeInTheDocument();
@@ -513,10 +535,12 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
 
-        // Preselected and selectable, not disabled.
-        expect(screen.getByLabelText("Kid One")).toBeChecked();
+        // Selectable and not disabled — but unchecked, so resuming the checkout
+        // is a deliberate click like any other enrollment.
+        expect(await screen.findByLabelText("Kid One")).not.toBeChecked();
         expect(screen.getByText("(Payment pending — select to finish payment)")).toBeInTheDocument();
 
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
 
         expect(await screen.findByText("Redirecting to Shopify for secure payment...")).toBeInTheDocument();
@@ -538,6 +562,7 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Robotics Club");
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
+        await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
 
         await screen.findByText("Redirecting to Shopify for secure payment...");
@@ -566,8 +591,9 @@ describe("ProgramEnrollmentPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         await screen.findByText("Which of your household wants to enroll?");
         // The household/EC probes that gate the button's disabled state are still
-        // in flight right after the panel appears — wait for it to actually enable
-        // before clicking (avoids a race with populateHousehold's fetches).
+        // in flight right after the panel appears — pick a member, then wait for
+        // it to actually enable (avoids a race with populateHousehold's fetches).
+        await selectMember("Kid One");
         await waitFor(() => expect(screen.getByRole("button", { name: "Pay on Shopify" })).toBeEnabled());
         fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
 
@@ -682,17 +708,37 @@ describe("ProgramEnrollmentPage", () => {
         expect(await screen.findByLabelText("Myself")).toBeInTheDocument();
     });
 
-    it("falls back to the first eligible household member when the signed-in caller isn't a member", async () => {
+    it("pre-checks nobody, so the enroll button starts disabled", async () => {
         setSession({ id: 999 });
-        // Jamie (id 100) is already enrolled in baseProgram, so the fallback must
-        // skip him and preselect the first enrollable member instead of a member
-        // whose POST would fail.
         mockFetchJson({ "/api/household": household, "/api/programs/10": baseProgram({ minAge: null, maxAge: null }) });
         renderPage();
         await screen.findByText("Robotics Club");
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
-        expect(await screen.findByLabelText("Kid One")).toBeChecked();
+        expect(await screen.findByLabelText("Kid One")).not.toBeChecked();
+        expect(screen.getByLabelText("Too Young")).not.toBeChecked();
+        expect(screen.getByRole("button", { name: "Complete Enrollment" })).toBeDisabled();
+        expect(screen.getByText("Check the box next to each person you want to enroll.")).toBeInTheDocument();
+    });
+
+    // An adult clears a program with no upper age limit, so auto-selecting the
+    // signed-in caller would enroll a household lead who came only to pay for a
+    // child — stranding an unpaid PENDING row that holds a capacity seat.
+    it("does not pre-check the signed-in adult on a program with no upper age limit", async () => {
+        setSession({ id: 100 });
+        mockFetchJson({
+            "/api/household": household,
+            "/api/programs/10": baseProgram({ participants: [], minAge: 9, maxAge: null }),
+        });
+        renderPage();
+        await screen.findByText("Robotics Club");
+        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+        await screen.findByText("Which of your household wants to enroll?");
+
+        // Jamie is eligible (no maxAge to fail), but never auto-selected.
+        expect(await screen.findByLabelText("Jamie Guardian")).toBeEnabled();
         expect(screen.getByLabelText("Jamie Guardian")).not.toBeChecked();
+        expect(screen.getByLabelText("Kid One")).not.toBeChecked();
+        expect(screen.getByRole("button", { name: "Complete Enrollment" })).toBeDisabled();
     });
 
     it("shows a generic failure message for non-404 program load errors", async () => {

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -436,6 +436,33 @@ describe("ProgramEnrollmentPage", () => {
         expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Successfully enrolled!" }));
     });
 
+    it("disables the override button once the selection is emptied", async () => {
+        setSession({ id: 5, isSysadmin: true });
+        global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/api/household")) return { ok: true, status: 200, json: async () => household } as Response;
+            if (url.includes("/api/programs/10/participants")) {
+                return { ok: false, status: 403, json: async () => ({ error: "Too young for this program.", requiresOverride: true }) } as Response;
+            }
+            if (url.includes("/api/programs/10")) return { ok: true, status: 200, json: async () => baseProgram({ minAge: null, maxAge: null, leadMentorId: 5 }) } as Response;
+            return { ok: false, status: 404, json: async () => ({}) } as Response;
+        });
+        renderPage();
+        await screen.findByText("Robotics Club");
+        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+        await screen.findByText("Which of your household wants to enroll?");
+        await selectMember("Kid One");
+        fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
+        await screen.findByText("Warning: Enrollment rules not met.");
+
+        // The checkbox group stays live while the override alert is up, so
+        // unchecking must disable the override too — handleEnroll returns on an
+        // empty selection, and a live button would do nothing with no feedback.
+        expect(screen.getByRole("button", { name: "Force Enroll (Override)" })).toBeEnabled();
+        fireEvent.click(screen.getByLabelText("Kid One"));
+        expect(screen.getByRole("button", { name: "Force Enroll (Override)" })).toBeDisabled();
+    });
+
     it("shows a network-error message when enrollment throws", async () => {
         setSession({ id: 101 });
         mockFetchJson({ "/api/household": household, "/api/programs/10": baseProgram({ minAge: null, maxAge: null }) });
@@ -706,6 +733,26 @@ describe("ProgramEnrollmentPage", () => {
         await screen.findByText("Robotics Club");
         fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
         expect(await screen.findByLabelText("Myself")).toBeInTheDocument();
+    });
+
+    it("offers household setup when the solo fallback can't clear an age-gated program", async () => {
+        setSession({ id: 777 });
+        global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/api/programs/10")) return { ok: true, status: 200, json: async () => baseProgram({ participants: [] }) } as Response;
+            return Promise.reject(new Error("down"));
+        });
+        renderPage();
+        await screen.findByText("Robotics Club");
+        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+
+        // The fallback entry has no DOB, so the program's 5-18 range blocks it.
+        // Without the setup affordance the panel is a dead end: the one row is
+        // disabled, and the hint asks for a box that can't be checked.
+        expect(await screen.findByRole("button", { name: "Finish setting up your household to enroll" })).toBeInTheDocument();
+        expect(screen.getByLabelText("Myself")).toBeDisabled();
+        expect(screen.queryByText("Check the box next to each person you want to enroll.")).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Complete Enrollment" })).not.toBeInTheDocument();
     });
 
     it("pre-checks nobody, so the enroll button starts disabled", async () => {

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -158,7 +158,13 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
       }
       setNeedsSetup(!hasEnrollable || !hasValidEmergencyContact);
     } catch {
-      setHouseholdMembers([{ id: currentUserId, name: "Myself", dateOfBirth: null }]);
+      const solo = { id: currentUserId, name: "Myself", dateOfBirth: null };
+      setHouseholdMembers([solo]);
+      // The solo entry carries no DOB, so an age-gated program blocks it and
+      // leaves nothing to check. Offer household setup instead of a panel whose
+      // only row is disabled.
+      const reason = enrollBlock(solo).reason;
+      setNeedsSetup(!(reason === null || reason === 'pending'));
     } finally {
       setLoadingHousehold(false);
     }
@@ -587,7 +593,12 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                     As an Admin or Lead Mentor, you can bypass this restriction. Are you sure you want
                     to force enroll?
                   </Text>
-                  <Button color="yellow" fullWidth onClick={() => handleEnroll(true)}>
+                  <Button
+                    color="yellow"
+                    fullWidth
+                    onClick={() => handleEnroll(true)}
+                    disabled={enrolling || selectedParticipantIds.length === 0 || loadingHousehold}
+                  >
                     Force Enroll (Override)
                   </Button>
                 </Alert>

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -134,19 +134,10 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
         if (data.household?.householdMembers) members = data.household.householdMembers;
       }
       setHouseholdMembers(members);
-      // Default to me if I'm eligible, else the first eligible member, else none —
-      // never auto-select someone who'd fail the age/DOB check.
-      const me = members.find((p) => p.id === currentUserId);
-      const def = me && enrollBlock(me).reason === null
-        ? me.id
-        : members.find((m) => enrollBlock(m).reason === null)?.id;
-      if (def != null) {
-        setSelectedParticipantIds([def]);
-      } else {
-        // Nobody new to enroll — preselect everyone with a payment still owed,
-        // so the page loads ready to finish that checkout in one click.
-        setSelectedParticipantIds(members.filter((m) => enrollBlock(m).reason === 'pending').map((m) => m.id));
-      }
+      // Nobody is pre-checked: enrolling creates a PENDING row and a payment
+      // obligation, so each participant must be an explicit click — including
+      // the account holder, the easiest person to enroll by accident.
+      setSelectedParticipantIds([]);
 
       const hasEnrollable = members.some((m) => { const r = enrollBlock(m).reason; return r === null || r === 'pending'; });
       // Emergency contact isn't in /api/household; probe the process-free intake
@@ -168,7 +159,6 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
       setNeedsSetup(!hasEnrollable || !hasValidEmergencyContact);
     } catch {
       setHouseholdMembers([{ id: currentUserId, name: "Myself", dateOfBirth: null }]);
-      setSelectedParticipantIds([currentUserId]);
     } finally {
       setLoadingHousehold(false);
     }
@@ -191,7 +181,8 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   };
 
   const handleRequestPaymentPlan = async () => {
-    if (!session || selectedParticipantIds.length === 0) return router.push('/');
+    if (!session) return router.push('/');
+    if (selectedParticipantIds.length === 0) return;
 
     setEnrolling(true);
     setMessage("");
@@ -240,10 +231,11 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   };
 
   const handleEnroll = async (override = false) => {
-    if (!session || selectedParticipantIds.length === 0) {
+    if (!session) {
       router.push('/');
       return;
     }
+    if (selectedParticipantIds.length === 0) return;
 
     const isPayingOnShopify = !override && (program?.orgMemberPriceCents || program?.nonOrgMemberPriceCents);
 
@@ -557,6 +549,12 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                 </Stack>
               ) : (
               <Stack align="center">
+                {selectedParticipantIds.length === 0 && (
+                  <Text size="sm" c="dimmed" ta="center">
+                    Check the box next to each person you want to enroll.
+                  </Text>
+                )}
+
                 <Button
                   fullWidth
                   size="md"
@@ -574,6 +572,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                     variant="light"
                     type="button"
                     onClick={handleRequestPaymentPlan}
+                    disabled={enrolling || selectedParticipantIds.length === 0 || loadingHousehold}
                     styles={{ root: { height: 'auto', paddingBlock: 'var(--mantine-spacing-xs)' }, label: { whiteSpace: 'normal' } }}
                   >
                     Request a scholarship or payment plan from the Scholarship Review Team


### PR DESCRIPTION
## The defect

The enrollment member-select pre-selected a participant on load:

```ts
const me = members.find((p) => p.id === currentUserId);
const def = me && enrollBlock(me).reason === null
  ? me.id
  : members.find((m) => enrollBlock(m).reason === null)?.id;
```

Default to me if I'm eligible, else the first eligible member. On a program with **no upper age limit** an adult clears the age check, so a household lead who opened the page to pay for a child arrived with themselves already ticked. One click on **Complete Enrollment** created a second `PENDING` row — holding a capacity seat, against a payment nobody meant to owe.

## The change

Nobody is pre-checked. Enrolling creates a `PENDING` row and a payment obligation, so each participant has to be an explicit click — including the account holder, the easiest person to enroll by accident.

The empty selection is now a real state the page handles rather than bounces out of:

- Both submit handlers `return` on an empty selection instead of `router.push('/')`. Losing the page you were on is a strange answer to "you haven't picked anyone."
- The scholarship button carries the same `disabled` guard as the enroll button — it didn't before, so it was reachable with nothing selected.
- A hint line ("Check the box next to each person you want to enroll.") keeps the disabled state from being a dead end.
- The `catch` fallback no longer selects the current user either.

### Behavior change worth calling out

This also drops the **one-click resume** for members with a payment still owed. Those rows stay selectable and labelled `(Payment pending — select to finish payment)`, but finishing that checkout is now a deliberate click like any other enrollment. That follows from the same rule — no `PENDING` row without a deliberate click — but it wasn't the reported defect, so it's a deliberate call rather than a side effect. Happy to carve out an exception for `reason === 'pending'` if the one-click resume is worth keeping.

## Tests

Every enrolling test now picks its participants the way a household does, through a `selectMember` helper. Two tests replace the obsolete "falls back to the first eligible member" case:

- nothing is pre-checked and **Complete Enrollment** starts disabled;
- the signed-in adult is not pre-checked on a program with `maxAge: null` — the specific shape that produced the incident.

## Verification

- `tsc --noEmit` — clean.
- The page's unit suite, narrowed with `--testPathPatterns` — **35 passed**, 0 failed.
- `eslint` on both changed files — clean.

Not run: the integration and flow tiers (no local DB / dev server). This change is client-only and no other suite renders this page.

### Unrelated pre-existing failure

`src/app/program-ops/programs/[id]/__tests__/page.test.tsx` fails 2 tests with `Exceeded timeout of 5000 ms`. Confirmed pre-existing — reproduced on a clean tree at 8dbe14c1 with these changes stashed, identical `2 failed, 20 passed`. Same mega-test-vs-5s-timeout class as #1388 and #1389. Left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
