### PR TITLE
feat(membership): confirm background-check attestations and allow a way back

### DIFF
--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -352,6 +352,33 @@ describe('background check is non-blocking', () => {
         expect(await statusOf(processId)).not.toBe('BLOCKED');
     });
 
+    it('reset returns a still-open review to neutral (the misclicked approval), but not a cleared one', async () => {
+        const { processId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+        await markContractSigned(processId);
+        await markBgConsent(processId, revA);
+        await attest(revA, processId, { result: 'APPROVE' }); // 1 of 2 — review still open
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
+
+        // The review never left its phase, so the reset only drops the attestations.
+        await overrideBlocked(processId, revB, 'reset');
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
+        expect(await prisma.backgroundCheckAttestation.count({ where: { processId } })).toBe(0);
+        const audits = await prisma.auditLog.findMany({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: processId } });
+        expect(audits.map((a) => normalizeAuditData(a.newData)).some((d) => (d as { action?: string }).action === 'board reset')).toBe(true);
+
+        // The withdrawn approval is genuinely gone: the same reviewer may attest again,
+        // and it takes two more approvals to clear.
+        await attest(revA, processId, { result: 'APPROVE' });
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT'); // 1 of 2 again, not cleared
+        await attest(revB, processId, { result: 'APPROVE' });
+        const cleared = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
+        expect(cleared?.bgClearedAt).not.toBeNull();
+
+        // Past clearance the side effects have already fanned out — reset is refused.
+        await expect(overrideBlocked(processId, revB, 'reset')).rejects.toMatchObject({ code: 'wrong_phase' });
+        expect(await prisma.backgroundCheckAttestation.count({ where: { processId } })).toBe(2);
+    });
+
     it('renewal with a still-valid background check: bgClearedAt stamped, signature opens payment, paying activates (not stuck)', async () => {
         await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
         const { orgMembershipId, processId } = await makeFreshRenewal();

--- a/checkin-app/src/app/api/membership-ops/applications/review-override/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/review-override/route.ts
@@ -7,11 +7,14 @@ import { apiError } from "@/lib/api-response";
 export const dynamic = "force-dynamic";
 
 /**
- * POST /api/membership-ops/applications/review-override — board action on a BLOCKED application.
+ * POST /api/membership-ops/applications/review-override — board action on an
+ * application's background-check review.
  * Body: { processId, action: 'reset' | 'approve' }
- *   reset   — clear attestations, send back for re-review (re-ping reviewers)
- *   approve — board override: clear the check, activating if already paid else
- *             leaving it at PENDING_PAYMENT
+ *   reset   — clear attestations, send back for re-review (re-ping reviewers).
+ *             Reaches a BLOCKED review and one still in progress (undoing an
+ *             accidental approval); a cleared one is out of reach.
+ *   approve — board override on a BLOCKED review: clear the check, activating if
+ *             already paid else leaving it at PENDING_PAYMENT
  */
 export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
     if (auth.type !== "session") return apiError("Unauthorized", 401);

--- a/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports -- jest.mock factories are hoisted above imports */
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 
 // Reactive next/navigation mock (mirrors src/components/__tests__/StatusFilter.test.tsx):
 // router.replace writes back into `search` so a `rerender()` after a click picks up
@@ -16,18 +16,26 @@ jest.mock("next/navigation", () => ({
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 import { MantineProvider } from "@mantine/core";
+import { ModalsProvider } from "@mantine/modals";
 import { EnvProvider } from "@/components/EnvProvider";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
 import { notifications } from "@mantine/notifications";
 import AdminMembershipPage from "../page";
 
-// rerender() replaces the whole root, so re-supplying it must mirror renderWithProviders'
+// modals.openConfirmModal is a no-op without a provider, so a confirmed action would
+// silently never fire. Wrapped here rather than in the shared harness: several suites
+// jest.mock("@mantine/modals") and would get an undefined ModalsProvider.
+const renderPage = () => renderWithProviders(<ModalsProvider><AdminMembershipPage /></ModalsProvider>);
+
+// rerender() replaces the whole root, so re-supplying it must mirror renderPage's
 // wrapper tree (same component types at each level) or React remounts instead of
 // reconciling, losing the page's already-fetched rows state.
 const rewrapped = () => (
     <MantineProvider>
         <EnvProvider value={{ checkinEnv: "prod", shopifyStoreDomain: null, isStaging: false }}>
-            <AdminMembershipPage />
+            <ModalsProvider>
+                <AdminMembershipPage />
+            </ModalsProvider>
         </EnvProvider>
     </MantineProvider>
 );
@@ -104,7 +112,7 @@ const rows = [
 describe("AdminMembershipPage", () => {
     it("renders in-flight applications and their status counts", async () => {
         mockFetchJson({ "/api/membership-ops/applications": { processes: rows } });
-        renderWithProviders(<AdminMembershipPage />);
+        renderPage();
 
         expect(await screen.findByText("Awaiting Family")).toBeInTheDocument();
         expect(screen.getByText("Payment Family")).toBeInTheDocument();
@@ -115,7 +123,7 @@ describe("AdminMembershipPage", () => {
 
     it("shows an empty state when there are no in-flight applications", async () => {
         mockFetchJson({ "/api/membership-ops/applications": { processes: [] } });
-        renderWithProviders(<AdminMembershipPage />);
+        renderPage();
         expect(await screen.findByText("No in-flight membership applications.")).toBeInTheDocument();
     });
 
@@ -126,7 +134,7 @@ describe("AdminMembershipPage", () => {
             "/api/membership-ops/applications/certify-payment": { ok: true },
             "/api/membership-ops/applications/review-override": { ok: true },
         });
-        renderWithProviders(<AdminMembershipPage />);
+        renderPage();
         await screen.findByText("Awaiting Family");
 
         fireEvent.click(screen.getByRole("button", { name: "Confirm contract signed" }));
@@ -151,9 +159,31 @@ describe("AdminMembershipPage", () => {
         await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Overridden to payment." })));
     });
 
+    it("clears a still-open review's approvals, behind a confirmation", async () => {
+        const fetchMock = mockFetchJson({
+            "/api/membership-ops/applications": { processes: rows },
+            "/api/membership-ops/applications/review-override": { ok: true },
+        });
+        renderPage();
+        await screen.findByText("Payment Family");
+
+        // Only the in-review row with an approval on it offers the reset.
+        const reset = screen.getByRole("button", { name: "Clear approvals — start the review over" });
+        fireEvent.click(reset);
+        expect(await screen.findByText("Start this background-check review over?")).toBeInTheDocument();
+        fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Clear approvals" }));
+
+        await waitFor(() =>
+            expect(fetchMock).toHaveBeenCalledWith(
+                "/api/membership-ops/applications/review-override",
+                expect.objectContaining({ body: JSON.stringify({ processId: 2, action: "reset" }) }),
+            ),
+        );
+    });
+
     it("clicking a legend badge narrows the list to that status; clicking again restores it", async () => {
         mockFetchJson({ "/api/membership-ops/applications": { processes: rows } });
-        const { rerender } = renderWithProviders(<AdminMembershipPage />);
+        const { rerender } = renderPage();
         await screen.findByText("Awaiting Family");
 
         fireEvent.click(screen.getByRole("button", { name: "PENDING PAYMENT: 1" }));
@@ -179,7 +209,7 @@ describe("AdminMembershipPage", () => {
     it("shows a clear-filter empty state when the active status has no matching rows", async () => {
         search = "status=PENDING_BG_REVIEW";
         mockFetchJson({ "/api/membership-ops/applications": { processes: rows } });
-        renderWithProviders(<AdminMembershipPage />);
+        renderPage();
 
         expect(await screen.findByText(/No applications in PENDING BG REVIEW/)).toBeInTheDocument();
         expect(screen.queryByText("Awaiting Family")).not.toBeInTheDocument();
@@ -199,7 +229,7 @@ describe("AdminMembershipPage", () => {
             "/api/membership-ops/applications?archived=1": { processes: archivedRows },
             "/api/membership-ops/applications": { processes: rows },
         });
-        renderWithProviders(<AdminMembershipPage />);
+        renderPage();
         await screen.findByText("Awaiting Family");
 
         fireEvent.click(screen.getByLabelText("Show archived"));

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -183,6 +183,24 @@ function ApplicationsBoard() {
     }
   };
 
+  // An awaiting row only ever holds APPROVE attestations (any REJECT blocks it).
+  const approvals = (r: ProcessRow) => r.attestations.filter((a) => a.result === "APPROVE").length;
+
+  const confirmResetReview = (r: ProcessRow) => {
+    modals.openConfirmModal({
+      title: "Start this background-check review over?",
+      children: (
+        <Text size="sm">
+          This discards the {approvals(r)} approval(s) recorded for <strong>{householdLabel(r)}</strong>{" "}
+          and asks the reviewers to start again. Use it when an approval was recorded by
+          mistake — the check itself has not cleared yet, so nothing else changes.
+        </Text>
+      ),
+      labels: { confirm: "Clear approvals", cancel: "Cancel" },
+      onConfirm: () => override(r.id, "reset"),
+    });
+  };
+
   // Disposing an abandoned application removes it from the board list. Confirm
   // because it's a deliberate cleanup action (kept in the audit log, not deleted).
   const confirmArchive = (r: ProcessRow) => {
@@ -381,9 +399,18 @@ function ApplicationsBoard() {
               )}
 
               {awaitingBg(r) && (
-                <Text size="sm" c="dimmed" mt="md">
-                  Background check (in parallel) — <Text component="span" fw={600}>{r.attestations.filter((a) => a.result === "APPROVE").length}/2</Text> approvals recorded.
-                </Text>
+                <Group mt="md" gap="md" wrap="wrap" align="center">
+                  <Text size="sm" c="dimmed">
+                    Background check (in parallel) — <Text component="span" fw={600}>{approvals(r)}/2</Text> approvals recorded.
+                  </Text>
+                  {/* The board's way back from a reviewer's misclick: the review is still
+                      open, so clearing the attestations undoes it with nothing to unwind. */}
+                  {approvals(r) > 0 && (
+                    <Button size="xs" fz={15} variant="default" disabled={busyId === r.id || ownHousehold(r)} onClick={() => confirmResetReview(r)}>
+                      Clear approvals — start the review over
+                    </Button>
+                  )}
+                </Group>
               )}
 
               {r.status === "PENDING_PAYMENT" && (

--- a/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
@@ -4,10 +4,16 @@ jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } }));
 
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { notifications } from "@mantine/notifications";
+import { ModalsProvider } from "@mantine/modals";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
 import MembershipReviewPage from "../page";
+
+// modals.openConfirmModal is a no-op without a provider, so the confirmed action
+// would silently never fire. Wrapped here rather than in the shared harness: several
+// suites jest.mock("@mantine/modals") and would get an undefined ModalsProvider.
+const renderPage = () => renderWithProviders(<ModalsProvider><MembershipReviewPage /></ModalsProvider>);
 
 beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
 
@@ -21,11 +27,14 @@ const queue = {
   ],
 };
 
+// The same household with no approvals yet — the first-reviewer confirmation.
+const firstApprovalQueue = { queue: [{ ...queue.queue[0], id: 101, _count: { attestations: 0 } }] };
+
 describe("membership-ops/review page", () => {
   it("loads and renders the review queue", async () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({ "/api/membership/reviews": queue });
-    renderWithProviders(<MembershipReviewPage />);
+    renderPage();
 
     expect(await screen.findByText("The Smiths")).toBeInTheDocument();
     expect(screen.getByText("Pat Smith <pat@example.com>", { exact: false })).toBeInTheDocument();
@@ -37,10 +46,16 @@ describe("membership-ops/review page", () => {
   it("approves an attestation", async () => {
     setSession({ id: 1, isSysadmin: true });
     const fetchMock = mockFetchJson({ "/api/membership/reviews": queue });
-    renderWithProviders(<MembershipReviewPage />);
+    renderPage();
     await screen.findByText("The Smiths");
 
     fireEvent.click(screen.getByRole("button", { name: "Attest — check is clean" }));
+    // This row already holds one approval, so the confirm names the consequence of
+    // the CLEARING approve rather than a generic "are you sure?".
+    expect(await screen.findByText("Clear this background check?")).toBeInTheDocument();
+    expect(screen.getByText(/emails the family/)).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // the queue GET only — nothing posted yet
+    fireEvent.click(screen.getByRole("button", { name: "Clear the check" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
@@ -54,10 +69,63 @@ describe("membership-ops/review page", () => {
     await waitFor(() => expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Attestation recorded — thank you." })));
   });
 
+  it("cancelling the confirmation posts nothing", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({ "/api/membership/reviews": queue });
+    renderPage();
+    await screen.findByText("The Smiths");
+
+    fireEvent.click(screen.getByRole("button", { name: "Attest — check is clean" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(screen.queryByText("Clear this background check?")).not.toBeInTheDocument());
+    expect(fetchMock).toHaveBeenCalledTimes(1); // the queue GET only
+  });
+
+  it("confirms a first approval without promising clearance", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({ "/api/membership/reviews": firstApprovalQueue });
+    renderPage();
+    await screen.findByText("The Smiths");
+
+    fireEvent.click(screen.getByRole("button", { name: "Attest — check is clean" }));
+    expect(await screen.findByText("Record your approval?")).toBeInTheDocument();
+    expect(screen.getByText(/A second\s+reviewer must also approve/)).toBeInTheDocument();
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Approve" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/membership/reviews",
+        expect.objectContaining({ body: JSON.stringify({ processId: 101, result: "APPROVE", isMarkedVolunteer: false }) }),
+      ),
+    );
+  });
+
+  it("confirms a rejection too — the note is not the confirmation", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const fetchMock = mockFetchJson({ "/api/membership/reviews": firstApprovalQueue });
+    renderPage();
+    await screen.findByText("The Smiths");
+
+    fireEvent.change(screen.getByLabelText("Notes"), { target: { value: "Record is concerning." } });
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+    expect(await screen.findByText("Reject this background check?")).toBeInTheDocument();
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Reject" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/membership/reviews",
+        expect.objectContaining({
+          body: JSON.stringify({ processId: 101, result: "REJECT", isMarkedVolunteer: false, note: "Record is concerning." }),
+        }),
+      ),
+    );
+  });
+
   it("shows the forbidden card when the queue endpoint returns 403", async () => {
     setSession({ id: 1, isSysadmin: true });
     global.fetch = jest.fn(async () => ({ ok: false, status: 403, json: async () => ({}) })) as unknown as typeof fetch;
-    renderWithProviders(<MembershipReviewPage />);
+    renderPage();
 
     expect(await screen.findByText("Background-check review")).toBeInTheDocument();
   });
@@ -65,7 +133,7 @@ describe("membership-ops/review page", () => {
   it("shows the empty state when nothing is queued", async () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({ "/api/membership/reviews": { queue: [] } });
-    renderWithProviders(<MembershipReviewPage />);
+    renderPage();
 
     expect(await screen.findByText("Nothing awaiting your review right now.")).toBeInTheDocument();
   });
@@ -82,7 +150,7 @@ describe("membership-ops/review page", () => {
         }],
       },
     });
-    renderWithProviders(<MembershipReviewPage />);
+    renderPage();
 
     expect(await screen.findByText("Dana Vol")).toBeInTheDocument();
     expect(screen.getByText("No household on file", { exact: false })).toBeInTheDocument();

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import { Alert, Button, Card, Checkbox, Container, Group, Stack, Text, Textarea, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
+import { modals } from "@mantine/modals";
 import { type AlertTone } from "@/components/admin/AlertBanner";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 
@@ -86,6 +87,48 @@ export default function MembershipReviewPage() {
     }
   };
 
+  // Who this review is about — the PERSON_BG subject, else the applicant household.
+  const applicantLabel = (item: QueueItem) =>
+    item.subjectPerson
+      ? item.subjectPerson.name || `Person #${item.subjectPerson.id}`
+      : item.orgMembership?.household?.name || `Household (application #${item.id})`;
+
+  // Attesting is a one-click, two-of-two decision, and the SECOND approval clears the
+  // check outright — stamping the household, opening payment or activating, and
+  // emailing the family. Confirm both actions, and say what the click actually does
+  // rather than "are you sure?", which trains people to click through.
+  const confirmSubmit = (item: QueueItem, result: "APPROVE" | "REJECT") => {
+    const who = applicantLabel(item);
+    const clearing = result === "APPROVE" && item._count.attestations >= 1;
+    modals.openConfirmModal({
+      title: result === "REJECT" ? "Reject this background check?" : clearing ? "Clear this background check?" : "Record your approval?",
+      children: (
+        <Text size="sm">
+          {result === "REJECT" ? (
+            <>
+              This blocks <strong>{who}</strong>&apos;s membership and notifies the board. The
+              applicant is not told the reason.
+            </>
+          ) : clearing ? (
+            <>
+              You are the second reviewer for <strong>{who}</strong>. This clears the background
+              check, records it against the household, opens payment (or activates the membership
+              if dues are already paid), and emails the family. It cannot be undone.
+            </>
+          ) : (
+            <>
+              This records your approval of <strong>{who}</strong>&apos;s background check. A second
+              reviewer must also approve before the check clears.
+            </>
+          )}
+        </Text>
+      ),
+      labels: { confirm: result === "REJECT" ? "Reject" : clearing ? "Clear the check" : "Approve", cancel: "Cancel" },
+      confirmProps: { color: result === "REJECT" ? "red" : clearing ? "orange" : undefined },
+      onConfirm: () => submit(item.id, result),
+    });
+  };
+
   if (sessionStatus === "loading" || loading) {
     return <PageLoader />;
   }
@@ -123,16 +166,14 @@ export default function MembershipReviewPage() {
             <Card key={item.id} withBorder radius="md" padding="lg">
               {subject ? (
                 <>
-                  <Text fw={700} fz="lg">{subject.name || `Person #${subject.id}`}</Text>
+                  <Text fw={700} fz="lg">{applicantLabel(item)}</Text>
                   <Text size="sm" c="dimmed" mt={4}>
                     Background check for an individual · {subject.household?.name ? `Household: ${subject.household.name}` : "No household on file"}
                   </Text>
                 </>
               ) : (
                 <>
-                  <Text fw={700} fz="lg">
-                    {item.orgMembership?.household?.name || `Household (application #${item.id})`}
-                  </Text>
+                  <Text fw={700} fz="lg">{applicantLabel(item)}</Text>
                   <Text size="sm" c="dimmed" mt={4}>
                     {parents.length > 0
                       ? parents.map((p) => `${p.name || "—"}${p.email ? ` <${p.email}>` : ""}`).join(", ")
@@ -170,10 +211,10 @@ export default function MembershipReviewPage() {
               />
 
               <Group gap="sm" wrap="wrap" mt="md">
-                <Button disabled={busyId === item.id} loading={busyId === item.id} onClick={() => submit(item.id, "APPROVE")}>
+                <Button disabled={busyId === item.id} loading={busyId === item.id} onClick={() => confirmSubmit(item, "APPROVE")}>
                   Attest — check is clean
                 </Button>
-                <Button color="red" variant="light" disabled={busyId === item.id || !reviewNotes[item.id]?.trim()} onClick={() => submit(item.id, "REJECT")}>
+                <Button color="red" variant="light" disabled={busyId === item.id || !reviewNotes[item.id]?.trim()} onClick={() => confirmSubmit(item, "REJECT")}>
                   Reject
                 </Button>
               </Group>

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -348,14 +348,26 @@ export async function applyVolunteerStatus(db: DbClient, orgMembershipId: number
     }
 }
 
-/** Board override on a BLOCKED application: reset for re-review, or force-clear the check. */
+/**
+ * Board action on a background-check review: `reset` returns it to neutral (zero
+ * attestations, ready for re-review), `approve` force-clears a BLOCKED one.
+ *
+ * `reset` reaches a review that is BLOCKED **or** still in progress — an
+ * accidental first approval is the same "restart this review" as a board reset,
+ * so both share one definition. A review that has already CLEARED is out of
+ * reach: its side effects (the guardians' lastBackgroundCheck stamp, activation,
+ * the opened PERSON_BG rows, the sent mail) have already fanned out, and
+ * deleting the attestations would leave a cleared row with nothing behind it.
+ * `approve` stays BLOCKED-only — force-clearing a review still open to its
+ * second reviewer is what the two-reviewer rule forbids.
+ */
 export async function overrideBlocked(processId: number, actorId: number, action: "reset" | "approve", opts?: { isSysadmin?: boolean }) {
     const process = await prisma.orgMembershipProcess.findUnique({
         where: { id: processId },
         include: { orgMembership: { select: { household: { select: { intakeNotes: true } } } } },
     });
     if (!process) throw new ReviewError("not_found", "Application not found.");
-    if (process.status !== "BLOCKED") throw new ReviewError("wrong_phase", "This application is not blocked.");
+    if (action === "approve" && process.status !== "BLOCKED") throw new ReviewError("wrong_phase", "This application is not blocked.");
 
     // Conflict of interest: a board member may not override their OWN household's blocked
     // application — else they could force-clear their family's failed background check, the
@@ -366,27 +378,27 @@ export async function overrideBlocked(processId: number, actorId: number, action
     }
 
     if (action === "reset") {
-        // Restore the review state that matches the cycle. The check runs in parallel,
-        // so a household process returns to PENDING_BG_CLEARANCE if it had already
-        // paid, else PENDING_PAYMENT. An unpaid one with a household intake note
-        // re-holds at PENDING_BG_REVIEW — the reset restarts review, and a note keeps
-        // payment gated on it (#907). Renewals follow the same household path, except
-        // one blocked BEFORE consent was recorded (only legacy RENEWAL_PENDING_BG
-        // rows — every current renewal path records consent before review can block)
-        // restarts at the external step itself — the parallel queue only lists
-        // PENDING_PAYMENT/PENDING_BG_CLEARANCE rows WITH consent, so parking an
-        // unconsented renewal there would strand it.
-        const reviewStatus: OrgMembershipProcessStatus =
-            process.kind === "PERSON_BG" ? "PENDING_BG_REVIEW"
-            : process.kind === "RENEWAL" && !process.bgConsentAt ? "PENDING_EXTERNAL_ACTION"
-            : process.paidAt ? "PENDING_BG_CLEARANCE"
-            : process.orgMembership?.household.intakeNotes?.trim() ? "PENDING_BG_REVIEW"
-            : "PENDING_PAYMENT";
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { processId } });
-        await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: reviewStatus, bgClearedAt: null, stageEnteredAt: new Date() } });
-        await audit(prisma, actorId, processId, { status: "BLOCKED" }, { status: reviewStatus, action: "board reset" });
+        const status = await prisma.$transaction(async (tx) => {
+            // FOR UPDATE per attest()'s contract: without it a concurrent second
+            // attestation could clear the check between the phase test and the delete,
+            // leaving a cleared process with no attestations behind it.
+            await tx.$queryRaw`SELECT id FROM "OrgMembershipProcess" WHERE id = ${processId} FOR UPDATE`;
+            const fresh = await tx.orgMembershipProcess.findUnique({ where: { id: processId }, select: { status: true, bgConsentAt: true, bgClearedAt: true } });
+            if (!fresh) throw new ReviewError("not_found", "Application not found.");
+            const blocked = fresh.status === "BLOCKED";
+            if (!blocked && !awaitingBgReview.has({ status: fresh.status, bgConsentAt: !!fresh.bgConsentAt, bgClearedAt: !!fresh.bgClearedAt })) {
+                throw new ReviewError("wrong_phase", "This background-check review is neither blocked nor still in progress.");
+            }
+            // A blocked application resumes at the review status its cycle calls for; one
+            // still in review already sits there, so only its attestations go.
+            const reviewStatus = blocked ? blockedResetStatus(process) : fresh.status;
+            await tx.backgroundCheckAttestation.deleteMany({ where: { processId } });
+            await tx.orgMembershipProcess.update({ where: { id: processId }, data: { status: reviewStatus, bgClearedAt: null, stageEnteredAt: new Date() } });
+            await audit(tx, actorId, processId, { status: fresh.status }, { status: reviewStatus, action: "board reset" });
+            return reviewStatus;
+        });
         await notifyReviewers();
-        return { status: reviewStatus };
+        return { status };
     }
 
     // FOR UPDATE per clearBackgroundCheck's contract: serializes a board approve
@@ -408,6 +420,33 @@ export async function overrideBlocked(processId: number, actorId: number, action
     // A cleared PERSON_BG resolves to ACTIVE; a household process gates on PENDING_PAYMENT.
     const status: OrgMembershipProcessStatus = activated ? "ACTIVE" : process.subjectPersonId ? "ACTIVE" : "PENDING_PAYMENT";
     return { status };
+}
+
+type BlockedResetRow = {
+    kind: string;
+    bgConsentAt: Date | null;
+    paidAt: Date | null;
+    orgMembership: { household: { intakeNotes: string | null } } | null;
+};
+
+/**
+ * The review status a BLOCKED application resumes at when the board resets it.
+ * The check runs in parallel, so a household process returns to
+ * PENDING_BG_CLEARANCE if it had already paid, else PENDING_PAYMENT. An unpaid one
+ * with a household intake note re-holds at PENDING_BG_REVIEW — the reset restarts
+ * review, and a note keeps payment gated on it (#907). Renewals follow the same
+ * household path, except one blocked BEFORE consent was recorded (only legacy
+ * RENEWAL_PENDING_BG rows — every current renewal path records consent before
+ * review can block) restarts at the external step itself: the parallel queue only
+ * lists PENDING_PAYMENT/PENDING_BG_CLEARANCE rows WITH consent, so parking an
+ * unconsented renewal there would strand it.
+ */
+function blockedResetStatus(process: BlockedResetRow): OrgMembershipProcessStatus {
+    return process.kind === "PERSON_BG" ? "PENDING_BG_REVIEW"
+        : process.kind === "RENEWAL" && !process.bgConsentAt ? "PENDING_EXTERNAL_ACTION"
+        : process.paidAt ? "PENDING_BG_CLEARANCE"
+        : process.orgMembership?.household.intakeNotes?.trim() ? "PENDING_BG_REVIEW"
+        : "PENDING_PAYMENT";
 }
 
 /**


### PR DESCRIPTION
Fixes #1398

## Why

Attesting a background check was a single unconfirmed click, and the recovery story was backwards from the risk: **reject** was reversible (`overrideBlocked(… "reset")`), while **approve** — including the second, clearing approve that stamps the guardians, activates or opens payment, sends mail, and opens `PERSON_BG` rows for the household's adults — had no gate and no way back.

## What changed

### 1. Confirmation on both actions

`membership-ops/review` now opens a confirm dialog before posting. It states **what the click does** rather than "are you sure?", because a generic dialog trains click-through:

| Case | Title | Body says |
|---|---|---|
| First approve | Record your approval? | records your approval of *X*; a second reviewer must also approve |
| Second (clearing) approve | Clear this background check? | you are the second reviewer for *X*; clears the check, records it against the household, opens payment (or activates if dues are paid), **emails the family**, cannot be undone |
| Reject | Reject this background check? | blocks *X*'s membership, notifies the board, applicant is not told the reason |

Symmetric on purpose — one code path, and the note that gates Reject today is friction, not a confirmation. The clearing approve is distinguished by copy + button colour rather than an extra gate.

### 2. A way back — one definition of "restart this review"

`overrideBlocked`'s `reset` now reaches a review that is **still in progress**, not only a `BLOCKED` one. Per the issue's Note, this extends the existing reset (attestation deletion, audit row, reviewer notification, conflict-of-interest rule) instead of adding a second one.

- **Still in review** → the row never left its phase, so the reset only drops the attestations; status and stamps are untouched. No new lifecycle edge, so `TRANSITIONS` / the generated lifecycle artifacts are unchanged.
- **BLOCKED** → unchanged behaviour; the per-cycle normalization ladder is extracted verbatim as `blockedResetStatus`.
- **CLEARED** → refused (`wrong_phase`). See "Not in this PR".
- `approve` stays `BLOCKED`-only: force-clearing a review still open to its second reviewer is exactly what the two-reviewer rule forbids.

The reset now runs inside a transaction holding the same `SELECT … FOR UPDATE` lock `attest()` takes. Without it, a concurrent second attestation can clear the check between the phase test and the delete, leaving a cleared process with no attestations behind it. The audit row records the real prior status (it was hardcoded `BLOCKED`).

### 3. Board surface

`membership-ops/applications` shows **"Clear approvals — start the review over"** on any in-review row holding ≥1 approval, behind its own confirm modal, disabled for the actor's own household like the neighbouring override controls.

It reuses `POST /api/membership-ops/applications/review-override` — **no new route, no registry entry, no response-shape change**, so nothing here touches the security boundary.

## Not in this PR (open policy questions)

Returning a **cleared** review to neutral. Deleting the attestations and nulling `bgClearedAt` is easy; the guardians' `lastBackgroundCheck` stamp, the `ACTIVE` membership, the sticky volunteer status, the opened `PERSON_BG` rows and the already-sent email are not, and the issue's own "which of those get unwound?" is a board decision, not an implementation detail. The service refuses it explicitly rather than half-unwinding, and the jsdoc says why.

Also skipped: a per-reviewer "withdraw my own attestation" button in the reviewer queue. `GET /api/membership/reviews` returns only rows the reviewer is *eligible to act on* (already-attested rows are filtered out), and the response is a stripped model bag — surfacing "mine" would need either a registry change or a new endpoint, i.e. its own boundary PR. The board-side reset covers the same slip today; say the word if the self-service version is wanted.

## Tests

- `membership-ops/review/__tests__/page.test.tsx` — clearing-approve confirmation names the consequence and posts nothing until confirmed; Cancel posts nothing; first-approve copy does not promise clearance; Reject is confirmed too.
- `membership-ops/applications/__tests__/page.test.tsx` — the in-review row with an approval offers the reset, and confirming posts `{ processId, action: "reset" }`.
- `membershipBgNonBlocking.integration.test.ts` — a still-open review resets to zero attestations with its status intact and a `board reset` audit row; the withdrawn approval is genuinely gone (same reviewer can attest again, and it still takes two to clear); once cleared, the reset is refused and the attestations survive.

`ModalsProvider` is wrapped **per suite**, not in the shared `test-helpers/rtl` harness: several suites `jest.mock("@mantine/modals")` and would receive an undefined provider from the harness (tried it — 6 suites / 99 tests fell over).

## Verification

- `tsc --noEmit` and eslint clean.
- Full unit tier: **2415/2415** passing (257 suites).
- Full integration tier against a live Postgres: **1255/1255** passing (128 suites).
- Flow tier not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)