### PR TITLE
fix(merge): keep one open PERSON_BG when both merge subjects owe a check

### DIFF
--- a/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
+++ b/checkin-app/src/__tests__/lifecycleStatusLiteralAllowlist.test.ts
@@ -105,8 +105,8 @@ function isDefinitionModule(rel: string): boolean {
  * is why files like facility/trends, renewal-status, notifications, payment.ts, and
  * orgMembership.ts (all single-status reads) are absent; likewise single-status CAS guards
  * (activateEnrollment PENDING→ACTIVE, archive ARCHIVED→target) and sets spelled with a
- * canonical constant (renewal's `{ in: [...IN_FLIGHT_RENEWAL] }`, which carries no bare
- * literal and cannot drift).
+ * canonical constant (renewal's `{ in: [...IN_FLIGHT_RENEWAL] }` and the PERSON_BG
+ * existence set's `...personBgOpen.where`, which carry no bare literal and cannot drift).
  */
 const ALLOWLIST: Record<string, string> = {
     // ── CAS transition guards now source their from-state status from the definition (#1080) ──
@@ -117,12 +117,6 @@ const ALLOWLIST: Record<string, string> = {
     // parity test (guardFromStateParity.test.ts) is what keeps them honest now. (renewal's
     // beginRenewalForUser read is a LONE single-status literal, which the sharpened scanner no
     // longer flags either, so it isn't listed.)
-
-    // Not a transition from-state: the PERSON_BG edge is ∅→PENDING_BG_REVIEW (no from-row).
-    // An idempotency EXISTENCE SET (already open/blocked → skip), broader than any one
-    // from-state, so it stays a literal set rather than misrepresent it via fromWhere.
-    'lib/membership/personBgTriggers.ts':
-        'PERSON_BG create idempotency existence set: where status in {PENDING_BG_REVIEW,BLOCKED}.',
 
     // ── invariant-driven reconciler (Phase 4) ──
     'lib/lifecycleDrift.ts':

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -702,6 +702,84 @@ describe("Merge Participants API", () => {
         expect(await prisma.session.count({ where: { userId: { in: [pKeepId, pMergeId] } } })).toBe(0);
     });
 
+    // One human owes ONE background check: both sides can hold an open PERSON_BG, and
+    // re-pointing both at the survivor would leave two concurrent 2-of-N reviews.
+    describe("duplicate open PERSON_BG on both merge subjects", () => {
+        const openPersonBg = (personId: number, extra: { status?: "PENDING_BG_REVIEW" | "BLOCKED"; bgConsentAt?: Date } = {}) =>
+            prisma.orgMembershipProcess.create({
+                data: { kind: "PERSON_BG", subjectPersonId: personId, status: extra.status ?? "PENDING_BG_REVIEW", bgConsentAt: extra.bgConsentAt ?? null },
+            });
+
+        const openForKeeper = () =>
+            prisma.orgMembershipProcess.findMany({
+                where: { kind: "PERSON_BG", subjectPersonId: pKeepId, status: { in: ["PENDING_BG_REVIEW", "BLOCKED"] } },
+            });
+
+        it("leaves the survivor exactly one open PERSON_BG, archiving the less-advanced row", async () => {
+            const keeperProc = await openPersonBg(pKeepId);
+            const tombstoneProc = await openPersonBg(pMergeId, { bgConsentAt: new Date() }); // further along: submitted for review
+            createdProcessIds.push(keeperProc.id, tombstoneProc.id);
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            const open = await openForKeeper();
+            expect(open.map(p => p.id)).toEqual([tombstoneProc.id]);
+
+            // The loser is ARCHIVED (not deleted), with archiveApplication's audit shape
+            // so the board can unarchive it if the merge picked wrong.
+            const loser = await prisma.orgMembershipProcess.findUnique({ where: { id: keeperProc.id } });
+            expect(loser?.status).toBe("ARCHIVED");
+            expect(loser?.subjectPersonId).toBe(pKeepId);
+            const log = await prisma.auditLog.findFirst({ where: { tableName: "OrgMembershipProcess", affectedEntityId: keeperProc.id } });
+            expect(log?.oldData).toMatchObject({ status: "PENDING_BG_REVIEW" });
+            expect(log?.newData).toMatchObject({ status: "ARCHIVED", survivorProcessId: tombstoneProc.id });
+
+            const mergeLog = await prisma.auditLog.findFirst({ where: { tableName: "Person", affectedEntityId: pKeepId, secondaryAffectedEntity: pMergeId } });
+            expect((mergeLog?.newData as { moved: { personBgArchived: number } }).moved.personBgArchived).toBe(1);
+        });
+
+        it("keeps the row with attestations when neither has consent", async () => {
+            const keeperProc = await openPersonBg(pKeepId);
+            const tombstoneProc = await openPersonBg(pMergeId);
+            createdProcessIds.push(keeperProc.id, tombstoneProc.id);
+            await prisma.backgroundCheckAttestation.create({ data: { processId: keeperProc.id, reviewerId: actorId, result: "APPROVE" } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            const open = await openForKeeper();
+            expect(open.map(p => p.id)).toEqual([keeperProc.id]);
+            // The reviewer's work is not orphaned onto the archived row.
+            expect(await prisma.backgroundCheckAttestation.count({ where: { processId: keeperProc.id } })).toBe(1);
+        });
+
+        it("never archives a BLOCKED row in favour of an open review", async () => {
+            const keeperProc = await openPersonBg(pKeepId, { bgConsentAt: new Date() });
+            const tombstoneProc = await openPersonBg(pMergeId, { status: "BLOCKED" });
+            createdProcessIds.push(keeperProc.id, tombstoneProc.id);
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            const open = await openForKeeper();
+            // The rejection survives; the pending review is the one archived.
+            expect(open.map(p => p.id)).toEqual([tombstoneProc.id]);
+            expect((await prisma.orgMembershipProcess.findUnique({ where: { id: keeperProc.id } }))?.status).toBe("ARCHIVED");
+        });
+
+        it("leaves a single open PERSON_BG alone (nothing to resolve)", async () => {
+            const tombstoneProc = await openPersonBg(pMergeId);
+            createdProcessIds.push(tombstoneProc.id);
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            const open = await openForKeeper();
+            expect(open.map(p => ({ id: p.id, status: p.status }))).toEqual([{ id: tombstoneProc.id, status: "PENDING_BG_REVIEW" }]);
+        });
+    });
+
     // Matrix 13
     it("moves closed visits; both-open leaves the tombstone's open visit in place", async () => {
         await prisma.visit.create({ data: { personId: pKeepId, arrivedAt: new Date(Date.now() - 3600000) } }); // keeper's own open visit

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -4,7 +4,9 @@ import type { Person } from "@/generated/prisma/client";
 import { withAuth } from "@/lib/auth";
 import { logBackendError } from "@/lib/logger";
 import { apiError } from "@/lib/api-response";
+import { personBgOpen } from "@/lib/membership/lifecycle";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import type { TxClient } from "@/lib/db-client";
 
 export const dynamic = 'force-dynamic';
 
@@ -101,6 +103,63 @@ function resolveKeeperUpdate(
     }
 
     return data;
+}
+
+/**
+ * One human owes at most ONE open background check. Both merge subjects can hold an
+ * open PERSON_BG, and re-pointing both at the survivor leaves two concurrent 2-of-N
+ * reviews for the same person — the trigger's own dedupe never sees them (it runs at
+ * create time). Keep the furthest-along row, archive the rest.
+ *
+ * Rank: BLOCKED outranks an open review — archiving a block in favour of a pending
+ * row would erase a rejection and hand the person a fresh path to clearance. Then
+ * more attestations, then consent recorded, then the older row.
+ *
+ * Attestations stay on the archived row: moving them onto the survivor would seat
+ * reviewers past attest()'s same-household/already-attested gates, and the archived
+ * row keeps the record. The audit row matches archiveApplication's shape, so the
+ * board can unarchive one archived by mistake.
+ *
+ * No new lifecycle edge: this is the declared §13 archive transition
+ * ({PENDING_BG_REVIEW,BLOCKED}→ARCHIVED) driven from a second site, and the CAS
+ * from-state comes from the definition (`personBgOpen.where` covers both).
+ */
+async function archiveDuplicatePersonBg(tx: TxClient, personId: number, actorId: number): Promise<number> {
+    const open = await tx.orgMembershipProcess.findMany({
+        where: { kind: "PERSON_BG", subjectPersonId: personId, ...personBgOpen.where },
+        select: { id: true, status: true, bgConsentAt: true, _count: { select: { attestations: true } } },
+    });
+    if (open.length < 2) return 0;
+
+    const rank = (p: (typeof open)[number]) => [p.status === "BLOCKED" ? 1 : 0, p._count.attestations, p.bgConsentAt ? 1 : 0, -p.id];
+    const [survivor, ...losers] = [...open].sort((a, b) => {
+        const [ra, rb] = [rank(a), rank(b)];
+        for (let i = 0; i < ra.length; i++) if (ra[i] !== rb[i]) return rb[i] - ra[i];
+        return 0;
+    });
+
+    let archived = 0;
+    for (const loser of losers) {
+        // CAS on the open set: a concurrent attest that just cleared or blocked this
+        // row wins, and we leave it alone.
+        const { count } = await tx.orgMembershipProcess.updateMany({
+            where: { id: loser.id, ...personBgOpen.where },
+            data: { status: "ARCHIVED", stageEnteredAt: new Date() },
+        });
+        if (count !== 1) continue;
+        await tx.auditLog.create({
+            data: {
+                actorId,
+                action: "EDIT",
+                tableName: "OrgMembershipProcess",
+                affectedEntityId: loser.id,
+                oldData: { status: loser.status },
+                newData: { status: "ARCHIVED", reason: "duplicate PERSON_BG resolved by participant merge", survivorProcessId: survivor.id },
+            },
+        });
+        archived++;
+    }
+    return archived;
 }
 
 export const POST = withAuth(
@@ -232,6 +291,7 @@ export const POST = withAuth(
 
                 const moved = {
                     visits: 0,
+                    personBgArchived: 0,
                     programParticipants: { migrated: 0, left: 0 },
                     programVolunteers: { migrated: 0, left: 0 },
                     rsvps: { migrated: 0, left: 0 },
@@ -312,6 +372,8 @@ export const POST = withAuth(
                 // (smaller and safer than moving a session onto a different person mid-use).
                 await tx.session.deleteMany({ where: { userId: mergeId } });
                 await tx.orgMembershipProcess.updateMany({ where: { subjectPersonId: mergeId }, data: { subjectPersonId: keepId } });
+                // Both sides can have owed a check — the survivor keeps exactly one.
+                moved.personBgArchived = await archiveDuplicatePersonBg(tx, keepId, auth.type === 'session' ? auth.user.id : 0);
                 await tx.program.updateMany({ where: { leadMentorId: mergeId }, data: { leadMentorId: keepId } });
                 await tx.trustedAdult.updateMany({ where: { trustedAdultPersonId: mergeId }, data: { trustedAdultPersonId: keepId } });
                 await tx.trustedAdult.updateMany({ where: { disclosedById: mergeId }, data: { disclosedById: keepId } });

--- a/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
+++ b/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
@@ -11,6 +11,7 @@ import {
     TRANSITIONS as MEMB_TX,
     ALL_STATUSES as MEMB_STATES,
     fromWhere as membFromWhere,
+    personBgOpen,
     type ProcessStatus,
 } from '../../membership/lifecycle';
 
@@ -120,11 +121,15 @@ describe('CAS guard ↔ TRANSITIONS from-state parity (#1080)', () => {
         }
     });
 
-    it('the personBg idempotency guard is left literal, and its states are valid', () => {
-        const src = read('lib/membership/personBgTriggers.ts');
-        // still a raw {in:[…]} literal (NOT fromWhere) — documented as an existence set
-        expect(/status:\s*\{\s*in:\s*\[\s*"PENDING_BG_REVIEW",\s*"BLOCKED"\s*\]/.test(src)).toBe(true);
-        expect(src).not.toMatch(/fromWhere\(/);
-        for (const s of ['PENDING_BG_REVIEW', 'BLOCKED']) expect(MEMB_STATES).toContain(s);
+    it('the personBg existence set lives in the definition, and both consumers spread it', () => {
+        // An existence set, not a from-state (the PERSON_BG edge is ∅→PENDING_BG_REVIEW),
+        // so it is a StateSet rather than fromWhere — and both sites read the SAME one:
+        // the create-idempotency guard and the merge's duplicate resolution.
+        for (const file of ['lib/membership/personBgTriggers.ts', 'app/api/membership-ops/participants/merge/route.ts']) {
+            expect({ file, spreads: /\.\.\.personBgOpen\.where/.test(read(file)) }).toEqual({ file, spreads: true });
+        }
+        expect(read('lib/membership/personBgTriggers.ts')).not.toMatch(/fromWhere\(/);
+        expect([...personBgOpen.statuses].sort()).toEqual(['BLOCKED', 'PENDING_BG_REVIEW']);
+        for (const s of personBgOpen.statuses) expect(MEMB_STATES).toContain(s);
     });
 });

--- a/checkin-app/src/lib/membership/lifecycle.ts
+++ b/checkin-app/src/lib/membership/lifecycle.ts
@@ -101,6 +101,21 @@ export const IN_FLIGHT_RENEWAL: readonly ProcessStatus[] = [
     "RENEWAL_PENDING_BG",
 ];
 
+/**
+ * A PERSON_BG obligation still outstanding for its subject: awaiting review, or
+ * BLOCKED (a manual follow-up the board owns, never auto-reopened). NOT a
+ * transition from-state — the PERSON_BG entry edge is ∅→PENDING_BG_REVIEW — so it
+ * stays an existence set rather than going through `fromWhere`.
+ *
+ * ONE definition because two sites must agree on it: `openPersonBg`'s
+ * create-idempotency guard, and the person merge's duplicate resolution. If they
+ * disagreed, a status the merge didn't count as open would let a survivor end up
+ * owing two concurrent 2-of-N reviews.
+ */
+export const personBgOpen = defineStateSet<Where>()({
+    statuses: ["PENDING_BG_REVIEW", "BLOCKED"],
+});
+
 // ── awaiting BG review (fix #1) ────────────────────────────────────────────────
 // Encodes review.ts:75 / AWAITING_BG_WHERE:97 EXACTLY, from one source. Not a
 // single defineStateSet: it's an OR of two sub-rules, both requiring

--- a/checkin-app/src/lib/membership/personBgTriggers.ts
+++ b/checkin-app/src/lib/membership/personBgTriggers.ts
@@ -1,6 +1,7 @@
 import prisma from "@/lib/prisma";
 import { bgFreshThreshold, personBgVerdict } from "@/lib/membership/personBgCheck";
 import { nextBoundary } from "@/lib/membership/renewal";
+import { personBgOpen } from "@/lib/membership/lifecycle";
 import { LIVE_PERSON, PROGRAM_ATTACHED_WHERE } from "@/lib/person/filters";
 
 /**
@@ -38,13 +39,12 @@ export async function openPersonBg(personId: number, asOf: Date, threshold: Date
         });
         if (!person) return null;
         if (personBgVerdict(person, asOf, threshold) !== "NEEDED") return null; // (b)
-        // Left literal on purpose (#1080): this is NOT a transition from-state — the
-        // PERSON_BG edge is ∅→PENDING_BG_REVIEW (no from-row). This `{in:…}` is an
-        // idempotency EXISTENCE set ("a PERSON_BG is already open or blocked for this
-        // person → skip"), broader than any single from-state, so it can't be sourced
-        // from `fromWhere` without misrepresenting it.
+        // The idempotency EXISTENCE set ("this person already owes a check → skip"),
+        // shared with the person merge's duplicate resolution — one definition, since
+        // the two must agree on what counts as open. Not `fromWhere`: this is broader
+        // than any from-state (the PERSON_BG edge is ∅→PENDING_BG_REVIEW, no from-row).
         const existing = await tx.orgMembershipProcess.findFirst({
-            where: { kind: "PERSON_BG", subjectPersonId: personId, status: { in: ["PENDING_BG_REVIEW", "BLOCKED"] } },
+            where: { kind: "PERSON_BG", subjectPersonId: personId, ...personBgOpen.where },
             select: { id: true },
         });
         if (existing) return null; // (a)


### PR DESCRIPTION
## The bug

`POST /api/membership-ops/participants/merge` re-pointed every `OrgMembershipProcess` at the survivor with a blind `updateMany`:

```ts
await tx.orgMembershipProcess.updateMany({ where: { subjectPersonId: mergeId }, data: { subjectPersonId: keepId } });
```

If BOTH merge subjects held an open PERSON_BG (`PENDING_BG_REVIEW` or `BLOCKED`), the survivor ended up with **two concurrent open PERSON_BG rows** — one human owing two separate 2-of-N background-check reviews, each needing its own attestations.

Nothing prevented it:
- `openPersonBg`'s dedupe (`lib/membership/personBgTriggers.ts`) runs at **create** time only — the merge bypasses it entirely.
- No DB backstop: `membership_one_inflight_initial` / `membership_one_inflight_renewal` are both keyed on `orgMembershipId`, never `subjectPersonId`.

Pre-existing, found while analysing #1396 — independent of it, and #1396 is untouched here.

Confirmed first with a failing integration test (`Expected [23], Received [22, 23]` open rows on the survivor), then fixed.

## The fix

`archiveDuplicatePersonBg` in the merge route: keep the furthest-along row, archive the rest.

Rank, descending:
1. **BLOCKED outranks an open review** — archiving a block in favour of a pending row would erase a rejection and hand the person a fresh path to clearance.
2. More attestations.
3. Consent recorded (`bgConsentAt`).
4. Older row.

The loser flips to `ARCHIVED` under a CAS on the open set (`where: { id, ...personBgOpen.where }`), so a concurrent `attest()` that just cleared or blocked it wins and we leave it alone. Its audit row matches `archiveApplication`'s shape, so the board can `unarchive` a wrong pick; the merge audit gains a `moved.personBgArchived` tally.

**Attestations are deliberately not combined** onto the survivor: moving them would seat reviewers past `attest()`'s same-household / already-attested gates (`lib/membership/review.ts`), and the archived row keeps the record either way.

## One definition for "open"

The open-set now lives once, as the `personBgOpen` StateSet in `lib/membership/lifecycle.ts`, spread by both the trigger's idempotency guard and the merge's resolution. If those two disagreed on what counts as open, this bug comes straight back. Knock-on:
- retires the `personBgTriggers.ts` entry in the status-literal allowlist (it no longer carries a bare literal),
- `guardFromStateParity.test.ts`'s PERSON_BG case now pins **both** consumers spreading `...personBgOpen.where`.

## Lifecycle

No `TRANSITIONS` edge added, so no artifact regeneration: `{PENDING_BG_REVIEW,BLOCKED}→ARCHIVED` are already declared archive edges — this is a second enforcement site for them, with the CAS from-state sourced from the definition (a set, since the guard covers both states). LIFECYCLE.md rules 1/3/5 hold.

## Reviewer notes

- Consciously skipped: a partial unique index on `(subjectPersonId) WHERE kind='PERSON_BG' AND status IN (…)`. It can't be created if prod already holds duplicate rows, and the merge would still have to choose a survivor — worth adding later as a backstop, not as the fix.
- **Separate pre-existing hole, not touched here:** the attestation move at `route.ts:322` re-points `reviewerId` mergeId→keepId even when the process's subject becomes keepId, so the survivor can end up attesting their own PERSON_BG. Leaving the row on the tombstone doesn't help (approval counting ignores reviewer tombstoning), so the fix is a deletion in a route built on no-deletes — deserves its own change.

## Testing

- 4 new integration tests in `merge/__tests__/route.integration.test.ts`: survivor keeps exactly one open row (loser ARCHIVED + restorable audit + tally), attestation-count tiebreak, BLOCKED never archived for an open review, single open row untouched. All 4 fail on `main`.
- `tsc --noEmit` clean.
- Unit suite (`npm run test:ci`) — 2421/2421 passed, 257 suites.
- Integration suite (`npm run test:integration`, runInBand) — 1262/1262 passed, 128 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
