### PR TITLE
refactor: move PROGRAM_ATTACHED_WHERE to person/filters

### DIFF
--- a/checkin-app/src/lib/membership/personBgTriggers.ts
+++ b/checkin-app/src/lib/membership/personBgTriggers.ts
@@ -1,7 +1,7 @@
 import prisma from "@/lib/prisma";
 import { bgFreshThreshold, personBgVerdict } from "@/lib/membership/personBgCheck";
 import { nextBoundary } from "@/lib/membership/renewal";
-import { LIVE_PERSON } from "@/lib/person/filters";
+import { LIVE_PERSON, PROGRAM_ATTACHED_WHERE } from "@/lib/person/filters";
 
 /**
  * Triggers that OPEN a per-person background-check obligation (PERSON_BG process,
@@ -14,15 +14,6 @@ import { LIVE_PERSON } from "@/lib/person/filters";
  */
 
 const SYSTEM_ACTOR = 0;
-
-/** Person is attached to at least one program in any of the three roles. */
-const PROGRAM_ATTACHED_WHERE = {
-    OR: [
-        { programParticipants: { some: {} } },
-        { programVolunteers: { some: {} } },
-        { programsLed: { some: {} } },
-    ],
-};
 
 /**
  * Open one PERSON_BG obligation for `personId`, evaluated as of `asOf` (the annual

--- a/checkin-app/src/lib/person/filters.ts
+++ b/checkin-app/src/lib/person/filters.ts
@@ -10,3 +10,20 @@ import type { Prisma } from "@/generated/prisma/client";
  * historical record, etc).
  */
 export const LIVE_PERSON: Prisma.PersonWhereInput = { mergedIntoId: null };
+
+/**
+ * Person is attached to at least one program in any of the three roles — the shared
+ * "who is in the building" population behind the PERSON_BG and PERSON_AGREEMENT
+ * obligations and the board compliance lists.
+ *
+ * Lives here rather than in either trigger module: both need it, and importing one
+ * trigger from the other closes an import cycle (personBgTriggers → renewal → payment →
+ * personAgreementTriggers → personBgTriggers) that fails at module init with a TDZ error.
+ */
+export const PROGRAM_ATTACHED_WHERE: Prisma.PersonWhereInput = {
+    OR: [
+        { programParticipants: { some: {} } },
+        { programVolunteers: { some: {} } },
+        { programsLed: { some: {} } },
+    ],
+};


### PR DESCRIPTION
## What

Moves the `PROGRAM_ATTACHED_WHERE` Person filter ("attached to at least one program in any of the three roles") out of `personBgTriggers.ts` and into `person/filters.ts`, next to `LIVE_PERSON`.

No behavior change: same object, same three role branches, same two call sites.

## Why

`personBgTriggers.ts` sits inside an import cycle that already exists on `main`:

| | |
|---|---|
| [renewal.ts:4](https://github.com/innovationtreehouse/checkin/blob/main/checkin-app/src/lib/membership/renewal.ts#L4) | → `./payment` |
| [payment.ts:6](https://github.com/innovationtreehouse/checkin/blob/main/checkin-app/src/lib/membership/payment.ts#L6) | → `personBgTriggers` |
| [personBgTriggers.ts:3](https://github.com/innovationtreehouse/checkin/blob/main/checkin-app/src/lib/membership/personBgTriggers.ts#L3) | → `renewal` |

That cycle is benign **only** because every binding crossing it is a hoisted `function` declaration — `certifyPaymentPlan`, `openPersonBgForNewMember`, `nextBoundary` — which is initialized before the cycle resolves.

A `const` is not hoisted that way. Any module that both sits in the cycle and imports a `const` from another member of it dies at load with:

```
ReferenceError: Cannot access 'PROGRAM_ATTACHED_WHERE' before initialization
```

`PROGRAM_ATTACHED_WHERE` is a `const`, so it is a live trip-wire for the next feature that needs it. This surfaced while building #1224, whose new trigger module needs the same filter — type-checking and the full unit suite were green with the broken import; only the integration run caught it.

`person/filters.ts` is a leaf module and already owns the sibling `LIVE_PERSON` fragment, so the filter is importable from anywhere.

## What this does NOT do

It does not break the underlying cycle. That remains, and remains a trap for the next `const` or `class` reached across it. Worth its own cleanup; not attempted here.

## Verification

Run in isolation on this branch — the rest of the #1224 work stashed, Prisma client regenerated from the baseline schema:

- type-check clean
- full unit suite: 2431 passed, 257 suites, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
