### PR TITLE
fix(test): derive the announce-boundary dates from the boundary, not literals

### DIFF
--- a/checkin-app/src/app/__tests__/programAnnounceRecipients.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAnnounceRecipients.integration.test.ts
@@ -15,6 +15,7 @@ jest.mock('@/lib/email', () => ({
 }));
 
 import { notifyNewProgramAnnounced } from '@/lib/notifications';
+import { nextBoundary } from '@/lib/membership/renewal';
 import { sendEmail } from '@/lib/email';
 import prisma from '@/lib/prisma';
 
@@ -107,6 +108,12 @@ describe('notifyNewProgramAnnounced recipient set (#1153 covered-member audience
     describe('expired-at-midyear boundary', () => {
         let prevBoardSettings: { orgMembershipYearBoundary: Date | null; bgRecheckMonths: number } | null = null;
         const AUG1 = new Date(Date.UTC(2020, 7, 1)); // only month/day matter to nextBoundary()
+        // Both program dates are derived from the boundary the code will actually
+        // compute, never hardcoded: a literal date silently swaps the two cases
+        // once the real clock passes it.
+        const boundary = nextBoundary(AUG1, new Date());
+        const ENDS_AFTER_BOUNDARY = new Date(boundary.getTime() + 30 * 24 * 60 * 60 * 1000);
+        const ENDS_BEFORE_BOUNDARY = new Date((Date.now() + boundary.getTime()) / 2);
 
         beforeAll(async () => {
             const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
@@ -129,13 +136,13 @@ describe('notifyNewProgramAnnounced recipient set (#1153 covered-member audience
         });
 
         it('excludes the covered household when the program ends AFTER the boundary (unrenewed)', async () => {
-            await notifyNewProgramAnnounced({ name: 'Robotics Past Boundary', startAt: null, endAt: new Date('2026-12-01') });
+            await notifyNewProgramAnnounced({ name: 'Robotics Past Boundary', startAt: null, endAt: ENDS_AFTER_BOUNDARY });
             const recipients = mockSendEmail.mock.calls.map((c) => c[0]);
             expect(recipients).not.toContain(`covered-${TAG}@example.com`);
         });
 
         it('includes the SAME covered household when the program ends BEFORE the boundary', async () => {
-            await notifyNewProgramAnnounced({ name: 'Robotics Before Boundary', startAt: null, endAt: new Date('2026-07-25') });
+            await notifyNewProgramAnnounced({ name: 'Robotics Before Boundary', startAt: null, endAt: ENDS_BEFORE_BOUNDARY });
             const recipients = mockSendEmail.mock.calls.map((c) => c[0]);
             expect(recipients).toContain(`covered-${TAG}@example.com`);
         });


### PR DESCRIPTION
`main` is currently red, and so is every open PR. The cause is a self-expiring test, not anyone's change.

## What happened

`programAnnounceRecipients.integration.test.ts` configures an **Aug 1** membership-year boundary, then asserts both sides of the #1061 full-duration rule with hardcoded program end dates:

- ends AFTER the boundary → household excluded — used `2026-12-01`
- ends BEFORE the boundary → household included — used `2026-07-25`

Both only hold while the real clock is before **2026-08-01**. Past it, `nextBoundary()` rolls to `2027-08-01`, `2026-12-01` is suddenly *before* the boundary, and the exclusion case inverts:

```
● excludes the covered household when the program ends AFTER the boundary (unrenewed)
  Expected value: not "covered-announce-recip-test@example.com"
  Received array:     ["covered-announce-recip-test@example.com", ...]
```

The last green `main` run was 2026-07-31T23:08Z. Everything after the UTC date rollover fails, on any branch, regardless of content — I hit it simultaneously on two unrelated PRs (#1357, #1395), one of which only edits `src/security/registry.ts`.

## The fix

Derive both dates from the boundary the code will actually compute, so the cases stay on their intended sides forever:

```ts
const boundary = nextBoundary(AUG1, new Date());
const ENDS_AFTER_BOUNDARY  = new Date(boundary.getTime() + 30 * 24 * 60 * 60 * 1000);
const ENDS_BEFORE_BOUNDARY = new Date((Date.now() + boundary.getTime()) / 2);
```

`ENDS_BEFORE_BOUNDARY` is the midpoint between now and the boundary rather than `boundary - 1 day`, so it is strictly inside the window at every point in the year — including the rollover instant itself, where a one-day offset would land on today.

Verified by running `nextBoundary` standalone at four points across the calendar (just before the rollover, at the failing instant, mid-year, and the day before the next boundary). In all four: `after > boundary`, `before < boundary`, and `before >= now`.

## Not fixed here

`authzRoutes.integration.test.ts:51` seeds `lastBackgroundCheck: new Date('2026-01-01')`, which will drift stale as the clock advances. It is not asserting freshness today so it is not failing, but it is the same class. Flagging rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier