### PR TITLE
fix(test): derive the person-BG minor DOB from the boundary, not a literal

### DIFF
--- a/checkin-app/src/app/__tests__/personBgComplianceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgComplianceAPI.integration.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { GET } from '@/app/api/membership-audit/compliance/route';
+import { nextBoundary } from '@/lib/membership/renewal';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 
@@ -19,6 +20,13 @@ jest.mock('next-auth/next', () => ({
 
 const TAG = 'person-bg-test';
 const RECHECK_MONTHS = 12;
+const BOUNDARY_SEED = new Date('2000-06-01'); // only month/day matter to nextBoundary()
+// Age is judged as-of the boundary the route computes from the real clock, so the
+// minor's DOB is derived from that same boundary — a literal year would age past
+// 18 and flip the verdict to NEEDED. 10 as of the boundary keeps clear of the
+// inclusive ≥18 edge.
+const BOUNDARY = nextBoundary(BOUNDARY_SEED, new Date());
+const MINOR_DOB = new Date(Date.UTC(BOUNDARY.getUTCFullYear() - 10, BOUNDARY.getUTCMonth(), BOUNDARY.getUTCDate()));
 
 function get() {
     return GET(new Request('http://localhost:4000/api/membership-audit/compliance', {
@@ -76,8 +84,8 @@ describe('GET /api/membership-audit/compliance — person BG buckets', () => {
         savedSettings = prev ? { bgRecheckMonths: prev.bgRecheckMonths, orgMembershipYearBoundary: prev.orgMembershipYearBoundary } : null;
         await prisma.boardSettings.upsert({
             where: { id: 1 },
-            create: { id: 1, bgRecheckMonths: RECHECK_MONTHS, orgMembershipYearBoundary: new Date('2000-06-01') },
-            update: { bgRecheckMonths: RECHECK_MONTHS, orgMembershipYearBoundary: new Date('2000-06-01') },
+            create: { id: 1, bgRecheckMonths: RECHECK_MONTHS, orgMembershipYearBoundary: BOUNDARY_SEED },
+            update: { bgRecheckMonths: RECHECK_MONTHS, orgMembershipYearBoundary: BOUNDARY_SEED },
         });
 
         const board = await prisma.person.create({
@@ -85,14 +93,14 @@ describe('GET /api/membership-audit/compliance — person BG buckets', () => {
         });
         boardId = board.id;
 
-        // Adult (37), no check → NEEDED. Enrolled as a participant.
+        // Adult, no check → NEEDED. Enrolled as a participant.
         participantId = (await makePerson('participant', { dateOfBirth: new Date('1990-01-01') })).id;
         // Adult, no check, in a non-member household → NEEDED, must appear in the person list.
         volunteerId = (await makePerson('volunteer', { dateOfBirth: new Date('1988-01-01') })).id;
         // Adult, no check → NEEDED. Program lead.
         leadId = (await makePerson('lead', { dateOfBirth: new Date('1985-01-01') })).id;
         // Under 18 → excluded even though attached as a volunteer.
-        minorId = (await makePerson('minor', { dateOfBirth: new Date('2015-01-01') })).id;
+        minorId = (await makePerson('minor', { dateOfBirth: MINOR_DOB })).id;
         // Adult with a current check → FRESH, excluded.
         freshId = (await makePerson('fresh', { dateOfBirth: new Date('1980-01-01'), lastBackgroundCheck: new Date() })).id;
         // No DOB, not declared adult → DOB_MISSING, not NEEDED.


### PR DESCRIPTION
Finding 3 of the clock-dependent-test inventory in #1415. Plain reference, no closing keyword — four other findings in that issue are still open.

## The bug

`personBgComplianceAPI.integration.test.ts` seeded its "minor" fixture with a hardcoded `dateOfBirth: new Date('2015-01-01')` and asserted `expect(needIds.has(minorId)).toBe(false)`.

The test configures a Jun 1 membership-year boundary, but the route computes the live boundary as `nextBoundary(settings.orgMembershipYearBoundary, new Date())` — the real clock — and `personBgVerdict` judges age as-of it, **boundary-inclusive**. Once the real clock passes **2032-06-01** the boundary rolls to 2033-06-01, DOB 2015-01-01 is 18 as of it, the verdict flips `MINOR` → `NEEDED`, the person lands in `peopleNeedingBgCheck`, and the exclusion assertion inverts. Permanent from that date.

Same class as #1413 (`8b0ba9f1`), and the same fix shape.

## What changed

One file, +9/-4.

```ts
const BOUNDARY_SEED = new Date('2000-06-01'); // only month/day matter to nextBoundary()
const BOUNDARY = nextBoundary(BOUNDARY_SEED, new Date());
const MINOR_DOB = new Date(Date.UTC(BOUNDARY.getUTCFullYear() - 10, BOUNDARY.getUTCMonth(), BOUNDARY.getUTCDate()));
```

- **Minor DOB** — derived from the same `nextBoundary()` the route calls, so it tracks the boundary by construction. Exactly 10 as of the boundary: 8 years of margin, and deliberately not on the inclusive ≥18 edge.
- **`BoardSettings` seed** — the `2000-06-01` literal appeared twice in the upsert (create + update); both now use `BOUNDARY_SEED`, so the fixture and the settings write cannot drift apart.
- **One comment** — `// Adult (37), no check → NEEDED` → `// Adult, no check → NEEDED`. The parenthetical age is itself a clock-dependent claim and is already wrong (1990-01-01 is 36 today).

No production code touched, no other test files touched.

## Left alone, deliberately

- **The 1990 / 1988 / 1985 / 1980 adult DOBs.** All asserted as `NEEDED`. Age only increases, so the ≥18 gate is true today and stays true; no date flips them. Deriving them would be churn against a failure that cannot happen.
- **`fresh`'s `lastBackgroundCheck: new Date()`.** Compared against `bgFreshThreshold(boundary, bgRecheckMonths)` = boundary − 12 months, which is always behind now. Robust by construction.

## Verification

Real integration run, not just reasoning. Throwaway Postgres, `prisma db push` + `prisma/seed.ts`, then the narrowed integration script.

1. **Real clock** — passes.
2. **Clock faked to 2040-07-15** (`jest.useFakeTimers` with every timer API in `doNotFake`, per the `programAgeStartDate.integration.test.ts` recipe, so Prisma's pg pool keeps working) — passes. Boundary resolves to 2041-06-01, derived DOB is 2031-06-01, still 10.
3. **Negative control** — same 2040 clock with the old `2015-01-01` literal restored: `✕ Expected: false / Received: true` at the `needIds.has(minorId)` assertion. Confirms the fake clock actually bit, and that the derivation is what carries the test past 2032.

The fake-timer block and the control were reverted before commit; the diff is the four hunks above only. `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
