### PR TITLE
fix(membership): gate the dues, checkout link, and every lead-only step on household leadership

### DIFF
--- a/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzOwnershipBoundary.integration.test.ts
@@ -21,7 +21,8 @@
  *   HH_B   — leadB (lead of a DIFFERENT household). The cross-household attacker
  *            used to prove the id-addressed trusted-adult routes reject a lead
  *            of the wrong household.
- *   HH_PAY        — payUser; membership process PENDING_PAYMENT.
+ *   HH_PAY        — payLead (lead) + payMember (NOT a lead); membership process
+ *                   PENDING_PAYMENT.
  *   HH_RENEWAL    — renewalLead (lead); membership process PENDING_RENEWAL (read-only:
  *                   renewal-status).
  *   HH_RENEW      — renewUser; membership process PENDING_RENEWAL (mutated by renew).
@@ -86,7 +87,7 @@ function taAuditCount(taId: number) {
 describe('Ownership-boundary authorization', () => {
     let leadA = 0, memberA = 0, hhA = 0;
     let leadB = 0, hhB = 0;
-    let payUser = 0, hhPay = 0;
+    let payLead = 0, payMember = 0, hhPay = 0;
     let renewalLead = 0, hhRenewal = 0;
     let renewUser = 0, hhRenew = 0;
     let taWithdrawId = 0, taRenewId = 0;
@@ -131,7 +132,8 @@ describe('Ownership-boundary authorization', () => {
         leadB = await mkMember(hhB, 'LeadB', true);
 
         hhPay = await mkHousehold('HH_PAY');
-        payUser = await mkMember(hhPay, 'PayUser');
+        payLead = await mkMember(hhPay, 'PayLead', true);
+        payMember = await mkMember(hhPay, 'PayMember');
         await mkPendingProcess(hhPay, 'PENDING_PAYMENT', 'INITIAL');
 
         hhRenewal = await mkHousehold('HH_RENEWAL');
@@ -312,22 +314,27 @@ describe('Ownership-boundary authorization', () => {
         });
     });
 
-    // ---- membership/payment (GET) — self-scoped (no id param) ------------------
+    // ---- membership/payment (GET) — self-scoped (no id param), lead-only -------
     // No IDOR vector: the route derives the household from the session user, so a
-    // caller can only ever reach their OWN household's process. The boundary test
-    // is isolation: a user from a household with no pending payment must NOT see
-    // another household's link.
+    // caller can only ever reach their OWN household's process. Two boundaries:
+    // the dues figure and the live checkout link are the lead's (a non-lead member
+    // of the paying household gets 403), and a lead of another household must NOT
+    // see this household's link.
     describe('GET /api/membership/payment', () => {
         it('401 unauthenticated', async () => {
             anon();
             expect((await PAYMENT_GET(req())).status).toBe(401);
         });
-        it('200 for a member of the household awaiting payment', async () => {
-            as(payUser, { householdId: hhPay });
+        it('403 for a non-lead member of the household awaiting payment', async () => {
+            as(payMember, { householdId: hhPay });
+            expect((await PAYMENT_GET(req())).status).toBe(403);
+        });
+        it('200 for the lead of the household awaiting payment', async () => {
+            as(payLead, { householdId: hhPay });
             expect((await PAYMENT_GET(req())).status).toBe(200);
         });
         it('does not expose another household\'s payment process (409, not 200)', async () => {
-            as(memberA, { householdId: hhA });
+            as(leadA, { householdId: hhA });
             expect((await PAYMENT_GET(req())).status).toBe(409);
         });
     });

--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -11,6 +11,7 @@ import crypto from 'crypto';
 import { normalizeAuditData } from '@/lib/auditPayload';
 import { POST as SHOPIFY_WEBHOOK } from '@/app/api/webhooks/shopify/route';
 import { POST as CERTIFY } from '@/app/api/membership-ops/applications/certify-payment/route';
+import { GET as PAYMENT } from '@/app/api/membership/payment/route';
 import { ensurePaymentLink, ensurePaymentLinkForUser, activate } from '@/lib/membership/payment';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
@@ -49,6 +50,7 @@ describe('Membership payment API', () => {
     let normalProc: number, normalMembership: number;
     let volProc: number;
     let certProc: number;
+    let gateProc: number, gateLeadId: number, gateNonLeadId: number;
     const prevWebhookSecret = process.env.SHOPIFY_WEBHOOK_SECRET;
     const prevStoreDomain = process.env.SHOPIFY_STORE_DOMAIN;
     let prevSettings: { normalDuesCents: number; volunteerDuesCents: number; orgMembershipVariantId: string | null; volunteerDiscountCode: string | null } | null = null;
@@ -103,6 +105,16 @@ describe('Membership payment API', () => {
         normalMembership = normal.orgMembershipId;
         volProc = (await makeProc('Vol', true)).processId;
         certProc = (await makeProc('Cert', false)).processId;
+
+        // A household awaiting payment with both a lead and a non-lead member, for
+        // the GET /api/membership/payment lead gate below.
+        const gate = await makeProc('Gate', false);
+        gateProc = gate.processId;
+        const gLead = await prisma.person.create({ data: { email: `gate-lead-${TAG}@example.com`, name: 'Gate Lead', householdId: gate.householdId } });
+        await prisma.person.update({ where: { id: gLead.id }, data: { isHouseholdLead: true } });
+        gateLeadId = gLead.id;
+        const gMember = await prisma.person.create({ data: { email: `gate-member-${TAG}@example.com`, name: 'Gate Member', householdId: gate.householdId } });
+        gateNonLeadId = gMember.id;
     });
 
     afterAll(async () => {
@@ -131,6 +143,47 @@ describe('Membership payment API', () => {
     it('resolves the payment link for the calling user', async () => {
         const res = await ensurePaymentLinkForUser(leadId);
         expect(res.amountCents).toBe(10000);
+    });
+
+    // ── GET /api/membership/payment: dues + checkout are lead-only ────────────
+    const paymentReq = () => new Request('http://localhost:4000/api/membership/payment') as never;
+
+    it('serves the dues amount and checkout link to a household lead', async () => {
+        asUser(gateLeadId);
+        const res = await PAYMENT(paymentReq());
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.amountCents).toBe(10000);
+        expect(body.checkoutUrl).toContain(`attributes[Membership_Process_ID]=${gateProc}`);
+    });
+
+    it('refuses a non-lead household member (no dues, no checkout link)', async () => {
+        asUser(gateNonLeadId);
+        const res = await PAYMENT(paymentReq());
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error).toMatch(/household lead/);
+        expect(body.amountCents).toBeUndefined();
+        expect(body.checkoutUrl).toBeUndefined();
+    });
+
+    it('still serves a board member who is not a household lead', async () => {
+        asBoard(gateNonLeadId);
+        const res = await PAYMENT(paymentReq());
+        expect(res.status).toBe(200);
+        expect((await res.json()).amountCents).toBe(10000);
+    });
+
+    it('still serves a sysadmin who is not a household lead', async () => {
+        await prisma.person.update({ where: { id: gateNonLeadId }, data: { isSysadmin: true } });
+        try {
+            asUser(gateNonLeadId);
+            const res = await PAYMENT(paymentReq());
+            expect(res.status).toBe(200);
+            expect((await res.json()).amountCents).toBe(10000);
+        } finally {
+            await prisma.person.update({ where: { id: gateNonLeadId }, data: { isSysadmin: false } });
+        }
     });
 
     it('orders/paid webhook activates the membership (and is idempotent)', async () => {

--- a/checkin-app/src/app/api/membership/payment/route.ts
+++ b/checkin-app/src/app/api/membership/payment/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
+import { householdLeadship } from "@/lib/household/leads";
 import { ensurePaymentLinkForUser, PaymentError } from "@/lib/membership/payment";
 import { apiError } from "@/lib/api-response";
 
@@ -9,6 +10,16 @@ export const dynamic = "force-dynamic";
 // GET /api/membership/payment — the caller's dues amount + Shopify checkout link.
 export const GET = withAuth({}, async (_req, auth) => {
     if (auth.type !== "session") return apiError("Unauthorized", 401);
+
+    // The dues figure and the live checkout link are the household lead's to see
+    // (canManage folds in sysadmin), plus the board — matching request-payment-plan.
+    // Every other household member, youth included, resolves the same household
+    // here, so without this gate they would get the amount and the checkout URL.
+    const household = await householdLeadship(auth.user.id);
+    if (!household?.canManage && !auth.user.isBoardMember) {
+        return apiError("Forbidden: Only a household lead can view membership dues", 403);
+    }
+
     try {
         return NextResponse.json(await ensurePaymentLinkForUser(auth.user.id));
     } catch (error) {

--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -194,6 +194,44 @@ describe("membership page", () => {
     expect(screen.getByRole("link", { name: /Pay here with Shopify/ })).toHaveAttribute("href", "https://shop.example/checkout");
   });
 
+  // ── non-lead household members see progress, never a lead-only task ────────
+  it("hides the intake form from a non-lead household member", async () => {
+    setSession({ id: 2 });
+    mockFetchJson({ "/api/membership": state({ isLead: false, process: { id: 1, kind: "INITIAL", status: "INTAKE" } }) });
+    renderWithProviders(<MembershipPage />);
+
+    expect(await screen.findByText("Membership application in progress")).toBeInTheDocument();
+    expect(screen.queryByText("Your household")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save progress" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Submit & continue" })).not.toBeInTheDocument();
+  });
+
+  it("hides contract signing and background-check consent from a non-lead household member", async () => {
+    setSession({ id: 2 });
+    mockFetchJson({
+      "/api/membership": state({
+        isLead: false,
+        process: { id: 1, kind: "INITIAL", status: "PENDING_EXTERNAL_ACTION" },
+        external: { contractSigned: false, contractStarted: false, bgConsented: false, bgCleared: false, deepLinkUrl: "https://averity.example/consent" },
+      }),
+    });
+    renderWithProviders(<MembershipPage />);
+
+    expect(await screen.findByText("Membership application in progress")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Sign your membership agreement/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Consent on Averity/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: /I submitted my consent on Averity/ })).not.toBeInTheDocument();
+  });
+
+  it("hides the renewal confirmation from a non-lead household member", async () => {
+    setSession({ id: 2 });
+    mockFetchJson({ "/api/membership": state({ isLead: false, process: { id: 1, kind: "RENEWAL", status: "PENDING_RENEWAL" } }) });
+    renderWithProviders(<MembershipPage />);
+
+    expect(await screen.findByText("Your household is up for renewal")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Renew now" })).not.toBeInTheDocument();
+  });
+
   it("hides the dues and the checkout link from a non-lead household member", async () => {
     setSession({ id: 2 });
     const fetchMock = mockFetchJson({

--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -194,6 +194,25 @@ describe("membership page", () => {
     expect(screen.getByRole("link", { name: /Pay here with Shopify/ })).toHaveAttribute("href", "https://shop.example/checkout");
   });
 
+  it("hides the dues and the checkout link from a non-lead household member", async () => {
+    setSession({ id: 2 });
+    const fetchMock = mockFetchJson({
+      "/api/membership/payment": { amountCents: 12500, checkoutUrl: "https://shop.example/checkout" },
+      "/api/membership": state({
+        isLead: false,
+        process: { id: 1, kind: "INITIAL", status: "PENDING_PAYMENT" },
+        external: { contractSigned: true, contractStarted: true, bgConsented: true, bgCleared: true, deepLinkUrl: null },
+      }),
+    });
+    renderWithProviders(<MembershipPage />);
+
+    expect(await screen.findByText("Membership application in progress")).toBeInTheDocument();
+    expect(screen.queryByText("$125.00", { exact: false })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Pay here with Shopify/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Request a scholarship or payment plan/ })).not.toBeInTheDocument();
+    expect(fetchMock.mock.calls.some(([u]) => String(u).includes("/api/membership/payment"))).toBe(false);
+  });
+
   it("renders PENDING_BG_CLEARANCE", async () => {
     setSession({ id: 1 });
     mockFetchJson({ "/api/membership": state({ process: { id: 1, kind: "INITIAL", status: "PENDING_BG_CLEARANCE" } }) });

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -651,6 +651,10 @@ export default function MembershipPage() {
   const isIntake = inStatus === "INTAKE";
   const isActive = state?.membershipStatus === "ACTIVE";
   const isRenewal = state?.process?.kind === "RENEWAL";
+  // Steps whose every action is the lead's — household details, contract signing,
+  // background-check consent, dues and checkout. Each backing route refuses a
+  // non-lead, so rendering the controls for one would only produce a 403.
+  const isLeadOnlyStep = isIntake || inStatus === "PENDING_EXTERNAL_ACTION" || inStatus === "PENDING_PAYMENT";
 
   return (
     <Container size="lg" pb="md">
@@ -692,6 +696,14 @@ export default function MembershipPage() {
             )}
           </Card>
         )
+      ) : isRenewal && inStatus === "PENDING_RENEWAL" && !state.isLead ? (
+        <Card withBorder radius="md" padding="xl" maw={640}>
+          <Title order={2}>Your household is up for renewal</Title>
+          <Text c="dimmed" mt="sm">
+            Your household lead will confirm the renewal — nothing for you to do right now. Your
+            membership stays active in the meantime.
+          </Text>
+        </Card>
       ) : isRenewal && inStatus === "PENDING_RENEWAL" ? (
         <Card withBorder radius="md" padding="xl" maw={640}>
           <Title order={2}>Time to renew</Title>
@@ -724,7 +736,15 @@ export default function MembershipPage() {
           </Box>
 
           <Box style={{ flex: "1 1 420px", minWidth: "min(320px, 100%)" }}>
-            {isIntake ? (
+            {!state.isLead && isLeadOnlyStep ? (
+              <Card withBorder radius="md" padding="lg">
+                <Title order={2} mb="sm">Membership application in progress</Title>
+                <Text c="dimmed">
+                  Your household&apos;s membership application is in progress. Your household lead
+                  will complete it — nothing for you to do right now.
+                </Text>
+              </Card>
+            ) : isIntake ? (
               <Card withBorder radius="md" padding="lg">
                 <Stack gap="lg">
                   <section>
@@ -898,16 +918,6 @@ export default function MembershipPage() {
                     Refresh status
                   </Button>
                 </Stack>
-              </Card>
-            ) : inStatus === "PENDING_PAYMENT" && !state.isLead ? (
-              /* Dues and the checkout link are the lead's business — a non-lead
-                 household member still learns the application is moving. */
-              <Card withBorder radius="md" padding="lg">
-                <Title order={2} mb="sm">Membership application in progress</Title>
-                <Text c="dimmed">
-                  Your household&apos;s membership application is in progress. Your household lead
-                  will complete it — nothing for you to do right now.
-                </Text>
               </Card>
             ) : inStatus === "PENDING_PAYMENT" ? (
               <Card withBorder radius="md" padding="lg">

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -282,16 +282,17 @@ export default function MembershipPage() {
     })();
   }, [sessionStatus, load]);
 
-  // When awaiting payment, fetch the dues amount and Shopify checkout link.
+  // When awaiting payment, fetch the dues amount and Shopify checkout link. Leads
+  // only — the route refuses anyone else, and the card hides the money from them.
   useEffect(() => {
-    if (state?.process?.status !== "PENDING_PAYMENT") return;
+    if (state?.process?.status !== "PENDING_PAYMENT" || !state.isLead) return;
     let cancelled = false;
     fetch("/api/membership/payment")
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => { if (!cancelled && data) setPayment(data); })
       .catch(() => { /* shown as link-unavailable */ });
     return () => { cancelled = true; };
-  }, [state?.process?.status]);
+  }, [state?.process?.status, state?.isLead]);
 
   // Restore an in-flight payment holdoff after a tab refresh mid-Shopify-checkout.
   useEffect(() => {
@@ -897,6 +898,16 @@ export default function MembershipPage() {
                     Refresh status
                   </Button>
                 </Stack>
+              </Card>
+            ) : inStatus === "PENDING_PAYMENT" && !state.isLead ? (
+              /* Dues and the checkout link are the lead's business — a non-lead
+                 household member still learns the application is moving. */
+              <Card withBorder radius="md" padding="lg">
+                <Title order={2} mb="sm">Membership application in progress</Title>
+                <Text c="dimmed">
+                  Your household&apos;s membership application is in progress. Your household lead
+                  will complete it — nothing for you to do right now.
+                </Text>
               </Card>
             ) : inStatus === "PENDING_PAYMENT" ? (
               <Card withBorder radius="md" padding="lg">


### PR DESCRIPTION
## What

`GET /api/membership/payment` was `withAuth({})` — any authenticated caller — and resolved the dues amount and Shopify checkout URL from the caller's own household via `ensurePaymentLinkForUser(auth.user.id)`. Every household member, youth included, could read the dues figure and open a live checkout link.

The same missing check ran through the `/membership` page: `state?.isLead` guarded only the "Start application" button, inside the `{!state?.process ? ... }` branch. Once a process existed, every downstream branch rendered unguarded.

Two commits:

1. **`GET /api/membership/payment` + the payment card.** Gate on `householdLeadship().canManage` (folds in sysadmin) plus board, matching `POST /api/membership/request-payment-plan`. The page skips the dues fetch entirely for a non-lead.
2. **The remaining branches.** One `isLeadOnlyStep` guard covers `INTAKE`, `PENDING_EXTERNAL_ACTION` and `PENDING_PAYMENT` with a single progress card; `PENDING_RENEWAL` gets its own note (it sits outside that column and reads differently).

Non-lead copy: *"Your household's membership application is in progress. Your household lead will complete it — nothing for you to do right now."* The flow stepper still renders, so a non-lead can see where the application stands.

## Why this was more than a dead-button cleanup

The contract-signing and BG-consent services already threw `not_lead` → 403, so those buttons did nothing. Two things were live:

- **The payment route.** No gate at any layer. Dues amount and a working Shopify checkout URL, to any authenticated household member.
- **The intake form.** `saveIntake`/`submitIntake` call `assertLead`, so writes were refused — but the *read* was not. The prefilled form rendered the household address, every child's name, date of birth and allergies, and the emergency contact's name/phone/email to any household member, including the children themselves.

Also newly hidden: `state.external.deepLinkUrl`, the household's Averity background-check consent form, which rendered as an anchor a non-lead could open.

## Behaviour change reviewers should weigh

A household caps at two leads (`MAX_HOUSEHOLD_LEADS`), so **a non-lead adult** household member also loses the dues screen and the intake form — not only children. That matches the start path and `request-payment-plan`, which already gate on lead, but it is new for a third adult who was using those screens. If that is wrong for the org, the fix is a separate "billing contact" concept, not loosening this route.

Sysadmin and board keep access exactly as the sibling routes allow. Note that `canManage` reads `isSysadmin` from the `Person` row (same as `assertLead` in `lib/membership/intake.ts`), while board comes from the session — consistent with the existing code, but worth knowing.

## Deliberately unchanged

- Read-only cards: `PENDING_BG_REVIEW`, `PENDING_BG_CLEARANCE`, `RENEWAL_PENDING_BG`, and the default in-progress card. No actions on any of them, and their copy tells a non-lead more than the generic note would.
- The security boundary layer (`src/security/`). These routes use `withAuth`, not the registry handler — no registry or scope-binding edits here.

## Tests

`src/app/__tests__/membershipPaymentAPI.integration.test.ts` — 4 new cases: lead gets `amountCents` + checkout URL; non-lead 403 with neither field in the body; board non-lead 200; DB-sysadmin non-lead 200.

`src/app/membership/__tests__/page.test.tsx` — 4 new cases: non-lead at `INTAKE` (no form, no Save/Submit), `PENDING_EXTERNAL_ACTION` (no Sign button, no Averity link, no consent checkbox), `PENDING_PAYMENT` (no dues figure, no pay button, and the payment endpoint is never called), `PENDING_RENEWAL` (no Renew button).

`src/app/__tests__/authzOwnershipBoundary.integration.test.ts` — **two existing assertions had to change.** That file is the repo's IDOR tripwire, and it was pinning the leak in place: `200 for a member of the household awaiting payment` asserted the old behaviour as correct. `HH_PAY` now has a lead and a non-lead (it had only `payUser`, a non-lead), and the cross-household isolation case uses `leadA` so it still exercises the 409 rather than short-circuiting on the new 403.

```
npm run test:ci
Test Suites: 257 passed, 257 total
Tests:       2440 passed, 2440 total
```

```
integration — authzOwnershipBoundary, membershipPaymentAPI, membershipExternalAPI,
membershipIntakeAPI, membershipRenewalAPI, membershipContractSignAPI  (--runInBand)
Test Suites: 6 passed, 6 total
Tests:       94 passed, 94 total
```

`tsc --noEmit` clean, eslint clean. Integration ran against a throwaway local Postgres (`prisma db push` + `prisma/seed.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)