### PR TITLE
fix(test): teach the LIVE_PERSON guard to see writes and renamed Person relations

### DIFF
--- a/checkin-app/src/__tests__/livePersonDriftGuard.test.ts
+++ b/checkin-app/src/__tests__/livePersonDriftGuard.test.ts
@@ -193,10 +193,6 @@ const ALLOWLIST: Record<string, string> = {
 
     // ── unresolved: listed so the guard stays green, NOT because it is correct ──
     'app/api/safety/emergency-contacts/route.ts': 'NEEDS REVIEW — deliberately left unfiltered pending a product call. This is the evacuation roster: every member carries its open `visits` and `isPresent` is derived from them, and a merge leaves a concurrently-open visit on the TOMBSTONE (see lib/scan-service.ts). Filtering here would therefore trade a duplicate ghost row for the chance of reporting a household absent while someone is still in the building. Which way a safety surface should fail is not a call to make from a drift guard.',
-
-    // ── fixed in flight elsewhere (drop these when the PR lands) ───────────────
-    'app/api/membership-ops/participants/merge/route.ts': 'The `householdMembers: true` pull feeding the household-lead guard counts tombstones, so a legitimate merge can be falsely blocked — a real bug, already fixed by the in-flight PR #1448 (`where: LIVE_PERSON`). Listed only so this widened guard can land independently of it; remove the entry when #1448 merges.',
-    'app/api/membership-ops/participants/merge/analyze/route.ts': 'Same in-flight fix (PR #1448) for the analyze view\'s `householdMembers` pull, which must agree with the POST\'s guard; remove the entry when #1448 merges.',
 };
 
 // ── scanner (walk / captureObject copied from lifecycleStatusLiteralAllowlist.test.ts) ──
@@ -211,6 +207,35 @@ function walk(dir: string, out: string[] = []): string[] {
         }
     }
     return out;
+}
+
+/** A copy of `src` with comment bodies blanked to spaces — same length, so every
+ *  index computed below still lines up with the original. Without it a relation
+ *  name quoted in a comment ("a plain `householdMembers: true` returns…") reads as
+ *  a site, and a LIVE_PERSON mentioned in one reads as its filter. */
+function maskComments(s: string): string {
+    const out = s.split('');
+    for (let i = 0; i < s.length; i++) {
+        const c = s[i];
+        const d = s[i + 1];
+        if (c === '/' && d === '/') {
+            while (i < s.length && s[i] !== '\n') out[i++] = ' ';
+        } else if (c === '/' && d === '*') {
+            const end = s.indexOf('*/', i + 2);
+            const stop = end < 0 ? s.length : end + 2;
+            while (i < stop) {
+                if (s[i] !== '\n') out[i] = ' ';
+                i++;
+            }
+        } else if (c === "'" || c === '"' || c === '`') {
+            i++;
+            while (i < s.length && s[i] !== c) {
+                if (s[i] === '\\') i++;
+                i++;
+            }
+        }
+    }
+    return out.join('');
 }
 
 /** Capture the object literal at/after `from`, skipping strings & comments so a
@@ -314,7 +339,7 @@ function enclosingCallArgsStart(s: string, pos: number): number {
 function scan(): Set<string> {
     const hits = new Set<string>();
     for (const file of walk(SRC)) {
-        const src = readFileSync(file, 'utf8');
+        const src = maskComments(readFileSync(file, 'utf8'));
         const rel = relative(SRC, file).split(sep).join('/');
 
         PERSON_CALL_RE.lastIndex = 0;

--- a/checkin-app/src/__tests__/livePersonDriftGuard.test.ts
+++ b/checkin-app/src/__tests__/livePersonDriftGuard.test.ts
@@ -19,16 +19,24 @@ import { join, relative, sep } from 'node:path';
  * WHAT COUNTS AS A "SITE" (three independent patterns, matching how this codebase
  * actually reads Person — see lib/person/filters.ts's consumers):
  *
- *   1. A direct list/count call on the Person delegate:
+ *   1. A direct list/count/mass-write call on the Person delegate:
  *        prisma.person.findMany(...) / .findFirst(...) / .count(...) /
- *        .aggregate(...) / .groupBy(...)   (via prisma, tx, or db)
- *      excluding `findUnique` / `findUniqueOrThrow`.
+ *        .aggregate(...) / .groupBy(...) / .updateMany(...) / .deleteMany(...)
+ *                                                  (via prisma, tx, or db)
+ *      excluding `findUnique` / `findUniqueOrThrow` and the single-row writes
+ *      `update` / `delete` / `upsert` — see the boundary note below.
  *
- *   2. A nested pull of Person data through another model's query:
- *        `person: true`                          (include shorthand), or
- *        `person: { ... select: ... }`           (nested select), or
- *        `person: { ... include: ... }`          (nested include)
- *      A `person: { <field>: <value> }` object that carries neither `select:`
+ *   2. A nested pull of Person data through another model's query, under ANY of
+ *      the Person-typed relation names in prisma/schema.prisma — `person`, but
+ *      equally `householdMembers`, `subjectPerson`, `reviewer`, `leadMentor`, `user`, …:
+ *        `<rel>: true`                          (include shorthand), or
+ *        `<rel>: { ... select: ... }`           (nested select), or
+ *        `<rel>: { ... include: ... }`          (nested include)
+ *      That name list is DERIVED from the schema at test time
+ *      (PERSON_RELATION_NAMES below), never hand-written: a Person relation under
+ *      an unobvious name is exactly the blind spot this pattern exists to close,
+ *      and a hand-kept list reopens it the day someone adds one.
+ *      A `<rel>: { <field>: <value> }` object that carries neither `select:`
  *      nor `include:` — e.g. `person: { isKeyholder: true }`, `person: { householdId }`
  *      — is a WHERE-relation FILTER, not a data pull: it narrows the parent rows,
  *      it doesn't expose a Person's identity. That shape is intentionally out of
@@ -48,13 +56,18 @@ import { join, relative, sep } from 'node:path';
  *      join-table list/count is a site in its own right: it must filter through the
  *      `person` relation (`where: { person: LIVE_PERSON }`) or be allowlisted.
  *
- * BOUNDARY — why `findUnique`/`findUniqueOrThrow` are excluded entirely (from
+ * BOUNDARY — why the unique-key shapes (`findUnique`/`findUniqueOrThrow`, and the
+ * single-row writes `update`/`delete`/`upsert`) are excluded entirely (from
  * BOTH patterns: a `visit.findUnique({ include: { person: true } })` is just as
  * excluded as a bare `prisma.person.findUnique(...)`):
  *   thpr's model is LISTS AND COUNTS. A `findUnique` takes a unique key (id,
  *   email, a compound unique) and returns AT MOST ONE row picked by that key —
  *   it can never leak an extra tombstone into a roster or inflate a count, so
- *   filtering it is a no-op at best. This is also exactly the shape merge/analyze/
+ *   filtering it is a no-op at best. `update`/`delete`/`upsert` take that same
+ *   unique key on the write side: they touch the one row the caller already
+ *   resolved, so they carry the same reasoning (only `updateMany`/`deleteMany`,
+ *   whose where is an unrestricted filter, can sweep tombstones in unnoticed).
+ *   This is also exactly the shape merge/analyze/
  *   scan (app/api/membership-ops/participants/merge{,/analyze}/route.ts,
  *   app/api/scan/route.ts) use to load the specific record they operate ON —
  *   which is why none of those three routes needs an ALLOWLIST entry: they
@@ -69,12 +82,39 @@ import { join, relative, sep } from 'node:path';
  *     "reconcilers and cleanup sweeps must still see tombstone rows; only
  *      human-facing lists and counts filter them."
  *
+ * THE WRITE RULE (mass writes — `updateMany`/`deleteMany`) — the read rule does
+ * NOT transfer, so allowlisting a write needs its own judgement. A read that sees
+ * a tombstone is a ghost in a list; a write that hits one silently corrupts a row
+ * nobody will ever look at again. The default therefore flips: a mass write
+ * filters unless it is one of two things.
+ *   - TOMBSTONE MACHINERY: the merge CAS itself, which targets the tombstone on
+ *     purpose (it names `mergedIntoId`, so it passes this guard for free).
+ *   - STRUCTURAL: a write that must touch every row pointing at something,
+ *     liveness irrelevant — e.g. reparenting a household's members before
+ *     deleting the household, where skipping the tombstones leaves the RESTRICT
+ *     FK unsatisfiable and the whole operation fails.
+ * Everything that mutates the LIVE population — stamping a background check,
+ * flagging an address, flipping a flag someone reads back — filters.
+ *
  * Two assertions: no unlisted unfiltered site, and no stale allowlist entry
  * (a listed file that no longer has an unfiltered site must be removed —
  * keeps the list honest, same as the lifecycle guard).
  */
 
 const SRC = join(__dirname, '..');
+const SCHEMA = join(SRC, '..', 'prisma', 'schema.prisma');
+
+/**
+ * Every relation field typed `Person` / `Person[]` in the schema — the class-2
+ * keys. Read from the schema rather than listed here on purpose: `person` is the
+ * obvious name, `householdMembers` / `subjectPerson` / `reviewer` / `user` are
+ * not, and the next one nobody thinks of should be in scope the moment it exists.
+ */
+const PERSON_RELATION_NAMES = [
+    ...new Set(
+        [...readFileSync(SCHEMA, 'utf8').matchAll(/^[ \t]+(\w+)[ \t]+Person(?:\[\])?\??(?:[ \t]|$)/gm)].map((m) => m[1]),
+    ),
+];
 
 /**
  * Every file with a Person-query site that intentionally does NOT route
@@ -99,6 +139,9 @@ const ALLOWLIST: Record<string, string> = {
     'lib/scan-service.ts': 'Facility force-checkout sweep (last keyholder leaving): must see every open visit, including a merge-orphaned tombstone\'s (merge/route.ts leaves a concurrently-open visit in place), or it never gets force-closed.',
     'app/api/cron/nightly/route.ts': 'Nightly force-checkout sweep: must see every open visit, including a merge-orphaned tombstone\'s, or a stranded open visit is never released (same rationale as lifecycleDrift.ts\'s I1 heal).',
 
+    // ── structural mass writes (the write rule\'s second exception) ────────────
+    'app/api/membership-ops/participants/import/route.ts': 'Household merge, structural write: `tx.person.updateMany({ where: { householdId: source } })` reparents EVERY row in the source household so the following `household.delete` can run. A tombstone skipped here keeps pointing at the source household, the RESTRICT FK rejects the delete, and the whole merge rolls back. The two lead-cap reads and the cap re-check in the same file DO filter LIVE_PERSON — only the reparent is unfiltered, and deliberately.',
+
     // ── id-scoped findFirst (one-row shape, same boundary as findUnique-by-id) ─
     'lib/orgMembership.ts': 'isActiveOrgMember ANDs an explicit `id: personId` into the where — at most one row, same shape as findUnique-by-id.',
     'app/api/nav/todo-counts/route.ts': 'isLead check ANDs `id: user.id` (the caller\'s own session id) into the where — at most one row, same shape as findUnique-by-id.',
@@ -106,7 +149,16 @@ const ALLOWLIST: Record<string, string> = {
     'app/api/programs/[id]/request-payment-plan/route.ts': 'leadRecord check ANDs `id: currentUserId` (the caller\'s own session id) into the where — at most one row, same shape as findUnique-by-id. (This file also nests `person: true` off a programParticipant `findUnique` by compound key — same excluded shape as a bare findUnique-by-id.)',
     'lib/trusted-adult/service.ts': 'assertHouseholdLead ANDs an explicit `id: actorId` into the where — at most one row, same shape as findUnique-by-id.',
     'app/api/attendance/route.ts': 'Checkout POST loads the target visit via `visit.findUnique({ where: { id: visitId }, include: { person: true } })` — the outer query is a findUnique-by-id; nesting `person: true` off it is the same excluded one-row shape.',
-    'lib/auth-options.ts': 'Dev persona mint ANDs an explicit `id: personaId` into the where (and is separately scoped to `@example.com`, mirroring dev-personas/route.ts) — at most one row, same shape as findUnique-by-id.',
+    'lib/auth-options.ts': 'Dev persona mint ANDs an explicit `id: personaId` into the where (and is separately scoped to `@example.com`, mirroring dev-personas/route.ts) — at most one row, same shape as findUnique-by-id. The adapter\'s `account.findUnique({ include: { user: true } })` (Account.user is a Person relation) is the same excluded shape: one Person reached through a unique provider key.',
+
+    // ── FK-pinned to-one Person relations (class 2, one row chosen by the FK) ──
+    // A to-one relation pull resolves the single Person that record already points
+    // at — it can neither leak an extra tombstone into a list nor inflate a count,
+    // the same boundary as findUnique-by-id. Prisma also takes no `where` on a
+    // to-one include, so the only available decision is whether the PARENT row
+    // should exist at all, which belongs to the parent query.
+    'app/api/membership/reviews/route.ts': 'The household-lead pull now filters LIVE_PERSON. `subjectPerson` is a to-one pinned by OrgMembershipProcess.subjectPersonId. NEEDS REVIEW: whether a PERSON_BG process whose subject has since been merged away should still sit in the reviewer queue is a lifecycle question about the PROCESS (cancel/retarget it), not a filter on this read — left as-is rather than guessed at.',
+    'lib/membership/review.ts': 'The household-lead BG stamp (`tx.person.updateMany`) filters LIVE_PERSON. The remaining hits are to-one relations selected for eligibility math, not display: `subjectPerson` (the process\'s own subject, for the conflict-of-interest household compare) and `reviewer` on an existing attestation (the actor who already voted — a historical record that must still resolve, or the same-household guard silently stops applying to it).',
 
     // ── person-scoped join reads (class 3, one already-identified person) ─────
     // A join-table list whose where pins `personId` to a single already-known id
@@ -122,7 +174,7 @@ const ALLOWLIST: Record<string, string> = {
     // ── historical / audit trail (showing a since-merged identity is correct) ──
     'app/api/system-status/audit-log/route.ts': 'Resolves actor names for audit-log rows by their recorded actorId — a historical record must still name an actor who has since been merged away.',
     'lib/finance/matchAudit.ts': 'Mixed file: the reconciliation match itself filters LIVE_PERSON (line ~280). Separately, resolving certifier/comper NAMES for the audit report needs any historical actor, including one since merged — a report-only id→name lookup, not a live roster.',
-    'app/api/finance-ops/payments/route.ts': 'Resolves names/emails for a fixed set of person ids already attached to processed payment records — historical financial records must still name a payer who has since been merged.',
+    'app/api/finance-ops/payments/route.ts': 'Resolves names/emails for a fixed set of person ids already attached to processed payment records — historical financial records must still name a payer who has since been merged. (The queue\'s household-lead contact pull is the opposite case — a live address to chase — and does filter LIVE_PERSON.)',
     'app/api/facility/trends/route.ts': 'Visit-history report: shows who was physically present at the time, including the rare merge-orphaned open visit (see lib/scan-service.ts) — historical accuracy, not a live roster.',
     'app/api/facility/visits/route.ts': 'Recent-visits log: same historical-accuracy rationale as facility/trends.',
     'app/api/facility/badges/route.ts': 'Raw badge-scan log: same historical-accuracy rationale as facility/trends.',
@@ -138,6 +190,13 @@ const ALLOWLIST: Record<string, string> = {
     'app/api/auth/dev-personas/route.ts': 'Dev-only persona picker (config.isDevInstance() gated), scoped to `email: { endsWith: "@example.com" }` — a merge tombstone\'s email is always rewritten to merged-*@deleted.invalid (merge/route.ts step 1 CAS), so it can never match this domain filter.',
     'app/api/dev/shopify/orders-paid/route.ts': 'Dev-only mock-webhook firer (config.isDevInstance() gated). Both join reads pin `personId: { in: participantIds }` from the request body and are echoed back to the dev UI — no production or user-facing effect.',
     'lib/dev/seed-helpers.ts': 'Dev seed helper: picks an arbitrary sample of existing persons for local macro/demo flows. No production or user-facing effect.',
+
+    // ── unresolved: listed so the guard stays green, NOT because it is correct ──
+    'app/api/safety/emergency-contacts/route.ts': 'NEEDS REVIEW — deliberately left unfiltered pending a product call. This is the evacuation roster: every member carries its open `visits` and `isPresent` is derived from them, and a merge leaves a concurrently-open visit on the TOMBSTONE (see lib/scan-service.ts). Filtering here would therefore trade a duplicate ghost row for the chance of reporting a household absent while someone is still in the building. Which way a safety surface should fail is not a call to make from a drift guard.',
+
+    // ── fixed in flight elsewhere (drop these when the PR lands) ───────────────
+    'app/api/membership-ops/participants/merge/route.ts': 'The `householdMembers: true` pull feeding the household-lead guard counts tombstones, so a legitimate merge can be falsely blocked — a real bug, already fixed by the in-flight PR #1448 (`where: LIVE_PERSON`). Listed only so this widened guard can land independently of it; remove the entry when #1448 merges.',
+    'app/api/membership-ops/participants/merge/analyze/route.ts': 'Same in-flight fix (PR #1448) for the analyze view\'s `householdMembers` pull, which must agree with the POST\'s guard; remove the entry when #1448 merges.',
 };
 
 // ── scanner (walk / captureObject copied from lifecycleStatusLiteralAllowlist.test.ts) ──
@@ -193,15 +252,17 @@ function captureObject(s: string, from: number): { text: string; end: number } |
     return null;
 }
 
-// Class 1: a direct list/count call on the Person delegate. findUnique(OrThrow)
-// is deliberately absent from this alternation — see the boundary note above.
-const PERSON_CALL_RE = /\b(?:prisma|tx|db)\.person\.(findMany|findFirst|count|aggregate|groupBy)\s*\(/g;
+// Class 1: a direct list/count/mass-write call on the Person delegate. The
+// unique-key shapes — findUnique(OrThrow), update, delete, upsert — are
+// deliberately absent from this alternation; see the boundary note above.
+const PERSON_CALL_RE =
+    /\b(?:prisma|tx|db)\.person\.(findMany|findFirst|count|aggregate|groupBy|updateMany|deleteMany)\s*\(/g;
 
-// Class 2: a nested pull of Person data through another model's query —
-// `person: true` or `person: {` (the latter only counts as a hit when its body
-// carries `select:`/`include:`; a pure relation FILTER like `person: { isKeyholder: true }`
-// is checked below and skipped).
-const PERSON_RELATION_RE = /\bperson\s*:\s*(true|\{)/g;
+// Class 2: a nested pull of Person data through another model's query, under any
+// Person-typed relation name — `<rel>: true` or `<rel>: {` (the latter only counts
+// as a hit when its body carries `select:`/`include:`; a pure relation FILTER like
+// `person: { isKeyholder: true }` is checked below and skipped).
+const PERSON_RELATION_RE = new RegExp(String.raw`\b(?:${PERSON_RELATION_NAMES.join('|')})\s*:\s*(true|\{)`, 'g');
 
 // Class 3: a list/count call on a join delegate carrying a `person` relation.
 // Same findUnique(OrThrow) exclusion as class 1, and the captured argument object
@@ -300,6 +361,12 @@ describe('LIVE_PERSON drift guard', () => {
         // added to ALLOWLIST above with a reviewed justification (see the
         // sweep-vs-display rule in this file's header).
         expect(unexpected).toEqual([]);
+    });
+
+    // An empty/short name list would silently make class 2 scan for nothing, so
+    // the schema parse is asserted rather than trusted.
+    it('derives the Person relation names from the schema', () => {
+        expect(PERSON_RELATION_NAMES).toEqual(expect.arrayContaining(['person', 'householdMembers', 'subjectPerson']));
     });
 
     it('has no stale allowlist entry (a listed file no longer has an unfiltered site)', () => {

--- a/checkin-app/src/app/api/admin/broken-households/route.ts
+++ b/checkin-app/src/app/api/admin/broken-households/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { BROKEN_HOUSEHOLD_WHERE } from "@/lib/household/filters";
+import { LIVE_PERSON } from "@/lib/person/filters";
 
 export const dynamic = "force-dynamic";
 
@@ -20,6 +21,7 @@ export const GET = withAuth(
                 where: BROKEN_HOUSEHOLD_WHERE,
                 include: {
                     householdMembers: {
+                        where: LIVE_PERSON,
                         select: { id: true, name: true, dateOfBirth: true },
                         orderBy: { id: "asc" },
                     },

--- a/checkin-app/src/app/api/finance-ops/payments/route.ts
+++ b/checkin-app/src/app/api/finance-ops/payments/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { ordersByLegacyIds, type MirrorOrder } from "@/lib/shopifyRead/client";
+import { LIVE_PERSON } from "@/lib/person/filters";
 
 /**
  * GET /api/finance-ops/payments — the board's queue of reconciler-detected
@@ -41,7 +42,7 @@ export const GET = withAuth(
                                           name: true,
                                           // The household lead carries the contact email shown in the queue.
                                           householdMembers: {
-                                              where: { isHouseholdLead: true },
+                                              where: { isHouseholdLead: true, ...LIVE_PERSON },
                                               select: { name: true, email: true },
                                               take: 1,
                                           },

--- a/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
+++ b/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
@@ -14,6 +14,7 @@ import { getServerSession } from "next-auth/next";
 import { getKioskPublicKeys, verifyKioskSignature } from "@/lib/verify-kiosk";
 import prisma from "@/lib/prisma";
 import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
+import { LIVE_PERSON } from "@/lib/person/filters";
 import { GET as householdGET } from "@/app/api/household/route";
 import { GET as attendanceGET } from "@/app/api/attendance/route";
 
@@ -111,7 +112,7 @@ describe("Participant PII minimization (M1, M2)", () => {
 
         // Pin the actual query shape, not just this test's mock.
         const callArgs = (prisma.person.findUnique as jest.Mock).mock.calls[0][0];
-        expect(callArgs.include.household.include.householdMembers).toEqual({ select: HOUSEHOLD_PEER_SELECT });
+        expect(callArgs.include.household.include.householdMembers).toEqual({ where: LIVE_PERSON, select: HOUSEHOLD_PEER_SELECT });
     });
 
     // Household.intakeNotes is the family's free-text note TO the board (tier

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -9,6 +9,7 @@ import { isOrgAccount } from "@/lib/orgAccount";
 import { HOUSEHOLD_PEER_SELECT } from "@/lib/household/participantProjection";
 import { householdLeadship } from "@/lib/household/leads";
 import { normalizeAdultDob } from "@/lib/person/adultDob";
+import { LIVE_PERSON } from "@/lib/person/filters";
 import { apiError } from "@/lib/api-response";
 
 export const GET = withAuth(
@@ -23,7 +24,7 @@ export const GET = withAuth(
                 include: {
                     household: {
                         include: {
-                            householdMembers: { select: HOUSEHOLD_PEER_SELECT },
+                            householdMembers: { where: LIVE_PERSON, select: HOUSEHOLD_PEER_SELECT },
                             orgMembership: true,
                         }
                     }

--- a/checkin-app/src/app/api/membership-audit/compliance/route.ts
+++ b/checkin-app/src/app/api/membership-audit/compliance/route.ts
@@ -139,7 +139,7 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
         where: { id: { in: [...reasons.keys()] } },
         include: {
             householdMembers: {
-                where: { isHouseholdLead: true },
+                where: { isHouseholdLead: true, ...LIVE_PERSON },
                 select: { id: true, name: true, phone: true, email: true, lastBackgroundCheck: true },
             },
         },

--- a/checkin-app/src/app/api/membership-audit/households-missing-contact/route.ts
+++ b/checkin-app/src/app/api/membership-audit/households-missing-contact/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { findHouseholdsMissingValidContact } from "@/lib/emergencyContacts/service";
+import { LIVE_PERSON } from "@/lib/person/filters";
 
 export const dynamic = "force-dynamic";
 
@@ -19,7 +20,7 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
         where: { id: { in: ids } },
         include: {
             householdMembers: {
-                where: { isHouseholdLead: true },
+                where: { isHouseholdLead: true, ...LIVE_PERSON },
                 select: { id: true, name: true, phone: true, email: true },
             },
         },

--- a/checkin-app/src/app/api/membership-audit/unclaimed-households/route.ts
+++ b/checkin-app/src/app/api/membership-audit/unclaimed-households/route.ts
@@ -4,6 +4,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { UNCLAIMED_OR_BROKEN_HOUSEHOLD_WHERE } from "@/lib/household/filters";
+import { LIVE_PERSON } from "@/lib/person/filters";
 
 export const dynamic = 'force-dynamic';
 
@@ -22,7 +23,7 @@ export const GET = withAuth(
             // shared predicate so the list and the badge can't drift.
             const households = await prisma.household.findMany({
                 where: UNCLAIMED_OR_BROKEN_HOUSEHOLD_WHERE,
-                include: { householdMembers: true }
+                include: { householdMembers: { where: LIVE_PERSON } }
             });
 
             const result = households.map(h => ({

--- a/checkin-app/src/app/api/membership-ops/applications/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/route.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { handler } from "@/security/handler";
+import { LIVE_PERSON } from "@/lib/person/filters";
 
 export const dynamic = "force-dynamic";
 
@@ -38,7 +39,7 @@ export const GET = handler("GET /api/membership-ops/applications", async ({ req 
                     household: {
                         select: {
                             name: true,
-                            householdMembers: { select: { id: true, name: true, email: true, isHouseholdLead: true } },
+                            householdMembers: { where: LIVE_PERSON, select: { id: true, name: true, email: true, isHouseholdLead: true } },
                         },
                     },
                 },

--- a/checkin-app/src/app/api/membership-ops/contacts/route.ts
+++ b/checkin-app/src/app/api/membership-ops/contacts/route.ts
@@ -5,6 +5,7 @@ import { withAuth } from "@/lib/auth";
 import { createParticipantWithHousehold } from "@/lib/auth-options";
 import { isValidEmail } from "@/lib/emergencyContacts/identity";
 import { normalizeEmail } from "@/lib/prismaEmailNormalize";
+import { LIVE_PERSON } from "@/lib/person/filters";
 import { logBackendError } from "@/lib/logger";
 import { apiError } from "@/lib/api-response";
 
@@ -59,7 +60,7 @@ export const POST = withAuth({ roles: ['isBoardMember', 'isOperations'] }, async
         // TypeErrors the Assign-household render path on the new row.
         const participant = await prisma.person.findUnique({
             where: { id: person.id },
-            include: { household: { include: { householdMembers: { select: { id: true, name: true, email: true } } } } },
+            include: { household: { include: { householdMembers: { where: LIVE_PERSON, select: { id: true, name: true, email: true } } } } },
         });
 
         return NextResponse.json({ success: true, participant });

--- a/checkin-app/src/app/api/membership-ops/households/route.ts
+++ b/checkin-app/src/app/api/membership-ops/households/route.ts
@@ -46,6 +46,7 @@ export const GET = withAuth(
                     where: { id: parseInt(id) },
                     include: {
                         householdMembers: {
+                            where: LIVE_PERSON,
                             select: {
                                 id: true, name: true, email: true, isHouseholdLead: true, lastBackgroundCheck: true,
                                 // dateOfBirth: the Edit Info modal excludes youth from the
@@ -132,6 +133,7 @@ export const GET = withAuth(
                 where: whereClause,
                 include: {
                     householdMembers: {
+                        where: LIVE_PERSON,
                         // isHouseholdLead + lastBackgroundCheck drive the household-level "BG valid
                         // until" below. Board-only endpoint; lastBackgroundCheck rides along in the
                         // JSON at the same trust level as the rest of the row.

--- a/checkin-app/src/app/api/membership/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/membership/request-payment-plan/route.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
 import { resolveScholarshipRecipients, notifyReviewTeam, sendScholarshipAck, resolveAckCopy } from "@/lib/scholarshipEmails";
 import { config } from "@/lib/config";
+import { LIVE_PERSON } from "@/lib/person/filters";
 
 export const POST = withAuth({}, async (req, auth) => {
     if (auth.type !== 'session') return apiError("Unauthorized", 401);
@@ -18,7 +19,7 @@ export const POST = withAuth({}, async (req, auth) => {
 
         const process = await prisma.orgMembershipProcess.findUnique({
             where: { id: processId },
-            include: { orgMembership: { include: { household: { include: { householdMembers: { where: { isHouseholdLead: true }, select: { id: true } } } } } } },
+            include: { orgMembership: { include: { household: { include: { householdMembers: { where: { isHouseholdLead: true, ...LIVE_PERSON }, select: { id: true } } } } } } },
         });
 
         if (!process || !process.orgMembership) {

--- a/checkin-app/src/app/api/membership/reviews/route.ts
+++ b/checkin-app/src/app/api/membership/reviews/route.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { handler, unauthorized } from "@/security/handler";
 import { eligibleReviewProcessIds, attest, ReviewError } from "@/lib/membership/review";
 import { apiError } from "@/lib/api-response";
+import { LIVE_PERSON } from "@/lib/person/filters";
 
 export const dynamic = "force-dynamic";
 
@@ -60,7 +61,7 @@ export const GET = handler("GET /api/membership/reviews", async ({ auth }) => {
                             // signal a volunteer-only household uses to ask the reviewer to
                             // mark them volunteer. Classified pii; reviewers hold that band.
                             intakeNotes: true,
-                            householdMembers: { where: { isHouseholdLead: true }, select: { id: true, name: true, email: true } },
+                            householdMembers: { where: { isHouseholdLead: true, ...LIVE_PERSON }, select: { id: true, name: true, email: true } },
                         },
                     },
                 },

--- a/checkin-app/src/app/api/safety/trusted-adults/route.ts
+++ b/checkin-app/src/app/api/safety/trusted-adults/route.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { handler } from "@/security/handler";
+import { LIVE_PERSON } from "@/lib/person/filters";
 
 export const dynamic = "force-dynamic";
 
@@ -25,7 +26,7 @@ export const GET = handler("GET /api/safety/trusted-adults", async () => {
             familyContext: true,
             origin: true,
             createdAt: true,
-            household: { select: { id: true, name: true, householdMembers: { where: { isHouseholdLead: true }, select: { id: true, name: true, email: true } } } },
+            household: { select: { id: true, name: true, householdMembers: { where: { isHouseholdLead: true, ...LIVE_PERSON }, select: { id: true, name: true, email: true } } } },
             trustedAdultPerson: { select: { id: true, name: true, email: true } },
             reviews: {
                 orderBy: { id: "desc" },

--- a/checkin-app/src/app/api/webhooks/resend/route.ts
+++ b/checkin-app/src/app/api/webhooks/resend/route.ts
@@ -88,7 +88,7 @@ export const POST = withWebhook({ provider: "resend", verify: verifyResendSignat
             for (const address of addresses) {
                 const ids = await findPersonIdsByEmail(address);
                 if (ids.length === 0) continue;
-                await prisma.person.updateMany({ where: { id: { in: ids } }, data: { emailUndeliverableAt: new Date() } });
+                await prisma.person.updateMany({ where: { id: { in: ids }, ...LIVE_PERSON }, data: { emailUndeliverableAt: new Date() } });
             }
             return NextResponse.json({ ok: true });
         }
@@ -96,7 +96,7 @@ export const POST = withWebhook({ provider: "resend", verify: verifyResendSignat
             for (const address of addresses) {
                 const ids = await findPersonIdsByEmail(address);
                 if (ids.length === 0) continue;
-                await prisma.person.updateMany({ where: { id: { in: ids } }, data: { emailUndeliverableAt: null } });
+                await prisma.person.updateMany({ where: { id: { in: ids }, ...LIVE_PERSON }, data: { emailUndeliverableAt: null } });
             }
             return NextResponse.json({ ok: true });
         }

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -302,7 +302,7 @@ async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: nu
 
     // Stamp the guardians' (household leads') lastBackgroundCheck. Expiry is derived from this
     // plus BoardSettings.bgRecheckMonths at read time (see householdBgIsFresh) — not stored.
-    await tx.person.updateMany({ where: { householdId, isHouseholdLead: true }, data: { lastBackgroundCheck: now } });
+    await tx.person.updateMany({ where: { householdId, isHouseholdLead: true, ...LIVE_PERSON }, data: { lastBackgroundCheck: now } });
     await applyVolunteerStatus(tx, process.orgMembershipId!, householdId, process.attestations.some((a) => a.isMarkedVolunteer));
 
     await tx.orgMembershipProcess.update({


### PR DESCRIPTION
## What

The `LIVE_PERSON` drift guard (`checkin-app/src/__tests__/livePersonDriftGuard.test.ts`) could only see half the ways this codebase touches `Person`. Its matcher was **read-only** and **name-bound**:

```js
const PERSON_CALL_RE = /\b(?:prisma|tx|db)\.person\.(findMany|findFirst|count|aggregate|groupBy)\s*\(/g;
```

…plus nested pulls keyed on the literal `person:`. Two blind spots, each of which had already let a real bug through:

1. **No write verbs.** `lib/membership/review.ts` stamped `lastBackgroundCheck` on household leads via an unfiltered `tx.person.updateMany` — never matched, so never reviewed.
2. **Person-typed relations under other names.** The merge route pulled `householdMembers: true` (a `Person[]` relation), counted tombstones into its household-lead guard, and falsely blocked legitimate merges. Invisible to a matcher looking for `person:`.

## Widening

- **Class 1** gains `updateMany` / `deleteMany`. `update` / `delete` / `upsert` stay out for the same reason `findUnique` does — they take a *unique key*, so they touch the one row the caller already resolved and can neither sweep in a tombstone nor inflate a count.
- **Class 2** now matches every relation field typed `Person` / `Person[]`, with the name list **derived from `prisma/schema.prisma` at test time** rather than hand-written. A relation under an unobvious name is exactly the blind spot, so a hand-kept list would reopen it on the next schema addition. Today that resolves to 13 names (`person`, `householdMembers`, `subjectPerson`, `reviewer`, `leadMentor`, `user`, …); a new one is in scope the day it lands. A third assertion pins the parse so it can't silently go empty.

The header gains a **write rule**, because the read rule does not transfer: a read that sees a tombstone is a ghost in a list, but a write that hits one is silent corruption of a row nobody will look at again. So mass writes filter by default, and are allowlisted only when they are *tombstone machinery* (the merge CAS, which targets the tombstone on purpose) or *structural* (a write that must touch every row pointing at something, liveness irrelevant).

## Triage

Widening flagged 19 files. Every one was reviewed individually; nothing was blanket-allowlisted.

**13 fixed** — all `where` narrowings, no behaviour change for live rows:

| Site | Why it needed the filter |
|---|---|
| `/household`, `admin/broken-households`, `membership-audit/{compliance,households-missing-contact,unclaimed-households}`, `membership-ops/{applications,contacts,households}`, `membership/reviews`, `safety/trusted-adults`, `finance-ops/payments` | Human-facing household rosters and lead-contact lists — the sweep-vs-display rule's display side. A tombstone's rewritten `merged-*@deleted.invalid` address showed up as a person to contact; on `finance-ops/payments` the pull is `take: 1`, so a tombstone could shadow the real lead entirely. |
| `membership/request-payment-plan` | The lead set is an **authorization** check (`some(p => p.id === currentUserId)`); a merged-away identity must not satisfy it. |
| `webhooks/resend` | Stamped/cleared `emailUndeliverableAt` on tombstones (the ids came from a helper that already filters — now self-guarding at the write). |
| `lib/membership/review.ts:305` | The household-lead background-check stamp. Minimal `...LIVE_PERSON` only — its logic is being redesigned in #1454, deliberately not restructured here. |

**6 allowlisted**, with reasons:

- `membership-ops/participants/import` — **structural** write: `person.updateMany({ where: { householdId: source } })` reparents every row so the following `household.delete` can run. Skipping tombstones leaves the RESTRICT FK unsatisfiable and rolls the whole merge back. (The lead-cap reads in the same file *do* filter.)
- `membership/reviews`, `lib/membership/review.ts` — FK-pinned **to-one** relations (`subjectPerson`, `reviewer`): one row chosen by the FK, the same boundary as `findUnique`-by-id, and Prisma takes no `where` on a to-one include anyway. Whether a `PERSON_BG` process whose subject was merged away should still sit in the queue is a lifecycle question about the *process*, flagged `NEEDS REVIEW` rather than guessed at.
- `membership-ops/participants/merge{,/analyze}` — untouched here; already fixed by the in-flight #1448. Listed so this guard can land independently; **the two entries come out when #1448 merges** (the stale-entry assertion will say so).
- `safety/emergency-contacts` — `NEEDS REVIEW`, deliberately left unfiltered. It's the evacuation roster: `isPresent` is derived from each member's open `visits`, and a merge leaves a concurrently-open visit on the *tombstone*. Filtering would trade a duplicate ghost row for the chance of reporting a household absent while someone is still in the building. Which way a safety surface should fail is a product call, not a drift guard's.

## Testing

- `npm run test:ci` — 2422 passed, 257 suites. One oracle updated: `participantPiiMinimization.test.ts` pins `/api/household`'s exact query shape, which now carries the `where`.
- `npm run test:integration` — 1258 passed, 128 suites, against a fresh seeded Postgres.
- `npx tsc --noEmit` clean.

Independent of #1260 and #1448 — this fixes the guard, not the bugs it should have caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
