### PR TITLE
docs(conventions): name the role, not the vendor

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -53,3 +53,32 @@ The failure is silent by construction. Forgetting produces no error, no failed
 test and no wrong-looking code — just a row that should not have been there,
 counted, rendered, or accepted as proof of who someone is. It is found when
 someone notices the number is wrong, which is not a mechanism.
+
+---
+
+## We name the role, not the vendor
+
+- **A rule that governs agents says "agent", never a product name.** More than
+  one works in this repo: `AGENTS.md` is the shared contract, and `CLAUDE.md`,
+  `GEMINI.md` and `.jules/sentinel.md` carry what is specific to each. A
+  convention written against one product binds that product alone — every other
+  agent is exempt from it while appearing to be covered.
+
+- **Where an artifact records which agent produced it, the agent supplies its
+  own name.** The rule fixes the field, not the answer. "Ends with a line naming
+  the agent" is a rule; "ends with `Posted by <product>`" is that product's
+  configuration written into everyone's rulebook.
+
+- **Product-specific detail belongs in that product's own instruction file** —
+  where a reader already looks for it, and where it can be deleted along with
+  the tool.
+
+This does not reach *records* of work already done. A comment that says which
+agent wrote it is a fact about that comment and stays true; the convention
+governs the rule, not the audit trail it produced.
+
+The failure is a rule that looks universal and is not. It reads as satisfied,
+because the named product does obey it and reviewers watch it obey — while the
+same work done by any other agent is silently unbound. It surfaces when the
+lineup changes, and the convention turns out to have described a vendor rather
+than a practice.


### PR DESCRIPTION
Adds one convention: rules that govern agents name the role, not the product.

Prompted by @thpr on #1505 — *"Can't hardcode Claude here if it's Jules/Antigravity/etc"* — against a stamping rule I had written as `_Posted by Claude._`. Fixed there; this generalises it so the next one doesn't need catching in review.

## Why it belongs in the repo rather than in one agent's file

Several agents work here. `AGENTS.md` is the shared contract, with `CLAUDE.md`, `GEMINI.md` and `.jules/sentinel.md` carrying what is specific to each — and the Sentinel PRs on this repo are opened by a bot that reads none of the other three. A convention written against one product binds that product alone. The failure mode is not that the rule is ignored; it is that the rule *appears* satisfied, because the named product obeys it and reviewers watch it obey, while identical work by any other agent is unbound.

Placed in `docs/conventions.md` — "how we build, independent of any domain" per `DOCUMENTATION_STANDARD.md` §2 — and written to that file's existing shape: bolded rules, then the failure the rule exists to prevent.

## The rule, in three parts

1. **A rule that governs agents says "agent", never a product name.**
2. **Where an artifact records which agent produced it, the agent supplies its own name.** The rule fixes the field, not the answer. "Ends with a line naming the agent" is a rule; "ends with `Posted by <product>`" is one product's configuration written into everyone's rulebook.
3. **Product-specific detail belongs in that product's own instruction file** — where a reader already looks, and where it is deleted along with the tool.

## Scope, deliberately

**This does not reach records of work already done.** A comment that says which agent wrote it is a fact about that comment and stays true. The convention governs the rule, not the audit trail the rule produced — stated explicitly in the text, because the obvious over-application is a sweep through several hundred existing comments that are all correct as written.

**No sweep is needed anyway.** I grepped `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.jules/`, and all of `docs/` on `main`: **no existing guidance hardcodes a vendor.** This is preventive. The single violation was in the unmerged #1505 and is fixed on that branch.

**Not included:** any mechanical check. This is the kind of rule a linter reads as satisfied while missing the point — a grep for product names would flag `CLAUDE.md`'s own filename and every legitimate historical stamp. Review is the enforcement, same as the three conventions already in this file.

## Verification

Docs only. No code, no schema, no board writes.

---
_Posted by Claude._
