### PR TITLE
ci(security-boundary): diff PR head, not the merge ref; fail loud on unreachable base

### DIFF
--- a/.github/workflows/security-boundary-isolation.yml
+++ b/.github/workflows/security-boundary-isolation.yml
@@ -63,11 +63,25 @@ jobs:
         if: github.event_name == 'pull_request' && github.base_ref == 'main'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$BASE_SHA" || true
-          mapfile -t CHANGED < <(git diff --name-only "$BASE_SHA"...HEAD)
-          [ "${#CHANGED[@]}" -eq 0 ] && { echo "No changes."; exit 0; }
+          # Diff the PR's OWN head, not the checked-out merge ref. On a
+          # pull_request, checkout resolves refs/pull/N/merge — the branch
+          # merged with the current tip of main — so HEAD carries main's newest
+          # commits. Diffing against HEAD would sweep in main's advance (any
+          # src/security/* it landed) and mis-flag it as this PR's boundary
+          # change. BASE_SHA...HEAD_SHA is merge-base(base,head)→head: only the
+          # branch's real changes. fetch-depth:0 already has both parents of the
+          # merge ref (= base.sha and head.sha) local, so no fetch is needed;
+          # if either SHA is unreachable the diff below fails loud, never a
+          # silent unaudited pass.
+          if ! CHANGED_RAW=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA"); then
+            echo "::error::Could not diff $BASE_SHA...$HEAD_SHA — a SHA is unreachable. Failing rather than passing this PR unaudited."
+            exit 1
+          fi
+          [ -z "$CHANGED_RAW" ] && { echo "No changes."; exit 0; }
+          mapfile -t CHANGED <<< "$CHANGED_RAW"
 
           is_boundary() { # policy/runtime files — the security boundary itself
             case "$1" in
@@ -100,7 +114,7 @@ jobs:
           RETIER=""
           CLS=checkin-app/src/security/generated/classifications.ts
           if printf '%s\n' "${CHANGED[@]}" | grep -qx "$CLS"; then
-            DIFF=$(git diff "$BASE_SHA"...HEAD -- "$CLS")
+            DIFF=$(git diff "$BASE_SHA"..."$HEAD_SHA" -- "$CLS")
             # `|| true`: under set -euo pipefail, grep's exit 1 on zero matches
             # would kill the script mid-step with no verdict — which failed every
             # PR whose classifications diff was PURELY ADDITIVE (the exact case

--- a/checkin-app/scripts/security-boundary-isolation-diff.selfcheck.sh
+++ b/checkin-app/scripts/security-boundary-isolation-diff.selfcheck.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Self-check for the changed-files diff logic in
+# .github/workflows/security-boundary-isolation.yml.
+#
+# Proves the two defects the workflow fix addresses:
+#   1. FALSE POSITIVE — diffing the checked-out merge ref (base...HEAD) sweeps
+#      in main's own advance, mis-flagging a boundary file main landed as this
+#      PR's change. The fix diffs the PR head (BASE...HEAD_SHA) so main's
+#      advance is excluded.
+#   2. FALSE NEGATIVE — an unreachable base SHA must FAIL loud, not degrade to
+#      an empty changed-set "No changes" pass.
+#
+# No framework. Builds a synthetic git repo in a temp dir and asserts. Run:
+#   bash checkin-app/scripts/security-boundary-isolation-diff.selfcheck.sh
+set -euo pipefail
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+git init -q -b main
+
+BOUNDARY=checkin-app/src/security/registry.ts
+mkdir -p "$(dirname "$BOUNDARY")" docs
+
+# M0: base branch point — includes the boundary file.
+mkdir -p checkin-app/src/security
+printf 'export const routes = []\n' > "$BOUNDARY"
+git add -A && git commit -qm "M0 base"
+M0=$(git rev-parse HEAD)
+
+# PR branch: one commit changing ONLY a doc.
+git checkout -q -b pr
+printf '# doc\n' > docs/foo.md
+git add -A && git commit -qm "PR: docs only"
+PR=$(git rev-parse HEAD)
+
+# main advances with a commit that MODIFIES the boundary file (main's advance).
+git checkout -q main
+printf 'export const routes = [1]\n' > "$BOUNDARY"
+git add -A && git commit -qm "M1 main advance: touch registry.ts"
+M1=$(git rev-parse HEAD)
+
+# The merge ref actions/checkout resolves for a pull_request: PR merged with
+# the current tip of main.
+MERGE=$(git commit-tree -p "$PR" -p "$M1" -m "merge ref" "$(git merge-tree --write-tree "$PR" "$M1" 2>/dev/null || git rev-parse "pr^{tree}")" 2>/dev/null || true)
+if [ -z "$MERGE" ]; then
+  git checkout -q -b mergeref "$PR"
+  git merge -q --no-edit "$M1" || true
+  MERGE=$(git rev-parse HEAD)
+  git checkout -q main
+fi
+
+# --- the FIXED diff logic (mirrors the workflow) ---
+fixed_changed() { # $1=BASE_SHA $2=HEAD_SHA -> prints changed files or fails
+  local BASE_SHA=$1 HEAD_SHA=$2 CHANGED_RAW
+  if ! CHANGED_RAW=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA"); then
+    return 1
+  fi
+  printf '%s' "$CHANGED_RAW"
+}
+
+pass=0 fail=0
+ok()  { echo "  ok: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+echo "1) FIXED logic, base=current-main-tip(M1), head=pr-tip -> only the doc"
+OUT=$(fixed_changed "$M1" "$PR")
+[ "$OUT" = "docs/foo.md" ] && ok "CHANGED == docs/foo.md (registry.ts excluded -> PASS)" \
+                           || bad "expected docs/foo.md, got: [$OUT]"
+
+echo "2) FIXED logic, base=divergence(M0), head=pr-tip -> still only the doc"
+OUT=$(fixed_changed "$M0" "$PR")
+[ "$OUT" = "docs/foo.md" ] && ok "CHANGED == docs/foo.md" \
+                           || bad "expected docs/foo.md, got: [$OUT]"
+
+echo "3) OLD logic (base...MERGE ref) WOULD sweep in main's advance"
+OLD=$(git diff --name-only "$M0"..."$MERGE")
+if echo "$OLD" | grep -qx "$BOUNDARY"; then
+  ok "old logic reports $BOUNDARY -> would false-flag the PR"
+else
+  bad "expected old logic to include $BOUNDARY, got: [$OLD]"
+fi
+
+echo "4) FALSE-NEGATIVE guard: unreachable base SHA must FAIL, not pass empty"
+if fixed_changed "0000000000000000000000000000000000000000" "$PR" >/dev/null 2>&1; then
+  bad "unreachable base SHA passed (silent no-changes) — false negative"
+else
+  ok "unreachable base SHA fails loud (non-zero) as required"
+fi
+
+echo
+echo "pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Fixes two defects in the `isolation` job's "Check boundary changes ship alone" step in `.github/workflows/security-boundary-isolation.yml`. CI-config only — no app/security-boundary code. (The workflow file is itself a listed companion, so this PR passes the isolation check trivially.)

### Defect 1 — false positive
`actions/checkout` on a `pull_request` checks out the merge ref (`refs/pull/N/merge` = PR branch merged with the current tip of main), so `HEAD` carries main's newest commits. Diffing `"$BASE_SHA"...HEAD` swept in **main's own advance**; whenever main's advance touched any `checkin-app/src/security/*` file (registry.ts, generated/classifications.ts), `BOUNDARY_TOUCHED` flipped and every non-companion file from main's advance was reported as an unisolated "violation" — for a PR that never touched the boundary. This is why the docs-only PR #1443 (one file) failed the isolation check twice, then passed only after a rebase. Not a fetch-depth issue (checkout is already full history) — `HEAD` was the wrong ref.

**Fix:** add `HEAD_SHA: ${{ github.event.pull_request.head.sha }}` and diff `"$BASE_SHA"..."$HEAD_SHA"` (merge-base→head = the branch's real changes only; main's advance is excluded because `HEAD_SHA` is the branch tip, not a merge with main). Same range applied to the RETIER classifications diff for consistency. `fetch-depth: 0` already has both parents of the merge ref (= base.sha and head.sha) local, so the base-fetch line is dropped.

### Defect 2 — false negative
`git fetch ... "$BASE_SHA" || true` swallowed a failed base fetch; if `$BASE_SHA` was ever unreachable the subsequent `git diff` fataled, `mapfile` (reading from process substitution) yielded an empty array, and the script printed "No changes." and `exit 0` — PASS. A genuine boundary-changing PR could sail through unaudited.

**Fix:** capture the diff and check its exit status explicitly — an unreachable SHA now fails the job (`exit 1`) instead of degrading to an empty-changed-set pass. A successful-but-empty diff is still a legitimate "No changes" pass.

## Unchanged
`merge_group` short-circuit, `base_ref != 'main'` (rel/**) short-circuit, `is_boundary`/`is_companion` lists, and the additive-classifications RETIER `|| true` (that one guards grep's exit-1-on-no-match — unrelated to the base-fetch mask, kept).

## Verification
`checkin-app/scripts/security-boundary-isolation-diff.selfcheck.sh` — synthetic git repo, no framework, `assert`-style:

```
1) FIXED logic, base=current-main-tip(M1), head=pr-tip -> only the doc
  ok: CHANGED == docs/foo.md (registry.ts excluded -> PASS)
2) FIXED logic, base=divergence(M0), head=pr-tip -> still only the doc
  ok: CHANGED == docs/foo.md
3) OLD logic (base...MERGE ref) WOULD sweep in main's advance
  ok: old logic reports checkin-app/src/security/registry.ts -> would false-flag the PR
4) FALSE-NEGATIVE guard: unreachable base SHA must FAIL, not pass empty
  ok: unreachable base SHA fails loud (non-zero) as required
pass=4 fail=0
```

Run: `bash checkin-app/scripts/security-boundary-isolation-diff.selfcheck.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)