### PR TITLE
test(integration): make the announce-recipient suite own its board settings

### DIFF
--- a/checkin-app/src/app/__tests__/personBgComplianceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgComplianceAPI.integration.test.ts
@@ -117,8 +117,12 @@ describe('GET /api/membership-audit/compliance — person BG buckets', () => {
 
     afterAll(async () => {
         await cleanup();
+        // Unconditional: a row this suite created must go, or its boundary leaks into
+        // suites that share this DB and expect none.
         if (savedSettings) {
             await prisma.boardSettings.update({ where: { id: 1 }, data: savedSettings });
+        } else {
+            await prisma.boardSettings.delete({ where: { id: 1 } }).catch(() => {});
         }
     });
 

--- a/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
@@ -114,7 +114,10 @@ describe('PERSON_BG triggers + subject-scoped clear + gate', () => {
 
     afterAll(async () => {
         await cleanup();
+        // Unconditional: a row this suite created must go, or its boundary leaks into
+        // suites that share this DB and expect none.
         if (savedSettings) await prisma.boardSettings.update({ where: { id: 1 }, data: savedSettings });
+        else await prisma.boardSettings.delete({ where: { id: 1 } }).catch(() => {});
         await prisma.$disconnect();
     });
 

--- a/checkin-app/src/app/__tests__/programAnnounceRecipients.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programAnnounceRecipients.integration.test.ts
@@ -24,6 +24,9 @@ const TAG = 'announce-recip-test';
 
 describe('notifyNewProgramAnnounced recipient set (#1153 covered-member audience)', () => {
     let tombstoneHouseholdId: number, tombstoneTargetId: number;
+    // Integration suites share one DB, so BoardSettings row 1 may already carry a
+    // boundary from another suite. The unbounded cases below require none.
+    let prevBoardSettingsOuter: { orgMembershipYearBoundary: Date | null; bgRecheckMonths: number } | null = null;
 
     async function wipe() {
         const hhs = await prisma.household.findMany({
@@ -42,6 +45,16 @@ describe('notifyNewProgramAnnounced recipient set (#1153 covered-member audience
 
     beforeAll(async () => {
         await wipe();
+
+        const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevBoardSettingsOuter = existing
+            ? { orgMembershipYearBoundary: existing.orgMembershipYearBoundary, bgRecheckMonths: existing.bgRecheckMonths }
+            : null;
+        await prisma.boardSettings.upsert({
+            where: { id: 1 },
+            create: { id: 1, orgMembershipYearBoundary: null },
+            update: { orgMembershipYearBoundary: null },
+        });
 
         // Covered: ACTIVE-membership household, default prefs -> included.
         await prisma.person.create({
@@ -83,6 +96,11 @@ describe('notifyNewProgramAnnounced recipient set (#1153 covered-member audience
 
     afterAll(async () => {
         await wipe();
+        if (prevBoardSettingsOuter) {
+            await prisma.boardSettings.update({ where: { id: 1 }, data: prevBoardSettingsOuter });
+        } else {
+            await prisma.boardSettings.delete({ where: { id: 1 } }).catch(() => {});
+        }
     });
 
     beforeEach(() => {
@@ -102,7 +120,7 @@ describe('notifyNewProgramAnnounced recipient set (#1153 covered-member audience
 
     // #1061 "full duration" gate: a covered household with NO settled renewal is only
     // valid through the current membership-year boundary. One boundary config (Aug 1,
-    // via BoardSettings row 1, absent by default in the integration DB) exercises both
+    // via BoardSettings row 1, which the outer beforeAll leaves unset) exercises both
     // sides: a program ending after the boundary excludes the household, a program
     // ending before it includes the SAME household.
     describe('expired-at-midyear boundary', () => {


### PR DESCRIPTION
## What

Fixes a pre-existing order-dependent failure in the integration tier. Test-only; no app code touched.

`programAnnounceRecipients.integration.test.ts`, first `it`:

> includes covered+opted-in live members, excludes uncovered/opted-out/tombstoned, **with no date boundary configured**

The name asserts a precondition the test never established. Integration tests run `--runInBand`, so all 130 suites share one per-worker database, and this test read whatever `BoardSettings` row 1 an earlier suite happened to leave behind.

`personBgTriggers.integration.test.ts` seeds `orgMembershipYearBoundary = 2000-09-01` and restored the previous value in `afterAll` only `if (savedSettings)` — so on a run where row 1 did not exist beforehand, the Sep 1 boundary stayed in the DB. `personBgComplianceAPI.integration.test.ts` has the same conditional-restore shape with a Jun 1 seed.

With Sep 1 left over, `nextBoundary(Sep 1, now)` resolves to the upcoming Sep 1, which is before the test's program `endAt` of `2026-12-01`. `coversThrough` then returns false for every household, `notifyNewProgramAnnounced` emails nobody, and the assertion sees an empty recipient array.

## Changes

- **`programAnnounceRecipients.integration.test.ts`** — the outer `beforeAll` now saves `BoardSettings` row 1 and upserts `orgMembershipYearBoundary: null`; `afterAll` restores the saved values or deletes the row it created. This is the same save/restore shape the nested `expired-at-midyear boundary` describe already used, just hoisted so the unbounded cases get the precondition their names claim.
- **`personBgTriggers.integration.test.ts`**, **`personBgComplianceAPI.integration.test.ts`** — restore is now unconditional: when the suite created row 1, `afterAll` deletes it instead of leaving the seed boundary behind. Defense in depth; the first change is what makes the failing test honest.

## Verification

Deterministic reproduction — a custom `--testSequencer` forcing `personBgTriggers` to run immediately before `programAnnounceRecipients`, scoped with `--testPathPatterns "(personBgTriggers|programAnnounceRecipients)"`:

- On the unmodified tree: `Test Suites: 1 failed, 1 passed` / `Tests: 1 failed, 9 passed` — the failure is exactly the named test.
- With this change: `Test Suites: 2 passed` / `Tests: 10 passed`.

Full integration tier with this change: `Test Suites: 130 passed, 130 total` / `Tests: 9 skipped, 1308 passed, 1317 total`.

Run against a throwaway local Postgres via `npm run test:integration` from `checkin-app/`.

## Reviewer notes

The order dependency is latent on `main` — jest's default sequencer happens not to produce the failing order today, so this was never a red CI run. It becomes one the moment suite timings shift. No production behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)