### PR TITLE
refactor(shopify): remove the legacy two-variant program/membership code paths

### DIFF
--- a/checkin-app/__tests__/programLifecycle.integration.test.ts
+++ b/checkin-app/__tests__/programLifecycle.integration.test.ts
@@ -71,8 +71,7 @@ describe('Program Lifecycle Integration Tests', () => {
                 orgMemberPriceCents: 50,
                 nonOrgMemberPriceCents: 100,
                 shopifyProductId: "test-prod",
-                shopifyOrgMemberVariantId: "test-mem-var",
-                shopifyNonOrgMemberVariantId: "test-non-var",
+                shopifyVariantId: "test-non-var",
                 enrollmentStatus: "OPEN"
             }
         });
@@ -180,8 +179,8 @@ describe('Program Lifecycle Integration Tests', () => {
         });
 
         // 2. Build Shopify webhook payload. line_items must contain the program's
-        // own Shopify variant (shopifyNonOrgMemberVariantId set in beforeAll) —
-        // the route now verifies this before activating (see route.ts).
+        // own Shopify variant (shopifyVariantId set in beforeAll) — the route
+        // verifies this before activating (see route.ts).
         const payload = JSON.stringify({
             id: 12345,
             line_items: [{ variant_id: "test-non-var" }],

--- a/checkin-app/__tests__/programSignupIntegration.test.ts
+++ b/checkin-app/__tests__/programSignupIntegration.test.ts
@@ -17,11 +17,6 @@ jest.mock('@/lib/notifications', () => ({
 }));
 
 jest.mock('@/lib/shopify', () => ({
-    createShopifyProgramVariants: jest.fn().mockResolvedValue({
-        shopifyProductId: 'mock-product-id',
-        shopifyOrgMemberVariantId: 'mock-member-variant-id',
-        shopifyNonOrgMemberVariantId: 'mock-non-member-variant-id',
-    }),
     createShopifySingleVariantProgram: jest.fn().mockResolvedValue({
         shopifyProductId: 'mock-product-id',
         shopifyVariantId: 'mock-variant-id',

--- a/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
+++ b/checkin-app/docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md
@@ -35,19 +35,14 @@ This is an interim mechanism. `docs/designs/SHOPIFY_MEMBER_SEGMENT_PRICING.md` i
 planned upgrade — segment-gated automatic discounts, once checkout identity (that doc's
 §5) is solved — at which point per-checkout discount codes go away entirely.
 
-### Legacy two-variant transition
+### Legacy two-variant shape (removed)
 
-Programs created before this design still carry two variants
-(`shopifyOrgMemberVariantId` / `shopifyNonOrgMemberVariantId`), each with its own
-inventory pool mirrored via a sibling-adjustment on every seat-consuming event (the
-webhook's `orders/paid` handler mirrors the purchased tier's decrement onto the other
-pool). `adjustProgramInventory` prefers `shopifyVariantId` when set and falls back to the
-legacy pair otherwise — this is additive, not a widening of what any one program accepts;
-a given program only ever populates one shape or the other.
-
-This is an **expand** step. Dropping the legacy pair (**contract**) is a later release,
-once every program has migrated onto the single-pool model — per the repo's
-migration-safety convention of expand/contract as separate steps.
+An earlier design gave each program two variants
+(`shopifyOrgMemberVariantId` / `shopifyNonOrgMemberVariantId`) with separate inventory
+pools kept in step by a sibling-adjustment on every seat-consuming event. All of that
+code is gone: `shopifyVariantId` is the only variant any program has, and
+`adjustProgramInventory` adjusts exactly that one pool. The four dead columns are
+dropped in a follow-up release — see `docs/designs/975-LEGACY_VARIANT_CONTRACT.md`.
 
 ## 3. Scholarship lifecycle — the hold ledger
 

--- a/checkin-app/docs/designs/975-LEGACY_VARIANT_CONTRACT.md
+++ b/checkin-app/docs/designs/975-LEGACY_VARIANT_CONTRACT.md
@@ -228,19 +228,19 @@ table rebuild / accept-data-loss reset.
 > (`GET /api/programs` via `PUBLIC_PROGRAM_SELECT`), `GET /api/programs/[id]`,
 > `nav/todo-counts`, and the lifecycle-reconcile cron for the length of that window.
 
-## Shopify-side caveat (the plan is DB-only)
+## Shopify-side: nothing to clean up (confirmed 2026-08-02)
 
-Everything above is app + database. Nothing here archives/unpublishes the legacy
-two-variant Shopify **products** or voids carts already built against a legacy
-variant. Release 1 has removed the webhook matcher, so a customer still holding a
-stale legacy cart can now complete checkout against a legacy variant and the paid
-order will activate nothing — a silent paid-but-stuck order. Low likelihood once
-legacy programs are retired.
+This plan is app + database only — it never archived/unpublished the legacy
+two-variant Shopify **products**, and it can't void carts already built against a
+legacy variant.
 
-**Still outstanding — #1464 did not do this.** If any legacy two-variant product
-is still purchasable on the store, archive/unpublish it in Shopify. This is a
-store-side action with no code change, so it is not gated on Release 2; do it now
-rather than waiting for the migration.
+That was worth checking, because Release 1 removed the webhook matcher: a customer
+still holding a stale legacy cart could complete checkout against a legacy variant
+and have the paid order activate nothing — a silent paid-but-stuck order.
+
+**Confirmed there are no stale legacy items in the store**, so there is no
+purchasable legacy product and no cart that can reach that state. No store-side
+action is required, and this is not a Release 2 prerequisite.
 
 ## Not in scope
 

--- a/checkin-app/docs/designs/975-LEGACY_VARIANT_CONTRACT.md
+++ b/checkin-app/docs/designs/975-LEGACY_VARIANT_CONTRACT.md
@@ -1,9 +1,16 @@
 # Dropping the legacy two-variant product shape
 
-**Status: DESIGN — not built.** Addresses #975 ("Do we need the legacy product
-shape with 2 variants in Shopify?"). Answer: **no.** Both legacy two-variant
-pairs are dead — nothing writes them, and (confirmed by the board) no live prod
-row still depends on them. This doc is the plan to remove them safely.
+**Status: code removal SHIPPED (PR #1464); the `DROP COLUMN` migration is
+outstanding.** Addresses #975 ("Do we need the legacy product shape with 2
+variants in Shopify?"). Answer: **no.** Both legacy two-variant pairs are dead —
+nothing writes them, and (confirmed by the board) no live prod row still depends
+on them.
+
+Releases 0 and 1 below shipped together in PR #1464: the write path is closed and
+no code reads the columns any more. The four columns are still declared in
+`schema.prisma`, so **Release 2 is what actually closes #975** — see
+[the deploy hazard](#the-deploy-hazard-why-the-drop-is-its-own-release) for what's
+left and the two gotchas it must not miss.
 
 ## What "legacy two-variant shape" means
 
@@ -21,36 +28,37 @@ applies member pricing via a server-minted single-use discount code — no
 client-side tier pick, so the whole tier-confusion + variant-presence bug class
 (#739) goes away by construction.
 
-## Why it's safe to remove — and the one write path that isn't yet closed
+## Why it's safe to remove — and the write path that is now closed
+
+> **Closed by #1464.** The write described here is gone. Retained because it is
+> what justifies still running the cutover re-verify query before Release 2.
 
 - **No live data depends on them** (board-confirmed for #975): every program
   that had the legacy pair has retired; membership moved fully to
-  `orgMembershipVariantId`. The columns persist only as read-fallbacks for rows
+  `orgMembershipVariantId`. The columns persisted only as read-fallbacks for rows
   that no longer exist.
-- **Program *create* writes `shopifyVariantId` only** (`api/programs/route.ts`),
-  and nothing writes the membership pair at all.
+- **Program *create* wrote `shopifyVariantId` only** (`api/programs/route.ts`),
+  and nothing ever wrote the membership pair.
 
-**But the program pair is NOT write-dead.** `api/programs/[id]/route.ts:197-198`
-still accepts `shopifyOrgMemberVariantId` / `shopifyNonOrgMemberVariantId` from
-the PATCH body and writes them for any sysadmin/board caller — onto *any*
-program, including one that never had them. So a board member could mint a fresh
-legacy-dependent row **between the board's "no live rows" confirmation and the
-cutover.** If that happens, Release 1 (which removes the checkout ternary and the
-webhook matcher) leaves that program charging the wrong tier and its paid
-webhook unable to activate.
+**The program pair was not write-dead, though.** `PATCH /api/programs/[id]`
+accepted `shopifyOrgMemberVariantId` / `shopifyNonOrgMemberVariantId` from the
+body and wrote them for any sysadmin/board caller — onto *any* program, including
+one that never had them. A board member could therefore have minted a fresh
+legacy-dependent row **after the board's "no live rows" confirmation**, and the
+Release 1 removals (checkout ternary, webhook matcher) would leave that program
+charging the wrong tier with its paid webhook unable to activate.
 
-This does not block removal, but it means the board confirmation is a
-point-in-time fact, not a standing guarantee. The plan closes the gap with a
-**Release 0** below (strip the PATCH writes first) plus a **re-verify-at-cutover**
-gate.
+That made the board confirmation a point-in-time fact rather than a standing
+guarantee — which is why Release 0 closed the write, and why the cutover re-verify
+gate below still earns its keep even now that it has.
 
-The `isLegacy` branch of `api/programs/[id]/sync-shopify/route.ts` also re-writes
-the pair, but only for a program that **already** carries it — it cannot
-introduce the pair, so it is not a new-row source.
+The `isLegacy` branch of `api/programs/[id]/sync-shopify/route.ts` also re-wrote
+the pair, but only for a program that **already** carried it — it could not
+introduce the pair, so it was never a new-row source.
 
-Net: the columns are dead weight whose only remaining effect is misleading
-readers (human and Claude) about how checkout works today — the complaint that
-opened #975 — once the lingering PATCH write is closed.
+Net: the columns are dead weight whose only remaining effect is misleading readers
+(human and Claude) about how checkout works today — the complaint that opened
+#975.
 
 ## Blast radius
 
@@ -59,9 +67,13 @@ Dropping the four columns removes real legacy-only code, not just fields.
 ### Dead code that collapses (deletion)
 
 - **`lib/programs/activateEnrollment.ts`** — the `purchasedOrgMember` param and
-  the entire "sibling-inventory mirror" block. With no program carrying legacy
-  variants, `purchasedOrgMember` is always `null`, so the block is unreachable.
-  Drop the param; drop the block.
+  the entire "sibling-inventory mirror" block. (This doc originally justified it
+  as "`purchasedOrgMember` is always `null`" — that is wrong: on the webhook path
+  it is `false`, only the reconciler passes `null`. The block is dead anyway, for
+  a different reason: with no legacy program, either `shopifyVariantId` is set —
+  so the `!program?.shopifyVariantId` guard is false — or the program is free, in
+  which case `hasProgramItem` never matches and nothing activates in the first
+  place.) Drop the param; drop the block.
 - **`lib/shopify.ts` `createShopifyProgramVariants`** — its only non-test caller
   is the `isLegacy` branch below. Once that goes, the function is dead. Delete it.
 - **`api/programs/[id]/sync-shopify/route.ts`** — the `isLegacy` fork collapses;
@@ -70,8 +82,13 @@ Dropping the four columns removes real legacy-only code, not just fields.
   legacy ids (both membership and program); `purchasedOrgMember` computation and
   the arg passed to `activateProgramEnrollment` go away.
 - **`lib/finance/reconcile.ts` `membershipVariantIdSet`** — drop the two legacy
-  membership ids from the *live reconcile* match set. **NOT from the audit
-  universe** — see the audit hazard below.
+  membership ids. This is the one shared set the live reconciler and `matchAudit`
+  both consume; see the audit hazard below for why dropping them from it turned
+  out to be a no-op rather than a narrowing.
+- **`lib/shopify.ts` `adjustProgramInventory`** — takes `{ shopifyVariantId }`
+  only, and adjusts that one pool instead of looping a variant array. (Missed by
+  this doc's original blast radius; it is the function `lib/program/capacity.ts`
+  and `lib/lifecycleDrift.ts` both feed.)
 - **`app/programs/[id]/page.tsx`** — checkout link becomes
   `variantId = program.shopifyVariantId`; the member/non-member ternary and its
   `pricingEligible` plumbing (where used only for the variant pick) go away.
@@ -80,70 +97,108 @@ Dropping the four columns removes real legacy-only code, not just fields.
 
 - `api/programs/route.ts` — GET `select`.
 - `api/programs/[id]/route.ts` — PATCH body destructure, conditional writes, and
-  the `hasShopifyVariant` presence check. (Removing the two conditional writes is
-  also the Release-0 fix above — do it first, on its own.)
+  the `hasShopifyVariant` presence check. (The two conditional writes are the
+  Release-0 fix above.)
 - `lib/programCheckout.ts` — `isProgramCheckoutBroken` and the
   `PROGRAM_CHECKOUT_BROKEN_WHERE` Prisma `where`. **Shared predicate** — consumed
   by `api/nav/todo-counts`, both program-ops pages, and `sync-shopify`. Missing
   this means Release 2's DROP breaks nav/todo-counts during the drain window.
-- `lib/lifecycleDrift.ts:125-127` — `select` of all three variant columns; feeds
-  the lifecycle-reconcile cron / system-status. A stale `select` here aborts the
-  cron after DROP.
-- `lib/program/capacity.ts:69` — the `program` param type lists the legacy pair.
+- `lib/lifecycleDrift.ts` — `healEnrollmentI1`'s `program` `select` of all three
+  variant columns; feeds the lifecycle-reconcile cron / system-status. A stale
+  `select` here aborts the cron after DROP.
+- `lib/program/capacity.ts` — `withdrawAndReleaseHold`'s `program` param type
+  lists the legacy pair.
 - `api/dev/shopify/orders-paid/route.ts` — membership + program fallbacks.
 - `app/dev/shopify/page.tsx`, `app/program-ops/programs/page.tsx` — selects /
   presence checks.
 - `src/security/generated/classifications.ts` — **generated**; regenerate, don't
-  hand-edit.
-- ~10 test files reference the fields in fixtures/assertions — update alongside.
+  hand-edit. Because the fields are *removed* rather than re-tiered, the
+  `security-boundary-isolation` workflow's re-tier detection does not fire, so
+  this may ride along with the schema change (`generated/` is not a boundary file).
+- `shopify-live/product-inventory.shopify-live.ts` — builds a program literal for
+  `adjustProgramInventory`. No local or CI run executes it (`*.shopify-live.ts` is
+  excluded everywhere), but `tsconfig.json` includes `**/*.ts`, so **`tsc` type-checks
+  it** and a stale literal fails the build on excess-property. Also missed by the
+  original blast radius.
+- `docs/PROGRAM_CAPACITY_AND_SCHOLARSHIPS.md` §2 asserted the two-pool shape as
+  current — per the deploy doc's rule 2, docs asserting a shape are part of the
+  cutover.
+- 14 test files reference the fields in fixtures/assertions — update alongside.
+  Two of them (`activateEnrollmentRedelivery`, `enrollmentStateOracle`) name only
+  `purchasedOrgMember`, so a grep for the column names misses them; `tsc` catches
+  both.
 
-### The audit hazard — do NOT drop legacy ids from the audit universe
+### The audit hazard — RESOLVED: no snapshot needed
 
-`lib/finance/matchAudit.ts` builds its *entire* order universe from
+This section originally framed the removal as *causing* a loss of audit coverage,
+and left a choice open ("decide before Release 2") between snapshotting the legacy
+ids into a `LEGACY_AUDIT_VARIANT_IDS` const or accepting the loss. **Neither is
+needed. The premise was wrong.**
+
+`lib/finance/matchAudit.ts` builds its order universe from
 `mirror.ordersForVariants(allVariants)`, where `allVariants` = the membership
-variant set + every program variant. If the legacy ids simply disappear (both
-the membership pair and the program columns), historical legacy-era orders fall
-out of the audited set completely — they don't stay `MATCHED`, they stop being
-looked at. A legacy order whose claim later breaks (e.g. a refund) could then
-never surface as `UNCLAIMED_PAID`, reintroducing the #1074 invisible-money class
-**by construction.**
+variant set + every program variant. But it assembles `programByVariant` by
+iterating **live row values** and skipping nulls (`if (v)`). With no prod row
+carrying a legacy id, those ids contribute nothing to `allVariants` **today** —
+so removing the `select` entries is behaviour-identical, not a narrowing.
 
-The four DB columns are also literally the audit's only record of which variant
-ids were legacy, so once they're dropped the audit can't reconstruct the set.
-Resolution options (decide before Release 2):
+Two consequences worth stating plainly, because the original framing obscured
+both:
 
-- **(i) Snapshot the legacy ids into a static const** captured at drop time
-  (`LEGACY_AUDIT_VARIANT_IDS`) and keep feeding them into the audit universe
-  read-only. Preserves audit coverage with no live column.
-- **(ii) Accept the coverage loss** with a written rationale — only valid if the
-  board confirms every legacy order is fully settled and refund-closed, i.e. no
-  legacy claim can ever break. Stronger claim than "no live programs."
+- **There is nothing to snapshot.** A snapshot const would faithfully reproduce
+  the columns' contents, which is the empty set. Options (i) and (ii) collapse
+  into the same no-op.
+- **Any legacy-era-order coverage gap already exists** and was created when those
+  programs were retired, not by this work. If that gap matters, it is a separate
+  question about historical orders in the mirror — do not conflate it with this
+  removal, which cannot make it worse.
 
-Recommend (i): cheap, and it keeps the money-audit invariant intact.
+Note the decision *does* depend on the no-legacy-rows fact, so the cutover
+re-verify query below is what keeps this reasoning honest. Had a legacy row
+survived, option (i) as written would also have been insufficient: the audit maps
+variant → program to test a claim (`claimedSet.has(program.id)`), so a bare id
+list would leave every legacy order permanently `UNCLAIMED_PAID`. A real snapshot
+would have needed `{ variantId, programId, programName }`.
 
-## The deploy hazard (why this is two releases)
+## The deploy hazard (why the DROP is its own release)
 
-A dropped column cannot ship in the same release as the code that stops
-selecting it. During a rolling deploy the old pods keep running the old code —
-`select: { shopifyOrgMemberVariantId: true }` — against the already-migrated
-table, so every such query errors for the whole drain window. Standard
-expand/contract, in order:
+A dropped column cannot ship in the same release as the code that stops selecting
+it. The reason is **step ordering, not task concurrency**: `deploy-prod.yml` runs
+"Run database migrations" (`prisma migrate deploy`, to completion) as a separate,
+*earlier* step than "Deploy to ECS" (`update-service`). So the schema is fully
+migrated while the old task is still serving live traffic, and every query still
+selecting a dropped column errors until the new task takes over.
 
-0. **Release 0 — close the write.** Strip the two `shopifyOrgMemberVariantId` /
-   `shopifyNonOrgMemberVariantId` conditional writes from
-   `api/programs/[id]/route.ts` (and drop the fields from the program-ops edit
-   UI if present). After this deploys, no path can mint a fresh legacy row, so
-   the board's "no live rows" fact becomes stable. Tiny, low-risk, ships first.
-1. **Release 1 — code only.** Remove every read reference and all the dead code
-   above (keeping the audit-universe ids per the hazard section). Schema still
-   declares the four columns (now unused). After this deploys, nothing in the
-   running fleet selects them.
-2. **Release 2 — schema + migration.** Remove the four fields from
-   `schema.prisma` and add a `DROP COLUMN` migration. **Re-verify at cutover**
-   (query below) that no `Program` row has a legacy variant with a null
-   `shopifyVariantId` — the Release-0 → Release-2 window is short, but the check
-   is cheap and closes the race for good. Deploys only after Release 1 is fully
-   rolled out.
+Standard expand/contract, in order:
+
+0. **Release 0 — close the write.** ✅ *Shipped in #1464.* Strip the two
+   `shopifyOrgMemberVariantId` / `shopifyNonOrgMemberVariantId` conditional writes
+   from `api/programs/[id]/route.ts`, and the fields from the program-ops edit UI.
+   After this deploys, no path can mint a fresh legacy row, so the board's "no live
+   rows" fact becomes stable.
+   - The program-ops "Shopify Checkout Identifiers" card turned out to expose *only*
+     the two legacy inputs, with no `shopifyVariantId` field at all — so deleting
+     them outright would have removed the manual-repair path the card exists for.
+     Replaced with a single Variant ID input (the PATCH already accepted it).
+1. **Release 1 — code only.** ✅ *Shipped in #1464, folded in with Release 0.*
+   Remove every read reference and all the dead code above. Schema still declares
+   the four columns (now unused). After this deploys, nothing in the running fleet
+   selects them.
+   - Folding 0 into 1 is safe *because* Release 0 also replaces the only UI that
+     could mint a legacy row; the window it guarded is closed by the same deploy.
+2. **Release 2 — schema + migration.** ⬜ *Outstanding.* Remove the four fields
+   from `schema.prisma`, add a `DROP COLUMN` migration, regenerate
+   `classifications.ts`. **Re-verify at cutover** (query below) that no `Program`
+   row has a legacy variant with a null `shopifyVariantId`. Deploys only after
+   Release 1 is fully rolled out in **prod** — note that merging to `main` only
+   deploys *dev*; prod cuts from a published release, so two PRs merged before one
+   release still land in prod together and re-open this hazard.
+   - **Must also delete the `DROPPED_SOON` array** in
+     `src/app/__tests__/programsAPI.integration.test.ts`. That test derives its
+     expected public-column set from the generated classifications, which still
+     tier the two dead `Program` fields `public` while the schema declares them;
+     Release 1 excluded them by name to keep the oracle honest. Leaving the array
+     in place after the regeneration makes the oracle silently under-check.
 
 Cutover re-verify query:
 
@@ -160,20 +215,32 @@ Prod has live data — the migration is `DROP COLUMN` on four nullable columns
 (no backfill, no data movement), but it must still be a plain drop, never a
 table rebuild / accept-data-loss reset.
 
-**If deploys use a maintenance window / single instance** (no drain overlap),
-Releases 1 and 2 collapse into one PR — there is no old pod to break. Release 0
-still ships first so the cutover re-verify is meaningful.
+> **Correction — an earlier version of this doc said Releases 1 and 2 could
+> collapse into one PR "if deploys use a maintenance window / single instance (no
+> drain overlap), because there is no old pod to break." That escape clause does
+> not apply to this pipeline and must not be used.** The prod service does run at
+> `desiredCount 1`, but the hazard is not overlap: migrations complete in their own
+> earlier workflow step, before `update-service` is issued at all, so the old task
+> serves traffic against the migrated schema regardless of how many tasks there
+> are or what `minimumHealthyPercent` is set to. Only scaling the service to 0
+> *before* migrating would earn the collapse, and neither deploy workflow does
+> that. Concretely, collapsing them would 500 the **public** program catalog
+> (`GET /api/programs` via `PUBLIC_PROGRAM_SELECT`), `GET /api/programs/[id]`,
+> `nav/todo-counts`, and the lifecycle-reconcile cron for the length of that window.
 
 ## Shopify-side caveat (the plan is DB-only)
 
 Everything above is app + database. Nothing here archives/unpublishes the legacy
 two-variant Shopify **products** or voids carts already built against a legacy
-variant. After Release 1 removes the webhook matcher, a customer who still has a
-stale legacy cart open can complete checkout against a legacy variant and the
-paid order will not activate anything — a silent paid-but-stuck order. Low
-likelihood once legacy programs are retired, but if any legacy product is still
-purchasable, archive/unpublish it in Shopify as part of Release 1. Add to the
-cutover checklist.
+variant. Release 1 has removed the webhook matcher, so a customer still holding a
+stale legacy cart can now complete checkout against a legacy variant and the paid
+order will activate nothing — a silent paid-but-stuck order. Low likelihood once
+legacy programs are retired.
+
+**Still outstanding — #1464 did not do this.** If any legacy two-variant product
+is still purchasable on the store, archive/unpublish it in Shopify. This is a
+store-side action with no code change, so it is not gated on Release 2; do it now
+rather than waiting for the migration.
 
 ## Not in scope
 

--- a/checkin-app/shopify-live/product-inventory.shopify-live.ts
+++ b/checkin-app/shopify-live/product-inventory.shopify-live.ts
@@ -58,7 +58,7 @@ describe("live: single-pool product + inventory contract", () => {
     });
 
     it("adjustProgramInventory applies RELATIVE deltas (scholarship hold -1, release +1)", async () => {
-        const program = { shopifyVariantId: variantId, shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null };
+        const program = { shopifyVariantId: variantId };
         const variant = await getVariant(variantId);
 
         expect(await adjustProgramInventory(program, -1)).toBe(true);

--- a/checkin-app/src/app/__tests__/activateEnrollmentRedelivery.integration.test.ts
+++ b/checkin-app/src/app/__tests__/activateEnrollmentRedelivery.integration.test.ts
@@ -66,7 +66,7 @@ describe('activateProgramEnrollment — atomic collapse + redelivery no-op', () 
 
         // First activation (the paid webhook).
         const first = await activateProgramEnrollment({
-            programId, personIds: [personId], shopifyOrderId: 'order-redeliv-1', hasProgramItem: true, purchasedOrgMember: null,
+            programId, personIds: [personId], shopifyOrderId: 'order-redeliv-1', hasProgramItem: true,
         });
         expect(first).toEqual({ activatedCount: 1, releasedHoldCount: 1 });
 
@@ -86,7 +86,7 @@ describe('activateProgramEnrollment — atomic collapse + redelivery no-op', () 
 
         // Redelivery: same order arrives again. Guard finds the row already ACTIVE.
         const second = await activateProgramEnrollment({
-            programId, personIds: [personId], shopifyOrderId: 'order-redeliv-1', hasProgramItem: true, purchasedOrgMember: null,
+            programId, personIds: [personId], shopifyOrderId: 'order-redeliv-1', hasProgramItem: true,
         });
         expect(second).toEqual({ activatedCount: 0, releasedHoldCount: 0 }); // no double-activate, no double-release
         expect(mockAdjust).not.toHaveBeenCalled();                            // no double +1

--- a/checkin-app/src/app/__tests__/cronScholarshipGraceExpiry.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronScholarshipGraceExpiry.integration.test.ts
@@ -167,7 +167,7 @@ describe('Cron Scholarship-Grace-Expiry API Integration Tests', () => {
                 // Outside the window: auto-withdrawn (row gone) + released (+1 logged).
                 const outside = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId: ids.outside } } });
                 expect(outside).toBeNull();
-                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by 1 for variants: dev-mock-variant-grace-cron'));
+                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by 1 for variant: dev-mock-variant-grace-cron'));
 
                 const audit = await prisma.auditLog.findFirst({
                     where: { actorId: 0, tableName: 'ProgramParticipant', affectedEntityId: ids.outside, secondaryAffectedEntity: programId },

--- a/checkin-app/src/app/__tests__/enrollmentStateOracle.integration.test.ts
+++ b/checkin-app/src/app/__tests__/enrollmentStateOracle.integration.test.ts
@@ -148,7 +148,7 @@ describe('enrollment state — validator oracle over real transitions', () => {
     it('T4 activate (payment) from PENDING_HELD → ACTIVE, hold released', async () => {
         await seed({ req: true, held: true, den: false }); // PENDING_HELD
         const { activatedCount, releasedHoldCount } = await activateProgramEnrollment({
-            programId, personIds: [selfId], shopifyOrderId: 'order-oracle-1', hasProgramItem: true, purchasedOrgMember: null,
+            programId, personIds: [selfId], shopifyOrderId: 'order-oracle-1', hasProgramItem: true,
         });
         expect(activatedCount).toBe(1);
         expect(releasedHoldCount).toBe(1);
@@ -158,7 +158,7 @@ describe('enrollment state — validator oracle over real transitions', () => {
     it('T4 activate (payment) from PENDING_UNPAID → ACTIVE, no hold to release', async () => {
         await seed({ req: false, held: false, den: false }); // PENDING_UNPAID
         const { activatedCount, releasedHoldCount } = await activateProgramEnrollment({
-            programId, personIds: [selfId], shopifyOrderId: 'order-oracle-2', hasProgramItem: true, purchasedOrgMember: null,
+            programId, personIds: [selfId], shopifyOrderId: 'order-oracle-2', hasProgramItem: true,
         });
         expect(activatedCount).toBe(1);
         expect(releasedHoldCount).toBe(0);

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -490,7 +490,7 @@ describe('Program payment-plan routes', () => {
                     expect(data.warning).toBeUndefined();
 
                     expect(logSpy).toHaveBeenCalledWith(
-                        expect.stringContaining('Would adjust inventory by -1 for variants: dev-mock-variant-apply-pp'),
+                        expect.stringContaining('Would adjust inventory by -1 for variant: dev-mock-variant-apply-pp'),
                     );
                 } finally {
                     logSpy.mockRestore();

--- a/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
@@ -25,7 +25,6 @@ jest.mock('@/lib/notifications', () => ({
 }));
 // Avoid hitting the real Shopify API; the route tolerates a null result.
 jest.mock('@/lib/shopify', () => ({
-    createShopifyProgramVariants: jest.fn().mockResolvedValue(null),
     createShopifySingleVariantProgram: jest.fn().mockResolvedValue(null),
 }));
 

--- a/checkin-app/src/app/__tests__/programSyncShopifyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programSyncShopifyAPI.integration.test.ts
@@ -3,21 +3,14 @@
  */
 /**
  * Integration tests for POST /api/programs/[id]/sync-shopify — the checkout
- * repair path that mints Shopify variant(s) for a program that was priced AFTER
+ * repair path that mints a Shopify variant for a program that was priced AFTER
  * creation (PATCH never mints variants, so it sits checkout-broken). This was
  * the one fully-built-but-untested route in the program domain; webhookShopify
  * covers inbound MEMBERSHIP webhooks, not this outbound program-category sync.
  *
- * Single-pool transition (product decision 2026-07-06): a program with NO
- * legacy variant configured repairs onto the NEW single-variant model
- * (shopifyVariantId); a program already carrying one legacy variant repairs
- * via the LEGACY two-variant path (createShopifyProgramVariants), keeping the
- * matching set — see the route's own comment for why.
- *
  * Runs against the CHECKIN_ENV=local Shopify mock (config.shopifyMockActive) so
- * createShopifySingleVariantProgram/createShopifyProgramVariants return
- * synthetic dev-mock ids instead of hitting the real Admin API — same explicit
- * env gate PR #888 established.
+ * createShopifySingleVariantProgram returns synthetic dev-mock ids instead of
+ * hitting the real Admin API — same explicit env gate PR #888 established.
  *
  * NOTE (Q13): this route has NO empty/mis-categorized-category detection. An
  * IntegrationErrorLog row is written only inside the shopify.ts creation
@@ -114,8 +107,6 @@ describe('POST /api/programs/[id]/sync-shopify', () => {
         // Success contract: a product id + ONE variant id (single pool), echoed back...
         expect(data.program.shopifyProductId).toMatch(/^dev-mock-product-/);
         expect(data.program.shopifyVariantId).toMatch(/^dev-mock-variant-/);
-        expect(data.program.shopifyOrgMemberVariantId).toBeNull();
-        expect(data.program.shopifyNonOrgMemberVariantId).toBeNull();
 
         // ...and PERSISTED — this is what fails if the route stops upserting.
         const persisted = await prisma.program.findUnique({ where: { id: program.id } });
@@ -134,35 +125,9 @@ describe('POST /api/programs/[id]/sync-shopify', () => {
         expect(errLogsAfter).toBe(errLogsBefore);
     });
 
-    it('repairs a program already on the LEGACY model (one variant set) via the two-variant path', async () => {
-        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
-        // Already has ONE legacy variant (partial legacy state) -> still checkout-broken
-        // (the non-org tier has no variant) -> repairs via createShopifyProgramVariants,
-        // not the single-pool path.
-        const program = await prisma.program.create({
-            data: {
-                name: `Legacy Broken Prog ${TAG} ${Math.round(performance.now())}`,
-                phase: 'RUNNING',
-                orgMemberPriceCents: 5000,
-                nonOrgMemberPriceCents: 7500,
-                shopifyProductId: 'dev-mock-product-existing-legacy',
-                shopifyOrgMemberVariantId: 'dev-mock-variant-member-existing-legacy',
-            },
-        });
-
-        const res = await POST(req(), params(program.id));
-        expect(res.status).toBe(200);
-
-        const data = await res.json();
-        expect(data.success).toBe(true);
-        expect(data.program.shopifyVariantId).toBeNull();
-        expect(data.program.shopifyOrgMemberVariantId).toMatch(/^dev-mock-variant-member-/);
-        expect(data.program.shopifyNonOrgMemberVariantId).toMatch(/^dev-mock-variant-nonmember-/);
-    });
-
     it('refuses a program whose checkout is already configured (400)', async () => {
         (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
-        // Priced AND has both variants -> not broken.
+        // Priced AND has its variant -> not broken.
         const program = await prisma.program.create({
             data: {
                 name: `Configured Prog ${TAG}`,
@@ -170,8 +135,7 @@ describe('POST /api/programs/[id]/sync-shopify', () => {
                 orgMemberPriceCents: 5000,
                 nonOrgMemberPriceCents: 7500,
                 shopifyProductId: 'dev-mock-product-existing',
-                shopifyOrgMemberVariantId: 'dev-mock-variant-member-existing',
-                shopifyNonOrgMemberVariantId: 'dev-mock-variant-nonmember-existing',
+                shopifyVariantId: 'dev-mock-variant-existing',
             },
         });
 

--- a/checkin-app/src/app/__tests__/programVariantRoundtripShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programVariantRoundtripShopify.integration.test.ts
@@ -122,11 +122,8 @@ describe('Shopify variant round-trip: create -> persist -> webhook match', () =>
         expect(data.warning).toBeUndefined();
         programIds.push(data.program.id);
 
-        // Synthetic mock id, not a real Shopify product/variant. Single pool: no
-        // legacy org/non-org pair minted for a new program.
+        // Synthetic mock id, not a real Shopify product/variant.
         expect(data.program.shopifyVariantId).toMatch(/^dev-mock-variant-/);
-        expect(data.program.shopifyOrgMemberVariantId).toBeNull();
-        expect(data.program.shopifyNonOrgMemberVariantId).toBeNull();
 
         // Actually PERSISTED, not just echoed in the response.
         const persisted = await prisma.program.findUnique({ where: { id: data.program.id } });

--- a/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
@@ -158,9 +158,15 @@ describe('Programs API Integration Tests', () => {
              const programs = await res.json();
              const publicActive = programs.find((p: { name?: string }) => p.name === 'Public API Test Program');
 
+             // The legacy two-variant columns are still declared (and still
+             // classified 'public') but no route selects them any more — the
+             // schema fields and this exclusion both go away with the DROP COLUMN
+             // migration (docs/designs/975-LEGACY_VARIANT_CONTRACT.md, Release 2).
+             const DROPPED_SOON = ['shopifyOrgMemberVariantId', 'shopifyNonOrgMemberVariantId'];
              const publicColumns = Object.entries(classifications.Program)
                  .filter(([, tier]) => tier === 'public')
-                 .map(([field]) => field);
+                 .map(([field]) => field)
+                 .filter((field) => !DROPPED_SOON.includes(field));
 
              expect(publicActive).toBeDefined();
              expect(publicColumns).not.toHaveLength(0); // guard: a broken import would vacuously pass

--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -527,7 +527,7 @@ describe('Individual Program API Integration Tests', () => {
                     leadMentorId: leadId,
                     orgMemberPriceCents: 5000,
                     maxParticipants: 20,
-                    shopifyOrgMemberVariantId: 'dev-mock-variant-member-capacity',
+                    shopifyVariantId: 'dev-mock-variant-capacity',
                 },
             });
             cappedProgramId = capped.id;
@@ -539,7 +539,7 @@ describe('Individual Program API Integration Tests', () => {
                     leadMentorId: leadId,
                     orgMemberPriceCents: 5000,
                     maxParticipants: null,
-                    shopifyOrgMemberVariantId: 'dev-mock-variant-member-uncapped',
+                    shopifyVariantId: 'dev-mock-variant-uncapped',
                 },
             });
             uncappedProgramId = uncapped.id;

--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -400,7 +400,7 @@ describe('Program Participants API Integration Tests', () => {
                 expect(data.enrollment.status).toBe('ACTIVE'); // comp
                 expect(data.warning).toBeUndefined();
                 // The comp took a seat out of the Shopify pool: relative -1 on the variant.
-                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by -1 for variants: dev-mock-variant-comp-partic'));
+                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by -1 for variant: dev-mock-variant-comp-partic'));
                 // Comp is ACTIVE and NOT a hold: I1/I2/I3 keep inventoryHeldAt PENDING-only.
                 const row = await prisma.programParticipant.findUnique({
                     where: { programId_personId: { programId: shopifyProgram.id, personId: otherId } },
@@ -652,7 +652,7 @@ describe('Program Participants API Integration Tests', () => {
                 );
                 expect(res.status).toBe(200);
                 expect((await res.json()).warning).toBeUndefined();
-                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by 1 for variants: dev-mock-variant-withdraw-partic'));
+                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would adjust inventory by 1 for variant: dev-mock-variant-withdraw-partic'));
 
                 const row = await prisma.programParticipant.findUnique({
                     where: { programId_personId: { programId: shopifyProgram.id, personId: commonId } },

--- a/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/webhookShopify.integration.test.ts
@@ -59,11 +59,11 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
     let prevMembershipVariantId: string | null = null;
 
     beforeAll(async () => {
-        // shopifyNonOrgMemberVariantId is the variant the enroll flow's checkout
-        // link is built from — seed it so the guard under test has something to
-        // match line_items against.
+        // shopifyVariantId is the variant the enroll flow's checkout link is
+        // built from — seed it so the guard under test has something to match
+        // line_items against.
         const program = await prisma.program.create({
-            data: { name: `Webhook Test Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyNonOrgMemberVariantId: PROGRAM_VARIANT_ID },
+            data: { name: `Webhook Test Program ${TAG}`, enrollmentStatus: 'OPEN', shopifyVariantId: PROGRAM_VARIANT_ID },
         });
         programId = program.id;
 
@@ -340,150 +340,9 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
         expect(rows[0].context).toEqual({ operation: 'POST /api/webhooks/shopify' });
     });
 
-    // LEGACY-ONLY two-pool mirror (product decision 2026-07-06, single-pool
-    // redesign): the org-member/non-member variants each carry their OWN
-    // Shopify inventory pool. Shopify auto-decrements only the pool for the
-    // tier actually purchased, so the webhook mirrors the same drop onto the
-    // SIBLING pool after activation — but ONLY for programs still on this
-    // legacy model (no shopifyVariantId). See the 'single-pool model' describe
-    // block below for the new-model equivalent (no mirror needed).
-    describe('sibling inventory mirror after program activation (legacy two-variant programs)', () => {
-        let siblingProgramId: number;
-        let sp1: number;
-        let sp2: number;
-        let sh1: number;
-        let sh2: number;
-        const ORG_VARIANT_ID = '223344';
-        const NONORG_VARIANT_ID = '112233';
-
-        beforeAll(async () => {
-            const program = await prisma.program.create({
-                data: {
-                    name: `Webhook Sibling Test Program ${TAG}`,
-                    enrollmentStatus: 'OPEN',
-                    shopifyOrgMemberVariantId: ORG_VARIANT_ID,
-                    shopifyNonOrgMemberVariantId: NONORG_VARIANT_ID,
-                },
-            });
-            siblingProgramId = program.id;
-
-            const a = await prisma.person.create({
-                data: { name: 'Sib P1', email: `sib1-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
-            });
-            sp1 = a.id;
-            sh1 = a.householdId;
-            const b = await prisma.person.create({
-                data: { name: 'Sib P2', email: `sib2-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
-            });
-            sp2 = b.id;
-            sh2 = b.householdId;
-        });
-
-        afterAll(async () => {
-            await prisma.programParticipant.deleteMany({ where: { programId: siblingProgramId } });
-            await prisma.program.delete({ where: { id: siblingProgramId } });
-            await prisma.person.deleteMany({ where: { id: { in: [sp1, sp2] } } });
-            await prisma.household.deleteMany({ where: { id: { in: [sh1, sh2] } } });
-        });
-
-        async function setSiblingPending(participantId: number) {
-            await prisma.programParticipant.upsert({
-                where: { programId_personId: { programId: siblingProgramId, personId: participantId } },
-                update: { status: 'PENDING', pendingSince: new Date() },
-                create: { programId: siblingProgramId, personId: participantId, status: 'PENDING', pendingSince: new Date() },
-            });
-        }
-
-        function siblingPayload(accountIds: string, variantId: string) {
-            return JSON.stringify({
-                id: 777,
-                line_items: [{ variant_id: variantId }],
-                note_attributes: [
-                    { name: 'CheckMeIn_Account_ID', value: accountIds },
-                    { name: 'Program_ID', value: String(siblingProgramId) },
-                ],
-            });
-        }
-
-        it('mirrors the purchase onto the SIBLING pool after activating (Shopify already decremented the purchased pool)', async () => {
-            const prevEnv = process.env.CHECKIN_ENV;
-            // Arms config.shopifyMockActive() so adjustProgramInventory no-ops via a
-            // log line we can assert on, instead of a real Admin API call.
-            process.env.CHECKIN_ENV = 'local';
-            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-            try {
-                await setSiblingPending(sp1);
-                await setSiblingPending(sp2);
-                // Buys the NON-member tier for both participants in one order.
-                const body = siblingPayload(`${sp1},${sp2}`, NONORG_VARIANT_ID);
-
-                const res = await POST(webhookReq(body, sign(body)));
-                expect(res.status).toBe(200);
-
-                const rows = await prisma.programParticipant.findMany({
-                    where: { programId: siblingProgramId, personId: { in: [sp1, sp2] } },
-                });
-                expect(rows.every(r => r.status === 'ACTIVE')).toBe(true);
-
-                // Sibling = the ORG-member pool (the tier NOT purchased); delta = -2
-                // (both participants activated by this one order).
-                expect(logSpy).toHaveBeenCalledWith(
-                    expect.stringContaining(`Would adjust inventory by -2 for variants: ${ORG_VARIANT_ID}`),
-                );
-            } finally {
-                logSpy.mockRestore();
-                if (prevEnv === undefined) delete process.env.CHECKIN_ENV;
-                else process.env.CHECKIN_ENV = prevEnv;
-            }
-        });
-
-        it('does NOT re-fire the sibling mirror when the same order is redelivered (participant already ACTIVE)', async () => {
-            const prevEnv = process.env.CHECKIN_ENV;
-            process.env.CHECKIN_ENV = 'local';
-            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-            try {
-                await setSiblingPending(sp1);
-                const body = siblingPayload(String(sp1), NONORG_VARIANT_ID);
-
-                // First delivery activates and mirrors -1.
-                expect((await POST(webhookReq(body, sign(body)))).status).toBe(200);
-                const mirrorCalls = () => logSpy.mock.calls.filter(c =>
-                    String(c[0]).includes(`Would adjust inventory by -1 for variants: ${ORG_VARIANT_ID}`)).length;
-                expect(mirrorCalls()).toBe(1);
-
-                // Shopify redelivers the identical order (timeout / non-2xx retry):
-                // the participant is already ACTIVE, so no second -1 may fire.
-                expect((await POST(webhookReq(body, sign(body)))).status).toBe(200);
-                expect(mirrorCalls()).toBe(1);
-            } finally {
-                logSpy.mockRestore();
-                if (prevEnv === undefined) delete process.env.CHECKIN_ENV;
-                else process.env.CHECKIN_ENV = prevEnv;
-            }
-        });
-
-        it('activates the participant and still returns 200 even when the sibling inventory adjust fails', async () => {
-            // Default env here (no CHECKIN_ENV=local, no Shopify creds configured in
-            // this suite) — adjustProgramInventory's real "missing credentials" path
-            // returns false without throwing. Confirms the webhook never fails over an
-            // inventory call (a non-2xx would make Shopify retry the whole order).
-            await setSiblingPending(sp1);
-            const body = siblingPayload(String(sp1), NONORG_VARIANT_ID);
-
-            const res = await POST(webhookReq(body, sign(body)));
-            expect(res.status).toBe(200);
-
-            const row = await prisma.programParticipant.findUnique({
-                where: { programId_personId: { programId: siblingProgramId, personId: sp1 } },
-            });
-            expect(row?.status).toBe('ACTIVE');
-        });
-    });
-
-    // Single-pool model (product decision 2026-07-06): shopifyVariantId is
-    // matched alongside the legacy pair (transition), and activation needs NO
-    // mirror call at all — there's exactly one pool, and Shopify already
-    // auto-decremented it on the sale.
+    // Single-pool model (product decision 2026-07-06): activation needs NO
+    // inventory mirror call at all — there's exactly one pool, and Shopify
+    // already auto-decremented it on the sale.
     describe('single-pool model (shopifyVariantId)', () => {
         let singlePoolProgramId: number;
         let sgp1: number;
@@ -582,7 +441,7 @@ describe('POST /api/webhooks/shopify — negatives & idempotency', () => {
                 expect(row?.inventoryHeldAt).toBeNull(); // hold released
 
                 expect(logSpy).toHaveBeenCalledWith(
-                    expect.stringContaining(`Would adjust inventory by 1 for variants: ${SINGLE_VARIANT_ID}`),
+                    expect.stringContaining(`Would adjust inventory by 1 for variant: ${SINGLE_VARIANT_ID}`),
                 );
             } finally {
                 logSpy.mockRestore();

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/__tests__/route.integration.test.ts
@@ -44,11 +44,7 @@ function jsonReq(body?: unknown) {
 
 describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
     let originalFetch: typeof global.fetch;
-    let prevSettings: {
-        orgMembershipVariantId: string | null;
-        shopifyNormalVariantId: string | null;
-        shopifyVolunteerVariantId: string | null;
-    } | null;
+    let prevSettings: { orgMembershipVariantId: string | null } | null;
 
     async function wipe() {
         const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
@@ -76,7 +72,7 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
         await prisma.boardSettings.upsert({
             where: { id: 1 },
             create: { id: 1, orgMembershipVariantId: variantId },
-            update: { orgMembershipVariantId: variantId, shopifyNormalVariantId: null, shopifyVolunteerVariantId: null },
+            update: { orgMembershipVariantId: variantId },
         });
     }
 
@@ -99,13 +95,7 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
         for (const k of SHOPIFY_ENV_KEYS) delete process.env[k];
 
         const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-        prevSettings = existing
-            ? {
-                  orgMembershipVariantId: existing.orgMembershipVariantId,
-                  shopifyNormalVariantId: existing.shopifyNormalVariantId,
-                  shopifyVolunteerVariantId: existing.shopifyVolunteerVariantId,
-              }
-            : null;
+        prevSettings = existing ? { orgMembershipVariantId: existing.orgMembershipVariantId } : null;
         await wipe();
 
         global.fetch = jest.fn(async (input, init) => {
@@ -270,9 +260,14 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
             expect(row?.status).toBe('PENDING');
         });
 
-        it('200s, fires the real inbound webhook, and activates the PENDING participant (legacy variant)', async () => {
+        // The mock tool must echo the program's shopifyVariantId, or a fully
+        // configured program's local mock-pay flow 409s.
+        it('200s, fires the real inbound webhook, and activates the PENDING participant', async () => {
             asSession();
-            await prisma.program.update({ where: { id: programId }, data: { shopifyOrgMemberVariantId: 'dev-mock-variant-route-program-test' } });
+            await prisma.program.update({
+                where: { id: programId },
+                data: { shopifyVariantId: 'dev-mock-variant-route-program-test' },
+            });
             await prisma.programParticipant.create({
                 data: { programId, personId, status: 'PENDING', pendingSince: new Date() },
             });
@@ -283,29 +278,6 @@ describe('POST /api/dev/shopify/orders-paid (dev mock)', () => {
             expect(body).toEqual({ ok: true, participants: [{ personId, status: 'ACTIVE' }] });
 
             // The real proof: the webhook actually ran end-to-end and mutated the DB.
-            const row = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId } } });
-            expect(row?.status).toBe('ACTIVE');
-            expect(row?.pendingSince).toBeNull();
-        });
-
-        // Single-pool model (product decision 2026-07-06): the mock tool must
-        // echo shopifyVariantId too, or every new-model program's local mock-pay
-        // flow 409s despite being fully configured.
-        it('200s, fires the real inbound webhook, and activates the PENDING participant (single-pool variant)', async () => {
-            asSession();
-            await prisma.program.update({
-                where: { id: programId },
-                data: { shopifyOrgMemberVariantId: null, shopifyVariantId: 'dev-mock-variant-single-pool-route-test' },
-            });
-            await prisma.programParticipant.create({
-                data: { programId, personId, status: 'PENDING', pendingSince: new Date() },
-            });
-
-            const res = await POST(jsonReq({ programId, participantIds: [personId] }));
-            expect(res.status).toBe(200);
-            const body = await res.json();
-            expect(body).toEqual({ ok: true, participants: [{ personId, status: 'ACTIVE' }] });
-
             const row = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId } } });
             expect(row?.status).toBe('ACTIVE');
             expect(row?.pendingSince).toBeNull();

--- a/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
+++ b/checkin-app/src/app/api/dev/shopify/orders-paid/route.ts
@@ -75,7 +75,7 @@ async function fireMembership(processId: number): Promise<NextResponse> {
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
     // Mock stands in for the manual BoardSettings variant a local seed never sets;
     // the inbound handler echoes the same fallback so the order matches (config).
-    const variantId = settings?.orgMembershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId ?? DEV_MOCK_MEMBERSHIP_VARIANT_ID;
+    const variantId = settings?.orgMembershipVariantId ?? DEV_MOCK_MEMBERSHIP_VARIANT_ID;
 
     // Shape mirrors the subset the inbound handler reads: note_attributes (where
     // Shopify maps cart attributes) + line_items + an order id. Stable id so two
@@ -120,15 +120,14 @@ async function fireProgram(programId: number, rawParticipantIds: unknown): Promi
 
     // Mirror the membership variant echo: the program branch of the inbound
     // handler fails CLOSED unless the paid order's line_items contain one of the
-    // program's own Shopify variant ids (webhooks/shopify/route.ts). Program has a
+    // program's own Shopify variant id (webhooks/shopify/route.ts). Program has a
     // price (that's how the participant reached PENDING) but the variant may still
-    // be unset. Single-pool model (product decision 2026-07-06): shopifyVariantId
-    // takes priority — new programs never populate the legacy pair.
+    // be unset.
     const program = await prisma.program.findUnique({
         where: { id: programId },
-        select: { shopifyVariantId: true, shopifyOrgMemberVariantId: true, shopifyNonOrgMemberVariantId: true },
+        select: { shopifyVariantId: true },
     });
-    const variantId = program?.shopifyVariantId ?? program?.shopifyOrgMemberVariantId ?? program?.shopifyNonOrgMemberVariantId;
+    const variantId = program?.shopifyVariantId;
     if (!variantId) {
         return apiError("No Shopify variant configured on this program. Set one on the program in program-ops first, or the webhook leaves the participant PENDING.", 409);
     }

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -156,7 +156,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
 
         const body = await req.json();
         let { leadMentorId } = body;
-        const { name, startAt, endAt, orgMemberOnly, announceOnOpen, phase, enrollmentStatus, minAge, maxAge, maxParticipants, leadMentorNotificationSettings, memberPrice, nonMemberPrice, shopifyProductId, shopifyVariantId, shopifyOrgMemberVariantId, shopifyNonOrgMemberVariantId } = body;
+        const { name, startAt, endAt, orgMemberOnly, announceOnOpen, phase, enrollmentStatus, minAge, maxAge, maxParticipants, leadMentorNotificationSettings, memberPrice, nonMemberPrice, shopifyProductId, shopifyVariantId } = body;
 
         if (body.hasOwnProperty('leadMentorId')) {
             if (!leadMentorId) {
@@ -194,8 +194,6 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
             // no live Shopify to sync against (local/testing).
             ...(isSysAdminOrBoard && shopifyProductId !== undefined && { shopifyProductId: shopifyProductId || null }),
             ...(isSysAdminOrBoard && shopifyVariantId !== undefined && { shopifyVariantId: shopifyVariantId || null }),
-            ...(isSysAdminOrBoard && shopifyOrgMemberVariantId !== undefined && { shopifyOrgMemberVariantId: shopifyOrgMemberVariantId || null }),
-            ...(isSysAdminOrBoard && shopifyNonOrgMemberVariantId !== undefined && { shopifyNonOrgMemberVariantId: shopifyNonOrgMemberVariantId || null }),
         };
 
         const updatedProgram = await prisma.program.update({
@@ -230,7 +228,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
         let warning: string | undefined;
         const oldMax = currentProgram.maxParticipants;
         const newMax = updatedProgram.maxParticipants;
-        const hasShopifyVariant = !!(updatedProgram.shopifyVariantId || updatedProgram.shopifyOrgMemberVariantId || updatedProgram.shopifyNonOrgMemberVariantId);
+        const hasShopifyVariant = !!updatedProgram.shopifyVariantId;
 
         if (oldMax !== newMax && hasShopifyVariant) {
             if (oldMax !== null && newMax !== null) {

--- a/checkin-app/src/app/api/programs/[id]/sync-shopify/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/sync-shopify/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
-import { createShopifyProgramVariants, createShopifySingleVariantProgram } from "@/lib/shopify";
+import { createShopifySingleVariantProgram } from "@/lib/shopify";
 import { isProgramCheckoutBroken } from "@/lib/programCheckout";
 import { logBackendError } from "@/lib/logger";
 import { apiError } from "@/lib/api-response";
@@ -10,20 +10,6 @@ import { apiError } from "@/lib/api-response";
 // program-create (api/programs POST) can't reach but a later price edit
 // (api/programs/[id] PATCH) can, since PATCH never mints variants. Mirrors the
 // creation call so the dev/local mock branch (config.shopifyMockActive) works too.
-//
-// Single-pool transition: a program already carrying ONE of the legacy
-// org/non-org variant ids is mid-flight on the OLD model (or was created
-// before the single-pool switch) — repair it the same way (both legacy
-// columns, keeping the matching one). A program with NEITHER legacy column set
-// is either new or never got that far — repair it onto the single-pool model
-// instead, writing shopifyVariantId.
-//
-// ponytail: the legacy branch recreates the whole product+variants and
-// overwrites all IDs. For the common prod case (made free, then priced → no
-// product at all) that's exactly right. For the rarer partial case (one
-// variant exists, the other tier was added later) it orphans the old product.
-// Upgrade to patching only the missing variant onto the existing product if
-// partial repair ever matters.
 export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (_req, auth, ctx: { params: Promise<{ id: string }> }) => {
     if (auth.type !== 'session') return apiError("Unauthorized", 401);
     const { id } = await ctx.params;
@@ -37,35 +23,13 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
     }
 
     try {
-        const isLegacy = !!(program.shopifyOrgMemberVariantId || program.shopifyNonOrgMemberVariantId);
-
-        let updateData: { shopifyProductId: string; shopifyOrgMemberVariantId: string | null; shopifyNonOrgMemberVariantId: string | null }
-            | { shopifyProductId: string; shopifyVariantId: string }
-            | null = null;
-
-        if (isLegacy) {
-            const shopifyData = await createShopifyProgramVariants(
-                program.name,
-                program.orgMemberPriceCents,
-                program.nonOrgMemberPriceCents,
-                program.maxParticipants,
-            );
-            if (shopifyData) {
-                updateData = {
-                    shopifyProductId: shopifyData.shopifyProductId,
-                    shopifyOrgMemberVariantId: shopifyData.shopifyOrgMemberVariantId,
-                    shopifyNonOrgMemberVariantId: shopifyData.shopifyNonOrgMemberVariantId,
-                };
-            }
-        } else {
-            const basePriceCents = program.nonOrgMemberPriceCents ?? program.orgMemberPriceCents ?? null;
-            const shopifyData = basePriceCents
-                ? await createShopifySingleVariantProgram(program.name, basePriceCents, program.maxParticipants)
-                : null;
-            if (shopifyData) {
-                updateData = { shopifyProductId: shopifyData.shopifyProductId, shopifyVariantId: shopifyData.shopifyVariantId };
-            }
-        }
+        const basePriceCents = program.nonOrgMemberPriceCents ?? program.orgMemberPriceCents ?? null;
+        const shopifyData = basePriceCents
+            ? await createShopifySingleVariantProgram(program.name, basePriceCents, program.maxParticipants)
+            : null;
+        const updateData = shopifyData
+            ? { shopifyProductId: shopifyData.shopifyProductId, shopifyVariantId: shopifyData.shopifyVariantId }
+            : null;
 
         if (!updateData) {
             return apiError("Shopify sync failed or is not configured. Check Shopify credentials.", 502);

--- a/checkin-app/src/app/api/programs/__tests__/programsCreateDate.test.ts
+++ b/checkin-app/src/app/api/programs/__tests__/programsCreateDate.test.ts
@@ -21,7 +21,6 @@ jest.mock('@/lib/notifications', () => ({
 }));
 
 jest.mock('@/lib/shopify', () => ({
-    createShopifyProgramVariants: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('@/lib/logger', () => ({
@@ -72,8 +71,6 @@ describe('POST /api/programs — startAt/endAt date preservation', () => {
             phase: 'PLANNING',
             enrollmentStatus: 'CLOSED',
             shopifyProductId: null,
-            shopifyOrgMemberVariantId: null,
-            shopifyNonOrgMemberVariantId: null,
         };
         mockProgramCreate.mockResolvedValue(createdProgram);
 
@@ -156,8 +153,6 @@ describe('POST /api/programs — startAt/endAt date preservation', () => {
             phase: 'PLANNING',
             enrollmentStatus: 'CLOSED',
             shopifyProductId: null,
-            shopifyOrgMemberVariantId: null,
-            shopifyNonOrgMemberVariantId: null,
         };
         mockProgramCreate.mockResolvedValue(createdProgram);
 

--- a/checkin-app/src/app/api/programs/route.ts
+++ b/checkin-app/src/app/api/programs/route.ts
@@ -35,8 +35,6 @@ const PUBLIC_PROGRAM_SELECT = {
     orgMemberPriceCents: true,
     nonOrgMemberPriceCents: true,
     shopifyProductId: true,
-    shopifyOrgMemberVariantId: true,
-    shopifyNonOrgMemberVariantId: true,
     shopifyVariantId: true,
 } as const;
 
@@ -199,11 +197,9 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         const nmPrice = dollarsToCentsOrNull(nonMemberPrice != null ? String(nonMemberPrice) : undefined);
 
         // Single-pool model (product decision 2026-07-06): ONE Shopify variant,
-        // priced at the base/non-member rate — replaces the two-variant model for
-        // NEW program creation going forward (legacy programs keep working via
-        // the columns createShopifyProgramVariants still writes; see
-        // sync-shopify's repair route). ponytail: falls back to the member price
-        // only when no non-member price is set (e.g. a members-only-priced
+        // priced at the base/non-member rate; member pricing is a checkout-time
+        // discount code, not a second variant. ponytail: falls back to the member
+        // price only when no non-member price is set (e.g. a members-only-priced
         // program with no listed non-member tier) — normally sells at the
         // non-member/base rate per the design.
         const basePriceCents = nmPrice ?? mPrice ?? null;

--- a/checkin-app/src/app/api/webhooks/shopify/route.ts
+++ b/checkin-app/src/app/api/webhooks/shopify/route.ts
@@ -117,8 +117,6 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                 const membershipVariantIds = new Set(
                     [
                         settings?.orgMembershipVariantId,
-                        settings?.shopifyNormalVariantId,
-                        settings?.shopifyVolunteerVariantId,
                         // Local mock's self-fired order carries this synthetic id (config).
                         config.shopifyMockActive() ? DEV_MOCK_MEMBERSHIP_VARIANT_ID : null,
                     ].filter((v): v is string => !!v),
@@ -167,25 +165,9 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                 // built from — not order total. Fail CLOSED: no variant
                 // configured on the Program, or
                 // no line-item match, means we do NOT activate.
-                // Single-pool model (product decision 2026-07-06): shopifyVariantId,
-                // when set, is matched alongside the legacy pair during the
-                // transition — old programs never get shopifyVariantId, new ones
-                // never get the legacy pair, so this is additive, not a widening
-                // of what any one program accepts.
                 const program = await prisma.program.findUnique({ where: { id: programId } });
-                const programVariantIds = new Set(
-                    [program?.shopifyVariantId, program?.shopifyOrgMemberVariantId, program?.shopifyNonOrgMemberVariantId].filter(
-                        (v): v is string => !!v,
-                    ),
-                );
-                const hasProgramItem = (order.line_items ?? []).some((li) => programVariantIds.has(String(li.variant_id)));
-
-                // Which tier Shopify actually sold — needed for the legacy two-pool
-                // sibling-inventory mirror. buildShopifyCheckoutUrl fixes ONE variant per
-                // order (one household = one tier per checkout), so if hasProgramItem
-                // matched and this is false, the non-member tier is the one purchased.
-                const purchasedOrgMember = !!program?.shopifyOrgMemberVariantId &&
-                    (order.line_items ?? []).some((li) => String(li.variant_id) === program.shopifyOrgMemberVariantId);
+                const hasProgramItem = !!program?.shopifyVariantId &&
+                    (order.line_items ?? []).some((li) => String(li.variant_id) === program.shopifyVariantId);
 
                 // Shared choke point — same path the reconciler uses to recover a
                 // MISSED webhook (lib/programs/activateEnrollment). Idempotent; the
@@ -195,7 +177,6 @@ export const POST = withWebhook({ provider: "shopify", verify: verifyShopifyHmac
                     personIds: participantIds,
                     shopifyOrderId: order.id ? String(order.id) : "",
                     hasProgramItem,
-                    purchasedOrgMember,
                 });
 
                 outcome = `program ${programId}: activated ${activatedCount} of ${participantIds.length} participant(s)`;

--- a/checkin-app/src/app/dev/shopify/page.tsx
+++ b/checkin-app/src/app/dev/shopify/page.tsx
@@ -25,7 +25,7 @@ export default async function DevShopifyPage() {
 
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
     // Mock synthesizes a membership variant (config), so the fire tool is always usable on local.
-    const hasVariant = config.shopifyMockActive() || !!(settings?.orgMembershipVariantId ?? settings?.shopifyNormalVariantId ?? settings?.shopifyVolunteerVariantId);
+    const hasVariant = config.shopifyMockActive() || !!settings?.orgMembershipVariantId;
 
     const pendingParticipants = await prisma.programParticipant.findMany({
         where: { status: "PENDING", person: LIVE_PERSON },
@@ -34,7 +34,7 @@ export default async function DevShopifyPage() {
             personId: true,
             person: { select: { name: true } },
             program: {
-                select: { id: true, name: true, shopifyVariantId: true, shopifyOrgMemberVariantId: true, shopifyNonOrgMemberVariantId: true },
+                select: { id: true, name: true, shopifyVariantId: true },
             },
         },
     });
@@ -52,7 +52,7 @@ export default async function DevShopifyPage() {
                 programName: pp.program.name,
                 personId: pp.personId,
                 personName: pp.person.name ?? `Person #${pp.personId}`,
-                hasVariant: !!(pp.program.shopifyVariantId ?? pp.program.shopifyOrgMemberVariantId ?? pp.program.shopifyNonOrgMemberVariantId),
+                hasVariant: !!pp.program.shopifyVariantId,
             }))}
         />
     );

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -44,8 +44,7 @@ export type ProgramDetail = {
   orgMemberPriceCents: number | null;
   nonOrgMemberPriceCents: number | null;
   shopifyProductId: string | null;
-  shopifyOrgMemberVariantId: string | null;
-  shopifyNonOrgMemberVariantId: string | null;
+  shopifyVariantId: string | null;
 };
 
 export type ParticipantOption = { id: number; name: string | null; email: string; dateOfBirth?: string | null };
@@ -81,8 +80,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
   // Shopify identifiers, editable by sysadmin/board only (manual repair when
   // there's no live Shopify to sync against).
   const [shopifyProductIdInput, setShopifyProductIdInput] = useState("");
-  const [orgVariantInput, setOrgVariantInput] = useState("");
-  const [nonOrgVariantInput, setNonOrgVariantInput] = useState("");
+  const [variantInput, setVariantInput] = useState("");
 
   // EntityPicker owns the transient query/results/loading; we keep only the selected id + its display label.
   const [mentorSearch, setMentorSearch] = useState("");
@@ -115,8 +113,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
         setNonMemberPrice(data.nonOrgMemberPriceCents !== null ? String(data.nonOrgMemberPriceCents / 100) : "");
         setMentorSearch(data.leadMentor ? `${data.leadMentor.name || 'Unnamed'} (${data.leadMentor.email})` : "");
         setShopifyProductIdInput(data.shopifyProductId ?? "");
-        setOrgVariantInput(data.shopifyOrgMemberVariantId ?? "");
-        setNonOrgVariantInput(data.shopifyNonOrgMemberVariantId ?? "");
+        setVariantInput(data.shopifyVariantId ?? "");
         setIsEditingMentor(false);
       } else if (res.status === 404) {
         setMessage("Program not found.");
@@ -185,8 +182,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           shopifyProductId: shopifyProductIdInput || null,
-          shopifyOrgMemberVariantId: orgVariantInput || null,
-          shopifyNonOrgMemberVariantId: nonOrgVariantInput || null,
+          shopifyVariantId: variantInput || null,
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -333,14 +329,14 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                   <Card withBorder radius="md" padding="md">
                     <Text fw={500} mb={4}>Shopify Checkout Identifiers</Text>
                     <Text size="xs" c="dimmed" mb="sm">
-                      Admin/Board only. A priced tier needs its variant ID or paid enrollment can&apos;t check out.
+                      Admin/Board only. A priced program needs its variant ID or paid enrollment can&apos;t check out.
+                      One variant covers both tiers — member pricing is a discount code applied at checkout.
                       Set these manually here (e.g. local/testing where there is no live Shopify), or use “Sync to Shopify” above to create them.
                     </Text>
                     <SimpleGrid cols={{ base: 1, sm: 2 }}>
-                      <TextInput label="Member Variant ID" value={orgVariantInput} onChange={e => setOrgVariantInput(e.currentTarget.value)} placeholder="e.g. 40123456789" />
-                      <TextInput label="Non-Member Variant ID" value={nonOrgVariantInput} onChange={e => setNonOrgVariantInput(e.currentTarget.value)} placeholder="e.g. 40123456790" />
+                      <TextInput label="Variant ID" value={variantInput} onChange={e => setVariantInput(e.currentTarget.value)} placeholder="e.g. 40123456789" />
+                      <TextInput label="Product ID (optional)" value={shopifyProductIdInput} onChange={e => setShopifyProductIdInput(e.currentTarget.value)} placeholder="e.g. 80123456789" />
                     </SimpleGrid>
-                    <TextInput mt="sm" label="Product ID (optional)" value={shopifyProductIdInput} onChange={e => setShopifyProductIdInput(e.currentTarget.value)} placeholder="e.g. 80123456789" />
                     <Group mt="sm">
                       <Button type="button" variant="light" size="xs" loading={syncing} onClick={handleSaveShopifyIds}>
                         Save Shopify IDs

--- a/checkin-app/src/app/program-ops/programs/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/page.tsx
@@ -19,8 +19,6 @@ type Program = {
   orgMemberPriceCents?: number | null;
   nonOrgMemberPriceCents?: number | null;
   shopifyVariantId?: string | null;
-  shopifyOrgMemberVariantId?: string | null;
-  shopifyNonOrgMemberVariantId?: string | null;
   _count?: { participants?: number; events?: number };
 };
 

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -59,8 +59,7 @@ function baseProgram(overrides: Record<string, unknown> = {}) {
         enrollmentStatus: "OPEN",
         orgMemberPriceCents: null,
         nonOrgMemberPriceCents: null,
-        shopifyOrgMemberVariantId: null,
-        shopifyNonOrgMemberVariantId: null,
+        shopifyVariantId: null,
         minAge: 5,
         maxAge: 18,
         ...overrides,
@@ -237,7 +236,7 @@ describe("ProgramEnrollmentPage", () => {
             expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({
                 color: "red",
                 autoClose: false,
-                message: "Cannot enroll: no pricing variant set for this program tier — set one in program-ops.",
+                message: "Cannot enroll: no pricing variant set for this program — set one in program-ops.",
             })),
         );
         expect(fetchMock).not.toHaveBeenCalledWith("/api/programs/10/participants", expect.anything());
@@ -479,13 +478,13 @@ describe("ProgramEnrollmentPage", () => {
         );
     });
 
-    it("redirects to Shopify checkout for a priced enrollment with a configured member variant", async () => {
+    it("redirects to Shopify checkout for a priced enrollment with a configured variant", async () => {
         setSession({ id: 101 });
         setShopifyStoreDomain("shop.example.com"); // redirect requires a store domain
         const memberHousehold = { household: { ...household.household, orgMembership: { status: "ACTIVE" } } };
         mockFetchJson({
             "/api/household": memberHousehold,
-            "/api/programs/10": baseProgram({ orgMemberPriceCents: 5000, minAge: null, maxAge: null, shopifyOrgMemberVariantId: "gid://member", shopifyNonOrgMemberVariantId: "gid://nonmember" }),
+            "/api/programs/10": baseProgram({ orgMemberPriceCents: 5000, minAge: null, maxAge: null, shopifyVariantId: "gid://variant" }),
             "/api/programs/10/participants": { ok: true },
         });
         renderPage();
@@ -509,7 +508,7 @@ describe("ProgramEnrollmentPage", () => {
             "/api/household": memberHousehold,
             "/api/programs/10": baseProgram({
                 orgMemberPriceCents: 4000, nonOrgMemberPriceCents: 5000, minAge: null, maxAge: null,
-                shopifyVariantId: "gid://single-pool", shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+                shopifyVariantId: "gid://single-pool",
             }),
             "/api/programs/10/participants": { ok: true },
         });
@@ -544,7 +543,7 @@ describe("ProgramEnrollmentPage", () => {
             "/api/programs/10": baseProgram({
                 participants: [{ personId: 101, status: "PENDING" }],
                 orgMemberPriceCents: 4000, nonOrgMemberPriceCents: 5000, minAge: null, maxAge: null,
-                shopifyVariantId: "gid://single-pool", shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+                shopifyVariantId: "gid://single-pool",
             }),
             "/api/programs/10/participants": () => ({ error: "Participant is already enrolled in this program." }),
         });
@@ -576,26 +575,6 @@ describe("ProgramEnrollmentPage", () => {
         );
     });
 
-    it("does NOT fetch a discount code for a legacy two-variant program", async () => {
-        setSession({ id: 101 });
-        setShopifyStoreDomain("shop.example.com");
-        const memberHousehold = { household: { ...household.household, orgMembership: { status: "ACTIVE" } } };
-        const fetchMock = mockFetchJson({
-            "/api/household": memberHousehold,
-            "/api/programs/10": baseProgram({ orgMemberPriceCents: 5000, minAge: null, maxAge: null, shopifyOrgMemberVariantId: "gid://member", shopifyNonOrgMemberVariantId: "gid://nonmember" }),
-            "/api/programs/10/participants": { ok: true },
-        });
-        renderPage();
-        await screen.findByText("Robotics Club");
-        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
-        await screen.findByText("Which of your household wants to enroll?");
-        await selectMember("Kid One");
-        fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
-
-        await screen.findByText("Redirecting to Shopify for secure payment...");
-        expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/discount-code"))).toBe(false);
-    });
-
     // Membership-duration guard: pricing decisions use the server-computed
     // viewerMemberPricingEligible flag over the household-status-derived isMember,
     // so a current member not covered through the program's end doesn't get the
@@ -608,7 +587,7 @@ describe("ProgramEnrollmentPage", () => {
             "/api/household": memberHousehold,
             "/api/programs/10": baseProgram({
                 orgMemberPriceCents: 4000, nonOrgMemberPriceCents: 5000, minAge: null, maxAge: null,
-                shopifyVariantId: "gid://single-pool", shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+                shopifyVariantId: "gid://single-pool",
                 viewerIsMember: true, viewerMemberPricingEligible: false,
             }),
             "/api/programs/10/participants": { ok: true },

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -31,13 +31,10 @@ type ProgramDetail = {
   enrollmentStatus: string;
   orgMemberPriceCents: number | null;
   nonOrgMemberPriceCents: number | null;
-  // Single-pool model (product decision 2026-07-06): when set, this is the
-  // ONE variant for both tiers — member pricing comes from a checkout-time
-  // discount code (see handleEnroll), not a separate variant. Legacy programs
-  // leave this null and keep using the pair below.
+  // Single-pool model (product decision 2026-07-06): the ONE variant for both
+  // tiers — member pricing comes from a checkout-time discount code (see
+  // handleEnroll), not a separate variant.
   shopifyVariantId: string | null;
-  shopifyOrgMemberVariantId: string | null;
-  shopifyNonOrgMemberVariantId: string | null;
   minAge: number | null;
   maxAge: number | null;
   orgMemberOnly: boolean;
@@ -274,15 +271,15 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
           isMember = householdData.household?.orgMembership?.status === "ACTIVE" || false;
         }
         pricingEligible = program.viewerMemberPricingEligible ?? isMember;
-        // Single-pool programs sell the SAME variant to everyone — the discount
-        // code (below, at redirect time) does the member pricing, not a variant pick.
-        variantId = program.shopifyVariantId || (pricingEligible ? program.shopifyOrgMemberVariantId : program.shopifyNonOrgMemberVariantId);
+        // Every program sells the SAME variant to everyone — the discount code
+        // (below, at redirect time) does the member pricing, not a variant pick.
+        variantId = program.shopifyVariantId;
         storeDomain = shopifyStoreDomain ?? undefined;
         mockPay = isLocalInstance;
         if (!variantId || (!mockPay && !storeDomain)) {
           notifications.show({ color: "red", autoClose: false, message: variantId
             ? "Cannot enroll: Shopify store domain not configured. Contact an admin."
-            : "Cannot enroll: no pricing variant set for this program tier — set one in program-ops." });
+            : "Cannot enroll: no pricing variant set for this program — set one in program-ops." });
           return; // no enrollment created — payment path is broken
         }
       }

--- a/checkin-app/src/lib/__tests__/programCheckout.test.ts
+++ b/checkin-app/src/lib/__tests__/programCheckout.test.ts
@@ -3,70 +3,38 @@ import { isProgramCheckoutBroken, PROGRAM_CHECKOUT_BROKEN_WHERE } from "@/lib/pr
 describe("isProgramCheckoutBroken", () => {
   it("free program (no prices) is never broken", () => {
     expect(isProgramCheckoutBroken({
-      orgMemberPriceCents: null, nonOrgMemberPriceCents: null,
-      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
-    })).toBe(false);
-  });
-
-  it("both tiers priced with both variants is not broken", () => {
-    expect(isProgramCheckoutBroken({
-      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 8000,
-      shopifyOrgMemberVariantId: "gid-1", shopifyNonOrgMemberVariantId: "gid-2",
-    })).toBe(false);
-  });
-
-  it("priced org tier with a null org variant is broken", () => {
-    expect(isProgramCheckoutBroken({
-      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: null,
-      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
-    })).toBe(true);
-  });
-
-  it("priced non-org tier with a null non-org variant is broken", () => {
-    expect(isProgramCheckoutBroken({
-      orgMemberPriceCents: null, nonOrgMemberPriceCents: 8000,
-      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
-    })).toBe(true);
-  });
-
-  it("partial: org configured, non-org priced but missing its variant is broken", () => {
-    expect(isProgramCheckoutBroken({
-      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 8000,
-      shopifyOrgMemberVariantId: "gid-1", shopifyNonOrgMemberVariantId: null,
-    })).toBe(true);
-  });
-
-  it("a missing variant on a FREE tier does not flag (gate on price > 0)", () => {
-    // Org tier free (null price) with no org variant, non-org fully configured.
-    expect(isProgramCheckoutBroken({
-      orgMemberPriceCents: null, nonOrgMemberPriceCents: 8000,
-      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: "gid-2",
+      orgMemberPriceCents: null, nonOrgMemberPriceCents: null, shopifyVariantId: null,
     })).toBe(false);
   });
 
   it("zero price is treated as free, not broken", () => {
     expect(isProgramCheckoutBroken({
-      orgMemberPriceCents: 0, nonOrgMemberPriceCents: 0,
-      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+      orgMemberPriceCents: 0, nonOrgMemberPriceCents: 0, shopifyVariantId: null,
     })).toBe(false);
   });
 
-  // Single-pool model (product decision 2026-07-06): shopifyVariantId alone
-  // covers both tiers — never flag broken when it's set, regardless of the
-  // legacy pair's state.
-  it("shopifyVariantId set covers both priced tiers — not broken", () => {
+  // One variant covers both tiers — member pricing is a checkout-time discount code.
+  it("both tiers priced with the variant set is not broken", () => {
     expect(isProgramCheckoutBroken({
-      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 8000,
-      shopifyVariantId: "single-pool-gid",
-      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 8000, shopifyVariantId: "gid-1",
     })).toBe(false);
   });
 
-  it("a priced program with neither shopifyVariantId nor a legacy variant is broken", () => {
+  it("a priced program with no variant is broken", () => {
     expect(isProgramCheckoutBroken({
-      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 8000,
-      shopifyVariantId: null,
-      shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
+      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: 8000, shopifyVariantId: null,
+    })).toBe(true);
+  });
+
+  it("a priced org tier alone with no variant is broken", () => {
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: 5000, nonOrgMemberPriceCents: null, shopifyVariantId: null,
+    })).toBe(true);
+  });
+
+  it("a priced non-org tier alone with no variant is broken", () => {
+    expect(isProgramCheckoutBroken({
+      orgMemberPriceCents: null, nonOrgMemberPriceCents: 8000, shopifyVariantId: null,
     })).toBe(true);
   });
 });
@@ -81,8 +49,6 @@ type Row = {
   orgMemberPriceCents: number | null;
   nonOrgMemberPriceCents: number | null;
   shopifyVariantId: string | null;
-  shopifyOrgMemberVariantId: string | null;
-  shopifyNonOrgMemberVariantId: string | null;
 };
 
 /**
@@ -117,19 +83,12 @@ describe("PROGRAM_CHECKOUT_BROKEN_WHERE agrees with isProgramCheckoutBroken", ()
     for (const orgMemberPriceCents of PRICES) {
       for (const nonOrgMemberPriceCents of PRICES) {
         for (const shopifyVariantId of VARIANTS) {
-          for (const shopifyOrgMemberVariantId of VARIANTS) {
-            for (const shopifyNonOrgMemberVariantId of VARIANTS) {
-              const row: Row = {
-                orgMemberPriceCents, nonOrgMemberPriceCents, shopifyVariantId,
-                shopifyOrgMemberVariantId, shopifyNonOrgMemberVariantId,
-              };
-              const query = whereMatches(
-                PROGRAM_CHECKOUT_BROKEN_WHERE as Record<string, unknown>,
-                row,
-              );
-              expect({ row, broken: query }).toEqual({ row, broken: isProgramCheckoutBroken(row) });
-            }
-          }
+          const row: Row = { orgMemberPriceCents, nonOrgMemberPriceCents, shopifyVariantId };
+          const query = whereMatches(
+            PROGRAM_CHECKOUT_BROKEN_WHERE as Record<string, unknown>,
+            row,
+          );
+          expect({ row, broken: query }).toEqual({ row, broken: isProgramCheckoutBroken(row) });
         }
       }
     }

--- a/checkin-app/src/lib/__tests__/shopify.test.ts
+++ b/checkin-app/src/lib/__tests__/shopify.test.ts
@@ -1,4 +1,4 @@
-import { createShopifyProgramVariants, createShopifySingleVariantProgram, adjustProgramInventory, mintMemberDiscountCode, resetTokenCache } from '../shopify';
+import { createShopifySingleVariantProgram, adjustProgramInventory, mintMemberDiscountCode, resetTokenCache } from '../shopify';
 import { sendEmail } from '../email';
 import prisma from '../prisma';
 
@@ -28,369 +28,11 @@ function mockTokenResponse(fetchMock: jest.Mock) {
     });
 }
 
-describe('createShopifyProgramVariants', () => {
-    let originalEnv: NodeJS.ProcessEnv;
-    let fetchMock: jest.Mock;
-
-    beforeEach(() => {
-        originalEnv = { ...process.env };
-        process.env.SHOPIFY_STORE_DOMAIN = 'test.myshopify.com';
-        process.env.SHOPIFY_CLIENT_ID = 'test_client_id';
-        process.env.SHOPIFY_CLIENT_SECRET = 'test_client_secret';
-
-        fetchMock = jest.fn();
-        global.fetch = fetchMock;
-
-        jest.clearAllMocks();
-        resetTokenCache();
-    });
-
-    afterEach(() => {
-        process.env = originalEnv;
-        jest.restoreAllMocks();
-    });
-
-    it('should return null if credentials are missing in prod', async () => {
-        // In prod, unconfigured Shopify fails closed to null (no mock stand-in).
-        process.env.CHECKIN_ENV = 'prod';
-        delete process.env.SHOPIFY_STORE_DOMAIN;
-        const result = await createShopifyProgramVariants('Test Program', 10, 20);
-        expect(result).toBeNull();
-        expect(fetchMock).not.toHaveBeenCalled();
-    });
-
-    it('returns synthetic variant ids for priced tiers on local (mock active)', async () => {
-        // CHECKIN_ENV=local → shopifyMockActive: stand in for the real store so the
-        // seed → checkout → orders/paid dev tool works with zero env. Gated on the
-        // env, not on cred presence.
-        process.env.CHECKIN_ENV = 'local';
-        delete process.env.SHOPIFY_STORE_DOMAIN;
-        delete process.env.SHOPIFY_CLIENT_ID;
-        delete process.env.SHOPIFY_CLIENT_SECRET;
-
-        const result = await createShopifyProgramVariants('Test Program', 10, 20);
-        expect(result).not.toBeNull();
-        expect(result?.shopifyProductId).toBeTruthy();
-        expect(result?.shopifyOrgMemberVariantId).toBeTruthy();
-        expect(result?.shopifyNonOrgMemberVariantId).toBeTruthy();
-        expect(fetchMock).not.toHaveBeenCalled(); // no real API calls in mock mode
-
-        // Free tier (price 0/null) gets no variant, matching the real branch.
-        const freeMember = await createShopifyProgramVariants('Free Prog', null, 20);
-        expect(freeMember?.shopifyOrgMemberVariantId).toBeNull();
-        expect(freeMember?.shopifyNonOrgMemberVariantId).toBeTruthy();
-    });
-
-    it('should successfully create product and variants', async () => {
-        // Token request
-        mockTokenResponse(fetchMock);
-
-        // Product creation — variants come back inline on the created product
-        fetchMock.mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({ product: { id: 12345, variants: [
-                { id: 67890, option1: 'Member' },
-                { id: 11111, option1: 'Non-Member' },
-            ] } })
-        });
-
-        const result = await createShopifyProgramVariants('Test Program', 10, 20);
-
-        expect(result).toEqual({
-            shopifyProductId: '12345',
-            shopifyOrgMemberVariantId: '67890',
-            shopifyNonOrgMemberVariantId: '11111'
-        });
-
-        // ONE product call with inline variants — a bare product create would
-        // mint a physical $0 "Default Title" variant and 422 the follow-up
-        // variant POSTs (the original bug).
-        expect(fetchMock).toHaveBeenCalledTimes(2); // token + product (variants inline)
-        const productBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
-        expect(productBody.product.options).toEqual([{ name: 'Membership Type' }]);
-        expect(productBody.product.variants).toEqual([
-            expect.objectContaining({ option1: 'Member', price: '0.10', requires_shipping: false }),
-            expect.objectContaining({ option1: 'Non-Member', price: '0.20', requires_shipping: false }),
-        ]);
-        expect(sendEmail).not.toHaveBeenCalled();
-    });
-
-    it('should send email to admins and board members when product creation fails', async () => {
-        // Token request
-        mockTokenResponse(fetchMock);
-
-        // Product creation fails
-        fetchMock.mockResolvedValueOnce({
-            ok: false,
-            status: 400,
-            statusText: 'Bad Request',
-            text: async () => '{"errors": "Invalid data"}'
-        });
-
-        const mockAdmins = [
-            { email: 'admin1@test.com' },
-            { email: 'admin2@test.com' },
-            { email: 'board1@test.com' }
-        ];
-
-        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce(mockAdmins);
-
-        const result = await createShopifyProgramVariants('Test Error Program', 10, 20);
-
-        expect(result).toBeNull();
-
-        expect(prisma.person.findMany).toHaveBeenCalledWith({
-            where: {
-                OR: [{ isSysadmin: true }, { isBoardMember: true }],
-                email: { not: null },
-                mergedIntoId: null
-            },
-            select: { email: true }
-        });
-
-        expect(sendEmail).toHaveBeenCalledTimes(3);
-        expect(sendEmail).toHaveBeenCalledWith(
-            'admin1@test.com',
-            'Shopify Integration Error',
-            expect.stringContaining('Shopify API responded with status: 400')
-        );
-    });
-
-    it('should send email to admins and board members when fetch throws an error', async () => {
-        // Token request succeeds
-        mockTokenResponse(fetchMock);
-
-        // Product creation throws
-        fetchMock.mockRejectedValueOnce(new Error('Network error'));
-
-        const mockAdmins = [
-            { email: 'admin@test.com' }
-        ];
-
-        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce(mockAdmins);
-
-        const result = await createShopifyProgramVariants('Test Network Error', 10, 20);
-
-        expect(result).toBeNull();
-
-        expect(sendEmail).toHaveBeenCalledTimes(1);
-        expect(sendEmail).toHaveBeenCalledWith(
-            'admin@test.com',
-            'Shopify Integration Error',
-            expect.stringContaining('Network error')
-        );
-    });
-
-    it('should return null when token request fails', async () => {
-        fetchMock.mockResolvedValueOnce({
-            ok: false,
-            status: 401,
-            text: async () => '{"error":"invalid_client"}'
-        });
-
-        const result = await createShopifyProgramVariants('Test Program', 10, 20);
-
-        expect(result).toBeNull();
-        expect(fetchMock).toHaveBeenCalledTimes(1); // only token request
-    });
-
-    describe('inventory branch (maxParticipants configured, real Shopify path)', () => {
-        // Single priced tier (member only) keeps the fetch sequence short:
-        // token, product (variant inline), locations, [inventory_levels/set].
-        // Connect-first: token, product, locations, inventory_levels/connect, inventory_levels/set.
-        it('connects the item to the location, THEN sets inventory, when maxParticipants is configured', async () => {
-            mockTokenResponse(fetchMock);
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 500, variants: [{ id: 600, option1: 'Member', inventory_item_id: 700 }] } }) }); // product + inline variant
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 900 }] }) }); // locations
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/connect
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // inventory_levels/set
-
-            const result = await createShopifyProgramVariants('Inventory Program', 10, null, 5);
-
-            expect(result).toEqual({
-                shopifyProductId: '500',
-                shopifyOrgMemberVariantId: '600',
-                shopifyNonOrgMemberVariantId: null,
-            });
-            expect(fetchMock).toHaveBeenCalledTimes(5);
-            expect(String(fetchMock.mock.calls[2][0])).toContain('/locations.json');
-
-            // connect BEFORE set — a new tracked variant isn't stocked anywhere yet, and
-            // set alone 422s (that's the sold-out bug).
-            const connectCall = fetchMock.mock.calls[3];
-            expect(String(connectCall[0])).toContain('/inventory_levels/connect.json');
-            expect(JSON.parse((connectCall[1] as RequestInit).body as string)).toEqual({
-                location_id: 900,
-                inventory_item_id: 700,
-            });
-
-            const invCall = fetchMock.mock.calls[4];
-            expect(String(invCall[0])).toContain('/inventory_levels/set.json');
-            expect(JSON.parse((invCall[1] as RequestInit).body as string)).toEqual({
-                location_id: 900,
-                inventory_item_id: 700,
-                available: 5,
-            });
-            expect(logIntegrationError).not.toHaveBeenCalled();
-        });
-
-        it('picks an ACTIVE location, not locations[0], to connect+set against', async () => {
-            mockTokenResponse(fetchMock);
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 510, variants: [{ id: 610, option1: 'Member', inventory_item_id: 710 }] } }) });
-            // A deactivated location sorts first; the active one is second.
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 111, active: false }, { id: 222, active: true }] }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // connect
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // set
-
-            const result = await createShopifyProgramVariants('Active Location Program', 10, null, 4);
-
-            expect(result?.shopifyOrgMemberVariantId).toBe('610');
-            // the ACTIVE location (222), not the first (deactivated, 111) one — for both calls
-            expect(JSON.parse((fetchMock.mock.calls[3][1] as RequestInit).body as string)).toEqual({
-                location_id: 222,
-                inventory_item_id: 710,
-            });
-            expect(JSON.parse((fetchMock.mock.calls[4][1] as RequestInit).body as string)).toEqual({
-                location_id: 222,
-                inventory_item_id: 710,
-                available: 4,
-            });
-            expect(logIntegrationError).not.toHaveBeenCalled();
-        });
-
-        it('treats a 422 from connect as "level already exists" and still sets (e.g. a re-sync)', async () => {
-            mockTokenResponse(fetchMock);
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 520, variants: [{ id: 620, option1: 'Member', inventory_item_id: 720 }] } }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 990, active: true }] }) });
-            fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => 'inventory level already exists' }); // connect → 422
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // set still runs
-
-            const result = await createShopifyProgramVariants('Already Connected Program', 10, null, 6);
-
-            expect(result?.shopifyOrgMemberVariantId).toBe('620');
-            expect(fetchMock).toHaveBeenCalledTimes(5); // token, product, locations, connect(422), set
-            expect(String(fetchMock.mock.calls[4][0])).toContain('/inventory_levels/set.json');
-            expect(JSON.parse((fetchMock.mock.calls[4][1] as RequestInit).body as string)).toEqual({ location_id: 990, inventory_item_id: 720, available: 6 });
-            expect(logIntegrationError).not.toHaveBeenCalled(); // a 422 here is benign
-        });
-
-        it('surfaces and skips set when connect hard-fails (not a 422)', async () => {
-            mockTokenResponse(fetchMock);
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 530, variants: [{ id: 630, option1: 'Member', inventory_item_id: 730 }] } }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 991, active: true }] }) });
-            fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'connect boom' }); // connect → 500
-
-            jest.spyOn(console, 'error').mockImplementation(() => {});
-            const result = await createShopifyProgramVariants('Connect Fail Program', 10, null, 2);
-
-            expect(result?.shopifyOrgMemberVariantId).toBe('630');
-            expect(fetchMock).toHaveBeenCalledTimes(4); // no set — connect failed hard
-            expect(logIntegrationError).toHaveBeenCalledWith(
-                'shopify',
-                expect.objectContaining({ message: expect.stringContaining('inventory_levels/connect returned 500') }),
-                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
-            );
-        });
-
-        it('surfaces to IntegrationErrorLog when inventory set ultimately fails — a sold-out product is visible, not silent', async () => {
-            mockTokenResponse(fetchMock);
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 501, variants: [{ id: 601, option1: 'Member', inventory_item_id: 701 }] } }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 901, active: true }] }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // connect ok
-            fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'inventory boom' }); // set fails
-
-            jest.spyOn(console, 'error').mockImplementation(() => {});
-            const result = await createShopifyProgramVariants('Inventory Fail Program', 10, null, 3);
-
-            // Non-fatal to the create: the variant itself was made fine (returned),
-            // but the inventory failure is now logged to the Link Status tab so the
-            // resulting sold-out product doesn't ship silently. Still no admin email.
-            expect(result).toEqual({
-                shopifyProductId: '501',
-                shopifyOrgMemberVariantId: '601',
-                shopifyNonOrgMemberVariantId: null,
-            });
-            expect(logIntegrationError).toHaveBeenCalledWith(
-                'shopify',
-                expect.objectContaining({ message: expect.stringContaining('inventory_levels/set returned 500') }),
-                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
-            );
-            expect(sendEmail).not.toHaveBeenCalled();
-        });
-
-        it('surfaces (not silently skips) when the store has no locations configured', async () => {
-            mockTokenResponse(fetchMock);
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 502, variants: [{ id: 602, option1: 'Member', inventory_item_id: 702 }] } }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [] }) });
-
-            const result = await createShopifyProgramVariants('No Location Program', 10, null, 2);
-
-            expect(result?.shopifyOrgMemberVariantId).toBe('602');
-            // No inventory_levels/set call (no location), but the failure is surfaced.
-            expect(fetchMock).toHaveBeenCalledTimes(3);
-            expect(logIntegrationError).toHaveBeenCalledWith(
-                'shopify',
-                expect.objectContaining({ message: expect.stringContaining('no Shopify location') }),
-                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
-            );
-        });
-
-        it('surfaces when the created variant has no inventory_item_id (would be sold out)', async () => {
-            mockTokenResponse(fetchMock);
-            // Product create response omits inventory_item_id on the tracked variant.
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 503, variants: [{ id: 603, option1: 'Member' }] } }) });
-
-            const result = await createShopifyProgramVariants('No Inventory Item Program', 10, null, 2);
-
-            expect(result?.shopifyOrgMemberVariantId).toBe('603');
-            // Bails before locations/set (nothing to set stock on), but surfaces it.
-            expect(fetchMock).toHaveBeenCalledTimes(2); // token, product only
-            expect(logIntegrationError).toHaveBeenCalledWith(
-                'shopify',
-                expect.objectContaining({ message: expect.stringContaining('no inventory_item_id') }),
-                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
-            );
-        });
-    });
-
-    it('times out a hung product request and emails admins (does not hang)', async () => {
-        mockTokenResponse(fetchMock); // token succeeds (its own AbortSignal.timeout is untouched)...
-        // ...then the product create hangs: a fetch that only settles on abort stands in for a
-        // hung TCP connection. We drive the deadline by replacing AbortSignal.timeout for that
-        // one call with a controller we fire ourselves; without the timeout it never resolves.
-        const deadline = new AbortController();
-        const timeoutSpy = jest.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
-        fetchMock.mockImplementationOnce((_url: string, init: RequestInit) =>
-            new Promise((_resolve, reject) => {
-                const signal = init.signal as AbortSignal;
-                if (signal.aborted) return reject(signal.reason);
-                signal.addEventListener('abort', () => reject(signal.reason));
-            }),
-        );
-        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce([{ email: 'admin@test.com' }]);
-
-        const p = createShopifyProgramVariants('Test Hang', 10, 20);
-        deadline.abort(new DOMException('The operation timed out', 'TimeoutError'));
-        const result = await p;
-
-        expect(result).toBeNull();
-        expect(sendEmail).toHaveBeenCalledWith(
-            'admin@test.com',
-            'Shopify Integration Error',
-            expect.stringContaining('timed out after 20000ms'),
-        );
-        timeoutSpy.mockRestore();
-    });
-});
-
 describe('adjustProgramInventory', () => {
     let originalEnv: NodeJS.ProcessEnv;
     let fetchMock: jest.Mock;
 
-    const program = {
-        shopifyOrgMemberVariantId: '67890',
-        shopifyNonOrgMemberVariantId: '11111',
-    };
+    const program = { shopifyVariantId: '67890' };
 
     beforeEach(() => {
         originalEnv = { ...process.env };
@@ -410,40 +52,32 @@ describe('adjustProgramInventory', () => {
         jest.restoreAllMocks();
     });
 
-    it('resolves inventory_item_ids for both variants and adjusts both by delta at the store location', async () => {
+    it('resolves the variant inventory_item_id and adjusts it by delta at the store location', async () => {
         mockTokenResponse(fetchMock);
         fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 555 }] }) });
         fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { inventory_item_id: 111 } }) });
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // adjust member
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { inventory_item_id: 222 } }) });
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // adjust non-member
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // adjust
 
         const result = await adjustProgramInventory(program, 5);
 
         expect(result).toBe(true);
-        expect(fetchMock).toHaveBeenCalledTimes(6); // token + locations + 2 * (variant get + adjust)
+        expect(fetchMock).toHaveBeenCalledTimes(4); // token + locations + variant get + adjust
+        expect(String(fetchMock.mock.calls[2][0])).toContain('67890');
 
-        const adjustCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('inventory_levels/adjust.json'));
-        expect(adjustCalls).toHaveLength(2);
-        for (const [, init] of adjustCalls) {
-            const body = JSON.parse(init.body as string);
-            expect(body).toEqual({ location_id: 555, inventory_item_id: expect.any(Number), available_adjustment: 5 });
-        }
+        const adjustCall = fetchMock.mock.calls[3];
+        expect(String(adjustCall[0])).toContain('inventory_levels/adjust.json');
+        expect(JSON.parse((adjustCall[1] as RequestInit).body as string)).toEqual({
+            location_id: 555,
+            inventory_item_id: 111,
+            available_adjustment: 5,
+        });
     });
 
-    it('adjusts only the configured variant when the program has just one', async () => {
-        mockTokenResponse(fetchMock);
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 555 }] }) });
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { inventory_item_id: 111 } }) });
-        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-
-        const result = await adjustProgramInventory(
-            { shopifyOrgMemberVariantId: '67890', shopifyNonOrgMemberVariantId: null },
-            -3,
-        );
+    it('no-ops successfully (no fetch) when the program has no variant to adjust', async () => {
+        const result = await adjustProgramInventory({ shopifyVariantId: null }, -3);
 
         expect(result).toBe(true);
-        expect(fetchMock).toHaveBeenCalledTimes(4); // token + locations + variant get + adjust
+        expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('returns false and emails admins (non-fatal) when the adjust call fails', async () => {
@@ -454,10 +88,7 @@ describe('adjustProgramInventory', () => {
 
         (prisma.person.findMany as jest.Mock).mockResolvedValueOnce([{ email: 'admin@test.com' }]);
 
-        const result = await adjustProgramInventory(
-            { shopifyOrgMemberVariantId: '67890', shopifyNonOrgMemberVariantId: null },
-            5,
-        );
+        const result = await adjustProgramInventory(program, 5);
 
         expect(result).toBe(false);
         expect(sendEmail).toHaveBeenCalledWith(
@@ -483,50 +114,14 @@ describe('adjustProgramInventory', () => {
         delete process.env.SHOPIFY_STORE_DOMAIN;
         delete process.env.SHOPIFY_CLIENT_ID;
         delete process.env.SHOPIFY_CLIENT_SECRET;
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
 
         const result = await adjustProgramInventory(program, 5);
 
         expect(result).toBe(true);
         expect(fetchMock).not.toHaveBeenCalled();
-    });
-
-    // Single-pool model (product decision 2026-07-06): shopifyVariantId, when
-    // set, IS the whole capacity — adjust ONLY that id, never the legacy pair,
-    // even if stale legacy values linger on the row.
-    describe('single-pool preference', () => {
-        it('adjusts only shopifyVariantId when set, ignoring the legacy pair', async () => {
-            mockTokenResponse(fetchMock);
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 555 }] }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ variant: { inventory_item_id: 999 } }) });
-            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-
-            const result = await adjustProgramInventory(
-                { shopifyVariantId: 'single-pool-variant', shopifyOrgMemberVariantId: '67890', shopifyNonOrgMemberVariantId: '11111' },
-                -1,
-            );
-
-            expect(result).toBe(true);
-            expect(fetchMock).toHaveBeenCalledTimes(4); // token + locations + one variant get + one adjust
-            expect(String(fetchMock.mock.calls[2][0])).toContain('single-pool-variant');
-        });
-
-        it('no-ops in mock mode logging only shopifyVariantId, not the legacy pair', async () => {
-            process.env.CHECKIN_ENV = 'local';
-            delete process.env.SHOPIFY_STORE_DOMAIN;
-            delete process.env.SHOPIFY_CLIENT_ID;
-            delete process.env.SHOPIFY_CLIENT_SECRET;
-            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-
-            const result = await adjustProgramInventory(
-                { shopifyVariantId: 'single-pool-variant', shopifyOrgMemberVariantId: '67890', shopifyNonOrgMemberVariantId: '11111' },
-                -1,
-            );
-
-            expect(result).toBe(true);
-            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('single-pool-variant'));
-            expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('67890'));
-            logSpy.mockRestore();
-        });
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('67890'));
+        logSpy.mockRestore();
     });
 });
 
@@ -556,6 +151,70 @@ describe('createShopifySingleVariantProgram', () => {
         const result = await createShopifySingleVariantProgram('Free Prog', null);
         expect(result).toBeNull();
         expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns null if credentials are missing in prod', async () => {
+        // In prod, unconfigured Shopify fails closed to null (no mock stand-in).
+        process.env.CHECKIN_ENV = 'prod';
+        delete process.env.SHOPIFY_STORE_DOMAIN;
+
+        const result = await createShopifySingleVariantProgram('Test Program', 3500);
+
+        expect(result).toBeNull();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the token request fails', async () => {
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 401, text: async () => '{"error":"invalid_client"}' });
+
+        const result = await createShopifySingleVariantProgram('Test Program', 3500);
+
+        expect(result).toBeNull();
+        expect(fetchMock).toHaveBeenCalledTimes(1); // only the token request
+    });
+
+    it('emails admins when the product fetch throws', async () => {
+        mockTokenResponse(fetchMock);
+        fetchMock.mockRejectedValueOnce(new Error('Network error'));
+        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce([{ email: 'admin@test.com' }]);
+
+        const result = await createShopifySingleVariantProgram('Test Network Error', 3500);
+
+        expect(result).toBeNull();
+        expect(sendEmail).toHaveBeenCalledWith(
+            'admin@test.com',
+            'Shopify Integration Error',
+            expect.stringContaining('Network error'),
+        );
+    });
+
+    it('times out a hung product request and emails admins (does not hang)', async () => {
+        mockTokenResponse(fetchMock); // token succeeds (its own AbortSignal.timeout is untouched)...
+        // ...then the product create hangs: a fetch that only settles on abort stands in for a
+        // hung TCP connection. We drive the deadline by replacing AbortSignal.timeout for that
+        // one call with a controller we fire ourselves; without the timeout it never resolves.
+        const deadline = new AbortController();
+        const timeoutSpy = jest.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
+        fetchMock.mockImplementationOnce((_url: string, init: RequestInit) =>
+            new Promise((_resolve, reject) => {
+                const signal = init.signal as AbortSignal;
+                if (signal.aborted) return reject(signal.reason);
+                signal.addEventListener('abort', () => reject(signal.reason));
+            }),
+        );
+        (prisma.person.findMany as jest.Mock).mockResolvedValueOnce([{ email: 'admin@test.com' }]);
+
+        const p = createShopifySingleVariantProgram('Test Hang', 3500);
+        deadline.abort(new DOMException('The operation timed out', 'TimeoutError'));
+        const result = await p;
+
+        expect(result).toBeNull();
+        expect(sendEmail).toHaveBeenCalledWith(
+            'admin@test.com',
+            'Shopify Integration Error',
+            expect.stringContaining('timed out after 20000ms'),
+        );
+        timeoutSpy.mockRestore();
     });
 
     it('returns a synthetic single variant id on local (mock active)', async () => {
@@ -623,6 +282,124 @@ describe('createShopifySingleVariantProgram', () => {
             'Shopify Integration Error',
             expect.stringContaining('missing the created variant'),
         );
+    });
+
+    // setInitialShopifyInventory's failure modes. Non-fatal to the create by
+    // design (the variant is returned), but each must reach IntegrationErrorLog
+    // so a resulting sold-out product is visible on the Link Status tab rather
+    // than shipping silently.
+    describe('inventory branch (maxParticipants configured)', () => {
+        it('picks an ACTIVE location, not locations[0], to connect+set against', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 710, variants: [{ id: 810, inventory_item_id: 910 }] } }) });
+            // A deactivated location sorts first; the active one is second.
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 111, active: false }, { id: 222, active: true }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // connect
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // set
+
+            const result = await createShopifySingleVariantProgram('Active Location Program', 3500, 4);
+
+            expect(result?.shopifyVariantId).toBe('810');
+            // the ACTIVE location (222), not the first (deactivated, 111) one — for both calls
+            expect(JSON.parse((fetchMock.mock.calls[3][1] as RequestInit).body as string)).toEqual({
+                location_id: 222,
+                inventory_item_id: 910,
+            });
+            expect(JSON.parse((fetchMock.mock.calls[4][1] as RequestInit).body as string)).toEqual({
+                location_id: 222,
+                inventory_item_id: 910,
+                available: 4,
+            });
+            expect(logIntegrationError).not.toHaveBeenCalled();
+        });
+
+        it('treats a 422 from connect as "level already exists" and still sets (e.g. a re-sync)', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 720, variants: [{ id: 820, inventory_item_id: 920 }] } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 990, active: true }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: false, status: 422, text: async () => 'inventory level already exists' }); // connect → 422
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // set still runs
+
+            const result = await createShopifySingleVariantProgram('Already Connected Program', 3500, 6);
+
+            expect(result?.shopifyVariantId).toBe('820');
+            expect(fetchMock).toHaveBeenCalledTimes(5); // token, product, locations, connect(422), set
+            expect(String(fetchMock.mock.calls[4][0])).toContain('/inventory_levels/set.json');
+            expect(JSON.parse((fetchMock.mock.calls[4][1] as RequestInit).body as string)).toEqual({ location_id: 990, inventory_item_id: 920, available: 6 });
+            expect(logIntegrationError).not.toHaveBeenCalled(); // a 422 here is benign
+        });
+
+        it('surfaces and skips set when connect hard-fails (not a 422)', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 730, variants: [{ id: 830, inventory_item_id: 930 }] } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 991, active: true }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'connect boom' }); // connect → 500
+
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            const result = await createShopifySingleVariantProgram('Connect Fail Program', 3500, 2);
+
+            expect(result?.shopifyVariantId).toBe('830');
+            expect(fetchMock).toHaveBeenCalledTimes(4); // no set — connect failed hard
+            expect(logIntegrationError).toHaveBeenCalledWith(
+                'shopify',
+                expect.objectContaining({ message: expect.stringContaining('inventory_levels/connect returned 500') }),
+                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
+            );
+        });
+
+        it('surfaces to IntegrationErrorLog when inventory set ultimately fails — a sold-out product is visible, not silent', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 740, variants: [{ id: 840, inventory_item_id: 940 }] } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [{ id: 901, active: true }] }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // connect ok
+            fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'inventory boom' }); // set fails
+
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            const result = await createShopifySingleVariantProgram('Inventory Fail Program', 3500, 3);
+
+            // The variant itself was made fine (returned); only the stock level failed.
+            expect(result).toEqual({ shopifyProductId: '740', shopifyVariantId: '840' });
+            expect(logIntegrationError).toHaveBeenCalledWith(
+                'shopify',
+                expect.objectContaining({ message: expect.stringContaining('inventory_levels/set returned 500') }),
+                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
+            );
+            expect(sendEmail).not.toHaveBeenCalled();
+        });
+
+        it('surfaces (not silently skips) when the store has no locations configured', async () => {
+            mockTokenResponse(fetchMock);
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 750, variants: [{ id: 850, inventory_item_id: 950 }] } }) });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ locations: [] }) });
+
+            const result = await createShopifySingleVariantProgram('No Location Program', 3500, 2);
+
+            expect(result?.shopifyVariantId).toBe('850');
+            // No inventory_levels/set call (no location), but the failure is surfaced.
+            expect(fetchMock).toHaveBeenCalledTimes(3);
+            expect(logIntegrationError).toHaveBeenCalledWith(
+                'shopify',
+                expect.objectContaining({ message: expect.stringContaining('no Shopify location') }),
+                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
+            );
+        });
+
+        it('surfaces when the created variant has no inventory_item_id (would be sold out)', async () => {
+            mockTokenResponse(fetchMock);
+            // Product create response omits inventory_item_id on the tracked variant.
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ product: { id: 760, variants: [{ id: 860 }] } }) });
+
+            const result = await createShopifySingleVariantProgram('No Inventory Item Program', 3500, 2);
+
+            expect(result?.shopifyVariantId).toBe('860');
+            // Bails before locations/set (nothing to set stock on), but surfaces it.
+            expect(fetchMock).toHaveBeenCalledTimes(2); // token, product only
+            expect(logIntegrationError).toHaveBeenCalledWith(
+                'shopify',
+                expect.objectContaining({ message: expect.stringContaining('no inventory_item_id') }),
+                expect.objectContaining({ operation: 'setInitialShopifyInventory' }),
+            );
+        });
     });
 });
 

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -170,7 +170,7 @@ export const DEV_MOCK_SHOPIFY_WEBHOOK_SECRET = 'dev-shopify-mock-webhook-secret'
 
 /**
  * Synthetic membership variant id used when the Shopify mock is active. Programs
- * synthesize dev-mock-variant ids at creation (shopify.ts › createShopifyProgramVariants),
+ * synthesize a dev-mock-variant id at creation (shopify.ts › createShopifySingleVariantProgram),
  * but the membership variant is manual BoardSettings config that a local seed never
  * populates — so with no fallback the mock orders/paid webhook can't match a membership
  * order (webhooks/shopify/route.ts) and the dev fire tool 409s. Both the mock firer and

--- a/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
@@ -72,11 +72,9 @@ beforeEach(() => {
     mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set());
     prismaMock.boardSettings.findUnique.mockResolvedValue({
         orgMembershipVariantId: '111',
-        shopifyNormalVariantId: null,
-        shopifyVolunteerVariantId: '112',
     });
     prismaMock.program.findMany.mockResolvedValue([
-        { id: 7, name: 'Robotics', shopifyVariantId: '222', shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null },
+        { id: 7, name: 'Robotics', shopifyVariantId: '222' },
     ]);
     prismaMock.orgMembershipProcess.findMany.mockResolvedValue([]);
     prismaMock.programParticipant.findMany.mockResolvedValue([]);
@@ -98,7 +96,7 @@ it('reports configured:false without touching prisma or the mirror data when unw
 it('asks the mirror for exactly the union of settings + program variants', async () => {
     await runMatchAudit();
     const asked = mirrorMock.ordersForVariants.mock.calls[0][0] as string[];
-    expect([...asked].sort()).toEqual(['111', '112', '222']);
+    expect([...asked].sort()).toEqual(['111', '222']);
 });
 
 describe('order buckets (Shopify → activation)', () => {
@@ -337,15 +335,7 @@ describe('enrollment buckets', () => {
         const sweep = prismaMock.programParticipant.findMany.mock.calls[1][0];
         expect(sweep.where.status).toBe('ACTIVE');
         expect(sweep.where.OR).toContainEqual({ shopifyOrderId: { not: null } });
-        expect(sweep.where.OR).toContainEqual({
-            program: {
-                OR: [
-                    { shopifyVariantId: { not: null } },
-                    { shopifyOrgMemberVariantId: { not: null } },
-                    { shopifyNonOrgMemberVariantId: { not: null } },
-                ],
-            },
-        });
+        expect(sweep.where.OR).toContainEqual({ program: { shopifyVariantId: { not: null } } });
     });
 
     describe('ADMIN_COMPED', () => {

--- a/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
@@ -100,8 +100,8 @@ const VOLUNTEER_CODE = "VOLFAM";
 beforeAll(async () => {
     await prisma.boardSettings.upsert({
         where: { id: 1 },
-        create: { id: 1, normalDuesCents: 5000, volunteerDuesCents: 2000, shopifyNormalVariantId: MEMBERSHIP_VARIANT, volunteerDiscountCode: VOLUNTEER_CODE },
-        update: { normalDuesCents: 5000, volunteerDuesCents: 2000, shopifyNormalVariantId: MEMBERSHIP_VARIANT, volunteerDiscountCode: VOLUNTEER_CODE, shopifyReconcileCursorAt: null },
+        create: { id: 1, normalDuesCents: 5000, volunteerDuesCents: 2000, orgMembershipVariantId: MEMBERSHIP_VARIANT, volunteerDiscountCode: VOLUNTEER_CODE },
+        update: { normalDuesCents: 5000, volunteerDuesCents: 2000, orgMembershipVariantId: MEMBERSHIP_VARIANT, volunteerDiscountCode: VOLUNTEER_CODE, shopifyReconcileCursorAt: null },
     });
 });
 

--- a/checkin-app/src/lib/finance/matchAudit.ts
+++ b/checkin-app/src/lib/finance/matchAudit.ts
@@ -131,10 +131,10 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
     const [settings, programs, variantCoverage] = await Promise.all([
         prisma.boardSettings.findUnique({
             where: { id: 1 },
-            select: { orgMembershipVariantId: true, shopifyNormalVariantId: true, shopifyVolunteerVariantId: true },
+            select: { orgMembershipVariantId: true },
         }),
         prisma.program.findMany({
-            select: { id: true, name: true, shopifyVariantId: true, shopifyOrgMemberVariantId: true, shopifyNonOrgMemberVariantId: true },
+            select: { id: true, name: true, shopifyVariantId: true },
         }),
         mirror.lineVariantStats(),
     ]);
@@ -144,9 +144,7 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
     const membershipVariants = membershipVariantIdSet(settings ?? null);
     const programByVariant = new Map<string, { id: number; name: string }>();
     for (const p of programs) {
-        for (const v of [p.shopifyVariantId, p.shopifyOrgMemberVariantId, p.shopifyNonOrgMemberVariantId]) {
-            if (v) programByVariant.set(v, { id: p.id, name: p.name });
-        }
+        if (p.shopifyVariantId) programByVariant.set(p.shopifyVariantId, { id: p.id, name: p.name });
     }
     const allVariants = [...membershipVariants, ...programByVariant.keys()];
 
@@ -280,11 +278,7 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
                 person: LIVE_PERSON,
                 OR: [
                     { shopifyOrderId: { not: null } },
-                    { program: { OR: [
-                        { shopifyVariantId: { not: null } },
-                        { shopifyOrgMemberVariantId: { not: null } },
-                        { shopifyNonOrgMemberVariantId: { not: null } },
-                    ] } },
+                    { program: { shopifyVariantId: { not: null } } },
                 ],
             },
             select: {

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -139,14 +139,10 @@ export function isPaid(o: Pick<MirrorOrder, "financialStatus" | "cancelledAt" | 
  */
 export function membershipVariantIdSet(settings: {
     orgMembershipVariantId: string | null;
-    shopifyNormalVariantId: string | null;
-    shopifyVolunteerVariantId: string | null;
 } | null): Set<string> {
     return new Set(
         [
             settings?.orgMembershipVariantId,
-            settings?.shopifyNormalVariantId,
-            settings?.shopifyVolunteerVariantId,
             config.shopifyMockActive() ? DEV_MOCK_MEMBERSHIP_VARIANT_ID : null,
         ].filter((v): v is string => !!v),
     );
@@ -260,7 +256,7 @@ async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> 
 
     // Membership-item gate, parity with the orders/paid webhook: recover only if the
     // order actually CONTAINS a membership product (its variant id), the same
-    // {orgMembership, normal, volunteer} variant set the webhook builds — mirrored
+    // membershipVariantIdSet the webhook builds — mirrored
     // onto order lines since #1048. A variant id is stable and can't drift; the old
     // total-price gate false-raised AMOUNT_MISMATCH on every couponed order (volunteer
     // rate, promo), whose sub-dues total is indistinguishable from an underpayment by
@@ -269,8 +265,6 @@ async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> 
         where: { id: 1 },
         select: {
             orgMembershipVariantId: true,
-            shopifyNormalVariantId: true,
-            shopifyVolunteerVariantId: true,
             normalDuesCents: true,
             volunteerDuesCents: true,
             volunteerDiscountCode: true,
@@ -403,10 +397,8 @@ async function activateProgramFromOrder(order: MirrorOrder, programId: number, p
         // program recovery has no amount gate, so it never had the coupon false-positive
         // the membership path did, and widening it to a variant check is deferred (the
         // membership fix was the scoped concern). So hasProgramItem stays true here: the
-        // order is matched to THIS program's pending enrollments. Tier unknown → no
-        // legacy sibling-inventory mirror.
+        // order is matched to THIS program's pending enrollments.
         hasProgramItem: true,
-        purchasedOrgMember: null,
     });
     logger.info(`[reconcile] recovered program payment: program ${programId} ← order ${order.legacyId} (${res.activatedCount} activated)`);
     return true;

--- a/checkin-app/src/lib/lifecycleDrift.ts
+++ b/checkin-app/src/lib/lifecycleDrift.ts
@@ -120,13 +120,7 @@ async function healEnrollmentI1(): Promise<number> {
             programId: true,
             personId: true,
             inventoryHeldAt: true,
-            program: {
-                select: {
-                    shopifyVariantId: true,
-                    shopifyOrgMemberVariantId: true,
-                    shopifyNonOrgMemberVariantId: true,
-                },
-            },
+            program: { select: { shopifyVariantId: true } },
         },
     });
 

--- a/checkin-app/src/lib/program/capacity.ts
+++ b/checkin-app/src/lib/program/capacity.ts
@@ -66,7 +66,7 @@ export async function lockProgramAndCheckCapacity(
 export async function withdrawAndReleaseHold(
     programId: number,
     personId: number,
-    program: { shopifyVariantId?: string | null; shopifyOrgMemberVariantId: string | null; shopifyNonOrgMemberVariantId: string | null },
+    program: { shopifyVariantId?: string | null },
 ): Promise<{ enrollment: ProgramParticipant; released: boolean; shopifyOk: boolean }> {
     const enrollment = await prisma.programParticipant.delete({
         where: { programId_personId: { programId, personId } },

--- a/checkin-app/src/lib/programCheckout.ts
+++ b/checkin-app/src/lib/programCheckout.ts
@@ -8,14 +8,12 @@ import type { Prisma } from "@/generated/prisma/client";
  * program-create time (api/programs POST); a program made free, then priced via
  * edit (api/programs/[id] PATCH), never gets variants.
  *
- * FREE tiers legitimately have no variant, so gate on the tier's price being > 0
- * — never flag on a missing variant alone.
+ * A FREE program legitimately has no variant, so gate on a tier being priced at
+ * all — never flag on a missing variant alone.
  *
- * Single-pool model (product decision 2026-07-06): `shopifyVariantId`, when
- * set, covers BOTH tiers by itself (member pricing is a discount code, not a
- * separate variant) — a program is checkout-OK with either shopifyVariantId
- * alone, or the full legacy pair. Legacy programs (no shopifyVariantId) keep
- * the original per-tier check.
+ * Single-pool model (product decision 2026-07-06): `shopifyVariantId` covers
+ * BOTH tiers by itself — member pricing is a checkout-time discount code, not a
+ * separate variant — so it is the only variant a priced program needs.
  *
  * The JS predicate and the Prisma WHERE below are the same condition on two sides
  * of the wire — the count query (nav/todo-counts) and the per-row/detail UI.
@@ -27,22 +25,17 @@ type CheckoutFields = {
   orgMemberPriceCents?: number | null;
   nonOrgMemberPriceCents?: number | null;
   shopifyVariantId?: string | null;
-  shopifyOrgMemberVariantId?: string | null;
-  shopifyNonOrgMemberVariantId?: string | null;
 };
 
 export function isProgramCheckoutBroken(p: CheckoutFields): boolean {
   if (p.shopifyVariantId) return false; // single pool covers both tiers
-  return (
-    ((p.orgMemberPriceCents ?? 0) > 0 && !p.shopifyOrgMemberVariantId) ||
-    ((p.nonOrgMemberPriceCents ?? 0) > 0 && !p.shopifyNonOrgMemberVariantId)
-  );
+  return (p.orgMemberPriceCents ?? 0) > 0 || (p.nonOrgMemberPriceCents ?? 0) > 0;
 }
 
 export const PROGRAM_CHECKOUT_BROKEN_WHERE: Prisma.ProgramWhereInput = {
   shopifyVariantId: null,
   OR: [
-    { orgMemberPriceCents: { gt: 0 }, shopifyOrgMemberVariantId: null },
-    { nonOrgMemberPriceCents: { gt: 0 }, shopifyNonOrgMemberVariantId: null },
+    { orgMemberPriceCents: { gt: 0 } },
+    { nonOrgMemberPriceCents: { gt: 0 } },
   ],
 };

--- a/checkin-app/src/lib/programs/activateEnrollment.ts
+++ b/checkin-app/src/lib/programs/activateEnrollment.ts
@@ -14,11 +14,10 @@ import { fromWhere } from "@/lib/programs/enrollmentState";
  * clearing the pending timer, stamping the paying order id, and releasing any
  * scholarship inventory hold (compensating Shopify's sale-time auto-decrement).
  *
- * The membership-item / tier check lives with the CALLER, because only the webhook
- * has the order's line-item variant ids — the mirror does not. The webhook passes
- * the computed values; the reconciler passes hasProgramItem=true (it matched the
- * order to a pending enrollment by email) and purchasedTier=null (tier unknown), in
- * which case the legacy two-pool sibling-inventory mirror is skipped.
+ * The membership-item check lives with the CALLER, because only the webhook has
+ * the order's line-item variant ids — the mirror does not. The webhook passes the
+ * computed value; the reconciler passes hasProgramItem=true (it matched the order
+ * to a pending enrollment by email).
  */
 export interface ActivateEnrollmentInput {
     programId: number;
@@ -28,11 +27,6 @@ export interface ActivateEnrollmentInput {
     shopifyOrderId: string;
     /** Did the paid order contain this program's product? Fail-closed: false = don't activate. */
     hasProgramItem: boolean;
-    /**
-     * Which tier Shopify sold (true = org-member variant), for the legacy two-pool
-     * sibling-inventory mirror. null = unknown (reconciler path) → skip the mirror.
-     */
-    purchasedOrgMember: boolean | null;
 }
 
 export interface ActivateEnrollmentResult {
@@ -41,7 +35,7 @@ export interface ActivateEnrollmentResult {
 }
 
 export async function activateProgramEnrollment(input: ActivateEnrollmentInput): Promise<ActivateEnrollmentResult> {
-    const { programId, personIds, shopifyOrderId, hasProgramItem, purchasedOrgMember } = input;
+    const { programId, personIds, shopifyOrderId, hasProgramItem } = input;
     const program = await prisma.program.findUnique({ where: { id: programId } });
 
     let activatedCount = 0;
@@ -79,25 +73,8 @@ export async function activateProgramEnrollment(input: ActivateEnrollmentInput):
 
     // Compensating +1 for every hold released, in one call. Never fatal.
     if (releasedHoldCount > 0) {
-        const ok = await adjustProgramInventory(
-            {
-                shopifyVariantId: program?.shopifyVariantId ?? null,
-                shopifyOrgMemberVariantId: program?.shopifyOrgMemberVariantId ?? null,
-                shopifyNonOrgMemberVariantId: program?.shopifyNonOrgMemberVariantId ?? null,
-            },
-            releasedHoldCount,
-        );
+        const ok = await adjustProgramInventory({ shopifyVariantId: program?.shopifyVariantId ?? null }, releasedHoldCount);
         if (!ok) logger.error(`[enroll] Failed to release ${releasedHoldCount} scholarship hold(s) for program ${programId} — capacity may be out of sync.`);
-    }
-
-    // LEGACY two-pool sibling mirror: only when we know the tier. Single-pool programs
-    // (shopifyVariantId) need no mirror; the reconciler (tier unknown) skips it.
-    if (activatedCount > 0 && !program?.shopifyVariantId && purchasedOrgMember !== null) {
-        const siblingOnly = purchasedOrgMember
-            ? { shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: program?.shopifyNonOrgMemberVariantId ?? null }
-            : { shopifyOrgMemberVariantId: program?.shopifyOrgMemberVariantId ?? null, shopifyNonOrgMemberVariantId: null };
-        const ok = await adjustProgramInventory({ shopifyVariantId: null, ...siblingOnly }, -activatedCount);
-        if (!ok) logger.error(`[enroll] Failed to mirror sibling-variant inventory for program ${programId} — pools may be out of sync.`);
     }
 
     return { activatedCount, releasedHoldCount };

--- a/checkin-app/src/lib/shopify.ts
+++ b/checkin-app/src/lib/shopify.ts
@@ -334,143 +334,13 @@ async function setInitialShopifyInventory(
     }
 }
 
-export async function createShopifyProgramVariants(name: string, orgMemberPriceCents: number | null, nonOrgMemberPriceCents: number | null, maxParticipants: number | null = null) {
-  // ENV GATE: LOCAL ONLY (shopifyMockActive() ⇔ CHECKIN_ENV=local). No real store,
-  // so synthesize the variant ids the real store would return — otherwise a paid
-  // program stores null variants and the checkout → webhook path can't match. Only
-  // priced tiers get a variant, exactly like the real (dev/prod) branch below. Ids
-  // need not be globally unique: the inbound handler resolves the program by id, then
-  // matches line-items against that program's own variant set. dev/prod fall through
-  // to the real Shopify Admin API call below.
-  if (config.shopifyMockActive()) {
-    const slug = name.replace(/\W+/g, "-").toLowerCase().slice(0, 24);
-    return {
-      shopifyProductId: `dev-mock-product-${slug}`,
-      shopifyOrgMemberVariantId: orgMemberPriceCents && orgMemberPriceCents > 0 ? `dev-mock-variant-member-${slug}` : null,
-      shopifyNonOrgMemberVariantId: nonOrgMemberPriceCents && nonOrgMemberPriceCents > 0 ? `dev-mock-variant-nonmember-${slug}` : null,
-    };
-  }
-
-  const storeDomain = config.shopifyStoreDomain();
-  const accessToken = await getAccessToken();
-
-  if (!storeDomain || !accessToken) {
-    console.warn("Shopify integration is disabled: Missing credentials or unable to obtain access token");
-    return null;
-  }
-
-  // Hoisted so the catch can name an orphaned product (created, but variants/DB failed) for manual cleanup.
-  let productId: string | number | null = null;
-
-  try {
-    // Determine product title
-    const productTitle = `${name} Program Enrollment`;
-
-    // Variants go INLINE in the product-create call. Creating the product bare
-    // makes Shopify mint a "Default Title" variant (price $0, requires_shipping
-    // true), which then collides with any follow-up POST /variants.json that
-    // doesn't set a distinct option1 (422 "The variant 'Default Title' already
-    // exists") AND leaves a physical $0 variant on the product so checkout asks
-    // for a shipping address. Inline variants replace the default entirely.
-    const variants = [];
-
-    if (orgMemberPriceCents !== null && orgMemberPriceCents > 0) {
-        variants.push({
-            option1: "Member",
-            price: (orgMemberPriceCents / 100).toFixed(2),
-            requires_shipping: false,
-            inventory_management: maxParticipants ? 'shopify' : null,
-            inventory_policy: maxParticipants ? 'deny' : 'continue',
-        });
-    }
-
-    if (nonOrgMemberPriceCents !== null && nonOrgMemberPriceCents > 0) {
-        variants.push({
-            option1: "Non-Member",
-            price: (nonOrgMemberPriceCents / 100).toFixed(2),
-            requires_shipping: false,
-            inventory_management: maxParticipants ? 'shopify' : null,
-            inventory_policy: maxParticipants ? 'deny' : 'continue',
-        });
-    }
-
-    const productRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/products.json`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Shopify-Access-Token': accessToken,
-      },
-      body: JSON.stringify({
-        product: {
-          title: productTitle,
-          status: 'active',
-          product_type: "Educational Services",
-          ...(variants.length > 0 ? { options: [{ name: "Membership Type" }], variants } : {}),
-        }
-      })
-    }, "Shopify create product");
-
-    if (!productRes.ok) {
-        const errorData = await productRes.text();
-        console.error(`[Shopify API Error] ${productRes.status} ${productRes.statusText}`, errorData);
-        throw new Error(`Shopify API responded with status: ${productRes.status}`);
-    }
-
-    const productData = await productRes.json();
-    productId = productData.product.id;
-
-    let memberVariantId: string | null = null;
-    let nonMemberVariantId: string | null = null;
-
-    for (const created of productData.product.variants ?? []) {
-        if (created.option1 === "Member") {
-            memberVariantId = created.id.toString();
-        } else if (created.option1 === "Non-Member") {
-            nonMemberVariantId = created.id.toString();
-        } else {
-            continue; // e.g. a default variant on the no-priced-tiers path — nothing to track
-        }
-
-        // Set inventory level if maxParticipants is configured
-        if (maxParticipants) {
-            await setInitialShopifyInventory(storeDomain, accessToken, created.inventory_item_id, maxParticipants, created.option1);
-        }
-    }
-
-    return {
-        shopifyProductId: productId!.toString(),
-        shopifyOrgMemberVariantId: memberVariantId,
-        shopifyNonOrgMemberVariantId: nonMemberVariantId
-    };
-
-  } catch (error) {
-    console.error("[Shopify Error] Failed to create product/variants:", error);
-    if (productId) {
-        console.error("[Shopify] Orphaned product after variant failure, manual cleanup needed:", productId);
-    }
-
-    await reportShopifyFailure(
-        "createShopifyProgramVariants",
-        error,
-        { program: name, orphanedProductId: productId ?? null },
-        `An error occurred in the Shopify integration while creating variants for program: <strong>${escapeHtml(name)}</strong>.`,
-    );
-
-    // We log it but do not crash the app. Admin will need to create variants manually.
-    return null;
-  }
-}
-
 /**
  * Single-pool model (product decision 2026-07-06): mints ONE Shopify variant
  * per program, priced at the base/non-member rate — inventory IS the whole
  * program capacity, not a per-tier pool. Members buy the same variant and get
  * a per-enrollee discount code at checkout (see {@link mintMemberDiscountCode})
- * instead of a separate variant/pool. This is the creation path for NEW
- * programs going forward; {@link createShopifyProgramVariants} above stays
- * only for programs already on the legacy two-variant model — sync-shopify's
- * repair route picks between the two based on whether a program already has a
- * legacy variant configured (expand-only transition; see prisma/schema.prisma).
+ * instead of a separate variant/pool. This is the creation path for every
+ * program — both POST /api/programs and sync-shopify's repair route.
  */
 export async function createShopifySingleVariantProgram(
     name: string,
@@ -479,7 +349,12 @@ export async function createShopifySingleVariantProgram(
 ): Promise<{ shopifyProductId: string; shopifyVariantId: string } | null> {
     if (!basePriceCents || basePriceCents <= 0) return null; // free program: no Shopify object needed
 
-    // See createShopifyProgramVariants above for why this branch exists (CHECKIN_ENV=local mock).
+    // ENV GATE: LOCAL ONLY (shopifyMockActive() ⇔ CHECKIN_ENV=local). No real store,
+    // so synthesize the variant id the real store would return — otherwise a paid
+    // program stores a null variant and the checkout → webhook path can't match. The
+    // id need not be globally unique: the inbound handler resolves the program by id,
+    // then matches line-items against that program's own variant. dev/prod fall
+    // through to the real Shopify Admin API call below.
     if (config.shopifyMockActive()) {
         const slug = name.replace(/\W+/g, "-").toLowerCase().slice(0, 24);
         return {
@@ -579,10 +454,8 @@ export async function createShopifySingleVariantProgram(
  * POST /api/finance-ops/payment-plans/refuse (refusal, +1) — approval performs
  * NO Shopify operation (the applicant already holds the seat since apply-time).
  *
- * Single-pool preference: when `shopifyVariantId` is set (the single-pool
- * model), it IS the program's whole capacity and is the only id adjusted —
- * the legacy pair is ignored even if stale values linger on the row. Legacy
- * (two-variant) programs fall through to the pre-existing both-pools behavior.
+ * `shopifyVariantId` IS the program's whole capacity (single pool), so it is the
+ * only id adjusted; a program without one has nothing to adjust and no-ops.
  *
  * RELATIVE (inventory_levels/adjust, `available_adjustment: delta`) is deliberate,
  * not absolute set: Shopify decrements `available` itself as seats sell, and an
@@ -591,29 +464,22 @@ export async function createShopifySingleVariantProgram(
  * Shopify already has without the app needing to know that number.
  *
  * The schema doesn't persist inventory_item_id (only the variant id), so it's
- * resolved here per call via GET .../variants/{id}.json — one extra round trip per
- * configured variant, acceptable for an admin/scholarship-triggered edit.
+ * resolved here per call via GET .../variants/{id}.json — one extra round trip,
+ * acceptable for an admin/scholarship-triggered edit.
  *
- * Never throws: mirrors createShopifyProgramVariants' failure handling (log +
- * admin email), returns false so the caller can surface a non-fatal warning.
+ * Never throws: logs + emails the admin via reportShopifyFailure and returns
+ * false, so the caller can surface a non-fatal warning.
  */
 export async function adjustProgramInventory(
-    program: {
-        shopifyVariantId?: string | null;
-        shopifyOrgMemberVariantId: string | null;
-        shopifyNonOrgMemberVariantId: string | null;
-    },
+    program: { shopifyVariantId?: string | null },
     delta: number,
 ): Promise<boolean> {
-    const variantIds = program.shopifyVariantId
-        ? [program.shopifyVariantId]
-        : [program.shopifyOrgMemberVariantId, program.shopifyNonOrgMemberVariantId].filter((id): id is string => !!id);
+    const variantId = program.shopifyVariantId;
+    if (!variantId) return true;
 
-    if (variantIds.length === 0) return true;
-
-    // See createShopifyProgramVariants for why this branch exists (CHECKIN_ENV=local mock).
+    // See createShopifySingleVariantProgram for why this branch exists (CHECKIN_ENV=local mock).
     if (config.shopifyMockActive()) {
-        console.log(`[SHOPIFY] (mock) Would adjust inventory by ${delta} for variants: ${variantIds.join(", ")}`);
+        console.log(`[SHOPIFY] (mock) Would adjust inventory by ${delta} for variant: ${variantId}`);
         return true;
     }
 
@@ -626,7 +492,7 @@ export async function adjustProgramInventory(
     }
 
     try {
-        // Store's primary location — same lookup pattern as createShopifyProgramVariants.
+        // Store's primary location — same lookup pattern as setInitialShopifyInventory.
         const locRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/locations.json`, {
             headers: { 'X-Shopify-Access-Token': accessToken },
         }, "Shopify get locations");
@@ -635,33 +501,31 @@ export async function adjustProgramInventory(
         const locationId = locData.locations?.[0]?.id;
         if (!locationId) throw new Error("Shopify store has no locations configured");
 
-        for (const variantId of variantIds) {
-            const variantRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/variants/${variantId}.json`, {
-                headers: { 'X-Shopify-Access-Token': accessToken },
-            }, "Shopify get variant");
-            if (!variantRes.ok) throw new Error(`Shopify variant lookup failed for ${variantId}: ${variantRes.status}`);
-            const variantData = await variantRes.json();
-            const inventoryItemId = variantData.variant?.inventory_item_id;
-            if (!inventoryItemId) throw new Error(`Shopify variant ${variantId} has no inventory_item_id`);
+        const variantRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/variants/${variantId}.json`, {
+            headers: { 'X-Shopify-Access-Token': accessToken },
+        }, "Shopify get variant");
+        if (!variantRes.ok) throw new Error(`Shopify variant lookup failed for ${variantId}: ${variantRes.status}`);
+        const variantData = await variantRes.json();
+        const inventoryItemId = variantData.variant?.inventory_item_id;
+        if (!inventoryItemId) throw new Error(`Shopify variant ${variantId} has no inventory_item_id`);
 
-            const adjustRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/adjust.json`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Shopify-Access-Token': accessToken,
-                },
-                body: JSON.stringify({
-                    location_id: locationId,
-                    inventory_item_id: inventoryItemId,
-                    available_adjustment: delta,
-                }),
-            }, "Shopify adjust inventory");
-            if (!adjustRes.ok) {
-                throw new Error(`Shopify inventory adjust failed for variant ${variantId}: ${adjustRes.status} ${await adjustRes.text()}`);
-            }
-
-            console.log(`[SHOPIFY] Adjusted inventory for variant ${variantId} by ${delta} at location ${locationId}`);
+        const adjustRes = await shopifyFetch(`https://${storeDomain}/admin/api/${SHOPIFY_API_VERSION}/inventory_levels/adjust.json`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Shopify-Access-Token': accessToken,
+            },
+            body: JSON.stringify({
+                location_id: locationId,
+                inventory_item_id: inventoryItemId,
+                available_adjustment: delta,
+            }),
+        }, "Shopify adjust inventory");
+        if (!adjustRes.ok) {
+            throw new Error(`Shopify inventory adjust failed for variant ${variantId}: ${adjustRes.status} ${await adjustRes.text()}`);
         }
+
+        console.log(`[SHOPIFY] Adjusted inventory for variant ${variantId} by ${delta} at location ${locationId}`);
 
         return true;
     } catch (error) {
@@ -670,12 +534,7 @@ export async function adjustProgramInventory(
         await reportShopifyFailure(
             "adjustProgramInventory",
             error,
-            {
-                shopifyVariantId: program.shopifyVariantId ?? null,
-                shopifyOrgMemberVariantId: program.shopifyOrgMemberVariantId,
-                shopifyNonOrgMemberVariantId: program.shopifyNonOrgMemberVariantId,
-                delta,
-            },
+            { shopifyVariantId: variantId, delta },
             `Failed to adjust Shopify inventory (delta ${delta}) after a program capacity change.`,
         );
 
@@ -718,7 +577,7 @@ export async function mintMemberDiscountCode(
 
     const code = `PRG${programId}-${crypto.randomBytes(4).toString('hex').toUpperCase()}`;
 
-    // See createShopifyProgramVariants above for why this branch exists (CHECKIN_ENV=local mock).
+    // See createShopifySingleVariantProgram for why this branch exists (CHECKIN_ENV=local mock).
     if (config.shopifyMockActive()) {
         console.log(`[SHOPIFY] (mock) Would mint discount code ${code} for program ${programId} (-$${(amountOffCents / 100).toFixed(2)})`);
         return code;


### PR DESCRIPTION
Code-only half of the legacy two-variant removal for #975. Design:
[`checkin-app/docs/designs/975-LEGACY_VARIANT_CONTRACT.md`](https://github.com/innovationtreehouse/checkin/blob/main/checkin-app/docs/designs/975-LEGACY_VARIANT_CONTRACT.md).

Deliberately **no closing keyword** — the four columns are still declared, so #975 isn't done until the DROP COLUMN release lands.

## Why the split, and why R1 and R2 can't be one release

`deploy-prod.yml` runs **"Run database migrations"** (line 210, `prisma migrate deploy` to completion) as a *separate, earlier step* than **"Deploy to ECS"** (line 283, `update-service`). The schema is therefore fully migrated while the old task is still serving live traffic. That window exists at any `desiredCount` and any `minimumHealthyPercent` — it's step ordering, not task concurrency.

So the design doc's escape clause ("single instance / no drain overlap → Releases 1 and 2 collapse") does **not** apply to this pipeline. If the `DROP COLUMN` shipped here, then for the length of that window every route still selecting the dropped columns would throw: `GET /api/programs` (the **public** catalog, via `PUBLIC_PROGRAM_SELECT`), `GET /api/programs/[id]`, `nav/todo-counts`, and the lifecycle-reconcile cron.

The design's Release 0 (close the write) is folded in here: it's ~20 lines, and with no legacy rows in prod plus this PR replacing the only UI that could mint one, the risk it guards against is already nil.

## What's in here

**Closing the last write (design's Release 0)**

- `PATCH /api/programs/[id]` no longer accepts or writes `shopifyOrgMemberVariantId` / `shopifyNonOrgMemberVariantId`. Nothing can mint a fresh legacy-dependent row now.
- The program-ops "Shopify Checkout Identifiers" card exposed **only** the two legacy inputs — there was no `shopifyVariantId` field anywhere, so simply deleting them would have removed the manual-repair path entirely. Replaced with a single **Variant ID** input, which the PATCH already accepted.

**Dead code deleted**

- `lib/shopify.ts` `createShopifyProgramVariants` (its only non-test caller was the `isLegacy` fork below). `adjustProgramInventory` now takes just `shopifyVariantId` and adjusts one pool instead of looping a pair.
- `activateEnrollment`'s `purchasedOrgMember` param and the sibling-inventory mirror. Note the design doc's stated reason ("`purchasedOrgMember` is always `null`") isn't the operative one — on the webhook path it's `false`. The block is dead regardless: with no legacy program, either `shopifyVariantId` is set (guard false) or the program is free, in which case `hasProgramItem` never matches and nothing activates.
- `sync-shopify`'s `isLegacy` fork; the repair path is always single-pool.
- The webhook's variant-matcher sets, membership and program sides both.

**Mechanical read removals** — `programCheckout` (predicate **and** the Prisma `WHERE` it must stay equivalent to), `matchAudit`, `reconcile`'s `membershipVariantIdSet`, `lifecycleDrift`, `program/capacity`, the programs GET select, the public program page's tier ternary, and the dev Shopify tools.

## Two gaps in the design doc's blast radius

1. `adjustProgramInventory`'s own param shape (the doc lists `capacity.ts:69` but not the function both `capacity.ts` and `lifecycleDrift.ts` feed).
2. `shopify-live/product-inventory.shopify-live.ts` — `tsconfig.json` includes `**/*.ts`, so `tsc` type-checks it even though no local or CI run ever executes the file. It would have broken the build on excess-property.

## The audit hazard the doc left open

The doc flagged "decide before Release 2": snapshot the legacy variant ids into a const, or accept audit coverage loss. **Neither is needed.** `matchAudit` builds `programByVariant` from live row values and skips nulls, so with zero legacy rows in prod those ids are already absent from `allVariants` today. Dropping the selects is behaviour-identical, not a narrowing. Any historical-order coverage gap predates this work and isn't caused by it.

## Review notes

- **`shopify.test.ts`**: deleting `createShopifyProgramVariants` would have taken the only coverage of `setInitialShopifyInventory`'s error paths (no-inventory-item, locations failure, no-location, connect hard-fail, set failure) with it — and that helper is still live via `createShopifySingleVariantProgram` (`shopify.ts:550`). Those cases are **re-pointed** at the single-variant path, not dropped. Only the genuinely two-variant assertions are gone.
- **`programsAPI.integration.test.ts`**: its public-tier oracle derives expected columns from the generated classifications, which still tier the two dead fields `public`. Excluded by name via `DROPPED_SOON` with a pointer to the migration. **That coupling is real — the follow-up must delete that array when it regenerates `classifications.ts`, or the oracle silently under-checks.**
- The mock log string changed `for variants:` → `for variant:`, which is why four otherwise unrelated integration files appear in the diff. Accurate now, but it's the one part of this PR that isn't strictly removal — happy to revert it to shrink the blast radius.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| unit suite (CI default) | **2421 passed**, 257 suites |
| integration suite | **1257 passed**, 1 pre-existing failure |

Integration ran against a throwaway local Postgres (`db push` + `prisma/seed.ts`).

The single integration failure — `programAgeBounds › should block a participant who only turns minAge tomorrow` — **reproduces identically on untouched `main`** (verified by detaching to `a2cbaf72`). Its DOB fixtures build local midnight while `calculateAge` reads UTC fields since f23adab2, so past 19:00 CDT the UTC date has already rolled over. A fixture bug, not a production one; being fixed separately. Worth noting no workflow runs the integration suite at all, which is why it went unnoticed.

Residual references to the legacy names are `schema.prisma`, the generated `classifications.ts`, the coalesced baseline migration (never edited), the design doc, and that one self-deleting exclusion. **Zero in live code.**

## Design doc reconciled to what shipped (`faa56fce`)

The doc was a pre-build plan; three of its claims were stale or wrong. Corrected in
this PR so it doesn't mislead whoever picks up Release 2:

- **Removed the "single instance collapses Releases 1 and 2" escape clause**, with
  an explicit do-not-use note and the step-ordering reason. This is the dangerous
  one — acting on it would 500 the public catalog.
- **Resolved the audit hazard's open decision** as a false dilemma, and recorded why
  option (i) would have been insufficient *as written* had a legacy row survived
  (the audit needs `variant → programId` to test a claim, not a bare id list).
- **Corrected the `activateEnrollment` rationale** (`purchasedOrgMember` is `false`
  on the webhook path, not `null` — block is still dead, different reason).
- Status moved to "code removal shipped, DROP outstanding"; write-path section moved
  to past tense; the two missed blast-radius items added; and the two things
  Release 2 must not miss called out — the prod-vs-dev release gate, and deleting
  the `DROPPED_SOON` array.
- **Shopify-side: confirmed nothing to clean up.** Removing the webhook matcher
  would strand a paid order placed from a stale legacy cart, so this was worth
  checking — but there are no stale legacy items in the store. No store-side action
  needed, and not a Release 2 prerequisite. Recorded in the doc with the date.

## Follow-up release (after this is live in prod)

Run the doc's cutover query, then drop the four fields from `schema.prisma`, add a `BEGIN`/`COMMIT`-wrapped `DROP COLUMN` migration, regenerate `classifications.ts`, and delete the `DROPPED_SOON` exclusion. That PR carries `Fixes #975`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
