### PR TITLE
security(registry): declare BackgroundCheckAttestation on the reviewer queue

### DIFF
--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -210,8 +210,13 @@ defineRoute({
     authorize: { anyRole: ['isBackgroundCheckReviewer', 'isBoardMember'] },
     envelope: 'queue',
     // Bag: { OrgMembershipProcess } with membership (OrgMembership → household Household
-    // → householdMembers Person, leads flagged isHouseholdLead).
-    returns: ['OrgMembershipProcess', 'OrgMembership', 'Household', 'Person'],
+    // → householdMembers Person, leads flagged isHouseholdLead) and the process's
+    // attestations. Reviewers attest PER ADULT, so the card shows each lead's own
+    // approval count; the route selects `subjectPersonId` alone off each attestation.
+    // Widening that select is a policy decision, not a convenience: `reviewerId` is
+    // public-tier and would tell reviewer B that reviewer A already signed off, which
+    // the deliberate `_count`-only shape exists to prevent.
+    returns: ['OrgMembershipProcess', 'OrgMembership', 'Household', 'Person', 'BackgroundCheckAttestation'],
     orderedView: [
         ['isBackgroundCheckReviewer', ['everyones:pii', 'member', 'public']],
         ['isBoardMember', ['everyones:pii', 'member', 'public']],


### PR DESCRIPTION
Boundary-only PR. No app or feature code — per the isolation rule in `AGENTS.md`, the registry entry lands first and the route that depends on it follows in a stacked PR.

## What

Adds `BackgroundCheckAttestation` to the `returns` bag of `GET /api/membership/reviews`.

## Why now

The follow-up PR for #1260 makes background-check reviewers attest **per adult** rather than per application. The reviewer card has to show each household lead's own approval count — a reviewer needs to see that their household-mate is sitting at 1 of 2 before choosing whom to name — so the queue route starts returning attestation rows.

An unused `returns` declaration is inert: nothing reads it at request time (the handler never consults `spec.returns`), so this changes no behaviour on its own. It feeds the grant-resolvability validator and, more importantly, is the audit record of what actually leaves the server for that endpoint. Landing it separately keeps the widening reviewable on its own rather than buried in a feature diff.

## What a reviewer should check

The select the follow-up uses is deliberately **one field wide** — `attestations: { select: { subjectPersonId: true } }`:

- `reviewerId` is `public`-tier, so selecting it would pass the stripper and tell reviewer B that reviewer A already signed off. The existing `_count`-only shape exists precisely to prevent that anchoring; this must not undo it.
- `result` stays out as well — an awaiting process only ever holds `APPROVE`s (any `REJECT` moves it to `BLOCKED`), so it carries no information.

So the thing to hold the line on is not the model being listed, but that the select never widens. That reasoning is written into the registry comment so it travels with the entry.

No `EDGE_INCLUDE_ALLOWLIST` entry is needed: `routeAuthDrift` rule 3 covers `ProgramParticipant`/`ProgramVolunteer`/`RSVP`/`Visit` only, and this model is not all-public-tier (`result`, `note`, `isMarkedVolunteer` are `internal`).

## Tests

Security suites: 619 passed, 17 suites. Full unit suite green (2440 passed, 257 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
