### PR TITLE
docs(workflow): document Iteration, Priority, and the triage bar

### DIFF
--- a/docs/in-design/ISSUE_WORKFLOW_MIGRATION.md
+++ b/docs/in-design/ISSUE_WORKFLOW_MIGRATION.md
@@ -59,7 +59,12 @@ order:
    PR moves to **Design review** (#1258 at minimum).
 7. Decompose #975 into parent + one child per release (§5.3); label the Release 2
    child `blocked` with its gate in the body.
-8. Paste `ISSUE_WORKFLOW_RULES.md` over the `AGENTS.md` § "Issue workflow (org
+8. Backfill Iteration on everything at Planning or beyond. **34 items** qualify
+   and carry none today — 31 Planning, 2 In review, 1 In progress — against 11
+   items total currently in Iteration 2. Leave Ideation/Reporting unset; that is
+   the rule, not an omission. Until this runs, the `iteration:@current` view
+   shows 11 of the 44 items that are actually in flight.
+9. Paste `ISSUE_WORKFLOW_RULES.md` over the `AGENTS.md` § "Issue workflow (org
    project 1)", then delete both working docs.
 
 Built-in project workflows need no change. "Item closed" and "Pull request

--- a/docs/in-design/ISSUE_WORKFLOW_RULES.md
+++ b/docs/in-design/ISSUE_WORKFLOW_RULES.md
@@ -85,5 +85,80 @@ until its last child closes.
   issue saying what was abandoned and why**. The status can no longer tell the
   second pass from the first; that comment is what does.
 
-Project-field writes need the `project` token scope; if GraphQL returns
-INSUFFICIENT_SCOPES, have the user run `gh auth refresh -s project`.
+### Iteration and Priority
+
+Status is one field of several, and the ladder says nothing about the rest. Two
+of them decide whether an issue is visible at all and what order it gets worked
+in.
+
+**Iteration is what the canonical view filters on.** Project 1's default view is
+filtered `iteration:@current` (14-day iterations), so an item in no iteration is
+invisible there however far up the ladder it has climbed. Set it as the issue
+leaves Ideation/Reporting:
+
+- **Planning and beyond** — the current iteration, or a named future one when
+  the work is deliberately deferred.
+- **Ideation/Reporting** — leave unset. Nothing has been committed to, and a
+  triage backlog does not belong in a sprint view.
+
+Work that slips carries to the next iteration. That is a scheduling change, not
+a Status change; the two move independently and neither implies the other.
+
+**Priority is an org-level Issue field, not a project field.** It is projected
+into project 1, but its options and values live on the organization, so
+`updateProjectV2ItemFieldValue` fails against it — use `createIssueFieldValue`,
+which also takes a `rationale`. Fill the rationale: it is the only record of why
+a ranking was chosen.
+
+**High, Medium and Low are the working set. Never set Urgent.** Urgent means a
+human has decided something jumps the queue. Proposing it in a comment is fine;
+setting it is not an agent's call.
+
+The two big columns are ranked on different questions, because they are asking
+different things:
+
+| Column | Rank by |
+|---|---|
+| Ideation/Reporting | applicability to the business rules and the app's design — does this fit what the system is for |
+| Planning | relative importance against a codebase where every v1.1 feature is already complete |
+
+Size and Estimate are unused. Leave them empty rather than guessing.
+
+### The Ideation/Reporting → Planning bar
+
+This is the highest-traffic gate on the board and the easiest to apply
+inconsistently, so the bar is written down rather than left to taste. Read the
+item as a product manager would and promote only if it clears the standard for
+its kind:
+
+| Kind | Clears when it names |
+|---|---|
+| Bug report | the observed behaviour, the expected behaviour, and how to reach it |
+| Feature request | who it is for, what they cannot do today, and what "done" looks like |
+| Chore / refactor | the concrete cost of leaving it alone |
+| Question / idea | the decision being asked for, and who can make it |
+
+An item that does not clear its bar stays put — comment saying what is missing
+rather than promoting it and discovering the gap at Planning. Promotion claims
+the shape is discussable, not that the work is scheduled.
+
+### Working the board
+
+- **Record linkage when you see it.** When an item relates to another issue or a
+  PR — superseding, superseded by, blocked on, duplicating, or simply the PR
+  that will close it — say so in a comment on the item. Linkage is what the
+  ladder cannot encode, and it is how a stale claim gets caught: an issue whose
+  only implementation PR was closed unmerged looks identical, from Status alone,
+  to one being actively worked.
+- **Stamp agent-authored comments.** Anything an agent writes on an issue or a
+  PR ends with `_Posted by Claude._`, so a reader can tell a machine's reading
+  of the code from a human's decision about the product.
+- **This board is not automated, deliberately.** No label-mirror sync, no CLI
+  wrapper, no bot moving items between states beyond the two built-in workflows
+  already in use (Item closed, Pull request merged). The `blocked` label is
+  applied and removed by a person. Propose automation if you think it is
+  warranted; do not build it.
+
+Project queries need the `read:project` token scope and field writes need
+`project`; if GraphQL returns INSUFFICIENT_SCOPES, have the user run
+`gh auth refresh -s read:project` or `gh auth refresh -s project`.

--- a/docs/in-design/ISSUE_WORKFLOW_RULES.md
+++ b/docs/in-design/ISSUE_WORKFLOW_RULES.md
@@ -151,8 +151,10 @@ the shape is discussable, not that the work is scheduled.
   only implementation PR was closed unmerged looks identical, from Status alone,
   to one being actively worked.
 - **Stamp agent-authored comments.** Anything an agent writes on an issue or a
-  PR ends with `_Posted by Claude._`, so a reader can tell a machine's reading
-  of the code from a human's decision about the product.
+  PR ends with a line naming the agent that wrote it — `_Posted by <agent>._` —
+  so a reader can tell a machine's reading of the code from a human's decision
+  about the product. More than one agent works here; the rule fixes the field,
+  and each supplies its own name.
 - **This board is not automated, deliberately.** No label-mirror sync, no CLI
   wrapper, no bot moving items between states beyond the two built-in workflows
   already in use (Item closed, Pull request merged). The `blocked` label is


### PR DESCRIPTION
Stacked on #1504 — **base is `claude/amazing-tesla-df2a71`, not `main`.** Merge #1504 first; this then retargets cleanly.

#1504 writes down the Status ladder. Status is one field of several, and eight rules that actually govern this board exist only as verbal guidance — I checked, and none of them appear anywhere in the repo, including in the `AGENTS.md` section #1504 replaces. So these are not regressions in #1504; they are gaps it is the natural place to close, because after cutover that section is the board's only written contract.

## What this adds to the rules file

**1. Iteration.** Project 1's canonical view is filtered `iteration:@current`, so an item in no iteration is invisible there however far up the ladder it has climbed. The ladder otherwise governs a field the default view does not filter on. Rule: set it as the issue leaves Ideation/Reporting; leave Ideation/Reporting unset, because a triage backlog does not belong in a sprint view. Slipping carries forward — a scheduling change, not a Status change.

**2. Priority, and the Urgent rule.** `Priority` is an **org-level Issue field** projected into the project, so `updateProjectV2ItemFieldValue` fails against it — `createIssueFieldValue` is the mutation, and it takes a `rationale` worth filling. High/Medium/Low are the working set. **Urgent is never set by an agent**; proposing it in a comment is fine, setting it is a human's call.

**3. The two ranking questions.** Ideation/Reporting ranks by applicability to the business rules and the app's design. Planning ranks by relative importance against a codebase where every v1.1 feature is already complete. Different questions, so they were never one rubric.

**4. The Ideation/Reporting → Planning bar.** The transition table says only "Triage accepts it." That is the highest-traffic gate on the board — **141 of 210 items are queued behind it** — and the busiest gate had no stated criterion. Now a four-row table by request kind, with the rule that a failing item stays put and gets a comment naming what is missing.

**5. Linkage comments.** Record it when an item relates to another issue or PR. This is what the ladder cannot encode, and it is how a stale claim gets caught — an issue whose only implementation PR was closed unmerged is indistinguishable, from Status alone, from one being actively worked. #1504's own side-finding about #1396 is exactly this class of catch.

**6. The no-automation constraint.** #1504 complies — every migration step is manual — but never records the rule. That matters here specifically because #1504 introduces a `blocked` label, and syncing a label against a project field is the obvious next thing someone builds. Written down: no label-mirror sync, no CLI wrapper, no bot beyond the two built-in workflows already in use. Propose automation; do not build it.

**7. Agent comment stamping.** #1504 mandates comments in two places (the rework justification, the blocked gate) with nothing about attribution.

**8. `read:project`.** The existing note covers the write scope only; queries need `read:project` separately.

## Migration

One new step, inserted before the paste step (so the count is now nine, not eight):

**34 items sit at Planning or beyond with no Iteration** — 31 Planning, 2 In review, 1 In progress — against 11 items total in Iteration 2. Until that backfill runs, `iteration:@current` shows 11 of the 44 items actually in flight. Verified against the live board, not inferred.

## Notes

- Split per the §4.2 rule #1504 itself adds: permanent text in `ISSUE_WORKFLOW_RULES.md`, the expiring count and backfill step in `ISSUE_WORKFLOW_MIGRATION.md`.
- No board writes, no `AGENTS.md` change — same posture as #1504.
- Deliberately **not** included: Size and Estimate get one line saying they are unused, and nothing else. There is no guidance to record about them, and inventing some would be the defect #1504 is fixing.
- I have not touched #1504's open questions. Q3 (does Designing need an assignee) still gates its steps 1–3, and Q1 (is Ideation/Reporting one bucket or two) would change the §"bar" table above if it splits.

---
_Posted by Claude._
