### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix stack trace exposure in error logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Found early returns checking buffer lengths (e.g., `providedBuffer.length !== expectedBuffer.length`) on webhook secrets and cron auth tokens before using `crypto.timingSafeEqual`.
 **Learning:** Returning early on length mismatch leaks the exact length of the expected secret.
 **Prevention:** Hash both the expected and provided secrets to a fixed length (e.g., using SHA-256) before passing them to `crypto.timingSafeEqual` to avoid leaking secret lengths while still safely catching any mismatch.
+
+## 2024-05-24 - Exposed Stack Traces in Database Logs
+**Vulnerability:** Raw error stack traces were being persisted in the `ErrorLog` database table via `logBackendError`.
+**Learning:** Persisting raw error stack traces in database tables that feed application dashboards can expose internal server information (e.g., directory structures and dependency versions) to users with dashboard access, breaking defense-in-depth.
+**Prevention:** Do not persist raw error stack traces in database tables that feed application dashboards. Stack traces should only be sent to secure, centralized logging infrastructure (like standard output/console logs).

--- a/checkin-app/src/lib/__tests__/logger.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/logger.integration.test.ts
@@ -63,7 +63,10 @@ describe('logger DB persistence + TTL purge', () => {
         });
 
         // logBackendError writes the new row, then runs the 30-day purge.
+        // Spy to suppress the intentional console.error it now emits.
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         await logBackendError(new Error('trigger'), `${TAG}-trigger`);
+        consoleSpy.mockRestore();
 
         expect(await prisma.errorLog.findUnique({ where: { id: old.id } })).toBeNull();
         expect(await prisma.errorLog.findUnique({ where: { id: recent.id } })).not.toBeNull();

--- a/checkin-app/src/lib/logger.ts
+++ b/checkin-app/src/lib/logger.ts
@@ -16,14 +16,15 @@ export const logger = {
 export async function logBackendError(error: unknown, route?: string, context?: unknown) {
     try {
         const message = error instanceof Error ? error.message : String(error);
-        const stack = error instanceof Error ? error.stack : undefined;
 
-        // 1. Insert the new error log
+        // Send full error with stack trace to the secure centralized logging infrastructure
+        console.error(`[Backend Error] Route: ${route || 'unknown'}`, error);
+
+        // 1. Insert the new error log (without stack trace for dashboard defense-in-depth)
         await prisma.errorLog.create({
             data: {
                 message,
                 route,
-                stack,
                 context: context ? JSON.parse(JSON.stringify(context)) : undefined, // Ensure it's JSON serializable
             }
         });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw error stack traces were being persisted in the `ErrorLog` database table via `logBackendError`.
🎯 Impact: Internal server information (e.g., directory structures and dependency versions) could be exposed to users with dashboard access, breaking defense-in-depth.
🔧 Fix: Modified `logBackendError` to log the full error with stack trace to the console (for centralized logging infrastructure) and removed the `stack` field from the database insert payload.
✅ Verification: Ensure the application builds and tests pass, and review the changes to `logger.ts` and `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [18437251526346002660](https://jules.google.com/task/18437251526346002660) started by @dkaygithub*