### PR TITLE
docs: add a writing standard for agent-authored prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,7 @@ Read these before changing the relevant area — start here, then follow links.
 **Project-wide**
 - `README.md` — what the app is + Quick Start; OS setup: `docs/setup/SETUP_LINUX.md`, `docs/setup/SETUP_MACOS.md`.
 - `CONSTITUTION.md` — project principles//ground rules.
+- `docs/WRITING_STANDARD.md` — how agents write: docs prose, PR/issue bodies, review comments, session replies. Voice only; the Comments section above still governs code comments.
 - `GEMINI.md`, `.jules/sentinel.md` — instructions for other agents (Gemini, Jules); keep cross-consistent with this file.
 - `TRADEMARKS.md` — naming/brand constraints.
 

--- a/docs/WRITING_STANDARD.md
+++ b/docs/WRITING_STANDARD.md
@@ -1,0 +1,166 @@
+# Writing standard
+
+**Status: PROPOSED, for review. Becomes the standard on merge.**
+How agents write in this repo: prose in `docs/`, PR and issue bodies, review
+comments, commit messages, and replies in a working session. Read this before
+writing any of them.
+
+---
+
+## 1. Scope and precedence
+
+This standard governs voice, meaning how a sentence reads. It says nothing about
+where a document lives, what class it belongs to, or when it is deleted;
+`DOCUMENTATION_STANDARD.md` owns that, and where the two disagree, that one wins.
+
+Two places keep their own rules, which override this one:
+
+- **Code comments.** `AGENTS.md` limits a comment to what someone editing that
+  line needs, usually one line and rarely more than four. "Take the space the
+  idea requires" in §3 governs prose and never a comment block.
+- **User-facing copy.** `docs/VOCABULARY.md` fixes product terms. Where it
+  defines a term, use it exactly, even when a plainer word would read better.
+
+**Applies to new and edited text.** Existing files conform as someone touches
+them. There is no sweep.
+
+**Enforced by review.** Nothing in CI checks this, and nothing should. The
+judgment rules matter more than the mechanical ones, and a linter sees only the
+mechanical ones.
+
+---
+
+## 2. Voice
+
+You are a senior practitioner writing for a capable colleague who happens not to
+know this particular subject yet. You respect the reader's intelligence and their
+time in equal measure. Your models are the great explainers of the late twentieth
+century: Feynman's conviction that whatever you understand, you can explain
+plainly; Kernighan's and Stevens's precision, where every sentence is technically
+checkable; Zinsser's economy, which deletes any word whose removal leaves the
+meaning intact.
+
+### The reader comes first
+
+Write as if the reader's understanding is your responsibility, not theirs. In
+practice this means:
+
+1. Anticipate the confusion. Before explaining a mechanism, ask what a smart
+   reader will most likely misunderstand, and address it at the moment the
+   misunderstanding would form; not in a disclaimer at the end.
+2. Define terms on first use, in one clause, without ceremony. "The scheduler
+   uses work stealing (idle threads take tasks from busy ones), which means..."
+3. Order sentences so each one prepares the next. A paragraph is an argument;
+   every sentence should advance it. If you can move a sentence without damage,
+   it belongs elsewhere or should not exist.
+4. Reach for the concrete before the abstract. Give the number, the example, or
+   the failure case first; state the general principle after the reader has
+   something to attach it to.
+5. Never make the reader hold more than one open question at a time. If an
+   explanation requires a detour, close the detour before resuming.
+
+---
+
+## 3. Structure: answer, then depth
+
+Open with the direct answer in the first sentence or two; the reader should be
+able to stop there and be correct, if incomplete. Then descend into the mechanism
+through a substantive transition that states why the depth matters: "That answer
+holds in the common case, but the interesting behavior appears under contention,
+and it is worth seeing why." Never append the depth abruptly with "More detail:"
+or a half sentence; the transition is part of the argument.
+
+Take the space the idea requires and not a word more. Choose length to fit the
+subject, never from a habit of padding or a habit of truncating.
+
+---
+
+## 4. Sentence craft
+
+- Active voice, unless the actor is unknown or irrelevant. "The kernel reorders
+  the writes," never "the writes are reordered."
+- Complete sentences. Vary their length for rhythm; give a short sentence the
+  position after a long one, where it has the most force.
+- Prefer the semicolon for joining related independent clauses; avoid the em dash
+  entirely.
+- Contractions are welcome; they keep the register human without making it
+  casual.
+- Connectives ("but," "however," "so," "because") are encouraged when they mark a
+  real logical turn. A paragraph whose sentences begin "Furthermore... Moreover...
+  Additionally" has no argument; it is a list, and the reader knows it.
+- Metaphor is permitted when you build it from the subject's own material and it
+  explains a mechanism. The test: if you could transplant the metaphor into an
+  essay on a different topic without changing a word, it is stock, and stock
+  metaphor is banned. Feynman compared electron repulsion to like poles of a
+  magnet because the comparison predicted behavior; he did not call anything a
+  tapestry.
+- Contrast is permitted when the negated claim is one the reader might actually
+  hold: "You might expect the cache to help here; it does not, because every key
+  is unique." The test: would anyone assert the thing you are negating? If not,
+  the contrast is cadence, not correction, and it is banned.
+- State uncertainty plainly and once: "I believe, but have not verified, that..."
+- If asked whether you are an AI, say yes.
+
+---
+
+## 5. Tables, lists and code
+
+The sentence-level rules govern prose. A table cell is not a sentence and does
+not need to be one, and a bulleted row may be a fragment. The vocabulary bans in
+§6 apply everywhere, so no "leverage" or "seamless" inside a cell.
+
+Prefer a table when the content is a small set of enumerable facts, and prose
+when it carries an argument. A table of judgments with the reasoning stripped out
+is harder to act on than the paragraph it replaced.
+
+---
+
+## 6. What to avoid
+
+These are families, not exhaustive lists; when you meet an unlisted cousin of a
+listed phrase, treat it as banned too.
+
+- Labor and physics metaphors applied to ideas or prose: "load-bearing," "does
+  the heavy lifting," "does the work," "pulls its weight," "carries the
+  argument," "where it earns." Say what the sentence or component actually does.
+- Abstractions given bodies and addresses: "sits at," "lives in," "speaks to,"
+  "sits at the intersection of," "occupies the space between." Name the
+  relationship directly: X causes Y, X depends on Y, X resembles Y.
+- Gerund jargon where a plain verb exists: "surfacing," "unpacking," "grounding,"
+  "framing," "centering," "lowering." Write "finds," "explains," "reduces," or
+  whatever the action actually is.
+- Intensifier adverbs on claims: "quietly," "deeply," "genuinely," "truly,"
+  "fundamentally." Cut them; strengthen the claim instead. Exemption: adverbs
+  with literal technical meaning stay ("deeply nested," "tightly coupled,"
+  "widely distributed"). The test: does the adverb describe a measurable
+  property, or does it lean on the reader?
+- The negation-contrast tic ("It's not X; it's Y," "think X, not Y") when no one
+  would assert X. Real contrasts pass under the sentence-craft rule above.
+- Colon fragments as manufactured emphasis: "The result: chaos." Write the full
+  sentence.
+- One-word dramatic sentences. ("Exactly." "Fascinating.")
+- Praise openers ("Great question," "Excellent point"). Begin with the answer.
+- Marketing vocabulary: leverage, seamless, robust, streamline, elevate, harness,
+  unlock, delve, landscape, journey, game-changer, cutting-edge. Use the plain
+  verb: use, show, speed up, improve.
+- Rule-of-three adjective stacks ("fast, reliable, and scalable").
+- Closing boilerplate: no summary that restates the piece, no "Let me know if you
+  have any questions." End when the argument ends.
+- Apology boilerplate; say "sorry about that" and fix the thing.
+
+---
+
+## 7. Example
+
+Question: "Why is this endpoint slow?"
+
+Weak: "There are several factors that could potentially be impacting the
+performance of this endpoint. Let's delve into each one and explore how they
+might be affecting your system..."
+
+Strong: "The endpoint is slow because it issues one database query per user in
+the result set; for the payload you tested, that is 340 round trips. Batching
+them into a single query should bring the response under 50 ms. The fix is
+mechanical, but the pattern is worth understanding because it will recur anywhere
+an ORM hides the query boundary. When the serializer touches `user.orders`, the
+ORM..."

--- a/docs/WRITING_STANDARD.md
+++ b/docs/WRITING_STANDARD.md
@@ -16,10 +16,11 @@ where a document lives, what class it belongs to, or when it is deleted;
 Two places keep their own rules, which override this one:
 
 - **Code comments.** `AGENTS.md` limits a comment to what someone editing that
-  line needs, usually one line and rarely more than four. "Take the space the
+  line needs, and says to keep it short, usually one line. "Take the space the
   idea requires" in §3 governs prose and never a comment block.
-- **User-facing copy.** `docs/VOCABULARY.md` fixes product terms. Where it
-  defines a term, use it exactly, even when a plainer word would read better.
+- **User-facing copy.** `checkin-app/docs/VOCABULARY.md` fixes product terms.
+  Where it defines a term, use it exactly, even when a plainer word would read
+  better.
 
 **Applies to new and edited text.** Existing files conform as someone touches
 them. There is no sweep.


### PR DESCRIPTION
Voice rules for prose that agents write: `docs/`, PR and issue bodies, review comments, commit messages, and replies in a working session.

## Why it is separate from DOCUMENTATION_STANDARD.md

That document decides where a doc lives, what class it belongs to, and when it gets deleted. This one decides how a sentence reads. They do not overlap, and §1 makes the precedence explicit: on any structural question the existing standard wins.

Two carve-outs are stated rather than left to inference, because both would otherwise conflict:

- **Code comments keep the `AGENTS.md` rule** (one line, rarely more than four). Without this, someone cites "take the space the idea requires" to justify a twenty-line comment block, which is the pattern dkaygithub asked us to stop on infra #148.
- **User-facing copy keeps `VOCABULARY.md`.** Where a product term is defined there, it wins over the plainer word.

## Decisions baked in

- **Scope is agent behavior generally**, not documentation alone. That is why the AI-disclosure, praise-opener and apology rules belong here rather than reading as strays.
- **Enforced by review, with nothing in CI.** Several bans are mechanically checkable, so a linter is tempting. It would see only the mechanical ones, and the judgment rules are the ones that matter.
- **Applies to new and edited text.** No sweep. The em-dash ban alone would otherwise touch most of the corpus.

## Sections added beyond the source draft

**§1 Scope and precedence**, and **§5 Tables, lists and code**. §5 exists because every rule in the draft is written for prose, while a large share of what we produce is tables. "Complete sentences" has no clear reading inside a table cell. The rule adopted: sentence-level rules govern prose, the vocabulary bans apply everywhere, and prefer prose when the content carries an argument.

## Two deliberate departures from the draft

Both are places where the draft breaks a rule it states.

`Active voice, always, unless the actor is genuinely unknown or irrelevant` became `Active voice, unless the actor is unknown or irrelevant`. `genuinely` is on the intensifier list, and it fails the draft's own new test: it describes no measurable property and leans on the reader. `always ... unless` also argues with itself.

The draft's other self-violations are already fixed in it, and the fixes are better than the ones I proposed. `whatever you understand, you can explain plainly` beats deleting `truly`. Dropping `a list wearing a coat` and `hits hardest` removes two metaphors the ban list covers. `Never append the depth abruptly` removes `bolt on`.

The new metaphor and contrast rules in §4 replace the softenings I had proposed, and do the job better: they give a test rather than an exception.

## Self-check

Zero em dashes. The banned vocabulary appears only inside the ban list itself and in the deliberately-weak example. `A table cell is not a sentence` in §5 is a contrast a reader might actually hold, given §4 mandates complete sentences, so it passes the §4 test rather than reading as a tic.

## Also changed

One line in `AGENTS.md` pointing at the new file. Without it the standard governs writing that agents do without ever being loaded at the moment they write. Note that line uses an em dash to match the four sibling entries in the docs map, which the standard bans in prose; the ban does not obviously address punctuation used as a list separator, and that is worth settling in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier