### PR TITLE
fix(test): anchor the trends seed so it can't straddle a month boundary

### DIFF
--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -33,7 +33,18 @@ describe('Facility trends API', () => {
     let eventId: number;
     const visitIds: number[] = [];
 
-    const hoursAgo = (h: number) => new Date(Date.now() - h * 60 * 60 * 1000);
+    // Every seeded arrival hangs off one anchor, a few minutes apart and at least an hour
+    // into the month, so the whole seed lands in a single calendar-month bucket no matter
+    // when the suite runs. The route buckets on arrivedAt only, so departures that spill
+    // past midnight into the next month are fine.
+    const NOW = new Date();
+    const monthStart = (d: Date) => new Date(d.getFullYear(), d.getMonth(), 1);
+    const ANCHOR = new Date(Math.max(NOW.getTime(), monthStart(NOW).getTime() + 60 * 60 * 1000));
+    // The bucket the assertions inspect, keyed the way the route keys it (local month start).
+    const BUCKET_START = monthStart(ANCHOR);
+    const arrival = (minutesBefore: number) => new Date(ANCHOR.getTime() - minutesBefore * 60 * 1000);
+    const departure = (minutesBefore: number, hours: number) =>
+        new Date(arrival(minutesBefore).getTime() + hours * 60 * 60 * 1000);
 
     beforeAll(async () => {
         const admin = await prisma.person.create({
@@ -60,7 +71,7 @@ describe('Facility trends API', () => {
         const otherProgram = await prisma.program.create({ data: { name: `Other ${TAG}` } });
         otherProgramId = otherProgram.id;
         const event = await prisma.event.create({
-            data: { programId, name: `Event ${TAG}`, startAt: hoursAgo(5), endAt: hoursAgo(2) },
+            data: { programId, name: `Event ${TAG}`, startAt: arrival(2), endAt: departure(2, 3) },
         });
         eventId = event.id;
 
@@ -71,23 +82,23 @@ describe('Facility trends API', () => {
 
         // Structured visit (associated to the event): enrolled adult, 3 hours -> participant.
         const structured = await prisma.visit.create({
-            data: { personId: enrolledAdultId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SCANNER', associatedEventId: eventId },
+            data: { personId: enrolledAdultId, arrivedAt: arrival(2), departedAt: departure(2, 3), arrivedVia: 'SCANNER', associatedEventId: eventId },
         });
         // Structured visit (associated to the event): non-enrolled youth, 2 hours -> volunteer.
         const youthStructured = await prisma.visit.create({
-            data: { personId: youthId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(3), arrivedVia: 'SCANNER', associatedEventId: eventId },
+            data: { personId: youthId, arrivedAt: arrival(2), departedAt: departure(2, 2), arrivedVia: 'SCANNER', associatedEventId: eventId },
         });
         // Unstructured visit (no event): non-enrolled adult volunteer, 1 hour.
         const unstructured = await prisma.visit.create({
-            data: { personId: volunteerId, arrivedAt: hoursAgo(4), departedAt: hoursAgo(3), arrivedVia: 'WEB' },
+            data: { personId: volunteerId, arrivedAt: arrival(1), departedAt: departure(1, 1), arrivedVia: 'WEB' },
         });
         // Synthetic "marked present" visit (arrivedVia SYSTEM) — must be excluded entirely.
         const synthetic = await prisma.visit.create({
-            data: { personId: volunteerId, arrivedAt: hoursAgo(5), departedAt: hoursAgo(2), arrivedVia: 'SYSTEM', associatedEventId: eventId },
+            data: { personId: volunteerId, arrivedAt: arrival(2), departedAt: departure(2, 3), arrivedVia: 'SYSTEM', associatedEventId: eventId },
         });
         // Still-open visit (no departedAt) — excluded (departedAt: { not: null } in the where).
         const open = await prisma.visit.create({
-            data: { personId: youthId, arrivedAt: hoursAgo(1), arrivedVia: 'WEB' },
+            data: { personId: youthId, arrivedAt: arrival(0), arrivedVia: 'WEB' },
         });
         visitIds.push(structured.id, youthStructured.id, unstructured.id, synthetic.id, open.id);
     });
@@ -119,8 +130,10 @@ describe('Facility trends API', () => {
         expect(data.period).toBe('month');
         expect(Array.isArray(data.buckets)).toBe(true);
 
-        // Everything we seeded lands in the current month's bucket.
-        const thisMonth = data.buckets[data.buckets.length - 1];
+        // Look the anchor's bucket up by periodStart: the seed's month is not necessarily
+        // the last bucket, since any unrelated visit in a later month adds one.
+        expect(data.buckets.map((b: { periodStart: string }) => b.periodStart)).toContain(BUCKET_START.toISOString());
+        const thisMonth = data.buckets.find((b: { periodStart: string }) => b.periodStart === BUCKET_START.toISOString());
         expect(thisMonth.uniqueVolunteers).toBeGreaterThanOrEqual(1);
         expect(thisMonth.uniqueParticipants).toBeGreaterThanOrEqual(1);
         // Structured (event-associated) = the 3h enrolled-adult + 2h youth visits; unstructured =


### PR DESCRIPTION
## The failure

`facilityTrendsAPI.integration.test.ts` → `buckets visits, splitting volunteer/participant and structured/unstructured hours` is red on `main`, blocking the merge queue for #1404, #1408, #1410, #1411 and #1412:

```
expect(received).toBeGreaterThanOrEqual(expected)
Expected: >= 1   Received: 0        // thisMonth.uniqueParticipants
```

## Mechanism

The seed was wall-clock relative (`hoursAgo(h) = Date.now() - h*3600_000`), while `/api/facility/trends` buckets visits by the **calendar month of `arrivedAt`** (`getPeriodStart`, local time; CI runs UTC) — and the test read `data.buckets[data.buckets.length - 1]`, assuming everything seeded landed in one, final bucket.

The failing run started 2026-08-01 04:39 UTC:

| seeded visit | arrivedAt | bucket |
|---|---|---|
| enrolled adult, 3h, event-associated | `hoursAgo(5)` = Jul 31 23:39 | July |
| youth, 2h, event-associated | `hoursAgo(5)` = Jul 31 23:39 | July |
| volunteer, 1h, no event | `hoursAgo(4)` = Aug 1 00:39 | August |

August held the volunteer (so `uniqueVolunteers >= 1` passed) and no participant (so `uniqueParticipants >= 1` failed); `structuredHours >= 5` would have failed next.

This is **not a one-off**. The five-hour spread means any CI run in roughly the first five hours of the 1st splits the seed — it recurs every month. Same class of bug as #1413.

## What changed

Test-only; the route is correct.

1. **One anchor for the whole seed.** All three arrivals derive from a single `ANCHOR`, one to two minutes apart and clamped to at least an hour past the month start, so they can never straddle a boundary regardless of when the suite runs. Durations are untouched (3h / 2h / 1h) — bucketing reads `arrivedAt` only, so a departure crossing midnight into the next month is harmless.
2. **Look the bucket up, don't assume it's last.** `data.buckets[length - 1]` → a `find` on `periodStart === BUCKET_START.toISOString()`, where `BUCKET_START` is the anchor's month start computed the way the route computes it. A `toContain` assertion runs first, so a future regression reports the available `periodStart`s instead of throwing on `undefined`.

No assertion thresholds change (`>= 1` / `>= 5` / `>= 1`), and the volunteer-vs-participant split is untouched. The file's other cases read `data.totals` or assert an empty `buckets`, so they carry no month assumption and are unchanged.

## Proving the boundary case

Not just "the suite is green today". Temporarily moved the anchor to 30 minutes **before** the current month start (so all arrivals land in the previous month and every departure crosses the boundary) and added an unrelated visit 30 minutes **after** it, so a later bucket exists:

- with the fix → **1254 passed, 128 suites**;
- with only the lookup reverted to `buckets[buckets.length - 1]` → reproduces the reported failure exactly, `Expected: >= 1 / Received: 0` on `uniqueParticipants`;
- probe reverted, re-run → **1254 passed** again.

## Verified

Against a throwaway Postgres, from `checkin-app/`:

- `npm run test:integration` (full tier) — 128 suites / 1254 passed, nothing else regressed
- `npx tsc --noEmit` — clean
- `npx eslint src/app/__tests__/facilityTrendsAPI.integration.test.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
