### PR TITLE
feat(membership): an intake note no longer holds payment

### DIFF
--- a/checkin-app/docs/generated/lifecycle/membership.md
+++ b/checkin-app/docs/generated/lifecycle/membership.md
@@ -21,7 +21,7 @@ stateDiagram-v2
     BLOCKED --> ACTIVE: overrideBlocked approve
     BLOCKED --> ARCHIVED: archiveApplication
     BLOCKED --> PENDING_BG_CLEARANCE: overrideBlocked reset
-    BLOCKED --> PENDING_BG_REVIEW: overrideBlocked reset
+    BLOCKED --> PENDING_BG_REVIEW: overrideBlocked reset · PERSON_BG
     BLOCKED --> PENDING_EXTERNAL_ACTION: overrideBlocked reset · RENEWAL · legacy
     BLOCKED --> PENDING_PAYMENT: overrideBlocked reset
     INTAKE --> ARCHIVED: archiveApplication
@@ -32,10 +32,9 @@ stateDiagram-v2
     PENDING_BG_REVIEW --> ACTIVE: clearBackgroundCheck
     PENDING_BG_REVIEW --> ARCHIVED: archiveApplication
     PENDING_BG_REVIEW --> BLOCKED: attest REJECT
-    PENDING_BG_REVIEW --> PENDING_PAYMENT: clearBackgroundCheck
+    PENDING_BG_REVIEW --> PENDING_PAYMENT: clearBackgroundCheck · legacy
     PENDING_EXTERNAL_ACTION --> ACTIVE: markContractSigned · PERSON_AGREEMENT
     PENDING_EXTERNAL_ACTION --> ARCHIVED: archiveApplication
-    PENDING_EXTERNAL_ACTION --> PENDING_BG_REVIEW: advanceExternalIfComplete
     PENDING_EXTERNAL_ACTION --> PENDING_PAYMENT: advanceExternalIfComplete
     PENDING_PAYMENT --> ACTIVE: activate
     PENDING_PAYMENT --> ACTIVE: grantRenewalPayment · RENEWAL
@@ -60,7 +59,7 @@ A blank (`—`) cell is a **deliberate** absent edge — a decision to ratify, n
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | ∅ | — | — | — | — | — | — | PENDING_RENEWAL | — | — | — | — | PENDING_EXTERNAL_ACTION | PENDING_BG_REVIEW | INTAKE | — | — |
 | INTAKE | — | — | ARCHIVED | — | — | — | — | — | — | — | — | — | — | — | PENDING_EXTERNAL_ACTION | — |
-| PENDING_EXTERNAL_ACTION | — | PENDING_BG_REVIEW, PENDING_PAYMENT | ARCHIVED | — | — | — | — | — | ACTIVE | — | — | — | — | — | — | — |
+| PENDING_EXTERNAL_ACTION | — | PENDING_PAYMENT | ARCHIVED | — | — | — | — | — | ACTIVE | — | — | — | — | — | — | — |
 | PENDING_BG_REVIEW | — | — | ARCHIVED | BLOCKED | — | ACTIVE, PENDING_PAYMENT | — | — | — | — | — | — | — | — | — | — |
 | PENDING_PAYMENT | ACTIVE, PENDING_BG_CLEARANCE | — | ARCHIVED | BLOCKED | — | — | — | ACTIVE | — | — | — | — | — | — | — | — |
 | PENDING_BG_CLEARANCE | — | — | ARCHIVED | BLOCKED | — | ACTIVE | — | — | — | — | — | — | — | — | — | — |

--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -275,28 +275,19 @@ describe('background check is non-blocking', () => {
         expect(await isVolunteerOf(orgMembershipId)).toBe(true);
     });
 
-    it('an intake note holds payment at PENDING_BG_REVIEW until the review clears (#907)', async () => {
-        const { processId, householdId, orgMembershipId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
+    it('an intake note does not gate payment — the advance opens payment, review runs in parallel', async () => {
+        const { processId, householdId } = await makeApplicant('PENDING_EXTERNAL_ACTION');
         await prisma.household.update({ where: { id: householdId }, data: { intakeNotes: 'please treat us as a volunteer household' } });
 
         await markContractSigned(processId);
         await markBgConsent(processId, revA);
-        expect(await statusOf(processId)).toBe('PENDING_BG_REVIEW'); // held — not PENDING_PAYMENT
-
-        // Payment is genuinely gated while held.
-        await expect(certifyPaymentPlan(processId, revA)).rejects.toMatchObject({ code: 'wrong_phase' });
-
-        // The reviewers (who are shown the note) clear the check → payment opens
-        // with dues already settled by their volunteer mark.
-        await attest(revA, processId, { result: 'APPROVE', isMarkedVolunteer: true, subjectPersonIds: [leadId] });
-        await attest(revB, processId, { result: 'APPROVE', isMarkedVolunteer: true, subjectPersonIds: [leadId] });
         expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
-        expect(await isVolunteerOf(orgMembershipId)).toBe(true);
+
         await certifyPaymentPlan(processId, revA);
-        expect(await statusOf(processId)).toBe('ACTIVE');
+        expect(await statusOf(processId)).toBe('PENDING_BG_CLEARANCE'); // paid first, check still open
     });
 
-    it('fresh check + intake note → no auto-clear at submit; the note goes through review (#907)', async () => {
+    it('fresh check + intake note → the note does not disqualify the auto-clear at submit', async () => {
         await setBgPolicy();
         const { processId, householdId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION', { lastBackgroundCheck: new Date() });
         await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
@@ -309,14 +300,13 @@ describe('background check is non-blocking', () => {
         await submitIntake(leadId);
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(proc?.status).toBe('PENDING_EXTERNAL_ACTION');
-        expect(proc?.bgClearedAt).toBeNull(); // shortcut disqualified by the note
+        expect(proc?.bgClearedAt).not.toBeNull(); // still-valid check clears; the note is irrelevant
 
         await markContractSigned(processId);
-        await markBgConsent(processId, revA);
-        expect(await statusOf(processId)).toBe('PENDING_BG_REVIEW'); // held for the note
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
     });
 
-    it('fresh-check renewal with a household note re-reviews instead of opening payment (#907)', async () => {
+    it('fresh-check renewal with a household note opens payment on signature alone', async () => {
         await setBgPolicy();
         const { orgMembershipId, processId } = await makeFreshRenewal();
         const m = await prisma.orgMembership.findUnique({ where: { id: orgMembershipId } });
@@ -325,16 +315,11 @@ describe('background check is non-blocking', () => {
         await beginRenewal(processId);
 
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
-        // Every renewal re-signs at the external step; the note disqualifies the
-        // bgClearedAt shortcut for the still-valid background check (mirrors
-        // submitIntake), so after sign + consent the advance holds at
-        // PENDING_BG_REVIEW instead of opening payment.
         expect(proc?.status).toBe('PENDING_EXTERNAL_ACTION');
-        expect(proc?.bgClearedAt).toBeNull(); // shortcut disqualified by the note
+        expect(proc?.bgClearedAt).not.toBeNull(); // still-valid check clears; the note is irrelevant
 
         await markContractSigned(processId);
-        await markBgConsent(processId, revA);
-        expect(await statusOf(processId)).toBe('PENDING_BG_REVIEW'); // held for the note
+        expect(await statusOf(processId)).toBe('PENDING_PAYMENT');
     });
 
     it('conflict of interest: a certifier in the applicant household is blocked, sysadmin flag or not', async () => {

--- a/checkin-app/src/app/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership/__tests__/page.test.tsx
@@ -259,14 +259,6 @@ describe("membership page", () => {
     expect(await screen.findByText("Payment received 🎉", { exact: false })).toBeInTheDocument();
   });
 
-  it("renders the held-for-review card for PENDING_BG_REVIEW (#907)", async () => {
-    setSession({ id: 1 });
-    mockFetchJson({ "/api/membership": state({ process: { id: 1, kind: "INITIAL", status: "PENDING_BG_REVIEW" } }) });
-    renderWithProviders(<MembershipPage />);
-
-    expect(await screen.findByText("Hang tight — your application is being reviewed")).toBeInTheDocument();
-  });
-
   it("renders the default in-progress card for other statuses", async () => {
     setSession({ id: 1 });
     mockFetchJson({ "/api/membership": state({ process: { id: 1, kind: "INITIAL", status: "BLOCKED" } }) });

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -831,14 +831,7 @@ export default function MembershipPage() {
                   <section>
                     <Textarea
                       label="Anything else we should know?"
-                      description={
-                        <>
-                          Optional. Tell us anything that would help us review your application — for example, if your household is applying to volunteer only, with no students enrolled.{" "}
-                          <Text component="span" fw={700} c="red">
-                            Your application will pause for human review before you can pay
-                          </Text>
-                        </>
-                      }
+                      description="Optional. Tell us anything that would help us review your application — for example, if your household is applying to volunteer only, with no students enrolled."
                       autosize
                       minRows={3}
                       value={notes}
@@ -1006,15 +999,6 @@ export default function MembershipPage() {
                 ) : (
                   <Text c="dimmed">Preparing your invoice…</Text>
                 )}
-              </Card>
-            ) : inStatus === "PENDING_BG_REVIEW" ? (
-              <Card withBorder radius="md" padding="lg">
-                <Title order={2} mb="sm">Hang tight — your application is being reviewed</Title>
-                <Text c="dimmed">
-                  A person on our team is reviewing your application (this happens whenever you
-                  leave a note for us). You&apos;ll be able to pay your dues once the review is
-                  complete — we&apos;ll email you then. Nothing else to do right now.
-                </Text>
               </Card>
             ) : inStatus === "PENDING_BG_CLEARANCE" ? (
               <Card withBorder radius="md" padding="lg">

--- a/checkin-app/src/lib/membership/__tests__/external.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/external.test.ts
@@ -190,7 +190,7 @@ describe('advanceExternalIfComplete', () => {
 
     beforeEach(() => {
         prisma.$transaction.mockImplementation(async (fn: (tx: typeof prisma) => Promise<unknown>) => fn(prisma));
-        prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 7, household: { intakeNotes: null } });
+        prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 7 });
     });
 
     it('winner: applies the volunteer allowlist at the PENDING_PAYMENT transition (#874) and pings reviewers', async () => {
@@ -219,43 +219,6 @@ describe('advanceExternalIfComplete', () => {
         await advanceExternalIfComplete(20);
 
         expect(applyVolunteerStatus).toHaveBeenCalledWith(prisma, 42, 7, false);
-        expect(notifyReviewers).not.toHaveBeenCalled();
-    });
-
-    it('household intake note → holds at PENDING_BG_REVIEW instead of PENDING_PAYMENT (#907)', async () => {
-        prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 7, household: { intakeNotes: 'treat us as a volunteer household' } });
-        const held = { ...readyProcess, status: 'PENDING_BG_REVIEW' };
-        prisma.orgMembershipProcess.findUnique
-            .mockResolvedValueOnce(readyProcess)
-            .mockResolvedValueOnce(held);
-        prisma.orgMembershipProcess.updateMany.mockResolvedValue({ count: 1 });
-
-        const result = await advanceExternalIfComplete(20);
-
-        expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith(
-            expect.objectContaining({ data: expect.objectContaining({ status: 'PENDING_BG_REVIEW' }) }),
-        );
-        // Allowlist still applied (sticky/idempotent); reviewers pinged to read the note.
-        expect(applyVolunteerStatus).toHaveBeenCalledWith(prisma, 42, 7, false);
-        expect(notifyReviewers).toHaveBeenCalledTimes(1);
-        expect(result).toEqual(held);
-    });
-
-    it('note + already-cleared check (legacy in-flight row) keeps the direct PENDING_PAYMENT path', async () => {
-        // PENDING_BG_REVIEW would be invisible to the review queue once bgClearedAt is
-        // set, so such rows must not be held — they advance as before.
-        prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 7, household: { intakeNotes: 'a note' } });
-        const cleared = { ...readyProcess, bgConsentAt: null, bgClearedAt: new Date() };
-        prisma.orgMembershipProcess.findUnique
-            .mockResolvedValueOnce(cleared)
-            .mockResolvedValueOnce({ ...cleared, status: 'PENDING_PAYMENT' });
-        prisma.orgMembershipProcess.updateMany.mockResolvedValue({ count: 1 });
-
-        await advanceExternalIfComplete(20);
-
-        expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith(
-            expect.objectContaining({ data: expect.objectContaining({ status: 'PENDING_PAYMENT' }) }),
-        );
         expect(notifyReviewers).not.toHaveBeenCalled();
     });
 

--- a/checkin-app/src/lib/membership/__tests__/intake.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/intake.test.ts
@@ -503,7 +503,7 @@ describe('submitIntake', () => {
         expect(result).toEqual({ id: 11, status: 'PENDING_EXTERNAL_ACTION' });
     });
 
-    it('complete + fresh check + intake note → shortcut disqualified: no bgClearedAt, review holds payment (#907)', async () => {
+    it('complete + fresh check + intake note → the note does not disqualify the shortcut', async () => {
         prisma.person.findUnique.mockResolvedValue({
             ...inFlightUser,
             household: { ...inFlightUser.household, intakeNotes: 'please treat us as a volunteer household' },
@@ -514,8 +514,7 @@ describe('submitIntake', () => {
 
         expect(prisma.orgMembershipProcess.update).toHaveBeenCalledWith({
             where: { id: 11 },
-            data: expect.not.objectContaining({ bgClearedAt: expect.anything() }),
+            data: expect.objectContaining({ bgClearedAt: expect.any(Date) }),
         });
-        expect(applyVolunteerStatus).not.toHaveBeenCalled();
     });
 });

--- a/checkin-app/src/lib/membership/__tests__/lifecycle.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/lifecycle.test.ts
@@ -178,7 +178,6 @@ describe('isLegalTransition covers §5', () => {
         expect(isLegalTransition('INTAKE', 'PENDING_EXTERNAL_ACTION')).toBe(true);
         expect(isLegalTransition('PENDING_RENEWAL', 'PENDING_EXTERNAL_ACTION')).toBe(true);
         expect(isLegalTransition('PENDING_EXTERNAL_ACTION', 'PENDING_PAYMENT')).toBe(true);
-        expect(isLegalTransition('PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW')).toBe(true);
         expect(isLegalTransition('PENDING_PAYMENT', 'ACTIVE')).toBe(true);
         expect(isLegalTransition('PENDING_PAYMENT', 'PENDING_BG_CLEARANCE')).toBe(true);
         expect(isLegalTransition('PENDING_BG_REVIEW', 'PENDING_PAYMENT')).toBe(true);
@@ -211,6 +210,8 @@ describe('isLegalTransition covers §5', () => {
     });
 
     test('rejects undeclared edges', () => {
+        // The external advance always opens payment — an intake note no longer holds it.
+        expect(isLegalTransition('PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW')).toBe(false);
         expect(isLegalTransition('INTAKE', 'ACTIVE')).toBe(false);
         expect(isLegalTransition('ACTIVE', 'PENDING_PAYMENT')).toBe(false);
         expect(isLegalTransition('ARCHIVED', 'ACTIVE')).toBe(false);

--- a/checkin-app/src/lib/membership/__tests__/renewal.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/renewal.test.ts
@@ -167,7 +167,7 @@ describe('beginRenewal', () => {
 
         beforeEach(() => {
             prisma.orgMembershipProcess.findUnique.mockResolvedValue(pending);
-            prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 7, household: { intakeNotes: null } });
+            prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 7 });
             prisma.boardSettings.findUnique.mockResolvedValue({ orgMembershipYearBoundary: new Date(Date.UTC(2026, 8, 1)), bgRecheckMonths: 12 });
             prisma.orgMembershipProcess.updateMany.mockResolvedValue({ count: 1 });
             prisma.orgMembershipProcess.findUniqueOrThrow.mockResolvedValue({ ...pending, status: 'PENDING_PAYMENT' });
@@ -206,29 +206,6 @@ describe('beginRenewal', () => {
             // Nothing to review until the member consents on Averity — the
             // advance (advanceExternalIfComplete) pings, same as INITIAL.
             expect(notifyReviewers).not.toHaveBeenCalled();
-        });
-
-        it('valid background check + household intake note → no bgClearedAt shortcut: the note must reach a reviewer (#907)', async () => {
-            prisma.person.findFirst.mockResolvedValue({ id: 1 }); // a lead with a valid background check
-            prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 7, household: { intakeNotes: 'treat us as a volunteer household' } });
-            prisma.orgMembershipProcess.findUniqueOrThrow.mockResolvedValue({ ...pending, status: 'PENDING_EXTERNAL_ACTION' });
-
-            await beginRenewal(5);
-
-            expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith({
-                where: { id: 5, status: 'PENDING_RENEWAL' },
-                // No bgClearedAt despite the valid background check (mirrors submitIntake): the
-                // member consents anyway, and the advance holds at PENDING_BG_REVIEW
-                // so the note reaches a reviewer before payment. Clearing here would
-                // skip the hold — the review queue only lists uncleared rows.
-                data: expect.not.objectContaining({ bgClearedAt: expect.anything() }),
-            });
-            expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith({
-                where: { id: 5, status: 'PENDING_RENEWAL' },
-                data: expect.objectContaining({ status: 'PENDING_EXTERNAL_ACTION' }),
-            });
-            expect(applyVolunteerStatus).not.toHaveBeenCalled(); // the advance / clearBackgroundCheck applies it
-            expect(notifyReviewers).not.toHaveBeenCalled(); // pinged at consent, not before
         });
 
         it('double-submit loser (count 0) → no audit, no allowlist match, no ping', async () => {

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -79,10 +79,8 @@ export async function getExternalStatus(process: {
  * still-valid background check arrives here pre-cleared so only the signature
  * is pending. The background check no longer gates payment: when it still needs
  * a human review (no still-valid prior background check), it runs in PARALLEL
- * while the applicant pays, and only the final ACTIVE flip waits on it.
- * EXCEPTION: a household intake note holds the application at PENDING_BG_REVIEW
- * instead — payment opens only after the reviewers (who are shown the note) clear
- * the check, so a note like "treat us as a volunteer household" settles dues first.
+ * while the applicant pays, and only the final ACTIVE flip waits on it. A
+ * household intake note is shown to the reviewers but does not gate payment.
  *
  * The conditional updateMany (status guard) is the atomic gate: two concurrent
  * callers (Zoho webhook + board "mark bg consent") both reach here, but only the
@@ -102,18 +100,8 @@ export async function advanceExternalIfComplete(processId: number) {
         // only null for PERSON_BG, which never sits at PENDING_EXTERNAL_ACTION).
         const membership = await tx.orgMembership.findUnique({
             where: { id: process.orgMembershipId! },
-            select: { householdId: true, household: { select: { intakeNotes: true } } },
+            select: { householdId: true },
         });
-        // An applicant note ("anything else we should know?", #900) can change what
-        // the reviewer decides — e.g. "treat us as a volunteer household" from a
-        // family not on the allowlist — so payment must not run in parallel with a
-        // review that hasn't read it. Hold at PENDING_BG_REVIEW; clearBackgroundCheck
-        // moves it to PENDING_PAYMENT once two reviewers have seen the note. A
-        // still-valid prior check (bgClearedAt) keeps the direct path: submitIntake
-        // no longer takes the fresh shortcut when a note exists, so that combination
-        // is only pre-existing in-flight rows, which the review queue can't see.
-        const holdForNote = !process.bgClearedAt && !!membership?.household.intakeNotes?.trim();
-        const nextStatus = holdForNote ? "PENDING_BG_REVIEW" : "PENDING_PAYMENT";
         const { count } = await tx.orgMembershipProcess.updateMany({
             where: {
                 id: processId,
@@ -122,7 +110,7 @@ export async function advanceExternalIfComplete(processId: number) {
                 contractSignedAt: { not: null },
                 OR: [{ bgClearedAt: { not: null } }, { bgConsentAt: { not: null } }],
             },
-            data: { status: nextStatus, stageEnteredAt: new Date() },
+            data: { status: "PENDING_PAYMENT", stageEnteredAt: new Date() },
         });
         if (count !== 1) return null; // lost the race or no longer eligible — no audit, no notify
         // Dues are read at PENDING_PAYMENT (ensurePaymentLink), normally BEFORE the
@@ -137,7 +125,7 @@ export async function advanceExternalIfComplete(processId: number) {
                 tableName: "OrgMembershipProcess",
                 affectedEntityId: processId,
                 oldData: { status: "PENDING_EXTERNAL_ACTION" },
-                newData: { status: nextStatus },
+                newData: { status: "PENDING_PAYMENT" },
             },
         });
         return tx.orgMembershipProcess.findUnique({ where: { id: processId } });

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -396,13 +396,10 @@ export async function submitIntake(userId: number) {
 
     // If a household guardian already holds a still-valid background check (same
     // rule as renewals), auto-clear the BG requirement now — the applicant won't
-    // need to consent to or wait on a new check, just sign + pay. An intake note
-    // (#900) disqualifies the shortcut: it must reach a human reviewer before
-    // payment (#907), and the review track is the only surface that shows it —
-    // the application instead holds at PENDING_BG_REVIEW (advanceExternalIfComplete).
+    // need to consent to or wait on a new check, just sign + pay.
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
     const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, new Date()) : null;
-    const bgFresh = !household.intakeNotes?.trim() && (await householdBgIsFresh(household.id, boundary, settings?.bgRecheckMonths ?? 0));
+    const bgFresh = await householdBgIsFresh(household.id, boundary, settings?.bgRecheckMonths ?? 0);
 
     const advanced = await prisma.orgMembershipProcess.update({
         where: { id: process.id },

--- a/checkin-app/src/lib/membership/lifecycle.ts
+++ b/checkin-app/src/lib/membership/lifecycle.ts
@@ -317,7 +317,6 @@ export const TRANSITIONS: readonly Transition<TState, string, ProcessKind>[] = [
     { from: "PENDING_RENEWAL", to: "PENDING_EXTERNAL_ACTION", event: "beginRenewal", actor: "member", guardSite: "renewal.ts:219 updateMany where status=PENDING_RENEWAL", kind: "RENEWAL" },
     // Advance (§5 #7)
     { from: "PENDING_EXTERNAL_ACTION", to: "PENDING_PAYMENT", event: "advanceExternalIfComplete", actor: "system", guardSite: "external.ts:113 updateMany" },
-    { from: "PENDING_EXTERNAL_ACTION", to: "PENDING_BG_REVIEW", event: "advanceExternalIfComplete", actor: "system", guardSite: "external.ts:113 updateMany (household note held, #907)" },
     // Signature completes a person-scoped agreement outright — no payment, no BG gate
     { from: "PENDING_EXTERNAL_ACTION", to: "ACTIVE", event: "markContractSigned", actor: "subject", guardSite: "external.ts updateMany where contractSignedAt=null", kind: "PERSON_AGREEMENT" },
     // Payment convergence (§5 #8, #12)
@@ -325,7 +324,7 @@ export const TRANSITIONS: readonly Transition<TState, string, ProcessKind>[] = [
     { from: "PENDING_PAYMENT", to: "PENDING_BG_CLEARANCE", event: "activate", actor: "shopify/board", guardSite: "payment.ts:204 FOR UPDATE (not cleared)" },
     { from: "PENDING_PAYMENT", to: "ACTIVE", event: "grantRenewalPayment", actor: "board/sysadmin", guardSite: "renewal.ts:339 → certifyPaymentPlan (COI) → activate", kind: "RENEWAL" },
     // Clearance convergence (§5 #10, #14)
-    { from: "PENDING_BG_REVIEW", to: "PENDING_PAYMENT", event: "clearBackgroundCheck", actor: "reviewer", guardSite: "review.ts:256 FOR UPDATE (2nd APPROVE, unpaid)" },
+    { from: "PENDING_BG_REVIEW", to: "PENDING_PAYMENT", event: "clearBackgroundCheck", actor: "reviewer", guardSite: "review.ts:256 FOR UPDATE (2nd APPROVE, unpaid legacy household row)", legacy: true },
     { from: "PENDING_BG_REVIEW", to: "ACTIVE", event: "clearBackgroundCheck", actor: "reviewer", guardSite: "review.ts:256/304 FOR UPDATE (2nd APPROVE, paid / PERSON_BG subject)" },
     { from: "PENDING_BG_CLEARANCE", to: "ACTIVE", event: "clearBackgroundCheck", actor: "reviewer", guardSite: "review.ts:326 FOR UPDATE (2nd APPROVE)" },
     // Reject → BLOCKED (§5 #9)
@@ -333,9 +332,9 @@ export const TRANSITIONS: readonly Transition<TState, string, ProcessKind>[] = [
     { from: "PENDING_PAYMENT", to: "BLOCKED", event: "attest REJECT", actor: "reviewer", guardSite: "review.ts:247 FOR UPDATE (parallel review)" },
     { from: "PENDING_BG_CLEARANCE", to: "BLOCKED", event: "attest REJECT", actor: "reviewer", guardSite: "review.ts:247 FOR UPDATE" },
     // overrideBlocked reset/approve (§5 #11)
-    { from: "BLOCKED", to: "PENDING_PAYMENT", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (unpaid, no note)" },
+    { from: "BLOCKED", to: "PENDING_PAYMENT", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (unpaid)" },
     { from: "BLOCKED", to: "PENDING_BG_CLEARANCE", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (paid)" },
-    { from: "BLOCKED", to: "PENDING_BG_REVIEW", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (note / PERSON_BG)" },
+    { from: "BLOCKED", to: "PENDING_BG_REVIEW", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (PERSON_BG)", kind: "PERSON_BG" },
     { from: "BLOCKED", to: "PENDING_EXTERNAL_ACTION", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (RENEWAL, no consent)", kind: "RENEWAL", legacy: true },
     { from: "BLOCKED", to: "ACTIVE", event: "overrideBlocked approve", actor: "board/sysadmin", guardSite: "review.ts:411 FOR UPDATE (paid)" },
     // Archive (§5 #13) — every pre-terminal status

--- a/checkin-app/src/lib/membership/phases.ts
+++ b/checkin-app/src/lib/membership/phases.ts
@@ -35,8 +35,7 @@ export function stepperActiveIndex(status: OrgMembershipProcessStatus | null): n
     switch (status) {
         case "INTAKE": return 0;
         case "PENDING_EXTERNAL_ACTION": return 1;
-        // Held for review (household intake note): external actions are done and
-        // Payment is the pending step — it just won't open until the review clears.
+        // Legacy held-for-review rows: external actions are done, Payment pending.
         case "PENDING_BG_REVIEW": return 2;
         case "PENDING_PAYMENT": return 2;
         case "PENDING_BG_CLEARANCE": return 3;

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -171,9 +171,9 @@ export async function runRenewalSweep(now: Date) {
 /**
  * Member begins renewal: PENDING_RENEWAL -> PENDING_EXTERNAL_ACTION, always — a
  * fresh membership agreement is signed every cycle. A still-valid background
- * check (no household note) is pre-cleared so only the signature is left;
- * otherwise the member also requests a new background check, same flow as
- * INITIAL. Idempotent-ish: only acts from PENDING_RENEWAL.
+ * check is pre-cleared so only the signature is left; otherwise the member also
+ * requests a new background check, same flow as INITIAL. Idempotent-ish: only
+ * acts from PENDING_RENEWAL.
  */
 export async function beginRenewal(processId: number) {
     const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
@@ -183,24 +183,19 @@ export async function beginRenewal(processId: number) {
     // A RENEWAL always has a membership (orgMembershipId is only null for PERSON_BG).
     const membership = await prisma.orgMembership.findUnique({
         where: { id: process.orgMembershipId! },
-        select: { householdId: true, household: { select: { intakeNotes: true } } },
+        select: { householdId: true },
     });
     if (!membership) throw new RenewalError("not_found", "Membership not found.");
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
     const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, new Date()) : null;
-    const bgFresh = await householdBgIsFresh(membership.householdId, boundary, settings?.bgRecheckMonths ?? 0);
-    const hasNote = !!membership.household.intakeNotes?.trim();
 
-    // A still-valid background check with no household note ⇒ stamp bgClearedAt
-    // now: the external card shows "no new background check needed" and the
-    // signature alone opens payment. A note (#900) disqualifies the shortcut
-    // exactly like submitIntake —
-    // the member consents anyway and advanceExternalIfComplete holds the process
-    // at PENDING_BG_REVIEW so the note reaches a reviewer before payment (#907).
-    // Reviewers are NOT pinged here — nothing is reviewable until consent is
-    // recorded; the advance pings them, same as INITIAL. Volunteer allowlist
-    // matching (#874) also happens at the advance's PENDING_PAYMENT transition.
-    const clearNow = bgFresh && !hasNote;
+    // A still-valid background check ⇒ stamp bgClearedAt now: the external card
+    // shows "no new background check needed" and the signature alone opens
+    // payment. Reviewers are NOT pinged here — nothing is reviewable until
+    // consent is recorded; the advance pings them, same as INITIAL. Volunteer
+    // allowlist matching (#874) also happens at the advance's PENDING_PAYMENT
+    // transition.
+    const clearNow = await householdBgIsFresh(membership.householdId, boundary, settings?.bgRecheckMonths ?? 0);
     // Conditional on status PENDING_RENEWAL: a double-submit has both callers reach
     // here, but only the winner's updateMany flips it (count === 1) — so the audit
     // row is written exactly once. Mirrors external.ts markContractSigned.

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -19,10 +19,7 @@ import { LIVE_PERSON } from "@/lib/person/filters";
  * Background-check review — now a PARALLEL track, not a blocking phase.
  *
  * After intake the application advances to PENDING_PAYMENT regardless of the
- * check; the review happens while the applicant pays. Exception: a household
- * intake note (#900) holds the application at PENDING_BG_REVIEW until the review
- * completes, so a note like "treat us as a volunteer household" can settle dues
- * before payment opens (#907). Two DISTINCT eligible
+ * check; the review happens while the applicant pays. Two DISTINCT eligible
  * reviewers (role isBackgroundCheckReviewer) must each attest independently. A
  * reviewer may not share a household with the applicant or the other reviewer,
  * and may not attest twice.
@@ -471,10 +468,7 @@ export async function applyVolunteerStatus(db: DbClient, orgMembershipId: number
  * bgClearedAt with no adult behind it.
  */
 export async function overrideBlocked(processId: number, actorId: number, action: "reset" | "approve", subjectPersonIds?: number[]) {
-    const process = await prisma.orgMembershipProcess.findUnique({
-        where: { id: processId },
-        include: { orgMembership: { select: { household: { select: { intakeNotes: true } } } } },
-    });
+    const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new ReviewError("not_found", "Application not found.");
     if (action === "approve" && process.status !== "BLOCKED") throw new ReviewError("wrong_phase", "This application is not blocked.");
 
@@ -548,16 +542,14 @@ type BlockedResetRow = {
     kind: string;
     bgConsentAt: Date | null;
     paidAt: Date | null;
-    orgMembership: { household: { intakeNotes: string | null } } | null;
 };
 
 /**
  * The review status a BLOCKED application resumes at when the board resets it.
  * The check runs in parallel, so a household process returns to
- * PENDING_BG_CLEARANCE if it had already paid, else PENDING_PAYMENT. An unpaid one
- * with a household intake note re-holds at PENDING_BG_REVIEW — the reset restarts
- * review, and a note keeps payment gated on it (#907). Renewals follow the same
- * household path, except one blocked BEFORE consent was recorded (only legacy
+ * PENDING_BG_CLEARANCE if it had already paid, else PENDING_PAYMENT. Renewals
+ * follow the same household path, except one blocked BEFORE consent was
+ * recorded (only legacy
  * RENEWAL_PENDING_BG rows — every current renewal path records consent before
  * review can block) restarts at the external step itself: the parallel queue only
  * lists PENDING_PAYMENT/PENDING_BG_CLEARANCE rows WITH consent, so parking an
@@ -567,15 +559,13 @@ function blockedResetStatus(process: BlockedResetRow): OrgMembershipProcessStatu
     return process.kind === "PERSON_BG" ? "PENDING_BG_REVIEW"
         : process.kind === "RENEWAL" && !process.bgConsentAt ? "PENDING_EXTERNAL_ACTION"
         : process.paidAt ? "PENDING_BG_CLEARANCE"
-        : process.orgMembership?.household.intakeNotes?.trim() ? "PENDING_BG_REVIEW"
         : "PENDING_PAYMENT";
 }
 
 /**
  * The check cleared but dues aren't paid — the process just (re)entered
- * PENDING_PAYMENT. For an application that was held for review (intake note,
- * renewal re-check) this is the moment payment first opens, and the status
- * cards/banner promise an email at clearance. Best-effort (send failures log).
+ * PENDING_PAYMENT. The status cards/banner promise an email at clearance.
+ * Best-effort (send failures log).
  */
 async function notifyPaymentOpen(householdId: number) {
     const base = config.baseUrl();

--- a/docs/DOCUMENTATION_STANDARD.md
+++ b/docs/DOCUMENTATION_STANDARD.md
@@ -256,10 +256,9 @@ so a reviewer can judge a diff against it without opening code:
 
 ## Procedure
 
-- An intake note holds the application at background-check review, so reviewers
-  read it before dues are settled — a family writing "treat us as a volunteer
-  household" must not pay first. A household that already holds a still-valid
-  background clearance is exempt and goes straight to payment.
+- An application needs a fresh background check before it can activate. A
+  household whose lead already holds a still-valid clearance is exempt: the
+  requirement is cleared at submission and only the signature is left.
 ```
 
 Note what the second rule spends a whole clause on: the **exemption**. An earlier
@@ -272,8 +271,8 @@ policy-backed is settled during the migration, against the real policy corpus.)
 
 **Write rules as constraints, not descriptions.** If the sentence does not let a
 reviewer tell whether a change violates it, rewrite the sentence.
-"Payment does not open until reviewers have read the note" is checkable.
-"The intake system supports notes" is not.
+"Membership does not activate until two reviewers have cleared the check" is
+checkable. "The intake system supports notes" is not.
 
 **No PR numbers, issue numbers, or dates.** These files say what is true, not
 how it came to be. Change history lives in git and in the PR record, where it is

--- a/docs/backlog/CUJS.md
+++ b/docs/backlog/CUJS.md
@@ -21,11 +21,11 @@ Status: **ALL 7 chips folded (V1–V7).** Every step tagged vs live code at base
 0a. ❌ Pre-membership: prospect logs in, subscribes to newsletter, gets program notifications; open house on public calendar (`CM14`)
 0b. ❌ Preview the membership agreement as view-only PDF without triggering Zoho Sign (`M20`)
 1. ✅ Intake application incl "anything else" note (captured + surfaced to reviewers)
-2. ✅ Board pre-designation of volunteer household — but drives **dues only**, NOT skip-review→payment (that's a separate `bgFresh` path; a designated vol WITH an intake note is still held at review)
+2. ✅ Board pre-designation of volunteer household — but drives **dues only**, NOT skip-review→payment (that's a separate `bgFresh` path)
 3. ✅ Contract sent + signed (Zoho, embedded)
 4. ✅ BG sent + consent (self-attest honor + board backstop; no Averity API)
 5. ✅ BG review (2-of-N, anti-collusion gates, board override w/ COI gate)
-6. ✅ Reviewer volunteer bit / intake-note gates review
+6. ✅ Reviewer volunteer bit; intake note shown to reviewers (does NOT gate payment — review runs in parallel)
 7. ✅ Payment via Shopify (member vs volunteer price + discount code)
 8. ✅ Webhook validates payment→activation (HMAC + variant-id check; H2 no-item → stays PENDING + board alert). NOTE: volunteer discount-code entitlement still NOT validated (`CO2`/#278)
 9. 🟡 Post-activation fan-out: welcome/congrats ✅ · **mailing-list `CM1` ❌ + badge-print `AT11` ❌ NOT wired to activation**

--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -325,7 +325,7 @@ clearance now stamps only the adult the reviewers named, and the board gets a wo
 stamps the old blanket write left behind. Rules live in `docs/rules/membership.md` § background
 checks.
 
-**Verified built during triage (2026-07-21), removed from buckets:** M10 volunteer-household pre-designation (`/membership-ops/volunteer-memberships`) · M11 intake-notes → surfaced to reviewer + gates BG review (`membership-ops/review`, `Household.intakeNotes`) · SA5 BG posture (29mo, enforced at renewal) · SA8 dual-relationship = Trusted Adults · RB10 dual-email = 2-account model (#286 closed) · FD5 banker = board (no role).
+**Verified built during triage (2026-07-21), removed from buckets:** M10 volunteer-household pre-designation (`/membership-ops/volunteer-memberships`) · M11 intake-notes → surfaced to reviewer (`membership-ops/review`, `Household.intakeNotes`) · SA5 BG posture (29mo, enforced at renewal) · SA8 dual-relationship = Trusted Adults · RB10 dual-email = 2-account model (#286 closed) · FD5 banker = board (no role).
 
 **Merged to main (verified via rebase 2026-07-25), removed from buckets:** **AT10** unknown-DOB fails-open in two-deep → FIXED, now fails closed (#1353/#300) · **AT13** visit-edit UI/API mismatch → FIXED, board reaches the visit-edit UI (#1350/#1259) · **M18** person-merge orphaned/non-controlled email → FIXED via 3 merge-fixes: emailSuppressed carry (#1332), login-identity unit (#1329), tombstone `.invalid` domain (#1331); #1225 closed · **SA6** delete-DoB for adults → BUILT (#1326 "delete DoB for all adults (26+)"; #1356 declared-adults-still-supervise follow-up); #1165 closed · **P17** staff-household enrollment ban server-side → BUILT (#1009 "disable Add Participant & Grant Membership for staff households").
 

--- a/docs/in-design/DOCUMENTATION_MIGRATION.md
+++ b/docs/in-design/DOCUMENTATION_MIGRATION.md
@@ -14,10 +14,11 @@ lands.
 
 Two examples surfaced during a single design review:
 
-- **The intake-note hold.** An applicant note holds the membership application
-  at background-check review so reviewers read it before dues are settled —
-  unless the household already holds a still-valid background clearance, which
-  takes the direct path to payment. Stated only in a code comment in
+- **The intake-note hold** (since removed — the note no longer gates payment).
+  An applicant note held the membership application at background-check review
+  so reviewers read it before dues were settled — unless the household already
+  held a still-valid background clearance, which took the direct path to
+  payment. Stated only in a code comment in
   `checkin-app/src/lib/membership/external.ts`, a parenthetical inside the
   lifecycle transition table, and one aside in `docs/backlog/CUJS.md`.
 

--- a/docs/in-design/MERGE_BG_CARRYOVER.md
+++ b/docs/in-design/MERGE_BG_CARRYOVER.md
@@ -4,6 +4,14 @@ Issue: [#1396](https://github.com/innovationtreehouse/checkin/issues/1396)
 · Scope, related work, and why this is a design rather than a patch in the
 [appendix](#appendix--why-this-is-a-design-and-what-scoping-found).
 
+> **STALE — the intake-note hold has been removed.** A household intake note no
+> longer holds an application anywhere: `advanceExternalIfComplete` always opens
+> payment, and the `bgFresh` shortcut in `submitIntake`/`beginRenewal` is no
+> longer disqualified by a note. Every part of this design that reasons about
+> the note clause — the predicate discussion, the `holdForNote` bypass risk, and
+> board decision 0 — is moot. The `householdBgIsFresh` half stands. Re-derive
+> the state matrix before implementing.
+
 **Still a proposal.** Nothing here is authority; no `docs/designs/` document governs
 this work.
 
@@ -14,8 +22,8 @@ Everything below was re-verified against `main` at `a00331fa`. What changed:
 | Claim as written | Status now |
 |---|---|
 | Diagnosis — merge moves `lastBackgroundCheck`, nothing re-derives `bgClearedAt` | **holds.** `resolveKeeperUpdate` takes the newer date ([route.ts:97-103](../../checkin-app/src/app/api/membership-ops/participants/merge/route.ts:97)); the route mentions `bgClearedAt` / `householdBgIsFresh` / `clearBackgroundCheck` / `applyVolunteerStatus` nowhere. |
-| Only three edges enter `PENDING_BG_REVIEW` | **holds**, re-derived from `TRANSITIONS` and from every writer of the literal: [external.ts:113](../../checkin-app/src/lib/membership/external.ts:113), [personBgTriggers.ts:52](../../checkin-app/src/lib/membership/personBgTriggers.ts:52), [review.ts:445/448](../../checkin-app/src/lib/membership/review.ts:445). |
-| …therefore a household application cannot sit at `PENDING_BG_REVIEW` without a live note | **overstated — see [the note-deleted population](#the-note-deleted-population).** Both household edges require the note *at transition time*; neither keeps it there. |
+| Only three edges enter `PENDING_BG_REVIEW` | **now two**, both `PERSON_BG`: [personBgTriggers.ts:52](../../checkin-app/src/lib/membership/personBgTriggers.ts:52) and the blocked-reset at [review.ts:445](../../checkin-app/src/lib/membership/review.ts:445). Removing the intake-note hold deleted the two household edges (`external.ts`'s advance and `review.ts`'s note branch). |
+| …therefore a household application cannot sit at `PENDING_BG_REVIEW` without a live note | **dead.** No edge puts a household application there at all now; the only rows at that status are `PERSON_BG` and pre-existing legacy household rows. |
 | Item 3 — duplicate `PERSON_BG` after a merge | **dead.** Fixed on `main` by [#1449](https://github.com/innovationtreehouse/checkin/pull/1449) (`archiveDuplicatePersonBg`, [route.ts:127](../../checkin-app/src/app/api/membership-ops/participants/merge/route.ts:127)). |
 | Item 4 — lead guard counts tombstones | **dead.** Fixed on `main` by [#1448](https://github.com/innovationtreehouse/checkin/pull/1448) — the guard's `householdMembers` include carries `LIVE_PERSON` ([route.ts:203](../../checkin-app/src/app/api/membership-ops/participants/merge/route.ts:203)). |
 | Item 1b — `LIVE_PERSON` missing from the "needs a lead" surfaces | **still live**, `BROKEN_HOUSEHOLD_WHERE` unchanged ([household/filters.ts:12](../../checkin-app/src/lib/household/filters.ts:12)). [#1450](https://github.com/innovationtreehouse/checkin/pull/1450) open. |

--- a/docs/rules/membership.md
+++ b/docs/rules/membership.md
@@ -181,13 +181,9 @@ Procedure below is built on them.
 
 ### Application and review
 
-- An intake note holds the application at review so reviewers read it before
-  dues are settled. A household already holding a still-valid clearance goes
-  straight to payment regardless.
+- An intake note does not hold the application. It is shown to the reviewers,
+  who read it while the family pays.
   (`checkin-app/src/lib/membership/external.ts`)  [Decision]
-
-- Applicants are told about the hold where they write the note, not after
-  submitting.  [Decision]
 
 - An application in background-check review is the reviewers' work, not the
   board's. Board queues count blocked applications only.  [Decision]


### PR DESCRIPTION
## What changed

An applicant note ("anything else we should know?") used to park the membership application at `PENDING_BG_REVIEW` until two reviewers cleared the background check. A family that wrote anything in that box could not pay until a human had read it. That gate is removed: the note is still surfaced to the reviewers, but the review now runs in parallel with payment like every other application.

**Service layer**
- `advanceExternalIfComplete` always advances to `PENDING_PAYMENT` — the `holdForNote` branch and the `intakeNotes` read are gone.
- `submitIntake` / `beginRenewal` — a note no longer disqualifies the `bgClearedAt` shortcut for a household that already holds a still-valid check.
- `blockedResetStatus` — an unpaid board reset returns to `PENDING_PAYMENT` regardless of a note.

**Lifecycle**
- Removed the `PENDING_EXTERNAL_ACTION → PENDING_BG_REVIEW` edge; `BLOCKED → PENDING_BG_REVIEW` is now tagged `kind: PERSON_BG`, and `PENDING_BG_REVIEW → PENDING_PAYMENT` is marked `legacy`. `docs/generated/lifecycle/membership.md` regenerated via `npm run generate:lifecycle-artifacts`.

**UI**
- Dropped the red *"Your application will pause for human review before you can pay"* line under the intake note field.
- Dropped the "Hang tight — your application is being reviewed" status card.
- The reviewer-facing note alert on `/membership-ops/review` stays — that is the point of the field.

## Reviewer notes

- `PENDING_BG_REVIEW` stays in the enum: `PERSON_BG` still enters there, and any **legacy household row** currently parked at that status still clears to `PENDING_PAYMENT` through the untouched `clearBackgroundCheck` path. Those rows now render the generic "Application in progress" card instead of the removed held-for-review card. No data migration is included — say so if you want one.
- The volunteer-designation allowlist (#874) is unaffected: it is applied at the `PENDING_PAYMENT` transition, which every application now reaches directly. A household that wanted volunteer dues *and* is not on the allowlist will now pay full dues before a reviewer can mark them — that is the behavioural consequence of removing the gate.

## Docs

- `docs/rules/membership.md` — the hold rule rewritten; the "applicants are told about the hold" rule deleted.
- `docs/DOCUMENTATION_STANDARD.md` — the hold was the worked example in two places (the §3.8 format sample and the checkable-sentence example); both swapped for the background-check freshness carve-out, preserving the lesson about stating exemptions.
- `docs/backlog/CUJS.md` (A1 steps 2 and 6) and `docs/backlog/INDEX.md` (M11 triage entry) corrected.
- `docs/in-design/MERGE_BG_CARRYOVER.md` — STALE banner added. Its predicate discussion, `holdForNote` bypass risk, and board decision 0 are moot; the `householdBgIsFresh` half stands. Re-deriving that design is separate work.
- `docs/in-design/DOCUMENTATION_MIGRATION.md` — its evidence example marked as since-removed.

## Testing

- `npx tsc --noEmit` clean.
- Unit suite (`test:ci`) — 2499 tests, 264 suites, all pass.
- Integration, serial, scoped to `src/app/__tests__/(membership|personBg|navTodo)` — 195 tests, 19 suites, all pass against a throwaway Postgres.
- Flow tests **not run** — Docker was unavailable in this session, so the standalone flow harness could not start. `flow-tests/membership-intake-notes.flow.test.ts` asserts the note reaches the reviewer queue; that queue includes `PENDING_PAYMENT` rows with consent recorded, which is covered by the passing `membershipReviewAPI` integration suite, but CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
