### PR TITLE
test(external): stop mock implementations leaking between tests

### DIFF
--- a/checkin-app/src/lib/membership/__tests__/external.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/external.test.ts
@@ -70,8 +70,19 @@ const { loadAgreementPdf, stampWatermark, AgreementUnavailableError } = require(
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { notifyReviewers, applyVolunteerStatus } = require('@/lib/membership/review');
 
+// resetAllMocks, NOT clearAllMocks: clear wipes recorded calls but KEEPS
+// implementations, so a `mockResolvedValue` set in one test silently answers every
+// later test in the file. Harmless only for as long as no later test exercises a
+// path that reaches the same prisma method. Reset drops implementations too, so
+// each test states the prisma responses it depends on and nothing else.
+//
+// The three factory-level defaults below are re-established here, since reset
+// clears those as well.
 beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
+    prisma.boardSettings.findUnique.mockResolvedValue(null); // signingMockActive: no dev override
+    notifyReviewers.mockResolvedValue(undefined);
+    applyVolunteerStatus.mockResolvedValue(undefined);
     config.zohoAvailable.mockReturnValue(true);
     config.zohoMockActive.mockReturnValue(true);
     config.isProd.mockReturnValue(false);
@@ -423,6 +434,7 @@ describe('getOrCreateContractSigningUrl', () => {
             zohoSign.createRequest.mockResolvedValue({ requestId: 'req-stg', actionId: 'act-stg', documentId: 'doc-stg' });
             zohoSign.submitRequest.mockResolvedValue(undefined);
             zohoSign.getEmbeddedSignUrl.mockResolvedValue('https://sign.example/embed-stg');
+            prisma.orgMembershipProcess.updateMany.mockResolvedValue({ count: 1 }); // wins the id claim
 
             await getOrCreateContractSigningUrl(1);
 


### PR DESCRIPTION
## What

`external.test.ts` reset its mocks with `jest.clearAllMocks()`, which wipes recorded calls but **keeps implementations**. A `mockResolvedValue` set in one test therefore answered every later test in the file.

Switched to `jest.resetAllMocks()`, so each test states the prisma responses it depends on. No production code changes; same 26 tests, same assertions.

## Why it matters

The leak was inert only by luck — invisible for as long as no later test exercised a path that reached the same prisma method. Two tests were already riding on it rather than on their own setup:

- **`not_lead when the caller is not a household lead and not a sysadmin`** passed only because `findFirst` was still returning the `{ id: 9 }` row stubbed by the `findProcessByEnvelope` test ~200 lines earlier. It asserted the guard rejects a non-lead, but would stop doing so the moment the signing path began calling `findFirst` — which is exactly what happens in #1224, where that test flipped to a `TypeError` deep inside the Zoho path.

- **the ops-stg watermark test** never stubbed `updateMany` at all, reading its `{ count: 1 }` off a previous test. Switching to reset surfaced this immediately as `Cannot read properties of undefined (reading 'count')`. Stubbing it in that test is the second change here.

The first is the sharper one: a guard test that no longer guards, still green.

## Detail

`resetAllMocks` also clears the three implementations set in the `jest.mock` factories, so those are re-established in `beforeEach`:

- `boardSettings.findUnique` → `null` (`signingMockActive`: no dev signing-target override)
- `notifyReviewers` → resolved
- `applyVolunteerStatus` → resolved

## Verification

- `external.test.ts`: 26 passed
- full unit suite: 2436 passed, 257 suites, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
