### PR TITLE
fix(dates): read calendar-date fields UTC-pinned (F3/F4/F5/F6/F9)

### DIFF
--- a/checkin-app/src/app/attendance/household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/attendance/household/__tests__/page.test.tsx
@@ -3,11 +3,31 @@ import { screen } from "@testing-library/react";
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 import { renderWithProviders, mockFetchJson, setSession, resetRtl } from "@/test-helpers/rtl";
+import { pinTimezone } from "@/test-helpers/tz";
 import HouseholdCheckins from "../page";
+import { fireEvent } from "@testing-library/react";
 
 beforeEach(() => resetRtl());
 
 describe("HouseholdCheckins", () => {
+    pinTimezone();
+
+    it("labels the ±7-day window on the filter date's own calendar days", async () => {
+        setSession({ id: 1 });
+        mockFetchJson({ "/api/household/visits": { visits: [] } });
+        const { container } = renderWithProviders(<HouseholdCheckins />);
+
+        fireEvent.change(await screen.findByLabelText("Lookup Date"), { target: { value: "2026-06-15" } });
+
+        // 2026-06-15 ± 7d, UTC-pinned. Rendered in a wall-clock zone west of UTC
+        // both labels slip to the 7th/21st.
+        expect(container.textContent).toContain("6/8/2026");
+        expect(container.textContent).toContain("6/22/2026");
+        expect(container.textContent).not.toContain("6/7/2026");
+        expect(container.textContent).not.toContain("6/21/2026");
+    });
+
+
     it("shows a loader while the session resolves", () => {
         setSession(null, "loading");
         renderWithProviders(<HouseholdCheckins />);

--- a/checkin-app/src/app/attendance/household/page.tsx
+++ b/checkin-app/src/app/attendance/household/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { Badge, Group, Table, Text, TextInput, Title } from "@mantine/core";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { useRequireRole } from "@/hooks/useRequireRole";
-import { formatDate, formatVisitRange, formatDateTime } from "@/lib/time";
+import { formatDateOnly, formatVisitRange, formatDateTime } from "@/lib/time";
 import { AttendanceTabs } from "../AttendanceTabs";
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -47,7 +47,7 @@ export default function HouseholdCheckins() {
 
       <Text size="sm" c="dimmed" mb="lg">
         {filterDate ? (
-          <>Showing activity from <strong>{formatDate(new Date(filterDate).getTime() - 7 * 24 * 60 * 60 * 1000)}</strong> to <strong>{formatDate(new Date(filterDate).getTime() + 7 * 24 * 60 * 60 * 1000)}</strong></>
+          <>Showing activity from <strong>{formatDateOnly(new Date(filterDate).getTime() - 7 * 24 * 60 * 60 * 1000)}</strong> to <strong>{formatDateOnly(new Date(filterDate).getTime() + 7 * 24 * 60 * 60 * 1000)}</strong></>
         ) : (
           <>Showing activity for the <strong>past 7 days</strong></>
         )}

--- a/checkin-app/src/app/membership-audit/broken/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-audit/broken/__tests__/page.test.tsx
@@ -6,11 +6,27 @@ jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } 
 
 import { screen } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import { pinTimezone } from "@/test-helpers/tz";
 import BrokenHouseholdsPage from "../page";
 
 beforeEach(() => resetRtl());
 
 describe("membership-audit/broken page", () => {
+  pinTimezone();
+
+  it("renders a UTC-midnight DOB as its own calendar day, not the day before", async () => {
+    mockFetchJson({
+      "/api/admin/broken-households": {
+        households: [{ id: 1, name: "The Days", members: [{ id: 10, name: "Dee Day", dateOfBirth: "1990-08-15T00:00:00.000Z" }] }],
+      },
+    });
+    const { container } = renderWithProviders(<BrokenHouseholdsPage />);
+    await screen.findByText("Dee Day", { exact: false });
+
+    expect(container.textContent).toContain("8/15/1990");
+    expect(container.textContent).not.toContain("8/14/1990");
+  });
+
   it("shows the empty state when there are no broken households", async () => {
     mockFetchJson({ "/api/admin/broken-households": { households: [] } });
     renderWithProviders(<BrokenHouseholdsPage />);

--- a/checkin-app/src/app/membership-audit/broken/page.tsx
+++ b/checkin-app/src/app/membership-audit/broken/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Alert, Badge, Box, Button, Card, Group, Loader, Stack, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
-import { formatDate, isYouth } from "@/lib/time";
+import { formatDateOnly, isYouth } from "@/lib/time";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 
 type Member = { id: number; name: string | null; dateOfBirth: string | null };
@@ -96,7 +96,7 @@ export default function BrokenHouseholdsPage() {
                       <Group key={m.id} justify="space-between" wrap="nowrap">
                         <Text size="sm">
                           {m.name || "Unnamed"}
-                          {m.dateOfBirth ? ` • ${formatDate(m.dateOfBirth)}` : " • no birthdate"}
+                          {m.dateOfBirth ? ` • ${formatDateOnly(m.dateOfBirth)}` : " • no birthdate"}
                           {isYouth(m.dateOfBirth) && (
                             <Badge ml="xs" size="xs" color="gray" variant="light">youth</Badge>
                           )}

--- a/checkin-app/src/app/membership-audit/compliance/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/__tests__/page.test.tsx
@@ -1,10 +1,26 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
+import { pinTimezone } from "@/test-helpers/tz";
 import CompliancePage from "../page";
 
 beforeEach(() => resetRtl());
 
 describe("membership-audit/compliance page", () => {
+  pinTimezone();
+
+  it("renders a UTC-midnight lastBackgroundCheck as its own calendar day, not the day before", async () => {
+    mockFetchJson({
+      "/api/membership-audit/compliance": {
+        households: [{ id: 1, name: "The Days", reasons: ["STALE_BG"], lastBackgroundCheck: "2024-08-15T00:00:00.000Z", leads: [] }],
+      },
+    });
+    const { container } = renderWithProviders(<CompliancePage />);
+    await screen.findByText("The Days");
+
+    expect(container.textContent).toContain("8/15/2024");
+    expect(container.textContent).not.toContain("8/14/2024");
+  });
+
   it("renders the everyone-in-compliance empty state", async () => {
     mockFetchJson({ "/api/membership-audit/compliance": {} });
     renderWithProviders(<CompliancePage />);

--- a/checkin-app/src/app/membership-audit/compliance/page.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, type ReactNode } from "react";
 import { Badge, Button, Card, Center, Group, Paper, Stack, Text, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { formatPhone } from "@/lib/phone";
+import { formatDateOnly } from "@/lib/time";
 import { PageLoader } from "@/components/ui/PageLoader";
 
 type Lead = { id: number; name: string | null; phone: string | null; email: string | null };
@@ -174,9 +175,7 @@ export default function CompliancePage() {
               {h.reasons.includes("STALE_BG") && (
                 <Text size="sm" c="dimmed" mb="xs">
                   Last background check:{" "}
-                  {h.lastBackgroundCheck
-                    ? new Date(h.lastBackgroundCheck).toLocaleDateString()
-                    : "Never"}
+                  {h.lastBackgroundCheck ? formatDateOnly(h.lastBackgroundCheck) : "Never"}
                 </Text>
               )}
               <Text size="sm" c="dimmed" mb="xs">Household Leads:</Text>

--- a/checkin-app/src/app/membership-ops/households/[id]/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Badge, Button, Card, Group, Stack, Text, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { PageLoader } from "@/components/ui/PageLoader";
+import { formatDateOnly } from "@/lib/time";
 
 type Enrollment = {
   status: "PENDING" | "ACTIVE";
@@ -26,8 +27,10 @@ type Household = {
   bgValidUntil?: string | null;
 };
 
+// Every date this renders (memberSince, validUntil, bgValidUntil) is a calendar
+// date at UTC midnight, so it must be read UTC-pinned or it shows the day before.
 const fmtDate = (s?: string | null) =>
-  s ? new Date(s).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "—";
+  s ? formatDateOnly(s, { year: "numeric", month: "short", day: "numeric" }) : "—";
 
 // A household detail view for the board — its members and each member's program
 // enrollments in one focused screen, off the noisy households list.

--- a/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/households/__tests__/page.test.tsx
@@ -5,6 +5,7 @@ jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl, router } from "@/test-helpers/rtl";
+import { pinTimezone } from "@/test-helpers/tz";
 import AdminHouseholdsPage from "../page";
 
 beforeEach(() => resetRtl());
@@ -29,6 +30,25 @@ const households = {
 };
 
 describe("membership-ops/households page", () => {
+  pinTimezone();
+
+  it("renders a UTC-midnight memberSince as its own calendar day, not the day before", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({
+      "/api/membership-ops/households": {
+        households: [{
+          ...households.households[0],
+          orgMembership: { status: "ACTIVE", memberSince: "2024-08-15T00:00:00.000Z" },
+        }],
+      },
+    });
+    const { container } = renderWithProviders(<AdminHouseholdsPage />);
+    await screen.findByText("The Smiths");
+
+    expect(container.textContent).toContain("Aug 15, 2024");
+    expect(container.textContent).not.toContain("Aug 14, 2024");
+  });
+
   it("loads and renders households with membership status", async () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({ "/api/membership-ops/households": households });

--- a/checkin-app/src/app/membership-ops/households/page.tsx
+++ b/checkin-app/src/app/membership-ops/households/page.tsx
@@ -9,6 +9,7 @@ import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { AdminEditHouseholdModal } from '@/components/admin/AdminEditHouseholdModal';
 import { sharesHousehold } from '@/lib/conflictOfInterest';
+import { formatDateOnly } from '@/lib/time';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 type Household = {
@@ -24,8 +25,10 @@ type Household = {
   bgValidUntil?: string | null;
 };
 
+// Every date this renders (memberSince, validUntil, bgValidUntil) is a calendar
+// date at UTC midnight, so it must be read UTC-pinned or it shows the day before.
 const fmtDate = (s?: string | null) =>
-  s ? new Date(s).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "—";
+  s ? formatDateOnly(s, { year: "numeric", month: "short", day: "numeric" }) : "—";
 
 export default function AdminHouseholdsPage() {
   const { user: me, ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);

--- a/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/__tests__/page.test.tsx
@@ -7,6 +7,7 @@ jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } 
 import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl, router } from "@/test-helpers/rtl";
 import { notifications } from "@mantine/notifications";
+import { pinTimezone } from "@/test-helpers/tz";
 import MergeParticipants from "../page";
 
 beforeEach(() => { resetRtl(); (notifications.show as jest.Mock).mockClear(); });
@@ -41,6 +42,8 @@ async function selectBoth() {
 }
 
 describe("membership-ops/participants/merge page", () => {
+  pinTimezone();
+
   it("searches, selects two participants, and analyzes them", async () => {
     setSession({ id: 1, isSysadmin: true });
     mockRoutes();
@@ -421,9 +424,11 @@ describe("membership-ops/participants/merge page", () => {
     const warningText = await screen.findByText(/Different birth dates may mean these are NOT the same person/);
     const alertBox = warningText.closest(".mantine-Alert-root") as HTMLElement;
     expect(alertBox).toBeInTheDocument();
-    // Still resolvable via the radio, just nested inside the warning — exact date
-    // text is locale/timezone-formatted (toLocaleDateString), so just count them.
     expect(within(alertBox).getAllByRole("radio")).toHaveLength(2);
+    // DOB is a calendar date at UTC midnight: both options must read as their own
+    // day, not the day before, even west of UTC.
+    expect(alertBox.textContent).toContain("1/1/1990");
+    expect(alertBox.textContent).toContain("6/15/2005");
   });
 
   it("renders nothing for a background-check reviewer who navigates directly", () => {

--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -9,6 +9,7 @@ import { MergedBadge } from "@/components/ui/MergedBadge";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { PageLoader } from "@/components/ui/PageLoader";
 import { formatPhone } from "@/lib/phone";
+import { formatDateOnly } from "@/lib/time";
 
 interface ParticipantMergeView {
   id: number;
@@ -59,9 +60,11 @@ function identityOptionLabel(p: { email?: string; googleId?: string; emailVerifi
 }
 
 function formatFieldValue(field: ConflictField, value: unknown): string {
+  // dateOfBirth is the only date-kind field in CONFLICT_FIELDS, so the calendar-date
+  // (UTC-pinned) read is right for every value that reaches this branch.
   if (field === "dateOfBirth" && typeof value === "string") {
     const d = new Date(value);
-    return isNaN(d.getTime()) ? String(value) : d.toLocaleDateString();
+    return isNaN(d.getTime()) ? String(value) : formatDateOnly(d);
   }
   if (field === "phone" && typeof value === "string") return formatPhone(value);
   return String(value ?? "—");

--- a/checkin-app/src/app/my-household/__tests__/page.test.tsx
+++ b/checkin-app/src/app/my-household/__tests__/page.test.tsx
@@ -7,6 +7,7 @@ jest.mock("@mantine/notifications", () => ({ notifications: { show: jest.fn() } 
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { notifications } from "@mantine/notifications";
 import { renderWithProviders, mockFetchJson, setSession, resetRtl, router } from "@/test-helpers/rtl";
+import { pinTimezone } from "@/test-helpers/tz";
 import HouseholdPage from "../page";
 
 // Successes toast via notifications.show (no inline banner); assert on the mock.
@@ -67,6 +68,18 @@ function mockRoutes(overrides: Record<string, unknown | (() => unknown)> = {}) {
 }
 
 describe("HouseholdPage", () => {
+  pinTimezone();
+
+  // memberSince is a calendar date at UTC midnight; a Jan 1 start read with a
+  // local getFullYear() west of UTC reports the previous year.
+  it("reads the memberSince year in UTC, not the viewer's local zone", async () => {
+    setSession({ id: 10, email: "sam@example.com" });
+    mockRoutes();
+    renderWithProviders(<HouseholdPage />);
+
+    expect(await screen.findByText("✓ Member since 2024")).toBeInTheDocument();
+  });
+
   it("loads and renders household members", async () => {
     setSession({ id: 10, email: "sam@example.com" });
     mockRoutes();

--- a/checkin-app/src/app/my-household/page.tsx
+++ b/checkin-app/src/app/my-household/page.tsx
@@ -376,7 +376,8 @@ export default function HouseholdPage() {
             ) : household.orgMembership?.status === 'ACTIVE' ? (
               <Alert mb="lg">
                 <Group gap="xs" wrap="wrap">
-                  <Text fw={600}>✓ Member{household.orgMembership.memberSince ? ` since ${new Date(household.orgMembership.memberSince).getFullYear()}` : ''}</Text>
+                  {/* memberSince is a calendar date at UTC midnight — getUTCFullYear, or a Jan 1 start reads as the prior year. */}
+                  <Text fw={600}>✓ Member{household.orgMembership.memberSince ? ` since ${new Date(household.orgMembership.memberSince).getUTCFullYear()}` : ''}</Text>
                   {household.orgMembership.isVolunteer && <Badge variant="light">Volunteer-only family</Badge>}
                 </Group>
               </Alert>

--- a/checkin-app/src/test-helpers/tz.ts
+++ b/checkin-app/src/test-helpers/tz.ts
@@ -1,0 +1,15 @@
+/**
+ * Pin the process timezone to a zone west of UTC for the duration of a suite.
+ *
+ * Calendar-date fields are stored at UTC midnight; rendering one through a
+ * wall-clock zone west of UTC yields the previous day. These tests only prove
+ * that if the process is actually in such a zone — CI runs in UTC, where the
+ * bug is invisible. See docs/designs/1149_DATE_TIME_TZ_DESIGN.md.
+ *
+ * A jest lifecycle wrapper, not a React hook — call it inside a describe block.
+ */
+export function pinTimezone(tz = "America/Chicago") {
+    const original = process.env.TZ;
+    beforeAll(() => { process.env.TZ = tz; });
+    afterAll(() => { process.env.TZ = original; });
+}


### PR DESCRIPTION
Sequencing **step 2** of the date/time design of record — [`checkin-app/docs/designs/1149_DATE_TIME_TZ_DESIGN.md`](checkin-app/docs/designs/1149_DATE_TIME_TZ_DESIGN.md) — the calendar-date reader sweep. Covers findings **F3, F4, F5, F6, F9**.

#1366 added `formatDateOnly` to `lib/time.ts` and applied it to Program `startAt`/`endAt` (Finding 2). This is the rest of the calendar-date readers.

## The bug

A calendar-date field is stored at UTC midnight, then rendered through something that applies a wall-clock zone — `formatDate` (pinned to `America/Chicago`), a bare `toLocaleDateString()` (server/viewer local), or a local `getFullYear()`. West of UTC, all three render the **previous day**.

## Sites fixed

| Finding | Site | Change |
|---|---|---|
| F4 | `membership-audit/broken/page.tsx:99` | `formatDate(dateOfBirth)` → `formatDateOnly` |
| F6 | `membership-audit/compliance/page.tsx:177` | `new Date(x).toLocaleDateString()` → `formatDateOnly(x)` |
| F3 | `membership-ops/households/page.tsx:29`, `households/[id]/page.tsx:31` | local `fmtDate` routed through `formatDateOnly`, option bag kept |
| F3 | `my-household/page.tsx:380` | `getFullYear()` → `getUTCFullYear()` |
| F5 | `membership-ops/participants/merge/page.tsx:65` | `d.toLocaleDateString()` → `formatDateOnly(d)` |
| F9 | `attendance/household/page.tsx:50` | both ±7-day window label calls → `formatDateOnly` |

F6 is compliance-facing: a background-check date reading a day early is a report artifact. F9 is display-only — the actual query is server-side (F8, out of scope).

## F5 — traced, no split needed

`formatFieldValue(field, value)` is a *generic* value formatter across the merge diff, so the design flags it as "`formatDateOnly` for the DOB rows" — not a blanket convert. Tracing what actually reaches it:

`field: ConflictField` = `typeof CONFLICT_FIELDS[number]` = `"name" | "phone" | "dateOfBirth"`, and the date branch is **already gated** on `field === "dateOfBirth"`. Both call sites pass a `field` drawn from `conflicts`, a `.filter()` over `CONFLICT_FIELDS`. No `*At` audit field, no `pendingSince`, no instant of any kind can reach the date branch.

So only calendar dates flow through it — converted in place rather than split. **No instant is UTC-pinned by this change.** (The design doc describes the helper as rendering "DOB (and any date value)"; that's stale for the current source, which is DOB-only.)

## Note on F3: `validUntil` / `bgValidUntil`

The two `fmtDate` helpers also render `validUntil` and `bgValidUntil`, not just `memberSince`. Both derive from `nextBoundary` off `orgMembershipYearBoundary` — all-UTC per the design's confirmed-correct map — and `bgValidUntilBoundary` explicitly truncates to a UTC day. Both are calendar dates, so UTC-pinning them is correct, not collateral damage.

## ⚠️ Second behavior change beyond the finding — locale

The two `membership-ops/households` `fmtDate` helpers hardcoded the **`"en-US"` locale**. `formatDateOnly(date, options)` has **no locale parameter** — it passes `undefined`, deferring to the viewer. With `lib/time.ts` off-limits for this PR (see below) there was no way to preserve the pin, and deferring matches `formatDate` app-wide.

For a viewer whose browser locale isn't en-US, the format shifts: `Feb 24, 2026` → `24 Feb 2026`. Both pages are client-rendered, so there's no hydration-mismatch exposure.

Flagging it because a reviewer diffing those two lines will read the timezone fix and miss the locale one. If the en-US pin turns out to be deliberate rather than incidental, a `locale` parameter on `formatDateOnly` would restore it later — not proposed here, since deferring to the viewer is the better default.

## Tests

New `src/test-helpers/tz.ts` → `pinTimezone()`, a jest lifecycle wrapper that pins `process.env.TZ` to `America/Chicago` for a suite. **This is load-bearing: CI runs in UTC, where every one of these bugs is invisible.** Without it the assertions would prove nothing.

Six new assertions, one per site class — DOB, `lastBackgroundCheck`, `memberSince` (list render + `my-household` year), DOB in the merge diff, and the F9 label pair:

- Against pre-change source: **6 failed**, 58 passed
- Against this branch: **64 passed**
- Full unit suite: **257 suites, 2426 tests, all green**
- `npx tsc --noEmit` clean; `eslint` clean

## Deliberately left alone

- **`lib/time.ts`** — owned by an in-flight task (age → `getUTC*`). Not touched, no new helpers added.
- **All writers** — F1's DOB storage-convention split (`adultDob.ts:28`, the `"T12:00:00Z"` at `household/member/route.ts:59`, `intake.ts:221`, `importDob.ts`), plus the `memberSince` writer and its already-UTC-correct round-trip guard.
- **`program-ops/sessions/[id]/page.tsx:442`** and **`components/admin/AuditLogPanel.tsx:145`** — bare `toLocaleDateString()` on *true instants*. Real bugs, but the Axis 2 / step 5 org-timezone-provider class. UTC-pinning them would swap one wrong rendering for another.
- **`attendance/household/page.tsx:43`** — the `new Date().toISOString().split('T')[0]` filter default is "today in UTC", already tomorrow after ~7pm Chicago. A correct fix needs the org-timezone provider; reaching for the hardcoded `APP_TIMEZONE` would just pin a second wrong zone.
- **`membership-ops/households/[id]/page.tsx` has no test file** — its `fmtDate` is covered only via the identical helper on the list page. Standing up a first test file for that page was more scaffolding than the finding warranted; flagging rather than silently skipping.
- **F8, F10, F12** — out of scope per the design's sequencing.

## 🔀 Merge-order constraint

**This must merge BEFORE the F1 writer chip.**

F1 collapses the noon-UTC DOB writer (`household/member/route.ts:59`) down to midnight-UTC. Those noon-UTC DOBs render correctly today *only* because noon dodges the zone shift — they're the one convention that survives a Chicago-pinned `formatDate`. Landing the writer first would strip that accidental protection while the readers are still zone-applying, regressing every currently-correct DOB display.

Readers first, then writers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
