### PR TITLE
docs: bring the standard and the migration plan up to what the sweep taught

### DIFF
--- a/docs/DOCUMENTATION_STANDARD.md
+++ b/docs/DOCUMENTATION_STANDARD.md
@@ -24,7 +24,8 @@ domain rules — and gives everything else a shorter life.
 | Where | What | Lifetime |
 |---|---|---|
 | `docs/rules/` | Board and operations decisions; invariants new work must not violate | **Permanent, edited by later changes** |
-| `docs/ops/` | How to run, deploy, test, and mock things | Long-lived, edited as tooling changes |
+| `docs/conventions.md` | How we build, independent of any domain | Long-lived |
+| `docs/ops/` | How to run, deploy, test, and mock things; and states left by a data load, each with an exit condition | Long-lived; cleanup entries deleted as they close |
 | `docs/security/` | Security policy and boundary rules | Long-lived |
 | `checkin-app/docs/generated/` | Machine-derived artifacts, drift-tested | Regenerated, never hand-edited |
 | `docs/backlog/` | Journey inventory and gap tracking | Long-lived |
@@ -58,6 +59,9 @@ One file per domain, named for the domain and not for any feature:
 | `attendance-checkin.md` | check-in, kiosk, visits, hours |
 | `tools-certification.md` | tool levels, certification, shop access |
 
+Alongside them, `principles.md` — rules that hold across every domain. It is not
+a seventh domain; see §3.3.
+
 Add a file when a domain genuinely accumulates standing rules. Do not create
 empty ones in advance.
 
@@ -70,10 +74,12 @@ invariants that later work must not violate.
 drift-tested under `checkin-app/docs/generated/`), rollout sequencing, or
 anything a reader could derive by reading the code.
 
-### 3.2 Two tiers — policy first, then procedure
+### 3.2 Three sections, in this order
 
 Not every rule has the same authority, and a reviewer needs to know which kind
-they are looking at. Each domain file is split in two, **policy first**:
+they are looking at. Each domain file runs **Policy, then Assumptions, then
+Procedure** — highest authority first, so the constraints that cannot be
+renegotiated in a PR are read before the ones that can.
 
 **Policy** — the rule exists because the board or the organisation adopted a
 policy. The code implements it; it does not define it. **Cite the governing
@@ -81,18 +87,60 @@ policy.** A change that violates one of these is not a design disagreement to be
 settled in review: the policy has to change first, which is a board action. A
 reviewer's correct response is to stop and escalate, not to weigh trade-offs.
 
+**Assumptions** — things the app takes as true because they are handled outside
+it. The board appoints keyholders in writing; the flag in the database
+represents that act.
+
+These are not deficiencies, and they are not written as though the software
+ought to be doing the job. An assumption states what is assumed and the
+condition that keeps it true — nothing more. What makes it worth recording is
+that a change can invalidate one: make a role easier to acquire, and the act it
+stood for is no longer behind it.
+
 **Procedure** — everything else. Working agreements about how this system
-behaves: conventions, operational choices, invariants the team settled on
-because something had to be decided. Real rules that later work must not
-casually violate, but they can be renegotiated by the people doing the work,
-in a PR, without going to the board.
+behaves: operational choices, invariants the team settled on because something
+had to be decided. Real rules that later work must not casually violate, but
+they can be renegotiated by the people doing the work, in a PR, without going to
+the board.
 
-Order matters. Policy goes above procedure in every file so the
-highest-authority constraints are read first and cannot be lost in a list.
+### 3.3 Cross-cutting rules — `principles.md`
 
-**Citing a policy.** Name the policy and its **structural location** — article,
-section, subsection, clause, whichever that policy actually uses. `Background
-Check Policy §2`, `Bylaws Art. IV §3(b)`, `Financial Controls Policy §5.2`.
+Some rules hold in every domain — least privilege, for one. Writing them into
+six files means writing them six times, so they live in
+`docs/rules/principles.md` and the domain files cite them.
+
+They sit **between** the two authority levels. No policy names them, so they
+cannot be Policy; but they are not a PR-level trade either. A change that
+violates one escalates to the owner — not to the board, and not to whoever is
+reviewing that morning.
+
+A principle earns its place by being **cross-cutting** and by passing the same
+test as any rule: a change could violate it, and you can picture the change that
+does. If it only ever bites in one domain, state it in that domain. Before
+accepting that no policy names it, check the corpus — a principle that turns out
+to be policy-backed is a Policy line, which carries more weight.
+
+### 3.4 What does not belong in the register at all
+
+Two classes look like rules and are not:
+
+**How we build** goes in `docs/conventions.md`. The server recomputing anything
+that affects price or access, the interface gating on the same rule the server
+enforces — true, load-bearing, and containing no domain content. A reviewer
+checking a membership change should not read past them.
+
+**States left by a data load** go in `docs/ops/legacy-cleanup.md`: imported rows
+missing fields the app now requires, a superseded model still carried by old
+records. These are expected to reach zero, so **every entry names how it is
+surfaced and what "done" is**, and the entry is deleted when it closes. Without
+an exit condition "temporary" becomes permanent and the file becomes a second
+register nobody prunes.
+
+### 3.5 Citing
+
+**Policy.** Name the policy and its **structural location** — article, section,
+subsection, clause, whichever that policy actually uses. `Background Check
+Policy §2`, `Bylaws Art. IV §3(b)`, `Financial Controls Policy §5.2`.
 
 **Never cite a page number.** A page is an artifact of rendering: it moves when
 the document is reformatted, differs between PDF and print, and does not exist
@@ -101,7 +149,7 @@ text and survives everything except an actual amendment — at which point the
 citation *should* break, because the rule may have changed.
 
 **Never cite a filesystem path.** The policy corpus lives outside this repo (see
-§3.5), so a path dangles for everyone but its owner and rots the way line numbers
+§3.8), so a path dangles for everyone but its owner and rots the way line numbers
 do. The policy's name plus its section is what survives a reorganisation.
 
 If a policy has no internal numbering to cite, say so explicitly ("*Volunteer
@@ -112,7 +160,55 @@ page. That gap is worth surfacing: it usually means the policy needs structure.
 name the policy it comes from, it is procedure. A rule that merely *feels*
 official is the same defect as an unratified policy written as settled.
 
-### 3.3 Format
+**A principle** is cited the same shape: `— *Principle: fail closed*`.
+
+**Never cite a doc that is scheduled to be deleted.** A pointer into a folder
+the migration empties rots on a date already agreed. A bare source-file path is
+the most a "where this bites" hint should carry, and most rules need none.
+
+### 3.6 Tagging a procedure line
+
+A Procedure line carries a tag naming what kind of statement it is. The tag
+answers "what do I do about this?", so two kinds that lead to the same answer
+share one tag.
+
+| Tag | Means |
+|---|---|
+| `[Decision]` | A choice we made. Renegotiable in review. |
+| `[Decision — *Policy: …*]` | The app's specific expression of a policy stated generally above — a threshold picked, a proxy chosen, need-to-know made concrete for one field. Sometimes **stricter** than the policy requires, in which case say so: the risk is someone relaxing it while believing they are aligning to policy. |
+| `[Decision — *Principle: …*]` | The domain's application of a cross-cutting rule. States only what the domain adds. |
+| `[Decision — deliberate limit]` | The **absence** is chosen. The one most likely to be "fixed" by someone helpful. |
+| `[Unsettled — …]` | Genuinely not agreed. **Do not cite as precedent.** |
+
+### 3.7 Recording a divergence
+
+A domain file may end with a section for board rules the app does not implement,
+or implements more loosely than the policy states. Four things are **not**
+divergences, and putting them there is the failure mode this section exists to
+prevent:
+
+- **A policy value held in configuration.** The app is built to be configurable;
+  keeping a setting aligned to policy is operational work.
+- **A rule the data model already guarantees.** One price column rather than a
+  per-person amount means "the same for everyone" needs no assertion. The
+  absence of a check is not the absence of the constraint.
+- **Anything handled outside the app.** That is an assumption (§3.2).
+- **A deliberate balance.** Choosing not to block someone at the door for an
+  obligation better chased in conversation is a decision, and belongs in
+  Procedure as a deliberate limit.
+
+What survives is where the app **does** model something and models it weaker
+than the policy — a supervision check counting bare adults where policy requires
+two unrelated non-student volunteers. Before recording one, read the enforcement
+path, not just the write path that creates the value.
+
+**Recording it is not the end of it.** A divergence stays in the domain file,
+where it qualifies the rules around it, and is also tracked as work. It is not a
+feature request: what closes it is the policy, not a judgement about what is
+worth building, and the app meanwhile reports as acceptable something the board
+has said is not.
+
+### 3.8 Format
 
 Grouped under short headings, one rule per bullet, written in business language
 so a reviewer can judge a diff against it without opening code:
@@ -164,7 +260,7 @@ choice made to unblock a PR and never confirmed. Writing it here converts an ope
 question into a stated invariant nobody agreed to. Take it to the owner or the
 board first; record it only once it is answered.
 
-### 3.4 How much belongs
+### 3.9 How much belongs
 
 Enough but not too much. A domain has however many rules it has — some will be
 genuinely denser than others, and an arbitrary page count would either be
@@ -182,14 +278,14 @@ register has stopped working — and the cause is nearly always mechanism that
 crept in, not a domain that genuinely has too many rules. Look for that first.
 Splitting the file hides the symptom without fixing it.
 
-### 3.5 Where the policies live
+### 3.10 Where the policies live
 
 **The governing policies live on Google Drive.** That is the canonical source —
 what the board adopts and amends, and what a citation ultimately refers to.
 Anyone with Drive access can verify a policy-tier rule against the policy it
 names, which is what makes this tier meaningful rather than decorative.
 
-This is why §3.2 cites by policy name and article rather than by any locator. The
+This is why §3.5 cites by policy name and article rather than by any locator. The
 name and section are the one identifier stable across Drive and whatever format
 a policy is rendered in. A Drive URL is no better than a filesystem path: it rots
 on reorganisation and is permission-gated. Name the policy and its article; a
@@ -227,7 +323,7 @@ delete    the working doc
 ```
 
 How many is however many there are — often none, sometimes one, occasionally
-several. Ask of each candidate the §3.4 question: *could a later change violate
+several. Ask of each candidate the §3.9 question: *could a later change violate
 this?* If yes it is a rule and it goes in, however many that turns out to be. If
 no, leave it out, even if that empties the list.
 
@@ -281,7 +377,7 @@ rule says so explicitly rather than leaving the reviewer to notice.
 **Known limitation.** Nothing catches an *omitted* rule. A change that
 establishes a new invariant without writing it down leaves no trace a test or
 lint could find. The mitigation is that `docs/rules/` stays worth reading during
-review — see §3.4. This standard does not claim to close that gap mechanically,
+review — see §3.9. This standard does not claim to close that gap mechanically,
 and no test should be built to pretend otherwise.
 
 ---
@@ -295,21 +391,32 @@ and no test should be built to pretend otherwise.
 2. **Never promote a rule to the Policy tier without naming the policy**, and
    never cite one by page number or filesystem path — name plus article,
    section, or subsection only.
-3. **A working doc is fine while building — put it in `docs/in-design/`.** No
+3. **Before writing a rule, read the enforcement path, not just the write path.**
+   The code that sets a value is not the code that corrects it.
+4. **State the narrower version.** A rule claiming more than the code does marks
+   correct behaviour as a violation, and the likely response is someone
+   "fixing" working code to comply.
+5. **Handled outside the app is an assumption, not a gap.** Record what is
+   assumed and what keeps it true. Do not editorialise about the software not
+   verifying it — that is what the word means.
+6. **A choice not to do something is a deliberate limit, not a gap.** Say so, so
+   nobody closes it as an oversight.
+7. **A working doc is fine while building — put it in `docs/in-design/`.** No
    `Status:` header ceremony; the folder carries that meaning.
-4. **Never cite a doc in `docs/in-design/` as ground truth.** It describes
-   something that is not yet true. Check whether it landed before building on it.
-5. **At merge, extract and delete.** Move the standing rules into the domain
+8. **Never cite a doc in `docs/in-design/` as ground truth**, or one scheduled
+   to be deleted. It describes something that is not yet true, or will not exist.
+9. **At merge, extract and delete.** Move the standing rules into the domain
    doc; delete the working doc. Extracting nothing is normal.
-6. **Never put PR numbers, issue numbers, or dates in `docs/rules/`.**
-7. **Never put line-number citations in `docs/rules/`.**
-8. **Write rules as constraints.** A reviewer must be able to recognise a
-   violation from the sentence alone.
-9. **Do not add mechanism to a rules file.** Structure belongs in the generated
-   artifacts; how the code achieves something belongs in the code.
-10. **Do not create empty domain files** in anticipation of future rules.
-11. **Prefer cutting to adding.** Every line should be a rule a change could
-    violate; anything else dilutes the ones that matter.
-12. **Open a working doc with the problem in plain English** — then objective,
+10. **Never put PR numbers, issue numbers, or dates in `docs/rules/`.**
+11. **Never put line-number citations in `docs/rules/`.**
+12. **Write rules as constraints.** A reviewer must be able to recognise a
+    violation from the sentence alone.
+13. **Do not add mechanism to a rules file.** Structure belongs in the generated
+    artifacts; how the code achieves something belongs in the code.
+14. **Do not create empty domain files** in anticipation of future rules.
+15. **Prefer cutting to adding.** Every line should be a rule a change could
+    violate; anything else dilutes the ones that matter. Say it once — a rule
+    restated in a second file is one that will be updated in only one of them.
+16. **Open a working doc with the problem in plain English** — then objective,
     then outcome. Provenance and alternatives go below the design, never above
     the problem (§4.1).

--- a/docs/in-design/DOCUMENTATION_MIGRATION.md
+++ b/docs/in-design/DOCUMENTATION_MIGRATION.md
@@ -221,55 +221,94 @@ if a domain comes out with dozens of rules, it has almost certainly captured
 mechanism rather than policy, so re-apply the test before accepting the volume.
 Splitting the file is not the fix.
 
-### 3.5 Classify each rule: policy or procedure
+### 3.5 Classify each rule
 
-Standard §3.2 splits every domain file into a **Policy** section above a
-**Procedure** section. The mine cannot make that call on its own — a PR diff
-shows what the code does, never whether a board policy required it.
+Standard §3.2 gives every domain file three sections: **Policy**, then
+**Assumptions**, then **Procedure**. Classify as you write, reading the policy
+text alongside the mined rule rather than deferring every judgement to a later
+pass. The corpus is available (§3.6), so the tier is answerable at the moment
+the rule is drafted.
 
-So the sweep produces everything as **procedure by default**, and a separate
-pass promotes what is genuinely policy-backed:
+What still needs care:
 
-1. Draft every mined rule under Procedure. Never guess at policy authority; an
-   unsupported promotion is the same defect as writing an unratified policy as
-   settled.
-2. Flag candidates — anything touching dues, background checks, eligibility and
-   age gates, refunds, volunteer status, or access and certification is likely
-   to have a policy behind it. These are the ones worth checking.
-3. The owner checks each candidate against the policy corpus (§3.6) and either
-   promotes it with a citation by **policy name and article/section** — never a
-   page, never a path — or leaves it as procedure.
+- **Never promote to Policy without reading the article.** Search the corpus for
+  the rule, not for the topic. Several candidates in the first sweep read as
+  obviously policy-backed and turned out not to be — the college-age dependent
+  rule among them, where the policy defines a term that sounds right and covers
+  something narrower.
+- **Cite by policy name and article or section.** Never a page, a path, or a
+  URL. A citation should break when the policy is amended, which is exactly when
+  it should be re-read.
+- **A rule stricter than its policy says so.** The risk is a later reader
+  relaxing it while believing they are aligning to policy.
+- **Anything holding only because someone outside the app maintains it is an
+  Assumption**, not a Procedure line and not a divergence.
 
-Expect this to reclassify a meaningful share of the membership and finance
-rules, and almost none of the attendance or tooling ones.
-
-**A rule can also be neither.** If a candidate turns out to contradict the
-policy it supposedly implements, that is not a documentation finding — it is a
-compliance finding, and it goes to the owner directly rather than into any file.
+**A rule can also be none of the three.** Where a candidate turns out to be the
+app implementing a policy more loosely than the policy states, it is a
+divergence: it goes in the domain file's closing section (standard §3.7) and is
+also tracked as work. Recording it does not resolve it, and it is not a feature
+request — what closes it is the policy.
 
 ### 3.6 The policy corpus
 
-Canonical policies are on **Google Drive** (standard §3.5).
+Canonical policies live on **Google Drive** (standard §3.5), and a complete
+download of them is available locally to work from. That download is what makes
+§3.5 possible in one pass rather than two.
 
-Consequences for this step:
+- **Check the download's provenance once, at the start of a sweep.** It is sound
+  while it is a current export; the failure it guards against is a copy taken
+  before an amendment, which would enshrine a superseded rule behind a citation
+  that reads as correct.
+- **Citations stay verifiable.** Anyone with Drive access can check a policy-tier
+  rule against the policy it names — unlike the PR corpus (§3.1), this input is
+  not owner-only, so the tier carries real weight.
+- **Read the surrounding article, not the matching line.** Definitions carry
+  scope that a keyword match hides: a term may be defined more narrowly than its
+  everyday sense, and a rule built on the everyday sense will cite an article
+  that does not support it.
 
-- **Confirm on Drive before promoting.** A local or cached copy is fine for
-  finding candidates and drafting; the citation is only sound once checked
-  against Drive. A copy predating an amendment would enshrine a superseded rule
-  behind a citation that looks correct.
-- **Citations stay verifiable.** Anyone with Drive access can check a
-  policy-tier rule against the policy it names — unlike the PR corpus (§3.1),
-  this input is not owner-only, so the tier carries real weight.
-- **Cite name plus article/section only.** Not a page, not a path, not a Drive
-  URL.
+### 3.7 The second source — session transcripts
 
-### 3.7 Owner review
+A PR diff cannot record a decision that produced no diff, and cannot show a road
+deliberately not taken. Session transcripts can. Mining them as a second,
+independent pass yields a different kind of rule: the rejected alternative, the
+thing settled in conversation and never built, the reason behind a number.
 
-The register states board and operations decisions. A rule inferred from a PR
-diff is a *candidate* decision until the owner confirms it. Present each domain
-file for review before it merges; some candidates will turn out to be
-accidents-of-implementation rather than decisions, and those must not be
+Run it after the PR sweep, diffed against the drafts, so each finding arrives
+attached to the line it bears on. Two properties of that output govern how it is
+used:
+
+- **A report describing a decision is more reliable than one describing a
+  mechanism.** Decisions hold; mechanisms get settled after the conversation
+  that discussed them. Several findings in the first pass asserted the opposite
+  of what shipped, all of them mechanism.
+- **"No counterpart in the draft" and "cut on purpose" are indistinguishable
+  from outside.** Only whoever ran the earlier review can tell them apart, which
+  is why this pass hands findings over rather than applying them.
+
+**Verify every finding against the current tree before folding it.** Not the
+schema alone — the enforcement path. A state can be derived rather than stored,
+and a behaviour can live in a function rather than a column; searching for a
+field name and concluding "not built" is the specific mistake to avoid. This
+verification is worth its cost independently: the first pass surfaced two
+defects the reports had not found, both while checking something else.
+
+### 3.8 Owner review
+
+The register states board and operations decisions. A rule inferred from a diff
+or a transcript is a *candidate* until the owner confirms it. Present each
+domain file for review before it merges — grouped by what you propose to do with
+each finding, including the ones you propose to reject, since a silent rejection
+is invisible to the person reviewing. Some candidates will turn out to be
+accidents of implementation rather than decisions, and those must not be
 enshrined as rules.
+
+**Present, then wait.** Do not fold a domain while the answer is outstanding,
+and do not read "go ahead" on one domain as approval of the next. The rule is
+not ceremony: both times it was skipped during the first sweep, rules reached
+the register that the owner then had to catch — including one describing a kind
+of person the app does not have.
 
 ---
 
@@ -324,8 +363,35 @@ The ops-bucket definition already covers it.
 arguably its own thing).
 
 **Leave alone entirely:** `docs/security/`, `checkin-app/docs/generated/`,
-`docs/backlog/`, `checkin-app/docs/VOCABULARY.md`, and the deploy/migration docs
-under `checkin-app/docs/`.
+`docs/backlog/`, and the deploy/migration docs under `checkin-app/docs/`.
+
+**`checkin-app/docs/VOCABULARY.md` stays where it is, but three kinds of content
+leave it.** It is the canonical dictionary and should remain one; it currently
+also carries:
+
+- **Build conventions** — that identifiers and prose use the canonical word, that
+  a serialized wire key is a contract rather than a free rename, that age is
+  always derived through the shared helper. These belong in `docs/conventions.md`.
+- **A migration log** — the rename status section and the model-rename pattern
+  note, which cites PR numbers and git history. That is a lesson from past work;
+  per the standard it belongs in a design doc, not in a reference someone opens
+  to look up a term.
+- **Domain facts filed as "reference facts"** — the membership year, which is a
+  policy fact; the single facility and the integration vendors, which are
+  operating assumptions. Defined terms among them, such as *Treehouse Card*,
+  stay.
+
+Rules embedded in its tables move the same way — the per-tool versus global
+certifier grant, age gates enforced outside the software, core volunteers'
+authority being organisational.
+
+**This is already duplicated, not hypothetical.** The rules register now states
+the single facility and the certifier grant, both of which also remain in the
+dictionary. Resolving that is part of this step, not a follow-up.
+
+That covers content leaving the dictionary. Content flowing the other way —
+terms whose definitions are also constraints — is open question 3 in §8, and is
+not settled by this step.
 
 ### 5.1 Reference sweep — do this BEFORE any move or delete
 
@@ -399,6 +465,22 @@ do it last, after the rules register exists, so nothing moves twice.
    and finance-payments collapse into one?
 2. **Who owns a rules file?** CODEOWNERS on `docs/rules/` would route rule
    changes to the board or owner automatically. Worth it, or too heavy?
+3. **Where a definition is also a constraint.** Several terms are stated in both
+   the vocabulary register and the rules register: two deep, tripod, member
+   family, adult, youth, student, visitor, the tool levels and their age
+   minimums. Some of these constrain behaviour — code counting bare adults
+   violates what "two deep" means, which is a divergence the rules register
+   already records — and some only fix a word.
+
+   The tempting split is to leave the name in the dictionary and move the
+   constraint to the rules. **That makes the dictionary worse**: someone looking
+   up "member family" and getting the name without the two-adult cap has been
+   given a partial answer, which is the one thing a dictionary must not do.
+
+   So the duplication may be correct — each register complete for its own
+   purpose, overlapping by design — and the real question is how the two stay in
+   step rather than how to divide them. Needs a decision with the vocabulary
+   owner present, not one taken during a sweep.
 
 **Decided:**
 


### PR DESCRIPTION
Both documents were written before the domain rules register was built. Running the sweep changed several of their instructions and left two of them stating the opposite of what was decided.

## The standard

- **Three sections per domain file, not two.** Assumptions sits between Policy and Procedure: things the app takes as true because someone outside it maintains them. Roughly a third of what the sweep first drafted as procedure turned out to be this.
- **`principles.md` as a middle tier.** Rules no policy names that are not a per-PR trade either — a change violating one escalates to the owner. It earns its place by saving the same sentence being written six times.
- **A tag vocabulary for procedure lines**, so a reader knows what to do about each: a decision, a policy's specific expression, a principle applied, a deliberate absence, or something genuinely unsettled.
- **What is *not* a divergence**, which is the section's main failure mode: a value held in configuration, a rule the data model already guarantees, anything handled outside the app, and a deliberate balance.
- **What happens after one is recorded** — it stays in the domain file *and* is tracked as work, because describing a shortfall against board policy does not close it. It is not a feature request: what closes it is the policy.

## The migration plan

- **Classify while writing, not in a later pass.** §3.5 told the sweep to draft everything as procedure and defer the tier. That was written before the policy corpus was available to work from. What replaces the deferral is the care that proved necessary: search the corpus for the rule rather than the topic, and read the article rather than the matching line — a definition can be narrower than the everyday sense of the word it defines, which caught a rule mid-sweep.
- **A second source.** Session transcripts hold what no diff can: the rejected alternative, the thing settled and never built, the reason behind a number. The section also records how that output fails — a report describing a decision holds, a report describing a mechanism often does not, because mechanisms get settled after the conversation that discussed them.
- **Verify against the enforcement path, never the schema alone.** A state can be derived rather than stored; searching for a field name and concluding "not built" is the specific mistake. This pass surfaced two defects the reports had not found, both while checking something else.
- **Present, then wait.** Owner review already said to group findings including rejections. It now also says not to fold while an answer is outstanding — both times that was skipped, rules reached the register that had to be caught and removed.
- **The vocabulary register comes off the leave-alone list.** It stays canonical, but carries build conventions, a migration log, and operating assumptions filed as reference facts. Terms whose definitions are *also* constraints are left as an open question: splitting those would make the dictionary answer partially, which is the one thing a dictionary must not do.

## Note for the reviewer

`docs/rules/` does not exist on `main` yet — it is a separate branch. Two sentences in §5 describe duplication between the register and the vocabulary file as already real, which it is on that branch and will be here once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)