### PR TITLE
fix(programs): gate members-only enrollment on the POST write path

### DIFF
--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -25,11 +25,14 @@ describe('Program Participants API Integration Tests', () => {
     let otherId: number;
     let boardId: number;   // board member who leads a household
     let depId: number;     // dependent (25yo) in the board member's household
+    let memberId: number;  // person in a household with an ACTIVE OrgMembership
+    let memberHouseholdId: number;
 
     let standardProgramId: number;
     let freeProgramId: number;
     let fullProgramId: number;
     let exactAgeProgramId: number;
+    let memberOnlyProgramId: number;
 
     beforeAll(async () => {
         // Clean up any leaked state
@@ -41,6 +44,10 @@ describe('Program Participants API Integration Tests', () => {
 
         await prisma.programParticipant.deleteMany({
             where: { personId: { in: existingUserIds } }
+        });
+
+        await prisma.orgMembership.deleteMany({
+            where: { household: { householdMembers: { some: { id: { in: existingUserIds } } } } }
         });
 
         await prisma.program.deleteMany({
@@ -139,11 +146,32 @@ describe('Program Participants API Integration Tests', () => {
             data: { name: 'Age Restricted Partic API Test', phase: 'RUNNING', enrollmentStatus: 'OPEN', minAge: 18, maxAge: 21 }
         });
         exactAgeProgramId = exactAgeProgram.id;
+
+        // Treehouse Member (household carries the ACTIVE OrgMembership) + the
+        // members-only program they are the only eligible enroller for.
+        const memberHousehold = await prisma.household.create({
+            data: { name: "Test HH", orgMembership: { create: { status: 'ACTIVE' } } }
+        });
+        memberHouseholdId = memberHousehold.id;
+        const member = await prisma.person.create({
+            data: {
+                email: 'member-partic-api-test@example.com',
+                name: 'Org Member',
+                dateOfBirth: new Date(Date.now() - (25 * 31556952000)),
+                householdId: memberHouseholdId
+            }
+        });
+        memberId = member.id;
+
+        const memberOnlyProgram = await prisma.program.create({
+            data: { name: 'Member Only Partic API Test', phase: 'RUNNING', enrollmentStatus: 'OPEN', orgMemberOnly: true, orgMemberPriceCents: null, nonOrgMemberPriceCents: null }
+        });
+        memberOnlyProgramId = memberOnlyProgram.id;
     });
 
     afterAll(async () => {
-        const existingUserIds = [adminId, leadId, commonId, otherId, boardId, depId].filter(id => id !== undefined);
-        const validProgramIds = [standardProgramId, freeProgramId, fullProgramId, exactAgeProgramId].filter(id => id !== undefined);
+        const existingUserIds = [adminId, leadId, commonId, otherId, boardId, depId, memberId].filter(id => id !== undefined);
+        const validProgramIds = [standardProgramId, freeProgramId, fullProgramId, exactAgeProgramId, memberOnlyProgramId].filter(id => id !== undefined);
 
         if (existingUserIds.length > 0) {
             await prisma.programParticipant.deleteMany({
@@ -165,6 +193,10 @@ describe('Program Participants API Integration Tests', () => {
             await prisma.person.deleteMany({
                 where: { id: { in: existingUserIds } }
             });
+        }
+
+        if (memberHouseholdId !== undefined) {
+            await prisma.orgMembership.deleteMany({ where: { householdId: memberHouseholdId } });
         }
     });
 
@@ -422,6 +454,61 @@ describe('Program Participants API Integration Tests', () => {
                 await prisma.programParticipant.deleteMany({ where: { programId: shopifyProgram.id } });
                 await prisma.program.delete({ where: { id: shopifyProgram.id } });
             }
+        });
+
+        // The three read routes only HIDE an orgMemberOnly program; POSTing the id
+        // directly used to enroll a non-member outright.
+        it('should block a non-member from self-enrolling into a members-only program', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
+
+             const req = new Request(`http://localhost:4000/api/programs/${memberOnlyProgramId}/participants`, {
+                 method: 'POST',
+                 body: JSON.stringify({ participantId: commonId })
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest, createParams(memberOnlyProgramId) as unknown as never);
+             expect(res.status).toBe(400);
+
+             const data = await res.json();
+             expect(data.error).toMatch(/Treehouse Members only/);
+             expect(data.requiresOverride).toBe(true);
+
+             const row = await prisma.programParticipant.findUnique({
+                 where: { programId_personId: { programId: memberOnlyProgramId, personId: commonId } },
+             });
+             expect(row).toBeNull();
+        });
+
+        it('should allow a Treehouse Member to self-enroll into a members-only program', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: memberId } });
+
+             const req = new Request(`http://localhost:4000/api/programs/${memberOnlyProgramId}/participants`, {
+                 method: 'POST',
+                 body: JSON.stringify({ participantId: memberId })
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest, createParams(memberOnlyProgramId) as unknown as never);
+             expect(res.status).toBe(200);
+
+             const data = await res.json();
+             expect(data.success).toBe(true);
+             expect(data.enrollment.personId).toBe(memberId);
+        });
+
+        // The members-only gate lives inside enforceLimits, so it must not break
+        // the deliberate comp path — a confirmed board/sysadmin override still
+        // seats a non-member.
+        it('should let a confirmed admin comp a non-member into a members-only program', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+             const req = new Request(`http://localhost:4000/api/programs/${memberOnlyProgramId}/participants`, {
+                 method: 'POST',
+                 body: JSON.stringify({ participantId: otherId, override: true })
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest, createParams(memberOnlyProgramId) as unknown as never);
+             expect(res.status).toBe(200);
+
+             const data = await res.json();
+             expect(data.success).toBe(true);
+             expect(data.enrollment.status).toBe('ACTIVE');
         });
 
         it('should return 409 (not 500) when enrolling the same participant twice', async () => {

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
 import { lockProgramAndCheckCapacity, ProgramCapacityError, withdrawAndReleaseHold } from "@/lib/program/capacity";
 import { checkProgramAge } from "@/lib/programAge";
+import { isActiveOrgMember } from "@/lib/orgMembership";
 import { adjustProgramInventory } from "@/lib/shopify";
 import { apiError } from "@/lib/api-response";
 
@@ -90,6 +91,15 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             // Check Enrollment Status
             if (currentProgram.enrollmentStatus === 'CLOSED') {
                 return NextResponse.json({ error: "Program enrollment is currently closed.", requiresOverride: true }, { status: 400 });
+            }
+
+            // Members-only, judged on the PERSON being enrolled (a household lead
+            // enrolling a dependent is judged on the dependent's household). The
+            // sibling read routes only HIDE such a program; the id is a small
+            // integer and a program can flip to orgMemberOnly after it was public,
+            // so the write path needs its own gate.
+            if (currentProgram.orgMemberOnly && !(await isActiveOrgMember(participantId))) {
+                return NextResponse.json({ error: "This program is for Treehouse Members only.", requiresOverride: true }, { status: 400 });
             }
 
             // Check Age (as of program start; now for dateless programs). A declared


### PR DESCRIPTION
Fixes #1407

## The gap

`POST /api/programs/[id]/participants` — the enrollment write path — never read `Program.orgMemberOnly`. The three places that gate it are all **reads**:

- `api/programs/route.ts` — `canSeeOrgMemberOnly` filters the catalog list
- `api/programs/[id]/route.ts` — 403 `Forbidden: Member-Only Program` on program detail
- `api/programs/[id]/eligible-participants/route.ts` — filters the staff candidate list

So members-only enrollment was enforced only by the program being *hidden*. The program id is a small integer and a program can flip to `orgMemberOnly` after someone has already seen it, so the id is not a secret: POSTing it directly enrolled a non-member onto the roster — and for a free members-only program (`initialStatus = 'ACTIVE'` when both price fields are null) enrolled them outright.

Pre-existing; found while implementing #1397, which widened the three read gates but deliberately did not touch the write path.

## The fix

One check inside the existing `if (enforceLimits) { ... }` block, alongside the closed-enrollment and age checks:

```ts
if (currentProgram.orgMemberOnly && !(await isActiveOrgMember(participantId))) {
    return NextResponse.json({ error: "This program is for Treehouse Members only.", requiresOverride: true }, { status: 400 });
}
```

Two deliberate choices:

- **Inside `enforceLimits`**, so a confirmed board/sysadmin override can still comp someone in. That is the existing pattern for every soft limit here — see the `ponytail:` comment above `enforceLimits` and the `requiresOverride: true` responses the UI turns into a confirm button.
- **Checked against `participantId`, not the caller.** A household lead enrolling a dependent must be judged on the dependent's household (same household, but the argument matters).

Same `{ error, requiresOverride: true }` / 400 shape the sibling soft-limit rejections use.

## Predicate choice — `isActiveOrgMember`

The issue suggests `isDuesSettled`, the widened rule from #1397 ("ACTIVE, or dues paid with the background check still with the board"). That predicate **does not exist on this base** — `src/lib/orgMembership.ts` on current `main` exports only `isActiveOrgMember`, which is what the sibling read routes use (`[id]/route.ts` calls it directly; `eligible-participants` uses its `ACTIVE_ORG_MEMBER_PERSON_WHERE` twin).

**If #1397 merges first, swap this call to `isDuesSettled`** — otherwise a paid-pending household would be blocked from enrolling in a members-only program that #1397's widened read gates already let them *see*. Rebasing this branch onto a merged #1397 is a one-line change plus the fixture in the member test.

## Tests

Three integration cases added to `programsParticipantsAPI.integration.test.ts` (which already covered auth, age, capacity, and comp overrides, but had no members-only case):

1. Non-member self-enrolling into an `orgMemberOnly: true` program → 400 with `requiresOverride: true`, and no `ProgramParticipant` row created.
2. A member (household with `orgMembership.status: 'ACTIVE'`) into the same program → 200.
3. A sysadmin external-admin comp with `override: true` into that program → still 200 / ACTIVE. This is the one that would catch the gate being placed outside `enforceLimits`.

New fixtures: `memberId` / `memberHouseholdId` / `memberOnlyProgramId`. `orgMembership` cleanup added to both the leaked-state sweep in `beforeAll` and to `afterAll`, following the suite's existing style.

## Verification

Docker/OrbStack was down, so integration ran against a throwaway Homebrew Postgres 16 cluster (torn down afterwards).

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- unit suite (`test:ci`) — 2411 passed, 257 suites
- integration suite, full run (for the routeAuthDrift and security-registry guards that are sensitive to route changes) — 1257 passed, 128 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
