### PR TITLE
refactor(programs): drop the residual legacy-variant select left by #1464

### DIFF
--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -77,8 +77,6 @@ const getProgram = handler<{ id: string }>('GET /api/programs/[id]', async ({ au
             nonOrgMemberPriceCents: true,
             shopifyProductId: true,
             shopifyVariantId: true,
-            shopifyOrgMemberVariantId: true,
-            shopifyNonOrgMemberVariantId: true,
             volunteers: {
                 where: { person: LIVE_PERSON },
                 select: {


### PR DESCRIPTION
Refs #975. **This does not close the issue** — Release 2 (the `DROP COLUMN` migration) does. Deliberately no closing keyword.

## What changed

Two lines, one file. `GET /api/programs/[id]` no longer selects the dead legacy pair:

```diff
             shopifyVariantId: true,
-            shopifyOrgMemberVariantId: true,
-            shopifyNonOrgMemberVariantId: true,
```

`shopifyVariantId` — the live single-variant column — is untouched.

## Why

PR #1464 (`d9cd638b`) claimed "zero residual references in live code" for the legacy two-variant program shape. That was not accurate: this `select` block survived. It was flagged on the issue before merge and merged anyway.

This is not a tidy-up. Both columns are still declared in `schema.prisma` and still classified `public` in `src/security/generated/classifications.ts`, so until this change they were **serialized into this route's response** — a live read.

That turns Release 2 into a hazard. `deploy-prod.yml` runs `prisma migrate deploy` to completion in a step that *precedes* the ECS `update-service` step (~L210 vs ~L283). So the schema is fully migrated while the old task is still serving live traffic. Dropping the column in the same release as the code that stops selecting it means every `GET /api/programs/[id]` **500s for the length of the drain window**. Landing the strip on its own removes that hazard and leaves Release 2 as a pure schema change.

See `checkin-app/docs/designs/975-LEGACY_VARIANT_CONTRACT.md` — "The deploy hazard (why the DROP is its own release)". Note the doc's own correction: the "single instance, so no drain overlap" escape clause does **not** apply here, because the hazard is step ordering, not task concurrency.

## Reviewer notes

**No consumers.** `grep -rn` repo-wide for `shopifyOrgMemberVariantId|shopifyNonOrgMemberVariantId`, plus a looser sweep for `OrgMemberVariant|NonOrgMemberVariant|MemberVariantId` across `src`, `flow-tests`, `shopify-live`. Excluding the generated Prisma client, the only other hits are the `DROPPED_SOON` array, the generated classifications, `schema.prisma`, and the coalesced baseline migration. No component, hook, type, or test reads either key off this response. The row is spread wholesale (`{ Program: program }`, and `{ ...program }` on the non-privileged metadata path) and never read locally.

**Response shape / boundary.** `GET /api/programs/[id]` is registered (`src/security/registry.ts:64`), but `returns` is model-level, not field-level — dropping two `Program` fields does not change it. No exact-key-set oracle pins this route; the only such oracle is on the *list* route (`GET /api/programs`) and derives its expected set from the classifications, so it is unaffected. `npm run check-route-coverage`: 0 errors. Removing fields narrows exposure.

**Nothing boundary-governed was touched** — no `schema.prisma`, `scopeBindings.ts`, `registry.ts`, `security/generated/*`, and no migration. Those are Release 2 and must ship in their own PR per `.github/workflows/security-boundary-isolation.yml`.

**`DROPPED_SOON` deliberately left in place** (`src/app/__tests__/programsAPI.integration.test.ts:204`). It belongs to Release 2 and must be deleted only *after* the classifications are regenerated, otherwise the public-tier oracle silently under-checks. Its comment — "no route selects them any more" — was false before this change and is now accurate exactly as written, so it needed no edit.

**Release 2 is still unowned**: no PR, no issue. Remaining work is removing the four fields from `schema.prisma`, the `DROP COLUMN` migration, regenerating `classifications.ts`, deleting `DROPPED_SOON`, and running the cutover re-verify query in the design doc.

## Testing

All foreground, all real results:

| Run | Result |
|---|---|
| `tsc --noEmit` | exit 0, clean |
| unit suite narrowed to `program\|security\|Program` | 42 suites / 805 tests passed |
| full unit tier (`test:ci`) | 262 suites / 2472 tests passed |
| `check-route-coverage` | 0 errors (172 pre-existing unmigrated-route warnings) |
| full integration tier (`test:integration`) | 130 suites / 1287 tests passed |

Nothing failed. Docker was unavailable, so the integration tier ran against a throwaway local `postgresql@16` cluster (TCP-only, schema via `prisma db push`), torn down afterwards. Flow tier not run — it needs a live dev server, and no flow test references these keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
