### PR TITLE
security(scopes): add led_households scope, correct visit self-correction grants

### DIFF
--- a/checkin-app/src/security/__tests__/emergency-contact-program-scope.test.ts
+++ b/checkin-app/src/security/__tests__/emergency-contact-program-scope.test.ts
@@ -34,6 +34,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
         ...opts,
     };
 }

--- a/checkin-app/src/security/__tests__/payment-plans-strip.test.ts
+++ b/checkin-app/src/security/__tests__/payment-plans-strip.test.ts
@@ -27,6 +27,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
         ...opts,
     };
 }

--- a/checkin-app/src/security/__tests__/rsvp-program-scope.test.ts
+++ b/checkin-app/src/security/__tests__/rsvp-program-scope.test.ts
@@ -28,6 +28,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
         ...opts,
     };
 }

--- a/checkin-app/src/security/__tests__/shop-certifications-strip.test.ts
+++ b/checkin-app/src/security/__tests__/shop-certifications-strip.test.ts
@@ -36,6 +36,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
         ...opts,
     };
 }

--- a/checkin-app/src/security/__tests__/shop-org-members-strip.test.ts
+++ b/checkin-app/src/security/__tests__/shop-org-members-strip.test.ts
@@ -28,6 +28,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
         ...opts,
     };
 }

--- a/checkin-app/src/security/__tests__/toolstatus-self-scope.test.ts
+++ b/checkin-app/src/security/__tests__/toolstatus-self-scope.test.ts
@@ -20,6 +20,7 @@ const ctx: CallerContext = {
     householdIdsInScopePrograms: new Set(),
     eventIdsInScopePrograms: new Set(),
     activeVisitorIds: new Set(),
+    ledHouseholdMemberIds: new Set(),
 };
 
 describe('ToolStatus self-scoping after participantId -> personId rename', () => {

--- a/checkin-app/src/security/__tests__/visit-household-lead-scope.test.ts
+++ b/checkin-app/src/security/__tests__/visit-household-lead-scope.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Visit.led_households — the household lead's act-for-members grant (#1254, AT3).
+ *
+ * A lead may correct visits for the members of their household, so the response
+ * must carry those rows' `personal` fields (arrivedAt/departedAt). `their_own`
+ * alone cannot express that: it is `Visit.personId === selfId`, false on every
+ * row the capability exists to return. Visit has no householdId column either,
+ * so the grant matches personId against ctx.ledHouseholdMemberIds.
+ *
+ * These guards pin both edges of the token:
+ *   - a lead holds it on a member's visit, and the times survive stripping;
+ *   - a NON-lead of the same household holds nothing — led_households is
+ *     strictly narrower than their_households, which is the reason it is its
+ *     own scope rather than a re-reading of that one;
+ *   - self-correction still works via their_own (a plain member's roster is
+ *     empty, so they are not a household match);
+ *   - `internal` tombstone fields stay stripped for everyone here.
+ */
+import { scopesHeld, type CallerContext } from '../access-resolvers';
+import { stripValue } from '../stripper';
+import type { Token } from '../core';
+
+function ctx(opts: Partial<CallerContext> = {}): CallerContext {
+    return {
+        selfId: undefined,
+        householdId: undefined,
+        isKeyholder: false,
+        isKiosk: false,
+        programsLed: new Set(),
+        programsCoreVolIn: new Set(),
+        participantIdsInScopePrograms: new Set(),
+        householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
+        activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
+        ...opts,
+    };
+}
+
+// Household 2 = people 5 (the lead), 6, 9. Person 7 is outside it. The row
+// under test belongs to 9, so every caller below is a NON-owner except `owner`
+// — otherwise their_own would mask what led_households does or doesn't grant.
+const lead = ctx({ selfId: 5, householdId: 2, ledHouseholdMemberIds: new Set([5, 6, 9]) });
+// Same household, NOT a lead — buildCallerContext leaves the roster empty.
+const sibling = ctx({ selfId: 6, householdId: 2 });
+const owner = ctx({ selfId: 9, householdId: 2 });
+const stranger = ctx({ selfId: 77, householdId: 8 });
+
+// The view the registry grants both /api/attendance/manual/[id] verbs.
+const VIEW: Token[] = ['their_own:personal', 'led_households:personal', 'member', 'public'];
+
+const memberVisit = { id: 1, personId: 9, arrivedAt: new Date(0), departedAt: new Date(1), deletedAt: null };
+
+describe('Visit.led_households (household lead act-for-members)', () => {
+    it('grants led_households to a lead on a household member’s visit', () => {
+        expect(scopesHeld('Visit', memberVisit, lead).has('led_households')).toBe(true);
+    });
+
+    it('does NOT grant it to a non-lead member of the SAME household', () => {
+        expect(scopesHeld('Visit', memberVisit, sibling).has('led_households')).toBe(false);
+    });
+
+    it('does NOT grant it on a visit belonging to someone outside the household', () => {
+        const outside = { ...memberVisit, personId: 7 };
+        expect(scopesHeld('Visit', outside, lead).has('led_households')).toBe(false);
+    });
+
+    it('does NOT grant it to a caller who leads no household', () => {
+        expect(scopesHeld('Visit', memberVisit, stranger).has('led_households')).toBe(false);
+    });
+
+    it('a lead holds led_households but NOT their_own on a member’s visit', () => {
+        const held = scopesHeld('Visit', memberVisit, lead);
+        expect(held.has('their_own')).toBe(false);
+        expect(held.has('led_households')).toBe(true);
+    });
+
+    it('self-correction is unaffected — the owner still holds their_own', () => {
+        const held = scopesHeld('Visit', memberVisit, owner);
+        expect(held.has('their_own')).toBe(true);
+        // ...and holds it WITHOUT led_households: a plain member's roster is
+        // empty, which is why dropping their_own would break self-edit.
+        expect(held.has('led_households')).toBe(false);
+    });
+});
+
+describe('Visit.led_households — stripping under the registered view', () => {
+    it('keeps the times for a lead reading a member’s visit', () => {
+        const out = stripValue('Visit', memberVisit, VIEW, lead) as Record<string, unknown>;
+        expect(out.arrivedAt).toEqual(memberVisit.arrivedAt);
+        expect(out.departedAt).toEqual(memberVisit.departedAt);
+    });
+
+    it('strips the times for a non-lead sibling on the same row', () => {
+        const out = stripValue('Visit', memberVisit, VIEW, sibling) as Record<string, unknown>;
+        expect(out).not.toHaveProperty('arrivedAt');
+        expect(out).not.toHaveProperty('departedAt');
+        expect(out.personId).toBe(9); // public tier still rides through
+    });
+
+    it('keeps the times for the owner editing their own visit', () => {
+        const out = stripValue('Visit', memberVisit, VIEW, owner) as Record<string, unknown>;
+        expect(out.arrivedAt).toEqual(memberVisit.arrivedAt);
+    });
+
+    it('never exposes the internal tombstone fields — the view stops at personal', () => {
+        for (const caller of [lead, sibling, owner]) {
+            expect(stripValue('Visit', memberVisit, VIEW, caller)).not.toHaveProperty('deletedAt');
+        }
+    });
+});

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -38,6 +38,12 @@ export interface CallerContext {
     eventIdsInScopePrograms: Set<number>;
     /** Person IDs with an un-departed Visit. Only populated for keyholders. */
     activeVisitorIds: Set<number>;
+    /** Live members of the caller's household, INCLUDING the caller. Populated
+     *  only when the caller is a household lead — the empty set for everyone
+     *  else is what makes 'led_households' narrower than 'their_households'.
+     *  Visit has no householdId column; it reaches a household only via
+     *  personId ∈ this set. Drives 'led_households'. */
+    ledHouseholdMemberIds: Set<number>;
 }
 
 /**
@@ -60,6 +66,7 @@ export async function buildCallerContext(auth: AuthResult, needs: CtxNeeds): Pro
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
     };
 
     if (auth.type !== 'session') return ctx;
@@ -68,7 +75,7 @@ export async function buildCallerContext(auth: AuthResult, needs: CtxNeeds): Pro
     ctx.householdId = auth.user.householdId;
     ctx.isKeyholder = auth.user.isKeyholder;
 
-    const [ledPrograms, coreVols, visits] = await Promise.all([
+    const [ledPrograms, coreVols, visits, ledHouseholdMembers] = await Promise.all([
         needs.programs
             ? prisma.program.findMany({
                   where: { leadMentorId: auth.user.id },
@@ -90,6 +97,15 @@ export async function buildCallerContext(auth: AuthResult, needs: CtxNeeds): Pro
                   select: { personId: true },
               })
             : [],
+        // Lead-gated on purpose: sharing a household is not the relationship
+        // 'led_households' names. A non-lead member gets the empty set, so the
+        // scope never resolves for them. Mirrors lib/household/activityMembers.
+        needs.ledHouseholdMembers && auth.user.householdLead && ctx.householdId !== undefined
+            ? prisma.person.findMany({
+                  where: { householdId: ctx.householdId, ...LIVE_PERSON },
+                  select: { id: true },
+              })
+            : [],
     ]);
 
     for (const p of ledPrograms) {
@@ -101,6 +117,7 @@ export async function buildCallerContext(auth: AuthResult, needs: CtxNeeds): Pro
         for (const pp of v.program.participants) ctx.participantIdsInScopePrograms.add(pp.personId);
     }
     for (const v of visits) ctx.activeVisitorIds.add(v.personId);
+    for (const m of ledHouseholdMembers) ctx.ledHouseholdMemberIds.add(m.id);
 
     const scopePrograms = [...ctx.programsLed, ...ctx.programsCoreVolIn];
     await Promise.all([

--- a/checkin-app/src/security/core.ts
+++ b/checkin-app/src/security/core.ts
@@ -25,9 +25,10 @@
  *   scope = 'everyones'     — broad grant; held on every row by default, but a
  *                             row-scoped model missing its scope key fails
  *                             closed and does NOT hold it (see scopesHeld)
- *   scope = 'their_own' | 'their_households' | 'their_program_participants'
- *           | 'all_current_visitors' — per-row predicates evaluated by the
- *                             handler against a prefetched CallerContext.
+ *   scope = 'their_own' | 'their_households' | 'led_households'
+ *           | 'their_program_participants' | 'all_current_visitors' — per-row
+ *                             predicates evaluated by the handler against a
+ *                             prefetched CallerContext.
  *
  * Field visibility (per row):
  *   - field.tier === 'secret'        → never
@@ -57,6 +58,11 @@ export type Scope =
     | 'everyones'
     | 'their_own'
     | 'their_households'
+    // Caller LEADS the household the row belongs to. Deliberately distinct from
+    // their_households, which is household-WIDE (a non-lead member holds it):
+    // this one is the "may act for another member" relationship, so it is the
+    // right token wherever sharing a home is not by itself enough.
+    | 'led_households'
     | 'their_program_participants'
     // Caller leads/core-vols a program that a child of this row's household is
     // enrolled in (used for Trusted Adult pickup notes).
@@ -92,6 +98,7 @@ const VALID_SCOPES = new Set<Scope>([
     'everyones',
     'their_own',
     'their_households',
+    'led_households',
     'their_program_participants',
     'their_program_households',
     'keyholders',
@@ -212,6 +219,8 @@ export interface CtxNeeds {
     programEvents: boolean;
     /** activeVisitorIds (fetched only for keyholders) */
     activeVisitors: boolean;
+    /** ledHouseholdMemberIds (fetched only for household leads) */
+    ledHouseholdMembers: boolean;
 }
 
 export const ALL_CTX_NEEDS: CtxNeeds = Object.freeze({
@@ -219,6 +228,7 @@ export const ALL_CTX_NEEDS: CtxNeeds = Object.freeze({
     programHouseholds: true,
     programEvents: true,
     activeVisitors: true,
+    ledHouseholdMembers: true,
 });
 
 function scopeNeeds(scope: Scope): Partial<CtxNeeds> {
@@ -229,6 +239,10 @@ function scopeNeeds(scope: Scope): Partial<CtxNeeds> {
         case 'keyholders':
             // Resolved from the session alone — no prefetch.
             return {};
+        case 'led_households':
+            // Visit (and any future model keyed on personId rather than
+            // householdId) reaches the household only through its members.
+            return { ledHouseholdMembers: true };
         case 'their_program_participants':
             // participantIds AND (RSVP-only) eventIds both hang off this scope;
             // the bag's models aren't statically known, so fetch both.
@@ -290,6 +304,7 @@ export function deriveCtxNeeds(spec: RouteSpec): CtxNeeds {
         programHouseholds: false,
         programEvents: false,
         activeVisitors: false,
+        ledHouseholdMembers: false,
     };
     Object.assign(needs, authorizeNeeds(spec.authorize));
     for (const [role, tokens] of spec.orderedView) {

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -32,13 +32,21 @@ defineRoute({
     ],
 });
 
-// Self-correction of the caller's OWN visit: PATCH edits the times, DELETE
-// tombstones the row. `[id]` is a Visit id, NOT a person id, so 'self' cannot
-// express the gate — it compares the id param against auth.user.id. Ownership
-// is enforced in the route body, which 404s any id that is not the caller's own
-// live row; their_own (Visit.personId) is the per-row field backstop. The grant
-// stops at 'personal' (arrivedAt/departedAt); 'internal' tombstone fields stay
-// stripped.
+// Self-correction of a visit the caller may act for: PATCH edits the times,
+// DELETE tombstones the row. `[id]` is a Visit id, NOT a person id, so 'self'
+// cannot express the gate — it compares the id param against auth.user.id.
+// Subject ownership is enforced in the route body, which 404s any id the caller
+// may not act for; the two per-row tokens are the field backstop for the two
+// legitimate subjects:
+//   their_own      — Visit.personId === caller (a member editing their own row)
+//   led_households — Visit.personId is in a household the caller LEADS (AT3,
+//                    #1254: the lead is the responsible adult for members who
+//                    cannot self-serve). Lead-only, not household-wide: a
+//                    non-lead sibling holds neither token and sees nothing.
+// Both are needed — under led_households a plain member editing their own visit
+// is not a household match, so their_own is what keeps self-correction working.
+// The grant stops at 'personal' (arrivedAt/departedAt); 'internal' tombstone
+// fields stay stripped.
 defineRoute({
     endpoint: 'PATCH /api/attendance/manual/[id]',
     authorize: 'authenticated',
@@ -46,7 +54,7 @@ defineRoute({
     // Bag: { Visit }.
     returns: ['Visit'],
     orderedView: [
-        ['authenticated', ['their_own:personal', 'member', 'public']],
+        ['authenticated', ['their_own:personal', 'led_households:personal', 'member', 'public']],
     ],
 });
 
@@ -56,7 +64,7 @@ defineRoute({
     // No bag — the response is { success, flagged }, no model data.
     envelope: null,
     orderedView: [
-        ['authenticated', ['their_own:personal', 'member', 'public']],
+        ['authenticated', ['their_own:personal', 'led_households:personal', 'member', 'public']],
     ],
 });
 

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -93,8 +93,14 @@ export const SCOPE_BINDINGS = {
         their_own: { field: 'personId', eqCtx: 'selfId' },
         their_program_participants: { field: 'personId', inCtx: 'participantIdsInScopePrograms' },
     },
+    // No householdId column: a Visit reaches a household only through its
+    // person, so `led_households` matches personId against the caller's led
+    // household roster rather than comparing a householdId field. It is the
+    // lead-only scope, NOT `their_households` — a non-lead sibling has no claim
+    // on another member's arrival/departure times.
     Visit: {
         their_own: { field: 'personId', eqCtx: 'selfId' },
+        led_households: { field: 'personId', inCtx: 'ledHouseholdMemberIds' },
         all_current_visitors: {
             all: [{ flag: 'isKeyholder' }, { field: 'departedAt', isNull: true }],
         },

--- a/checkin-app/src/security/scopes.ts
+++ b/checkin-app/src/security/scopes.ts
@@ -31,7 +31,8 @@ export type CtxSet =
     | 'participantIdsInScopePrograms'
     | 'householdIdsInScopePrograms'
     | 'eventIdsInScopePrograms'
-    | 'activeVisitorIds';
+    | 'activeVisitorIds'
+    | 'ledHouseholdMemberIds';
 export type CtxFlag = 'isKeyholder' | 'isKiosk';
 
 export type ScopePredicate = (row: Record<string, unknown>, ctx: CallerContext) => boolean;

--- a/checkin-app/tests/security/ctxNeeds.test.ts
+++ b/checkin-app/tests/security/ctxNeeds.test.ts
@@ -58,6 +58,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
         ...opts,
     };
 }
@@ -88,14 +89,20 @@ const PERSONAS: Record<string, Persona> = {
     kiosk: { auth: { type: 'kiosk' }, full: ctx({ isKiosk: true }) },
     member: {
         auth: { type: 'session', user: sessionUser({ id: 5, householdId: 2 }) },
-        full: ctx({ selfId: 5, householdId: 2 }),
+        // ledHouseholdMemberIds populated for a NON-lead too (the runtime never
+        // does this) — same adversarial principle as the program sets below.
+        full: ctx({ selfId: 5, householdId: 2, ledHouseholdMemberIds: new Set([5, 6, 9]) }),
     },
     householdLead: {
         auth: {
             type: 'session',
             user: sessionUser({ id: 6, householdId: 2, householdLead: true }),
         },
-        full: ctx({ selfId: 6, householdId: 2 }),
+        full: ctx({
+            selfId: 6,
+            householdId: 2,
+            ledHouseholdMemberIds: new Set([5, 6, 9]),
+        }),
     },
     programLead: {
         auth: { type: 'session', user: sessionUser({ id: 10, householdId: 4 }) },
@@ -172,6 +179,9 @@ function maskToNeeds(full: CallerContext, needs: CtxNeeds): CallerContext {
             : new Set(),
         eventIdsInScopePrograms: needs.programEvents ? full.eventIdsInScopePrograms : new Set(),
         activeVisitorIds: needs.activeVisitors ? full.activeVisitorIds : new Set(),
+        ledHouseholdMemberIds: needs.ledHouseholdMembers
+            ? full.ledHouseholdMemberIds
+            : new Set(),
     };
 }
 
@@ -283,7 +293,26 @@ describe('deriveCtxNeeds — spot checks against the live registry', () => {
             programHouseholds: false,
             programEvents: false,
             activeVisitors: false,
+            ledHouseholdMembers: false,
         });
+    });
+
+    it('the self-correction routes need only the led-household roster', () => {
+        for (const ep of [
+            'PATCH /api/attendance/manual/[id]',
+            'DELETE /api/attendance/manual/[id]',
+        ]) {
+            expect({ ep, needs: byEndpoint.get(ep)?.ctxNeeds }).toEqual({
+                ep,
+                needs: {
+                    programs: false,
+                    programHouseholds: false,
+                    programEvents: false,
+                    activeVisitors: false,
+                    ledHouseholdMembers: true,
+                },
+            });
+        }
     });
 
     it('the program roster route needs the program prefetches', () => {
@@ -292,6 +321,7 @@ describe('deriveCtxNeeds — spot checks against the live registry', () => {
             programHouseholds: true,
             programEvents: true,
             activeVisitors: false,
+            ledHouseholdMembers: false,
         });
     });
 

--- a/checkin-app/tests/security/delivery.test.ts
+++ b/checkin-app/tests/security/delivery.test.ts
@@ -52,6 +52,7 @@ function emptyCtx(): CallerContext {
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
     };
 }
 

--- a/checkin-app/tests/security/resolveAccess.test.ts
+++ b/checkin-app/tests/security/resolveAccess.test.ts
@@ -37,6 +37,7 @@ const rctx = (
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
         ...callerOverrides,
     },
 });

--- a/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
+++ b/checkin-app/tests/security/scopeBindingsEquivalence.test.ts
@@ -173,6 +173,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
         ...opts,
     };
 }
@@ -181,6 +182,14 @@ const PERSONAS: Record<string, CallerContext> = {
     anonymous: ctx(),
     selfOnlyMember: ctx({ selfId: 5, householdId: 2 }),
     householdCoMember: ctx({ selfId: 6, householdId: 2 }),
+    // Lead of household 2 — the only persona with a non-empty led roster, which
+    // is what makes led_households strictly narrower than their_households:
+    // householdCoMember above shares household 2 and holds neither.
+    householdLead: ctx({
+        selfId: 6,
+        householdId: 2,
+        ledHouseholdMemberIds: new Set([5, 6, 9]),
+    }),
     programLead: ctx({
         selfId: 10,
         householdId: 4,
@@ -278,6 +287,15 @@ function eq(a: Set<string>, b: Set<string>): boolean {
  * via a 'keyholders:pii' token instead of a blanket 'everyones:pii'. On any
  * object row, a keyholder caller therefore holds 'keyholders' where the
  * snapshot did not. That is the second expected diff.
+ *
+ * Visit.led_households (#1254): the switch's Visit case bound only their_own +
+ * all_current_visitors, so a household lead held nothing on a member's visit —
+ * which would strip arrivedAt/departedAt from exactly the rows the AT3
+ * act-for-members capability returns. Visit carries no householdId, so the
+ * binding matches personId against ctx.ledHouseholdMemberIds (populated only
+ * for leads). On a Visit row whose personId is in that roster, a lead therefore
+ * holds 'led_households' where the snapshot did not. That is the third
+ * expected diff.
  */
 function expectedFromSnapshot(
     model: string,
@@ -296,6 +314,15 @@ function expectedFromSnapshot(
     }
     if (model === 'Person' && row && typeof row === 'object' && callerCtx.isKeyholder) {
         expected.add('keyholders');
+    }
+    if (
+        model === 'Visit' &&
+        row &&
+        typeof row === 'object' &&
+        typeof row.personId === 'number' &&
+        callerCtx.ledHouseholdMemberIds.has(row.personId)
+    ) {
+        expected.add('led_households');
     }
     return expected;
 }

--- a/checkin-app/tests/security/scopeValidators.test.ts
+++ b/checkin-app/tests/security/scopeValidators.test.ts
@@ -92,6 +92,25 @@ describe('validateRouteGrants — seam check', () => {
         expect(validateRouteGrants(routes, bindings)).toEqual([]);
     });
 
+    // The CI gate below passes only if the seam is actually EVALUATED for the
+    // self-correction grant — a route whose `returns` is missing is skipped, so
+    // "green" alone does not prove the grant was checked. Strip led_households
+    // from the Visit binding and the real spec must go red.
+    it('bites on the real self-correction spec when Visit loses its led_households binding', () => {
+        const patch = [...allRoutes()].find(
+            ([ep]) => ep === 'PATCH /api/attendance/manual/[id]',
+        )?.[1];
+        expect(patch?.returns).toEqual(['Visit']);
+        const errs = validateRouteGrants([patch as RouteGrantSpec], {
+            ...SCOPE_BINDINGS,
+            Visit: {
+                their_own: SCOPE_BINDINGS.Visit.their_own,
+                all_current_visitors: SCOPE_BINDINGS.Visit.all_current_visitors,
+            },
+        });
+        expect(errs.some(e => e.includes("grants 'led_households:*'"))).toBe(true);
+    });
+
     it('skips a route that has not declared `returns` (incremental coverage)', () => {
         const routes: RouteGrantSpec[] = [
             { endpoint: '/api/undeclared', orderedView: [['authenticated', ['their_households:pii']]] },

--- a/checkin-app/tests/security/stripper.test.ts
+++ b/checkin-app/tests/security/stripper.test.ts
@@ -23,6 +23,7 @@ function ctx(opts: Partial<CallerContext> = {}): CallerContext {
         householdIdsInScopePrograms: new Set(),
         eventIdsInScopePrograms: new Set(),
         activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
         ...opts,
     };
 }

--- a/docs/security/SECURITY-POLICY.md
+++ b/docs/security/SECURITY-POLICY.md
@@ -49,6 +49,7 @@ Schema annotations classify *data*. Registry views grant *access* in the form of
 | `everyones` | "everyone's …" — no relationship check (broad grant) |
 | `their_own` | "their own …" — row owner is the caller |
 | `their_households` | "their households' …" — caller and row owner share a household |
+| `led_households` | "their led households' …" — caller is a **lead** of the row owner's household. Strictly narrower than `their_households`: a non-lead member of the same household does not hold it. Use it where acting for another member is the capability, not merely sharing a home |
 | `their_program_participants` | "their program participants' …" — caller leads/coreVols a program containing the row owner |
 | `all_current_visitors` | "all current visitors' …" — keyholder view of people currently in the building |
 


### PR DESCRIPTION
Boundary-only PR. Corrects the security-registry declaration for the visit
self-correction routes, and adds the scope vocabulary that makes the correct
declaration expressible. Design context: AT3 in `checkin-app/docs/designs/1256_ATTENDANCE_CORRECTION_SURFACE.md` §3.

Refs #1254 — deliberately WITHOUT a closing keyword. This does not implement
AT3; it unblocks it.

## The finding

`registry.ts` declared `PATCH` and `DELETE /api/attendance/manual/[id]` with
`their_own:personal` as their only row-scoped grant, above prose claiming
ownership "404s any id that is not the caller's own live row".

`their_own` on `Visit` binds `{ field: 'personId', eqCtx: 'selfId' }`. After
AT3 (#1478) a household lead legitimately receives a **member's** `Visit` — a
row where that predicate is false — so `arrivedAt` / `departedAt` would be
stripped from exactly the rows the feature exists to return.

This is inert **today** only because the route is still `withAuth` and never
consults the registry at request time. It becomes real the moment that route
moves to `handler()`. The prose was wrong too, but the declaration is the part
that would have broken something.

## Why a new context set, not a `householdId` column

`their_households` is already bound on every model carrying a `householdId`
column — `Person`, `Household`, `EmergencyContact`, `OrgMembership`,
`TrustedAdult`, `TrustedAdultReview`, all as
`{ field: 'householdId', eqCtx: 'householdId' }`. **`Visit` has no
`householdId`**; it keys on `personId`. `Match` compares a row *field* against
caller context, so "this visit's person is in my household" was not sayable
with the existing vocabulary.

Two alternatives considered and rejected:

- **Denormalising `householdId` onto `Visit`** — duplicates a fact that moves
  when someone changes household, and it is a schema change, not a boundary one.
- **The `{ custom }` escape hatch** — `scopes.ts` documents that it SKIPS
  validation and must be logged. It forfeits exactly the auditability this
  layer exists to provide.

## Why `led_households` is its own Scope

The open question was whose relationship `their_households` should name on a
`Visit`:

- **Household-wide** is the established reading everywhere else in the register
  (the six models above), but it would let a non-lead sibling see another
  member's `arrivedAt`/`departedAt` on any route granting
  `their_households:personal` — visit times are `personal`, the strict band.
- **Lead-only** tracks the AT3 capability exactly and matches
  `lib/household/activityMembers.ts`, whose own comment calls the lead check
  "the trust boundary for cross-member reads/writes" — but it would make one
  token mean two different things depending on model, which is precisely how an
  audit layer starts lying.

Resolved by not overloading the token at all. `led_households` is a new `Scope`:
`their_households` keeps its household-wide meaning everywhere it already
holds, and lead authority gets a name of its own. A non-lead member of the same
household holds **neither** token on a sibling's visit.

This matters beyond AT3 — a scope binding is not a route gate. Whatever is bound
here applies to every route that ever grants the scope on `Visit`.

## Both tokens stay in the view

`orderedView` is now
`['their_own:personal', 'led_households:personal', 'member', 'public']`.

A plain member's led roster is empty, so a caller editing their **own** visit is
not a household match — self-correction breaks if `their_own` is replaced rather
than joined. Pinned by a test.

## Changes

| File | Change |
|---|---|
| `core.ts` | `led_households` in the `Scope` union + `VALID_SCOPES`; new `ledHouseholdMembers` flag on `CtxNeeds` (the `scopeNeeds` switch is total under `assertNever`, so the variant had to be answered there) |
| `scopes.ts` | `ledHouseholdMemberIds` added to `CtxSet` |
| `access-resolvers.ts` | `ledHouseholdMemberIds` on `CallerContext`, populated **only** when `auth.user.householdLead`, filtered through `LIVE_PERSON` |
| `scopeBindings.ts` | `Visit.led_households: { field: 'personId', inCtx: 'ledHouseholdMemberIds' }` |
| `registry.ts` | Corrected `orderedView` on both verbs + rewritten prose |
| `docs/security/SECURITY-POLICY.md` | New row in the Scope table |

The empty set for non-leads is what makes the scope narrower than
`their_households` rather than a synonym for it.

**Cost:** `ledHouseholdMembers` only ever derives `true` for these two routes,
so the extra indexed `Person` lookup is paid there and nowhere else. Every other
route granting `their_households` still costs zero context queries.

## Ordering — this does NOT wait on #1478

Registry-first is the required order in this repo (AGENTS.md § Boundary
isolation rule): an unused or widened `defineRoute` grant is inert because the
route is still `withAuth` and never reads it. #1478 implements AT3; this should
land **ahead** of it. There is no window in which this exposes anything.

## Verification

- `tsc --noEmit` and eslint over `src/security` + `tests/security` — clean.
- **`validateBindings` / `validateRouteGrants`** (the CI security validators) —
  green over the real registry. Green alone does not prove the new grant was
  *evaluated*, since `validateRouteGrants` skips any spec without `returns`, so
  this PR adds a bite test that pulls the real PATCH spec, strips
  `led_households` from the `Visit` binding, and asserts it goes red.
  **Known gap (pre-existing):** the DELETE spec has no `returns` (envelope
  `null`, no model bag), so the seam check skips it.
- Security suites — 18 suites / 639 tests, all pass.
- Full unit suite — 265 suites / 2514 tests, 0 failures.
- Registry integration suites against a real Postgres —
  `policy.contract.integration.test.ts` and `registryAuthz.integration.test.ts`
  both pass (105 passed / 9 skipped; the skips are pre-existing `it.skip`s for
  registered routes with no route file yet — the registry-first state).

### New + updated tests

- `visit-household-lead-scope.test.ts` (new) — pins both edges: a lead holds the
  scope on a member's visit and the times survive stripping; a **non-lead of the
  same household** holds nothing; self-correction still works via `their_own`;
  `internal` tombstone fields stay stripped for everyone.
- `scopeBindingsEquivalence.test.ts` — a new binding legitimately diverges from
  the frozen switch snapshot, so it is recorded as an explicit third documented
  delta with a `householdLead` persona, not silenced.
- `ctxNeeds.test.ts` — new mask arm, plus an assertion that the two routes need
  *only* the led-household roster.

## Reviewer notes

- Boundary-only per `.github/workflows/security-boundary-isolation.yml`: **no
  route, app, UI, schema, or migration file is touched.** All 19 files fall under
  the workflow's companion list.
- The scope-name choice is the reviewable decision here. `led_households` is a
  new, narrower sense than `their_households` deliberately — if you would rather
  `their_households` simply widen to cover `Visit` household-wide, that is a
  one-line change to the binding, but it grants sibling-to-sibling visibility of
  `personal`-tier visit times on every future route granting that token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
