### PR TITLE
docs: state how a working doc opens, not just where it lives

### DIFF
--- a/docs/DOCUMENTATION_STANDARD.md
+++ b/docs/DOCUMENTATION_STANDARD.md
@@ -244,6 +244,29 @@ instead of deleting it. It stays true and has no home in the rules register.
 A doc describing finished work that has nothing durable to say is sprawl. Delete
 it.
 
+### 4.1 How it opens
+
+A working doc is read by someone who does not yet know the problem. Order it so
+they learn it first:
+
+1. **Problem** — in plain English. What goes wrong, and for whom.
+2. **Objective** — what is true once this is done.
+3. **Executive summary** — the outcome: what changes for each affected group,
+   what deliberately does not change, what it costs.
+4. **Then** the rules the work relies on or intends to change (§5), mechanism,
+   detailed design, migration, tests.
+
+**The problem statement must be readable by someone who has never opened the
+code.** No symbol names, no file paths, no line numbers. If the opening needs
+any of them, it is describing the symptom in the source rather than the problem.
+
+**Provenance goes last.** Issue decomposition, related-issue lists, and backlog
+cross-references belong in an appendix; alternatives considered belong below the
+design they were rejected in favour of. Both justify the design to a reviewer;
+neither explains it to a reader, and above the problem they displace it. A doc
+that opens with a decomposition table has not stated its problem — a reader
+hits rejected options before learning what is being solved.
+
 ---
 
 ## 5. Enforcement
@@ -287,3 +310,6 @@ and no test should be built to pretend otherwise.
 10. **Do not create empty domain files** in anticipation of future rules.
 11. **Prefer cutting to adding.** Every line should be a rule a change could
     violate; anything else dilutes the ones that matter.
+12. **Open a working doc with the problem in plain English** — then objective,
+    then outcome. Provenance and alternatives go below the design, never above
+    the problem (§4.1).


### PR DESCRIPTION
## What

Adds **§4.1 "How it opens"** to `docs/DOCUMENTATION_STANDARD.md`, plus one matching line in §6's agent guidance. Docs only, 26 lines added, nothing moved or renumbered.

## Why

The standard covers **where** a working doc lives, **when** it dies, and **what to extract** from it. It says nothing about **how to write one** — §5 asks only that a doc "name the domain rules it relies on or intends to change."

That gap produced a real CHANGES_REQUESTED review on a design PR:

> Can design docs get some coherent scoping? Like: problem / objective / exec summary / then design, then detailed design. I feel like Claude often jumps into appendix or almost alternatives considered without sharing what the problem is that we're solving in plain English.

Two design docs currently under review both opened with an issue-decomposition table, a related-issue list, and backlog provenance — the actual problem was ~90 lines down. Both have since been restructured to lead with problem → objective → executive summary, and both read dramatically better for it. This encodes that shape so it does not have to be rediscovered per doc.

## What it says

The spine — problem (plain English), objective, executive summary, *then* rules/mechanism/design/migration/tests — and the two rules that are the actual failure mode:

- **The problem statement must be readable by someone who has never opened the code.** No symbol names, no file paths, no line numbers in the opening.
- **Provenance goes last.** Issue decomposition, related-issue lists, and backlog cross-references are appendix material; alternatives sit below the design. They justify the design to a reviewer; they do not explain it to a reader.

Written as constraints a reviewer can catch a violation against, not as a template to fill in. Scoped to working docs in `docs/in-design/` only — `docs/rules/` already has its own format rules in §3 and a different purpose. No PR numbers, issue numbers, or dates in the added text, per the same bar §6 sets for `docs/rules/`.

## Coordination with #1428 — one trivial conflict

#1428 (`claude/docs-standard-migration-update`) edits this same file. Merge-tested against that branch:

- **§4.1 merges clean.** #1428 does not touch §4 except one cross-reference.
- **One conflict, in §6's numbered list.** #1428 rewrites items 3–11 into 3–15; this PR appends item 12 after the old item 11. Same hunk, so git conflicts.

**Resolution, whichever lands second:** keep #1428's items 1–15 verbatim, then append this PR's item renumbered to 16:

```
16. **Open a working doc with the problem in plain English** — then objective,
    then outcome. Provenance and alternatives go below the design, never above
    the problem (§4.1).
```

Happy to stack this on #1428 instead if you'd rather not resolve it at merge — say the word and I'll rebase.

## Testing

Docs-only. `git diff --stat` is one file, 26 insertions, 0 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
