### PR TITLE
security(programs): gate the enrollment override and comp on conflict of interest

### DIFF
--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -25,6 +25,8 @@ describe('Program Participants API Integration Tests', () => {
     let otherId: number;
     let boardId: number;   // board member who leads a household
     let depId: number;     // dependent (25yo) in the board member's household
+    let boardNonLeadId: number; // board member in that household who is NOT its lead
+    let dep2Id: number;    // second dependent (25yo) in the same household
     let memberId: number;  // person in a household with an ACTIVE OrgMembership
     let memberHouseholdId: number;
 
@@ -117,6 +119,23 @@ describe('Program Participants API Integration Tests', () => {
             data: { isHouseholdLead: true }
         });
 
+        // Same household, board flag, but NOT the lead — the case `isHouseholdLead`
+        // alone misses. Plus a second dependent so this actor has an own-household
+        // target that no other test has already enrolled.
+        const boardNonLead = await prisma.person.create({
+            data: { email: 'board-nonlead-partic-api-test@example.com', name: 'Board Non-Lead', householdId: boardHousehold.id }
+        });
+        boardNonLeadId = boardNonLead.id;
+        const dependent2 = await prisma.person.create({
+            data: {
+                email: 'dep2-partic-api-test@example.com',
+                name: 'Board Dependent Two',
+                dateOfBirth: new Date(Date.now() - (25 * 31556952000)),
+                householdId: boardHousehold.id
+            }
+        });
+        dep2Id = dependent2.id;
+
         // Create mock programs
         const standardProgram = await prisma.program.create({
             data: { name: 'Standard Partic API Test', phase: 'RUNNING', enrollmentStatus: 'OPEN', leadMentorId: leadId, orgMemberPriceCents: 1000, nonOrgMemberPriceCents: 1500 }
@@ -170,7 +189,7 @@ describe('Program Participants API Integration Tests', () => {
     });
 
     afterAll(async () => {
-        const existingUserIds = [adminId, leadId, commonId, otherId, boardId, depId, memberId].filter(id => id !== undefined);
+        const existingUserIds = [adminId, leadId, commonId, otherId, boardId, depId, boardNonLeadId, dep2Id, memberId].filter(id => id !== undefined);
         const validProgramIds = [standardProgramId, freeProgramId, fullProgramId, exactAgeProgramId, memberOnlyProgramId].filter(id => id !== undefined);
 
         if (existingUserIds.length > 0) {
@@ -305,13 +324,37 @@ describe('Program Participants API Integration Tests', () => {
         });
 
         // INTENT LOCK: a board/isSysadmin override DELIBERATELY overfills a program
-        // past maxParticipants. The override is a confirmed action (the route first
-        // returns requiresOverride:true) and is meant to bypass every soft limit —
-        // closed enrollment, age, AND capacity. This 200 is correct, not a bug.
-        // The non-override path still cannot overbook (see the 400 test above and
-        // programsParticipantsConcurrency.integration.test.ts). Do not "fix" the
-        // capacity bypass at route.ts enforceLimits to make this fail.
-        it('should allow an admin override to enroll into a FULL program (deliberate overfill)', async () => {
+        // past maxParticipants FOR SOMEONE ELSE. The override is a confirmed action
+        // (the route first returns requiresOverride:true) and is meant to bypass
+        // every soft limit — closed enrollment, age, AND capacity. This 200 is
+        // correct, not a bug. The non-override path still cannot overbook (see the
+        // 400 test above and programsParticipantsConcurrency.integration.test.ts),
+        // and a conflicted actor cannot bypass at all (see the two tests below).
+        // Do not "fix" the capacity bypass at route.ts enforceLimits to make this
+        // fail — narrow it only to the conflicted case.
+        it('should allow an admin override to enroll a non-household person into a FULL program (deliberate overfill)', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+             const req = new Request(`http://localhost:4000/api/programs/${fullProgramId}/participants`, {
+                 method: 'POST',
+                 body: JSON.stringify({ participantId: commonId, override: true })
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest, createParams(fullProgramId) as unknown as never);
+             expect(res.status).toBe(200);
+
+             const data = await res.json();
+             expect(data.success).toBe(true);
+             expect(data.enrollment.status).toBe('ACTIVE'); // override → confirmed comp
+
+             // Program is now intentionally over its cap of 1.
+             const enrolled = await prisma.programParticipant.count({ where: { programId: fullProgramId } });
+             expect(enrolled).toBe(2);
+        });
+
+        // Conflict of interest: the override is a one-actor decision, so it cannot
+        // be spent on the actor's own seat. A sysadmin self-enrolling into a FULL
+        // program falls through to the ordinary enforced-limits path.
+        it('should NOT let a sysadmin override the capacity limit for their OWN enrollment', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
 
              const req = new Request(`http://localhost:4000/api/programs/${fullProgramId}/participants`, {
@@ -319,15 +362,38 @@ describe('Program Participants API Integration Tests', () => {
                  body: JSON.stringify({ participantId: adminId, override: true })
              });
              const res = await POST(req as unknown as import("next/server").NextRequest, createParams(fullProgramId) as unknown as never);
-             expect(res.status).toBe(200);
+             expect(res.status).toBe(400);
 
              const data = await res.json();
-             expect(data.success).toBe(true);
-             expect(data.enrollment.status).toBe('ACTIVE'); // override → confirmed/paid bypass
+             expect(data.error).toMatch(/maximum capacity/);
+             expect(data.requiresOverride).toBe(true);
 
-             // Program is now intentionally over its cap of 1.
-             const enrolled = await prisma.programParticipant.count({ where: { programId: fullProgramId } });
-             expect(enrolled).toBe(2);
+             const row = await prisma.programParticipant.findUnique({
+                 where: { programId_personId: { programId: fullProgramId, personId: adminId } },
+             });
+             expect(row).toBeNull();
+        });
+
+        // Same rule one step out: own household is the actor's own interest too.
+        it('should NOT let a board member override the age limit for their OWN household member', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+
+             // depId is 25 — outside the exact-age program's [18, 21] band.
+             const req = new Request(`http://localhost:4000/api/programs/${exactAgeProgramId}/participants`, {
+                 method: 'POST',
+                 body: JSON.stringify({ participantId: depId, override: true })
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest, createParams(exactAgeProgramId) as unknown as never);
+             expect(res.status).toBe(400);
+
+             const data = await res.json();
+             expect(data.error).toMatch(/maximum age is 21/);
+             expect(data.requiresOverride).toBe(true);
+
+             const row = await prisma.programParticipant.findUnique({
+                 where: { programId_personId: { programId: exactAgeProgramId, personId: depId } },
+             });
+             expect(row).toBeNull();
         });
 
         // A board member is also a parent. Enrolling their own dependent through
@@ -347,6 +413,24 @@ describe('Program Participants API Integration Tests', () => {
              const data = await res.json();
              expect(data.success).toBe(true);
              expect(data.enrollment.status).toBe('PENDING'); // pays like any parent
+        });
+
+        // "Own household" for the comp is shared-household, not lead-of-household:
+        // a board member who is an ordinary (non-lead) member of the household pays
+        // for their own household member too, and cannot buy the comp with an
+        // override.
+        it('should make a NON-LEAD board household member PAY (PENDING) for their own household member', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardNonLeadId, isBoardMember: true } });
+
+             const req = new Request(`http://localhost:4000/api/programs/${standardProgramId}/participants`, {
+                 method: 'POST',
+                 body: JSON.stringify({ participantId: dep2Id, override: true })
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest, createParams(standardProgramId) as unknown as never);
+             expect(res.status).toBe(200);
+
+             const data = await res.json();
+             expect(data.enrollment.status).toBe('PENDING'); // not a comp
         });
 
         // The comp still belongs to genuine admin action: a board member

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -5,6 +5,7 @@ import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
 import { lockProgramAndCheckCapacity, ProgramCapacityError, withdrawAndReleaseHold } from "@/lib/program/capacity";
 import { checkProgramAge } from "@/lib/programAge";
+import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 import { isDuesSettled } from "@/lib/orgMembership";
 import { adjustProgramInventory } from "@/lib/shopify";
 import { apiError } from "@/lib/api-response";
@@ -63,28 +64,37 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
 
         const override = body.override === true;
 
+        // Conflict of interest: an override and a comp are both one-actor
+        // decisions, so neither may be spent on yourself or your own household.
+        // Self is its own leg — an actor with no household is not caught by the
+        // household comparison, but is still enrolling themselves. This is the
+        // route's single notion of "own household"; `isHouseholdLead` above
+        // answers a different question (may you act for this person at all).
+        const isConflicted = isSelfEnrollment
+            || await hasHouseholdConflict(prisma, currentUserId, participantData?.householdId);
+
         // A board/isSysadmin enrolling someone OUTSIDE their own household (the
         // program-ops surface) is a real admin comp: it skips payment. A board
         // member enrolling their own self/dependent through the public program
-        // page is just a parent — they pay like anyone else. Without this, a
-        // board parent got a confusing "bypasses all payment / Force Enroll"
-        // prompt and a free enrollment instead of a Shopify checkout.
-        const isExternalAdmin = isSysAdminOrBoard && !isSelfEnrollment && !isHouseholdLead;
+        // page is just a parent — they pay like anyone else, whether or not they
+        // happen to be the household's lead.
+        const isExternalAdmin = isSysAdminOrBoard && !isConflicted;
 
         if (isExternalAdmin && !override) {
              return NextResponse.json({ error: "This bypasses all payment. Are you sure?", requiresOverride: true }, { status: 400 });
         }
 
         // ponytail: a confirmed board/isSysadmin override INTENTIONALLY bypasses
-        // every soft limit — closed enrollment, age, AND capacity — so the board
-        // can deliberately overfill a program. This is intent, not a missing
-        // guard: see the requiresOverride:true responses the UI turns into a
-        // confirm button. Normal users always hit enforceLimits=true and cannot
-        // overbook (capacity is locked under FOR UPDATE in the tx below; tested in
+        // every soft limit — closed enrollment, members-only, age, AND capacity —
+        // for OTHERS, so the board can deliberately overfill a program. This is
+        // intent, not a missing guard: see the requiresOverride:true responses the
+        // UI turns into a confirm button. Normal users, and any conflicted actor,
+        // always hit enforceLimits=true and cannot overbook (capacity is locked
+        // under FOR UPDATE in the tx below; tested in
         // programsParticipantsConcurrency.integration.test.ts and the FULL-program
         // override test in programsParticipantsAPI.integration.test.ts). Do not
-        // narrow this so it also gates normal users.
-        const enforceLimits = !override || (!isSysAdminOrBoard);
+        // narrow this so it also gates the non-conflicted admin path.
+        const enforceLimits = !override || !isSysAdminOrBoard || isConflicted;
 
         // Validation Checks
         if (enforceLimits) {

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -406,17 +406,19 @@ describe("ProgramEnrollmentPage", () => {
         );
     });
 
-    it("shows an override prompt when enrollment requires admin override, then force-enrolls", async () => {
+    // This picker only ever lists the caller's own household, so every enrollment
+    // started here is conflicted and the server refuses the limit override even for
+    // a sysadmin. Offering Force Enroll would be a button that always re-fails —
+    // the refusal reason is shown instead, and the request never carries `override`.
+    it("offers no force-enroll on a requiresOverride refusal — shows the reason instead", async () => {
         setSession({ id: 5, isSysadmin: true });
+        const bodies: string[] = [];
         global.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
             const url = typeof input === "string" ? input : input.toString();
             if (url.includes("/api/household")) return { ok: true, status: 200, json: async () => household } as Response;
             if (url.includes("/api/programs/10/participants")) {
-                const body = init?.body ? JSON.parse(init.body as string) : {};
-                if (!body.override) {
-                    return { ok: false, status: 403, json: async () => ({ error: "Too young for this program.", requiresOverride: true }) } as Response;
-                }
-                return { ok: true, status: 200, json: async () => ({}) } as Response;
+                bodies.push(String(init?.body ?? ""));
+                return { ok: false, status: 400, json: async () => ({ error: "Too young for this program.", requiresOverride: true }) } as Response;
             }
             if (url.includes("/api/programs/10")) return { ok: true, status: 200, json: async () => baseProgram({ minAge: null, maxAge: null, leadMentorId: 5 }) } as Response;
             return { ok: false, status: 404, json: async () => ({}) } as Response;
@@ -428,39 +430,10 @@ describe("ProgramEnrollmentPage", () => {
         await selectMember("Kid One");
         fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
 
-        expect(await screen.findByText("Warning: Enrollment rules not met.")).toBeInTheDocument();
-        expect(screen.getByText("Too young for this program.")).toBeInTheDocument();
-
-        fireEvent.click(screen.getByRole("button", { name: "Force Enroll (Override)" }));
-        await waitFor(() => expect(screen.queryByText("Warning: Enrollment rules not met.")).not.toBeInTheDocument());
-        expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Successfully enrolled!" }));
-    });
-
-    it("disables the override button once the selection is emptied", async () => {
-        setSession({ id: 5, isSysadmin: true });
-        global.fetch = jest.fn(async (input: RequestInfo | URL) => {
-            const url = typeof input === "string" ? input : input.toString();
-            if (url.includes("/api/household")) return { ok: true, status: 200, json: async () => household } as Response;
-            if (url.includes("/api/programs/10/participants")) {
-                return { ok: false, status: 403, json: async () => ({ error: "Too young for this program.", requiresOverride: true }) } as Response;
-            }
-            if (url.includes("/api/programs/10")) return { ok: true, status: 200, json: async () => baseProgram({ minAge: null, maxAge: null, leadMentorId: 5 }) } as Response;
-            return { ok: false, status: 404, json: async () => ({}) } as Response;
-        });
-        renderPage();
-        await screen.findByText("Robotics Club");
-        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
-        await screen.findByText("Which of your household wants to enroll?");
-        await selectMember("Kid One");
-        fireEvent.click(screen.getByRole("button", { name: "Complete Enrollment" }));
-        await screen.findByText("Warning: Enrollment rules not met.");
-
-        // The checkbox group stays live while the override alert is up, so
-        // unchecking must disable the override too — handleEnroll returns on an
-        // empty selection, and a live button would do nothing with no feedback.
-        expect(screen.getByRole("button", { name: "Force Enroll (Override)" })).toBeEnabled();
-        fireEvent.click(screen.getByLabelText("Kid One"));
-        expect(screen.getByRole("button", { name: "Force Enroll (Override)" })).toBeDisabled();
+        expect(await screen.findByText("Too young for this program.")).toBeInTheDocument();
+        expect(screen.queryByText("Warning: Enrollment rules not met.")).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Force Enroll (Override)" })).not.toBeInTheDocument();
+        expect(bodies.every(b => !JSON.parse(b).override)).toBe(true);
     });
 
     it("shows a network-error message when enrollment throws", async () => {

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -64,7 +64,6 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   const [enrolling, setEnrolling] = useState(false);
   const [message, setMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
-  const [requiresOverride, setRequiresOverride] = useState(false);
 
   const [showEnrollmentSelection, setShowEnrollmentSelection] = useState(false);
   const [householdMembers, setHouseholdMembers] = useState<{ id: number; name: string | null; dateOfBirth: string | null; isDeclaredAdult?: boolean }[]>([]);
@@ -236,14 +235,14 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
     }
   };
 
-  const handleEnroll = async (override = false) => {
+  const handleEnroll = async () => {
     if (!session) {
       router.push('/');
       return;
     }
     if (selectedParticipantIds.length === 0) return;
 
-    const isPayingOnShopify = !override && (program?.orgMemberPriceCents || program?.nonOrgMemberPriceCents);
+    const isPayingOnShopify = program?.orgMemberPriceCents || program?.nonOrgMemberPriceCents;
 
     setEnrolling(true);
     setMessage("");
@@ -292,7 +291,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
         const res = await fetch(`/api/programs/${id}/participants`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participantId, override })
+          body: JSON.stringify({ participantId })
         });
 
         // Only the error path carries a JSON body we need (error/requiresOverride);
@@ -301,7 +300,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
         outcomes.push({ participantId, ok: res.ok, status: res.status, error: data.error, requiresOverride: data.requiresOverride });
       }
 
-      const { enrolledIds, errors, needsOverride } = aggregateEnrollOutcomes(outcomes);
+      const { enrolledIds, errors } = aggregateEnrollOutcomes(outcomes);
 
       if (enrolledIds.length > 0) {
         notifyNavRefresh();
@@ -318,7 +317,6 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
           } else {
             notifications.show({ color: "red", autoClose: false, message: "Enrolled, but the mock payment failed — fire it from the Debug → Shopify tool." });
           }
-          setRequiresOverride(false);
           fetchProgram();
         } else if (isPayingOnShopify && program && variantId && storeDomain) {
           setSuccessMessage("Redirecting to Shopify for secure payment...");
@@ -342,12 +340,10 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
           return; // spinner stays; page unloads on redirect
         } else {
           notifications.show({ message: enrolledIds.length > 1 ? `Successfully enrolled ${enrolledIds.length} members!` : "Successfully enrolled!" });
-          setRequiresOverride(false);
           fetchProgram();
         }
       }
 
-      if (needsOverride) setRequiresOverride(true);
       if (errors.length > 0) setMessage(errors.join(" "));
     } catch {
       notifications.show({ color: "red", message: "Network error during enrollment.", autoClose: false });
@@ -564,7 +560,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                 <Button
                   fullWidth
                   size="md"
-                  onClick={() => handleEnroll(false)}
+                  onClick={() => handleEnroll()}
                   disabled={enrolling || selectedParticipantIds.length === 0 || loadingHousehold}
                   loading={enrolling}
                 >
@@ -587,22 +583,11 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
               </Stack>
               )}
 
-              {requiresOverride && canManage && (
-                <Alert color="yellow" variant="light" mt="lg" title="Warning: Enrollment rules not met.">
-                  <Text size="sm" mb="md">
-                    As an Admin or Lead Mentor, you can bypass this restriction. Are you sure you want
-                    to force enroll?
-                  </Text>
-                  <Button
-                    color="yellow"
-                    fullWidth
-                    onClick={() => handleEnroll(true)}
-                    disabled={enrolling || selectedParticipantIds.length === 0 || loadingHousehold}
-                  >
-                    Force Enroll (Override)
-                  </Button>
-                </Alert>
-              )}
+              {/* No force-enroll here: this picker only ever offers the caller's
+                  own household, so every enrollment from this page is conflicted
+                  and the server refuses the limit override. The refusal reason
+                  shows in the red message Alert above. Comping someone else is
+                  program-ops (ProgramRosterTab). */}
               </>
               )}
             </Card>


### PR DESCRIPTION
## The hole

`POST /api/programs/[id]/participants` decided whether to enforce soft limits with:

```ts
const enforceLimits = !override || (!isSysAdminOrBoard);
```

No check on **who** the enrollment is for. A sysadmin or board member could set
`override: true` and bypass every soft limit — CLOSED enrollment, `orgMemberOnly`,
`minAge`/`maxAge`, and `maxParticipants` — **for their own enrollment or someone in
their own household**. One actor, no second party, self-benefit: a seat in a full,
closed, members-only, or age-barred program.

That contradicts the uniform rule in
[`lib/conflictOfInterest.ts`](checkin-app/src/lib/conflictOfInterest.ts) — an actor
may not approve, certify, clear, or grant something for their own household, and no
role is exempt (`isSysadmin` explicitly cannot stand in for a non-conflicted
decider). The sweep that pushed that rule through membership, background-check,
payment-plan, and trusted-adult surfaces did it by changing the
`hasHouseholdConflict` primitive; this route was never caught because it doesn't call
the primitive at all — it rolled its own bypass. Pre-existing on `main`.

## The fix

The route now resolves **one** notion of "own household" up front:

```ts
const isConflicted = isSelfEnrollment
    || await hasHouseholdConflict(prisma, currentUserId, participantData?.householdId);
```

Self is its own leg on purpose: `sharesHousehold` returns false when the actor's
`householdId` is null, so a household-less person self-enrolling would not be caught
by the household comparison alone. `isHouseholdLead` stays exactly where it answers a
different question (may you act for this person at all — the 403 gate).

Both one-actor decisions on the route key off it:

**1. The limit override.**

```ts
const enforceLimits = !override || !isSysAdminOrBoard || isConflicted;
```

A conflicted actor falls through to the ordinary enforced-limits path and gets the
usual error with `requiresOverride: true`. Enrolling someone **outside** the actor's
household with override is untouched, including the comp (ACTIVE, Shopify −1).

**2. The comp** — adjacent pre-existing bug, found while fixing the above.

```diff
-const isExternalAdmin = isSysAdminOrBoard && !isSelfEnrollment && !isHouseholdLead;
+const isExternalAdmin = isSysAdminOrBoard && !isConflicted;
```

`isHouseholdLead` is only ever set by a query already pinned to
`householdId: participantData.householdId`, so `isHouseholdLead ⟹ isConflicted`. That
makes this a **strict narrowing** — the new predicate is a subset of the old, and the
sole element in the difference is the case it was missing: a sysadmin or board member
who is a **non-lead** member of the target's household counted as "external" and
could comp their own household member a free ACTIVE seat (plus the Shopify −1). The
comment above that line already stated the intent as *"someone OUTSIDE their own
household"*; lead-of-household was simply the wrong proxy for it. Nothing
genuinely-external changes behavior.

**3. Force Enroll removed from the public program page.**

That page's participant picker is populated only from `/api/household` (fallback:
`[{ id: currentUserId, name: "Myself" }]`), so every person selectable there is the
caller or their own household. With the server refusing the override for all of them,
the button could never succeed — it was not "dead sometimes", it was dead by
construction. It was also already inert for a plain lead mentor, who is not
sysadmin/board and so never had `enforceLimits` lifted.

Removed the Alert, the `requiresOverride` state, and the now-always-false `override`
argument to `handleEnroll`. No information is lost: the refusal reason already
rendered independently in the page's red `{message}` Alert. Comping someone else
remains program-ops `ProgramRosterTab`, which surfaces a refusal inline via
`setEnrollError`.

`enroll.ts` is untouched — it's a tested pure helper and the route still emits
`requiresOverride`, so `needsOverride` stays available for a future consumer.

## Note on the money path

The override never granted a free seat to *self*: `isExternalAdmin` already excluded
self-enrollment, so a self-override still paid (PENDING). What was broken was purely
the limit bypass — still a real self-granted benefit. The one payment-behavior change
here is the non-lead own-household comp in (2), which now correctly pays PENDING.

## Reviewer notes

- Not a boundary change: nothing under `checkin-app/src/security/`, no registry
  entries, no `@sensitivity` re-tiers.
- The **deliberate-overfill intent lock** in
  `programsParticipantsAPI.integration.test.ts` is preserved, not deleted. It was
  `adminId` enrolling `adminId`; it's re-pointed at a participant outside the admin's
  household so it still locks the "a confirmed override may overfill past
  `maxParticipants`" intent, with the surrounding comment updated to say the bypass is
  for **others**.
- `auditLog.integration.test.ts` and `programAgeBounds.integration.test.ts` already
  override across separate households (every fixture person gets its own household) —
  verified unaffected. `programsEnrollClosed` and `programsParticipantsConcurrency`
  never send `override`. `programPaymentPlansAPI`'s "override" is the payment-plan
  approve/deny one, a different route.
- Each new refusal check was verified to **fail** against the unpatched route before
  the fix landed.

## Verification

Added:
- self + override → still limit-enforced (400, `maximum capacity`, no row)
- own-household member + override by a board member → still limit-enforced (400,
  `maximum age is 21`, no row)
- non-lead own-household board member + override → 200 **PENDING**, not a comp

Changed:
- the FULL-program intent lock re-pointed at a non-household participant (still 200 /
  ACTIVE / count 2)
- the two page checks that drove the force-enroll prompt replaced by one asserting no
  prompt, no button, and no `override` on the wire

```
Integration (7 suites): 96 passed
  programsParticipantsAPI, programsHouseholdEnrollment, programPaymentPlansAPI,
  auditLog, programAgeBounds, programsEnrollClosed, programsParticipantsConcurrency

Unit (npm run test:ci): 257 suites, 2435 passed
tsc --noEmit: 0
npm run lint:  0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
