### PR TITLE
refactor(fees): drop all app/test reads of the dead Fee/FeePayment tables

### DIFF
--- a/checkin-app/docs/designs/354_KILL_FEE_FEEPAYMENT.md
+++ b/checkin-app/docs/designs/354_KILL_FEE_FEEPAYMENT.md
@@ -104,9 +104,16 @@ is a grant list; nothing asserts it equals the actual include, and `Fee` is not 
 | File | Change |
 |---|---|
 | `src/security/registry.ts:43` | drop `'Fee'` from `returns`; fix the `fees (Fee)` comment (line 41) |
-| `src/security/scopeBindings.ts:92-95` | remove the `FeePayment` binding; update the `Fee`/`RSVP` explainer comments (18-23, 74-77) |
 
-Both are now-unused grants → inert removals. No app code in this PR.
+A now-unused grant → inert removal. No app code in this PR.
+
+The `FeePayment` binding (`src/security/scopeBindings.ts:92-95`) **cannot** move here: while
+`FeePayment` is still in `schema.prisma`, its `personal` fields make it sensitive-and-scopable, so
+`validateBindings` coverage rule (b) (`scopes.ts`) errors "silent over-restriction" the moment the
+binding disappears. `OPT_OUT_PENDING_ROUTE` is a work queue for routes not built yet, not a
+graveyard for dying models. The binding goes in Release 2, where the model leaves `classifications`
+in the same PR (keeping it past that point flips the failure to rule (a), "binding for unknown
+model").
 
 Gate each PR: full `jest` (per `jest-run` skill), not just `tsc`. Watch the merge integration test (1a)
 and `routeAuthDrift` (1b).
@@ -118,6 +125,10 @@ and `routeAuthDrift` (1b).
 | `prisma/schema.prisma:893` | remove `fees Fee[]` on `Program` |
 | `prisma/schema.prisma:167` | remove `feePayments FeePayment[]` on `Person` |
 | `prisma/schema.prisma:956-992` | remove `model Fee` + `model FeePayment` |
+| `src/security/scopeBindings.ts:92-95` | remove the `FeePayment` binding (must land with the schema removal — see Release 1b); update the `Fee`/`RSVP` explainer comments (18-23, 74-77) |
+| `tests/security/scopeBindingsEquivalence.test.ts` | drop the `FeePayment` case + the unbound-model `'Fee'` entry; binding count 18 → 17 |
+| `tests/security/ctxNeeds.test.ts:194` | drop `'Fee'` from `MODELS` |
+| `src/__tests__/livePersonDriftGuard.test.ts:38,211` | drop `feePayment` from the person-scoped model regex |
 | `prisma/migrations/<new>/migration.sql` | the DROP below |
 | `src/security/generated/classifications.ts` | **regenerated** by `prisma generate` (schema-driven, not hand-edited); `check-route-coverage.ts` guards freshness. If `security-boundary-isolation.yml` flags `src/security/generated/`, split this regen into its own boundary PR |
 

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -49,7 +49,6 @@ describe("Merge Participants API", () => {
     // generically in afterEach so each test doesn't hand-roll teardown ordering.
     let extraPersonIds: number[];
     let createdProgramId: number | undefined;
-    let createdFeeId: number | undefined;
     let createdToolId: number | undefined;
     let createdEventId: number | undefined;
     let createdCorporationId: number | undefined;
@@ -80,7 +79,6 @@ describe("Merge Participants API", () => {
 
         extraPersonIds = [];
         createdProgramId = undefined;
-        createdFeeId = undefined;
         createdToolId = undefined;
         createdEventId = undefined;
         createdCorporationId = undefined;
@@ -97,7 +95,6 @@ describe("Merge Participants API", () => {
         await prisma.trustedAdult.deleteMany({ where: { householdId } });
         await prisma.toolStatus.deleteMany({ where: { personId: { in: personIds } } });
         await prisma.rSVP.deleteMany({ where: { personId: { in: personIds } } });
-        await prisma.feePayment.deleteMany({ where: { personId: { in: personIds } } });
         await prisma.visit.deleteMany({ where: { personId: { in: personIds } } });
         await prisma.programParticipant.deleteMany({ where: { personId: { in: personIds } } });
         await prisma.programVolunteer.deleteMany({ where: { personId: { in: personIds } } });
@@ -107,7 +104,6 @@ describe("Merge Participants API", () => {
         await prisma.person.deleteMany({ where: { id: { in: personIds } } });
 
         if (createdEventId) await prisma.event.deleteMany({ where: { id: createdEventId } });
-        if (createdFeeId) await prisma.fee.deleteMany({ where: { id: createdFeeId } });
         if (createdToolId) await prisma.tool.deleteMany({ where: { id: createdToolId } });
         if (createdProgramId) await prisma.program.deleteMany({ where: { id: createdProgramId } });
         if (createdCorporationId) await prisma.corporation.deleteMany({ where: { id: createdCorporationId } });
@@ -211,10 +207,6 @@ describe("Merge Participants API", () => {
     it("keeps BOTH rows on every join-table/loop-guarded collision — zero deletes", async () => {
         const program = await prisma.program.create({ data: { name: "Merge Conflict Program" } });
         createdProgramId = program.id;
-        const fee = await prisma.fee.create({
-            data: { programId: program.id, name: "Conflict Fee", nonOrgMemberPriceCents: 5000, orgMemberPriceCents: 2500 },
-        });
-        createdFeeId = fee.id;
         const tool = await prisma.tool.create({ data: { name: "Conflict Tool" } });
         createdToolId = tool.id;
         const event = await prisma.event.create({
@@ -231,8 +223,6 @@ describe("Merge Participants API", () => {
         await prisma.programParticipant.create({ data: { programId: program.id, personId: pMergeId } });
         await prisma.programVolunteer.create({ data: { programId: program.id, personId: pKeepId } });
         await prisma.programVolunteer.create({ data: { programId: program.id, personId: pMergeId } });
-        await prisma.feePayment.create({ data: { feeId: fee.id, personId: pKeepId } });
-        await prisma.feePayment.create({ data: { feeId: fee.id, personId: pMergeId } });
         await prisma.toolStatus.create({ data: { toolId: tool.id, personId: pKeepId, level: "BASIC" } });
         await prisma.toolStatus.create({ data: { toolId: tool.id, personId: pMergeId, level: "MAY_CERTIFY_OTHERS" } });
         await prisma.rSVP.create({ data: { eventId: event.id, personId: pKeepId, status: "ATTENDING" } });
@@ -250,7 +240,6 @@ describe("Merge Participants API", () => {
         // Every collision retained BOTH rows — zero deletes.
         expect(await prisma.programParticipant.count({ where: { programId: program.id } })).toBe(2);
         expect(await prisma.programVolunteer.count({ where: { programId: program.id } })).toBe(2);
-        expect(await prisma.feePayment.count({ where: { feeId: fee.id } })).toBe(2);
         expect(await prisma.toolStatus.count({ where: { toolId: tool.id } })).toBe(2);
         expect(await prisma.rSVP.count({ where: { eventId: event.id } })).toBe(2);
         expect(await prisma.corporationLead.count({ where: { corporationId: corp.id } })).toBe(2);
@@ -276,13 +265,9 @@ describe("Merge Participants API", () => {
     });
 
     // Matrix 2: non-collision move — the row relinks to the keeper, not duplicated.
-    it("moves a tombstone-only enrollment/fee/tool/rsvp to the keeper (no collision)", async () => {
+    it("moves a tombstone-only enrollment/tool/rsvp to the keeper (no collision)", async () => {
         const program = await prisma.program.create({ data: { name: "Non-Collision Program" } });
         createdProgramId = program.id;
-        const fee = await prisma.fee.create({
-            data: { programId: program.id, name: "Fee", nonOrgMemberPriceCents: 1000, orgMemberPriceCents: 500 },
-        });
-        createdFeeId = fee.id;
         const tool = await prisma.tool.create({ data: { name: "Tool" } });
         createdToolId = tool.id;
         const event = await prisma.event.create({
@@ -292,7 +277,6 @@ describe("Merge Participants API", () => {
 
         // Only the MERGE side has these — nothing for the keeper to collide with.
         await prisma.programParticipant.create({ data: { programId: program.id, personId: pMergeId } });
-        await prisma.feePayment.create({ data: { feeId: fee.id, personId: pMergeId } });
         await prisma.toolStatus.create({ data: { toolId: tool.id, personId: pMergeId, level: "CERTIFIED" } });
         await prisma.rSVP.create({ data: { eventId: event.id, personId: pMergeId, status: "MAYBE" } });
 
@@ -301,7 +285,6 @@ describe("Merge Participants API", () => {
 
         expect(await prisma.programParticipant.findUnique({ where: { programId_personId: { programId: program.id, personId: pKeepId } } })).not.toBeNull();
         expect(await prisma.programParticipant.findUnique({ where: { programId_personId: { programId: program.id, personId: pMergeId } } })).toBeNull();
-        expect((await prisma.feePayment.findUnique({ where: { feeId_personId: { feeId: fee.id, personId: pKeepId } } }))).not.toBeNull();
         expect((await prisma.toolStatus.findUnique({ where: { personId_toolId: { personId: pKeepId, toolId: tool.id } } }))?.level).toBe("CERTIFIED");
         expect((await prisma.rSVP.findUnique({ where: { eventId_personId: { eventId: event.id, personId: pKeepId } } }))?.status).toBe("MAYBE");
     });

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -120,7 +120,6 @@ export const POST = withAuth(
                     programVolunteers: true,
                     rsvps: true,
                     toolStatuses: true,
-                    feePayments: true,
                     bgAttestations: true,
                     corporationLeads: true,
                     corporationMembers: true,
@@ -134,7 +133,6 @@ export const POST = withAuth(
                     programVolunteers: true,
                     rsvps: true,
                     toolStatuses: true,
-                    feePayments: true,
                     bgAttestations: true,
                     corporationLeads: true,
                     corporationMembers: true,
@@ -234,7 +232,6 @@ export const POST = withAuth(
                     programParticipants: { migrated: 0, left: 0 },
                     programVolunteers: { migrated: 0, left: 0 },
                     rsvps: { migrated: 0, left: 0 },
-                    feePayments: { migrated: 0, left: 0 },
                     toolStatuses: { migrated: 0, left: 0 },
                     bgAttestations: { migrated: 0, left: 0 },
                     corporationLeads: { migrated: 0, left: 0 },
@@ -253,7 +250,7 @@ export const POST = withAuth(
                     data: { personId: keepId }
                 })).count;
 
-                // 4. Move the 5 join tables — no deletes. Migrate the non-colliding row;
+                // 4. Move the 4 join tables — no deletes. Migrate the non-colliding row;
                 // leave the colliding row on the tombstone (both survive; §3's LIVE_PERSON
                 // filter excludes the tombstone's from every count/roster).
                 for (const pp of mergeParticipant.programParticipants) {
@@ -289,18 +286,6 @@ export const POST = withAuth(
                         moved.rsvps.migrated++;
                     } else {
                         moved.rsvps.left++;
-                    }
-                }
-
-                for (const fee of mergeParticipant.feePayments) {
-                    if (!keepParticipant.feePayments.find(k => k.feeId === fee.feeId)) {
-                        await tx.feePayment.update({
-                            where: { feeId_personId: { feeId: fee.feeId, personId: mergeId } },
-                            data: { personId: keepId }
-                        });
-                        moved.feePayments.migrated++;
-                    } else {
-                        moved.feePayments.left++;
                     }
                 }
 

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -75,7 +75,6 @@ const getProgram = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
                 },
             },
             events: { orderBy: { startAt: 'asc' } },
-            fees: true,
             leadMentor: true,
             _count: { select: { participants: { where: { person: LIVE_PERSON } }, volunteers: { where: { person: LIVE_PERSON } } } },
         },

--- a/checkin-app/src/app/api/programs/price-cents.test.ts
+++ b/checkin-app/src/app/api/programs/price-cents.test.ts
@@ -1,8 +1,8 @@
 import { dollarsToCents, dollarsToCentsOrNull, formatCents } from "@inventory/money";
 
 // Guards the dollars→cents store / cents→dollars display round-trip used by the
-// Program + Fee price API boundary. Cents must not truncate $25.99 → $25.
-describe("program/fee price cents round-trip", () => {
+// Program price API boundary. Cents must not truncate $25.99 → $25.
+describe("program price cents round-trip", () => {
   it("stores $25.99 as cents and renders it back without truncation", () => {
     const cents = dollarsToCentsOrNull("25.99");
     expect(cents).toBe(2599);
@@ -15,7 +15,7 @@ describe("program/fee price cents round-trip", () => {
     expect(formatCents(null)).toBe("—");
   });
 
-  it("required Fee price round-trips through cents", () => {
+  it("required program price round-trips through cents", () => {
     expect(formatCents(dollarsToCents("40.00"))).toBe("$40.00");
   });
 });

--- a/checkin-app/src/lib/dev/__tests__/seed-helpers.integration.test.ts
+++ b/checkin-app/src/lib/dev/__tests__/seed-helpers.integration.test.ts
@@ -63,15 +63,14 @@ describe("dev seed-helpers (integration)", () => {
         expect(household?.householdMembers.length).toBe(3);
     });
 
-    it("+ Program adds a program with a fee and two participants", async () => {
+    it("+ Program adds a program with two participants", async () => {
         const summary = await createProgram(prisma);
         expect(summary).toMatch(/Test Program/);
         const program = await prisma.program.findFirst({
             where: { name: { startsWith: "Test Program" } },
-            include: { fees: true, participants: true },
+            include: { participants: true },
             orderBy: { id: "desc" },
         });
-        expect(program?.fees.length).toBe(1);
         expect(program?.participants.length).toBe(2);
     });
 

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -302,7 +302,7 @@ export async function createFamily(prisma: Db): Promise<string> {
     return `Created household "Test Family ${tag}" (lead + partner + 1 youth)`;
 }
 
-/** + Program — a program with a materials fee and a couple of active participants. */
+/** + Program — a program with a couple of active participants. */
 export async function createProgram(prisma: Db): Promise<string> {
     const tag = uid();
     const startAt = new Date();
@@ -318,17 +318,13 @@ export async function createProgram(prisma: Db): Promise<string> {
             maxParticipants: 20,
         },
     });
-    await prisma.fee.create({
-        // Integer cents: $25.00 member / $40.00 non-member.
-        data: { programId: program.id, name: "Materials", orgMemberPriceCents: 2500, nonOrgMemberPriceCents: 4000 },
-    });
     const enrollees = await prisma.person.findMany({ take: 2, orderBy: { id: "asc" } });
     for (const p of enrollees) {
         await prisma.programParticipant.create({
             data: { programId: program.id, personId: p.id, status: "ACTIVE" },
         });
     }
-    return `Created program "Test Program ${tag}" with a fee and ${enrollees.length} participants`;
+    return `Created program "Test Program ${tag}" with ${enrollees.length} participants`;
 }
 
 /** + Event — an event (tied to the latest program when one exists) with a few RSVPs. */


### PR DESCRIPTION
## What

**Release 1a** of the FR7 kill plan ([checkin-app/docs/designs/354_KILL_FEE_FEEPAYMENT.md](https://github.com/innovationtreehouse/checkin/blob/main/checkin-app/docs/designs/354_KILL_FEE_FEEPAYMENT.md), merged in #1337). Removes every app/test **read** of `Fee`/`FeePayment`. Schema and tables are untouched.

| File | Change |
|---|---|
| `src/app/api/programs/[id]/route.ts` | drop the `fees: true` include |
| `src/app/api/membership-ops/participants/merge/route.ts` | drop both `feePayments` includes, the `moved.feePayments` counter, and the reconcile loop; tally comment 5 → 4 join tables |
| `src/lib/dev/seed-helpers.ts` | `+ Program` macro no longer creates a `Fee` fixture (summary string + jsdoc follow) |
| `.../merge/__tests__/route.integration.test.ts` | drop the fee/feePayment fixtures, teardown, and assertions — non-fee merge cases untouched |
| `src/lib/dev/__tests__/seed-helpers.integration.test.ts` | drop the `fees` include + assertion |
| `src/app/api/programs/price-cents.test.ts` | stale "Fee" naming → Program (the util under test is Program pricing) |

## Why

Nothing has ever written `Fee`/`FeePayment`. Program payment lives authoritatively in the Shopify pipeline — `ProgramParticipant.status` + `shopifyOrderId` → `shopify_read` mirror → daily `reconcile.ts` → `PaymentException` — so every read removed here reconciles rows that cannot exist. Full rationale in §1 of the design doc.

## What's deliberately NOT here

- **The schema models and the tables.** Old pods keep issuing `include: { fees: true }` for the whole rolling-deploy drain window. Schema removal + `DROP TABLE` are Release 2, after this is fully deployed.
- **`src/security/registry.ts`.** Dropping the now-unused `'Fee'` grant is a boundary change and ships in its own PR (Release 1b, per AGENTS.md / `security-boundary-isolation.yml`). Until then `'Fee'` sits in `registry.returns` as an inert over-declaration: `returns` is a grant list, nothing asserts it equals the actual include, and `Fee` is not an EDGE_MODEL, so `routeAuthDrift` is unaffected.

## Doc correction (in this PR)

The plan's Release 1b said to remove the `FeePayment` scope binding alongside the registry grant. It can't go there: while `FeePayment` is still in `schema.prisma`, its `personal` fields make it sensitive-and-scopable, so `validateBindings` coverage rule (b) errors *"silent over-restriction"* the moment the binding disappears — and `OPT_OUT_PENDING_ROUTE` is a work queue for unbuilt routes, not a graveyard for dying models. It moves to Release 2, where the model leaves the generated classifications in the same PR (keeping it past that point flips the failure to rule (a), "binding for unknown model").

Release 2's table also gained three tsc-blind consumers the original plan missed: the `FeePayment` case + binding count `18 → 17` and the unbound-model `'Fee'` entry in `scopeBindingsEquivalence.test.ts`, `'Fee'` in `ctxNeeds.test.ts` MODELS, and `feePayment` in the `livePersonDriftGuard.test.ts` regex.

## Verification

- `tsc --noEmit` clean.
- Full unit suite: 257 suites / 2411 tests passed.
- Integration suites for both touched files (merge + seed-helpers) against a real Postgres: 6 suites / 73 tests passed.

Part of #354 (FR7). Release 2 closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)