### PR TITLE
fix(trusted-adult): hold sysadmins to the override conflict-of-interest check

### DIFF
--- a/checkin-app/src/app/__tests__/trustedAdultAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultAPI.integration.test.ts
@@ -205,6 +205,32 @@ describe('Trusted Adults API', () => {
         expect(auditJson(overrideLog.newData).override).toBe('approve');
     });
 
+    // The override route's gate accepts a sysadmin in place of a board member, but the
+    // conflict-of-interest check exempts no role: the household's own lead is refused
+    // whether they reach the route as a bare sysadmin or as board+sysadmin.
+    it("refuses a sysadmin overriding their OWN household's review, with or without the board role", async () => {
+        const ta = await prisma.trustedAdult.create({
+            data: {
+                householdId: familyHh, trustedAdultName: 'Great-aunt', trustedAdultPhone: '555-0201',
+                familyContext: 'Maternal great-aunt.', origin: 'SELF_DISCLOSED', disclosedById: leadId,
+                reviews: { create: { householdId: familyHh, kind: 'INITIAL', status: 'PENDING_BOARD_REVIEW' } },
+            },
+            include: { reviews: true },
+        });
+        const reviewId = ta.reviews[0].id;
+
+        for (const roles of [{ isSysadmin: true }, { isSysadmin: true, isBoardMember: true }]) {
+            as(leadId, familyHh, roles);
+            const res = await OVERRIDE(post('/api/safety/trusted-adults/override', { reviewId, action: 'approve', sharedNote: SHARED }));
+            expect(res.status).toBe(403);
+            expect((await res.json()).code).toBe('forbidden');
+        }
+        // Nothing decided: the review is still awaiting the board.
+        const after = await prisma.trustedAdultReview.findUnique({ where: { id: reviewId } });
+        expect(after?.status).toBe('PENDING_BOARD_REVIEW');
+        expect(after?.decidedById).toBeNull();
+    });
+
     // Full trusted-adult journey as one continuous flow through the real routes: a lead
     // SUBMITS → it's pending and NOT yet an authorized pickup → the board APPROVES →
     // it becomes an authorized pickup on the operational (front-desk) view → the nightly

--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -446,9 +446,9 @@ describe('Trusted Adults service', () => {
         expect(normalizeAuditData(audit?.newData)).toMatchObject({ status: 'APPROVED', override: 'approve' });
     });
 
-    // Conflict of interest on the OVERRIDE path — mirrors decideReview's rule. A board
-    // member who leads the disclosing household must not override its own review (they'd
-    // force-approve their own trusted adult). Only a sysadmin is the remedy that bypasses.
+    // Conflict of interest on the OVERRIDE path — mirrors decideReview's rule, and no
+    // role is exempt. A board member who leads the disclosing household must not override
+    // its own review (they'd force-approve their own trusted adult); nor may a sysadmin.
     it('refuses a board member overriding their OWN household review, leaving DB + audit untouched', async () => {
         const ta = await discloseOne();
         const reviewId = ta.reviews[0].id;
@@ -463,17 +463,6 @@ describe('Trusted Adults service', () => {
         expect(after!.decidedById).toBeNull();
         const auditAfter = await latestAudit(ta.id);
         expect(auditAfter?.id).toBe(auditBefore?.id); // no new audit row appended
-    });
-
-    it('allows a sysadmin to override their own household review (the deliberate remedy)', async () => {
-        const ta = await discloseOne();
-        // Same actor whose board role is conflicted, but acting AS sysadmin → bypass.
-        const approved = await overrideReview(ta.reviews[0].id, boardLeadId, 'approve', SHARED, { isSysadmin: true });
-        expect(approved.status).toBe('APPROVED');
-
-        const audit = await latestAudit(ta.id);
-        expect(audit?.actorId).toBe(boardLeadId);
-        expect(normalizeAuditData(audit?.newData)).toMatchObject({ status: 'APPROVED', override: 'approve' });
     });
 
     it('allows a cross-household board member to override (no conflict)', async () => {

--- a/checkin-app/src/app/api/safety/trusted-adults/override/route.ts
+++ b/checkin-app/src/app/api/safety/trusted-adults/override/route.ts
@@ -30,9 +30,7 @@ export const POST = withAuth({ roles: ["isBoardMember", "isSysadmin"] }, async (
         return apiError("reviewId and action (approve|deny|revoke) are required", 400);
     }
     try {
-        const outcome = await overrideReview(body.reviewId, auth.user.id, body.action!, body.sharedNote, {
-            isSysadmin: auth.user.isSysadmin === true,
-        });
+        const outcome = await overrideReview(body.reviewId, auth.user.id, body.action!, body.sharedNote);
         return NextResponse.json({ status: outcome.status });
     } catch (error) {
         if (error instanceof TrustedAdultError) {

--- a/checkin-app/src/app/safety/trusted-adults/page.tsx
+++ b/checkin-app/src/app/safety/trusted-adults/page.tsx
@@ -396,7 +396,7 @@ export default function AdminTrustedAdultsPage() {
                                 <Button
                                     size="xs" fz={15}
                                     variant="subtle"
-                                    disabled={isSelf && !user?.isSysadmin}
+                                    disabled={isSelf}
                                     loading={busyId === latest.id}
                                     onClick={() => openPrompt({
                                         title: "Shared note (required to force-approve)",
@@ -405,10 +405,10 @@ export default function AdminTrustedAdultsPage() {
                                 >
                                     Force approve
                                 </Button>
-                                <Button size="xs" fz={15} variant="subtle" color="red" disabled={isSelf && !user?.isSysadmin} loading={busyId === latest.id} onClick={() => override(latest.id, "deny")}>
+                                <Button size="xs" fz={15} variant="subtle" color="red" disabled={isSelf} loading={busyId === latest.id} onClick={() => override(latest.id, "deny")}>
                                     Force deny
                                 </Button>
-                                <Button size="xs" fz={15} variant="subtle" color="gray" disabled={isSelf && !user?.isSysadmin} loading={busyId === latest.id} onClick={() => override(latest.id, "revoke")}>
+                                <Button size="xs" fz={15} variant="subtle" color="gray" disabled={isSelf} loading={busyId === latest.id} onClick={() => override(latest.id, "revoke")}>
                                     Revoke
                                 </Button>
                             </Group>

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -459,17 +459,16 @@ export async function decideReview(reviewId: number, boardMemberId: number, inpu
 /**
  * Board / sysadmin override: force a review to a terminal state regardless of phase.
  *
- * Same conflict-of-interest rule as decideReview — a board member may not override
- * their OWN household's review (else they could force-approve their own trusted adult,
- * the very thing decideReview forbids). A sysadmin is the deliberate remedy and bypasses
- * the check (opts.isSysadmin); the route sets it only when the actor holds that role.
+ * Same conflict-of-interest rule as decideReview, and no role is exempt from it — a
+ * board member may not override their OWN household's review (else they could
+ * force-approve their own trusted adult, the very thing decideReview forbids), and
+ * neither may a sysadmin. Someone outside the household has to decide the case.
  */
 export async function overrideReview(
     reviewId: number,
     actorId: number,
     action: "approve" | "deny" | "revoke",
     sharedNote?: string | null,
-    opts?: { isSysadmin?: boolean },
 ) {
     const review = await prisma.trustedAdultReview.findUnique({
         where: { id: reviewId },
@@ -477,18 +476,16 @@ export async function overrideReview(
     });
     if (!review) throw new TrustedAdultError("not_found", "Review not found.");
 
-    if (!opts?.isSysadmin) {
-        const me = await prisma.person.findUnique({ where: { id: actorId }, select: { householdId: true } });
-        if (
-            isTrustedAdultConflict({
-                actorParticipantId: actorId,
-                actorHouseholdId: me?.householdId,
-                taHouseholdId: review.trustedAdult.householdId,
-                taTrustedAdultPersonId: review.trustedAdult.trustedAdultPersonId,
-            })
-        ) {
-            throw new TrustedAdultError("forbidden", "You can't override your own household's trusted-adult review — a sysadmin must.");
-        }
+    const me = await prisma.person.findUnique({ where: { id: actorId }, select: { householdId: true } });
+    if (
+        isTrustedAdultConflict({
+            actorParticipantId: actorId,
+            actorHouseholdId: me?.householdId,
+            taHouseholdId: review.trustedAdult.householdId,
+            taTrustedAdultPersonId: review.trustedAdult.trustedAdultPersonId,
+        })
+    ) {
+        throw new TrustedAdultError("forbidden", "You can't override your own household's trusted-adult review — someone outside your household must.");
     }
 
     const now = new Date();


### PR DESCRIPTION
`overrideReview` in `checkin-app/src/lib/trusted-adult/service.ts` skipped the `isTrustedAdultConflict` guard entirely whenever the caller passed `isSysadmin`, and `POST /api/safety/trusted-adults/override` set that flag straight from the session role. So a sysadmin could force-approve, force-deny, or revoke the trusted-adult review of their own household — or one where they are the trusted adult themselves, the counterparty leg of the same rule.

This is the structurally identical bypass to the one #1391 removed from `hasHouseholdConflict`, deliberately left out of that PR's scope (different primitive, different approval regime). Removing it here means the codebase gives one answer to "may a sysadmin decide their own household's case" instead of two.

Decision: option 1 on the issue — remove the bypass outright, matching #1391, rather than keeping it and documenting why the trusted-adult regime is different. The `opts` parameter is deleted rather than ignored, so any stale caller becomes a compile error and there is no role-shaped hole left to pass `true` into. (Unlike #1391, `tsc` surfaced no hidden caller here — the override route was the only non-test one.)

A sysadmin can still override any **other** household's review; only the self-approval path closes. As in #1391, a review whose only eligible deciders all live in the subject household is now a visible 403 rather than a silent bypass — the gap the planned break-glass / admin-auditing mechanism is meant to fill, deliberately out of scope here.

Fixes #1393

---

<details>
<summary><b>Appendix</b></summary>

### What changed

| File | Change |
|---|---|
| `src/lib/trusted-adult/service.ts` | dropped `opts?: { isSysadmin?: boolean }` and the `if (!opts?.isSysadmin)` wrapper around the conflict check; doc comment rewritten (it previously described the sysadmin as "the deliberate remedy"); error copy → "— someone outside your household must." |
| `src/app/api/safety/trusted-adults/override/route.ts` | dropped the `isSysadmin: auth.user.isSysadmin === true` argument. The route's own role gate is unchanged — a sysadmin may still reach it, just not for their own household. |
| `src/app/safety/trusted-adults/page.tsx` | the three override buttons (Force approve / Force deny / Revoke) drop `&& !user?.isSysadmin` from their disabled predicate, so the client can't offer an action the server now refuses. The `decide` buttons above them already gated on bare `isSelf`. |

### Tests

The service-level test asserting the bypass as correct behavior (`allows a sysadmin to override their own household review (the deliberate remedy)`) is deleted rather than inverted: with `opts` gone the service no longer knows anything about roles, so a "sysadmin is also refused" assertion there would be a duplicate of the board-member case sitting one line above it.

The assertion moves to `trustedAdultAPI.integration.test.ts`, where roles actually exist — the disclosing household's own lead is refused (403 / `forbidden`) both as a bare sysadmin and as board+sysadmin, and the review is left `PENDING_BOARD_REVIEW` with `decidedById` null. Both role shapes are exercised because the route gate accepts `isSysadmin` **in place of** `isBoardMember`, so each is a distinct way to reach the guard.

### Validation

- `tsc --noEmit` clean.
- Full unit suite (`test:ci`): **2411 passed, 257 suites, 0 failed.**
- Integration, `trustedAdult` pattern: 47 passed / 4 suites.
- Integration, `authz` pattern: 215 passed / 4 suites (these import the override route).

Integration runs used a throwaway Postgres seeded with `prisma/seed.ts`, torn down afterwards.

### Relationship to #1391

File-disjoint — #1391 touches membership/finance routes, their UI mirrors, and `conflictOfInterest.ts`; this touches only trusted-adult files. No merge interaction in either direction, and this does not depend on #1391 landing first.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
