### PR TITLE
fix(attendance): serialize visit writes and stop the 500 on a walk-in Present mark

### DIFF
--- a/checkin-app/jest.setup.js
+++ b/checkin-app/jest.setup.js
@@ -46,7 +46,7 @@ process.env.CHECKIN_ENV = 'dev';
   // pool of >= 2 so their two enroll transactions run on separate connections,
   // making the program-row FOR UPDATE lock (not pool-1 serialization) the thing
   // that serializes them — matching production.
-  if (testPath && /(scanConcurrency|attendanceManualConcurrency|attendanceManualCheckinConcurrency|programsParticipantsConcurrency|programsPublicRegisterConcurrency|trustedAdultConcurrency|householdLeadsConcurrency)\.integration\.test\.[jt]sx?$/.test(testPath)) {
+  if (testPath && /(scanConcurrency|attendanceManualConcurrency|attendanceManualCheckinConcurrency|visitWriteLockConcurrency|programsParticipantsConcurrency|programsPublicRegisterConcurrency|trustedAdultConcurrency|householdLeadsConcurrency)\.integration\.test\.[jt]sx?$/.test(testPath)) {
     process.env.TEST_DB_POOL_MAX = '2';
   }
 }

--- a/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
@@ -217,6 +217,86 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
         });
     });
 
+    // ─── 2b. PRESENT vs AN OPEN VISIT THIS EVENT DOESN'T OWN ────────────────
+
+    describe('manualEditAttendance — Present while an open visit exists elsewhere', () => {
+        it('adopts an unassociated open visit into the event instead of failing the one-open-visit index', async () => {
+            const event = await makeEvent('manual-present-walkin', -1 * HOUR);
+            // Ordinary walk-in badge-in: open, not tied to any event.
+            const walkIn = await prisma.visit.create({
+                data: { personId: participantId, arrivedAt: new Date(Date.now() - 90 * MIN), departedAt: null, associatedEventId: null },
+            });
+
+            const newArrival = new Date(Date.now() - 80 * MIN);
+            const res = await patch(event.id, {
+                action: 'manualEditAttendance',
+                participantId,
+                status: 'Present',
+                arrivedAt: newArrival.toISOString(),
+                departedAt: null,
+            });
+            expect(res.status).toBe(200);
+
+            const visits = await prisma.visit.findMany({ where: { personId: participantId } });
+            expect(visits.length).toBe(1);              // no second visit written
+            expect(visits[0].id).toBe(walkIn.id);       // the walk-in row itself
+            expect(visits[0].associatedEventId).toBe(event.id);
+            expect(visits[0].departedAt).toBeNull();    // still on-site
+            expect(visits[0].arrivedAt.getTime()).toBe(newArrival.getTime());
+        });
+
+        it('rejects with an actionable 400 when the open visit belongs to another event', async () => {
+            const other = await makeEvent('manual-present-other', -3 * HOUR);
+            const event = await makeEvent('manual-present-target', -1 * HOUR);
+            const openElsewhere = await prisma.visit.create({
+                data: { personId: participantId, arrivedAt: new Date(Date.now() - 150 * MIN), departedAt: null, associatedEventId: other.id },
+            });
+
+            const res = await patch(event.id, {
+                action: 'manualEditAttendance',
+                participantId,
+                status: 'Present',
+                arrivedAt: new Date(Date.now() - 50 * MIN).toISOString(),
+                departedAt: null,
+            });
+            expect(res.status).toBe(400);
+            const body = await res.json();
+            expect(body.error).toMatch(/checked in/i);
+
+            // Nothing written: the other event keeps its open visit.
+            const visits = await prisma.visit.findMany({ where: { personId: participantId } });
+            expect(visits.length).toBe(1);
+            expect(visits[0].id).toBe(openElsewhere.id);
+            expect(visits[0].associatedEventId).toBe(other.id);
+        });
+
+        it('closes the open walk-in in place when a departure time is supplied', async () => {
+            const event = await makeEvent('manual-present-close-walkin', -2 * HOUR);
+            const walkIn = await prisma.visit.create({
+                data: { personId: participantId, arrivedAt: new Date(Date.now() - 150 * MIN), departedAt: null, associatedEventId: null },
+            });
+
+            const arrival = new Date(Date.now() - 140 * MIN);
+            const departure = new Date(Date.now() - 60 * MIN);
+            const res = await patch(event.id, {
+                action: 'manualEditAttendance',
+                participantId,
+                status: 'Present',
+                arrivedAt: arrival.toISOString(),
+                departedAt: departure.toISOString(),
+            });
+            expect(res.status).toBe(200);
+
+            // A closed result can't collide with the index, so the walk-in is left
+            // alone and this event gets its own closed record.
+            const visits = await prisma.visit.findMany({ where: { personId: participantId }, orderBy: { id: 'asc' } });
+            expect(visits.length).toBe(2);
+            expect(visits.find(v => v.id === walkIn.id)!.departedAt).toBeNull();
+            const forEvent = visits.find(v => v.associatedEventId === event.id)!;
+            expect(forEvent.departedAt!.getTime()).toBe(departure.getTime());
+        });
+    });
+
     // ─── 3. PAST-EVENT GUARD ────────────────────────────────────────────────
 
     describe('past-event editTime — rejected', () => {

--- a/checkin-app/src/app/__tests__/visitWriteLockConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/visitWriteLockConcurrency.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Concurrency regression tests for the two visit-write paths that had no
+ * per-person advisory lock: PATCH /api/events/[id] (manualEditAttendance) and
+ * DELETE /api/facility/visits.
+ *
+ * Both did a read-then-write on Visit with nothing serializing them, so a
+ * concurrent writer could invalidate the pre-check before the write landed:
+ * two Present marks on different events both saw "no open visit" and both
+ * created one (P2002 on Visit_one_open_per_participant → 500), and two deletes
+ * both saw the row live and both tombstoned it, the second overwriting who
+ * deleted it. Each now runs inside a $transaction that takes
+ * `pg_advisory_xact_lock(<the visit's personId>)` and re-checks under the lock,
+ * matching /api/scan and /api/attendance/manual.
+ *
+ * (jest.setup.js gives this suite a pool of 2 via TEST_DB_POOL_MAX so the two
+ * transactions run on separate connections — the advisory lock is then the only
+ * thing serializing them, as in production. Deleting a pg_advisory_xact_lock
+ * line from either route makes this suite fail.)
+ */
+import { PATCH as EVENT_PATCH } from '@/app/api/events/[id]/route';
+import { DELETE as VISIT_DELETE } from '@/app/api/facility/visits/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+const TAG = 'visit-write-lock-concurrency-test';
+const HOUR = 60 * 60 * 1000;
+
+function eventPatch(eventId: number, body: Record<string, unknown>) {
+    const req = new Request('http://localhost:4000/api/events/x', {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+    });
+    return EVENT_PATCH(req as unknown as import('next/server').NextRequest, {
+        params: Promise.resolve({ id: String(eventId) }),
+    }) as Promise<Response>;
+}
+
+function visitDelete(visitId: number) {
+    const req = new Request('http://localhost:4000/api/facility/visits', {
+        method: 'DELETE',
+        body: JSON.stringify({ visitId }),
+    });
+    return VISIT_DELETE(req as unknown as import('next/server').NextRequest) as Promise<Response>;
+}
+
+describe('visit-write advisory locks', () => {
+    let adminId: number;
+    let subjectId: number;
+    let householdIds: number[];
+
+    beforeAll(async () => {
+        const leaked = await prisma.person.findMany({
+            where: { email: { contains: TAG } },
+            select: { id: true, householdId: true },
+        });
+        const leakedIds = leaked.map(p => p.id);
+        await prisma.visit.deleteMany({ where: { personId: { in: leakedIds } } });
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: leakedIds } } });
+        await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { id: { in: leakedIds } } });
+        await prisma.household.deleteMany({ where: { id: { in: leaked.map(p => p.householdId) } } });
+
+        const admin = await prisma.person.create({
+            data: { name: 'Lock Admin', email: `admin-${TAG}@example.com`, isSysadmin: true, household: { create: { name: 'Test HH' } } },
+        });
+        adminId = admin.id;
+        const subject = await prisma.person.create({
+            data: { name: 'Lock Subject', email: `subject-${TAG}@example.com`, household: { create: { name: 'Test HH' } } },
+        });
+        subjectId = subject.id;
+        householdIds = [admin.householdId, subject.householdId];
+    });
+
+    beforeEach(() => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+    });
+
+    afterAll(async () => {
+        await prisma.visit.deleteMany({ where: { personId: { in: [adminId, subjectId] } } });
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: [adminId, subjectId] } } });
+        await prisma.event.deleteMany({ where: { name: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { id: { in: [adminId, subjectId] } } });
+        await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
+    });
+
+    function makeEvent(label: string) {
+        const start = new Date(Date.now() - 2 * HOUR);
+        return prisma.event.create({
+            data: { name: `${TAG} ${label}`, startAt: start, endAt: new Date(start.getTime() + HOUR), description: 'x' },
+        });
+    }
+
+    it('two concurrent Present marks on different events → one open visit, no 500', async () => {
+        await prisma.visit.deleteMany({ where: { personId: subjectId } });
+        const [eventA, eventB] = await Promise.all([makeEvent('race-a'), makeEvent('race-b')]);
+
+        const markPresent = (eventId: number) => eventPatch(eventId, {
+            action: 'manualEditAttendance',
+            participantId: subjectId,
+            status: 'Present',
+            arrivedAt: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
+            departedAt: null,
+        });
+
+        const [resA, resB] = await Promise.all([markPresent(eventA.id), markPresent(eventB.id)]);
+
+        // Winner records the open visit (200); the loser sees it under the lock and
+        // returns the "checked in for another session" 400. Neither 500s.
+        expect([resA.status, resB.status].sort()).toEqual([200, 400]);
+        expect(await prisma.visit.count({ where: { personId: subjectId, departedAt: null, deletedAt: null } })).toBe(1);
+    });
+
+    it('two concurrent facility deletes of one visit → 200 + 404, tombstoned once', async () => {
+        await prisma.visit.deleteMany({ where: { personId: subjectId } });
+        const visit = await prisma.visit.create({
+            data: {
+                personId: subjectId,
+                arrivedAt: new Date(Date.now() - 2 * HOUR),
+                departedAt: new Date(Date.now() - HOUR),
+            },
+        });
+
+        const [resA, resB] = await Promise.all([visitDelete(visit.id), visitDelete(visit.id)]);
+
+        expect([resA.status, resB.status].sort()).toEqual([200, 404]);
+
+        // Delete is a tombstone: the row survives, deleted exactly once, and the
+        // loser never overwrote deletedById.
+        const after = await prisma.visit.findUniqueOrThrow({ where: { id: visit.id } });
+        expect(after.deletedAt).not.toBeNull();
+        expect(after.deletedById).toBe(adminId);
+        expect(await prisma.visit.count({ where: { personId: subjectId, deletedAt: null } })).toBe(0);
+    });
+});

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -211,32 +211,10 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                 }
             }
 
-            if (status === 'Absent') {
-                // An open visit (departedAt = null) means they physically scanned in
-                // and are currently on-site. Deleting it would destroy the live
-                // roster of who's in the building — reject instead.
-                const openVisit = await prisma.visit.findFirst({
-                    where: {
-                        personId: Number(participantId),
-                        associatedEventId: eventId,
-                        departedAt: null,
-                        ...LIVE_VISIT
-                    }
-                });
-                if (openVisit) {
-                    return apiError("Participant is currently checked in — check them out before marking Absent", 400);
-                }
-                // Only closed visits remain; safe to remove on an Absent correction.
-                // Never hard-delete a tombstone: it is the reviewable record of
-                // an earlier self-deletion.
-                await prisma.visit.deleteMany({
-                    where: {
-                        personId: Number(participantId),
-                        associatedEventId: eventId,
-                        ...LIVE_VISIT
-                    }
-                });
-            } else if (status === 'Present') {
+            // Input validation before the lock — it depends on nothing we read.
+            let dep: Date | null = null;
+            let arrival: Date | null = null;
+            if (status === 'Present') {
                 if (!arrivedAt) {
                     return apiError("Arrival time is required for Present status", 400);
                 }
@@ -244,8 +222,8 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                 const now = new Date();
                 const ar = parseVisitTime(arrivedAt, "arrival", now);
                 if (!ar.ok) return apiError(ar.error, 400);
+                arrival = ar.value;
 
-                let dep: Date | null = null;
                 if (departedAt) {
                     const dr = parseVisitTime(departedAt, "departure", now);
                     if (!dr.ok) return apiError(dr.error, 400);
@@ -257,39 +235,81 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                     }
                     dep = dr.value;
                 }
+            }
 
-                // Check if there is an existing visit
-                const existingVisit = await prisma.visit.findFirst({
-                    where: {
-                        personId: Number(participantId),
-                        associatedEventId: eventId,
-                        ...LIVE_VISIT
+            // Read-modify-write on this person's visit state, exactly like /api/scan
+            // and /api/attendance/manual: take the per-person advisory xact lock so a
+            // correction can't race a kiosk scan or the facility-close sweep, and
+            // re-read the visit state inside the lock. Returns an error message to
+            // surface as a 400, or null on success.
+            const failure = await prisma.$transaction(async (tx): Promise<string | null> => {
+                await tx.$executeRaw`SELECT pg_advisory_xact_lock(${targetId})`;
+
+                if (status === 'Absent') {
+                    // An open visit (departedAt = null) means they physically scanned in
+                    // and are currently on-site. Deleting it would destroy the live
+                    // roster of who's in the building — reject instead.
+                    const openVisit = await tx.visit.findFirst({
+                        where: { personId: targetId, associatedEventId: eventId, departedAt: null, ...LIVE_VISIT }
+                    });
+                    if (openVisit) {
+                        return "Participant is currently checked in — check them out before marking Absent";
                     }
+                    // Only closed visits remain; safe to remove on an Absent correction.
+                    // Never hard-delete a tombstone: it is the reviewable record of
+                    // an earlier self-deletion.
+                    await tx.visit.deleteMany({
+                        where: { personId: targetId, associatedEventId: eventId, ...LIVE_VISIT }
+                    });
+                    return null;
+                }
+
+                if (status !== 'Present') return null;
+
+                // A person has at most one open LIVE visit
+                // (Visit_one_open_per_participant excludes tombstones), so this finds
+                // it whichever event — if any — it belongs to.
+                const openVisit = await tx.visit.findFirst({
+                    where: { personId: targetId, departedAt: null, ...LIVE_VISIT }
                 });
 
+                // A Present mark with no departure leaves the person open, and their
+                // existing open visit IS that presence. Adopt an ordinary walk-in
+                // (unassociated) into this event rather than writing a second open
+                // visit, which the one-open-visit index rejects outright.
+                const adoptable = openVisit !== null && (
+                    openVisit.associatedEventId === eventId ||
+                    (dep === null && openVisit.associatedEventId === null)
+                );
+                if (dep === null && openVisit && !adoptable) {
+                    return "Participant is currently checked in for another session. Check them out, or set a departure time, before marking them Present here.";
+                }
+
+                const existingVisit = adoptable ? openVisit : await tx.visit.findFirst({
+                    where: { personId: targetId, associatedEventId: eventId, ...LIVE_VISIT }
+                });
+
+                const times = {
+                    arrivedAt: arrival!,
+                    departedAt: dep,
+                    arrivedVia: "WEB",
+                    departedVia: departedAt ? "WEB" : null
+                } satisfies Prisma.VisitUncheckedUpdateInput;
+
                 if (existingVisit) {
-                    await prisma.visit.update({
+                    await tx.visit.update({
                         where: { id: existingVisit.id },
-                        data: {
-                            arrivedAt: ar.value,
-                            departedAt: dep,
-                            arrivedVia: "WEB",
-                            departedVia: departedAt ? "WEB" : null
-                        }
+                        data: { ...times, associatedEventId: eventId }
                     });
                 } else {
-                    await prisma.visit.create({
-                        data: {
-                            personId: Number(participantId),
-                            associatedEventId: eventId,
-                            arrivedAt: ar.value,
-                            departedAt: dep,
-                            arrivedVia: "WEB",
-                            departedVia: departedAt ? "WEB" : null
-                        }
+                    await tx.visit.create({
+                        data: { ...times, personId: targetId, associatedEventId: eventId }
                     });
                 }
-            }
+                return null;
+            }, { maxWait: 5000, timeout: 15000 });
+
+            if (failure) return apiError(failure, 400);
 
             return NextResponse.json({ success: true });
         }

--- a/checkin-app/src/app/api/facility/visits/route.ts
+++ b/checkin-app/src/app/api/facility/visits/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
+import type { Visit } from "@/generated/prisma/client";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { parseVisitTime, departureAfterArrival, withinMaxDuration } from "@/lib/visitTimes";
@@ -44,38 +45,57 @@ export const PATCH = withAuth(
             }
 
             const now = new Date();
-            let nextArrived = existing.arrivedAt;
-            let nextDeparted = existing.departedAt;
+            let parsedArrived: Date | null = null;
+            let parsedDeparted: Date | null = null;
 
             if (arrivedAt) {
                 const r = parseVisitTime(arrivedAt, "arrival", now);
                 if (!r.ok) return apiError(r.error, 400);
-                nextArrived = r.value;
+                parsedArrived = r.value;
             }
             if (departedAt) {
                 const r = parseVisitTime(departedAt, "departure", now);
                 if (!r.ok) return apiError(r.error, 400);
-                nextDeparted = r.value;
+                parsedDeparted = r.value;
             }
 
-            // Result must be closed: can close an open visit, never reopen a closed one.
-            if (nextDeparted === null) {
-                return apiError("Departure time is required to close this visit.", 400);
-            }
-            if (!departureAfterArrival(nextArrived, nextDeparted)) {
-                return apiError("Departure time must be after arrival time", 400);
-            }
-            if (!withinMaxDuration(nextArrived, nextDeparted)) {
-                return apiError("A visit cannot be longer than 24 hours.", 400);
-            }
+            // Editing a visit is a read-modify-write on this person's visit state, so
+            // it takes the same per-person advisory xact lock as /api/scan and re-reads
+            // the row inside it — the pre-check above ran unserialized and a racing
+            // scan or the facility-close sweep may have closed or removed the visit.
+            const result = await prisma.$transaction(async (tx): Promise<{ error: string; status: number } | { visit: Visit }> => {
+                await tx.$executeRaw`SELECT pg_advisory_xact_lock(${existing.personId})`;
 
-            const updatedVisit = await prisma.visit.update({
-                where: { id: visitId },
-                data: {
-                    ...(arrivedAt ? { arrivedAt: nextArrived, arrivedVia: "WEB" } : {}),
-                    ...(departedAt ? { departedAt: nextDeparted, departedVia: "WEB" } : {}),
-                },
-            });
+                const current = await tx.visit.findUnique({ where: { id: visitId } });
+                if (!current || current.deletedAt) return { error: "Visit not found.", status: 404 as const };
+
+                const nextArrived = parsedArrived ?? current.arrivedAt;
+                const nextDeparted = parsedDeparted ?? current.departedAt;
+
+                // Result must be closed: can close an open visit, never reopen a closed one.
+                if (nextDeparted === null) {
+                    return { error: "Departure time is required to close this visit.", status: 400 as const };
+                }
+                if (!departureAfterArrival(nextArrived, nextDeparted)) {
+                    return { error: "Departure time must be after arrival time", status: 400 as const };
+                }
+                if (!withinMaxDuration(nextArrived, nextDeparted)) {
+                    return { error: "A visit cannot be longer than 24 hours.", status: 400 as const };
+                }
+
+                return {
+                    visit: await tx.visit.update({
+                        where: { id: visitId },
+                        data: {
+                            ...(parsedArrived ? { arrivedAt: nextArrived, arrivedVia: "WEB" } : {}),
+                            ...(parsedDeparted ? { departedAt: nextDeparted, departedVia: "WEB" } : {}),
+                        },
+                    })
+                };
+            }, { maxWait: 5000, timeout: 15000 });
+
+            if ('error' in result) return apiError(result.error, result.status);
+            const updatedVisit = result.visit;
 
             // Log the manual edit in the audit trail
             if (auth.type === 'session') {
@@ -113,12 +133,25 @@ export const DELETE = withAuth(
                 return apiError("Visit not found.", 404);
             }
 
-            // Tombstone, matching the member's own self-delete: a deleted visit
-            // keeps its row so the deletion stays reviewable and reversible.
-            await prisma.visit.update({
-                where: { id: visitId },
-                data: { deletedAt: new Date(), deletedById: auth.type === 'session' ? auth.user.id : null },
-            });
+            // Same per-person advisory xact lock as the PATCH above, with the
+            // existence check re-run inside it so a racing delete can't tombstone
+            // the row twice and overwrite who deleted it.
+            const removed = await prisma.$transaction(async (tx) => {
+                await tx.$executeRaw`SELECT pg_advisory_xact_lock(${existing.personId})`;
+
+                const current = await tx.visit.findUnique({ where: { id: visitId } });
+                if (!current || current.deletedAt) return null;
+
+                // Tombstone, matching the member's own self-delete: a deleted visit
+                // keeps its row so the deletion stays reviewable and reversible.
+                await tx.visit.update({
+                    where: { id: visitId },
+                    data: { deletedAt: new Date(), deletedById: auth.type === 'session' ? auth.user.id : null },
+                });
+                return current;
+            }, { maxWait: 5000, timeout: 15000 });
+
+            if (!removed) return apiError("Visit not found.", 404);
 
             // Log the manual deletion in the audit trail — oldData carries the
             // pre-delete row so the review needs no join.
@@ -129,7 +162,7 @@ export const DELETE = withAuth(
                         action: "DELETE",
                         tableName: "Visit",
                         affectedEntityId: visitId,
-                        oldData: JSON.parse(JSON.stringify(existing)),
+                        oldData: JSON.parse(JSON.stringify(removed)),
                     },
                 });
             }


### PR DESCRIPTION
## What's broken

Two visit-write paths do a read-then-write on `Visit` with no per-person advisory lock, and one of them hard-fails on a database constraint with **no race at all**.

### The no-race bug: `PATCH /api/events/[id]` → `manualEditAttendance`, status `Present`

The route looks up an existing visit scoped to `associatedEventId`:

```ts
const existingVisit = await prisma.visit.findFirst({
    where: { personId: <target>, associatedEventId: eventId }
});
```

...but the partial unique index is scoped to `personId` alone:

```sql
CREATE UNIQUE INDEX "Visit_one_open_per_participant"
  ON public."Visit" USING btree ("personId") WHERE ("departedAt" IS NULL);
```

So a person with an ordinary **open walk-in visit** (`associatedEventId: null`) is missed by that lookup. The route falls through to `create`, writes a second open visit, and Postgres rejects it. Confirmed by an integration test against a real DB:

```
Invalid `prisma.visit.create()` invocation in .../api/events/[id]/route.ts:275:40
Unique constraint failed on the fields: (`"personId"`)
code: 'P2002'
```

The route's catch-all turns that into a **500 "Failed to update event"** — the lead gets no idea what went wrong.

This is reachable from the UI, not just the API: `program-ops/sessions/[id]/page.tsx` sends `departedAt: null` when the departure field is left blank on a Present mark. Marking a member Present who is currently badged in is an ordinary thing for a lead to do.

### The missing locks

`PATCH`/`DELETE` on `/api/facility/visits` and the whole `manualEditAttendance` branch each run a `findUnique`/`findFirst` pre-check, then write, with nothing serializing them. Exposure is milder than the above (facility `PATCH` can only close a visit, never reopen one), but the pre-check can be invalidated before the write lands.

## What changed

**The Present path now resolves the person's single open visit regardless of event** (the index guarantees at most one exists):

- open visit is **unassociated** (a walk-in) → **adopt it into the event**. That row already *is* the person's presence, and the route already did exactly this for a same-event open visit — this extends it to the walk-in case.
- the lookup filters through `LIVE_VISIT`: since #1357 the index reads `WHERE (departedAt IS NULL AND deletedAt IS NULL)`, so a tombstoned open visit is not a conflict and must not be adopted.
- open visit belongs to **another session** → **400** naming the conflict: *"Participant is currently checked in for another session. Check them out, or set a departure time, before marking them Present here."* The session-roster modal renders `data.error` next to Save, so the lead sees an actionable message instead of a 500.
- a departure time was supplied → closed result, can't collide with the index → unchanged behaviour.

**Advisory locks.** `manualEditAttendance` (both Absent and Present) and the facility `PATCH`/`DELETE` now run inside a `prisma.$transaction` that takes `pg_advisory_xact_lock(<the visit's personId>)` and re-checks the pre-condition under the lock — matching `/api/scan`, `/api/attendance`, and `/api/attendance/manual`. The re-check includes the tombstone test, so a racing delete can't tombstone the same row twice and overwrite `deletedById`. The facility `DELETE` also audit-logs the row it read under the lock rather than the stale pre-check read.

This is the invariant stated in `checkin-app/docs/designs/1256_ATTENDANCE_CORRECTION_SURFACE.md` §5 (the AT9 entry): every visit write — self-service, staff, automated — goes through the advisory lock plus the one-open-visit guard, so a correction cannot race the facility-close sweep.

## Tests

- Three cases added to `eventCancelAndManualAttendance.integration.test.ts` covering the walk-in scenarios. The first two **fail with a 500 before this change**.
- New `visitWriteLockConcurrency.integration.test.ts`: two concurrent Present marks on different events → `[200, 400]` with exactly one open visit; two concurrent facility deletes → `[200, 404]` with the row tombstoned exactly once and `deletedById` intact. Registered in the `TEST_DB_POOL_MAX=2` list in `jest.setup.js` so the two transactions run on separate connections and the **advisory lock is the only thing serializing them**, as in production.
- Verified negatively: stripping both `pg_advisory_xact_lock` lines makes both concurrency cases fail with 500.

Rebased onto `origin/main` (post-#1357), full runs green:

```
test:integration   130 suites, 1287 passed
test:ci            261 suites, 2475 passed   (incl. liveVisitDriftGuard)
tsc --noEmit       clean
lint               clean
```

## Reviewer notes

- Rebased onto current `main` after #1357 (AT5 self-correction) landed. That PR introduced Visit tombstones and recreated the one-open-visit index with `deletedAt` in the predicate; this branch's new queries filter through `LIVE_VISIT` accordingly, and the facility `DELETE` keeps #1357's tombstone write — the lock wraps it rather than replacing it. Related design context: #254 (AT9, force-close race), #1254.
- No schema, migration, registry, or response-shape changes — the security boundary is untouched.
- The design decision worth a second opinion is **adopt vs. reject** for the unassociated walk-in. Adoption was chosen because the lead's intent ("this person is here, at my session") is exactly what the open row already records, and rejecting would leave the lead unable to record attendance until the member physically leaves — they can't check someone out from the session-roster screen. The other-event case still rejects, since adopting there would silently steal a row off another session's roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
