### PR TITLE
fix(test): build program age-bound DOB fixtures in UTC

### DIFF
--- a/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
@@ -32,19 +32,24 @@ describe('Program Age Bounds Integration Tests', () => {
     let testProgramId: number;
 
     beforeAll(async () => {
-        // Calculate Birthdates dynamically relative to execution time
+        // Calculate Birthdates dynamically relative to execution time.
+        // Built in UTC because calculateAge() compares UTC date components — a
+        // local-midnight fixture lands on the wrong UTC day off-zero-offset and
+        // shifts the "day before/after the birthday" cases by a year.
         const now = new Date();
-        const dob16 = new Date(now.getFullYear() - 16, now.getMonth(), now.getDate());
-        const dob12 = new Date(now.getFullYear() - 12, now.getMonth(), now.getDate());
-        const dob20 = new Date(now.getFullYear() - 20, now.getMonth(), now.getDate());
+        const dobYearsAgo = (years: number, dayOffset = 0) =>
+            new Date(Date.UTC(now.getUTCFullYear() - years, now.getUTCMonth(), now.getUTCDate() + dayOffset));
+        const dob16 = dobYearsAgo(16);
+        const dob12 = dobYearsAgo(12);
+        const dob20 = dobYearsAgo(20);
         // Exact boundaries for program [minAge=14, maxAge=18].
         // Birthday is today => exactly N years old today (eligible at both ends).
-        const dobExactly14 = new Date(now.getFullYear() - 14, now.getMonth(), now.getDate());
-        const dobExactly18 = new Date(now.getFullYear() - 18, now.getMonth(), now.getDate());
+        const dobExactly14 = dobYearsAgo(14);
+        const dobExactly18 = dobYearsAgo(18);
         // Birthday tomorrow, born 14 years ago => still 13 today (under).
-        const dobTurns14Tomorrow = new Date(now.getFullYear() - 14, now.getMonth(), now.getDate() + 1);
+        const dobTurns14Tomorrow = dobYearsAgo(14, 1);
         // Birthday yesterday, born 19 years ago => turned 19 already (over).
-        const dobTurned19Yesterday = new Date(now.getFullYear() - 19, now.getMonth(), now.getDate() - 1);
+        const dobTurned19Yesterday = dobYearsAgo(19, -1);
 
         // Clean up any leaked state from previous runs
         await prisma.auditLog.deleteMany({});


### PR DESCRIPTION
## What

`programAgeBounds.integration.test.ts` built its DOB fixtures with the local-time `Date` constructor (local midnight). They now come from a small `dobYearsAgo(years, dayOffset)` helper built on `Date.UTC` with `now`'s UTC components, matching what `calculateAge` reads.

## Why

f23adab2 ("fix(time): read calculateAge from UTC fields, not local") made `calculateAge` compare UTC date components. The fixtures stayed on local midnight, so the two off-by-one-day boundary cases drifted apart from the code under test:

- In a negative-offset zone (e.g. `America/Chicago`) once local time passes 19:00, the UTC date has already rolled to tomorrow. "Turns 14 tomorrow" is "turns 14 today" in UTC, the person reads as 14, and `should block a participant who only turns minAge tomorrow (still under today)` got 200 instead of 400.
- `dobTurned19Yesterday` had the mirror-image exposure in a positive-offset zone.

Test-only change — no production code touched. The failure is on `main` (verified at a2cbaf72), not introduced by any feature branch.

## Verification

Ran the integration suite against a local Postgres under three timezones, all green:

- `TZ=America/Chicago` — fails before the fix (reproduced at 19:15 CDT, i.e. UTC already on the next day), passes after.
- `TZ=Pacific/Kiritimati` (+14) — passes.
- `TZ=UTC` — passes.

Each run was the full 128-suite / 1269-test integration set.

## Reviewer notes

- Other DOB fixtures in the test tree use `new Date()` + `setFullYear(-n)`, which preserves the instant's UTC time-of-day and so has no boundary exposure. `adminRolesAPI.integration.test.ts:88` does build a local-midnight DOB, but it only needs "a minor" (10 vs 9 both satisfy it), so it is left alone.
- **No CI workflow runs `npm run test:integration`.** That is why this went unnoticed, and it stays true after this PR — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)