### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in dev sent mail view

### DIFF
--- a/checkin-app/src/app/dev/sent-mail/page.tsx
+++ b/checkin-app/src/app/dev/sent-mail/page.tsx
@@ -64,11 +64,11 @@ export default async function DevSentMailPage() {
                                 <span>{new Date(email.createdAt).toLocaleString()}</span>
                             </div>
                             <div style={{ fontWeight: 600, margin: "0.4rem 0 0.75rem" }}>{email.subject}</div>
-                            <div
-                                style={{ border: "1px solid rgba(0,0,0,0.08)", borderRadius: 6, padding: "0.75rem", background: "#fff", color: "#111" }}
-                                // Dev-only rendering of our own captured template HTML so embedded links/tokens
-                                // are clickable. Never runs in prod (page 404s); content is what we ourselves sent.
-                                dangerouslySetInnerHTML={{ __html: email.html }}
+                            <iframe
+                                title={`Email subject: ${email.subject}`}
+                                sandbox="allow-popups allow-popups-to-escape-sandbox"
+                                srcDoc={email.html}
+                                style={{ border: "1px solid rgba(0,0,0,0.08)", borderRadius: 6, padding: "0.75rem", background: "#fff", color: "#111", width: "100%", minHeight: "200px" }}
                             />
                         </li>
                     ))}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The dev-only "Sent Mail" view was rendering the captured email HTML using `dangerouslySetInnerHTML`. Since the email body can contain user-controlled data (like names or addresses inputted by applicants), this could execute arbitrary JavaScript in the context of the dev server, posing an XSS risk.
🎯 **Impact:** An attacker could inject malicious scripts into fields that end up in emails. When an administrator or developer views the email on the Sent Mail dashboard, the script executes, which could lead to session hijacking or sensitive data exposure on the dev/local environment.
🔧 **Fix:** Replaced the `dangerouslySetInnerHTML` implementation with an `iframe` using the `srcDoc` attribute, and heavily restricted it with a `sandbox` attribute (`allow-popups allow-popups-to-escape-sandbox`). This allows the HTML (and styles) to render safely and links to be clickable, while strictly prohibiting script execution.
✅ **Verification:** Verified visually (via code review) that the iframe utilizes `sandbox` constraints correctly and replaces the vulnerable `div` element. Checked that `srcDoc` properly isolates the content.

---
*PR created automatically by Jules for task [10289915271227998364](https://jules.google.com/task/10289915271227998364) started by @dkaygithub*