### PR TITLE
docs: the domain rules register

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,37 @@
+# Engineering conventions
+
+How we build, as distinct from what the domain requires. Nothing here is a
+statement about membership, programs, or people — those live in `docs/rules/`,
+and a reviewer checking a domain change does not need this file.
+
+A convention earns a place here the same way a rule does: a change could violate
+it, and you can picture the change that does.
+
+---
+
+## The server decides, the client mirrors
+
+- **Anything affecting price, access, or eligibility is computed on the server.**
+  A value the client asserts about itself — a membership tier, a role, a
+  discount — is an input to be re-derived, never a fact to act on.
+
+- **Where the interface hides or disables a control, it does so on the same rule
+  the server enforces.** The two are written against one source so they cannot
+  drift, and the client's version is a convenience, never the gate. A control
+  that is merely hidden is not protected.
+
+The failure is a gate that exists only in the interface. It looks correct in
+every screenshot and every manual test, because the button is not there — and
+the endpoint behind it answers anyone who asks.
+
+---
+
+## We do not write addresses at domains we do not own
+
+- **Any address the app generates uses a domain the organisation controls, or a
+  reserved non-routable one.** This holds for addresses nobody will ever read —
+  a tombstone on a merged record still resolves somewhere, and somewhere is
+  someone else's mail server.
+
+A domain choice is invisible in review. A plausible-looking name is registrable
+by anyone, and the mistake is only visible to whoever owns it.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -35,3 +35,21 @@ the endpoint behind it answers anyone who asks.
 
 A domain choice is invisible in review. A plausible-looking name is registrable
 by anyone, and the mistake is only visible to whoever owns it.
+
+---
+
+## An invariant everyone must remember is not an invariant
+
+- **Where something must never be read, make it impossible to read rather than
+  everyone's job to exclude.** A rule held by convention holds until the first
+  person who has not read the convention writes a query.
+
+- **A filter every caller must remember, a guard that hunts for the ones who
+  forgot, and a list of justified exceptions are one smell, not three.** That
+  arrangement is how a design announces it needs the invariant moved into the
+  data rather than reasserted at each site.
+
+The failure is silent by construction. Forgetting produces no error, no failed
+test and no wrong-looking code — just a row that should not have been there,
+counted, rendered, or accepted as proof of who someone is. It is found when
+someone notices the number is wrong, which is not a mechanism.

--- a/docs/ops/legacy-cleanup.md
+++ b/docs/ops/legacy-cleanup.md
@@ -1,0 +1,56 @@
+# Legacy load and cleanup
+
+States that exist because of how data arrived, not because the domain wants
+them. They are expected to trend to zero. **None of this is a rule** — it is not
+read while changing behaviour, and it does not belong in `docs/rules/`.
+
+Every entry names how it is surfaced, what "done" looks like, and whether code
+still has to tolerate it. **When an entry's count reaches zero, delete the entry.
+When the file is empty, delete the file.**
+
+The exit condition is the point. Without one, "temporary" becomes permanent and
+this file becomes a second register nobody prunes. If an entry has sat here
+through a release or two with no movement, it is not cleanup — it is a gap
+wearing a cleanup label, and it should be raised as one.
+
+> **Counts are live data.** This file cannot tell you whether any of these is
+> actually shrinking. Check the surfaces named below.
+
+---
+
+## Households nobody has claimed
+
+People imported with an email address who have never signed in. Some of these
+will never be claimed — a family that has left, an address that was wrong — so
+zero may not be the honest target.
+
+- **Surfaced:** Membership Audit → unclaimed households, with a nav count.
+- **Exit:** either claimed, or written off deliberately. Decide which before
+  treating a non-zero count as failure.
+- **Code must tolerate it:** yes. A person may exist with no sign-in ever.
+
+## Payments that predate the mirror, and imported memberships
+
+The reconciler classifies orders it cannot match against app state. Two of its
+buckets are load artifacts rather than problems: orders placed before the
+mirror began, and memberships imported from a spreadsheet with no order behind
+them.
+
+- **Surfaced:** Finance Ops → match audit, as their own categories.
+- **Exit:** these age out as the mirror's coverage window moves past the
+  cutover; imported memberships persist until those memberships lapse.
+- **Code must tolerate it:** yes. An activation with no order is legitimate and
+  must not be reported as a missing payment.
+
+## The dead fee tables
+
+`Fee` and `FeePayment` were designed as the payment store and never received a
+production write. Payment truth is the store plus enrollment status.
+
+- **Surfaced:** nowhere — it is schema, not data.
+- **Exit:** references removed from the merge route, the security scope
+  bindings, and the generated classifications, then the tables dropped a
+  release later.
+- **Code must tolerate it:** the models still exist and are still referenced.
+  The removal design has merged; the deletion has not. Do not read this as
+  progress — the tables are live in the schema today.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,0 +1,47 @@
+# Domain rules register
+
+One file per domain. Read the file for the area you are changing before you
+change behaviour in it.
+
+Sections, tagging, citation, and what counts as a divergence are defined by
+`docs/DOCUMENTATION_STANDARD.md` §3. This file does not restate them.
+
+## Where these came from
+
+Two independent sources, neither able to see the other:
+
+- **The pull-request history**, showing what shipped, read alongside the policy
+  corpus, showing what the board decided.
+- **Session transcripts**, showing what was said — including decisions that
+  produced no diff, and roads deliberately not taken.
+
+Both were checked against the current tree before anything was written down.
+Where a source described an intention as though it had shipped, the code won, so
+several rules here are narrower than the discussion that produced them.
+
+## Divergences
+
+Each file may end with a section naming board rules the app implements more
+loosely than the policy states. Those stay here, where they qualify the rules
+they sit under — **and** they are tracked as work, because a divergence from
+board policy is not something a domain file can resolve by describing it.
+
+Recording one is therefore not the end of it. It is not a feature request
+either: what closes it is the policy, not a judgement about what is worth
+building.
+
+## Files
+
+| File | Covers |
+|---|---|
+| `principles.md` | rules holding across every domain — the middle tier |
+| `membership.md` | application, review, activation, fees, renewal |
+| `people-households.md` | households, leads, identity, age, emergency contacts, trusted adults |
+| `programs.md` | eligibility, enrollment, pricing, capacity, scholarships |
+| `finance-payments.md` | fees, refunds, payment plans, reconciliation |
+| `attendance-checkin.md` | opening and closing, supervision, the kiosk, visits |
+| `tools-certification.md` | certification levels, who may certify, shop access |
+
+Two registers sit outside this directory and are not duplicated here:
+`checkin-app/docs/VOCABULARY.md` defines what the words mean, and
+`docs/conventions.md` holds how we build rather than what the domain requires.

--- a/docs/rules/attendance-checkin.md
+++ b/docs/rules/attendance-checkin.md
@@ -1,0 +1,152 @@
+# Attendance and check-in
+
+Opening and closing a facility, supervision, the kiosk, and the visit record.
+
+---
+
+## Policy
+
+### Two deep
+
+- **Two deep means two non-student adult volunteers who are unrelated and do not
+  share a household.** Adult presence alone does not satisfy it. — *Definitions
+  Policy, Art. III, "Two Deep"*
+
+- Any event or location must meet the two-deep principle. — *Event, Location and
+  Keyholder Policy, Art. III*
+
+- A facility must be two deep **and** have a keyholder to be open and
+  operational. — *Event, Location and Keyholder Policy, Art. VI*
+
+- A group containing a student that is out of sight and earshot of another group
+  must be a tripod, and must be observable and interruptible. Behind a locked
+  door it must be two deep. Where someone is both a student and a volunteer, the
+  more appropriate role governs. — *Event, Location and Keyholder Policy,
+  Art. III*
+
+- A tripod is three members, each at least 9 years old, in a place that is
+  observable and interruptible. A closed, locked door does not qualify.
+  — *Definitions Policy, Art. III, "Tripod"*
+
+### Keyholders
+
+- Keyholders are volunteers, appointed in writing by the board, and the board may
+  revoke the status at any time in writing. — *Event, Location and Keyholder
+  Policy, Art. VII*
+
+- Nobody opens or closes a facility without being an active keyholder, so nobody
+  else can be in it while no keyholder is present. — *Event, Location and
+  Keyholder Policy, Arts. VI–VII*
+
+- There is one primary keyholder for a facility at a time. A primary keyholder
+  leaving must either transfer the role, with the other keyholder's consent, or
+  close the facility — they cannot simply leave while the building is occupied.
+  — *Event, Location and Keyholder Policy, Art. VIII, §VIII.3*
+
+- The primary keyholder present at closing is responsible for securing the
+  facility, and must ensure appropriate adult and youth presence while closing —
+  **two adults on site with a last youth.** — *Event, Location and Keyholder
+  Policy, §§VIII.4*
+
+---
+
+## Assumptions
+
+Things the app takes as true because they are handled outside it.
+
+- A keyholder was appointed in writing by the board, and the board revokes that
+  status in writing when it ends. The keyholder flag is what represents the
+  appointment.
+
+- The tripod rule is kept in the room — its composition, the
+  observable-and-interruptible condition, and whether a student group is within
+  range of another are judged by the people present, not tracked here. Nothing
+  here controls the shop doors or the tools, so a record of tripod state would
+  drive no action; it is left out because it would buy nothing, not because it
+  was overlooked.
+
+- Check-in happens at the one facility. Other locations exist and are temporary,
+  and checking in at them is out of scope.
+
+---
+
+## Procedure
+
+### Opening and closing
+
+- Closing takes a second deliberate badge within a few seconds, which checks
+  everyone out. A single stray badge does neither.  [Decision]
+
+### Supervision
+
+- Someone whose age is unknown counts as a youth in the supervision check: not
+  one of the supervising adults, and one of the people needing cover.  [Decision — *Principle: fail closed*]
+
+- Two deep is shown as a warning. It does not stop anyone entering or checking
+  in — surfacing the shortfall to the people in the room is the whole of what the
+  app does about it.  [Decision — deliberate limit]
+
+- Keyholders reach every household's emergency contacts, not only those of the
+  people currently in the building.  [Decision]
+
+- Departure is interrupted on the keyholder count, not the adult-to-youth
+  composition: the last keyholder is stopped to confirm, any other adult is not.  [Decision — deliberate limit]
+
+### The kiosk
+
+- The kiosk shows only what an unattended public screen may — no dates of birth,
+  phone numbers, emergency contacts or email addresses. Where a person has no
+  name recorded, what shows is the part of their address before the @, never the
+  address itself.  [Decision — *Policy: Records Policy, Art. IV*]
+
+### The visit record
+
+- A member inserts their own past visit, backdated as far as they need — there is
+  no limit on how far, and the audit trail stands in for one. They cannot edit it
+  once it is in.  [Decision]
+
+- A visit cannot run longer than 24 hours.  [Decision]
+
+- The board and sysadmins edit or delete any visit. Adding one for someone else
+  is scoped to an event roster or a live scan, never an arbitrary past time.  [Decision]
+
+- Facility hours split by program enrollment, not age: anyone present and not
+  enrolled counts on the volunteer side.  [Decision]
+
+### Marking an event's roster
+
+Distinct from a visit, which is presence at the facility and belongs to no
+program. This is a record of who was at one session of one program.
+
+- Only people enrolled in or volunteering on that program can be marked present.
+  Someone else in the list is refused by name rather than dropped from it, and
+  having been in the building at the time proves nothing — a walk-in who is not
+  enrolled needs enrolling first.  [Decision — *Principle: identity is not authorisation*]
+
+- Who attended is for the people running it — the program's leader, keyholders,
+  the board and sysadmins. Anyone else is refused outright rather than handed a
+  trimmed version, because the names are the part that matters and they survive
+  any trimming.  [Decision — *Principle: least privilege*]
+
+---
+
+## Policy requirements not yet enforced here
+
+- **Correcting a visit is settled design rather than policy, and is not built.**
+  A member cannot correct their own visit and a household lead cannot correct one
+  for their household. Both were decided; the implementation is pending.
+
+- **The supervision check is weaker than the policy on three counts.** It counts
+  adults present. Policy requires two adults who are *volunteers*, who are *not
+  students*, and who are *unrelated and from different households*. Any of those
+  three can be false while the app reports the room compliant.
+
+- **Primary keyholder is not modelled.** There is no single designated primary,
+  no consent-based transfer, and no obligation on a departing primary to
+  transfer or close.
+
+- **The closing guard is keyed on keyholders, not on the last youth.** A last
+  keyholder is stopped and made to confirm, which covers the common case — but
+  policy's requirement is two adults on site with a last youth, and a
+  non-keyholder adult can leave a youth with a single remaining adult without
+  being interrupted.

--- a/docs/rules/finance-payments.md
+++ b/docs/rules/finance-payments.md
@@ -1,0 +1,169 @@
+# Finance and payments
+
+Fees, refunds, payment plans, and reconciliation.
+
+---
+
+## Policy
+
+### Fees are fees
+
+- Membership and program fees are fees, not charitable donations, and cannot be
+  paid by means of giving from which the payer must receive no benefit.
+  — *Membership Policy, Art. XI; Sponsored Program Policy, Art. VI §VI.2*
+
+- The board sets the cost of all memberships, and may discount for financial
+  need, college students, partner organisations, service-program participants,
+  and volunteers with no youth in any program. — *Membership Policy, Art. XI*
+
+- Program fees before scholarship adjustment are equal for all members.
+  — *Sponsored Program Policy, Art. VI §VI.2*
+
+- A participant who completes a registration is responsible for paying for it.
+  — *Sponsored Program Policy, Art. VIII*
+
+### Refunds and plans
+
+- The membership fee is refunded on denial of membership; an accepted offset for
+  the background check is not. Otherwise no refund once membership or program
+  participation is approved, absent an extreme circumstance. A program refund is
+  the program leader's decision with board approval; a Treehouse-level refund is
+  the board's alone. — *Membership Policy, Art. XII*
+
+- Dismissal from membership is without refund. — *Definitions Policy, Art. III,
+  "Dismiss from Membership"*
+
+- A membership payment plan does not extend beyond the membership year it
+  covers. A program payment plan does not extend beyond the later of the
+  program's end and 90 days from its start. Late payment under a plan may lead
+  to dismissal. — *Membership Policy, Art. XIII*
+
+- No more than 20% of total participant fees may be waived by scholarship
+  without board approval, rising to 50% where total fees are $20 or less per
+  participant; externally designated scholarship funds are excluded from the
+  count. — *Sponsored Program Policy, Art. VII*
+
+### Program money
+
+- Funds supporting a program flow through the Treehouse; anything else needs
+  specific board approval. — *Sponsored Program Policy, Art. III §III.5*
+
+- A program budget is approved by the board before any spending is committed.
+  — *Sponsored Program Policy, Art. III §III.6*
+
+- A program budget cannot be approved where a majority of the affirmative votes
+  come from people with a conflict of interest with the program leader or
+  program treasurer. — *Sponsored Program Policy, Art. III §III.7*
+
+- Someone with a conflict of interest in a matter takes no part in deciding it,
+  and the same person does not authorise, execute, and monitor a transaction.
+  — *Ethics Policy, Art. III §III.5; Financial Policy, Art. III*
+
+- Payment processors must be PCI DSS compliant; storage and SaaS vendors must be
+  SOC 2 and ISO 27001 compliant. — *Definitions Policy, Art. III, "Suitably
+  Secure Electronic Means"*
+
+---
+
+## Assumptions
+
+Things the app takes as true because they are handled outside it.
+
+- Refunds are issued outside the app, in the store and the books. The app sees a
+  reversal after the fact; it never owes one.
+
+- Payment-plan terms are agreed within the limits policy sets, and the books hold
+  them. The app records that a plan was approved, never its schedule or its
+  amounts.
+
+- A plan finishing happens in the books too. When a family completes their
+  instalments finance records it there; the app has no screen for marking a plan
+  paid off, and was never meant to.
+
+- Program budgets live outside the app — their approval, the conflict-of-interest
+  rule on that vote, and the requirement that program funds flow through the
+  Treehouse are all handled there.
+
+---
+
+## Procedure
+
+### Ownership
+
+- Finance Ops belongs to the board; sysadmins are excluded outright.  [Unsettled — which superuser]
+
+- The store is the source of truth for what was paid. The local mirror is a copy
+  that reconciliation reads; no payment fact is authored here.  [Decision]
+
+- Nobody decides a scholarship or payment plan for their own household.  [Decision — *Policy: Ethics Policy, Art. III §III.5*]
+
+- A financial control is a flag a person signs off, with the sign-off recorded.
+  It is not a gate that decides on its own.  [Decision — *Principle: people decide about people*]
+
+- Whether a payment goes to the real store, the test store, or a local stand-in
+  is decided by which environment the app is told it is running in — never
+  guessed from whether store credentials happen to be present.  [Decision — *Principle: fail closed*]
+
+- A program's price lives on the program. Where one run of it needs a different
+  price, that is set against the run — not by issuing a code people pass around.
+  Early-bird and sliding rates are the store's to run, not ours to model.  [Decision — deliberate limit]
+
+- The volunteer membership rate is the exception, and it is a code. Anyone
+  holding it can redeem it, entitled or not: checkout does not check. A household
+  that used it without being a volunteer household is caught afterwards, when
+  reconciliation compares who redeemed it against who was owed it.  [Decision — deliberate limit]
+
+### Reconciliation
+
+- Charged is owed minus discount, so a charge below the amount owed is expected,
+  never a mismatch.  [Decision]
+
+- A reversal seen at the store — a refund, chargeback or cancellation — must
+  reach membership and enrollment state. The app raises it for the board to work;
+  it does not undo anything by itself.  [Decision — *Principle: people decide about people*]
+
+- The store owns what a discount comes to; the app owns who may use one and until
+  when. An order carrying the right item is correct whatever it totals — checking
+  the total against a configured price drifts the moment the two disagree.  [Decision — deliberate limit]
+
+- Only what the app sells reconciles: a membership, or a program. Donations and
+  merchandise pass through untouched.  [Decision]
+
+- Reconciliation problems surface on the finance board, where payments live. A
+  payment crosses membership and programs, so neither of those views alone is the
+  place to raise one.  [Decision]
+
+- The board can force the mirror to catch up. It only ever catches up; replaying
+  history is not reachable that way.  [Decision — deliberate limit]
+
+- An activation's payment basis is paid, free, comped or scholarship; one with
+  none is reported as a gap.  [Decision — *Principle: accountability*]
+
+- Payment against a blocked application is a refund obligation, never a
+  satisfied claim.  [Decision]
+
+### Requests and communication
+
+- Membership and program payment plans are separate queues, and store holds are
+  a third. One list covering all of them was rejected.  [Decision — deliberate limit]
+
+- An applicant gets exactly one automatic message about a request — the
+  acknowledgement that it arrived. Non-payment notices are a separate stream.
+  That acknowledgement never suggests the matter is closed or that nothing
+  further is needed, because the amount, the schedule and any discount are still
+  to be agreed — finance settles those with the board and writes to the family
+  itself. The app never learns those terms, so it cannot speak for them.  [Decision — *Principle: people decide about people*]
+
+- Submitting a request for a scholarship or a payment plan does not settle the
+  fee it concerns. The membership stays unactivated and the enrollment stays
+  unconfirmed until finance approves the request; until then the record waits
+  where it is.  [Decision]
+
+- A balance the household can pay looks different from one waiting on finance.
+  The second is not theirs to act on.  [Decision]
+
+- A request for something starting after the next membership year is marked as
+  such, never hidden or filtered away.  [Decision — deliberate limit]
+
+
+- Removal for non-payment is a human decision on an admin surface.  [Decision — *Principle: people decide about people*]

--- a/docs/rules/membership.md
+++ b/docs/rules/membership.md
@@ -1,0 +1,344 @@
+# Membership
+
+Application, background-check review, activation, dues, and renewal.
+
+---
+
+## Policy
+
+### What membership is
+
+- Membership belongs to a family, not an individual: everyone gains membership
+  by being part of a member family, and the fee is per family per membership
+  year. — *Membership Policy, Art. III §III.1*
+
+- A member family is one household containing no more than two adults, with all
+  youth being their children or dependents. — *Definitions Policy, Art. III,
+  "Member Family"*
+
+- The membership year runs 1 September to 31 August. One boundary applies to the
+  whole organisation — membership is not a per-household anniversary running
+  twelve months from the day a family joined. — *Definitions Policy, Art. III,
+  "Membership Year"*
+
+- A payment for a membership year may therefore buy less than twelve months, as
+  when a family joins partway through one. — *Membership Policy, Art. XI*
+
+- A family agrees in writing to the current membership agreement, separately for
+  each membership year — a prior signature never carries over. Participation is
+  not open to a family that has not. — *Membership Policy, Art. III §III.1*
+
+- Members are responsible for keeping their information current within a
+  membership year, including family composition, contact details, insurance, and
+  emergency contacts. — *Membership Policy, Art. III §III.1*
+
+- Nobody who has been dismissed from membership, or whose background check comes
+  back without clear recognition of the individual, may be a member.
+  — *Membership Policy, Art. IX*
+
+### Deciding a matter you have an interest in
+
+- A conflict of interest exists whenever someone is in a position to approve or
+  influence an action that could benefit or harm themselves, their family by
+  kinship — spouse, parents, guardians, children, siblings, grandparents,
+  grandchildren, in-laws — or even a close friend. The appearance of one counts
+  as much as the fact. — *Ethics Policy, Art. III §III.2*
+
+- Someone with a conflict in a matter refrains from participating in any decision
+  on that matter. A board member abstains from the vote; any other leader stays
+  out of the decision entirely. There is no exception for seniority or for
+  holding a privileged role. — *Ethics Policy, Art. III §III.5*
+
+- A conflict is disclosed to the board in writing, before the person discharges
+  any duty touching the matter. — *Ethics Policy, Art. III §III.3*
+
+- The board may void any action taken by someone who participated despite a
+  conflict. — *Ethics Policy, Art. III §III.5*
+
+- The same person does not authorise, execute, and monitor a transaction.
+  — *Financial Policy, Art. III*
+
+### Background checks
+
+- At least one adult in each family is checked; so is any other family member 18
+  or over who will be present regularly. Third-party checks are not accepted.
+  — *Membership Policy, Art. VI §VI.1*
+
+- Every volunteer 18 or older is checked. The obligation attaches to the role,
+  not only to the household. — *Volunteer Policy, Art. IV*
+
+- No entry to a location, event, or program until the check completes. A family
+  mid-application may still attend as a hosted visitor. — *Membership Policy,
+  Art. VI §VI.1*
+
+- A check is valid for 29 months, after which a new one is performed at the next
+  renewal. The board may check more often, or shift the timing to line up with
+  membership years. — *Membership Policy, Art. VI §VI.1*
+
+- Reports are ordered, reviewed, and processed by at least two individuals who
+  are independent of one another — not related — who have signed the key
+  volunteer agreement and either serve on the board or are authorised in writing
+  by it. — *Membership Policy, Art. VI §VI.2*
+
+- Two clearances therefore means two distinct people. One reviewer cannot supply
+  both, so the same person may not review an application twice, and a second
+  reviewer related to the first does not count either. — *Membership Policy,
+  Art. VI §VI.2*
+
+- Every reviewer has signed the key volunteer agreement. — *Membership Policy,
+  Art. VI §VI.2*
+
+- The check itself and any criminal-history detail stay between the person
+  checked, the authorised reviewers, and the board. — *Membership Policy,
+  Art. VI §VI.2*
+
+- A check may result in approval, a restriction on how the person may volunteer,
+  or denial. — *Membership Policy, Art. VI §VI.2*
+
+- Where the board treats an offence as disqualifying, objective supporting
+  documentation is gathered, consistent with the obligation to document a
+  denial. — *Membership Policy, Art. IX*
+
+- A disqualified applicant receives the rights summary, a letter of
+  disqualification, and a copy of the results, and may appeal in writing to a
+  three-person committee kept as independent as possible from the original
+  reviewers. — *Membership Policy, Art. VI §§VI.3–VI.4*
+
+### Dues, refunds, and plans
+
+- The board sets the cost of all memberships. The fee is a fee, not a charitable
+  donation. — *Membership Policy, Art. XI*
+
+- The board may discount the fee for financial need, college students, partner
+  organisations, participants solely in service programs, and volunteers with no
+  youth participating in any sponsored program. — *Membership Policy, Art. XI*
+
+- The fee is refunded if the family is denied membership. An accepted offset for
+  the cost of the background check is not refunded even then. Otherwise no
+  refund is provided once membership is approved, absent an extreme circumstance
+  approved by the board. — *Membership Policy, Art. XII*
+
+- A membership payment plan does not extend beyond the membership year it
+  covers. Late payment under a plan can lead to dismissal from membership.
+  — *Membership Policy, Art. XIII*
+
+### Member data
+
+- Member information is shared on a need-to-know basis and is not sold.
+  — *Records Policy, Art. IV; Art. V §V.1*
+
+- A member may ask for inaccurate information to be corrected. — *Records
+  Policy, Art. V §V.3*
+
+- A member may ask for personal information to be deleted, except where it is
+  legally required, needed for member safety, or a condition of the membership
+  or program participation they wish to keep. — *Records Policy, Art. V §V.4*
+
+---
+
+## Assumptions
+
+Things the app takes as true because they are handled outside it. They sit
+between the two tiers because the Policy rules above rest on them and the
+Procedure below is built on them.
+
+- Every board member has signed the key volunteer agreement and is a designated
+  background-check reviewer. Board membership alone therefore qualifies someone
+  wherever a reviewer is required — the queue, the attestation, and the sensitive
+  fields that go with it.
+
+- A non-board reviewer was authorised in writing by the board before the reviewer
+  role was granted. Granting the role is what represents that authorisation, so
+  the assumption holds as long as granting it stays a deliberate act.
+
+- Payment-plan terms are agreed within the limits policy sets. The app records
+  that a plan was certified, not its schedule.
+
+- Refunds are handled outside the app, including the one owed on denial of
+  membership.
+
+- A background check is cleared within days of being performed, so dating the
+  clearance rather than the check itself is immaterial against a window measured
+  in months. Board and sysadmin can correct the date on the rare occasion it is
+  not.
+
+- The background-check vendor has no API. A check is started through a hosted
+  consent link and its result comes back by hand. That is the arrangement, not a
+  stopgap waiting to be automated.
+
+- Declining a scholarship or payment-plan request is a conversation between two
+  people. The app has no deny route and needs none.
+
+- Adult children in a member household are handled by hand. Nothing in the app
+  gates on their status.
+
+---
+
+## Procedure
+
+### Application and review
+
+- An intake note holds the application at review so reviewers read it before
+  dues are settled. A household already holding a still-valid clearance goes
+  straight to payment regardless.
+  (`checkin-app/src/lib/membership/external.ts`)  [Decision]
+
+- Applicants are told about the hold where they write the note, not after
+  submitting.  [Decision]
+
+- An application in background-check review is the reviewers' work, not the
+  board's. Board queues count blocked applications only.  [Decision]
+
+- A single rejection blocks the application; approvals do not outweigh it.  [Decision]
+
+- The background-check result is never stored. The record is that reviewers saw
+  it and what they judged — stricter than the policy, which permits the board to
+  hold it.  [Decision — *Policy: Membership Policy, Art. VI §VI.2*]
+
+- A clearance is dated when the second reviewer clears it, and the validity
+  window runs from that date.  [Decision]
+
+- Every background-check decision and every payment certification records a
+  written reason — wider than the policy, which requires documentation only for a
+  disqualifying offence.  [Decision — *Policy: Membership Policy, Art. IX*]
+
+- An abandoned application is archived, never destroyed, and restores to the
+  status it held before.  [Decision — *Principle: decisions are reversible*]
+
+- Pre-designating a household volunteer-only sets what it owes and nothing else
+  — it does not skip review or open payment. The policy grants only the
+  discounting power; the limit is ours.  [Decision — *Policy: Membership Policy, Art. XI*]
+
+### Approving your own family
+
+- Shared household is the app's test for a conflict — a workable proxy for the
+  kinship, friendship and appearance tests policy states. Passing it is not a
+  finding that no conflict exists.  [Decision — deliberate limit]
+
+- No role is exempt from the bar, however senior. A case whose only eligible
+  deciders are all in the subject's household cannot be decided until the board
+  finds someone who is not.  [Decision — *Policy: Ethics Policy, Art. III §III.5*]
+
+### Activation
+
+- Nothing advances toward payment until the agreement is signed and the
+  background check is handled — either a still-valid prior clearance or fresh
+  consent on file.  [Decision — *Policy: Membership Policy, Art. III §III.1; Art. VI §VI.1*]
+
+- From there payment and review run in parallel, and membership activates on
+  whichever finishes last. Neither alone activates.  [Decision]
+
+- Granting the coming year completes the payment step on a renewal already under
+  way. It stamps no other gate.  [Decision]
+
+- A denied household holds no authority anywhere in the app.  [Decision — *Principle: identity is not authorisation*]
+
+- Denial locks every member of the household out of sign-in. Revocation does not
+  — a former member keeps app access and loses facility privileges. Because the
+  lockout reaches the whole household, denial is confirmed before it executes.  [Decision — *Principle: accountability*]
+
+- A household containing a board member cannot be denied. Removing the board role
+  first is a separate act, as it is outside the app.  [Decision — deliberate limit]
+
+- The denied landing page says only that access is denied. No reason, no contact,
+  no mention of membership, no way to sign out.  [Decision — deliberate limit; *Principle: no existence oracle*]
+
+- A household may have no membership. Facts only a membership carries are then
+  absent, not zero.  [Decision — *Principle: fail closed*]
+
+### Dues
+
+- Dues have two rates, standard and volunteer household. The designation changes
+  what a household pays and nothing about its review.  [Decision]
+
+- A volunteer designation matches on canonical email, so address variants cannot
+  change what a family owes.  [Decision]
+
+- The board can activate a household with no payment by certifying a payment
+  plan.  [Decision — *Policy: Membership Policy, Art. XIII*]
+
+### Renewal
+
+- A renewal needs a new background check unless a lead's is still valid at the
+  boundary. Where the validity length is unset, no clearance counts as fresh and
+  the compliance view reports nothing stale.  [Decision — *Policy: Membership Policy, Art. VI §VI.1*; *Principle: fail closed*]
+
+- A membership stays active while its renewal is in progress.  [Decision]
+
+- A household is never told its background check has gone stale, because nothing
+  acts on staleness between renewals. It is read inside a renewal, where it
+  decides whether that renewal needs a fresh one.  [Decision — *Policy: Membership Policy, Art. VI §VI.1*]
+
+- Membership intake requires a complete mailing address. Program registration
+  deliberately does not.  [Decision]
+
+- Treehouse accounts are not program families: no self-service member add, no
+  membership grant. Only the member add is enforced server-side.  [Decision]
+
+- An intake note is readable by the household's leads and the reviewers, not by
+  its other members.  [Decision — *Policy: Membership Policy, Art. VI §VI.2; Records Policy, Art. IV*]
+
+### Compliance
+
+- Nobody is removed for falling out of compliance. The view reports and sends
+  nothing, so a violation waits until a person looks.  [Decision — deliberate limit; *Principle: people decide about people*]
+
+### Background checks for program-attached adults
+
+- Activating a membership opens a background-check obligation for that
+  household's program-attached adults. It is surfaced for follow-up and gates
+  nothing — chasing it is a conversation, not a refusal at the door.  [Decision — deliberate limit; *Policy: Volunteer Policy, Art. IV*]
+
+- Age is judged as of the membership-year boundary, which counts as inside it.
+  Turning 18 afterwards waits for the next boundary rather than firing on the
+  birthday.  [Decision — deliberate limit]
+
+- Under 18 is never checked, a minor being ineligible for one. This covers the
+  young adult mentors, who volunteer without one.  [Decision — *Policy: Volunteer Policy, Art. IV*]
+
+- No date of birth and no over-25 declaration means the age is unknown. Such a
+  person is neither checked nor counted as covered; they are set aside for
+  someone to resolve.  [Decision — *Principle: fail closed*]
+
+- A check covers the adult who took it. One person's clearance never satisfies
+  another's.  [Decision]
+
+- An adult child who needs a background check needs their own sign-in, and the
+  lead supplies an email address for them.  [Decision]
+
+---
+
+## Policy requirements not yet enforced here
+
+- **A household clearance stamps every lead, not the person who was checked.**
+  The household path carries one consent and one clearance for the whole
+  application, then writes that date onto each of its leads, with nothing tying
+  it to whoever submitted. This answers the household question correctly — policy
+  wants one adult checked — but the date is a per-person fact, and the
+  program-attached surface reads it per person. A lead who never took a check
+  reads there as covered rather than needed.
+
+- **A household that loses its only checked adult mid-year keeps its membership.**
+  Removing or demoting that person leaves the household active with youth still
+  enrolled, and nothing responds. Whether the answer is a block, a grace period,
+  or a warning is undecided.
+
+- **The sysadmin role decides membership matters policy reserves to the board,
+  and has no policy existence at all.** The policy corpus enumerates board
+  members, officers, Treehouse leaders, program leaders, tool certifiers,
+  keyholders, and shop stewards. There is no sysadmin. Yet someone holding only
+  that flag can override a blocked application, certify a payment plan, and
+  grant a membership outright — while policy requires reviewers to be board
+  members or authorised in writing by the board, and makes the remedy for a
+  contested check an independent three-person appeals committee.
+
+  Compounding it: a sysadmin who is not a board member can **grant board
+  membership**, including to themselves. They cannot remove a sitting board
+  member, board membership can never be revoked to zero, and every action is
+  audit-logged with a required reason — so the board keeps the power to revoke
+  the flag. But who sits on the board can be changed by someone the policy does
+  not recognise.
+
+  **This needs a board decision, not a code change chosen by whoever touches it
+  next.** Narrowing which surfaces accept the flag, or making it easier to
+  obtain, belongs to the board.

--- a/docs/rules/people-households.md
+++ b/docs/rules/people-households.md
@@ -1,0 +1,209 @@
+# People and households
+
+Households, leads, identity and age status, emergency contacts, and trusted
+adults.
+
+---
+
+## Policy
+
+### Who is who
+
+- An adult is 18 or older. A youth is anyone under 18, and throughout the
+  policies "child" is interchangeable with it. — *Definitions Policy, Art. III,
+  "Adult" / "Youth"*
+
+- A student is anyone enrolled in school through twelfth grade, which can run to
+  age 19. Student and youth are therefore not the same set, and neither is
+  interchangeable with a program's participants. — *Definitions Policy,
+  Art. III, "Student"*
+
+- A member family resides at one address, contains no more than two adults, and
+  all its youth are the children or dependents of those adults. — *Definitions
+  Policy, Art. III, "Member Family"*
+
+- A visitor is anyone at a location or event who is not a member. — *Definitions
+  Policy, Art. III, "Visitor"*
+
+- Being removed from a volunteer role is not dismissal from membership: one
+  removes a role, the other ends all association. — *Volunteer Policy, Art. V*
+
+### Responsibility for youth
+
+- Parents, guardians, or authorised caregivers are responsible for their youth
+  at drop-off and pickup and throughout events and locations, including travel
+  for a program. — *Membership Policy, Art. IV*
+
+- Youth under 10 are never dropped off and left. — *Event, Location and
+  Keyholder Policy, Art. IX*
+
+- A drop-off is allowed only when the youth is attending a specific program
+  whose leader knows they are there, or when the parent or guardian has checked
+  with a named adult over 21 who agrees to be responsible — and **both parties
+  hold each other's emergency contact information**. — *Event, Location and
+  Keyholder Policy, Art. IX*
+
+- A dual relationship exists where the adult is the youth's parent, guardian, or
+  sibling, or where a parent or guardian has specifically identified that person
+  and had the status approved. — *Definitions Policy, Art. III, "Dual
+  Relationship"*
+
+### Member information
+
+- Members keep their information current within the membership year, including
+  changes to family members, contact details, and emergency contacts.
+  — *Membership Policy, Art. III §III.1*
+
+- Personal information is shared on a need-to-know basis and is not sold.
+  — *Records Policy, Art. IV; Art. V §V.1*
+
+- A member may ask for inaccurate information to be corrected, and may ask for
+  personal information to be deleted except where it is legally required, needed
+  for member safety, or a condition of the membership or program participation
+  they wish to keep. — *Records Policy, Art. V §§V.3–V.4*
+
+- Records no longer needed for operations or required by law should not be kept.
+  — *Records Policy, Art. VI §VI.2*
+
+---
+
+## Assumptions
+
+Things the app takes as true because they are handled outside it.
+
+- A family and the adult they name exchange contact details between themselves.
+  The app records the family's side of that.
+
+- Drop-off practice is handled at the door, including who may be left and the
+  rule against leaving a youth under 10.
+
+- A trusted adult is over 21, confirmed by the board when it approves them. They
+  are a named counterparty rather than a person record, so the app holds no date
+  of birth to check.
+
+- The app owns who people are, and deduplicating them is its job. The
+  background-check vendor holds the sensitive detail behind a check; none of it
+  is imported.
+
+- An email address identifies one person, because that is how signing in works.
+  Two people cannot share one, and a household wanting to share an address is
+  asking for something the sign-in cannot express.
+
+---
+
+## Procedure
+
+### Households and leads
+
+- Every person belongs to a household from sign-up. There is no householdless
+  person.  [Decision]
+
+- A household has at most two leads, and removing the last one is refused. The
+  lead cap is the app's proxy for the two-adult limit; membership itself is not
+  capped.  [Decision — *Policy: Definitions Policy, Art. III, "Member Family"*]
+
+- A lead always leads their own household; leading another is unsupported.  [Decision]
+
+- A youth cannot be made a household lead. An unknown date of birth reads as
+  adult here — a standing exception to *Principle: fail closed*.  [Decision — deliberate limit]
+
+- A household adds its own members through its leads. The board and sysadmin path
+  into any household is a separate one and is unaffected.  [Decision — *Principle: self-scope and repair*]
+
+- A young adult still part of their family — away at college included — stays a
+  member of that household rather than leading one of their own.  [Decision — *Policy: Definitions Policy, Art. III, "Member Family"*]
+
+- A household counts as claimed once a lead has signed in, by any route. Waiting
+  for every member to sign in was rejected — the list exists to find families who
+  never arrived, not to reach a state nobody can guarantee.  [Decision — deliberate limit]
+
+- An account on the organisation's own email domain is a Treehouse account, not
+  a member family, and cannot add members to its own household. The board and
+  sysadmin path for adding someone to any household is unaffected.  [Decision]
+
+### Identity and age
+
+- Every household member has a date of birth or an over-25 declaration. Neither
+  present is a surfaced gap.  [Decision]
+
+- Date of birth is not retained past 25; the declaration replaces it
+  automatically as members age out. Twenty-five holds three things at once: we
+  keep nothing we do not need, by then nobody's own age restricts what they may
+  do here, and it is young enough that someone of 25 is very unlikely to be the
+  parent of anyone in our programs.  [Decision — *Policy: Records Policy, Art. VI §VI.2*]
+
+- Date of birth is the only field with an ageing-out rule. Broader retention is
+  deliberately not automated while the organisation is young and little has
+  accumulated; the general obligation is met by hand until that stops being true.  [Decision — deliberate limit]
+
+- A youth cannot edit their own profile. As with leadership, an unknown date of
+  birth reads as adult.  [Decision — deliberate limit]
+
+- Self-service member add always creates a new person, never adopts an existing
+  account by email. Where the address is already in use the add is refused
+  without saying whether anyone holds it — only what will happen if they do.  [Decision — *Principle: no existence oracle*]
+
+- Email identity is case-insensitive.  [Decision]
+
+- Where someone signs in with Google, the address they sign in with is the
+  address they are contacted at. There is no second one to diverge from it.  [Decision]
+
+- A person is never deleted. A merged record stays as a tombstone and drops out
+  of every list, count and roster rather than out of the database.  [Decision — *Principle: decisions are reversible*]
+
+- A merge moves email, sign-in identity and verification together as one unit,
+  never split across the two records.  [Decision]
+
+- A merged person's pre-merge state is recorded so the merge can be undone.  [Decision — *Principle: decisions are reversible*]
+
+### Who may see what
+
+- A program leader reaches a participant's contact details and their emergency
+  contact, never their date of birth.  [Decision — *Principle: least privilege*]
+
+- Keyholders hold the board's email and phone as the front desk's emergency
+  reference. It is a grant made on purpose, not an over-share to be narrowed.  [Decision]
+
+### Emergency contacts
+
+- An emergency contact is someone outside the household; one matching a member
+  by phone, email or name is refused.  [Decision — *Policy: Event, Location and Keyholder Policy, Art. IX*]
+
+- An emergency contact needs a name and a phone number. One missing either does
+  not count toward the household's obligation to have one.  [Decision]
+
+- A household names at least one emergency contact at intake, and its last valid
+  contact cannot be removed.  [Decision]
+
+- A household change that invalidates a contact flags the row and keeps it.
+  Nothing is blocked; the household resolves it.  [Decision]
+
+- A missing emergency contact is the household's to fix, not board work.  [Decision]
+
+### Trusted adults
+
+- Trusted-adult approval belongs to the household, not to an individual member.  [Decision — *Policy: Event, Location and Keyholder Policy, Art. IX*]
+
+- The board reads the family's context note; keyholders and program leaders read
+  the board's operational note. Neither side sees the other's.  [Decision — *Policy: Ethics Policy, Art. IV*]
+
+- Relationships are free text, with no picklist of types.  [Decision — deliberate limit]
+
+- Amending a trusted adult's details does not disturb the live approval, and
+  rejecting the amendment is a separate action from revoking the person.  [Decision]
+
+- Withdrawing a trusted adult retires every approval they hold, not just the
+  most recent, and drops them from the pickup list at once.  [Decision]
+
+- An approval lasts a year. The family is warned a month out and resubmits
+  without re-entering what the board already holds.  [Decision]
+
+- A withdrawn trusted adult can be hidden from the household's own view. The
+  record stays and the board still sees it; the household cannot bring it back.  [Decision]
+
+- One board member settles a disclosure; it does not need the whole board.  [Decision]
+
+- A visitor may raise one, not only a member.  [Decision]
+
+- Approving one requires a note the front desk can act on — read by the family,
+  keyholders and program leaders, and never shown on the kiosk.  [Decision — *Policy: Records Policy, Art. IV*]

--- a/docs/rules/principles.md
+++ b/docs/rules/principles.md
@@ -126,6 +126,13 @@ when the answer is not available at the time it is needed.
   age, not age zero. Anything that reads, sorts, counts or renders such a value
   carries the difference through rather than flattening it.
 
+- **Where finishing an operation would take inventing a fact, refuse to finish
+  it.** Not a plausible departure time for someone whose visit was never closed,
+  not a guess at which of two conflicting records is the real one. Refusing is
+  visible and recoverable; an invented value is neither, because nothing
+  downstream can tell it from a real one. The operation stops and says what it
+  needs — the person who knows supplies it.
+
 The tell is a default. Every `?? 0`, `|| false`, and empty-result branch is this
 principle being decided, usually without anyone noticing they decided it.
 

--- a/docs/rules/principles.md
+++ b/docs/rules/principles.md
@@ -1,0 +1,238 @@
+# Principles
+
+Rules that no policy names but that are not a PR-level trade either. They sit
+between the two tiers in every domain file: a change that violates one escalates
+to the owner, not to the board, and not to whoever is reviewing that morning.
+
+## What belongs here
+
+The same test as any rule: **could a change violate it, and can you picture the
+PR that gets it wrong?** "Least privilege" passes — a route requiring two roles
+where one would do violates it. "Write clear code" does not.
+
+Two further conditions, or it belongs in a domain file instead:
+
+- **It is cross-cutting.** If it only ever bites in one domain, state it there.
+  A principle earns its place here by saving the same sentence being written six
+  times.
+- **No policy names it.** Check the policy corpus before accepting that. A rule
+  that turns out to be policy-backed is a Policy line with a citation, which
+  carries more weight than anything here.
+
+A domain file cites a principle the way it cites a policy —
+`— *Principle: self-scope and repair*` — and states only what its domain adds on
+top.
+
+---
+
+## Self-scope and repair
+
+- **A person acts on their own records, and nobody else's.** Ownership is the
+  default boundary for every write: your household, your enrollment, your visit,
+  your profile.
+
+- **Every state a person can reach is repairable by a superuser through the
+  app.** Not by hand-editing the database. If the only way out of a state is a
+  raw SQL update, the repair surface has not been built and the work is not
+  finished.
+
+  This is a build obligation, not a statement about permissions. Shipping a
+  workflow means shipping the way back out of every state it can produce —
+  the screen, the endpoint, and the audit row that goes with them. A feature
+  that can strand someone is incomplete however well its happy path works.
+
+*Which* superuser is not settled by this principle, and today it varies — some
+surfaces admit the board and a sysadmin, others only the board. That inconsistency
+is a live question, not an application of this rule.
+
+The two halves are load-bearing together. Scope without repair produces states
+nobody can fix; repair without scope is just an absence of access control.
+
+---
+
+## Decisions are reversible
+
+Distinct from repair above: repair gets someone out of a state they are stuck
+in, this puts back what a decision changed. Undoing restores what was there
+before, not an approximation of it.
+
+- **The cost of reversal scales with what the action destroys, and so does the
+  obligation.** Flipping a flag back — member to non-member, paid to unpaid —
+  needs nothing kept. An action that collapses structure has to capture the
+  pre-image *before* it acts, because afterwards there is nothing left to read.
+
+- **Merging two people is the hard case.** Two records become one and the second
+  stops existing; without what they were, there is no undo, only a guess.
+
+- **Reconstructing from the audit trail is a fallback, not a design.** Where the
+  restore path has to infer what a row used to be from log entries, the decision
+  was made without capturing what it destroyed. It works until a log is pruned or
+  a shape changes.
+
+- **Whether a record may be removed turns on two things: who points at it, and
+  what it would be needed to prove.** *(Under review.)* Something other records
+  refer to is kept and marked, because removing it breaks everything pointing at
+  it. But a record nothing refers to may still have to be kept, where it is the
+  evidence of a decision someone could later be answerable for — who a family
+  said could collect their child is that; an enrollment is not.
+
+  What is still open is where those lines sit, and whether capturing a whole
+  record into the audit trail counts as capturing it or merely defers the same
+  dependency. Only people are kept today; enrollments and visits are removed with
+  the row written to the audit trail.
+
+The tell is a status that swallows its predecessor — a row that goes to ARCHIVED
+or MERGED with no record of what it was before. That is the moment to capture,
+not the moment someone asks to undo.
+
+---
+
+## Least privilege
+
+- **A surface is reachable by the narrowest set of roles that can do the work.**
+  A role is not added to a gate because its holders are senior, because they
+  already have a session, or because it is convenient — only because the work
+  cannot be done without it.
+
+- **Holding a role is not a reason to use it.** Where someone could act in more
+  than one capacity, the narrower one governs; seniority is not an argument for
+  reaching further.
+
+Adding a role to a gate is the change this principle catches, and it is almost
+never noticed in review, because it makes something work that did not work
+before. Removing one is visible; widening is not.
+
+---
+
+## Fail closed
+
+The same instinct as least privilege, at a different moment: least privilege
+decides who gets a grant when the system is designed, this decides what happens
+when the answer is not available at the time it is needed.
+
+- **Missing or ambiguous data resolves to the more restrictive reading.** An
+  absent date of birth means treat as a youth, not as an adult. Not knowing is
+  never the permissive answer.
+
+- **An unconfigured setting does not act.** A board setting that has not been set
+  disables its feature; it never falls back to a guessed value. A number nobody
+  chose is worse than a feature nobody turned on.
+
+- **A check that cannot run has not passed.** An unreachable service, a failed
+  lookup, a query returning nothing — none of these are a clearance.
+
+- **Absent data is absent, not a zero.** A household with no membership has no
+  member-since date, not one at the epoch; a person with no date of birth has no
+  age, not age zero. Anything that reads, sorts, counts or renders such a value
+  carries the difference through rather than flattening it.
+
+The tell is a default. Every `?? 0`, `|| false`, and empty-result branch is this
+principle being decided, usually without anyone noticing they decided it.
+
+---
+
+## No existence oracle
+
+- **A response never reveals whether a person, account, or record exists to
+  someone not entitled to know it.** This governs the shape of failures, not just
+  successes: a distinct error message, a different status code, a slower reply, or
+  a count that changes are all disclosures.
+
+- **A helpful message is the usual way this breaks.** "That address already has an
+  account" is friendlier and tells an unauthenticated caller that the address is
+  registered. Where a caller is not entitled to the answer, failures are
+  indistinguishable from one another.
+
+This bites hardest on anything reachable without a session — registration,
+lookups, password-adjacent flows — where the caller is by definition not entitled
+to anything.
+
+---
+
+## Identity is not authorisation
+
+Distinct from least privilege, which is about how much a grant covers. This is
+about whether there is a grant at all: existing in the system is not permission
+to do anything in it.
+
+- **A surviving identifier is not a grant.** A session, a person id, a row that
+  is still there — none of these authorise anything on their own. Where standing
+  is withdrawn, everything that reads as authority has to be re-derived, not
+  inferred from what is left behind.
+
+- **A record that is no longer a person here holds nothing.** Merged away,
+  tombstoned, denied, revoked — such a record appears in no roster, no headcount,
+  no capacity calculation, and passes no gate.
+
+The failure looks like a gate that tests the wrong thing: authorising on the
+presence of an id rather than on a right the caller currently holds. It survives
+review easily, because the check is right there and does return true for the
+people it should.
+
+---
+
+## People decide about people
+
+- **Automation classifies, warns, and escalates. It does not act on a person.**
+  A job may mark someone overdue, send a reminder, and put them in front of the
+  board. It does not remove them, revoke their standing, or withdraw what they
+  hold.
+
+- **A decision about someone is delivered by someone.** Approvals, denials and
+  the consequences that follow are communicated by a person who can answer the
+  reply. An automatic acknowledgement that a request arrived is not a decision
+  and does not count.
+
+The line is between a person's live standing and a request that has not become
+one. A held seat expiring after a board-set grace is not a violation — nothing
+was taken from anyone; an unpaid request simply stopped waiting. Removing an
+active enrollment, or a member, is.
+
+The temptation is always the same: the sweep already knows who is overdue, so
+having it finish the job looks like an obvious improvement. It is the change
+this principle exists to stop.
+
+---
+
+## This codebase is not this organisation
+
+- **Our own particulars are inputs, not facts the software knows.** A date, a
+  rate, a threshold or a name that this organisation chose is something someone
+  can change without a deploy. When the membership year runs, what a membership
+  costs, how long a background check stands — these are answers we hold, not
+  truths built in.
+
+- **This covers identity as much as values.** What the organisation is called and
+  how it is branded are given to the software, not written inside it.
+
+*Fail closed* governs what happens when one of these has not been set. This
+governs whether it is a setting in the first place.
+
+The tell is a literal sitting in domain code — a date, a threshold, a fee, a
+name — that someone would have to edit and redeploy to change. The reason is not
+engineering taste: other organisations may run parts of this, so anything true
+only of us has to be something they can replace. Which also means the goal is not
+reusability in the abstract, and this principle never asks for a plugin system.
+
+---
+
+## Accountability
+
+- **Anything that changes standing, money, or access is attributable.** Who did
+  it, when, what it changed from and to. This is not a per-feature courtesy: a
+  new decision surface that writes no audit row is unfinished in the same way a
+  missing repair path is.
+
+- **A discretionary decision records why.** Where someone chose rather than
+  followed a rule — an override, a comp, a certification, a denial — who and when
+  is not enough to answer the question that gets asked later.
+
+- **A system actor names itself.** A cron sweep, a webhook, or a migration writes
+  its own identity, never an anonymous or borrowed one. "The system did it" is
+  only an answer if the trail says which part of it.
+
+- **A trail nobody can read is not a trail.** Being written is half of it; being
+  retrievable by the person who has to answer for it is the other half.
+
+The failure mode is not usually a missing log — it is a log that records the
+happy path and goes quiet exactly where a human exercised judgement.

--- a/docs/rules/principles.md
+++ b/docs/rules/principles.md
@@ -223,6 +223,24 @@ reusability in the abstract, and this principle never asks for a plugin system.
 
 ---
 
+## Capture a fact where it is known
+
+- **Record something at the point someone can verify it, not the point it is
+  convenient to ask.** Where one person holds the document and another is being
+  asked to remember, ask the one holding the document.
+
+- **Accepting a claim nobody can check is a decision, not a default.** It is a
+  fair one where the risk has been weighed and taken. It is not one where
+  somebody downstream does hold the evidence and simply was not asked.
+
+The tell is a field filled in by the person the fact is *about*, on a path where
+someone else later reads the paperwork that settles it. Self-assertion is the
+cheaper place to put the control and it looks like trusting people, but a family
+saying "we both did the check" cannot catch a family that submitted one form and
+believed it covered two.
+
+---
+
 ## Accountability
 
 - **Anything that changes standing, money, or access is attributable.** Who did

--- a/docs/rules/programs.md
+++ b/docs/rules/programs.md
@@ -1,0 +1,235 @@
+# Programs
+
+Eligibility, enrollment, pricing, capacity, and scholarships.
+
+---
+
+## Policy
+
+### What a program is and who runs it
+
+- Every activity of the Treehouse operates as a sponsored program, unless it is
+  coordinated and budgeted by the board directly, charges no fee, and has no
+  specific group of participants. — *Sponsored Program Policy, Art. III §III.1*
+
+- Every sponsored program has a program budget and a program leader identified
+  in writing. — *Sponsored Program Policy, Art. III §III.2*
+
+- A program leader is at least 23, is a member, and has passed the background
+  check. — *Sponsored Program Policy, Art. IV*
+
+- A program leader holds exclusive, non-transferable authority over their
+  program. Programs do not create their own governance — committees, voting
+  memberships, or budget authority — without written board authorisation, and
+  the board may modify or terminate a program at its discretion. — *Sponsored
+  Program Policy, Art. IX*
+
+- A second adult volunteer is required when the program is not running alongside
+  another program at the same facility or event. — *Sponsored Program Policy,
+  Art. III §III.2*
+
+- Every use of a facility has an agreed keyholder, agreed by both the program
+  leader and the keyholder. — *Sponsored Program Policy, Art. III §III.3*
+
+- The membership fee does not buy participation in a program that carries an
+  application, a fee, or other restrictions. — *Membership Policy, Art. V;
+  Definitions Policy, Art. III, "Member Family"*
+
+### Fees and scholarships
+
+- Program fees, before any scholarship adjustment, are equal for all members —
+  including a board member enrolling their own family, who pays what everyone
+  else pays. A fee may be assessed at several points across the program's life,
+  and those assessments need not be equal to one another. — *Sponsored Program
+  Policy, Art. VI §VI.2*
+
+- Holding a role is not a reason to decide a matter that benefits your own
+  family. — *Ethics Policy, Art. III §§III.2, III.5*
+
+- A program fee is a fee, not a charitable donation. — *Sponsored Program
+  Policy, Art. VI §VI.2*
+
+- No more than 20% of total participant fees may be waived by scholarship
+  without board approval. Externally designated scholarship funds do not count
+  toward that limit, and where total fees are $20 or less per participant the
+  limit rises to 50%. — *Sponsored Program Policy, Art. VII*
+
+- A scholarship has a specific intent and is budgeted for in the program budget.
+  — *Sponsored Program Policy, Art. VII*
+
+- A program payment plan does not extend beyond the later of the program's end
+  and 90 days from its start. — *Membership Policy, Art. XIII*
+
+- A participant who completes a registration is responsible for paying for it.
+  — *Sponsored Program Policy, Art. VIII*
+
+### Youth participation
+
+- Youth are enrolled in school — public, private, or home — unless they hold a
+  high-school diploma or equivalent. — *Membership Policy, Art. IV*
+
+- A program leader may require a parent or guardian to stay during a program,
+  and may apply that to some families and not others. — *Sponsored Program
+  Policy, Art. III §III.4*
+
+---
+
+## Assumptions
+
+Things the app takes as true because they are handled outside it.
+
+- Scholarship totals are tracked in the program budget, where the cap on waived
+  fees and the board approval it triggers are applied.
+
+- Payment-plan terms are agreed within the limits policy sets. The app records
+  that a plan was approved, not its schedule.
+
+---
+
+## Procedure
+
+### Eligibility
+
+- Age eligibility is measured at the program's start date, not at registration.
+  A program with no start date falls back to the moment of the request.  [Decision]
+
+- No program targets anyone over 25, and an age limit above that is refused.  [Decision]
+
+- A declared adult clears any youth minimum and fails any youth maximum. Nothing
+  verifies the claim. Checking a date of birth and telling a guardian were both
+  considered and refused; a minor who declares themselves an adult is a risk
+  taken knowingly.  [Decision — deliberate limit]
+
+- A program leader is 23 or older, the floor belonging to the role rather than to
+  adulthood. A program volunteer has no age floor at all — youth volunteer too.  [Decision — *Policy: Sponsored Program Policy, Art. IV*]
+
+- Nobody under 18 enrolls themselves. A youth is enrolled by their household lead.  [Decision]
+
+### Enrollment
+
+- A program never enrolls beyond capacity, including on a simultaneous claim of
+  the last seat. A confirmed admin override on another household is the one
+  exception.  [Decision]
+
+- Enrollment is done by the person, their household lead, the board, or a
+  sysadmin — not by the program's lead.  [Decision — *Principle: least privilege*;
+  superuser scope unsettled]
+
+- The fee waiver applies only to an administrator acting on another household.
+  Waiving a limit is a separate power from waiving a fee.  [Decision — *Policy: Sponsored Program Policy, Art. VI §VI.2; Ethics Policy, Art. III*]
+
+- Unpaid enrollments are warned, then escalated to the board. Overdue is a
+  classification, not an action.  [Decision — *Principle: people decide about people*]
+
+- Enrolling in a public workshop takes no membership agreement, and a household
+  that only ever enrolls in programs need give no mailing address.  [Decision]
+
+- A household that cannot enroll — nobody eligible, or no valid emergency contact
+  — is offered the way to fix it rather than a refusal.  [Decision]
+
+- Registration signs someone in before intake begins, so whether an account
+  exists is answered by signing in and never by a public reply.  [Decision — *Principle: no existence oracle*]
+
+- Removing a paid enrollment returns nothing to sale. A person decides whether
+  the freed seat goes back, and does it at the store.  [Decision — deliberate limit; *Principle: people decide about people*]
+
+- A request for a payment plan is never swept away for sitting too long.  [Decision]
+
+### Pricing
+
+- A failed discount degrades to undiscounted checkout, never an error.  [Decision — deliberate limit]
+
+- A program priced on a tier with nothing wired to sell it is broken and is
+  reported as such. A free tier has nothing to wire and is never reported.  [Decision]
+
+> **Candidate, not settled — for owner ratification.** Member pricing requires
+> the membership to cover the program's end date, not merely be active today; a
+> program with no end date requires coverage only through its start. Two cases
+> fall back to status alone: a program carrying no dates, and any program while
+> the membership-year boundary is unset. The source tags the ongoing-program
+> carve-out as a policy call awaiting a veto, so it is recorded as a candidate
+> rather than written into the register.
+> (`checkin-app/src/lib/orgMembership.ts`)
+
+### Capacity and scholarship holds
+
+- A program has one capacity pool, with no separate member-priced pool. The
+  number is how many people fit in the room, so a comped place takes one like any
+  other.  [Decision]
+
+- A request whose seat was never taken off sale is its own state, not an unpaid
+  applicant — the family did nothing wrong when the store call failed. It waits
+  in its own queue until a board member removes the seat by hand and confirms it,
+  which records the hold and returns the request to the normal decision.  [Decision]
+
+- The self-approval bar covers deciding a request, not repairing one. Confirming
+  a hold somebody's failed store call never made benefits nobody.  [Decision — *Policy: Ethics Policy, Art. III §III.5*]
+
+- A scholarship or payment-plan request takes its seat when requested, not when
+  approved.  [Decision]
+
+- A held seat is returned exactly once — by withdrawal, payment, or grace expiry
+  — or consumed permanently by approval, and an approved seat is never credited
+  back. This holds against a failed store call, not a crash between the two
+  writes; that drift is repaired by hand.  [Decision]
+
+- Denying a request does not release the seat; the family may still pay for it.  [Decision]
+
+- A denial starts the grace clock and sends nothing, so the board's own message
+  has to state the deadline.  [Decision — deliberate limit]
+
+- The grace period is a board setting. Unset means the feature is off.  [Decision — *Principle: fail closed*]
+
+- A request whose seat hold failed cannot be approved as though it held one.  [Decision]
+
+### Access to program information
+
+- A program's catalogue entry is public; its roster is visible only to the people
+  running it — its leader, its core volunteers, the board and sysadmins — and to
+  people enrolled in it. The catalogue route is never gated: an anonymous caller
+  reaches it and the response is filtered instead.  [Decision — *Policy: Records Policy, Art. IV*]
+
+- A program leader is defined by the program they lead, not by a role they hold.
+  They reach the programs they lead and no others; the board and sysadmins reach
+  all of them.  [Decision — superuser scope unsettled]
+
+- A program announces to families only if its leader opts in, and only to those
+  whose membership covers it. It fires on becoming both upcoming and open to
+  enrollment — neither alone — and once in the program's life, so closing and
+  reopening cannot send it again.  [Decision — deliberate limit]
+
+- A program leader sees whether a participant has paid, never how. Method,
+  scholarship, and payment plan are not theirs.  [Decision — *Principle: least privilege*]
+
+- Only the board and sysadmins set a program's store variant.  [Decision — *Principle: least privilege*]
+
+- A program's detail page shows which of the household is already enrolled and
+  what the program limits, and hides the non-member price where the program is
+  members only.  [Decision]
+
+- Participant hours are hours logged by people enrolled in a program. Age says
+  nothing about it.  [Decision]
+
+- Cross-selling one program from another will not be built.  [Decision — deliberate limit]
+
+---
+
+## Policy requirements not yet enforced here
+
+- **A program can be created with no dates at all.** Both start and end are
+  optional and nothing rejects either being absent. A start date should be
+  required, and an absent end should default to the end of the fiscal year
+  (30 June) rather than staying null.
+
+  Three rules quietly change meaning when they are missing. Age eligibility
+  falls back to the registration date, which is the thing that rule exists to
+  avoid. The catalogue reads a null end as running indefinitely. Member-pricing
+  coverage falls back to status alone.
+
+- **The program-leader minimum age of 23 is not checked**, nor is the
+  requirement that a leader be a member who has passed a check.
+
+- **The second-adult-volunteer requirement is not modelled** as a precondition of
+  scheduling a session.
+
+- **School enrollment for youth is not captured.**

--- a/docs/rules/tools-certification.md
+++ b/docs/rules/tools-certification.md
@@ -1,0 +1,103 @@
+# Tools and certification
+
+Certification levels, who may certify, and shop access.
+
+*Shop Safety Rules and Certification Process* has no article or section
+numbering — it is organised by heading, with a single numbered rule list. Its
+citations name the heading, or the rule number where there is one.
+
+---
+
+## Policy
+
+### Who may use a tool
+
+- Only trained members in good standing may use a tool that requires
+  certification. — *Tools Policy, Art. III*
+
+- Tool use qualification and restrictions are age-appropriate to the risk of the
+  tool. — *Tools Policy, Art. III*
+
+- High-hazard tools — table saw, lathe, and similar — are available only to shop
+  certifiers, or occasionally to students under a shop certifier's direct
+  supervision. — *Shop Safety Rules and Certification Process, "High Hazard
+  Tools"*
+
+- Someone at basic level may not use machine tools alone; they must have the
+  full attention of a certified defender of the fingers or higher on the tool in
+  use. — *Shop Safety Rules and Certification Process, rule 22*
+
+- The shop runs an enhanced tripod: at least three people present, one an adult,
+  and for each person using a tool two others at least 13 years old — one of
+  whom may be that adult. — *Shop Safety Rules and Certification Process,
+  rule 14*
+
+### Certification itself
+
+- Certification is per tool. Someone may be an instructor on one tool and basic
+  on another. — *Shop Safety Rules and Certification Process, "Certification
+  Levels"*
+
+- **Shop certifiers are the only people who can attest to a move from one level
+  to the next.** It is an internal designation decided by the board. Instructors
+  may do initial training but cannot certify a level change. — *Shop Safety
+  Rules and Certification Process, "Shop Certifier (Purple)" and
+  "Certification"*
+
+- A tool certifier is appointed in writing by the board, so a certifier grants
+  levels below their own and cannot create another certifier. — *Definitions
+  Policy, Art. III, "Tool Certifier"*
+
+- Age minimums attach to levels: basic from 10; certified from 10 on hand and
+  heat tools and from 13 on powered-motion tools; defender of the fingers and
+  instructor from 13; shop certifier from 21. — *Shop Safety Rules and
+  Certification Process, "Certification Categories" and "Certification Levels"*
+
+- **Tool certification levels are displayed in the shop area**, and the list of
+  shop certifiers is posted in the workshop. — *Shop Safety Rules and
+  Certification Process, "Certification" and "Certification Levels"*
+
+---
+
+## Assumptions
+
+Things the app takes as true because they are handled outside it.
+
+- A tool certifier was appointed in writing by the board before the certifier
+  level was granted. Holding that level is what represents the appointment.
+
+- Supervision at the tool is handled in the shop — the defender-of-the-fingers
+  requirement and the enhanced tripod are enforced by the people present. The app
+  records who is certified, not who is watching.
+
+---
+
+## Procedure
+
+- Sysadmins grant certifier authority alongside the board.  [Unsettled — which superuser]
+
+- Certifications carry no expiry. A downgrade is an explicit act by someone
+  holding the authority.  [Decision — deliberate limit]
+
+- A certification is kept regardless of membership standing — a lapsed record
+  keeps its levels. Standing governs using the tool, not holding the
+  certification.  [Decision — deliberate limit]
+
+- A person's certification level is visible to members.  [Decision — *Policy: Shop Safety Rules and Certification Process, "Certification"*]
+
+- The full certification matrix is readable by tool certifiers and keyholders,
+  not only the board.  [Decision]
+
+- Certifying authority is per tool; a certifier's reach across the app is not.
+  Holding the level on any tool opens the certification surfaces for all of them.  [Decision — deliberate limit]
+
+---
+
+## Policy requirements not yet enforced here
+
+- **No age minimum is checked against a level.** Nothing stops a 9-year-old
+  being recorded as certified, or someone under 21 as a certifier.
+
+- **Tool category is not modelled**, so the split between hand, heat,
+  powered-motion, and high-hazard tools — and the different age floors and
+  supervision rules that follow from it — has no representation.


### PR DESCRIPTION
Step 2 of the documentation migration: recover the standing rules of this organisation and write them where someone changing behaviour in a domain will read them.

**Depends on #1428**, which updates the standard these files are written against. Merge that first — `main`'s copy still describes two sections per file, and these have three.

## What's here

**The register — 8 files.** A README, a `principles.md` holding what crosses every domain, and one file per domain: membership, people and households, programs, finance and payments, attendance and check-in, tools and certification.

Each domain file reads **Policy** (cited by policy name and article), then **Assumptions** (things that hold because someone outside the app maintains them), then **Procedure** (what the app decides for itself, each line tagged with what kind of statement it is). Several close with a section naming where the app implements a policy more loosely than the policy states.

**Two more, because the fold produced rules that were not domain rules:**

- `docs/conventions.md` — how we build rather than what the domain requires. Anything affecting price, access or eligibility is computed on the server, and a control that is merely hidden is not protected. We never write an address at a domain we do not own, including on dead records. And where something must never be read, we make it impossible to read rather than everyone's job to exclude — a filter every caller must remember, a guard hunting for the ones who forgot, and a list of justified exceptions are one smell rather than three.
- `docs/ops/legacy-cleanup.md` — three states the code must tolerate because of how data arrived, each naming how it surfaces and what ends it. It is built to delete itself: an entry goes when its count reaches zero, and an entry that sits through a release or two without moving is a gap wearing a cleanup label.

## Where the rules came from

Two sources that cannot see each other. The pull-request history shows what shipped; session transcripts show what was said, including decisions that produced no diff and roads deliberately not taken. Both were diffed against the drafts and then **verified against the tree**.

That verification mattered more than expected. Four times a source described an intention as though it had shipped, and the code disagreed:

- a stale-check to-do that does not exist — a household is never told its background check has gone stale, because nothing acts on staleness between renewals
- an announcement said to re-send on reopening, which is once-per-lifetime and cannot
- a failed-payment-hold state reported as unbuilt, which ships as a derived state with its own queue
- visits reported as soft-deleted, which are not

Several rules here are therefore narrower than the discussions that produced them.

## Three principles drawn from designs in flight

Reading #1454 and #1457 while they were open produced three rules that hold regardless of whether either is built:

- **Where finishing an operation would take inventing a fact, refuse to finish it.** Not a plausible departure time for a visit nobody closed, not a guess at which of two conflicting records is real. Refusing is visible and recoverable; an invented value is neither, because nothing downstream can tell it from a real one.
- **Capture a fact where it is known.** Record something where someone can verify it, not where it is convenient to ask — where one person holds the document and another is being asked to remember, ask the one holding the document. Accepting an unverifiable claim stays a fair decision where the risk has been weighed, which is what `programs.md` records for the declared adult; it is not one where somebody downstream does hold the evidence and simply was not asked.
- **An invariant everyone must remember is not an invariant** (the convention above).

If #1457 lands, `people-households.md`'s tombstone rule inverts and the under-review bullet on removal loses the case it rests on. That is tracked for re-check rather than pre-empted here.

## What it also turned up

Two defects neither source found, both while checking something else:

- **A household's background-check clearance is stamped onto every lead**, not the person who was checked. Correct for the household question policy asks; wrong as the per-person fact the program-attached surface reads back. #1454 reaches the same conclusion independently.
- **Restoring an archived application guesses what it used to be** by working backwards through the audit trail, rather than from anything captured when it was archived.

## Review order

`README.md` and `principles.md` first — they set what the rest means. Then the domain files, largest first: membership, programs, people and households.

🤖 Generated with [Claude Code](https://claude.com/claude-code)