### PR TITLE
test(programs): anchor programAgeBounds fixtures to a fixed start date

### DIFF
--- a/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
@@ -19,6 +19,12 @@ jest.mock('@/lib/notifications', () => ({
     sendNotification: jest.fn()
 }));
 
+// The program's start date, and the anchor every birthdate fixture is measured
+// from. A literal, not the real clock: reconstructing today's month/day N years
+// back only round-trips when that day exists in the target year, which Feb 29
+// does not. Jun 15 has a counterpart in every year, and a day on either side.
+const NOW = new Date('2026-06-15T12:00:00.000Z');
+
 describe('Program Age Bounds Integration Tests', () => {
     let testAdminId: number;
     let validUserId: number;
@@ -32,23 +38,24 @@ describe('Program Age Bounds Integration Tests', () => {
     let testProgramId: number;
 
     beforeAll(async () => {
-        // Calculate Birthdates dynamically relative to execution time.
+        // Birthdates are relative to NOW, which is also the program's start date —
+        // the instant the enroll route judges age against (calculateAge(dob,
+        // program.startAt)).
         // Built in UTC because calculateAge() compares UTC date components — a
         // local-midnight fixture lands on the wrong UTC day off-zero-offset and
         // shifts the "day before/after the birthday" cases by a year.
-        const now = new Date();
         const dobYearsAgo = (years: number, dayOffset = 0) =>
-            new Date(Date.UTC(now.getUTCFullYear() - years, now.getUTCMonth(), now.getUTCDate() + dayOffset));
+            new Date(Date.UTC(NOW.getUTCFullYear() - years, NOW.getUTCMonth(), NOW.getUTCDate() + dayOffset));
         const dob16 = dobYearsAgo(16);
         const dob12 = dobYearsAgo(12);
         const dob20 = dobYearsAgo(20);
         // Exact boundaries for program [minAge=14, maxAge=18].
-        // Birthday is today => exactly N years old today (eligible at both ends).
+        // Birthday is the start date => exactly N years old then (eligible at both ends).
         const dobExactly14 = dobYearsAgo(14);
         const dobExactly18 = dobYearsAgo(18);
-        // Birthday tomorrow, born 14 years ago => still 13 today (under).
+        // Birthday the day after, born 14 years ago => still 13 on the start date (under).
         const dobTurns14Tomorrow = dobYearsAgo(14, 1);
-        // Birthday yesterday, born 19 years ago => turned 19 already (over).
+        // Birthday the day before, born 19 years ago => turned 19 already (over).
         const dobTurned19Yesterday = dobYearsAgo(19, -1);
 
         // Clean up any leaked state from previous runs
@@ -112,7 +119,7 @@ describe('Program Age Bounds Integration Tests', () => {
                 name: 'Age Bounds Integration Test Program',
                 minAge: 14,
                 maxAge: 18,
-                startAt: new Date(),
+                startAt: NOW,
                 phase: 'UPCOMING',
                 enrollmentStatus: 'OPEN'
             }


### PR DESCRIPTION
Fixes finding 4 of the clock-dependent-test inventory (#1415). Deliberately **no** closing keyword — #1415 covers five findings and stays open for the other four.

Rebased onto main after #1465; see the review reply below for what changed.

## The bug

`programAgeBounds.integration.test.ts` builds its birthdate fixtures from today's UTC month/day N years back, and creates the program with `startAt: new Date()`:

```ts
const now = new Date();
const dobYearsAgo = (years, dayOffset = 0) =>
    new Date(Date.UTC(now.getUTCFullYear() - years, now.getUTCMonth(), now.getUTCDate() + dayOffset));
```

That construction does not round-trip on Feb 29. Run on **2028-02-29**: `Date.UTC(2014, 1, 29)` — February 2014 has 28 days — rolls forward to **Mar 1 2014**, and `calculateAge(2014-03-01, 2028-02-29)` is **13**, not 14. The "EXACTLY minAge today" fixture is a 13-year-old, the enroll route 400s, and the `expect(res.status).toBe(200)` assertion fails.

It recovers the next day: a one-day flake every four years, which is exactly why nobody would diagnose it while it was happening.

## What else the leap day does

Simulated against main's current `dobYearsAgo` + UTC `calculateAge`:

| Fixture | Constructed on 2028-02-29 | Age | Result |
|---|---|---|---|
| `dobExactly14` | `Date.UTC(2014,1,29)` → **2014-03-01** | **13** | **fails** — expects 200, gets 400 |
| `dobExactly18` | `Date.UTC(2010,1,29)` → **2010-03-01** | **17** | **passes for the wrong reason** — 17 sits inside [14,18], so the maxAge boundary is silently untested that day rather than failing loudly |
| `dobTurns14Tomorrow` | `Date.UTC(2014,1,30)` → **2014-03-02** | 13 | passes; fixture is a day off (birthday 2 days out, not "tomorrow") but lands on the right side of the bound |
| `dobTurned19Yesterday` | `Date.UTC(2009,1,28)` → **2009-02-28** | 19 | **unaffected** — `getUTCDate() - 1 = 28` exists in every February |
| `dob16` / `dob12` / `dob20` | 2012 / 2016 / 2008 | 16/12/20 | **unaffected** — 12, 16 and 20 years back from a leap year are themselves leap years |

Only 14, 18 and 19 years back from a leap year land on non-leap years, and only the `+0` and `+1` day offsets actually roll.

## The fix

The enroll route reads **no clock**: age is `calculateAge(dob, program.startAt)` off the stored row (`src/app/api/programs/[id]/participants/route.ts` → `checkProgramAge(..., asOf: currentProgram.startAt)`). So there is nothing to freeze — the fixtures and the start date just need to stop reasoning about `now` independently and share one literal anchor:

```ts
const NOW = new Date('2026-06-15T12:00:00.000Z');
```

used as `dobYearsAgo`'s anchor and as `startAt`. That is option 2 from #1415 ("inject `now`, use only literals"), which the issue ranks above pinning the clock — no fake timers, no leap-safe clamp helper, 14 lines added / 7 removed. Jun 15 has a counterpart in every year plus a day on either side, so all eight fixtures round-trip exactly.

**#1465's UTC construction is preserved** — `dobYearsAgo` and its `Date.UTC` are untouched apart from the anchor, because `calculateAge` compares UTC components and a local-midnight fixture would land on the wrong UTC day west of the meridian.

**Boundary intent is unchanged** — the point of these cases is to pin the exact edge, so none of it was blurred to buy robustness: birthday on the start date is eligible at both ends, turning minAge the day after is blocked, turning maxAge+1 the day before is blocked.

No production code touched. `calculateAge` is correct on the dates it is given.

## Verification

Real Postgres 16 (throwaway cluster, `prisma db push`, no seed needed — the suite self-cleans). Full integration tier, **129 suites / 1282 tests green** in each of four timezones, chosen to span the offset range since `TZ` is pinned nowhere (#1415's closing section):

| TZ | offset | result |
|---|---|---|
| `America/Chicago` (CDT) | −5 | 1282 passed |
| `UTC` | 0 | 1282 passed |
| `Pacific/Kiritimati` | +14 | 1282 passed |
| `Pacific/Midway` | −11 | 1282 passed |

Plus a simulation of the fixture arithmetic against `calculateAge` for anchor = 2028-02-29, 2026-01-31 (month-end, exercises the `± 1` day rollovers) and 2026-06-15 — the table above is that output. After the change every run behaves like the 2026-06-15 row regardless of the real clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)