### PR TITLE
security(registry): declare the member-year 18+ roster route

### DIFF
--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -300,6 +300,33 @@ defineRoute({
     ],
 });
 
+// The "who is 18 as of the member-year start" roster (Membership Audit). Ships
+// the CLASSIFIED INPUTS, not a verdict: dateOfBirth plus the board's year
+// boundary, so the two as-of ages are derived client-side — the stripper drops
+// ad-hoc computed fields, same reason GET /api/finance-ops/payment-plans ships
+// startAt + boundary instead of a next-year boolean.
+//
+// The grant is deliberately NARROWER than the sibling audit views' everyones:*:
+// this response needs exactly dateOfBirth ('personal') on top of public identity
+// (name, household name, program name). No email/phone, so no ':pii'; no
+// lastBackgroundCheck, so no ':internal'. A later widening has to show up here.
+//
+// ProgramParticipant rides along to mark which of these people are enrolled in a
+// program. That edge is all-public-tier — row EXISTENCE is the sensitive part —
+// so admission is the real boundary, and this view is board/sysadmin only.
+defineRoute({
+    endpoint: 'GET /api/membership-audit/turning-18',
+    authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
+    envelope: null,
+    // Bag: { Person } with household (Household) and programParticipants
+    // (ProgramParticipant → program Program), plus { BoardSettings }.
+    returns: ['Person', 'Household', 'ProgramParticipant', 'Program', 'BoardSettings'],
+    orderedView: [
+        ['isSysadmin',    ['everyones:personal', 'member', 'public']],
+        ['isBoardMember', ['everyones:personal', 'member', 'public']],
+    ],
+});
+
 // Board's membership payment-plan approval queue. Returns PENDING_PAYMENT
 // OrgMembershipProcess rows the household asked to pay by plan, with the
 // membership + household nested. Board/sysadmin only, and they hold everyones:*


### PR DESCRIPTION
Boundary-only PR for #1230, split out per the AGENTS.md isolation rule: an unused `defineRoute` is inert, so the grant is reviewable on its own before any handler serves it. The route + view ship in #1447, which is stacked on this branch.

## The grant

```
GET /api/membership-audit/turning-18
authorize: anyRole [isSysadmin, isBoardMember]
orderedView: sysadmin / board → ['everyones:personal', 'member', 'public']
```

**Deliberately narrower than the sibling audit routes**, which all hold `everyones:pii + everyones:personal + everyones:internal`. This response needs exactly `dateOfBirth` (`personal`) on top of public identity — name, household name, program name. No email or phone, so no `:pii`. No `lastBackgroundCheck`, so no `:internal`. Any later widening has to show up as a diff to this entry.

## Why the response shape drives the entry

The route ships **classified inputs, not a verdict**: `dateOfBirth` plus `BoardSettings.orgMembershipYearBoundary`, with the two as-of ages derived client-side. The stripper drops ad-hoc computed fields, which is exactly why `GET /api/finance-ops/payment-plans` ships `startAt` + boundary instead of a precomputed next-year boolean. Same pattern, same reason.

`ProgramParticipant` is in `returns` so the roster can mark who is enrolled in a program. That edge is all-public-tier — row *existence* is the sensitive part, not any field — so admission is the real boundary, and this view is board/sysadmin only.

## Verification

- `npm run check-route-coverage` → `0 error(s)` (unchanged; the entry is inert with no route file on this branch).
- `tests/security` + `src/__tests__` → **631 passed / 18 suites**, including `routeAuthDrift`, `scopeBindingsEquivalence`, and the registry equivalence oracle.

Part of #1230 (no closing keyword — #1447 carries that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)