### PR TITLE
fix(data): normalize pre-#1494 DOB rows to UTC midnight (#1149)

### DIFF
--- a/checkin-app/prisma/migrations/20260806120000_normalize_dob_utc_midnight/migration.sql
+++ b/checkin-app/prisma/migrations/20260806120000_normalize_dob_utc_midnight/migration.sql
@@ -1,0 +1,9 @@
+-- dateOfBirth is a calendar date stored as timestamp(3). Normalizes rows written
+-- before #1494 put every writer on UTC midnight.
+-- Plain ::date, never (col AT TIME ZONE 'UTC')::date: the column is naive, so
+-- AT TIME ZONE reads it as timestamptz and casts in the session TimeZone,
+-- shifting every row back a day on any connection west of UTC.
+UPDATE "Person"
+SET "dateOfBirth" = "dateOfBirth"::date
+WHERE "dateOfBirth" IS NOT NULL
+  AND "dateOfBirth" <> "dateOfBirth"::date;


### PR DESCRIPTION
Completes the last unclaimed work item in `checkin-app/docs/designs/1149_DATE_TIME_TZ_DESIGN.md`.

`Person.dateOfBirth` is a calendar date stored as `timestamp(3)`. #1494 put every writer on UTC midnight but deliberately left existing rows alone. This truncates them to the date part.

## Why this is safe under either storage model

#1494's body defers the backfill to Sequencing step 7, "alongside the calendar-date storage decision" (F12). That deferral is stricter than it needs to be: `::date` computes the same value under both candidates.

- **Model A** (`DateTime` at UTC midnight by convention) — this *is* the target state.
- **Model B** (`@db.Date`) — the design's own mechanics specify `ALTER COLUMN … TYPE date USING (col::date)`, which produces the identical calendar day. Run the backfill first and that cast is a no-op on these rows; skip it and the cast does the same work.

So it cannot conflict with a decision whose two possible outcomes both agree with it. F12 stays open and unprejudiced.

## The predicate

```sql
WHERE "dateOfBirth" IS NOT NULL AND "dateOfBirth" <> "dateOfBirth"::date
```

`"dateOfBirth"::date` promotes back to a midnight timestamp for the comparison, so this means "time-of-day is not `00:00:00`". It matters that it is written this way rather than `= '12:00:00'`: the residual is **not** only noon rows. Pre-#1494 `importDob.ts` also wrote fractional Excel serials, so `33239.75` landed as `18:00:00Z`. The same expression doubles as the idempotency guard — a re-run matches zero rows.

No `26+` clause is needed: `20260724120000_purge_adult_dob` and the nightly cron already NULL those, and `IS NOT NULL` excludes them. No `LIVE_PERSON` filter — tombstoned rows normalize too, matching `purge_adult_dob`.

## What changes, and what provably does not

**Unchanged.** Every JS reader takes only the UTC date part. `calculateAge` reads `getUTC*` since #1422, so no age moves — including the highest-stakes caller, `normalizeAdultDob`, which decides a *persisted* DOB strip. Display goes through `formatDateOnly`, which is UTC-pinned, so nothing visible changes. The user-facing off-by-one was already fixed by #1424 for both conventions; this is about SQL comparison honesty, not rendering.

**Changes, all in the correcting direction — SQL predicates that compare against a midnight bound:**

- **Import dedup** (`participants/import/preview/route.ts:256`, `import/route.ts:243`) — exact-equality match on `dateOfBirth`. A noon-stored row silently missed the match and created a **duplicate Person**. This closes that gap, which also means step 7's Model-A "same-UTC-day range query" clause is no longer needed.
- **`people/search`** (`:48`) — a noon row on the exact 18th birthday previously passed only after 12:00 UTC; now it passes all day, agreeing with `calculateAge`.
- **Nightly 26+ purge** (`api/cron/nightly/route.ts:83-85`) — raw SQL against `CURRENT_DATE`. A noon row escaped the #1165 purge for one extra day; it will now be purged on the birthday. **This is the one place the backfill causes DOB deletion.** It is what #1165 intends and what midnight rows already do, but it is a real behaviour change and is called out here deliberately.

## Release sequencing — this must not ship in the same release as #1494

Prod is on `v1.1.1` (2026-08-03) and carries none of #1422, #1424 or #1494, so it still writes noon-UTC DOBs today. Ship the backfill in a release **strictly after** the one carrying those three. Otherwise old code re-mints non-midnight rows during the drain window, and the pre-#1424 `formatDate` readers would render freshly-truncated rows a day early.

Merging this PR now is fine. Cutting it into the same release is not.

## Verification

`migration-safety.yml` will pass, and it proves nothing here — the seeded DB has no non-midnight DOBs, so the predicate matches zero rows and the migration is a no-op. The real check is against the one database that has these rows:

```sql
-- before: distribution. Anything outside 00:00 / 12:00 / serial-derived times
-- deserves a look before applying.
SELECT "dateOfBirth"::time AS time_of_day, count(*)
FROM "Person" WHERE "dateOfBirth" IS NOT NULL GROUP BY 1 ORDER BY 2 DESC;

-- before and after: capture and diff. Must be identical — proves no calendar day moved.
SELECT id, "dateOfBirth"::date FROM "Person" WHERE "dateOfBirth" IS NOT NULL ORDER BY id;

-- after: must return 0.
SELECT count(*) FROM "Person"
WHERE "dateOfBirth" IS NOT NULL AND "dateOfBirth" <> "dateOfBirth"::date;
```

`tsc` clean above the two pre-existing `@aws-sdk/client-lambda` errors; `npm run lint` exit 0. Data-only, so no `schema.prisma` change, no `@sensitivity` edit, no `classifications.ts` regeneration.

## Scope

After this, every finding and step in the 1149 design is either shipped or deferred by the design itself. F12 (the storage decision) and step 5 (the org-timezone display provider) are tracked by **#1346**, which the design defers explicitly.

**Note for the milestone:** #1149 is on v1.1 and #1346 has no milestone, so closing this drops the storage decision out of any milestone. Worth milestoning #1346 or consciously calling it backlog.

This PR does **not** answer F12, implement step 5, migrate any column to `@db.Date`, or change the schema. It is not a user-visible fix.

Closes #1149

---
_Posted by Claude._
