### PR TITLE
security(boundary): register POST /api/facility/visits/insert (registry-first)

### DIFF
--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -60,6 +60,38 @@ defineRoute({
     ],
 });
 
+// Staff insert of a past visit for ANOTHER person (AT3, #1254) — the walk-in
+// neither the kiosk (live only, personId from the badge) nor the event roster
+// mark (program-scoped, event window) can record. Unlike the self-service
+// routes above, the target personId comes from the REQUEST BODY, so the role
+// gate is the entire subject boundary — there is no 'their_own' leg to fall
+// back on and no scope resolver in play. Sysadmin and board only: the same set
+// the sibling GET/PATCH/DELETE on /api/facility/visits carry and the same set
+// facility-ops/visits gates the page on, which must stay equal (their drifting
+// apart was AT13/#1259). Widening to isOperations is an open decision, #1476.
+//
+// Its own endpoint rather than a POST on /api/facility/visits: adding a verb to
+// an existing legacy route file cannot satisfy this registry's own lints in any
+// PR ordering — registry-first trips `orphan-registry` (the file exports no such
+// verb yet), route-first trips `new-route-old-authz`, and shipping both together
+// trips boundary isolation. A new path has no route file, which is exactly the
+// register-first state `orphan-registry` warns for. See #1491.
+//
+// The response echoes the single Visit just created, so everyones:internal
+// covers the tombstone columns the model carries (deletedAt/deletedById — both
+// null on a fresh row, declared rather than accidentally stripped).
+defineRoute({
+    endpoint: 'POST /api/facility/visits/insert',
+    authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },
+    envelope: 'visit',
+    // Bag: { Visit }.
+    returns: ['Visit'],
+    orderedView: [
+        ['isSysadmin',    ['everyones:personal', 'everyones:internal', 'member', 'public']],
+        ['isBoardMember', ['everyones:personal', 'everyones:internal', 'member', 'public']],
+    ],
+});
+
 defineRoute({
     endpoint: 'GET /api/programs/[id]',
     authorize: 'public',


### PR DESCRIPTION
Boundary-only PR. One `defineRoute` entry, no app code — the registry-first half of AT3's staff insert-for-others (#1254). Same sequence #1395 used for the self-correction verbs ahead of #1357.

## What it declares

`POST /api/facility/visits/insert` — staff recording a past visit for **another** person. The walk-in that neither the kiosk (live only, `personId` from the badge) nor the event roster mark (program-scoped, event window) can capture.

`{ anyRole: ['isSysadmin', 'isBoardMember'] }` — the set the sibling `GET/PATCH/DELETE /api/facility/visits` already carry, and the set `facility-ops/visits` gates the page on. Those two must stay equal; their drifting apart was AT13 (#1259). Widening to `isOperations` is the open decision in #1476 and is deliberately **not** taken here.

Unlike the self-service visit routes, there is no `their_own` leg and no scope resolver: the target `personId` comes from the request body, so the role gate is the entire subject boundary. Worth a reviewer's eye on exactly that point.

The response echoes the one `Visit` just created, so `everyones:internal` covers the tombstone columns the model carries (`deletedAt`/`deletedById` — both null on a fresh row, declared rather than accidentally stripped).

## Why a new path instead of a POST on `/api/facility/visits`

Adding a verb to an existing legacy route file cannot satisfy the repo's own lints in **any** PR ordering — registry-first trips `orphan-registry` (the file exports no such verb yet), route-first trips `new-route-old-authz`, both together trip boundary isolation. All three verified locally. A path with no route file is precisely the state `orphan-registry` already warns for: *"the register-first state while its route PR is pending."*

Filed as #1491. If that gets fixed, this endpoint can be folded back onto `/api/facility/visits` as a plain POST.

## Inert until the route lands

```
⚠ [orphan-registry] registry entry POST /api/facility/visits/insert has no route file
  — the register-first state while its route PR is pending.
```

`check-route-coverage --strict` exits 0. Security suites: 641 tests / 19 suites green. `tsc --noEmit` clean. The route itself follows in #1478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
