### PR TITLE
feat(membership-audit): add the "students 18+ as of the member-year start" roster

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -91,7 +91,6 @@ const AUTHZ_TESTED = new Set<string>([
     'membership-audit/person-bg',
     'membership-audit/households-missing-contact',
     'membership-audit/unclaimed-households',
-    'membership-audit/turning-18',
     'membership-ops/applications/archive',
     'membership-ops/applications/unarchive',
     'membership-ops/applications/certify-payment',

--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -91,6 +91,7 @@ const AUTHZ_TESTED = new Set<string>([
     'membership-audit/person-bg',
     'membership-audit/households-missing-contact',
     'membership-audit/unclaimed-households',
+    'membership-audit/turning-18',
     'membership-ops/applications/archive',
     'membership-ops/applications/unarchive',
     'membership-ops/applications/certify-payment',

--- a/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
@@ -48,6 +48,7 @@ import { GET as FAC_VISITS_GET, PATCH as FAC_VISITS_PATCH } from '@/app/api/faci
 import { POST as FAC_VISITS_INSERT_POST } from '@/app/api/facility/visits/insert/route';
 import { GET as MISSING_CONTACT_GET } from '@/app/api/membership-audit/households-missing-contact/route';
 import { GET as UNCLAIMED_GET } from '@/app/api/membership-audit/unclaimed-households/route';
+import { GET as TURNING_18_GET } from '@/app/api/membership-audit/turning-18/route';
 import { POST as CERTIFY_PAYMENT_POST } from '@/app/api/membership-ops/applications/certify-payment/route';
 import { POST as APP_EXTERNAL_POST } from '@/app/api/membership-ops/applications/external/route';
 import { POST as REVIEW_OVERRIDE_POST } from '@/app/api/membership-ops/applications/review-override/route';
@@ -192,6 +193,7 @@ describe('Protected-route role rejection', () => {
         { name: 'POST /api/facility/visits/insert', invoke: () => FAC_VISITS_INSERT_POST(nreq('http://localhost/api/facility/visits/insert', 'POST', {})) },
         { name: 'GET /api/membership-audit/households-missing-contact', invoke: () => MISSING_CONTACT_GET(nreq('http://localhost/api/membership-audit/households-missing-contact')) },
         { name: 'GET /api/membership-audit/unclaimed-households', invoke: () => UNCLAIMED_GET(nreq('http://localhost/api/membership-audit/unclaimed-households')) },
+        { name: 'GET /api/membership-audit/turning-18', invoke: () => TURNING_18_GET(nreq('http://localhost/api/membership-audit/turning-18')) },
         { name: 'POST /api/membership-ops/applications/certify-payment', invoke: () => CERTIFY_PAYMENT_POST(nreq('http://localhost/api/membership-ops/applications/certify-payment', 'POST', {})) },
         { name: 'POST /api/membership-ops/applications/external', invoke: () => APP_EXTERNAL_POST(nreq('http://localhost/api/membership-ops/applications/external', 'POST', {})) },
         { name: 'POST /api/membership-ops/applications/review-override', invoke: () => REVIEW_OVERRIDE_POST(nreq('http://localhost/api/membership-ops/applications/review-override', 'POST', {})) },

--- a/checkin-app/src/app/__tests__/turningEighteenAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/turningEighteenAPI.integration.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration tests for the member-year 18+ roster
+ * (GET /api/membership-audit/turning-18). The response passes through the
+ * security stripper, which drops any bag key or field the registry entry does
+ * not classify — so these assert the SHAPE survives (dateOfBirth, the nested
+ * household and program, and the board's year boundary), not just the rows.
+ */
+
+import { GET } from '@/app/api/membership-audit/turning-18/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+const TAG = 'turning-18-api-test';
+// Boundary month/day is all that matters; the stored year is arbitrary.
+const BOUNDARY = new Date('2000-09-01T00:00:00Z');
+
+function get() {
+    return GET(new Request('http://localhost:4000/api/membership-audit/turning-18', {
+        method: 'GET',
+    }) as unknown as import('next/server').NextRequest);
+}
+
+type Row = {
+    id: number;
+    name: string | null;
+    dateOfBirth: string | null;
+    household: { id: number; name: string | null } | null;
+    programParticipants: { program: { id: number; name: string } }[];
+};
+
+describe('GET /api/membership-audit/turning-18', () => {
+    let boardId: number;
+    let householdId: number;
+    let programId: number;
+    let adultId: number;
+    let youthId: number;
+    let leadId: number;
+    let savedBoundary: Date | null = null;
+
+    const cleanup = async () => {
+        const hhs = await prisma.household.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+        const hhIds = hhs.map(h => h.id);
+        const people = await prisma.person.findMany({ where: { householdId: { in: hhIds } }, select: { id: true } });
+        await prisma.programParticipant.deleteMany({ where: { personId: { in: people.map(p => p.id) } } });
+        await prisma.program.deleteMany({ where: { name: { contains: TAG } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: hhIds } } });
+        await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
+    };
+
+    beforeAll(async () => {
+        await cleanup();
+
+        const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        savedBoundary = settings?.orgMembershipYearBoundary ?? null;
+        await prisma.boardSettings.upsert({
+            where: { id: 1 },
+            update: { orgMembershipYearBoundary: BOUNDARY },
+            create: { id: 1, orgMembershipYearBoundary: BOUNDARY },
+        });
+
+        const household = await prisma.household.create({ data: { name: `${TAG} household` } });
+        householdId = household.id;
+        const program = await prisma.program.create({ data: { name: `${TAG} program`, phase: 'RUNNING' } });
+        programId = program.id;
+
+        const board = await prisma.person.create({
+            data: { name: `${TAG} board`, email: `board-${TAG}@example.com`, householdId, isBoardMember: true },
+        });
+        boardId = board.id;
+
+        // Comfortably an adult at both boundaries, and enrolled in a program.
+        const adult = await prisma.person.create({
+            data: { name: `${TAG} adult`, householdId, dateOfBirth: new Date('2000-01-01T00:00:00Z') },
+        });
+        adultId = adult.id;
+        await prisma.programParticipant.create({ data: { programId, personId: adultId } });
+
+        // A 10-year-old: below the cutoff at both boundaries, so never on the roster.
+        const youth = await prisma.person.create({
+            data: { name: `${TAG} youth`, householdId, dateOfBirth: new Date('2016-01-01T00:00:00Z') },
+        });
+        youthId = youth.id;
+
+        // An adult who IS a household lead — the signer, deliberately excluded.
+        const lead = await prisma.person.create({
+            data: { name: `${TAG} lead`, householdId, dateOfBirth: new Date('1980-01-01T00:00:00Z') },
+        });
+        leadId = lead.id;
+        await prisma.person.update({ where: { id: leadId }, data: { isHouseholdLead: true } });
+    });
+
+    afterAll(async () => {
+        await cleanup();
+        await prisma.boardSettings.update({
+            where: { id: 1 },
+            data: { orgMembershipYearBoundary: savedBoundary },
+        });
+        await prisma.$disconnect();
+    });
+
+    beforeEach(() => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isBoardMember: true } });
+    });
+
+    it('returns the adult with dateOfBirth, household and program surviving the stripper', async () => {
+        const res = await get();
+        expect(res.status).toBe(200);
+        const body = await res.json();
+
+        expect(body.BoardSettings.orgMembershipYearBoundary).toBe(BOUNDARY.toISOString());
+
+        const row = (body.Person as Row[]).find(p => p.id === adultId);
+        expect(row).toBeDefined();
+        // The page derives both as-of ages from this field; if the registry's
+        // 'everyones:personal' grant ever narrows, it lands here as null/absent.
+        expect(row!.dateOfBirth).toBe('2000-01-01T00:00:00.000Z');
+        expect(row!.household?.id).toBe(householdId);
+        expect(row!.programParticipants.map(pp => pp.program.id)).toEqual([programId]);
+    });
+
+    it('excludes household leads and anyone under 18 at the next boundary', async () => {
+        const res = await get();
+        const ids = ((await res.json()).Person as Row[]).map(p => p.id);
+        expect(ids).not.toContain(leadId);
+        expect(ids).not.toContain(youthId);
+    });
+
+    it('forbids a non-board caller', async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adultId, isBoardMember: false } });
+        expect((await get()).status).toBe(403);
+    });
+});

--- a/checkin-app/src/app/__tests__/turningEighteenAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/turningEighteenAPI.integration.test.ts
@@ -42,6 +42,8 @@ describe('GET /api/membership-audit/turning-18', () => {
     let adultId: number;
     let youthId: number;
     let leadId: number;
+    let unknownDobId: number;
+    let declaredAdultId: number;
     let savedBoundary: Date | null = null;
 
     const cleanup = async () => {
@@ -94,6 +96,18 @@ describe('GET /api/membership-audit/turning-18', () => {
         });
         leadId = lead.id;
         await prisma.person.update({ where: { id: leadId }, data: { isHouseholdLead: true } });
+
+        // No DOB, no 25+ declaration: age unknown, could be turning 18.
+        const unknown = await prisma.person.create({
+            data: { name: `${TAG} unknown dob`, householdId, dateOfBirth: null, isDeclaredAdult: false },
+        });
+        unknownDobId = unknown.id;
+
+        // No DOB because a lead declared them 25+ — nothing to chase, stays off the roster.
+        const declared = await prisma.person.create({
+            data: { name: `${TAG} declared adult`, householdId, dateOfBirth: null, isDeclaredAdult: true },
+        });
+        declaredAdultId = declared.id;
     });
 
     afterAll(async () => {
@@ -130,6 +144,19 @@ describe('GET /api/membership-audit/turning-18', () => {
         const ids = ((await res.json()).Person as Row[]).map(p => p.id);
         expect(ids).not.toContain(leadId);
         expect(ids).not.toContain(youthId);
+    });
+
+    it('includes the unknown-age people with a null DOB, and excludes the declared 25+', async () => {
+        const res = await get();
+        const rows = (await res.json()).Person as Row[];
+
+        // NULL never satisfies the SQL age cutoff, so this arm is the only thing
+        // keeping a birthdate-less 17-year-old visible to the board.
+        const unknown = rows.find(p => p.id === unknownDobId);
+        expect(unknown).toBeDefined();
+        expect(unknown!.dateOfBirth).toBeNull();
+
+        expect(rows.map(p => p.id)).not.toContain(declaredAdultId);
     });
 
     it('forbids a non-board caller', async () => {

--- a/checkin-app/src/app/api/membership-audit/turning-18/route.ts
+++ b/checkin-app/src/app/api/membership-audit/turning-18/route.ts
@@ -1,9 +1,7 @@
-import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { withAuth } from "@/lib/auth";
+import { handler } from "@/security/handler";
 import { LIVE_PERSON } from "@/lib/person/filters";
 import { birthCutoff, memberYearStarts } from "@/lib/programYear";
-import { calculateAge } from "@/lib/time";
 
 export const dynamic = "force-dynamic";
 
@@ -18,23 +16,24 @@ export const dynamic = "force-dynamic";
  * scoping the query — students in non-member households belong on the roster too,
  * and the view differentiates them instead of dropping them.
  *
- * People with no date of birth can't be judged at all, so they're returned as a
- * count: an unmeasurable row is a data-hygiene task, not an empty table cell.
+ * Ships the classified INPUTS (dateOfBirth + the year boundary) and lets the page
+ * derive both as-of ages: the stripper drops ad-hoc computed fields, so an
+ * `ageAtNext` on the row would never reach the wire.
+ *
+ * LIVE_PERSON is load-bearing — a merged-away person keeps its row as a tombstone
+ * and would otherwise show up as a second entry for someone already listed.
  */
-export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async () => {
-    const settings = await prisma.boardSettings.findUnique({
-        where: { id: 1 },
-        select: { orgMembershipYearBoundary: true },
-    });
-    // No configured boundary means there is no member year to judge against.
-    if (!settings?.orgMembershipYearBoundary) {
-        return NextResponse.json({ currentYearStart: null, nextYearStart: null, rows: [], unknownDobCount: 0 });
-    }
-    const { current, next } = memberYearStarts(settings.orgMembershipYearBoundary, new Date());
+export const GET = handler('GET /api/membership-audit/turning-18', async () => {
+    const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+    // No configured boundary means there is no member year to judge against; the
+    // page says so rather than rendering an age nobody chose the basis for.
+    if (!settings?.orgMembershipYearBoundary) return { BoardSettings: settings, Person: [] };
+
+    const { next } = memberYearStarts(settings.orgMembershipYearBoundary, new Date());
 
     const people = await prisma.person.findMany({
         // 18 by the NEXT boundary is the superset — anyone already 18 at the
-        // current one clears it too, and the per-row ages tell the two apart.
+        // current one clears it too, and the two rendered ages tell them apart.
         where: { ...LIVE_PERSON, isHouseholdLead: false, dateOfBirth: { lte: birthCutoff(next) } },
         select: {
             id: true,
@@ -49,30 +48,5 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
         orderBy: { name: "asc" },
     });
 
-    // isDeclaredAdult carries no DOB by design (a lead marked them 25+), so those
-    // are known adults with nothing to chase — not a hygiene gap.
-    const unknownDobCount = await prisma.person.count({
-        where: { ...LIVE_PERSON, isHouseholdLead: false, dateOfBirth: null, isDeclaredAdult: false },
-    });
-
-    const rows = people.map((p) => {
-        const dob = p.dateOfBirth as Date; // the lte filter above guarantees one
-        return {
-            personId: p.id,
-            name: p.name || `Person #${p.id}`,
-            householdId: p.household.id,
-            householdName: p.household.name,
-            dateOfBirth: dob.toISOString(),
-            ageAtCurrent: calculateAge(dob, current),
-            ageAtNext: calculateAge(dob, next),
-            programs: p.programParticipants.map((pp) => pp.program),
-        };
-    });
-
-    return NextResponse.json({
-        currentYearStart: current.toISOString(),
-        nextYearStart: next.toISOString(),
-        rows,
-        unknownDobCount,
-    });
+    return { BoardSettings: settings, Person: people };
 });

--- a/checkin-app/src/app/api/membership-audit/turning-18/route.ts
+++ b/checkin-app/src/app/api/membership-audit/turning-18/route.ts
@@ -16,6 +16,10 @@ export const dynamic = "force-dynamic";
  * scoping the query — students in non-member households belong on the roster too,
  * and the view differentiates them instead of dropping them.
  *
+ * People with no DOB and no 25+ declaration ride along with a null dateOfBirth:
+ * their age is unknown, so the page counts them as a hygiene note instead of
+ * placing them in the table.
+ *
  * Ships the classified INPUTS (dateOfBirth + the year boundary) and lets the page
  * derive both as-of ages: the stripper drops ad-hoc computed fields, so an
  * `ageAtNext` on the row would never reach the wire.
@@ -32,9 +36,20 @@ export const GET = handler('GET /api/membership-audit/turning-18', async () => {
     const { next } = memberYearStarts(settings.orgMembershipYearBoundary, new Date());
 
     const people = await prisma.person.findMany({
-        // 18 by the NEXT boundary is the superset — anyone already 18 at the
-        // current one clears it too, and the two rendered ages tell them apart.
-        where: { ...LIVE_PERSON, isHouseholdLead: false, dateOfBirth: { lte: birthCutoff(next) } },
+        where: {
+            ...LIVE_PERSON,
+            isHouseholdLead: false,
+            OR: [
+                // 18 by the NEXT boundary is the superset — anyone already 18 at the
+                // current one clears it too, and the two rendered ages tell them apart.
+                { dateOfBirth: { lte: birthCutoff(next) } },
+                // No DOB and no 25+ declaration is age UNKNOWN, not age 26+ (the purge
+                // that strips a DOB always sets isDeclaredAdult). NULL never satisfies
+                // the cutoff, so without this arm a 17-year-old with no birthdate on
+                // file — exactly who this roster is for — would be silently absent.
+                { dateOfBirth: null, isDeclaredAdult: false },
+            ],
+        },
         select: {
             id: true,
             name: true,

--- a/checkin-app/src/app/api/membership-audit/turning-18/route.ts
+++ b/checkin-app/src/app/api/membership-audit/turning-18/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { LIVE_PERSON } from "@/lib/person/filters";
+import { birthCutoff, memberYearStarts } from "@/lib/programYear";
+import { calculateAge } from "@/lib/time";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Board-only, read-only roster of the org's non-lead household members who are 18
+ * or older as of a member-year start — the current one and the next, so the board
+ * can see both who is already an adult this year and who ages in on the coming
+ * boundary. Age is judged as-of each boundary, never as-of today.
+ *
+ * Household leads are excluded: this is the "child of the signer turns 18" list,
+ * and a lead is the signer. Program enrollment rides along per row rather than
+ * scoping the query — students in non-member households belong on the roster too,
+ * and the view differentiates them instead of dropping them.
+ *
+ * People with no date of birth can't be judged at all, so they're returned as a
+ * count: an unmeasurable row is a data-hygiene task, not an empty table cell.
+ */
+export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async () => {
+    const settings = await prisma.boardSettings.findUnique({
+        where: { id: 1 },
+        select: { orgMembershipYearBoundary: true },
+    });
+    // No configured boundary means there is no member year to judge against.
+    if (!settings?.orgMembershipYearBoundary) {
+        return NextResponse.json({ currentYearStart: null, nextYearStart: null, rows: [], unknownDobCount: 0 });
+    }
+    const { current, next } = memberYearStarts(settings.orgMembershipYearBoundary, new Date());
+
+    const people = await prisma.person.findMany({
+        // 18 by the NEXT boundary is the superset — anyone already 18 at the
+        // current one clears it too, and the per-row ages tell the two apart.
+        where: { ...LIVE_PERSON, isHouseholdLead: false, dateOfBirth: { lte: birthCutoff(next) } },
+        select: {
+            id: true,
+            name: true,
+            dateOfBirth: true,
+            household: { select: { id: true, name: true } },
+            programParticipants: {
+                where: { program: { phase: { not: "FINISHED" } } },
+                select: { program: { select: { id: true, name: true } } },
+            },
+        },
+        orderBy: { name: "asc" },
+    });
+
+    // isDeclaredAdult carries no DOB by design (a lead marked them 25+), so those
+    // are known adults with nothing to chase — not a hygiene gap.
+    const unknownDobCount = await prisma.person.count({
+        where: { ...LIVE_PERSON, isHouseholdLead: false, dateOfBirth: null, isDeclaredAdult: false },
+    });
+
+    const rows = people.map((p) => {
+        const dob = p.dateOfBirth as Date; // the lte filter above guarantees one
+        return {
+            personId: p.id,
+            name: p.name || `Person #${p.id}`,
+            householdId: p.household.id,
+            householdName: p.household.name,
+            dateOfBirth: dob.toISOString(),
+            ageAtCurrent: calculateAge(dob, current),
+            ageAtNext: calculateAge(dob, next),
+            programs: p.programParticipants.map((pp) => pp.program),
+        };
+    });
+
+    return NextResponse.json({
+        currentYearStart: current.toISOString(),
+        nextYearStart: next.toISOString(),
+        rows,
+        unknownDobCount,
+    });
+});

--- a/checkin-app/src/app/membership-audit/layout.tsx
+++ b/checkin-app/src/app/membership-audit/layout.tsx
@@ -15,6 +15,7 @@ const NAV_LINKS = [
   { name: "Unclaimed Accounts", href: "/membership-audit/unclaimed", icon: "📨" },
   { name: "Broken Households", href: "/membership-audit/broken", icon: "⚠️" },
   { name: "Compliance", href: "/membership-audit/compliance", icon: "🚩" },
+  { name: "Students 18+", href: "/membership-audit/turning-18", icon: "🎓" },
 ];
 
 export default function MembershipAuditLayout({ children }: { children: React.ReactNode }) {

--- a/checkin-app/src/app/membership-audit/turning-18/page.tsx
+++ b/checkin-app/src/app/membership-audit/turning-18/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Badge, Card, Center, Checkbox, Group, Stack, Table, Text, Title } from "@mantine/core";
+import Link from "next/link";
+import { Alert, Anchor, Badge, Card, Center, Checkbox, Group, Stack, Table, Text, Title } from "@mantine/core";
 import { PageLoader } from "@/components/ui/PageLoader";
 import { calculateAge, formatDateOnly } from "@/lib/time";
 import { memberYearStarts } from "@/lib/programYear";
@@ -92,6 +93,18 @@ export default function TurningEighteenPage() {
           &ldquo;next&rdquo; column ages in on that boundary. Read-only.
         </Text>
       </Card>
+
+      <Alert color="blue" variant="light" title="Why this differs from the agreement lists">
+        <Text size="sm">
+          This roster judges age <b>as of the member-year start</b>, because that is the cohort
+          the board plans the year around. The individual-agreement lists on{" "}
+          <Anchor component={Link} href="/membership-audit/compliance">Compliance</Anchor> judge
+          age <b>as of today</b>, because an agreement is opened the day someone turns 18 — a
+          minor cannot be bound by their own signature. Both are right for their own purpose, so
+          the two will not match: anyone with a birthday between today and the next member-year
+          start appears there but not here.
+        </Text>
+      </Alert>
 
       <Checkbox
         label="Hide those not in a program"

--- a/checkin-app/src/app/membership-audit/turning-18/page.tsx
+++ b/checkin-app/src/app/membership-audit/turning-18/page.tsx
@@ -75,8 +75,12 @@ export default function TurningEighteenPage() {
   }
 
   const { current, next } = memberYearStarts(new Date(boundary));
-  const rows = (data.Person ?? [])
-    .filter((p) => p.dateOfBirth && (!enrolledOnly || p.programParticipants.length > 0))
+  // A null dateOfBirth here means age unknown, not age 26+ — the endpoint only
+  // sends those without the 25+ declaration. They can't be placed in the table.
+  const unknownDobCount = (data.Person ?? []).filter((p) => !p.dateOfBirth).length;
+  const dated = (data.Person ?? []).filter((p) => p.dateOfBirth);
+  const rows = dated
+    .filter((p) => !enrolledOnly || p.programParticipants.length > 0)
     .map((p) => ({
       ...p,
       ageAtCurrent: calculateAge(p.dateOfBirth!, current),
@@ -92,7 +96,23 @@ export default function TurningEighteenPage() {
           <strong>{formatDateOnly(next)}</strong>, the next one. Someone 18 only in the
           &ldquo;next&rdquo; column ages in on that boundary. Read-only.
         </Text>
+        <Text c="dimmed" mt="xs">
+          Effectively an 18&ndash;25 list: a birthdate is dropped once someone turns 26, so
+          nobody older has an age to judge. Their absence is not a signal.
+        </Text>
       </Card>
+
+      {unknownDobCount > 0 && (
+        <Alert color="yellow" variant="light" title="Ages we cannot judge">
+          <Text size="sm">
+            {unknownDobCount === 1
+              ? "1 household member has no date of birth on file and is"
+              : `${unknownDobCount} household members have no date of birth on file and are`}{" "}
+            not marked 25 or over, so their age is unknown. They are missing from the table
+            below and could be turning 18 — add a birthdate on their household to place them.
+          </Text>
+        </Alert>
+      )}
 
       <Alert color="blue" variant="light" title="Why this differs from the agreement lists">
         <Text size="sm">
@@ -115,9 +135,9 @@ export default function TurningEighteenPage() {
       {rows.length === 0 ? (
         <Card withBorder radius="md" padding="xl" ta="center">
           <Text c="dimmed">
-            {enrolledOnly && (data.Person?.length ?? 0) > 0
+            {enrolledOnly && dated.length > 0
               ? "Nobody on this list is enrolled in a program."
-              : "Nobody turns 18 by the next member year."}
+              : "Nobody with a birthdate on file turns 18 by the next member year."}
           </Text>
         </Card>
       ) : (

--- a/checkin-app/src/app/membership-audit/turning-18/page.tsx
+++ b/checkin-app/src/app/membership-audit/turning-18/page.tsx
@@ -3,31 +3,29 @@
 import { useState, useEffect } from "react";
 import { Badge, Card, Center, Checkbox, Group, Stack, Table, Text, Title } from "@mantine/core";
 import { PageLoader } from "@/components/ui/PageLoader";
+import { calculateAge, formatDateOnly } from "@/lib/time";
+import { memberYearStarts } from "@/lib/programYear";
 
 type ProgramRef = { id: number; name: string };
-type Row = {
-  personId: number;
-  name: string;
-  householdId: number;
-  householdName: string | null;
-  dateOfBirth: string;
-  ageAtCurrent: number;
-  ageAtNext: number;
-  programs: ProgramRef[];
+type PersonRow = {
+  id: number;
+  name: string | null;
+  dateOfBirth: string | null;
+  household: { id: number; name: string | null } | null;
+  programParticipants: { program: ProgramRef }[];
 };
 type Payload = {
-  currentYearStart: string | null;
-  nextYearStart: string | null;
-  rows: Row[];
-  unknownDobCount: number;
+  BoardSettings: { orgMembershipYearBoundary: string | null } | null;
+  Person: PersonRow[];
 };
-
-const fmt = (iso: string) => new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
 
 /**
  * Membership Audit view: non-lead household members who are 18+ as of the current
  * member-year start and as of the next one, so the board can act on both the
  * standing adults and the ones aging in. Read-only.
+ *
+ * The endpoint ships dateOfBirth + the year boundary; both as-of ages are derived
+ * here, because the security stripper drops computed fields from a response.
  */
 export default function TurningEighteenPage() {
   const [data, setData] = useState<Payload | null>(null);
@@ -63,7 +61,8 @@ export default function TurningEighteenPage() {
     );
   }
 
-  if (!data.currentYearStart || !data.nextYearStart) {
+  const boundary = data.BoardSettings?.orgMembershipYearBoundary;
+  if (!boundary) {
     return (
       <Card withBorder radius="md" padding="lg">
         <Text c="dimmed">
@@ -74,24 +73,24 @@ export default function TurningEighteenPage() {
     );
   }
 
-  const rows = enrolledOnly ? data.rows.filter((r) => r.programs.length > 0) : data.rows;
+  const { current, next } = memberYearStarts(new Date(boundary));
+  const rows = (data.Person ?? [])
+    .filter((p) => p.dateOfBirth && (!enrolledOnly || p.programParticipants.length > 0))
+    .map((p) => ({
+      ...p,
+      ageAtCurrent: calculateAge(p.dateOfBirth!, current),
+      ageAtNext: calculateAge(p.dateOfBirth!, next),
+    }));
 
   return (
     <Stack>
       <Card withBorder radius="md" padding="lg">
         <Text c="dimmed">
           Household members (excluding household leads) who are 18 or older as of{" "}
-          <strong>{fmt(data.currentYearStart)}</strong> — the current member year — or as of{" "}
-          <strong>{fmt(data.nextYearStart)}</strong>, the next one. Someone 18 only in the
+          <strong>{formatDateOnly(current)}</strong> — the current member year — or as of{" "}
+          <strong>{formatDateOnly(next)}</strong>, the next one. Someone 18 only in the
           &ldquo;next&rdquo; column ages in on that boundary. Read-only.
         </Text>
-        {data.unknownDobCount > 0 && (
-          <Text size="sm" c="orange" mt="xs">
-            {data.unknownDobCount} household{" "}
-            {data.unknownDobCount === 1 ? "member has" : "members have"} no date of birth on
-            file and could not be judged.
-          </Text>
-        )}
       </Card>
 
       <Checkbox
@@ -103,7 +102,7 @@ export default function TurningEighteenPage() {
       {rows.length === 0 ? (
         <Card withBorder radius="md" padding="xl" ta="center">
           <Text c="dimmed">
-            {enrolledOnly && data.rows.length > 0
+            {enrolledOnly && (data.Person?.length ?? 0) > 0
               ? "Nobody on this list is enrolled in a program."
               : "Nobody turns 18 by the next member year."}
           </Text>
@@ -116,17 +115,17 @@ export default function TurningEighteenPage() {
                 <Table.Th>Name</Table.Th>
                 <Table.Th>Household</Table.Th>
                 <Table.Th>Date of birth</Table.Th>
-                <Table.Th>Age {fmt(data.currentYearStart)}</Table.Th>
-                <Table.Th>Age {fmt(data.nextYearStart)}</Table.Th>
+                <Table.Th>Age {formatDateOnly(current)}</Table.Th>
+                <Table.Th>Age {formatDateOnly(next)}</Table.Th>
                 <Table.Th>Programs</Table.Th>
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
               {rows.map((r) => (
-                <Table.Tr key={r.personId}>
-                  <Table.Td fw={600}>{r.name}</Table.Td>
-                  <Table.Td>{r.householdName || `Household #${r.householdId}`}</Table.Td>
-                  <Table.Td>{fmt(r.dateOfBirth)}</Table.Td>
+                <Table.Tr key={r.id}>
+                  <Table.Td fw={600}>{r.name || `Person #${r.id}`}</Table.Td>
+                  <Table.Td>{r.household?.name || `Household #${r.household?.id ?? "?"}`}</Table.Td>
+                  <Table.Td>{formatDateOnly(r.dateOfBirth)}</Table.Td>
                   <Table.Td>
                     {r.ageAtCurrent >= 18 ? (
                       r.ageAtCurrent
@@ -141,10 +140,10 @@ export default function TurningEighteenPage() {
                     </Group>
                   </Table.Td>
                   <Table.Td>
-                    {r.programs.length > 0 ? (
+                    {r.programParticipants.length > 0 ? (
                       <Group gap={6}>
-                        {r.programs.map((p) => (
-                          <Badge key={p.id} variant="light">{p.name}</Badge>
+                        {r.programParticipants.map((pp) => (
+                          <Badge key={pp.program.id} variant="light">{pp.program.name}</Badge>
                         ))}
                       </Group>
                     ) : (

--- a/checkin-app/src/app/membership-audit/turning-18/page.tsx
+++ b/checkin-app/src/app/membership-audit/turning-18/page.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Badge, Card, Center, Checkbox, Group, Stack, Table, Text, Title } from "@mantine/core";
+import { PageLoader } from "@/components/ui/PageLoader";
+
+type ProgramRef = { id: number; name: string };
+type Row = {
+  personId: number;
+  name: string;
+  householdId: number;
+  householdName: string | null;
+  dateOfBirth: string;
+  ageAtCurrent: number;
+  ageAtNext: number;
+  programs: ProgramRef[];
+};
+type Payload = {
+  currentYearStart: string | null;
+  nextYearStart: string | null;
+  rows: Row[];
+  unknownDobCount: number;
+};
+
+const fmt = (iso: string) => new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
+
+/**
+ * Membership Audit view: non-lead household members who are 18+ as of the current
+ * member-year start and as of the next one, so the board can act on both the
+ * standing adults and the ones aging in. Read-only.
+ */
+export default function TurningEighteenPage() {
+  const [data, setData] = useState<Payload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [enrolledOnly, setEnrolledOnly] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/membership-audit/turning-18");
+        if (res.ok) {
+          setData(await res.json());
+        } else {
+          setError("Failed to load the roster. Ensure you have the proper authorizations.");
+        }
+      } catch (e) {
+        console.error("Failed to load the 18+ roster:", e);
+        setError("Network error loading the roster.");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  if (loading) return <PageLoader />;
+
+  if (error || !data) {
+    return (
+      <Center mih="60vh">
+        <Title order={3} c="red">{error || "No data."}</Title>
+      </Center>
+    );
+  }
+
+  if (!data.currentYearStart || !data.nextYearStart) {
+    return (
+      <Card withBorder radius="md" padding="lg">
+        <Text c="dimmed">
+          No membership-year start date is configured, so there is no boundary to judge
+          ages against. Set it in Settings → Membership.
+        </Text>
+      </Card>
+    );
+  }
+
+  const rows = enrolledOnly ? data.rows.filter((r) => r.programs.length > 0) : data.rows;
+
+  return (
+    <Stack>
+      <Card withBorder radius="md" padding="lg">
+        <Text c="dimmed">
+          Household members (excluding household leads) who are 18 or older as of{" "}
+          <strong>{fmt(data.currentYearStart)}</strong> — the current member year — or as of{" "}
+          <strong>{fmt(data.nextYearStart)}</strong>, the next one. Someone 18 only in the
+          &ldquo;next&rdquo; column ages in on that boundary. Read-only.
+        </Text>
+        {data.unknownDobCount > 0 && (
+          <Text size="sm" c="orange" mt="xs">
+            {data.unknownDobCount} household{" "}
+            {data.unknownDobCount === 1 ? "member has" : "members have"} no date of birth on
+            file and could not be judged.
+          </Text>
+        )}
+      </Card>
+
+      <Checkbox
+        label="Hide those not in a program"
+        checked={enrolledOnly}
+        onChange={(e) => setEnrolledOnly(e.currentTarget.checked)}
+      />
+
+      {rows.length === 0 ? (
+        <Card withBorder radius="md" padding="xl" ta="center">
+          <Text c="dimmed">
+            {enrolledOnly && data.rows.length > 0
+              ? "Nobody on this list is enrolled in a program."
+              : "Nobody turns 18 by the next member year."}
+          </Text>
+        </Card>
+      ) : (
+        <Table.ScrollContainer minWidth={700}>
+          <Table striped highlightOnHover withTableBorder verticalSpacing="xs">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Name</Table.Th>
+                <Table.Th>Household</Table.Th>
+                <Table.Th>Date of birth</Table.Th>
+                <Table.Th>Age {fmt(data.currentYearStart)}</Table.Th>
+                <Table.Th>Age {fmt(data.nextYearStart)}</Table.Th>
+                <Table.Th>Programs</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {rows.map((r) => (
+                <Table.Tr key={r.personId}>
+                  <Table.Td fw={600}>{r.name}</Table.Td>
+                  <Table.Td>{r.householdName || `Household #${r.householdId}`}</Table.Td>
+                  <Table.Td>{fmt(r.dateOfBirth)}</Table.Td>
+                  <Table.Td>
+                    {r.ageAtCurrent >= 18 ? (
+                      r.ageAtCurrent
+                    ) : (
+                      <Text span c="dimmed">{r.ageAtCurrent}</Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    <Group gap={6} wrap="nowrap">
+                      {r.ageAtNext}
+                      {r.ageAtCurrent < 18 && <Badge color="orange" variant="light">Turns 18</Badge>}
+                    </Group>
+                  </Table.Td>
+                  <Table.Td>
+                    {r.programs.length > 0 ? (
+                      <Group gap={6}>
+                        {r.programs.map((p) => (
+                          <Badge key={p.id} variant="light">{p.name}</Badge>
+                        ))}
+                      </Group>
+                    ) : (
+                      <Text span c="dimmed">Not in a program</Text>
+                    )}
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      )}
+    </Stack>
+  );
+}

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -118,6 +118,7 @@ export const PAGES: PageEntry[] = [
   { href: '/membership-audit/unclaimed', label: 'Unclaimed Accounts', section: 'Membership Audit', visible: BOARD },
   { href: '/membership-audit/broken', label: 'Broken Households', section: 'Membership Audit', keywords: 'lead leadless no lead unclaimed', visible: BOARD },
   { href: '/membership-audit/compliance', label: 'Membership Compliance', section: 'Membership Audit', keywords: 'violations background check revoked denied stale follow-up', visible: BOARD },
+  { href: '/membership-audit/turning-18', label: 'Students 18+', section: 'Membership Audit', keywords: 'age 18 adult turning eighteen agreement member year sept 1 september', visible: BOARD },
 
   // Program Ops — board
   { href: '/program-ops', label: 'Program Ops', section: 'Program Ops', visible: BOARD },

--- a/checkin-app/src/lib/__tests__/programYear.test.ts
+++ b/checkin-app/src/lib/__tests__/programYear.test.ts
@@ -1,4 +1,5 @@
-import { nextBoundary, landsNextYear } from '@/lib/programYear';
+import { nextBoundary, landsNextYear, memberYearStarts, birthCutoff } from '@/lib/programYear';
+import { calculateAge } from '@/lib/time';
 
 // Anchor "now" so the rollover branch is deterministic.
 const NOW = new Date('2026-07-06T00:00:00Z');
@@ -29,5 +30,37 @@ describe('landsNextYear', () => {
     it('false (unknown) when start date or cutoff is missing', () => {
         expect(landsNextYear(null, SEPT1, NOW)).toBe(false);
         expect(landsNextYear('2026-09-15T00:00:00Z', null, NOW)).toBe(false);
+    });
+});
+
+describe('memberYearStarts', () => {
+    it('brackets now with the year in progress and the upcoming one', () => {
+        const { current, next } = memberYearStarts(new Date(SEPT1), NOW);
+        expect(current.toISOString()).toBe('2025-09-01T00:00:00.000Z');
+        expect(next.toISOString()).toBe('2026-09-01T00:00:00.000Z');
+    });
+
+    it('rolls both forward once the boundary has passed', () => {
+        const { current, next } = memberYearStarts(new Date(SEPT1), new Date('2026-10-01T00:00:00Z'));
+        expect(current.toISOString()).toBe('2026-09-01T00:00:00.000Z');
+        expect(next.toISOString()).toBe('2027-09-01T00:00:00.000Z');
+    });
+});
+
+describe('birthCutoff', () => {
+    const asOf = new Date('2026-09-01T00:00:00Z');
+
+    it('is the DOB that turns exactly 18 on the boundary', () => {
+        expect(birthCutoff(asOf).toISOString()).toBe('2008-09-01T00:00:00.000Z');
+    });
+
+    // The SQL-side `dateOfBirth <= birthCutoff(asOf)` filter must agree with the
+    // JS age shown on the row, birthday-on-the-boundary included.
+    it('agrees with calculateAge on both sides of the boundary', () => {
+        const cutoff = birthCutoff(asOf);
+        const dayLate = new Date('2008-09-02T00:00:00Z');
+        expect(calculateAge(cutoff, asOf)).toBe(18);
+        expect(calculateAge(dayLate, asOf)).toBe(17);
+        expect(dayLate.getTime() <= cutoff.getTime()).toBe(false);
     });
 });

--- a/checkin-app/src/lib/programYear.ts
+++ b/checkin-app/src/lib/programYear.ts
@@ -19,3 +19,23 @@ export function landsNextYear(startAt: string | null, cutoff: string | null, now
     if (!startAt || !cutoff) return false;
     return new Date(startAt).getTime() >= nextBoundary(new Date(cutoff), now).getTime();
 }
+
+/**
+ * The two member-year start dates an age report is judged against: `next` is the
+ * upcoming boundary, `current` the one the org is living in (a year earlier).
+ */
+export function memberYearStarts(boundary: Date, now: Date = new Date()): { current: Date; next: Date } {
+    const next = nextBoundary(boundary, now);
+    const current = new Date(next);
+    current.setUTCFullYear(current.getUTCFullYear() - 1);
+    return { current, next };
+}
+
+/**
+ * Latest date of birth that still makes someone `years` old as of `asOf` — the
+ * SQL-side form of calculateAge(dob, asOf) >= years, so an age filter can run in
+ * the query instead of over every loaded row.
+ */
+export function birthCutoff(asOf: Date, years = 18): Date {
+    return new Date(Date.UTC(asOf.getUTCFullYear() - years, asOf.getUTCMonth(), asOf.getUTCDate()));
+}

--- a/checkin-app/tests/security/routeAuthDrift.test.ts
+++ b/checkin-app/tests/security/routeAuthDrift.test.ts
@@ -321,7 +321,7 @@ const EDGE_INCLUDE_ALLOWLIST: Record<string, string> = {
     'household/visits': "query-shaped — own household only (where householdId = caller's)",
     'kioskdisplay/certifications': 'admin-role-gated — sysadmin/board/keyholder (+ kiosk)',
     'membership-audit/compliance': 'admin-role-gated — withAuth roles [sysadmin, board]; reads ProgramParticipant/Volunteer to flag people needing a background check',
-    'membership-audit/turning-18': 'admin-role-gated — withAuth roles [sysadmin, board]; reads ProgramParticipant to mark which 18-year-olds are enrolled in a program',
+    'membership-audit/turning-18': 'admin-role-gated — registry authorize anyRole [sysadmin, board]; reads ProgramParticipant to mark which 18-year-olds are enrolled in a program',
     'membership-ops/households': 'admin-role-gated — withAuth roles [sysadmin, board]; ?id= branch includes each member ProgramParticipant for the household detail view',
     'membership-ops/participants/merge/analyze': 'admin-role-gated — sysadmin/board',
     'nav/todo-counts': 'query-shaped — counts scoped to caller (own household + programs the caller leads)',

--- a/checkin-app/tests/security/routeAuthDrift.test.ts
+++ b/checkin-app/tests/security/routeAuthDrift.test.ts
@@ -321,6 +321,7 @@ const EDGE_INCLUDE_ALLOWLIST: Record<string, string> = {
     'household/visits': "query-shaped — own household only (where householdId = caller's)",
     'kioskdisplay/certifications': 'admin-role-gated — sysadmin/board/keyholder (+ kiosk)',
     'membership-audit/compliance': 'admin-role-gated — withAuth roles [sysadmin, board]; reads ProgramParticipant/Volunteer to flag people needing a background check',
+    'membership-audit/turning-18': 'admin-role-gated — withAuth roles [sysadmin, board]; reads ProgramParticipant to mark which 18-year-olds are enrolled in a program',
     'membership-ops/households': 'admin-role-gated — withAuth roles [sysadmin, board]; ?id= branch includes each member ProgramParticipant for the household detail view',
     'membership-ops/participants/merge/analyze': 'admin-role-gated — sysadmin/board',
     'nav/todo-counts': 'query-shaped — counts scoped to caller (own household + programs the caller leads)',


### PR DESCRIPTION
Fixes #1230 (backlog item M7).

Re-lands #1447, which merged into `claude/registry-turning-18` rather than `main`. That branch's own PR (#1490, the registry declaration) had already merged to `main` 29 minutes earlier, so #1447's app code was left stranded on the branch tip and never reached `main`. #1447 is closed and cannot be retargeted, so both of its commits are cherry-picked onto current `main` here — same nine files, no conflicts.

The registry entry this route depends on is already on `main` from #1490, so the handler wiring resolves without any boundary-file change in this PR.

## Why

The board needs to know which household members are legally adults **for a given member year** — the age-18 individual-agreement obligation and the person-level background-check trigger both key on it — and no surface answered that. Age was only ever judged as-of today, which is the wrong question when the obligation attaches at the year boundary.

## What

A board-only Membership Audit view (`/membership-audit/turning-18`, "Students 18+") listing non-lead household members who are 18 or older as of the **current** member-year start and as of the **next** one, so both the standing adults and the ones aging in on the coming boundary are visible in one table.

- **Household leads are excluded.** This is the "child of the signer turns 18" list, and a lead is the signer.
- **Not scoped to program enrollees.** Program students can sit in non-member households, so scoping the query would drop exactly the rows worth seeing. Instead every row carries the programs the person is enrolled in (any program not yet `FINISHED`), with a "Hide those not in a program" checkbox that filters the already-fetched list client-side.
- **No DOB → a count, not a blank row.** People whose age can't be judged come back as `unknownDobCount` and render as a hygiene note. `isDeclaredAdult` people are excluded from that count — a lead marked them 25+, there is nothing to chase.
- **The boundary is the configured `BoardSettings.orgMembershipYearBoundary`**, not a hardcoded Sept 1. With none configured the page says so and renders nothing to act on.

The age filter runs in the query (`dateOfBirth <= birthCutoff(next)`) rather than over every loaded person. `programYear.test.ts` pins `birthCutoff` against `calculateAge` on both sides of the boundary so the SQL-side bound and the displayed age can't drift apart.

## Reviewer notes

Three drift guards fired during the original build and each is registered rather than worked around:

- **`livePersonDriftGuard`** rejected `...LIVE_PERSON` spread through a shared local const — it text-scans the query's own argument object. Inlined at both query sites.
- **`authzRegistry`** required negative-authz coverage: a row in `authzRoleRejection.integration.test.ts` (401 anon / 403 plain user) plus the `AUTHZ_TESTED` entry.
- **`routeAuthDrift` rule 3** flagged the `ProgramParticipant` edge include (all-public-tier, so row *existence* is the sensitive thing). The handler is `withAuth roles [sysadmin, board]`, so it gets a keyed `EDGE_INCLUDE_ALLOWLIST` entry with that justification. That file is `checkin-app/tests/security/*`, an allowed companion under the boundary-isolation workflow — not a boundary file — so this does not need to ship as its own PR.

## Verification

Re-run against current `main` after the cherry-pick:

- `tsc --noEmit` clean.
- Unit tests covering the touched files (`programYear`, `routeAuthDrift`, `pageRegistry`): 3 suites, 458 passed.
- The two integration suites (`turningEighteenAPI`, `authzRoleRejection`) were **not** re-run locally — leaving those to CI.

From the original #1447 run: full unit suite 2428 passed / 257 suites; full integration suite 1260 passed / 128 suites; live query smoke against real Postgres returned `ageAtCurrent 17 / ageAtNext 18` for a synthetic member born 2008-08-15 with boundaries `2025-09-01` / `2026-09-01`; `npm run lint` clean.

Deliberately skipped: CSV export and column sorting. The list is small and the board's next step is opening a household, not exporting. Worth adding when it outgrows a screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update — rebased onto `main` @ `a00bed98`.** The branch carries a third commit, `feat(membership-audit): explain why this roster differs from the agreement lists`, which adds a note to the page explaining why this roster (age as of the member-year start) lists different people than the individual-agreement lists on Compliance (age as of today). #1477 carries the reciprocal note.

Re-verified after the rebase — which pulled in the UTC-midnight DOB changes (#1494, #1496) that this route's `dateOfBirth <= birthCutoff` filter depends on: `tsc --noEmit` clean; `programYear` / `routeAuthDrift` / `pageRegistry` suites 458 passed.

The earlier `isolation` failure on this PR was a false positive, not a boundary change. That job diffs the PR **merge ref** against `pull_request.base.sha`, which is pinned at PR-open. `main` advanced five commits afterwards — two of them registry PRs (#1492, #1489) touching `checkin-app/src/security/` — so the job attributed those upstream boundary files to this PR and listed 18 unrelated files as violations. This PR touches no file under `checkin-app/src/security/`.
