### PR TITLE
fix(merge): refuse a person merge across mismatched household membership

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -356,26 +356,60 @@ describe("Merge Participants API", () => {
     });
 
     // OrgMembership is 1:1 with Household and the merge never moves it: the tombstone
-    // keeps its householdId, the keeper stays in its own household. So the two sides'
-    // membership status must already agree, or the merge either strands the membership
-    // or drops a restriction.
+    // keeps its householdId, the keeper stays in its own household. Both resulting
+    // harms depend on which side is merged away, so the guard is asymmetric.
     describe("household membership guard", () => {
-        it("400s when the merged-away record holds an ACTIVE membership and the keeper's household is NONE (value stranded)", async () => {
-            // Tombstone is the SOLE live member of an ACTIVE household — the lead guard
-            // (lead + others > 0) can't see this shape.
+        it("400s when the merged-away record is the last live member of an ACTIVE household (value stranded)", async () => {
+            // Sole live member AND lead — the existing lead guard (lead + others > 0)
+            // cannot see this shape.
             const memberHh = await makeHousehold("Paid Member Household", "ACTIVE");
             await prisma.person.update({ where: { id: pMergeId }, data: { householdId: memberHh, isHouseholdLead: true } });
 
             const res = await POST(mergeReq(pKeepId, pMergeId));
             expect(res.status).toBe(400);
             const data = await res.json();
-            expect(data.error).toContain("different Treehouse membership status");
+            expect(data.error).toContain("last live member");
             expect(data.error).toContain("ACTIVE");
 
             // Refused before the transaction: the ACTIVE membership still has a live
             // member, and the surviving human isn't sitting in the NONE household.
             expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBeNull();
             expect(await prisma.person.count({ where: { householdId: memberHh, mergedIntoId: null } })).toBe(1);
+        });
+
+        it("400s on ACTIVE keeper vs ACTIVE merged-away when the merged-away side is its household's last live member", async () => {
+            // Equal status on both sides, and still a stranding: the equality alone
+            // says nothing about who is left to use the merged-away membership.
+            await prisma.orgMembership.create({ data: { householdId, status: "ACTIVE" } });
+            const otherActive = await makeHousehold("Other Active Household", "ACTIVE");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: otherActive } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toContain("last live member");
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBeNull();
+        });
+
+        it("counts only LIVE others: an ACTIVE household whose remaining members are all tombstones still blocks", async () => {
+            const memberHh = await makeHousehold("Hollow Member Household", "ACTIVE");
+            const alreadyMerged = await prisma.person.create({ data: { name: "Prior Tombstone", householdId: memberHh, mergedIntoId: pKeepId } });
+            extraPersonIds.push(alreadyMerged.id);
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: memberHh } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toContain("last live member");
+        });
+
+        it("allows an ACTIVE household merge when another live member remains", async () => {
+            const memberHh = await makeHousehold("Shared Member Household", "ACTIVE");
+            const sibling = await prisma.person.create({ data: { name: "Sibling", householdId: memberHh } });
+            extraPersonIds.push(sibling.id);
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: memberHh } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBe(pKeepId);
         });
 
         it("400s when the merged-away record's household is DENIED and the keeper's is NONE (restriction laundered)", async () => {
@@ -385,7 +419,7 @@ describe("Merge Participants API", () => {
             const res = await POST(mergeReq(pKeepId, pMergeId));
             expect(res.status).toBe(400);
             const data = await res.json();
-            expect(data.error).toContain("different Treehouse membership status");
+            expect(data.error).toContain("which restriction applies");
             expect(data.error).toContain("DENIED");
 
             // The login block is derived live from the person's household (authClaims),
@@ -400,20 +434,37 @@ describe("Merge Participants API", () => {
         it("400s when the KEEPER's household carries the restriction and the merged-away side is weaker", async () => {
             const revokedHh = await makeHousehold("Revoked Household", "REVOKED");
             await prisma.person.update({ where: { id: pKeepId }, data: { householdId: revokedHh } });
-            const activeHh = await makeHousehold("Active Household", "ACTIVE");
-            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: activeHh } });
+            const noneHh = await makeHousehold("Plain Household", "NONE");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: noneHh } });
 
             const res = await POST(mergeReq(pKeepId, pMergeId));
             expect(res.status).toBe(400);
             const data = await res.json();
             expect(data.error).toContain("REVOKED");
-            expect(data.error).toContain("ACTIVE");
+            expect(data.error).toContain("which restriction applies");
         });
 
-        it("allows the merge when both households are ACTIVE", async () => {
+        it("allows two restricted households at the same status to merge", async () => {
+            // Both on fresh households — the fixture's own household holds the board
+            // actor, and a household containing a board member cannot be DENIED.
+            const keepDenied = await makeHousehold("Keeper Denied Household", "DENIED");
+            await prisma.person.update({ where: { id: pKeepId }, data: { householdId: keepDenied } });
+            const otherDenied = await makeHousehold("Other Denied Household", "DENIED");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: otherDenied } });
+
+            // Nothing of value is stranded by a live-empty DENIED household, and the
+            // survivor stays denied either way — no restriction changes hands.
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+        });
+
+        // The archetypal dedupe: createParticipantWithHousehold gives every fresh
+        // Google sign-in its own membership-less household and makes them its lead,
+        // so the duplicate is NONE and its own sole member.
+        it("allows the ordinary dedupe — ACTIVE keeper, duplicate alone in its own membership-less household", async () => {
             await prisma.orgMembership.create({ data: { householdId, status: "ACTIVE" } });
-            const otherActive = await makeHousehold("Other Active Household", "ACTIVE");
-            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: otherActive } });
+            const dupHh = await makeHousehold("Duplicate's Own Household");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: dupHh, isHouseholdLead: true } });
 
             const res = await POST(mergeReq(pKeepId, pMergeId));
             expect(res.status).toBe(200);
@@ -428,19 +479,22 @@ describe("Merge Participants API", () => {
             expect(res.status).toBe(200);
         });
 
-        it("analyze reports the mismatch so the picker warns before the operator commits", async () => {
-            const deniedHh = await makeHousehold("Analyze Denied Household", "DENIED");
-            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: deniedHh } });
+        it("analyze reports the block per direction, so the picker can warn and point at the swap", async () => {
+            // A alone in a NONE household, B alone in an ACTIVE one: merging B away
+            // strands the membership, merging A away is the ordinary dedupe.
+            const activeHh = await makeHousehold("Analyze Active Household", "ACTIVE");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: activeHh } });
 
             const res = await analyzeGET(analyzeReq(pKeepId, pMergeId));
             expect(res.status).toBe(200);
             const data = await res.json();
-            expect(data.membershipMismatch).toEqual({ a: "NONE", b: "DENIED" });
+            expect(data.membershipBlock.aAsKeeper).toContain("last live member");
+            expect(data.membershipBlock.bAsKeeper).toBeNull();
 
-            // Matching households produce no warning.
+            // Back in one household, neither direction is blocked.
             await prisma.person.update({ where: { id: pMergeId }, data: { householdId } });
             const clean = await analyzeGET(analyzeReq(pKeepId, pMergeId));
-            expect((await clean.json()).membershipMismatch).toBeNull();
+            expect((await clean.json()).membershipBlock).toEqual({ aAsKeeper: null, bAsKeeper: null });
         });
     });
 

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -22,6 +22,8 @@ jest.mock("@/lib/shopifyRead/client", () => ({
     minRealOrderLegacyId: async () => null,
 }));
 import { runMatchAudit } from "@/lib/finance/matchAudit";
+import { orgMembershipStatusBlocksLogin } from "@/lib/orgMembership";
+import type { OrgMembershipStatus } from "@/generated/prisma/client";
 
 // Base fixture participants differ on name+email by design (realistic collision
 // data for the field-picker tests below). name is a per-field conflict and both
@@ -87,6 +89,14 @@ describe("Merge Participants API", () => {
         createdProcessIds = [];
     });
 
+    /** A second household for the membership-guard tests; no OrgMembership row reads as NONE. */
+    async function makeHousehold(name: string, status?: OrgMembershipStatus): Promise<number> {
+        const hh = await prisma.household.create({ data: { name } });
+        extraHouseholdIds.push(hh.id);
+        if (status) await prisma.orgMembership.create({ data: { householdId: hh.id, status } });
+        return hh.id;
+    }
+
     afterEach(async () => {
         const personIds = [pKeepId, pMergeId, actorId, ...extraPersonIds];
 
@@ -109,6 +119,7 @@ describe("Merge Participants API", () => {
         if (createdToolId) await prisma.tool.deleteMany({ where: { id: createdToolId } });
         if (createdProgramId) await prisma.program.deleteMany({ where: { id: createdProgramId } });
         if (createdCorporationId) await prisma.corporation.deleteMany({ where: { id: createdCorporationId } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: [householdId, ...extraHouseholdIds] } } });
         if (householdId) await prisma.household.deleteMany({ where: { id: householdId } });
         if (extraHouseholdIds.length) await prisma.household.deleteMany({ where: { id: { in: extraHouseholdIds } } });
     });
@@ -342,6 +353,95 @@ describe("Merge Participants API", () => {
         const { participants } = await res.json();
         const members = participants[1].household.householdMembers as { id: number }[];
         expect(members.map(m => m.id)).toEqual([lead.id]);
+    });
+
+    // OrgMembership is 1:1 with Household and the merge never moves it: the tombstone
+    // keeps its householdId, the keeper stays in its own household. So the two sides'
+    // membership status must already agree, or the merge either strands the membership
+    // or drops a restriction.
+    describe("household membership guard", () => {
+        it("400s when the merged-away record holds an ACTIVE membership and the keeper's household is NONE (value stranded)", async () => {
+            // Tombstone is the SOLE live member of an ACTIVE household — the lead guard
+            // (lead + others > 0) can't see this shape.
+            const memberHh = await makeHousehold("Paid Member Household", "ACTIVE");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: memberHh, isHouseholdLead: true } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(400);
+            const data = await res.json();
+            expect(data.error).toContain("different Treehouse membership status");
+            expect(data.error).toContain("ACTIVE");
+
+            // Refused before the transaction: the ACTIVE membership still has a live
+            // member, and the surviving human isn't sitting in the NONE household.
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBeNull();
+            expect(await prisma.person.count({ where: { householdId: memberHh, mergedIntoId: null } })).toBe(1);
+        });
+
+        it("400s when the merged-away record's household is DENIED and the keeper's is NONE (restriction laundered)", async () => {
+            const deniedHh = await makeHousehold("Denied Household", "DENIED");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: deniedHh } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(400);
+            const data = await res.json();
+            expect(data.error).toContain("different Treehouse membership status");
+            expect(data.error).toContain("DENIED");
+
+            // The login block is derived live from the person's household (authClaims),
+            // so had the merge run, the surviving record would simply not be denied.
+            const merged = await prisma.person.findUnique({ where: { id: pMergeId }, include: { household: { include: { orgMembership: true } } } });
+            const kept = await prisma.person.findUnique({ where: { id: pKeepId }, include: { household: { include: { orgMembership: true } } } });
+            expect(merged?.mergedIntoId).toBeNull();
+            expect(orgMembershipStatusBlocksLogin(merged?.household?.orgMembership?.status)).toBe(true);
+            expect(orgMembershipStatusBlocksLogin(kept?.household?.orgMembership?.status)).toBe(false);
+        });
+
+        it("400s when the KEEPER's household carries the restriction and the merged-away side is weaker", async () => {
+            const revokedHh = await makeHousehold("Revoked Household", "REVOKED");
+            await prisma.person.update({ where: { id: pKeepId }, data: { householdId: revokedHh } });
+            const activeHh = await makeHousehold("Active Household", "ACTIVE");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: activeHh } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(400);
+            const data = await res.json();
+            expect(data.error).toContain("REVOKED");
+            expect(data.error).toContain("ACTIVE");
+        });
+
+        it("allows the merge when both households are ACTIVE", async () => {
+            await prisma.orgMembership.create({ data: { householdId, status: "ACTIVE" } });
+            const otherActive = await makeHousehold("Other Active Household", "ACTIVE");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: otherActive } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBe(pKeepId);
+        });
+
+        it("allows the merge when one household has an explicit NONE row and the other has no membership at all", async () => {
+            const noneHh = await makeHousehold("Explicit None Household", "NONE");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: noneHh } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+        });
+
+        it("analyze reports the mismatch so the picker warns before the operator commits", async () => {
+            const deniedHh = await makeHousehold("Analyze Denied Household", "DENIED");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: deniedHh } });
+
+            const res = await analyzeGET(analyzeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            expect(data.membershipMismatch).toEqual({ a: "NONE", b: "DENIED" });
+
+            // Matching households produce no warning.
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId } });
+            const clean = await analyzeGET(analyzeReq(pKeepId, pMergeId));
+            expect((await clean.json()).membershipMismatch).toBeNull();
+        });
     });
 
     // Matrix 4

--- a/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
@@ -4,7 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { LIVE_PERSON } from "@/lib/person/filters";
-import { householdMembershipStatus } from "../membershipGuard";
+import { householdMembershipStatus, membershipMergeBlock } from "../membershipGuard";
 
 export const dynamic = 'force-dynamic';
 
@@ -52,12 +52,13 @@ export const GET = withAuth(
                             select: {
                                 id: true,
                                 name: true,
-                                // Public-tier; feeds the membership-mismatch warning the
-                                // POST guard enforces (see ../membershipGuard.ts).
+                                // Public-tier; feeds the membership warning the POST guard
+                                // enforces (see ../membershipGuard.ts).
                                 orgMembership: { select: { status: true } },
                                 householdMembers: {
                                     // Tombstones are not members: the page's
-                                    // isLeadWithOthers guard must match the POST's.
+                                    // isLeadWithOthers guard must match the POST's, and
+                                    // the membership block counts live members only.
                                     where: LIVE_PERSON,
                                     select: { id: true, name: true, isHouseholdLead: true }
                                 }
@@ -86,14 +87,25 @@ export const GET = withAuth(
                 return apiError("Cannot analyze: one of these participants has already been merged.", 409);
             }
 
-            // Mirrors the POST guard so the picker can warn before the operator
-            // commits. Direction-agnostic: the keeper isn't chosen until the UI
-            // scores/swaps, and any difference blocks the merge either way.
-            const statusA = householdMembershipStatus(pA.household);
-            const statusB = householdMembershipStatus(pB.household);
-            const membershipMismatch = statusA === statusB ? null : { a: statusA, b: statusB };
+            // Mirrors the POST guard so the picker warns before the operator commits.
+            // The rule is asymmetric (it turns on which record is merged away) and the
+            // keeper isn't fixed until the UI scores and the operator swaps, so both
+            // directions are reported and the page applies the live one.
+            // householdMembers is already LIVE_PERSON-filtered, so "others" is the count.
+            const subject = (p: typeof pA) => ({
+                status: householdMembershipStatus(p.household),
+                liveOthers: p.household?.householdMembers.filter(m => m.id !== p.id).length ?? 0,
+            });
+            const a = subject(pA);
+            const b = subject(pB);
 
-            return NextResponse.json({ participants: [pA, pB], membershipMismatch });
+            return NextResponse.json({
+                participants: [pA, pB],
+                membershipBlock: {
+                    aAsKeeper: membershipMergeBlock(a, b),
+                    bAsKeeper: membershipMergeBlock(b, a),
+                },
+            });
         } catch (error) {
             logger.error("Failed to analyze participants:", error);
             return apiError("Server error", 500);

--- a/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import { householdMembershipStatus } from "../membershipGuard";
 
 export const dynamic = 'force-dynamic';
 
@@ -51,6 +52,9 @@ export const GET = withAuth(
                             select: {
                                 id: true,
                                 name: true,
+                                // Public-tier; feeds the membership-mismatch warning the
+                                // POST guard enforces (see ../membershipGuard.ts).
+                                orgMembership: { select: { status: true } },
                                 householdMembers: {
                                     // Tombstones are not members: the page's
                                     // isLeadWithOthers guard must match the POST's.
@@ -82,7 +86,14 @@ export const GET = withAuth(
                 return apiError("Cannot analyze: one of these participants has already been merged.", 409);
             }
 
-            return NextResponse.json({ participants: [pA, pB] });
+            // Mirrors the POST guard so the picker can warn before the operator
+            // commits. Direction-agnostic: the keeper isn't chosen until the UI
+            // scores/swaps, and any difference blocks the merge either way.
+            const statusA = householdMembershipStatus(pA.household);
+            const statusB = householdMembershipStatus(pB.household);
+            const membershipMismatch = statusA === statusB ? null : { a: statusA, b: statusB };
+
+            return NextResponse.json({ participants: [pA, pB], membershipMismatch });
         } catch (error) {
             logger.error("Failed to analyze participants:", error);
             return apiError("Server error", 500);

--- a/checkin-app/src/app/api/membership-ops/participants/merge/membershipGuard.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/membershipGuard.ts
@@ -1,0 +1,28 @@
+import type { OrgMembershipStatus } from "@/generated/prisma/client";
+
+/** A household with no OrgMembership row has never been a Treehouse Member. */
+export function householdMembershipStatus(
+    household: { orgMembership?: { status: OrgMembershipStatus } | null } | null | undefined,
+): OrgMembershipStatus {
+    return household?.orgMembership?.status ?? "NONE";
+}
+
+/**
+ * Both sides of a merge must sit on the same household membership status.
+ *
+ * OrgMembership is 1:1 with Household and a merge never moves it: the tombstone
+ * keeps its householdId and the keeper stays in its own household. So a mismatch
+ * either strands the tombstone household's membership (no live member left to
+ * use it) or drops a DENIED/REVOKED restriction — the login gate derives `denied`
+ * from the person's CURRENT household (lib/authClaims.ts), so the surviving human
+ * stops inheriting it on the next token refresh.
+ *
+ * Returns the operator-facing reason, or null when the merge may proceed.
+ */
+export function membershipMergeBlock(
+    keepStatus: OrgMembershipStatus,
+    mergeStatus: OrgMembershipStatus,
+): string | null {
+    if (keepStatus === mergeStatus) return null;
+    return `Cannot merge: these records are in households with different Treehouse membership status (kept record: ${keepStatus}, merged-away record: ${mergeStatus}). A merge never moves a membership, so this would either strand the membership or drop the restriction. Resolve the membership on these households first, then merge.`;
+}

--- a/checkin-app/src/app/api/membership-ops/participants/merge/membershipGuard.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/membershipGuard.ts
@@ -7,22 +7,46 @@ export function householdMembershipStatus(
     return household?.orgMembership?.status ?? "NONE";
 }
 
+/** Negative state: these restrict a household rather than granting it anything. */
+function isRestricted(status: OrgMembershipStatus): boolean {
+    return status === "DENIED" || status === "REVOKED";
+}
+
+export type MergeSubjectMembership = {
+    status: OrgMembershipStatus;
+    /** Live (un-merged) members of this household other than the merge subject itself. */
+    liveOthers: number;
+};
+
 /**
- * Both sides of a merge must sit on the same household membership status.
+ * Why this merge must be refused on household membership grounds, or null.
  *
  * OrgMembership is 1:1 with Household and a merge never moves it: the tombstone
- * keeps its householdId and the keeper stays in its own household. So a mismatch
- * either strands the tombstone household's membership (no live member left to
- * use it) or drops a DENIED/REVOKED restriction — the login gate derives `denied`
- * from the person's CURRENT household (lib/authClaims.ts), so the surviving human
- * stops inheriting it on the next token refresh.
+ * keeps its householdId and the keeper stays in its own household. Two harms
+ * follow, and both are asymmetric — which side is merged away decides them.
  *
- * Returns the operator-facing reason, or null when the merge may proceed.
+ * 1. A restriction on one side only. `denied` is derived live from the person's
+ *    CURRENT household (lib/authClaims.ts), so merging across a DENIED/REVOKED
+ *    boundary changes which restriction the surviving human carries.
+ * 2. An ACTIVE membership left with no live member. Only ACTIVE carries value
+ *    worth stranding — NONE grants nothing and DENIED/REVOKED are negative
+ *    state, so a live-empty household in those states strands nothing.
+ *
+ * A duplicate sitting alone in its own membership-less household — what every
+ * fresh Google sign-in gets from createParticipantWithHousehold — is the
+ * ordinary dedupe, and stays mergeable into a keeper of any status.
  */
 export function membershipMergeBlock(
-    keepStatus: OrgMembershipStatus,
-    mergeStatus: OrgMembershipStatus,
+    keep: { status: OrgMembershipStatus },
+    merge: MergeSubjectMembership,
 ): string | null {
-    if (keepStatus === mergeStatus) return null;
-    return `Cannot merge: these records are in households with different Treehouse membership status (kept record: ${keepStatus}, merged-away record: ${mergeStatus}). A merge never moves a membership, so this would either strand the membership or drop the restriction. Resolve the membership on these households first, then merge.`;
+    if (keep.status !== merge.status && (isRestricted(keep.status) || isRestricted(merge.status))) {
+        return `Cannot merge: the kept record's household is ${keep.status} and the merged-away record's household is ${merge.status}. Login and facility access are read from the surviving record's household, so this merge would change which restriction applies to this person. Settle that first — assign the person to the right household from the Participants page, or set the household's membership on the Households page — then merge.`;
+    }
+
+    if (merge.status === "ACTIVE" && merge.liveOthers === 0) {
+        return `Cannot merge: the merged-away record is the last live member of a household holding an ACTIVE Treehouse membership, and the kept record is in a different household (${keep.status}). The merge would leave that membership with nobody in it. Swap which record is kept, or assign the kept record to that household from the Participants page, then merge.`;
+    }
+
+    return null;
 }

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -7,6 +7,7 @@ import { apiError } from "@/lib/api-response";
 import { personBgOpen } from "@/lib/membership/lifecycle";
 import { LIVE_PERSON } from "@/lib/person/filters";
 import type { TxClient } from "@/lib/db-client";
+import { householdMembershipStatus, membershipMergeBlock } from "./membershipGuard";
 
 export const dynamic = 'force-dynamic';
 
@@ -183,6 +184,11 @@ export const POST = withAuth(
                     bgAttestations: true,
                     corporationLeads: true,
                     corporationMembers: true,
+                    household: {
+                        include: {
+                            orgMembership: true
+                        }
+                    },
                 }
             });
 
@@ -200,7 +206,8 @@ export const POST = withAuth(
                         include: {
                             // The lead guard below asks "would this leave live members
                             // leaderless" — tombstones are not members.
-                            householdMembers: { where: LIVE_PERSON }
+                            householdMembers: { where: LIVE_PERSON },
+                            orgMembership: true
                         }
                     }
                 }
@@ -220,6 +227,14 @@ export const POST = withAuth(
 
             if (isLead && householdOthersCount > 0) {
                 return apiError("Cannot merge: the to-be-deleted participant is the lead of a household with other members.", 400);
+            }
+
+            const membershipBlock = membershipMergeBlock(
+                householdMembershipStatus(keepParticipant.household),
+                householdMembershipStatus(mergeParticipant.household),
+            );
+            if (membershipBlock) {
+                return apiError(membershipBlock, 400);
             }
 
             // ---- Server-side fieldChoices validation (recompute conflicts; never trust the client's) ----

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -229,9 +229,11 @@ export const POST = withAuth(
                 return apiError("Cannot merge: the to-be-deleted participant is the lead of a household with other members.", 400);
             }
 
+            // householdMembers is LIVE_PERSON-filtered above, so this is the count of
+            // people who would still be left to use the household's membership.
             const membershipBlock = membershipMergeBlock(
-                householdMembershipStatus(keepParticipant.household),
-                householdMembershipStatus(mergeParticipant.household),
+                { status: householdMembershipStatus(keepParticipant.household) },
+                { status: householdMembershipStatus(mergeParticipant.household), liveOthers: householdOthersCount },
             );
             if (membershipBlock) {
                 return apiError(membershipBlock, 400);

--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -94,6 +94,10 @@ export default function MergeParticipants() {
 
   const [previewMode, setPreviewMode] = useState(false);
 
+  // Set when the two records' households carry different Treehouse membership
+  // status — the merge server-side refuses (see the API's membershipGuard).
+  const [membershipMismatch, setMembershipMismatch] = useState<{ a: string; b: string } | null>(null);
+
   // One choice per true conflict field ('keep' | 'merge'); default 'keep' (the
   // keeper's value). Recomputed below (derived from analyzedA/analyzedB + keepId)
   // and reset whenever the keeper flips (Swap Kept/Merged).
@@ -155,6 +159,7 @@ export default function MergeParticipants() {
           if (d.participants) {
             setAnalyzedA(d.participants[0]);
             setAnalyzedB(d.participants[1]);
+            setMembershipMismatch(d.membershipMismatch ?? null);
 
             // Recommend keeping the one with more activity or better data
             const score = (p: ParticipantMergeView) => {
@@ -181,6 +186,7 @@ export default function MergeParticipants() {
       setAnalyzedB(null);
       setKeepId(null);
       setPreviewMode(false);
+      setMembershipMismatch(null);
     }
   }, [pA, pB]);
 
@@ -367,6 +373,15 @@ export default function MergeParticipants() {
                 </Button>
               </Group>
 
+              {membershipMismatch && (
+                <Alert color="red" variant="light" fw={700} title="Membership status differs">
+                  {analyzedA.name || `ID ${analyzedA.id}`}&apos;s household is {membershipMismatch.a} and{" "}
+                  {analyzedB.name || `ID ${analyzedB.id}`}&apos;s household is {membershipMismatch.b}. A merge never
+                  moves a membership between households, so it would either strand the membership or drop the
+                  restriction. Resolve the membership on these households first, then merge.
+                </Alert>
+              )}
+
               <SimpleGrid cols={{ base: 1, md: 2 }}>
                 {renderStats(analyzedA, keepId === analyzedA.id, analyzedA.id !== keepId ? isLeadWithOthers : false)}
                 {renderStats(analyzedB, keepId === analyzedB.id, analyzedB.id !== keepId ? isLeadWithOthers : false)}
@@ -422,7 +437,7 @@ export default function MergeParticipants() {
               )}
 
               <Group justify="flex-end">
-                <Button size="md" disabled={isLeadWithOthers} onClick={() => setPreviewMode(true)}>
+                <Button size="md" disabled={isLeadWithOthers || !!membershipMismatch} onClick={() => setPreviewMode(true)}>
                   Proceed to Preview
                 </Button>
               </Group>

--- a/checkin-app/src/app/membership-ops/participants/merge/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/merge/page.tsx
@@ -94,9 +94,9 @@ export default function MergeParticipants() {
 
   const [previewMode, setPreviewMode] = useState(false);
 
-  // Set when the two records' households carry different Treehouse membership
-  // status — the merge server-side refuses (see the API's membershipGuard).
-  const [membershipMismatch, setMembershipMismatch] = useState<{ a: string; b: string } | null>(null);
+  // Why the merge is refused on household-membership grounds, per direction —
+  // the rule turns on which record is merged away (see the API's membershipGuard).
+  const [membershipBlock, setMembershipBlock] = useState<{ aAsKeeper: string | null; bAsKeeper: string | null } | null>(null);
 
   // One choice per true conflict field ('keep' | 'merge'); default 'keep' (the
   // keeper's value). Recomputed below (derived from analyzedA/analyzedB + keepId)
@@ -105,6 +105,13 @@ export default function MergeParticipants() {
 
   const mergeParticipant = keepId === analyzedA?.id ? analyzedB : analyzedA;
   const keepParticipant = keepId === analyzedA?.id ? analyzedA : analyzedB;
+
+  // The membership rule turns on which record is merged away, so the block
+  // follows the current keeper — and Swap Kept/Merged can clear it outright.
+  const keeperIsA = keepId === analyzedA?.id;
+  const membershipBlockReason = (keeperIsA ? membershipBlock?.aAsKeeper : membershipBlock?.bAsKeeper) ?? null;
+  const swapDirectionBlock = (keeperIsA ? membershipBlock?.bAsKeeper : membershipBlock?.aAsKeeper) ?? null;
+  const swapClearsMembershipBlock = !!membershipBlockReason && !swapDirectionBlock;
 
   const conflicts: ConflictField[] = keepParticipant && mergeParticipant
     ? CONFLICT_FIELDS.filter((f) => {
@@ -159,7 +166,7 @@ export default function MergeParticipants() {
           if (d.participants) {
             setAnalyzedA(d.participants[0]);
             setAnalyzedB(d.participants[1]);
-            setMembershipMismatch(d.membershipMismatch ?? null);
+            setMembershipBlock(d.membershipBlock ?? null);
 
             // Recommend keeping the one with more activity or better data
             const score = (p: ParticipantMergeView) => {
@@ -186,7 +193,7 @@ export default function MergeParticipants() {
       setAnalyzedB(null);
       setKeepId(null);
       setPreviewMode(false);
-      setMembershipMismatch(null);
+      setMembershipBlock(null);
     }
   }, [pA, pB]);
 
@@ -373,12 +380,10 @@ export default function MergeParticipants() {
                 </Button>
               </Group>
 
-              {membershipMismatch && (
-                <Alert color="red" variant="light" fw={700} title="Membership status differs">
-                  {analyzedA.name || `ID ${analyzedA.id}`}&apos;s household is {membershipMismatch.a} and{" "}
-                  {analyzedB.name || `ID ${analyzedB.id}`}&apos;s household is {membershipMismatch.b}. A merge never
-                  moves a membership between households, so it would either strand the membership or drop the
-                  restriction. Resolve the membership on these households first, then merge.
+              {membershipBlockReason && (
+                <Alert color="red" variant="light" fw={700} title="Household membership blocks this merge">
+                  {membershipBlockReason}
+                  {swapClearsMembershipBlock && " Swapping which record is kept clears this."}
                 </Alert>
               )}
 
@@ -437,7 +442,7 @@ export default function MergeParticipants() {
               )}
 
               <Group justify="flex-end">
-                <Button size="md" disabled={isLeadWithOthers || !!membershipMismatch} onClick={() => setPreviewMode(true)}>
+                <Button size="md" disabled={isLeadWithOthers || !!membershipBlockReason} onClick={() => setPreviewMode(true)}>
                   Proceed to Preview
                 </Button>
               </Group>


### PR DESCRIPTION
## What

`POST /api/membership-ops/participants/merge` never compared the two subjects' household membership state. `OrgMembership` is 1:1 with `Household` (`householdId Int @unique`) and the merge never writes it — the only membership statement in the route is the `PERSON_BG` `subjectPersonId` re-point. The tombstone keeps its `householdId`; the keeper stays in the keeper's household. Nothing reconciled the two.

This adds a pre-transaction guard that refuses the merge with a 400, and mirrors the check in the analyze route so the picker warns before the operator commits.

Found while analysing #1396. Independent of it — this is a separate, pre-existing bug and this PR does not implement #1396.

## Why — two failure modes

**1. Value stranded.** The merged-away record is the last live member of a household whose membership is `ACTIVE`. Post-merge the paid membership sits on a household with zero live members, while the surviving human is in a different household. The existing lead guard (`isLead && householdOthersCount > 0`) does not fire for a sole member, so nothing caught this.

**2. Restriction laundered.** `DENIED`/`REVOKED` are negative state, and the login block is derived **live** from the person's current household:

```ts
const denied = orgMembershipStatusBlocksLogin(p.household?.orgMembership?.status);
```

(`src/lib/authClaims.ts:34` — `denied` then clears every role flag, `householdLead`, `toolStatuses` and `programsLed`.) Merge a duplicate sitting in a `DENIED` household into a record in a clean household and the surviving human is simply **not denied** on the next token refresh. This does not require the household to be emptied, so no existing guard fired at all.

## The rule

Both harms turn on **which side is merged away**, so the guard is asymmetric. It refuses when either holds:

- **Restriction differential** — the two statuses differ and either is `DENIED` or `REVOKED`. Access is read from the survivor's current household, so the merge would change which restriction applies to this person.
- **Stranded membership** — the merged-away household is `ACTIVE` and would be left with no live member. Only `ACTIVE` carries value worth stranding: `NONE` grants nothing and `DENIED`/`REVOKED` are negative state, so a live-empty household in those states strands nothing.

The live-member count ignores tombstones — a household whose remaining members are all merged away has nobody left to use its membership.

| kept / merged-away | merged-away is its household's last live member | outcome |
| --- | --- | --- |
| NONE / NONE | either | merge |
| ACTIVE / NONE — the ordinary dedupe | either | merge |
| ACTIVE / ACTIVE | no | merge |
| ACTIVE / ACTIVE | yes | refuse — membership stranded |
| NONE / ACTIVE | yes | refuse — membership stranded |
| DENIED or REVOKED on one side, anything different on the other | either | refuse — restriction changes hands |
| DENIED / DENIED, REVOKED / REVOKED | either | merge |

The ordinary dedupe row matters: `createParticipantWithHousehold` gives every fresh Google sign-in its own household with no `OrgMembership` row and makes that person its lead, so a duplicate account reads `NONE` and is its own sole live member. A member's family creating a second account has to stay mergeable.

## What changed

- **New** `src/app/api/membership-ops/participants/merge/membershipGuard.ts` — `householdMembershipStatus()` (a household with no `OrgMembership` row reads as `NONE`) and `membershipMergeBlock(keep, merge)` implementing the rule above.
- **`merge/route.ts`** — both `findUnique`s now include `household.orgMembership`; the guard runs pre-transaction alongside the existing `mergedIntoId` / lead / stranded-login-identity guards, counting live (un-merged) others in the merged-away household.
- **`merge/analyze/route.ts`** — selects `orgMembership.status` (public tier) and `mergedIntoId` on household members, and returns `membershipBlock: { aAsKeeper, bAsKeeper }`. Both directions, because the rule is asymmetric and the keeper isn't fixed until the UI scores and the operator swaps.
- **`membership-ops/participants/merge/page.tsx`** — applies the direction matching the current keeper, renders the reason, disables **Proceed to Preview**, and adds "Swapping which record is kept clears this" when only one direction is blocked.

Error copy names remedies that exist in the app: assign the person to another household from the Participants page, or set the household's membership on the Households page.

## Out of scope, deliberately

The guard does **not** move or merge the two `OrgMembership` rows. That drags in dues, Shopify orders and process history. Refusing and letting the board resolve it by hand is the intended scope.

## Tests

Ten in `merge/__tests__/route.integration.test.ts`:

- Merged-away record is the last live member of an ACTIVE household — refuse. It is the sole member **and** the lead, so the test proves the existing lead guard cannot see this shape.
- ACTIVE keeper vs ACTIVE merged-away, merged-away side is its household's last live member — refuse. Equal status, still a stranding.
- An ACTIVE household whose other members are all tombstones — refuse. Pins the live-only count.
- ACTIVE household with another live member remaining — allow.
- DENIED merged-away / NONE keeper — refuse. Asserts through `orgMembershipStatusBlocksLogin` that the merged-away side is denied and the keeper is not, i.e. exactly the state the merge would have laundered.
- REVOKED keeper / NONE merged-away — refuse. The restriction on the keeper's side counts too.
- DENIED / DENIED — allow.
- ACTIVE keeper / duplicate alone in its own membership-less household — allow. The archetypal dedupe.
- Explicit `NONE` row vs. no `OrgMembership` row at all — allow.
- Analyze reports per direction and reports both null once the two share a household.

The fixture gained `makeHousehold()` plus `extraHouseholdIds` teardown.

Runs (all foreground):

- The merge integration suite → **42/42** (was 32 before this PR).
- Guard replaced with the earlier symmetric equality check → **8 fail**, including both directions of the bug: the ordinary-dedupe allow case and the ACTIVE/ACTIVE stranding refusal.
- Full unit run (`test:ci`) → **2421/2421**, 257 suites.
- `authzRoleRejection` + `auditLog` integration (the other suites touching this route), together with the merge suite → **168/168**.
- `tsc --noEmit` and `eslint` clean.

No flow test: the journey needs board-side membership setup that HTTP alone can't reach cheaply, and the integration tests cover the guard directly. No unit test for the page Alert.

## Live-data audit — NOT RUN, needs someone with prod read access

Both queries below are read-only. They were syntax-checked against a throwaway Postgres and confirmed to **detect** on a synthetic tombstone (ACTIVE household, sole member, merged into a NONE household): 1 row each on that fixture, 0 rows on a clean DB. They have **not** been run against live data.

**A. Households that are live-empty (every member has `mergedIntoId` set) with a non-NONE membership:**

```sql
SELECT h.id AS household_id, h.name, m.status,
       (SELECT count(*) FROM "Person" p WHERE p."householdId" = h.id) AS people_rows
FROM "Household" h
JOIN "OrgMembership" m ON m."householdId" = h.id
WHERE m.status <> 'NONE'
  AND NOT EXISTS (SELECT 1 FROM "Person" p WHERE p."householdId" = h.id AND p."mergedIntoId" IS NULL)
ORDER BY h.id;
```

**B. People whose current household membership status differs from that of a household they were merged out of:**

```sql
WITH RECURSIVE chain AS (
    SELECT id AS tombstone_id, "mergedIntoId" AS survivor_id, 1 AS depth
    FROM "Person" WHERE "mergedIntoId" IS NOT NULL
    UNION ALL
    SELECT c.tombstone_id, p."mergedIntoId", c.depth + 1
    FROM chain c JOIN "Person" p ON p.id = c.survivor_id
    WHERE p."mergedIntoId" IS NOT NULL
),
terminal AS (
    SELECT DISTINCT ON (tombstone_id) tombstone_id, survivor_id
    FROM chain ORDER BY tombstone_id, depth DESC
)
SELECT t.tombstone_id,
       tp."householdId" AS merged_away_household,
       COALESCE(tm.status, 'NONE') AS merged_away_status,
       t.survivor_id,
       sp."householdId" AS surviving_household,
       COALESCE(sm.status, 'NONE') AS surviving_status
FROM terminal t
JOIN "Person" tp ON tp.id = t.tombstone_id
JOIN "Person" sp ON sp.id = t.survivor_id
LEFT JOIN "OrgMembership" tm ON tm."householdId" = tp."householdId"
LEFT JOIN "OrgMembership" sm ON sm."householdId" = sp."householdId"
WHERE COALESCE(tm.status, 'NONE') IS DISTINCT FROM COALESCE(sm.status, 'NONE')
ORDER BY t.tombstone_id;
```

Query B follows merge chains (A→B→C) to the terminal survivor, so a mid-chain tombstone isn't mistaken for the survivor.

Reading the results: rows in query A with status `ACTIVE` are stranded value. Rows in query B where `merged_away_status` is `DENIED`/`REVOKED` against a weaker survivor are escaped restrictions — those want a login-access check on the surviving person, not just a membership fix. Query B also surfaces `NONE` → `ACTIVE` pairs, which the new rule permits and which are not harm; read it as a superset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
