### PR TITLE
feat(security): let program leads reach the parents' contact details

### DIFF
--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -265,9 +265,10 @@ model Household {
   /// @sensitivity:public
   name    String
   /// Home address is strict-band intimate data. 'internal' (not 'personal')
-  /// so it sits ABOVE the *:personal grants that deliver emergency contacts to
-  /// program leads (their_program_households:personal) and keyholders
-  /// (keyholders:personal): they get EC, never the family's address. Only
+  /// so it sits ABOVE every household-scoped grant that reaches program leads
+  /// (their_program_households:pii/:personal — emergency contacts plus the
+  /// parents' own contact details) and keyholders (keyholders:personal): they
+  /// get people to call, never the family's address. Only
   /// board/sysadmin (everyones:internal) see it on registered routes; the
   /// household's own view is hand-shaped by the self-household routes.
   /// @sensitivity:internal
@@ -285,10 +286,13 @@ model Household {
   /// volunteer-only household types the note that tells a background-check
   /// reviewer to mark them volunteer. Stays 'pii' (NOT internal like the other
   /// narrative fields) because reviewers hold exactly everyones:pii on
-  /// GET /api/membership/reviews and must read it. GUARD: no household-scoped
-  /// pii token may ever be granted to a lead/keyholder-facing view that
-  /// returns Household rows, or this narrative leaks — leads/keyholders get
-  /// household data via *:personal (EC) only.
+  /// GET /api/membership/reviews and must read it. GUARD: what keeps it away
+  /// from leads/keyholders is that Household binds NO scope but their_households
+  /// (scopeBindings.ts) — a household-scoped token like
+  /// their_program_households:pii resolves to nothing on a Household row, which
+  /// is why GET /api/programs/[id] can grant one for the parents' Person rows
+  /// without exposing this. Never bind Household to a program- or
+  /// keyholder-scoped scope, or the narrative leaks with it.
   /// @sensitivity:pii
   intakeNotes String?
 

--- a/checkin-app/src/security/__tests__/household-lead-program-scope.test.ts
+++ b/checkin-app/src/security/__tests__/household-lead-program-scope.test.ts
@@ -22,6 +22,7 @@
 import { stripValue } from '@/security/stripper';
 import { scopesHeld, type CallerContext } from '@/security/access-resolvers';
 import { getRoute, type Role, type Token } from '@/security/core';
+import { SCOPE_BINDINGS } from '@/security/scopeBindings';
 import '@/security/registry';
 
 function ctx(opts: Partial<CallerContext> = {}): CallerContext {
@@ -137,6 +138,12 @@ describe('Parent field-stripping on GET /api/programs/[id]', () => {
         expect(out.phone).toBeUndefined();
     });
 
+    it('the Household model stays bound to their_households only', () => {
+        // The intakeNotes GUARD in schema.prisma rests on this: a program- or
+        // keyholder-scoped token must never resolve on a Household row.
+        expect(Object.keys(SCOPE_BINDINGS.Household)).toEqual(['their_households']);
+    });
+
     it('the pii grant does NOT reach Household.intakeNotes or the address', () => {
         const tokens = tokensFor(ENDPOINT, 'programLeadMentor');
         const household = { id: 42, name: 'Smith', intakeNotes: 'please call mom first', line1: '1 Main St', city: 'Austin' };
@@ -145,5 +152,59 @@ describe('Parent field-stripping on GET /api/programs/[id]', () => {
         expect(out.intakeNotes).toBeUndefined();
         expect(out.line1).toBeUndefined();
         expect(out.city).toBeUndefined();
+    });
+});
+
+// The route ships `volunteers: { include: { person: true } }` and `leadMentor: true`
+// — full-row Person selects outside the participant bag. A volunteer who is also a
+// household lead of an in-scope household (a parent volunteer) therefore resolves the
+// new binding on merge, with no follow-up. These pin what that delivers.
+describe('Parent volunteers, the shape the route already returns', () => {
+    const parentVolunteerRow = {
+        programId: 100,
+        personId: 500,
+        isCore: false,
+        person: {
+            ...parentRow,
+            dateOfBirth: new Date('1985-04-02'),
+            allergies: 'penicillin',
+            emailSuppressed: false,
+        },
+    };
+
+    it('delivers the parent volunteer contact details to a lead', () => {
+        const tokens = tokensFor(ENDPOINT, 'programLeadMentor');
+        const out = stripValue('ProgramVolunteer', parentVolunteerRow, tokens, lead) as {
+            person: Record<string, unknown>;
+        };
+        expect(out.person.email).toBe('sam@example.com');
+        expect(out.person.phone).toBe('5125551234');
+    });
+
+    it('also delivers their personal tier — the collateral of reusing the scope', () => {
+        // their_program_households:personal is pre-existing on this view; binding
+        // Person to the scope is what makes it resolve here. Narrowing the route's
+        // select is what takes these back off the wire.
+        const tokens = tokensFor(ENDPOINT, 'programLeadMentor');
+        const out = stripValue('ProgramVolunteer', parentVolunteerRow, tokens, lead) as {
+            person: Record<string, unknown>;
+        };
+        expect(out.person.dateOfBirth).toEqual(new Date('1985-04-02'));
+        expect(out.person.allergies).toBe('penicillin');
+        expect(out.person.emailSuppressed).toBe(false);
+    });
+
+    it('a volunteer who is not a household lead keeps public tier only', () => {
+        const tokens = tokensFor(ENDPOINT, 'programLeadMentor');
+        const row = {
+            ...parentVolunteerRow,
+            person: { ...parentVolunteerRow.person, isHouseholdLead: false },
+        };
+        const out = stripValue('ProgramVolunteer', row, tokens, lead) as {
+            person: Record<string, unknown>;
+        };
+        expect(out.person.name).toBe('Sam Smith');
+        expect(out.person.email).toBeUndefined();
+        expect(out.person.allergies).toBeUndefined();
     });
 });

--- a/checkin-app/src/security/__tests__/household-lead-program-scope.test.ts
+++ b/checkin-app/src/security/__tests__/household-lead-program-scope.test.ts
@@ -37,6 +37,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
         ...opts,
     };
 }

--- a/checkin-app/src/security/__tests__/household-lead-program-scope.test.ts
+++ b/checkin-app/src/security/__tests__/household-lead-program-scope.test.ts
@@ -84,13 +84,13 @@ describe('Person.their_program_households scope resolution', () => {
         expect(scopesHeld('Person', outsiderParentRow, lead).has('their_program_households')).toBe(false);
     });
 
-    it('fails closed when the row omits isHouseholdLead', () => {
-        const { isHouseholdLead: _omitted, ...noFlag } = parentRow;
+    it('fails closed when the select omitted isHouseholdLead', () => {
+        const noFlag = { id: 500, householdId: 42, name: 'Sam Smith', phone: '5125551234' };
         expect(scopesHeld('Person', noFlag, lead).has('their_program_households')).toBe(false);
     });
 
-    it('fails closed when the row omits householdId', () => {
-        const { householdId: _omitted, ...noHousehold } = parentRow;
+    it('fails closed when the select omitted householdId', () => {
+        const noHousehold = { id: 500, isHouseholdLead: true, name: 'Sam Smith', phone: '5125551234' };
         expect(scopesHeld('Person', noHousehold, lead).has('their_program_households')).toBe(false);
     });
 

--- a/checkin-app/src/security/__tests__/household-lead-program-scope.test.ts
+++ b/checkin-app/src/security/__tests__/household-lead-program-scope.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Parent (household lead) visibility on GET /api/programs/[id].
+ *
+ * A program lead needs to phone a child's parents, and a parent is not a
+ * program participant — so `their_program_participants` never reaches them.
+ * Person is bound `their_program_households` on (householdId ∈
+ * householdIdsInScopePrograms AND isHouseholdLead), and the registry grants
+ * that view their_program_households:pii, so a lead/core-vol sees the parents'
+ * name/email/phone.
+ *
+ * The conjunct is the policy, so both halves are asserted negative: a sibling
+ * in the same household (no isHouseholdLead) and a household lead in a family
+ * with no child in the program each hold nothing.
+ *
+ * The same pii token must NOT reach Household.intakeNotes — Household binds no
+ * scope but their_households, so it resolves to nothing on a Household row.
+ * Pulls live view tokens from the registry so this tracks future policy edits.
+ */
+import { stripValue } from '@/security/stripper';
+import { scopesHeld, type CallerContext } from '@/security/access-resolvers';
+import { getRoute, type Role, type Token } from '@/security/core';
+import '@/security/registry';
+
+function ctx(opts: Partial<CallerContext> = {}): CallerContext {
+    return {
+        selfId: undefined,
+        householdId: undefined,
+        isKeyholder: false,
+        isKiosk: false,
+        programsLed: new Set(),
+        programsCoreVolIn: new Set(),
+        participantIdsInScopePrograms: new Set(),
+        householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
+        activeVisitorIds: new Set(),
+        ...opts,
+    };
+}
+
+function tokensFor(endpoint: string, role: Role): readonly Token[] {
+    const spec = getRoute(endpoint);
+    if (!spec) throw new Error(`no registry entry for ${endpoint}`);
+    const entry = spec.orderedView.find(([r]) => r === role);
+    if (!entry) throw new Error(`no orderedView entry for ${role} on ${endpoint}`);
+    return entry[1];
+}
+
+const ENDPOINT = 'GET /api/programs/[id]';
+
+// A parent of household 42, as the roster route ships them.
+const parentRow = {
+    id: 500,
+    householdId: 42,
+    isHouseholdLead: true,
+    name: 'Sam Smith',
+    email: 'sam@example.com',
+    phone: '5125551234',
+};
+// Same household, not a lead — the enrolled child's sibling.
+const siblingRow = { ...parentRow, id: 501, isHouseholdLead: false, name: 'Kai Smith' };
+// A lead of a household with no child in this program.
+const outsiderParentRow = { ...parentRow, id: 502, householdId: 77, name: 'Rae Jones' };
+
+// Lead of a program that a child of household 42 is enrolled in.
+const lead = ctx({ selfId: 10, programsLed: new Set([100]), householdIdsInScopePrograms: new Set([42]) });
+const coreVol = ctx({ selfId: 11, programsCoreVolIn: new Set([101]), householdIdsInScopePrograms: new Set([42]) });
+// Unrelated authenticated caller — no programs, different household.
+const outsider = ctx({ selfId: 99, householdId: 999 });
+
+describe('Person.their_program_households scope resolution', () => {
+    it('grants their_program_households on a parent of an in-scope household', () => {
+        expect(scopesHeld('Person', parentRow, lead).has('their_program_households')).toBe(true);
+        expect(scopesHeld('Person', parentRow, coreVol).has('their_program_households')).toBe(true);
+    });
+
+    it('grants nothing on a non-lead member of the same household', () => {
+        expect(scopesHeld('Person', siblingRow, lead).has('their_program_households')).toBe(false);
+    });
+
+    it('grants nothing on a household lead outside the program', () => {
+        expect(scopesHeld('Person', outsiderParentRow, lead).has('their_program_households')).toBe(false);
+    });
+
+    it('fails closed when the row omits isHouseholdLead', () => {
+        const { isHouseholdLead: _omitted, ...noFlag } = parentRow;
+        expect(scopesHeld('Person', noFlag, lead).has('their_program_households')).toBe(false);
+    });
+
+    it('fails closed when the row omits householdId', () => {
+        const { householdId: _omitted, ...noHousehold } = parentRow;
+        expect(scopesHeld('Person', noHousehold, lead).has('their_program_households')).toBe(false);
+    });
+
+    it('grants an unrelated caller only everyones', () => {
+        expect([...scopesHeld('Person', parentRow, outsider)]).toEqual(['everyones']);
+    });
+});
+
+describe('Parent field-stripping on GET /api/programs/[id]', () => {
+    it('a program lead sees the parent name/email/phone', () => {
+        const tokens = tokensFor(ENDPOINT, 'programLeadMentor');
+        const out = stripValue('Person', parentRow, tokens, lead) as Record<string, unknown>;
+        expect(out.name).toBe('Sam Smith');
+        expect(out.email).toBe('sam@example.com');
+        expect(out.phone).toBe('5125551234');
+    });
+
+    it('a core volunteer sees them too', () => {
+        const tokens = tokensFor(ENDPOINT, 'programCoreVolunteer');
+        const out = stripValue('Person', parentRow, tokens, coreVol) as Record<string, unknown>;
+        expect(out.phone).toBe('5125551234');
+    });
+
+    it('a lead sees no contact details for a non-lead household member', () => {
+        const tokens = tokensFor(ENDPOINT, 'programLeadMentor');
+        const out = stripValue('Person', siblingRow, tokens, lead) as Record<string, unknown>;
+        expect(out.name).toBe('Kai Smith'); // public tier survives
+        expect(out.email).toBeUndefined();
+        expect(out.phone).toBeUndefined();
+    });
+
+    it('a lead sees no contact details for a parent outside their programs', () => {
+        const tokens = tokensFor(ENDPOINT, 'programLeadMentor');
+        const out = stripValue('Person', outsiderParentRow, tokens, lead) as Record<string, unknown>;
+        expect(out.email).toBeUndefined();
+        expect(out.phone).toBeUndefined();
+    });
+
+    it('an unrelated authenticated caller sees no contact details', () => {
+        const tokens = tokensFor(ENDPOINT, 'authenticated');
+        const out = stripValue('Person', parentRow, tokens, outsider) as Record<string, unknown>;
+        expect(out.id).toBe(500);
+        expect(out.email).toBeUndefined();
+        expect(out.phone).toBeUndefined();
+    });
+
+    it('the pii grant does NOT reach Household.intakeNotes or the address', () => {
+        const tokens = tokensFor(ENDPOINT, 'programLeadMentor');
+        const household = { id: 42, name: 'Smith', intakeNotes: 'please call mom first', line1: '1 Main St', city: 'Austin' };
+        const out = stripValue('Household', household, tokens, lead) as Record<string, unknown>;
+        expect(out.name).toBe('Smith');
+        expect(out.intakeNotes).toBeUndefined();
+        expect(out.line1).toBeUndefined();
+        expect(out.city).toBeUndefined();
+    });
+});

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -118,11 +118,16 @@ defineRoute({
         // rows, so the pii grant reaches the two adults a lead would call and no
         // one else — siblings and other household members hold nothing.
         //
-        // FINDING for the CODEOWNERS reviewer: the pre-existing :personal token now
-        // also resolves on those same parent rows, so Person.dateOfBirth/allergies/
-        // notificationSettings/emailSuppressed become deliverable for a parent. The
-        // route's select is what keeps them off the wire (id/householdId/name/email/
-        // phone/isHouseholdLead only) — this view no longer strips them.
+        // FINDING for the CODEOWNERS reviewer: this widens live traffic. The route
+        // already returns full-row Person selects outside the participant bag —
+        // `volunteers.include.person` and `leadMentor` — so a lead/core-vol now
+        // receives, for any program volunteer or lead mentor who is also a household
+        // lead of an in-scope household (a parent volunteer, the common case):
+        // email/phone from this pii grant, plus dateOfBirth/allergies/
+        // notificationSettings/emailSuppressed from the pre-existing :personal token,
+        // which now resolves on those rows too. Those rows held `everyones` only
+        // before. Narrowing the two selects to what the roster renders is a route
+        // change, not a boundary one.
         //
         // Still out of reach: the family's home address (Household.line1..postalCode
         // are 'internal', above every token here) and Household.intakeNotes ('pii',

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -112,17 +112,30 @@ defineRoute({
     orderedView: [
         ['isSysadmin',             ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
         ['isBoardMember',          ['everyones:pii', 'everyones:personal', 'everyones:internal', 'member', 'public']],
-        // their_program_households:personal delivers the household band leads
-        // operationally need — emergency contacts (personal). It deliberately
-        // does NOT reach the family's home address or intake notes: address is
-        // 'internal' and intakeNotes is 'pii', both outside a household-scoped
-        // personal grant. EC yes, address no.
+        // their_program_households delivers the household band leads operationally
+        // need: the family's emergency contacts (personal) and the parents' own
+        // contact details (pii). Person binds this scope ONLY on isHouseholdLead
+        // rows, so the pii grant reaches the two adults a lead would call and no
+        // one else — siblings and other household members hold nothing.
+        //
+        // FINDING for the CODEOWNERS reviewer: the pre-existing :personal token now
+        // also resolves on those same parent rows, so Person.dateOfBirth/allergies/
+        // notificationSettings/emailSuppressed become deliverable for a parent. The
+        // route's select is what keeps them off the wire (id/householdId/name/email/
+        // phone/isHouseholdLead only) — this view no longer strips them.
+        //
+        // Still out of reach: the family's home address (Household.line1..postalCode
+        // are 'internal', above every token here) and Household.intakeNotes ('pii',
+        // but Household binds no scope beyond their_households, so a
+        // their_program_households token resolves to nothing on a Household row).
         ['programLeadMentor',    ['their_program_participants:pii',
                                   'their_program_participants:personal',
+                                  'their_program_households:pii',
                                   'their_program_households:personal',
                                   'member', 'public']],
         ['programCoreVolunteer', ['their_program_participants:pii',
                                   'their_program_participants:personal',
+                                  'their_program_households:pii',
                                   'their_program_households:personal',
                                   'member', 'public']],
         ['authenticated',        ['their_own:pii', 'their_own:personal', 'member', 'public']],

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -42,6 +42,9 @@ export const SCOPE_BINDINGS = {
         // would actually call are reachable. Requires the row to carry BOTH
         // householdId and isHouseholdLead; either one unselected fails closed
         // (isTrue is strict === true, and inCtx rejects a non-number).
+        // ctx.householdIdsInScopePrograms is the union across ALL programs the caller
+        // leads/core-vols, so on program A's page a lead of both A and B also resolves
+        // this on a row whose household's child is enrolled in B, not A.
         their_program_households: {
             all: [
                 { field: 'householdId', inCtx: 'householdIdsInScopePrograms' },

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -35,6 +35,19 @@ export const SCOPE_BINDINGS = {
         their_own: { field: 'id', eqCtx: 'selfId' },
         their_households: { field: 'householdId', eqCtx: 'householdId' },
         their_program_participants: { field: 'id', inCtx: 'participantIdsInScopePrograms' },
+        // The PARENTS of the children a program lead/core-vol oversees: household
+        // leads (isHouseholdLead) of ctx.householdIdsInScopePrograms. The
+        // isHouseholdLead conjunct IS the policy — a sibling or any other member of
+        // an in-scope household holds nothing here, so only the two adults a lead
+        // would actually call are reachable. Requires the row to carry BOTH
+        // householdId and isHouseholdLead; either one unselected fails closed
+        // (isTrue is strict === true, and inCtx rejects a non-number).
+        their_program_households: {
+            all: [
+                { field: 'householdId', inCtx: 'householdIdsInScopePrograms' },
+                { field: 'isHouseholdLead', isTrue: true },
+            ],
+        },
         // Global front-desk grant, unconditional per row (mirrors TrustedAdult).
         // Only GET /api/safety/board-contacts grants keyholders:* on Person, and
         // that route returns board members only. Any future Person view granting

--- a/checkin-app/src/security/scopes.ts
+++ b/checkin-app/src/security/scopes.ts
@@ -44,6 +44,7 @@ export type ScopePredicate = (row: Record<string, unknown>, ctx: CallerContext) 
  *   { field, inCtx } — ctx[set].has(row[field])     (array = OR over sets)
  *   { flag }         — ctx[flag] === true
  *   { field, isNull }— row[field] == null
+ *   { field, isTrue }— row[field] === true
  *   { all }          — every sub-match (AND)
  *   { custom }       — escape hatch; SKIPS validation, must be logged
  */
@@ -52,6 +53,7 @@ export type Match =
     | { field: string; inCtx: CtxSet | readonly CtxSet[] }
     | { flag: CtxFlag }
     | { field: string; isNull: true }
+    | { field: string; isTrue: true }
     | { all: readonly Match[] }
     | { custom: ScopePredicate };
 
@@ -68,6 +70,8 @@ export type ScopeBindings = Record<string, Partial<Record<Scope, Match>>>;
 export function evalMatch(m: Match, row: Record<string, unknown>, ctx: CallerContext): boolean {
     if ('flag' in m) return ctx[m.flag] === true;
     if ('isNull' in m) return row[m.field] == null;
+    // Strict === true: an unselected column is `undefined`, which must not match.
+    if ('isTrue' in m) return row[m.field] === true;
     if ('all' in m) return m.all.every(s => evalMatch(s, row, ctx));
     if ('custom' in m) return m.custom(row, ctx);
     if ('eqCtx' in m) {

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -232,16 +232,20 @@ const ROWS: Array<{ label: string; row: unknown }> = [
         row: { id: 5, householdId: 2, participantId: 5, personId: 5, programId: 100, eventId: 200, userId: 5, actorId: 5, departedAt: null },
     },
     {
-        label: 'household co-member (hh 2)',
-        row: { id: 6, householdId: 2, participantId: 6, personId: 6, programId: 100, eventId: 200, userId: 6, actorId: 6, departedAt: null },
+        // isHouseholdLead exercises Person.their_program_households (hh 2 is in
+        // the lead's/core-vol's scope). Row id 9 below is the same household
+        // WITHOUT the flag, and row id 7 carries the flag in an out-of-scope
+        // household — together the positive and both negatives.
+        label: 'household co-member + household lead (hh 2)',
+        row: { id: 6, householdId: 2, isHouseholdLead: true, participantId: 6, personId: 6, programId: 100, eventId: 200, userId: 6, actorId: 6, departedAt: null },
     },
     {
         label: 'program participant / coreVol prog / active visitor',
         row: { id: 9, householdId: 2, participantId: 9, personId: 9, programId: 101, eventId: 201, userId: 9, actorId: 9, departedAt: null },
     },
     {
-        label: "another's / out-of-program / departed",
-        row: { id: 7, householdId: 99, participantId: 7, personId: 7, programId: 88, eventId: 88, userId: 7, actorId: 7, departedAt: new Date() },
+        label: "another's / out-of-program / departed / household lead",
+        row: { id: 7, householdId: 99, isHouseholdLead: true, participantId: 7, personId: 7, programId: 88, eventId: 88, userId: 7, actorId: 7, departedAt: new Date() },
     },
     {
         label: "lead's own program (Program row id 100)",
@@ -296,6 +300,15 @@ function eq(a: Set<string>, b: Set<string>): boolean {
  * for leads). On a Visit row whose personId is in that roster, a lead therefore
  * holds 'led_households' where the snapshot did not. That is the third
  * expected diff.
+ *
+ * Person.their_program_households: the switch's Person case had no household-
+ * scoped program grant, so a lead held nothing on a parent's row. Person was
+ * later bound `their_program_households` on (householdId ∈
+ * householdIdsInScopePrograms AND isHouseholdLead), so GET /api/programs/[id]
+ * can hand a program lead the parents' phone/email on the roster. On a
+ * household-lead row in an in-scope household the resolver therefore adds
+ * their_program_households where the snapshot did not. That is the fourth
+ * expected diff.
  */
 function expectedFromSnapshot(
     model: string,
@@ -323,6 +336,16 @@ function expectedFromSnapshot(
         callerCtx.ledHouseholdMemberIds.has(row.personId)
     ) {
         expected.add('led_households');
+    }
+    if (
+        model === 'Person' &&
+        row &&
+        typeof row === 'object' &&
+        row.isHouseholdLead === true &&
+        typeof row.householdId === 'number' &&
+        callerCtx.householdIdsInScopePrograms.has(row.householdId)
+    ) {
+        expected.add('their_program_households');
     }
     return expected;
 }


### PR DESCRIPTION
## What & why

The Roster tab of `/program-ops/programs/[id]` shows a child's emergency
contacts but not their parents' phone numbers — #1400. A parent is not a
program participant, so `their_program_participants` never reaches them, and
`Person` had no household-scoped binding at all: a lead holds only `everyones`
on a parent's row, and `Person.phone` (`pii`) strips to `undefined` no matter
what the route selects. Delivering it is a policy widening, so it ships alone
and ahead of the feature, per the registry-first flow.

**This PR widens live traffic on merge** — see the FINDING below. The follow-up
adds the household-members select + the roster UI, but the widening does not
wait for it.

## The grant

`Person.their_program_households`, bound as a conjunction:

```ts
their_program_households: {
    all: [
        { field: 'householdId', inCtx: 'householdIdsInScopePrograms' },
        { field: 'isHouseholdLead', isTrue: true },
    ],
},
```

granted at `pii` on the `programLeadMentor` / `programCoreVolunteer` views of
`GET /api/programs/[id]`.

The `isHouseholdLead` conjunct **is** the policy: only the (at most two) adults
modeled as the family's leads are reachable — siblings and other members of an
in-scope household hold nothing. `isTrue` is a new `Match` kind in the scope
grammar, strict `=== true`, so a row that failed to select the column fails
closed. It carries a `field:`, so `validateBindings`' field-existence check
covers it like every other matcher.

## FINDING for the CODEOWNERS reviewer — what reaches a lead the moment this merges

`GET /api/programs/[id]` already returns **full-row** `Person` selects outside
the participant bag:

- `checkin-app/src/app/api/programs/[id]/route.ts:56` — `volunteers: { where: { person: LIVE_PERSON }, include: { person: true } }`
- `checkin-app/src/app/api/programs/[id]/route.ts:78` — `leadMentor: true`

`stripValue` recurses both as model `Person` and resolves scopes per row, so for
**any program volunteer or lead mentor who is also a household lead of a
household with a child in one of the caller's programs** — a parent volunteer,
the common case — a lead / core-vol now receives:

- `email`, `phone` — `pii`, the grant this PR adds;
- `dateOfBirth`, `allergies`, `notificationSettings`, `emailSuppressed` —
  `personal`, via the **pre-existing** `their_program_households:personal`
  token, which now resolves on those same rows because `Person` is bound to the
  scope for the first time.

Those rows resolved `everyones` only before, i.e. public tier. Nothing gates
this behind the follow-up.

Two ways to take it back to inert, both deliberately **not** taken here:

1. A route PR first narrowing `volunteers.include.person` / `leadMentor` to the
   fields the roster renders. That is a route change, not a boundary one, so it
   cannot ship in this PR under the isolation rule.
2. A purpose-built `their_program_household_leads` scope granted only at `pii`.
   That removes the personal-tier collateral, but parent-volunteer email/phone
   still ships on merge — it shrinks the finding, it does not eliminate it — at
   the cost of a new token in the grammar. Reusing the existing scope name was
   the chosen trade-off.

**Cross-program bleed.** `householdIdsInScopePrograms` is the union across *all*
programs the caller leads/core-vols, while the row set is "any Person in this
program's bag". On program A's page, a lead of both A and B resolves `pii` on a
volunteer of A who leads a household with a child in **B**. Pre-existing scope
semantics, but previously unreachable on this route — EC rows in this bag only
ever came from this program's own households. Noted in the binding comment.

## What this deliberately does NOT widen

`fieldVisible` (core.ts) matches tiers **exactly** — there is no lattice — so a
`pii` token reaches `pii` fields only, on rows where the scope resolves:

- **`Household.intakeNotes` (pii)** — unreachable. `Household` binds no scope
  but `their_households`, so a `their_program_households` token resolves to
  nothing on a Household row. The schema GUARD comment previously said "no
  household-scoped pii token may ever be granted to a lead-facing view that
  returns Household rows"; this PR rewrites it to state the invariant that is
  actually load-bearing — *never bind Household to a program- or
  keyholder-scoped scope* — since the old blanket wording would forbid a change
  that provably does not leak.
- **`Household.line1..postalCode`** — unreachable. `internal`, and no view here
  holds an internal token. Comment updated to stay accurate now that leads also
  get parent contacts.
- **`GET /api/trusted-adults/operational`**, the only other route granting this
  scope, selects `household: { select: { id, name } }` and no Person rows —
  its views are unchanged. `GET /api/safety/trusted-adults` returns Person but
  grants `everyones:*` only.

## Tests

- `src/security/__tests__/household-lead-program-scope.test.ts` (new) — scope
  resolution (parent yes; non-lead same household no; lead of an out-of-scope
  household no; missing `isHouseholdLead` or `householdId` fails closed) and
  field-stripping against the **live registry tokens**, including a positive
  delivery assertion (lead actually receives name/email/phone) and a negative
  that the pii grant does not reach `intakeNotes` or the address.
  Also covers the **`ProgramVolunteer.person` row shape the route already
  ships** — the FINDING above is pinned by a test, not just described: one
  assertion for the pii delivery, one for the personal-tier collateral
  (`dateOfBirth`/`allergies`/`emailSuppressed`), one negative for a volunteer
  who is not a household lead. Plus
  `Object.keys(SCOPE_BINDINGS.Household) === ['their_households']`, which makes
  the rewritten `intakeNotes` GUARD enforceable rather than prose-only.
- `tests/security/scopeBindingsEquivalence.test.ts` — the new binding is
  encoded as an explicit, documented delta in `expectedFromSnapshot` (the
  third), never by editing the frozen oracle. Fixture rows gained
  `isHouseholdLead` so the binding is actually exercised: one positive plus
  both negatives.

`registryAuthz.integration.test.ts` still has no volunteer-row coverage; the
unit-level pins above stand in for it.

`npx tsc --noEmit` clean; the security-scoped jest run is 634/634 green
(18 suites). The full unit suite has 8 failures across 4 page suites, all
5s-timeout flakes under load — 3 pass in isolation and the 4th
(`ProgramDetailsPage > edits general-tab fields and saves settings
successfully`) fails identically on clean `main` at 8dbe14c1.

Design for #1400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
