### PR TITLE
fix(test): make the getFullAttendance youth fixture relative to now

### DIFF
--- a/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
+++ b/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
@@ -9,6 +9,15 @@ jest.mock("@/lib/prisma", () => ({ __esModule: true, default: { visit: { findMan
 
 import { getFullAttendance } from "@/lib/getFullAttendance";
 
+// Age fixtures are relative to now so they never age past the youth boundary the
+// way a hardcoded year would; the day step keeps the age unambiguous mid-year.
+const yearsAgo = (n: number) => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() - n);
+    d.setDate(d.getDate() - 1);
+    return d;
+};
+
 const rows = [
     {
         id: 201, arrivedAt: new Date("2026-07-01T14:00:00Z"), departedAt: null, personId: 50,
@@ -23,7 +32,7 @@ const rows = [
         id: 203, arrivedAt: new Date("2026-07-01T14:10:00Z"), departedAt: null, personId: 70,
         person: {
             id: 70, email: "stu@example.com", name: null, isKeyholder: false,
-            dateOfBirth: new Date("2012-01-01"), householdId: 8, phone: "5557654321",
+            dateOfBirth: yearsAgo(10), householdId: 8, phone: "5557654321",
             household: { id: 8, emergencyContacts: [{ id: 2, name: "Con Two", phone: "5559990002", relationship: null }] },
         },
         event: null,


### PR DESCRIPTION
Finding #2 of #1415 (the clock-dependent-test inventory). Test-only, one file.

## The bug

`checkin-app/src/lib/__tests__/getFullAttendance.test.ts:26` seeded the person-70 fixture with a hardcoded `dateOfBirth: new Date("2012-01-01")`, and the suite asserts that person is a youth.

`getFullAttendance` classifies via `isYouth(v.person.dateOfBirth, { unknownIs: 'youth' })` → `calculateAge(dob)` against the real `Date.now()`. On **2030-01-01** that person turns 18 and `youthMap` reclassifies them as an adult. That cascades:

- `expect(attendance[1].participant.isYouth).toBe(true)`
- both `counts` aggregates — the youth moves into the `volunteers` bucket
- `safety.isTwoDeepViolation` — `unaccompaniedYouth.length > 0 && adultVisits.length < 2`. With no youth left it goes false on the first prong; in the null-DOB tests person 70 becomes the *second* adult and it goes false on the second.

Three of the file's seven tests, permanently red from that date, with nothing in the diff to bisect to.

## The fix

Build the DOB relative to now, using the day-step variant already in `src/lib/person/__tests__/adultDob.test.ts:5` — stepping one day off the birthday keeps the age unambiguous mid-year and sidesteps the leap-day rollover where `setFullYear` on Feb 29 lands on Mar 1.

```ts
const yearsAgo = (n: number) => {
    const d = new Date();
    d.setFullYear(d.getFullYear() - n);
    d.setDate(d.getDate() - 1);
    return d;
};
```

## Reviewer notes

- **The 1985 DOB on person 50 is left as a literal, deliberately.** An adult fixture only gets more adult — there is no boundary for it to cross. Same for the `arrivedAt` literals: `findMany` is mocked, so they only drive row order and are echoed straight back.
- **No production code touched.**
- The issue says "4 of the file's 6 tests". The file actually has 7 tests and the cascade lands on 3 — the `isYouth` and `counts`/`safety` assertions at L63 and L67–68 share one `it`.

## Verification

Plain unit test (prisma mocked in `jest.setup.js`), no DB. `npm run test:ci -- src/lib/__tests__/getFullAttendance.test.ts` — 7/7 pass.

Then a three-way check with the clock temporarily faked to `2031-01-01`:

| | result |
|---|---|
| relative fixture @ 2031 | 7/7 pass |
| old `2012-01-01` literal @ 2031 | **3 failed**, 4 passed — reproduces the predicted cascade |
| fake timer removed, re-run | 7/7 pass |

The fake timer is not part of the diff; the final `git diff` is the helper plus the one fixture line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)