### PR TITLE
fix(people): refuse the over-25 declaration when a DOB is on file

### DIFF
--- a/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
@@ -293,34 +293,59 @@ describe('Admin Participants API Integration Tests', () => {
             // Cleanup is handled by afterEach
         });
 
-        it('rejects the over-25 declaration when the person has a date of birth on file', async () => {
+        it('sets the over-25 declaration on a person with no date of birth', async () => {
             (getServerSession as jest.Mock).mockResolvedValue({
                 user: { id: testAdminId, isSysadmin: true, isBoardMember: false }
             });
 
-            // A 12-year-old: a declared-adult flag on this row would make them match
-            // the adults filter in /api/people/search and count as a supervising
-            // adult in the check-in safety calc.
+            const adult = await prisma.person.create({
+                data: { email: 'edit-test-user-nodob@example.com', name: 'Adult No DOB', household: { create: { name: "Test HH" } } },
+            });
+
+            const req = new Request(`http://localhost:4000/api/membership-ops/participants/${adult.id}`, {
+                method: 'PUT',
+                body: JSON.stringify({ isDeclaredAdult: true })
+            });
+
+            const res = await PUT(req as unknown as Parameters<typeof PUT>[0], { params: Promise.resolve({ id: adult.id.toString() }) });
+            expect(res.status).toBe(200);
+
+            const dbCheck = await prisma.person.findUnique({ where: { id: adult.id } });
+            expect(dbCheck?.isDeclaredAdult).toBe(true);
+        });
+
+        it('drops the over-25 declaration when the person has a date of birth on file', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true, isBoardMember: false }
+            });
+
+            // A 12-year-old already carrying a stale flag, as a bulk import that writes
+            // a DOB without touching it leaves them. The edit form resubmits the whole
+            // record, so an unrelated name edit must still save AND heal the pair — a
+            // declared-adult flag here would make them match the adults filter in
+            // /api/people/search and count as a supervising adult in the safety calc.
             const youth = await prisma.person.create({
                 data: {
                     email: 'edit-test-user-dob@example.com',
                     name: 'Youth With DOB',
                     dateOfBirth: new Date(Date.UTC(2014, 0, 15)),
+                    isDeclaredAdult: true,
                     household: { create: { name: "Test HH" } },
                 },
             });
 
             const req = new Request(`http://localhost:4000/api/membership-ops/participants/${youth.id}`, {
                 method: 'PUT',
-                body: JSON.stringify({ isDeclaredAdult: true })
+                body: JSON.stringify({ name: 'Youth Renamed', isDeclaredAdult: true })
             });
 
             const res = await PUT(req as unknown as Parameters<typeof PUT>[0], { params: Promise.resolve({ id: youth.id.toString() }) });
-            expect(res.status).toBe(400);
+            expect(res.status).toBe(200);
 
             const dbCheck = await prisma.person.findUnique({ where: { id: youth.id } });
+            expect(dbCheck?.name).toBe('Youth Renamed');
             expect(dbCheck?.isDeclaredAdult).toBe(false);
-            // The DOB is the authoritative value — refusing the flag must not clear it.
+            // The DOB is the authoritative value — dropping the flag must not clear it.
             expect(dbCheck?.dateOfBirth).toEqual(new Date(Date.UTC(2014, 0, 15)));
         });
 

--- a/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
@@ -292,5 +292,63 @@ describe('Admin Participants API Integration Tests', () => {
 
             // Cleanup is handled by afterEach
         });
+
+        it('rejects the over-25 declaration when the person has a date of birth on file', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true, isBoardMember: false }
+            });
+
+            // A 12-year-old: a declared-adult flag on this row would make them match
+            // the adults filter in /api/people/search and count as a supervising
+            // adult in the check-in safety calc.
+            const youth = await prisma.person.create({
+                data: {
+                    email: 'edit-test-user-dob@example.com',
+                    name: 'Youth With DOB',
+                    dateOfBirth: new Date(Date.UTC(2014, 0, 15)),
+                    household: { create: { name: "Test HH" } },
+                },
+            });
+
+            const req = new Request(`http://localhost:4000/api/membership-ops/participants/${youth.id}`, {
+                method: 'PUT',
+                body: JSON.stringify({ isDeclaredAdult: true })
+            });
+
+            const res = await PUT(req as unknown as Parameters<typeof PUT>[0], { params: Promise.resolve({ id: youth.id.toString() }) });
+            expect(res.status).toBe(400);
+
+            const dbCheck = await prisma.person.findUnique({ where: { id: youth.id } });
+            expect(dbCheck?.isDeclaredAdult).toBe(false);
+            // The DOB is the authoritative value — refusing the flag must not clear it.
+            expect(dbCheck?.dateOfBirth).toEqual(new Date(Date.UTC(2014, 0, 15)));
+        });
+
+        it('allows clearing the over-25 declaration on a person with a date of birth', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true, isBoardMember: false }
+            });
+
+            const youth = await prisma.person.create({
+                data: {
+                    email: 'edit-test-user-dob@example.com',
+                    name: 'Youth With DOB',
+                    dateOfBirth: new Date(Date.UTC(2014, 0, 15)),
+                    isDeclaredAdult: true,
+                    household: { create: { name: "Test HH" } },
+                },
+            });
+
+            const req = new Request(`http://localhost:4000/api/membership-ops/participants/${youth.id}`, {
+                method: 'PUT',
+                body: JSON.stringify({ isDeclaredAdult: false })
+            });
+
+            const res = await PUT(req as unknown as Parameters<typeof PUT>[0], { params: Promise.resolve({ id: youth.id.toString() }) });
+            expect(res.status).toBe(200);
+
+            const dbCheck = await prisma.person.findUnique({ where: { id: youth.id } });
+            expect(dbCheck?.isDeclaredAdult).toBe(false);
+        });
     });
 });

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
@@ -56,11 +56,13 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
             select: { name: true, email: true, phone: true, dateOfBirth: true, isDeclaredAdult: true, lastBackgroundCheck: true },
         })) ?? {};
 
-        // A date of birth on file and the over-25 declaration are mutually exclusive
-        // (normalizeAdultDob). A real DOB is the more authoritative value, so refuse
-        // the flag rather than clear the date.
+        // A date of birth on file supersedes the over-25 declaration (normalizeAdultDob):
+        // a person has one or the other, never both. Coerced rather than refused so a row
+        // that holds both — bulk import writes a DOB without touching the flag — is
+        // repaired on its next edit instead of being unsaveable, since the edit form
+        // resubmits the whole record.
         if (updateData.isDeclaredAdult === true && priorDob) {
-            return apiError("This person has a date of birth on file, so the over-25 declaration does not apply.", 400);
+            updateData.isDeclaredAdult = false;
         }
 
         const updatedParticipant = await prisma.person.update({

--- a/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/[id]/route.ts
@@ -49,10 +49,19 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
             return apiError("No fields to update provided", 400);
         }
 
-        const prior = await prisma.person.findUnique({
+        // dateOfBirth is read for the guard below but deliberately kept out of the
+        // audit payload — this route neither ships nor writes it.
+        const { dateOfBirth: priorDob, ...prior } = (await prisma.person.findUnique({
             where: { id },
-            select: { name: true, email: true, phone: true, isDeclaredAdult: true, lastBackgroundCheck: true },
-        });
+            select: { name: true, email: true, phone: true, dateOfBirth: true, isDeclaredAdult: true, lastBackgroundCheck: true },
+        })) ?? {};
+
+        // A date of birth on file and the over-25 declaration are mutually exclusive
+        // (normalizeAdultDob). A real DOB is the more authoritative value, so refuse
+        // the flag rather than clear the date.
+        if (updateData.isDeclaredAdult === true && priorDob) {
+            return apiError("This person has a date of birth on file, so the over-25 declaration does not apply.", 400);
+        }
 
         const updatedParticipant = await prisma.person.update({
             where: { id },
@@ -68,7 +77,7 @@ export const PUT = withAuth<{ params: Promise<{ id: string }> }>(
                 action: "EDIT",
                 tableName: "Person",
                 affectedEntityId: id,
-                oldData: prior ?? undefined,
+                oldData: prior,
                 newData: updateData,
             },
         });


### PR DESCRIPTION
## What

`PUT /api/membership-ops/participants/[id]` set `Person.isDeclaredAdult` unconditionally:

```ts
if (body.isDeclaredAdult !== undefined) updateData.isDeclaredAdult = Boolean(body.isDeclaredAdult);
```

The route never reads or writes `dateOfBirth`, so an ops/board editor could flag a person holding a real sub-26 DOB. That breaks the app-wide invariant — recorded in `docs/rules/people-households.md` ("Identity and age") and enforced at write time by `normalizeAdultDob` (`src/lib/person/adultDob.ts`) — that a person has a date of birth **or** an over-25 declaration, never both.

This route was the only unguarded flag-writer. Every sibling already guards on `!dob`: `api/household/member`, `api/household`, `api/profile`, `lib/membership/intake.ts` (×3). The nightly cron and the `20260724120000_purge_adult_dob` migration only ever write the pair consistently.

## Fix

Select `dateOfBirth` on the `prior` fetch the route already makes, and drop the flag when one is present:

```ts
if (updateData.isDeclaredAdult === true && priorDob) {
    updateData.isDeclaredAdult = false;
}
```

**Coerce, not 400.** This matches the rule the guard cites: `normalizeAdultDob` treats a sub-26 DOB as superseding the flag and sets it `false`. Refusing the write would diverge from that, and — more importantly — would make an already-inconsistent person **unsaveable**: the edit modal resubmits the whole form (`membership-ops/participants/page.tsx:181`) with `isDeclaredAdult` seeded from the row, so editing that person's name, phone, or background-check date would submit the flag and take the 400 back. Coercing repairs the pair on the next edit instead.

Such rows are reachable today: `membership-ops/participants/import` writes `dateOfBirth` at lines 188, 223 and 230 without touching the flag and without `normalizeAdultDob` — the bulk-import case that helper's own docstring names as slipping past. Nothing reconciles them afterwards; the nightly cron only handles the 26+ direction.

Nothing is silently lost by the coercion: the edit modal hides the switch entirely when a DOB is on file, so no editor can deliberately submit the flag for such a person. The only submitters are the form echoing a stale row back, and direct API calls.

**The DOB is never cleared to make the flag stick.** A real DOB is the more authoritative value; destroying it to satisfy a checkbox would be the worse outcome.

`dateOfBirth` is destructured out before `oldData`, so the audit row's shape is unchanged — no new sensitive field lands in `AuditLog`.

## Why it matters

Readers that take the flag *before* the DOB, and so mis-classify a flagged youth as an adult:

| Reader | Effect |
|---|---|
| `src/lib/getFullAttendance.ts:80` | counts them as a **supervising adult** in the two-deep safety calc |
| `src/lib/membership/personBgCheck.ts:66` | treats them as ≥18 — a **minor pulled into background-check scope** |
| `src/app/api/people/search/route.ts:49` | `isDeclaredAdult: true` OR-leg — a flagged youth matches an adult search |
| `src/app/my-household/page.tsx:45` | renders an "Adult" badge |

`isKnownAdult` (`src/lib/programAge.ts:15`) reads the flag only on the no-DOB path, so the **program-enrolment gate was never affected** — a real DOB already wins there.

## No UI change needed

`src/app/membership-ops/participants/page.tsx:442` already hides the switch when `editingParticipant?.dateOfBirth` is set (landed with #1008), and `/api/people/search` ships `dateOfBirth` to board/sysadmin — the only roles that see the Details button (`isStaff`). The server-side coercion backstops direct API calls and stale client rows.

## Verification

Three integration cases in `src/app/__tests__/adminParticipants.integration.test.ts`:

- **happy path** — no DOB, flag `true` → 200, flag set (so an over-broad guard can't pass unnoticed)
- **DOB present** — a youth already carrying a stale flag, renamed *and* resubmitting the flag → 200, name saved, flag healed to `false`, DOB intact. This is the exact interaction the edit modal produces.
- still allows clearing the flag on a DOB row

Confirmed the DOB case fails against `main`'s route (the flag lands as `true`).

- `npm run test:ci` — 2503 passed, 264 suites
- `npm run test:integration -- --testPathPatterns "auditLog|authzRoleRejection|adminParticipant"` — 145 passed
- `npx tsc --noEmit`, `npm run lint` — clean

The integration run used a throwaway Postgres provisioned with `prisma migrate deploy` (not `db push`, which drops the partial unique indexes).

## Existing data

Rows may already violate the invariant. Detection query (read-only) — **not run against any real database**:

```sql
SELECT id, name, "dateOfBirth"
FROM "Person"
WHERE "dateOfBirth" IS NOT NULL AND "isDeclaredAdult" = true
ORDER BY "dateOfBirth" DESC;
```

The coercion above heals such a row whenever someone next edits that person, but does not reach rows nobody touches. Neither the `purge_adult_dob` migration nor the nightly cron will find them either: both only fix the 26+ direction (null the DOB, set the flag), so a flagged sub-26 row is invisible to them. A one-off sweep setting `isDeclaredAdult = false` where a DOB exists — never nulling the DOB — is worth running; it is deliberately **not** in this PR.

Follow-up worth filing separately: `membership-ops/participants/import` should route its `dateOfBirth` writes through `normalizeAdultDob`, which is what stops these rows being created in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
