### PR TITLE
fix(dates): store every DOB at UTC midnight (F1, F11)

### DIFF
--- a/checkin-app/docs/designs/1149_DATE_TIME_TZ_DESIGN.md
+++ b/checkin-app/docs/designs/1149_DATE_TIME_TZ_DESIGN.md
@@ -70,10 +70,13 @@ edit form (noon UTC), the *stored value shifts forward by a calendar day* and
 the display "corrects itself." Same person, same field, two different stored
 dates depending on which UI last touched it.
 
-**Direction:** pick ONE convention for `dateOfBirth` and use it at every writer.
-Cheapest: standardize on noon-UTC (the existing safe outlier) so display is
-tz-robust without touching every reader; OR standardize on midnight-UTC and read
-with `formatDateOnly` everywhere. Do not leave both.
+**Resolved — UTC midnight at every writer.** Step 2 made every calendar-date
+reader UTC-pinned through `formatDateOnly`, which settles the noon-vs-midnight
+fork in favour of midnight: `parseDateOnly` is the write-side seam and
+`normalizeAdultDob` routes through it, the `+"T12:00:00Z"` at
+household/member:59 is gone, and `intake.ts` + `importDob.ts` (Finding 11) now
+funnel through the same convention. Rows written at noon UTC before that are
+**not** backfilled — that is step 7's, alongside the storage decision.
 
 ### 2. Program `startAt`/`endAt` off-by-one — BUG (CONFIRMED; reported as #1149) — SHIPPED (#1366)
 

--- a/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdMemberAPI.integration.test.ts
@@ -217,6 +217,35 @@ describe('Household Member API Integration Tests', () => {
             expect(updatedProfile?.phone).toBeNull();
         });
 
+        // #1149 F1 / #1447: this form once stored DoB at noon UTC while every
+        // other writer stored midnight. A non-midnight DoB fails an SQL age
+        // filter cut at UTC midnight, so the student who turns 18 exactly on the
+        // member-year boundary — the row the 18+ roster exists to show — is
+        // silently dropped while calculateAge still reports them as 18.
+        it('stores a DoB at UTC midnight so a boundary birthday passes a UTC-midnight age cutoff', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({ user: { id: testLeadId } });
+
+            const birthCutoff = new Date(Date.UTC(new Date().getUTCFullYear() - 18, 8, 1));
+            const dob = birthCutoff.toISOString().slice(0, 10);
+
+            const req = new Request('http://localhost:4000/api/household/member', {
+                method: 'PATCH',
+                body: JSON.stringify({ participantId: testMemberId, dob })
+            });
+
+            const res = await PATCH(req as unknown as import("next/server").NextRequest);
+            expect(res.status).toBe(200);
+
+            const updatedProfile = await prisma.person.findUnique({ where: { id: testMemberId } });
+            expect(updatedProfile?.dateOfBirth?.toISOString()).toBe(`${dob}T00:00:00.000Z`);
+
+            const onRoster = await prisma.person.findFirst({
+                where: { id: testMemberId, dateOfBirth: { lte: birthCutoff } },
+                select: { id: true }
+            });
+            expect(onRoster).not.toBeNull();
+        });
+
         it('should allow a lead to designate another adult as a lead', async () => {
              (getServerSession as jest.Mock).mockResolvedValue({ user: { id: testLeadId } });
 

--- a/checkin-app/src/app/api/household/member/route.ts
+++ b/checkin-app/src/app/api/household/member/route.ts
@@ -56,7 +56,7 @@ export const PATCH = withAuth(
                         // #1165: a real sub-26 DoB is kept and supersedes the 25+ flag; a
                         // 26+ DoB is stripped and forces the flag on; an empty DoB honors
                         // the checkbox. `undefined` dob leaves the field unchanged.
-                        ...(dob !== undefined ? normalizeAdultDob(dob === "" ? null : dob + "T12:00:00Z") : {}),
+                        ...(dob !== undefined ? normalizeAdultDob(dob) : {}),
                         ...(over25 !== undefined && !dob ? { isDeclaredAdult: !!over25 } : {}),
                         allergies: allergies !== undefined ? (allergies === "" ? null : allergies) : undefined,
                     },

--- a/checkin-app/src/lib/__tests__/importDob.test.ts
+++ b/checkin-app/src/lib/__tests__/importDob.test.ts
@@ -21,4 +21,27 @@ describe("parseImportDob", () => {
         expect(parseImportDob(undefined)).toBeUndefined();
         expect(parseImportDob("not a date")).toBeUndefined();
     });
+
+    // F11: a DOB is a calendar date, so every branch stores UTC midnight — same
+    // convention as the interactive writers (normalizeAdultDob).
+    describe("UTC-midnight convention west of UTC", () => {
+        const realTz = process.env.TZ;
+        beforeAll(() => { process.env.TZ = "America/Chicago"; });
+        afterAll(() => { if (realTz === undefined) delete process.env.TZ; else process.env.TZ = realTz; });
+
+        it("pins a non-ISO spreadsheet date to UTC midnight of the written day", () => {
+            // "5/4/1990" parses as LOCAL midnight; unpinned it stores 1990-05-04T05:00Z
+            // in Chicago, and any other zone's rows disagree with it.
+            expect(parseImportDob("5/4/1990")!.toISOString()).toBe("1990-05-04T00:00:00.000Z");
+        });
+
+        it("pins a bare ISO date to UTC midnight", () => {
+            expect(parseImportDob("1991-01-01")!.toISOString()).toBe("1991-01-01T00:00:00.000Z");
+        });
+
+        it("truncates a fractional Excel serial's time of day", () => {
+            // 33239.75 is 1991-01-01 18:00 — the day is the DOB, the time is noise.
+            expect(parseImportDob("33239.75")!.toISOString()).toBe("1991-01-01T00:00:00.000Z");
+        });
+    });
 });

--- a/checkin-app/src/lib/importDob.ts
+++ b/checkin-app/src/lib/importDob.ts
@@ -8,17 +8,27 @@
  * xlsx may hand us an Excel serial number (days since 1899-12-30) as a digit
  * string when no bookType is provided, so handle that before falling back to
  * the native Date parser.
+ *
+ * A DoB is a calendar date, so every branch returns UTC midnight — the storage
+ * convention shared with the interactive writers (normalizeAdultDob).
+ * See docs/designs/1149_DATE_TIME_TZ_DESIGN.md.
  */
 export function parseImportDob(dobString: string | undefined): Date | undefined {
     if (!dobString) return undefined;
 
     if (/^\d+(\.\d+)?$/.test(dobString)) {
-        // Excel serial number
-        const serial = parseFloat(dobString);
-        const excelEpoch = new Date(Date.UTC(1899, 11, 30));
-        return new Date(excelEpoch.getTime() + serial * 86400000);
+        // Excel serial number. A fractional serial carries a time of day; floor
+        // it so the result is the calendar day, not a mid-day instant.
+        const serial = Math.floor(parseFloat(dobString));
+        return new Date(Date.UTC(1899, 11, 30) + serial * 86400000);
     }
 
     const d = new Date(dobString);
-    return isNaN(d.getTime()) ? undefined : d;
+    if (isNaN(d.getTime())) return undefined;
+    // A bare ISO date parses as UTC; every other spreadsheet format ("5/4/1990")
+    // parses as LOCAL time and would land a day early west of UTC. Read the
+    // calendar fields from whichever zone the string was parsed in, then re-pin.
+    return /^\d{4}-\d{2}-\d{2}/.test(dobString.trim())
+        ? new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+        : new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
 }

--- a/checkin-app/src/lib/membership/__tests__/intake.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/intake.test.ts
@@ -292,6 +292,39 @@ describe('saveIntake', () => {
         });
     });
 
+    // Intake used to write DoB with a bare `new Date`, bypassing the #1165 guard
+    // that every other interactive path funnels through: signup could persist an
+    // exact DoB for a 26+ person, with only the nightly cron as the net.
+    it('strips a 26+ DoB at signup and declares the person an adult', async () => {
+        prisma.person.create.mockResolvedValue({ id: 55 });
+
+        await saveIntake(1, {
+            primaryParent: { dob: '1985-04-01' },
+            secondaryParent: { name: 'New Parent', dob: '1980-02-02' },
+        });
+
+        expect(prisma.person.update).toHaveBeenCalledWith({
+            where: { id: 1 },
+            data: { dateOfBirth: null, isDeclaredAdult: true },
+        });
+        expect(prisma.person.create).toHaveBeenCalledWith({
+            data: { householdId: 7, name: 'New Parent', dateOfBirth: null, isDeclaredAdult: true, allergies: null },
+        });
+    });
+
+    // F1: one calendar-date convention across every DoB writer. A DoB stored at
+    // any other time of day fails SQL age filters cut at UTC midnight (#1447).
+    it('stores a kept DoB at UTC midnight', async () => {
+        const childBirthYear = new Date().getUTCFullYear() - 12;
+
+        await saveIntake(1, { children: [{ id: 4, dob: `${childBirthYear}-05-04` }] });
+
+        expect(prisma.person.update).toHaveBeenCalledWith({
+            where: { id: 4 },
+            data: { dateOfBirth: new Date(`${childBirthYear}-05-04T00:00:00.000Z`), isDeclaredAdult: false },
+        });
+    });
+
     it('secondary parent already a household member → update + addLeadOrRecord', async () => {
         await saveIntake(1, { secondaryParent: { id: 4, name: 'Existing Parent' } });
 

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -8,6 +8,7 @@ import { addHouseholdLead, HouseholdLeadLimitError, MAX_HOUSEHOLD_LEADS } from "
 import { upsertPrimaryContact, reconcileHouseholdConflicts } from "@/lib/emergencyContacts/service";
 import { normalizeAddressInput, pickAddress, type StructuredAddress } from "@/lib/address";
 import { INTAKE_PROFILES, missingRequiredFields } from "@/lib/intake/profiles";
+import { normalizeAdultDob } from "@/lib/person/adultDob";
 
 /**
  * Membership intake service — the write/read model behind the "Join the
@@ -218,8 +219,6 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
     const householdId = user.householdId!;
     const householdMemberIds = new Set((user.household?.householdMembers ?? []).map((p) => p.id));
 
-    const toDate = (d?: string | null) => (d ? new Date(d) : null);
-
     // Promote a guardian to household lead. The per-household cap (#269) is a
     // soft stop here, not a hard failure: the guardian's other details are still
     // saved (above), and the rest of the form (children) still saves below. We
@@ -275,8 +274,11 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
             where: { id: userId },
             data: {
                 ...(input.primaryParent.name !== undefined && { name: input.primaryParent.name }),
-                ...(input.primaryParent.dob !== undefined && { dateOfBirth: toDate(input.primaryParent.dob) }),
-                ...(input.primaryParent.over25 !== undefined && { isDeclaredAdult: input.primaryParent.dob ? false : !!input.primaryParent.over25 }),
+                // #1165: a real sub-26 DoB is kept and supersedes the 25+ flag; a
+                // 26+ DoB is stripped and forces the flag on; an empty DoB honors
+                // the checkbox.
+                ...(input.primaryParent.dob !== undefined && normalizeAdultDob(input.primaryParent.dob)),
+                ...(input.primaryParent.over25 !== undefined && !input.primaryParent.dob && { isDeclaredAdult: !!input.primaryParent.over25 }),
                 ...(input.primaryParent.allergies !== undefined && { allergies: input.primaryParent.allergies }),
             },
         });
@@ -290,8 +292,8 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
                 where: { id: sp.id },
                 data: {
                     ...(sp.name !== undefined && { name: sp.name }),
-                    ...(sp.dob !== undefined && { dateOfBirth: toDate(sp.dob) }),
-                    ...(sp.over25 !== undefined && { isDeclaredAdult: sp.dob ? false : !!sp.over25 }),
+                    ...(sp.dob !== undefined && normalizeAdultDob(sp.dob)),
+                    ...(sp.over25 !== undefined && !sp.dob && { isDeclaredAdult: !!sp.over25 }),
                     ...(sp.allergies !== undefined && { allergies: sp.allergies }),
                 },
             });
@@ -303,8 +305,8 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
                     householdId,
                     name: sp.name ?? null,
                     ...(sp.email && { email: sp.email.toLowerCase() }),
-                    dateOfBirth: toDate(sp.dob),
-                    isDeclaredAdult: sp.dob ? false : !!sp.over25,
+                    ...normalizeAdultDob(sp.dob),
+                    ...(!sp.dob && { isDeclaredAdult: !!sp.over25 }),
                     allergies: sp.allergies ?? null,
                 },
             });
@@ -320,7 +322,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
                 where: { id: child.id },
                 data: {
                     ...(child.name !== undefined && { name: child.name }),
-                    ...(child.dob !== undefined && { dateOfBirth: toDate(child.dob) }),
+                    ...(child.dob !== undefined && normalizeAdultDob(child.dob)),
                     ...(child.allergies !== undefined && { allergies: child.allergies }),
                 },
             });
@@ -330,7 +332,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
                     householdId,
                     name: child.name,
                     ...(child.email && { email: child.email.toLowerCase() }),
-                    dateOfBirth: toDate(child.dob),
+                    ...normalizeAdultDob(child.dob),
                     allergies: child.allergies ?? null,
                 },
             });

--- a/checkin-app/src/lib/person/__tests__/adultDob.test.ts
+++ b/checkin-app/src/lib/person/__tests__/adultDob.test.ts
@@ -28,6 +28,16 @@ describe("normalizeAdultDob", () => {
     expect(normalizeAdultDob(yearsAgo(40))).toEqual({ dateOfBirth: null, isDeclaredAdult: true });
   });
 
+  // F1: this is the choke-point that owns the calendar-date storage convention
+  // for interactive DoB writes. One convention, or the same person's stored DoB
+  // shifts by a calendar day depending on which form last touched it — and a
+  // non-midnight DoB silently fails SQL age filters cut at UTC midnight (#1447).
+  it("stores a date-only string at UTC midnight", () => {
+    const teenBirthYear = new Date().getUTCFullYear() - 14;
+    expect(normalizeAdultDob(`${teenBirthYear}-05-04`).dateOfBirth!.toISOString())
+      .toBe(`${teenBirthYear}-05-04T00:00:00.000Z`);
+  });
+
   // The 26th-birthday boundary decides a persisted DoB strip, so a UTC-midnight
   // DoB read through local calendar fields would destroy the date a day early.
   describe("26th-birthday boundary west of UTC", () => {

--- a/checkin-app/src/lib/person/adultDob.ts
+++ b/checkin-app/src/lib/person/adultDob.ts
@@ -1,4 +1,4 @@
-import { calculateAge } from "@/lib/time";
+import { calculateAge, parseDateOnly } from "@/lib/time";
 import { MAX_PROGRAM_AGE } from "@/lib/programAge";
 
 /**
@@ -20,12 +20,17 @@ import { MAX_PROGRAM_AGE } from "@/lib/programAge";
  * Route EVERY interactive path that persists Person.dateOfBirth through this. The
  * nightly cron + the #1165 backfill migration are the safety net for rows that
  * slip past (e.g. bulk import); this is the write-time guard so it can't creep back.
+ *
+ * A DoB is a calendar date, so a date string is parsed through `parseDateOnly` —
+ * this is the choke-point that owns the UTC-midnight storage convention for
+ * interactive writes. Callers pass a bare "yyyy-MM-dd", never a timed string.
+ * See docs/designs/1149_DATE_TIME_TZ_DESIGN.md.
  */
 export function normalizeAdultDob(
   dob: Date | string | null | undefined,
 ): { dateOfBirth: Date | null; isDeclaredAdult?: boolean } {
   if (dob === null || dob === undefined || dob === "") return { dateOfBirth: null };
-  const d = new Date(dob);
+  const d = typeof dob === "string" ? parseDateOnly(dob)! : dob;
   if (calculateAge(d) > MAX_PROGRAM_AGE) return { dateOfBirth: null, isDeclaredAdult: true };
   return { dateOfBirth: d, isDeclaredAdult: false };
 }


### PR DESCRIPTION
Sequencing **step 3** of `checkin-app/docs/designs/1149_DATE_TIME_TZ_DESIGN.md` — findings **F1** (DOB written at two conventions) and **F11** (`parseImportDob` time-of-day leakage).

Part of #1149. No closing keyword — F12 and the remaining findings keep it open.

## The problem

`Person.dateOfBirth` was written at **two incompatible conventions**. Most writers funneled through `normalizeAdultDob` and stored UTC midnight; the household-member edit form passed `dob + "T12:00:00Z"` *into that same helper* and stored noon UTC. The same person's stored DOB shifted by a calendar day depending on which form last touched it. Two more paths — membership intake and the bulk-import parser — set their own conventions independently, bypassing the guard entirely.

This is no longer only a display off-by-one. **A noon-UTC DOB silently drops rows from SQL age filters.** The pending "students 18+ as of the member-year start" roster (#1447) compares `dateOfBirth: { lte: birthCutoff }` against a UTC-midnight cutoff, so a student who turns 18 exactly on the boundary and whose DOB was last saved through the household-member form fails the `lte` and is **missing from the roster** — the precise row the report exists to show — while `calculateAge` reports them as 18.

## The convention

**UTC midnight, at every writer.** The noon-vs-midnight fork Finding 1 left open is settled by step 2 having shipped (#1424, #1422, #1366): every calendar-date reader is already UTC-pinned through `formatDateOnly`, so midnight is what the read side expects. `parseDateOnly` (`lib/time.ts:106`) is the write-side seam.

## Changes

| Site | Kind | Change |
|---|---|---|
| [`lib/person/adultDob.ts`](checkin-app/src/lib/person/adultDob.ts) | contract-tightening | Date strings parse through `parseDateOnly`, so the shared choke-point owns the convention for the four delegating routes (profile, household, household/member, membership-ops/participants). A `Date` already in hand passes through unchanged. `new Date(dob)` on a bare date string already yielded UTC midnight — no behavior change here. |
| [`api/household/member/route.ts:59`](checkin-app/src/app/api/household/member/route.ts) | **genuine bug** | Stripped `+ "T12:00:00Z"`. Also dropped the now-redundant `dob === "" ? null : dob` — `normalizeAdultDob("")` already returns `{dateOfBirth: null}`. |
| [`lib/membership/intake.ts`](checkin-app/src/lib/membership/intake.ts) | **genuine bug** (guard bypass) | Deleted the local `toDate`; all five DOB writes route through `normalizeAdultDob`. |
| [`lib/importDob.ts`](checkin-app/src/lib/importDob.ts) | **genuine bug**, both branches | A fractional Excel serial is floored to its calendar day (`33239.75` stored `1991-01-01T18:00Z`). The fallback re-pins to UTC midnight — reading UTC fields for a bare-ISO string and local fields otherwise, since a non-ISO format like `5/4/1990` parses as LOCAL midnight and stored `1990-05-04T05:00Z` in Chicago. Preview and commit still share the one function, so they cannot drift. |

### Reviewer notes on the intake rewrite

`normalizeAdultDob` returns `{ dateOfBirth, isDeclaredAdult? }`, not a bare `Date`, so each site became a spread. The three conditional sites are `...(x.dob !== undefined && normalizeAdultDob(x.dob))`; the two unconditional creates are bare spreads. The `over25` overrides now match the household/member pattern — `over25 !== undefined && !dob` — so a stripped 26+ DOB's `isDeclaredAdult: true` isn't clobbered back to `false`. Semantics for every pre-existing input shape are unchanged; only the 26+ case is new.

`intake.ts:108`'s `p.dateOfBirth.toISOString().slice(0, 10)` readback stays correct under UTC midnight.

### Intended side effect — closes a live #1165 hole

Routing intake through `normalizeAdultDob` means signup can no longer persist an exact DOB for a 26+ person. Previously only the nightly cron and the purge migration were the net; it is now stripped at write time like every other interactive path. No existing test or fixture asserted a 26+ DOB survives signup (`membershipIntakeAPI.integration.test.ts:133` passes `dob: '1985-04-01'` but only asserts name/allergies), so nothing needed updating.

## Not in this PR

- **No backfill.** Rows already stored at noon UTC are untouched. This repo has live production data; the design defers the data migration to step 7 alongside the calendar-date storage decision. Read-only count for whoever has prod access:
  ```sql
  SELECT count(*) FILTER (WHERE "dateOfBirth"::time <> '00:00:00') AS non_midnight,
         count(*) FILTER (WHERE "dateOfBirth"::time =  '12:00:00') AS noon_utc,
         count(*) AS total
  FROM "Person" WHERE "dateOfBirth" IS NOT NULL;
  ```
- **No schema change** — F12 / `@db.Date` is the gated storage decision.
- **No boundary file** (`src/security/*`), no migration, no `prisma migrate` run.
- **F8 / F10** belong to #1423.

## Doc edit

Finding 1's "Direction" paragraph still presented the noon-vs-midnight fork as open. Replaced with the resolution plus the explicit "not backfilled" note, so step 4 doesn't re-litigate it.

## Tests

Every new test was verified to **fail** against the pre-change code, not merely pass after:

```
● stores a DoB at UTC midnight so a boundary birthday passes a UTC-midnight age cutoff
    Expected: "2008-09-01T00:00:00.000Z"
    Received: "2008-09-01T12:00:00.000Z"
● pins a non-ISO spreadsheet date to UTC midnight of the written day
    Expected: "1990-05-04T00:00:00.000Z"
    Received: "1990-05-04T05:00:00.000Z"
● truncates a fractional Excel serial's time of day
    Expected: "1991-01-01T00:00:00.000Z"
    Received: "1991-01-01T18:00:00.000Z"
● strips a 26+ DoB at signup and declares the person an adult   (failed)
● stores a kept DoB at UTC midnight                             (failed)
```

Results with the fix in place:

| Run | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| `eslint` (changed files) | exit 0 |
| Unit suite (CI default) | 262 suites, **2478 passed**, 0 failed |
| Integration suite (full, serial) | 130 suites, **1288 passed**, 0 failed |

Integration ran against a throwaway local Postgres (docker unavailable), schema via `prisma db push`. Flow tests not run — nothing here changes an HTTP shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
