### PR TITLE
fix(time): compute age from UTC fields so a UTC-midnight DOB isn't read a day early

### DIFF
--- a/checkin-app/src/lib/__tests__/time.test.ts
+++ b/checkin-app/src/lib/__tests__/time.test.ts
@@ -1,4 +1,4 @@
-import { formatDate, formatTime, formatDateTime, formatVisitRange, APP_TIMEZONE, toDatetimeLocal, fromDatetimeLocal, formatDateOnly, parseDateOnly, isYouth } from '../time';
+import { formatDate, formatTime, formatDateTime, formatVisitRange, APP_TIMEZONE, toDatetimeLocal, fromDatetimeLocal, formatDateOnly, parseDateOnly, isYouth, calculateAge } from '../time';
 
 describe('calendar-date helpers', () => {
   it('stores a picked date at UTC midnight', () => {
@@ -29,6 +29,41 @@ describe('calendar-date helpers', () => {
     expect(parseDateOnly('')).toBeNull();
     expect(parseDateOnly(null)).toBeNull();
     expect(formatDateOnly(null)).toBe('');
+  });
+});
+
+// A DOB is a calendar date stored at UTC midnight, so age must be read from the
+// UTC fields. Every case here is run with the process timezone west of UTC —
+// where a local-field read sees the DOB a day early.
+describe('calculateAge west of UTC', () => {
+  const realTz = process.env.TZ;
+  beforeAll(() => { process.env.TZ = 'America/Chicago'; });
+  afterAll(() => { if (realTz === undefined) delete process.env.TZ; else process.env.TZ = realTz; });
+
+  const DOB = '2008-07-24T00:00:00.000Z';
+
+  it('does not age someone up the day before their birthday', () => {
+    // noon Chicago on 23 July, the day before the 18th birthday
+    expect(calculateAge(DOB, '2026-07-23T17:00:00.000Z')).toBe(17);
+  });
+
+  it('ages them up on the birthday', () => {
+    expect(calculateAge(DOB, '2026-07-24T17:00:00.000Z')).toBe(18);
+  });
+
+  it('judges a program age gate as-of a UTC-midnight start date', () => {
+    // program.asOf is a calendar date; leap birth year vs non-leap eval year is
+    // the case where two local reads disagree by a day and the age comes out low
+    expect(calculateAge('2008-03-01T00:00:00.000Z', '2026-03-01T00:00:00.000Z')).toBe(18);
+    expect(calculateAge(DOB, '2026-07-24T00:00:00.000Z')).toBe(18);
+    expect(calculateAge(DOB, '2026-07-23T00:00:00.000Z')).toBe(17);
+  });
+
+  it('rolls the birthday over at UTC midnight, not org-local midnight', () => {
+    // Documented ceiling of reading both sides as UTC (see calculateAge): from
+    // 7 PM Chicago on the eve, UTC is already the birthday. Fixed by the
+    // org-timezone provider, not by reading local fields here.
+    expect(calculateAge(DOB, '2026-07-24T00:30:00.000Z')).toBe(18);
   });
 });
 

--- a/checkin-app/src/lib/person/__tests__/adultDob.test.ts
+++ b/checkin-app/src/lib/person/__tests__/adultDob.test.ts
@@ -27,4 +27,29 @@ describe("normalizeAdultDob", () => {
     expect(normalizeAdultDob(yearsAgo(26))).toEqual({ dateOfBirth: null, isDeclaredAdult: true });
     expect(normalizeAdultDob(yearsAgo(40))).toEqual({ dateOfBirth: null, isDeclaredAdult: true });
   });
+
+  // The 26th-birthday boundary decides a persisted DoB strip, so a UTC-midnight
+  // DoB read through local calendar fields would destroy the date a day early.
+  describe("26th-birthday boundary west of UTC", () => {
+    const realTz = process.env.TZ;
+    const DOB = "2000-07-24T00:00:00.000Z";
+    beforeAll(() => {
+      process.env.TZ = "America/Chicago";
+      jest.useFakeTimers();
+    });
+    afterAll(() => {
+      jest.useRealTimers();
+      if (realTz === undefined) delete process.env.TZ; else process.env.TZ = realTz;
+    });
+
+    it("keeps the DoB at noon on the day before the 26th birthday", () => {
+      jest.setSystemTime(new Date("2026-07-23T17:00:00.000Z"));
+      expect(normalizeAdultDob(DOB)).toEqual({ dateOfBirth: new Date(DOB), isDeclaredAdult: false });
+    });
+
+    it("strips the DoB on the 26th birthday", () => {
+      jest.setSystemTime(new Date("2026-07-24T17:00:00.000Z"));
+      expect(normalizeAdultDob(DOB)).toEqual({ dateOfBirth: null, isDeclaredAdult: true });
+    });
+  });
 });

--- a/checkin-app/src/lib/time.ts
+++ b/checkin-app/src/lib/time.ts
@@ -115,13 +115,20 @@ export function parseDateOnly(value: string | null | undefined): Date | null {
  * `asOf` defaults to now (the common case). Program age gates pass the program's
  * start date so the bound is judged as-of when the program begins, not when the
  * person happens to register.
+ *
+ * Both sides are read via getUTC* because a DOB is a calendar date stored at UTC
+ * midnight — local fields off that instant read a day early west of UTC.
+ * ponytail: that pins the birthday rollover to UTC midnight (7 PM Chicago) for
+ * the default `asOf = now`, so an evening lookup can register a birthday a few
+ * hours early. Upgrade path is the org-timezone provider (design Axis 2 /
+ * Sequencing step 5), not a local-field read here — mixing the two is the bug.
  */
 export function calculateAge(dob: Date | string, asOf: Date | string = new Date()): number {
     const birthDate = new Date(dob);
     const today = new Date(asOf);
-    let age = today.getFullYear() - birthDate.getFullYear();
-    const m = today.getMonth() - birthDate.getMonth();
-    if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) age--;
+    let age = today.getUTCFullYear() - birthDate.getUTCFullYear();
+    const m = today.getUTCMonth() - birthDate.getUTCMonth();
+    if (m < 0 || (m === 0 && today.getUTCDate() < birthDate.getUTCDate())) age--;
     return age;
 }
 


### PR DESCRIPTION
Implements **Finding 7 / Sequencing step 4** of the date/time design of record
(`checkin-app/docs/designs/1149_DATE_TIME_TZ_DESIGN.md`) — the age half of step 1.
One bullet of the umbrella #1346; deliberately **no closing keyword**, since the
rest of that issue (F1, F3/F6, F8/F10, the org-tz source, the storage decision)
is untouched.

## What changed

Three lines in `calculateAge` (`checkin-app/src/lib/time.ts`), plus tests.

```diff
-    let age = today.getFullYear() - birthDate.getFullYear();
-    const m = today.getMonth() - birthDate.getMonth();
-    if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) age--;
+    let age = today.getUTCFullYear() - birthDate.getUTCFullYear();
+    const m = today.getUTCMonth() - birthDate.getUTCMonth();
+    if (m < 0 || (m === 0 && today.getUTCDate() < birthDate.getUTCDate())) age--;
```

`isYouth` delegates to it and needed no change of its own.

## Why

`dateOfBirth` is a **calendar date** stored at UTC midnight, but the age math read
**local** calendar fields off it. The deploy runs `America/Chicago`, where
`new Date("2008-07-24T00:00:00Z").getDate()` is **23** — the DOB reads a day early,
so the computed age is one day out on the person's actual birthday.

I brute-forced all 365 DOBs against both implementations under `TZ=America/Chicago`.
The old code failed in **two** directions:

1. **One year high**, on the day before every birthday — **364 of 365 DOBs**. The
   shifted DOB makes the birthday appear to arrive a day early. This is the
   dominant case.
2. **One year low**, on the birthday itself, when `asOf` is a UTC-midnight calendar
   date (a program start date) — exactly one DOB: **1 March with a leap birth year
   judged in a non-leap year**. Both sides shift back a day, into Februaries of
   different length, so they stop cancelling.

Worth noting for reviewers: with a calendar-date `asOf` the two local reads
normally shift symmetrically and cancel, so case 2 is much narrower than case 1.

## Highest-stakes caller

`normalizeAdultDob` (`lib/person/adultDob.ts:29`) uses `calculateAge(d) > MAX_PROGRAM_AGE`
to decide whether to **permanently strip a DOB** and set `isDeclaredAdult`. The
day-early read destroyed the date of a 25-year-old on the eve of their 26th
birthday — a persisted mutation, not just a display artifact. Covered by a
fake-timer test at that boundary.

## The `asOf` tradeoff — please review this call

`asOf` is mixed-kind: a **calendar date** from the program gates, a true **instant**
from the `new Date()` default. Reading both sides as UTC is exact for the
calendar-date case, but for the `now` case it moves the birthday rollover to UTC
midnight — **7 PM Chicago** — so a birthday can register ~5h early in the evening.

Defaulted to both-sides-UTC anyway, because it trades a **24h** wrongness window
for a **5h** one, and a mixed local/UTC comparison is the bug itself. The ceiling
is marked with a `ponytail:` comment on the function; the real fix is the
org-timezone provider (design Axis 2 / Sequencing step 5), not a local-field read
here. Easy to override if you'd rather wait for the provider.

## Callers verified, none changed

Every caller passes a calendar-date value (a Prisma UTC-midnight `Date`, an
`<input type="date">` string, or an ISO string), so the UTC read is correct at each:
`adultDob:29`, `programAge:37`, `getFullAttendance:82`, `my-household:42/407/424`,
`attendance/current:85`, `roles:52`, plus `personBgCheck:66`,
`participants/import:72`, `ProgramRosterTab:206`, `profile/page:94`,
`participants/new:42`, `household/leads:121`, `profile/onboarding-status:29`.

`personBgCheck:66` is worth a look: it passes the membership `boundary` from
`nextBoundary` (all-UTC) and its docstring promises "an 18th birthday landing
exactly on the boundary counts as ≥18". Under the old local read that promise was
false. This makes it true.

## Tests

- `src/lib/__tests__/time.test.ts` — new `calculateAge west of UTC` block, `TZ`
  forced to `America/Chicago` and restored after. Covers the eve-of-birthday case,
  the birthday, the calendar-`asOf` program gate (incl. the leap case), and one
  test that **asserts the UTC-midnight rollover ceiling** so the tradeoff is
  greppable rather than a surprise.
- `src/lib/person/__tests__/adultDob.test.ts` — fake-timer 26th-birthday boundary:
  keep-on-eve, strip-on-birthday.

Verified by reverting `calculateAge` and re-running: **3 fail**, restored → all pass.

Full unit suite: **257 suites / 2427 tests, all pass.** `npx tsc --noEmit`: clean.

## Out of scope (spotted, left alone)

- **F1** (DOB writer convention) is what made F7 exploitable: `adultDob.ts:28` gives
  midnight-UTC while `household/member/route.ts:59` passes a `"T12:00:00Z"` string
  into the same helper, so noon-UTC DOBs were immune and midnight ones weren't. This
  change makes both read identically for age purposes, but the storage split stands.
- **F8/F10** (visit windows, trends bucketing) — same local/UTC mixing, untouched.
- `attendance/household/page.tsx:43` defaults its filter to
  `new Date().toISOString().split('T')[0]` — "tomorrow" late in the Chicago evening
  (F9's class).
- The instant half of step 1 and `APP_TIMEZONE` are untouched — they need the
  AppSettings provider from step 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
