### PR TITLE
fix(program-ops): surface failed roster mutations instead of swallowing them

### DIFF
--- a/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
@@ -33,6 +33,21 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, fetchP
   const activeParticipants = program.participants.filter(p => p.status === 'ACTIVE');
   const pendingParticipants = program.participants.filter(p => p.status === 'PENDING');
 
+  // Roster mutations must never fail silently: a rejected remove (403 from a
+  // caller who isn't this program's lead, a 400, a 500) is otherwise
+  // indistinguishable from a successful one — the row just stays put.
+  const mutate = async (path: string, init: RequestInit): Promise<boolean> => {
+    try {
+      const res = await fetch(path, { headers: { 'Content-Type': 'application/json' }, ...init });
+      if (res.ok) return true;
+      const data = await res.json().catch(() => ({}));
+      notifications.show({ color: 'red', message: data.error || `Request failed (${res.status}).`, autoClose: 6000 });
+    } catch {
+      notifications.show({ color: 'red', message: 'Network error — please try again.', autoClose: 6000 });
+    }
+    return false;
+  };
+
   // Volunteer + participant pickers both search this program's eligible members.
   const searchEligible = useCallback(async (query: string): Promise<ParticipantOption[]> => {
     const res = await fetch(`/api/programs/${programId}/eligible-participants?q=${encodeURIComponent(query)}`);
@@ -46,11 +61,11 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, fetchP
     if (!newVolId) return;
     setSaving(true);
     try {
-      const res = await fetch(`/api/programs/${programId}/volunteers`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
+      const ok = await mutate(`/api/programs/${programId}/volunteers`, {
+        method: 'POST',
         body: JSON.stringify({ participantId: parseInt(newVolId) })
       });
-      if (res.ok) { setNewVolId(""); setVolLabel(""); fetchProgram(); }
+      if (ok) { setNewVolId(""); setVolLabel(""); fetchProgram(); }
     } finally {
       setSaving(false);
     }
@@ -66,17 +81,15 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, fetchP
     closeConfirmRemoveVol();
     const participantId = pendingRemoveVolId;
     setPendingRemoveVolId(null);
-    try {
-      await fetch(`/api/programs/${programId}/volunteers`, { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ participantId }) });
-      fetchProgram();
-    } catch { }
+    const ok = await mutate(`/api/programs/${programId}/volunteers`, { method: 'DELETE', body: JSON.stringify({ participantId }) });
+    if (ok) fetchProgram();
   };
 
   const handleToggleCore = async (participantId: number, isCore: boolean) => {
     setSaving(true);
     try {
-      const res = await fetch(`/api/programs/${programId}/volunteers`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ participantId, isCore }) });
-      if (res.ok) fetchProgram();
+      const ok = await mutate(`/api/programs/${programId}/volunteers`, { method: 'PATCH', body: JSON.stringify({ participantId, isCore }) });
+      if (ok) fetchProgram();
     } finally {
       setSaving(false);
     }
@@ -130,10 +143,8 @@ export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, fetchP
     closeConfirmRemovePart();
     const participantId = pendingRemovePartId;
     setPendingRemovePartId(null);
-    try {
-      await fetch(`/api/programs/${programId}/participants`, { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ participantId }) });
-      fetchProgram();
-    } catch { }
+    const ok = await mutate(`/api/programs/${programId}/participants`, { method: 'DELETE', body: JSON.stringify({ participantId }) });
+    if (ok) fetchProgram();
   };
 
   return (

--- a/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
@@ -489,6 +489,85 @@ describe("ProgramDetailsPage", () => {
     );
   });
 
+  it("surfaces the server error when removing a pending participant is rejected", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = routedFetch([
+      {
+        url: "/api/programs/1/participants", method: "DELETE",
+        result: { ok: false, status: 403, body: { error: "Forbidden: Not authorized to remove this participant" } },
+      },
+      { url: "/api/programs/1", method: "GET", result: { ok: true, body: programData } },
+    ]);
+    renderPage();
+    await screen.findByRole("heading", { name: "Robotics Club", level: 1 });
+    fireEvent.click(screen.getByRole("tab", { name: "Roster" }));
+    await screen.findByText(/Charlie Kid/);
+
+    // Volunteer (201), active participant (101), then the pending one (102).
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[2]);
+    const modal = await screen.findByRole("dialog", { name: "Remove Participant" });
+    fireEvent.click(within(modal).getByRole("button", { name: "Remove" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/programs/1/participants",
+        expect.objectContaining({ method: "DELETE", body: JSON.stringify({ participantId: 102 }) }),
+      ),
+    );
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red", message: "Forbidden: Not authorized to remove this participant" }),
+      ),
+    );
+    // The row is still there — the failed removal must not look like it worked.
+    expect(screen.getByText(/Charlie Kid/)).toBeInTheDocument();
+  });
+
+  it("surfaces a network error when the remove request throws", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    routedFetch([
+      { url: "/api/programs/1/participants", method: "DELETE", result: { throws: true } },
+      { url: "/api/programs/1", method: "GET", result: { ok: true, body: programData } },
+    ]);
+    renderPage();
+    await screen.findByRole("heading", { name: "Robotics Club", level: 1 });
+    fireEvent.click(screen.getByRole("tab", { name: "Roster" }));
+    await screen.findByText(/Charlie Kid/);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[2]);
+    const modal = await screen.findByRole("dialog", { name: "Remove Participant" });
+    fireEvent.click(within(modal).getByRole("button", { name: "Remove" }));
+
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red", message: "Network error — please try again." }),
+      ),
+    );
+  });
+
+  it("surfaces the server error when removing a volunteer is rejected", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    routedFetch([
+      { url: "/api/programs/1/volunteers", method: "DELETE", result: { ok: false, status: 500, body: {} } },
+      { url: "/api/programs/1", method: "GET", result: { ok: true, body: programData } },
+    ]);
+    renderPage();
+    await screen.findByRole("heading", { name: "Robotics Club", level: 1 });
+    fireEvent.click(screen.getByRole("tab", { name: "Roster" }));
+    await screen.findByText(/Vera Volunteer/);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[0]);
+    const modal = await screen.findByRole("dialog", { name: "Remove Volunteer" });
+    fireEvent.click(within(modal).getByRole("button", { name: "Remove" }));
+
+    // No `error` in the body -> the status-code fallback.
+    await waitFor(() =>
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red", message: "Request failed (500)." }),
+      ),
+    );
+  });
+
   it("shows past-confirmed and future events distinctly, and can schedule a new session", async () => {
     const eventsProgram = {
       ...programData,


### PR DESCRIPTION
Investigating #1399 ("unable to remove a pending participant"). This PR fixes the one
defect I could reproduce on that flow; it deliberately does **not** claim to close the
issue, because it makes the failure *visible* rather than proving what the reporter's
failure actually was.

## What I verified

Against a freshly seeded local instance (real dev server, persona-mint login, real DB),
`DELETE /api/programs/[id]/participants` removes a **PENDING** participant:

- as the program's **lead mentor** → 200, row gone
- as **board/sysadmin** → 200, row gone
- for a PENDING row holding scholarship inventory (`inventoryHeldAt` set) → 200,
  `released: true`, row gone
- through the **actual roster UI** in a browser (click Remove → confirm) → row gone

So the route itself is not the bug.

## The bug

`ProgramRosterTab.tsx` threw the response away on every mutation — `await fetch(...)`
inside an empty `catch {}` for the two removals, an unchecked `res.ok` for the volunteer
add/core toggle. Any server rejection (403 for a caller who isn't this program's lead
mentor, a 400, a 500) was therefore **indistinguishable from success**: the confirm
dialog closed, nothing was shown, and the row was still there after a refresh — exactly
the symptom in #1399.

## The change

One `mutate()` helper for all four roster mutations:

- checks `res.ok`
- shows the server's `error` as a red notification, falling back to
  `Request failed (<status>).` and `Network error — please try again.`
- refetches the program only when the call actually succeeded (a failed remove no longer
  triggers a pointless refetch that redraws the same row)

No server-side change, no permission change: a caller who was rejected before is still
rejected — they are now told why.

## Tests

Three new cases in `program-ops/programs/[id]/__tests__/page.test.tsx`:

1. rejected pending-participant removal (403 + `error` body) → red notification carrying
   the server message, and the row stays rendered
2. remove request throws → network-error notification
3. rejected volunteer removal with no `error` body → status-code fallback

Scoped run of that suite: 28/28 passing. `tsc --noEmit` and eslint clean.

## Follow-ups (not in this PR)

- The lead-mentor view of the roster shows **"Pending Since: Unknown"** for every pending
  participant — `ProgramParticipant.pendingSince` is `internal` tier and the
  `GET /api/programs/[id]` orderedView grants a lead mentor only
  `their_program_participants:pii/personal`. That is a registry decision and, under the
  boundary-isolation rule, its own PR. Filed separately.
- #1345 wants the Shopify `notice`/`warning` surfaced from these same functions — the
  `mutate()` helper is the seam that needs, no conflict.
- #1399 stays open: if the reporter was rejected by the auth gate, the message they now
  see (plus which account and which program) is what closes the remaining half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
