### PR TITLE
fix(security): narrow GET /api/events/[id] to an explicit select

### DIFF
--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -28,28 +28,55 @@ export const GET = handler<{ id: string }>('GET /api/events/[id]', async ({ auth
     const eventId = parseInt(params.id, 10);
     if (isNaN(eventId)) throw badRequest('Invalid event ID');
 
+    // Explicit select, not include: whole rows would ship every pii/personal/
+    // internal Person and ProgramParticipant column to this event's lead mentors
+    // and core volunteers, whose view grants their_program_participants on all
+    // three tiers. Ids and the join keys below are not rendered — they are the
+    // scope keys scopesHeld() reads to resolve their_program_participants /
+    // their_own; drop one and the row strips to nothing for those roles.
     const event = await prisma.event.findUnique({
         where: { id: eventId },
-        include: {
+        select: {
+            id: true,
+            programId: true,
+            name: true,
+            startAt: true,
+            endAt: true,
+            attendanceConfirmedAt: true,
+            recurringGroupId: true,
+            attendanceConfirmedBy: { select: { name: true } },
             program: {
-                include: {
+                select: {
+                    id: true,
+                    name: true,
+                    leadMentorId: true,
                     volunteers: {
                         where: { person: LIVE_PERSON },
-                        include: { person: true }
+                        select: {
+                            programId: true,
+                            personId: true,
+                            isCore: true,
+                            person: { select: { id: true, name: true, email: true } }
+                        }
                     },
                     participants: {
                         where: { person: LIVE_PERSON },
-                        include: { person: true }
+                        select: {
+                            programId: true,
+                            personId: true,
+                            status: true,
+                            person: { select: { id: true, name: true, email: true } }
+                        }
                     }
                 }
             },
-            visits: { where: LIVE_VISIT },
+            visits: {
+                where: LIVE_VISIT,
+                select: { id: true, personId: true, arrivedAt: true, departedAt: true }
+            },
             rsvps: {
                 where: { person: LIVE_PERSON },
-                include: { person: true }
-            },
-            attendanceConfirmedBy: {
-                select: { name: true }
+                select: { eventId: true, personId: true, status: true }
             }
         }
     });


### PR DESCRIPTION
## What

`GET /api/events/[id]` fetched the event with a bare `include` tree and no top-level `select`, so it returned **whole rows** for `Event`, `Program`, `Person`, `ProgramParticipant`, `ProgramVolunteer`, `Visit` and `RSVP`. This replaces that tree with an explicit `select`.

## Why

The route's `authenticated` view (`src/security/registry.ts`) grants `their_program_participants` on **pii, personal AND internal**, and the inline staff gate at `route.ts:60-66` means the non-admin caller reaching that view is a lead mentor or core volunteer of this event's program. `SCOPE_BINDINGS.Person.their_program_participants` resolves off `participantIdsInScopePrograms`, which `buildCallerContext` fills from every program the caller leads or core-volunteers — so the scope resolves and the stripper passes the whole row through.

A lead mentor was therefore receiving, per rostered participant:

- **pii**: `googleId`, `email` (only `email` is rendered), `phone`
- **personal**: `dateOfBirth`, `notificationSettings`, `emailSuppressed`, `allergies`
- **internal**: `emailVerified`, `isDeclaredAdult`, `lastWaiverSign`, `waiverSignedBy`, `lastBackgroundCheck`, `emailUndeliverableAt`, `mergedIntoId`, `isSysadmin`, `isKeyholder`, `isBackgroundCheckReviewer`, `canAccessStaging`

and per `ProgramParticipant` row: `isPaymentPlanRequested` + `paymentPlanDeniedAt` (a scholarship / financial-hardship signal), `pendingSince`, `wasOrgMemberAtApproval`, `inventoryHeldAt`, `shopifyOrderId` — plus every unrendered `Event` and `Program` scalar.

The frontend consumes none of it. Beyond the live over-disclosure, the whole-row shape meant any column added later and tagged `pii`/`personal`/`internal` would ship to leads with no route diff and no failing test. It now takes a route diff.

## What a reviewer should know

- **The unrendered ids in the select are load-bearing.** `Person.id`, `Event.programId`, `Program.id`, the `programId`/`personId` pairs on `ProgramParticipant`/`ProgramVolunteer`, `RSVP.eventId`+`personId`, `Visit.personId` are the keys `scopesHeld()` reads to resolve `their_program_participants` / `their_own`. Drop one and the row strips to nothing for exactly the roles this route serves — the same failure the `EmergencyContact` `householdId` comment in `programs/[id]/route.ts:66-68` documents. A short comment above the query says so.
- **Only consumer is `program-ops/sessions/[id]/page.tsx`.** Its `EventData` / `ParticipantDetail` types are the contract; the select matches them field for field, as does the existing `baseEvent()` fixture in that page's test. Grepped `src`, `tests`, `__tests__` and `flow-tests` for other callers — everything else hits `/mine`, `/rsvp`, `/attendance`, or this file's `PATCH`.
- **`rsvps.person` was dead weight** (the page reads only `{ personId, status }`); the include is gone but its `where: { person: LIVE_PERSON }` filter stays, so the `livePersonDriftGuard` site is unchanged.
- **`ProgramParticipant.status` is kept** although nothing renders it — kept rather than guessed away.
- **Deliberately not "fixed" here**: `Visit.arrivedAt`/`departedAt` are `personal` and `Visit` binds only to `their_own`/`all_current_visitors`, so they are *already* stripped for lead mentors today even though the attendance table renders them. That is a pre-existing question about that table, not this query — the fields stay in the select and no grant changed.
- **No security-boundary files touched** (per the AGENTS.md boundary-isolation rule): no registry entry, scope binding, or classification. Route file only. `prisma/schema.prisma` untouched. `PATCH` untouched, including its `volunteers: true` read, which is used for authorization and never returned.

## Testing

Docker was unavailable, so integration tests ran against a throwaway local Postgres 16 cluster.

- `npx tsc --noEmit` — clean
- unit, narrowed to `sessions/[id]` — 19/19 pass
- integration (serial), narrowed to `event` — 8 suites, 41/41 pass
- integration (serial), narrowed to `authzRoleRejection|registryAuthz` — 166/166 pass (the `event` regex misses `authzRoleRejection`, which holds this route's GET 401/403 gate assertions)
- unit, narrowed to `stripper|routeAuthDrift|livePersonDriftGuard|pageRegistry` — 489/489 pass

No test asserted on a field the narrowed select drops; no assertion was reconciled or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
