### PR TITLE
fix(test): derive the PERSON_BG minor DOB from the boundary, not a literal

### DIFF
--- a/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { runPersonBgAnnualSweep } from '@/lib/membership/personBgTriggers';
+import { nextBoundary } from '@/lib/membership/renewal';
 import { attest, eligibleReviewProcessIds, ReviewError } from '@/lib/membership/review';
 import { activate } from '@/lib/membership/payment';
 import prisma from '@/lib/prisma';
@@ -25,6 +26,16 @@ const BOUNDARY_SEED = new Date('2000-09-01');
 
 /** Adult born long ago → ≥18 at any as-of date. */
 const ADULT_DOB = new Date('1990-01-01');
+
+/**
+ * The boundary the sweep itself will compute, and a DOB whose 18th birthday lands
+ * two months past it → 17 as of the boundary → MINOR. Derived, never a literal:
+ * nextBoundary() rolls with the real clock, so a fixed DOB ages past the boundary
+ * on a date nobody wrote down. The age gate is boundary-inclusive (a birthday
+ * exactly on the boundary counts as ≥18), hence the two-month margin.
+ */
+const BOUNDARY = nextBoundary(BOUNDARY_SEED, new Date());
+const NOT_YET_18_DOB = new Date(Date.UTC(BOUNDARY.getUTCFullYear() - 18, BOUNDARY.getUTCMonth() + 2, BOUNDARY.getUTCDate()));
 
 async function makeHousehold(slug: string) {
     return prisma.household.create({ data: { name: `${TAG} ${slug}` } });
@@ -111,8 +122,8 @@ describe('PERSON_BG triggers + subject-scoped clear + gate', () => {
         await setRecheckMonths(RECHECK_MONTHS);
         const hh = await makeHousehold('cohortA');
         const adult = await makePerson('cohort-adult', hh.id, { dateOfBirth: ADULT_DOB });
-        // Turns 18 AFTER the Sept-1 boundary → 17 as of the boundary → MINOR, not opened.
-        const notYet18 = await makePerson('cohort-notyet', hh.id, { dateOfBirth: new Date('2008-10-01') });
+        // Turns 18 AFTER the boundary → 17 as of the boundary → MINOR, not opened.
+        const notYet18 = await makePerson('cohort-notyet', hh.id, { dateOfBirth: NOT_YET_18_DOB });
         const fresh = await makePerson('cohort-fresh', hh.id, { dateOfBirth: ADULT_DOB, lastBackgroundCheck: new Date() });
         for (const p of [adult, notYet18, fresh]) await attachToProgram(`cohort-${p.id}`, p.id);
         // Not program-attached → out of scope even though ≥18.
@@ -165,7 +176,7 @@ describe('PERSON_BG triggers + subject-scoped clear + gate', () => {
         // no role-assignment trigger, and the annual run judges age as-of the boundary —
         // so nothing opens until the next annual run.
         const existingHh = await makeHousehold('existingHh');
-        const roleTaker = await makePerson('role-taker', existingHh.id, { dateOfBirth: new Date('2008-10-01') });
+        const roleTaker = await makePerson('role-taker', existingHh.id, { dateOfBirth: NOT_YET_18_DOB });
         await attachToProgram('role-taker', roleTaker.id);
         await runPersonBgAnnualSweep(new Date());
         expect(await personBgCountFor(roleTaker.id)).toBe(0);


### PR DESCRIPTION
Finding #1 of the clock-dependent-test audit in #1415. Same shape as the fix in #1413.

## The bug

`personBgTriggers.integration.test.ts` sets a Sept 1 membership-year boundary and calls `runPersonBgAnnualSweep(new Date())` — the real clock. The sweep resolves the boundary with `nextBoundary(settings.orgMembershipYearBoundary, now)`, which returns the next occurrence **>= now**, then judges age as of it via `personBgVerdict` → `calculateAge(dob, boundary)`.

Two fixtures hardcoded `dateOfBirth: new Date('2008-10-01')` — `notYet18` and `roleTaker`, both meaning "turns 18 after the boundary, so MINOR, so nothing opens". That holds only while the real clock sits before 2026-09-01. Past it, `nextBoundary` rolls to 2027-09-01, that DOB is 18 as of it, the verdict flips `MINOR` → `NEEDED`, the sweep opens a PERSON_BG process, and both `expect(personBgCountFor(...)).toBe(0)` assertions fail. Permanently, from 2026-09-01 onward — about a month out.

## The fix

Derive the DOB from the same `nextBoundary()` the sweep computes, never a literal:

```ts
const BOUNDARY = nextBoundary(BOUNDARY_SEED, new Date());
const NOT_YET_18_DOB = new Date(Date.UTC(BOUNDARY.getUTCFullYear() - 18, BOUNDARY.getUTCMonth() + 2, BOUNDARY.getUTCDate()));
```

Both fixtures use it. The 18th birthday lands two months past the boundary rather than on it: the age gate is boundary-**inclusive** (`calculateAge(dob, boundary) >= 18`, so a birthday exactly on the boundary counts as 18), and `calculateAge` reads *local* calendar getters against a UTC-midnight boundary — the margin absorbs both.

One file, test-only. No production code touched.

## Verification

**Math simulation** — mirrored `nextBoundary` + `calculateAge` standalone and swept every day 2026→2032 × 4 hours-of-day × 4 timezones (America/Chicago, UTC, UTC+14, UTC−11) = 8764 clocks. Age as of the boundary is 17 in every one.

**Real integration run** — throwaway Postgres, `prisma db push` + seed, full integration tier: **1254 passed, 128 suites**.

**Clock-fake probe with a control** — temporarily faked the date at module scope (the fixture consts evaluate at import, so faking in `beforeAll` is too late) using the `doNotFake` recipe from `programAgeStartDate.integration.test.ts`:

| Faked now | This PR's DOB | Old literal DOB |
|---|---|---|
| 2026-09-15 | 1254 passed | **2 failed** — `Expected: 0, Received: 1` at both assertions |
| 2027-06-01 | 1254 passed | — |
| 2029-11-20 | 1254 passed | — |

The control reproduces the predicted failure exactly; the fix eliminates it. Probe fully reverted, and the final real-clock run after reverting is green.

## Notes for the reviewer

- References #1415 without a closing keyword on purpose — that issue inventories five findings and four remain open.
- Unrelated but worth recording: the `test:integration` script cannot be narrowed by appending a path argument. Its `--testRegex` flag is variadic and swallows the positional as a second regex, which made jest treat the production `personBgTriggers.ts` as a test file ("Your test suite must contain at least one test"). The whole integration tier runs in ~15s, so running it unnarrowed is fine — but the "narrow by appending one path regex" guidance in the jest-run skill does not hold for this particular script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
