### PR TITLE
fix(household): route the createNew promotion through addHouseholdLead

### DIFF
--- a/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts
@@ -64,6 +64,10 @@ describe('Admin Participant Household API Integration Tests', () => {
         await prisma.person.deleteMany({
             where: { name: 'Subject Test' }
         });
+        // createNew names the household after the subject.
+        await prisma.household.deleteMany({
+            where: { name: "Subject Test's Household" }
+        });
     });
 
     describe('POST /api/membership-ops/participants/[id]/household', () => {
@@ -154,13 +158,96 @@ describe('Admin Participant Household API Integration Tests', () => {
             expect(data.participant.householdId).not.toBe(testHouseholdId);
 
             const newHouseholdId = data.participant.householdId;
+            expect(data.participant.isHouseholdLead).toBe(true);
 
-            // Check if they are a lead
-            const lead = await prisma.person.findFirst({
-                where: { id: testParticipantId, householdId: newHouseholdId, isHouseholdLead: true },
+            // Sole lead of the household that was just created for them.
+            const leads = await prisma.person.findMany({
+                where: { householdId: newHouseholdId, isHouseholdLead: true },
                 select: { id: true }
             });
-            expect(lead).not.toBeNull();
+            expect(leads.map(l => l.id)).toEqual([testParticipantId]);
+        });
+
+        it('moves the lead flag with a lead who is given a new household of their own', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true, isBoardMember: false }
+            });
+
+            const subjectBefore = await prisma.person.findUnique({ where: { id: testParticipantId } });
+            const priorHouseholdId = subjectBefore!.householdId!;
+            await prisma.person.update({ where: { id: testParticipantId }, data: { isHouseholdLead: true } });
+
+            const req = new Request(`http://localhost:4000/api/membership-ops/participants/${testParticipantId}/household`, {
+                method: 'POST',
+                body: JSON.stringify({ createNew: true })
+            });
+            const res = await POST(req as unknown as import("next/server").NextRequest, { params: Promise.resolve({ id: String(testParticipantId) }) });
+            expect(res.status).toBe(200);
+
+            const data = await res.json();
+            expect(data.participant.householdId).not.toBe(priorHouseholdId);
+
+            // They lead the NEW household, and the old one is left leadless.
+            const moved = await prisma.person.findUnique({ where: { id: testParticipantId } });
+            expect(moved?.isHouseholdLead).toBe(true);
+            expect(moved?.householdId).toBe(data.participant.householdId);
+            const oldLeads = await prisma.person.count({ where: { householdId: priorHouseholdId, isHouseholdLead: true } });
+            expect(oldLeads).toBe(0);
+        });
+
+        // A youth cannot be a household lead (addHouseholdLead's youth exclusion),
+        // and a household with no possible lead must not be created at all — the
+        // whole reassign is refused, not partially applied.
+        it('refuses createNew on a youth and creates no household', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true, isBoardMember: false }
+            });
+
+            const twelveYearsAgo = new Date();
+            twelveYearsAgo.setFullYear(twelveYearsAgo.getFullYear() - 12);
+            await prisma.person.update({
+                where: { id: testParticipantId },
+                data: { dateOfBirth: twelveYearsAgo }
+            });
+            const priorHouseholdId = (await prisma.person.findUnique({ where: { id: testParticipantId } }))!.householdId;
+
+            const req = new Request(`http://localhost:4000/api/membership-ops/participants/${testParticipantId}/household`, {
+                method: 'POST',
+                body: JSON.stringify({ createNew: true })
+            });
+            const res = await POST(req as unknown as import("next/server").NextRequest, { params: Promise.resolve({ id: String(testParticipantId) }) });
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toMatch(/youth cannot lead a household/i);
+
+            // The household create and the move roll back with the refused promotion.
+            const unmoved = await prisma.person.findUnique({ where: { id: testParticipantId } });
+            expect(unmoved?.householdId).toBe(priorHouseholdId);
+            expect(await prisma.household.count({ where: { name: "Subject Test's Household" } })).toBe(0);
+        });
+
+        it('refuses createNew on a youth already flagged a lead, leaving the flag as it was', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true, isBoardMember: false }
+            });
+
+            const twelveYearsAgo = new Date();
+            twelveYearsAgo.setFullYear(twelveYearsAgo.getFullYear() - 12);
+            await prisma.person.update({
+                where: { id: testParticipantId },
+                data: { dateOfBirth: twelveYearsAgo, isHouseholdLead: true }
+            });
+
+            const req = new Request(`http://localhost:4000/api/membership-ops/participants/${testParticipantId}/household`, {
+                method: 'POST',
+                body: JSON.stringify({ createNew: true })
+            });
+            const res = await POST(req as unknown as import("next/server").NextRequest, { params: Promise.resolve({ id: String(testParticipantId) }) });
+            expect(res.status).toBe(400);
+
+            // The de-lead that precedes the promotion must roll back too — a refused
+            // reassign leaves the person exactly as it found them.
+            const unmoved = await prisma.person.findUnique({ where: { id: testParticipantId } });
+            expect(unmoved?.isHouseholdLead).toBe(true);
         });
     });
 });

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/household/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/household/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { logBackendError, logger } from "@/lib/logger";
 import { apiError } from "@/lib/api-response";
+import { addHouseholdLead, HouseholdLeadLimitError, HouseholdLeadYouthError } from "@/lib/household/leads";
 
 export const POST = withAuth<{ params: Promise<{ id: string }> }>(
     { roles: ['isSysadmin', 'isBoardMember'] },
@@ -30,45 +31,54 @@ export const POST = withAuth<{ params: Promise<{ id: string }> }>(
             return apiError("Participant not found", 404);
         }
 
-        let targetHouseholdId: number;
-
-        if (createNew) {
-            const newHousehold = await prisma.household.create({
-                data: {
-                    name: `${participant.name || 'User'}'s Household`,
-                }
-            });
-            targetHouseholdId = newHousehold.id;
-            // New household starts as a visitor (no membership) — membership is
-            // earned via the application process or set on the households page.
-            // Leadership (isHouseholdLead) is set on the person.update below.
-        } else {
-            targetHouseholdId = parseInt(householdId);
-            if (isNaN(targetHouseholdId)) {
+        // Validate the destination before the write transaction below.
+        const requestedHouseholdId = createNew ? null : parseInt(householdId);
+        if (requestedHouseholdId !== null) {
+            if (isNaN(requestedHouseholdId)) {
                 return apiError("Invalid household ID", 400);
             }
 
-            const household = await prisma.household.findUnique({ where: { id: targetHouseholdId } });
+            const household = await prisma.household.findUnique({ where: { id: requestedHouseholdId } });
             if (!household) {
                 return apiError("Household not found", 404);
             }
         }
 
-        // a1 leadership (HOUSEHOLD_LEAD_MODEL.md): createNew makes the person the
-        // sole lead of the household we just created; a real move into another
-        // household de-leads them (they lead their OWN household — re-promote if
-        // they should lead the new one). A same-household no-op leaves the flag
-        // untouched, matching the prior behavior that only cleaned up on a change.
-        const leadFlag = createNew
-            ? { isHouseholdLead: true }
-            : participant.householdId !== targetHouseholdId
-                ? { isHouseholdLead: false }
-                : {};
+        // a1 leadership (HOUSEHOLD_LEAD_MODEL.md): a person leads their OWN
+        // household, so a change of household always clears the flag, and
+        // createNew then re-promotes them in the household created here. The
+        // promotion goes through addHouseholdLead — the only writer of
+        // isHouseholdLead: true — which owns the youth exclusion and the lead cap
+        // under a Household row lock. It rejects a person whose householdId isn't
+        // the target household, so the move must be written first; one
+        // transaction keeps the whole reassign atomic and puts the helper's lock
+        // in it. A same-household no-op leaves the flag untouched.
+        const { updatedParticipant, targetHouseholdId } = await prisma.$transaction(async (tx) => {
+            // New household starts as a visitor (no membership) — membership is
+            // earned via the application process or set on the households page.
+            const targetHouseholdId = requestedHouseholdId ?? (await tx.household.create({
+                data: { name: `${participant.name || 'User'}'s Household` },
+            })).id;
 
-        const updatedParticipant = await prisma.person.update({
-            where: { id: participantId },
-            data: { householdId: targetHouseholdId, ...leadFlag },
-            include: { household: true }
+            const updated = await tx.person.update({
+                where: { id: participantId },
+                data: {
+                    householdId: targetHouseholdId,
+                    ...(participant.householdId !== targetHouseholdId ? { isHouseholdLead: false } : {}),
+                },
+                include: { household: true }
+            });
+
+            if (!createNew) return { updatedParticipant: updated, targetHouseholdId };
+
+            // A rejected promotion aborts the whole reassign: the household just
+            // created would have no possible lead, so it must not exist. The throw
+            // rolls back the create and the move with it.
+            const { created } = await addHouseholdLead(tx, targetHouseholdId, participantId);
+            return {
+                updatedParticipant: { ...updated, isHouseholdLead: updated.isHouseholdLead || created },
+                targetHouseholdId,
+            };
         });
 
         await prisma.auditLog.create({
@@ -84,6 +94,12 @@ export const POST = withAuth<{ params: Promise<{ id: string }> }>(
 
         return NextResponse.json({ success: true, participant: updatedParticipant });
     } catch (error) {
+        if (error instanceof HouseholdLeadYouthError) {
+            return apiError("A youth cannot lead a household, so they cannot be given one of their own. Assign them to an existing household instead.", 400);
+        }
+        if (error instanceof HouseholdLeadLimitError) {
+            return apiError(error.message, 400);
+        }
         await logBackendError(error, "POST /api/membership-ops/participants/[id]/household");
         return apiError(`Internal server error`, 500);
     }


### PR DESCRIPTION
Closes the promote-leg half of #1471. Deliberately **no closing keyword** — that issue is filed as a design question about what bounds semi-valid household states, and it stays open for that; see "What this does NOT fix" below.

## The bug

`POST /api/membership-ops/participants/[id]/household` (sysadmin/board) built its own `isHouseholdLead: true` and folded it into a plain `prisma.person.update`:

```ts
const leadFlag = createNew
    ? { isHouseholdLead: true }
    : participant.householdId !== targetHouseholdId
        ? { isHouseholdLead: false }
        : {};

await prisma.person.update({
    where: { id: participantId },
    data: { householdId: targetHouseholdId, ...leadFlag },
});
```

That direct write skipped both invariants `lib/household/leads.ts` exists to enforce:

1. **The youth exclusion** — `addHouseholdLeadTx` throws `HouseholdLeadYouthError` for a youth target. Via this route, moving a youth into a newly created household silently made them its lead.
2. **The `MAX_HOUSEHOLD_LEADS` cap** — enforced under a `SELECT ... FOR UPDATE` row lock on the `Household`, which this path never took.

Every other promotion path routes through `addHouseholdLead` (promote route, membership intake, bulk import, membership-ops participant create, first-sign-in provisioning in `lib/auth-options.ts`, dev seed helpers). This one was the outlier.

## The fix

The household create, the person's move, and the promotion now share one `prisma.$transaction`, with the tx client passed to `addHouseholdLead` so the helper's row lock joins the same transaction and the whole reassign is atomic.

Ordering matters: `addHouseholdLeadTx` throws `HouseholdLeadMismatchError` unless `person.householdId` already equals the `householdId` argument (a1's invariant — `isHouseholdLead` means "lead of their OWN household"), so the move is written before the promotion runs.

`lib/household/leads.ts` is now the only writer of `isHouseholdLead: true` in the codebase.

### Extra root cause found while fixing

The old `createNew` leg never de-leaded. Someone already flagged lead of their *old* household kept the flag across the move, so the helper would have seen `isHouseholdLead: true`, returned `{created: false}`, and skipped the youth check anyway. Now **any** change of household clears the flag first, and `createNew` re-promotes through the helper — so the promotion is always re-decided rather than inherited.

## Youth: refused, not accommodated

`createNew` on a youth returns **400 and creates nothing**. The refused promotion propagates out of the transaction, rolling back the household create and the move with it:

> A youth cannot lead a household, so they cannot be given one of their own. Assign them to an existing household instead.

The alternative considered was to create the household, move the youth, and leave it leadless (already a modeled state — `BROKEN_HOUSEHOLD_WHERE`). Rejected: a household whose only member cannot lead it has no business existing, and manufacturing a fresh entry for the broken-households remediation queue is not a sensible outcome for a staff action. `HouseholdLeadLimitError` maps to a 400 the same way, matching the shape in `src/app/api/household/lead/route.ts`.

No UI change needed — the participants page already surfaces `data.error` from a non-ok response, so the operator gets that sentence in the failure notification.

## What this does NOT fix

#1471 names a second defect on the **de-lead leg**: a real move bypasses `removeHouseholdLead`'s last-lead guard, so moving a household's only lead out leaves the remaining members leadless. That leg is untouched here — it is the demote direction, it needs its own decision about refuse-vs-enqueue, and it is entangled with the client-side `canSubmitAssign` / `canChangeHousehold` guards the issue describes. Same for the four open questions in #1471 about where invariants should live. This PR closes the hole where a youth could be flagged a lead; the design question stays open.

## Tests

Extended `src/app/__tests__/adminParticipantHouseholdAPI.integration.test.ts` rather than adding a file:

- `refuses createNew on a youth and creates no household` — 400, person still in their prior household, zero household rows created.
- `refuses createNew on a youth already flagged a lead, leaving the flag as it was` — asserts the de-lead preceding the promotion rolls back too.
- `moves the lead flag with a lead who is given a new household of their own` — covers the stale-flag path above.
- Extended the existing adult `createNew` case to assert **sole** lead of the new household.
- The existing de-lead-on-real-move case is unchanged and still passes.

Also cleaned up the household rows the `createNew` cases have always leaked (`afterEach` now drops `Subject Test's Household`).

Confirmed the new tests bite: stashing only the route fix fails them.

```
Integration (13 household suites):  93 passed
Unit (npm run test:ci):            2436 passed, 257 suites
tsc --noEmit: clean    npm run lint: clean
```

Ran against a throwaway local Postgres (docker was unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)