### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix exposed stack trace in ErrorLog

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,7 @@
 **Vulnerability:** Found early returns checking buffer lengths (e.g., `providedBuffer.length !== expectedBuffer.length`) on webhook secrets and cron auth tokens before using `crypto.timingSafeEqual`.
 **Learning:** Returning early on length mismatch leaks the exact length of the expected secret.
 **Prevention:** Hash both the expected and provided secrets to a fixed length (e.g., using SHA-256) before passing them to `crypto.timingSafeEqual` to avoid leaking secret lengths while still safely catching any mismatch.
+## 2024-05-24 - Exposed Stack Traces in Database
+**Vulnerability:** The application was persisting raw error stack traces to the `ErrorLog` table via `logBackendError` in `src/lib/logger.ts`.
+**Learning:** Storing raw error stack traces in database tables that feed application dashboards exposes internal server information, directory structures, and dependency versions. This violates defense-in-depth principles.
+**Prevention:** Do not persist raw error stack traces to database tables. Stack traces should only be sent to secure, centralized logging infrastructure (e.g. via `console.error`).

--- a/checkin-app/src/lib/logger.ts
+++ b/checkin-app/src/lib/logger.ts
@@ -18,12 +18,15 @@ export async function logBackendError(error: unknown, route?: string, context?: 
         const message = error instanceof Error ? error.message : String(error);
         const stack = error instanceof Error ? error.stack : undefined;
 
+        if (stack) {
+            console.error(`[Backend Error Stack] Route: ${route || 'Unknown'}\n`, stack);
+        }
+
         // 1. Insert the new error log
         await prisma.errorLog.create({
             data: {
                 message,
                 route,
-                stack,
                 context: context ? JSON.parse(JSON.stringify(context)) : undefined, // Ensure it's JSON serializable
             }
         });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was persisting raw error stack traces to the `ErrorLog` table via `logBackendError`.
🎯 Impact: Storing raw error stack traces in database tables that feed application dashboards could expose internal server information, directory structures, and dependency versions.
🔧 Fix: Modified `logBackendError` to log the stack trace to `console.error` instead of persisting it to the database.
✅ Verification: Verified the code by running `npm run lint` and checking that `logBackendError` no longer sends the stack trace to Prisma.

---
*PR created automatically by Jules for task [16131513855484460870](https://jules.google.com/task/16131513855484460870) started by @dkaygithub*