### PR TITLE
fix(merge): count only live members in the household-lead guard

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -48,6 +48,7 @@ describe("Merge Participants API", () => {
     // Extra rows/ids a given test creates beyond the base fixture — cleaned up
     // generically in afterEach so each test doesn't hand-roll teardown ordering.
     let extraPersonIds: number[];
+    let extraHouseholdIds: number[];
     let createdProgramId: number | undefined;
     let createdToolId: number | undefined;
     let createdEventId: number | undefined;
@@ -78,6 +79,7 @@ describe("Merge Participants API", () => {
         pMergeId = pMerge.id;
 
         extraPersonIds = [];
+        extraHouseholdIds = [];
         createdProgramId = undefined;
         createdToolId = undefined;
         createdEventId = undefined;
@@ -108,6 +110,7 @@ describe("Merge Participants API", () => {
         if (createdProgramId) await prisma.program.deleteMany({ where: { id: createdProgramId } });
         if (createdCorporationId) await prisma.corporation.deleteMany({ where: { id: createdCorporationId } });
         if (householdId) await prisma.household.deleteMany({ where: { id: householdId } });
+        if (extraHouseholdIds.length) await prisma.household.deleteMany({ where: { id: { in: extraHouseholdIds } } });
     });
 
     it("should successfully merge two participants", async () => {
@@ -296,6 +299,49 @@ describe("Merge Participants API", () => {
         expect(res.status).toBe(400);
         const data = await res.json();
         expect(data.error).toContain("lead of a household with other members");
+    });
+
+    // The lead guard counts LIVE household members only: a tombstone left in the
+    // household by an earlier merge is not another member.
+    it("merges a household lead whose only other household row is a tombstone", async () => {
+        const hh = await prisma.household.create({ data: { name: "Lead + Tombstone Household" } });
+        extraHouseholdIds.push(hh.id);
+
+        const lead = await prisma.person.create({
+            data: { name: "Lead Person", householdId: hh.id, isHouseholdLead: true }
+        });
+        const ghost = await prisma.person.create({
+            data: { name: "Already Merged", householdId: hh.id, mergedIntoId: pKeepId }
+        });
+        extraPersonIds.push(lead.id, ghost.id);
+
+        // name is the only conflict — the lead carries no email/googleId, so the
+        // keeper's identity is untouched and no `identity` choice is needed.
+        const res = await POST(mergeReq(pKeepId, lead.id, { name: "keep" }));
+        expect({ status: res.status, data: await res.json() }).toEqual({ status: 200, data: { success: true } });
+
+        expect((await prisma.person.findUnique({ where: { id: lead.id } }))?.mergedIntoId).toBe(pKeepId);
+        // ghost stays put — a tombstone is never cleaned up by a merge.
+        expect((await prisma.person.findUnique({ where: { id: ghost.id } }))?.householdId).toBe(hh.id);
+    });
+
+    it("analyze omits a tombstoned household member from householdMembers", async () => {
+        const hh = await prisma.household.create({ data: { name: "Analyze Tombstone Household" } });
+        extraHouseholdIds.push(hh.id);
+
+        const lead = await prisma.person.create({
+            data: { name: "Analyze Lead", householdId: hh.id, isHouseholdLead: true }
+        });
+        const ghost = await prisma.person.create({
+            data: { name: "Analyze Ghost", householdId: hh.id, mergedIntoId: pKeepId }
+        });
+        extraPersonIds.push(lead.id, ghost.id);
+
+        const res = await analyzeGET(analyzeReq(pKeepId, lead.id));
+        expect(res.status).toBe(200);
+        const { participants } = await res.json();
+        const members = participants[1].household.householdMembers as { id: number }[];
+        expect(members.map(m => m.id)).toEqual([lead.id]);
     });
 
     // Matrix 4

--- a/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
+import { LIVE_PERSON } from "@/lib/person/filters";
 
 export const dynamic = 'force-dynamic';
 
@@ -51,6 +52,9 @@ export const GET = withAuth(
                                 id: true,
                                 name: true,
                                 householdMembers: {
+                                    // Tombstones are not members: the page's
+                                    // isLeadWithOthers guard must match the POST's.
+                                    where: LIVE_PERSON,
                                     select: { id: true, name: true, isHouseholdLead: true }
                                 }
                             }

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -4,6 +4,7 @@ import type { Person } from "@/generated/prisma/client";
 import { withAuth } from "@/lib/auth";
 import { logBackendError } from "@/lib/logger";
 import { apiError } from "@/lib/api-response";
+import { LIVE_PERSON } from "@/lib/person/filters";
 
 export const dynamic = 'force-dynamic';
 
@@ -138,7 +139,9 @@ export const POST = withAuth(
                     corporationMembers: true,
                     household: {
                         include: {
-                            householdMembers: true
+                            // The lead guard below asks "would this leave live members
+                            // leaderless" — tombstones are not members.
+                            householdMembers: { where: LIVE_PERSON }
                         }
                     }
                 }


### PR DESCRIPTION
## What

The participant-merge route refuses to merge someone who leads a household with other members:

```ts
const householdOthersCount = mergeParticipant.household?.householdMembers.filter(p => p.id !== mergeId).length || 0;
if (isLead && householdOthersCount > 0) return apiError("Cannot merge: ...", 400);
```

That count had no live-person filter. Merged-away records are **tombstoned, not deleted** — they keep their `householdId` and are marked only by `mergedIntoId`. So a household whose only remaining "other member" is a previously-merged tombstone reports `householdOthersCount === 1`, and merging that household's lead is refused with a spurious 400. Nothing in the UI explains it, and there is no way for an operator to clear it.

The guard's intent is clearly *live* members — every other freshness/roster read applies `LIVE_PERSON` (`checkin-app/src/lib/person/filters.ts`).

## Change

`where: LIVE_PERSON` on the nested `householdMembers` pull, in **both** places that feed this decision:

- `merge/route.ts` — the POST guard's count.
- `merge/analyze/route.ts` — the same lead/others projection the merge page derives its `isLeadWithOthers` guard (and disabled Preview button) from. Fixing only the POST would leave the UI still greying out a merge the server now accepts, so the preview and the POST agree.

No client change needed: the page reads `isLeadWithOthers` off this response.

## Tests

Two integration tests in `merge/__tests__/route.integration.test.ts`:

1. household with a lead + one already-merged tombstone → merging the lead into someone else succeeds (200), tombstone stays put.
2. `analyze` omits the tombstone from `householdMembers`.

Both fail on the unmodified routes (`2 failed, 32 passed`) and pass with the fix (`34 passed`). The fixture needed its own household (`householdId` is required on `Person`), hence the small `extraHouseholdIds` teardown slot.

## Reviewer notes

- **No security-boundary surface.** Both call sites are `findUnique`, which `livePersonDriftGuard` excludes by design (one-row-by-key can't leak a tombstone into a list or inflate a count) — so no allowlist entry appears or disappears.
- Independent of #1396; found while reading that issue, not part of it.
- Verified: `npm run test:ci` 2421 passed / 257 suites, `tsc --noEmit` clean, `npm run test:integration` on the merge suite 34 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)