### PR TITLE
fix(security): narrow GET /api/programs/[id] to an explicit select

### DIFF
--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -49,17 +49,59 @@ const getProgram = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
     const programId = parseInt(params.id, 10);
     if (isNaN(programId)) throw badRequest('Invalid program ID');
 
+    // Explicit select, not include: whole rows would ship every pii/personal
+    // column a lead mentor's view happens to grant (googleId, dateOfBirth,
+    // allergies, the payment-plan flags) plus any column added later. The id /
+    // programId / personId / householdId keys below are ROW_SCOPE_KEYs — drop
+    // one and scopesHeld() fails closed and strips the row for the very roles
+    // this route serves (see the emergencyContacts note).
     const program = await prisma.program.findUnique({
         where: { id: programId },
-        include: {
-            volunteers: { where: { person: LIVE_PERSON }, include: { person: true } },
+        select: {
+            id: true,
+            name: true,
+            leadMentorId: true,
+            startAt: true,
+            endAt: true,
+            phase: true,
+            enrollmentStatus: true,
+            orgMemberOnly: true,
+            announceOnOpen: true,
+            minAge: true,
+            maxAge: true,
+            maxParticipants: true,
+            orgMemberPriceCents: true,
+            nonOrgMemberPriceCents: true,
+            shopifyProductId: true,
+            shopifyVariantId: true,
+            shopifyOrgMemberVariantId: true,
+            shopifyNonOrgMemberVariantId: true,
+            volunteers: {
+                where: { person: LIVE_PERSON },
+                select: {
+                    programId: true,
+                    personId: true,
+                    isCore: true,
+                    person: { select: { id: true, name: true, email: true } },
+                },
+            },
             participants: {
                 where: { person: LIVE_PERSON },
-                include: {
+                select: {
+                    programId: true,
+                    personId: true,
+                    status: true,
+                    pendingSince: true,
                     person: {
-                        include: {
+                        select: {
+                            id: true,
+                            name: true,
+                            email: true,
+                            phone: true,
+                            householdId: true,
                             household: {
-                                include: {
+                                select: {
+                                    id: true,
                                     emergencyContacts: {
                                         where: { conflictParticipantId: null, name: { not: "" }, phone: { not: "" } },
                                         orderBy: [{ priority: "asc" }, { id: "asc" }],
@@ -74,8 +116,18 @@ const getProgram = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
                     },
                 },
             },
-            events: { orderBy: { startAt: 'asc' } },
-            leadMentor: true,
+            events: {
+                orderBy: { startAt: 'asc' },
+                select: {
+                    id: true,
+                    programId: true,
+                    name: true,
+                    startAt: true,
+                    endAt: true,
+                    attendanceConfirmedAt: true,
+                },
+            },
+            leadMentor: { select: { id: true, name: true, email: true } },
             _count: { select: { participants: { where: { person: LIVE_PERSON } }, volunteers: { where: { person: LIVE_PERSON } } } },
         },
     });


### PR DESCRIPTION
## What

`getProgram` in `checkin-app/src/app/api/programs/[id]/route.ts` built its query with `include`, which pulls **whole rows**. Replaced the include tree with an explicit `select`. `PATCH` in the same file is untouched.

## Why

The route's `programLeadMentor` / `programCoreVolunteer` registry views grant `their_program_participants:pii` and `:personal`, and `SCOPE_BINDINGS.Person.their_program_participants` resolves for every program the caller leads or core-volunteers. Whole rows meant those grants were fully spent. A program lead or core volunteer received, per enrolled participant `Person`:

- `pii` — `googleId`, `email`, `phone`
- `personal` — `dateOfBirth`, `notificationSettings`, `emailSuppressed`, `allergies`

and per `ProgramParticipant` row: `isPaymentPlanRequested` + `paymentPlanDeniedAt` — a scholarship / financial-hardship signal. The frontend renders `name`, `email`, and `phone`.

Beyond the live over-disclosure, the whole-row shape auto-widens: any column added later and tagged `pii`/`personal` would ship to leads with no route diff and no failing test.

No `internal` was ever exposed here — this route's lead/core-vol view grants no `:internal` token.

## Fields kept deliberately

These are `ROW_SCOPE_KEY`s. `scopesHeld()` reads them off the row; drop one and it fails closed, stripping the row for the very roles the route serves — the failure mode the existing `householdId` comment on `emergencyContacts` already warns about.

- `Person.id`, `Person.householdId` — `their_own`, `their_households`, `their_program_participants`. `householdId` is doubly load-bearing: the route's own enrollment gate reads `p.person?.householdId`.
- `Household.id` — `their_households`
- `Program.id`, `ProgramParticipant.programId`, `ProgramVolunteer.programId`, `Event.programId` — `their_program_participants`
- `ProgramParticipant.personId`, `ProgramVolunteer.personId` — `their_own`

Two more that no rendered element reads:

- `shopifyVariantId` — `isProgramCheckoutBroken(program)` reads it at runtime through `CheckoutFields`, where it's optional, so **tsc is blind here**; the program-ops `ProgramDetail` type doesn't declare it. The public enroll page also picks the single-pool variant from it.
- `pendingSince` — the consumer type declares it and admin/board render it. It's `internal`, so it already strips for leads; the stripper makes that call, not the query.

The `emergencyContacts` sub-select is unchanged, comment included — it was already correct and is the model for the rest.

## Reviewer notes

- **Not a security-boundary change.** No edits under `checkin-app/src/security/` — no registry entry, no scope binding, no classification, no re-tier. Route file only, so the `AGENTS.md` boundary-isolation rule doesn't apply.
- No schema change.
- Narrowing the root select also narrows the `{ ...program }` metadata spread, which is the **public catalog payload**. Verified against `checkin-app/src/app/programs/[id]/page.tsx` — `leadMentor`, `participants[].person.{name,householdId}`, `_count.participants`, prices, dates, ages, `orgMemberOnly`, and all Shopify variant ids still arrive.

## Testing

Run from `checkin-app/`, all foreground. The worktree had no `node_modules`, so `npm install` + `prisma generate` ran first.

- `npx tsc --noEmit` — clean
- `test:ci -- "programs/\[id\]"` — 3 suites, 70 passed
- `test:ci -- "emergency-contact-program-scope"` — 9 passed
- `test:integration -- --runInBand "programsIdAPI"` — 27 passed, against a throwaway local Postgres
- `test:ci -- "src/security/__tests__"` — 39 passed
- `test:ci -- "routeAuthDrift"` — 440 passed (the drift guard parses route sources for edge-model reads, which is exactly the shape `include`→`select` changes)

No test asserted on a field the narrowed select drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
