### PR TITLE
feat(programs): only a known adult may self-enroll, and youth see no payment (#167)

### DIFF
--- a/checkin-app/docs/designs/167-youth-enrollment-rules.md
+++ b/checkin-app/docs/designs/167-youth-enrollment-rules.md
@@ -246,28 +246,27 @@ Checked and clear: the programs directory, `my-household`, `my-programs`,
 `FirstTimeIntakePanel`, and `attendance/current` (its "force checkout" is a
 kiosk departure, not a payment).
 
-**`membership/page.tsx` is a confirmed leak — checked, not closed.** The lead
-gate is on the *start* path only: `state?.isLead` guards the "Start application"
-button inside the `!state?.process` branch. Once a process exists the page falls
-into the process branches, and none of them check `isLead`. The intake state is
+**`membership/page.tsx` was a leak, and #1473 closed it.** The lead gate used to
+sit on the *start* path only: `state?.isLead` guarded the "Start application"
+button inside the `!state?.process` branch, and once a process existed every
+downstream branch rendered unguarded. Because the intake state is
 household-scoped (`lib/membership/intake.ts` returns the household's `process`
-to any member; `isLead` is the only per-user field), so a youth in a household
-with an in-flight application lands straight in those branches.
+to any member, with `isLead` the only per-user field), a youth in a household
+with an in-flight application landed straight in those branches — seeing "Your
+annual household dues are $X" and a live "Pay here with Shopify →" button.
 
-At `PENDING_PAYMENT` a youth sees "Your annual household dues are $X" and a
-"Pay here with Shopify →" button, and can click it. This is not UI-only:
-`GET /api/membership/payment` is `withAuth({})` — any authenticated user — and
-resolves the amount and checkout URL from the caller's household, so the data is
-served to a youth by the API itself. The same unguarded branches also expose the
-contract-signing and background-check tasks.
+It was not UI-only: `GET /api/membership/payment` was `withAuth({})` — any
+authenticated caller — and resolved the amount and checkout URL from the
+caller's own household.
 
-Not everything is open: `POST /api/membership/request-payment-plan` does check
-lead membership and 403s a non-lead, and `renewal-status` returns
-`renewalDue: false` to non-leads. The hole is the payment display and checkout,
-not every membership action.
+#1473 gated that route on `householdLeadship` (403 for a non-lead) and put the
+same check on every lead-only step of the page. Already correct before it, and
+left alone: `POST /api/membership/request-payment-plan` checks lead membership,
+and `renewal-status` returns `renewalDue: false` to non-leads.
 
 This is org-membership dues, a different domain from program enrollment — see
-"Out of scope" below. Fixed separately in #1473.
+"Out of scope" below. Recorded because this design's rule (a youth is never
+shown a payment obligation) is what that fix satisfies on the dues side.
 
 ## Open gaps
 

--- a/checkin-app/docs/designs/167-youth-enrollment-rules.md
+++ b/checkin-app/docs/designs/167-youth-enrollment-rules.md
@@ -1,7 +1,7 @@
 # Youth enrollment rules (issue #167)
 
-**Status: DESIGN — not built.** Policy + rationale only. No code here; the
-mechanics land in the implementation when we agree to build.
+**Status: IN BUILD.** The gate itself is being implemented; the open gaps at the
+end are not settled and nothing in them is built.
 
 ## Problem
 
@@ -75,6 +75,20 @@ unverified self-report, so a minor willing to misreport can clear the gate and
 self-enroll + pay. The only trustworthy age signal is one set by *someone other
 than the subject* — a lead/board, or staff import.
 
+The household-lead flag falls under the same acceptance. `leads.ts` blocks a
+youth from becoming a lead by reading `dateOfBirth` only — it never consults
+`isDeclaredAdult` — so the same misreport that clears the enroll gate clears the
+lead check too. Its unknown-DOB default (`unknownIs: 'adult'`) therefore grants
+a determined minor nothing that lying would not. Two residues, both narrow: it
+needs no lie at all, so a youth who signs in and touches nothing is silently
+made a lead (`auth-options.ts` provisions the household and calls
+`addHouseholdLead` unconditionally); and lead authority is over *other people*,
+which this section's reasoning about self-commitment never weighed — worth
+remembering, since the paragraph below offers "a lead enrolling the minor" as
+the trustworthy alternative. Reaching real third parties still requires an admin
+to reassign real people into that household, so it is a design inconsistency
+more than an exploit.
+
 **Decision: accept it.** A self-declared adult (DOB or the over-25 tick, whoever
 set it, including the member themselves) is trusted, and the possibility that a
 minor lies to bypass the gate is an accepted residual risk. We do **not** add a
@@ -85,18 +99,170 @@ who simply lands on the enroll page), not to defeat deliberate misrepresentation
 which no self-service flow can. The trustworthy path (a lead enrolling the minor)
 remains available for anyone who wants the stronger guarantee.
 
-## Open question — does the self-gate apply to admin overrides?
+## Resolved — the self-gate and admin overrides
 
-A confirmed board/sysadmin `override` already deliberately bypasses every soft
-limit (closed enrollment, age, capacity) — that's an existing, tested intent
-lock. Placing the known-adult **self**-gate *before* that override path would
-also block an admin who self-enrolls-with-override and happens to have no DOB.
+The original question was whether a confirmed board/sysadmin `override` — which
+already bypasses every other soft limit — should also skip the known-adult
+self-gate.
 
-Proposed resolution: the self-gate is about ordinary self-enrollers, so it
-should live under the **same override exemption** as the other soft limits — a
-confirmed admin override skips it too. (Concretely: the gate runs only when
-limits are being enforced, not on the admin-override path.) **Needs your
-sign-off** before implementation.
+**It is moot, because overriding a limit for yourself is a conflict of
+interest.** `lib/conflictOfInterest.ts` states the rule the rest of the app
+follows: an actor may not decide their own household's case, and no role is
+exempt. The enroll route never adopted it — `enforceLimits` keys only off
+`override` and the actor's roles, never off *who the enrollment is for* — so a
+sysadmin or board member can currently self-override past closed enrollment,
+age bounds, members-only, and capacity. That is a pre-existing hole, being
+fixed separately.
+
+Once a conflicted actor can no longer reach the override exemption at all,
+"inside `enforceLimits`" and "outside `enforceLimits`" are the same behaviour
+for every case the self-gate can reach: the gate only fires when actor ==
+target, and limits are then always enforced. So the gate lives **inside**
+`enforceLimits` — one exemption rule, at one layer.
+
+**Ordering dependency:** that only holds once the conflict-of-interest fix has
+landed. Until it does, an admin can `override` past this gate on themselves.
+
+## Known adult — DOB outranks the declared-adult flag
+
+"Known adult" is 18+ by `dateOfBirth`, or `isDeclaredAdult` when there is no DOB
+on file. Where both exist and disagree, the DOB wins: the flag stands in for a
+missing DOB, it does not overrule one. (`checkProgramAge` already reads the flag
+only on the no-DOB path; `isKnownAdult` matches it.) Unknown age is not an
+adult — the helper fails closed.
+
+## A youth never sees a payment situation
+
+The governing rule, and it is a hard one: **a youth is never shown a payment
+obligation, a payment action, or a payment status — their own or their
+household's.** Not "disabled", not "explained" — absent.
+
+What follows from it:
+
+1. **No self-completion of a lead's checkout.** A pending enrollment created by
+   a household lead is a payment the household owes, not one the youth may
+   settle. The enroll route refuses a self-POST from a non-known-adult
+   unconditionally — there is no "row already exists, so let them finish paying"
+   carve-out.
+2. **A youth's own pending row reads `Awaiting confirmation`.** The "Payment
+   pending — select to finish payment" affordance is never shown to them. This
+   is true whether or not the household ever pays, names no money, and puts the
+   next action with someone else — so unlike a flat `Enrolled` it does not
+   become a lie if the payment is abandoned. A youth cannot infer a checkout
+   from it: pending could be capacity, review, or anything else. An ACTIVE row
+   still reads `Enrolled`.
+3. **The household summary is hidden from a youth entirely.** It names *other*
+   members' pending payments; suppressing only the qualifier would still leak
+   who owes what. The whole block goes.
+4. **Payment actions are hidden.** "Pay on Shopify" and "Request a scholarship
+   or payment plan" are not rendered for a youth.
+5. **Withdrawal is not a youth action.** A youth may not `DELETE` their own
+   enrollment — a lead does it. Beyond the consent symmetry, withdrawing a
+   scholarship-held seat fires `withdrawAndReleaseHold` and a Shopify inventory
+   release, which is a financial side effect a youth must not be able to
+   trigger.
+6. **Price stays public.** A program's cost is program information, on the card
+   and the directory, and is not a payment *situation* — no obligation, no
+   state, no action. A youth sees what a program costs; they never see that
+   money is owed or a way to pay it.
+7. **The enroll CTA states the rule, not the money.** A youth gets a disabled
+   "a household lead must enroll you" — the same message on free and paid
+   programs alike, because it names *who may act* rather than what it costs.
+   One message, no price-dependent branch.
+
+An **unverifiable-age** viewer is treated the opposite way throughout: they may
+well be an adult, so they keep the `dob` reason that routes into the intake
+panel. Hiding the enrollment surface from them would strand a brand-new adult
+with no lead — the dead-end this design exists to avoid. Known minor → hide;
+unverifiable → capture the age.
+
+## The viewer signal — a session claim
+
+Nothing client-side could previously tell a youth from an adult at render time,
+so every suppression above needs one signal. **Decision: a JWT claim**, stamped
+in `lib/authClaims.ts` beside the existing ones.
+
+Why the claim rather than a per-response `viewerIsMember`-style flag:
+
+- **It is not a stale token.** The `jwt` callback re-reads the Person from the
+  DB on every subsequent request and re-stamps all claims, deliberately, so a
+  revoked role cannot outlive its revocation (`session.updateAge` 15 minutes,
+  `maxAge` 8 hours). Freshness is bounded by that window, not by re-login.
+- **It costs no extra query.** Both callback branches use
+  `findUnique({ where, include })` with no `select`, so every Person scalar —
+  `dateOfBirth` and `isDeclaredAdult` included — is already loaded. The claim is
+  a derived boolean over data already in hand.
+- **Per-response scales as endpoints × signals.** Youth-gating alone would need
+  `GET /api/programs/[id]` and `/api/programs/mine`, and each addition is a
+  response-shape change to justify and a place to forget.
+- **Per-response cannot gate shared chrome** — nav, badges, layout belong to no
+  endpoint.
+- **The codebase already made this choice.** Five role flags plus
+  `householdLead`, `householdId`, `toolStatuses`, `programsLed`,
+  `canAccessStaging`, and `denied` all live in the token for exactly this
+  reason. A per-response flag would be the exception, not the safe path.
+
+Two constraints that ride with it:
+
+1. **Refresh on the remedy path.** Set-a-DOB-then-enroll is the one flow where
+   the refresh window would be visibly wrong — the member fixes their age and
+   the gate must open *now*, not up to 15 minutes later. The intake save calls
+   `useSession().update()` to force a re-stamp before returning to the
+   member-select.
+2. **Stamp the boolean, never the date.** `dateOfBirth` is
+   `@sensitivity:personal`; a derived `isKnownAdult` in the token is fine, the
+   raw date is not.
+
+`viewerIsMember` / `viewerMemberPricingEligible` stay as they are — an existing
+exception, not the pattern to copy.
+
+## Surface sweep
+
+Every participant-reachable surface that renders payment state or a payment
+action. Ops surfaces (`program-ops`, `finance-ops`, `membership-ops`) are
+role-gated and out of a youth's reach, so they are not listed.
+
+| Surface | What it shows | Action |
+|---|---|---|
+| `programs/[id]` member-select row | "Payment pending — select to finish payment" | Suppress (done) |
+| `programs/[id]` household summary | "*Name* — Enrolled, payment pending", incl. other members | Hide the block for youth |
+| `programs/[id]` primary CTA | "Continue enrollment" when the household owes | Falls back to the lead-required message |
+| `programs/[id]` "Pay on Shopify" | Checkout action | Hide for youth |
+| `programs/[id]` scholarship button | "Request a scholarship or payment plan" | Hide for youth |
+| `my-activities/programs` | "Payment due" badge per enrollment | Hide for youth |
+| `POST request-payment-plan` | Authorises on `isSelf`, no age gate | Add the known-adult self-gate (server) |
+| `DELETE participants` | Authorises self-removal, no age gate | Add the known-adult self-gate (server) |
+
+Checked and clear: the programs directory, `my-household`, `my-programs`,
+`FirstTimeIntakePanel`, and `attendance/current` (its "force checkout" is a
+kiosk departure, not a payment).
+
+**`membership/page.tsx` is a confirmed leak — checked, not closed.** The lead
+gate is on the *start* path only: `state?.isLead` guards the "Start application"
+button inside the `!state?.process` branch. Once a process exists the page falls
+into the process branches, and none of them check `isLead`. The intake state is
+household-scoped (`lib/membership/intake.ts` returns the household's `process`
+to any member; `isLead` is the only per-user field), so a youth in a household
+with an in-flight application lands straight in those branches.
+
+At `PENDING_PAYMENT` a youth sees "Your annual household dues are $X" and a
+"Pay here with Shopify →" button, and can click it. This is not UI-only:
+`GET /api/membership/payment` is `withAuth({})` — any authenticated user — and
+resolves the amount and checkout URL from the caller's household, so the data is
+served to a youth by the API itself. The same unguarded branches also expose the
+contract-signing and background-check tasks.
+
+Not everything is open: `POST /api/membership/request-payment-plan` does check
+lead membership and 403s a non-lead, and `renewal-status` returns
+`renewalDue: false` to non-leads. The hole is the payment display and checkout,
+not every membership action.
+
+This is org-membership dues, a different domain from program enrollment — see
+"Out of scope" below. It needs its own issue.
+
+## Open gaps
+
+None. Every decision is recorded above; what remains is build work.
 
 ## Threshold
 
@@ -108,16 +274,49 @@ from *who may initiate*).
 
 - Minor with no active household lead — you said ignore.
 - Waiver / consent capture at enroll time (`lastWaiverSign` exists, unused here).
-- Any change to payment, capacity, or the Shopify path.
+- Any change to payment *mechanics*, capacity, or the Shopify path. Payment UI
+  is now hidden from youth and withdrawal is gated, but no charge, hold, or
+  inventory rule changes — the gated `DELETE` still runs the same
+  `withdrawAndReleaseHold` when a lead performs it.
+- **Org-membership dues.** Program enrollment is the subject here. If the
+  `membership/page.tsx` check above turns up a leak, it is its own issue.
+- **Reconciling the missing-DOB posture across the app.** `leads.ts` reads an
+  unknown DOB as adult, this design reads it as not-adult. Both are deliberate;
+  making them agree is a decision, not a bug fix, and does not belong in this
+  change.
+- **Household-lead integrity.** A youth cannot hold `isHouseholdLead` —
+  `addHouseholdLead` refuses, and every promotion path routes through it — so
+  the lead-enrolls-a-household-member path this design relies on is sound. The
+  remaining edges (one route writing the flag directly, and what should bound
+  leadless or otherwise semi-valid household states) are issue #1471.
 
-## If/when we build it (sketch, not a spec)
+## Build shape
 
-- Enroll route: after the existing authz check and under the same
-  limits-enforced condition as the age check, refuse a non-known-adult
-  self-enroller with the two messages above.
-- Enroll page `enrollBlock`: on the viewer's own row, a known-minor → the
-  lead-required reason; an unverifiable age → the existing `dob` reason, which
-  already drops into the intake panel.
-- Tests: known minor self → refused; unverifiable-age self → refused; declared/
-  DOB adult self → allowed; admin override self (per the open question) →
-  allowed. Personas used elsewhere for non-age self-enroll must be known adults.
+- `isKnownAdult` in `lib/programAge.ts`, next to `checkProgramAge`, so the route
+  and the page judge adulthood by one rule.
+Server (the enforcement; each is a refusal a direct POST cannot talk past):
+
+- Enroll route `POST`: inside the limits-enforced block, after the age check,
+  refuse a non-known-adult self-enroller — 403, with the minor and unverifiable
+  messages above.
+- Enroll route `DELETE`: refuse a non-known-adult self-removal.
+- `request-payment-plan POST`: same self-gate.
+
+Client (the absence; every item waits on the viewer signal):
+
+- Enroll page `enrollBlock`: on the viewer's own row, a known minor → the
+  lead-required reason on a fresh enrollment and a plain `Enrolled` on an
+  existing one; an unverifiable age → the `dob` reason, which already drops into
+  the intake panel.
+- The rest of the sweep table: household summary, CTA label, "Pay on Shopify",
+  the scholarship button, and the `my-activities` payment badge.
+
+Tests — new cases: known minor self → refused; unverifiable-age self → refused;
+declared/DOB adult self → allowed; a lead enrolling a minor → still allowed; a
+youth cannot withdraw themselves.
+
+Tests — existing suites encode the old rule and must be re-pointed to a
+lead-enrolls-child shape, since any persona used for a non-age self-enroll now
+has to be a known adult: `programAgeBounds`, `programAgeStartDate`,
+`programsParticipantsAPI`, and `programsEnrollClosed` (integration), plus the
+enroll page suite.

--- a/checkin-app/src/app/__tests__/enrollmentStateOracle.integration.test.ts
+++ b/checkin-app/src/app/__tests__/enrollmentStateOracle.integration.test.ts
@@ -36,7 +36,14 @@ describe('enrollment state — validator oracle over real transitions', () => {
 
     beforeAll(async () => {
         const self = await prisma.person.create({
-            data: { name: 'Oracle Self', email: `self-${TAG}@example.com`, household: { create: { name: 'HH' } } },
+            // Adult DOB: the oracle drives self-service transitions (request a
+            // payment plan), which only a known adult may do.
+            data: {
+                name: 'Oracle Self',
+                email: `self-${TAG}@example.com`,
+                dateOfBirth: new Date(Date.now() - (30 * 31556952000)),
+                household: { create: { name: 'HH' } },
+            },
         });
         selfId = self.id;
         const board = await prisma.person.create({

--- a/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeBounds.integration.test.ts
@@ -21,6 +21,7 @@ jest.mock('@/lib/notifications', () => ({
 
 describe('Program Age Bounds Integration Tests', () => {
     let testAdminId: number;
+    let guardianUserId: number;
     let validUserId: number;
     let underageUserId: number;
     let overageUserId: number;
@@ -33,18 +34,23 @@ describe('Program Age Bounds Integration Tests', () => {
 
     beforeAll(async () => {
         // Calculate Birthdates dynamically relative to execution time
+        // Built from UTC parts because calculateAge reads UTC fields: local-part
+        // construction shifts these by a day west of UTC, which flips the exact
+        // boundary personas late in the day.
         const now = new Date();
-        const dob16 = new Date(now.getFullYear() - 16, now.getMonth(), now.getDate());
-        const dob12 = new Date(now.getFullYear() - 12, now.getMonth(), now.getDate());
-        const dob20 = new Date(now.getFullYear() - 20, now.getMonth(), now.getDate());
+        const [uy, um, ud] = [now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()];
+        const utcDob = (yearsAgo: number, dayOffset = 0) => new Date(Date.UTC(uy - yearsAgo, um, ud + dayOffset));
+        const dob16 = utcDob(16);
+        const dob12 = utcDob(12);
+        const dob20 = utcDob(20);
         // Exact boundaries for program [minAge=14, maxAge=18].
         // Birthday is today => exactly N years old today (eligible at both ends).
-        const dobExactly14 = new Date(now.getFullYear() - 14, now.getMonth(), now.getDate());
-        const dobExactly18 = new Date(now.getFullYear() - 18, now.getMonth(), now.getDate());
+        const dobExactly14 = utcDob(14);
+        const dobExactly18 = utcDob(18);
         // Birthday tomorrow, born 14 years ago => still 13 today (under).
-        const dobTurns14Tomorrow = new Date(now.getFullYear() - 14, now.getMonth(), now.getDate() + 1);
+        const dobTurns14Tomorrow = utcDob(14, 1);
         // Birthday yesterday, born 19 years ago => turned 19 already (over).
-        const dobTurned19Yesterday = new Date(now.getFullYear() - 19, now.getMonth(), now.getDate() - 1);
+        const dobTurned19Yesterday = utcDob(19, -1);
 
         // Clean up any leaked state from previous runs
         await prisma.auditLog.deleteMany({});
@@ -62,8 +68,22 @@ describe('Program Age Bounds Integration Tests', () => {
         });
         testAdminId = admin.id;
 
+        // Eligible-age youth live in a household with an adult lead: only a lead
+        // may enroll a participant under 18 (docs/designs/167-youth-enrollment-rules.md).
+        const guardianHousehold = await prisma.household.create({ data: { name: "Test HH" } });
+        const guardian = await prisma.person.create({
+            data: {
+                email: 'guardian-age-test@example.com',
+                name: 'Guardian Age Test',
+                dateOfBirth: utcDob(40),
+                isHouseholdLead: true,
+                householdId: guardianHousehold.id,
+            }
+        });
+        guardianUserId = guardian.id;
+
         const pValid = await prisma.person.create({
-            data: { email: 'valid-age-test@example.com', name: 'Valid Age Test', dateOfBirth: dob16, household: { create: { name: "Test HH" } } }
+            data: { email: 'valid-age-test@example.com', name: 'Valid Age Test', dateOfBirth: dob16, householdId: guardianHousehold.id }
         });
         validUserId = pValid.id;
 
@@ -83,7 +103,7 @@ describe('Program Age Bounds Integration Tests', () => {
         noDobUserId = pNoDob.id;
 
         const pExactlyMin = await prisma.person.create({
-            data: { email: 'exactly-min-age-test@example.com', name: 'Exactly Min Age Test', dateOfBirth: dobExactly14, household: { create: { name: "Test HH" } } }
+            data: { email: 'exactly-min-age-test@example.com', name: 'Exactly Min Age Test', dateOfBirth: dobExactly14, householdId: guardianHousehold.id }
         });
         exactlyMinUserId = pExactlyMin.id;
 
@@ -122,7 +142,7 @@ describe('Program Age Bounds Integration Tests', () => {
             await prisma.program.deleteMany({ where: { id: testProgramId } });
         }
 
-        const actorIds = [testAdminId, validUserId, underageUserId, overageUserId, noDobUserId, exactlyMinUserId, exactlyMaxUserId, turns14TomorrowUserId, turned19YesterdayUserId].filter(id => id !== undefined);
+        const actorIds = [testAdminId, guardianUserId, validUserId, underageUserId, overageUserId, noDobUserId, exactlyMinUserId, exactlyMaxUserId, turns14TomorrowUserId, turned19YesterdayUserId].filter(id => id !== undefined);
         if (actorIds.length > 0) {
             await prisma.auditLog.deleteMany({
                 where: { actorId: { in: actorIds } }
@@ -138,10 +158,9 @@ describe('Program Age Bounds Integration Tests', () => {
         await prisma.programParticipant.deleteMany({ where: { programId: testProgramId } });
     });
 
-    it('should allow self-enrollment for a participant within the valid age range', async () => {
-        // Mock session to standard valid user
+    it('should allow a household lead to enroll a participant within the valid age range', async () => {
         (getServerSession as jest.Mock).mockResolvedValue({
-            user: { id: validUserId, isSysadmin: false, isBoardMember: false }
+            user: { id: guardianUserId, isSysadmin: false, isBoardMember: false }
         });
 
         const req = new Request(`http://localhost:4000/api/programs/${testProgramId}/participants`, {
@@ -213,9 +232,9 @@ describe('Program Age Bounds Integration Tests', () => {
         expect(data.requiresOverride).toBe(true);
     });
 
-    it('should allow self-enrollment for a participant who is EXACTLY minAge today (birthday today)', async () => {
+    it('should allow enrollment for a participant who is EXACTLY minAge today (birthday today)', async () => {
         (getServerSession as jest.Mock).mockResolvedValue({
-            user: { id: exactlyMinUserId, isSysadmin: false, isBoardMember: false }
+            user: { id: guardianUserId, isSysadmin: false, isBoardMember: false }
         });
 
         const req = new Request(`http://localhost:4000/api/programs/${testProgramId}/participants`, {

--- a/checkin-app/src/app/__tests__/programAgeStartDate.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAgeStartDate.integration.test.ts
@@ -35,6 +35,7 @@ const FAKE_TIMER_OPTS: Parameters<typeof jest.useFakeTimers>[0] = {
 describe('Program Age Start-Date Basis (authenticated route)', () => {
     let programId: number;
     let userId: number;
+    let guardianId: number;
 
     beforeAll(async () => {
         await prisma.programParticipant.deleteMany({ where: { person: { email: { contains: 'age-startdate-test' } } } });
@@ -55,8 +56,22 @@ describe('Program Age Start-Date Basis (authenticated route)', () => {
 
         // Born 2012-04-01: age 13 as of 2026-01-01 (frozen now), turns 14 on
         // 2026-04-01 — BEFORE the 2026-09-01 start. Eligible as of startAt only.
+        // The subject is 13 at enrollment time, so a household lead enrolls them —
+        // only a known adult may self-enroll (167-youth-enrollment-rules.md). The
+        // age-as-of-startAt rule under test is unaffected by who submits.
+        const household = await prisma.household.create({ data: { name: "Test HH" } });
+        const guardian = await prisma.person.create({
+            data: {
+                email: 'guardian-age-startdate-test@example.com',
+                name: 'Guardian',
+                dateOfBirth: new Date('1985-01-01T00:00:00.000Z'),
+                isHouseholdLead: true,
+                householdId: household.id,
+            }
+        });
+        guardianId = guardian.id;
         const user = await prisma.person.create({
-            data: { email: 'turns14-age-startdate-test@example.com', name: 'Turns 14 Before Start', dateOfBirth: new Date('2012-04-01T00:00:00.000Z'), household: { create: { name: "Test HH" } } }
+            data: { email: 'turns14-age-startdate-test@example.com', name: 'Turns 14 Before Start', dateOfBirth: new Date('2012-04-01T00:00:00.000Z'), householdId: household.id }
         });
         userId = user.id;
     });
@@ -64,7 +79,7 @@ describe('Program Age Start-Date Basis (authenticated route)', () => {
     afterAll(async () => {
         await prisma.programParticipant.deleteMany({ where: { programId } });
         await prisma.program.deleteMany({ where: { id: programId } });
-        await prisma.person.deleteMany({ where: { id: userId } });
+        await prisma.person.deleteMany({ where: { id: { in: [userId, guardianId] } } });
     });
 
     afterEach(async () => {
@@ -75,7 +90,7 @@ describe('Program Age Start-Date Basis (authenticated route)', () => {
         jest.useFakeTimers(FAKE_TIMER_OPTS);
         try {
             (getServerSession as jest.Mock).mockResolvedValue({
-                user: { id: userId, isSysadmin: false, isBoardMember: false }
+                user: { id: guardianId, isSysadmin: false, isBoardMember: false }
             });
 
             const req = new Request(`http://localhost:4000/api/programs/${programId}/participants`, {

--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -90,13 +90,27 @@ describe('Program payment-plan routes', () => {
         boardKinId = boardKin.id;
 
         const self = await prisma.person.create({
-            data: { name: 'PP Self', email: `self-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
+            // Adult DOB: this persona requests its OWN payment plan, and only a
+            // known adult may (docs/designs/167-youth-enrollment-rules.md).
+            data: {
+                name: 'PP Self',
+                email: `self-${TAG}@example.com`,
+                dateOfBirth: new Date(Date.now() - (30 * 31556952000)),
+                household: { create: { name: "Test HH" } },
+            },
         });
         selfId = self.id;
         householdIds.push(self.householdId);
 
         const other = await prisma.person.create({
-            data: { name: 'PP Other', email: `other-${TAG}@example.com`, household: { create: { name: "Test HH" } } },
+            // Adult DOB: this persona self-enrolls and self-requests in tests whose
+            // subject is capacity / ACK copy, not the youth gate.
+            data: {
+                name: 'PP Other',
+                email: `other-${TAG}@example.com`,
+                dateOfBirth: new Date(Date.now() - (30 * 31556952000)),
+                household: { create: { name: "Test HH" } },
+            },
         });
         otherId = other.id;
         householdIds.push(other.householdId);
@@ -963,6 +977,8 @@ describe('Program payment-plan routes', () => {
                     name: `Email ${label}`,
                     email,
                     householdId,
+                    // Adult DOB: these personas request their own payment plans.
+                    dateOfBirth: new Date(Date.now() - (30 * 31556952000)),
                     isHouseholdLead: opts.isHouseholdLead ?? false,
                 },
             });

--- a/checkin-app/src/app/__tests__/programsHouseholdEnrollment.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsHouseholdEnrollment.integration.test.ts
@@ -61,7 +61,13 @@ describe('Multi-select household enrollment (integration)', () => {
         // One household: a lead + three adult dependents (no age limits in play).
         const household = await prisma.household.create({ data: { name: "Test HH" } });
         const lead = await prisma.person.create({
-            data: { email: `lead-${TAG}@example.com`, name: 'HH Lead', householdId: household.id }
+            // Adult DOB: the lead self-enrolls below, and only a known adult may.
+            data: {
+                email: `lead-${TAG}@example.com`,
+                name: 'HH Lead',
+                dateOfBirth: new Date(Date.now() - (30 * 31556952000)),
+                householdId: household.id,
+            }
         });
         leadId = lead.id;
         const mkDep = async (label: string) => (await prisma.person.create({

--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -25,6 +25,7 @@ describe('Program Participants API Integration Tests', () => {
     let otherId: number;
     let boardId: number;   // board member who leads a household
     let depId: number;     // dependent (25yo) in the board member's household
+    let youthDepId: number; // youth dependent in the same household
     let memberId: number;  // person in a household with an ACTIVE OrgMembership
     let memberHouseholdId: number;
 
@@ -70,7 +71,13 @@ describe('Program Participants API Integration Tests', () => {
 
         // Create Lead
         const lead = await prisma.person.create({
-            data: { email: 'lead-partic-api-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } }
+            // Adult DOB: this persona self-enrolls in the double-submit test below.
+            data: {
+                email: 'lead-partic-api-test@example.com',
+                name: 'Lead',
+                dateOfBirth: new Date(Date.now() - (30 * 31556952000)),
+                household: { create: { name: "Test HH" } },
+            }
         });
         leadId = lead.id;
 
@@ -112,9 +119,18 @@ describe('Program Participants API Integration Tests', () => {
             }
         });
         depId = dependent.id;
+        const youthDependent = await prisma.person.create({
+            data: {
+                email: 'youthdep-partic-api-test@example.com',
+                name: 'Board Youth Dependent',
+                dateOfBirth: new Date(Date.now() - (10 * 31556952000)),
+                householdId: boardHousehold.id
+            }
+        });
+        youthDepId = youthDependent.id;
         await prisma.person.update({
             where: { id: boardId },
-            data: { isHouseholdLead: true }
+            data: { isHouseholdLead: true, dateOfBirth: new Date(Date.now() - (40 * 31556952000)) }
         });
 
         // Create mock programs
@@ -170,7 +186,7 @@ describe('Program Participants API Integration Tests', () => {
     });
 
     afterAll(async () => {
-        const existingUserIds = [adminId, leadId, commonId, otherId, boardId, depId, memberId].filter(id => id !== undefined);
+        const existingUserIds = [adminId, leadId, commonId, otherId, boardId, depId, youthDepId, memberId].filter(id => id !== undefined);
         const validProgramIds = [standardProgramId, freeProgramId, fullProgramId, exactAgeProgramId, memberOnlyProgramId].filter(id => id !== undefined);
 
         if (existingUserIds.length > 0) {
@@ -511,6 +527,65 @@ describe('Program Participants API Integration Tests', () => {
              expect(data.enrollment.status).toBe('ACTIVE');
         });
 
+        // Only a KNOWN adult may commit themselves. A youth needs a household
+        // lead; an unverifiable age is refused too and routed to age capture.
+        it('should block a youth from self-enrolling, even into a free program', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: otherId } }); // 10 years old
+
+             const req = new Request(`http://localhost:4000/api/programs/${freeProgramId}/participants`, {
+                 method: 'POST',
+                 body: JSON.stringify({ participantId: otherId })
+             });
+             const res = await POST(req as unknown as import("next/server").NextRequest, createParams(freeProgramId) as unknown as never);
+             expect(res.status).toBe(403);
+             expect((await res.json()).error).toMatch(/household lead must enroll/i);
+
+             const row = await prisma.programParticipant.findUnique({
+                 where: { programId_personId: { programId: freeProgramId, personId: otherId } },
+             });
+             expect(row).toBeNull();
+        });
+
+        it('should block a self-enroller whose age is unverifiable, pointing them at age capture', async () => {
+             const noAge = await prisma.person.create({
+                 data: { email: 'noage-partic-api-test@example.com', name: 'No Age', household: { create: { name: "Test HH" } } }
+             });
+             try {
+                 (getServerSession as jest.Mock).mockResolvedValue({ user: { id: noAge.id } });
+
+                 const res = await POST(
+                     new Request(`http://localhost:4000/api/programs/${freeProgramId}/participants`, {
+                         method: 'POST',
+                         body: JSON.stringify({ participantId: noAge.id })
+                     }) as unknown as import("next/server").NextRequest,
+                     createParams(freeProgramId) as unknown as never,
+                 );
+                 expect(res.status).toBe(403);
+                 // Not the lead-required message: the remedy is to establish an age.
+                 expect((await res.json()).error).toMatch(/date of birth|over 25/i);
+             } finally {
+                 await prisma.programParticipant.deleteMany({ where: { personId: noAge.id } });
+                 await prisma.person.delete({ where: { id: noAge.id } });
+                 await prisma.household.deleteMany({ where: { householdMembers: { none: {} }, name: "Test HH" } });
+             }
+        });
+
+        // The gate is about who INITIATES: a lead enrolling their own child is
+        // the supported path and must keep working.
+        it('should let a household lead enroll a youth in their household', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId } }); // lead, no board flag on the session
+
+             const res = await POST(
+                 new Request(`http://localhost:4000/api/programs/${freeProgramId}/participants`, {
+                     method: 'POST',
+                     body: JSON.stringify({ participantId: youthDepId })
+                 }) as unknown as import("next/server").NextRequest,
+                 createParams(freeProgramId) as unknown as never,
+             );
+             expect(res.status).toBe(200);
+             expect((await res.json()).enrollment.personId).toBe(youthDepId);
+        });
+
         it('should return 409 (not 500) when enrolling the same participant twice', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: leadId } });
 
@@ -586,14 +661,42 @@ describe('Program Participants API Integration Tests', () => {
              expect(row).toBeNull();
         });
         
-        it('should allow a common user to drop out of their own program', async () => {
-             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: otherId } });
+        // A youth may not withdraw themselves: beyond matching the enroll gate,
+        // withdrawing a scholarship-held seat releases Shopify inventory, a
+        // financial side effect that is the household lead's to trigger.
+        it('should block a youth from dropping out of their own program', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: otherId } }); // 10 years old
 
              const req = new Request(`http://localhost:4000/api/programs/${fullProgramId}/participants`, {
                  method: 'DELETE',
-                 body: JSON.stringify({ participantId: otherId }) // self-removal
+                 body: JSON.stringify({ participantId: otherId })
              });
              const res = await DELETE(req as unknown as import("next/server").NextRequest, createParams(fullProgramId) as unknown as never);
+             expect(res.status).toBe(403);
+             expect((await res.json()).error).toMatch(/household lead must withdraw/i);
+
+             // Still enrolled — the refusal wrote nothing.
+             const row = await prisma.programParticipant.findUnique({
+                 where: { programId_personId: { programId: fullProgramId, personId: otherId } },
+             });
+             expect(row).not.toBeNull();
+        });
+
+        it('should allow an adult to drop out of their own program', async () => {
+             // An earlier POST test may already have seated them; make the fixture
+             // independent of test order.
+             await prisma.programParticipant.upsert({
+                 where: { programId_personId: { programId: freeProgramId, personId: commonId } },
+                 create: { programId: freeProgramId, personId: commonId, status: 'ACTIVE' },
+                 update: { status: 'ACTIVE' },
+             });
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
+
+             const req = new Request(`http://localhost:4000/api/programs/${freeProgramId}/participants`, {
+                 method: 'DELETE',
+                 body: JSON.stringify({ participantId: commonId }) // self-removal
+             });
+             const res = await DELETE(req as unknown as import("next/server").NextRequest, createParams(freeProgramId) as unknown as never);
              expect(res.status).toBe(200);
 
              const data = await res.json();
@@ -601,15 +704,15 @@ describe('Program Participants API Integration Tests', () => {
         });
 
         it('should be idempotent (200, not 500) when un-enrolling a participant twice', async () => {
-             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: otherId } });
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
 
-             // otherId already self-removed from fullProgram in the test above.
+             // commonId already self-removed from freeProgram in the test above.
              // A second delete hits a missing row (Prisma P2025) — must stay 200.
-             const req = new Request(`http://localhost:4000/api/programs/${fullProgramId}/participants`, {
+             const req = new Request(`http://localhost:4000/api/programs/${freeProgramId}/participants`, {
                  method: 'DELETE',
-                 body: JSON.stringify({ participantId: otherId })
+                 body: JSON.stringify({ participantId: commonId })
              });
-             const res = await DELETE(req as unknown as import("next/server").NextRequest, createParams(fullProgramId) as unknown as never);
+             const res = await DELETE(req as unknown as import("next/server").NextRequest, createParams(freeProgramId) as unknown as never);
              expect(res.status).toBe(200);
              const data = await res.json();
              expect(data.success).toBe(true);

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -4,7 +4,7 @@ import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { sendNotification } from "@/lib/notifications";
 import { lockProgramAndCheckCapacity, ProgramCapacityError, withdrawAndReleaseHold } from "@/lib/program/capacity";
-import { checkProgramAge } from "@/lib/programAge";
+import { checkProgramAge, isKnownAdult } from "@/lib/programAge";
 import { isActiveOrgMember } from "@/lib/orgMembership";
 import { adjustProgramInventory } from "@/lib/shopify";
 import { apiError } from "@/lib/api-response";
@@ -118,6 +118,17 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
                             ? `Participant maximum age is ${currentProgram.maxAge} years old.`
                             : "Participant is outside this program's age range.";
                 return NextResponse.json({ error, requiresOverride: true }, { status: 400 });
+            }
+
+            // Only a KNOWN adult may commit THEMSELVES to a program (and to its
+            // Shopify charge). Everyone else needs a household lead to enroll
+            // them — the guardian-consent line at 18, independent of the
+            // program's own minAge/maxAge above. Unverifiable age refuses too,
+            // and routes to the age capture the enroll page already offers.
+            if (isSelfEnrollment && participantData && !isKnownAdult(participantData)) {
+                return apiError(participantData.dateOfBirth
+                    ? "A household lead must enroll a participant under 18."
+                    : "Add your date of birth (or confirm you are over 25) before enrolling yourself.", 403);
             }
         }
 
@@ -243,6 +254,19 @@ export const DELETE = withAuth({}, async (req, auth, { params }: { params: Promi
 
         if (!isSelfRemoval && !isLeadMentor && !isSysAdminOrBoard) {
             return apiError("Forbidden: Not authorized to remove this participant", 403);
+        }
+
+        // Withdrawal is a household lead's action, not a youth's: beyond matching
+        // the enroll gate, withdrawing a scholarship-held seat releases inventory
+        // back to Shopify below — a financial side effect a youth must not fire.
+        if (isSelfRemoval && !isSysAdminOrBoard) {
+            const self = await prisma.person.findUnique({
+                where: { id: participantId },
+                select: { dateOfBirth: true, isDeclaredAdult: true },
+            });
+            if (self && !isKnownAdult(self)) {
+                return apiError("A household lead must withdraw a participant under 18.", 403);
+            }
         }
 
         // Hold-ledger (product decision 2026-07-06): withdrawal is one of the

--- a/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/request-payment-plan/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
+import { isKnownAdult } from "@/lib/programAge";
 import { adjustProgramInventory } from "@/lib/shopify";
 import { fromWhere } from "@/lib/programs/enrollmentState";
 import { resolveScholarshipRecipients, notifyReviewTeam, sendScholarshipAck, resolveAckCopy } from "@/lib/scholarshipEmails";
@@ -66,6 +67,16 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
 
         if (!isSelf && !isSysAdminOrBoard && !isHouseholdLead) {
             return apiError("Forbidden: Not authorized to request a payment plan for this participant", 403);
+        }
+
+        // A scholarship request IS a payment situation, so it is not a youth's to
+        // make about themselves — a household lead does it. Same known-adult rule
+        // as the enroll route (docs/designs/167-youth-enrollment-rules.md).
+        if (isSelf && !isKnownAdult({
+            dateOfBirth: participant.person?.dateOfBirth ?? null,
+            isDeclaredAdult: participant.person?.isDeclaredAdult,
+        })) {
+            return apiError("A household lead must request a payment plan for a participant under 18.", 403);
         }
 
         if (participant.status !== 'PENDING') {

--- a/checkin-app/src/app/my-activities/programs/page.tsx
+++ b/checkin-app/src/app/my-activities/programs/page.tsx
@@ -27,8 +27,11 @@ type UserProgram = {
 // approve a payment plan (gray, not actionable — don't imply it's settled).
 // ponytail: "Payment due" reads more like a warning than a success state — mechanical
 // off-palette-sweep target is theme-primary green; a maintainer may prefer gray/yellow here.
-function paymentPill(status: string, planRequested: boolean) {
+function paymentPill(status: string, planRequested: boolean, viewerIsYouth: boolean) {
   if (status === 'ACTIVE') return null;
+  // A youth is shown no payment state at all — "Awaiting confirmation" is true
+  // whoever owes it (docs/designs/167-youth-enrollment-rules.md).
+  if (viewerIsYouth) return <Badge color="gray" variant="filled">Awaiting confirmation</Badge>;
   return planRequested
     ? <Badge color="gray" variant="filled">Awaiting finance approval</Badge>
     : <Badge variant="filled">Payment due</Badge>;
@@ -37,6 +40,9 @@ function paymentPill(status: string, planRequested: boolean) {
 export default function MyProgramsDashboard() {
   const { data: session, status } = useSession();
   const router = useRouter();
+
+  // See docs/designs/167-youth-enrollment-rules.md — a youth sees no payment state.
+  const viewerIsYouth = (session?.user as { ageBand?: string } | undefined)?.ageBand === 'youth';
 
   const [enrollments, setEnrollments] = useState<UserProgram[]>([]);
   const [loading, setLoading] = useState(true);
@@ -102,7 +108,7 @@ export default function MyProgramsDashboard() {
                 {showMembers && (
                   <Badge variant="light">{person.name ?? 'Member'}</Badge>
                 )}
-                {paymentPill(enrollStatus, isPaymentPlanRequested)}
+                {paymentPill(enrollStatus, isPaymentPlanRequested, viewerIsYouth)}
               </Group>
               <Title order={4} mb="sm">{program.name}</Title>
               <Text c="dimmed" style={{ flex: 1 }}>

--- a/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/[id]/__tests__/page.test.tsx
@@ -68,8 +68,8 @@ function baseProgram(overrides: Record<string, unknown> = {}) {
 }
 
 describe("ProgramEnrollmentPage", () => {
-    it("free program: enrolls the signed-in household member", async () => {
-        setSession({ id: 101 });
+    it("free program: a lead enrolls a household member", async () => {
+        setSession({ id: 100, ageBand: 'adult' });
         mockFetchJson({
             "/api/programs/10/participants": { ok: true },
             "/api/household": household,
@@ -93,8 +93,71 @@ describe("ProgramEnrollmentPage", () => {
         );
     });
 
+    // A youth is shown no payment obligation, action, or status — their own or
+    // their household's. The refusal is an absence, not a door that won't open:
+    // the CTA names who may act and never mentions money, on free and paid alike.
+    it("shows a youth the lead-required CTA and no payment surface", async () => {
+        setSession({ id: 101, ageBand: 'youth' });
+        mockFetchJson({
+            "/api/household": household,
+            "/api/programs/10": baseProgram({
+                participants: [{ personId: 101, status: "PENDING", person: { name: "Kid One", householdId: 7 } }],
+                orgMemberPriceCents: 5000, minAge: null, maxAge: null,
+            }),
+        });
+        renderPage();
+
+        await screen.findByText("Robotics Club");
+        const cta = screen.getByRole("button", { name: "A household lead must enroll you" });
+        expect(cta).toBeDisabled();
+        // Never the payment-pending wording, and never the resume affordance.
+        expect(screen.queryByRole("button", { name: "Continue enrollment" })).not.toBeInTheDocument();
+        expect(screen.queryByText(/payment pending/i)).not.toBeInTheDocument();
+        expect(screen.queryByText("Already enrolled from your household:")).not.toBeInTheDocument();
+        // Price stays public — it is program information, not a payment situation.
+        expect(screen.getByText("$50.00")).toBeInTheDocument();
+    });
+
+    // The same household seen by an adult still offers the checkout, so the
+    // assertions above are about the viewer's age and not a broken fixture.
+    it("still shows the payment-pending resume to an adult in the same household", async () => {
+        // householdId is what links the pending row to the viewer in myEnrolled.
+        setSession({ id: 100, ageBand: 'adult', householdId: 7 });
+        mockFetchJson({
+            "/api/household": household,
+            "/api/programs/10": baseProgram({
+                participants: [{ personId: 101, status: "PENDING", person: { name: "Kid One", householdId: 7 } }],
+                orgMemberPriceCents: 5000, minAge: null, maxAge: null,
+            }),
+        });
+        renderPage();
+
+        await screen.findByText("Robotics Club");
+        expect(screen.getByRole("button", { name: "Continue enrollment" })).toBeEnabled();
+        expect(screen.getByText("Already enrolled from your household:")).toBeInTheDocument();
+    });
+
+    it("routes a viewer of unverifiable age into intake rather than blocking on a lead", async () => {
+        setSession({ id: 300, ageBand: 'unknown' });
+        mockFetchJson({
+            "/api/household": { household: { householdMembers: [{ id: 300, name: "New Adult", dateOfBirth: null }] } },
+            "/api/programs/10": baseProgram({ participants: [], minAge: null, maxAge: null }),
+        });
+        renderPage();
+
+        await screen.findByText("Robotics Club");
+        fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+        await screen.findByText("Which of your household wants to enroll?");
+
+        // A brand-new adult is "age unverifiable", not a minor — the remedy is the
+        // intake panel (DOB or "over 25"), never a lead they don't have.
+        expect(screen.getByText("(DOB missing)")).toBeInTheDocument();
+        expect(screen.queryByText("(A household lead must enroll you)")).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Finish setting up your household to enroll" })).toBeInTheDocument();
+    });
+
     it("first-time user finishes household setup, then enrolls a child (auth-first)", async () => {
-        setSession({ id: 500 });
+        setSession({ id: 500, ageBand: 'unknown' });
         let childAdded = false;
         const adult = { id: 500, name: "New Parent", dateOfBirth: null };
         const child = { id: 501, name: "New Kid", dateOfBirth: "2015-01-01" };
@@ -530,19 +593,20 @@ describe("ProgramEnrollmentPage", () => {
     // must be able to re-run checkout (participants POST 409s -> folded back in;
     // a FRESH single-use discount code is minted — the old one is 48h/one-use).
     it("lets a payment-pending member resume checkout with a fresh discount code", async () => {
-        setSession({ id: 101 });
+        setSession({ id: 100, ageBand: 'adult' });
         setShopifyStoreDomain("shop.example.com");
         // One-member household whose only participant is already PENDING — the
-        // resume case: nobody new to enroll, payment still owed.
+        // resume case: nobody new to enroll, payment still owed. The viewer is an
+        // adult: only a known adult may finish a checkout.
         const memberHousehold = { household: {
-            householdMembers: [{ id: 101, name: "Kid One", dateOfBirth: "2015-01-01" }],
+            householdMembers: [{ id: 100, name: "Jamie Guardian", dateOfBirth: "1990-01-01" }],
             orgMembership: { status: "ACTIVE" },
         } };
         const fetchMock = mockFetchJson({
             "/api/programs/10/discount-code": { code: "PRG10-FRESH" },
             "/api/household": memberHousehold,
             "/api/programs/10": baseProgram({
-                participants: [{ personId: 101, status: "PENDING" }],
+                participants: [{ personId: 100, status: "PENDING" }],
                 orgMemberPriceCents: 4000, nonOrgMemberPriceCents: 5000, minAge: null, maxAge: null,
                 shopifyVariantId: "gid://single-pool", shopifyOrgMemberVariantId: null, shopifyNonOrgMemberVariantId: null,
             }),
@@ -564,10 +628,10 @@ describe("ProgramEnrollmentPage", () => {
 
         // Selectable and not disabled — but unchecked, so resuming the checkout
         // is a deliberate click like any other enrollment.
-        expect(await screen.findByLabelText("Kid One")).not.toBeChecked();
+        expect(await screen.findByLabelText("Jamie Guardian")).not.toBeChecked();
         expect(screen.getByText("(Payment pending — select to finish payment)")).toBeInTheDocument();
 
-        await selectMember("Kid One");
+        await selectMember("Jamie Guardian");
         fireEvent.click(screen.getByRole("button", { name: "Pay on Shopify" }));
 
         expect(await screen.findByText("Redirecting to Shopify for secure payment...")).toBeInTheDocument();
@@ -771,7 +835,7 @@ describe("ProgramEnrollmentPage", () => {
     // signed-in caller would enroll a household lead who came only to pay for a
     // child — stranding an unpaid PENDING row that holds a capacity seat.
     it("does not pre-check the signed-in adult on a program with no upper age limit", async () => {
-        setSession({ id: 100 });
+        setSession({ id: 100, ageBand: 'adult' });
         mockFetchJson({
             "/api/household": household,
             "/api/programs/10": baseProgram({ participants: [], minAge: 9, maxAge: null }),

--- a/checkin-app/src/app/programs/[id]/page.tsx
+++ b/checkin-app/src/app/programs/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { Alert, Button, Card, Center, Checkbox, Container, Divider, Group, Loader, Stack, Text, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { formatDateOnly } from '@/lib/time';
-import { checkProgramAge } from '@/lib/programAge';
+import { checkProgramAge, type AgeBand } from '@/lib/programAge';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { formatCents } from '@inventory/money';
 import { aggregateEnrollOutcomes, buildShopifyCheckoutUrl, type EnrollOutcome } from './enroll';
@@ -50,11 +50,11 @@ type ProgramDetail = {
   viewerMemberPricingEligible?: boolean;
 };
 
-type SessionUser = { isSysadmin?: boolean; isBoardMember?: boolean; id: number; householdId?: number | null };
+type SessionUser = { isSysadmin?: boolean; isBoardMember?: boolean; id: number; householdId?: number | null; ageBand?: AgeBand };
 
 export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { data: session, status } = useSession();
+  const { data: session, status, update: updateSession } = useSession();
   const router = useRouter();
   const isLocalInstance = useIsLocalInstance();
   const shopifyStoreDomain = useShopifyStoreDomain();
@@ -101,22 +101,41 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   // Why a member can't be enrolled. Shared by the default selection and the row
   // render so an ineligible member is never auto-selected and then POSTed (which
   // returned a confusing "Date of Birth is missing" for over-25 adults).
-  const enrollBlock = (member: { id: number; dateOfBirth: string | null; isDeclaredAdult?: boolean }): { reason: 'enrolled' | 'pending' | 'age' | 'dob' | null; label: string } => {
+  const enrollBlock = (member: { id: number; dateOfBirth: string | null; isDeclaredAdult?: boolean }): { reason: 'enrolled' | 'pending' | 'awaiting' | 'age' | 'dob' | 'lead' | null; label: string } => {
+    // Only a known adult may commit THEMSELVES to a program and its charge — the
+    // enroll route refuses the rest, so the viewer's own row must never offer it.
+    const viewer = session?.user as SessionUser | undefined;
+    const selfBlocked = member.id === viewer?.id && viewer?.ageBand !== 'adult';
     const enrolledRow = (program?.participants ?? []).find(p => p.personId === member.id);
     // ACTIVE = paid/free/override (truly done) — locked. PENDING = payment still
     // owed: SELECTABLE, so the household can re-run checkout to finish paying
     // (the participants POST 409s and aggregateEnrollOutcomes folds a 409 back
     // into the checkout set — the same idempotent path as a double-click).
     if (enrolledRow) {
-        return enrolledRow.status === 'ACTIVE'
-            ? { reason: 'enrolled', label: 'Enrolled' }
-            : { reason: 'pending', label: 'Payment pending — select to finish payment' };
+        if (enrolledRow.status === 'ACTIVE') return { reason: 'enrolled', label: 'Enrolled' };
+        // A youth is never shown the payment behind a pending row — the resume
+        // affordance is a checkout they may not reach. "Awaiting confirmation"
+        // stays true whether or not the household ever pays.
+        if (selfBlocked) {
+            return viewer?.ageBand === 'youth'
+                ? { reason: 'awaiting', label: 'Awaiting confirmation' }
+                : { reason: 'dob', label: 'DOB missing' };
+        }
+        return { reason: 'pending', label: 'Payment pending — select to finish payment' };
     }
     if (!program) return { reason: null, label: '' };
     // Same eligibility rule as the enroll route: a declared over-25 adult clears
     // a youth minimum like "16 and up" without a DOB on file.
     const check = checkProgramAge(member, { minAge: program.minAge, maxAge: program.maxAge, asOf: program.startAt ?? undefined });
-    return check.ok ? { reason: null, label: '' } : { reason: check.reason, label: check.label };
+    if (!check.ok) return { reason: check.reason, label: check.label };
+    // An unverifiable age keeps the 'dob' reason so the row still routes into the
+    // intake panel, where a DOB or "over 25" can be set.
+    if (selfBlocked) {
+      return viewer?.ageBand === 'youth'
+        ? { reason: 'lead', label: 'A household lead must enroll you' }
+        : { reason: 'dob', label: 'DOB missing' };
+    }
+    return { reason: null, label: '' };
   };
 
   // Load the caller's household into the member-select, and decide whether they
@@ -183,6 +202,11 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
   // emergency contact are now saved) and drop into the normal member-select.
   const handleIntakeSaved = async () => {
     setShowIntake(false);
+    // Intake just set a DOB or the over-25 flag. Re-stamp the session so the
+    // ageBand claim reflects it NOW — the jwt callback refreshes on its own
+    // schedule, and this is the one flow where waiting would leave a member who
+    // just proved their age still blocked from enrolling.
+    await updateSession();
     await populateHousehold();
   };
 
@@ -385,6 +409,11 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
     }));
   const isClosed = program.enrollmentStatus === 'CLOSED';
   const hasPrice = !!(program.orgMemberPriceCents || program.nonOrgMemberPriceCents);
+  // A youth is shown no payment obligation, action, or status — their own or
+  // their household's (docs/designs/167-youth-enrollment-rules.md). An
+  // unverifiable age is NOT a youth: they keep every affordance so they can
+  // reach the intake panel and establish an age.
+  const viewerIsYouth = user?.ageBand === 'youth';
 
   const ageRange = program.minAge !== null && program.maxAge !== null ? `ages ${program.minAge}–${program.maxAge}`
     : program.minAge !== null ? `ages ${program.minAge} and up`
@@ -444,7 +473,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                 {program.orgMemberOnly && <Text><strong>Eligibility:</strong> Treehouse Members only</Text>}
               </>
             )}
-            {myEnrolled.length > 0 && (
+            {myEnrolled.length > 0 && !viewerIsYouth && (
               <>
                 <Divider />
                 <Text><strong>Already enrolled from your household:</strong></Text>
@@ -482,11 +511,14 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
           {!showEnrollmentSelection ? (
             <Group justify="center" wrap="wrap">
               {session ? (
-                <Button size="md" onClick={startEnrollmentProcess} disabled={isClosed}>
+                <Button size="md" onClick={startEnrollmentProcess} disabled={isClosed || viewerIsYouth}>
                   {/* A payment-pending household reads "Continue enrollment" — the
                       button resumes their checkout (see the pending picker state),
-                      it doesn't start a new one. */}
-                  {isClosed ? <>Enrollment Closed{closedSuffix}</> : myEnrolled.some((m) => !m.active) ? "Continue enrollment" : "Enroll"}
+                      it doesn't start a new one. A youth is told who may act
+                      instead, which holds whether or not the program is priced. */}
+                  {isClosed ? <>Enrollment Closed{closedSuffix}</>
+                    : viewerIsYouth ? "A household lead must enroll you"
+                    : myEnrolled.some((m) => !m.active) ? "Continue enrollment" : "Enroll"}
                 </Button>
               ) : (
                 // Auth-first: route through /signin (which picks Google vs. the
@@ -532,8 +564,8 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                               label={member.name || 'Unnamed Participant'}
                             />
                             {reason === 'enrolled' && <Text size="sm" c="green">({label})</Text>}
-                            {reason === 'pending' && <Text size="sm" c="yellow">({label})</Text>}
-                            {disabled && reason !== 'enrolled' && <Text size="sm" c="red">({label})</Text>}
+                            {(reason === 'pending' || reason === 'awaiting') && <Text size="sm" c="yellow">({label})</Text>}
+                            {disabled && reason !== 'enrolled' && reason !== 'awaiting' && <Text size="sm" c="red">({label})</Text>}
                           </Group>
                         </Card>
                       );
@@ -571,7 +603,7 @@ export default function ProgramEnrollmentPage({ params }: { params: Promise<{ id
                   {hasPrice ? "Pay on Shopify" : "Complete Enrollment"}
                 </Button>
 
-                {hasPrice && !isClosed && (
+                {hasPrice && !isClosed && !viewerIsYouth && (
                   <Button
                     fullWidth
                     size="md"

--- a/checkin-app/src/lib/__tests__/authClaims.test.ts
+++ b/checkin-app/src/lib/__tests__/authClaims.test.ts
@@ -15,6 +15,8 @@ function participant(overrides: Partial<ClaimSourceParticipant> = {}): ClaimSour
         roles: ALL_ROLES,
         householdId: 99,
         isHouseholdLead: false,
+        dateOfBirth: new Date('1990-01-01'),
+        isDeclaredAdult: false,
         toolStatuses: [{ toolId: 1, level: 'CERTIFIED' }],
         household: { orgMembership: { status: 'ACTIVE' } },
         canAccessStaging: false,

--- a/checkin-app/src/lib/__tests__/programAge.test.ts
+++ b/checkin-app/src/lib/__tests__/programAge.test.ts
@@ -1,4 +1,4 @@
-import { checkProgramAge, validateProgramAgeBounds, MAX_PROGRAM_AGE } from "@/lib/programAge";
+import { checkProgramAge, isKnownAdult, validateProgramAgeBounds, MAX_PROGRAM_AGE } from "@/lib/programAge";
 
 // as-of date pins calculateAge so the DOB cases don't drift with wall-clock time.
 const asOf = "2026-01-01";
@@ -41,6 +41,34 @@ describe("checkProgramAge", () => {
       label: "Too old",
     });
     expect(checkProgramAge({ dateOfBirth: "2000-01-01" }, { minAge: 16, maxAge: 40, asOf }).ok).toBe(true);
+  });
+});
+
+describe("isKnownAdult", () => {
+  const yearsAgo = (n: number) => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() - n);
+    return d;
+  };
+
+  it("admits an 18+ DOB and a declared over-25 adult", () => {
+    expect(isKnownAdult({ dateOfBirth: yearsAgo(18) })).toBe(true);
+    expect(isKnownAdult({ dateOfBirth: yearsAgo(40) })).toBe(true);
+    expect(isKnownAdult({ dateOfBirth: null, isDeclaredAdult: true })).toBe(true);
+  });
+
+  it("refuses a under-18 DOB", () => {
+    expect(isKnownAdult({ dateOfBirth: yearsAgo(17) })).toBe(false);
+    expect(isKnownAdult({ dateOfBirth: yearsAgo(10) })).toBe(false);
+  });
+
+  it("fails closed on an unverifiable age", () => {
+    expect(isKnownAdult({ dateOfBirth: null })).toBe(false);
+    expect(isKnownAdult({ dateOfBirth: null, isDeclaredAdult: false })).toBe(false);
+  });
+
+  it("lets a real DOB outrank the declared-adult flag", () => {
+    expect(isKnownAdult({ dateOfBirth: yearsAgo(15), isDeclaredAdult: true })).toBe(false);
   });
 });
 

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -411,6 +411,7 @@ export const authOptions: NextAuthOptions = {
                 }
                 session.user.householdId = token.householdId;
                 session.user.householdLead = token.householdLead ?? false;
+                session.user.ageBand = token.ageBand ?? "unknown";
                 session.user.programsLed = token.programsLed ?? [];
                 session.user.toolStatuses = token.toolStatuses || [];
                 session.user.impersonatedBy = token.impersonatedBy ?? null;

--- a/checkin-app/src/lib/authClaims.ts
+++ b/checkin-app/src/lib/authClaims.ts
@@ -1,6 +1,7 @@
 import type { JWT } from "next-auth/jwt";
 import type { OrgMembershipStatus, PersonRoleKind } from "@/generated/prisma/client";
 import { orgMembershipStatusBlocksLogin } from "@/lib/orgMembership";
+import { ageBand } from "@/lib/programAge";
 import { ROLE_FLAGS, rolesToFlags } from "@/lib/roles";
 
 /** The participant fields the JWT carries, plus the household membership the login gate reads. */
@@ -13,6 +14,10 @@ export type ClaimSourceParticipant = {
     // Leadership of their own household. Single source of truth (a1) — supersedes
     // the former HouseholdLead join.
     isHouseholdLead: boolean;
+    // Age inputs for the isKnownAdult claim. Both are plain Person scalars the
+    // callback already loads; only the derived boolean reaches the token.
+    dateOfBirth: Date | null;
+    isDeclaredAdult: boolean;
     // Programs this participant is the lead mentor of (Program.leadMentorId === id).
     // Drives the client-side program-ops row gate; mirrors access-resolvers' programsLed.
     programsLed?: { id: number }[];
@@ -41,6 +46,9 @@ export function assignParticipantClaims(token: JWT, p: ClaimSourceParticipant): 
     }
     token.householdId = p.householdId;
     token.householdLead = denied ? false : p.isHouseholdLead;
+    // Derived band, never the DOB itself. Not a role, so DENIED doesn't clear
+    // it — age is a fact about the person, not an authority grant.
+    token.ageBand = ageBand(p);
     token.toolStatuses = denied ? [] : p.toolStatuses;
     token.programsLed = denied ? [] : (p.programsLed?.map((prog) => prog.id) ?? []);
     // ops-stg access gate escape hatch — forced false on DENIED, same as every role flag.

--- a/checkin-app/src/lib/programAge.ts
+++ b/checkin-app/src/lib/programAge.ts
@@ -1,4 +1,33 @@
-import { calculateAge } from "@/lib/time";
+import { calculateAge, isYouth } from "@/lib/time";
+
+/**
+ * Whether we KNOW this person is an adult: declared over 25, or 18+ by DOB.
+ * Fails closed — an unknown age is not an adult — because the only caller is the
+ * self-enrollment gate, where "can't prove adult" must refuse rather than admit.
+ *
+ * A declared adult is trusted whoever set the flag, including the member
+ * themselves; see docs/designs/167-youth-enrollment-rules.md for why that
+ * self-attestation risk is accepted rather than closed.
+ */
+export function isKnownAdult(person: { dateOfBirth: Date | string | null; isDeclaredAdult?: boolean | null }): boolean {
+  // A real DOB outranks the flag, as in checkProgramAge: the flag exists to stand
+  // in for a missing DOB, not to contradict one on file.
+  return person.dateOfBirth ? !isYouth(person.dateOfBirth) : !!person.isDeclaredAdult;
+}
+
+/**
+ * The three age states the youth rules act on, as one value so an impossible
+ * pair can't be represented. `youth` and `unknown` are treated OPPOSITELY: a
+ * youth has the enrollment and payment surfaces hidden, while an unverifiable
+ * age keeps them and is routed to age capture — hiding from the latter would
+ * strand a brand-new adult who has no other household lead.
+ */
+export type AgeBand = "adult" | "youth" | "unknown";
+
+export function ageBand(person: { dateOfBirth: Date | string | null; isDeclaredAdult?: boolean | null }): AgeBand {
+  if (isKnownAdult(person)) return "adult";
+  return person.dateOfBirth ? "youth" : "unknown";
+}
 
 /**
  * Single source of truth for "can this person enroll in this age-gated program".

--- a/checkin-app/src/test-helpers/__tests__/rtl.smoke.test.tsx
+++ b/checkin-app/src/test-helpers/__tests__/rtl.smoke.test.tsx
@@ -29,7 +29,7 @@ describe("rtl test-helper", () => {
         setSession({ id: 1, isSysadmin: true });
         expect(navMock().usePathname()).toBe("/x");
         expect(navMock().useRouter()).toBe(router);
-        expect(authMock().useSession()).toEqual({ data: { user: { id: 1, isSysadmin: true } }, status: "authenticated" });
+        expect(authMock().useSession()).toEqual({ data: { user: { id: 1, isSysadmin: true } }, status: "authenticated", update: expect.any(Function) });
     });
 
     it("resetRtl clears router spies and state", () => {

--- a/checkin-app/src/test-helpers/rtl.tsx
+++ b/checkin-app/src/test-helpers/rtl.tsx
@@ -94,7 +94,7 @@ export const router = {
 };
 let pathname = "/";
 let searchParams = new URLSearchParams();
-let session: { data: unknown; status: string } = { data: null, status: "unauthenticated" };
+let session: { data: unknown; status: string; update?: jest.Mock } = { data: null, status: "unauthenticated" };
 
 /** Factory for `jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock())`. */
 export function navMock() {
@@ -125,7 +125,10 @@ export function setSearchParams(sp: URLSearchParams | string) {
 }
 /** Set the mocked session user (pass null for signed-out). */
 export function setSession(user: Record<string, unknown> | null, status = user ? "authenticated" : "unauthenticated") {
-    session = { data: user ? { user } : null, status };
+    // `update` is next-auth's force-a-re-stamp hook; components call it after a
+    // write that changes their own claims. Resolving to the same session keeps
+    // those call sites from hanging on an undefined function.
+    session = { data: user ? { user } : null, status, update: jest.fn().mockResolvedValue(null) };
 }
 /** Reset router spies + pathname/search/session between tests. */
 export function resetRtl() {

--- a/checkin-app/src/types/next-auth.d.ts
+++ b/checkin-app/src/types/next-auth.d.ts
@@ -1,3 +1,4 @@
+import type { AgeBand } from "@/lib/programAge";
 import "next-auth";
 import "next-auth/jwt";
 
@@ -17,6 +18,10 @@ declare module "next-auth" {
       isOperations?: boolean;
       householdId?: number | null;
       householdLead?: boolean;
+      // adult / youth / unknown — the derived band only, never the date
+      // (dateOfBirth is @sensitivity:personal). Gates the youth surfaces in
+      // docs/designs/167-youth-enrollment-rules.md; the routes are the boundary.
+      ageBand?: AgeBand;
       // Program ids this user is the lead mentor of. Client-side row gate only
       // (the API is the real boundary); mirrors access-resolvers' programsLed.
       programsLed?: number[];
@@ -65,6 +70,8 @@ declare module "next-auth/jwt" {
     isOperations?: boolean;
     householdId?: number | null;
     householdLead?: boolean;
+    // See Session.user.ageBand above — derived band, never the DOB.
+    ageBand?: AgeBand;
     programsLed?: number[];
     toolStatuses?: { toolId: number; level: string }[];
     // ops-stg access gate escape hatch — see Session.user.canAccessStaging above.


### PR DESCRIPTION
Fixes #167. Design + rationale: [`checkin-app/docs/designs/167-youth-enrollment-rules.md`](checkin-app/docs/designs/167-youth-enrollment-rules.md) (updated in this PR — the doc was previously "DESIGN — not built" with an open question).

## The problem

Anyone with a Google-linked account could open `programs/[id]` and enroll **themselves** — committing to the program and to a Shopify charge with no guardian involved. `POST /api/programs/[id]/participants` admitted self-enrollment on nothing more than `actor === target`. A minor could do it.

## The rule

**Only a KNOWN adult may act on their own enrollment** — 18+ by `dateOfBirth`, or `isDeclaredAdult` when no DOB is on file. A real DOB outranks the flag: the flag stands in for a missing date, it does not overrule one.

Unknown age **fails closed** — an earlier draft blocked only a *known* minor, which meant "omit your DOB and the gate opens" — but the two refusals differ, because the remedies do:

| Self-enroller | Outcome |
|---|---|
| 18+ by DOB, or declared over 25 | Allowed |
| Under 18 by DOB | Refused → a household lead must enroll them |
| Age unverifiable | Refused → set a DOB or confirm over 25, **then** self-enroll |

That second split matters: first Google sign-in provisions a Person with no DOB who leads their own household, so a brand-new *adult* is "unverifiable". Hiding the flow from them would strand someone with no other lead. Known minor → hide; unverifiable → capture the age.

Leads, sysadmin, and board enrolling *someone else* are untouched — a parent still enrolls their child, staff still comp.

## What changed

**Server (the enforcement).** Three gates on `isKnownAdult`, all refusals a direct POST cannot talk past:
- `POST /participants` — self-enroll, with the two messages above.
- `DELETE /participants` — self-withdrawal. Beyond consent symmetry, withdrawing a scholarship-held seat fires `withdrawAndReleaseHold` → a Shopify inventory release, a financial side effect a youth must not trigger.
- `POST /request-payment-plan` — a scholarship request is a payment situation.

**A youth is shown no payment obligation, action, or status — their own or their household's.** The refusal is an absence, not a door that won't open:
- Their pending row reads **`Awaiting confirmation`**, not "Payment pending — select to finish payment". True whether or not the household ever pays, so unlike a flat `Enrolled` it doesn't become a lie if payment is abandoned.
- The "Already enrolled from your household" block is hidden entirely — it names *other* members' pending payments.
- "Pay on Shopify", the scholarship button, and the `my-activities` payment badge are not rendered.
- The CTA reads **"A household lead must enroll you"**, disabled — naming who may act rather than what it costs, and therefore identical on free and paid programs.
- **Price stays public.** What a program costs is program information, not a payment situation.

**The viewer signal.** Nothing client-side could tell a youth from an adult at render time (`SessionUser` has no DOB), so an `ageBand` claim now rides in the JWT beside `householdLead` and the role flags.

Chosen over a per-response `viewerIsMember`-style flag because the `jwt` callback already re-reads the Person on **every** request (so it isn't a stale token) and already loads every Person scalar with no `select` (so the claim costs no extra query), while per-response scales as endpoints × signals and can't gate shared chrome at all.

It's a **band** (`adult` / `youth` / `unknown`), not a boolean: "not a known adult" covers both a youth and an unverifiable adult, and this design treats those oppositely — one boolean would have hidden the enroll path from the very person it exists to serve. Only the derived band reaches the token, **never the DOB** (`@sensitivity:personal`). Intake calls `useSession().update()` so a member who has just proved their age can enroll immediately rather than waiting on the refresh window.

## Reviewer notes

**Two test changes alter meaning, not just fixtures.** `programAgeBounds`'s two "should allow self-enrollment" cases are now lead-enrolls-child — a 16-year-old self-enrolling is precisely what this forbids — and `programsParticipantsAPI`'s "drop out of their own program" split into a youth-refused case and an adult-allowed one. Worth an eye.

**A pre-existing evening flake, surfaced not caused.** `programAgeBounds` built boundary DOBs from *local* date parts while `calculateAge` reads *UTC*, so after ~19:00 local the "turns 14 tomorrow" persona read as 14 and that test failed on its own, independent of this change. Those fixtures now use `Date.UTC`.

**Persona churn.** Nine suites had DOB-less or minor personas self-enrolling or self-requesting; they now carry a real age or go through a lead. Per the design: any persona used for a non-age self-enroll has to be a known adult.

**Accepted residual risk, unchanged from the design.** No self-entered age is verified — a minor willing to tick "over 25" clears the gate. Accepted deliberately: the gate stops the accidental case, not deliberate misrepresentation, which no self-service flow can. The trustworthy path (a lead enrolling them) stays available.

**Out of scope, recorded in the doc.** Org-membership dues (a separate payment domain, and a confirmed leak — non-leads can see dues and reach checkout); reconciling the missing-DOB posture between `leads.ts` (unknown ⇒ adult) and this design (unknown ⇒ not adult); household-lead integrity edges, filed as #1471.

## Verification

- `tsc --noEmit` clean; `eslint --max-warnings 0` clean
- **2438 unit tests**, 257 suites — all pass
- **1267 integration tests**, 128 suites against a real Postgres — all pass (4 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
